### PR TITLE
[TK-06987] Limit amount of publishes for an op

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,7 +1400,7 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.0.1"
+version = "0.0.100"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -100,9 +100,9 @@ pub async fn publish_dht_ops_workflow_inner(
                     .unwrap_or(true);
                 if needs_publish {
                     r.last_publish_time = Some(now_ts);
-                    // HACK: Incrementing the receipt count to prevent publishing 
+                    // HACK: Incrementing the receipt count to prevent publishing
                     // forever although without receipts this could lead to data loss
-                    // and relies on gossip for data integrity. 
+                    // and relies on gossip for data integrity.
                     // This should be removed when receipts are implemented.
                     r.receipt_count += 1;
                     Some((DhtOpHash::from_raw_39_panicky(k.to_vec()), r))

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -100,6 +100,11 @@ pub async fn publish_dht_ops_workflow_inner(
                     .unwrap_or(true);
                 if needs_publish {
                     r.last_publish_time = Some(now_ts);
+                    // HACK: Incrementing the receipt count to prevent publishing 
+                    // forever although without receipts this could lead to data loss
+                    // and relies on gossip for data integrity. 
+                    // This should be removed when receipts are implemented.
+                    r.receipt_count += 1;
                     Some((DhtOpHash::from_raw_39_panicky(k.to_vec()), r))
                 } else {
                     None


### PR DESCRIPTION
make receipt count increment on every publish so that ops aren't published forever