### PR TITLE
[TK-06836] Move network to initialize step

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  # "crates/admin",
   "crates/dna_util",
   "crates/fixt",
   "crates/fixt/test",

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -133,7 +133,7 @@ impl Cell {
         id: CellId,
         conductor_handle: ConductorHandle,
         env: EnvironmentWrite,
-        mut holochain_p2p_cell: holochain_p2p::HolochainP2pCell,
+        holochain_p2p_cell: holochain_p2p::HolochainP2pCell,
         managed_task_add_sender: sync::mpsc::Sender<ManagedTaskAdd>,
         managed_task_stop_broadcaster: sync::broadcast::Sender<()>,
     ) -> CellResult<Self> {
@@ -146,7 +146,6 @@ impl Cell {
         };
 
         if has_genesis {
-            holochain_p2p_cell.join().await?;
             let queue_triggers = spawn_queue_consumer_tasks(
                 &env,
                 holochain_p2p_cell.clone(),
@@ -173,6 +172,11 @@ impl Cell {
     /// multiple times.
     pub fn initialize_workflows(&mut self) {
         self.queue_triggers.initialize_workflows();
+    }
+
+    /// Join the network for this cell
+    pub async fn join_network(&mut self) -> CellResult<()> {
+        Ok(self.holochain_p2p_cell.join().await?)
     }
 
     /// Performs the Genesis workflow the Cell, ensuring that its initial

--- a/crates/holochain/src/conductor/cell/test.rs
+++ b/crates/holochain/src/conductor/cell/test.rs
@@ -42,7 +42,7 @@ async fn test_cell_handle_publish() {
     let (add_task_sender, shutdown) = spawn_task_manager();
     let (stop_tx, _) = sync::broadcast::channel(1);
 
-    let cell = super::Cell::create(
+    let mut cell = super::Cell::create(
         cell_id,
         mock_handler,
         env.clone(),
@@ -52,6 +52,8 @@ async fn test_cell_handle_publish() {
     )
     .await
     .unwrap();
+
+    cell.join_network().await.unwrap();
 
     let sig = fixt!(Signature);
     let header = header::Header::Dna(header::Dna {

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -618,10 +618,12 @@ where
         }
     }
 
-    pub(super) fn initialize_cell_workflows(&mut self) {
+    pub(super) async fn initialize_cells(&mut self) -> ConductorResult<()> {
         for cell in self.cells.values_mut() {
+            cell.cell.join_network().await?;
             cell.cell.initialize_workflows();
         }
+        Ok(())
     }
 
     pub(super) async fn load_wasms_into_dna_files(

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -481,7 +481,7 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
             .filter_map(|r| r)
             .collect();
         {
-            self.conductor.write().await.initialize_cell_workflows();
+            self.conductor.write().await.initialize_cells().await?;
         }
         Ok(r)
     }


### PR DESCRIPTION
The network is joined before the cell is installed which means for a period of time network events are routed to a cell that doesn't exist yet. I tried moving the network join to the cell initialization step but it's not working.
I'm leaving this for a little bit because it's not a huge issue and after talking to zippy it seems like a different problem to the one they are seeing.

### Possible issues:
- Joining networking more then one?
- Something between create and initialize needs the network.