### PR TITLE
add list active AppId to ws admin_api

### DIFF
--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -660,6 +660,11 @@ where
         Ok(self.cells.keys().cloned().collect())
     }
 
+    pub(super) async fn list_active_app_ids(&self) -> ConductorResult<Vec<AppId>> {
+        let active_apps = self.get_state().await?.active_apps;
+        Ok(active_apps.keys().cloned().collect())
+    }
+
     pub(super) async fn dump_cell_state(&self, cell_id: &CellId) -> ConductorApiResult<String> {
         let cell = self.cell_by_id(cell_id)?;
         let arc = cell.env();

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -177,6 +177,9 @@ pub trait ConductorHandleT: Send + Sync {
     /// List Cell Ids
     async fn list_cell_ids(&self) -> ConductorResult<Vec<CellId>>;
 
+    /// List Active AppIds
+    async fn list_active_app_ids(&self) -> ConductorResult<Vec<AppId>>;
+
     /// Dump the cells state
     #[allow(clippy::ptr_arg)]
     async fn dump_cell_state(&self, cell_id: &CellId) -> ConductorApiResult<String>;
@@ -405,6 +408,10 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
 
     async fn list_cell_ids(&self) -> ConductorResult<Vec<CellId>> {
         self.conductor.read().await.list_cell_ids().await
+    }
+
+    async fn list_active_app_ids(&self) -> ConductorResult<Vec<AppId>> {
+        self.conductor.read().await.list_active_app_ids().await
     }
 
     async fn dump_cell_state(&self, cell_id: &CellId) -> ConductorApiResult<String> {


### PR DESCRIPTION
A discussion was had in the holochain rsm discord channel about this. 

We talked about the cases where a UI will want to "recall" what apps it has installed to the conductor, so that it can proceed to call `appInfo` to fetch more details on those individual apps if it wants to.