### PR TITLE
No concurrent init

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Fixed
+
+- Concurrent zome calls could cause the `init()` zome callback to run multiple times concurrently, causing `HeadMoved` errors. This is fixed, so that `init()` can only ever run once.
+  - If a zome call has been waiting for another zome call to finish running `init()` for longer than 30 seconds, it will timeout.
+
 ### Changed
 
 - Apps now have a more complex status. Apps now can be either enabled/disabled as well as running/stopped, the combination of which is captured by three distinctly named states:

--- a/crates/holochain/src/conductor/cell/error.rs
+++ b/crates/holochain/src/conductor/cell/error.rs
@@ -1,3 +1,4 @@
+use super::INIT_MUTEX_TIMEOUT_SECS;
 use crate::conductor::entry_def_store::error::EntryDefStoreError;
 use crate::conductor::{api::error::ConductorApiError, error::ConductorError};
 use crate::core::ribosome::error::RibosomeError;
@@ -45,6 +46,11 @@ pub enum CellError {
     SourceChainError(#[from] SourceChainError),
     #[error("The cell tried to run the initialize zomes callback but failed because {0:?}")]
     InitFailed(InitResult),
+    #[error(
+        "Another zome function has triggered the `init()` callback, which has been blocking this zome call for longer than {} seconds. Giving up.",
+        INIT_MUTEX_TIMEOUT_SECS
+    )]
+    InitTimeout,
     #[error("Failed to get or create the cache for this dna {0:?}")]
     FailedToCreateCache(Box<ConductorError>),
     #[error(transparent)]

--- a/crates/holochain/src/sweettest/sweet_app.rs
+++ b/crates/holochain/src/sweettest/sweet_app.rs
@@ -57,7 +57,7 @@ impl SweetApp {
         self.into_cells()
             .into_iter()
             .collect_tuple::<Inner>()
-            .expect("Can't destructure more than 4 Cells")
+            .expect("Wrong number of Cells in destructuring pattern, or too many (must be 4 or less)")
     }
 }
 
@@ -93,10 +93,10 @@ impl SweetAppBatch {
                 a.into_cells()
                     .into_iter()
                     .collect_tuple::<Inner>()
-                    .expect("Can't destructure more than 4 DNAs")
+                    .expect("Wrong number of DNAs in destructuring pattern, or too many (must be 4 or less)")
             })
             .collect_tuple::<Outer>()
-            .expect("Can't destructure more than 4 Agents")
+            .expect("Wrong number of Agents in destructuring pattern, or too many (must be 4 or less)")
     }
 
     /// Access all Cells across all Apps, with Cells from the same App being contiguous

--- a/crates/holochain/src/sweettest/sweet_app.rs
+++ b/crates/holochain/src/sweettest/sweet_app.rs
@@ -57,7 +57,9 @@ impl SweetApp {
         self.into_cells()
             .into_iter()
             .collect_tuple::<Inner>()
-            .expect("Wrong number of Cells in destructuring pattern, or too many (must be 4 or less)")
+            .expect(
+                "Wrong number of Cells in destructuring pattern, or too many (must be 4 or less)",
+            )
     }
 }
 

--- a/crates/holochain/src/test_utils/test_conductor/test_handle.rs
+++ b/crates/holochain/src/test_utils/test_conductor/test_handle.rs
@@ -100,10 +100,10 @@ macro_rules! destructure_test_cells {
             .map(|(_, v)| {
                 v.into_iter()
                     .collect_tuple()
-                    .expect("Can't destructure more than 4 DNAs")
+                    .expect("Wrong number of DNAs in destructuring pattern, or too many (must be 4 or less)")
             })
             .collect_tuple()
-            .expect("Can't destructure more than 4 Agents")
+            .expect("Wrong number of Agents in destructuring pattern, or too many (must be 4 or less)")
     }};
 }
 #[macro_export]
@@ -114,7 +114,7 @@ macro_rules! destructure_test_cell_vec {
         vec.into_iter()
             .map(|blob| destructure_test_cells!(blob))
             .collect_tuple()
-            .expect("Can't destructure more than 4 Conductors")
+            .expect("Wrong number of Conductors in destructuring pattern, or too many (must be 4 or less)")
     }};
 }
 


### PR DESCRIPTION
Each Cell has a tokio Mutex guarding its init check, so init can only ever be entered once. The test I added in this PR fails with `HeadMoved` errors if the mutex is not in place, so this seems to confirm that that was the problem.