### PR TITLE
Rename: cool -> sweet

### DIFF
--- a/crates/holochain/src/core/ribosome/host_fn/capability_grants.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/capability_grants.rs
@@ -18,10 +18,10 @@ pub fn capability_grants(
 #[cfg(feature = "slow_tests")]
 pub mod wasm_test {
     use crate::fixt::ZomeCallHostAccessFixturator;
-    use crate::{conductor::dna_store::MockDnaStore, test_utils::cool::MaybeElement};
-    use crate::{conductor::ConductorBuilder, test_utils::cool::CoolConductor};
+    use crate::{conductor::dna_store::MockDnaStore, test_utils::sweetest::MaybeElement};
+    use crate::{conductor::ConductorBuilder, test_utils::sweetest::SweetConductor};
     use crate::{
-        core::workflow::call_zome_workflow::CallZomeWorkspace, test_utils::cool::CoolDnaFile,
+        core::workflow::call_zome_workflow::CallZomeWorkspace, test_utils::sweetest::SweetDnaFile,
     };
     use ::fixt::prelude::*;
     use hdk3::prelude::*;
@@ -94,7 +94,7 @@ pub mod wasm_test {
     #[tokio::test(threaded_scheduler)]
     async fn ribosome_authorized_call() {
         observability::test_run().ok();
-        let (dna_file, _) = CoolDnaFile::unique_from_test_wasms(vec![TestWasm::Capability])
+        let (dna_file, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Capability])
             .await
             .unwrap();
 
@@ -110,7 +110,7 @@ pub mod wasm_test {
         dna_store.expect_add_entry_defs::<Vec<_>>().return_const(());
 
         let mut conductor =
-            CoolConductor::from_builder(ConductorBuilder::with_mock_dna_store(dna_store)).await;
+            SweetConductor::from_builder(ConductorBuilder::with_mock_dna_store(dna_store)).await;
 
         let apps = conductor
             .setup_app_for_agents(

--- a/crates/holochain/src/core/ribosome/host_fn/remote_signal.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/remote_signal.rs
@@ -57,8 +57,8 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     use super::*;
-    use crate::test_utils::cool::CoolDnaFile;
-    use crate::test_utils::cool::{CoolAgents, CoolConductorBatch};
+    use crate::test_utils::sweetest::SweetDnaFile;
+    use crate::test_utils::sweetest::{SweetAgents, SweetConductorBatch};
     use futures::future;
     use hdk3::prelude::*;
     use holochain_types::dna::zome::inline_zome::InlineZome;
@@ -116,11 +116,11 @@ mod tests {
 
         let num_signals = Arc::new(AtomicUsize::new(0));
 
-        let mut conductors = CoolConductorBatch::from_standard_config(NUM_CONDUCTORS).await;
+        let mut conductors = SweetConductorBatch::from_standard_config(NUM_CONDUCTORS).await;
         let agents =
-            future::join_all(conductors.iter().map(|c| CoolAgents::one(c.keystore()))).await;
+            future::join_all(conductors.iter().map(|c| SweetAgents::one(c.keystore()))).await;
 
-        let (dna_file, _) = CoolDnaFile::unique_from_inline_zome(
+        let (dna_file, _) = SweetDnaFile::unique_from_inline_zome(
             "zome1",
             zome(agents.clone(), num_signals.clone()),
         )

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -42,11 +42,11 @@ use tokio::sync::mpsc;
 
 pub use itertools;
 
-use self::cool::CoolCell;
+use self::sweetest::SweetCell;
 
 pub mod conductor_setup;
-pub mod cool;
 pub mod host_fn_caller;
+pub mod sweetest;
 
 /// Produce file and line number info at compile-time
 #[macro_export]
@@ -357,7 +357,7 @@ impl WaitOps {
 }
 
 /// Wait for all cells to reach consistency for 10 seconds
-pub async fn consistency_10s(all_cells: &[&CoolCell]) {
+pub async fn consistency_10s(all_cells: &[&SweetCell]) {
     const NUM_ATTEMPTS: usize = 100;
     const DELAY_PER_ATTEMPT: std::time::Duration = std::time::Duration::from_millis(100);
     consistency(all_cells, NUM_ATTEMPTS, DELAY_PER_ATTEMPT).await
@@ -365,7 +365,7 @@ pub async fn consistency_10s(all_cells: &[&CoolCell]) {
 
 /// Wait for all cells to reach consistency
 #[tracing::instrument(skip(all_cells))]
-pub async fn consistency(all_cells: &[&CoolCell], num_attempts: usize, delay: Duration) {
+pub async fn consistency(all_cells: &[&SweetCell], num_attempts: usize, delay: Duration) {
     let all_cell_envs: Vec<_> = all_cells.iter().map(|c| c.env()).collect();
     consistency_envs(&all_cell_envs[..], num_attempts, delay).await
 }

--- a/crates/holochain/src/test_utils/sweetest/mod.rs
+++ b/crates/holochain/src/test_utils/sweetest/mod.rs
@@ -1,22 +1,24 @@
+//! Sweetest = Streamlined Holochain test utils with lots of added sugar
+//!
 //! A wrapper around ConductorHandle which provides useful methods for setup
 //! and zome calling, as well as some helpful references to Cells and Zomes
 //! which make zome interaction much less verbose
 
-mod cool_agents;
-mod cool_app;
-mod cool_cell;
-mod cool_conductor;
-mod cool_dna;
-mod cool_network;
-mod cool_zome;
+mod sweet_agents;
+mod sweet_app;
+mod sweet_cell;
+mod sweet_conductor;
+mod sweet_dna;
+mod sweet_network;
+mod sweet_zome;
 
-pub use cool_agents::*;
-pub use cool_app::*;
-pub use cool_cell::*;
-pub use cool_conductor::*;
-pub use cool_dna::*;
-pub use cool_network::*;
-pub use cool_zome::*;
+pub use sweet_agents::*;
+pub use sweet_app::*;
+pub use sweet_cell::*;
+pub use sweet_conductor::*;
+pub use sweet_dna::*;
+pub use sweet_network::*;
+pub use sweet_zome::*;
 
 use hdk3::prelude::Element;
 use holochain_serialized_bytes::prelude::*;

--- a/crates/holochain/src/test_utils/sweetest/sweet_agents.rs
+++ b/crates/holochain/src/test_utils/sweetest/sweet_agents.rs
@@ -5,9 +5,9 @@ use holo_hash::AgentPubKey;
 use holochain_keystore::KeystoreSender;
 
 /// Provides simple methods for generating collections of AgentPubKeys for use in tests
-pub struct CoolAgents;
+pub struct SweetAgents;
 
-impl CoolAgents {
+impl SweetAgents {
     /// Get an infinite stream of AgentPubKeys
     pub fn stream(keystore: KeystoreSender) -> impl futures::Stream<Item = AgentPubKey> {
         use holochain_keystore::KeystoreSenderExt;

--- a/crates/holochain/src/test_utils/sweetest/sweet_app.rs
+++ b/crates/holochain/src/test_utils/sweetest/sweet_app.rs
@@ -1,19 +1,19 @@
-use super::CoolCell;
+use super::SweetCell;
 use holo_hash::AgentPubKey;
 use holochain_types::app::InstalledAppId;
 use itertools::traits::HomogeneousTuple;
 use itertools::Itertools;
 
-/// An installed app, with prebuilt CoolCells
+/// An installed app, with prebuilt SweetCells
 #[derive(Clone)]
-pub struct CoolApp {
+pub struct SweetApp {
     installed_app_id: InstalledAppId,
-    cells: Vec<CoolCell>,
+    cells: Vec<SweetCell>,
 }
 
-impl CoolApp {
+impl SweetApp {
     /// Constructor
-    pub(super) fn new(installed_app_id: InstalledAppId, cells: Vec<CoolCell>) -> Self {
+    pub(super) fn new(installed_app_id: InstalledAppId, cells: Vec<SweetCell>) -> Self {
         // Ensure that all Agents are the same
         assert!(cells.iter().map(|c| c.agent_pubkey()).dedup().count() == 1);
         Self {
@@ -28,12 +28,12 @@ impl CoolApp {
     }
 
     /// Accessor
-    pub fn cells(&self) -> &Vec<CoolCell> {
+    pub fn cells(&self) -> &Vec<SweetCell> {
         &self.cells
     }
 
     /// Accessor
-    pub fn into_cells(self) -> Vec<CoolCell> {
+    pub fn into_cells(self) -> Vec<SweetCell> {
         self.cells
     }
 
@@ -48,11 +48,11 @@ impl CoolApp {
 #[derive(
     Clone, derive_more::From, derive_more::Into, derive_more::AsRef, derive_more::IntoIterator,
 )]
-pub struct CoolAppBatch(pub(super) Vec<CoolApp>);
+pub struct SweetAppBatch(pub(super) Vec<SweetApp>);
 
-impl CoolAppBatch {
+impl SweetAppBatch {
     /// Get the underlying data
-    pub fn into_inner(self) -> Vec<CoolApp> {
+    pub fn into_inner(self) -> Vec<SweetApp> {
         self.0
     }
 
@@ -64,11 +64,11 @@ impl CoolAppBatch {
     pub fn into_tuples<Outer, Inner>(self) -> Outer
     where
         Outer: HomogeneousTuple<Item = Inner>,
-        Inner: HomogeneousTuple<Item = CoolCell>,
+        Inner: HomogeneousTuple<Item = SweetCell>,
         Outer::Buffer: std::convert::AsRef<[Option<Inner>]>,
         Outer::Buffer: std::convert::AsMut<[Option<Inner>]>,
-        Inner::Buffer: std::convert::AsRef<[Option<CoolCell>]>,
-        Inner::Buffer: std::convert::AsMut<[Option<CoolCell>]>,
+        Inner::Buffer: std::convert::AsRef<[Option<SweetCell>]>,
+        Inner::Buffer: std::convert::AsMut<[Option<SweetCell>]>,
     {
         self.into_inner()
             .into_iter()
@@ -83,12 +83,12 @@ impl CoolAppBatch {
     }
 
     /// Access all Cells across all Apps, with Cells from the same App being contiguous
-    pub fn cells_flattened(&self) -> Vec<&CoolCell> {
+    pub fn cells_flattened(&self) -> Vec<&SweetCell> {
         self.0.iter().flat_map(|app| app.cells().iter()).collect()
     }
 
     /// Get the underlying data
-    pub fn iter(&self) -> impl Iterator<Item = &CoolApp> {
+    pub fn iter(&self) -> impl Iterator<Item = &SweetApp> {
         self.0.iter()
     }
 }

--- a/crates/holochain/src/test_utils/sweetest/sweet_cell.rs
+++ b/crates/holochain/src/test_utils/sweetest/sweet_cell.rs
@@ -1,17 +1,17 @@
-use super::CoolZome;
+use super::SweetZome;
 use hdk3::prelude::*;
 use holo_hash::DnaHash;
 use holochain_lmdb::env::EnvironmentWrite;
 
-/// A reference to a Cell created by a CoolConductor installation function.
+/// A reference to a Cell created by a SweetConductor installation function.
 /// It has very concise methods for calling a zome on this cell
 #[derive(Clone, derive_more::Constructor)]
-pub struct CoolCell {
+pub struct SweetCell {
     pub(super) cell_id: CellId,
     pub(super) cell_env: EnvironmentWrite,
 }
 
-impl CoolCell {
+impl SweetCell {
     /// Accessor for CellId
     pub fn cell_id(&self) -> &CellId {
         &self.cell_id
@@ -32,8 +32,8 @@ impl CoolCell {
         &self.cell_id.dna_hash()
     }
 
-    /// Get a CoolZome with the given name
-    pub fn zome<Z: Into<ZomeName>>(&self, zome_name: Z) -> CoolZome {
-        CoolZome::new(self.cell_id.clone(), zome_name.into())
+    /// Get a SweetZome with the given name
+    pub fn zome<Z: Into<ZomeName>>(&self, zome_name: Z) -> SweetZome {
+        SweetZome::new(self.cell_id.clone(), zome_name.into())
     }
 }

--- a/crates/holochain/src/test_utils/sweetest/sweet_conductor.rs
+++ b/crates/holochain/src/test_utils/sweetest/sweet_conductor.rs
@@ -1,7 +1,7 @@
 //! A wrapper around ConductorHandle with more convenient methods for testing
 // TODO [ B-03669 ] move to own crate
 
-use super::{CoolAgents, CoolApp, CoolAppBatch, CoolCell, CoolZome};
+use super::{SweetAgents, SweetApp, SweetAppBatch, SweetCell, SweetZome};
 use crate::conductor::{
     api::ZomeCall, config::ConductorConfig, dna_store::DnaStore, handle::ConductorHandle,
     Conductor, ConductorBuilder,
@@ -18,53 +18,53 @@ use kitsune_p2p::KitsuneP2pConfig;
 use std::sync::Arc;
 use unwrap_to::unwrap_to;
 
-/// A collection of CoolConductors, with methods for operating on the entire collection
+/// A collection of SweetConductors, with methods for operating on the entire collection
 #[derive(derive_more::From, derive_more::Into, derive_more::IntoIterator)]
-pub struct CoolConductorBatch(Vec<CoolConductor>);
+pub struct SweetConductorBatch(Vec<SweetConductor>);
 
-impl CoolConductorBatch {
-    /// Map the given ConductorConfigs into CoolConductors, each with its own new TestEnvironments
+impl SweetConductorBatch {
+    /// Map the given ConductorConfigs into SweetConductors, each with its own new TestEnvironments
     pub async fn from_configs<I: IntoIterator<Item = ConductorConfig>>(
         configs: I,
-    ) -> CoolConductorBatch {
-        future::join_all(configs.into_iter().map(CoolConductor::from_config))
+    ) -> SweetConductorBatch {
+        future::join_all(configs.into_iter().map(SweetConductor::from_config))
             .await
             .into()
     }
 
-    /// Create the given number of new CoolConductors, each with its own new TestEnvironments
-    pub async fn from_config(num: usize, config: ConductorConfig) -> CoolConductorBatch {
+    /// Create the given number of new SweetConductors, each with its own new TestEnvironments
+    pub async fn from_config(num: usize, config: ConductorConfig) -> SweetConductorBatch {
         Self::from_configs(std::iter::repeat(config).take(num)).await
     }
 
-    /// Create the given number of new CoolConductors, each with its own new TestEnvironments
-    pub async fn from_standard_config(num: usize) -> CoolConductorBatch {
+    /// Create the given number of new SweetConductors, each with its own new TestEnvironments
+    pub async fn from_standard_config(num: usize) -> SweetConductorBatch {
         Self::from_configs(std::iter::repeat_with(standard_config).take(num)).await
     }
 
     /// Get the underlying data
-    pub fn iter(&self) -> impl Iterator<Item = &CoolConductor> {
+    pub fn iter(&self) -> impl Iterator<Item = &SweetConductor> {
         self.0.iter()
     }
 
     /// Get the underlying data
-    pub fn into_inner(self) -> Vec<CoolConductor> {
+    pub fn into_inner(self) -> Vec<SweetConductor> {
         self.0
     }
 
     /// Opinionated app setup.
     /// Creates one app on each Conductor in this batch, creating a new AgentPubKey for each.
-    /// The created AgentPubKeys can be retrieved via each CoolApp.
+    /// The created AgentPubKeys can be retrieved via each SweetApp.
     pub async fn setup_app(
         &mut self,
         installed_app_id: &str,
         dna_files: &[DnaFile],
-    ) -> CoolAppBatch {
+    ) -> SweetAppBatch {
         let apps = self
             .0
             .iter_mut()
             .map(|conductor| async move {
-                let agent = CoolAgents::one(conductor.keystore()).await;
+                let agent = SweetAgents::one(conductor.keystore()).await;
                 conductor
                     .setup_app_for_agent(installed_app_id, agent, dna_files)
                     .await
@@ -81,14 +81,14 @@ impl CoolConductorBatch {
     /// in this batch. Each Agent will be used to create one app on one Conductor,
     /// hence the "zipped" in the function name
     ///
-    /// Returns a batch of CoolApps, sorted in the same order as the Conductors in
+    /// Returns a batch of SweetApps, sorted in the same order as the Conductors in
     /// this batch.
     pub async fn setup_app_for_zipped_agents(
         &mut self,
         installed_app_id: &str,
         agents: &[AgentPubKey],
         dna_files: &[DnaFile],
-    ) -> CoolAppBatch {
+    ) -> SweetAppBatch {
         if agents.len() != self.0.len() {
             panic!("setup_app_for_zipped_agents must take as many Agents as there are Conductors in this batch.")
         }
@@ -117,10 +117,10 @@ impl CoolConductorBatch {
 ///
 /// This is intentionally NOT `Clone`, because the drop handle triggers a shutdown of
 /// the conductor handle, which would render all other cloned instances useless.
-/// If you need multiple references to a CoolConductor, put it in an Arc
+/// If you need multiple references to a SweetConductor, put it in an Arc
 #[derive(derive_more::From)]
-pub struct CoolConductor {
-    handle: Option<Arc<CoolConductorHandle>>,
+pub struct SweetConductor {
+    handle: Option<Arc<SweetConductorHandle>>,
     envs: TestEnvironments,
     config: ConductorConfig,
     dnas: Vec<DnaFile>,
@@ -139,14 +139,14 @@ fn standard_config() -> ConductorConfig {
     }
 }
 
-impl CoolConductor {
-    /// Create a CoolConductor from an already-build ConductorHandle and environments
+impl SweetConductor {
+    /// Create a SweetConductor from an already-build ConductorHandle and environments
     pub fn new(
         handle: ConductorHandle,
         envs: TestEnvironments,
         config: ConductorConfig,
-    ) -> CoolConductor {
-        let handle = Arc::new(CoolConductorHandle(handle));
+    ) -> SweetConductor {
+        let handle = Arc::new(SweetConductorHandle(handle));
         Self {
             handle: Some(handle),
             envs,
@@ -155,17 +155,17 @@ impl CoolConductor {
         }
     }
 
-    /// Create a CoolConductor with a new set of TestEnvironments from the given config
-    pub async fn from_config(config: ConductorConfig) -> CoolConductor {
+    /// Create a SweetConductor with a new set of TestEnvironments from the given config
+    pub async fn from_config(config: ConductorConfig) -> SweetConductor {
         let envs = test_environments();
         let handle = Self::from_existing(&envs, &config).await;
         Self::new(handle, envs, config)
     }
 
-    /// Create a CoolConductor from a partially-configured ConductorBuilder
+    /// Create a SweetConductor from a partially-configured ConductorBuilder
     pub async fn from_builder<DS: DnaStore + 'static>(
         builder: ConductorBuilder<DS>,
-    ) -> CoolConductor {
+    ) -> SweetConductor {
         let envs = test_environments();
         let config = builder.config.clone();
         let handle = builder.test(&envs).await.unwrap();
@@ -181,8 +181,8 @@ impl CoolConductor {
             .unwrap()
     }
 
-    /// Create a CoolConductor with a new set of TestEnvironments from the given config
-    pub async fn from_standard_config() -> CoolConductor {
+    /// Create a SweetConductor with a new set of TestEnvironments from the given config
+    pub async fn from_standard_config() -> SweetConductor {
         Self::from_config(standard_config()).await
     }
 
@@ -239,7 +239,7 @@ impl CoolConductor {
             .expect("Could not activate app");
     }
 
-    /// Build the CoolCells after `setup_cells` has been run
+    /// Build the SweetCells after `setup_cells` has been run
     /// The setup is split into two parts because the Cell environments
     /// are not available until after `setup_cells` has run, and it is
     /// better to do that once for all apps in the case of multiple apps being
@@ -249,8 +249,8 @@ impl CoolConductor {
         installed_app_id: &str,
         agent: AgentPubKey,
         dna_hashes: impl Iterator<Item = DnaHash>,
-    ) -> CoolApp {
-        let mut cool_cells = Vec::new();
+    ) -> SweetApp {
+        let mut sweet_cells = Vec::new();
         for dna_hash in dna_hashes {
             let cell_id = CellId::new(dna_hash, agent.clone());
             let cell_env = self
@@ -259,11 +259,11 @@ impl CoolConductor {
                 .get_cell_env(&cell_id)
                 .await
                 .expect("Couldn't get cell environment");
-            let cell = CoolCell { cell_id, cell_env };
-            cool_cells.push(cell);
+            let cell = SweetCell { cell_id, cell_env };
+            sweet_cells.push(cell);
         }
 
-        CoolApp::new(installed_app_id.into(), cool_cells)
+        SweetApp::new(installed_app_id.into(), sweet_cells)
     }
 
     /// Opinionated app setup.
@@ -273,7 +273,7 @@ impl CoolConductor {
         installed_app_id: &str,
         agent: AgentPubKey,
         dna_files: &[DnaFile],
-    ) -> CoolApp {
+    ) -> SweetApp {
         self.setup_app_part_1(dna_files).await;
         self.setup_app_part_2(installed_app_id, agent.clone(), dna_files)
             .await;
@@ -292,9 +292,9 @@ impl CoolConductor {
 
     /// Opinionated app setup.
     /// Creates an app using the given DnaFiles, with no extra configuration.
-    /// An AgentPubKey will be generated, and is accessible via the returned CoolApp.
-    pub async fn setup_app(&mut self, installed_app_id: &str, dna_files: &[DnaFile]) -> CoolApp {
-        let agent = CoolAgents::one(self.keystore()).await;
+    /// An AgentPubKey will be generated, and is accessible via the returned SweetApp.
+    pub async fn setup_app(&mut self, installed_app_id: &str, dna_files: &[DnaFile]) -> SweetApp {
+        let agent = SweetAgents::one(self.keystore()).await;
         self.setup_app_for_agent(installed_app_id, agent, dna_files)
             .await
     }
@@ -307,13 +307,13 @@ impl CoolConductor {
     /// - InstalledAppId: {app_id_prefix}-{agent_pub_key}
     /// - CellNick: {dna_hash}
     ///
-    /// Returns a batch of CoolApps, sorted in the same order as Agents passed in.
+    /// Returns a batch of SweetApps, sorted in the same order as Agents passed in.
     pub async fn setup_app_for_agents(
         &mut self,
         app_id_prefix: &str,
         agents: &[AgentPubKey],
         dna_files: &[DnaFile],
-    ) -> CoolAppBatch {
+    ) -> SweetAppBatch {
         self.setup_app_part_1(dna_files).await;
         for agent in agents.iter() {
             let installed_app_id = format!("{}{}", app_id_prefix, agent);
@@ -341,7 +341,7 @@ impl CoolConductor {
             );
         }
 
-        CoolAppBatch(apps)
+        SweetAppBatch(apps)
     }
 
     /// Shutdown this conductor.
@@ -360,7 +360,7 @@ impl CoolConductor {
     /// Start up this conductor if it's not already running.
     pub async fn startup(&mut self) {
         if self.handle.is_none() {
-            self.handle = Some(Arc::new(CoolConductorHandle(
+            self.handle = Some(Arc::new(SweetConductorHandle(
                 Self::from_existing(&self.envs, &self.config).await,
             )));
 
@@ -382,7 +382,7 @@ impl CoolConductor {
     }
 
     // NB: keep this private to prevent leaking out owned references
-    fn handle(&self) -> Arc<CoolConductorHandle> {
+    fn handle(&self) -> Arc<SweetConductorHandle> {
         self.handle
             .clone()
             .expect("Tried to use a conductor that is offline")
@@ -391,12 +391,12 @@ impl CoolConductor {
 /// A wrapper around ConductorHandle with more convenient methods for testing
 /// and a cleanup drop
 #[derive(shrinkwraprs::Shrinkwrap, derive_more::From)]
-pub struct CoolConductorHandle(pub(crate) ConductorHandle);
+pub struct SweetConductorHandle(pub(crate) ConductorHandle);
 
-impl CoolConductorHandle {
+impl SweetConductorHandle {
     /// Make a zome call to a Cell, as if that Cell were the caller. Most common case.
     /// No capability is necessary, since the authorship capability is automatically granted.
-    pub async fn call<I, O, F, E>(&self, zome: &CoolZome, fn_name: F, payload: I) -> O
+    pub async fn call<I, O, F, E>(&self, zome: &SweetZome, fn_name: F, payload: I) -> O
     where
         E: std::fmt::Debug,
         FunctionName: From<F>,
@@ -413,7 +413,7 @@ impl CoolConductorHandle {
         &self,
         provenance: &AgentPubKey,
         cap: Option<CapSecret>,
-        zome: &CoolZome,
+        zome: &SweetZome,
         fn_name: F,
         payload: I,
     ) -> O
@@ -452,7 +452,7 @@ impl CoolConductorHandle {
     }
 }
 
-impl Drop for CoolConductor {
+impl Drop for SweetConductor {
     fn drop(&mut self) {
         if let Some(handle) = self.handle.take() {
             tokio::task::spawn(async move {
@@ -466,16 +466,16 @@ impl Drop for CoolConductor {
     }
 }
 
-impl AsRef<Arc<CoolConductorHandle>> for CoolConductor {
-    fn as_ref(&self) -> &Arc<CoolConductorHandle> {
+impl AsRef<Arc<SweetConductorHandle>> for SweetConductor {
+    fn as_ref(&self) -> &Arc<SweetConductorHandle> {
         self.handle
             .as_ref()
             .expect("Tried to use a conductor that is offline")
     }
 }
 
-impl std::ops::Deref for CoolConductor {
-    type Target = Arc<CoolConductorHandle>;
+impl std::ops::Deref for SweetConductor {
+    type Target = Arc<SweetConductorHandle>;
 
     fn deref(&self) -> &Self::Target {
         self.handle
@@ -484,23 +484,23 @@ impl std::ops::Deref for CoolConductor {
     }
 }
 
-impl std::borrow::Borrow<Arc<CoolConductorHandle>> for CoolConductor {
-    fn borrow(&self) -> &Arc<CoolConductorHandle> {
+impl std::borrow::Borrow<Arc<SweetConductorHandle>> for SweetConductor {
+    fn borrow(&self) -> &Arc<SweetConductorHandle> {
         self.handle
             .as_ref()
             .expect("Tried to use a conductor that is offline")
     }
 }
 
-impl std::ops::Index<usize> for CoolConductorBatch {
-    type Output = CoolConductor;
+impl std::ops::Index<usize> for SweetConductorBatch {
+    type Output = SweetConductor;
 
     fn index(&self, index: usize) -> &Self::Output {
         &self.0[index]
     }
 }
 
-impl std::ops::IndexMut<usize> for CoolConductorBatch {
+impl std::ops::IndexMut<usize> for SweetConductorBatch {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.0[index]
     }

--- a/crates/holochain/src/test_utils/sweetest/sweet_dna.rs
+++ b/crates/holochain/src/test_utils/sweetest/sweet_dna.rs
@@ -8,9 +8,9 @@ use holochain_zome_types::zome::ZomeName;
 
 /// Helpful constructors for DnaFiles used in tests
 #[derive(Clone, Debug, derive_more::From, derive_more::Into, shrinkwraprs::Shrinkwrap)]
-pub struct CoolDnaFile(DnaFile);
+pub struct SweetDnaFile(DnaFile);
 
-impl CoolDnaFile {
+impl SweetDnaFile {
     /// Create a DnaFile from a collection of Zomes
     pub async fn from_zomes(
         uuid: String,

--- a/crates/holochain/src/test_utils/sweetest/sweet_network.rs
+++ b/crates/holochain/src/test_utils/sweetest/sweet_network.rs
@@ -1,9 +1,9 @@
 use kitsune_p2p::KitsuneP2pConfig;
 
 /// Helper for constructing common kitsune networks
-pub struct CoolNetwork;
+pub struct SweetNetwork;
 
-impl CoolNetwork {
+impl SweetNetwork {
     /// Get a remote kitsune proxy address from the
     /// env var `KIT_PROXY` if it's set.
     pub fn env_var_proxy() -> Option<KitsuneP2pConfig> {

--- a/crates/holochain/src/test_utils/sweetest/sweet_zome.rs
+++ b/crates/holochain/src/test_utils/sweetest/sweet_zome.rs
@@ -1,14 +1,14 @@
 use hdk3::prelude::*;
 
-/// A reference to a Zome in a Cell created by a CoolConductor installation function.
-/// Think of it as a partially applied CoolCell, with the ZomeName baked in.
+/// A reference to a Zome in a Cell created by a SweetConductor installation function.
+/// Think of it as a partially applied SweetCell, with the ZomeName baked in.
 #[derive(Clone, derive_more::Constructor)]
-pub struct CoolZome {
+pub struct SweetZome {
     cell_id: CellId,
     name: ZomeName,
 }
 
-impl CoolZome {
+impl SweetZome {
     /// Accessor
     pub fn cell_id(&self) -> &CellId {
         &self.cell_id

--- a/crates/holochain/tests/agent_scaling.rs
+++ b/crates/holochain/tests/agent_scaling.rs
@@ -2,9 +2,9 @@
 
 use hdk3::prelude::Links;
 use holochain::test_utils::consistency_10s;
-use holochain::test_utils::cool::CoolAgents;
-use holochain::test_utils::cool::CoolConductor;
-use holochain::test_utils::cool::CoolDnaFile;
+use holochain::test_utils::sweetest::SweetAgents;
+use holochain::test_utils::sweetest::SweetConductor;
+use holochain::test_utils::sweetest::SweetDnaFile;
 use holochain_serialized_bytes::prelude::*;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
@@ -31,14 +31,14 @@ async fn many_agents_can_reach_consistency_agent_links() {
     observability::test_run().ok();
     const NUM_AGENTS: usize = 20;
 
-    let (dna_file, _) = CoolDnaFile::unique_from_inline_zome("links", links_zome())
+    let (dna_file, _) = SweetDnaFile::unique_from_inline_zome("links", links_zome())
         .await
         .unwrap();
 
     // Create a Conductor
-    let mut conductor = CoolConductor::from_config(Default::default()).await;
+    let mut conductor = SweetConductor::from_config(Default::default()).await;
 
-    let agents = CoolAgents::get(conductor.keystore(), NUM_AGENTS).await;
+    let agents = SweetAgents::get(conductor.keystore(), NUM_AGENTS).await;
     let apps = conductor
         .setup_app_for_agents("app", &agents, &[dna_file])
         .await;
@@ -82,14 +82,14 @@ async fn many_agents_can_reach_consistency_normal_links() {
     observability::test_run().ok();
     const NUM_AGENTS: usize = 30;
 
-    let (dna_file, _) = CoolDnaFile::unique_from_test_wasms(vec![TestWasm::Link])
+    let (dna_file, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Link])
         .await
         .unwrap();
 
     // Create a Conductor
-    let mut conductor = CoolConductor::from_config(Default::default()).await;
+    let mut conductor = SweetConductor::from_config(Default::default()).await;
 
-    let agents = CoolAgents::get(conductor.keystore(), NUM_AGENTS).await;
+    let agents = SweetAgents::get(conductor.keystore(), NUM_AGENTS).await;
     let apps = conductor
         .setup_app_for_agents("app", &agents, &[dna_file])
         .await;
@@ -118,10 +118,10 @@ async fn many_agents_can_reach_consistency_normal_links() {
 async fn stuck_conductor_wasm_calls() -> anyhow::Result<()> {
     observability::test_run().ok();
     // Bundle the single zome into a DnaFile
-    let (dna_file, _) = CoolDnaFile::unique_from_test_wasms(vec![TestWasm::MultipleCalls]).await?;
+    let (dna_file, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::MultipleCalls]).await?;
 
     // Create a Conductor
-    let mut conductor = CoolConductor::from_standard_config().await;
+    let mut conductor = SweetConductor::from_standard_config().await;
 
     // Install DNA and install and activate apps in conductor
     let alice = conductor
@@ -143,7 +143,7 @@ async fn stuck_conductor_wasm_calls() -> anyhow::Result<()> {
     tracing::debug!("starting slow fn");
 
     // NB: there's currently no reason to independently create a bunch of tasks here,
-    // since they are all running in series. Hence, there is no reason to put the CoolConductor
+    // since they are all running in series. Hence, there is no reason to put the SweetConductor
     // in an Arc. However, maybe this test was written to make it easy to try running some
     // or all of the closures concurrently, in which case the Arc is indeed necessary.
     let conductor_arc = std::sync::Arc::new(conductor);

--- a/crates/holochain/tests/inline_zome_sketch.rs
+++ b/crates/holochain/tests/inline_zome_sketch.rs
@@ -1,6 +1,6 @@
 use hdk3::prelude::*;
-use holochain::test_utils::cool::{CoolAgents, CoolConductor, CoolDnaFile, MaybeElement};
 use holochain::test_utils::display_agent_infos;
+use holochain::test_utils::sweetest::{MaybeElement, SweetAgents, SweetConductor, SweetDnaFile};
 use holochain::test_utils::wait_for_integration_10s;
 use holochain::test_utils::WaitOps;
 use holochain_types::dna::zome::inline_zome::InlineZome;
@@ -46,13 +46,13 @@ fn simple_crud_zome() -> InlineZome {
 #[cfg(feature = "test_utils")]
 async fn inline_zome_2_agents_1_dna() -> anyhow::Result<()> {
     // Bundle the single zome into a DnaFile
-    let (dna_file, _) = CoolDnaFile::unique_from_inline_zome("zome1", simple_crud_zome()).await?;
+    let (dna_file, _) = SweetDnaFile::unique_from_inline_zome("zome1", simple_crud_zome()).await?;
 
     // Create a Conductor
-    let mut conductor = CoolConductor::from_standard_config().await;
+    let mut conductor = SweetConductor::from_standard_config().await;
 
     // Get two agents
-    let (alice, bobbo) = CoolAgents::two(conductor.keystore()).await;
+    let (alice, bobbo) = SweetAgents::two(conductor.keystore()).await;
 
     // Install DNA and install and activate apps in conductor
     let apps = conductor
@@ -93,12 +93,12 @@ async fn inline_zome_2_agents_1_dna() -> anyhow::Result<()> {
 #[cfg(feature = "test_utils")]
 async fn inline_zome_3_agents_2_dnas() -> anyhow::Result<()> {
     observability::test_run().ok();
-    let mut conductor = CoolConductor::from_standard_config().await;
+    let mut conductor = SweetConductor::from_standard_config().await;
 
-    let (dna_foo, _) = CoolDnaFile::unique_from_inline_zome("foozome", simple_crud_zome()).await?;
-    let (dna_bar, _) = CoolDnaFile::unique_from_inline_zome("barzome", simple_crud_zome()).await?;
+    let (dna_foo, _) = SweetDnaFile::unique_from_inline_zome("foozome", simple_crud_zome()).await?;
+    let (dna_bar, _) = SweetDnaFile::unique_from_inline_zome("barzome", simple_crud_zome()).await?;
 
-    let agents = CoolAgents::get(conductor.keystore(), 3).await;
+    let agents = SweetAgents::get(conductor.keystore(), 3).await;
 
     let apps = conductor
         .setup_app_for_agents("app", &agents, &[dna_foo, dna_bar])
@@ -149,7 +149,7 @@ async fn inline_zome_3_agents_2_dnas() -> anyhow::Result<()> {
 
     // Verify that carol can run "read" on her cell and get alice's Header
     // on the "bar" DNA
-    // Let's do it with the CoolZome instead of the CoolCell too, for fun
+    // Let's do it with the SweetZome instead of the SweetCell too, for fun
     let element: MaybeElement = conductor
         .call(&carol_bar.zome("barzome"), "read", hash_bar)
         .await;
@@ -170,12 +170,12 @@ async fn inline_zome_3_agents_2_dnas() -> anyhow::Result<()> {
 #[ignore = "Needs to be completed when HolochainP2pEvents is accessible"]
 async fn invalid_cell() -> anyhow::Result<()> {
     observability::test_run().ok();
-    let mut conductor = CoolConductor::from_standard_config().await;
+    let mut conductor = SweetConductor::from_standard_config().await;
 
-    let (dna_foo, _) = CoolDnaFile::unique_from_inline_zome("foozome", simple_crud_zome()).await?;
-    let (dna_bar, _) = CoolDnaFile::unique_from_inline_zome("barzome", simple_crud_zome()).await?;
+    let (dna_foo, _) = SweetDnaFile::unique_from_inline_zome("foozome", simple_crud_zome()).await?;
+    let (dna_bar, _) = SweetDnaFile::unique_from_inline_zome("barzome", simple_crud_zome()).await?;
 
-    // let agents = CoolAgents::get(conductor.keystore(), 2).await;
+    // let agents = SweetAgents::get(conductor.keystore(), 2).await;
 
     let _app_foo = conductor.setup_app("foo", &[dna_foo]).await;
 
@@ -201,10 +201,10 @@ async fn invalid_cell() -> anyhow::Result<()> {
 async fn get_deleted() -> anyhow::Result<()> {
     observability::test_run().ok();
     // Bundle the single zome into a DnaFile
-    let (dna_file, _) = CoolDnaFile::unique_from_inline_zome("zome1", simple_crud_zome()).await?;
+    let (dna_file, _) = SweetDnaFile::unique_from_inline_zome("zome1", simple_crud_zome()).await?;
 
     // Create a Conductor
-    let mut conductor = CoolConductor::from_config(Default::default()).await;
+    let mut conductor = SweetConductor::from_config(Default::default()).await;
 
     // Install DNA and install and activate apps in conductor
     let alice = conductor

--- a/crates/holochain/tests/multi_conductor.rs
+++ b/crates/holochain/tests/multi_conductor.rs
@@ -1,10 +1,10 @@
 use hdk3::prelude::*;
 use holochain::conductor::config::ConductorConfig;
-use holochain::test_utils::cool::CoolNetwork;
-use holochain::test_utils::cool::MaybeElement;
-use holochain::test_utils::cool::{CoolConductorBatch, CoolDnaFile};
 use holochain::test_utils::host_fn_caller::Post;
 use holochain::test_utils::show_authored;
+use holochain::test_utils::sweetest::MaybeElement;
+use holochain::test_utils::sweetest::SweetNetwork;
+use holochain::test_utils::sweetest::{SweetConductorBatch, SweetDnaFile};
 
 use holochain::test_utils::wait_for_integration_10s;
 use holochain::test_utils::wait_for_integration_with_others_10s;
@@ -57,9 +57,9 @@ async fn multi_conductor() -> anyhow::Result<()> {
     let _g = observability::test_run().ok();
     const NUM_CONDUCTORS: usize = 3;
 
-    let mut conductors = CoolConductorBatch::from_standard_config(NUM_CONDUCTORS).await;
+    let mut conductors = SweetConductorBatch::from_standard_config(NUM_CONDUCTORS).await;
 
-    let (dna_file, _) = CoolDnaFile::unique_from_inline_zome("zome1", simple_crud_zome())
+    let (dna_file, _) = SweetDnaFile::unique_from_inline_zome("zome1", simple_crud_zome())
         .await
         .unwrap();
 
@@ -100,16 +100,16 @@ async fn invalid_cell() -> anyhow::Result<()> {
     let _g = observability::test_run().ok();
     const NUM_CONDUCTORS: usize = 3;
 
-    let network = CoolNetwork::env_var_proxy().unwrap_or_else(|| {
+    let network = SweetNetwork::env_var_proxy().unwrap_or_else(|| {
         info!("KIT_PROXY not set using local quic network");
-        CoolNetwork::local_quic()
+        SweetNetwork::local_quic()
     });
     let mut config = ConductorConfig::default();
     config.network = Some(network);
 
-    let mut conductors = CoolConductorBatch::from_config(NUM_CONDUCTORS, config).await;
+    let mut conductors = SweetConductorBatch::from_config(NUM_CONDUCTORS, config).await;
 
-    let (dna_file, _) = CoolDnaFile::unique_from_inline_zome("zome1", invalid_cell_zome())
+    let (dna_file, _) = SweetDnaFile::unique_from_inline_zome("zome1", invalid_cell_zome())
         .await
         .unwrap();
 

--- a/crates/holochain/tests/websocket.rs
+++ b/crates/holochain/tests/websocket.rs
@@ -4,9 +4,9 @@ use assert_cmd::prelude::*;
 use futures::future;
 use futures::Future;
 use hdk3::prelude::RemoteSignal;
-use holochain::test_utils::cool::CoolAgents;
-use holochain::test_utils::cool::CoolConductorBatch;
-use holochain::test_utils::cool::CoolDnaFile;
+use holochain::test_utils::sweetest::SweetAgents;
+use holochain::test_utils::sweetest::SweetConductorBatch;
+use holochain::test_utils::sweetest::SweetDnaFile;
 use holochain::{
     conductor::api::ZomeCall,
     conductor::{
@@ -392,13 +392,13 @@ async fn remote_signals() {
     observability::test_run().ok();
     const NUM_CONDUCTORS: usize = 5;
 
-    let mut conductors = CoolConductorBatch::from_standard_config(NUM_CONDUCTORS).await;
+    let mut conductors = SweetConductorBatch::from_standard_config(NUM_CONDUCTORS).await;
 
     // TODO: write helper for agents across conductors
     let all_agents: Vec<HoloHash<hash_type::Agent>> =
-        future::join_all(conductors.iter().map(|c| CoolAgents::one(c.keystore()))).await;
+        future::join_all(conductors.iter().map(|c| SweetAgents::one(c.keystore()))).await;
 
-    let dna_file = CoolDnaFile::unique_from_test_wasms(vec![TestWasm::EmitSignal])
+    let dna_file = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::EmitSignal])
         .await
         .unwrap()
         .0;


### PR DESCRIPTION
This is just a massive rename. No logic changes.

All `CoolFoo` now become `SweetFoo`, and the framework itself is called `sweetest`. The reason being, it's mainly about sugar. And it's for testing. So sweet test. Get it?