### PR TITLE
[TK-02292] Store entry defs

### DIFF
--- a/crates/holochain/src/conductor/cell/error.rs
+++ b/crates/holochain/src/conductor/cell/error.rs
@@ -9,6 +9,7 @@ use holochain_state::error::DatabaseError;
 use holochain_types::cell::CellId;
 use std::path::PathBuf;
 use thiserror::Error;
+use holochain_zome_types::zome::ZomeName;
 
 #[derive(Error, Debug)]
 pub enum CellError {
@@ -32,6 +33,8 @@ pub enum CellError {
     RibosomeError(#[from] RibosomeError),
     #[error("The cell tried to run the initialize zomes callback but failed because {0:?}")]
     InitFailed(InitResult),
+    #[error("The cell tried to run the get the entry definitions for {0} but failed because {0}")]
+    EntryDefs(ZomeName, String)
 }
 
 pub type CellResult<T> = Result<T, CellError>;

--- a/crates/zome_types/src/entry_def.rs
+++ b/crates/zome_types/src/entry_def.rs
@@ -19,6 +19,12 @@ impl From<&str> for EntryDefId {
     }
 }
 
+impl From<EntryDefId> for Vec<u8> {
+    fn from(e: EntryDefId) -> Self {
+        e.0.into_bytes()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes)]
 pub enum EntryVisibility {
     Public,
@@ -71,6 +77,12 @@ impl EntryDef {
 
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct EntryDefs(Vec<EntryDef>);
+
+impl EntryDefs {
+    pub fn into_inner(self) -> Vec<EntryDef> {
+        self.0
+    }
+}
 
 impl From<Vec<EntryDef>> for EntryDefs {
     fn from(v: Vec<EntryDef>) -> Self {


### PR DESCRIPTION
We need to store the `EntryDef` data in the `Cell` (I think that's the right place) to avoid calling into wasm to get things like visibility and `RequiredValidations`.
I attempted to  do this but have hit a wall with a few things:
- ZomeName vs ZomeId. All through the ribosome we are using the ZomeName to talk about a zome but in the `AppEntryType` we hold a ZomeId. The ZomeId is never actually constructed anywhere and I'm not sure how it would be (maybe just an increment of the order the zomes are created?). Anyhow we probably need a map from ZomeName to ZomeId or vice versa?
- @thedavidmeister suggested removing visibility from `AppEntryType` and using it as the key to the map of `EntryDef` Which I think makes sense because each `EntryDef` has a unique to zome `EntryDefId` which means if the `AppEntryType` has the this information we can find the def easily. However we are already using visibility in a lot of places and this change would require all those places to have access to he cell to get the EntryDef for visibility.