### PR TITLE
[TK-06119] add cert gen / use from file to kitsune proxy binary

### DIFF
--- a/crates/kitsune_p2p/proxy/src/bin/kitsune-p2p-proxy/opt.rs
+++ b/crates/kitsune_p2p/proxy/src/bin/kitsune-p2p-proxy/opt.rs
@@ -2,6 +2,15 @@
 #[derive(structopt::StructOpt, Debug)]
 #[structopt(name = "kitsune-p2p-proxy")]
 pub struct Opt {
+    /// Generate a new self-signed certificate file/priv key and exit.
+    /// Danger - this cert is written unencrypted to disk.
+    #[structopt(long)]
+    pub danger_gen_unenc_cert: Option<std::path::PathBuf>,
+
+    /// Use a dangerous unencryted tls cert/priv key for this proxy.
+    #[structopt(long)]
+    pub danger_use_unenc_cert: Option<std::path::PathBuf>,
+
     /// To which network interface / port should we bind?
     /// Default: "kitsune-quic://0.0.0.0:0".
     #[structopt(short = "b", long)]


### PR DESCRIPTION
### note new `--help` options
```
$ cargo run --bin kitsune-p2p-proxy -- --help
<..snip..>
        --danger-gen-unenc-cert <danger-gen-unenc-cert>
            Generate a new self-signed certificate file/priv key and exit. Danger - this cert is written unencrypted to
            disk
        --danger-use-unenc-cert <danger-use-unenc-cert>    Use a dangerous unencryted tls cert/priv key for this proxy
```

### generate a new cert file
```
$ cargo run --bin kitsune-p2p-proxy -- --danger-gen-unenc-cert my-kitsune-proxy.cert
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/kitsune-p2p-proxy --danger-gen-unenc-cert my-kitsune-proxy.cert`
Generated "my-kitsune-proxy.cert".
```

### run proxy with generated cert file
```
$ cargo run --bin kitsune-p2p-proxy -- --danger-use-unenc-cert my-kitsune-proxy.cert
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/kitsune-p2p-proxy --danger-use-unenc-cert my-kitsune-proxy.cert`
kitsune-proxy://sq3jLNjj8rRqXd4oM02S9qk8-SX7TWtJzMvEepGTevM/kitsune-quic/h/10.0.0.105/p/44238/--
```

### do it again, note the same cert digest
```
$ cargo run --bin kitsune-p2p-proxy -- --danger-use-unenc-cert my-kitsune-proxy.cert
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/kitsune-p2p-proxy --danger-use-unenc-cert my-kitsune-proxy.cert`
kitsune-proxy://sq3jLNjj8rRqXd4oM02S9qk8-SX7TWtJzMvEepGTevM/kitsune-quic/h/10.0.0.105/p/43150/--
```