### PR TITLE
[TK-10124] ci: compile test with all features

### DIFF
--- a/nix/pkgs/core.nix
+++ b/nix/pkgs/core.nix
@@ -18,13 +18,13 @@ rec {
 
     # alas, we cannot specify --features in the virtual workspace
     # run the specific slow tests in the holochain crate
-    cargo test --no-run --all-targets --manifest-path=crates/holochain/Cargo.toml --features slow_tests,test_utils,build_wasms,db-encryption -- --nocapture --test-threads 1
+    cargo test --no-run --all-targets --manifest-path=crates/holochain/Cargo.toml --features slow_tests,test_utils,build_wasms,db-encryption
     cargo test --manifest-path=crates/holochain/Cargo.toml --features slow_tests,test_utils,build_wasms,db-encryption -- --nocapture --test-threads 1
     # run all the remaining cargo tests
-    cargo test --no-run --all-targets --workspace --exclude holochain -- --nocapture --test-threads 1
+    cargo test --no-run --all-features --all-targets --workspace --exclude holochain
     cargo test --workspace --exclude holochain -- --nocapture --test-threads 1
     # run all the wasm tests (within wasm) with the conductor mocked
-    cargo test --no-run --all-targets --lib --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml --all-features -- --nocapture --test-threads 1
+    cargo test --no-run --all-targets --lib --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml --all-features
     cargo test --lib --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml --all-features -- --nocapture --test-threads 1
   '';
 

--- a/nix/pkgs/core.nix
+++ b/nix/pkgs/core.nix
@@ -18,7 +18,7 @@ rec {
 
     # alas, we cannot specify --features in the virtual workspace
     # run the specific slow tests in the holochain crate
-    cargo test --no-run --all-targets --manifest-path=crates/holochain/Cargo.toml --features slow_tests,test_utils,build_wasms,db-encryption
+    cargo test --no-run --all-features --all-targets --manifest-path=crates/holochain/Cargo.toml
     cargo test --manifest-path=crates/holochain/Cargo.toml --features slow_tests,test_utils,build_wasms,db-encryption -- --nocapture --test-threads 1
     # run all the remaining cargo tests
     cargo test --no-run --all-features --all-targets --workspace --exclude holochain


### PR DESCRIPTION
Split off from #897 

The second commit exposes the issue which is now documented on CI in [this failed run](https://app.circleci.com/pipelines/github/holochain/holochain/7061/workflows/9640c641-2235-4b2f-b1a4-01df2b33fa9f/jobs/8631?invite=true#step-104-3456).

After rebasing/merging in https://github.com/holochain/holochain/pull/897 the error should go away.