### PR TITLE
[TK-05873] Kitsune gossip transports

### DIFF
--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -277,7 +277,7 @@ pub async fn install_app(
 
     let errors = conductor_handle.setup_cells().await.unwrap();
 
-    assert!(errors.is_empty());
+    assert!(errors.is_empty(), "{:?}", errors);
 }
 
 /// Payload for installing cells

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -1,7 +1,7 @@
 use crate::agent_store::AgentInfoSigned;
 
 use super::*;
-use ghost_actor::dependencies::{tracing, tracing_futures::Instrument};
+use ghost_actor::dependencies::{futures::TryStreamExt, tracing, tracing_futures::Instrument};
 use kitsune_p2p_types::codec::Codec;
 use std::{collections::HashSet, convert::TryFrom};
 
@@ -83,85 +83,151 @@ impl gossip::GossipEventHandler for Space {
         &mut self,
     ) -> gossip::GossipEventHandlerResult<Vec<Arc<KitsuneAgent>>> {
         // while full-sync this is just a clone of list_by_basis
-        let res = self.agents.keys().cloned().collect();
-        Ok(async move { Ok(res) }.boxed().into())
+        let all_agents = self
+            .agents
+            .keys()
+            .cloned()
+            .map(|agent| {
+                self.evt_sender
+                    .query_agent_info_signed(QueryAgentInfoSignedEvt {
+                        space: self.space.clone(),
+                        agent,
+                    })
+            })
+            .collect::<Vec<_>>();
+        Ok(async move {
+            let res = futures::stream::iter(all_agents)
+                .buffer_unordered(10)
+                .map_ok(|res| {
+                    res.into_iter()
+                        .map(|ai| Arc::new(ai.into_agent()))
+                        .collect::<Vec<_>>()
+                })
+                .try_collect::<Vec<_>>()
+                .await?
+                .into_iter()
+                .flatten()
+                .collect();
+            Ok(res)
+        }
+        .boxed()
+        .into())
     }
 
     fn handle_req_op_hashes(
         &mut self,
-        _from_agent: Arc<KitsuneAgent>,
-        to_agent: Arc<KitsuneAgent>,
-        dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
-        since_utc_epoch_s: i64,
-        until_utc_epoch_s: i64,
+        input: ReqOpHashesEvt,
     ) -> gossip::GossipEventHandlerResult<OpHashesAgentHashes> {
-        // while full-sync just redirecting to self...
-        // but eventually some of these will be outgoing remote requests
-        let fut = self
-            .evt_sender
-            .fetch_op_hashes_for_constraints(FetchOpHashesForConstraintsEvt {
-                space: self.space.clone(),
-                agent: to_agent.clone(),
+        if self.agents.contains_key(&input.to_agent) {
+            // while full-sync just redirecting to self...
+            // but eventually some of these will be outgoing remote requests
+            let fut = local_req_op_hashes(&self.evt_sender, self.space.clone(), input);
+            Ok(async move { fut.await }.boxed().into())
+        } else {
+            let ReqOpHashesEvt {
+                to_agent,
                 dht_arc,
                 since_utc_epoch_s,
                 until_utc_epoch_s,
-            });
-        let peer_fut = self
-            .evt_sender
-            .query_agent_info_signed(QueryAgentInfoSignedEvt {
-                space: self.space.clone(),
-                agent: to_agent,
-            });
-        Ok(async move {
-            let agent_infos = peer_fut.await?;
-            let agent_infos = agent_infos
-                .into_iter()
-                .map(|ai| {
-                    let ai = types::agent_store::AgentInfo::try_from(&ai)?;
-                    let time = ai.signed_at_ms();
-                    Ok((Arc::new(ai.into()), time))
-                })
-                .collect::<Result<Vec<_>, KitsuneP2pError>>()?;
-            Ok((fut.await?, agent_infos))
+                from_agent,
+            } = input;
+            let transport_tx = self.transport.clone();
+            let evt_sender = self.evt_sender.clone();
+            let space = self.space.clone();
+            Ok(async move {
+                // see if we have an entry for this agent in our agent_store
+                let info = match evt_sender
+                    .get_agent_info_signed(GetAgentInfoSignedEvt {
+                        space: space.clone(),
+                        agent: to_agent.clone(),
+                    })
+                    .await?
+                {
+                    None => return Err(KitsuneP2pError::RoutingAgentError(to_agent)),
+                    Some(i) => i,
+                };
+                let data = wire::Wire::fetch_op_hashes(
+                    space,
+                    from_agent,
+                    to_agent,
+                    dht_arc,
+                    since_utc_epoch_s,
+                    until_utc_epoch_s,
+                )
+                .encode_vec()?;
+                let info = types::agent_store::AgentInfo::try_from(&info)?;
+                let url = info.as_urls_ref().get(0).unwrap().clone();
+                let (_, mut write, read) = transport_tx.create_channel(url).await?;
+                write.write_and_close(data.to_vec()).await?;
+                let read = read.read_to_end().await;
+                let (_, read) = wire::Wire::decode_ref(&read)?;
+                match read {
+                    wire::Wire::Failure(wire::Failure { reason }) => Err(reason.into()),
+                    wire::Wire::FetchOpHashesResponse(wire::FetchOpHashesResponse {
+                        hashes,
+                        peer_hashes,
+                    }) => Ok((hashes, peer_hashes)),
+                    _ => unreachable!(),
+                }
+            }
+            .boxed()
+            .into())
         }
-        .boxed()
-        .into())
     }
 
     fn handle_req_op_data(
         &mut self,
-        _from_agent: Arc<KitsuneAgent>,
-        to_agent: Arc<KitsuneAgent>,
-        op_hashes: Vec<Arc<KitsuneOpHash>>,
-        peer_hashes: Vec<Arc<KitsuneAgent>>,
+        input: ReqOpDataEvt,
     ) -> gossip::GossipEventHandlerResult<OpDataAgentInfo> {
-        // while full-sync just redirecting to self...
-        // but eventually some of these will be outgoing remote requests
-        let fut = self.evt_sender.fetch_op_hash_data(FetchOpHashDataEvt {
-            space: self.space.clone(),
-            agent: to_agent.clone(),
-            op_hashes,
-        });
-        let peer_fut = self
-            .evt_sender
-            .query_agent_info_signed(QueryAgentInfoSignedEvt {
-                space: self.space.clone(),
-                agent: to_agent,
-            });
-        Ok(async move {
-            let agent_infos = peer_fut.await?;
-            let peer_hashes = peer_hashes
-                .into_iter()
-                .map(|a| (*a).clone())
-                .collect::<HashSet<_>>();
-            let agent_infos = agent_infos
-                .into_iter()
-                .filter(|ai| peer_hashes.contains(ai.as_agent_ref()))
-                .collect();
-            Ok((fut.await?, agent_infos))
+        if self.agents.contains_key(&input.to_agent) {
+            let fut = local_req_op_data(&self.evt_sender, self.space.clone(), input);
+            Ok(async move { fut.await }.boxed().into())
+        } else {
+            let ReqOpDataEvt {
+                from_agent,
+                to_agent,
+                op_hashes,
+                peer_hashes,
+            } = input;
+            let transport_tx = self.transport.clone();
+            let evt_sender = self.evt_sender.clone();
+            let space = self.space.clone();
+            Ok(async move {
+                // see if we have an entry for this agent in our agent_store
+                let info = match evt_sender
+                    .get_agent_info_signed(GetAgentInfoSignedEvt {
+                        space: space.clone(),
+                        agent: to_agent.clone(),
+                    })
+                    .await?
+                {
+                    None => return Err(KitsuneP2pError::RoutingAgentError(to_agent)),
+                    Some(i) => i,
+                };
+                let data =
+                    wire::Wire::fetch_op_data(space, from_agent, to_agent, op_hashes, peer_hashes)
+                        .encode_vec()?;
+                let info = types::agent_store::AgentInfo::try_from(&info)?;
+                let url = info.as_urls_ref().get(0).unwrap().clone();
+                let (_, mut write, read) = transport_tx.create_channel(url).await?;
+                write.write_and_close(data.to_vec()).await?;
+                let read = read.read_to_end().await;
+                let (_, read) = wire::Wire::decode_ref(&read)?;
+                match read {
+                    wire::Wire::Failure(wire::Failure { reason }) => Err(reason.into()),
+                    wire::Wire::FetchOpDataResponse(wire::FetchOpDataResponse {
+                        op_data,
+                        agent_infos,
+                    }) => Ok((
+                        op_data.into_iter().map(|(h, d)| (h, d.into())).collect(),
+                        agent_infos,
+                    )),
+                    _ => unreachable!(),
+                }
+            }
+            .boxed()
+            .into())
         }
-        .boxed()
-        .into())
     }
 
     fn handle_gossip_ops(
@@ -213,6 +279,79 @@ impl gossip::GossipEventHandler for Space {
         }
         .boxed()
         .into())
+    }
+}
+
+pub fn local_req_op_hashes(
+    evt_sender: &futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+    space: Arc<KitsuneSpace>,
+    input: ReqOpHashesEvt,
+) -> impl std::future::Future<Output = Result<OpHashesAgentHashes, KitsuneP2pError>> {
+    let ReqOpHashesEvt {
+        to_agent,
+        dht_arc,
+        since_utc_epoch_s,
+        until_utc_epoch_s,
+        ..
+    } = input;
+    let fut = evt_sender.fetch_op_hashes_for_constraints(FetchOpHashesForConstraintsEvt {
+        space: space.clone(),
+        agent: to_agent.clone(),
+        dht_arc,
+        since_utc_epoch_s,
+        until_utc_epoch_s,
+    });
+    let peer_fut = evt_sender.query_agent_info_signed(QueryAgentInfoSignedEvt {
+        space,
+        agent: to_agent,
+    });
+    async move {
+        let agent_infos = peer_fut.await?;
+        let agent_infos = agent_infos
+            .into_iter()
+            .map(|ai| {
+                let ai = types::agent_store::AgentInfo::try_from(&ai)?;
+                let time = ai.signed_at_ms();
+                Ok((Arc::new(ai.into()), time))
+            })
+            .collect::<Result<Vec<_>, KitsuneP2pError>>()?;
+        Ok((fut.await?, agent_infos))
+    }
+}
+
+pub fn local_req_op_data(
+    evt_sender: &futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+    space: Arc<KitsuneSpace>,
+    input: ReqOpDataEvt,
+) -> impl std::future::Future<Output = Result<OpDataAgentInfo, KitsuneP2pError>> {
+    let ReqOpDataEvt {
+        to_agent,
+        op_hashes,
+        peer_hashes,
+        ..
+    } = input;
+    // while full-sync just redirecting to self...
+    // but eventually some of these will be outgoing remote requests
+    let fut = evt_sender.fetch_op_hash_data(FetchOpHashDataEvt {
+        space: space.clone(),
+        agent: to_agent.clone(),
+        op_hashes,
+    });
+    let peer_fut = evt_sender.query_agent_info_signed(QueryAgentInfoSignedEvt {
+        space,
+        agent: to_agent,
+    });
+    async move {
+        let agent_infos = peer_fut.await?;
+        let peer_hashes = peer_hashes
+            .into_iter()
+            .map(|a| (*a).clone())
+            .collect::<HashSet<_>>();
+        let agent_infos = agent_infos
+            .into_iter()
+            .filter(|ai| peer_hashes.contains(ai.as_agent_ref()))
+            .collect();
+        Ok((fut.await?, agent_infos))
     }
 }
 
