### PR TITLE
Allow changing all UUIDs en masse when installing an AppBundle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
+name = "arbitrary"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "698b65a961a9d730fb45b6b0327e20207810c9f61ee421b082b27ba003f49e2b"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,6 +931,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df89dd0d075dea5cc5fdd6d5df6b8a61172a710b3efac1d6bdb9dd8b78f82c1a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1583,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 name = "holo_hash"
 version = "0.0.2-alpha.1"
 dependencies = [
+ "arbitrary",
  "base64",
  "blake2b_simd",
  "derive_more",
@@ -1919,6 +1940,7 @@ name = "holochain_types"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "async-trait",
  "automap",
  "backtrace",
@@ -2750,6 +2772,7 @@ name = "mr_bundle"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "arbitrary",
  "bytes",
  "derive_more",
  "either",

--- a/crates/hc_sandbox/examples/setup_5.rs
+++ b/crates/hc_sandbox/examples/setup_5.rs
@@ -54,6 +54,7 @@ async fn main() -> anyhow::Result<()> {
             agent_key,
             source: AppBundleSource::Bundle(bundle),
             membrane_proofs: Default::default(),
+            uuid: None,
         };
 
         let r = AdminRequest::InstallAppBundle(Box::new(payload));

--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -17,7 +17,6 @@ use holochain_conductor_api::AdminResponse;
 use holochain_conductor_api::InterfaceDriver;
 use holochain_p2p::kitsune_p2p;
 use holochain_p2p::kitsune_p2p::agent_store::AgentInfoSigned;
-use holochain_types::prelude::DnaSource;
 use holochain_types::prelude::InstallAppDnaPayload;
 use holochain_types::prelude::InstallAppPayload;
 use holochain_types::prelude::InstalledCell;
@@ -26,6 +25,7 @@ use holochain_types::prelude::YamlProperties;
 use holochain_types::prelude::{AgentPubKey, AppBundleSource};
 use holochain_types::prelude::{CellId, InstallAppBundlePayload};
 use holochain_types::prelude::{DnaHash, InstalledApp};
+use holochain_types::prelude::{DnaSource, Uuid};
 use std::convert::TryFrom;
 
 use crate::cmds::Existing;
@@ -156,6 +156,9 @@ pub struct InstallAppBundle {
     #[structopt(required = true)]
     /// Location of the *.happ bundle file to install.
     pub path: PathBuf,
+
+    /// Optional UUID override for every DNA in this app
+    pub uuid: Option<Uuid>,
 }
 
 #[derive(Debug, StructOpt, Clone)]
@@ -468,6 +471,7 @@ pub async fn install_app_bundle(
         app_id,
         agent_key,
         path,
+        uuid,
     } = args;
 
     let bundle = AppBundleSource::Path(path).resolve().await?;
@@ -482,6 +486,7 @@ pub async fn install_app_bundle(
         agent_key,
         source: AppBundleSource::Bundle(bundle),
         membrane_proofs: Default::default(),
+        uuid,
     };
 
     let r = AdminRequest::InstallAppBundle(Box::new(payload));

--- a/crates/hc_sandbox/src/sandbox.rs
+++ b/crates/hc_sandbox/src/sandbox.rs
@@ -27,6 +27,7 @@ pub async fn default_with_network(
         app_id: Some(app_id),
         agent_key: None,
         path: happ,
+        uuid: None,
     };
     crate::calls::install_app_bundle(&mut cmd, install_bundle).await?;
     Ok(path)

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -14,6 +14,7 @@ documentation = "https://github.com/holochain/holochain"
 serde = "1"
 serde_bytes = "0.11"
 
+arbitrary = {version = "1.0", optional = true}
 base64 = {version = "0.13", optional = true}
 blake2b_simd = {version = "0.5.10", optional = true}
 derive_more = { version = "0.99", optional = true }

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -64,6 +64,7 @@ macro_rules! assert_length {
 ///
 /// There is custom de/serialization implemented in [ser.rs]
 #[derive(Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct HoloHash<T: HashType> {
     hash: Vec<u8>,
     hash_type: T,

--- a/crates/holo_hash/src/hash_b64.rs
+++ b/crates/holo_hash/src/hash_b64.rs
@@ -25,6 +25,7 @@ use crate::{error::HoloHashResult, HashType};
     derive_more::Into,
     derive_more::AsRef,
 )]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[serde(transparent)]
 pub struct HoloHashB64<T: HashType>(HoloHash<T>);
 

