### PR TITLE
Fix ZomeCall RibosomeError

### DIFF
--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -73,10 +73,12 @@ impl AppInterfaceApi for RealAppInterfaceApi {
                 self.handle_app_request_inner(AppRequest::ZomeCall(call))
                     .await
                     .map(|r| {
-                        AppResponse::ZomeCallInvocation(match r {
-                            AppResponse::ZomeCall(zc) => zc,
-                            other => panic!("Found {:?} when ZomeCall was expected", other),
-                        })
+                        match r {
+                            // if successful, re-wrap in the deprecated response type
+                            AppResponse::ZomeCall(zc) => AppResponse::ZomeCallInvocation(zc),
+                            // else (probably an error), return as-is
+                            other => other,
+                        }
                     })
             }
             AppRequest::ZomeCall(call) => {


### PR DESCRIPTION
the panic looks like this:

```
Dec 11 03:05:00 hpos holochain[28639]: FATAL PANIC PanicInfo {
Dec 11 03:05:00 hpos holochain[28639]:     payload: Any,
Dec 11 03:05:00 hpos holochain[28639]:     message: Some(
Dec 11 03:05:00 hpos holochain[28639]:         Found Error(RibosomeError("Wasm error while working with Ribosome: CallError(\"RuntimeError: unknown error\")")) when ZomeCall was expected,
Dec 11 03:05:00 hpos holochain[28639]:     ),
Dec 11 03:05:00 hpos holochain[28639]:     location: Location {
Dec 11 03:05:00 hpos holochain[28639]:         file: "crates/holochain/src/conductor/api/api_external/app_interface.rs",
Dec 11 03:05:00 hpos holochain[28639]:         line: 78,
Dec 11 03:05:00 hpos holochain[28639]:         col: 38,
Dec 11 03:05:00 hpos holochain[28639]:     },
Dec 11 03:05:00 hpos holochain[28639]: }
```