@@ -269,12 +408,8 @@ impl SpaceInternalHandler for Space {
                     None => return Err(KitsuneP2pError::RoutingAgentError(to_agent)),
                     Some(i) => i,
                 };
-                let url = info
-                    .as_agent_info_ref()
-                    .as_urls_ref()
-                    .get(0)
-                    .unwrap()
-                    .clone();
+                let info = types::agent_store::AgentInfo::try_from(&info)?;
+                let url = info.as_urls_ref().get(0).unwrap().clone();
                 let (_, mut write, read) = tx.create_channel(url).await?;
                 write.write_and_close(data.to_vec()).await?;
                 let read = read.read_to_end().await;
@@ -306,7 +441,7 @@ impl SpaceInternalHandler for Space {
             });
         Ok(async move {
             for peer in all_peers_fut.await? {
-                res.insert(Arc::new(peer.as_agent_info_ref().as_agent_ref().clone()));
+                res.insert(Arc::new(peer.as_agent_ref().clone()));
             }
             Ok(res)
         }

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_actor.rs
@@ -297,7 +297,7 @@ impl HarnessControlApiHandler for HarnessActor {
             let infos = futures::future::try_join_all(infos).await?;
             let infos = infos.into_iter().fold(HashMap::new(), |acc, x| {
                 x.into_iter().fold(acc, |mut acc, x| {
-                    acc.insert(Arc::new(x.as_agent_info_ref().as_agent_ref().clone()), x);
+                    acc.insert(Arc::new(x.as_agent_ref().clone()), x);
                     acc
                 })
             });

--- a/crates/kitsune_p2p/kitsune_p2p/src/types.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types.rs
@@ -210,6 +210,7 @@ impl std::fmt::Debug for KitsuneSignature {
 pub mod actor;
 pub mod agent_store;
 pub mod event;
+pub mod gossip;
 pub(crate) mod wire;
 
 pub use kitsune_p2p_types::dht_arc;

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/agent_store.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/agent_store.rs
@@ -49,6 +49,11 @@ impl AgentInfoSigned {
         self.as_ref()
     }
 
+    /// Thin wrapper around Into for KitsuneAgent.
+    pub fn into_agent(self) -> KitsuneAgent {
+        self.into()
+    }
+
     /// Thin wrapper around AsRef for AgentInfo
     pub fn as_agent_info_ref(&self) -> &[u8] {
         self.agent_info.as_ref()

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/gossip.rs
@@ -1,0 +1,42 @@
+//! # Gossip Event Types
+
+use kitsune_p2p_types::dht_arc::DhtArc;
+
+use crate::agent_store::AgentInfoSigned;
+
+use super::*;
+
+#[derive(Debug, derive_more::Constructor)]
+/// Request dht op hashes and
+/// agent store information from an agent.
+/// This is the lightweight hashes only call.
+pub struct ReqOpHashesEvt {
+    /// Agent Requesting the ops.
+    pub from_agent: Arc<KitsuneAgent>,
+    /// The agent you are requesting ops from.
+    pub to_agent: Arc<KitsuneAgent>,
+    /// The arc on the dht that you want ops from.
+    pub dht_arc: DhtArc,
+    /// Get ops from this time.
+    pub since_utc_epoch_s: i64,
+    /// Get ops till this time.
+    pub until_utc_epoch_s: i64,
+}
+
+#[derive(Debug, derive_more::Constructor)]
+/// Request dht ops from an agent.
+pub struct ReqOpDataEvt {
+    /// Agent Requesting the ops.
+    pub from_agent: Arc<KitsuneAgent>,
+    /// The agent you are requesting ops from.
+    pub to_agent: Arc<KitsuneAgent>,
+    /// The hashes of the ops you want.
+    pub op_hashes: Vec<Arc<KitsuneOpHash>>,
+    /// The hashes of the agent store information you want.
+    pub peer_hashes: Vec<Arc<KitsuneAgent>>,
+}
+
+/// Dht op and agent hashes that the agent has information on.
+pub type OpHashesAgentHashes = (Vec<Arc<KitsuneOpHash>>, Vec<(Arc<KitsuneAgent>, u64)>);
+/// The Dht op data and agent store information
+pub type OpDataAgentInfo = (Vec<(Arc<KitsuneOpHash>, Vec<u8>)>, Vec<AgentInfoSigned>);

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/wire.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/wire.rs
@@ -47,27 +47,35 @@ kitsune_p2p_types::write_codec_enum! {
             data.0: AgentInfoSigned,
         },
 
-        /// Fetch Agent Info Hashes with Constraints
-        AgentFetchHashes(0x31) {
-            dht_arc.0: DhtArc,
-            since_utc_epoch_s.1: i64,
-            until_utc_epoch_s.2: i64,
-            hashes.3: Vec<WireData>,
+        /// Fetch DhtOp and Agent Hashes with Constraints
+        FetchOpHashes(0x31) {
+            space.0: Arc<KitsuneSpace>,
+            from_agent.1: Arc<KitsuneAgent>,
+            to_agent.2: Arc<KitsuneAgent>,
+            dht_arc.3: DhtArc,
+            since_utc_epoch_s.4: i64,
+            until_utc_epoch_s.5: i64,
         },
 
-        /// List of hashes response to AgentFetchHashes
-        AgentFetchHashesResponse(0x32) {
-            hashes.0: Vec<WireData>,
+        /// List of hashes response to FetchOpHashes
+        FetchOpHashesResponse(0x32) {
+            hashes.0: Vec<Arc<KitsuneOpHash>>,
+            peer_hashes.1: Vec<(Arc<KitsuneAgent>, u64)>,
         },
 
-        /// Fetch Agent Info Data for Hash List
-        AgentFetchDataForHashList(0x33) {
-            hashes.0: Vec<WireData>,
+        /// Fetch DhtOp data and AgentInfo for hashes lists
+        FetchOpData(0x33) {
+            space.0: Arc<KitsuneSpace>,
+            from_agent.1: Arc<KitsuneAgent>,
+            to_agent.2: Arc<KitsuneAgent>,
+            op_hashes.3: Vec<Arc<KitsuneOpHash>>,
+            peer_hashes.4: Vec<Arc<KitsuneAgent>>,
         },
 
-        /// List of agent data response to AgentFetchDataForHashList
-        AgentFetchDataForHashListResponse(0x34) {
-            agent_info.0: Vec<(WireData, AgentInfoSigned)>,
+        /// Lists of data in response to FetchOpData
+        FetchOpDataResponse(0x34) {
+            op_data.0: Vec<(Arc<KitsuneOpHash>, WireData)>,
+            agent_infos.1: Vec<AgentInfoSigned>,
         },
     }
 }


### PR DESCRIPTION
Adds:
- `list_neighbour_agents` pulls agent info from agent stores
- `fetch_op_hashes` and `fetch_op_data` can be sent over transport layers