--- a/crates/holo_hash/src/hash_type/primitive.rs
+++ b/crates/holo_hash/src/hash_type/primitive.rs
@@ -69,6 +69,7 @@ macro_rules! primitive_hash_type {
     ($name: ident, $display: ident, $visitor: ident, $prefix: ident) => {
         /// The $name PrimitiveHashType
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+        #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
         pub struct $name;
 
         impl PrimitiveHashType for $name {

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -519,11 +519,7 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
             if let Some(uuid) = uuid {
                 let mut manifest = original_bundle.manifest().to_owned();
                 manifest.set_uuid(uuid);
-                AppBundle::from(
-                    original_bundle
-                        .into_inner()
-                        .update_manifest(manifest.into())?,
-                )
+                AppBundle::from(original_bundle.into_inner().update_manifest(manifest)?)
             } else {
                 original_bundle
             }

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -51,6 +51,8 @@ tokio_helper = { version = "0.0.1", path = "../tokio_helper" }
 tracing = "=0.1.21"
 derive_builder = "0.9.0"
 
+arbitrary = { version = "1.0", features = ["derive"], optional = true}
+
 [dev-dependencies]
 maplit = "1"
 matches = "0.1"
@@ -59,4 +61,4 @@ tokio = { version = "1.3", features = [ "full" ] }
 [features]
 default = ["fixturators", "test_utils"]
 fixturators = ["holochain_zome_types/fixturators"]
-test_utils = ["holochain_zome_types/test_utils"]
+test_utils = ["holochain_zome_types/test_utils", "arbitrary", "holo_hash/arbitrary", "mr_bundle/arbitrary"]

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -118,6 +118,11 @@ pub struct InstallAppBundlePayload {
     /// Include proof-of-membrane-membership data for cells that require it,
     /// keyed by the CellNick specified in the app bundle manifest.
     pub membrane_proofs: HashMap<CellNick, MembraneProof>,
+
+    /// Optional: overwrites all UUIDs for all DNAs of Cells created by this app.
+    /// The app can still use existing Cells, i.e. this does not require that
+    /// all Cells have DNAs with the same overridden DNA.
+    pub uuid: Option<Uuid>,
 }
 
 /// The possible locations of an AppBundle

--- a/crates/holochain_types/src/app/app_bundle.rs
+++ b/crates/holochain_types/src/app/app_bundle.rs
@@ -37,6 +37,11 @@ impl AppBundle {
             .map_err(Into::into)
     }
 
+    /// Convert to the inner Bundle
+    pub fn into_inner(self) -> mr_bundle::Bundle<AppManifest> {
+        self.0
+    }
+
     /// Given a DnaGamut, decide which of the available DNAs or Cells should be
     /// used for each cell in this app.
     pub async fn resolve_cells(

--- a/crates/holochain_types/src/app/app_manifest.rs
+++ b/crates/holochain_types/src/app/app_manifest.rs
@@ -60,4 +60,12 @@ impl AppManifest {
             Self::V1(manifest) => manifest.validate(),
         }
     }
+
+    /// Update the UUID for all DNAs used in Create-provisioned Cells.
+    /// Cells with other provisioning strategies are not affected.
+    pub fn set_uuid(&mut self, uuid: Uuid) {
+        match self {
+            Self::V1(manifest) => manifest.set_uuid(uuid),
+        }
+    }
 }

--- a/crates/holochain_types/src/dna/dna_def.rs
+++ b/crates/holochain_types/src/dna/dna_def.rs
@@ -38,6 +38,14 @@ impl From<()> for YamlProperties {
     }
 }
 
+/// Not a great implementation: always returns null
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for YamlProperties {
+    fn arbitrary(_: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(serde_yaml::Value::Null.into())
+    }
+}
+
 /// The definition of a DNA: the hash of this data is what produces the DnaHash.
 ///
 /// Historical note: This struct was written before `DnaManifest` appeared.

--- a/crates/mr_bundle/Cargo.toml
+++ b/crates/mr_bundle/Cargo.toml
@@ -18,6 +18,7 @@ serde_bytes = "0.11"
 serde_derive = "1.0"
 thiserror = "1.0"
 
+arbitrary = {version = "1.0", features = ["derive"], optional = true}
 serde_yaml = {version = "0.8", optional = true}
 
 [dev-dependencies]

--- a/crates/mr_bundle/src/bundle.rs
+++ b/crates/mr_bundle/src/bundle.rs
@@ -19,6 +19,7 @@ pub type ResourceMap = HashMap<PathBuf, ResourceBytes>;
 ///
 /// The manifest may describe locations of resources not included in the Bundle.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Bundle<M>
 where
     M: Manifest,
@@ -107,6 +108,12 @@ where
 
     pub fn manifest(&self) -> &M {
         &self.manifest
+    }
+
+    /// Return a new Bundle with an updated manifest, subject to the same
+    /// validation constraints as creating a new Bundle from scratch.
+    pub fn update_manifest(self, manifest: M) -> MrBundleResult<Self> {
+        Self::from_parts(manifest, self.resources, self.root_dir)
     }
 
     pub async fn read_from_file(path: &Path) -> MrBundleResult<Self> {

--- a/crates/mr_bundle/src/location.rs
+++ b/crates/mr_bundle/src/location.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 /// being flattened.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[allow(missing_docs)]
 pub enum Location {
     /// Expect file to be part of this bundle


### PR DESCRIPTION
Also introduces [`Arbitrary`](https://crates.io/crates/arbitrary) impls for mr_bundle, holo_hash, and some holochain_types structs, because it was easier than creating Fixturators for `mr_bundle`. `Arbitrary` is roughly equivalent to Unpredictable fixturators, and a good replacement when that's all that's needed.