### PR TITLE
Rework InstalledApp to allow returning a status from API; more consistent use of InstalledAppInfo in API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1982,6 +1982,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
+ "serde_json",
  "serde_yaml",
  "shrinkwraprs",
  "strum",

--- a/crates/hc_sandbox/examples/setup_5.rs
+++ b/crates/hc_sandbox/examples/setup_5.rs
@@ -69,7 +69,7 @@ async fn main() -> anyhow::Result<()> {
         hc_sandbox::calls::activate_app(
             &mut cmd,
             ActivateApp {
-                app_id: installed_app.installed_app_id().clone(),
+                app_id: installed_app.installed_app_id,
             },
         )
         .await?;

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -521,13 +521,14 @@ mod test {
         let agent_key2 = fake_agent_pubkey_2();
         let path_payload = InstallAppDnaPayload::hash_only(dna_hash.clone(), "".to_string());
         let cell_id2 = CellId::new(dna_hash.clone(), agent_key2.clone());
-        let expected_installed_app = InstalledApp::new_active(
+        let expected_installed_app = InstalledApp::new_inactive(
             InstalledAppCommon::new_legacy(
                 "test-by-path".to_string(),
                 vec![InstalledCell::new(cell_id2.clone(), "".to_string())],
             )
             .unwrap(),
         );
+        let expected_installed_app_info: InstalledAppInfo = (&expected_installed_app).into();
         let path_install_payload = InstallAppPayload {
             dnas: vec![path_payload],
             installed_app_id: "test-by-path".to_string(),
@@ -537,9 +538,11 @@ mod test {
         let install_response = admin_api
             .handle_admin_request(AdminRequest::InstallApp(Box::new(path_install_payload)))
             .await;
+        dbg!(&install_response);
+        dbg!(&expected_installed_app_info);
         assert_matches!(
             install_response,
-            AdminResponse::AppInstalled(info) if info == (&expected_installed_app).into()
+            AdminResponse::AppInstalled(info) if info == expected_installed_app_info
         );
         let dna_list = admin_api.handle_admin_request(AdminRequest::ListDnas).await;
         let expects = vec![dna_hash.clone()];

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -592,7 +592,7 @@ pub mod test {
         let maybe_info = state.get_app_info(&"test app".to_string());
         if let Some(info) = maybe_info {
             assert_eq!(info.installed_app_id, "test app");
-            assert_matches!(info.status, InstalledAppStatus::Inactive(_));
+            assert_matches!(info.status, InstalledAppStatus::Inactive {..});
         } else {
             assert!(false);
         }

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -548,7 +548,7 @@ pub mod test {
         let maybe_info = state.get_app_info(&"test app".to_string());
         if let Some(info) = maybe_info {
             assert_eq!(info.installed_app_id, "test app");
-            assert!(info.active);
+            assert_matches!(info.status, InstalledAppStatus::Active);
         } else {
             assert!(false);
         }
@@ -592,7 +592,7 @@ pub mod test {
         let maybe_info = state.get_app_info(&"test app".to_string());
         if let Some(info) = maybe_info {
             assert_eq!(info.installed_app_id, "test app");
-            assert!(!info.active);
+            assert_matches!(info.status, InstalledAppStatus::Inactive(_));
         } else {
             assert!(false);
         }

--- a/crates/holochain/src/conductor/manager/mod.rs
+++ b/crates/holochain/src/conductor/manager/mod.rs
@@ -214,7 +214,7 @@ async fn run(
                         context
                     );
                     for app_id in app_ids.iter() {
-                        conductor.deactivate_app(app_id.to_string(), DeactivationReason::Quarantined).await.map_err(TaskManagerError::internal)?;
+                        conductor.deactivate_app(app_id.to_string(), DeactivationReason::Quarantined { error: error.to_string() } ).await.map_err(TaskManagerError::internal)?;
                     }
                     tracing::error!("Apps quarantined via deactivation.");
                 },

--- a/crates/holochain/src/conductor/state.rs
+++ b/crates/holochain/src/conductor/state.rs
@@ -65,11 +65,11 @@ impl ConductorState {
     pub fn get_app_info(&self, installed_app_id: &InstalledAppId) -> Option<InstalledAppInfo> {
         self.active_apps
             .get(installed_app_id)
-            .map(|app| InstalledAppInfo::from_installed_app(app, true))
+            .map(|app| InstalledAppInfo::from_installed_app(&app.clone().into()))
             .or_else(|| {
                 self.inactive_apps
                     .get(installed_app_id)
-                    .map(|app| InstalledAppInfo::from_installed_app(app, false))
+                    .map(|app| InstalledAppInfo::from_installed_app(&app.clone().into()))
             })
     }
 

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -3,6 +3,8 @@ use holochain_types::prelude::*;
 use holochain_zome_types::cell::CellId;
 use kitsune_p2p::agent_store::AgentInfoSigned;
 
+use crate::InstalledAppInfo;
+
 /// Represents the available conductor functions to call over an Admin interface
 /// and will result in a corresponding [`AdminResponse`] message being sent back over the
 /// interface connection.
@@ -243,27 +245,27 @@ pub enum AdminResponse {
 
     /// The successful response to an [`AdminRequest::InstallApp`].
     ///
-    /// The resulting [`InstalledApp`] contains the App id,
+    /// The resulting [`InstalledAppInfo`] contains the App id,
     /// the [`CellNick`]s and, most usefully, the new [`CellId`]s
-    /// of the newly installed `Dna`s. See the [`InstalledApp`] docs for details.
+    /// of the newly installed `Dna`s. See the [`InstalledAppInfo`] docs for details.
     ///
     /// [`AdminRequest::InstallApp`]: enum.AdminRequest.html#variant.InstallApp
-    /// [`InstalledApp`]: ../../../holochain_types/app/struct.InstalledApp.html
+    /// [`InstalledAppInfo`]: ../../../holochain_types/app/struct.InstalledAppInfo.html
     /// [`CellNick`]: ../../../holochain_types/app/type.CellNick.html
     /// [`CellId`]: ../../../holochain_types/cell/struct.CellId.html
-    AppInstalled(InstalledApp),
+    AppInstalled(InstalledAppInfo),
 
     /// The successful response to an [`AdminRequest::InstallAppBundle`].
     ///
-    /// The resulting [`InstalledApp`] contains the App id,
+    /// The resulting [`InstalledAppInfo`] contains the App id,
     /// the [`CellNick`]s and, most usefully, the new [`CellId`]s
-    /// of the newly installed `Dna`s. See the [`InstalledApp`] docs for details.
+    /// of the newly installed `Dna`s. See the [`InstalledAppInfo`] docs for details.
     ///
     /// [`AdminRequest::InstallApp`]: enum.AdminRequest.html#variant.InstallApp
-    /// [`InstalledApp`]: ../../../holochain_types/app/struct.InstalledApp.html
+    /// [`InstalledAppInfo`]: ../../../holochain_types/app/struct.InstalledAppInfo.html
     /// [`CellNick`]: ../../../holochain_types/app/type.CellNick.html
     /// [`CellId`]: ../../../holochain_types/cell/struct.CellId.html
-    AppBundleInstalled(InstalledApp),
+    AppBundleInstalled(InstalledAppInfo),
 
     /// The successful response to an [`AdminRequest::CreateCloneCell`].
     ///

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -65,7 +65,7 @@ pub enum AppResponse {
     /// The succesful response to an [`AppRequest::AppInfo`].
     ///
     /// Option will be `None` if there is no installed app with the given `installed_app_id` value from the request.
-    /// Check out [`InstalledApp`] for details on when the Option is `Some<InstalledApp>`
+    /// Check out [`InstalledApp`] for details on when the Option is `Some<InstalledAppInfo>`
     ///
     /// [`InstalledApp`]: ../../../holochain_types/app/struct.InstalledApp.html
     /// [`AppRequest::AppInfo`]: enum.AppRequest.html#variant.AppInfo
@@ -118,7 +118,7 @@ pub enum CryptoRequest {
     Encrypt(String),
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, SerializedBytes)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, SerializedBytes)]
 /// Info about an installed app, returned as part of [`AppResponse::AppInfo`]
 pub struct InstalledAppInfo {
     /// The unique identifier for an installed app in this conductor
@@ -126,12 +126,13 @@ pub struct InstalledAppInfo {
     /// Info about the Cells installed in this app
     pub cell_data: Vec<InstalledCell>,
     /// Is this app currently active?
-    pub active: bool,
+    pub status: InstalledAppStatus,
 }
 
 impl InstalledAppInfo {
-    pub fn from_installed_app(app: &InstalledApp, active: bool) -> Self {
+    pub fn from_installed_app(app: &InstalledApp) -> Self {
         let installed_app_id = app.installed_app_id().clone();
+        let status = app.status();
         let cell_data = app
             .provisioned_cells()
             .map(|(nick, id)| InstalledCell::new(id.clone(), nick.clone()))
@@ -139,7 +140,13 @@ impl InstalledAppInfo {
         Self {
             installed_app_id,
             cell_data,
-            active,
+            status,
         }
+    }
+}
+
+impl From<&InstalledApp> for InstalledAppInfo {
+    fn from(app: &InstalledApp) -> Self {
+        Self::from_installed_app(app)
     }
 }

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -56,6 +56,7 @@ arbitrary = { version = "1.0", features = ["derive"], optional = true}
 [dev-dependencies]
 maplit = "1"
 matches = "0.1"
+serde_json = "1"
 tokio = { version = "1.3", features = [ "full" ] }
 
 [features]

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -236,7 +236,7 @@ impl InstalledApp {
 
     /// Constructor for freshly installed app
     pub fn new_active(app: InstalledAppCommon) -> Self {
-        Self::Active(ActiveApp(app.into()))
+        Self::Active(ActiveApp(app))
     }
 
     /// Return the common app info, as well as a status which encodes the remaining

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -685,6 +685,9 @@ mod tests {
         };
 
         let json = serde_json::to_string(&status).unwrap();
-        assert_eq!(json, "{\"inactive\":{\"reason\":{\"quarantined\":{\"error\":\"because\"}}}}");
+        assert_eq!(
+            json,
+            "{\"inactive\":{\"reason\":{\"quarantined\":{\"error\":\"because\"}}}}"
+        );
     }
 }


### PR DESCRIPTION
- Puts an enum around InstalledApp to have stronger separation between the Active and Inactive cases.
- Separate types for Active and Inactive, the latter of which contains a DeactivationReason
- Never leak `InstalledApp` out over API calls: use `InstalledAppInfo` for that

That last bullet entails a few breaking changes to the conductor API, but I'm not sure how big of a problem this is for people. Namely, we would have to replace `InstalledApp` with `InstalledAppInfo` for every API call that returns the former. Namely, this type would go away:

https://github.com/holochain/holochain-conductor-api/blob/3d04b87ea4a254605f8d2f858ccbe66cdc327cc4/src/api/types.ts#L17