### PR TITLE
Have debug!() zome api display debug log when in debug

### DIFF
--- a/crates/holochain/src/core/ribosome/host_fn/debug.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/debug.rs
@@ -13,7 +13,7 @@ pub fn debug(
     input: DebugInput,
 ) -> RibosomeResult<DebugOutput> {
     let msg: DebugMsg = input.into_inner();
-    trace!(
+    debug!(
         "{}:{}:{} {}",
         msg.module_path(),
         msg.file(),


### PR DESCRIPTION
I got confused by my debug logs not showing up with RUST_LOG=debug. I had to set RUST_LOG=trace to see them which is counterintuitive.