### PR TITLE
Add RegisterDna to conductor api and allow InstallApp to take a hash

### DIFF
--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -120,7 +120,7 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     }
                     if let Some(path) = maybe_path {
                         // TODO: this if let will be removed after deprecation period
-                        tracing::info!("specifying dna by path with register side-effect is deprecated, please use RegisterDna and install by hash");
+                        tracing::warn!("specifying dna by path with register side-effect is deprecated, please use RegisterDna and install by hash");
                         let dna = read_parse_dna(path, properties).await?;
                         let hash = dna.dna_hash().clone();
                         let cell_id = CellId::from((hash.clone(), agent_key.clone()));
@@ -132,12 +132,12 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                         // been installed via properties?
                         let dna_list = self.conductor_handle.list_dnas().await?;
                         if !dna_list.contains(&hash) {
-                            return Err(ConductorApiError::DnaReadError("Given dna has not been registered".to_string()));
+                            return Err(ConductorApiError::DnaReadError(format!("Given dna has not been registered: {}", hash)));
                         }
                         let cell_id = CellId::from((hash.clone(), agent_key.clone()));
                         ConductorApiResult::Ok((InstalledCell::new(cell_id, nick), membrane_proof))
                     } else {
-                        Err(ConductorApiError::DnaReadError("unreachable".to_string()))
+                        unreachable!()
                     }
                 });
 

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -73,7 +73,7 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                 Ok(AdminResponse::AdminInterfacesAdded)
             }
             RegisterDna(payload) => {
-                trace!(?payload);
+                trace!(register_dna_payload = ?payload);
                 let dna = match payload.source {
                     DnaSource::Hash(ref hash) => {
                         let props = payload.properties.ok_or(ConductorApiError::DnaReadError(
@@ -143,8 +143,6 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                         ConductorApiResult::Ok((InstalledCell::new(cell_id, nick), membrane_proof))
                     } else if let Some(hash) = maybe_hash {
                         // confirm that hash has been installed
-                        // TODO: make sure this is only for real DNAs not ones that have
-                        // been installed via properties?
                         let dna_list = self.conductor_handle.list_dnas().await?;
                         if !dna_list.contains(&hash) {
                             return Err(ConductorApiError::DnaReadError(format!("Given dna has not been registered: {}", hash)));

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -106,7 +106,7 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                 let dna_list = self.conductor_handle.list_dnas().await?;
                 if dna_list.contains(&hash) {
                     return Err(ConductorApiError::DnaReadError(
-                        "Given dna has allready been registered".to_string(),
+                        "Given dna has already been registered".to_string(),
                     ));
                 }
                 self.conductor_handle.install_dna(dna).await?;
@@ -344,7 +344,7 @@ mod test {
             .await;
         assert_matches!(
             install_response,
-            AdminResponse::Error(ExternalApiWireError::DnaReadError(e)) if e == String::from("Given dna has allready been registered")
+            AdminResponse::Error(ExternalApiWireError::DnaReadError(e)) if e == String::from("Given dna has already been registered")
         );
 
         let dna_list = admin_api.handle_admin_request(AdminRequest::ListDnas).await;

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -76,16 +76,18 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                 trace!(register_dna_payload = ?payload);
                 let dna = match payload.source {
                     DnaSource::Hash(ref hash) => {
-                        let props = payload.properties.ok_or(ConductorApiError::DnaReadError(
-                            "Hash Dna source requires properties to create a derived Dna"
-                                .to_string(),
-                        ))?;
-                        let dna = self.conductor_handle.get_dna(hash).await.ok_or(
+                        let props = payload.properties.ok_or(|| {
+                            ConductorApiError::DnaReadError(
+                                "Hash Dna source requires properties to create a derived Dna"
+                                    .to_string(),
+                            )
+                        })?;
+                        let dna = self.conductor_handle.get_dna(hash).await.ok_or(|| {
                             ConductorApiError::DnaReadError(format!(
                                 "Unable to create derived Dna: {} not registered",
                                 hash
-                            )),
-                        )?;
+                            ))
+                        })?;
                         let properties =
                             SerializedBytes::try_from(props).map_err(SerializationError::from)?;
                         dna.with_properties(properties).await?

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -76,13 +76,13 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                 trace!(register_dna_payload = ?payload);
                 let dna = match payload.source {
                     DnaSource::Hash(ref hash) => {
-                        let props = payload.properties.ok_or(|| {
+                        let props = payload.properties.ok_or_else(|| {
                             ConductorApiError::DnaReadError(
                                 "Hash Dna source requires properties to create a derived Dna"
                                     .to_string(),
                             )
                         })?;
-                        let dna = self.conductor_handle.get_dna(hash).await.ok_or(|| {
+                        let dna = self.conductor_handle.get_dna(hash).await.ok_or_else(|| {
                             ConductorApiError::DnaReadError(format!(
                                 "Unable to create derived Dna: {} not registered",
                                 hash

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -76,7 +76,7 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                 trace!(?payload);
                 let dna = match payload.source {
                     DnaSource::Path(path) => read_parse_dna(path, payload.properties).await?,
-                    DnaSource::Wasm(dna) => match payload.properties {
+                    DnaSource::DnaFile(dna) => match payload.properties {
                         Some(p) => {
                             let properties =
                                 SerializedBytes::try_from(p).map_err(SerializationError::from)?;
@@ -373,7 +373,7 @@ mod test {
             .await;
         assert_matches!(
             install_response,
-            AdminResponse::Error(ExternalApiWireError::DnaReadError(e)) if e == String::from("Given dna has not been registered")
+            AdminResponse::Error(ExternalApiWireError::DnaReadError(e)) if e == format!("Given dna has not been registered: {}", dna_hash)
         );
 
         // now install it using the path which should add the dna to the database

--- a/crates/holochain/src/fixt.rs
+++ b/crates/holochain/src/fixt.rs
@@ -99,13 +99,13 @@ fixturator!(
 );
 
 fixturator!(
-    Wasms;
-    curve Empty BTreeMap::new();
+    WasmMap;
+    curve Empty BTreeMap::new().into();
     curve Unpredictable {
         let mut rng = rand::thread_rng();
         let number_of_wasms = rng.gen_range(0, 5);
 
-        let mut wasms: Wasms = BTreeMap::new();
+        let mut wasms = BTreeMap::new();
         let mut dna_wasm_fixturator = DnaWasmFixturator::new(Unpredictable);
         for _ in 0..number_of_wasms {
             let wasm = dna_wasm_fixturator.next().unwrap();
@@ -116,10 +116,10 @@ fixturator!(
                 wasm,
             );
         }
-        wasms
+        wasms.into()
     };
     curve Predictable {
-        let mut wasms: Wasms = BTreeMap::new();
+        let mut wasms = BTreeMap::new();
         let mut dna_wasm_fixturator = DnaWasmFixturator::new_indexed(Predictable, get_fixt_index!());
         for _ in 0..3 {
             let wasm = dna_wasm_fixturator.next().unwrap();
@@ -130,7 +130,7 @@ fixturator!(
                 wasm,
             );
         }
-        wasms
+        wasms.into()
     };
 );
 
@@ -141,13 +141,13 @@ fixturator!(
             dna: tokio_safe_block_on::tokio_safe_block_forever_on(async move {
                 DnaDefHashed::from_content(DnaDefFixturator::new(Empty).next().unwrap()).await
             }),
-            code: WasmsFixturator::new(Empty).next().unwrap(),
+            code: WasmMapFixturator::new(Empty).next().unwrap(),
         }
     },
     {
         // align the wasm hashes across the file and def
         let mut zome_name_fixturator = ZomeNameFixturator::new(Unpredictable);
-        let wasms = WasmsFixturator::new(Unpredictable).next().unwrap();
+        let wasms = WasmMapFixturator::new(Unpredictable).next().unwrap();
         let mut zomes: Zomes = Vec::new();
         for (hash, _) in wasms {
             zomes.push((
@@ -165,14 +165,14 @@ fixturator!(
         });
         DnaFile {
             dna,
-            code: WasmsFixturator::new(Unpredictable).next().unwrap(),
+            code: WasmMapFixturator::new(Unpredictable).next().unwrap(),
         }
     },
     {
         // align the wasm hashes across the file and def
         let mut zome_name_fixturator =
             ZomeNameFixturator::new_indexed(Predictable, get_fixt_index!());
-        let wasms = WasmsFixturator::new_indexed(Predictable, get_fixt_index!())
+        let wasms = WasmMapFixturator::new_indexed(Predictable, get_fixt_index!())
             .next()
             .unwrap();
         let mut zomes: Zomes = Vec::new();
@@ -194,7 +194,7 @@ fixturator!(
         });
         DnaFile {
             dna,
-            code: WasmsFixturator::new_indexed(Predictable, get_fixt_index!())
+            code: WasmMapFixturator::new_indexed(Predictable, get_fixt_index!())
                 .next()
                 .unwrap(),
         }

--- a/crates/holochain/tests/websocket.rs
+++ b/crates/holochain/tests/websocket.rs
@@ -160,7 +160,8 @@ async fn call_admin() {
     // Install Dna
     let (fake_dna_path, _tmpdir) = write_fake_dna_file(dna.clone()).await.unwrap();
     let dna_payload = InstallAppDnaPayload {
-        path: fake_dna_path,
+        path: Some(fake_dna_path),
+        hash: None,
         nick: "nick".into(),
         properties: Some(properties.clone()),
         membrane_proof: None,

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -29,6 +29,16 @@ pub enum AdminRequest {
     /// [`AdminResponse::AdminInterfacesAdded`]: enum.AdminResponse.html#variant.AdminInterfacesAdded
     /// [`AdminResponse::Error`]: enum.AppResponse.html#variant.Error
     AddAdminInterfaces(Vec<crate::config::AdminInterfaceConfig>),
+
+    /// Register a DNA for later use in InstallApp
+    /// Stores the given DNA into the holochain dnas database and returns the hash of the DNA
+    /// Will be responded to with an [`AdminResponse::DnaRegistered`]
+    /// or an [`AdminResponse::Error`]
+    ///
+    /// [`InstallDnaPayload`]: ../../../holochain_types/app/struct.InstallDnaPayload.html
+    /// [`AdminResponse::DnaRegistered`]: enum.AdminResponse.html#variant.DnaRegistered
+    RegisterDna(Box<RegisterDnaPayload>),
+
     /// Install an app from a list of `Dna` paths.
     /// Triggers genesis to be run on all `Cell`s and to be stored.
     /// An `App` is intended for use by
@@ -56,6 +66,7 @@ pub enum AdminRequest {
     /// [`AdminResponse::DnasListed`]: enum.AdminResponse.html#variant.DnasListed
     /// [`AdminResponse::Error`]: enum.AppResponse.html#variant.Error
     ListDnas,
+
     /// Generate a new AgentPubKey.
     /// Takes no arguments.
     ///
@@ -65,6 +76,7 @@ pub enum AdminRequest {
     /// [`AdminResponse::AgentPubKeyGenerated`]: enum.AdminResponse.html#variant.AgentPubKeyGenerated
     /// [`AdminResponse::Error`]: enum.AppResponse.html#variant.Error
     GenerateAgentPubKey,
+
     /// List all the cell ids in the conductor.
     /// Takes no arguments.
     ///
@@ -188,7 +200,12 @@ pub enum AdminResponse {
     /// [`AdminRequest`]: enum.AdminRequest.html
     /// [`ExternalApiWireError`]: error/enum.ExternalApiWireError.html
     Error(ExternalApiWireError),
-    /// The succesful response to an [`AdminRequest::InstallApp`].
+    /// The successful response to an [`AdminRequest::RegisterDna`]
+    ///
+    /// [`AdminRequest::RegisterDna`]: enum.AdminRequest.html#variant.RegisterDna
+    DnaRegistered(DnaHash),
+
+    /// The successful response to an [`AdminRequest::InstallApp`].
     ///
     /// The resulting [`InstalledApp`] contains the App id,
     /// the [`CellNick`]s and, most usefully, the new [`CellId`]s

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -19,7 +19,7 @@ pub enum DnaSource {
     /// register the dna loaded from a file on disk
     Path(PathBuf),
     /// register the dna as provided in the DnaFile data structure
-    Wasm(DnaFile),
+    DnaFile(DnaFile),
 }
 
 /// The instructions on how to get the DNA to be registered

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -14,6 +14,7 @@ pub type CellNick = String;
 
 /// The source of the DNA to be installed, either as binary data, or from a path
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum DnaSource {
     /// register the dna loaded from a file on disk
     Path(PathBuf),

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -20,6 +20,8 @@ pub enum DnaSource {
     Path(PathBuf),
     /// register the dna as provided in the DnaFile data structure
     DnaFile(DnaFile),
+    /// register the dna from an existing registered DNA (assumes properties will be set)
+    Hash(DnaHash),
 }
 
 /// The instructions on how to get the DNA to be registered

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -1,7 +1,7 @@
 //! Collection of cells to form a holochain application
-use crate::dna::JsonProperties;
+use crate::dna::{DnaFile, JsonProperties};
 use derive_more::Into;
-use holo_hash::AgentPubKey;
+use holo_hash::{AgentPubKey, DnaHash};
 use holochain_serialized_bytes::SerializedBytes;
 use holochain_zome_types::cell::CellId;
 use std::path::PathBuf;
@@ -11,6 +11,24 @@ pub type InstalledAppId = String;
 
 /// A friendly (nick)name used by UIs to refer to the Cells which make up the app
 pub type CellNick = String;
+
+/// The source of the DNA to be installed, either as binary data, or from a path
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub enum DnaSource {
+    /// register the dna loaded from a file on disk
+    Path(PathBuf),
+    /// register the dna as provided in the DnaFile data structure
+    Wasm(DnaFile),
+}
+
+/// The instructions on how to get the DNA to be registered
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct RegisterDnaPayload {
+    /// Properties to override when installing this Dna
+    pub properties: Option<JsonProperties>,
+    /// The dna source
+    pub source: DnaSource,
+}
 
 /// A collection of [DnaHash]es paired with an [AgentPubKey] and an app id
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -27,7 +45,9 @@ pub struct InstallAppPayload {
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct InstallAppDnaPayload {
     /// The path of the DnaFile
-    pub path: PathBuf,
+    pub path: Option<PathBuf>, // This is a deprecated field should register dna contents via register
+    /// The path of the DnaFile
+    pub hash: Option<DnaHash>, // When path is removed, this will become non-opt
     /// The CellNick which will be assigned to this Dna when installed
     pub nick: CellNick,
     /// Properties to override when installing this Dna
@@ -40,7 +60,18 @@ impl InstallAppDnaPayload {
     /// Create a payload with no JsonProperties or MembraneProof. Good for tests.
     pub fn path_only(path: PathBuf, nick: CellNick) -> Self {
         Self {
-            path,
+            path: Some(path),
+            hash: None,
+            nick,
+            properties: None,
+            membrane_proof: None,
+        }
+    }
+    /// Create a payload with no JsonProperties or MembraneProof. Good for tests.
+    pub fn hash_only(hash: DnaHash, nick: CellNick) -> Self {
+        Self {
+            path: None,
+            hash: Some(hash),
             nick,
             properties: None,
             membrane_proof: None,

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -27,6 +27,8 @@ pub enum DnaSource {
 /// The instructions on how to get the DNA to be registered
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct RegisterDnaPayload {
+    /// UUID to override when installing this Dna
+    pub uuid: Option<String>,
     /// Properties to override when installing this Dna
     pub properties: Option<JsonProperties>,
     /// The dna source

--- a/crates/holochain_types/src/dna.rs
+++ b/crates/holochain_types/src/dna.rs
@@ -17,9 +17,7 @@ use std::collections::BTreeMap;
 pub type Zomes = Vec<(ZomeName, zome::ZomeDef)>;
 
 /// A type to allow json values to be used as [SerializedBytes]
-#[derive(
-    Debug, Clone, derive_more::From, serde::Serialize, serde::Deserialize, SerializedBytes,
-)]
+#[derive(Debug, Clone, derive_more::From, serde::Serialize, serde::Deserialize, SerializedBytes)]
 pub struct JsonProperties(serde_json::Value);
 
 impl JsonProperties {

--- a/crates/holochain_types/src/dna.rs
+++ b/crates/holochain_types/src/dna.rs
@@ -17,7 +17,9 @@ use std::collections::BTreeMap;
 pub type Zomes = Vec<(ZomeName, zome::ZomeDef)>;
 
 /// A type to allow json values to be used as [SerializedBytes]
-#[derive(Debug, Clone, derive_more::From, serde::Serialize, serde::Deserialize, SerializedBytes)]
+#[derive(
+    Debug, Clone, derive_more::From, serde::Serialize, serde::Deserialize, SerializedBytes,
+)]
 pub struct JsonProperties(serde_json::Value);
 
 impl JsonProperties {
@@ -108,7 +110,35 @@ pub type DnaDefHashed = HoloHashed<DnaDef>;
 impl_hashable_content!(DnaDef, Dna);
 
 /// Wasms need to be an ordered map from WasmHash to a wasm::DnaWasm
-pub type Wasms = BTreeMap<holo_hash::WasmHash, wasm::DnaWasm>;
+#[derive(
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    serde::Serialize,
+    serde::Deserialize,
+    derive_more::AsRef,
+    derive_more::From,
+    derive_more::IntoIterator,
+)]
+#[serde(from = "WasmMapSerialized", into = "WasmMapSerialized")]
+pub struct WasmMap(BTreeMap<holo_hash::WasmHash, wasm::DnaWasm>);
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+struct WasmMapSerialized(Vec<(holo_hash::WasmHash, wasm::DnaWasm)>);
+
+impl From<WasmMap> for WasmMapSerialized {
+    fn from(w: WasmMap) -> Self {
+        Self(w.0.into_iter().collect())
+    }
+}
+
+impl From<WasmMapSerialized> for WasmMap {
+    fn from(w: WasmMapSerialized) -> Self {
+        Self(w.0.into_iter().collect())
+    }
+}
 
 /// Represents a full DNA file including WebAssembly bytecode.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, SerializedBytes)]
@@ -117,7 +147,7 @@ pub struct DnaFile {
     pub dna: DnaDefHashed,
 
     /// The bytes of the WASM zomes referenced in the Dna portion.
-    pub code: Wasms,
+    pub code: WasmMap,
 }
 
 impl From<DnaFile> for (DnaDef, Vec<wasm::DnaWasm>) {
@@ -141,7 +171,10 @@ impl DnaFile {
             code.insert(wasm_hash, wasm);
         }
         let dna = DnaDefHashed::from_content(dna).await;
-        Ok(Self { dna, code })
+        Ok(Self {
+            dna,
+            code: code.into(),
+        })
     }
 
     /// The DnaDef along with its hash
@@ -204,13 +237,13 @@ impl DnaFile {
 
     /// The bytes of the WASM zomes referenced in the Dna portion.
     pub fn code(&self) -> &BTreeMap<holo_hash::WasmHash, wasm::DnaWasm> {
-        &self.code
+        &self.code.0
     }
 
     /// Fetch the Webassembly byte code for a zome.
     pub fn get_wasm_for_zome(&self, zome_name: &ZomeName) -> Result<&wasm::DnaWasm, DnaError> {
         let wasm_hash = &self.dna.get_wasm_zome(zome_name)?.wasm_hash;
-        self.code.get(wasm_hash).ok_or(DnaError::InvalidWasmHash)
+        self.code.0.get(wasm_hash).ok_or(DnaError::InvalidWasmHash)
     }
 
     /// Render this dna_file as bytecode to send over the wire, or store in a file.


### PR DESCRIPTION
This PR adds the ability to register dna's separately from installing apps, and the install apps using hashes of already registered DNAs.  Additionally, it allows registering DNA's by passing in the DnaFile binary directly instead of a path to it, or by passing in a hash of a previously registered DNA.  Additionally it exposes overriding the UUID during the registration process.