### PR TITLE
sharded get - mock additions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -1825,7 +1825,7 @@ dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
  "parking_lot 0.10.2",
- "paste 1.0.5",
+ "paste",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "serde",
@@ -1838,7 +1838,7 @@ name = "fixt_test"
 version = "0.0.1"
 dependencies = [
  "fixt",
- "paste 1.0.5",
+ "paste",
 ]
 
 [[package]]
@@ -1971,7 +1971,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "waker-fn",
 ]
 
@@ -2014,7 +2014,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -2094,14 +2094,15 @@ dependencies = [
 
 [[package]]
 name = "ghost_actor"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5180a86962ed70e36dd39b469d1c17d1a4cfefa610e63be5bbb10a4cec9bcc"
+checksum = "22877bceb1241ee31bf21ebd4e622988d15370cfa36c0088a4b7309079e09918"
 dependencies = [
  "futures",
+ "mockall 0.10.2",
  "must_future",
  "observability",
- "paste 0.1.18",
+ "paste",
  "thiserror",
  "tracing",
  "tracing-futures",
@@ -2249,7 +2250,7 @@ dependencies = [
  "holochain_wasmer_guest",
  "holochain_zome_types",
  "mockall 0.8.3",
- "paste 1.0.5",
+ "paste",
  "serde",
  "serde_bytes",
  "thiserror",
@@ -2263,7 +2264,7 @@ name = "hdk_derive"
 version = "0.0.4-dev.0"
 dependencies = [
  "holochain_zome_types",
- "paste 1.0.5",
+ "paste",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
  "syn 1.0.73",
@@ -2364,7 +2365,7 @@ dependencies = [
  "fallible-iterator",
  "fixt",
  "futures",
- "ghost_actor 0.3.0-alpha.1",
+ "ghost_actor 0.3.0-alpha.2",
  "hdk",
  "holo_hash",
  "holochain_cascade",
@@ -2436,7 +2437,7 @@ dependencies = [
  "fallible-iterator",
  "fixt",
  "futures",
- "ghost_actor 0.3.0-alpha.1",
+ "ghost_actor 0.3.0-alpha.2",
  "hdk",
  "hdk_derive",
  "holo_hash",
@@ -2548,7 +2549,7 @@ dependencies = [
 name = "holochain_keystore"
 version = "0.0.2-dev.0"
 dependencies = [
- "ghost_actor 0.3.0-alpha.1",
+ "ghost_actor 0.3.0-alpha.2",
  "holo_hash",
  "holochain_serialized_bytes",
  "holochain_sqlite",
@@ -2569,7 +2570,7 @@ dependencies = [
  "async-trait",
  "fixt",
  "futures",
- "ghost_actor 0.3.0-alpha.1",
+ "ghost_actor 0.3.0-alpha.2",
  "holo_hash",
  "holochain_keystore",
  "holochain_serialized_bytes",
@@ -2866,7 +2867,7 @@ dependencies = [
  "holochain_wasmer_common",
  "nanoid",
  "num_enum",
- "paste 1.0.5",
+ "paste",
  "rand 0.7.3",
  "rusqlite",
  "serde",
@@ -2917,7 +2918,7 @@ checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes",
  "http",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2969,7 +2970,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "socket2 0.4.0",
  "tokio",
  "tower-service",
@@ -3212,13 +3213,14 @@ dependencies = [
  "derive_more",
  "fixt",
  "futures",
- "ghost_actor 0.3.0-alpha.1",
+ "ghost_actor 0.3.0-alpha.2",
  "kitsune_p2p_mdns",
  "kitsune_p2p_proxy",
  "kitsune_p2p_transport_quic",
  "kitsune_p2p_types",
  "lair_keystore_api",
  "matches",
+ "mockall 0.10.2",
  "observability",
  "once_cell",
  "rand 0.7.3",
@@ -3383,7 +3385,7 @@ dependencies = [
  "criterion",
  "derive_more",
  "futures",
- "ghost_actor 0.3.0-alpha.1",
+ "ghost_actor 0.3.0-alpha.2",
  "kitsune_p2p_dht_arc",
  "lair_keystore_api",
  "lru",
@@ -3392,7 +3394,7 @@ dependencies = [
  "observability",
  "once_cell",
  "parking_lot 0.11.1",
- "paste 1.0.5",
+ "paste",
  "rmp-serde",
  "rustls",
  "serde",
@@ -3431,7 +3433,7 @@ dependencies = [
  "derive_more",
  "directories 3.0.2",
  "futures",
- "ghost_actor 0.3.0-alpha.1",
+ "ghost_actor 0.3.0-alpha.2",
  "nanoid",
  "num_cpus",
  "once_cell",
@@ -3451,7 +3453,7 @@ version = "0.0.1-alpha.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5474d1cee8bc9c09a78809debd815f05b7026042d2426ecaaf372062278f4b5"
 dependencies = [
- "ghost_actor 0.3.0-alpha.1",
+ "ghost_actor 0.3.0-alpha.2",
  "lair_keystore_api",
  "tempfile",
  "tokio",
@@ -4411,28 +4413,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880"
-dependencies = [
- "paste-impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "paste"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
-
-[[package]]
-name = "paste-impl"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6"
-dependencies = [
- "proc-macro-hack",
-]
 
 [[package]]
 name = "pem"
@@ -4577,12 +4560,6 @@ dependencies = [
  "quote 1.0.9",
  "syn 1.0.73",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
@@ -5374,7 +5351,7 @@ dependencies = [
  "mime",
  "native-tls",
  "percent-encoding 2.1.0",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6409,7 +6386,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot 0.11.1",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
  "winapi",
@@ -6443,7 +6420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "tokio",
  "tokio-util",
 ]
@@ -6486,7 +6463,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.7",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -6518,13 +6495,13 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.1.12",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3244,6 +3244,7 @@ dependencies = [
  "mockall 0.10.2",
  "observability",
  "once_cell",
+ "parking_lot 0.11.1",
  "rand 0.7.3",
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
  "holo_hash",
  "holochain_wasmer_guest",
  "holochain_zome_types",
- "mockall",
+ "mockall 0.8.3",
  "paste 1.0.5",
  "serde",
  "serde_bytes",
@@ -2388,7 +2388,7 @@ dependencies = [
  "lazy_static",
  "maplit",
  "matches",
- "mockall",
+ "mockall 0.8.3",
  "mr_bundle",
  "must_future",
  "nanoid",
@@ -2448,7 +2448,7 @@ dependencies = [
  "holochain_zome_types",
  "kitsune_p2p",
  "matches",
- "mockall",
+ "mockall 0.8.3",
  "observability",
  "pretty_assertions 0.7.2",
  "serde",
@@ -2578,7 +2578,7 @@ dependencies = [
  "holochain_zome_types",
  "kitsune_p2p",
  "kitsune_p2p_types",
- "mockall",
+ "mockall 0.8.3",
  "observability",
  "serde",
  "serde_bytes",
@@ -2682,7 +2682,7 @@ dependencies = [
  "holochain_zome_types",
  "kitsune_p2p",
  "matches",
- "mockall",
+ "mockall 0.8.3",
  "observability",
  "parking_lot 0.10.2",
  "pretty_assertions 0.6.1",
@@ -2732,7 +2732,7 @@ dependencies = [
  "lazy_static",
  "maplit",
  "matches",
- "mockall",
+ "mockall 0.8.3",
  "mr_bundle",
  "must_future",
  "nanoid",
@@ -3387,6 +3387,7 @@ dependencies = [
  "kitsune_p2p_dht_arc",
  "lair_keystore_api",
  "lru",
+ "mockall 0.10.2",
  "nanoid",
  "observability",
  "once_cell",
@@ -3819,7 +3820,22 @@ dependencies = [
  "downcast",
  "fragile",
  "lazy_static",
- "mockall_derive",
+ "mockall_derive 0.8.3",
+ "predicates 1.0.8",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab571328afa78ae322493cacca3efac6a0f2e0a67305b4df31fd439ef129ac0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive 0.10.2",
  "predicates 1.0.8",
  "predicates-tree",
 ]
@@ -3831,6 +3847,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c461918bf7f59eefb1459252756bf2351a995d6bd510d0b2061bd86bcdabfa6"
 dependencies = [
  "cfg-if 0.1.10",
+ "proc-macro2 1.0.27",
+ "quote 1.0.9",
+ "syn 1.0.73",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e25b214433f669161f414959594216d8e6ba83b6679d3db96899c0b4639033"
+dependencies = [
+ "cfg-if 1.0.0",
  "proc-macro2 1.0.27",
  "quote 1.0.9",
  "syn 1.0.73",

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -21,7 +21,7 @@ either = "1.5.0"
 fallible-iterator = "0.2.0"
 fixt = { version = "0.0.4-dev.0", path = "../fixt" }
 futures = "0.3.1"
-ghost_actor = "0.3.0-alpha.1"
+ghost_actor = "=0.3.0-alpha.2"
 holo_hash = { version = "0.0.4-dev.0", path = "../holo_hash", features = ["full"] }
 holochain_cascade = { version = "0.0.2-dev.0", path = "../holochain_cascade" }
 holochain_conductor_api = { version = "0.0.2-dev.0", path = "../holochain_conductor_api" }
@@ -62,9 +62,9 @@ tokio = { version = "1.3", features = [ "full" ] }
 tokio-stream = "0.1"
 holochain_util = { version = "0.0.2-dev.0", path = "../holochain_util" }
 toml = "0.5.6"
-tracing = "=0.1.21"
-tracing-futures = "0.2.4"
-tracing-subscriber = "0.2.15"
+tracing = "0.1.26"
+tracing-futures = "0.2.5"
+tracing-subscriber = "0.2.19"
 url = "1.7.2"
 url2 = "0.0.6"
 url_serde = "0.2.0"

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -14,7 +14,7 @@ either = "1.5"
 fallible-iterator = "0.2"
 fixt = { version = "0.0.4-dev.0", path = "../fixt" }
 futures = "0.3"
-ghost_actor = "0.3.0-alpha.1"
+ghost_actor = "=0.3.0-alpha.2"
 hdk = { version = "0.0.102-dev.0", path = "../hdk" }
 hdk_derive = { version = "0.0.4-dev.0", path = "../hdk_derive" }
 holo_hash = { version = "0.0.4-dev.0", path = "../holo_hash", features = ["full"] }

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_yaml = "0.8"
 structopt = "0.3"
-tracing = "=0.1.21"
+tracing = "0.1.26"
 thiserror = "1.0.22"
 url2 = "0.0.6"
 

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -11,7 +11,7 @@ categories = [ "cryptography" ]
 edition = "2018"
 
 [dependencies]
-ghost_actor = "0.3.0-alpha.1"
+ghost_actor = "=0.3.0-alpha.2"
 holo_hash = { version = "0.0.4-dev.0", path = "../holo_hash", features = ["full"] }
 holochain_serialized_bytes = "=0.0.50"
 holochain_zome_types = { path = "../holochain_zome_types", version = "0.0.4-dev.0"}

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 async-trait = "0.1"
 fixt = { path = "../fixt", version = "0.0.4-dev.0"}
 futures = "0.3"
-ghost_actor = "0.3.0-alpha.1"
+ghost_actor = "=0.3.0-alpha.2"
 holo_hash = { version = "0.0.4-dev.0", path = "../holo_hash" }
 holochain_keystore = { version = "0.0.2-dev.0", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.50"

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -31,8 +31,8 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 thiserror = "1.0.22"
 tokio = { version = "1.3", features = [ "full" ] }
-tracing = "=0.1.21"
-tracing-futures = "0.2.4"
+tracing = "0.1.26"
+tracing-futures = "0.2.5"
 
 tempdir = { version = "0.3", optional = true }
 base64 = {version = "0.13", optional = true}

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -50,7 +50,7 @@ tempdir = "0.3.7"
 thiserror = "1.0.22"
 tokio = { version = "1.3", features = [ "rt" ] }
 holochain_util = { version = "0.0.2-dev.0", path = "../holochain_util", features = ["backtrace"] }
-tracing = "=0.1.21"
+tracing = "0.1.26"
 derive_builder = "0.9.0"
 
 arbitrary = { version = "1.0", features = ["derive"], optional = true}

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -16,12 +16,13 @@ base64 = "0.13"
 bloomfilter = { version = "1.0.5", features = [ "serde" ] }
 derive_more = "0.99.11"
 futures = "0.3"
-ghost_actor = "0.3.0-alpha.1"
+ghost_actor = "=0.3.0-alpha.2"
 kitsune_p2p_mdns = { version = "0.0.2-dev.0", path = "../mdns" }
 kitsune_p2p_types = { version = "0.0.2-dev.0", path = "../types" }
 kitsune_p2p_proxy = { version = "0.0.2-dev.0", path = "../proxy" }
 kitsune_p2p_transport_quic = { version = "0.0.2-dev.0", path = "../transport_quic" }
 lair_keystore_api = "=0.0.1-alpha.12"
+mockall = { version = "0.10.2", optional = true }
 rand = "0.7"
 shrinkwraprs = "0.3.0"
 thiserror = "1.0.22"
@@ -38,3 +39,9 @@ observability = "0.1.3"
 [dev-dependencies]
 matches = "0.1"
 tracing-subscriber = "0.2"
+
+[features]
+test_utils = [
+  "ghost_actor/test_utils",
+  "mockall",
+]

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -23,10 +23,11 @@ kitsune_p2p_proxy = { version = "0.0.2-dev.0", path = "../proxy" }
 kitsune_p2p_transport_quic = { version = "0.0.2-dev.0", path = "../transport_quic" }
 lair_keystore_api = "=0.0.1-alpha.12"
 mockall = { version = "0.10.2", optional = true }
+parking_lot = "0.11.1"
 rand = "0.7"
 shrinkwraprs = "0.3.0"
 thiserror = "1.0.22"
-tokio = { version = "1.3", features = [ "full" ] }
+tokio = { version = "1.8.2", features = [ "full" ] }
 tokio-stream = "0.1"
 url2 = "0.0.6"
 serde = { version = "1.0", features = [ "derive" ] }
@@ -42,6 +43,7 @@ tracing-subscriber = "0.2"
 
 [features]
 test_utils = [
+  "tokio/test-util",
   "ghost_actor/test_utils",
   "kitsune_p2p_types/test_utils",
   "mockall",

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -43,5 +43,6 @@ tracing-subscriber = "0.2"
 [features]
 test_utils = [
   "ghost_actor/test_utils",
+  "kitsune_p2p_types/test_utils",
   "mockall",
 ]

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -27,10 +27,17 @@ mod space;
 use ghost_actor::dependencies::tracing;
 use space::*;
 
+type EvtRcv = futures::channel::mpsc::Receiver<KitsuneP2pEvent>;
+type KSpace = Arc<KitsuneSpace>;
+type KAgent = Arc<KitsuneAgent>;
+type KBasis = Arc<KitsuneBasis>;
+type WireConHnd = Tx2ConHnd<wire::Wire>;
+type Payload = Box<[u8]>;
+
 ghost_actor::ghost_chan! {
     pub(crate) chan Internal<crate::KitsuneP2pError> {
         /// Register space event handler
-        fn register_space_event_handler(recv: futures::channel::mpsc::Receiver<KitsuneP2pEvent>) -> ();
+        fn register_space_event_handler(recv: EvtRcv) -> ();
 
         /// Incoming Delegate Broadcast
         /// We are being requested to delegate a broadcast to our neighborhood
@@ -38,16 +45,16 @@ ghost_actor::ghost_chan! {
         /// neighbors we are responsible for.
         /// (See comments in actual method impl for more detail.)
         fn incoming_delegate_broadcast(
-            space: Arc<KitsuneSpace>,
-            basis: Arc<KitsuneBasis>,
-            to_agent: Arc<KitsuneAgent>,
+            space: KSpace,
+            basis: KBasis,
+            to_agent: KAgent,
             mod_idx: u32,
             mod_cnt: u32,
             data: crate::wire::WireData,
         ) -> ();
 
         /// Incoming Gossip
-        fn incoming_gossip(space: Arc<KitsuneSpace>, con: Tx2ConHnd<wire::Wire>, data: Box<[u8]>) -> ();
+        fn incoming_gossip(space: KSpace, con: WireConHnd, data: Payload) -> ();
     }
 }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/discover.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/discover.rs
@@ -149,6 +149,9 @@ pub(crate) fn search_remotes_covering_basis(
     async move {
         let backoff = timeout.backoff(INITIAL_DELAY, MAX_DELAY);
         loop {
+            //let s_remain = timeout.time_remaining().as_secs_f64();
+            //tracing::trace!(%s_remain, "search_remotes_covering_basis iteration");
+
             let mut cover_nodes = Vec::new();
             let mut near_nodes = Vec::new();
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -10,19 +10,25 @@ use url2::Url2;
 
 mod rpc_multi_logic;
 
+type KSpace = Arc<KitsuneSpace>;
+type KAgent = Arc<KitsuneAgent>;
+type KBasis = Arc<KitsuneBasis>;
+type WireConHnd = Tx2ConHnd<wire::Wire>;
+type Payload = Box<[u8]>;
+
 ghost_actor::ghost_chan! {
     pub(crate) chan SpaceInternal<crate::KitsuneP2pError> {
         /// List online agents that claim to be covering a basis hash
-        fn list_online_agents_for_basis_hash(space: Arc<KitsuneSpace>, from_agent: Arc<KitsuneAgent>, basis: Arc<KitsuneBasis>) -> HashSet<Arc<KitsuneAgent>>;
+        fn list_online_agents_for_basis_hash(space: KSpace, from_agent: KAgent, basis: KBasis) -> HashSet<KAgent>;
 
         /// Update / publish our agent info
         fn update_agent_info() -> ();
 
         /// Update / publish a single agent info
-        fn update_single_agent_info(agent: Arc<KitsuneAgent>) -> ();
+        fn update_single_agent_info(agent: KAgent) -> ();
 
         /// see if an agent is locally joined
-        fn is_agent_local(agent: Arc<KitsuneAgent>) -> bool;
+        fn is_agent_local(agent: KAgent) -> bool;
 
         /// Incoming Delegate Broadcast
         /// We are being requested to delegate a broadcast to our neighborhood
@@ -30,16 +36,16 @@ ghost_actor::ghost_chan! {
         /// neighbors we are responsible for.
         /// (See comments in actual method impl for more detail.)
         fn incoming_delegate_broadcast(
-            space: Arc<KitsuneSpace>,
-            basis: Arc<KitsuneBasis>,
-            to_agent: Arc<KitsuneAgent>,
+            space: KSpace,
+            basis: KBasis,
+            to_agent: KAgent,
             mod_idx: u32,
             mod_cnt: u32,
             data: crate::wire::WireData,
         ) -> ();
 
         /// Incoming Gossip
-        fn incoming_gossip(space: Arc<KitsuneSpace>, con: Tx2ConHnd<wire::Wire>, data: Box<[u8]>) -> ();
+        fn incoming_gossip(space: KSpace, con: WireConHnd, data: Payload) -> ();
     }
 }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic.rs
@@ -455,3 +455,7 @@ impl Outer {
         );
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "test_utils")]
+mod test;

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
@@ -1,0 +1,81 @@
+use super::*;
+
+use kitsune_p2p_types::tx2::tx2_adapter::test_utils::*;
+use kitsune_p2p_types::tx2::tx2_adapter::*;
+
+#[tokio::test]
+async fn test_rpc_multi_logic_mocked() {
+    let space = Arc::new(KitsuneSpace(vec![0; 36]));
+    let this_addr = url2::url2!("fake://");
+
+    let m = MockSpaceInternalHandler::new();
+    let b = ghost_actor::actor_builder::GhostActorBuilder::new();
+    let i_s = b
+        .channel_factory()
+        .create_channel::<SpaceInternal>()
+        .await
+        .unwrap();
+    tokio::task::spawn(b.spawn(m));
+
+    let m = MockKitsuneP2pEventHandler::new();
+    let b = ghost_actor::actor_builder::GhostActorBuilder::new();
+    let (evt_sender, r) = futures::channel::mpsc::channel::<KitsuneP2pEvent>(4096);
+    b.channel_factory().attach_receiver(r).await.unwrap();
+    tokio::task::spawn(b.spawn(m));
+
+    let config = Arc::new(KitsuneP2pConfig::default());
+
+    let mut m = MockBindAdapt::new();
+    m.expect_bind().returning(|_, _| {
+        async move {
+            let mut m = MockEndpointAdapt::new();
+            let uniq = Uniq::default();
+            m.expect_uniq().returning(move || uniq);
+            m.expect_local_cert().returning(|| vec![0; 32].into());
+            let ep: Arc<dyn EndpointAdapt> = Arc::new(m);
+            let c = gen_mock_con_recv_adapt(futures::stream::pending().boxed());
+            Ok((ep, c))
+        }
+        .boxed()
+    });
+    let f: AdapterFactory = Arc::new(m);
+    let f = tx2_pool_promote(f, config.tuning_params.clone());
+    let f = tx2_api::<wire::Wire>(f, Default::default());
+
+    let mut ep = f
+        .bind("fake://", config.tuning_params.implicit_timeout())
+        .await
+        .unwrap();
+    let ep_hnd = ep.handle().clone();
+    tokio::task::spawn(async move { while let Some(_) = ep.next().await {} });
+
+    let ro_inner = Arc::new(SpaceReadOnlyInner {
+        space: space.clone(),
+        this_addr,
+        i_s,
+        evt_sender,
+        ep_hnd,
+        config,
+    });
+
+    let agent = Arc::new(KitsuneAgent(vec![0; 36]));
+    let basis = Arc::new(KitsuneBasis(vec![0; 36]));
+
+    let res = handle_rpc_multi(
+        actor::RpcMulti {
+            space,
+            from_agent: agent.clone(),
+            basis,
+            payload: b"test".to_vec(),
+            max_remote_agent_count: 3,
+            max_timeout: KitsuneTimeout::from_millis(3000),
+            remote_request_grace_ms: 3000,
+        },
+        ro_inner,
+        HashSet::new(),
+    )
+    .await
+    .unwrap();
+
+    println!("{:#?}", res);
+}

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
@@ -3,12 +3,42 @@ use super::*;
 use kitsune_p2p_types::tx2::tx2_adapter::test_utils::*;
 use kitsune_p2p_types::tx2::tx2_adapter::*;
 
-#[tokio::test]
-async fn test_rpc_multi_logic_mocked() {
-    let space = Arc::new(KitsuneSpace(vec![0; 36]));
-    let this_addr = url2::url2!("fake://");
+use once_cell::sync::Lazy;
 
-    let m = MockSpaceInternalHandler::new();
+use std::sync::atomic;
+
+/// create a "signed" agent info uniq by a u8
+fn make_agent(c: u8) -> AgentInfoSigned {
+    let space = Arc::new(KitsuneSpace(vec![0; 36]));
+    let agent = Arc::new(KitsuneAgent(vec![c; 36]));
+    futures::executor::block_on(AgentInfoSigned::sign(
+        space,
+        agent,
+        u32::MAX,
+        vec![format!("fake://{}", c).into()],
+        42,
+        69,
+        |_| async move { Ok(Arc::new(vec![0; 64].into())) },
+    ))
+    .unwrap()
+}
+
+static A1: Lazy<AgentInfoSigned> = Lazy::new(|| make_agent(1));
+static A2: Lazy<AgentInfoSigned> = Lazy::new(|| make_agent(2));
+static A3: Lazy<AgentInfoSigned> = Lazy::new(|| make_agent(3));
+static A4: Lazy<AgentInfoSigned> = Lazy::new(|| make_agent(4));
+
+static CERT_IDX: atomic::AtomicU8 = atomic::AtomicU8::new(0);
+
+/// create incrementing "uniq" Tx2Certs
+fn next_cert() -> Tx2Cert {
+    vec![CERT_IDX.fetch_add(1, atomic::Ordering::Relaxed); 32].into()
+}
+
+/// spawn a ghost actor for SpaceInternal
+async fn build_space_internal(
+    m: MockSpaceInternalHandler,
+) -> ghost_actor::GhostSender<SpaceInternal> {
     let b = ghost_actor::actor_builder::GhostActorBuilder::new();
     let i_s = b
         .channel_factory()
@@ -16,39 +46,193 @@ async fn test_rpc_multi_logic_mocked() {
         .await
         .unwrap();
     tokio::task::spawn(b.spawn(m));
+    i_s
+}
 
-    let m = MockKitsuneP2pEventHandler::new();
+/// spawn a ghost actor for KitsuneP2pEvent
+async fn build_event_handler(
+    m: MockKitsuneP2pEventHandler,
+) -> futures::channel::mpsc::Sender<KitsuneP2pEvent> {
     let b = ghost_actor::actor_builder::GhostActorBuilder::new();
     let (evt_sender, r) = futures::channel::mpsc::channel::<KitsuneP2pEvent>(4096);
     b.channel_factory().attach_receiver(r).await.unwrap();
     tokio::task::spawn(b.spawn(m));
+    evt_sender
+}
 
-    let config = Arc::new(KitsuneP2pConfig::default());
-
-    let mut m = MockBindAdapt::new();
-    m.expect_bind().returning(|_, _| {
-        async move {
-            let mut m = MockEndpointAdapt::new();
-            let uniq = Uniq::default();
-            m.expect_uniq().returning(move || uniq);
-            m.expect_local_cert().returning(|| vec![0; 32].into());
-            let ep: Arc<dyn EndpointAdapt> = Arc::new(m);
-            let c = gen_mock_con_recv_adapt(futures::stream::pending().boxed());
-            Ok((ep, c))
-        }
-        .boxed()
-    });
+/// spawn an endpoint adapter factory, then fetch a single ep handle
+async fn build_ep_hnd(config: Arc<KitsuneP2pConfig>, m: MockBindAdapt) -> Tx2EpHnd<wire::Wire> {
     let f: AdapterFactory = Arc::new(m);
     let f = tx2_pool_promote(f, config.tuning_params.clone());
     let f = tx2_api::<wire::Wire>(f, Default::default());
 
     let mut ep = f
-        .bind("fake://", config.tuning_params.implicit_timeout())
+        .bind("fake://0", config.tuning_params.implicit_timeout())
         .await
         .unwrap();
     let ep_hnd = ep.handle().clone();
     tokio::task::spawn(async move { while let Some(_) = ep.next().await {} });
+    ep_hnd
+}
 
+#[tokio::test]
+async fn test_rpc_multi_logic_mocked() {
+    observability::test_run().ok();
+
+    // allow fake timing during test
+    tokio::time::pause();
+
+    let space = Arc::new(KitsuneSpace(vec![0; 36]));
+    let this_addr = url2::url2!("fake://");
+
+    // build our "SpaceInternal" sender
+    let mut m = MockSpaceInternalHandler::new();
+    // just make is_agent_local always return false
+    m.expect_handle_is_agent_local()
+        .returning(|_| Ok(async move { Ok(false) }.boxed().into()));
+    let i_s = build_space_internal(m).await;
+
+    // build our "KitsuneP2pEvent" sender
+    let mut m = MockKitsuneP2pEventHandler::new();
+    let start = tokio::time::Instant::now();
+    // don't return any infos to start, then return 4 to test our loops
+    m.expect_handle_query_agent_info_signed_near_basis()
+        .returning(move |_, _, _| {
+            println!("QUERY: {}", start.elapsed().as_secs_f64());
+            let mut out = Vec::new();
+            if start.elapsed().as_secs_f64() > 1.0 {
+                out.push(A1.clone());
+                out.push(A2.clone());
+                out.push(A3.clone());
+                out.push(A4.clone());
+            }
+            Ok(async move { Ok(out) }.boxed().into())
+        });
+    let evt_sender = build_event_handler(m).await;
+
+    let config = Arc::new(KitsuneP2pConfig::default());
+
+    // mock out our bind adapter
+    let mut m = MockBindAdapt::new();
+    m.expect_bind().returning(move |_, _| {
+        async move {
+            let mut m = MockEndpointAdapt::new();
+            let uniq = Uniq::default();
+            // return a uniq identifier
+            m.expect_uniq().returning(move || uniq);
+            let cert = next_cert();
+            // return a uniq cert
+            m.expect_local_cert().returning(move || cert.clone());
+            // allow making "outgoing" connections that will respond how
+            // we configure them to
+            m.expect_connect().returning(move |_, _| {
+                async move {
+                    let (w_send, w_recv) = tokio::sync::mpsc::channel(1);
+                    let w_recv = Arc::new(parking_lot::Mutex::new(Some(w_recv)));
+
+                    // mock out our connection adapter
+                    let mut m = MockConAdapt::new();
+                    let uniq = Uniq::default();
+                    // return a uniq identifier
+                    m.expect_uniq().returning(move || uniq);
+                    // this is an "outgoing" connection
+                    m.expect_dir().returning(|| Tx2ConDir::Outgoing);
+                    let cert = next_cert();
+                    // return a uniq cert to identify our peer
+                    m.expect_peer_cert().returning(move || cert.clone());
+                    // allow making "outgoing" channels that will respond
+                    // how we configure them to
+                    m.expect_out_chan().returning(move |_| {
+                        let w_send = w_send.clone();
+                        let mut m = MockAsFramedWriter::new();
+                        // when we get an outgoing write event
+                        // turn around and respond appropriately for
+                        // our test
+                        m.expect_write().returning(move |msg_id, mut buf, _| {
+                            let w_send = w_send.clone();
+                            use kitsune_p2p_types::codec::Codec;
+                            let (_, wire) = wire::Wire::decode_ref(&buf).unwrap();
+                            async move {
+                                let resp = match wire {
+                                    wire::Wire::Call(wire::Call {
+                                        space: _,
+                                        from_agent: _,
+                                        to_agent: _,
+                                        data,
+                                    }) => {
+                                        println!(
+                                            "GOT CALL: {:?} {}",
+                                            msg_id,
+                                            String::from_utf8_lossy(&data)
+                                        );
+                                        wire::Wire::call_resp(data)
+                                    }
+                                    oth => {
+                                        let reason =
+                                            format!("test doesn't handle {:?} requests", oth);
+                                        wire::Wire::failure(reason)
+                                    }
+                                };
+                                let data = resp.encode_vec().unwrap();
+                                buf.clear();
+                                buf.extend_from_slice(&data);
+                                // forward this message to our "recv" side
+                                w_send.send((msg_id.as_res(), buf)).await.unwrap();
+
+                                Ok(())
+                            }
+                            .boxed()
+                        });
+                        let out: OutChan = Box::new(m);
+                        async move { Ok(out) }.boxed()
+                    });
+                    let con: Arc<dyn ConAdapt> = Arc::new(m);
+
+                    // make an incoming reader that will forward responses
+                    // according to the logic in the writer above
+                    let mut m = MockAsFramedReader::new();
+                    m.expect_read().returning(move |_| {
+                        let w_recv = w_recv.clone();
+                        async move {
+                            let mut w = match w_recv.lock().take() {
+                                Some(w) => w,
+                                None => return Err("end".into()),
+                            };
+
+                            let r = match w.recv().await {
+                                Some(r) => r,
+                                None => return Err("end".into()),
+                            };
+
+                            *w_recv.lock() = Some(w);
+                            Ok(r)
+                        }
+                        .boxed()
+                    });
+
+                    // we'll only establish one single in channel
+                    let once: InChan = Box::new(m);
+                    let once =
+                        futures::stream::once(async move { async move { Ok(once) }.boxed() });
+                    // then just pend the stream
+                    let s = once.chain(futures::stream::pending());
+                    let rcv = gen_mock_in_chan_recv_adapt(s.boxed());
+                    Ok((con, rcv))
+                }
+                .boxed()
+            });
+            let ep: Arc<dyn EndpointAdapt> = Arc::new(m);
+
+            // we will never receive any "incoming" connections
+            let c = gen_mock_con_recv_adapt(futures::stream::pending().boxed());
+
+            Ok((ep, c))
+        }
+        .boxed()
+    });
+    let ep_hnd = build_ep_hnd(config.clone(), m).await;
+
+    // build up the ro_inner that discover calls expect
     let ro_inner = Arc::new(SpaceReadOnlyInner {
         space: space.clone(),
         this_addr,
@@ -61,6 +245,7 @@ async fn test_rpc_multi_logic_mocked() {
     let agent = Arc::new(KitsuneAgent(vec![0; 36]));
     let basis = Arc::new(KitsuneBasis(vec![0; 36]));
 
+    // excercise the rpc multi logic
     let res = handle_rpc_multi(
         actor::RpcMulti {
             space,
@@ -68,7 +253,7 @@ async fn test_rpc_multi_logic_mocked() {
             basis,
             payload: b"test".to_vec(),
             max_remote_agent_count: 3,
-            max_timeout: KitsuneTimeout::from_millis(3000),
+            max_timeout: KitsuneTimeout::from_millis(30000),
             remote_request_grace_ms: 3000,
         },
         ro_inner,
@@ -77,5 +262,11 @@ async fn test_rpc_multi_logic_mocked() {
     .await
     .unwrap();
 
+    // await responses
     println!("{:#?}", res);
+    assert_eq!(3, res.len());
+    for r in res {
+        let RpcMultiResponse { response, .. } = r;
+        assert_eq!(b"test", response.as_slice());
+    }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_actor.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+type KAgent = Arc<KitsuneAgent>;
+
 ghost_actor::ghost_chan! {
     /// The api for the test harness controller
     pub chan HarnessControlApi<KitsuneP2pError> {
@@ -31,13 +33,13 @@ ghost_actor::ghost_chan! {
         fn magic_peer_info_exchange() -> ();
 
         /// Inject data for one specific agent to gossip to others
-        fn inject_gossip_data(agent: Arc<KitsuneAgent>, data: String) -> Arc<KitsuneOpHash>;
+        fn inject_gossip_data(agent: KAgent, data: String) -> Arc<KitsuneOpHash>;
 
         /// Dump all local gossip data from a specific agent
-        fn dump_local_gossip_data(agent: Arc<KitsuneAgent>) -> HashMap<Arc<KitsuneOpHash>, String>;
+        fn dump_local_gossip_data(agent: KAgent) -> HashMap<Arc<KitsuneOpHash>, String>;
 
         /// Dump all local peer data from a specific agent
-        fn dump_local_peer_data(agent: Arc<KitsuneAgent>) -> HashMap<Arc<KitsuneAgent>, Arc<AgentInfoSigned>>;
+        fn dump_local_peer_data(agent: KAgent) -> HashMap<Arc<KitsuneAgent>, Arc<AgentInfoSigned>>;
     }
 }
 
@@ -97,13 +99,16 @@ pub async fn spawn_test_harness(
     Ok((controller, harness_chan))
 }
 
+type KP2p = ghost_actor::GhostSender<KitsuneP2p>;
+type KCtl = ghost_actor::GhostSender<HarnessAgentControl>;
+
 ghost_actor::ghost_chan! {
     /// The api for the test harness controller
     chan HarnessInner<KitsuneP2pError> {
         fn finish_agent(
-            agent: Arc<KitsuneAgent>,
-            p2p: ghost_actor::GhostSender<KitsuneP2p>,
-            ctrl: ghost_actor::GhostSender<HarnessAgentControl>,
+            agent: KAgent,
+            p2p: KP2p,
+            ctrl: KCtl,
         ) -> ();
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
@@ -1,5 +1,8 @@
 use super::*;
 
+type KAgent = Arc<KitsuneAgent>;
+type KAgentMap = HashMap<KAgent, Arc<AgentInfoSigned>>;
+
 ghost_actor::ghost_chan! {
     /// controller for test harness agent actor
     pub(crate) chan HarnessAgentControl<KitsuneP2pError> {
@@ -7,7 +10,7 @@ ghost_actor::ghost_chan! {
         fn dump_agent_info() -> Vec<Arc<AgentInfoSigned>>;
 
         /// inject a bunch of agent info
-        fn inject_agent_info(info: HashMap<Arc<KitsuneAgent>, Arc<AgentInfoSigned>>) -> ();
+        fn inject_agent_info(info: KAgentMap) -> ();
 
         /// inject data to be gradually gossiped
         fn inject_gossip_data(data: String) -> Arc<KitsuneOpHash>;

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/actor.rs
@@ -65,6 +65,12 @@ pub struct RpcMultiResponse {
     pub response: Vec<u8>,
 }
 
+type KSpace = Arc<super::KitsuneSpace>;
+type KAgent = Arc<super::KitsuneAgent>;
+type KBasis = Arc<super::KitsuneBasis>;
+type Payload = Vec<u8>;
+type OptU64 = Option<u64>;
+
 ghost_actor::ghost_chan! {
     /// The KitsuneP2pSender allows async remote-control of the KitsuneP2p actor.
     pub chan KitsuneP2p<super::KitsuneP2pError> {
@@ -72,14 +78,14 @@ ghost_actor::ghost_chan! {
         fn list_transport_bindings() -> Vec<Url2>;
 
         /// Announce a space/agent pair on this network.
-        fn join(space: Arc<super::KitsuneSpace>, agent: Arc<super::KitsuneAgent>) -> ();
+        fn join(space: KSpace, agent: KAgent) -> ();
 
         /// Withdraw this space/agent pair from this network.
-        fn leave(space: Arc<super::KitsuneSpace>, agent: Arc<super::KitsuneAgent>) -> ();
+        fn leave(space: KSpace, agent: KAgent) -> ();
 
         /// Make a request of a single remote agent, expecting a response.
         /// The remote side will receive a "Call" event.
-        fn rpc_single(space: Arc<super::KitsuneSpace>, to_agent: Arc<super::KitsuneAgent>, from_agent: Arc<super::KitsuneAgent>, payload: Vec<u8>, timeout_ms: Option<u64>) -> Vec<u8>;
+        fn rpc_single(space: KSpace, to_agent: KAgent, from_agent: KAgent, payload: Payload, timeout_ms: OptU64) -> Vec<u8>;
 
         /// Make a request to multiple destination agents - awaiting/aggregating the responses.
         /// The remote sides will see these messages as "Call" events.
@@ -91,10 +97,10 @@ ghost_actor::ghost_chan! {
         /// least one connection with a node in the target neighborhood.
         /// The remote sides will see these messages as "Notify" events.
         fn broadcast(
-            space: Arc<super::KitsuneSpace>,
-            basis: Arc<super::KitsuneBasis>,
+            space: KSpace,
+            basis: KBasis,
             timeout: KitsuneTimeout,
-            payload: Vec<u8>
+            payload: Payload
         ) -> ();
     }
 }

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -18,6 +18,7 @@ ghost_actor = "0.3.0-alpha.1"
 kitsune_p2p_dht_arc = { version = "0.0.2-dev.0", path = "../dht_arc" }
 lair_keystore_api = "=0.0.1-alpha.12"
 lru = "0.6.5"
+mockall = { version = "0.10.2", optional = true }
 nanoid = "0.3"
 observability = "0.1.3"
 once_cell = "1.4"
@@ -47,5 +48,6 @@ harness = false
 
 [features]
 test_utils = [
-  "kitsune_p2p_dht_arc/test_utils"
+  "kitsune_p2p_dht_arc/test_utils",
+  "mockall",
 ]

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 base64 = "0.13"
 derive_more = "0.99.7"
 futures = "0.3"
-ghost_actor = "0.3.0-alpha.1"
+ghost_actor = "=0.3.0-alpha.2"
 kitsune_p2p_dht_arc = { version = "0.0.2-dev.0", path = "../dht_arc" }
 lair_keystore_api = "=0.0.1-alpha.12"
 lru = "0.6.5"
@@ -49,5 +49,6 @@ harness = false
 [features]
 test_utils = [
   "kitsune_p2p_dht_arc/test_utils",
+  "ghost_actor/test_utils",
   "mockall",
 ]

--- a/crates/kitsune_p2p/types/src/lib.rs
+++ b/crates/kitsune_p2p/types/src/lib.rs
@@ -20,13 +20,13 @@ pub mod dependencies {
 /// This value is on the scale of microseconds.
 pub type ProcCountMicros = i64;
 
-/// Monotonically nondecreasing process tick count, backed by std::time::Instant
+/// Monotonically nondecreasing process tick count, backed by tokio::time::Instant
 /// as an i64 to facilitate reference times that may be less than the first
 /// call to this function.
 /// The returned value is on the scale of microseconds.
 pub fn proc_count_now_us() -> ProcCountMicros {
     use once_cell::sync::Lazy;
-    use std::time::Instant;
+    use tokio::time::Instant;
     static PROC_COUNT: Lazy<Instant> = Lazy::new(Instant::now);
     let r = *PROC_COUNT;
     Instant::now().saturating_duration_since(r).as_micros() as i64

--- a/crates/kitsune_p2p/types/src/reverse_semaphore.rs
+++ b/crates/kitsune_p2p/types/src/reverse_semaphore.rs
@@ -93,13 +93,13 @@ mod tests {
     async fn test_reverse_semaphore() {
         let rs = ReverseSemaphore::new();
 
-        let s = std::time::Instant::now();
+        let s = tokio::time::Instant::now();
         rs.wait_on_zero_permits().await;
         let es = s.elapsed().as_secs_f64();
         assert!(es < 0.00015);
         println!("zero wait, after {} s", es);
 
-        let s = std::time::Instant::now();
+        let s = tokio::time::Instant::now();
         for t in 10..15 {
             let permit = rs.acquire();
             tokio::task::spawn(async move {

--- a/crates/kitsune_p2p/types/src/timeout.rs
+++ b/crates/kitsune_p2p/types/src/timeout.rs
@@ -52,12 +52,12 @@ impl KitsuneBackoff {
 
 /// Kitsune Timeout
 #[derive(Debug, Clone, Copy)]
-pub struct KitsuneTimeout(std::time::Instant);
+pub struct KitsuneTimeout(tokio::time::Instant);
 
 impl KitsuneTimeout {
     /// Create a new timeout for duration in the future.
     pub fn new(duration: std::time::Duration) -> Self {
-        Self(std::time::Instant::now().checked_add(duration).unwrap())
+        Self(tokio::time::Instant::now().checked_add(duration).unwrap())
     }
 
     /// Convenience fn to create a new timeout for an amount of milliseconds.
@@ -72,12 +72,13 @@ impl KitsuneTimeout {
 
     /// Get Duration until timeout expires.
     pub fn time_remaining(&self) -> std::time::Duration {
-        self.0.saturating_duration_since(std::time::Instant::now())
+        self.0
+            .saturating_duration_since(tokio::time::Instant::now())
     }
 
     /// Has this timeout expired?
     pub fn is_expired(&self) -> bool {
-        self.0 <= std::time::Instant::now()
+        self.0 <= tokio::time::Instant::now()
     }
 
     /// `Ok(())` if not expired, `Err(KitsuneError::TimedOut)` if expired.
@@ -131,7 +132,7 @@ mod tests {
     async fn kitsune_backoff() {
         let t = KitsuneTimeout::from_millis(100);
         let mut times = Vec::new();
-        let start = std::time::Instant::now();
+        let start = tokio::time::Instant::now();
         let bo = t.backoff(2, 15);
         while !t.is_expired() {
             times.push(start.elapsed().as_millis() as u64);

--- a/crates/kitsune_p2p/types/src/timeout.rs
+++ b/crates/kitsune_p2p/types/src/timeout.rs
@@ -36,7 +36,10 @@ impl KitsuneBackoff {
             cur,
             std::cmp::min(
                 self.max_ms,
-                self.timeout.time_remaining().as_millis() as u64,
+                // add 1ms to our time remaining so we don't have a weird
+                // race condition where we don't wait at all, but our
+                // timer hasn't quite expired yet...
+                self.timeout.time_remaining().as_millis() as u64 + 1,
             ),
         );
 

--- a/crates/kitsune_p2p/types/src/transport_pool.rs
+++ b/crates/kitsune_p2p/types/src/transport_pool.rs
@@ -9,12 +9,14 @@ use ghost_actor::dependencies::tracing;
 use ghost_actor::GhostControlSender;
 use std::collections::HashMap;
 
+type SubListener = ghost_actor::GhostSender<TransportListener>;
+
 ghost_actor::ghost_chan! {
     /// Additional control functions for a transport pool
     pub chan TransportPool<TransportError> {
         /// Push a new sub-transport listener into the pool
         fn push_sub_transport(
-            sub_listener: ghost_actor::GhostSender<TransportListener>,
+            sub_listener: SubListener,
             sub_event: TransportEventReceiver,
         ) -> ();
     }
@@ -51,7 +53,7 @@ ghost_actor::ghost_chan! {
     chan InnerChan<TransportError> {
         fn inject_listener(
             scheme: String,
-            sub_listener: ghost_actor::GhostSender<TransportListener>,
+            sub_listener: SubListener,
         ) -> ();
     }
 }

--- a/crates/kitsune_p2p/types/src/tx2/tx2_adapter.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_adapter.rs
@@ -47,6 +47,7 @@ pub type OutChan = Box<dyn AsFramedWriter>;
 pub type OutChanFut = BoxFuture<'static, KitsuneResult<OutChan>>;
 
 /// Tx backend adapter represents an open connection to a remote.
+#[cfg_attr(feature = "test_utils", mockall::automock)]
 pub trait ConAdapt: 'static + Send + Sync + Unpin {
     /// Get the opaque Uniq identifier for this connection.
     fn uniq(&self) -> Uniq;
@@ -82,6 +83,7 @@ pub type ConFut = BoxFuture<'static, KitsuneResult<Con>>;
 pub trait ConRecvAdapt: 'static + Send + Unpin + Stream<Item = ConFut> {}
 
 /// Tx backend adapter represents a bound local endpoint.
+#[cfg_attr(feature = "test_utils", mockall::automock)]
 pub trait EndpointAdapt: 'static + Send + Sync + Unpin {
     /// Capture a debugging internal state dump.
     fn debug(&self) -> serde_json::Value;
@@ -113,6 +115,7 @@ pub type Endpoint = (Arc<dyn EndpointAdapt>, Box<dyn ConRecvAdapt>);
 pub type EndpointFut = BoxFuture<'static, KitsuneResult<Endpoint>>;
 
 /// Tx bind adapter represents the ability to bind local endpoints.
+#[cfg_attr(feature = "test_utils", mockall::automock)]
 pub trait BindAdapt: 'static + Send + Sync + Unpin {
     /// Bind a local endpoint, given a url spec.
     fn bind(&self, url: TxUrl, timeout: KitsuneTimeout) -> EndpointFut;
@@ -120,3 +123,150 @@ pub trait BindAdapt: 'static + Send + Sync + Unpin {
 
 /// Tx backend endpoint binding factory type.
 pub type AdapterFactory = Arc<dyn BindAdapt>;
+
+/// mockall helper generators
+#[cfg(feature = "test_utils")]
+pub mod test_utils {
+    use super::*;
+    use futures::stream::BoxStream;
+
+    /// generate an InChanRecvAdapt from a generic stream
+    pub fn gen_mock_in_chan_recv_adapt(
+        s: BoxStream<'static, InChanFut>,
+    ) -> Box<dyn InChanRecvAdapt> {
+        struct Out(BoxStream<'static, InChanFut>);
+        impl futures::stream::Stream for Out {
+            type Item = InChanFut;
+
+            fn poll_next(
+                mut self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<Option<Self::Item>> {
+                futures::stream::Stream::poll_next(std::pin::Pin::new(&mut self.0), cx)
+            }
+        }
+        impl InChanRecvAdapt for Out {}
+
+        Box::new(Out(s))
+    }
+
+    /// generate a ConRecvAdapt from a generic stream
+    pub fn gen_mock_con_recv_adapt(s: BoxStream<'static, ConFut>) -> Box<dyn ConRecvAdapt> {
+        struct Out(BoxStream<'static, ConFut>);
+        impl futures::stream::Stream for Out {
+            type Item = ConFut;
+
+            fn poll_next(
+                mut self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<Option<Self::Item>> {
+                futures::stream::Stream::poll_next(std::pin::Pin::new(&mut self.0), cx)
+            }
+        }
+        impl ConRecvAdapt for Out {}
+
+        Box::new(Out(s))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::tx2::tx2_utils::PoolBuf;
+        use futures::future::FutureExt;
+        use futures::stream::StreamExt;
+
+        #[tokio::test]
+        async fn test_mock_adapter_factory() {
+            let gen_con = move || {
+                let mut m = MockConAdapt::new();
+                m.expect_out_chan().returning(move |_t| {
+                    async move {
+                        let mut m = MockAsFramedWriter::new();
+                        m.expect_write().returning(move |_, buf, _| {
+                            assert_eq!(b"test", buf.as_ref());
+                            async move { Ok(()) }.boxed()
+                        });
+                        let out: OutChan = Box::new(m);
+                        Ok(out)
+                    }
+                    .boxed()
+                });
+                let out: Arc<dyn ConAdapt> = Arc::new(m);
+                out
+            };
+
+            let gen_in_chan_recv = move || {
+                gen_mock_in_chan_recv_adapt(
+                    futures::stream::repeat_with(move || {
+                        async move {
+                            let mut m = MockAsFramedReader::new();
+                            m.expect_read().returning(move |_t| {
+                                async move {
+                                    let mut buf = PoolBuf::new();
+                                    buf.extend_from_slice(b"test");
+                                    Ok((0.into(), buf))
+                                }
+                                .boxed()
+                            });
+                            let out: InChan = Box::new(m);
+                            Ok(out)
+                        }
+                        .boxed()
+                    })
+                    .boxed(),
+                )
+            };
+
+            let gen_ep = move || {
+                let mut m = MockEndpointAdapt::new();
+                m.expect_connect().returning(move |_, _| {
+                    async move { Ok((gen_con(), gen_in_chan_recv())) }.boxed()
+                });
+                let out: Arc<dyn EndpointAdapt> = Arc::new(m);
+                out
+            };
+
+            let gen_con_recv = move || {
+                gen_mock_con_recv_adapt(
+                    futures::stream::repeat_with(move || {
+                        async move { Ok((gen_con(), gen_in_chan_recv())) }.boxed()
+                    })
+                    .boxed(),
+                )
+            };
+
+            let mut m = MockBindAdapt::new();
+            m.expect_bind()
+                .returning(move |_, _| async move { Ok((gen_ep(), gen_con_recv())) }.boxed());
+            let f = Arc::new(m);
+
+            let t = KitsuneTimeout::from_millis(100);
+
+            let (ep, mut con_recv) = f.bind("test://none".into(), t).await.unwrap();
+
+            let (con, mut chan_recv) = con_recv.next().await.unwrap().await.unwrap();
+
+            let mut chan_recv = chan_recv.next().await.unwrap().await.unwrap();
+
+            let (_, buf) = chan_recv.read(t).await.unwrap();
+            assert_eq!(b"test", buf.as_ref());
+
+            let mut chan_send = con.out_chan(t).await.unwrap();
+            let mut buf = PoolBuf::new();
+            buf.extend_from_slice(b"test");
+            chan_send.write(0.into(), buf, t).await.unwrap();
+
+            let (con, mut chan_recv) = ep.connect("test://test".into(), t).await.unwrap();
+
+            let mut chan_recv = chan_recv.next().await.unwrap().await.unwrap();
+
+            let (_, buf) = chan_recv.read(t).await.unwrap();
+            assert_eq!(b"test", buf.as_ref());
+
+            let mut chan_send = con.out_chan(t).await.unwrap();
+            let mut buf = PoolBuf::new();
+            buf.extend_from_slice(b"test");
+            chan_send.write(0.into(), buf, t).await.unwrap();
+        }
+    }
+}

--- a/crates/kitsune_p2p/types/src/tx2/tx2_api.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_api.rs
@@ -23,7 +23,7 @@ type ShareRMap<C> = Arc<Share<RMap<C>>>;
 
 struct RMapItem<C: Codec + 'static + Send + Unpin> {
     sender: RSend<C>,
-    start: std::time::Instant,
+    start: tokio::time::Instant,
     timeout: std::time::Duration,
     dbg_name: &'static str,
     req_byte_count: usize,
@@ -55,7 +55,7 @@ impl<C: Codec + 'static + Send + Unpin> RMap<C> {
             (uniq, msg_id),
             RMapItem {
                 sender: s_res,
-                start: std::time::Instant::now(),
+                start: tokio::time::Instant::now(),
                 timeout,
                 dbg_name,
                 req_byte_count,
@@ -511,7 +511,7 @@ impl<C: Codec + 'static + Send + Unpin> Tx2EpHnd<C> {
 pub struct Tx2Respond<C: Codec + 'static + Send + Unpin> {
     local_cert: Tx2Cert,
     peer_cert: Tx2Cert,
-    time: std::time::Instant,
+    time: tokio::time::Instant,
     dbg_name: &'static str,
     req_byte_count: usize,
     con: ConHnd,
@@ -534,7 +534,7 @@ impl<C: Codec + 'static + Send + Unpin> Tx2Respond<C> {
         con: ConHnd,
         msg_id: u64,
     ) -> Self {
-        let time = std::time::Instant::now();
+        let time = tokio::time::Instant::now();
         Self {
             local_cert,
             peer_cert,

--- a/crates/kitsune_p2p/types/src/tx2/tx2_pool_promote.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_pool_promote.rs
@@ -331,7 +331,7 @@ impl ConItem {
 
     // register this connection
     pub async fn reg_con_inner(
-        con_init: std::time::Instant,
+        con_init: tokio::time::Instant,
         local_cert: Tx2Cert,
         tuning_params: KitsuneP2pTuningParams,
         inner: Share<PromoteEpInner>,
@@ -433,7 +433,7 @@ impl ConItem {
     // The raw fallible inner future
     // `inner_connect` must catch errors to delete the entry from pend_cons
     pub fn inner_con_inner(
-        con_init: std::time::Instant,
+        con_init: tokio::time::Instant,
         local_cert: Tx2Cert,
         tuning_params: KitsuneP2pTuningParams,
         inner: Share<PromoteEpInner>,
@@ -475,7 +475,7 @@ impl ConItem {
         remote: TxUrl,
         timeout: KitsuneTimeout,
     ) -> Shared<BoxFuture<'static, KitsuneResult<Self>>> {
-        let con_init = std::time::Instant::now();
+        let con_init = tokio::time::Instant::now();
         async move {
             match Self::inner_con_inner(
                 con_init,
@@ -712,7 +712,7 @@ async fn con_recv_logic(
     // This *is* actually bound, by the max connections semaphore.
     pend_stream
         .for_each_concurrent(None, move |r| async move {
-            let con_init = std::time::Instant::now();
+            let con_init = tokio::time::Instant::now();
             let (permit, r) = r;
             let (con, in_chan_recv) = match r.await {
                 Err(e) => {

--- a/crates/kitsune_p2p/types/src/tx2/tx2_utils/latency.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_utils/latency.rs
@@ -2,7 +2,7 @@ use once_cell::sync::Lazy;
 
 /// this is a reference instance in time
 /// all latency info is encoded relative to this
-static LOC_EPOCH: Lazy<std::time::Instant> = Lazy::new(std::time::Instant::now);
+static LOC_EPOCH: Lazy<tokio::time::Instant> = Lazy::new(tokio::time::Instant::now);
 
 /// this tag identifies that a latency marker will follow
 /// as a little endian ieee f64, this will decode to NaN.
@@ -18,7 +18,7 @@ pub fn fill_with_latency_info(buf: &mut [u8]) {
     // make sure we call this first, so we don't go back in time
     let epoch = *LOC_EPOCH;
 
-    let now = std::time::Instant::now();
+    let now = tokio::time::Instant::now();
     let now = now.duration_since(epoch).as_secs_f64();
 
     // create a pattern of tag/marker
@@ -50,7 +50,7 @@ pub fn parse_latency_info(buf: &[u8]) -> Result<std::time::Duration, ()> {
             let mut time = [0; 8];
             time.copy_from_slice(&buf[i + 8..i + 16]);
             let time = f64::from_le_bytes(time);
-            let now = std::time::Instant::now();
+            let now = tokio::time::Instant::now();
             let now = now.duration_since(*LOC_EPOCH).as_secs_f64();
             let time = std::time::Duration::from_secs_f64(now - time);
             return Ok(time);


### PR DESCRIPTION
DEPENDS ON https://github.com/holochain/holochain/pull/876

- adds `test_utils` feature to kitsune_p2p_types which adds mockall mocks to tx2 adapters
- updates to ghost_actor that includes `test_utils` feature that adds mockall mocks to channel handler traits
- adds mock test for rpc_multi_logic function