### PR TITLE
Add TimestampKey

### DIFF
--- a/crates/types/src/timestamp.rs
+++ b/crates/types/src/timestamp.rs
@@ -95,6 +95,7 @@ const NSEC: usize = std::mem::size_of::<u32>();
 /// should not be directly used. However, ordering is preserved when mapping
 /// to a TimestampKey, which is what allows us to use it for an LMDB key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(transparent)]
 pub struct TimestampKey([u8; SEC + NSEC]);
 
 impl From<Timestamp> for TimestampKey {


### PR DESCRIPTION
We currently use the SerializedBytes representation of `Timestamp` as an LMDB key for the Integration Queue DB. However, SerializedBytes makes no guarantee of the lexicographic ordering of its encoded bytes relative to the decoded source (because msgpack doesn't either). So, I think our timestamps can show up out-of-order in the DB, defeating the purpose.

This adds a `TimestampKey`, essentially a newtype around a byte array, with transformations carefully chosen to preserve ordering when encoding to bytes, and the ability to go into and out of byte slices in-place.