### PR TITLE
Check if agent is authority and set dht arcs.

### DIFF
--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -232,6 +232,7 @@ impl Cell {
             PutAgentInfoSigned { .. }
             | GetAgentInfoSigned { .. }
             | QueryAgentInfoSigned { .. }
+            | QueryPeerDensity { .. }
             | QueryAgentInfoSignedNearBasis { .. } => {
                 // PutAgentInfoSigned needs to be handled at the conductor level where the p2p
                 // store lives.

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -60,6 +60,7 @@ use super::Cell;
 use super::CellError;
 use super::Conductor;
 use crate::conductor::p2p_agent_store::get_single_agent_info;
+use crate::conductor::p2p_agent_store::query_peer_density;
 use crate::conductor::p2p_metrics::put_metric_datum;
 use crate::conductor::p2p_metrics::query_metrics;
 use crate::core::ribosome::real_ribosome::RealRibosome;
@@ -532,6 +533,17 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
             } => {
                 let env = { self.p2p_env(space) };
                 let res = query_agent_info_signed_near_basis(env, kitsune_space, basis_loc, limit)
+                    .map_err(holochain_p2p::HolochainP2pError::other);
+                respond.respond(Ok(async move { res }.boxed().into()));
+            }
+            QueryPeerDensity {
+                kitsune_space,
+                dht_arc,
+                respond,
+                ..
+            } => {
+                let env = { self.p2p_env(space) };
+                let res = query_peer_density(env, kitsune_space, dht_arc)
                     .map_err(holochain_p2p::HolochainP2pError::other);
                 respond.respond(Ok(async move { res }.boxed().into()));
             }

--- a/crates/holochain_p2p/src/lib.rs
+++ b/crates/holochain_p2p/src/lib.rs
@@ -292,10 +292,15 @@ impl HolochainP2pCellT for HolochainP2pCell {
     /// Check if an agent is an authority for a hash.
     async fn authority_for_hash(
         &self,
-        _dht_hash: holo_hash::AnyDhtHash,
+        dht_hash: holo_hash::AnyDhtHash,
     ) -> actor::HolochainP2pResult<bool> {
-        // Currently everyone is an authority
-        Ok(true)
+        self.sender
+            .authority_for_hash(
+                (*self.dna_hash).clone(),
+                (*self.from_agent).clone(),
+                dht_hash,
+            )
+            .await
     }
 }
 

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -104,6 +104,19 @@ impl WrapEvtSender {
         )
     }
 
+    fn query_peer_density(
+        &self,
+        dna_hash: DnaHash,
+        kitsune_space: Arc<kitsune_p2p::KitsuneSpace>,
+        dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
+    ) -> impl Future<Output = HolochainP2pResult<kitsune_p2p_types::dht_arc::PeerDensity>> + 'static + Send
+    {
+        timing_trace!(
+            { self.0.query_peer_density(dna_hash, kitsune_space, dht_arc) },
+            "(hp2p:handle) query_peer_density",
+        )
+    }
+
     fn put_metric_datum(
         &self,
         dna_hash: DnaHash,
@@ -605,6 +618,24 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
         Ok(async move {
             Ok(evt_sender
                 .query_agent_info_signed_near_basis(h_space, space, basis_loc, limit)
+                .await?)
+        }
+        .boxed()
+        .into())
+    }
+
+    #[tracing::instrument(skip(self), level = "trace")]
+    fn handle_query_peer_density(
+        &mut self,
+        space: Arc<kitsune_p2p::KitsuneSpace>,
+        dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
+    ) -> kitsune_p2p::event::KitsuneP2pEventHandlerResult<kitsune_p2p_types::dht_arc::PeerDensity>
+    {
+        let h_space = DnaHash::from_kitsune(&space);
+        let evt_sender = self.evt_sender.clone();
+        Ok(async move {
+            Ok(evt_sender
+                .query_peer_density(h_space, space, dht_arc)
                 .await?)
         }
         .boxed()
@@ -1189,5 +1220,24 @@ impl HolochainP2pHandler for HolochainP2pActor {
         }
         .boxed()
         .into())
+    }
+
+    #[tracing::instrument(skip(self), level = "trace")]
+    fn handle_authority_for_hash(
+        &mut self,
+        dna_hash: DnaHash,
+        agent: AgentPubKey,
+        dht_hash: AnyDhtHash,
+    ) -> HolochainP2pHandlerResult<bool> {
+        let space = dna_hash.into_kitsune();
+        let agent = agent.into_kitsune();
+        let basis = dht_hash.to_kitsune();
+
+        let kitsune_p2p = self.kitsune_p2p.clone();
+        Ok(
+            async move { Ok(kitsune_p2p.authority_for_hash(space, agent, basis).await?) }
+                .boxed()
+                .into(),
+        )
     }
 }

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -103,6 +103,14 @@ impl HolochainP2pHandler for StubNetwork {
     ) -> HolochainP2pHandlerResult<()> {
         Err("stub".into())
     }
