### PR TITLE
More convenient wait_for_any macros (but merged into develop instead of sqlite branch)

### DIFF
--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -707,7 +707,7 @@ pub mod test {
         let p2p_store = AgentKv::new(env.clone().into()).unwrap();
 
         // - Give time for the agents to join the network.
-        crate::wait_for_any_10s!(
+        crate::assert_eq_retry_10s!(
             {
                 fresh_reader_test!(env, |r| p2p_store
                     .as_store_ref()
@@ -716,8 +716,7 @@ pub mod test {
                     .count()
                     .unwrap())
             },
-            |&count| count == 4,
-            |count| assert_eq!(count, 4)
+            4
         );
 
         // - Get agents and space

--- a/crates/holochain/src/core/ribosome/host_fn/remote_signal.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/remote_signal.rs
@@ -141,11 +141,7 @@ mod tests {
             .call(&cells[0].zome("zome1"), "signal_others", ())
             .await;
 
-        crate::wait_for_any_10s!(
-            num_signals.load(Ordering::SeqCst),
-            |&n| n == NUM_CONDUCTORS,
-            |n| assert_eq!(n, NUM_CONDUCTORS)
-        );
+        crate::assert_eq_retry_10s!(num_signals.load(Ordering::SeqCst), NUM_CONDUCTORS);
 
         for mut signal in signals {
             let r = signal.try_recv();

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -52,6 +52,9 @@ pub mod conductor_setup;
 pub mod host_fn_caller;
 pub mod sweetest;
 
+mod wait_for_any;
+pub use wait_for_any::*;
+
 /// Produce file and line number info at compile-time
 #[macro_export]
 macro_rules! here {
@@ -387,82 +390,6 @@ pub async fn consistency_envs(
     }
     for &env in all_cell_envs.iter() {
         wait_for_integration(env, expected_count, num_attempts, delay).await
-    }
-}
-
-#[macro_export]
-macro_rules! wait_for_any {
-    ($wait:expr, $test:expr, $check:expr, $assert:expr) => {{
-        loop {
-            let o = $test;
-            if !$wait.wait_any().await || $check(&o) {
-                $assert(o);
-                break;
-            }
-        }
-    }};
-}
-
-#[macro_export]
-macro_rules! wait_for_any_10s {
-    ($test:expr, $check:expr, $assert:expr) => {
-        let mut wait_for = $crate::test_utils::WaitForAny::ten_s();
-        $crate::wait_for_any!(wait_for, $test, $check, $assert)
-    };
-}
-
-#[macro_export]
-macro_rules! wait_for_any_1m {
-    ($test:expr, $check:expr, $assert:expr) => {
-        let mut wait_for = $crate::test_utils::WaitForAny::one_m();
-        $crate::wait_for_any!(wait_for, $test, $check, $assert)
-    };
-}
-
-#[derive(Debug, Clone)]
-/// Generic waiting for some test property to
-/// be true. This allows early exit from waiting when
-/// the condition becomes true but will wait up to a
-/// maximum if the condition is not true.
-pub struct WaitForAny {
-    num_attempts: usize,
-    attempt: usize,
-    delay: Duration,
-}
-
-impl WaitForAny {
-    /// Create a new wait for from a number of attempts and delay in between attempts
-    pub fn new(num_attempts: usize, delay: Duration) -> Self {
-        Self {
-            num_attempts,
-            attempt: 0,
-            delay,
-        }
-    }
-
-    /// Wait for 10s checking every 100ms.
-    pub fn ten_s() -> Self {
-        const DELAY_PER_ATTEMPT: std::time::Duration = std::time::Duration::from_millis(100);
-        Self::new(100, DELAY_PER_ATTEMPT)
-    }
-
-    /// Wait for 1 minute checking every 500ms.
-    pub fn one_m() -> Self {
-        const DELAY_PER_ATTEMPT: std::time::Duration = std::time::Duration::from_millis(500);
-        Self::new(120, DELAY_PER_ATTEMPT)
-    }
-
-    /// Wait for some time before trying again.
-    /// Will return false when you should stop waiting.
-    #[tracing::instrument(skip(self))]
-    pub async fn wait_any(&mut self) -> bool {
-        if self.attempt >= self.num_attempts {
-            return false;
-        }
-        self.attempt += 1;
-        tracing::debug!(attempt = ?self.attempt, out_of = ?self.num_attempts, delaying_for = ?self.delay);
-        tokio::time::sleep(self.delay).await;
-        true
     }
 }
 

--- a/crates/holochain/src/test_utils/wait_for_any.rs
+++ b/crates/holochain/src/test_utils/wait_for_any.rs
@@ -1,0 +1,123 @@
+use std::time::Duration;
+
+#[macro_export]
+macro_rules! wait_for_any {
+    ($wait:expr, $test:expr, $check:expr, $assert:expr) => {{
+        loop {
+            let o = $test;
+            if !$wait.wait_any().await || $check(&o) {
+                $assert(o);
+                break;
+            }
+        }
+    }};
+}
+
+#[macro_export]
+macro_rules! wait_for_any_10s {
+    ($test:expr, $check:expr, $assert:expr) => {
+        let mut wait_for = $crate::test_utils::WaitForAny::ten_s();
+        $crate::wait_for_any!(wait_for, $test, $check, $assert)
+    };
+}
+
+#[macro_export]
+macro_rules! wait_for_any_1m {
+    ($test:expr, $check:expr, $assert:expr) => {
+        let mut wait_for = $crate::test_utils::WaitForAny::one_m();
+        $crate::wait_for_any!(wait_for, $test, $check, $assert)
+    };
+}
+
+#[macro_export]
+macro_rules! assert_retry {
+    ($wait:expr, $test:expr, $check:expr $(, $reason:literal)?) => {
+        $crate::wait_for_any!($wait, $test, $check, |x| assert!(x $(, $reason)?))
+    };
+}
+
+#[macro_export]
+macro_rules! assert_eq_retry {
+    ($wait:expr, $test:expr, $check:expr $(, $reason:literal)?) => {
+        $crate::wait_for_any!($wait, $test, |x| x == &$check, |x| assert_eq!(x, $check $(, $reason)?))
+    };
+}
+
+#[macro_export]
+macro_rules! assert_retry_10s {
+    ($test:expr, $check:expr $(, $reason:literal)? $(,)?) => {
+        let mut wait_for = $crate::test_utils::WaitForAny::ten_s();
+        $crate::assert_retry!(wait_for, $test, $check  $(, $reason:literal)?)
+    };
+}
+
+#[macro_export]
+macro_rules! assert_eq_retry_10s {
+    ($test:expr, $check:expr $(, $reason:literal)? $(,)?) => {
+        let mut wait_for = $crate::test_utils::WaitForAny::ten_s();
+        $crate::assert_eq_retry!(wait_for, $test, $check  $(, $reason:literal)?)
+    };
+}
+
+#[macro_export]
+macro_rules! assert_retry_1m {
+    ($test:expr, $check:expr $(, $reason:literal)? $(,)?) => {
+        let mut wait_for = $crate::test_utils::WaitForAny::one_m();
+        $crate::assert_retry!(wait_for, $test, $check  $(, $reason:literal)?)
+    };
+}
+
+#[macro_export]
+macro_rules! assert_eq_retry_1m {
+    ($test:expr, $check:expr $(, $reason:literal)? $(,)?) => {
+        let mut wait_for = $crate::test_utils::WaitForAny::one_m();
+        $crate::assert_eq_retry!(wait_for, $test, $check  $(, $reason:literal)?)
+    };
+}
+
+#[derive(Debug, Clone)]
+/// Generic waiting for some test property to
+/// be true. This allows early exit from waiting when
+/// the condition becomes true but will wait up to a
+/// maximum if the condition is not true.
+pub struct WaitForAny {
+    num_attempts: usize,
+    attempt: usize,
+    delay: Duration,
+}
+
+impl WaitForAny {
+    /// Create a new wait for from a number of attempts and delay in between attempts
+    pub fn new(num_attempts: usize, delay: Duration) -> Self {
+        Self {
+            num_attempts,
+            attempt: 0,
+            delay,
+        }
+    }
+
+    /// Wait for 10s checking every 100ms.
+    pub fn ten_s() -> Self {
+        const DELAY_PER_ATTEMPT: std::time::Duration = std::time::Duration::from_millis(100);
+        Self::new(100, DELAY_PER_ATTEMPT)
+    }
+
+    /// Wait for 1 minute checking every 500ms.
+    pub fn one_m() -> Self {
+        const DELAY_PER_ATTEMPT: std::time::Duration = std::time::Duration::from_millis(500);
+        Self::new(120, DELAY_PER_ATTEMPT)
+    }
+
+    /// Wait for some time before trying again.
+    /// Will return false when you should stop waiting.
+    #[tracing::instrument(skip(self))]
+    pub async fn wait_any(&mut self) -> bool {
+        if self.attempt >= self.num_attempts {
+            return false;
+        }
+        self.attempt += 1;
+        tracing::debug!(attempt = ?self.attempt, out_of = ?self.num_attempts, delaying_for = ?self.delay);
+        tokio::time::sleep(self.delay).await;
+        true
+    }
+}


### PR DESCRIPTION
This is the same commit as in #698, but merged into `develop` instead of `sqlite`