### PR TITLE
[TK-01420] - async the state functions needed to do async header signatures

### DIFF
--- a/crates/holochain/src/core/state/cascade/test.rs
+++ b/crates/holochain/src/core/state/cascade/test.rs
@@ -66,7 +66,7 @@ async fn live_local_return() -> DatabaseResult<()> {
         mock_cache_meta,
         ..
     } = setup_env(&reader, &dbs)?;
-    source_chain.put_entry(jimbo.clone(), &jimbo_id)?;
+    source_chain.put_entry(jimbo.clone(), &jimbo_id).await?;
     let hash: EntryHash = (&jimbo).try_into()?;
 
     // set it's metadata to LIVE
@@ -107,7 +107,7 @@ async fn dead_local_none() -> DatabaseResult<()> {
         mock_cache_meta,
         ..
     } = setup_env(&reader, &dbs)?;
-    source_chain.put_entry(jimbo.clone(), &jimbo_id)?;
+    source_chain.put_entry(jimbo.clone(), &jimbo_id).await?;
     let hash: EntryHash = jimbo.try_into()?;
 
     // set it's metadata to Dead
@@ -148,7 +148,7 @@ async fn notfound_goto_cache_live() -> DatabaseResult<()> {
         mut mock_cache_meta,
         ..
     } = setup_env(&reader, &dbs)?;
-    cache.put_entry(jimbo.clone(), &jimbo_id)?;
+    cache.put_entry(jimbo.clone(), &jimbo_id).await?;
     let hash: EntryHash = (&jimbo).try_into()?;
 
     // set it's metadata to Live
@@ -224,8 +224,8 @@ async fn links_local_return() -> DatabaseResult<()> {
         mut mock_primary_meta,
         mock_cache_meta,
     } = setup_env(&reader, &dbs)?;
-    source_chain.put_entry(jimbo.clone(), &jimbo_id)?;
-    source_chain.put_entry(jessy.clone(), &jessy_id)?;
+    source_chain.put_entry(jimbo.clone(), &jimbo_id).await?;
+    source_chain.put_entry(jessy.clone(), &jessy_id).await?;
     let base: EntryHash = jimbo.try_into()?;
     let target: EntryHash = jessy.try_into()?;
     let result = target.clone();
@@ -272,8 +272,8 @@ async fn links_cache_return() -> DatabaseResult<()> {
         mut mock_primary_meta,
         mut mock_cache_meta,
     } = setup_env(&reader, &dbs)?;
-    source_chain.put_entry(jimbo.clone(), &jimbo_id)?;
-    source_chain.put_entry(jessy.clone(), &jessy_id)?;
+    source_chain.put_entry(jimbo.clone(), &jimbo_id).await?;
+    source_chain.put_entry(jessy.clone(), &jessy_id).await?;
     let base: EntryHash = jimbo.try_into()?;
     let target: EntryHash = jessy.try_into()?;
     let result = target.clone();