+    fn handle_authority_for_hash(
+        &mut self,
+        dna_hash: DnaHash,
+        agent: AgentPubKey,
+        dht_hash: AnyDhtHash,
+    ) -> HolochainP2pHandlerResult<bool> {
+        Err("stub".into())
+    }
 }
 
 /// Spawn a stub network that doesn't respond to any messages.

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -262,6 +262,9 @@ ghost_actor::ghost_chan! {
 
         /// Send a validation receipt to a remote node.
         fn send_validation_receipt(dna_hash: DnaHash, to_agent: AgentPubKey, from_agent: AgentPubKey, receipt: SerializedBytes) -> ();
+
+        /// Check if an agent is an authority for a hash.
+        fn authority_for_hash(dna_hash: DnaHash, from_agent: AgentPubKey, dht_hash: AnyDhtHash) -> bool;
     }
 }
 

--- a/crates/holochain_p2p/src/types/event.rs
+++ b/crates/holochain_p2p/src/types/event.rs
@@ -121,6 +121,9 @@ ghost_actor::ghost_chan! {
         /// query agent info in order of closeness to a basis location.
         fn query_agent_info_signed_near_basis(dna_hash: DnaHash, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>, basis_loc: u32, limit: u32) -> Vec<AgentInfoSigned>;
 
+        /// Query the peer density of a space for a given [`DhtArc`].
+        fn query_peer_density(dna_hash: DnaHash, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>, dht_arc: kitsune_p2p_types::dht_arc::DhtArc) -> kitsune_p2p_types::dht_arc::PeerDensity;
+
         /// We need to store some metric data on behalf of kitsune.
         fn put_metric_datum(dna_hash: DnaHash, to_agent: AgentPubKey, agent: AgentPubKey, metric: MetricKind, timestamp: SystemTime) -> ();
 
@@ -255,13 +258,16 @@ impl HolochainP2pEvent {
     pub fn dna_hash(&self) -> &DnaHash {
         match_p2p_evt!(self => |dna_hash| { dna_hash }, {
             HolochainP2pEvent::QueryAgentInfoSignedNearBasis { dna_hash, .. } => { dna_hash }
+            HolochainP2pEvent::QueryPeerDensity { dna_hash, .. } => { dna_hash }
         })
     }
 
     /// The agent_pub_key associated with this network p2p event.
     pub fn target_agent_as_ref(&self) -> &AgentPubKey {
         match_p2p_evt!(self => |to_agent| { to_agent }, {
-            HolochainP2pEvent::QueryAgentInfoSignedNearBasis { .. } => { unimplemented!() }
+            HolochainP2pEvent::QueryAgentInfoSignedNearBasis { .. } |
+            HolochainP2pEvent::QueryPeerDensity { .. }
+            => { unimplemented!() }
         })
     }
 }

--- a/crates/holochain_sqlite/src/db/p2p_agent_store.rs
+++ b/crates/holochain_sqlite/src/db/p2p_agent_store.rs
@@ -288,7 +288,7 @@ impl P2pRecord {
         let expires_at_ms = signed.expires_at_ms;
         let arc = signed.storage_arc;
 
-        let storage_center_loc = arc.center_loc.into();
+        let storage_center_loc = arc.center_loc().into();
 
         let is_active = !signed.url_list.is_empty();
 

--- a/crates/holochain_sqlite/src/db/p2p_agent_store/p2p_test.rs
+++ b/crates/holochain_sqlite/src/db/p2p_agent_store/p2p_test.rs
@@ -87,7 +87,10 @@ async fn test_p2p_agent_store_gossip_query_sanity() {
 
     // agents with zero arc lengths will never be returned, so count only the
     // nonzero ones
-    let num_nonzero = all.iter().filter(|a| a.storage_arc.half_length > 0).count();
+    let num_nonzero = all
+        .iter()
+        .filter(|a| a.storage_arc.half_length() > 0)
+        .count();
 
     // make sure we can get our example result
     println!("after insert select all count: {}", all.len());

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
@@ -153,10 +153,10 @@ fn converge(current: f64, density: PeerDensity) -> f64 {
 /// ```
 pub struct DhtArc {
     /// The center location of this dht arc
-    pub center_loc: DhtLocation,
+    center_loc: DhtLocation,
 
     /// The "half-length" of this dht arc
-    pub half_length: u32,
+    half_length: u32,
 }
 
 impl DhtArc {
@@ -168,6 +168,16 @@ impl DhtArc {
             center_loc: center_loc.into(),
             half_length,
         }
+    }
+
+    /// Create a full arc from a center location
+    pub fn full<I: Into<DhtLocation>>(center_loc: I) -> Self {
+        Self::new(center_loc, MAX_HALF_LENGTH)
+    }
+
+    /// Create an empty arc from a center location
+    pub fn empty<I: Into<DhtLocation>>(center_loc: I) -> Self {
+        Self::new(center_loc, 0)
     }
 
     /// Update the half length based on a density reading.
@@ -262,6 +272,16 @@ impl DhtArc {
     /// by this arc.
     pub fn coverage(&self) -> f64 {
         self.absolute_length() as f64 / U32_LEN as f64
+    }
+
+    /// Get the half length of this arc.
+    pub fn half_length(&self) -> u32 {
+        self.half_length
+    }
+
+    /// Get the center location of this arc.
+    pub fn center_loc(&self) -> DhtLocation {
+        self.center_loc
     }
 }
 

--- a/crates/kitsune_p2p/direct/src/persist_mem.rs
+++ b/crates/kitsune_p2p/direct/src/persist_mem.rs
@@ -387,6 +387,40 @@ impl AsKdPersist for PersistMem {
         .boxed()
     }
 
+    fn query_peer_density(
+        &self,
+        root: KdHash,
+        dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
+    ) -> BoxFuture<'static, KdResult<kitsune_p2p_types::dht_arc::PeerDensity>> {
+        let store = self.0.share_mut(move |i, _| match i.agent_info.get(&root) {
+            Some(store) => Ok(store.clone()),
+            None => Err("root not found".into()),
+        });
+        async move {
+            let store = match store {
+                Err(_) => return Err("root not found".into()),
+                Ok(store) => store,
+            };
+            let arcs = store
+                .get_all()?
+                .into_iter()
+                .filter_map(|v| {
+                    if dht_arc.contains(v.agent().as_loc()) {
+                        Some(*v.storage_arc())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            // contains is already checked in the iterator
+            let bucket = kitsune_p2p::dht_arc::DhtArcBucket::new_unchecked(dht_arc, arcs);
+
+            Ok(bucket.density())
+        }
+        .boxed()
+    }
+
     fn put_metric_datum(&self, datum: MetricDatum) -> BoxFuture<'static, KdResult<()>> {
         let inner = self.0.clone();
         async move {

--- a/crates/kitsune_p2p/direct/src/types/persist.rs
+++ b/crates/kitsune_p2p/direct/src/types/persist.rs
@@ -50,6 +50,13 @@ pub trait AsKdPersist: 'static + Send + Sync {
         limit: u32,
     ) -> BoxFuture<'static, KdResult<Vec<KdAgentInfo>>>;
 
+    /// Query the peer density of a space for a given [`DhtArc`].
+    fn query_peer_density(
+        &self,
+        root: KdHash,
+        dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
+    ) -> BoxFuture<'static, KdResult<kitsune_p2p_types::dht_arc::PeerDensity>>;
+
     /// Store agent info
     fn put_metric_datum(&self, datum: MetricDatum) -> BoxFuture<'static, KdResult<()>>;
 
@@ -171,6 +178,16 @@ impl KdPersist {
         limit: u32,
     ) -> impl Future<Output = KdResult<Vec<KdAgentInfo>>> + 'static + Send {
         AsKdPersist::query_agent_info_near_basis(&*self.0, root, basis_loc, limit)
+    }
+
+    /// Query the peer density of a space for a given [`DhtArc`].
+    pub fn query_peer_density(
+        &self,
+        root: KdHash,
+        dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
+    ) -> impl Future<Output = KdResult<kitsune_p2p_types::dht_arc::PeerDensity>> + 'static + Send
+    {
+        AsKdPersist::query_peer_density(&*self.0, root, dht_arc)
     }
 
     /// Store agent info

--- a/crates/kitsune_p2p/direct/src/v1.rs
+++ b/crates/kitsune_p2p/direct/src/v1.rs
@@ -629,6 +629,21 @@ async fn handle_events(
                     .boxed()
                     .into()));
                 }
+                event::KitsuneP2pEvent::QueryPeerDensity {
+                    respond,
+                    space,
+                    dht_arc,
+                    ..
+                } => {
+                    respond.r(Ok(handle_query_peer_density(
+                        kdirect.clone(),
+                        space,
+                        dht_arc,
+                    )
+                    .map_err(KitsuneP2pError::other)
+                    .boxed()
+                    .into()));
+                }
                 event::KitsuneP2pEvent::PutMetricDatum { respond, datum, .. } => {
                     respond.r(Ok(handle_put_metric_datum(kdirect.clone(), datum)
                         .map_err(KitsuneP2pError::other)
@@ -785,6 +800,16 @@ async fn handle_query_agent_info_signed_near_basis(
         .query_agent_info_near_basis(root, basis_loc, limit)
         .await?;
     Ok(map.into_iter().map(|a| a.to_kitsune()).collect())
+}
+
+async fn handle_query_peer_density(
+    kdirect: Arc<Kd1>,
+    space: Arc<KitsuneSpace>,
+    dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
+) -> KdResult<kitsune_p2p_types::dht_arc::PeerDensity> {
+    let root = KdHash::from_kitsune_space(&space);
+    let density = kdirect.persist.query_peer_density(root, dht_arc).await?;
+    Ok(density)
 }
 
 async fn handle_put_metric_datum(kdirect: Arc<Kd1>, datum: MetricDatum) -> KdResult<()> {

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -38,3 +38,6 @@ observability = "0.1.3"
 [dev-dependencies]
 matches = "0.1"
 tracing-subscriber = "0.2"
+
+[features]
+sharded = []

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -466,6 +466,14 @@ impl KitsuneP2pEventHandler for KitsuneP2pActor {
             .query_agent_info_signed_near_basis(space, basis_loc, limit))
     }
 
+    fn handle_query_peer_density(
+        &mut self,
+        space: Arc<KitsuneSpace>,
+        dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
+    ) -> KitsuneP2pEventHandlerResult<kitsune_p2p_types::dht_arc::PeerDensity> {
+        Ok(self.evt_sender.query_peer_density(space, dht_arc))
+    }
+
     fn handle_put_metric_datum(&mut self, datum: MetricDatum) -> KitsuneP2pEventHandlerResult<()> {
         Ok(self.evt_sender.put_metric_datum(datum))
     }
@@ -643,6 +651,24 @@ impl KitsuneP2pHandler for KitsuneP2pActor {
         Ok(async move {
             let (space_sender, _) = space_sender.await;
             space_sender.broadcast(space, basis, timeout, payload).await
+        }
+        .boxed()
+        .into())
+    }
+
+    fn handle_authority_for_hash(
+        &mut self,
+        space: Arc<KitsuneSpace>,
+        agent: Arc<KitsuneAgent>,
+        basis: Arc<KitsuneBasis>,
+    ) -> KitsuneP2pHandlerResult<bool> {
+        let space_sender = match self.spaces.get_mut(&space) {
+            None => return Err(KitsuneP2pError::RoutingSpaceError(space)),
+            Some(space) => space.get(),
+        };
+        Ok(async move {
+            let (space_sender, _) = space_sender.await;
+            space_sender.authority_for_hash(space, agent, basis).await
         }
         .boxed()
         .into())

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -4,6 +4,7 @@ use ghost_actor::dependencies::tracing;
 use ghost_actor::dependencies::tracing_futures::Instrument;
 use kitsune_p2p_mdns::*;
 use kitsune_p2p_types::codec::{rmp_decode, rmp_encode};
+use kitsune_p2p_types::dht_arc::DhtArc;
 use kitsune_p2p_types::tx2::tx2_utils::TxUrl;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicBool;
@@ -26,6 +27,9 @@ ghost_actor::ghost_chan! {
 
         /// see if an agent is locally joined
         fn is_agent_local(agent: Arc<KitsuneAgent>) -> bool;
+
+        /// Update the arc of a local agent.
+        fn update_agent_arc(agent: Arc<KitsuneAgent>, arc: DhtArc) -> ();
 
         /// Incoming Delegate Broadcast
         /// We are being requested to delegate a broadcast to our neighborhood
@@ -115,20 +119,27 @@ impl SpaceInternalHandler for Space {
         let space = self.space.clone();
         let mut mdns_handles = self.mdns_handles.clone();
         let network_type = self.config.network_type.clone();
-        let agent_list: Vec<Arc<KitsuneAgent>> = self.local_joined_agents.iter().cloned().collect();
+        let mut agent_list = Vec::with_capacity(self.local_joined_agents.len());
+        for agent in self.local_joined_agents.iter().cloned() {
+            let arc = self.get_agent_arc(&agent);
+            agent_list.push((agent, arc));
+        }
         let bound_url = self.this_addr.clone();
         let evt_sender = self.evt_sender.clone();
         let bootstrap_service = self.config.bootstrap_service.clone();
         let expires_after = self.config.tuning_params.agent_info_expires_after_ms as u64;
+        let internal_sender = self.i_s.clone();
         Ok(async move {
             let urls = vec![bound_url.into()];
-            for agent in agent_list {
+            for (agent, arc) in agent_list {
                 let input = UpdateAgentInfoInput {
                     expires_after,
                     space: space.clone(),
                     agent,
+                    arc,
                     urls: &urls,
                     evt_sender: &evt_sender,
+                    internal_sender: &internal_sender,
                     network_type: network_type.clone(),
                     mdns_handles: &mut mdns_handles,
                     bootstrap_service: &bootstrap_service,
@@ -150,16 +161,21 @@ impl SpaceInternalHandler for Space {
         let network_type = self.config.network_type.clone();
         let bound_url = self.this_addr.clone();
         let evt_sender = self.evt_sender.clone();
+        let internal_sender = self.i_s.clone();
         let bootstrap_service = self.config.bootstrap_service.clone();
         let expires_after = self.config.tuning_params.agent_info_expires_after_ms as u64;
+        let arc = self.get_agent_arc(&agent);
+
         Ok(async move {
             let urls = vec![bound_url.into()];
             let input = UpdateAgentInfoInput {
                 expires_after,
                 space: space.clone(),
                 agent,
+                arc,
                 urls: &urls,
                 evt_sender: &evt_sender,
+                internal_sender: &internal_sender,
                 network_type: network_type.clone(),
                 mdns_handles: &mut mdns_handles,
                 bootstrap_service: &bootstrap_service,
@@ -177,6 +193,15 @@ impl SpaceInternalHandler for Space {
     ) -> SpaceInternalHandlerResult<bool> {
         let res = self.local_joined_agents.contains(&agent);
         Ok(async move { Ok(res) }.boxed().into())
+    }
+
+    fn handle_update_agent_arc(
+        &mut self,
+        agent: Arc<KitsuneAgent>,
+        arc: DhtArc,
+    ) -> SpaceInternalHandlerResult<()> {
+        self.agent_arcs.insert(agent, arc);
+        Ok(async move { Ok(()) }.boxed().into())
     }
 
     fn handle_incoming_delegate_broadcast(
@@ -275,11 +300,36 @@ struct UpdateAgentInfoInput<'borrow> {
     expires_after: u64,
     space: Arc<KitsuneSpace>,
     agent: Arc<KitsuneAgent>,
+    arc: DhtArc,
     urls: &'borrow Vec<TxUrl>,
     evt_sender: &'borrow futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+    internal_sender: &'borrow ghost_actor::GhostSender<SpaceInternal>,
     network_type: NetworkType,
     mdns_handles: &'borrow mut HashMap<Vec<u8>, Arc<AtomicBool>>,
     bootstrap_service: &'borrow Option<Url2>,
+}
+
+#[cfg(feature = "sharded")]
+async fn update_arc_length(
+    evt_sender: &futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+    space: Arc<KitsuneSpace>,
+    arc: &mut DhtArc,
+) -> KitsuneP2pResult<()> {
+    // TODO: Get the peer density and update the arc if feature flag is set.
+    let density = evt_sender
+        .query_peer_density(space.clone(), arc.clone())
+        .await?;
+    arc.update_length(density);
+    Ok(())
+}
+
+#[cfg(not(feature = "sharded"))]
+async fn update_arc_length(
+    _evt_sender: &futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+    _space: Arc<KitsuneSpace>,
+    _arc: &mut DhtArc,
+) -> KitsuneP2pResult<()> {
+    Ok(())
 }
 
 async fn update_single_agent_info(input: UpdateAgentInfoInput<'_>) -> KitsuneP2pResult<()> {
@@ -287,20 +337,28 @@ async fn update_single_agent_info(input: UpdateAgentInfoInput<'_>) -> KitsuneP2p
         expires_after,
         space,
         agent,
+        mut arc,
         urls,
         evt_sender,
+        internal_sender,
         network_type,
         mdns_handles,
         bootstrap_service,
     } = input;
     use kitsune_p2p_types::agent_info::AgentInfoSigned;
+
+    update_arc_length(evt_sender, space.clone(), &mut arc).await?;
+
+    // Update the agents arc through the internal sender.
+    internal_sender.update_agent_arc(agent.clone(), arc).await?;
+
     let signed_at_ms = crate::spawn::actor::bootstrap::now_once(None).await?;
     let expires_at_ms = signed_at_ms + expires_after;
 
     let agent_info_signed = AgentInfoSigned::sign(
         space.clone(),
         agent.clone(),
-        u32::MAX,
+        arc.half_length(),
         urls.clone(),
         signed_at_ms,
         expires_at_ms,
@@ -458,6 +516,7 @@ impl KitsuneP2pHandler for Space {
         agent: Arc<KitsuneAgent>,
     ) -> KitsuneP2pHandlerResult<()> {
         self.local_joined_agents.remove(&agent);
+        self.agent_arcs.remove(&agent);
         self.gossip_mod.local_agent_leave(agent.clone());
         self.publish_leave_agent_info(agent)
     }
@@ -671,6 +730,19 @@ impl KitsuneP2pHandler for Space {
         .boxed()
         .into())
     }
+
+    fn handle_authority_for_hash(
+        &mut self,
+        _space: Arc<KitsuneSpace>,
+        agent: Arc<KitsuneAgent>,
+        basis: Arc<KitsuneBasis>,
+    ) -> KitsuneP2pHandlerResult<bool> {
+        let r = match self.agent_arcs.get(&agent) {
+            Some(agent_arc) => agent_arc.contains(basis.get_loc()),
+            None => false,
+        };
+        Ok(async move { Ok(r) }.boxed().into())
+    }
 }
 
 pub(crate) struct SpaceReadOnlyInner {
@@ -693,6 +765,7 @@ pub(crate) struct Space {
     pub(crate) i_s: ghost_actor::GhostSender<SpaceInternal>,
     pub(crate) evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
     pub(crate) local_joined_agents: HashSet<Arc<KitsuneAgent>>,
+    pub(crate) agent_arcs: HashMap<Arc<KitsuneAgent>, DhtArc>,
     pub(crate) config: Arc<KitsuneP2pConfig>,
     mdns_handles: HashMap<Vec<u8>, Arc<AtomicBool>>,
     mdns_listened_spaces: HashSet<String>,
@@ -821,6 +894,7 @@ impl Space {
             i_s,
             evt_sender,
             local_joined_agents: HashSet::new(),
+            agent_arcs: HashMap::new(),
             config,
             mdns_handles: HashMap::new(),
             mdns_listened_spaces: HashSet::new(),
@@ -990,5 +1064,15 @@ impl Space {
         .instrument(tracing::debug_span!("multi_inner"))
         .boxed()
         .into())
+    }
+
+    /// Get the existing agent storage arc or create a new one.
+    fn get_agent_arc(&self, agent: &Arc<KitsuneAgent>) -> DhtArc {
+        // TODO: We are simply setting the initial arc to full.
+        // In the future we may want to do something more intelligent.
+        self.agent_arcs
+            .get(agent)
+            .cloned()
+            .unwrap_or_else(|| DhtArc::full(agent.get_loc()))
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -315,7 +315,6 @@ async fn update_arc_length(
     space: Arc<KitsuneSpace>,
     arc: &mut DhtArc,
 ) -> KitsuneP2pResult<()> {
-    // TODO: Get the peer density and update the arc if feature flag is set.
     let density = evt_sender
         .query_peer_density(space.clone(), arc.clone())
         .await?;

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
@@ -176,6 +176,14 @@ impl KitsuneP2pEventHandler for AgentHarness {
         Ok(async move { Ok(out) }.boxed().into())
     }
 
+    fn handle_query_peer_density(
+        &mut self,
+        _space: Arc<KitsuneSpace>,
+        _dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
+    ) -> KitsuneP2pEventHandlerResult<kitsune_p2p_types::dht_arc::PeerDensity> {
+        todo!()
+    }
+
     fn handle_put_metric_datum(&mut self, datum: MetricDatum) -> KitsuneP2pEventHandlerResult<()> {
         self.metric_store.put_metric_datum(datum);
         Ok(async move { Ok(()) }.boxed().into())

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/actor.rs
@@ -70,5 +70,12 @@ ghost_actor::ghost_chan! {
             timeout: KitsuneTimeout,
             payload: Vec<u8>
         ) -> ();
+
+        /// Check if an agent is an authority for a hash.
+        fn authority_for_hash(
+            space: Arc<super::KitsuneSpace>,
+            agent: Arc<super::KitsuneAgent>,
+            basis: Arc<super::KitsuneBasis>,
+        ) -> bool;
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
@@ -155,6 +155,9 @@ ghost_actor::ghost_chan! {
         /// query agent info in order of closeness to a basis location.
         fn query_agent_info_signed_near_basis(space: Arc<super::KitsuneSpace>, basis_loc: u32, limit: u32) -> Vec<crate::types::agent_store::AgentInfoSigned>;
 
+        /// Query the peer density of a space for a given [`DhtArc`].
+        fn query_peer_density(space: Arc<super::KitsuneSpace>, dht_arc: kitsune_p2p_types::dht_arc::DhtArc) -> kitsune_p2p_types::dht_arc::PeerDensity;
+
         /// Record a metric datum about an agent.
         fn put_metric_datum(datum: MetricDatum) -> ();
 

--- a/crates/kitsune_p2p/types/src/agent_info.rs
+++ b/crates/kitsune_p2p/types/src/agent_info.rs
@@ -162,11 +162,8 @@ impl<'de> serde::Deserialize<'de> for AgentInfoSigned {
             return Err(serde::de::Error::custom("agent mismatch"));
         }
 
-        let center_loc = agent.get_loc().into();
-        let storage_arc = DhtArc {
-            center_loc,
-            half_length: meta.dht_storage_arc_half_length,
-        };
+        let center_loc = agent.get_loc();
+        let storage_arc = DhtArc::new(center_loc, meta.dht_storage_arc_half_length);
 
         let AgentInfoEncode {
             space,
@@ -228,14 +225,11 @@ impl AgentInfoSigned {
 
         let signature = f(&encoded_bytes).await?;
 
-        let center_loc = agent.get_loc().into();
+        let center_loc = agent.get_loc();
         let inner = AgentInfoInner {
             space,
             agent,
-            storage_arc: DhtArc {
-                center_loc,
-                half_length: dht_storage_arc_half_length,
-            },
+            storage_arc: DhtArc::new(center_loc, dht_storage_arc_half_length),
             url_list,
             signed_at_ms,
             expires_at_ms,

--- a/shell.nix
+++ b/shell.nix
@@ -10,6 +10,7 @@ let
   default = import (builtins.toString ./default.nix) (builtins.removeAttrs args [
     "flavor"
     "flavour"
+    "inNixShell"
   ]);
 in
 


### PR DESCRIPTION
This makes the cascade check with kitsune if the current agent is an authority before doing gets etc.
This also updates the agent info's arc using the peer density calculation. Calculating the real storage arc length is behind a feature flag `sharded`. If this is not set then all agents get a full arc.