### PR TITLE
prepare release hdk-0.0.100-alpha.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,18 +18,6 @@ commands:
       command: ./docker/push.sh << parameters.box >> $CIRCLE_BRANCH
 
 jobs:
-  build-binary-packages:
-    docker:
-     - image: nixos/nix
-    environment:
-     NIXPKGS_ALLOW_UNFREE: 1
-    steps:
-      - checkout
-      - run:
-         name: Build the Nix packages
-         no_output_timeout: 45m
-         command: nix build --verbose -f default.nix pkgs.applications
-
   merge-test:
     docker:
      - image: holochain/holochain:circle.build.develop
@@ -90,11 +78,6 @@ workflows:
  version: 2.1
  tests:
   jobs:
-   - build-binary-packages:
-      filters:
-       branches:
-        only:
-          - /.*release.*/
    - merge-test
    # - merge-test-mac
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,7 +1338,7 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "hdk"
-version = "0.0.1"
+version = "0.0.99"
 dependencies = [
  "fixt",
  "hdk_derive",

--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+* holochain 0.0.100 (RSM) compatibility
+* Extensive doc comments

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "hdk"
-version = "0.0.1"
-description = "third iteration of the holochain hdk"
+version = "0.0.99"
+description = "The Holochain HDK"
 license-file = "LICENSE_CAL-1.0"
-homepage = "https://github.com/holochain/holochain"
-documentation = "https://github.com/holochain/holochain"
+homepage = "https://github.com/holochain/holochain/tree/develop/crates/hdk"
+documentation = "https://docs.rs/hdk/"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
 keywords = [ "holochain", "holo", "hdk" ]
 categories = [ "cryptography" ]

--- a/crates/hdk/README.md
+++ b/crates/hdk/README.md
@@ -1,8 +1,8 @@
-# Holochain Development Kit 3.0 (HDK)
+# Holochain Development Kit (HDK)
 
-This is the third major iteration of the holochain development kit.
+This HDK is currently in flux, expect rapid changes.
 
-There are two big differences between this kit and previous kits.
+There are a few big differences between this kit and previous kits.
 
 This kit:
 
@@ -19,8 +19,6 @@ Old kits:
 
 ## HDK API
 
-Welcome to the HDK 3.0.
-This HDK is currently in flux, expect rapid changes.
 There are low-level macros and high-level functions to aid writing happs.
 
 The intention is that most of the time most developers will use the high level

--- a/crates/hdk/release.toml
+++ b/crates/hdk/release.toml
@@ -1,0 +1,11 @@
+[[pre-release-replacements]]
+file = "Cargo.toml"
+search = "/develop/"
+replace = "/{{crate_name}}-v{{version}}/"
+prerelease = true
+
+[[post-release-replacements]]
+file = "Cargo.toml"
+search = "/{{crate_name}}-v{{version}}/"
+replace = "/develop/"
+prerelease = true

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -28,7 +28,7 @@ serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 
 [features]
 
-default = ["serialized-bytes"]
+default = ["serialized-bytes", "fixturators"]
 full = ["fixturators", "hashing", "string-encoding"]
 
 fixturators = ["fixt", "rand", "serialized-bytes", "string-encoding"]

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -15,7 +15,7 @@ fallible-iterator = "0.2"
 fixt = { version = "0.0.1", path = "../fixt" }
 futures = "0.3"
 ghost_actor = "0.3.0-alpha.1"
-hdk = { version = "0.0.1", path = "../hdk" }
+hdk = { version = "0.0.99", path = "../hdk" }
 hdk_derive = { version = "0.0.1", path = "../hdk_derive" }
 holo_hash = { version = "0.0.1", path = "../holo_hash", features = ["full"] }
 holochain_lmdb = { version = "0.0.1", path = "../holochain_lmdb" }

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -34,7 +34,7 @@ tokio_safe_block_on = "0.1.2"
 [dev-dependencies]
 anyhow = "1.0.26"
 fixt = { version = "0.0.1", path = "../fixt" }
-hdk = { version = "0.0.1", path = "../hdk" }
+hdk = { version = "0.0.99", path = "../hdk" }
 holochain_wasm_test_utils = { path = "../test_utils/wasm" }
 matches = "0.1.8"
 observability = "0.1.3"

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,3 @@
+sign-commit = true
+sign-tag = true
+consolidate-commits = true


### PR DESCRIPTION
Split off #657.

This will be marked as alpha because we have known issues with the autogenerated documentation which we'll fix before 0.0.100.