### PR TITLE
additional tx2 utils updates

### DIFF
--- a/crates/kitsune_p2p/types/src/tx2/tx2_utils.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_utils.rs
@@ -25,5 +25,8 @@ pub use resource_bucket::*;
 mod share;
 pub use share::*;
 
+mod t_chan;
+pub use t_chan::*;
+
 mod tx_url;
 pub use tx_url::*;

--- a/crates/kitsune_p2p/types/src/tx2/tx2_utils/active.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_utils/active.rs
@@ -10,6 +10,13 @@ impl ActiveInner {
         Self(NotifyAll::new())
     }
 
+    pub fn register_kill_cb<F>(&self, cb: F)
+    where
+        F: FnOnce() + 'static + Send,
+    {
+        self.0.wait_cb(cb);
+    }
+
     pub fn kill(&self) {
         self.0.notify();
     }
@@ -64,6 +71,20 @@ impl Active {
         Self(out.into_boxed_slice())
     }
 
+    /// Register a callback to be invoked on kill.
+    /// Beware the cb may be invoked multiple times if this Active is mixed.
+    pub fn register_kill_cb<F>(&self, cb: F)
+    where
+        F: Fn() + 'static + Send + Sync,
+    {
+        type CB = Arc<dyn Fn() + 'static + Send + Sync>;
+        let cb: CB = Arc::new(cb);
+        for i in self.0.iter() {
+            let cb = cb.clone();
+            i.register_kill_cb(move || cb());
+        }
+    }
+
     /// Kill this active tracker (all trackers if mixed).
     pub fn kill(&self) {
         for i in self.0.iter() {
@@ -104,6 +125,25 @@ impl Active {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_active_cb() {
+        let count = Arc::new(atomic::AtomicUsize::new(0));
+
+        let a1 = Active::new();
+        let a2 = Active::new();
+        let mix = a1.mix(&a2);
+
+        let c2 = count.clone();
+        mix.register_kill_cb(move || {
+            c2.fetch_add(1, atomic::Ordering::Relaxed);
+        });
+
+        a1.kill();
+        a2.kill();
+        assert_eq!(2, count.load(atomic::Ordering::Relaxed));
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_active() {

--- a/crates/kitsune_p2p/types/src/tx2/tx2_utils/notify_all.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_utils/notify_all.rs
@@ -100,10 +100,14 @@ impl NotifyAll {
         F: FnOnce() + 'static + Send,
     {
         let mut maybe_sync_cb: Option<NotifySyncCb> = Some(Box::new(sync_cb));
+
+        // if we have not already notified, take it to be notified later
         let _ = self.0.share_mut(|i, _| {
             i.cbs.push(maybe_sync_cb.take().unwrap());
             Ok(())
         });
+
+        // if the cb was not taken, we have already notified, so call it now
         if let Some(sync_cb) = maybe_sync_cb {
             sync_cb();
         }

--- a/crates/kitsune_p2p/types/src/tx2/tx2_utils/notify_all.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_utils/notify_all.rs
@@ -3,9 +3,17 @@
 use crate::tx2::tx2_utils::*;
 use crate::*;
 
-type Inner = Arc<Share<Vec<std::task::Waker>>>;
+/// Sync callback signature to be invoked on notify()
+type NotifySyncCb = Box<dyn FnOnce() + 'static + Send>;
 
-struct WaitFut(Inner, Option<usize>);
+struct Inner {
+    wakers: Vec<std::task::Waker>,
+    cbs: Vec<NotifySyncCb>,
+}
+
+type InnerWrap = Arc<Share<Inner>>;
+
+struct WaitFut(InnerWrap, Option<usize>);
 
 impl std::future::Future for WaitFut {
     type Output = ();
@@ -19,11 +27,11 @@ impl std::future::Future for WaitFut {
             .0
             .share_mut(|i, _| {
                 if let Some(idx) = index {
-                    i[idx] = cx.waker().clone();
+                    i.wakers[idx] = cx.waker().clone();
                     index = Some(idx);
                 } else {
-                    index = Some(i.len());
-                    i.push(cx.waker().clone());
+                    index = Some(i.wakers.len());
+                    i.wakers.push(cx.waker().clone());
                 }
                 Ok(())
             })
@@ -36,10 +44,36 @@ impl std::future::Future for WaitFut {
     }
 }
 
+fn do_notify(inner: &InnerWrap) {
+    if let Ok((wakers, cbs)) = inner.share_mut(|i, c| {
+        *c = true;
+        Ok((
+            i.wakers.drain(..).collect::<Vec<_>>(),
+            i.cbs.drain(..).collect::<Vec<_>>(),
+        ))
+    }) {
+        for waker in wakers {
+            waker.wake();
+        }
+        for cb in cbs {
+            cb();
+        }
+    }
+}
+
+#[derive(Clone)]
+struct NotifyOnDrop(InnerWrap);
+
+impl Drop for NotifyOnDrop {
+    fn drop(&mut self) {
+        do_notify(&self.0)
+    }
+}
+
 /// Many tasks can await on this notify struct.
 /// They will all be notified once notify is called.
 #[derive(Clone)]
-pub struct NotifyAll(Inner);
+pub struct NotifyAll(InnerWrap, Arc<NotifyOnDrop>);
 
 impl Default for NotifyAll {
     fn default() -> Self {
@@ -50,7 +84,29 @@ impl Default for NotifyAll {
 impl NotifyAll {
     /// Construct a new NotifyAll instance.
     pub fn new() -> Self {
-        Self(Arc::new(Share::new(Vec::new())))
+        let inner = Inner {
+            wakers: Vec::new(),
+            cbs: Vec::new(),
+        };
+        let wrap = Arc::new(Share::new(inner));
+        let notify_on_drop = Arc::new(NotifyOnDrop(wrap.clone()));
+        Self(wrap, notify_on_drop)
+    }
+
+    /// Register a sync cb to be invoked on notify
+    /// (will be invoked immediately if did_notify())
+    pub fn wait_cb<F>(&self, sync_cb: F)
+    where
+        F: FnOnce() + 'static + Send,
+    {
+        let mut maybe_sync_cb: Option<NotifySyncCb> = Some(Box::new(sync_cb));
+        let _ = self.0.share_mut(|i, _| {
+            i.cbs.push(maybe_sync_cb.take().unwrap());
+            Ok(())
+        });
+        if let Some(sync_cb) = maybe_sync_cb {
+            sync_cb();
+        }
     }
 
     /// Wait on this NotifyAll instance.
@@ -60,14 +116,7 @@ impl NotifyAll {
 
     /// Trigger all waiters.
     pub fn notify(&self) {
-        if let Ok(wakers) = self.0.share_mut(|i, c| {
-            *c = true;
-            Ok(i.drain(..).collect::<Vec<_>>())
-        }) {
-            for waker in wakers {
-                waker.wake();
-            }
-        }
+        do_notify(&self.0)
     }
 
     /// Has this notify all already been triggered?
@@ -80,6 +129,55 @@ impl NotifyAll {
 mod tests {
     use super::*;
     use std::sync::atomic;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_notify_all_on_drop() {
+        let count = Arc::new(atomic::AtomicUsize::new(0));
+
+        let t = {
+            let n = NotifyAll::new();
+            let c2 = count.clone();
+            n.wait_cb(move || {
+                c2.fetch_add(1, atomic::Ordering::Relaxed);
+            });
+            let c3 = count.clone();
+            let not = n.wait();
+            let t = tokio::task::spawn(async move {
+                not.await;
+                c3.fetch_add(1, atomic::Ordering::Relaxed);
+            });
+
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+            assert_eq!(0, count.load(atomic::Ordering::Relaxed));
+
+            t
+        };
+
+        t.await.unwrap();
+
+        assert_eq!(2, count.load(atomic::Ordering::Relaxed));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_notify_all_sync() {
+        let count = Arc::new(atomic::AtomicUsize::new(0));
+
+        let n = NotifyAll::new();
+
+        let c2 = count.clone();
+        n.wait_cb(move || {
+            c2.fetch_add(1, atomic::Ordering::Relaxed);
+        });
+        let c3 = count.clone();
+        n.wait_cb(move || {
+            c3.fetch_add(1, atomic::Ordering::Relaxed);
+        });
+
+        n.notify();
+
+        assert_eq!(2, count.load(atomic::Ordering::Relaxed));
+    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_notify_all() {

--- a/crates/kitsune_p2p/types/src/tx2/tx2_utils/t_chan.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_utils/t_chan.rs
@@ -1,0 +1,116 @@
+use crate::tx2::tx2_utils::*;
+use crate::*;
+use std::future::Future;
+
+use futures::future::FutureExt;
+use tokio::sync::mpsc::{channel, Receiver, Sender};
+
+/// tokio::sync::mpsc::Sender is cheaply clonable,
+/// futures::channel::mpsc::Sender can be closed from the sender side.
+/// We want both these things.
+/// Produce a TChan - a wrapper around a tokio::sync::mpsc::channel.
+/// Provides futures::stream::Stream impl on TReceive.
+/// Allows channel close from sender side.
+pub fn t_chan<T: 'static + Send>(bound: usize) -> (TSender<T>, TReceiver<T>) {
+    let (s, r) = channel(bound);
+    (TSender(Arc::new(Share::new(s))), TReceiver(r))
+}
+
+/// The sender side of a t_chan - this is cheaply clone-able.
+pub struct TSender<T: 'static + Send>(Arc<Share<Sender<T>>>);
+
+impl<T: 'static + Send> Clone for TSender<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: 'static + Send> PartialEq for TSender<T> {
+    fn eq(&self, oth: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &oth.0)
+    }
+}
+
+impl<T: 'static + Send> Eq for TSender<T> {}
+
+impl<T: 'static + Send> std::hash::Hash for TSender<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        Arc::as_ptr(&self.0).hash(state);
+    }
+}
+
+impl<T: 'static + Send> TSender<T> {
+    /// Send a type instance to this channel sender's receiver.
+    pub fn send(&self, t: T) -> impl Future<Output = Result<(), T>> + 'static + Send + Unpin {
+        let sender = match self.0.share_mut(|i, _| Ok(i.clone())) {
+            Err(_) => return async move { Err(t) }.boxed(),
+            Ok(s) => s,
+        };
+        async move { sender.send(t).await.map_err(|e| e.0) }.boxed()
+    }
+
+    /// Close this channel from the sender side.
+    /// The receiver can accept all pending sends, and then will close.
+    pub fn close_channel(&self) {
+        let _ = self.0.share_mut(|_, c| {
+            *c = true;
+            Ok(())
+        });
+    }
+}
+
+/// The receiver side of a t_chan.
+pub struct TReceiver<T: 'static + Send>(Receiver<T>);
+
+impl<T: 'static + Send> TReceiver<T> {
+    /// Async receive the next item in the stream.
+    pub async fn recv(&mut self) -> Option<T> {
+        self.0.recv().await
+    }
+
+    /// Poll function for implementing low-level futures streams.
+    pub fn poll_recv(&mut self, cx: &mut std::task::Context<'_>) -> std::task::Poll<Option<T>> {
+        self.0.poll_recv(cx)
+    }
+}
+
+impl<T: 'static + Send> futures::stream::Stream for TReceiver<T> {
+    type Item = T;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        self.poll_recv(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_t_chan() {
+        let (s, r) = t_chan::<u8>(2);
+
+        let f = futures::future::try_join_all(vec![s.send(2), s.send(1), s.send(3)]);
+
+        let t = tokio::task::spawn(async move {
+            let f = futures::future::try_join_all(vec![s.send(5), s.send(4), s.send(6)]);
+            s.close_channel();
+            f.await
+        });
+
+        let r = tokio::task::spawn(async move {
+            use futures::stream::StreamExt;
+            r.collect::<Vec<_>>().await
+        });
+
+        f.await.unwrap();
+        t.await.unwrap().unwrap();
+
+        let mut r = r.await.unwrap();
+        r.sort();
+        assert_eq!(&[1, 2, 3, 4, 5, 6], r.as_slice());
+    }
+}


### PR DESCRIPTION
Introduces `t_chan` wrapper around `tokio::sync::mpsc` && ability to kill mem chans via `Active` instances.