### PR TITLE
[B-03499] update tokio to 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,11 +2,11 @@
 # It is not intended for manual editing.
 [[package]]
 name = "addr2line"
-version = "0.14.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
+checksum = "1b6a2d3371669ab3ca9797670853d61402b03d0b4b9ebf33d677dfa720203072"
 dependencies = [
- "gimli 0.23.0",
+ "gimli 0.22.0",
 ]
 
 [[package]]
@@ -26,18 +26,18 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.4.6"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
+checksum = "0adac150c2dd5a9c864d054e07bda5e6bc010cd10036ea5f17e82a2f5867f735"
 dependencies = [
  "const-random",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
 dependencies = [
  "memchr",
 ]
@@ -62,9 +62,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.34"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
+checksum = "a1fd36ffbb1fb7c834eac128ea8d0e310c5aeb635548f9d58861e1308d46e71c"
+
+[[package]]
+name = "arc-swap"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d25d88fd6b8041580a654f9d0c581a047baee2b3efee13275f2fc392fc75034"
 
 [[package]]
 name = "arrayref"
@@ -83,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "arrayvec"
-version = "0.5.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 
 [[package]]
 name = "assert_cmd"
@@ -142,12 +148,12 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.54"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2baad346b2d4e94a24347adeee9c7a93f412ee94b9cc26e5b59dea23848e9f28"
+checksum = "ec1931848a574faa8f7c71a12ea00453ff5effbb5f51afe7f77d7a48cace6ac1"
 dependencies = [
  "addr2line",
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "libc",
  "miniz_oxide",
  "object",
@@ -193,12 +199,12 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.11"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec 0.5.1",
  "constant_time_eq",
 ]
 
@@ -209,40 +215,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46080006c1505f12f64dd2a09264b343381ed3190fa02c8005d5d662ac571c63"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.2",
+ "arrayvec 0.5.1",
  "cc",
  "cfg-if 0.1.10",
  "constant_time_eq",
  "crypto-mac",
- "digest",
+ "digest 0.8.1",
 ]
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
 name = "bstr"
-version = "0.2.14"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
+checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -255,12 +249,6 @@ name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
@@ -281,6 +269,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
+
+[[package]]
 name = "cast"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.61"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
+checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
 
 [[package]]
 name = "cfg-if"
