### PR TITLE
Fix binary heaps

### DIFF
--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -94,15 +94,12 @@ async fn sys_validation_workflow_inner(
 ) -> WorkflowResult<WorkComplete> {
     let env = workspace.validation_limbo.env().clone();
     // Drain all the ops
-    let sorted_ops: BinaryHeap<std::cmp::Reverse<OrderedOp<ValidationLimboValue>>> =
-        fresh_reader!(env, |r| {
-            let validation_limbo = &mut workspace.validation_limbo;
-            let element_pending = &workspace.element_pending;
+    let sorted_ops: BinaryHeap<OrderedOp<ValidationLimboValue>> = fresh_reader!(env, |r| {
+        let validation_limbo = &mut workspace.validation_limbo;
+        let element_pending = &workspace.element_pending;
 
-            let sorted_ops: Result<
-                BinaryHeap<std::cmp::Reverse<OrderedOp<ValidationLimboValue>>>,
-                WorkflowError,
-            > = validation_limbo
+        let sorted_ops: Result<BinaryHeap<OrderedOp<ValidationLimboValue>>, WorkflowError> =
+            validation_limbo
                 .drain_iter_filter(&r, |(_, vlv)| {
                     match vlv.status {
                         // We only want pending or awaiting sys dependency ops
@@ -125,22 +122,21 @@ async fn sys_validation_workflow_inner(
                         op,
                         value: vlv,
                     };
-                    // We want a min-heap
-                    Ok(std::cmp::Reverse(v))
+                    Ok(v)
                 })
                 .iterator()
                 .collect();
-            sorted_ops
-        })?;
+        sorted_ops
+    })?;
 
     // Process each op
-    for so in sorted_ops {
+    for so in sorted_ops.into_sorted_vec() {
         let OrderedOp {
             hash: op_hash,
             op,
             value: mut vlv,
             ..
-        } = so.0;
+        } = so;
 
         // Create an incoming ops sender for any dependencies we find
         // that we are meant to be holding but aren't.


### PR DESCRIPTION
I made a silly mistake that @maackle found where binary heaps don't actually return a sorted iterator unless you call `into_vec_sorted` and I also realized I had my min-heap max-heap around the wrong way. This fixes those two issues.

On a side note I was a bit confused by which is the best way to take an iterator collect it so it's sorted so I made a simple test to compare `BTreeSet`(bt), `BinaryHeap`(pq), and `Vec.sort_unstable()`(vec).
The pq uses the `into_vec_sorted()`.
You can see it makes no difference at small values but the larger it gets the fast pq is (but it's not a lot).
```
10 items bt took 0s, 0ms 24us 24778ns
10 items vec took 0s, 0ms 23us 23323ns
10 items pq took 0s, 0ms 26us 26438ns
100 items bt took 0s, 1ms 1151us 1151425ns
100 items vec took 0s, 1ms 1495us 1495585ns
100 items pq took 0s, 1ms 1187us 1187353ns
1000 items bt took 0s, 31ms 31830us 31830667ns
1000 items vec took 0s, 32ms 32559us 32559983ns
1000 items pq took 0s, 25ms 25702us 25702389ns
10000 items bt took 0s, 503ms 503591us 503591771ns
10000 items vec took 0s, 485ms 485417us 485417824ns
10000 items pq took 0s, 417ms 417083us 417083738ns
100000 items bt took 6s, 6891ms 6891228us 6891228336ns
100000 items vec took 6s, 6243ms 6243607us 6243607694ns
100000 items pq took 5s, 5909ms 5909932us 5909932277ns
``` 