### PR TITLE
Allow lmdb mmap size to be set from HC_LMDB_SIZE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ perf.data.old
 .todo.md
 result
 test_cert
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,6 +1582,7 @@ dependencies = [
  "must_future",
  "nanoid",
  "observability",
+ "page_size",
  "parking_lot",
  "rand 0.7.3",
  "rkv",

--- a/crates/holochain/benches/bench.rs
+++ b/crates/holochain/benches/bench.rs
@@ -82,7 +82,7 @@ pub fn wasm_call_n(c: &mut Criterion) {
                         zome: zome.clone(),
                         cap: Some(CAP.lock().unwrap().clone()),
                         fn_name: "echo_bytes".into(),
-                        payload: ExternIO::encode(&bytes).unwrap(),
+                        payload: ExternInput::new(sb.clone()),
                         provenance: AGENT_KEY.lock().unwrap().clone(),
                     };
                     REAL_RIBOSOME

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -128,9 +128,7 @@ impl Cell {
         if has_genesis {
             tokio::spawn({
                 let mut network = holochain_p2p_cell.clone();
-                async move {
-                    network.join().await
-                }
+                async move { network.join().await }
             });
             let (queue_triggers, initial_queue_triggers) = spawn_queue_consumer_tasks(
                 &env,

--- a/crates/holochain_lmdb/Cargo.toml
+++ b/crates/holochain_lmdb/Cargo.toml
@@ -25,6 +25,7 @@ holochain_zome_types = { version = "0.0.1", path = "../holochain_zome_types" }
 lazy_static = "1.4.0"
 must_future = "0.1.1"
 nanoid = "0.3.0"
+page_size = "0.4.2"
 parking_lot = "0.10"
 rand = "0.7"
 rkv = "=0.10.4"

--- a/crates/holochain_lmdb/examples/test_size.rs
+++ b/crates/holochain_lmdb/examples/test_size.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use hl::prelude::*;
+use holochain_lmdb as hl;
+
+#[tokio::main(threaded_scheduler)]
+async fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    match args.get(1) {
+        Some(path) => {
+            let env =
+                EnvironmentWrite::new(Path::new(path), EnvironmentKind::Wasm, test_keystore())
+                    .unwrap();
+            let info = env.guard().rkv().info().unwrap().map_size();
+            let size = info / 1_000_000;
+            println!("Map size: {}MB", size);
+        }
+        None => {
+            let env = test_wasm_env();
+            let tmp = env.tmpdir();
+            let info = env.env().guard().rkv().info().unwrap().map_size();
+            let size = info / 1_000_000;
+            drop(env);
+            let tmp = Arc::try_unwrap(tmp).unwrap();
+            let p = tmp.into_path();
+            println!("Map size: {}MB Path: {}", size, p.display());
+        }
+    }
+}

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/gossip.rs
@@ -5,7 +5,7 @@ use crate::types::actor::KitsuneP2pResult;
 use crate::types::gossip::*;
 use crate::*;
 use ghost_actor::dependencies::tracing;
-//use ghost_actor::dependencies::tracing_futures;
+use ghost_actor::dependencies::tracing_futures;
 use ghost_actor::GhostError;
 use kitsune_p2p_types::dht_arc::DhtArc;
 use std::collections::HashMap;

--- a/crates/test_utils/wasm/build.rs
+++ b/crates/test_utils/wasm/build.rs
@@ -2,8 +2,8 @@
 //use std::process::Stdio;
 
 fn main() {
-    return;
-/*    let should_build = std::env::var_os("CARGO_FEATURE_BUILD").is_some();
+    // return;
+    /*    let should_build = std::env::var_os("CARGO_FEATURE_BUILD").is_some();
     let only_check = std::env::var_os("CARGO_FEATURE_ONLY_CHECK").is_some();
 
     if !(should_build || only_check) {


### PR DESCRIPTION
Allow lmdb mmap size to be set from HC_LMDB_SIZE, size is in bytes and is automatically converted to a multiple of the pages size