@@ -345,6 +339,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "const-random"
-version = "0.1.11"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dc82c12dc2ee6e1ded861cf7d582b46f66f796d1b6c93fa28b911ead95da02"
+checksum = "47715816826addf701caff29a519860e7e49de0d0b1584f3418ae7a676d75324"
 dependencies = [
  "const-random-macro",
  "proc-macro-hack",
@@ -365,19 +368,13 @@ dependencies = [
 
 [[package]]
 name = "const-random-macro"
-version = "0.1.11"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc757bbb9544aa296c2ae00c679e81f886b37e28e59097defe0cf524306f6685"
+checksum = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
 dependencies = [
- "getrandom 0.2.0",
+ "getrandom",
  "proc-macro-hack",
 ]
-
-[[package]]
-name = "const_fn"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
 
 [[package]]
 name = "constant_time_eq"
@@ -391,17 +388,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 dependencies = [
- "core-foundation-sys 0.7.0",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
-dependencies = [
- "core-foundation-sys 0.8.2",
+ "core-foundation-sys",
  "libc",
 ]
 
@@ -412,10 +399,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.2"
+name = "cpuid-bool"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "cranelift-bforest"
@@ -479,11 +466,11 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -528,41 +515,32 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
 dependencies = [
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
  "maybe-uninit",
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.0",
-]
-
-[[package]]
 name = "crossbeam-deque"
-version = "0.8.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
 dependencies = [
- "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
+ "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
 dependencies = [
- "cfg-if 1.0.0",
- "const_fn",
- "crossbeam-utils 0.8.0",
+ "autocfg 1.0.1",
+ "cfg-if 0.1.10",
+ "crossbeam-utils",
  "lazy_static",
+ "maybe-uninit",
  "memoffset",
  "scopeguard",
 ]
@@ -579,32 +557,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 1.0.0",
- "const_fn",
- "lazy_static",
-]
-
-[[package]]
 name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
  "subtle 1.0.0",
 ]
 
 [[package]]
 name = "csv"
-version = "1.1.4"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
+checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
 dependencies = [
  "bstr",
  "csv-core",
@@ -686,7 +652,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -754,7 +729,7 @@ dependencies = [
  "structopt",
  "tempdir",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
 ]
 
 [[package]]
@@ -815,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.7"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa68f2fb9cae9d37c9b2b3584aba698a2e97f72d7aef7b9f7aa71d8b54ce46fe"
+checksum = "6eab5ee3df98a279d9b316b1af6ac95422127b1290317e6d18c1743c99418b01"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -857,12 +832,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -874,7 +843,7 @@ version = "0.0.1"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
- "parking_lot",
+ "parking_lot 0.10.2",
  "paste 1.0.2",
  "rand 0.7.3",
  "rand_core 0.5.1",
@@ -893,11 +862,11 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.19"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+checksum = "da80be589a72651dcda34d8b35bcdc9b7254ad06325611074d9cc0fbb19f60ee"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -932,16 +901,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
-dependencies = [
- "matches",
- "percent-encoding 2.1.0",
-]
 
 [[package]]
 name = "fragile"
@@ -1082,21 +1041,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.1.15"
+name = "generic-array"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.0"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8025cf36f917e6a52cce185b7c7177689b838b7ec138364e50cc2277a56cf4"
+checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -1111,7 +1069,7 @@ checksum = "cd7af7fc240a7e45b281fa1babdf35b7716f5244ab905d8c960ed190ab15f70b"
 dependencies = [
  "futures",
  "must_future",
- "paste 0.1.18",
+ "paste 0.1.12",
  "thiserror",
  "tracing",
  "tracing-futures",
@@ -1129,9 +1087,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.23.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+checksum = "aaf91faf136cb47367fa430cd46e37a788775e7fa104f8b4bcb3861dc389b724"
 
 [[package]]
 name = "h2"
@@ -1139,7 +1097,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1147,7 +1105,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 0.2.22",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -1274,7 +1232,7 @@ dependencies = [
  "num_cpus",
  "observability",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.10.2",
  "predicates",
  "pretty_assertions",
  "rand 0.7.3",
@@ -1290,7 +1248,8 @@ dependencies = [
  "test-case",
  "test_wasm_common",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
+ "tokio_helper",
  "tokio_safe_block_on",
  "toml",
  "tracing",
@@ -1315,7 +1274,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
  "tracing",
 ]
 
@@ -1346,7 +1305,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
+ "tokio_helper",
  "tokio_safe_block_on",
 ]
 
@@ -1395,7 +1355,7 @@ dependencies = [
  "lazy_static",
  "must_future",
  "nanoid",
- "parking_lot",
+ "parking_lot 0.10.2",
  "rand 0.7.3",
  "rkv",
  "rmp-serde",
@@ -1404,7 +1364,8 @@ dependencies = [
  "shrinkwraprs",
  "tempdir",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
+ "tokio_helper",
  "tokio_safe_block_on",
  "tracing",
  "tracing-futures",
@@ -1441,7 +1402,8 @@ dependencies = [
  "strum",
  "tempdir",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
+ "tokio_helper",
  "tokio_safe_block_on",
  "tracing",
 ]
@@ -1457,6 +1419,7 @@ dependencies = [
  "rand 0.7.3",
  "strum",
  "strum_macros",
+ "tokio_helper",
  "tokio_safe_block_on",
  "toml",
  "walkdir",
@@ -1510,7 +1473,7 @@ dependencies = [
  "net2",
  "serde",
  "serde_bytes",
- "tokio",
+ "tokio 0.3.3",
  "tokio-tungstenite",
  "tracing",
  "tracing-futures",
@@ -1538,7 +1501,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -1549,7 +1512,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "http",
 ]
 
@@ -1586,7 +1549,7 @@ version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1598,7 +1561,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.1",
  "socket2",
- "tokio",
+ "tokio 0.2.22",
  "tower-service",
  "tracing",
  "want",
@@ -1610,10 +1573,10 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "hyper",
  "native-tls",
- "tokio",
+ "tokio 0.2.22",
  "tokio-tls",
 ]
 
@@ -1641,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.6.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28538916eb3f3976311f5dfbe67b5362d0add1293d0a9cad17debf86f8e3aa48"
+checksum = "f12906406f12abf5569643c46b29aec78313dc1537b17dd5c5250169790c4db9"
 dependencies = [
  "if-addrs-sys",
  "libc",
@@ -1652,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "if-addrs-sys"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de74b9dd780476e837e5eb5ab7c88b49ed304126e412030a0adba99c8efe79ea"
+checksum = "9e2556f16544202bcfe0aa5d20a01a6b815f736b136b3ad76dc547ee6b5bb1df"
 dependencies = [
  "cc",
  "libc",
@@ -1677,9 +1640,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48b0b7698c16bccca4617de8f9ede9f58ab44a68ad6b2a4920fd74e491de580d"
 dependencies = [
- "ahash 0.4.6",
- "crossbeam-channel 0.4.4",
- "crossbeam-utils 0.7.2",
+ "ahash 0.4.5",
+ "crossbeam-channel",
+ "crossbeam-utils",
  "dashmap",
  "env_logger",
  "indexmap",
@@ -1700,7 +1663,16 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19a8a95243d5a0398cae618ec29477c6e3cb631152be5c19481f80bc71559754"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1781,7 +1753,8 @@ dependencies = [
  "serde_bytes",
  "shrinkwraprs",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
+ "tokio-compat-02",
  "tracing-subscriber",
  "url2",
 ]
@@ -1803,7 +1776,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "structopt",
- "tokio",
+ "tokio 0.3.3",
+ "tokio-compat-02",
  "tracing-subscriber",
  "webpki",
 ]
@@ -1821,7 +1795,7 @@ dependencies = [
  "rcgen",
  "rustls 0.17.0",
  "serde",
- "tokio",
+ "tokio 0.2.22",
  "webpki",
 ]
 
@@ -1839,16 +1813,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
  "tracing-subscriber",
  "url2",
 ]
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.0.1-alpha.5"
+version = "0.0.1-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f755ad496c4332f0d42f5546aed724f1ff7dd94a32bd09bafca3f17a4abbae"
+checksum = "9a202891bdc663df1304799c16e4ceda648e81a5874d63dee10ed55d5f7e2b31"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -1863,20 +1837,20 @@ dependencies = [
  "rcgen",
  "ring",
  "thiserror",
- "tokio",
+ "tokio 0.3.3",
  "toml",
 ]
 
 [[package]]
 name = "lair_keystore_client"
-version = "0.0.1-alpha.5"
+version = "0.0.1-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e87fb9a70a15f542c09122bf41ef885997c44ea1e8305910ba66c908b2def0e"
+checksum = "a2fb093f5a0fd95c27ba4a04b194570bc0ad1ea601ee7c0305620af3b5e31a7a"
 dependencies = [
  "ghost_actor",
  "lair_keystore_api",
  "tempfile",
- "tokio",
+ "tokio 0.3.3",
  "tracing",
 ]
 
@@ -1888,9 +1862,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "linefeed"
@@ -1940,6 +1914,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1977,9 +1960,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memmap"
@@ -2018,9 +2001,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "c60c0dfe32c10b43a144bad8fc83538c52f58302c92300ea7ec7bf7b38d5a7b9"
 dependencies = [
  "adler",
  "autocfg 1.0.1",
@@ -2046,13 +2029,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8962c171f57fcfffa53f4df1bb15ec4c8cf26a7569459c9ceb62d94aab0d9584"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.5",
+ "ntapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "mio-named-pipes"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log",
- "mio",
+ "mio 0.6.22",
  "miow 0.3.5",
  "winapi 0.3.9",
 ]
@@ -2065,7 +2061,7 @@ checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
 dependencies = [
  "iovec",
  "libc",
- "mio",
+ "mio 0.6.22",
 ]
 
 [[package]]
@@ -2092,9 +2088,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.8.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cabea45a7fc0e37093f4f30a5e2b62602253f91791c057d5f0470c63260c3d"
+checksum = "68ecfc6340c5b98a9a270b56e5f43353d87ebb18d9458a9301344bc79317c563"
 dependencies = [
  "cfg-if 0.1.10",
  "downcast",
@@ -2107,9 +2103,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.8.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c461918bf7f59eefb1459252756bf2351a995d6bd510d0b2061bd86bcdabfa6"
+checksum = "b873f753808fe0c3827ce76edb3ace27804966dfde3043adfac1c24d0a2559df"
 dependencies = [
  "cfg-if 0.1.10",
  "proc-macro2 1.0.24",
@@ -2154,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.5"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a1cda389c26d6b88f3d2dc38aa1b750fe87d298cc5d795ec9e975f402f00372"
+checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2165,8 +2161,8 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 2.0.0",
- "security-framework-sys 2.0.0",
+ "security-framework",
+ "security-framework-sys",
  "tempfile",
 ]
 
@@ -2230,6 +2226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "num-format"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2241,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
  "autocfg 1.0.1",
  "num-traits",
@@ -2251,9 +2256,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg 1.0.1",
 ]
@@ -2270,9 +2275,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.22.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "observability"
@@ -2303,9 +2308,9 @@ checksum = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -2383,8 +2388,19 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
- "lock_api",
- "parking_lot_core",
+ "lock_api 0.3.4",
+ "parking_lot_core 0.7.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api 0.4.1",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -2394,7 +2410,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if 0.1.10",
- "cloudabi",
+ "cloudabi 0.0.3",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.4.2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if 0.1.10",
+ "cloudabi 0.1.0",
+ "instant",
  "libc",
  "redox_syscall",
  "smallvec 1.4.2",
@@ -2403,9 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.18"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
+checksum = "0a229b1c58c692edcaa5b9b0948084f130f55d2dcc15b02fcc5340b2b4521476"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -2419,11 +2450,14 @@ checksum = "ba7ae1a2180ed02ddfdb5ab70c70d596a26dd642e097bb6fe78b1bde8588ed97"
 
 [[package]]
 name = "paste-impl"
-version = "0.1.18"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
+checksum = "2e0bf239e447e67ff6d16a8bb5e4d4bd2343acf5066061c0e8e06ac5ba8ca68c"
 dependencies = [
  "proc-macro-hack",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
 ]
 
 [[package]]
@@ -2489,11 +2523,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "13fbdfd6bdee3dc9be46452f86af4a4072975899cf8592466668620bebfbcc17"
 dependencies = [
- "pin-project-internal 0.4.27",
+ "pin-project-internal 0.4.26",
 ]
 
 [[package]]
@@ -2507,9 +2541,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
+checksum = "c82fb1329f632c3552cf352d14427d57a511b1cf41db93b3a7d77906a82dcc8e"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -2529,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.11"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
+checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
 
 [[package]]
 name = "pin-utils"
@@ -2541,9 +2575,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.19"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
 name = "plotters"
@@ -2559,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.10"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
 name = "predicates"
@@ -2630,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro-nested"
@@ -2673,14 +2707,14 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88de58d76d8f82fb28e5c89302119c102bb5b9ce57b034186b559b63ba147a0f"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "err-derive",
  "futures",
  "libc",
- "mio",
+ "mio 0.6.22",
  "quinn-proto",
  "rustls 0.17.0",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
  "webpki",
 ]
@@ -2691,7 +2725,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0ea0a358c179c6b7af34805c675d1664a9c6a234a7acd7efdbb32d2f39d3d2a"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "ct-logs",
  "err-derive",
  "rand 0.7.3",
@@ -2759,7 +2793,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -2808,7 +2842,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom",
 ]
 
 [[package]]
@@ -2855,7 +2889,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
- "cloudabi",
+ "cloudabi 0.0.3",
  "fuchsia-cprng",
  "libc",
  "rand_core 0.4.2",
@@ -2904,9 +2938,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "dcf6960dc9a5b4ee8d3e4c5787b4a112a8818e0290a42ff664ad60692fdf2032"
 dependencies = [
  "autocfg 1.0.1",
  "crossbeam-deque",
@@ -2916,13 +2950,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
 dependencies = [
- "crossbeam-channel 0.5.0",
+ "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.0",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
@@ -2960,16 +2994,16 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom",
  "redox_syscall",
  "rust-argon2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2989,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "remove_dir_all"
@@ -3009,7 +3043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
 dependencies = [
  "base64 0.12.3",
- "bytes",
+ "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -3028,9 +3062,9 @@ dependencies = [
  "pin-project-lite",
  "serde",
  "serde_urlencoded",
- "tokio",
+ "tokio 0.2.22",
  "tokio-tls",
- "url 2.2.0",
+ "url 2.1.1",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3076,7 +3110,7 @@ dependencies = [
  "ordered-float",
  "serde",
  "serde_derive",
- "url 2.2.0",
+ "url 2.1.1",
  "uuid 0.8.1",
 ]
 
@@ -3110,14 +3144,14 @@ dependencies = [
  "base64 0.12.3",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.18"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
+checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
 name = "rustc_version"
@@ -3163,14 +3197,19 @@ dependencies = [
  "openssl-probe",
  "rustls 0.17.0",
  "schannel",
- "security-framework 0.4.4",
+ "security-framework",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5d2a036dc6d2d8fd16fde3498b04306e29bd193bf306a57427019b823d5acd"
+checksum = "b9bdc5e856e51e685846fb6c13a1f5e5432946c2c90501bdc76a1319f19e29da"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
+]
 
 [[package]]
 name = "ryu"
@@ -3220,23 +3259,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
 dependencies = [
  "bitflags",
- "core-foundation 0.7.0",
- "core-foundation-sys 0.7.0",
+ "core-foundation",
+ "core-foundation-sys",
  "libc",
- "security-framework-sys 0.4.3",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.1",
- "core-foundation-sys 0.8.2",
- "libc",
- "security-framework-sys 2.0.0",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -3245,17 +3271,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
- "core-foundation-sys 0.7.0",
- "libc",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
-dependencies = [
- "core-foundation-sys 0.8.2",
+ "core-foundation-sys",
  "libc",
 ]
 
@@ -3334,9 +3350,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3353,14 +3369,14 @@ dependencies = [
  "dtoa",
  "itoa",
  "serde",
- "url 2.2.0",
+ "url 2.1.1",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.14"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7baae0a99f1a324984bcdc5f0718384c1f69775f1c7eec8b859b71b443e3fd7"
+checksum = "ae3e2dd40a7cdc18ca80db804b7f461a39bb721160a85c9a1fa30134bf3c02a5"
 dependencies = [
  "dtoa",
  "linked-hash-map",
@@ -3375,7 +3391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fef5f7c7434b2f2c598adc6f9494648a1e41274a75c0ba4056f680ae0c117fd6"
 dependencies = [
  "lazy_static",
- "parking_lot",
+ "parking_lot 0.10.2",
  "serial_test_derive",
 ]
 
@@ -3392,13 +3408,14 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
 dependencies = [
  "block-buffer",
- "digest",
- "fake-simd",
+ "cfg-if 0.1.10",
+ "cpuid-bool",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
@@ -3426,10 +3443,11 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
+checksum = "a3e12110bc539e657a646068aaf5eb5b63af9d0c1f7b29c97113fad80e15f035"
 dependencies = [
+ "arc-swap",
  "libc",
 ]
 
@@ -3501,9 +3519,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.20"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
+checksum = "a33f6461027d7f08a13715659b2948e1602c31a3756aeae9378bfe7518c72e82"
 dependencies = [
  "clap",
  "lazy_static",
@@ -3512,9 +3530,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.13"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
+checksum = "c92e775028122a4b3dd55d58f14fc5120289c69bee99df1d117ae30f84b225c9"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -3678,18 +3696,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -3738,22 +3756,57 @@ version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
  "libc",
  "memchr",
- "mio",
+ "mio 0.6.22",
  "mio-named-pipes",
  "mio-uds",
  "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "tokio-macros",
+ "tokio-macros 0.2.5",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ca08accbcb46f11fd8d2d1c6158c348b7888009a1f39260bcad66f6a454250"
+dependencies = [
+ "autocfg 1.0.1",
+ "bytes 0.6.0",
+ "futures-core",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "mio 0.7.5",
+ "num_cpus",
+ "parking_lot 0.11.0",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "slab",
+ "tokio-macros 0.3.1",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio-compat-02"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4cec419b8b6f06c32e74aae6d8c5e79646d038a38e5ea2b36045f2c3296e22"
+dependencies = [
+ "bytes 0.5.6",
+ "once_cell",
+ "pin-project-lite",
+ "tokio 0.2.22",
+ "tokio 0.3.3",
 ]
 
 [[package]]
@@ -3768,27 +3821,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-macros"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d30fdbb5dc2d8f91049691aa1a9d4d4ae422a21c334ce8936e5886d30c5c45"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "syn 1.0.48",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501c8252b73bd01379aaae1521523c2629ff1bc6ea46c29e0baff515cee60f1b"
+dependencies = [
+ "native-tls",
+ "tokio 0.3.3",
+]
+
+[[package]]
 name = "tokio-tls"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b8fe88007ebc363512449868d7da4389c9400072a3f666f212c7280082882a"
+version = "0.11.0"
+source = "git+https://github.com/snapview/tokio-tungstenite.git?rev=3c6d4280d77fdff3e25f68ad703d94e89f38dae2#3c6d4280d77fdff3e25f68ad703d94e89f38dae2"
 dependencies = [
- "futures",
+ "futures-util",
  "log",
  "native-tls",
- "pin-project 0.4.27",
- "tokio",
- "tokio-tls",
+ "pin-project 1.0.1",
+ "tokio 0.3.3",
+ "tokio-native-tls",
  "tungstenite",
 ]
 
@@ -3798,28 +3871,38 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio",
+ "tokio 0.2.22",
+]
+
+[[package]]
+name = "tokio_helper"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "num_cpus",
+ "once_cell",
+ "tokio 0.3.3",
 ]
 
 [[package]]
 name = "tokio_safe_block_on"
-version = "0.1.2"
-source = "git+https://github.com/neonphog/tokio_safe_block_on.git?branch=fix_holochain_bug#927f5a809fbc383df96c20ac8546ee0d9d205e1a"
+version = "0.2.0"
+source = "git+https://github.com/neonphog/tokio_safe_block_on.git?rev=074d40929ccab649b0dcc83a4ebdbdcb70b317fb#074d40929ccab649b0dcc83a4ebdbdcb70b317fb"
 dependencies = [
  "futures",
- "tokio",
+ "tokio 0.3.3",
 ]
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
  "serde",
 ]
@@ -3879,7 +3962,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
- "pin-project 0.4.27",
+ "pin-project 0.4.26",
  "tracing",
 ]
 
@@ -3938,13 +4021,13 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tungstenite"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfea31758bf674f990918962e8e5f07071a3161bd7c4138ed23e416e1ac4264e"
+checksum = "f0308d80d86700c5878b9ef6321f020f29b1bb9d5ff3cab25e75e23f3a492a23"
 dependencies = [
- "base64 0.11.0",
+ "base64 0.12.3",
  "byteorder",
- "bytes",
+ "bytes 0.5.6",
  "http",
  "httparse",
  "input_buffer",
@@ -3952,7 +4035,7 @@ dependencies = [
  "native-tls",
  "rand 0.7.3",
  "sha-1",
- "url 2.2.0",
+ "url 2.1.1",
  "utf-8",
 ]
 
@@ -4038,11 +4121,10 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 dependencies = [
- "form_urlencoded",
  "idna 0.2.0",
  "matches",
  "percent-encoding 2.1.0",
@@ -4056,7 +4138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89cd13f1de9862d363308f5ffdadcd2b64b2a4a812fb296a80b7d3e80011b1e"
 dependencies = [
  "serde",
- "url 2.2.0",
+ "url 2.1.1",
 ]
 
 [[package]]
@@ -4303,7 +4385,7 @@ dependencies = [
  "bincode",
  "blake3",
  "cc",
- "digest",
+ "digest 0.8.1",
  "errno",
  "hex",
  "indexmap",
@@ -4311,7 +4393,7 @@ dependencies = [
  "libc",
  "nix 0.15.0",
  "page_size",
- "parking_lot",
+ "parking_lot 0.10.2",
  "rustc_version",
  "serde",
  "serde-bench",
@@ -4440,3 +4522,8 @@ checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
 dependencies = [
  "chrono",
 ]
+
+[[patch.unused]]
+name = "tokio_safe_block_on"
+version = "0.1.2"
+source = "git+https://github.com/neonphog/tokio_safe_block_on.git?branch=fix_holochain_bug#927f5a809fbc383df96c20ac8546ee0d9d205e1a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "crates/test_utils/wasm_common",
   "crates/types",
   "crates/websocket",
+  "crates/tokio_helper"
 ]
 
 exclude = [

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -15,7 +15,7 @@ holochain_state = { path = "../state"}
 holochain_types = { path = "../types"}
 rkv = "0.10.4"
 structopt = "0.3"
-tokio = { version = "0.2", features = [ "full" ] }
+tokio = { version = "0.3.3", features = [ "full" ] }
 
 
 [patch.crates-io]

--- a/crates/diagnostics/src/main.rs
+++ b/crates/diagnostics/src/main.rs
@@ -80,7 +80,7 @@ async fn run() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::main(threaded_scheduler)]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() {
     if let Err(err) = run().await {
         eprintln!("holochain-analyzer: {}", err);

--- a/crates/dna_util/Cargo.toml
+++ b/crates/dna_util/Cargo.toml
@@ -20,7 +20,7 @@ serde_bytes = "0.11"
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 structopt = "0.3.11"
 thiserror = "1.0.10"
-tokio = { version = "0.2", features = [ "full" ] }
+tokio = { version = "0.3.3", features = [ "full" ] }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/crates/dna_util/src/bin/dna-util.rs
+++ b/crates/dna_util/src/bin/dna-util.rs
@@ -56,7 +56,7 @@ async fn run() -> DnaUtilResult<()> {
 }
 
 /// Main `dna-util` executable entrypoint.
-#[tokio::main(threaded_scheduler)]
+#[tokio::main(flavor = "multi_thread")]
 pub async fn main() {
     if let Err(err) = run().await {
         eprintln!("dna-util: {}", err);

--- a/crates/dna_util/src/lib.rs
+++ b/crates/dna_util/src/lib.rs
@@ -255,7 +255,7 @@ impl DnaDefJson {
 mod tests {
     use super::*;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_extract_then_compile() {
         let tmp_dir = tempdir::TempDir::new("dna_util_test").unwrap();
 

--- a/crates/holo_hash/src/tests.rs
+++ b/crates/holo_hash/src/tests.rs
@@ -22,7 +22,7 @@ struct TestHeader(String);
 impl_hashable_content!(TestDhtOp, DhtOp);
 impl_hashable_content!(TestHeader, Header);
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_hashed_type() {
     let my_type = TestDhtOp {
         s: "test".to_string(),
@@ -81,8 +81,7 @@ fn holo_hash_parse() {
         &format!("{:?}", h),
     );
 
-    let h = EntryHash::try_from("uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm")
-        .unwrap();
+    let h = EntryHash::try_from("uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm").unwrap();
     assert_eq!(3_860_645_936, h.get_loc());
     assert_eq!(
         "EntryHash(uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm)",
@@ -97,7 +96,7 @@ fn holo_hash_parse() {
     );
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn agent_id_as_bytes() {
     tokio::task::spawn(async move {
         let hash = vec![0xdb; 32];
@@ -109,7 +108,7 @@ async fn agent_id_as_bytes() {
     .unwrap();
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn agent_id_prehash_display() {
     tokio::task::spawn(async move {
         let agent_id = HeaderHash::from_raw_32(vec![0xdb; 32]);
@@ -129,7 +128,7 @@ fn agent_id_try_parse() {
     assert_eq!(3_492_283_899, agent_id.get_loc());
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn agent_id_debug() {
     tokio::task::spawn(async move {
         let agent_id = HeaderHash::with_data_sync(&TestHeader("hi".to_string()));
@@ -142,7 +141,7 @@ async fn agent_id_debug() {
     .unwrap();
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn agent_id_display() {
     tokio::task::spawn(async move {
         let agent_id = HeaderHash::with_data_sync(&TestHeader("hi".to_string()));
@@ -155,7 +154,7 @@ async fn agent_id_display() {
     .unwrap();
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn agent_id_loc() {
     tokio::task::spawn(async move {
         let agent_id = HeaderHash::with_data_sync(&TestHeader("hi".to_string()));

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -53,8 +53,8 @@ structopt = "0.3.11"
 strum = "0.18.0"
 tempdir = "0.3.7"
 thiserror = "1.0.10"
-tokio = { version = "0.2.11", features = [ "full" ] }
-tokio_safe_block_on = "0.1.2"
+tokio = { version = "0.3.3", features = [ "full" ] }
+tokio_safe_block_on = { git = "https://github.com/neonphog/tokio_safe_block_on.git", rev = "074d40929ccab649b0dcc83a4ebdbdcb70b317fb" }
 toml = "0.5.6"
 tracing = "=0.1.18"
 tracing-futures = "0.2.4"
@@ -63,6 +63,7 @@ url2 = "0.0.6"
 url_serde = "0.2.0"
 uuid = { version = "0.7", features = [ "serde", "v4" ] }
 kitsune_p2p = { version = "0.0.1", path = "../kitsune_p2p/kitsune_p2p" }
+tokio_helper = { path = "../tokio_helper" }
 
 [dev-dependencies]
 anyhow = "1.0.26"

--- a/crates/holochain/src/bin/holochain/main.rs
+++ b/crates/holochain/src/bin/holochain/main.rs
@@ -50,9 +50,8 @@ struct Opt {
 }
 
 fn main() {
-    holochain::conductor::tokio_runtime()
-        // the async_main function should only end if our program is done
-        .block_on(async_main())
+    // the async_main function should only end if our program is done
+    tokio_helper::block_on(async_main())
 }
 
 async fn async_main() {

--- a/crates/holochain/src/conductor.rs
+++ b/crates/holochain/src/conductor.rs
@@ -36,21 +36,3 @@ pub mod state;
 pub use cell::{error::CellError, Cell};
 pub use conductor::{Conductor, ConductorBuilder, ConductorStateDb};
 pub use handle::ConductorHandle;
-
-/// setup a tokio runtime that meets the conductor's needs
-pub fn tokio_runtime() -> tokio::runtime::Runtime {
-    tokio::runtime::Builder::new()
-        // we use both IO and Time tokio utilities
-        .enable_all()
-        // we want to use multiple threads
-        .threaded_scheduler()
-        // we want to use thread count matching cpu count
-        // (sometimes tokio by default only uses half cpu core threads)
-        .core_threads(num_cpus::get())
-        // give our threads a descriptive name (they'll be numbered too)
-        .thread_name("holochain-tokio-thread")
-        // build the runtime
-        .build()
-        // panic if we cannot (we cannot run without it)
-        .expect("can build tokio runtime")
-}

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -470,7 +470,7 @@ mod test {
     use matches::assert_matches;
     use uuid::Uuid;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn install_list_dna_app() -> Result<()> {
         observability::test_run().ok();
         let test_env = test_conductor_env();
@@ -546,7 +546,7 @@ mod test {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn dna_read_parses() -> Result<()> {
         let uuid = Uuid::new_v4();
         let dna = fake_dna_file(&uuid.to_string());

--- a/crates/holochain/src/conductor/cell/test.rs
+++ b/crates/holochain/src/conductor/cell/test.rs
@@ -16,7 +16,7 @@ use holochain_zome_types::header;
 use std::sync::Arc;
 use tokio::sync;
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_cell_handle_publish() {
     let TestEnvironment {
         env,

--- a/crates/holochain/src/conductor/compat.rs
+++ b/crates/holochain/src/conductor/compat.rs
@@ -322,7 +322,7 @@ pub mod tests {
         assert!(config.dpki.is_some());
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_build_conductor_from_legacy() {
         let (legacy_config, _, dir) = legacy_fixtures_1();
         let dna1 = fake_dna_zomes(
@@ -404,7 +404,7 @@ pub mod tests {
             .unwrap();
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_build_conductor_from_legacy_regression() {
         let (legacy_config, _, dir) = legacy_fixtures_2();
         let dna1 = fake_dna_zomes(

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1069,7 +1069,7 @@ pub mod tests {
     };
     use holochain_types::test_utils::fake_cell_id;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn can_update_state() {
         let TestEnvironment {
             env: environment,
@@ -1123,7 +1123,7 @@ pub mod tests {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn can_set_fake_state() {
         let test_env = test_conductor_env();
         let _tmpdir = test_env.tmpdir.clone();

--- a/crates/holochain/src/conductor/entry_def_store.rs
+++ b/crates/holochain/src/conductor/entry_def_store.rs
@@ -231,7 +231,7 @@ mod tests {
         entry_def::{EntryDef, EntryVisibility},
     };
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_store_entry_defs() {
         holochain_types::observability::test_run().ok();
 

--- a/crates/holochain/src/conductor/interface.rs
+++ b/crates/holochain/src/conductor/interface.rs
@@ -26,7 +26,7 @@ impl SignalBroadcaster {
         self.0
             .iter_mut()
             .map(|tx| tx.send(sig.clone()))
-            .collect::<Result<Vec<_>, broadcast::SendError<Signal>>>()
+            .collect::<Result<Vec<_>, broadcast::error::SendError<Signal>>>()
             .map_err(InterfaceError::SignalSend)?;
         Ok(())
     }

--- a/crates/holochain/src/conductor/interface/error.rs
+++ b/crates/holochain/src/conductor/interface/error.rs
@@ -9,9 +9,9 @@ pub enum InterfaceError {
     #[error(transparent)]
     JoinError(#[from] tokio::task::JoinError),
     #[error("Error while sending a Signal to an Interface: {0:?}")]
-    SignalSend(tokio::sync::broadcast::SendError<Signal>),
+    SignalSend(tokio::sync::broadcast::error::SendError<Signal>),
     #[error(transparent)]
-    SignalReceive(tokio::sync::broadcast::RecvError),
+    SignalReceive(tokio::sync::broadcast::error::RecvError),
     #[error(transparent)]
     RequestHandler(Box<ConductorError>),
     #[error("Got an unexpected message: {0}")]

--- a/crates/holochain/src/conductor/manager/error.rs
+++ b/crates/holochain/src/conductor/manager/error.rs
@@ -15,7 +15,7 @@ pub enum ManagedTaskError {
     Join(#[from] tokio::task::JoinError),
 
     #[error(transparent)]
-    Recv(#[from] tokio::sync::broadcast::RecvError),
+    Recv(#[from] tokio::sync::broadcast::error::RecvError),
 }
 
 pub type ManagedTaskResult = Result<(), ManagedTaskError>;

--- a/crates/holochain/src/conductor/manager/mod.rs
+++ b/crates/holochain/src/conductor/manager/mod.rs
@@ -133,7 +133,7 @@ mod test {
     #[tokio::test]
     async fn spawn_and_handle_dying_task() -> Result<()> {
         observability::test_run().ok();
-        let (mut send_task_handle, main_task) = spawn_task_manager();
+        let (send_task_handle, main_task) = spawn_task_manager();
         let handle = tokio::spawn(async {
             Err(ConductorError::Todo("This task gotta die".to_string()).into())
         });
@@ -151,7 +151,7 @@ mod test {
         );
         // Check that the main task doesn't close straight away
         let main_handle = tokio::spawn(main_task);
-        tokio::time::delay_for(std::time::Duration::from_secs(2)).await;
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
         // Now send the handle
         if let Err(_) = send_task_handle.send(handle).await {

--- a/crates/holochain/src/conductor/p2p_store.rs
+++ b/crates/holochain/src/conductor/p2p_store.rs
@@ -133,7 +133,7 @@ mod tests {
         assert_eq!(&bytes[32..], agent_info.as_agent_ref().get_bytes(),);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_store_agent_info_signed() {
         holochain_types::observability::test_run().ok();
 

--- a/crates/holochain/src/core/queue_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer.rs
@@ -59,7 +59,7 @@ pub async fn spawn_queue_consumer_tasks(
     env: &EnvironmentWrite,
     cell_network: HolochainP2pCell,
     conductor_api: impl CellConductorApiT + 'static,
-    mut task_sender: sync::mpsc::Sender<ManagedTaskAdd>,
+    task_sender: sync::mpsc::Sender<ManagedTaskAdd>,
     stop: sync::broadcast::Sender<()>,
 ) -> InitialQueueTriggers {
     // Publish

--- a/crates/holochain/src/core/ribosome.rs
+++ b/crates/holochain/src/core/ribosome.rs
@@ -273,7 +273,7 @@ impl ZomeCallInvocation {
         let check_agent = self.provenance.clone();
         let check_secret = self.cap;
 
-        tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+        tokio_helper::block_on(async move {
             let maybe_grant: Option<CapGrant> = host_access
                 .workspace
                 .read()
@@ -612,7 +612,7 @@ pub mod wasm_test {
 #[cfg(feature = "slow_tests")]
 mod slow_tests {
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn warm_wasm_tests() {
         crate::test_utils::warm_wasm_tests();
     }

--- a/crates/holochain/src/core/ribosome/guest_callback.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback.rs
@@ -87,7 +87,7 @@ mod tests {
     use mockall::Sequence;
     use std::convert::TryInto;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn call_iterator_iterates() {
         // stuff we need to test with
         let mut sequence = Sequence::new();

--- a/crates/holochain/src/core/ribosome/guest_callback/entry_defs.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/entry_defs.rs
@@ -187,7 +187,7 @@ mod test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn entry_defs_invocation_zomes() {
         let entry_defs_invocation = EntryDefsInvocationFixturator::new(fixt::Unpredictable)
             .next()
@@ -195,7 +195,7 @@ mod test {
         assert_eq!(ZomesToInvoke::All, entry_defs_invocation.zomes(),);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn entry_defs_invocation_fn_components() {
         let entry_defs_invocation = EntryDefsInvocationFixturator::new(fixt::Unpredictable)
             .next()
@@ -207,7 +207,7 @@ mod test {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn entry_defs_invocation_host_input() {
         let entry_defs_invocation = EntryDefsInvocationFixturator::new(fixt::Unpredictable)
             .next()
@@ -239,7 +239,7 @@ mod slow_tests {
     use holochain_zome_types::zome::ZomeName;
     use std::collections::BTreeMap;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_entry_defs_unimplemented() {
         let ribosome = WasmRibosomeFixturator::new(Zomes(vec![TestWasm::Foo]))
             .next()
@@ -254,7 +254,7 @@ mod slow_tests {
         assert_eq!(result, EntryDefsResult::Defs(BTreeMap::new()),);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_entry_defs_implemented_defs() {
         let ribosome = WasmRibosomeFixturator::new(Zomes(vec![TestWasm::EntryDefs]))
             .next()

--- a/crates/holochain/src/core/ribosome/guest_callback/init.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/init.rs
@@ -175,7 +175,7 @@ mod test {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn init_access() {
         let init_host_access = InitHostAccessFixturator::new(fixt::Unpredictable)
             .next()
@@ -231,7 +231,7 @@ mod slow_tests {
     use ::fixt::prelude::*;
     use holochain_wasm_test_utils::TestWasm;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_init_unimplemented() {
         let ribosome = WasmRibosomeFixturator::new(Zomes(vec![TestWasm::Crud]))
             .next()
@@ -244,7 +244,7 @@ mod slow_tests {
         assert_eq!(result, InitResult::Pass,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_init_implemented_pass() {
         let ribosome = WasmRibosomeFixturator::new(Zomes(vec![TestWasm::InitPass]))
             .next()
@@ -257,7 +257,7 @@ mod slow_tests {
         assert_eq!(result, InitResult::Pass,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_init_implemented_fail() {
         let ribosome = WasmRibosomeFixturator::new(Zomes(vec![TestWasm::InitFail]))
             .next()
@@ -273,7 +273,7 @@ mod slow_tests {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_init_multi_implemented_fail() {
         let ribosome =
             WasmRibosomeFixturator::new(Zomes(vec![TestWasm::InitPass, TestWasm::InitFail]))

--- a/crates/holochain/src/core/ribosome/guest_callback/migrate_agent.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/migrate_agent.rs
@@ -173,7 +173,7 @@ mod test {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn migrate_agent_invocation_allow_side_effects() {
         use holochain_types::dna::zome::Permission::*;
         let migrate_agent_host_access = MigrateAgentHostAccessFixturator::new(fixt::Unpredictable)
@@ -246,7 +246,7 @@ mod slow_tests {
     use crate::fixt::WasmRibosomeFixturator;
     use holochain_wasm_test_utils::TestWasm;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_migrate_agent_unimplemented() {
         let host_access = MigrateAgentHostAccessFixturator::new(fixt::Unpredictable)
             .next()
@@ -265,7 +265,7 @@ mod slow_tests {
         assert_eq!(result, MigrateAgentResult::Pass,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_migrate_agent_implemented_pass() {
         let host_access = MigrateAgentHostAccessFixturator::new(fixt::Unpredictable)
             .next()
@@ -284,7 +284,7 @@ mod slow_tests {
         assert_eq!(result, MigrateAgentResult::Pass,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_migrate_agent_implemented_fail() {
         let host_access = MigrateAgentHostAccessFixturator::new(fixt::Unpredictable)
             .next()
@@ -306,7 +306,7 @@ mod slow_tests {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_migrate_agent_multi_implemented_fail() {
         let host_access = MigrateAgentHostAccessFixturator::new(fixt::Unpredictable)
             .next()

--- a/crates/holochain/src/core/ribosome/guest_callback/post_commit.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/post_commit.rs
@@ -149,7 +149,7 @@ mod test {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn post_commit_invocation_access() {
         let post_commit_host_access = PostCommitHostAccessFixturator::new(fixt::Unpredictable)
             .next()
@@ -215,7 +215,7 @@ mod slow_tests {
     use holo_hash::fixt::HeaderHashFixturator;
     use holochain_wasm_test_utils::TestWasm;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_post_commit_unimplemented() {
         let host_access = PostCommitHostAccessFixturator::new(fixt::Unpredictable)
             .next()
@@ -234,7 +234,7 @@ mod slow_tests {
         assert_eq!(result, PostCommitResult::Success,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_post_commit_implemented_success() {
         let host_access = PostCommitHostAccessFixturator::new(fixt::Unpredictable)
             .next()
@@ -253,7 +253,7 @@ mod slow_tests {
         assert_eq!(result, PostCommitResult::Success,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_post_commit_implemented_fail() {
         let host_access = PostCommitHostAccessFixturator::new(fixt::Unpredictable)
             .next()

--- a/crates/holochain/src/core/ribosome/guest_callback/validate.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validate.rs
@@ -149,7 +149,7 @@ mod test {
     use rand::seq::SliceRandom;
     use std::sync::Arc;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validate_callback_result_fold() {
         let mut rng = fixt::rng();
 
@@ -188,7 +188,7 @@ mod test {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validate_invocation_allow_side_effects() {
         let validate_host_access = ValidateHostAccessFixturator::new(fixt::Unpredictable)
             .next()
@@ -199,7 +199,7 @@ mod test {
         assert_eq!(HostFnAccess::from(&validate_host_access), access);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validate_invocation_zomes() {
         let validate_invocation = ValidateInvocationFixturator::new(fixt::Unpredictable)
             .next()
@@ -208,7 +208,7 @@ mod test {
         assert_eq!(zomes_to_invoke, validate_invocation.zomes(),);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validate_invocation_fn_components() {
         let mut validate_invocation = ValidateInvocationFixturator::new(fixt::Unpredictable)
             .next()
@@ -267,7 +267,7 @@ mod test {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validate_invocation_host_input() {
         let validate_invocation = ValidateInvocationFixturator::new(fixt::Unpredictable)
             .next()
@@ -302,7 +302,7 @@ mod slow_tests {
     use holochain_zome_types::Entry;
     use std::sync::Arc;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_validate_unimplemented() {
         let ribosome = WasmRibosomeFixturator::new(Zomes(vec![TestWasm::Foo]))
             .next()
@@ -318,7 +318,7 @@ mod slow_tests {
         assert_eq!(result, ValidateResult::Valid,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_validate_implemented_valid() {
         let ribosome = WasmRibosomeFixturator::new(Zomes(vec![TestWasm::ValidateValid]))
             .next()
@@ -334,7 +334,7 @@ mod slow_tests {
         assert_eq!(result, ValidateResult::Valid,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_validate_implemented_invalid() {
         let ribosome = WasmRibosomeFixturator::new(Zomes(vec![TestWasm::ValidateInvalid]))
             .next()
@@ -350,7 +350,7 @@ mod slow_tests {
         assert_eq!(result, ValidateResult::Invalid("esoteric edge case".into()),);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_validate_implemented_multi() {
         let ribosome = WasmRibosomeFixturator::new(Zomes(vec![TestWasm::ValidateInvalid]))
             .next()
@@ -376,7 +376,7 @@ mod slow_tests {
         assert_eq!(result, ValidateResult::Invalid("esoteric edge case".into()));
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn pass_validate_test<'a>() {
         // test workspace boilerplate
         let test_env = holochain_state::test_utils::test_cell_env();
@@ -396,7 +396,7 @@ mod slow_tests {
             crate::call_test_ribosome!(host_access, TestWasm::Validate, "always_validates", ());
 
         // the chain head should be the committed entry header
-        let chain_head = tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+        let chain_head = tokio_helper::block_on(async move {
             SourceChainResult::Ok(
                 workspace_lock
                     .read()
@@ -411,7 +411,7 @@ mod slow_tests {
         assert_eq!(chain_head, output.into_inner(),);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn fail_validate_test<'a>() {
         // test workspace boilerplate
         let test_env = holochain_state::test_utils::test_cell_env();
@@ -432,7 +432,7 @@ mod slow_tests {
             crate::call_test_ribosome!(host_access, TestWasm::Validate, "never_validates", ());
 
         // the chain head should be the committed entry header
-        let chain_head = tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+        let chain_head = tokio_helper::block_on(async move {
             SourceChainResult::Ok(
                 workspace_lock
                     .read()

--- a/crates/holochain/src/core/ribosome/guest_callback/validate_link.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validate_link.rs
@@ -194,7 +194,7 @@ mod test {
     use holochain_zome_types::ExternInput;
     use rand::seq::SliceRandom;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validate_link_add_callback_result_fold() {
         let mut rng = fixt::rng();
 
@@ -227,7 +227,7 @@ mod test {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validate_link_add_invocation_allow_side_effects() {
         let validate_link_add_host_access =
             ValidateLinkHostAccessFixturator::new(fixt::Unpredictable)
@@ -238,7 +238,7 @@ mod test {
         assert_eq!(HostFnAccess::from(&validate_link_add_host_access), access,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validate_link_add_invocation_zomes() {
         let validate_create_link_invocation =
             ValidateCreateLinkInvocationFixturator::new(fixt::Unpredictable)
@@ -251,7 +251,7 @@ mod test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validate_link_add_invocation_fn_components() {
         let validate_create_link_invocation =
             ValidateCreateLinkInvocationFixturator::new(fixt::Unpredictable)
@@ -264,7 +264,7 @@ mod test {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validate_link_add_invocation_host_input() {
         let validate_create_link_invocation =
             ValidateCreateLinkInvocationFixturator::new(fixt::Unpredictable)
@@ -303,7 +303,7 @@ mod slow_tests {
     use holochain_wasm_test_utils::TestWasm;
     use holochain_zome_types::zome::ZomeName;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_validate_link_add_unimplemented() {
         let ribosome = WasmRibosomeFixturator::new(Zomes(vec![TestWasm::Foo]))
             .next()
@@ -319,7 +319,7 @@ mod slow_tests {
         assert_eq!(result, ValidateLinkResult::Valid,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_validate_implemented_valid() {
         let ribosome = WasmRibosomeFixturator::new(Zomes(vec![TestWasm::ValidateCreateLinkValid]))
             .next()
@@ -336,7 +336,7 @@ mod slow_tests {
         assert_eq!(result, ValidateLinkResult::Valid,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_validate_link_add_implemented_invalid() {
         let ribosome =
             WasmRibosomeFixturator::new(Zomes(vec![TestWasm::ValidateCreateLinkInvalid]))
@@ -360,7 +360,7 @@ mod slow_tests {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn pass_validate_link_add_test<'a>() {
         // test workspace boilerplate
         let test_env = holochain_state::test_utils::test_cell_env();
@@ -380,7 +380,7 @@ mod slow_tests {
             crate::call_test_ribosome!(host_access, TestWasm::ValidateLink, "add_valid_link", ());
 
         // the chain head should be the committed entry header
-        let chain_head = tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+        let chain_head = tokio_helper::block_on(async move {
             SourceChainResult::Ok(
                 workspace_lock
                     .read()
@@ -395,7 +395,7 @@ mod slow_tests {
         assert_eq!(chain_head, output,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn fail_validate_link_add_test<'a>() {
         // test workspace boilerplate
         let test_env = holochain_state::test_utils::test_cell_env();
@@ -416,7 +416,7 @@ mod slow_tests {
             crate::call_test_ribosome!(host_access, TestWasm::ValidateLink, "add_invalid_link", ());
 
         // the chain head should be the committed entry header
-        let chain_head = tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+        let chain_head = tokio_helper::block_on(async move {
             SourceChainResult::Ok(
                 workspace_lock
                     .read()

--- a/crates/holochain/src/core/ribosome/guest_callback/validation_package.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validation_package.rs
@@ -137,7 +137,7 @@ mod test {
     use holochain_zome_types::ExternInput;
     use rand::prelude::*;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validate_package_callback_result_fold() {
         let mut rng = fixt::rng();
 
@@ -177,7 +177,7 @@ mod test {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validation_package_invocation_allow_side_effects() {
         use holochain_types::dna::zome::Permission::*;
         let validation_package_host_access =
@@ -198,7 +198,7 @@ mod test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validation_package_invocation_zomes() {
         let validation_package_invocation =
             ValidationPackageInvocationFixturator::new(fixt::Unpredictable)
@@ -211,7 +211,7 @@ mod test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validation_package_invocation_fn_components() {
         let validation_package_invocation =
             ValidationPackageInvocationFixturator::new(fixt::Unpredictable)
@@ -230,7 +230,7 @@ mod test {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn validation_package_invocation_host_input() {
         let validation_package_invocation =
             ValidationPackageInvocationFixturator::new(fixt::Unpredictable)
@@ -262,7 +262,7 @@ mod slow_tests {
     use holochain_wasm_test_utils::TestWasm;
     use holochain_zome_types::validate::ValidationPackage;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_validation_package_unimplemented() {
         let host_access = ValidationPackageHostAccessFixturator::new(fixt::Unpredictable)
             .next()
@@ -282,7 +282,7 @@ mod slow_tests {
         assert_eq!(result, ValidationPackageResult::NotImplemented,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_validation_package_implemented_success() {
         let host_access = ValidationPackageHostAccessFixturator::new(fixt::Unpredictable)
             .next()
@@ -307,7 +307,7 @@ mod slow_tests {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_validation_package_implemented_fail() {
         let host_access = ValidationPackageHostAccessFixturator::new(fixt::Unpredictable)
             .next()

--- a/crates/holochain/src/core/ribosome/host_fn/agent_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/agent_info.rs
@@ -12,7 +12,7 @@ pub fn agent_info<'a>(
     call_context: Arc<CallContext>,
     _input: AgentInfoInput,
 ) -> RibosomeResult<AgentInfoOutput> {
-    let agent_pubkey = tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    let agent_pubkey = tokio_helper::block_on(async move {
         let lock = call_context.host_access.workspace().read().await;
         lock.source_chain.agent_pubkey()
     })?;
@@ -34,7 +34,7 @@ pub mod test {
     use holochain_zome_types::AgentInfoInput;
     use holochain_zome_types::AgentInfoOutput;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn invoke_import_agent_info_test() {
         let test_env = holochain_state::test_utils::test_cell_env();
         let env = test_env.env();

--- a/crates/holochain/src/core/ribosome/host_fn/call.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call.rs
@@ -34,7 +34,7 @@ pub fn call(
     };
 
     // Make the call using this workspace
-    let result: ZomeCallResponse = tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    let result: ZomeCallResponse = tokio_helper::block_on(async move {
         conductor_handle
             .call_zome(invocation, workspace)
             .await
@@ -65,7 +65,7 @@ pub mod wasm_test {
         test_utils::{conductor_setup::ConductorTestData, install_app, new_invocation},
     };
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn call_test() {
         observability::test_run().ok();
 
@@ -133,7 +133,7 @@ pub mod wasm_test {
     /// When calling the same cell we need to make sure
     /// the "as at" doesn't cause the original zome call to fail
     /// when they are both writing (moving the source chain forward)
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn call_the_same_cell() {
         observability::test_run().ok();
 
@@ -171,7 +171,7 @@ pub mod wasm_test {
 
     /// test calling a different zome
     /// in a different cell.
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn bridge_call() {
         observability::test_run().ok();
 

--- a/crates/holochain/src/core/ribosome/host_fn/call_remote.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call_remote.rs
@@ -14,7 +14,7 @@ pub fn call_remote(
     input: CallRemoteInput,
 ) -> RibosomeResult<CallRemoteOutput> {
     // it is the network's responsibility to handle timeouts and return an Err result in that case
-    let result: ZomeCallResponse = tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    let result: ZomeCallResponse = tokio_helper::block_on(async move {
         let mut network = call_context.host_access().network().clone();
         let call_remote = input.into_inner();
         network
@@ -51,7 +51,7 @@ pub mod wasm_test {
     pub use holochain_zome_types::capability::CapSecret;
     use holochain_zome_types::ExternInput;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     /// we can call a fn on a remote
     async fn call_remote_test() {
         // ////////////

--- a/crates/holochain/src/core/ribosome/host_fn/capability_grants.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/capability_grants.rs
@@ -35,7 +35,7 @@ pub mod wasm_test {
     use holochain_types::test_utils::fake_agent_pubkey_2;
     use holochain_wasm_test_utils::TestWasm;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_capability_secret_test<'a>() {
         holochain_types::observability::test_run().ok();
         // test workspace boilerplate
@@ -54,7 +54,7 @@ pub mod wasm_test {
             crate::call_test_ribosome!(host_access, TestWasm::Capability, "cap_secret", ());
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_transferable_cap_grant<'a>() {
         holochain_types::observability::test_run().ok();
         // test workspace boilerplate
@@ -93,7 +93,7 @@ pub mod wasm_test {
         assert_eq!(entry_secret, secret,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_authorized_call() {
         // /////////
         // START DNA

--- a/crates/holochain/src/core/ribosome/host_fn/create.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/create.rs
@@ -60,7 +60,7 @@ pub fn create<'a>(
     // note that validation is handled by the workflow
     // if the validation fails this commit will be rolled back by virtue of the lmdb transaction
     // being atomic
-    tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    tokio_helper::block_on(async move {
         let mut guard = call_context.host_access.workspace().write().await;
         let workspace: &mut CallZomeWorkspace = &mut guard;
         let source_chain = &mut workspace.source_chain;
@@ -149,7 +149,7 @@ pub mod wasm_test {
     use test_wasm_common::TestBytes;
     use test_wasm_common::TestInt;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     /// we cannot commit before genesis
     async fn create_pre_genesis_test() {
         // test workspace boilerplate
@@ -185,7 +185,7 @@ pub mod wasm_test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     /// we can get an entry hash out of the fn directly
     async fn create_entry_test<'a>() {
         // test workspace boilerplate
@@ -216,7 +216,7 @@ pub mod wasm_test {
         let output = create(Arc::new(ribosome), Arc::new(call_context), input).unwrap();
 
         // the chain head should be the committed entry header
-        let chain_head = tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+        let chain_head = tokio_helper::block_on(async move {
             SourceChainResult::Ok(
                 workspace_lock
                     .read()
@@ -231,7 +231,7 @@ pub mod wasm_test {
         assert_eq!(chain_head, output.into_inner(),);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_create_entry_test<'a>() {
         holochain_types::observability::test_run().ok();
         // test workspace boilerplate
@@ -252,7 +252,7 @@ pub mod wasm_test {
             crate::call_test_ribosome!(host_access, TestWasm::Create, "create_entry", ());
 
         // the chain head should be the committed entry header
-        let chain_head = tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+        let chain_head = tokio_helper::block_on(async move {
             SourceChainResult::Ok(
                 workspace_lock
                     .read()
@@ -277,7 +277,7 @@ pub mod wasm_test {
         assert_eq!(&vec![163, 102, 111, 111], sb.bytes(),)
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     #[ignore = "david.b (this test is flaky)"]
     // maackle: this consistently passes for me with n = 37
     //          but starts to randomly lock up at n = 38,
@@ -400,7 +400,7 @@ pub mod wasm_test {
         shutdown.await.unwrap();
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_serialize_bytes_hash() {
         holochain_types::observability::test_run().ok();
         #[derive(Default, SerializedBytes, Serialize, Deserialize)]

--- a/crates/holochain/src/core/ribosome/host_fn/create_link.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/create_link.rs
@@ -24,24 +24,23 @@ pub fn create_link<'a>(
     // Construct the link add
     let header_builder = builder::CreateLink::new(base_address, target_address, zome_id, tag);
 
-    let header_hash =
-        tokio_safe_block_on::tokio_safe_block_forever_on(tokio::task::spawn(async move {
-            let mut guard = call_context.host_access.workspace().write().await;
-            let workspace: &mut CallZomeWorkspace = &mut guard;
-            // push the header into the source chain
-            let header_hash = workspace.source_chain.put(header_builder, None).await?;
-            let element = workspace
-                .source_chain
-                .get_element(&header_hash)?
-                .expect("Element we just put in SourceChain must be gettable");
-            integrate_to_authored(
-                &element,
-                workspace.source_chain.elements(),
-                &mut workspace.meta_authored,
-            )
-            .map_err(Box::new)?;
-            SourceChainResult::Ok(header_hash)
-        }))??;
+    let header_hash = tokio_helper::block_on(tokio::task::spawn(async move {
+        let mut guard = call_context.host_access.workspace().write().await;
+        let workspace: &mut CallZomeWorkspace = &mut guard;
+        // push the header into the source chain
+        let header_hash = workspace.source_chain.put(header_builder, None).await?;
+        let element = workspace
+            .source_chain
+            .get_element(&header_hash)?
+            .expect("Element we just put in SourceChain must be gettable");
+        integrate_to_authored(
+            &element,
+            workspace.source_chain.elements(),
+            &mut workspace.meta_authored,
+        )
+        .map_err(Box::new)?;
+        SourceChainResult::Ok(header_hash)
+    }))??;
 
     // return the hash of the committed link
     // note that validation is handled by the workflow

--- a/crates/holochain/src/core/ribosome/host_fn/debug.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/debug.rs
@@ -40,7 +40,7 @@ pub mod wasm_test {
     use std::sync::Arc;
 
     /// we can get an entry hash out of the fn directly
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn debug_test() {
         let ribosome = WasmRibosomeFixturator::new(crate::fixt::curve::Zomes(vec![]))
             .next()
@@ -55,7 +55,7 @@ pub mod wasm_test {
         assert_eq!(DebugOutput::new(()), output);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_debug_test() {
         let test_env = holochain_state::test_utils::test_cell_env();
         let env = test_env.env();
@@ -81,7 +81,7 @@ pub mod wasm_test {
         assert_eq!(output, DebugOutput::new(()));
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn wasm_line_numbers_test() {
         let test_env = holochain_state::test_utils::test_cell_env();
         let env = test_env.env();

--- a/crates/holochain/src/core/ribosome/host_fn/delete.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/delete.rs
@@ -25,7 +25,7 @@ pub fn delete<'a>(
     let host_access = call_context.host_access();
 
     // handle timeouts at the source chain layer
-    tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    tokio_helper::block_on(async move {
         let mut guard = host_access.workspace().write().await;
         let workspace: &mut CallZomeWorkspace = &mut guard;
         let source_chain = &mut workspace.source_chain;
@@ -57,7 +57,7 @@ pub(crate) fn get_original_address<'a>(
     let network = call_context.host_access.network().clone();
     let workspace_lock = call_context.host_access.workspace();
 
-    tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    tokio_helper::block_on(async move {
         let mut workspace = workspace_lock.write().await;
         let mut cascade = workspace.cascade(network);
         // TODO: Think about what options to use here
@@ -97,7 +97,7 @@ pub mod wasm_test {
     use hdk3::prelude::*;
     use holochain_wasm_test_utils::TestWasm;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_delete_entry_test<'a>() {
         holochain_types::observability::test_run().ok();
 

--- a/crates/holochain/src/core/ribosome/host_fn/delete_link.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/delete_link.rs
@@ -31,21 +31,20 @@ pub fn delete_link<'a>(
     let call_context_2 = call_context.clone();
 
     // handle timeouts at the network layer
-    let maybe_add_link: Option<SignedHeaderHashed> =
-        tokio_safe_block_on::tokio_safe_block_forever_on(async move {
-            CascadeResult::Ok(
-                call_context_2
-                    .clone()
-                    .host_access
-                    .workspace()
-                    .write()
-                    .await
-                    .cascade(network)
-                    .dht_get(address.into(), GetOptions::default())
-                    .await?
-                    .map(|el| el.into_inner().0),
-            )
-        })?;
+    let maybe_add_link: Option<SignedHeaderHashed> = tokio_helper::block_on(async move {
+        CascadeResult::Ok(
+            call_context_2
+                .clone()
+                .host_access
+                .workspace()
+                .write()
+                .await
+                .cascade(network)
+                .dht_get(address.into(), GetOptions::default())
+                .await?
+                .map(|el| el.into_inner().0),
+        )
+    })?;
 
     let base_address = match maybe_add_link {
         Some(add_link_signed_header_hash) => {
@@ -69,7 +68,7 @@ pub fn delete_link<'a>(
     // handle timeouts at the source chain layer
 
     // add a DeleteLink to the source chain
-    tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    tokio_helper::block_on(async move {
         let mut guard = workspace_lock.write().await;
         let workspace: &mut CallZomeWorkspace = &mut guard;
         let source_chain = &mut workspace.source_chain;
@@ -103,7 +102,7 @@ pub mod slow_tests {
     use holochain_zome_types::link::Links;
     use holochain_zome_types::DeleteLinkInput;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_delete_link_add_remove() {
         let test_env = holochain_state::test_utils::test_cell_env();
         let env = test_env.env();

--- a/crates/holochain/src/core/ribosome/host_fn/get.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get.rs
@@ -16,7 +16,7 @@ pub fn get<'a>(
     let network = call_context.host_access.network().clone();
 
     // timeouts must be handled by the network
-    tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    tokio_helper::block_on(async move {
         let maybe_element = call_context
             .host_access
             .workspace()

--- a/crates/holochain/src/core/ribosome/host_fn/get_agent_activity.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_agent_activity.rs
@@ -28,7 +28,7 @@ pub fn get_agent_activity(
     let network = call_context.host_access.network().clone();
 
     // timeouts must be handled by the network
-    tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    tokio_helper::block_on(async move {
         let activity = call_context
             .host_access
             .workspace()

--- a/crates/holochain/src/core/ribosome/host_fn/get_details.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_details.rs
@@ -15,7 +15,7 @@ pub fn get_details<'a>(
     let network = call_context.host_access.network().clone();
 
     // timeouts must be handled by the network
-    tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    tokio_helper::block_on(async move {
         let maybe_details = call_context
             .host_access
             .workspace()
@@ -36,7 +36,7 @@ pub mod wasm_test {
     use hdk3::prelude::*;
     use holochain_wasm_test_utils::TestWasm;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_get_details_test<'a>() {
         holochain_types::observability::test_run().ok();
 

--- a/crates/holochain/src/core/ribosome/host_fn/get_link_details.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_link_details.rs
@@ -23,7 +23,7 @@ pub fn get_link_details<'a>(
     // Get the network from the context
     let network = call_context.host_access.network().clone();
 
-    tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    tokio_helper::block_on(async move {
         // Create the key
         let key = match tag.as_ref() {
             Some(tag) => LinkMetaKey::BaseZomeTag(&base_address, zome_id, tag),
@@ -57,7 +57,7 @@ pub mod slow_tests {
     use holochain_zome_types::Header;
     use test_wasm_common::*;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_entry_hash_path_children_details() {
         let test_env = holochain_state::test_utils::test_cell_env();
         let env = test_env.env();

--- a/crates/holochain/src/core/ribosome/host_fn/get_links.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_links.rs
@@ -22,7 +22,7 @@ pub fn get_links<'a>(
     // Get the network from the context
     let network = call_context.host_access.network().clone();
 
-    tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    tokio_helper::block_on(async move {
         // Create the key
         let key = match tag.as_ref() {
             Some(tag) => LinkMetaKey::BaseZomeTag(&base_address, zome_id, tag),
@@ -53,7 +53,7 @@ pub mod slow_tests {
     use holochain_wasm_test_utils::TestWasm;
     use test_wasm_common::*;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_entry_hash_path_children() {
         let test_env = holochain_state::test_utils::test_cell_env();
         let env = test_env.env();
@@ -128,7 +128,7 @@ pub mod slow_tests {
         assert_eq!(links[1].target, foo_bar,);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn hash_path_anchor_get_anchor() {
         let test_env = holochain_state::test_utils::test_cell_env();
         let env = test_env.env();

--- a/crates/holochain/src/core/ribosome/host_fn/hash_entry.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/hash_entry.rs
@@ -38,7 +38,7 @@ pub mod wasm_test {
     use std::sync::Arc;
     use test_wasm_common::TestString;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     /// we can get an entry hash out of the fn directly
     async fn hash_entry_test() {
         let ribosome = WasmRibosomeFixturator::new(crate::fixt::curve::Zomes(vec![]))
@@ -59,7 +59,7 @@ pub mod wasm_test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     /// we can get an entry hash out of the fn via. a wasm call
     async fn ribosome_hash_entry_test() {
         let test_env = holochain_state::test_utils::test_cell_env();
@@ -84,7 +84,7 @@ pub mod wasm_test {
         );
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     /// the hash path underlying anchors wraps entry_hash
     async fn ribosome_hash_path_pwd_test() {
         let test_env = holochain_state::test_utils::test_cell_env();

--- a/crates/holochain/src/core/ribosome/host_fn/query.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/query.rs
@@ -11,7 +11,7 @@ pub fn query(
     call_context: Arc<CallContext>,
     input: QueryInput,
 ) -> RibosomeResult<QueryOutput> {
-    tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    tokio_helper::block_on(async move {
         let elements: Vec<Element> = call_context
             .host_access
             .workspace()
@@ -55,7 +55,7 @@ pub mod slow_tests {
         (test_env, host_access)
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn query_smoke_test() {
         let (_test_env, host_access) = setup().await;
 

--- a/crates/holochain/src/core/ribosome/host_fn/random_bytes.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/random_bytes.rs
@@ -35,7 +35,7 @@ pub mod wasm_test {
     use std::convert::TryInto;
     use std::sync::Arc;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     /// we can get some random data out of the fn directly
     async fn random_bytes_test() {
         let ribosome = WasmRibosomeFixturator::new(crate::fixt::curve::Zomes(vec![]))
@@ -55,7 +55,7 @@ pub mod wasm_test {
         assert_ne!(&[0; LEN], output.into_inner().as_ref(),);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     /// we can get some random data out of the fn via. a wasm call
     async fn ribosome_random_bytes_test() {
         let test_env = holochain_state::test_utils::test_cell_env();

--- a/crates/holochain/src/core/ribosome/host_fn/sign.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/sign.rs
@@ -11,15 +11,13 @@ pub fn sign(
     call_context: Arc<CallContext>,
     input: SignInput,
 ) -> RibosomeResult<SignOutput> {
-    Ok(SignOutput::new(
-        tokio_safe_block_on::tokio_safe_block_forever_on(async move {
-            call_context
-                .host_access
-                .keystore()
-                .sign(input.into_inner())
-                .await
-        })?,
-    ))
+    Ok(SignOutput::new(tokio_helper::block_on(async move {
+        call_context
+            .host_access
+            .keystore()
+            .sign(input.into_inner())
+            .await
+    })?))
 }
 
 #[cfg(test)]
@@ -33,7 +31,7 @@ pub mod wasm_test {
     use hdk3::prelude::*;
     use holochain_wasm_test_utils::TestWasm;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_sign_test() {
         let test_env = holochain_state::test_utils::test_cell_env();
         let env = test_env.env();

--- a/crates/holochain/src/core/ribosome/host_fn/sys_time.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/sys_time.rs
@@ -26,7 +26,7 @@ pub mod wasm_test {
     use holochain_wasm_test_utils::TestWasm;
     use holochain_zome_types::SysTimeOutput;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn invoke_import_sys_time_test() {
         let test_env = holochain_state::test_utils::test_cell_env();
         let env = test_env.env();

--- a/crates/holochain/src/core/ribosome/host_fn/update.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/update.rs
@@ -62,7 +62,7 @@ pub fn update<'a>(
     // note that validation is handled by the workflow
     // if the validation fails this update will be rolled back by virtue of the lmdb transaction
     // being atomic
-    tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    tokio_helper::block_on(async move {
         let mut guard = workspace_lock.write().await;
         let workspace: &mut CallZomeWorkspace = &mut guard;
         let source_chain = &mut workspace.source_chain;

--- a/crates/holochain/src/core/ribosome/host_fn/verify_signature.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/verify_signature.rs
@@ -12,14 +12,14 @@ pub fn verify_signature(
     input: VerifySignatureInput,
 ) -> RibosomeResult<VerifySignatureOutput> {
     let input = input.into_inner();
-    Ok(VerifySignatureOutput::new(
-        tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    Ok(VerifySignatureOutput::new(tokio_helper::block_on(
+        async move {
             input
                 .key
                 .verify_signature_raw(input.as_ref(), input.as_data_ref().bytes())
                 .await
-        })?,
-    ))
+        },
+    )?))
 }
 
 #[cfg(test)]
@@ -33,7 +33,7 @@ pub mod wasm_test {
     use hdk3::prelude::*;
     use holochain_wasm_test_utils::TestWasm;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_verify_signature_test() {
         let test_env = holochain_state::test_utils::test_cell_env();
         let env = test_env.env();

--- a/crates/holochain/src/core/ribosome/host_fn/zome_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/zome_info.rs
@@ -31,7 +31,7 @@ pub mod test {
     use holochain_wasm_test_utils::TestWasm;
     use holochain_zome_types::ZomeInfoOutput;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn invoke_import_zome_info_test() {
         let test_env = holochain_state::test_utils::test_cell_env();
         let env = test_env.env();

--- a/crates/holochain/src/core/state/cascade/authored_test.rs
+++ b/crates/holochain/src/core/state/cascade/authored_test.rs
@@ -19,7 +19,7 @@ use crate::{
 /// - Bob doesn't have the entry in their authored store
 /// - Bob does have the entry in their integrated store
 /// - Bob commits the entry and it is now in their authored store
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn authored_test() {
     observability::test_run().ok();
     // Check if the correct number of ops are integrated

--- a/crates/holochain/src/core/state/cascade/test.rs
+++ b/crates/holochain/src/core/state/cascade/test.rs
@@ -45,16 +45,17 @@ fn setup_env(env: EnvironmentRead) -> DatabaseResult<Chains> {
 
     let jimbo_id = fake_agent_pubkey_1();
     let jessy_id = fake_agent_pubkey_2();
-    let (jimbo_entry, jessy_entry) = tokio_safe_block_on::tokio_safe_block_on(
-        async {
-            (
-                EntryHashed::from_content_sync(Entry::Agent(jimbo_id.clone().into())),
-                EntryHashed::from_content_sync(Entry::Agent(jessy_id.clone().into())),
-            )
-        },
-        std::time::Duration::from_secs(1),
-    )
-    .unwrap();
+    let (jimbo_entry, jessy_entry) = tokio_helper::new_runtime()
+        .block_on(
+            async {
+                (
+                    EntryHashed::from_content_sync(Entry::Agent(jimbo_id.clone().into())),
+                    EntryHashed::from_content_sync(Entry::Agent(jessy_id.clone().into())),
+                )
+            },
+            std::time::Duration::from_secs(1),
+        )
+        .unwrap();
 
     let jimbo_header = Header::Create(header::Create {
         author: jimbo_id.clone(),
@@ -92,7 +93,7 @@ fn setup_env(env: EnvironmentRead) -> DatabaseResult<Chains> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn live_local_return() -> SourceChainResult<()> {
     // setup some data thats in the scratch
     let test_env = test_cell_env();
@@ -137,7 +138,7 @@ async fn live_local_return() -> SourceChainResult<()> {
     Ok(())
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn dead_local_none() -> SourceChainResult<()> {
     observability::test_run().ok();
     // setup some data thats in the scratch
@@ -183,7 +184,7 @@ async fn dead_local_none() -> SourceChainResult<()> {
     Ok(())
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn notfound_goto_cache_live() -> SourceChainResult<()> {
     observability::test_run().ok();
     // setup some data thats in the scratch
@@ -231,7 +232,7 @@ async fn notfound_goto_cache_live() -> SourceChainResult<()> {
     Ok(())
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn notfound_cache() -> DatabaseResult<()> {
     observability::test_run().ok();
     // setup some data thats in the scratch
@@ -269,7 +270,7 @@ async fn notfound_cache() -> DatabaseResult<()> {
     Ok(())
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn links_local_return() -> SourceChainResult<()> {
     // setup some data thats in the scratch
     let test_env = test_cell_env();
@@ -343,7 +344,7 @@ async fn links_local_return() -> SourceChainResult<()> {
     Ok(())
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn links_cache_return() -> SourceChainResult<()> {
     observability::test_run().ok();
     // setup some data thats in the scratch
@@ -436,7 +437,7 @@ async fn links_cache_return() -> SourceChainResult<()> {
     Ok(())
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn links_notauth_cache() -> DatabaseResult<()> {
     observability::test_run().ok();
     // setup some data thats in the scratch

--- a/crates/holochain/src/core/state/chain_sequence.rs
+++ b/crates/holochain/src/core/state/chain_sequence.rs
@@ -205,7 +205,7 @@ pub mod tests {
     use holochain_types::observability;
     use matches::assert_matches;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn chain_sequence_scratch_awareness() -> DatabaseResult<()> {
         observability::test_run().ok();
         let test_env = test_cell_env();
@@ -268,7 +268,7 @@ pub mod tests {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn chain_sequence_functionality() -> SourceChainResult<()> {
         let test_env = test_cell_env();
         let arc = test_env.env();
@@ -385,7 +385,7 @@ pub mod tests {
 
     /// If we attempt to move the chain head, but it has already moved from
     /// under us, error
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn chain_sequence_head_moved_triggers_error() -> anyhow::Result<()> {
         let test_env = test_cell_env();
         let arc1 = test_env.env();
@@ -483,7 +483,7 @@ pub mod tests {
 
     /// If the chain head has moved from under us, but we are not moving the
     /// chain head ourselves, proceed as usual
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn chain_sequence_head_moved_triggers_no_error_if_clean() -> anyhow::Result<()> {
         let test_env = test_cell_env();
         let arc1 = test_env.env();

--- a/crates/holochain/src/core/state/dht_op_integration.rs
+++ b/crates/holochain/src/core/state/dht_op_integration.rs
@@ -167,7 +167,7 @@ mod tests {
     };
     use pretty_assertions::assert_eq;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_query() {
         let test_env = test_cell_env();
         let env = test_env.env();

--- a/crates/holochain/src/core/state/element_buf.rs
+++ b/crates/holochain/src/core/state/element_buf.rs
@@ -337,7 +337,7 @@ mod tests {
     use holochain_state::{prelude::*, test_utils::test_cell_env};
     use holochain_zome_types::entry_def::EntryVisibility;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn can_write_private_entry_when_enabled() -> anyhow::Result<()> {
         let keystore = spawn_test_keystore().await?;
         let test_env = test_cell_env();
@@ -384,7 +384,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn cannot_write_private_entry_when_disabled() -> anyhow::Result<()> {
         let keystore = spawn_test_keystore().await?;
         let test_env = test_cell_env();

--- a/crates/holochain/src/core/state/metadata/chain_test.rs
+++ b/crates/holochain/src/core/state/metadata/chain_test.rs
@@ -23,7 +23,7 @@ fn setup() -> (TestEnvironment, MetadataBuf, Create, Create, AgentPubKey) {
     (test_env, meta_buf, h1, h2, agent_pubkey)
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_different_seq_num_on_separate_queries() {
     let (_te, mut meta_buf, mut h1, mut h2, agent_pubkey) = setup();
     h1.header_seq = 1;
@@ -60,7 +60,7 @@ async fn check_different_seq_num_on_separate_queries() {
     );
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_equal_seq_num_on_same_query() {
     let (_te, mut meta_buf, mut h1, mut h2, agent_pubkey) = setup();
     h1.header_seq = 1;
@@ -104,7 +104,7 @@ async fn check_equal_seq_num_on_same_query() {
     );
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn chain_item_keys_ser() {
     let (_te, mut meta_buf, mut h, _, agent_pubkey) = setup();
     h.header_seq = 1;
@@ -134,7 +134,7 @@ async fn chain_item_keys_ser() {
     assert_eq!(headers.pop().unwrap().header_hash, expect_hash);
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_large_seq_queries() {
     let (_te, mut meta_buf, mut h1, mut h2, agent_pubkey) = setup();
     h1.header_seq = 256;

--- a/crates/holochain/src/core/state/metadata/links_test.rs
+++ b/crates/holochain/src/core/state/metadata/links_test.rs
@@ -360,7 +360,7 @@ impl TestData {
     }
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn can_add_and_delete_link() {
     let test_env = test_cell_env();
     let arc = test_env.env();
@@ -452,7 +452,7 @@ async fn can_add_and_delete_link() {
     td.only_on_half_tag(here!("db"), &meta_buf).await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn multiple_links() {
     let test_env = test_cell_env();
     let arc = test_env.env();
@@ -532,7 +532,7 @@ async fn multiple_links() {
         .not_on_full_key(here!("removed in db"), &meta_buf)
         .await;
 }
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn duplicate_links() {
     observability::test_run().ok();
     let test_env = test_cell_env();
@@ -606,7 +606,7 @@ async fn duplicate_links() {
     }
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn links_on_same_base() {
     observability::test_run().ok();
     let test_env = test_cell_env();
@@ -686,7 +686,7 @@ async fn links_on_same_base() {
     }
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn links_on_same_zome_id() {
     observability::test_run().ok();
     let test_env = test_cell_env();
@@ -781,7 +781,7 @@ async fn links_on_same_zome_id() {
     }
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn links_on_same_tag() {
     observability::test_run().ok();
     let test_env = test_cell_env();

--- a/crates/holochain/src/core/state/metadata/sys_meta.rs
+++ b/crates/holochain/src/core/state/metadata/sys_meta.rs
@@ -106,7 +106,7 @@ mod tests {
         (delete, header)
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     #[ignore = "can't be tested until redirects are implemented"]
     /// Test that a header can be redirected a single hop
     async fn test_redirect_header_one_hop() -> anyhow::Result<()> {
@@ -131,7 +131,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     #[ignore = "can't be tested until redirects are implemented"]
     /// Test that a header can be redirected three hops
     async fn test_redirect_header_three_hops() -> anyhow::Result<()> {
@@ -173,7 +173,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     #[ignore = "can't be tested until redirects are implemented"]
     /// Test that an entry can be redirected a single hop
     async fn test_redirect_entry_one_hop() -> anyhow::Result<()> {
@@ -206,7 +206,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     #[ignore = "can't be tested until redirects are implemented"]
     /// Test that an entry can be redirected three hops
     async fn test_redirect_entry_three_hops() -> anyhow::Result<()> {
@@ -254,7 +254,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     #[ignore = "can't be tested until redirects are implemented"]
     /// Test that a header can be redirected a single hop
     async fn test_redirect_header_and_entry() -> anyhow::Result<()> {
@@ -301,7 +301,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn add_entry_get_headers() {
         let test_env = test_cell_env();
         let arc = test_env.env();
@@ -348,7 +348,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn add_entry_get_updates() {
         let test_env = test_cell_env();
         let arc = test_env.env();
@@ -404,7 +404,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn add_entry_get_updates_header() {
         let test_env = test_cell_env();
         let arc = test_env.env();
@@ -460,7 +460,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn add_entry_get_deletes() {
         let test_env = test_cell_env();
         let arc = test_env.env();
@@ -542,7 +542,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_entry_dht_status() {
         let test_env = test_cell_env();
         let arc = test_env.env();
@@ -680,7 +680,7 @@ mod tests {
         assert_eq!(status, EntryDhtStatus::Dead);
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_entry_dht_status_one_less() {
         let test_env = test_cell_env();
         let arc = test_env.env();

--- a/crates/holochain/src/core/state/source_chain.rs
+++ b/crates/holochain/src/core/state/source_chain.rs
@@ -332,7 +332,7 @@ pub mod tests {
     use holochain_zome_types::capability::{CapAccess, ZomeCallCapGrant};
     use std::collections::HashSet;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_get_cap_grant() -> SourceChainResult<()> {
         let test_env = test_cell_env();
         let env = test_env.env();
@@ -490,7 +490,7 @@ pub mod tests {
     }
 
     // @todo bring all this back when we want to administer cap claims better
-    // #[tokio::test(threaded_scheduler)]
+    // #[tokio::test(flavor = "multi_thread")]
     // async fn test_get_cap_claim() -> SourceChainResult<()> {
     //     let test_env = test_cell_env();
     //     let env = test_env.env();

--- a/crates/holochain/src/core/state/source_chain/source_chain_buffer.rs
+++ b/crates/holochain/src/core/state/source_chain/source_chain_buffer.rs
@@ -334,25 +334,29 @@ pub mod tests {
         let agent_entry = Entry::Agent(agent_pubkey.clone().into());
 
         let (dna_header, agent_header) = tokio_safe_block_on::tokio_safe_block_on(
-            async {
-                let dna_header = Header::Dna(header::Dna {
-                    author: agent_pubkey.clone(),
-                    timestamp: Timestamp(0, 0).into(),
-                    hash: dna.dna_hash().clone(),
-                });
-                let dna_header = HeaderHashed::from_content_sync(dna_header);
+            {
+                let agent_pubkey = agent_pubkey.clone();
 
-                let agent_header = Header::Create(header::Create {
-                    author: agent_pubkey.clone(),
-                    timestamp: Timestamp(1, 0).into(),
-                    header_seq: 1,
-                    prev_header: dna_header.as_hash().to_owned().into(),
-                    entry_type: header::EntryType::AgentPubKey,
-                    entry_hash: agent_pubkey.clone().into(),
-                });
-                let agent_header = HeaderHashed::from_content_sync(agent_header);
+                async move {
+                    let dna_header = Header::Dna(header::Dna {
+                        author: agent_pubkey.clone(),
+                        timestamp: Timestamp(0, 0).into(),
+                        hash: dna.dna_hash().clone(),
+                    });
+                    let dna_header = HeaderHashed::from_content_sync(dna_header);
 
-                (dna_header, agent_header)
+                    let agent_header = Header::Create(header::Create {
+                        author: agent_pubkey.clone(),
+                        timestamp: Timestamp(1, 0).into(),
+                        header_seq: 1,
+                        prev_header: dna_header.as_hash().to_owned().into(),
+                        entry_type: header::EntryType::AgentPubKey,
+                        entry_hash: agent_pubkey.clone().into(),
+                    });
+                    let agent_header = HeaderHashed::from_content_sync(agent_header);
+
+                    (dna_header, agent_header)
+                }
             },
             std::time::Duration::from_secs(1),
         )
@@ -367,7 +371,7 @@ pub mod tests {
         )
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn source_chain_buffer_iter_back() -> SourceChainResult<()> {
         let test_env = test_cell_env();
         let arc = test_env.env();
@@ -434,7 +438,7 @@ pub mod tests {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn source_chain_buffer_dump_entries_json() -> SourceChainResult<()> {
         let test_env = test_cell_env();
         let arc = test_env.env();
@@ -474,7 +478,7 @@ pub mod tests {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_header_cas_roundtrip() {
         let test_env = test_cell_env();
         let arc = test_env.env();

--- a/crates/holochain/src/core/state/validation_receipts_db.rs
+++ b/crates/holochain/src/core/state/validation_receipts_db.rs
@@ -170,7 +170,7 @@ mod tests {
         receipt.sign(keystore).await.unwrap()
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_validation_receipts_db_populate_and_list() -> DatabaseResult<()> {
         holochain_types::observability::test_run().ok();
 

--- a/crates/holochain/src/core/state/wasm.rs
+++ b/crates/holochain/src/core/state/wasm.rs
@@ -40,7 +40,7 @@ mod tests {
     use holo_hash::HasHash;
     use holochain_types::dna::wasm::DnaWasm;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn wasm_store_round_trip() -> DatabaseResult<()> {
         use holochain_state::prelude::*;
         holochain_types::observability::test_run().ok();

--- a/crates/holochain/src/core/state/workspace.rs
+++ b/crates/holochain/src/core/state/workspace.rs
@@ -74,7 +74,7 @@ pub mod tests {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn workspace_sanity_check() -> anyhow::Result<()> {
         let test_env = test_cell_env();
         let arc = test_env.env();

--- a/crates/holochain/src/core/sys_validate/tests.rs
+++ b/crates/holochain/src/core/sys_validate/tests.rs
@@ -18,7 +18,7 @@ use holochain_zome_types::Header;
 use matches::assert_matches;
 use std::convert::TryFrom;
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn verify_header_signature_test() {
     let keystore = holochain_state::test_utils::test_keystore();
     let author = fake_agent_pubkey_1();
@@ -39,7 +39,7 @@ async fn verify_header_signature_test() {
     );
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_previous_header() {
     let mut header = fixt!(CreateLink);
     header.prev_header = fixt!(HeaderHash);
@@ -57,7 +57,7 @@ async fn check_previous_header() {
     assert_matches!(check_prev_header(&header.into()), Ok(()));
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_valid_if_dna_test() {
     let env: EnvironmentRead = test_cell_env().env.into();
     // Test data
@@ -90,7 +90,7 @@ async fn check_valid_if_dna_test() {
     );
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_previous_timestamp() {
     let mut header = fixt!(CreateLink);
     let mut prev_header = fixt!(CreateLink);
@@ -112,7 +112,7 @@ async fn check_previous_timestamp() {
     );
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_previous_seq() {
     let mut header = fixt!(CreateLink);
     let mut prev_header = fixt!(CreateLink);
@@ -156,7 +156,7 @@ async fn check_previous_seq() {
     );
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_entry_type_test() {
     let entry_fixt = EntryFixturator::new(Predictable);
     let et_fixt = EntryTypeFixturator::new(Predictable);
@@ -180,7 +180,7 @@ async fn check_entry_type_test() {
     }
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_entry_hash_test() {
     let mut ec = fixt!(Create);
     let entry = fixt!(Entry);
@@ -209,7 +209,7 @@ async fn check_entry_hash_test() {
     );
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_entry_size_test() {
     // let tiny = Entry::App(SerializedBytes::from(UnsafeBytes::from(vec![0; 1])));
     // let bytes = (0..16_000_000).map(|_| 0u8).into_iter().collect::<Vec<_>>();
@@ -222,7 +222,7 @@ async fn check_entry_size_test() {
     // );
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_update_reference_test() {
     let mut ec = fixt!(Create);
     let mut eu = fixt!(Update);
@@ -257,7 +257,7 @@ async fn check_update_reference_test() {
     );
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_link_tag_size_test() {
     let tiny = LinkTag(vec![0; 1]);
     let bytes = (0..401).map(|_| 0u8).into_iter().collect::<Vec<_>>();
@@ -270,7 +270,7 @@ async fn check_link_tag_size_test() {
     );
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_app_entry_type_test() {
     observability::test_run().ok();
     // Setup test data
@@ -341,7 +341,7 @@ async fn check_app_entry_type_test() {
     assert_matches!(check_app_entry_type(&aet, &conductor_api).await, Ok(_));
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn check_entry_not_private_test() {
     let mut ed = fixt!(EntryDef);
     ed.visibility = EntryVisibility::Public;

--- a/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
@@ -42,7 +42,7 @@ const GET_AGENT_ACTIVITY_TIMEOUT_MS: u64 = 1000;
 const NUM_ATTEMPTS: usize = 100;
 const DELAY_PER_ATTEMPT: std::time::Duration = std::time::Duration::from_millis(100);
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn get_validation_package_test() {
     observability::test_run().ok();
 
@@ -203,7 +203,7 @@ async fn get_validation_package_test() {
     ConductorTestData::shutdown_conductor(handle).await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn get_agent_activity_test() {
     observability::test_run().ok();
 
@@ -488,7 +488,7 @@ async fn get_agent_activity_test() {
     ConductorTestData::shutdown_conductor(handle).await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn get_custom_package_test() {
     observability::test_run().ok();
 
@@ -589,7 +589,7 @@ async fn get_custom_package_test() {
     ConductorTestData::shutdown_conductor(handle).await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn get_agent_activity_host_fn_test() {
     observability::test_run().ok();
 
@@ -719,7 +719,7 @@ async fn check_cascade(
     validation_package
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "Only shows a potential problem, doesn't prove something is correct"]
 /// This test shows a potential slow read issue.
 /// The exact same code running here in this test is 10x

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -29,7 +29,7 @@ use std::{
 };
 use tracing::*;
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn app_validation_workflow_test() {
     observability::test_run().ok();
 

--- a/crates/holochain/src/core/workflow/call_zome_workflow.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow.rs
@@ -424,7 +424,7 @@ pub mod tests {
     // - Check entry content matches entry schema
     //   Depending on the type of the commit, validate all possible validations for the
     //   DHT Op that would be produced by it
-    #[ignore = "TODO: B-01100 Make sure this test is in the right place when SysValidation 
+    #[ignore = "TODO: B-01100 Make sure this test is in the right place when SysValidation
     complete so we aren't duplicating the unit test inside sys val."]
     #[tokio::test]
     async fn calls_system_validation<'a>() {
@@ -506,7 +506,7 @@ pub mod tests {
     // 4.3. Write output results via SC gatekeeper (wrap in transaction): (MVI)
     // This is handled by the workflow runner however I should test that
     // we can create outputs
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn creates_outputs() {
         let test_env = test_cell_env();
         let env = test_env.env();

--- a/crates/holochain/src/core/workflow/call_zome_workflow/validation_test.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow/validation_test.rs
@@ -11,7 +11,7 @@ use holochain_types::{
 use holochain_wasm_test_utils::TestWasm;
 use std::convert::TryFrom;
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn direct_validation_test() {
     observability::test_run().ok();
 

--- a/crates/holochain/src/core/workflow/genesis_workflow.rs
+++ b/crates/holochain/src/core/workflow/genesis_workflow.rs
@@ -128,7 +128,7 @@ pub mod tests {
         source_chain.genesis(dna_hash, agent_pubkey, None).await
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn genesis_initializes_source_chain() -> Result<(), anyhow::Error> {
         observability::test_run()?;
         let test_env = test_cell_env();

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow/test.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow/test.rs
@@ -5,7 +5,7 @@ use holochain_state::test_utils::TestEnvironment;
 use holochain_types::{dht_op::DhtOp, fixt::*};
 use holochain_zome_types::{test_utils::fake_agent_pubkey_1, Header};
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn incoming_ops_to_limbo() {
     let TestEnvironment { env, tmpdir: _t } = holochain_state::test_utils::test_cell_env();
     let keystore = holochain_state::test_utils::test_keystore();

--- a/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
+++ b/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
@@ -84,7 +84,7 @@ pub mod tests {
     use holochain_zome_types::Header;
     use matches::assert_matches;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn adds_init_marker() {
         let test_env = test_cell_env();
         let env = test_env.env();

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
@@ -817,7 +817,7 @@ fn register_delete_link_missing_base(a: TestData) -> (Vec<Db>, Vec<Db>, &'static
 }
 
 // This runs the above tests
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_ops_state() {
     observability::test_run().ok();
     let test_env = test_cell_env();
@@ -1075,7 +1075,7 @@ async fn get_links(
 // This test is designed to run like the
 // register_add_link test except all the
 // pre-state is added through real host fn calls
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_metadata_from_wasm_api() {
     // test workspace boilerplate
     observability::test_run().ok();
@@ -1141,7 +1141,7 @@ async fn test_metadata_from_wasm_api() {
 }
 
 // This doesn't work without inline integration
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_wasm_api_without_integration_links() {
     // test workspace boilerplate
     observability::test_run().ok();
@@ -1193,7 +1193,7 @@ async fn test_wasm_api_without_integration_links() {
 }
 
 #[ignore = "Evaluate if this test adds any value or remove"]
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_wasm_api_without_integration_delete() {
     // test workspace boilerplate
     observability::test_run().ok();
@@ -1260,7 +1260,7 @@ async fn test_wasm_api_without_integration_delete() {
     );
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "write this test"]
 async fn test_integrate_single_register_replaced_by_for_header() {
     // For RegisterUpdatedContent with intended_for Header
@@ -1268,7 +1268,7 @@ async fn test_integrate_single_register_replaced_by_for_header() {
     todo!("write this test")
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "write this test"]
 async fn test_integrate_single_register_replaced_by_for_entry() {
     // For RegisterUpdatedContent with intended_for Entry
@@ -1276,7 +1276,7 @@ async fn test_integrate_single_register_replaced_by_for_entry() {
     todo!("write this test")
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "write this test"]
 async fn test_integrate_single_register_delete_on_headerd_by() {
     // For RegisterDeletedBy
@@ -1284,7 +1284,7 @@ async fn test_integrate_single_register_delete_on_headerd_by() {
     todo!("write this test")
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "write this test"]
 async fn test_integrate_single_register_add_link() {
     // For RegisterAddLink
@@ -1292,7 +1292,7 @@ async fn test_integrate_single_register_add_link() {
     todo!("write this test")
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "write this test"]
 async fn test_integrate_single_register_delete_link() {
     // For RegisterAddLink
@@ -1330,7 +1330,7 @@ mod slow_tests {
 
     /// The aim of this test is to show from a high level that committing
     /// data on one agent results in integrated data on another agent
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     #[ignore = "flaky"]
     async fn commit_entry_add_link() {
         //////////////

--- a/crates/holochain/src/core/workflow/produce_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/produce_dht_ops_workflow.rs
@@ -146,7 +146,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn elements_produce_ops() {
         observability::test_run().ok();
         let test_env = test_cell_env();

--- a/crates/holochain/src/core/workflow/produce_dht_ops_workflow/dht_op_light/tests.rs
+++ b/crates/holochain/src/core/workflow/produce_dht_ops_workflow/dht_op_light/tests.rs
@@ -217,7 +217,7 @@ impl ElementTest {
     }
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_all_ops() {
     observability::test_run().ok();
     let builder = ElementTest::new();
@@ -249,7 +249,7 @@ async fn test_all_ops() {
     }
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_dht_basis() {
     let test_env = test_cell_env();
     let env = test_env.env();

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -361,7 +361,7 @@ mod tests {
     #[test_case(100, 10)]
     #[test_case(100, 100)]
     fn test_sent_to_r_nodes(num_agents: u32, num_hash: u32) {
-        crate::conductor::tokio_runtime().block_on(async {
+        tokio_helper::new_runtime().block_on(async {
             observability::test_run().ok();
 
             // Create test env
@@ -377,7 +377,7 @@ mod tests {
             // Wait for expected # of responses, or timeout
             tokio::select! {
                 _ = rx_complete => {}
-                _ = tokio::time::delay_for(RECV_TIMEOUT) => {
+                _ = tokio::time::sleep(RECV_TIMEOUT) => {
                     panic!("Timed out while waiting for expected responses.")
                 }
             };
@@ -412,7 +412,7 @@ mod tests {
     #[test_case(100, 10)]
     #[test_case(100, 100)]
     fn test_no_republish(num_agents: u32, num_hash: u32) {
-        crate::conductor::tokio_runtime().block_on(async {
+        tokio_helper::new_runtime().block_on(async {
             observability::test_run().ok();
 
             // Create test env
@@ -458,7 +458,7 @@ mod tests {
             call_workflow(env.clone().into(), cell_network).await;
 
             // If we can wait a while without receiving any publish, we have succeeded
-            tokio::time::delay_for(Duration::from_millis(
+            tokio::time::sleep(Duration::from_millis(
                 std::cmp::min(50, std::cmp::max(2000, 10 * num_agents * num_hash)).into(),
             ))
             .await;
@@ -490,7 +490,7 @@ mod tests {
     #[test_case(10)]
     #[test_case(100)]
     fn test_private_entries(num_agents: u32) {
-        crate::conductor::tokio_runtime().block_on(
+        tokio_helper::new_runtime().block_on(
             async {
                 observability::test_run().ok();
 
@@ -756,7 +756,7 @@ mod tests {
                 // Wait for expected # of responses, or timeout
                 tokio::select! {
                     _ = rx_complete => {}
-                    _ = tokio::time::delay_for(RECV_TIMEOUT) => {
+                    _ = tokio::time::sleep(RECV_TIMEOUT) => {
                         panic!("Timed out while waiting for expected responses.")
                     }
                 };

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
@@ -22,7 +22,7 @@ use holochain_zome_types::fixt::*;
 /// failing a chain validation is just a log error so the only way to
 /// verify this works is to run this with logging and check it outputs
 /// use `RUST_LOG=[agent_activity]=warn`
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "TODO: complete when chain validation returns actual error"]
 async fn sys_validation_agent_activity_test() {
     observability::test_run().ok();

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -25,7 +25,7 @@ use std::{
 };
 use tracing::*;
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn sys_validation_workflow_test() {
     observability::test_run().ok();
 

--- a/crates/holochain/src/fixt.rs
+++ b/crates/holochain/src/fixt.rs
@@ -119,7 +119,7 @@ fixturator!(
         for _ in 0..number_of_wasms {
             let wasm = dna_wasm_fixturator.next().unwrap();
             wasms.insert(
-                tokio_safe_block_on::tokio_safe_block_forever_on(
+                tokio_helper::block_on(
                     async { WasmHash::with_data(&wasm).await },
                 )
                 .into(),
@@ -134,7 +134,7 @@ fixturator!(
         for _ in 0..3 {
             let wasm = dna_wasm_fixturator.next().unwrap();
             wasms.insert(
-                tokio_safe_block_on::tokio_safe_block_forever_on(
+                tokio_helper::block_on(
                     async { WasmHash::with_data(&wasm).await },
                 )
                 .into(),
@@ -252,14 +252,14 @@ fixturator!(
 fixturator!(
     KeystoreSender;
     curve Empty {
-        tokio_safe_block_on::tokio_safe_block_forever_on(async {
+        tokio_helper::block_on(async {
             // an empty keystore
             holochain_keystore::test_keystore::spawn_test_keystore().await.unwrap()
         })
     };
     curve Unpredictable {
         // TODO: Make this unpredictable
-        tokio_safe_block_on::tokio_safe_block_forever_on(async {
+        tokio_helper::block_on(async {
             holochain_keystore::test_keystore::spawn_test_keystore().await.unwrap()
         })
     };

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -417,7 +417,7 @@ pub async fn wait_for_integration(
         } else {
             tracing::debug!(?count);
         }
-        tokio::time::delay_for(delay).await;
+        tokio::time::sleep(delay).await;
     }
 }
 

--- a/crates/holochain/tests/ser_regression.rs
+++ b/crates/holochain/tests/ser_regression.rs
@@ -32,7 +32,7 @@ struct CreateMessageInput {
 #[derive(Debug, Serialize, Deserialize, SerializedBytes)]
 pub struct ChannelName(String);
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn ser_entry_hash_test() {
     observability::test_run().ok();
     let eh = fixt!(EntryHash);
@@ -44,7 +44,7 @@ async fn ser_entry_hash_test() {
     let _eh: EntryHash = sb.try_into().unwrap();
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 /// we can call a fn on a remote
 async fn ser_regression_test() {
     observability::test_run().ok();

--- a/crates/holochain/tests/speed_tests.rs
+++ b/crates/holochain/tests/speed_tests.rs
@@ -46,13 +46,13 @@ mod test_utils;
 
 const DEFAULT_NUM: usize = 2000;
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_prep() {
     warm_wasm_tests();
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_flame() {
     let _g = observability::flame_run().unwrap();
@@ -60,37 +60,37 @@ async fn speed_test_flame() {
     speed_test(None).await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_timed() {
     let _g = observability::test_run_timed().unwrap();
     speed_test(None).await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_timed_json() {
     let _g = observability::test_run_timed_json().unwrap();
     speed_test(None).await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_timed_flame() {
     let _g = observability::test_run_timed_flame(None).unwrap();
     speed_test(None).await;
-    tokio::time::delay_for(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_timed_ice() {
     let _g = observability::test_run_timed_ice(None).unwrap();
     speed_test(None).await;
-    tokio::time::delay_for(std::time::Duration::from_millis(100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_normal() {
     observability::test_run().unwrap();
@@ -99,7 +99,7 @@ async fn speed_test_normal() {
 
 /// Run this test to execute the speed test, but then keep the LMDB env files
 /// around in temp dirs for inspection by e.g. `mdb_stat`
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_persisted() {
     observability::test_run().unwrap();
@@ -123,7 +123,7 @@ async fn speed_test_persisted() {
 #[ignore = "speed tests are ignored by default; unignore to run"]
 fn speed_test_all(n: usize) {
     observability::test_run().unwrap();
-    holochain::conductor::tokio_runtime().block_on(speed_test(Some(n)));
+    tokio_helper::new_runtime().block_on(speed_test(Some(n)));
 }
 
 #[instrument]

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -26,5 +26,6 @@ mockall = "0.8.1"
 serde = { version = "1.0.104", features = [ "derive" ] }
 serde_bytes = "0.11"
 thiserror = "1.0.18"
-tokio = { version = "0.2", features = [ "full" ] }
-tokio_safe_block_on = "0.1.2"
+tokio = { version = "0.3.3", features = [ "full" ] }
+tokio_safe_block_on = { git = "https://github.com/neonphog/tokio_safe_block_on.git",rev = "074d40929ccab649b0dcc83a4ebdbdcb70b317fb" }
+tokio_helper = { path = "../tokio_helper" }

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -124,7 +124,7 @@ pub async fn stub_network() -> ghost_actor::GhostSender<HolochainP2p> {
 fixturator!(
     HolochainP2pCell;
     curve Empty {
-        tokio_safe_block_on::tokio_safe_block_forever_on(async {
+        tokio_helper::block_on(async {
             let holochain_p2p = crate::test::stub_network().await;
             holochain_p2p.to_cell(
                 DnaHashFixturator::new(Empty).next().unwrap(),
@@ -173,7 +173,7 @@ mod tests {
         )
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_call_remote_workflow() {
         let (dna, a1, a2, _) = test_setup();
 
@@ -227,7 +227,7 @@ mod tests {
         r_task.await.unwrap();
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_send_validation_receipt_workflow() {
         let (dna, a1, a2, _) = test_setup();
 
@@ -274,7 +274,7 @@ mod tests {
         r_task.await.unwrap();
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     // @TODO flaky test
     // ---- test::tests::test_publish_workflow stdout ----
     // thread 'test::tests::test_publish_workflow' panicked at 'assertion failed: `(left == right)`
@@ -329,7 +329,7 @@ mod tests {
         r_task.await.unwrap();
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_get_workflow() {
         let (dna, a1, a2, a3) = test_setup();
 
@@ -415,7 +415,7 @@ mod tests {
         r_task.await.unwrap();
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_get_links_workflow() {
         let (dna, a1, a2, _) = test_setup();
 

--- a/crates/keystore/Cargo.toml
+++ b/crates/keystore/Cargo.toml
@@ -15,10 +15,10 @@ ghost_actor = "0.2.1"
 holo_hash = { version = "0.0.1", path = "../holo_hash", features = ["full"] }
 holochain_serialized_bytes = "=0.0.45"
 holochain_zome_types = { path = "../zome_types" }
-lair_keystore_api = "=0.0.1-alpha.5"
-lair_keystore_client = "=0.0.1-alpha.5"
+lair_keystore_api = "=0.0.1-alpha.6"
+lair_keystore_client = "=0.0.1-alpha.6"
 serde = { version = "1.0.104", features = [ "derive" ] }
 serde_bytes = "0.11"
 thiserror = "1"
-tokio = { version = "0.2", features = [ "full" ] }
+tokio = { version = "0.3.3", features = [ "full" ] }
 tracing = "0.1"

--- a/crates/keystore/README.md
+++ b/crates/keystore/README.md
@@ -20,7 +20,7 @@ use holo_hash::AgentPubKey;
 use holochain_keystore::*;
 use holochain_serialized_bytes::prelude::*;
 
-#[tokio::main(threaded_scheduler)]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() {
     tokio::task::spawn(async move {
         let _ = holochain_crypto::crypto_init_sodium();

--- a/crates/keystore/src/lib.rs
+++ b/crates/keystore/src/lib.rs
@@ -11,7 +11,7 @@
 //! use holochain_keystore::*;
 //! use holochain_serialized_bytes::prelude::*;
 //!
-//! #[tokio::main(threaded_scheduler)]
+//! #[tokio::main(flavor = "multi_thread")]
 //! async fn main() {
 //!     tokio::task::spawn(async move {
 //!         let keystore = test_keystore::spawn_test_keystore().await.unwrap();

--- a/crates/keystore/src/test_keystore.rs
+++ b/crates/keystore/src/test_keystore.rs
@@ -77,7 +77,7 @@ pub async fn spawn_test_keystore() -> KeystoreApiResult<KeystoreSender> {
 mod tests {
     use super::*;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_test_keystore() {
         tokio::task::spawn(async move {
             let keystore = spawn_test_keystore().await.unwrap();

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -17,11 +17,12 @@ ghost_actor = "0.2.1"
 kitsune_p2p_types = { version = "0.0.1", path = "../types" }
 kitsune_p2p_proxy = { version = "0.0.1", path = "../proxy" }
 kitsune_p2p_transport_quic = { version = "0.0.1", path = "../transport_quic" }
-lair_keystore_api = "0.0.1-alpha.5"
+lair_keystore_api = "0.0.1-alpha.6"
 rand = "0.7"
 shrinkwraprs = "0.3.0"
 thiserror = "1.0.18"
-tokio = { version = "0.2", features = [ "full" ] }
+tokio = { version = "0.3.3", features = [ "full" ] }
+tokio-compat-02 = "0.1"
 url2 = "0.0.6"
 serde = { version = "1.0.104", features = [ "derive" ] }
 serde_bytes = "0.11"

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -7,6 +7,7 @@ use std::{
     collections::{hash_map::Entry, HashMap},
     sync::Arc,
 };
+use tokio_compat_02::FutureExt as _;
 
 pub mod bootstrap;
 mod gossip;
@@ -54,7 +55,11 @@ fn build_transport(
                     .set_bind_to(bind_to)
                     .set_override_host(override_host)
                     .set_override_port(override_port);
-                Ok(kitsune_p2p_transport_quic::spawn_transport_listener_quic(sub_conf).await?)
+                Ok(
+                    kitsune_p2p_transport_quic::spawn_transport_listener_quic(sub_conf)
+                        .compat()
+                        .await?,
+                )
             }
             TransportConfig::Proxy {
                 sub_transport,

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/gossip.rs
@@ -63,7 +63,7 @@ async fn gossip_loop(
     loop {
         gossip_data.take_action().await?;
 
-        tokio::time::delay_for(std::time::Duration::from_millis(10)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
     }
 }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -409,8 +409,7 @@ impl KitsuneP2pHandler for Space {
                 }
 
                 // the attempt failed - wait a bit to allow agents to connect
-                tokio::time::delay_for(std::time::Duration::from_millis(NET_CONNECT_INTERVAL_MS))
-                    .await;
+                tokio::time::sleep(std::time::Duration::from_millis(NET_CONNECT_INTERVAL_MS)).await;
             }
         }
         .boxed()
@@ -520,7 +519,7 @@ impl Space {
         let i_s_c = i_s.clone();
         tokio::task::spawn(async move {
             loop {
-                tokio::time::delay_for(std::time::Duration::from_secs(5 * 60)).await;
+                tokio::time::sleep(std::time::Duration::from_secs(5 * 60)).await;
                 if i_s_c.update_agent_info().await.is_err() {
                     break;
                 }
@@ -581,7 +580,7 @@ impl Space {
                     }
                 }
 
-                tokio::time::delay_for(std::time::Duration::from_millis(20)).await;
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
             }
 
             let mut out = Vec::new();
@@ -686,7 +685,7 @@ impl Space {
                 if (start.elapsed().as_millis() as u64) >= timeout_ms {
                     break;
                 }
-                tokio::time::delay_for(std::time::Duration::from_millis(check_interval)).await;
+                tokio::time::sleep(std::time::Duration::from_millis(check_interval)).await;
             }
             Ok(send_success_count.load(std::sync::atomic::Ordering::Relaxed))
         }

--- a/crates/kitsune_p2p/kitsune_p2p/src/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test.rs
@@ -4,7 +4,7 @@ mod tests {
     use ghost_actor::{dependencies::tracing, GhostControlSender};
     use std::sync::Arc;
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_peer_info_store() -> Result<(), KitsuneP2pError> {
         init_tracing();
 
@@ -33,7 +33,7 @@ mod tests {
         panic!("Failed to receive agent_info_signed");
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_transport_binding() -> Result<(), KitsuneP2pError> {
         init_tracing();
 
@@ -61,7 +61,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_request_workflow() -> Result<(), KitsuneP2pError> {
         init_tracing();
 
@@ -80,7 +80,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_broadcast_workflow() -> Result<(), KitsuneP2pError> {
         init_tracing();
 
@@ -125,7 +125,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_multi_request_workflow() -> Result<(), KitsuneP2pError> {
         init_tracing();
 
@@ -167,7 +167,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_single_agent_multi_request_workflow() -> Result<(), KitsuneP2pError> {
         init_tracing();
 
@@ -202,7 +202,7 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_gossip_workflow() -> Result<(), KitsuneP2pError> {
         init_tracing();
 
@@ -223,7 +223,7 @@ mod tests {
         //        we need to actually add_*_agent to do this
         //let op2 = harness.inject_gossip_data(a2, "agent-2-data".to_string()).await?;
 
-        tokio::time::delay_for(std::time::Duration::from_millis(200)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         let res = harness.dump_local_gossip_data(a1).await?;
         let (op_hash, data) = res.into_iter().next().unwrap();

--- a/crates/kitsune_p2p/proxy/Cargo.toml
+++ b/crates/kitsune_p2p/proxy/Cargo.toml
@@ -17,13 +17,14 @@ derive_more = "0.99.7"
 futures = "0.3"
 kitsune_p2p_types = { version = "0.0.1", path = "../types" }
 kitsune_p2p_transport_quic = { version = "0.0.1", path = "../transport_quic" }
-lair_keystore_api = "0.0.1-alpha.5"
+lair_keystore_api = "0.0.1-alpha.6"
 nanoid = "0.3"
 rmp-serde = "0.14"
 rustls = { version = "0.18", features = [ "dangerous_configuration" ] }
 serde = { version = "1", features = [ "derive" ] }
 serde_bytes = "0.11"
 structopt = "0.3"
-tokio = { version = "0.2", features = [ "full" ] }
+tokio = { version = "0.3.3", features = [ "full" ] }
+tokio-compat-02 = "0.1"
 tracing-subscriber = "0.2"
 webpki = "0.21.2"

--- a/crates/kitsune_p2p/proxy/src/bin/kitsune-p2p-proxy/main.rs
+++ b/crates/kitsune_p2p/proxy/src/bin/kitsune-p2p-proxy/main.rs
@@ -7,6 +7,7 @@ use kitsune_p2p_types::{
     transport::*,
 };
 use structopt::StructOpt;
+use tokio_compat_02::FutureExt as _;
 
 mod opt;
 use opt::*;
@@ -19,7 +20,7 @@ async fn main() {
             .finish(),
     );
 
-    if let Err(e) = inner().await {
+    if let Err(e) = inner().compat().await {
         eprintln!("{:?}", e);
     }
 }

--- a/crates/kitsune_p2p/proxy/src/inner_listen.rs
+++ b/crates/kitsune_p2p/proxy/src/inner_listen.rs
@@ -71,7 +71,7 @@ pub async fn spawn_kitsune_proxy_listener(
         // Set up a timer to refresh our proxy contract at keepalive interval
         let i_s_c = i_s.clone();
         tokio::task::spawn(async move {
-            tokio::time::delay_for(std::time::Duration::from_millis(PROXY_KEEPALIVE_MS)).await;
+            tokio::time::sleep(std::time::Duration::from_millis(PROXY_KEEPALIVE_MS)).await;
 
             if i_s_c.req_proxy(proxy_url.clone()).await.is_err() {
                 // either we failed because the actor is already shutdown

--- a/crates/kitsune_p2p/proxy/src/tls_tests.rs
+++ b/crates/kitsune_p2p/proxy/src/tls_tests.rs
@@ -10,7 +10,7 @@ fn init_tracing() {
     );
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn tls_server_and_client() {
     init_tracing();
     if let Err(e) = tls_server_and_client_inner().await {

--- a/crates/kitsune_p2p/proxy/tests/proxy_integration.rs
+++ b/crates/kitsune_p2p/proxy/tests/proxy_integration.rs
@@ -12,7 +12,7 @@ fn init_tracing() {
     );
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_proxy_integration() {
     if let Err(e) = test_inner().await {
         panic!("{:?}", e);

--- a/crates/kitsune_p2p/proxy/tests/srv_cli_dump_test.rs
+++ b/crates/kitsune_p2p/proxy/tests/srv_cli_dump_test.rs
@@ -39,7 +39,7 @@ fn run_cli(proxy: &str) -> (String, std::process::Child) {
     (out_str, cmd)
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn srv_cli_dump_test() {
     let (proxy, mut srv) = run_srv();
     let (dump, mut cli) = run_cli(&proxy);

--- a/crates/kitsune_p2p/transport_quic/Cargo.toml
+++ b/crates/kitsune_p2p/transport_quic/Cargo.toml
@@ -14,11 +14,12 @@ edition = "2018"
 futures = "0.3"
 if-addrs = "0.6"
 kitsune_p2p_types = { version = "0.0.1", path = "../types" }
-lair_keystore_api = "0.0.1-alpha.5"
+lair_keystore_api = "0.0.1-alpha.6"
 nanoid = "0.3"
 quinn = "0.6.1"
 rcgen = "0.8.5"
 rustls = { version = "0.17", features = [ "dangerous_configuration" ] }
 serde = { version = "1.0.104", features = [ "derive" ] }
 tokio = { version = "0.2", features = [ "full" ] }
+# tokio-compat-02 = "0.1.2"
 webpki = "0.21.2"

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -21,7 +21,7 @@ rmp-serde = "0.14"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = { version = "1", features = [ "preserve_order" ] }
 thiserror = "1.0.18"
-tokio = { version = "0.2", features = [ "full" ] }
+tokio = { version = "0.3.3", features = [ "full" ] }
 url2 = "0.0.6"
 
 [dev-dependencies]

--- a/crates/kitsune_p2p/types/src/transport_mem.rs
+++ b/crates/kitsune_p2p/types/src/transport_mem.rs
@@ -155,7 +155,7 @@ mod tests {
         });
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn it_can_mem_transport() -> TransportResult<()> {
         let (bind1, evt1) = spawn_bind_transport_mem().await?;
         test_receiver(evt1);

--- a/crates/kitsune_p2p/types/src/transport_pool.rs
+++ b/crates/kitsune_p2p/types/src/transport_pool.rs
@@ -213,7 +213,7 @@ mod tests {
         });
     }
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn it_can_pool_transport() -> TransportResult<()> {
         let _ = ghost_actor::dependencies::tracing::subscriber::set_global_default(
             tracing_subscriber::FmtSubscriber::builder()

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -34,8 +34,9 @@ serde_derive = "1.0.104"
 shrinkwraprs = "0.3.0"
 tempdir = "0.3.7"
 thiserror = "1.0.10"
-tokio = { version = "0.2.11", features = [ "macros", "rt-threaded", "rt-util", "sync" ] }
-tokio_safe_block_on = "0.1.2"
+tokio = { version = "0.3.3", features = [ "macros", "rt-multi-thread", "io-util", "sync" ] }
+tokio_safe_block_on = { git = "https://github.com/neonphog/tokio_safe_block_on.git",rev = "074d40929ccab649b0dcc83a4ebdbdcb70b317fb" }
+tokio_helper = { path = "../tokio_helper" }
 tracing = "0.1.18"
 tracing-futures = "0.2"
 

--- a/crates/state/src/buffer/cas/buf_async.rs
+++ b/crates/state/src/buffer/cas/buf_async.rs
@@ -100,7 +100,7 @@ where
     }
 
     fn deserialize_and_hash_blocking(hash: &[u8], content: C) -> HoloHashed<C> {
-        tokio_safe_block_on::tokio_safe_block_forever_on(Self::deserialize_and_hash(hash, content))
+        tokio_helper::block_on(Self::deserialize_and_hash(hash, content))
         // TODO: make this a stream?
     }
 

--- a/crates/state/src/buffer/kv/buf/iter_tests.rs
+++ b/crates/state/src/buffer/kv/buf/iter_tests.rs
@@ -15,7 +15,7 @@ use tracing::*;
 
 pub(super) type Store = KvBufUsed<DbString, V>;
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_iter_from_partial() {
     let test_env = test_cell_env();
     let arc = test_env.env();
@@ -236,7 +236,7 @@ fn re_do_test<R: Readable>(
 // but I couldn't easily figure out how to generate
 // expected values and integrate with our need to
 // test scratch and db
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_single_iter() {
     holochain_types::observability::test_run().ok();
     let mut rng = rand::thread_rng();
@@ -361,7 +361,7 @@ async fn kv_single_iter() {
     .unwrap();
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_single_iter_found_1() {
     holochain_types::observability::test_run().ok();
     let in_scratch = vec![
@@ -408,7 +408,7 @@ async fn kv_single_iter_found_1() {
     .await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 #[should_panic]
 async fn kv_single_iter_found_2() {
     holochain_types::observability::test_run().ok();
@@ -427,7 +427,7 @@ async fn kv_single_iter_found_2() {
     .await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_single_iter_found_3() {
     holochain_types::observability::test_run().ok();
     let in_scratch = vec![
@@ -459,7 +459,7 @@ async fn kv_single_iter_found_3() {
     .await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_single_iter_found_4() {
     holochain_types::observability::test_run().ok();
     let in_scratch = vec![TestData::Put((".".into(), V(0)))];
@@ -483,7 +483,7 @@ async fn kv_single_iter_found_4() {
     .await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn exhaust_both_ends() {
     let test_env = test_cell_env();
     let arc = test_env.env();

--- a/crates/state/src/buffer/kv/buf/tests.rs
+++ b/crates/state/src/buffer/kv/buf/tests.rs
@@ -46,7 +46,7 @@ fn test_buf(a: &BTreeMap<Vec<u8>, KvOp<V>>, b: impl Iterator<Item = (&'static st
     }
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_iterators() -> DatabaseResult<()> {
     let test_env = test_cell_env();
     let arc = test_env.env();
@@ -89,7 +89,7 @@ async fn kv_iterators() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_empty_iterators() -> DatabaseResult<()> {
     let test_env = test_cell_env();
     let arc = test_env.env();
@@ -112,7 +112,7 @@ async fn kv_empty_iterators() -> DatabaseResult<()> {
 }
 
 /// TODO break up into smaller tests
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_store_sanity_check() -> DatabaseResult<()> {
     let test_env = test_cell_env();
     let arc = test_env.env();
@@ -152,7 +152,7 @@ async fn kv_store_sanity_check() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_indicate_value_overwritten() -> DatabaseResult<()> {
     holochain_types::observability::test_run().ok();
     let test_env = test_cell_env();
@@ -170,7 +170,7 @@ async fn kv_indicate_value_overwritten() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_deleted_persisted() -> DatabaseResult<()> {
     use tracing::*;
     holochain_types::observability::test_run().ok();
@@ -213,7 +213,7 @@ async fn kv_deleted_persisted() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_deleted_buffer() -> DatabaseResult<()> {
     holochain_types::observability::test_run().ok();
     let test_env = test_cell_env();
@@ -252,7 +252,7 @@ async fn kv_deleted_buffer() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_get_buffer() -> DatabaseResult<()> {
     holochain_types::observability::test_run().ok();
     let test_env = test_cell_env();
@@ -273,7 +273,7 @@ async fn kv_get_buffer() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_get_persisted() -> DatabaseResult<()> {
     holochain_types::observability::test_run().ok();
     let test_env = test_cell_env();
@@ -301,7 +301,7 @@ async fn kv_get_persisted() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_get_del_buffer() -> DatabaseResult<()> {
     holochain_types::observability::test_run().ok();
     let test_env = test_cell_env();
@@ -323,7 +323,7 @@ async fn kv_get_del_buffer() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kv_get_del_persisted() -> DatabaseResult<()> {
     holochain_types::observability::test_run().ok();
     let test_env = test_cell_env();

--- a/crates/state/src/buffer/kv/test.rs
+++ b/crates/state/src/buffer/kv/test.rs
@@ -1,17 +1,17 @@
 use super::KvBufUsed;
 use crate::test_utils::DbString;
 use crate::{
+    buffer::{kv::generic::KvStoreT, BufferedStore},
     env::{ReadManager, WriteManager},
     error::{DatabaseError, DatabaseResult},
-    buffer::{kv::generic::KvStoreT, BufferedStore},
     test_utils::test_cell_env,
 };
 use rkv::StoreOptions;
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kvbuf_scratch_and_persistence() -> DatabaseResult<()> {
     let test_env = test_cell_env();
-let arc = test_env.env();
+    let arc = test_env.env();
     let env = arc.guard();
     let db1 = env.inner().open_single("kv1", StoreOptions::create())?;
     let db2 = env.inner().open_single("kv1", StoreOptions::create())?;
@@ -96,7 +96,7 @@ let arc = test_env.env();
 
 // fixturator!(V; from u32;);
 
-// #[tokio::test(threaded_scheduler)]
+// #[tokio::test(flavor = "multi_thread")]
 // async fn kv_iterators() -> DatabaseResult<()> {
 //     let test_env = test_cell_env();
 //     let arc = test_env.env();
@@ -132,7 +132,7 @@ let arc = test_env.env();
 //     })
 // }
 
-// #[tokio::test(threaded_scheduler)]
+// #[tokio::test(flavor = "multi_thread")]
 // async fn kv_empty_iterators() -> DatabaseResult<()> {
 //     let test_env = test_cell_env();
 //     let arc = test_env.env();

--- a/crates/state/src/buffer/kvv/buf/tests.rs
+++ b/crates/state/src/buffer/kvv/buf/tests.rs
@@ -45,7 +45,7 @@ fn collect_sorted<T: Ord, E, I: IntoIterator<Item = Result<T, E>>>(
     Ok(vec)
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kvvbuf_basics() {
     let test_env = test_cell_env();
     let arc = test_env.env();
@@ -150,7 +150,7 @@ async fn kvvbuf_basics() {
     .unwrap();
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn delete_all() {
     holochain_types::observability::test_run().ok();
     let test_env = test_cell_env();
@@ -260,7 +260,7 @@ async fn delete_all() {
 /// before and after our idempotent operation
 /// both in the actual persistence and in our scratch
 /// that duplicates are not returned on get
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn idempotent_inserts() {
     let test_env = test_cell_env();
     let arc = test_env.env();
@@ -327,7 +327,7 @@ async fn idempotent_inserts() {
     .unwrap();
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kvv_indicate_value_appends() -> DatabaseResult<()> {
     holochain_types::observability::test_run().ok();
     let test_env = test_cell_env();
@@ -348,7 +348,7 @@ async fn kvv_indicate_value_appends() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kvv_indicate_value_overwritten() -> DatabaseResult<()> {
     holochain_types::observability::test_run().ok();
     let test_env = test_cell_env();
@@ -370,7 +370,7 @@ async fn kvv_indicate_value_overwritten() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kvv_deleted_persisted() -> DatabaseResult<()> {
     holochain_types::observability::test_run().ok();
     let test_env = test_cell_env();
@@ -407,7 +407,7 @@ async fn kvv_deleted_persisted() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kvv_deleted_buffer() -> DatabaseResult<()> {
     use KvvOp::*;
     holochain_types::observability::test_run().ok();
@@ -459,7 +459,7 @@ async fn kvv_deleted_buffer() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kvv_get_buffer() -> DatabaseResult<()> {
     holochain_types::observability::test_run().ok();
     let test_env = test_cell_env();
@@ -480,7 +480,7 @@ async fn kvv_get_buffer() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kvv_get_persisted() -> DatabaseResult<()> {
     holochain_types::observability::test_run().ok();
     let test_env = test_cell_env();
@@ -507,7 +507,7 @@ async fn kvv_get_persisted() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kvv_get_del_buffer() -> DatabaseResult<()> {
     holochain_types::observability::test_run().ok();
     let test_env = test_cell_env();
@@ -528,7 +528,7 @@ async fn kvv_get_del_buffer() -> DatabaseResult<()> {
     })
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "multi_thread")]
 async fn kvv_get_del_persisted() -> DatabaseResult<()> {
     holochain_types::observability::test_run().ok();
     let test_env = test_cell_env();

--- a/crates/test_utils/wasm/Cargo.toml
+++ b/crates/test_utils/wasm/Cargo.toml
@@ -22,7 +22,8 @@ holochain_zome_types = { path = "../../zome_types" }
 rand = "0.7"
 strum = "0.18.0"
 strum_macros = "0.18.0"
-tokio_safe_block_on = "0.1.2"
+tokio_safe_block_on = { git = "https://github.com/neonphog/tokio_safe_block_on.git",rev = "074d40929ccab649b0dcc83a4ebdbdcb70b317fb" }
+tokio_helper = { path = "../../tokio_helper" }
 
 [build-dependencies]
 toml = "0.5"

--- a/crates/test_utils/wasm/src/lib.rs
+++ b/crates/test_utils/wasm/src/lib.rs
@@ -213,7 +213,7 @@ fn get_code(path: &'static str) -> Vec<u8> {
 
 impl From<TestWasm> for Zome {
     fn from(test_wasm: TestWasm) -> Self {
-        tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+        tokio_helper::block_on(async move {
             let dna_wasm: DnaWasm = test_wasm.into();
             let (_, wasm_hash) = holochain_types::dna::wasm::DnaWasmHashed::from_content(dna_wasm)
                 .await

--- a/crates/tokio_helper/Cargo.toml
+++ b/crates/tokio_helper/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "tokio_helper"
+version = "0.1.0"
+authors = ["Stefan Junker <mail@stefanjunker.de>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+once_cell = "1.4"
+tokio = { version = "0.3", features = [ "full" ]}
+num_cpus = "1.8"
+futures = "0.3"

--- a/crates/tokio_helper/src/lib.rs
+++ b/crates/tokio_helper/src/lib.rs
@@ -1,0 +1,76 @@
+use once_cell::sync::Lazy;
+use tokio::runtime::Runtime;
+
+pub static TOKIO: Lazy<Runtime> = Lazy::new(new_runtime);
+
+/// Instantiate a new runtime.
+pub fn new_runtime() -> Runtime {
+    // we want to use multiple threads
+    tokio::runtime::Builder::new_multi_thread()
+        // we use both IO and Time tokio utilities
+        .enable_all()
+        // we want to use thread count matching cpu count
+        // (sometimes tokio by default only uses half cpu core threads)
+        .worker_threads(num_cpus::get())
+        // give our threads a descriptive name (they'll be numbered too)
+        .thread_name("holochain-tokio-thread")
+        // build the runtime
+        .build()
+        // panic if we cannot (we cannot run without it)
+        .expect("can build tokio runtime")
+}
+
+fn block_on_given<F>(f: F, runtime: &Runtime) -> F::Output
+where
+    F: futures::future::Future,
+{
+    let _g = runtime.enter();
+    tokio::task::block_in_place(|| runtime.block_on(async { f.await }))
+}
+
+/// Run a blocking thread on `TOKIO`.
+pub fn block_on<F>(f: F) -> F::Output
+where
+    F: futures::future::Future,
+{
+    block_on_given(f, &TOKIO)
+}
+
+/// Run a blocking thread on a new runtime.
+pub fn block_on_new<F>(f: F) -> F::Output
+where
+    F: futures::future::Future,
+{
+    block_on_given(f, &new_runtime())
+}
+
+#[cfg(test)]
+mod test {
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn block_on_works() {
+        crate::block_on(async { println!("stdio can block") });
+        assert_eq!(1, super::block_on(async { 1 }));
+
+        let r = "1";
+        let test1 = super::block_on(async { r.to_string() });
+        assert_eq!("1", &test1);
+
+        // - wasm style use case -
+        // we are in a non-tokio context
+        let test2 = std::thread::spawn(|| {
+            let r = "2";
+            super::block_on(async { r.to_string() })
+        })
+        .join()
+        .unwrap();
+        assert_eq!("2", &test2);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn block_on_allows_spawning() {
+        let r = "works";
+        let test = super::block_on(tokio::task::spawn(async move { r.to_string() })).unwrap();
+        assert_eq!("works", &test);
+    }
+}

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -39,10 +39,11 @@ shrinkwraprs = "0.3.0"
 strum = "0.18.0"
 tempdir = "0.3.7"
 thiserror = "1.0.10"
-tokio = { version = "0.2", features = [ "blocking" ] }
-tokio_safe_block_on = "0.1.2"
+tokio = { version = "0.3.3", features = [ "full" ] }
+tokio_safe_block_on = { git = "https://github.com/neonphog/tokio_safe_block_on.git",rev = "074d40929ccab649b0dcc83a4ebdbdcb70b317fb" }
+tokio_helper = { path = "../tokio_helper" }
 tracing = "=0.1.18"
 
 [dev-dependencies]
 # rmp-serde = "0.14.3"
-tokio = { version = "0.2", features = [ "full" ] }
+tokio = { version = "0.3.3", features = [ "full" ] }

--- a/crates/types/src/element.rs
+++ b/crates/types/src/element.rs
@@ -376,7 +376,7 @@ mod tests {
     use ::fixt::prelude::*;
     use holo_hash::{HasHash, HoloHashed};
 
-    #[tokio::test(threaded_scheduler)]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_signed_header_roundtrip() {
         let signature = SignatureFixturator::new(Unpredictable).next().unwrap();
         let header = HeaderFixturator::new(Unpredictable).next().unwrap();

--- a/crates/types/src/test_utils.rs
+++ b/crates/types/src/test_utils.rs
@@ -45,7 +45,7 @@ pub fn fake_dna_zomes(uuid: &str, zomes: Vec<(ZomeName, DnaWasm)>) -> DnaFile {
         uuid: uuid.to_string(),
         zomes: Vec::new(),
     };
-    tokio_safe_block_on::tokio_safe_block_forever_on(async move {
+    tokio_helper::block_on(async move {
         let mut wasm_code = Vec::new();
         for (zome_name, wasm) in zomes {
             let wasm = crate::dna::wasm::DnaWasmHashed::from_content(wasm).await;

--- a/crates/websocket/Cargo.toml
+++ b/crates/websocket/Cargo.toml
@@ -15,11 +15,13 @@ nanoid = "0.3"
 net2 = "0.2"
 serde = { version = "1", features = [ "derive" ] }
 serde_bytes = "0.11"
-tokio = { version = "0.2", features = [ "full" ] }
-tokio-tungstenite = { version = "0.10.1", features = [ "tls" ] }
+tokio = { version = "0.3.3", features = [ "full" ] }
+# No tokio 0.3 compatible release yet: https://github.com/snapview/tokio-tungstenite/issues/130
+tokio-tungstenite = { git = "https://github.com/snapview/tokio-tungstenite.git", rev = "3c6d4280d77fdff3e25f68ad703d94e89f38dae2", features = [ "tls" ] }
+
 tracing = "0.1"
 tracing-futures = "0.2"
-tungstenite = "0.10"
+tungstenite = "0.11.1"
 url2 = "0.0.6"
 
 [dev-dependencies]

--- a/crates/websocket/examples/echo_client.rs
+++ b/crates/websocket/examples/echo_client.rs
@@ -11,7 +11,7 @@ try_from_serialized_bytes!(BroadcastMessage);
 struct ResponseMessage(pub String);
 try_from_serialized_bytes!(ResponseMessage);
 
-#[tokio::main(threaded_scheduler)]
+#[tokio::main(flavor = "multi_thread")]
 async fn main() {
     let (mut send_socket, mut recv_socket) = websocket_connect(
         url2!("ws://127.0.0.1:12345"),

--- a/crates/websocket/src/lib.rs
+++ b/crates/websocket/src/lib.rs
@@ -74,8 +74,7 @@
 //! # }
 //! #
 //! # fn main() {
-//! #     tokio::runtime::Builder::new()
-//! #         .threaded_scheduler()
+//! #     tokio::runtime::Builder::new_multi_thread()
 //! #         .enable_all()
 //! #         .build()
 //! #         .unwrap()

--- a/crates/websocket/src/task_dispatch_incoming.rs
+++ b/crates/websocket/src/task_dispatch_incoming.rs
@@ -108,7 +108,7 @@ async fn process_incoming_message(
                 WireMessage::Request { id, data } => {
                     let data: SerializedBytes = UnsafeBytes::from(data).into();
                     tracing::trace!(message = "received request", ?data,);
-                    let mut loc_send_sink = send_sink.clone();
+                    let loc_send_sink = send_sink.clone();
                     let respond: WebsocketRespond = Box::new(move |data| {
                         //let span = tracing::debug_span!("respond");
                         async move {
@@ -304,10 +304,10 @@ mod tests {
         let Prep {
             mut recv_pub,
             mut recv_sink,
-            mut send_dispatch,
+            send_dispatch,
         } = prep_test();
 
-        let (mut my_sink_send, mut my_sink_recv) = tokio::sync::mpsc::channel(1);
+        let (my_sink_send, mut my_sink_recv) = tokio::sync::mpsc::channel(1);
 
         tokio::task::spawn(async move {
             while let Some((msg, complete)) = recv_sink.next().await {

--- a/crates/websocket/src/task_socket_sink.rs
+++ b/crates/websocket/src/task_socket_sink.rs
@@ -65,7 +65,7 @@ mod tests {
 
         use tokio::stream::StreamExt;
 
-        let (mut send, mut recv) = prep_test();
+        let (send, mut recv) = prep_test();
         let (os, or) = tokio::sync::oneshot::channel();
         send.send((tungstenite::Message::Text("test1".to_string()), os))
             .await

--- a/crates/websocket/src/task_socket_stream.rs
+++ b/crates/websocket/src/task_socket_stream.rs
@@ -162,7 +162,7 @@ mod tests {
         let Prep {
             mut recv_sink,
             mut recv_dispatch,
-            mut send_stream,
+            send_stream,
         } = prep_test();
 
         send_stream

--- a/crates/websocket/src/websocket_listener.rs
+++ b/crates/websocket/src/websocket_listener.rs
@@ -81,9 +81,10 @@ async fn connect(
 ) -> Result<(WebsocketSender, WebsocketReceiver)> {
     match socket_result {
         Ok(socket) => {
-            socket.set_keepalive(Some(std::time::Duration::from_secs(
-                config.tcp_keepalive_s as u64,
-            )))?;
+            // TODO(steveeJ): investigate whether we need an alternative
+            // socket.set_keepalive(Some(std::time::Duration::from_secs(
+            //     config.tcp_keepalive_s as u64,
+            // )))?;
             tracing::debug!(
                 message = "accepted incoming raw socket",
                 remote_addr = %socket.peer_addr()?,

--- a/crates/websocket/src/websocket_receiver.rs
+++ b/crates/websocket/src/websocket_receiver.rs
@@ -107,9 +107,10 @@ pub async fn websocket_connect(
 ) -> Result<(WebsocketSender, WebsocketReceiver)> {
     let addr = url_to_addr(&url, config.scheme).await?;
     let socket = tokio::net::TcpStream::connect(addr).await?;
-    socket.set_keepalive(Some(std::time::Duration::from_secs(
-        config.tcp_keepalive_s as u64,
-    )))?;
+    // TODO(steveeJ): this is not available in tokio 0.3
+    // socket.set_keepalive(Some(std::time::Duration::from_secs(
+    //     config.tcp_keepalive_s as u64,
+    // )))?;
     let (socket, _) = tokio_tungstenite::client_async_with_config(
         url.as_str(),
         socket,

--- a/crates/websocket/src/websocket_sender.rs
+++ b/crates/websocket/src/websocket_sender.rs
@@ -30,7 +30,7 @@ impl WebsocketSender {
     /// Close the websocket
     #[must_use]
     pub fn close(&mut self, code: u16, reason: String) -> BoxFuture<'static, Result<()>> {
-        let mut send_sink = self.send_sink.clone();
+        let send_sink = self.send_sink.clone();
         async move {
             let (send, recv) = tokio::sync::oneshot::channel();
 
@@ -61,7 +61,7 @@ impl WebsocketSender {
             'static + std::error::Error + Send + Sync,
     {
         //let span = tracing::debug_span!("sender_signal");
-        let mut send_sink = self.send_sink.clone();
+        let send_sink = self.send_sink.clone();
         async move {
             let bytes: SerializedBytes = msg
                 .try_into()
@@ -99,8 +99,8 @@ impl WebsocketSender {
         <SB2 as std::convert::TryFrom<SerializedBytes>>::Error:
             'static + std::error::Error + Send + Sync,
     {
-        let mut send_sink = self.send_sink.clone();
-        let mut send_dispatch = self.send_dispatch.clone();
+        let send_sink = self.send_sink.clone();
+        let send_dispatch = self.send_dispatch.clone();
         async move {
             tracing::trace!(request_msg = ?msg);
             let bytes: SerializedBytes = msg


### PR DESCRIPTION
This update is as mechanical as possible, i.e. it's trying to purely
adapt to the changes introduced in tokio 0.3 without unrelated
refactors.

Dependencies that need to update to tokio 0.3 before we can cleanly move forward with this:
* [x] reqwest https://github.com/seanmonstar/reqwest/pull/1076 , https://github.com/seanmonstar/reqwest/issues/1060
* [x] quinn: https://github.com/quinn-rs/quinn/issues/872