### PR TITLE
hc-test: limit parallel jobs to 4 to reduce memory impact

### DIFF
--- a/nix/pkgs/core.nix
+++ b/nix/pkgs/core.nix
@@ -12,6 +12,10 @@ rec {
     set -euxo pipefail
     export RUST_BACKTRACE=1
 
+    # limit parallel jobs to reduce memory consumption
+    export NUM_JOBS=4
+    export CARGO_BUILD_JOBS=4
+
     # ensure plain build works
     cargo build --no-default-features --manifest-path=crates/holochain/Cargo.toml
 


### PR DESCRIPTION
CI is having jobs terminated likely due to memory limits. This should
mitigate the issue.