### PR TITLE
adds systemd ready notification to main conductor process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,6 +1660,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.7.3",
  "ring",
+ "sd-notify",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -4069,6 +4070,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "sd-notify"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cd08a21f852bd2fe42e3b2a6c76a0db6a95a5b5bd29c0521dd0b30fa1712ec8"
 
 [[package]]
 name = "security-framework"

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -48,6 +48,7 @@ parking_lot = "0.10"
 predicates = "1.0.4"
 rand = "0.7"
 ring = "0.16"
+sd-notify = "0.3.0"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 serde_yaml = "0.8"

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -48,7 +48,6 @@ parking_lot = "0.10"
 predicates = "1.0.4"
 rand = "0.7"
 ring = "0.16"
-sd-notify = "0.3.0"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 serde_yaml = "0.8"
@@ -79,6 +78,9 @@ holochain_test_wasm_common = { version = "0.0.1", path = "../test_utils/wasm_com
 unwrap_to = { version = "0.1.0", optional = true }
 itertools = { version = "0.10", optional = true }
 kitsune_p2p_types = { version = "0.0.1", path = "../kitsune_p2p/types", optional = true }
+
+[target.'cfg(unix)'.dependencies]
+sd-notify = "0.3.0"
 
 
 [dev-dependencies]

--- a/crates/holochain/src/bin/holochain/main.rs
+++ b/crates/holochain/src/bin/holochain/main.rs
@@ -6,6 +6,7 @@ use holochain::conductor::Conductor;
 use holochain::conductor::ConductorHandle;
 use holochain_conductor_api::conductor::ConductorConfigError;
 use observability::Output;
+use sd_notify;
 use std::path::PathBuf;
 use structopt::StructOpt;
 use tracing::*;
@@ -68,6 +69,11 @@ async fn async_main() {
     // that the conductor has been initialized, in particular that the admin
     // interfaces are running, and can be connected to.
     println!("{}", MAGIC_CONDUCTOR_READY_STRING);
+
+    // Lets systemd units know that holochain is ready via sd_notify socket
+    // Requires NotifyAccess=all and Type=notify attributes on holochain systemd unit
+    // and NotifyAccess=all on dependant systemd unit
+    let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]);
 
     // Await on the main JoinHandle, keeping the process alive until all
     // Conductor activity has ceased

--- a/crates/holochain/src/bin/holochain/main.rs
+++ b/crates/holochain/src/bin/holochain/main.rs
@@ -73,6 +73,7 @@ async fn async_main() {
     // Lets systemd units know that holochain is ready via sd_notify socket
     // Requires NotifyAccess=all and Type=notify attributes on holochain systemd unit
     // and NotifyAccess=all on dependant systemd unit
+    #[cfg(unix)]
     let _ = notify(true, &[NotifyState::Ready]);
 
     // Await on the main JoinHandle, keeping the process alive until all

--- a/crates/holochain/src/bin/holochain/main.rs
+++ b/crates/holochain/src/bin/holochain/main.rs
@@ -6,6 +6,7 @@ use holochain::conductor::Conductor;
 use holochain::conductor::ConductorHandle;
 use holochain_conductor_api::conductor::ConductorConfigError;
 use observability::Output;
+#[cfg(unix)]
 use sd_notify::{notify, NotifyState};
 use std::path::PathBuf;
 use structopt::StructOpt;

--- a/crates/holochain/src/bin/holochain/main.rs
+++ b/crates/holochain/src/bin/holochain/main.rs
@@ -6,7 +6,7 @@ use holochain::conductor::Conductor;
 use holochain::conductor::ConductorHandle;
 use holochain_conductor_api::conductor::ConductorConfigError;
 use observability::Output;
-use sd_notify::{ notify, NotifyState };
+use sd_notify::{notify, NotifyState};
 use std::path::PathBuf;
 use structopt::StructOpt;
 use tracing::*;

--- a/crates/holochain/src/bin/holochain/main.rs
+++ b/crates/holochain/src/bin/holochain/main.rs
@@ -6,7 +6,7 @@ use holochain::conductor::Conductor;
 use holochain::conductor::ConductorHandle;
 use holochain_conductor_api::conductor::ConductorConfigError;
 use observability::Output;
-use sd_notify;
+use sd_notify::{ notify, NotifyState };
 use std::path::PathBuf;
 use structopt::StructOpt;
 use tracing::*;
@@ -73,7 +73,7 @@ async fn async_main() {
     // Lets systemd units know that holochain is ready via sd_notify socket
     // Requires NotifyAccess=all and Type=notify attributes on holochain systemd unit
     // and NotifyAccess=all on dependant systemd unit
-    let _ = sd_notify::notify(true, &[sd_notify::NotifyState::Ready]);
+    let _ = notify(true, &[NotifyState::Ready]);
 
     // Await on the main JoinHandle, keeping the process alive until all
     // Conductor activity has ceased


### PR DESCRIPTION
Adds ability to send a notification to systemd that holochain is ready for interactions. This feature is important when holochain is running as a systemd unit and there are other units depending on holocahin's readiness.