### PR TITLE
nix-hc-binary-wrapper: support for running from a different directory

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,8 @@ let
         if [[ -n "$NIX_ENV_PREFIX" ]]; then
           # don't touch it
           :
+        elif test -w "$PWD"; then
+          export NIX_ENV_PREFIX="$PWD"
         elif test -d "${builtins.toString self.hcToplevelDir}" &&
             test -w "${builtins.toString self.hcToplevelDir}"; then
           export NIX_ENV_PREFIX="${builtins.toString self.hcToplevelDir}"

--- a/nix/pkgs/default.nix
+++ b/nix/pkgs/default.nix
@@ -13,7 +13,7 @@ let
 
     crate=''${1:?The first argument needs to define the crate name}
     shift
-    cargo run --target-dir=''${CARGO_TARGET_DIR:?} --manifest-path=${hcToplevelDir}/crates/$crate/Cargo.toml -- $@
+    cargo run --target-dir=''${NIX_ENV_PREFIX:-?}/target/hc-run-crate --manifest-path=${hcToplevelDir}/crates/$crate/Cargo.toml -- $@
   '';
 
   ci = callPackage ./ci.nix { };


### PR DESCRIPTION
Giving the binary wrapper a separate target directory avoids sharing the
compiler cache with compilation of other crates in the repository, that
could have other feature sets. This is because sharing the target
directory has surfaced compiler errors that suggest erroneous cache
handling.

As an example, from a directory next to the holochain directory you
could run:

```
nix-shell ../holochain/shell.nix --argstr flavor happDev --run "make test"
```

Where `make test` could run the binary wrapper script `holochain`.


---

Split off #869