### PR TITLE
Fix bug in integration workflow

### DIFF
--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -282,7 +282,7 @@ async fn op_dependencies_held(
                             let op_hash = DhtOpHash::with_data_sync(
                                 &UniqueForm::RegisterAgentActivity(prev_header.header()),
                             );
-                            if !workspace.integration_limbo.contains(&op_hash)? {
+                            if !workspace.integrated_dht_ops.contains(&op_hash)? {
                                 return Ok(false);
                             }
                         }

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -282,8 +282,8 @@ async fn op_dependencies_held(
                             let op_hash = DhtOpHash::with_data_sync(
                                 &UniqueForm::RegisterAgentActivity(prev_header.header()),
                             );
-                            if workspace.integration_limbo.contains(&op_hash)? {
-                                return Ok(true);
+                            if !workspace.integration_limbo.contains(&op_hash)? {
+                                return Ok(false);
                             }
                         }
                         None => return Ok(false),


### PR DESCRIPTION
The logic was wrong and allowed agent chain items to be integrated before previous headers.