### PR TITLE
fix the broken async/blocking model for holo_hash

### DIFF
--- a/crates/dna_util/src/lib.rs
+++ b/crates/dna_util/src/lib.rs
@@ -238,7 +238,7 @@ impl DnaDefJson {
             let zome_content = tokio::fs::read(zome_file_path).await?;
 
             let wasm: DnaWasm = zome_content.into();
-            let wasm_hash = holo_hash::WasmHash::with_data(&wasm.code()).await;
+            let wasm_hash = holo_hash::WasmHash::with_data(wasm.code().to_vec()).await;
             let wasm_hash: holo_hash_core::WasmHash = wasm_hash.into();
             zomes.push((zome_name.clone(), Zome { wasm_hash }));
             wasm_list.push(wasm);

--- a/crates/holo_hash/src/lib.rs
+++ b/crates/holo_hash/src/lib.rs
@@ -58,7 +58,7 @@
 //!
 //! let entry_content = b"test entry content";
 //!
-//! let content_hash: HoloHash = EntryContentHash::with_data(entry_content).await.into();
+//! let content_hash: HoloHash = EntryContentHash::with_data(entry_content.to_vec()).await.into();
 //!
 //! assert_eq!(
 //!     "EntryContentHash(uhCEkhPbA5vaw3Fk-ZvPSKuyyjg8eoX98fve75qiUEFgAE3BO7D4d)",
@@ -77,7 +77,7 @@
 //! // pretend our pub key is all 0xdb bytes
 //! let agent_pub_key = vec![0xdb; 32];
 //!
-//! let agent_id: HoloHash = AgentPubKey::with_pre_hashed(agent_pub_key).await.into();
+//! let agent_id: HoloHash = AgentPubKey::with_pre_hashed(agent_pub_key).into();
 //!
 //! assert_eq!(
 //!     "AgentPubKey(uhCAk29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29uTp5Iv)",
@@ -187,6 +187,10 @@ fn blake2b_128(data: &[u8]) -> Vec<u8> {
 
 /// internal compute the holo dht location u32
 fn holo_dht_location_bytes(data: &[u8]) -> Vec<u8> {
+    // Assert the data size is relatively small so we are
+    // comfortable executing this synchronously / blocking tokio thread.
+    assert_eq!(32, data.len(), "only 32 byte hashes supported");
+
     let hash = blake2b_128(data);
     let mut out = vec![hash[0], hash[1], hash[2], hash[3]];
     for i in (4..16).step_by(4) {
@@ -251,13 +255,13 @@ fn holo_hash_parse(s: &str) -> Result<HoloHash, HoloHashError> {
 /// Common methods for all HoloHash base hash types
 pub trait HoloHashBaseExt: Sized {
     /// Construct a new hash instance from an already generated hash.
-    fn with_pre_hashed(hash: Vec<u8>) -> MustBoxFuture<'static, Self>;
+    fn with_pre_hashed(hash: Vec<u8>) -> Self;
 }
 
 /// Common methods for all HoloHash hash types
 pub trait HoloHashExt: HoloHashBaseExt + Sized {
     /// Construct a new hash instance from raw data.
-    fn with_data(data: &[u8]) -> MustBoxFuture<'static, Self>;
+    fn with_data(data: Vec<u8>) -> MustBoxFuture<'static, Self>;
 }
 
 macro_rules! new_holo_hash {
@@ -269,23 +273,27 @@ macro_rules! new_holo_hash {
 
             impl HoloHashBaseExt for $name {
                 /// Construct a new hash instance from an already generated hash.
-                fn with_pre_hashed(mut hash: Vec<u8>) -> MustBoxFuture<'static, Self> {
-                    async {
-                        assert_eq!(32, hash.len(), "only 32 byte hashes supported");
-                        tokio::task::block_in_place(|| {
-                            hash.append(&mut holo_dht_location_bytes(&hash));
-                            Self(holo_hash_core::$name::new(hash))
-                        })
-                    }
-                    .boxed().into()
+                fn with_pre_hashed(mut hash: Vec<u8>) -> Self {
+                    // Assert the data size is relatively small so we are
+                    // comfortable executing this synchronously / blocking
+                    // tokio thread.
+                    assert_eq!(32, hash.len(), "only 32 byte hashes supported");
+
+                    hash.append(&mut holo_dht_location_bytes(&hash));
+                    Self(holo_hash_core::$name::new(hash))
                 }
             }
 
             impl HoloHashExt for $name {
 
                 /// Construct a new hash instance from raw data.
-                fn with_data(data: &[u8]) -> MustBoxFuture<'static, Self> {
-                    $name::with_pre_hashed(blake2b_256(data))
+                fn with_data(data: Vec<u8>) -> MustBoxFuture<'static, Self> {
+                    async move {
+                        tokio::task::spawn_blocking(move || {
+                            use $crate::HoloHashBaseExt;
+                            $name::with_pre_hashed(blake2b_256(&data))
+                        }).await.expect("spawn_blocking thread panic")
+                    }.boxed().into()
                 }
             }
 
@@ -377,26 +385,14 @@ macro_rules! new_holo_hash {
             fixturator!(
                 $name,
                 {
-                    tokio_safe_block_on::tokio_safe_block_on(
-                        async { $crate::$name::with_pre_hashed(vec![0; 32]).await },
-                        std::time::Duration::from_millis(10),
-                    )
-                    .unwrap()
+                    $crate::$name::with_pre_hashed(vec![0; 32])
                 },
                 {
                     let mut random_bytes: Vec<u8> = (0..32).map(|_| rand::random::<u8>()).collect();
-                    tokio_safe_block_on::tokio_safe_block_on(
-                        async { $crate::$name::with_pre_hashed(random_bytes).await },
-                        std::time::Duration::from_millis(10),
-                    )
-                    .unwrap()
+                    $crate::$name::with_pre_hashed(random_bytes)
                 },
                 {
-                    let ret = tokio_safe_block_on::tokio_safe_block_on(
-                        async { $crate::$name::with_pre_hashed(vec![self.0.index as _; 32]).await },
-                        std::time::Duration::from_millis(10),
-                    )
-                    .unwrap();
+                    let ret = $crate::$name::with_pre_hashed(vec![self.0.index as _; 32]);
                     self.0.index = (self.0.index as u8).wrapping_add(1) as usize;
                     ret
                 }
@@ -659,7 +655,7 @@ mod tests {
         tokio::task::spawn(async move {
             let hash = vec![0xdb; 32];
             let hash: &[u8] = &hash;
-            let agent_id = AgentPubKey::with_pre_hashed(hash.to_vec()).await;
+            let agent_id = AgentPubKey::with_pre_hashed(hash.to_vec());
             assert_eq!(hash, agent_id.get_bytes());
         })
         .await
@@ -669,7 +665,7 @@ mod tests {
     #[tokio::test(threaded_scheduler)]
     async fn agent_id_prehash_display() {
         tokio::task::spawn(async move {
-            let agent_id = AgentPubKey::with_pre_hashed(vec![0xdb; 32]).await;
+            let agent_id = AgentPubKey::with_pre_hashed(vec![0xdb; 32]);
             assert_eq!(
                 "uhCAk29vb29vb29vb29vb29vb29vb29vb29vb29vb29vb29uTp5Iv",
                 &format!("{}", agent_id),
@@ -690,7 +686,7 @@ mod tests {
     #[tokio::test(threaded_scheduler)]
     async fn agent_id_debug() {
         tokio::task::spawn(async move {
-            let agent_id = AgentPubKey::with_data(&[0xdb; 32]).await;
+            let agent_id = AgentPubKey::with_data(vec![0xdb; 32]).await;
             assert_eq!(
                 "AgentPubKey(uhCAkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm)",
                 &format!("{:?}", agent_id),
@@ -703,7 +699,7 @@ mod tests {
     #[tokio::test(threaded_scheduler)]
     async fn agent_id_display() {
         tokio::task::spawn(async move {
-            let agent_id = AgentPubKey::with_data(&[0xdb; 32]).await;
+            let agent_id = AgentPubKey::with_data(vec![0xdb; 32]).await;
             assert_eq!(
                 "uhCAkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm",
                 &format!("{}", agent_id),
@@ -716,7 +712,7 @@ mod tests {
     #[tokio::test(threaded_scheduler)]
     async fn agent_id_loc() {
         tokio::task::spawn(async move {
-            let agent_id = AgentPubKey::with_data(&[0xdb; 32]).await;
+            let agent_id = AgentPubKey::with_data(vec![0xdb; 32]).await;
             assert_eq!(3_860_645_936, agent_id.get_loc());
         })
         .await

--- a/crates/holo_hash/src/make_hashed_macro.rs
+++ b/crates/holo_hash/src/make_hashed_macro.rs
@@ -159,7 +159,7 @@ macro_rules! make_hashed {
                 use futures::future::FutureExt;
                 async {
                     let sb = ::holochain_serialized_bytes::SerializedBytes::try_from(&content)?;
-                    Ok(Self::with_pre_hashed(content, Self::HashType::with_data(sb.bytes()).await))
+                    Ok(Self::with_pre_hashed(content, Self::HashType::with_data(::holochain_serialized_bytes::UnsafeBytes::from(sb).into()).await))
                 }
                 .boxed().into()
             }

--- a/crates/holochain/src/core/state/workspace.rs
+++ b/crates/holochain/src/core/state/workspace.rs
@@ -72,7 +72,7 @@ pub mod tests {
         let arc = test_cell_env();
         let env = arc.guard().await;
         let dbs = arc.dbs().await;
-        let addr1 = EntryContentHash::with_data("hello".as_bytes()).await;
+        let addr1 = EntryContentHash::with_data("hello".as_bytes().to_vec()).await;
         let addr2 = "hi".to_string();
         {
             let reader = env.reader()?;

--- a/crates/holochain/src/core/sys_validate.rs
+++ b/crates/holochain/src/core/sys_validate.rs
@@ -117,7 +117,7 @@ mod tests {
     use std::convert::TryInto;
 
     async fn fake_addr(n: &str) -> HeaderAddress {
-        HeaderHash::with_data(n.as_bytes()).await.into()
+        HeaderHash::with_data(n.as_bytes().to_vec()).await.into()
     }
 
     async fn test_gen(ts: Timestamp, seq: u32, prev: HeaderAddress) -> ChainElement {

--- a/crates/holochain/src/fixt.rs
+++ b/crates/holochain/src/fixt.rs
@@ -230,7 +230,7 @@ fixturator!(
             let wasm = dna_wasm_fixturator.next().unwrap();
             wasms.insert(
                 tokio_safe_block_on::tokio_safe_block_on(
-                    async { WasmHash::with_data(&*wasm.code()).await },
+                    async { WasmHash::with_data(wasm.code().to_vec()).await },
                     std::time::Duration::from_millis(10),
                 )
                 .unwrap()
@@ -247,7 +247,7 @@ fixturator!(
             let wasm = dna_wasm_fixturator.next().unwrap();
             wasms.insert(
                 tokio_safe_block_on::tokio_safe_block_on(
-                    async { WasmHash::with_data(&*wasm.code()).await },
+                    async { WasmHash::with_data(wasm.code().to_vec()).await },
                     std::time::Duration::from_millis(10),
                 )
                 .unwrap()

--- a/crates/keystore/src/test_keystore.rs
+++ b/crates/keystore/src/test_keystore.rs
@@ -81,7 +81,7 @@ impl KeystoreHandler<(), TestKeystoreInternal> for TestKeystore {
         Ok(async move {
             let (pub_key, sec_key) = crypto_sign_keypair(None).await?;
             let pub_key = pub_key.read().to_vec();
-            let agent_pubkey = holo_hash::AgentPubKey::with_pre_hashed(pub_key).await;
+            let agent_pubkey = holo_hash::AgentPubKey::with_pre_hashed(pub_key);
             let sec_key = PrivateKey(sec_key);
             i_s.ghost_actor_internal()
                 .finalize_new_keypair(agent_pubkey.clone(), sec_key)

--- a/crates/types/src/dna.rs
+++ b/crates/types/src/dna.rs
@@ -49,7 +49,7 @@ impl DnaDef {
     /// Calculate DnaHash for DnaDef
     pub async fn dna_hash(&self) -> DnaHash {
         let sb: SerializedBytes = self.try_into().expect("failed to hash DnaDef");
-        DnaHash::with_data(&sb.bytes()).await
+        DnaHash::with_data(UnsafeBytes::from(sb).into()).await
     }
 
     /// Return a Zome
@@ -103,12 +103,12 @@ impl DnaFile {
     ) -> Result<Self, DnaError> {
         let mut code = BTreeMap::new();
         for wasm in wasm {
-            let wasm_hash = holo_hash::WasmHash::with_data(&wasm.code()).await;
+            let wasm_hash = holo_hash::WasmHash::with_data(wasm.code().to_vec()).await;
             let wasm_hash: holo_hash_core::WasmHash = wasm_hash.into();
             code.insert(wasm_hash, wasm);
         }
         let dna_sb: SerializedBytes = (&dna).try_into()?;
-        let dna_hash = holo_hash::DnaHash::with_data(dna_sb.bytes()).await;
+        let dna_hash = holo_hash::DnaHash::with_data(UnsafeBytes::from(dna_sb).into()).await;
         Ok(Self {
             dna,
             dna_hash,

--- a/crates/types/src/entry.rs
+++ b/crates/types/src/entry.rs
@@ -27,7 +27,9 @@ impl Hashable for EntryHashed {
                 Entry::Agent(key) => EntryHash::Agent(key.to_owned().into()),
                 entry => {
                     let sb = SerializedBytes::try_from(entry)?;
-                    EntryHash::Entry(EntryContentHash::with_data(sb.bytes()).await)
+                    EntryHash::Entry(
+                        EntryContentHash::with_data(UnsafeBytes::from(sb).into()).await,
+                    )
                 }
             };
             Ok(EntryHashed::with_pre_hashed(entry, hash))

--- a/crates/types/src/header.rs
+++ b/crates/types/src/header.rs
@@ -142,7 +142,7 @@ impl HeaderHashed {
         let sb = SerializedBytes::try_from(&header)?;
         Ok(HeaderHashed::with_pre_hashed(
             header,
-            HeaderHash::with_data(sb.bytes()).await,
+            HeaderHash::with_data(UnsafeBytes::from(sb).into()).await,
         ))
     }
 }

--- a/crates/types/src/test_utils.rs
+++ b/crates/types/src/test_utils.rs
@@ -82,7 +82,7 @@ pub fn fake_cell_id(name: &str) -> CellId {
 /// A fixture example DnaHash for unit testing.
 pub fn fake_dna_hash(name: &str) -> DnaHash {
     tokio_safe_block_on::tokio_safe_block_on(
-        DnaHash::with_data(name.as_bytes()),
+        DnaHash::with_data(name.as_bytes().to_vec()),
         std::time::Duration::from_secs(1),
     )
     .unwrap()
@@ -103,7 +103,7 @@ pub fn fake_agent_pubkey_2() -> AgentPubKey {
 /// A fixture example HeaderHash for unit testing.
 pub fn fake_header_hash(name: &str) -> HeaderHash {
     tokio_safe_block_on::tokio_safe_block_on(
-        HeaderHash::with_data(name.as_bytes()),
+        HeaderHash::with_data(name.as_bytes().to_vec()),
         std::time::Duration::from_secs(1),
     )
     .unwrap()


### PR DESCRIPTION
Switch from `block_in_place` running in the wrong function to the more efficient `spawn_blocking` running in the correct function.

As a side-effect also switched to taking a `Vec<u8>` instead of a `&[u8]` which, due to the way SerializedBytes works, didn't add an additional clone in most cases.