### PR TITLE
Update build_tutorial.md

### DIFF
--- a/docs/build_tutorial.md
+++ b/docs/build_tutorial.md
@@ -1,38 +1,79 @@
 # How to build Holochain DNA
 
-*as of 12-08-2020*
-
-## Important note about dependencies
-
-Effective zome development requires a few cargo dependencies which are not yet published to crates.io and exist only in the private [holochain-rsm GitHub repo](https://github.com/holochain/holochain). Since the repo is private, we cannot simply point our Cargo.toml file directly to it without some configuration. There are two options:
-
-1. Clone the Holochain repo, and use local paths in your Cargo.toml(s) to refer to your local checkout of Holochain, or
-2. If you use SSH keys for GitHub, configure your ssh-agent so that Cargo can be aware of your key, per https://doc.rust-lang.org/cargo/appendix/git-authentication.html. Then you can use remote git deps in your zomes' Cargo.toml(s).
-
-At the time of writing, I could not get the remote option to work, so the example zomes here use local paths (option 1).
+*as of 28-10-2020*
 
 ## Steps
 
 ### 0. Build `holochain` and `dna-util`
 
-You'll need two binaries to develop DNAs: the actual Holochain conductor binary, and the dna-util library which assists with assembling Wasms into a DNA file.
+You'll need two binaries on your PATH to develop DNAs: the actual Holochain (`holochain`) conductor binary, and the dna-util library which assists with assembling Wasms into a DNA file.
 
-- Clone the repo: `git clone https://github.com/holochain/holochain && cd ./holochain`
-- Install conductor binary: `cargo install --path crates/holochain`
-- Install dna-util binary: `cargo install --path crates/dna_util`
+There are two ways you can approach that, via a [nix-shell](https://nixos.org/manual/nix/stable/#ch-installing-binary) which handles the majority for you, or via direct Rust installation to your computer. Instructions for both follow.
 
-You should now have `holochain` and `dna-util` on your PATH.
+#### nix-shell
+
+Install nix, **linux**
+```bash
+sh <(curl -L https://nixos.org/nix/install) --no-daemon
+```
+Install nix, **macOS**
+```bash
+sh <(curl -L https://nixos.org/nix/install) --darwin-use-unencrypted-nix-store-volume
+```
+
+Clone the holochain/holochain repo
+```bash
+git clone git@github.com:holochain/holochain.git
+```
+
+Enter the directory
+```bash
+cd holochain
+```
+
+Launch a nix-shell, based on holochain/holochain's nix-shell configuration
+```bash
+nix-shell
+```
+
+Install the `holochain` and `dna-util` binaries using the built-in installer
+```bash
+hc-install
+```
+
+Confirm that they are there by running `holochain -V` and `dna-util -V`, and that you see simple version number outputs.
+
+#### native rust
+
+Install Rust
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+Switch to the proper Rust "toolchain" that Holochain needs
+```bash
+rustup install stable-2020-08-03
+rustup default stable-2020-08-03
+```
+
+Grab and install the binaries for `holochain` and `dna-util` from github, at the right version
+```bash
+cargo install holochain --git https://github.com/holochain/holochain.git --branch develop
+cargo install dna_util --git https://github.com/holochain/holochain.git --branch develop
+```
+
+Confirm that they are there by running `holochain -V` and `dna-util -V`, and that you see simple version number outputs.
 
 ### 1. Write your Zomes
 
-Each zome is a Rust crate. See [crates/test_utils/wasm/whoami](../crates/test_utils/wasm/whoami) and [crates/test_utils/wasm/foo](../crates/test_utils/wasm/foo) for examples.
+Each zome is a Rust crate. See [crates/test_utils/wasm/wasm_workspace/whoami](../crates/test_utils/wasm/wasm_workspace/whoami) and [crates/test_utils/wasm/foo](../crates/test_utils/wasm/wasm_workspace/foo) or any other folder in [crates/test_utils/wasm/wasm_workspace](../crates/test_utils/wasm/wasm_workspace) for examples.
 
 ### 2. Build your Zomes into Wasm
 
 When you want to (re)build your zomes into Wasm, simply run
 
 ```bash
-cargo build --release --target wasm32-unknown-unknown
+CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown
 ```
 
 and they will be available in `target/wasm32-unknown-unknown/release/`
@@ -54,10 +95,10 @@ This will produce a `demo.dna.gz` file as a sibling of the `demo.dna.workdir` di
 
 ### 4. Use the Conductor's admin interface to install your DNA
 
-If you are using Tryorama to run tests against your DNA, you can jump over to the [tryorama README](https://github.com/Holo-Host/tryorama-rsm) (also a private repo) and follow the instructions there.
+If you are using Tryorama to run tests against your DNA, you can jump over to the [tryorama (rsm branch) README](https://github.com/holochain/tryorama/tree/rsm) and follow the instructions there.
 
 If you are running Holochain using your own setup, you'll have to have a deeper understanding of Holochain than is in scope for this tutorial. Roughly speaking, you'll need to:
 
 - make sure `holochain` is running with a configuration that includes an admin interface websocket port
-- send a properly encoded [`InstallApp`](https://github.com/holochain/holochain/blob/66ca899d23842cadebc214d591475987f4af4f43/crates/holochain/src/conductor/api/api_external/admin_interface.rs#L240) command over the websocket
+- send a properly encoded [`InstallApp`](https://github.com/holochain/holochain/blob/7db6c1e340dd0e741dcc9ffd51ffc832caa36449/crates/types/src/app.rs#L14-L23) command over the websocket
 - be sure to `ActivateApp` and `AttachAppInterface` as well.

--- a/docs/build_tutorial.md
+++ b/docs/build_tutorial.md
@@ -50,12 +50,6 @@ Install Rust
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-Switch to the proper Rust "toolchain" that Holochain needs
-```bash
-rustup install stable-2020-08-03
-rustup default stable-2020-08-03
-```
-
 Grab and install the binaries for `holochain` and `dna-util` from github, at the right version
 ```bash
 cargo install holochain --git https://github.com/holochain/holochain.git --branch develop


### PR DESCRIPTION
This piece of documentation is out of date going back to the time before `holochain/holochain` was public, and tryorama rsm was in a branch of public tryorama repo so this PR brings it back in date for now.

also fix other broken links

This piece of documentation is linked to from the interim RSM docs overview on developer.holochain.org so it can actually get traffic. 
https://developer.holochain.org/holochain-rsm-guidance