### PR TITLE
[TK-10124] kitsune_p2p: remove all '<>' from ghost_chan invocations

### DIFF
--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -32,7 +32,7 @@ ghost_actor::ghost_chan! {
         fn is_agent_local(agent: KAgent) -> bool;
 
         /// Update the arc of a local agent.
-        fn update_agent_arc(agent: Arc<KitsuneAgent>, arc: DhtArc) -> ();
+        fn update_agent_arc(agent: KAgent, arc: DhtArc) -> ();
 
         /// Incoming Delegate Broadcast
         /// We are being requested to delegate a broadcast to our neighborhood

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/actor.rs
@@ -105,9 +105,9 @@ ghost_actor::ghost_chan! {
 
         /// Check if an agent is an authority for a hash.
         fn authority_for_hash(
-            space: Arc<super::KitsuneSpace>,
-            agent: Arc<super::KitsuneAgent>,
-            basis: Arc<super::KitsuneBasis>,
+            space: KSpace,
+            agent: KAgent,
+            basis: KBasis,
         ) -> bool;
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
@@ -161,7 +161,7 @@ ghost_actor::ghost_chan! {
         fn query_agent_info_signed_near_basis(space: KSpace, basis_loc: u32, limit: u32) -> Vec<crate::types::agent_store::AgentInfoSigned>;
 
         /// Query the peer density of a space for a given [`DhtArc`].
-        fn query_peer_density(space: Arc<super::KitsuneSpace>, dht_arc: kitsune_p2p_types::dht_arc::DhtArc) -> kitsune_p2p_types::dht_arc::PeerDensity;
+        fn query_peer_density(space: KSpace, dht_arc: kitsune_p2p_types::dht_arc::DhtArc) -> kitsune_p2p_types::dht_arc::PeerDensity;
 
         /// Record a metric datum about an agent.
         fn put_metric_datum(datum: MetricDatum) -> ();


### PR DESCRIPTION
Otherwise this causes a compiler error that surfaced with `cargo check --all-features`.
As a next step I'd like to identify why this error wasn't caught by our CI test.