### PR TITLE
add verify_signature access to validation

### DIFF
--- a/crates/holochain/src/core/ribosome/guest_callback/validate.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validate.rs
@@ -48,6 +48,7 @@ impl From<&ValidateHostAccess> for HostFnAccess {
     fn from(_: &ValidateHostAccess) -> Self {
         let mut access = Self::none();
         access.read_workspace = Permission::Allow;
+        access.keystore = Permission::Allow;
         access
     }
 }
@@ -194,6 +195,7 @@ mod test {
             .unwrap();
         let mut access = HostFnAccess::none();
         access.read_workspace = Permission::Allow;
+        access.keystore = Permission::Allow;
         assert_eq!(HostFnAccess::from(&validate_host_access), access);
     }
 


### PR DESCRIPTION
This only allows calling `verify_signature` not `sign`