### PR TITLE
Various improvements, some of which actually fix a test

### DIFF
--- a/crates/holochain/src/conductor/entry_def_store.rs
+++ b/crates/holochain/src/conductor/entry_def_store.rs
@@ -126,7 +126,7 @@ mod tests {
 
         // all the stuff needed to have a WasmBuf
         let envs = test_environments();
-        let handle = Conductor::builder().test(&envs).await.unwrap();
+        let handle = Conductor::builder().test(&envs, &[]).await.unwrap();
 
         let dna = fake_dna_zomes(
             "",
@@ -175,7 +175,7 @@ mod tests {
         std::mem::drop(handle);
 
         // Restart conductor and check defs are still here
-        let handle = Conductor::builder().test(&envs.into()).await.unwrap();
+        let handle = Conductor::builder().test(&envs.into(), &[]).await.unwrap();
 
         assert_eq!(handle.get_entry_def(&post_def_key).await, Some(post_def));
         assert_eq!(

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -408,7 +408,7 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
     ) -> ConductorResult<CellStartupErrors> {
         self.load_dnas().await?;
 
-        let delta = {
+        {
             let mut conductor = self.conductor.write().await;
 
             // Start the task manager
@@ -431,11 +431,12 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
                 .startup_app_interfaces_via_handle(self.clone())
                 .await?;
 
-            conductor.start_paused_apps().await?
+            // We don't care what fx are returned here, since all cells need to
+            // be spun up
+            let _ = conductor.start_paused_apps().await?;
         };
 
-        tracing::debug!(delta = ?delta, "Paused apps started");
-        self.process_app_status_fx(delta, None).await
+        self.process_app_status_fx(AppStatusFx::SpinUp, None).await
     }
 
     async fn add_app_interface(self: Arc<Self>, port: u16) -> ConductorResult<u16> {

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -237,7 +237,7 @@ pub mod test_utils {
         let envs = test_environments();
 
         let conductor_handle = ConductorBuilder::with_mock_dna_store(dna_store)
-            .test(&envs)
+            .test(&envs, &[])
             .await
             .unwrap();
 
@@ -321,7 +321,7 @@ pub mod test {
 
     async fn setup_admin() -> (Arc<TempDir>, ConductorHandle) {
         let envs = test_environments();
-        let conductor_handle = Conductor::builder().test(&envs).await.unwrap();
+        let conductor_handle = Conductor::builder().test(&envs, &[]).await.unwrap();
         (Arc::new(envs.into_tempdir()), conductor_handle)
     }
 
@@ -331,7 +331,7 @@ pub mod test {
     ) -> (Arc<TempDir>, ConductorHandle) {
         let envs = test_environments();
         let conductor_handle = ConductorBuilder::with_mock_dna_store(dna_store)
-            .test(&envs)
+            .test(&envs, &[])
             .await
             .unwrap();
 

--- a/crates/holochain/src/conductor/manager/mod.rs
+++ b/crates/holochain/src/conductor/manager/mod.rs
@@ -211,7 +211,8 @@ async fn run(
                         //   you can also pass in a PausedAppReason override, so that the reason for the apps being paused
                         //   can be set to the specific error message encountered here, rather than having to read it from
                         //   the logs.
-                        conductor.reconcile_app_status_with_cell_status(None).await.map_err(TaskManagerError::internal)?;
+                        let delta = conductor.reconcile_app_status_with_cell_status(None).await.map_err(TaskManagerError::internal)?;
+                        tracing::debug!(delta = ?delta);
 
                         tracing::error!("Apps paused.");
                     } else {

--- a/crates/holochain/src/conductor/state.rs
+++ b/crates/holochain/src/conductor/state.rs
@@ -147,7 +147,7 @@ impl ConductorState {
         &mut self,
         id: &InstalledAppId,
         transition: AppStatusTransition,
-    ) -> ConductorResult<(&InstalledApp, AppStatusTransitionEffects)> {
+    ) -> ConductorResult<(&InstalledApp, AppStatusFx)> {
         let app = self
             .installed_apps
             .get_mut(id)

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -298,7 +298,7 @@ pub async fn setup_app_inner(
             network,
             ..Default::default()
         })
-        .test(&envs)
+        .test(&envs, &[])
         .await
         .unwrap();
 

--- a/crates/holochain/tests/ser_regression.rs
+++ b/crates/holochain/tests/ser_regression.rs
@@ -183,7 +183,7 @@ pub async fn setup_app(
 ) -> (TestEnvs, RealAppInterfaceApi, ConductorHandle) {
     let envs = test_environments();
     let conductor_handle = ConductorBuilder::with_mock_dna_store(dna_store)
-        .test(&envs)
+        .test(&envs, &[])
         .await
         .unwrap();
 

--- a/crates/holochain/tests/speed_tests.rs
+++ b/crates/holochain/tests/speed_tests.rs
@@ -317,7 +317,7 @@ pub async fn setup_app(
             }]),
             ..Default::default()
         })
-        .test(&envs)
+        .test(&envs, &[])
         .await
         .unwrap();
 

--- a/crates/holochain/tests/websocket.rs
+++ b/crates/holochain/tests/websocket.rs
@@ -392,6 +392,7 @@ async fn call_zome() {
     assert_eq!(app_port, app_port_rcvd);
 
     // Call Zome
+    tracing::info!("Calling zome");
     call_foo_fn(app_port, original_dna_hash.clone(), &mut holochain).await;
 
     // Ensure that the other client does not receive any messages, i.e. that
@@ -408,12 +409,14 @@ async fn call_zome() {
     holochain.kill().await.expect("Failed to kill holochain");
     std::mem::drop(client);
 
-    // Call zome after resart
+    // Call zome after restart
+    tracing::info!("Restarting conductor");
     let mut holochain = start_holochain(config_path).await;
 
     tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
 
     // Call Zome again on the existing app interface port
+    tracing::info!("Calling zome again");
     call_foo_fn(app_port, original_dna_hash, &mut holochain).await;
 
     // Shutdown holochain


### PR DESCRIPTION
This is kind of a big PR to fix one test, but it took a while to figure out the problem, and all of the changes I believe are improvements:

- make `AppStatusFx` (previously `AppStatusTransitionEffects`) `#[must_use]`
    - this helps ensure that any time an app state transition occurs, a followup processing of the after-effects must be done at some point to reconcile cell state with app state
- make `AppStatusFx` a monoid
    - this just means that it's easy to fold over a collection of FX to get a single FX to process, which allows us to effectively process after-effects from multiple state transitions, which is especially powerful when combined with must_use
- reorders the registration of dnas, in particular the "extra dnas" that get added by SweetConductor