### PR TITLE
Make tokio_helper available as unqualified import

### DIFF
--- a/crates/holochain/src/bin/holochain/main.rs
+++ b/crates/holochain/src/bin/holochain/main.rs
@@ -5,6 +5,7 @@ use holochain::conductor::paths::ConfigFilePath;
 use holochain::conductor::Conductor;
 use holochain::conductor::ConductorHandle;
 use holochain_conductor_api::conductor::ConductorConfigError;
+use holochain_util::tokio_helper;
 use observability::Output;
 #[cfg(unix)]
 use sd_notify::{notify, NotifyState};
@@ -48,7 +49,7 @@ struct Opt {
 
 fn main() {
     // the async_main function should only end if our program is done
-    holochain_util::tokio_helper::block_forever_on(async_main())
+    tokio_helper::block_forever_on(async_main())
 }
 
 async fn async_main() {

--- a/crates/holochain/src/core/ribosome.rs
+++ b/crates/holochain/src/core/ribosome.rs
@@ -263,7 +263,7 @@ impl ZomeCallInvocation {
         let check_agent = self.provenance.clone();
         let check_secret = self.cap;
 
-        holochain_util::tokio_helper::block_forever_on(async move {
+        tokio_helper::block_forever_on(async move {
             let maybe_grant: Option<CapGrant> = host_access
                 .workspace
                 .read()

--- a/crates/holochain/src/core/ribosome/guest_callback/validate.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validate.rs
@@ -390,7 +390,7 @@ mod slow_tests {
             crate::call_test_ribosome!(host_access, TestWasm::Validate, "always_validates", ());
 
         // the chain head should be the committed entry header
-        let chain_head = holochain_util::tokio_helper::block_forever_on(async move {
+        let chain_head = tokio_helper::block_forever_on(async move {
             SourceChainResult::Ok(
                 workspace_lock
                     .read()
@@ -426,7 +426,7 @@ mod slow_tests {
             crate::call_test_ribosome!(host_access, TestWasm::Validate, "never_validates", ());
 
         // the chain head should be the committed entry header
-        let chain_head = holochain_util::tokio_helper::block_forever_on(async move {
+        let chain_head = tokio_helper::block_forever_on(async move {
             SourceChainResult::Ok(
                 workspace_lock
                     .read()

--- a/crates/holochain/src/core/ribosome/guest_callback/validate_link.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validate_link.rs
@@ -368,7 +368,7 @@ mod slow_tests {
             crate::call_test_ribosome!(host_access, TestWasm::ValidateLink, "add_valid_link", ());
 
         // the chain head should be the committed entry header
-        let chain_head = holochain_util::tokio_helper::block_forever_on(async move {
+        let chain_head = tokio_helper::block_forever_on(async move {
             SourceChainResult::Ok(
                 workspace_lock
                     .read()
@@ -404,7 +404,7 @@ mod slow_tests {
             crate::call_test_ribosome!(host_access, TestWasm::ValidateLink, "add_invalid_link", ());
 
         // the chain head should be the committed entry header
-        let chain_head = holochain_util::tokio_helper::block_forever_on(async move {
+        let chain_head = tokio_helper::block_forever_on(async move {
             SourceChainResult::Ok(
                 workspace_lock
                     .read()

--- a/crates/holochain/src/core/ribosome/host_fn/agent_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/agent_info.rs
@@ -10,7 +10,7 @@ pub fn agent_info<'a>(
     call_context: Arc<CallContext>,
     _input: (),
 ) -> Result<AgentInfo, WasmError> {
-    let agent_pubkey = holochain_util::tokio_helper::block_forever_on(async move {
+    let agent_pubkey = tokio_helper::block_forever_on(async move {
         let lock = call_context.host_access.workspace().read().await;
         lock.source_chain.agent_pubkey()
     })

--- a/crates/holochain/src/core/ribosome/host_fn/call.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call.rs
@@ -33,7 +33,7 @@ pub fn call(
     };
 
     // Make the call using this workspace
-    Ok(holochain_util::tokio_helper::block_forever_on(async move {
+    Ok(tokio_helper::block_forever_on(async move {
         conductor_handle
             .call_zome(invocation, workspace)
             .await

--- a/crates/holochain/src/core/ribosome/host_fn/call_remote.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call_remote.rs
@@ -11,19 +11,18 @@ pub fn call_remote(
     input: CallRemote,
 ) -> Result<ZomeCallResponse, WasmError> {
     // it is the network's responsibility to handle timeouts and return an Err result in that case
-    let result: Result<SerializedBytes, _> =
-        holochain_util::tokio_helper::block_forever_on(async move {
-            let mut network = call_context.host_access().network().clone();
-            network
-                .call_remote(
-                    input.target_agent_as_ref().to_owned(),
-                    input.zome_name_as_ref().to_owned(),
-                    input.fn_name_as_ref().to_owned(),
-                    input.cap_as_ref().to_owned(),
-                    input.payload_as_ref().to_owned(),
-                )
-                .await
-        });
+    let result: Result<SerializedBytes, _> = tokio_helper::block_forever_on(async move {
+        let mut network = call_context.host_access().network().clone();
+        network
+            .call_remote(
+                input.target_agent_as_ref().to_owned(),
+                input.zome_name_as_ref().to_owned(),
+                input.fn_name_as_ref().to_owned(),
+                input.cap_as_ref().to_owned(),
+                input.payload_as_ref().to_owned(),
+            )
+            .await
+    });
     let result = match result {
         Ok(r) => ZomeCallResponse::try_from(r)?,
         Err(e) => ZomeCallResponse::NetworkError(e.to_string()),

--- a/crates/holochain/src/core/ribosome/host_fn/create.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/create.rs
@@ -55,7 +55,7 @@ pub fn create<'a>(
     // if the validation fails this commit will be rolled back by virtue of the lmdb transaction
     // being atomic
     let entry = AsRef::<Entry>::as_ref(&input).to_owned();
-    holochain_util::tokio_helper::block_forever_on(async move {
+    tokio_helper::block_forever_on(async move {
         let mut guard = call_context.host_access.workspace().write().await;
         let workspace: &mut CallZomeWorkspace = &mut guard;
         let source_chain = &mut workspace.source_chain;
@@ -209,7 +209,7 @@ pub mod wasm_test {
         let output = create(Arc::new(ribosome), Arc::new(call_context), input).unwrap();
 
         // the chain head should be the committed entry header
-        let chain_head = holochain_util::tokio_helper::block_forever_on(async move {
+        let chain_head = tokio_helper::block_forever_on(async move {
             SourceChainResult::Ok(
                 workspace_lock
                     .read()
@@ -245,7 +245,7 @@ pub mod wasm_test {
             crate::call_test_ribosome!(host_access, TestWasm::Create, "create_entry", ());
 
         // the chain head should be the committed entry header
-        let chain_head = holochain_util::tokio_helper::block_forever_on(async move {
+        let chain_head = tokio_helper::block_forever_on(async move {
             SourceChainResult::Ok(
                 workspace_lock
                     .read()

--- a/crates/holochain/src/core/ribosome/host_fn/create_link.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/create_link.rs
@@ -28,26 +28,25 @@ pub fn create_link<'a>(
     // Construct the link add
     let header_builder = builder::CreateLink::new(base_address, target_address, zome_id, tag);
 
-    let header_hash =
-        holochain_util::tokio_helper::block_forever_on(tokio::task::spawn(async move {
-            let mut guard = call_context.host_access.workspace().write().await;
-            let workspace: &mut CallZomeWorkspace = &mut guard;
-            // push the header into the source chain
-            let header_hash = workspace.source_chain.put(header_builder, None).await?;
-            let element = workspace
-                .source_chain
-                .get_element(&header_hash)?
-                .expect("Element we just put in SourceChain must be gettable");
-            integrate_to_authored(
-                &element,
-                workspace.source_chain.elements(),
-                &mut workspace.meta_authored,
-            )
-            .map_err(Box::new)?;
-            Ok::<HeaderHash, RibosomeError>(header_hash)
-        }))
-        .map_err(|join_error| WasmError::Host(join_error.to_string()))?
-        .map_err(|ribosome_error| WasmError::Host(ribosome_error.to_string()))?;
+    let header_hash = tokio_helper::block_forever_on(tokio::task::spawn(async move {
+        let mut guard = call_context.host_access.workspace().write().await;
+        let workspace: &mut CallZomeWorkspace = &mut guard;
+        // push the header into the source chain
+        let header_hash = workspace.source_chain.put(header_builder, None).await?;
+        let element = workspace
+            .source_chain
+            .get_element(&header_hash)?
+            .expect("Element we just put in SourceChain must be gettable");
+        integrate_to_authored(
+            &element,
+            workspace.source_chain.elements(),
+            &mut workspace.meta_authored,
+        )
+        .map_err(Box::new)?;
+        Ok::<HeaderHash, RibosomeError>(header_hash)
+    }))
+    .map_err(|join_error| WasmError::Host(join_error.to_string()))?
+    .map_err(|ribosome_error| WasmError::Host(ribosome_error.to_string()))?;
 
     // return the hash of the committed link
     // note that validation is handled by the workflow

--- a/crates/holochain/src/core/ribosome/host_fn/create_x25519_keypair.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/create_x25519_keypair.rs
@@ -1,6 +1,7 @@
 use crate::core::ribosome::CallContext;
 use crate::core::ribosome::RibosomeT;
 use holochain_keystore::keystore_actor::KeystoreSenderExt;
+use holochain_util::tokio_helper;
 use holochain_wasmer_host::prelude::WasmError;
 use holochain_zome_types::X25519PubKey;
 use std::sync::Arc;
@@ -10,7 +11,7 @@ pub fn create_x25519_keypair(
     call_context: Arc<CallContext>,
     _input: (),
 ) -> Result<X25519PubKey, WasmError> {
-    Ok(holochain_util::tokio_helper::block_forever_on(async move {
+    Ok(tokio_helper::block_forever_on(async move {
         call_context
             .host_access
             .keystore()

--- a/crates/holochain/src/core/ribosome/host_fn/delete.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/delete.rs
@@ -22,7 +22,7 @@ pub fn delete<'a>(
     let host_access = call_context.host_access();
 
     // handle timeouts at the source chain layer
-    holochain_util::tokio_helper::block_forever_on(async move {
+    tokio_helper::block_forever_on(async move {
         let mut guard = host_access.workspace().write().await;
         let workspace: &mut CallZomeWorkspace = &mut guard;
         let source_chain = &mut workspace.source_chain;
@@ -57,7 +57,7 @@ pub(crate) fn get_original_address<'a>(
     let network = call_context.host_access.network().clone();
     let workspace_lock = call_context.host_access.workspace();
 
-    holochain_util::tokio_helper::block_forever_on(async move {
+    tokio_helper::block_forever_on(async move {
         let mut workspace = workspace_lock.write().await;
         let mut cascade = workspace.cascade(network);
         // TODO: Think about what options to use here

--- a/crates/holochain/src/core/ribosome/host_fn/delete_link.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/delete_link.rs
@@ -25,7 +25,7 @@ pub fn delete_link<'a>(
 
     // handle timeouts at the network layer
     let maybe_add_link: Option<SignedHeaderHashed> =
-        holochain_util::tokio_helper::block_forever_on(async move {
+        tokio_helper::block_forever_on(async move {
             CascadeResult::Ok(
                 call_context_2
                     .clone()
@@ -64,7 +64,7 @@ pub fn delete_link<'a>(
     // handle timeouts at the source chain layer
 
     // add a DeleteLink to the source chain
-    holochain_util::tokio_helper::block_forever_on(async move {
+    tokio_helper::block_forever_on(async move {
         let mut guard = workspace_lock.write().await;
         let workspace: &mut CallZomeWorkspace = &mut guard;
         let source_chain = &mut workspace.source_chain;

--- a/crates/holochain/src/core/ribosome/host_fn/get.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get.rs
@@ -19,7 +19,7 @@ pub fn get<'a>(
     let network = call_context.host_access.network().clone();
 
     // timeouts must be handled by the network
-    holochain_util::tokio_helper::block_forever_on(async move {
+    tokio_helper::block_forever_on(async move {
         let maybe_element = call_context
             .host_access
             .workspace()

--- a/crates/holochain/src/core/ribosome/host_fn/get_agent_activity.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_agent_activity.rs
@@ -32,7 +32,7 @@ pub fn get_agent_activity(
     let network = call_context.host_access.network().clone();
 
     // timeouts must be handled by the network
-    holochain_util::tokio_helper::block_forever_on(async move {
+    tokio_helper::block_forever_on(async move {
         let activity = call_context
             .host_access
             .workspace()

--- a/crates/holochain/src/core/ribosome/host_fn/get_details.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_details.rs
@@ -19,7 +19,7 @@ pub fn get_details<'a>(
     let network = call_context.host_access.network().clone();
 
     // timeouts must be handled by the network
-    holochain_util::tokio_helper::block_forever_on(async move {
+    tokio_helper::block_forever_on(async move {
         let maybe_details = call_context
             .host_access
             .workspace()

--- a/crates/holochain/src/core/ribosome/host_fn/get_link_details.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_link_details.rs
@@ -25,7 +25,7 @@ pub fn get_link_details<'a>(
     // Get the network from the context
     let network = call_context.host_access.network().clone();
 
-    holochain_util::tokio_helper::block_forever_on(async move {
+    tokio_helper::block_forever_on(async move {
         // Create the key
         let key = match tag_prefix.as_ref() {
             Some(tag_prefix) => LinkMetaKey::BaseZomeTag(&base_address, zome_id, tag_prefix),

--- a/crates/holochain/src/core/ribosome/host_fn/get_links.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_links.rs
@@ -25,7 +25,7 @@ pub fn get_links<'a>(
     // Get the network from the context
     let network = call_context.host_access.network().clone();
 
-    holochain_util::tokio_helper::block_forever_on(async move {
+    tokio_helper::block_forever_on(async move {
         // Create the key
         let key = match tag_prefix.as_ref() {
             Some(tag_prefix) => LinkMetaKey::BaseZomeTag(&base_address, zome_id, tag_prefix),

--- a/crates/holochain/src/core/ribosome/host_fn/query.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/query.rs
@@ -9,7 +9,7 @@ pub fn query(
     call_context: Arc<CallContext>,
     input: ChainQueryFilter,
 ) -> Result<Vec<Element>, WasmError> {
-    holochain_util::tokio_helper::block_forever_on(async move {
+    tokio_helper::block_forever_on(async move {
         let elements: Vec<Element> = call_context
             .host_access
             .workspace()

--- a/crates/holochain/src/core/ribosome/host_fn/sign.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/sign.rs
@@ -10,7 +10,7 @@ pub fn sign(
     call_context: Arc<CallContext>,
     input: Sign,
 ) -> Result<Signature, WasmError> {
-    Ok(holochain_util::tokio_helper::block_forever_on(async move {
+    Ok(tokio_helper::block_forever_on(async move {
         call_context.host_access.keystore().sign(input).await
     })
     .map_err(|keystore_error| WasmError::Host(keystore_error.to_string()))?)

--- a/crates/holochain/src/core/ribosome/host_fn/update.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/update.rs
@@ -66,7 +66,7 @@ pub fn update<'a>(
     // if the validation fails this update will be rolled back by virtue of the lmdb transaction
     // being atomic
     let entry = AsRef::<Entry>::as_ref(&entry_with_def_id).to_owned();
-    holochain_util::tokio_helper::block_forever_on(async move {
+    tokio_helper::block_forever_on(async move {
         let mut guard = workspace_lock.write().await;
         let workspace: &mut CallZomeWorkspace = &mut guard;
         let source_chain = &mut workspace.source_chain;

--- a/crates/holochain/src/core/ribosome/host_fn/verify_signature.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/verify_signature.rs
@@ -10,7 +10,7 @@ pub fn verify_signature(
     _call_context: Arc<CallContext>,
     input: VerifySignature,
 ) -> Result<bool, WasmError> {
-    Ok(holochain_util::tokio_helper::block_forever_on(async move {
+    Ok(tokio_helper::block_forever_on(async move {
         input
             .key
             .verify_signature_raw(input.as_ref(), input.as_data_ref())

--- a/crates/holochain/src/core/ribosome/host_fn/x_25519_x_salsa20_poly1305_decrypt.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/x_25519_x_salsa20_poly1305_decrypt.rs
@@ -10,7 +10,7 @@ pub fn x_25519_x_salsa20_poly1305_decrypt(
     call_context: Arc<CallContext>,
     input: X25519XSalsa20Poly1305Decrypt,
 ) -> Result<Option<XSalsa20Poly1305Data>, WasmError> {
-    Ok(holochain_util::tokio_helper::block_forever_on(async move {
+    Ok(tokio_helper::block_forever_on(async move {
         call_context
             .host_access
             .keystore()

--- a/crates/holochain/src/core/ribosome/host_fn/x_25519_x_salsa20_poly1305_encrypt.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/x_25519_x_salsa20_poly1305_encrypt.rs
@@ -10,7 +10,7 @@ pub fn x_25519_x_salsa20_poly1305_encrypt(
     call_context: Arc<CallContext>,
     input: X25519XSalsa20Poly1305Encrypt,
 ) -> Result<XSalsa20Poly1305EncryptedData, WasmError> {
-    Ok(holochain_util::tokio_helper::block_forever_on(async move {
+    Ok(tokio_helper::block_forever_on(async move {
         call_context
             .host_access
             .keystore()

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -331,7 +331,7 @@ mod tests {
     #[test_case(100, 10)]
     #[test_case(100, 100)]
     fn test_sent_to_r_nodes(num_agents: u32, num_hash: u32) {
-        holochain_util::tokio_helper::block_forever_on(async {
+        tokio_helper::block_forever_on(async {
             observability::test_run().ok();
 
             // Create test env
@@ -382,7 +382,7 @@ mod tests {
     #[test_case(100, 10)]
     #[test_case(100, 100)]
     fn test_no_republish(num_agents: u32, num_hash: u32) {
-        holochain_util::tokio_helper::block_forever_on(async {
+        tokio_helper::block_forever_on(async {
             observability::test_run().ok();
 
             // Create test env
@@ -460,7 +460,7 @@ mod tests {
     #[test_case(10)]
     #[test_case(100)]
     fn test_private_entries(num_agents: u32) {
-        holochain_util::tokio_helper::block_forever_on(
+        tokio_helper::block_forever_on(
             async {
                 observability::test_run().ok();
 

--- a/crates/holochain/src/fixt.rs
+++ b/crates/holochain/src/fixt.rs
@@ -47,6 +47,7 @@ use rand::Rng;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
+use tokio_helper;
 
 pub use holochain_types::fixt::*;
 
@@ -108,7 +109,7 @@ fixturator!(
         for _ in 0..number_of_wasms {
             let wasm = dna_wasm_fixturator.next().unwrap();
             wasms.insert(
-                holochain_util::tokio_helper::block_forever_on(
+                tokio_helper::block_forever_on(
                     async { WasmHash::with_data(&wasm).await },
                 ),
                 wasm,
@@ -122,7 +123,7 @@ fixturator!(
         for _ in 0..3 {
             let wasm = dna_wasm_fixturator.next().unwrap();
             wasms.insert(
-                holochain_util::tokio_helper::block_forever_on(
+                tokio_helper::block_forever_on(
                     async { WasmHash::with_data(&wasm).await },
                 ),
                 wasm,
@@ -136,7 +137,7 @@ fixturator!(
     DnaFile;
     curve Empty {
         DnaFile::from_parts(
-            holochain_util::tokio_helper::block_forever_on(async move {
+            tokio_helper::block_forever_on(async move {
                 DnaDefHashed::from_content_sync(DnaDefFixturator::new(Empty).next().unwrap())
             }),
             WasmMapFixturator::new(Empty).next().unwrap(),
@@ -158,7 +159,7 @@ fixturator!(
         let mut dna_def = DnaDefFixturator::new(Unpredictable).next().unwrap();
         dna_def.zomes = zomes;
         let dna =
-            holochain_util::tokio_helper::block_forever_on(async move { DnaDefHashed::from_content_sync(dna_def) });
+            tokio_helper::block_forever_on(async move { DnaDefHashed::from_content_sync(dna_def) });
         DnaFile::from_parts(dna, WasmMapFixturator::new(Unpredictable).next().unwrap())
     };
     curve Predictable {
@@ -182,7 +183,7 @@ fixturator!(
             .unwrap();
         dna_def.zomes = zomes;
         let dna =
-            holochain_util::tokio_helper::block_forever_on(async move { DnaDefHashed::from_content_sync(dna_def) });
+            tokio_helper::block_forever_on(async move { DnaDefHashed::from_content_sync(dna_def) });
         DnaFile::from_parts(
             dna,
             WasmMapFixturator::new_indexed(Predictable, get_fixt_index!())
@@ -235,14 +236,14 @@ fixturator!(
 fixturator!(
     KeystoreSender;
     curve Empty {
-        holochain_util::tokio_helper::block_forever_on(async {
+        tokio_helper::block_forever_on(async {
             // an empty keystore
             holochain_keystore::test_keystore::spawn_test_keystore().await.unwrap()
         })
     };
     curve Unpredictable {
         // TODO: Make this unpredictable
-        holochain_util::tokio_helper::block_forever_on(async {
+        tokio_helper::block_forever_on(async {
             holochain_keystore::test_keystore::spawn_test_keystore().await.unwrap()
         })
     };

--- a/crates/holochain/src/fixt.rs
+++ b/crates/holochain/src/fixt.rs
@@ -47,7 +47,6 @@ use rand::Rng;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
-use tokio_helper;
 
 pub use holochain_types::fixt::*;
 

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -1,6 +1,16 @@
 use std::convert::TryFrom;
 use std::sync::Arc;
 
+use crate::conductor::p2p_store::all_agent_infos;
+use crate::conductor::p2p_store::exchange_peer_info;
+use crate::conductor::ConductorHandle;
+use crate::core::ribosome::error::RibosomeError;
+use crate::core::ribosome::error::RibosomeResult;
+use crate::test_utils::host_fn_caller::Post;
+use crate::test_utils::install_app;
+use crate::test_utils::new_zome_call;
+use crate::test_utils::setup_app_with_network;
+use crate::test_utils::wait_for_integration_with_others;
 use hdk::prelude::CellId;
 use hdk::prelude::WasmError;
 use holo_hash::AgentPubKey;
@@ -13,21 +23,11 @@ use holochain_wasm_test_utils::TestWasm;
 use holochain_zome_types::ZomeCallResponse;
 use kitsune_p2p::KitsuneP2pConfig;
 use matches::assert_matches;
-use tempdir::TempDir;
-use tracing::debug_span;
-
-use crate::conductor::p2p_store::all_agent_infos;
-use crate::conductor::p2p_store::exchange_peer_info;
-use crate::conductor::ConductorHandle;
-use crate::core::ribosome::error::RibosomeError;
-use crate::core::ribosome::error::RibosomeResult;
-use crate::test_utils::host_fn_caller::Post;
-use crate::test_utils::install_app;
-use crate::test_utils::new_zome_call;
-use crate::test_utils::setup_app_with_network;
-use crate::test_utils::wait_for_integration_with_others;
 use shrinkwraprs::Shrinkwrap;
+use tempdir::TempDir;
 use test_case::test_case;
+use tokio_helper;
+use tracing::debug_span;
 
 const TIMEOUT_ERROR: &'static str = "inner function \'call_create_entry_remotely\' failed: ZomeCallNetworkError(\"Other: timeout\")";
 
@@ -84,7 +84,7 @@ fn conductors_call_remote(num_conductors: usize) {
         }
         shutdown(handles).await;
     };
-    holochain_util::tokio_helper::block_forever_on(f);
+    tokio_helper::block_forever_on(f);
 }
 
 #[test_case(2, 1, 1)]
@@ -111,7 +111,7 @@ fn conductors_local_gossip(num_committers: usize, num_conductors: usize, new_con
         network,
         true,
     );
-    holochain_util::tokio_helper::block_forever_on(f);
+    tokio_helper::block_forever_on(f);
 }
 
 #[test_case(2, 1, 1)]
@@ -139,7 +139,7 @@ fn conductors_boot_gossip(num_committers: usize, num_conductors: usize, new_cond
         network,
         false,
     );
-    holochain_util::tokio_helper::block_forever_on(f);
+    tokio_helper::block_forever_on(f);
 }
 
 #[test_case(2, 1, 1)]
@@ -171,7 +171,7 @@ fn conductors_local_boot_gossip(
         network,
         false,
     );
-    holochain_util::tokio_helper::block_forever_on(f);
+    tokio_helper::block_forever_on(f);
 }
 
 #[test_case(2, 1, 1)]
@@ -218,7 +218,7 @@ fn conductors_remote_gossip(num_committers: usize, num_conductors: usize, new_co
         network,
         true,
     );
-    holochain_util::tokio_helper::block_forever_on(f);
+    tokio_helper::block_forever_on(f);
 }
 
 #[test_case(2, 1, 1)]
@@ -257,7 +257,7 @@ fn conductors_remote_boot_gossip(
         network,
         false,
     );
-    holochain_util::tokio_helper::block_forever_on(f);
+    tokio_helper::block_forever_on(f);
 }
 
 async fn conductors_gossip_inner(

--- a/crates/holochain/tests/speed_tests.rs
+++ b/crates/holochain/tests/speed_tests.rs
@@ -118,7 +118,7 @@ async fn speed_test_persisted() {
 #[ignore = "speed tests are ignored by default; unignore to run"]
 fn speed_test_all(n: usize) {
     observability::test_run().unwrap();
-    holochain_util::tokio_helper::block_forever_on(speed_test(Some(n)));
+    tokio_helper::block_forever_on(speed_test(Some(n)));
 }
 
 #[instrument]

--- a/crates/holochain_lmdb/src/buffer/cas/buf_async.rs
+++ b/crates/holochain_lmdb/src/buffer/cas/buf_async.rs
@@ -14,6 +14,7 @@ use holo_hash::HashableContent;
 use holo_hash::HoloHashOf;
 use holo_hash::HoloHashed;
 use holo_hash::PrimitiveHashType;
+use holochain_util::tokio_helper;
 
 /// A wrapper around a KvBufFresh where keys are always Addresses,
 /// and values are always AddressableContent.
@@ -104,7 +105,7 @@ where
     }
 
     fn deserialize_and_hash_blocking(hash: &[u8], content: C) -> HoloHashed<C> {
-        holochain_util::tokio_helper::block_forever_on(Self::deserialize_and_hash(hash, content))
+        tokio_helper::block_forever_on(Self::deserialize_and_hash(hash, content))
         // TODO: make this a stream?
     }
 

--- a/crates/holochain_lmdb/src/test_utils.rs
+++ b/crates/holochain_lmdb/src/test_utils.rs
@@ -4,6 +4,7 @@ use crate::env::EnvironmentKind;
 use crate::env::EnvironmentWrite;
 use crate::prelude::BufKey;
 use holochain_keystore::KeystoreSender;
+use holochain_util::tokio_helper;
 use holochain_zome_types::test_utils::fake_cell_id;
 use shrinkwraprs::Shrinkwrap;
 use std::sync::Arc;
@@ -34,7 +35,7 @@ pub fn test_p2p_env() -> TestEnvironment {
 pub fn test_keystore() -> holochain_keystore::KeystoreSender {
     use holochain_keystore::KeystoreSenderExt;
 
-    holochain_util::tokio_helper::block_on(
+    tokio_helper::block_on(
         async move {
             let keystore = holochain_keystore::test_keystore::spawn_test_keystore()
                 .await

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -125,7 +125,7 @@ pub async fn stub_network() -> ghost_actor::GhostSender<HolochainP2p> {
 fixturator!(
     HolochainP2pCell;
     curve Empty {
-        holochain_util::tokio_helper::block_forever_on(async {
+        tokio_helper::block_forever_on(async {
             let holochain_p2p = crate::test::stub_network().await;
             holochain_p2p.to_cell(
                 DnaHashFixturator::new(Empty).next().unwrap(),

--- a/crates/holochain_state/src/source_chain/source_chain_buffer.rs
+++ b/crates/holochain_state/src/source_chain/source_chain_buffer.rs
@@ -349,7 +349,7 @@ pub mod tests {
 
         let agent_entry = Entry::Agent(agent_pubkey.clone().into());
 
-        let (dna_header, agent_header) = holochain_util::tokio_helper::block_on(
+        let (dna_header, agent_header) = tokio_helper::block_on(
             async {
                 let dna_header = Header::Dna(header::Dna {
                     author: agent_pubkey.clone(),

--- a/crates/holochain_types/src/prelude.rs
+++ b/crates/holochain_types/src/prelude.rs
@@ -38,3 +38,5 @@ pub use crate::fixt::TimestampFixturator;
 pub use crate::fixt::*;
 #[cfg(feature = "test_utils")]
 pub use crate::test_utils::*;
+
+pub use holochain_util::{ffs, tokio_helper};

--- a/crates/holochain_types/src/test_utils.rs
+++ b/crates/holochain_types/src/test_utils.rs
@@ -29,7 +29,7 @@ pub fn fake_dna_zomes(uid: &str, zomes: Vec<(ZomeName, DnaWasm)>) -> DnaFile {
         uid: uid.to_string(),
         zomes: Vec::new(),
     };
-    holochain_util::tokio_helper::block_forever_on(async move {
+    tokio_helper::block_forever_on(async move {
         let mut wasm_code = Vec::new();
         for (zome_name, wasm) in zomes {
             let wasm = crate::dna::wasm::DnaWasmHashed::from_content(wasm).await;

--- a/crates/test_utils/wasm/src/lib.rs
+++ b/crates/test_utils/wasm/src/lib.rs
@@ -226,7 +226,7 @@ fn get_code(path: &'static str) -> Vec<u8> {
 
 impl From<TestWasm> for ZomeDef {
     fn from(test_wasm: TestWasm) -> Self {
-        holochain_util::tokio_helper::block_forever_on(async move {
+        tokio_helper::block_forever_on(async move {
             let dna_wasm: DnaWasm = test_wasm.into();
             let (_, wasm_hash) = holochain_types::dna::wasm::DnaWasmHashed::from_content(dna_wasm)
                 .await


### PR DESCRIPTION
addition to #779 to make merges, especially into `sqlite`, less painful