### PR TITLE
[TK-06004] test_utils/wasm/build.rs: make 'cargo check' opt-out

### DIFF
--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -100,7 +100,7 @@ name = "holochain"
 path = "src/bin/holochain/main.rs"
 
 [features]
-default = ["slow_tests", "test_utils"]
+default = ["slow_tests", "test_utils", "only_check_wasms"]
 
 # Exposes additional functionality only needed for integration tests.
 # This feature should be turned off for production builds.
@@ -116,3 +116,4 @@ slow_tests = []
 
 # Includes the wasm build script, which we don't need when not building wasms
 build_wasms = ['holochain_wasm_test_utils/build']
+only_check_wasms = ['holochain_wasm_test_utils/only_check']

--- a/crates/test_utils/wasm/Cargo.toml
+++ b/crates/test_utils/wasm/Cargo.toml
@@ -12,6 +12,7 @@ path = "./src/lib.rs"
 [features]
 default = []
 build = []
+only_check = []
 
 
 [dependencies]

--- a/crates/test_utils/wasm/build.rs
+++ b/crates/test_utils/wasm/build.rs
@@ -3,6 +3,12 @@ use std::process::Stdio;
 
 fn main() {
     let should_build = std::env::var_os("CARGO_FEATURE_BUILD").is_some();
+    let only_check = std::env::var_os("CARGO_FEATURE_ONLY_CHECK").is_some();
+
+    if !(should_build || only_check) {
+        return;
+    }
+
     let wasms_path = format!("{}/{}/", env!("CARGO_MANIFEST_DIR"), "wasm_workspace");
     println!("cargo:rerun-if-changed=Cargo.toml");
     println!("cargo:rerun-if-changed=../../../Cargo.lock");


### PR DESCRIPTION
This introduces a feature named `only_check_wasms` for the case where we
want to check but not build the crate at
`crates/test_utils/wasm/wasm_workspace`.

The new feature is enabled by default but can be disabled by passing
`--no-default-features` to `cargo` which will then effectively avoid any
operation on the `wasm_workspace`crate. This saves effort on non-test
related builds.