### PR TITLE
crypto: Use `[T]::copy_from_slice` for safe and efficient memcpy

### DIFF
--- a/crates/crypto/src/bytes.rs
+++ b/crates/crypto/src/bytes.rs
@@ -1,6 +1,12 @@
 use crate::*;
 
-mod safe_mem_copy;
+pub(crate) fn mem_copy(dst: &mut [u8], dst_offset: usize, src: &[u8]) -> CryptoResult<()> {
+    let dst_subslice = dst
+        .get_mut(dst_offset..dst_offset + src.len())
+        .ok_or(CryptoError::WriteOverflow)?;
+    dst_subslice.copy_from_slice(src);
+    Ok(())
+}
 
 /// read guard for crypto bytes
 pub trait CryptoBytesRead<'lt>: 'lt + std::ops::Deref<Target = [u8]> {}
@@ -33,7 +39,7 @@ pub trait CryptoBytes: 'static + Send + std::fmt::Debug {
 
     /// copy data from another byte array into this buffer
     fn copy_from(&mut self, offset: usize, data: &[u8]) -> CryptoResult<()> {
-        safe_mem_copy::safe_mem_copy(&mut self.write(), offset, data)
+        mem_copy(&mut self.write(), offset, data)
     }
 }
 

--- a/crates/crypto/src/bytes/safe_mem_copy.rs
+++ b/crates/crypto/src/bytes/safe_mem_copy.rs
@@ -1,9 +1,0 @@
-use crate::*;
-
-pub(crate) fn safe_mem_copy(dst: &mut [u8], dst_offset: usize, src: &[u8]) -> CryptoResult<()> {
-    let dst_subslice = dst
-        .get_mut(dst_offset..dst_offset + src.len())
-        .ok_or(CryptoError::WriteOverflow)?;
-    dst_subslice.copy_from_slice(src);
-    Ok(())
-}


### PR DESCRIPTION
[The docs for `copy_from_slice`](https://doc.rust-lang.org/std/primitive.slice.html#method.copy_from_slice) state that it is guaranteed to be a `memcpy`. In fact, by looking at the source code, it will likely be faster than the previous `unsafe` implementation because it uses `copy_non_overlapping`.

This is part of a series of PRs in which I work to make `unsafe` code in `sx_crypto` unnecessary.

As with all of my PRs, I recommend reviewing commit-by-commit.