### PR TITLE
[TK-08013 TK-08014] tx2 quic backend && proxy benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2401,13 +2401,16 @@ dependencies = [
  "derive_more",
  "futures",
  "ghost_actor 0.3.0-alpha.1",
+ "lair_keystore_api",
  "nanoid",
  "observability",
  "once_cell",
  "parking_lot 0.11.1",
  "paste 1.0.3",
  "rmp-serde",
+ "rustls",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sysinfo",
  "thiserror",
@@ -2416,6 +2419,7 @@ dependencies = [
  "tracing-subscriber",
  "url 2.2.1",
  "url2",
+ "webpki",
 ]
 
 [[package]]

--- a/crates/kitsune_p2p/proxy/src/config.rs
+++ b/crates/kitsune_p2p/proxy/src/config.rs
@@ -1,5 +1,7 @@
 use crate::*;
 
+pub use kitsune_p2p_types::tls::TlsConfig;
+
 /// Callback function signature for proxy accept/deny.
 pub type AcceptProxyCallbackFn =
     Arc<dyn Fn(CertDigest) -> MustBoxFuture<'static, bool> + 'static + Send + Sync>;
@@ -17,35 +19,6 @@ impl AcceptProxyCallback {
     /// Callback that blanket accepts all proxy requests.
     pub fn accept_all() -> Self {
         Self(Arc::new(|_| async { true }.boxed().into()))
-    }
-}
-
-/// Tls Configuration for proxy.
-#[derive(Clone)]
-pub struct TlsConfig {
-    /// Cert
-    pub cert: Cert,
-
-    /// Cert Priv Key
-    pub cert_priv_key: CertPrivKey,
-
-    /// Cert Digest
-    pub cert_digest: CertDigest,
-}
-
-impl TlsConfig {
-    /// Create a new ephemeral tls certificate that will not be persisted.
-    pub async fn new_ephemeral() -> TransportResult<Self> {
-        let mut options = lair_keystore_api::actor::TlsCertOptions::default();
-        options.alg = lair_keystore_api::actor::TlsCertAlg::PkcsEcdsaP256Sha256;
-        let cert = lair_keystore_api::internal::tls::tls_cert_self_signed_new_from_entropy(options)
-            .await
-            .map_err(TransportError::other)?;
-        Ok(Self {
-            cert: cert.cert_der,
-            cert_priv_key: cert.priv_key_der,
-            cert_digest: cert.cert_digest,
-        })
     }
 }
 
@@ -91,76 +64,12 @@ impl ProxyConfig {
 /// Tls ALPN identifier for kitsune proxy handshaking
 const ALPN_KITSUNE_PROXY_0: &[u8] = b"kitsune-proxy/0";
 
-/// Allow only these cipher suites for kitsune proxy Tls.
-static CIPHER_SUITES: &[&rustls::SupportedCipherSuite] = &[
-    &rustls::ciphersuite::TLS13_CHACHA20_POLY1305_SHA256,
-    &rustls::ciphersuite::TLS13_AES_256_GCM_SHA384,
-];
-
 /// Helper to generate rustls configs given a TlsConfig reference.
 #[allow(dead_code)]
 pub(crate) fn gen_tls_configs(
     tls: &TlsConfig,
     tuning_params: Arc<kitsune_p2p_types::config::KitsuneP2pTuningParams>,
 ) -> TransportResult<(Arc<rustls::ServerConfig>, Arc<rustls::ClientConfig>)> {
-    let cert = rustls::Certificate(tls.cert.0.to_vec());
-    let cert_priv_key = rustls::PrivateKey(tls.cert_priv_key.0.to_vec());
-
-    let root_cert = rustls::Certificate(lair_keystore_api::internal::tls::WK_CA_CERT_DER.to_vec());
-    let mut root_store = rustls::RootCertStore::empty();
-    root_store.add(&root_cert).unwrap();
-
-    let mut tls_server_config = rustls::ServerConfig::with_ciphersuites(
-        rustls::AllowAnyAuthenticatedClient::new(root_store),
-        CIPHER_SUITES,
-    );
-
-    tls_server_config
-        .set_single_cert(vec![cert.clone()], cert_priv_key.clone())
-        .map_err(TransportError::other)?;
-    // put this in a database at some point
-    tls_server_config.set_persistence(rustls::ServerSessionMemoryCache::new(
-        tuning_params.tls_in_mem_session_storage as usize,
-    ));
-    tls_server_config.ticketer = rustls::Ticketer::new();
-    tls_server_config.set_protocols(&[ALPN_KITSUNE_PROXY_0.to_vec()]);
-    let tls_server_config = Arc::new(tls_server_config);
-
-    let mut tls_client_config = rustls::ClientConfig::with_ciphersuites(CIPHER_SUITES);
-    tls_client_config
-        .set_single_client_cert(vec![cert], cert_priv_key)
-        .map_err(TransportError::other)?;
-    tls_client_config
-        .dangerous()
-        .set_certificate_verifier(TlsServerVerifier::new());
-    // put this in a database at some point
-    tls_client_config.set_persistence(rustls::ClientSessionMemoryCache::new(
-        tuning_params.tls_in_mem_session_storage as usize,
-    ));
-    tls_client_config.set_protocols(&[ALPN_KITSUNE_PROXY_0.to_vec()]);
-    let tls_client_config = Arc::new(tls_client_config);
-
-    Ok((tls_server_config, tls_client_config))
-}
-
-struct TlsServerVerifier;
-
-impl TlsServerVerifier {
-    fn new() -> Arc<Self> {
-        Arc::new(Self)
-    }
-}
-
-impl rustls::ServerCertVerifier for TlsServerVerifier {
-    fn verify_server_cert(
-        &self,
-        _roots: &rustls::RootCertStore,
-        _presented_certs: &[rustls::Certificate],
-        _dns_name: webpki::DNSNameRef,
-        _ocsp_response: &[u8],
-    ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
-        // TODO - check acceptable cert digest
-
-        Ok(rustls::ServerCertVerified::assertion())
-    }
+    kitsune_p2p_types::tls::gen_tls_configs(ALPN_KITSUNE_PROXY_0, tls, tuning_params)
+        .map_err(TransportError::other)
 }

--- a/crates/kitsune_p2p/transport_quic/src/lib.rs
+++ b/crates/kitsune_p2p/transport_quic/src/lib.rs
@@ -56,3 +56,5 @@ mod listener;
 pub use listener::*;
 
 mod test;
+
+pub mod tx2;

--- a/crates/kitsune_p2p/transport_quic/src/tx2.rs
+++ b/crates/kitsune_p2p/transport_quic/src/tx2.rs
@@ -1,0 +1,392 @@
+#![allow(clippy::new_ret_no_self)]
+//! kitsune tx2 quic transport backend
+
+use futures::future::{BoxFuture, FutureExt};
+use futures::stream::{BoxStream, StreamExt};
+use kitsune_p2p_types::config::*;
+use kitsune_p2p_types::tls::*;
+use kitsune_p2p_types::tx2::tx2_backend::*;
+use kitsune_p2p_types::tx2::tx2_utils::*;
+use kitsune_p2p_types::tx2::*;
+use kitsune_p2p_types::*;
+use std::sync::Arc;
+
+/// Tls ALPN identifier for kitsune quic handshaking
+const ALPN_KITSUNE_QUIC_0: &[u8] = b"kitsune-quic/0";
+
+/// Configuration for QuicBackendAdapt
+#[non_exhaustive]
+pub struct QuicConfig {
+    /// Tls config
+    /// Default: None = ephemeral.
+    pub tls: Option<TlsConfig>,
+
+    /// Tuning Params
+    /// Default: None = default.
+    pub tuning_params: Option<Arc<KitsuneP2pTuningParams>>,
+}
+
+impl Default for QuicConfig {
+    fn default() -> Self {
+        Self {
+            tls: None,
+            tuning_params: None,
+        }
+    }
+}
+
+impl QuicConfig {
+    /// into inner contents with default application
+    pub async fn split(self) -> KitsuneResult<(TlsConfig, Arc<KitsuneP2pTuningParams>)> {
+        let QuicConfig { tls, tuning_params } = self;
+
+        let tls = match tls {
+            None => TlsConfig::new_ephemeral().await?,
+            Some(tls) => tls,
+        };
+
+        let tuning_params =
+            tuning_params.unwrap_or_else(|| Arc::new(KitsuneP2pTuningParams::default()));
+
+        Ok((tls, tuning_params))
+    }
+}
+
+struct QuicInChanRecvAdapt(BoxStream<'static, InChanFut>);
+
+impl QuicInChanRecvAdapt {
+    pub fn new(recv: quinn::IncomingUniStreams) -> Self {
+        Self(
+            futures::stream::unfold(recv, move |mut recv| async move {
+                match recv.next().await {
+                    None => None,
+                    Some(in_) => Some((
+                        async move {
+                            let in_ = in_.map_err(KitsuneError::other)?;
+                            let in_: InChan = Box::new(FramedReader::new(Box::new(in_)));
+                            Ok(in_)
+                        }
+                        .boxed(),
+                        recv,
+                    )),
+                }
+            })
+            .boxed(),
+        )
+    }
+}
+
+impl futures::stream::Stream for QuicInChanRecvAdapt {
+    type Item = InChanFut;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let inner = &mut self.0;
+        tokio::pin!(inner);
+        futures::stream::Stream::poll_next(inner, cx)
+    }
+}
+
+impl InChanRecvAdapt for QuicInChanRecvAdapt {}
+
+struct QuicConAdaptInner {
+    con: quinn::Connection,
+}
+
+struct QuicConAdapt(Share<QuicConAdaptInner>, Uniq);
+
+impl QuicConAdapt {
+    pub fn new(con: quinn::Connection) -> Self {
+        Self(Share::new(QuicConAdaptInner { con }), Uniq::default())
+    }
+}
+
+impl ConAdapt for QuicConAdapt {
+    fn uniq(&self) -> Uniq {
+        self.1
+    }
+
+    fn remote_addr(&self) -> KitsuneResult<TxUrl> {
+        let addr = self.0.share_mut(|i, _| Ok(i.con.remote_address()))?;
+
+        use kitsune_p2p_types::dependencies::url2;
+        let url = url2::url2!("{}://{}", crate::SCHEME, addr);
+
+        Ok(url.into())
+    }
+
+    fn out_chan(&self, timeout: KitsuneTimeout) -> OutChanFut {
+        let maybe_out_fut = self.0.share_mut(|i, _| Ok(i.con.open_uni()));
+        timeout
+            .mix(async move {
+                let out = maybe_out_fut?.await.map_err(KitsuneError::other)?;
+                let out: OutChan = Box::new(FramedWriter::new(Box::new(out)));
+                Ok(out)
+            })
+            .boxed()
+    }
+
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
+
+    fn close(&self, code: u32, reason: &str) -> BoxFuture<'static, ()> {
+        let _ = self.0.share_mut(|i, c| {
+            *c = true;
+            i.con.close(code.into(), reason.as_bytes());
+            Ok(())
+        });
+        async move {}.boxed()
+    }
+}
+
+fn connecting(con_fut: quinn::Connecting) -> ConFut {
+    async move {
+        let quinn::NewConnection {
+            connection,
+            uni_streams,
+            ..
+        } = con_fut.await.map_err(KitsuneError::other)?;
+
+        let con: Arc<dyn ConAdapt> = Arc::new(QuicConAdapt::new(connection));
+        let chan_recv: Box<dyn InChanRecvAdapt> = Box::new(QuicInChanRecvAdapt::new(uni_streams));
+
+        Ok((con, chan_recv))
+    }
+    .boxed()
+}
+
+struct QuicConRecvAdapt(BoxStream<'static, ConFut>);
+
+impl QuicConRecvAdapt {
+    pub fn new(recv: quinn::Incoming) -> Self {
+        Self(
+            futures::stream::unfold(recv, move |mut recv| async move {
+                match recv.next().await {
+                    None => None,
+                    Some(con) => Some((connecting(con), recv)),
+                }
+            })
+            .boxed(),
+        )
+    }
+}
+
+impl futures::stream::Stream for QuicConRecvAdapt {
+    type Item = ConFut;
+
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let inner = &mut self.0;
+        tokio::pin!(inner);
+        futures::stream::Stream::poll_next(inner, cx)
+    }
+}
+
+impl ConRecvAdapt for QuicConRecvAdapt {}
+
+struct QuicEndpointAdaptInner {
+    ep: quinn::Endpoint,
+}
+
+struct QuicEndpointAdapt(Share<QuicEndpointAdaptInner>, Uniq);
+
+impl QuicEndpointAdapt {
+    pub fn new(ep: quinn::Endpoint) -> Self {
+        Self(Share::new(QuicEndpointAdaptInner { ep }), Uniq::default())
+    }
+}
+
+impl EndpointAdapt for QuicEndpointAdapt {
+    fn uniq(&self) -> Uniq {
+        self.1
+    }
+
+    fn local_addr(&self) -> KitsuneResult<TxUrl> {
+        let addr = self
+            .0
+            .share_mut(|i, _| i.ep.local_addr().map_err(KitsuneError::other))?;
+
+        use kitsune_p2p_types::dependencies::url2;
+        let mut url = url2::url2!("{}://{}", crate::SCHEME, addr);
+
+        if let Some(host) = url.host_str() {
+            if host == "0.0.0.0" {
+                for iface in if_addrs::get_if_addrs().map_err(KitsuneError::other)? {
+                    // super naive - just picking the first v4 that is not 127.0.0.1
+                    let addr = iface.addr.ip();
+                    if let std::net::IpAddr::V4(addr) = addr {
+                        if addr != std::net::Ipv4Addr::from([127, 0, 0, 1]) {
+                            url.set_host(Some(&iface.addr.ip().to_string())).unwrap();
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(url.into())
+    }
+
+    fn connect(&self, url: TxUrl, timeout: KitsuneTimeout) -> ConFut {
+        let maybe_ep = self.0.share_mut(|i, _| Ok(i.ep.clone()));
+        timeout
+            .mix(async move {
+                let ep = maybe_ep?;
+                let addr = crate::url_to_addr(url.as_url2(), crate::SCHEME)
+                    .await
+                    .map_err(KitsuneError::other)?;
+                let con = ep.connect(&addr, "stub.stub").map_err(KitsuneError::other);
+                connecting(con?).await
+            })
+            .boxed()
+    }
+
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
+    }
+
+    fn close(&self, code: u32, reason: &str) -> BoxFuture<'static, ()> {
+        let _ = self.0.share_mut(|i, c| {
+            *c = true;
+            i.ep.close(code.into(), reason.as_bytes());
+            Ok(())
+        });
+        async move {}.boxed()
+    }
+}
+
+/// Quic endpoint backend bind adapter for kitsune tx2
+pub struct QuicBackendAdapt {
+    quic_srv: quinn::ServerConfig,
+    quic_cli: quinn::ClientConfig,
+}
+
+impl QuicBackendAdapt {
+    /// Construct a new quic tx2 backend bind adapter
+    pub async fn new(config: QuicConfig) -> KitsuneResult<BackendFactory> {
+        let (tls, tuning_params) = config.split().await?;
+
+        let (tls_srv, tls_cli) = gen_tls_configs(ALPN_KITSUNE_QUIC_0, &tls, tuning_params)?;
+
+        let mut transport = quinn::TransportConfig::default();
+
+        // We don't use bidi streams in kitsune - only uni streams
+        transport
+            .max_concurrent_bidi_streams(0)
+            .map_err(KitsuneError::other)?;
+
+        // We don't use "Application" datagrams in kitsune -
+        // only bidi streams.
+        transport.datagram_receive_buffer_size(None);
+
+        // Disable spin bit - we'd like the extra privacy
+        // any metrics we implement will be opt-in self reporting
+        transport.allow_spin(false);
+
+        // see also `keep_alive_interval`.
+        // right now keep_alive_interval is None,
+        // so connections will idle timeout after 20 seconds.
+        transport
+            .max_idle_timeout(Some(std::time::Duration::from_millis(30_000)))
+            .unwrap();
+
+        let transport = Arc::new(transport);
+
+        let mut quic_srv = quinn::ServerConfig::default();
+        quic_srv.transport = transport.clone();
+        quic_srv.crypto = tls_srv;
+
+        let mut quic_cli = quinn::ClientConfig::default();
+        quic_cli.transport = transport;
+        quic_cli.crypto = tls_cli;
+
+        let out: BackendFactory = Arc::new(Self { quic_srv, quic_cli });
+
+        Ok(out)
+    }
+}
+
+impl BackendAdapt for QuicBackendAdapt {
+    fn bind(&self, url: TxUrl, timeout: KitsuneTimeout) -> EndpointFut {
+        let quic_srv = self.quic_srv.clone();
+        let quic_cli = self.quic_cli.clone();
+        timeout
+            .mix(async move {
+                let mut builder = quinn::Endpoint::builder();
+                builder.listen(quic_srv);
+                builder.default_client_config(quic_cli);
+
+                let addr = crate::url_to_addr(url.as_url2(), crate::SCHEME)
+                    .await
+                    .map_err(KitsuneError::other)?;
+
+                let (ep, inc) = builder.bind(&addr).map_err(KitsuneError::other)?;
+
+                let ep: Arc<dyn EndpointAdapt> = Arc::new(QuicEndpointAdapt::new(ep));
+                let con_recv: Box<dyn ConRecvAdapt> = Box::new(QuicConRecvAdapt::new(inc));
+
+                Ok((ep, con_recv))
+            })
+            .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_quic_tx2() {
+        let t = KitsuneTimeout::from_millis(5000);
+
+        let config = QuicConfig::default();
+        let factory = QuicBackendAdapt::new(config).await.unwrap();
+
+        let (s_done, r_done) = tokio::sync::oneshot::channel();
+
+        let (ep1, _con_recv1) = factory
+            .bind("kitsune-quic://0.0.0.0:0".into(), t)
+            .await
+            .unwrap();
+
+        let (ep2, mut con_recv2) = factory
+            .bind("kitsune-quic://0.0.0.0:0".into(), t)
+            .await
+            .unwrap();
+
+        let addr2 = ep2.local_addr().unwrap();
+        println!("addr2: {}", addr2);
+
+        let rt = tokio::task::spawn(async move {
+            if let Some(mc) = con_recv2.next().await {
+                let (_con, mut recv) = mc.await.unwrap();
+                if let Some(mc) = recv.next().await {
+                    let mut c = mc.await.unwrap();
+                    let t = KitsuneTimeout::from_millis(5000);
+                    let (_, data) = c.read(t).await.unwrap();
+                    println!("GOT: {:?}", data.as_ref());
+                    s_done.send(()).unwrap();
+                }
+            }
+        });
+
+        let (c, _recv) = ep1.connect(addr2, t).await.unwrap();
+        let mut c = c.out_chan(t).await.unwrap();
+
+        let mut data = PoolBuf::new();
+        data.extend_from_slice(b"hello");
+        c.write(0.into(), data, t).await.unwrap();
+
+        r_done.await.unwrap();
+
+        ep1.close(0, "").await;
+        ep2.close(0, "").await;
+
+        rt.await.unwrap();
+    }
+}

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -14,13 +14,16 @@ edition = "2018"
 derive_more = "0.99.7"
 futures = "0.3"
 ghost_actor = "0.3.0-alpha.1"
+lair_keystore_api = "=0.0.1-alpha.11"
 nanoid = "0.3"
 observability = "0.1.3"
 once_cell = "1.4"
 parking_lot = "0.11"
 paste = "1.0.3"
 rmp-serde = "0.15"
+rustls = { version = "0.19", features = [ "dangerous_configuration" ] }
 serde = { version = "1", features = [ "derive", "rc" ] }
+serde_bytes = "0.11"
 serde_json = { version = "1", features = [ "preserve_order" ] }
 sysinfo = "0.15.9"
 thiserror = "1.0.22"
@@ -28,6 +31,7 @@ tokio = { version = "1.3", features = [ "full" ] }
 tokio-stream = { version = "0.1", features = [ "sync", "net" ] }
 url = "2"
 url2 = "0.0.6"
+webpki = "0.21.2"
 
 [dev-dependencies]
 tracing-subscriber = "0.2"

--- a/crates/kitsune_p2p/types/src/lib.rs
+++ b/crates/kitsune_p2p/types/src/lib.rs
@@ -5,7 +5,9 @@
 pub mod dependencies {
     pub use ::futures;
     pub use ::ghost_actor;
+    pub use ::lair_keystore_api;
     pub use ::paste;
+    pub use ::rustls;
     pub use ::serde;
     pub use ::serde_json;
     pub use ::thiserror;
@@ -128,6 +130,7 @@ pub mod codec;
 pub mod config;
 pub mod dht_arc;
 pub mod metrics;
+pub mod tls;
 pub mod transport;
 pub mod transport_mem;
 pub mod transport_pool;

--- a/crates/kitsune_p2p/types/src/tls.rs
+++ b/crates/kitsune_p2p/types/src/tls.rs
@@ -1,0 +1,113 @@
+//! TLS utils for kitsune
+
+use crate::config::*;
+use crate::*;
+use lair_keystore_api::actor::*;
+
+/// Tls Configuration.
+#[derive(Clone)]
+pub struct TlsConfig {
+    /// Cert
+    pub cert: Cert,
+
+    /// Cert Priv Key
+    pub cert_priv_key: CertPrivKey,
+
+    /// Cert Digest
+    pub cert_digest: CertDigest,
+}
+
+impl TlsConfig {
+    /// Create a new ephemeral tls certificate that will not be persisted.
+    pub async fn new_ephemeral() -> KitsuneResult<Self> {
+        let mut options = lair_keystore_api::actor::TlsCertOptions::default();
+        options.alg = lair_keystore_api::actor::TlsCertAlg::PkcsEcdsaP256Sha256;
+        let cert = lair_keystore_api::internal::tls::tls_cert_self_signed_new_from_entropy(options)
+            .await
+            .map_err(KitsuneError::other)?;
+        Ok(Self {
+            cert: cert.cert_der,
+            cert_priv_key: cert.priv_key_der,
+            cert_digest: cert.cert_digest,
+        })
+    }
+}
+
+/// Allow only these cipher suites for kitsune Tls.
+static CIPHER_SUITES: &[&rustls::SupportedCipherSuite] = &[
+    &rustls::ciphersuite::TLS13_CHACHA20_POLY1305_SHA256,
+    &rustls::ciphersuite::TLS13_AES_256_GCM_SHA384,
+];
+
+/// Helper to generate rustls configs given a TlsConfig reference.
+#[allow(dead_code)]
+pub fn gen_tls_configs(
+    alpn: &[u8],
+    tls: &TlsConfig,
+    tuning_params: Arc<KitsuneP2pTuningParams>,
+) -> KitsuneResult<(Arc<rustls::ServerConfig>, Arc<rustls::ClientConfig>)> {
+    let cert = rustls::Certificate(tls.cert.0.to_vec());
+    let cert_priv_key = rustls::PrivateKey(tls.cert_priv_key.0.to_vec());
+
+    let root_cert = rustls::Certificate(lair_keystore_api::internal::tls::WK_CA_CERT_DER.to_vec());
+    let mut root_store = rustls::RootCertStore::empty();
+    root_store.add(&root_cert).unwrap();
+
+    let mut tls_server_config = rustls::ServerConfig::with_ciphersuites(
+        rustls::AllowAnyAuthenticatedClient::new(root_store),
+        CIPHER_SUITES,
+    );
+
+    tls_server_config
+        .set_single_cert(vec![cert.clone()], cert_priv_key.clone())
+        .map_err(KitsuneError::other)?;
+
+    // put this in a database at some point
+    tls_server_config.set_persistence(rustls::ServerSessionMemoryCache::new(
+        tuning_params.tls_in_mem_session_storage as usize,
+    ));
+    tls_server_config.ticketer = rustls::Ticketer::new();
+    tls_server_config.set_protocols(&[alpn.to_vec()]);
+    tls_server_config.versions = vec![rustls::ProtocolVersion::TLSv1_3];
+    let tls_server_config = Arc::new(tls_server_config);
+
+    let mut tls_client_config = rustls::ClientConfig::with_ciphersuites(CIPHER_SUITES);
+    tls_client_config
+        .set_single_client_cert(vec![cert], cert_priv_key)
+        .map_err(KitsuneError::other)?;
+    tls_client_config
+        .dangerous()
+        .set_certificate_verifier(TlsServerVerifier::new());
+
+    // put this in a database at some point
+    tls_client_config.set_persistence(rustls::ClientSessionMemoryCache::new(
+        tuning_params.tls_in_mem_session_storage as usize,
+    ));
+    tls_client_config.set_protocols(&[alpn.to_vec()]);
+    tls_client_config.versions = vec![rustls::ProtocolVersion::TLSv1_3];
+    let tls_client_config = Arc::new(tls_client_config);
+
+    Ok((tls_server_config, tls_client_config))
+}
+
+struct TlsServerVerifier;
+
+impl TlsServerVerifier {
+    fn new() -> Arc<Self> {
+        Arc::new(Self)
+    }
+}
+
+impl rustls::ServerCertVerifier for TlsServerVerifier {
+    fn verify_server_cert(
+        &self,
+        _roots: &rustls::RootCertStore,
+        _presented_certs: &[rustls::Certificate],
+        _dns_name: webpki::DNSNameRef,
+        _ocsp_response: &[u8],
+    ) -> Result<rustls::ServerCertVerified, rustls::TLSError> {
+        // TODO - check acceptable cert digest
+
+        Ok(rustls::ServerCertVerified::assertion())
+    }
+}

--- a/crates/kitsune_p2p/types/src/transport.rs
+++ b/crates/kitsune_p2p/types/src/transport.rs
@@ -50,6 +50,12 @@ impl From<TransportError> for () {
     fn from(_: TransportError) {}
 }
 
+impl From<crate::KitsuneError> for TransportError {
+    fn from(k: crate::KitsuneError) -> Self {
+        TransportError::other(k)
+    }
+}
+
 /// Result type for remote communication.
 pub type TransportResult<T> = Result<T, TransportError>;
 

--- a/crates/kitsune_p2p/types/src/tx2.rs
+++ b/crates/kitsune_p2p/types/src/tx2.rs
@@ -1,5 +1,5 @@
 //! Next-gen performance kitsune transport abstractions
-//!
+
 mod framed;
 pub use framed::*;
 

--- a/crates/kitsune_p2p/types/src/tx2/tx2_utils/tx_url.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_utils/tx_url.rs
@@ -7,6 +7,13 @@ use std::sync::Arc;
 )]
 pub struct TxUrl(Arc<url2::Url2>);
 
+impl TxUrl {
+    /// reference this txurl as a Url2.
+    pub fn as_url2(&self) -> &url2::Url2 {
+        &self.0
+    }
+}
+
 impl std::ops::Deref for TxUrl {
     type Target = url::Url;
 
@@ -30,6 +37,12 @@ impl From<TxUrl> for Arc<url2::Url2> {
 impl From<Arc<url2::Url2>> for TxUrl {
     fn from(r: Arc<url2::Url2>) -> Self {
         Self(r)
+    }
+}
+
+impl From<url2::Url2> for TxUrl {
+    fn from(r: url2::Url2) -> Self {
+        Self(Arc::new(r))
     }
 }
 


### PR DESCRIPTION
DEPENDS ON https://github.com/holochain/holochain/pull/706

- moves TLS config generation into types crate so it can be shared between quic && proxy code
- implements tx2 quic backend
- modifies proxy benchmark so it can run also with the quic backend