### PR TITLE
types: Re-export `chain_header::ChainHeader` to `ChainHeader`

### DIFF
--- a/crates/holochain/src/core/state/cascade/test.rs
+++ b/crates/holochain/src/core/state/cascade/test.rs
@@ -9,11 +9,11 @@ use holochain_state::{
 };
 use holochain_types::{
     address::EntryAddress,
-    chain_header::ChainHeader,
     entry::Entry,
     header, observability,
     prelude::*,
     test_utils::{fake_agent_pubkey_1, fake_agent_pubkey_2, fake_header_hash},
+    ChainHeader,
 };
 use maplit::hashset;
 use mockall::*;

--- a/crates/holochain/src/core/state/chain_cas.rs
+++ b/crates/holochain/src/core/state/chain_cas.rs
@@ -15,9 +15,8 @@ use holochain_state::{
 };
 use holochain_types::{
     address::{EntryAddress, HeaderAddress},
-    chain_header::ChainHeader,
     entry::Entry,
-    header,
+    header, ChainHeader,
 };
 
 pub type EntryCas<'env, R> = CasBuf<'env, Entry, R>;

--- a/crates/holochain/src/core/state/source_chain.rs
+++ b/crates/holochain/src/core/state/source_chain.rs
@@ -6,9 +6,7 @@
 use holo_hash::*;
 use holochain_keystore::Signature;
 use holochain_state::{db::DbManager, error::DatabaseResult, prelude::Readable};
-use holochain_types::{
-    address::HeaderAddress, chain_header::ChainHeader, entry::Entry, prelude::*,
-};
+use holochain_types::{address::HeaderAddress, entry::Entry, prelude::*, ChainHeader};
 use shrinkwraprs::Shrinkwrap;
 
 pub use error::*;

--- a/crates/holochain/src/core/state/source_chain/source_chain_buffer.rs
+++ b/crates/holochain/src/core/state/source_chain/source_chain_buffer.rs
@@ -11,9 +11,7 @@ use holochain_state::{
     error::DatabaseResult,
     prelude::{Readable, Writer},
 };
-use holochain_types::{
-    address::HeaderAddress, chain_header::ChainHeader, entry::Entry, prelude::*,
-};
+use holochain_types::{address::HeaderAddress, entry::Entry, prelude::*, ChainHeader};
 
 use tracing::*;
 
@@ -195,11 +193,11 @@ pub mod tests {
     use fallible_iterator::FallibleIterator;
     use holochain_state::{prelude::*, test_utils::test_cell_env};
     use holochain_types::{
-        chain_header::ChainHeader,
         entry::Entry,
         header,
         prelude::*,
         test_utils::{fake_agent_pubkey_1, fake_dna_file},
+        ChainHeader,
     };
 
     fn fixtures() -> (

--- a/crates/holochain/src/core/workflow/genesis.rs
+++ b/crates/holochain/src/core/workflow/genesis.rs
@@ -1,6 +1,6 @@
 use super::{WorkflowEffects, WorkflowError, WorkflowResult};
 use crate::{conductor::api::CellConductorApiT, core::state::workspace::GenesisWorkspace};
-use holochain_types::{chain_header::ChainHeader, dna::DnaFile, entry::Entry, header, prelude::*};
+use holochain_types::{dna::DnaFile, entry::Entry, header, prelude::*, ChainHeader};
 
 /// Initialize the source chain with the initial entries:
 /// - Dna
@@ -70,9 +70,9 @@ mod tests {
     use fallible_iterator::FallibleIterator;
     use holochain_state::{env::*, test_utils::test_cell_env};
     use holochain_types::{
-        chain_header::ChainHeader,
         header, observability,
         test_utils::{fake_agent_pubkey_1, fake_dna_file},
+        ChainHeader,
     };
 
     #[tokio::test(threaded_scheduler)]

--- a/crates/holochain/tests/cascade.rs
+++ b/crates/holochain/tests/cascade.rs
@@ -5,11 +5,11 @@ use holochain_2020::core::state::{
 };
 use holochain_state::{env::ReadManager, test_utils::test_cell_env};
 use holochain_types::{
-    chain_header::ChainHeader,
     entry::Entry,
     header,
     prelude::*,
     test_utils::{fake_agent_pubkey_1, fake_agent_pubkey_2, fake_header_hash},
+    ChainHeader,
 };
 
 fn fixtures() -> (

--- a/crates/types/src/address.rs
+++ b/crates/types/src/address.rs
@@ -1,6 +1,6 @@
 //! wraps holo_hashes for the use of those hashes as storage addresses, either CAS or DHT
 
-use crate::{chain_header::ChainHeader, entry::Entry};
+use crate::{entry::Entry, ChainHeader};
 use holo_hash::*;
 use holochain_serialized_bytes::prelude::*;
 

--- a/crates/types/src/chain_header.rs
+++ b/crates/types/src/chain_header.rs
@@ -1,10 +1,11 @@
-//! This module contains definitions of the ChainHeader struct, constructor, and getters. This struct really defines a local source chain,
-//! in the sense that it implements the pointers between hashes that a hash chain relies on, which
-//! are then used to check the integrity of data using cryptographic hash functions.
-
 use crate::{address::HeaderAddress, header, prelude::*};
 
 /// ChainHeader contains variants for each type of header.
+///
+/// This struct really defines a local source chain, in the sense that it
+/// implements the pointers between hashes that a hash chain relies on, which
+/// are then used to check the integrity of data using cryptographic hash
+/// functions.
 #[allow(missing_docs)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, SerializedBytes)]
 #[serde(tag = "type")]

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -6,7 +6,6 @@
 pub mod address;
 pub mod autonomic;
 pub mod cell;
-pub mod chain_header;
 pub mod db;
 pub mod dna;
 pub mod entry;
@@ -17,6 +16,7 @@ pub mod observability;
 pub mod persistence;
 pub mod prelude;
 
+mod chain_header;
 pub use chain_header::ChainHeader;
 
 /// Placeholders to allow other things to compile
@@ -77,7 +77,7 @@ serial_hash!(
     crate::entry::Entry,
     EntryHash
 
-    crate::chain_header::ChainHeader,
+    crate::ChainHeader,
     HeaderHash
 
     crate::dna::wasm::DnaWasm,


### PR DESCRIPTION
Replaces #107

cc @neonphog

based on Mattermost chat consensus.

As always I recommend reviewing commit-by-commit.