--- a/crates/holochain/src/core/state/source_chain/source_chain_buffer.rs
+++ b/crates/holochain/src/core/state/source_chain/source_chain_buffer.rs
@@ -63,8 +63,8 @@ impl<'env, R: Readable> SourceChainBuf<'env, R> {
 
     // FIXME: put this function in SourceChain, replace with simple put_entry and put_header
     #[allow(dead_code, unreachable_code)]
-    pub fn put_entry(&mut self, entry: Entry, agent_hash: &AgentHash) -> DatabaseResult<()> {
-        let header = header_for_entry(&entry, agent_hash, self.chain_head().cloned())?;
+    pub async fn put_entry(&mut self, entry: Entry, agent_hash: &AgentHash) -> DatabaseResult<()> {
+        let header = header_for_entry(&entry, agent_hash, self.chain_head().cloned()).await?;
         self.sequence.put_header((&header).try_into()?);
         self.cas.put((header, entry))?;
         Ok(())
@@ -124,7 +124,7 @@ impl<'env, R: Readable> BufferedStore<'env> for SourceChainBuf<'env, R> {
     }
 }
 
-fn header_for_entry(
+async fn header_for_entry(
     entry: &Entry,
     agent_hash: &AgentHash,
     prev_head: Option<HeaderAddress>,
@@ -198,15 +198,19 @@ pub mod tests {
         let dna_entry = Entry::Dna(Box::new(dna));
         let agent_entry = Entry::AgentKey(agent_hash.clone());
 
-        env.with_reader(|reader| {
+        {
+            let reader = env.reader()?;
+
             let mut store = SourceChainBuf::new(&reader, &dbs)?;
             assert!(store.chain_head().is_none());
-            store.put_entry(dna_entry.clone(), &agent_hash)?;
-            store.put_entry(agent_entry.clone(), &agent_hash)?;
-            env.with_commit(|writer| store.flush_to_txn(writer))
-        })?;
+            store.put_entry(dna_entry.clone(), &agent_hash).await?;
+            store.put_entry(agent_entry.clone(), &agent_hash).await?;
+            env.with_commit(|writer| store.flush_to_txn(writer))?;
+        }
 
-        env.with_reader(|reader| {
+        {
+            let reader = env.reader()?;
+
             let store = SourceChainBuf::new(&reader, &dbs)?;
             assert!(store.chain_head().is_some());
             let dna_entry_fetched = store
@@ -228,7 +232,7 @@ pub mod tests {
                 vec![Some(agent_entry), Some(dna_entry)]
             );
             Ok(())
-        })
+        }
     }
 
     #[tokio::test]
@@ -243,14 +247,18 @@ pub mod tests {
         let dna_entry = Entry::Dna(Box::new(dna));
         let agent_entry = Entry::AgentKey(agent_hash.clone());
 
-        env.with_reader(|reader| {
-            let mut store = SourceChainBuf::new(&reader, &dbs)?;
-            store.put_entry(dna_entry.clone(), &agent_hash)?;
-            store.put_entry(agent_entry.clone(), &agent_hash)?;
-            env.with_commit(|writer| store.flush_to_txn(writer))
-        })?;
+        {
+            let reader = env.reader()?;
 
-        env.with_reader(|reader| {
+            let mut store = SourceChainBuf::new(&reader, &dbs)?;
+            store.put_entry(dna_entry.clone(), &agent_hash).await?;
+            store.put_entry(agent_entry.clone(), &agent_hash).await?;
+            env.with_commit(|writer| store.flush_to_txn(writer))?;
+        }
+
+        {
+            let reader = env.reader()?;
+
             let store = SourceChainBuf::new(&reader, &dbs)?;
             let json = store.dump_as_json()?;
             let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -294,10 +302,7 @@ pub mod tests {
                 "[\"AgentKey\",\"Dna\"]",
                 &serde_json::to_string(&parsed).unwrap(),
             );
-
-            Ok(())
-        })
+        }
+        Ok(())
     }
-
-    // async fn header_for_entry() -> SourceChainResult<()> {}
 }

--- a/crates/holochain/src/core/workflow/genesis.rs
+++ b/crates/holochain/src/core/workflow/genesis.rs
@@ -26,10 +26,12 @@ pub async fn genesis(
 
     workspace
         .source_chain
-        .put_entry(Entry::Dna(Box::new(dna)), &agent_hash)?;
+        .put_entry(Entry::Dna(Box::new(dna)), &agent_hash)
+        .await?;
     workspace
         .source_chain
-        .put_entry(Entry::AgentKey(agent_hash.clone()), &agent_hash)?;
+        .put_entry(Entry::AgentKey(agent_hash.clone()), &agent_hash)
+        .await?;
 
     Ok(WorkflowEffects {
         workspace,

--- a/crates/holochain/tests/cascade.rs
+++ b/crates/holochain/tests/cascade.rs
@@ -25,8 +25,8 @@ async fn get_links() -> DatabaseResult<()> {
     let jessy_id = fake_agent_hash("Jessy");
     let jessy = Entry::AgentKey(jessy_id.clone());
     let base: EntryHash = (&jimbo).try_into()?;
-    source_chain.put_entry(jimbo, &jimbo_id)?;
-    source_chain.put_entry(jessy, &jessy_id)?;
+    source_chain.put_entry(jimbo, &jimbo_id).await?;
+    source_chain.put_entry(jessy, &jessy_id).await?;
 
     // Pass in stores as references
     let cascade = Cascade::new(


### PR DESCRIPTION
Turned out to not be as big a deal as I had been fearing : ) - Though this makes the `with_reader` helper on the lmdb environment useless - since it takes a sync callback.