### PR TITLE
Put host fns directly on CallData

### DIFF
--- a/crates/holochain/src/core/state/cascade/authored_test.rs
+++ b/crates/holochain/src/core/state/cascade/authored_test.rs
@@ -37,13 +37,10 @@ async fn authored_test() {
     let entry = Post("Hi there".into());
     let entry_hash = EntryHash::with_data_sync(&Entry::try_from(entry.clone()).unwrap());
     // 3
-    commit_entry(
-        &alice_call_data.env,
-        alice_call_data.call_data(TestWasm::Create),
-        entry.clone().try_into().unwrap(),
-        POST_ID,
-    )
-    .await;
+    alice_call_data
+        .call_data(TestWasm::Create)
+        .commit_entry(entry.clone().try_into().unwrap(), POST_ID)
+        .await;
 
     // Produce and publish these commits
     let mut triggers = handle
@@ -86,13 +83,10 @@ async fn authored_test() {
         .expect("Bob should have the entry in their integrated store because they received gossip");
 
     // Now bob commits the entry
-    commit_entry(
-        &bob_call_data.env,
-        bob_call_data.call_data(TestWasm::Create),
-        entry.clone().try_into().unwrap(),
-        POST_ID,
-    )
-    .await;
+    bob_call_data
+        .call_data(TestWasm::Create)
+        .commit_entry(entry.clone().try_into().unwrap(), POST_ID)
+        .await;
 
     // Produce and publish these commits
     let mut triggers = handle

--- a/crates/holochain/src/core/state/cascade/authored_test.rs
+++ b/crates/holochain/src/core/state/cascade/authored_test.rs
@@ -38,7 +38,7 @@ async fn authored_test() {
     let entry_hash = EntryHash::with_data_sync(&Entry::try_from(entry.clone()).unwrap());
     // 3
     alice_call_data
-        .call_data(TestWasm::Create)
+        .get_api(TestWasm::Create)
         .commit_entry(entry.clone().try_into().unwrap(), POST_ID)
         .await;
 
@@ -84,7 +84,7 @@ async fn authored_test() {
 
     // Now bob commits the entry
     bob_call_data
-        .call_data(TestWasm::Create)
+        .get_api(TestWasm::Create)
         .commit_entry(entry.clone().try_into().unwrap(), POST_ID)
         .await;
 

--- a/crates/holochain/src/core/state/cascade/network_tests.rs
+++ b/crates/holochain/src/core/state/cascade/network_tests.rs
@@ -230,31 +230,23 @@ async fn get_from_another_agent() {
     let entry = Post("Bananas are good for you".into());
     let entry_hash = EntryHash::with_data_sync(&Entry::try_from(entry.clone()).unwrap());
     let header_hash = {
-        let (bob_env, call_data) = CallData::create(&bob_cell_id, &handle, &dna_file).await;
-        let header_hash = commit_entry(
-            &bob_env,
-            call_data.clone(),
-            entry.clone().try_into().unwrap(),
-            POST_ID,
-        )
-        .await;
+        let call_data = CallData::create(&bob_cell_id, &handle, &dna_file).await;
+        let header_hash = call_data
+            .commit_entry(entry.clone().try_into().unwrap(), POST_ID)
+            .await;
 
         // Bob is not an authority yet
         // Make Bob an "authority"
-        fake_authority(&bob_env, header_hash.clone().into(), call_data.clone()).await;
+        fake_authority(header_hash.clone().into(), &call_data).await;
         header_hash
     };
 
     // Alice get element from bob
     let element = {
-        let (alice_env, call_data) = CallData::create(&alice_cell_id, &handle, &dna_file).await;
-        get(
-            &alice_env,
-            call_data,
-            entry_hash.clone().into(),
-            options.clone(),
-        )
-        .await
+        let call_data = CallData::create(&alice_cell_id, &handle, &dna_file).await;
+        call_data
+            .get(entry_hash.clone().into(), options.clone())
+            .await
     };
 
     let (signed_header, ret_entry) = element.unwrap().into_inner();
@@ -270,42 +262,33 @@ async fn get_from_another_agent() {
 
     let new_entry = Post("Bananas are bendy".into());
     let (remove_hash, update_hash) = {
-        let (bob_env, call_data) = CallData::create(&bob_cell_id, &handle, &dna_file).await;
-        let remove_hash = delete_entry(&bob_env, call_data.clone(), header_hash.clone()).await;
+        let call_data = CallData::create(&bob_cell_id, &handle, &dna_file).await;
+        let remove_hash = call_data.delete_entry(header_hash.clone()).await;
 
-        fake_authority(&bob_env, remove_hash.clone().into(), call_data.clone()).await;
-        let update_hash = update_entry(
-            &bob_env,
-            call_data.clone(),
-            new_entry.clone().try_into().unwrap(),
-            POST_ID,
-            header_hash.clone(),
-        )
-        .await;
-        fake_authority(&bob_env, update_hash.clone().into(), call_data.clone()).await;
+        fake_authority(remove_hash.clone().into(), &call_data).await;
+        let update_hash = call_data
+            .update_entry(
+                new_entry.clone().try_into().unwrap(),
+                POST_ID,
+                header_hash.clone(),
+            )
+            .await;
+        fake_authority(update_hash.clone().into(), &call_data).await;
         (remove_hash, update_hash)
     };
 
     // Alice get element from bob
     let (entry_details, header_details) = {
-        let (alice_env, call_data) = CallData::create(&alice_cell_id, &handle, &dna_file).await;
+        let call_data = CallData::create(&alice_cell_id, &handle, &dna_file).await;
         debug!(the_entry_hash = ?entry_hash);
-        let entry_details = get_details(
-            &alice_env,
-            call_data.clone(),
-            entry_hash.into(),
-            options.clone(),
-        )
-        .await
-        .unwrap();
-        let header_details = get_details(
-            &alice_env,
-            call_data.clone(),
-            header_hash.clone().into(),
-            options.clone(),
-        )
-        .await
-        .unwrap();
+        let entry_details = call_data
+            .get_details(entry_hash.into(), options.clone())
+            .await
+            .unwrap();
+        let header_details = call_data
+            .get_details(header_hash.clone().into(), options.clone())
+            .await
+            .unwrap();
         (entry_details, header_details)
     };
 
@@ -394,58 +377,39 @@ async fn get_links_from_another_agent() {
     let target_entry_hash = EntryHash::with_data_sync(&Entry::try_from(target.clone()).unwrap());
     let link_tag = fixt!(LinkTag);
     let link_add_hash = {
-        let (bob_env, call_data) = CallData::create(&bob_cell_id, &handle, &dna_file).await;
-        let base_header_hash = commit_entry(
-            &bob_env,
-            call_data.clone(),
-            base.clone().try_into().unwrap(),
-            POST_ID,
-        )
-        .await;
+        let call_data = CallData::create(&bob_cell_id, &handle, &dna_file).await;
+        let base_header_hash = call_data
+            .commit_entry(base.clone().try_into().unwrap(), POST_ID)
+            .await;
 
-        let target_header_hash = commit_entry(
-            &bob_env,
-            call_data.clone(),
-            target.clone().try_into().unwrap(),
-            POST_ID,
-        )
-        .await;
+        let target_header_hash = call_data
+            .commit_entry(target.clone().try_into().unwrap(), POST_ID)
+            .await;
 
-        fake_authority(
-            &bob_env,
-            target_header_hash.clone().into(),
-            call_data.clone(),
-        )
-        .await;
-        fake_authority(&bob_env, base_header_hash.clone().into(), call_data.clone()).await;
+        fake_authority(target_header_hash.clone().into(), &call_data).await;
+        fake_authority(base_header_hash.clone().into(), &call_data).await;
 
         // Link the entries
-        let link_add_hash = create_link(
-            &bob_env,
-            call_data.clone(),
-            base_entry_hash.clone(),
-            target_entry_hash.clone(),
-            link_tag.clone(),
-        )
-        .await;
+        let link_add_hash = call_data
+            .create_link(
+                base_entry_hash.clone(),
+                target_entry_hash.clone(),
+                link_tag.clone(),
+            )
+            .await;
 
-        fake_authority(&bob_env, link_add_hash.clone().into(), call_data.clone()).await;
+        fake_authority(link_add_hash.clone().into(), &call_data).await;
 
         link_add_hash
     };
 
     // Alice get links from bob
     let links = {
-        let (alice_env, call_data) = CallData::create(&alice_cell_id, &handle, &dna_file).await;
+        let call_data = CallData::create(&alice_cell_id, &handle, &dna_file).await;
 
-        get_links(
-            &alice_env,
-            call_data.clone(),
-            base_entry_hash.clone(),
-            None,
-            link_options.clone(),
-        )
-        .await
+        call_data
+            .get_links(base_entry_hash.clone(), None, link_options.clone())
+            .await
     };
 
     assert_eq!(links.len(), 1);
@@ -460,26 +424,24 @@ async fn get_links_from_another_agent() {
 
     // Remove the link
     {
-        let (bob_env, call_data) = CallData::create(&bob_cell_id, &handle, &dna_file).await;
+        let call_data = CallData::create(&bob_cell_id, &handle, &dna_file).await;
 
         // Link the entries
-        let link_remove_hash =
-            delete_link(&bob_env, call_data.clone(), link_add_hash.clone()).await;
+        let link_remove_hash = call_data.delete_link(link_add_hash.clone()).await;
 
-        fake_authority(&bob_env, link_remove_hash.clone().into(), call_data.clone()).await;
+        fake_authority(link_remove_hash.clone().into(), &call_data).await;
     }
 
     let links = {
-        let (alice_env, call_data) = CallData::create(&alice_cell_id, &handle, &dna_file).await;
+        let call_data = CallData::create(&alice_cell_id, &handle, &dna_file).await;
 
-        get_link_details(
-            &alice_env,
-            call_data.clone(),
-            base_entry_hash.clone(),
-            link_tag.clone(),
-            link_options.clone(),
-        )
-        .await
+        call_data
+            .get_link_details(
+                base_entry_hash.clone(),
+                link_tag.clone(),
+                link_options.clone(),
+            )
+            .await
     };
 
     assert_eq!(links.len(), 1);
@@ -642,19 +604,15 @@ async fn generate_fixt_store() -> (
     (store, meta_store)
 }
 
-async fn fake_authority<'env>(env: &EnvironmentWrite, hash: AnyDhtHash, call_data: CallData) {
+async fn fake_authority(hash: AnyDhtHash, call_data: &CallData) {
     // Check bob can get the entry
-    let element = get(
-        &env.clone().into(),
-        call_data,
-        hash.clone().into(),
-        GetOptions::default(),
-    )
-    .await
-    .unwrap();
+    let element = call_data
+        .get(hash.clone().into(), GetOptions::default())
+        .await
+        .unwrap();
 
-    let mut element_vault = ElementBuf::vault(env.clone().into(), false).unwrap();
-    let mut meta_vault = MetadataBuf::vault(env.clone().into()).unwrap();
+    let mut element_vault = ElementBuf::vault(call_data.env.clone().into(), false).unwrap();
+    let mut meta_vault = MetadataBuf::vault(call_data.env.clone().into()).unwrap();
 
     // Write to the meta vault to fake being an authority
     let (shh, e) = element.clone().into_inner();
@@ -665,7 +623,9 @@ async fn fake_authority<'env>(env: &EnvironmentWrite, hash: AnyDhtHash, call_dat
         .await
         .unwrap();
 
-    env.guard()
+    call_data
+        .env
+        .guard()
         .with_commit(|writer| {
             element_vault.flush_to_txn(writer)?;
             meta_vault.flush_to_txn(writer)

--- a/crates/holochain/src/core/state/cascade/network_tests.rs
+++ b/crates/holochain/src/core/state/cascade/network_tests.rs
@@ -230,7 +230,7 @@ async fn get_from_another_agent() {
     let entry = Post("Bananas are good for you".into());
     let entry_hash = EntryHash::with_data_sync(&Entry::try_from(entry.clone()).unwrap());
     let header_hash = {
-        let call_data = CallData::create(&bob_cell_id, &handle, &dna_file).await;
+        let call_data = HostFnApi::create(&bob_cell_id, &handle, &dna_file).await;
         let header_hash = call_data
             .commit_entry(entry.clone().try_into().unwrap(), POST_ID)
             .await;
@@ -243,7 +243,7 @@ async fn get_from_another_agent() {
 
     // Alice get element from bob
     let element = {
-        let call_data = CallData::create(&alice_cell_id, &handle, &dna_file).await;
+        let call_data = HostFnApi::create(&alice_cell_id, &handle, &dna_file).await;
         call_data
             .get(entry_hash.clone().into(), options.clone())
             .await
@@ -262,7 +262,7 @@ async fn get_from_another_agent() {
 
     let new_entry = Post("Bananas are bendy".into());
     let (remove_hash, update_hash) = {
-        let call_data = CallData::create(&bob_cell_id, &handle, &dna_file).await;
+        let call_data = HostFnApi::create(&bob_cell_id, &handle, &dna_file).await;
         let remove_hash = call_data.delete_entry(header_hash.clone()).await;
 
         fake_authority(remove_hash.clone().into(), &call_data).await;
@@ -279,7 +279,7 @@ async fn get_from_another_agent() {
 
     // Alice get element from bob
     let (entry_details, header_details) = {
-        let call_data = CallData::create(&alice_cell_id, &handle, &dna_file).await;
+        let call_data = HostFnApi::create(&alice_cell_id, &handle, &dna_file).await;
         debug!(the_entry_hash = ?entry_hash);
         let entry_details = call_data
             .get_details(entry_hash.into(), options.clone())
@@ -377,7 +377,7 @@ async fn get_links_from_another_agent() {
     let target_entry_hash = EntryHash::with_data_sync(&Entry::try_from(target.clone()).unwrap());
     let link_tag = fixt!(LinkTag);
     let link_add_hash = {
-        let call_data = CallData::create(&bob_cell_id, &handle, &dna_file).await;
+        let call_data = HostFnApi::create(&bob_cell_id, &handle, &dna_file).await;
         let base_header_hash = call_data
             .commit_entry(base.clone().try_into().unwrap(), POST_ID)
             .await;
@@ -405,7 +405,7 @@ async fn get_links_from_another_agent() {
 
     // Alice get links from bob
     let links = {
-        let call_data = CallData::create(&alice_cell_id, &handle, &dna_file).await;
+        let call_data = HostFnApi::create(&alice_cell_id, &handle, &dna_file).await;
 
         call_data
             .get_links(base_entry_hash.clone(), None, link_options.clone())
@@ -424,7 +424,7 @@ async fn get_links_from_another_agent() {
 
     // Remove the link
     {
-        let call_data = CallData::create(&bob_cell_id, &handle, &dna_file).await;
+        let call_data = HostFnApi::create(&bob_cell_id, &handle, &dna_file).await;
 
         // Link the entries
         let link_remove_hash = call_data.delete_link(link_add_hash.clone()).await;
@@ -433,7 +433,7 @@ async fn get_links_from_another_agent() {
     }
 
     let links = {
-        let call_data = CallData::create(&alice_cell_id, &handle, &dna_file).await;
+        let call_data = HostFnApi::create(&alice_cell_id, &handle, &dna_file).await;
 
         call_data
             .get_link_details(
@@ -604,7 +604,7 @@ async fn generate_fixt_store() -> (
     (store, meta_store)
 }
 
-async fn fake_authority(hash: AnyDhtHash, call_data: &CallData) {
+async fn fake_authority(hash: AnyDhtHash, call_data: &HostFnApi) {
     // Check bob can get the entry
     let element = call_data
         .get(hash.clone().into(), GetOptions::default())

--- a/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
@@ -25,9 +25,7 @@ use crate::{
     core::state::element_buf::ElementBuf,
     core::state::metadata::{ChainItemKey, MetadataBuf, MetadataBufT},
     test_utils::host_fn_api::Post,
-    test_utils::{
-        conductor_setup::ConductorCallData, host_fn_api, new_invocation, wait_for_integration,
-    },
+    test_utils::{conductor_setup::ConductorCallData, new_invocation, wait_for_integration},
 };
 use crate::{
     core::state::source_chain::SourceChain, test_utils::conductor_setup::ConductorTestData,
@@ -630,14 +628,14 @@ async fn get_agent_activity_host_fn_test() {
     )
     .await;
 
-    let agent_activity = host_fn_api::get_agent_activity(
-        &alice_call_data.env,
-        alice_call_data.call_data(TestWasm::Create),
-        alice_agent_id,
-        &ChainQueryFilter::new(),
-        ActivityRequest::Full,
-    )
-    .await;
+    let agent_activity = alice_call_data
+        .call_data(TestWasm::Create)
+        .get_agent_activity(
+            alice_agent_id,
+            &ChainQueryFilter::new(),
+            ActivityRequest::Full,
+        )
+        .await;
     let expected_activity = get_expected();
     assert_eq!(agent_activity, expected_activity);
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
@@ -25,7 +25,7 @@ use crate::{
     core::state::element_buf::ElementBuf,
     core::state::metadata::{ChainItemKey, MetadataBuf, MetadataBufT},
     test_utils::host_fn_api::Post,
-    test_utils::{conductor_setup::ConductorCallData, new_invocation, wait_for_integration},
+    test_utils::{conductor_setup::CellHostFnApi, new_invocation, wait_for_integration},
 };
 use crate::{
     core::state::source_chain::SourceChain, test_utils::conductor_setup::ConductorTestData,
@@ -629,7 +629,7 @@ async fn get_agent_activity_host_fn_test() {
     .await;
 
     let agent_activity = alice_call_data
-        .call_data(TestWasm::Create)
+        .get_api(TestWasm::Create)
         .get_agent_activity(
             alice_agent_id,
             &ChainQueryFilter::new(),
@@ -662,7 +662,7 @@ async fn get_agent_activity_host_fn_test() {
 
 async fn commit_some_data(
     call: &str,
-    alice_call_data: &ConductorCallData,
+    alice_call_data: &CellHostFnApi,
     handle: &ConductorHandle,
 ) -> HeaderHash {
     let mut header_hash = None;
@@ -682,7 +682,7 @@ async fn commit_some_data(
 // Cascade helper function for easily getting the validation package
 async fn check_cascade(
     header_hashed: &HeaderHashed,
-    call_data: &ConductorCallData,
+    call_data: &CellHostFnApi,
 ) -> Option<ValidationPackage> {
     let mut element_cache = ElementBuf::cache(call_data.env.clone().into()).unwrap();
     let mut meta_cache = MetadataBuf::cache(call_data.env.clone().into()).unwrap();

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -446,7 +446,7 @@ async fn commit_invalid(
 ) -> (HeaderHash, EntryHash) {
     let entry = ThisWasmEntry::NeverValidates;
     let entry_hash = EntryHash::with_data_sync(&Entry::try_from(entry.clone()).unwrap());
-    let call_data = CallData::create(bob_cell_id, handle, dna_file).await;
+    let call_data = HostFnApi::create(bob_cell_id, handle, dna_file).await;
     // 4
     let invalid_header_hash = call_data
         .commit_entry(entry.clone().try_into().unwrap(), INVALID_ID)
@@ -469,7 +469,7 @@ async fn commit_invalid_post(
     let entry = Post("Banana".into());
     let entry_hash = EntryHash::with_data_sync(&Entry::try_from(entry.clone()).unwrap());
     // Create call data for the 3rd zome Create
-    let call_data = CallData::create_for_zome(bob_cell_id, handle, dna_file, 2).await;
+    let call_data = HostFnApi::create_for_zome(bob_cell_id, handle, dna_file, 2).await;
     // 9
     let invalid_header_hash = call_data
         .commit_entry(entry.clone().try_into().unwrap(), POST_ID)
@@ -487,7 +487,7 @@ async fn call_zome_directly(
     dna_file: &DnaFile,
     invocation: ZomeCallInvocation,
 ) -> SerializedBytes {
-    let call_data = CallData::create(bob_cell_id, handle, dna_file).await;
+    let call_data = HostFnApi::create(bob_cell_id, handle, dna_file).await;
     // 4
     let output = call_data.call_zome_direct(invocation).await;
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -446,15 +446,11 @@ async fn commit_invalid(
 ) -> (HeaderHash, EntryHash) {
     let entry = ThisWasmEntry::NeverValidates;
     let entry_hash = EntryHash::with_data_sync(&Entry::try_from(entry.clone()).unwrap());
-    let (bob_env, call_data) = CallData::create(bob_cell_id, handle, dna_file).await;
+    let call_data = CallData::create(bob_cell_id, handle, dna_file).await;
     // 4
-    let invalid_header_hash = commit_entry(
-        &bob_env,
-        call_data.clone(),
-        entry.clone().try_into().unwrap(),
-        INVALID_ID,
-    )
-    .await;
+    let invalid_header_hash = call_data
+        .commit_entry(entry.clone().try_into().unwrap(), INVALID_ID)
+        .await;
 
     // Produce and publish these commits
     let mut triggers = handle.get_cell_triggers(&bob_cell_id).await.unwrap();
@@ -473,15 +469,11 @@ async fn commit_invalid_post(
     let entry = Post("Banana".into());
     let entry_hash = EntryHash::with_data_sync(&Entry::try_from(entry.clone()).unwrap());
     // Create call data for the 3rd zome Create
-    let (bob_env, call_data) = CallData::create_for_zome(bob_cell_id, handle, dna_file, 2).await;
+    let call_data = CallData::create_for_zome(bob_cell_id, handle, dna_file, 2).await;
     // 9
-    let invalid_header_hash = commit_entry(
-        &bob_env,
-        call_data.clone(),
-        entry.clone().try_into().unwrap(),
-        POST_ID,
-    )
-    .await;
+    let invalid_header_hash = call_data
+        .commit_entry(entry.clone().try_into().unwrap(), POST_ID)
+        .await;
 
     // Produce and publish these commits
     let mut triggers = handle.get_cell_triggers(&bob_cell_id).await.unwrap();
@@ -495,9 +487,9 @@ async fn call_zome_directly(
     dna_file: &DnaFile,
     invocation: ZomeCallInvocation,
 ) -> SerializedBytes {
-    let (bob_env, call_data) = CallData::create(bob_cell_id, handle, dna_file).await;
+    let call_data = CallData::create(bob_cell_id, handle, dna_file).await;
     // 4
-    let output = call_zome_direct(&bob_env, call_data.clone(), invocation).await;
+    let output = call_data.call_zome_direct(invocation).await;
 
     // Produce and publish these commits
     let mut triggers = handle.get_cell_triggers(&bob_cell_id).await.unwrap();

--- a/crates/holochain/src/core/workflow/call_zome_workflow/call_zome_workspace_lock.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow/call_zome_workspace_lock.rs
@@ -10,8 +10,13 @@ impl CallZomeWorkspaceLock {
     pub fn new(workspace: CallZomeWorkspace) -> Self {
         Self(Arc::new(RwLock::new(workspace)))
     }
+
     pub fn into_inner(self) -> Arc<RwLock<CallZomeWorkspace>> {
         self.0
+    }
+
+    pub async fn env(&self) -> EnvironmentRead {
+        self.0.read().await.env().clone()
     }
 }
 

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
@@ -1383,7 +1383,7 @@ mod slow_tests {
         // Commit the base and target.
         // Link them together.
         {
-            let call_data = CallData::create(&alice_cell_id, &conductor, &dna_file).await;
+            let call_data = HostFnApi::create(&alice_cell_id, &conductor, &dna_file).await;
 
             // 3
             call_data
@@ -1412,7 +1412,7 @@ mod slow_tests {
 
         // Check the ops
         {
-            let call_data = CallData::create(&bob_cell_id, &conductor, &dna_file).await;
+            let call_data = HostFnApi::create(&bob_cell_id, &conductor, &dna_file).await;
 
             // Wait for the ops to integrate but early exit if they do
             // 14 ops for genesis and 9 ops for two commits and a link

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
@@ -1383,37 +1383,27 @@ mod slow_tests {
         // Commit the base and target.
         // Link them together.
         {
-            let (alice_env, call_data) =
-                CallData::create(&alice_cell_id, &conductor, &dna_file).await;
+            let call_data = CallData::create(&alice_cell_id, &conductor, &dna_file).await;
 
             // 3
-            commit_entry(
-                &alice_env,
-                call_data.clone(),
-                base.clone().try_into().unwrap(),
-                POST_ID,
-            )
-            .await;
+            call_data
+                .commit_entry(base.clone().try_into().unwrap(), POST_ID)
+                .await;
 
             // 4
-            commit_entry(
-                &alice_env,
-                call_data.clone(),
-                target.clone().try_into().unwrap(),
-                POST_ID,
-            )
-            .await;
+            call_data
+                .commit_entry(target.clone().try_into().unwrap(), POST_ID)
+                .await;
 
             // 5
             // Link the entries
-            create_link(
-                &alice_env,
-                call_data.clone(),
-                base_entry_hash.clone(),
-                target_entry_hash.clone(),
-                link_tag.clone(),
-            )
-            .await;
+            call_data
+                .create_link(
+                    base_entry_hash.clone(),
+                    target_entry_hash.clone(),
+                    link_tag.clone(),
+                )
+                .await;
 
             // Produce and publish these commits
             let mut triggers = conductor.get_cell_triggers(&alice_cell_id).await.unwrap();
@@ -1422,24 +1412,24 @@ mod slow_tests {
 
         // Check the ops
         {
-            let (bob_env, call_data) = CallData::create(&bob_cell_id, &conductor, &dna_file).await;
+            let call_data = CallData::create(&bob_cell_id, &conductor, &dna_file).await;
 
             // Wait for the ops to integrate but early exit if they do
             // 14 ops for genesis and 9 ops for two commits and a link
             // Try 100 times for 100 millis each so maximum wait is 10 seconds
-            wait_for_integration(&bob_env, 14 + 9, 100, Duration::from_millis(100)).await;
+            wait_for_integration(&call_data.env, 14 + 9, 100, Duration::from_millis(100)).await;
 
             // Check the ops are not empty
-            let env_ref = bob_env.guard();
+            let env_ref = call_data.env.guard();
             let reader = env_ref.reader().unwrap();
-            let db = bob_env.get_db(&*INTEGRATED_DHT_OPS).unwrap();
-            let ops_db = IntegratedDhtOpsStore::new(bob_env.clone().into(), db);
+            let db = call_data.env.get_db(&*INTEGRATED_DHT_OPS).unwrap();
+            let ops_db = IntegratedDhtOpsStore::new(call_data.env.clone().into(), db);
             let ops = ops_db.iter(&reader).unwrap().collect::<Vec<_>>().unwrap();
             debug!(?ops);
             assert!(!ops.is_empty());
 
             // Check the correct links is in bobs integrated metadata vault
-            let meta = MetadataBuf::vault(bob_env.clone().into()).unwrap();
+            let meta = MetadataBuf::vault(call_data.env.clone().into()).unwrap();
             let key = LinkMetaKey::Base(&base_entry_hash);
             let links = meta
                 .get_live_links(&reader, &key)
@@ -1450,37 +1440,24 @@ mod slow_tests {
             assert_eq!(link.target, target_entry_hash);
 
             // Check bob can get the links
-            let links = get_links(
-                &bob_env,
-                call_data.clone(),
-                base_entry_hash.clone(),
-                Some(link_tag),
-                Default::default(),
-            )
-            .await;
+            let links = call_data
+                .get_links(base_entry_hash.clone(), Some(link_tag), Default::default())
+                .await;
             let link = links[0].clone();
             assert_eq!(link.target, target_entry_hash);
 
             // Check bob can get the target
-            let e = get(
-                &bob_env,
-                call_data.clone(),
-                target_entry_hash.clone().into(),
-                Default::default(),
-            )
-            .await
-            .unwrap();
+            let e = call_data
+                .get(target_entry_hash.clone().into(), Default::default())
+                .await
+                .unwrap();
             assert_eq!(e.into_inner().1.into_option().unwrap(), target_entry);
 
             // Check bob can get the base
-            let e = get(
-                &bob_env,
-                call_data.clone(),
-                base_entry_hash.clone().into(),
-                Default::default(),
-            )
-            .await
-            .unwrap();
+            let e = call_data
+                .get(base_entry_hash.clone().into(), Default::default())
+                .await
+                .unwrap();
             assert_eq!(e.into_inner().1.into_option().unwrap(), base_entry);
         }
 

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -308,35 +308,26 @@ async fn bob_links_in_a_legit_way(
     let base_entry_hash = EntryHash::with_data_sync(&Entry::try_from(base.clone()).unwrap());
     let target_entry_hash = EntryHash::with_data_sync(&Entry::try_from(target.clone()).unwrap());
     let link_tag = fixt!(LinkTag);
-    let (bob_env, call_data) = CallData::create(bob_cell_id, handle, dna_file).await;
+    let call_data = CallData::create(bob_cell_id, handle, dna_file).await;
     // 3
-    commit_entry(
-        &bob_env,
-        call_data.clone(),
-        base.clone().try_into().unwrap(),
-        POST_ID,
-    )
-    .await;
+    call_data
+        .commit_entry(base.clone().try_into().unwrap(), POST_ID)
+        .await;
 
     // 4
-    commit_entry(
-        &bob_env,
-        call_data.clone(),
-        target.clone().try_into().unwrap(),
-        POST_ID,
-    )
-    .await;
+    call_data
+        .commit_entry(target.clone().try_into().unwrap(), POST_ID)
+        .await;
 
     // 5
     // Link the entries
-    let link_add_address = create_link(
-        &bob_env,
-        call_data.clone(),
-        base_entry_hash.clone(),
-        target_entry_hash.clone(),
-        link_tag.clone(),
-    )
-    .await;
+    let link_add_address = call_data
+        .create_link(
+            base_entry_hash.clone(),
+            target_entry_hash.clone(),
+            link_tag.clone(),
+        )
+        .await;
 
     // Produce and publish these commits
     let mut triggers = handle.get_cell_triggers(&bob_cell_id).await.unwrap();
@@ -360,47 +351,37 @@ async fn bob_makes_a_large_link(
     let bytes = (0..401).map(|_| 0u8).into_iter().collect::<Vec<_>>();
     let link_tag = LinkTag(bytes);
 
-    let (bob_env, call_data) = CallData::create(bob_cell_id, handle, dna_file).await;
+    let call_data = CallData::create(bob_cell_id, handle, dna_file).await;
 
     // 6
-    let original_header_address = commit_entry(
-        &bob_env,
-        call_data.clone(),
-        base.clone().try_into().unwrap(),
-        POST_ID,
-    )
-    .await;
+    let original_header_address = call_data
+        .commit_entry(base.clone().try_into().unwrap(), POST_ID)
+        .await;
 
     // 7
-    commit_entry(
-        &bob_env,
-        call_data.clone(),
-        target.clone().try_into().unwrap(),
-        POST_ID,
-    )
-    .await;
+    call_data
+        .commit_entry(target.clone().try_into().unwrap(), POST_ID)
+        .await;
 
     // 8
     // Commit a large header
-    let link_add_address = create_link(
-        &bob_env,
-        call_data.clone(),
-        base_entry_hash.clone(),
-        target_entry_hash.clone(),
-        link_tag.clone(),
-    )
-    .await;
+    let link_add_address = call_data
+        .create_link(
+            base_entry_hash.clone(),
+            target_entry_hash.clone(),
+            link_tag.clone(),
+        )
+        .await;
 
     // 9
     // Commit a bad update entry
-    let bad_update_header = update_entry(
-        &bob_env,
-        call_data.clone(),
-        bad_update.clone().try_into().unwrap(),
-        MSG_ID,
-        original_header_address,
-    )
-    .await;
+    let bad_update_header = call_data
+        .update_entry(
+            bad_update.clone().try_into().unwrap(),
+            MSG_ID,
+            original_header_address,
+        )
+        .await;
 
     // Produce and publish these commits
     let mut triggers = handle.get_cell_triggers(&bob_cell_id).await.unwrap();
@@ -414,28 +395,23 @@ async fn dodgy_bob(bob_cell_id: &CellId, handle: &ConductorHandle, dna_file: &Dn
     let base_entry_hash = EntryHash::with_data_sync(&Entry::try_from(base.clone()).unwrap());
     let target_entry_hash = EntryHash::with_data_sync(&Entry::try_from(target.clone()).unwrap());
     let link_tag = fixt!(LinkTag);
-    let (bob_env, call_data) = CallData::create(bob_cell_id, handle, dna_file).await;
+    let call_data = CallData::create(bob_cell_id, handle, dna_file).await;
 
     // 11
-    commit_entry(
-        &bob_env,
-        call_data.clone(),
-        base.clone().try_into().unwrap(),
-        POST_ID,
-    )
-    .await;
+    call_data
+        .commit_entry(base.clone().try_into().unwrap(), POST_ID)
+        .await;
 
     // Whoops forgot to commit that proof
 
     // Link the entries
-    create_link(
-        &bob_env,
-        call_data.clone(),
-        base_entry_hash.clone(),
-        target_entry_hash.clone(),
-        link_tag.clone(),
-    )
-    .await;
+    call_data
+        .create_link(
+            base_entry_hash.clone(),
+            target_entry_hash.clone(),
+            link_tag.clone(),
+        )
+        .await;
 
     // Produce and publish these commits
     let mut triggers = handle.get_cell_triggers(&bob_cell_id).await.unwrap();

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -308,7 +308,7 @@ async fn bob_links_in_a_legit_way(
     let base_entry_hash = EntryHash::with_data_sync(&Entry::try_from(base.clone()).unwrap());
     let target_entry_hash = EntryHash::with_data_sync(&Entry::try_from(target.clone()).unwrap());
     let link_tag = fixt!(LinkTag);
-    let call_data = CallData::create(bob_cell_id, handle, dna_file).await;
+    let call_data = HostFnApi::create(bob_cell_id, handle, dna_file).await;
     // 3
     call_data
         .commit_entry(base.clone().try_into().unwrap(), POST_ID)
@@ -351,7 +351,7 @@ async fn bob_makes_a_large_link(
     let bytes = (0..401).map(|_| 0u8).into_iter().collect::<Vec<_>>();
     let link_tag = LinkTag(bytes);
 
-    let call_data = CallData::create(bob_cell_id, handle, dna_file).await;
+    let call_data = HostFnApi::create(bob_cell_id, handle, dna_file).await;
 
     // 6
     let original_header_address = call_data
@@ -395,7 +395,7 @@ async fn dodgy_bob(bob_cell_id: &CellId, handle: &ConductorHandle, dna_file: &Dn
     let base_entry_hash = EntryHash::with_data_sync(&Entry::try_from(base.clone()).unwrap());
     let target_entry_hash = EntryHash::with_data_sync(&Entry::try_from(target.clone()).unwrap());
     let link_tag = fixt!(LinkTag);
-    let call_data = CallData::create(bob_cell_id, handle, dna_file).await;
+    let call_data = HostFnApi::create(bob_cell_id, handle, dna_file).await;
 
     // 11
     call_data

--- a/crates/holochain/src/test_utils/conductor_setup.rs
+++ b/crates/holochain/src/test_utils/conductor_setup.rs
@@ -70,6 +70,7 @@ impl ConductorCallData {
         let zome_path = (self.cell_id.clone(), zome_name).into();
         let call_zome_handle = self.cell_conductor_api.clone().into_call_zome_handle();
         CallData {
+            env: self.env.clone(),
             ribosome: self.ribosome.clone(),
             zome_path,
             network: self.network.clone(),

--- a/crates/holochain/src/test_utils/conductor_setup.rs
+++ b/crates/holochain/src/test_utils/conductor_setup.rs
@@ -1,6 +1,6 @@
 #![allow(missing_docs)]
 
-use super::{host_fn_api::CallData, install_app, setup_app_inner};
+use super::{host_fn_api::HostFnApi, install_app, setup_app_inner};
 use crate::{
     conductor::{
         api::{CellConductorApi, CellConductorApiT},
@@ -28,8 +28,8 @@ use kitsune_p2p::KitsuneP2pConfig;
 use std::{collections::HashMap, convert::TryFrom, sync::Arc};
 use tempdir::TempDir;
 
-/// Everything you need to make a call with the host fn api
-pub struct ConductorCallData {
+/// A "factory" for HostFnApi, which will produce them when given a ZomeName
+pub struct CellHostFnApi {
     pub cell_id: CellId,
     pub env: EnvironmentWrite,
     pub ribosome: WasmRibosome,
@@ -40,7 +40,7 @@ pub struct ConductorCallData {
     pub cell_conductor_api: CellConductorApi,
 }
 
-impl ConductorCallData {
+impl CellHostFnApi {
     pub async fn new(cell_id: &CellId, handle: &ConductorHandle, dna_file: &DnaFile) -> Self {
         let env = handle.get_cell_env(cell_id).await.unwrap();
         let keystore = env.keystore().clone();
@@ -52,7 +52,7 @@ impl ConductorCallData {
 
         let ribosome = WasmRibosome::new(dna_file.clone());
         let signal_tx = handle.signal_broadcaster().await;
-        ConductorCallData {
+        CellHostFnApi {
             cell_id: cell_id.clone(),
             env,
             ribosome,
@@ -64,12 +64,12 @@ impl ConductorCallData {
         }
     }
 
-    /// Create a CallData for a specific zome and call
-    pub fn call_data<I: Into<ZomeName>>(&self, zome_name: I) -> CallData {
+    /// Create a HostFnApi for a specific zome and call
+    pub fn get_api<I: Into<ZomeName>>(&self, zome_name: I) -> HostFnApi {
         let zome_name: ZomeName = zome_name.into();
         let zome_path = (self.cell_id.clone(), zome_name).into();
         let call_zome_handle = self.cell_conductor_api.clone().into_call_zome_handle();
-        CallData {
+        HostFnApi {
             env: self.env.clone(),
             ribosome: self.ribosome.clone(),
             zome_path,
@@ -82,10 +82,11 @@ impl ConductorCallData {
 }
 
 /// Everything you need to run a test that uses the conductor
+// TODO: refactor this to be the "Test Conductor" wrapper
 pub struct ConductorTestData {
     __tmpdir: Arc<TempDir>,
     handle: ConductorHandle,
-    call_data: HashMap<CellId, ConductorCallData>,
+    cell_apis: HashMap<CellId, CellHostFnApi>,
 }
 
 impl ConductorTestData {
@@ -120,13 +121,13 @@ impl ConductorTestData {
         )
         .await;
 
-        let mut call_data = HashMap::new();
+        let mut cell_apis = HashMap::new();
 
         for (dna_file, cell_ids) in cell_id_by_dna_file.iter() {
             for cell_id in cell_ids {
-                call_data.insert(
+                cell_apis.insert(
                     cell_id.clone(),
-                    ConductorCallData::new(&cell_id, &handle, &dna_file).await,
+                    CellHostFnApi::new(&cell_id, &handle, &dna_file).await,
                 );
             }
         }
@@ -135,7 +136,7 @@ impl ConductorTestData {
             __tmpdir,
             // app_api,
             handle,
-            call_data,
+            cell_apis,
         };
         let installed = cell_id_by_dna_file
             .into_iter()
@@ -207,9 +208,9 @@ impl ConductorTestData {
             let bob_installed_cell = InstalledCell::new(bob_cell_id.clone(), "bob_handle".into());
             let cell_data = vec![(bob_installed_cell, None)];
             install_app("bob_app", cell_data, vec![dna_file.clone()], self.handle()).await;
-            self.call_data.insert(
+            self.cell_apis.insert(
                 bob_cell_id.clone(),
-                ConductorCallData::new(&bob_cell_id, &self.handle(), &dna_file).await,
+                CellHostFnApi::new(&bob_cell_id, &self.handle(), &dna_file).await,
             );
         }
     }
@@ -219,21 +220,21 @@ impl ConductorTestData {
     }
 
     #[allow(clippy::iter_nth_zero)]
-    pub fn alice_call_data(&self) -> &ConductorCallData {
-        &self.call_data.values().nth(0).unwrap()
+    pub fn alice_call_data(&self) -> &CellHostFnApi {
+        &self.cell_apis.values().nth(0).unwrap()
     }
 
-    pub fn bob_call_data(&self) -> Option<&ConductorCallData> {
-        self.call_data.values().nth(1)
+    pub fn bob_call_data(&self) -> Option<&CellHostFnApi> {
+        self.cell_apis.values().nth(1)
     }
 
     #[allow(clippy::iter_nth_zero)]
-    pub fn alice_call_data_mut(&mut self) -> &mut ConductorCallData {
-        let key = self.call_data.keys().nth(0).unwrap().clone();
-        self.call_data.get_mut(&key).unwrap()
+    pub fn alice_call_data_mut(&mut self) -> &mut CellHostFnApi {
+        let key = self.cell_apis.keys().nth(0).unwrap().clone();
+        self.cell_apis.get_mut(&key).unwrap()
     }
 
-    pub fn call_data(&mut self, cell_id: &CellId) -> Option<&mut ConductorCallData> {
-        self.call_data.get_mut(cell_id)
+    pub fn get_cell(&mut self, cell_id: &CellId) -> Option<&mut CellHostFnApi> {
+        self.cell_apis.get_mut(cell_id)
     }
 }

--- a/crates/holochain/src/test_utils/host_fn_api.rs
+++ b/crates/holochain/src/test_utils/host_fn_api.rs
@@ -110,16 +110,12 @@ pub struct HostFnApi {
 
 impl HostFnApi {
     /// Create HostFnApi for the first zome.
+    #[deprecated = "use create_for_zome"]
     pub async fn create(
         cell_id: &CellId,
         handle: &ConductorHandle,
         dna_file: &DnaFile,
     ) -> HostFnApi {
-        assert_eq!(
-            dna_file.dna().zomes.len(),
-            1,
-            "Can't use HostFnApi::create with a DNA containing more than one zome."
-        );
         Self::create_for_zome(cell_id, handle, dna_file, 0).await
     }
 

--- a/crates/holochain/tests/agent_scaling.rs
+++ b/crates/holochain/tests/agent_scaling.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "test_utils")]
 
 use hdk3::prelude::Links;
-use holochain::test_utils::host_fn_api;
 use holochain::{
     core::ribosome::ZomeCallInvocation, test_utils::conductor_setup::ConductorTestData,
 };
@@ -55,14 +54,10 @@ async fn many_agents_can_reach_consistency_agent_links() {
     let base = cell_ids[0].agent_pubkey().clone();
     let target = cell_ids[1].agent_pubkey().clone();
 
-    host_fn_api::create_link(
-        &committer.env,
-        committer.call_data(TestWasm::Link),
-        base.clone().into(),
-        target.into(),
-        ().into(),
-    )
-    .await;
+    committer
+        .call_data(TestWasm::Link)
+        .create_link(base.clone().into(), target.into(), ().into())
+        .await;
 
     committer.triggers.produce_dht_ops.trigger();
 
@@ -73,14 +68,10 @@ async fn many_agents_can_reach_consistency_agent_links() {
         let cell_id = cell_ids[i].clone();
         let cd = conductor.call_data(&cell_id).unwrap();
 
-        let links = host_fn_api::get_links(
-            &cd.env,
-            cd.call_data(TestWasm::Link),
-            base.clone().into(),
-            None,
-            Default::default(),
-        )
-        .await;
+        let links = cd
+            .call_data(TestWasm::Link)
+            .get_links(base.clone().into(), None, Default::default())
+            .await;
 
         seen[i] = links.len();
     }

--- a/crates/holochain/tests/agent_scaling.rs
+++ b/crates/holochain/tests/agent_scaling.rs
@@ -50,12 +50,12 @@ async fn many_agents_can_reach_consistency_agent_links() {
         ConductorTestData::new(envs, vec![dna_file], agents, Default::default()).await;
 
     let cell_ids = cell_ids.values().next().unwrap();
-    let committer = conductor.call_data(&cell_ids[1]).unwrap();
+    let committer = conductor.get_cell(&cell_ids[1]).unwrap();
     let base = cell_ids[0].agent_pubkey().clone();
     let target = cell_ids[1].agent_pubkey().clone();
 
     committer
-        .call_data(TestWasm::Link)
+        .get_api(TestWasm::Link)
         .create_link(base.clone().into(), target.into(), ().into())
         .await;
 
@@ -66,10 +66,10 @@ async fn many_agents_can_reach_consistency_agent_links() {
 
     for i in 0..NUM_AGENTS {
         let cell_id = cell_ids[i].clone();
-        let cd = conductor.call_data(&cell_id).unwrap();
+        let cd = conductor.get_cell(&cell_id).unwrap();
 
         let links = cd
-            .call_data(TestWasm::Link)
+            .get_api(TestWasm::Link)
             .get_links(base.clone().into(), None, Default::default())
             .await;
 

--- a/crates/state/src/env.rs
+++ b/crates/state/src/env.rs
@@ -293,6 +293,16 @@ impl<'e> WriteManager<'e> for EnvironmentWriteRef<'e> {
     }
 }
 
+impl<'e> WriteManager<'e> for EnvironmentWrite {
+    fn with_commit<E, R, F: Send>(&self, f: F) -> Result<R, E>
+    where
+        E: From<DatabaseError>,
+        F: FnOnce(&mut Writer) -> Result<R, E>,
+    {
+        EnvironmentWriteRef::with_commit(&self.guard(), f)
+    }
+}
+
 impl<'e> EnvironmentWriteRef<'e> {
     /// Access the underlying Rkv lock guard
     #[cfg(test)]


### PR DESCRIPTION
Reimagines CallData as a standalone struct which contains the entire host fn api, rather than having host fns be standalone functions which take CallData (and redundant EnvironmentWrite)

Renames:

```
CallData -> HostFnApi
ConductorCallData -> CellHostFnApi
ConductorCallData::{call_data() -> get_api()}
ConductorTestData::{call_data() -> get_cell()}
```