### PR TITLE
types/dna: only import InlineZome with test_utils feature

### DIFF
--- a/crates/types/src/dna.rs
+++ b/crates/types/src/dna.rs
@@ -15,8 +15,11 @@ use std::collections::BTreeMap;
 
 use self::{
     error::DnaResult,
-    zome::{inline_zome::InlineZome, Zome, ZomeDef},
+    zome::{Zome, ZomeDef},
 };
+
+#[cfg(feature = "test_utils")]
+use zome::inline_zome::InlineZome;
 
 /// Zomes need to be an ordered map from ZomeName to a Zome
 pub type Zomes = Vec<(ZomeName, zome::ZomeDef)>;


### PR DESCRIPTION
Otherwise, this leads to an unused code warning which we want to deny by
default.