### PR TITLE
Avg consistency test

### DIFF
--- a/crates/holochain/src/core/ribosome.rs
+++ b/crates/holochain/src/core/ribosome.rs
@@ -538,16 +538,7 @@ mod slow_tests {
 
     #[tokio::test(threaded_scheduler)]
     async fn warm_wasm_tests() {
-        holochain_types::observability::test_run().ok();
-        use strum::IntoEnumIterator;
-
-        // If HC_WASM_CACHE_PATH is set warm the cache
-        if let Some(_path) = std::env::var_os("HC_WASM_CACHE_PATH") {
-            let wasms: Vec<_> = TestWasm::iter().collect();
-            crate::fixt::WasmRibosomeFixturator::new(crate::fixt::curve::Zomes(wasms))
-                .next()
-                .unwrap();
-        }
+        crate::test_utils::warm_wasm_tests();
     }
 
     #[tokio::test(threaded_scheduler)]

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -12,6 +12,7 @@ use holochain_types::{
     test_utils::fake_header_hash,
     Entry, EntryHashed, HeaderHashed, Timestamp,
 };
+use holochain_wasm_test_utils::TestWasm;
 use holochain_zome_types::entry_def::EntryVisibility;
 use holochain_zome_types::header::{EntryCreate, EntryType, Header};
 use std::convert::TryInto;
@@ -62,4 +63,14 @@ pub async fn test_network(
     let cell_network = network.to_cell(dna.clone(), agent_key.clone());
     network.join(dna.clone(), agent_key).await.unwrap();
     (network, recv, cell_network)
+}
+
+pub fn warm_wasm_tests() {
+    // If HC_WASM_CACHE_PATH is set warm the cache
+    if let Some(_path) = std::env::var_os("HC_WASM_CACHE_PATH") {
+        let wasms: Vec<_> = TestWasm::iter().collect();
+        crate::fixt::WasmRibosomeFixturator::new(crate::fixt::curve::Zomes(wasms))
+            .next()
+            .unwrap();
+    }
 }

--- a/crates/holochain/tests/speed_tests.rs
+++ b/crates/holochain/tests/speed_tests.rs
@@ -22,7 +22,7 @@ use holochain::conductor::{
     dna_store::MockDnaStore,
     ConductorBuilder, ConductorHandle,
 };
-use holochain::core::ribosome::ZomeCallInvocation;
+use holochain::{core::ribosome::ZomeCallInvocation, test_utils::warm_wasm_tests};
 use holochain_state::test_utils::{test_conductor_env, test_wasm_env, TestEnvironment};
 use holochain_types::app::InstalledCell;
 use holochain_types::cell::CellId;
@@ -45,6 +45,12 @@ use tracing::instrument;
 mod test_utils;
 
 const DEFAULT_NUM: usize = 2000;
+
+#[tokio::test(threaded_scheduler)]
+#[ignore]
+async fn speed_test_prep() {
+    warm_wasm_tests();
+}
 
 #[tokio::test(threaded_scheduler)]
 #[ignore]

--- a/test/default.nix
+++ b/test/default.nix
@@ -3,8 +3,7 @@ let
   t-test = pkgs.writeShellScriptBin "hc-test"
   ''
   set -euxo pipefail
-  cargo test --no-run --manifest-path=crates/holochain/Cargo.toml --features "build_wasms"
-  cargo test warm_wasm_tests
+  cargo test warm_wasm_tests --manifest-path=crates/holochain/Cargo.toml --features "slow_tests build_wasms"
   RUST_BACKTRACE=1 \
   cargo test -- --nocapture
 
@@ -86,9 +85,8 @@ let
 
   t-speed = pkgs.writeShellScriptBin "hc-speed-test"
   ''
-  cargo test --release --no-run --manifest-path=crates/holochain/Cargo.toml --features "build_wasms"
-  cargo test --release warm_wasm_tests
-  cargo test speed_test_all --release -- --ignored
+  cargo test speed_test_prep --test speed_tests --release --manifest-path=crates/holochain/Cargo.toml --features "build_wasms" -- --ignored
+  cargo test speed_test_all --test speed_tests --release --manifest-path=crates/holochain/Cargo.toml --features "build_wasms" -- --ignored --nocapture
   '';
 
   maybe_linux = if pkgs.stdenv.isLinux then [ t-cover ] else [ ];


### PR DESCRIPTION
## Speed test
This adds the ability run easily run a local speed test to get a high level latency on reaching consistency with N anchors.
The test is not a perfect usecase and we could create more realistic tests in the future but it's a good start.
To run simply do:
```
hc-speed-test
```
## Follow ups
The following would be helpful but are out of scope for this PR
- Integrate with the benchmark sever
- Add commands for producing flame and ice graphs easily