### PR TITLE
Sharded tests pt. 2: Toggle publish, gossip, and arc resizing during tests

### DIFF
--- a/crates/holochain/benches/consistency.rs
+++ b/crates/holochain/benches/consistency.rs
@@ -7,6 +7,7 @@ use criterion::Criterion;
 
 use holo_hash::EntryHash;
 use holo_hash::EntryHashes;
+use holochain::conductor::handle::DevSettingsDelta;
 use holochain::sweettest::*;
 use holochain_conductor_api::conductor::ConductorConfig;
 use holochain_conductor_api::AdminInterfaceConfig;
@@ -189,7 +190,10 @@ async fn setup() -> (Producer, Consumer, Others) {
     let configs = vec![config(), config(), config(), config(), config()];
     let mut conductors = SweetConductorBatch::from_configs(configs.clone()).await;
     for c in conductors.iter() {
-        c.set_skip_publish(true);
+        c.update_dev_settings(DevSettingsDelta {
+            publish: Some(false),
+            ..Default::default()
+        });
     }
     let apps = conductors.setup_app("app", &[dna]).await.unwrap();
     let mut cells = apps

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1191,6 +1191,7 @@ where
 mod builder {
     use super::*;
     use crate::conductor::dna_store::RealDnaStore;
+    use crate::conductor::handle::DevSettings;
     use crate::conductor::ConductorHandle;
     use holochain_sqlite::db::DbKind;
     #[cfg(any(test, feature = "test_utils"))]
@@ -1324,11 +1325,11 @@ mod builder {
                 conductor: RwLock::new(conductor),
                 keystore,
                 holochain_p2p,
-
-                #[cfg(any(test, feature = "test_utils"))]
-                skip_publish: std::sync::atomic::AtomicBool::new(false),
                 p2p_env: Arc::new(parking_lot::Mutex::new(HashMap::new())),
                 p2p_metrics_env: Arc::new(parking_lot::Mutex::new(HashMap::new())),
+
+                #[cfg(any(test, feature = "test_utils"))]
+                dev_settings: parking_lot::RwLock::new(DevSettings::default()),
             });
 
             Self::finish(handle, config, p2p_evt).await
@@ -1429,8 +1430,9 @@ mod builder {
                 holochain_p2p,
                 p2p_env: envs.p2p(),
                 p2p_metrics_env: envs.p2p_metrics(),
+
                 #[cfg(any(test, feature = "test_utils"))]
-                skip_publish: std::sync::atomic::AtomicBool::new(false),
+                dev_settings: parking_lot::RwLock::new(DevSettings::default()),
             });
 
             // Install extra DNAs, in particular:

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -346,7 +346,7 @@ pub trait ConductorHandleT: Send + Sync {
     ) -> ConductorResult<(InstalledApp, AppStatusFx)>;
 
     // TODO: would be nice to have methods for accessing the underlying Conductor,
-    // but this trait doesn't know the concrete type of Conductor underlying,
+    // but this trait doesn't know the concrete type of underlying Conductor,
     // and using generics seems problematic with mockall::automock.
     // Something like this would be desirable, but ultimately doesn't work.
     //
@@ -376,10 +376,8 @@ pub trait ConductorHandleT: Send + Sync {
 pub struct DevSettings {
     /// Determines whether publishing should be enabled
     pub publish: bool,
-    /// Determines whether gossiping should be enabled
-    pub gossip: bool,
     /// Determines whether storage arc resizing should be enabled
-    pub arc_resizing: bool,
+    pub _arc_resizing: bool,
 }
 
 /// Specify changes to be made to the Devsettings.
@@ -388,8 +386,6 @@ pub struct DevSettings {
 pub struct DevSettingsDelta {
     /// Determines whether publishing should be enabled
     pub publish: Option<bool>,
-    /// Determines whether gossiping should be enabled
-    pub gossip: Option<bool>,
     /// Determines whether storage arc resizing should be enabled
     pub arc_resizing: Option<bool>,
 }
@@ -398,8 +394,7 @@ impl Default for DevSettings {
     fn default() -> Self {
         Self {
             publish: true,
-            gossip: true,
-            arc_resizing: true,
+            _arc_resizing: true,
         }
     }
 }
@@ -409,11 +404,9 @@ impl DevSettings {
         if let Some(v) = delta.publish {
             self.publish = v;
         }
-        if let Some(v) = delta.gossip {
-            self.gossip = v;
-        }
         if let Some(v) = delta.arc_resizing {
-            self.arc_resizing = v;
+            self._arc_resizing = v;
+            tracing::warn!("Arc resizing is not yet implemented, and can't be enabled/disabled.");
         }
     }
 }

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -325,13 +325,13 @@ pub trait ConductorHandleT: Send + Sync {
     async fn add_test_app_interface(&self, id: super::state::AppInterfaceId)
         -> ConductorResult<()>;
 
+    /// Get the current dev settings
     #[cfg(any(test, feature = "test_utils"))]
-    /// Check whether this conductor should skip publish.
-    fn should_skip_publish(&self) -> bool;
+    fn dev_settings(&self) -> DevSettings;
 
+    /// Update the current dev settings
     #[cfg(any(test, feature = "test_utils"))]
-    /// For testing we can choose to skip publish.
-    fn set_skip_publish(&self, skip_publish: bool);
+    fn update_dev_settings(&self, delta: DevSettingsDelta);
 
     /// Manually coerce cells to a given CellStatus. FOR TESTING ONLY.
     #[cfg(any(test, feature = "test_utils"))]
@@ -371,6 +371,53 @@ pub trait ConductorHandleT: Send + Sync {
     // }
 }
 
+/// Special switches for features to be used during development and testing
+#[derive(Clone)]
+pub struct DevSettings {
+    /// Determines whether publishing should be enabled
+    pub publish: bool,
+    /// Determines whether gossiping should be enabled
+    pub gossip: bool,
+    /// Determines whether storage arc resizing should be enabled
+    pub arc_resizing: bool,
+}
+
+/// Specify changes to be made to the Devsettings.
+/// None means no change, Some means make the specified change.
+#[derive(Default)]
+pub struct DevSettingsDelta {
+    /// Determines whether publishing should be enabled
+    pub publish: Option<bool>,
+    /// Determines whether gossiping should be enabled
+    pub gossip: Option<bool>,
+    /// Determines whether storage arc resizing should be enabled
+    pub arc_resizing: Option<bool>,
+}
+
+impl Default for DevSettings {
+    fn default() -> Self {
+        Self {
+            publish: true,
+            gossip: true,
+            arc_resizing: true,
+        }
+    }
+}
+
+impl DevSettings {
+    fn apply(&mut self, delta: DevSettingsDelta) {
+        if let Some(v) = delta.publish {
+            self.publish = v;
+        }
+        if let Some(v) = delta.gossip {
+            self.gossip = v;
+        }
+        if let Some(v) = delta.arc_resizing {
+            self.arc_resizing = v;
+        }
+    }
+}
+
 /// The current "production" implementation of a ConductorHandle.
 /// The implementation specifies how read/write access to the Conductor
 /// should be synchronized across multiple concurrent Handles.
@@ -393,11 +440,11 @@ pub struct ConductorHandleImpl<DS: DnaStore + 'static> {
     /// The database for storing p2p MetricDatum(s)
     pub(super) p2p_metrics_env: Arc<parking_lot::Mutex<HashMap<Arc<KitsuneSpace>, EnvWrite>>>,
 
-    // Testing:
+    // This is only available in tests currently, but could be extended to
+    // normal usage.
     #[cfg(any(test, feature = "test_utils"))]
-    /// All conductors should skip publishing.
-    /// This is useful for testing gossip.
-    pub skip_publish: std::sync::atomic::AtomicBool,
+    /// Selectively enable/disable certain functionalities
+    pub dev_settings: parking_lot::RwLock<DevSettings>,
 }
 
 #[async_trait::async_trait]
@@ -1133,14 +1180,13 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
     }
 
     #[cfg(any(test, feature = "test_utils"))]
-    fn should_skip_publish(&self) -> bool {
-        self.skip_publish.load(std::sync::atomic::Ordering::Relaxed)
+    fn dev_settings(&self) -> DevSettings {
+        self.dev_settings.read().clone()
     }
 
     #[cfg(any(test, feature = "test_utils"))]
-    fn set_skip_publish(&self, skip_publish: bool) {
-        self.skip_publish
-            .store(skip_publish, std::sync::atomic::Ordering::Relaxed);
+    fn update_dev_settings(&self, delta: DevSettingsDelta) {
+        self.dev_settings.write().apply(delta);
     }
 
     #[cfg(any(test, feature = "test_utils"))]

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -373,6 +373,7 @@ pub trait ConductorHandleT: Send + Sync {
 
 /// Special switches for features to be used during development and testing
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct DevSettings {
     /// Determines whether publishing should be enabled
     pub publish: bool,
@@ -383,6 +384,7 @@ pub struct DevSettings {
 /// Specify changes to be made to the Devsettings.
 /// None means no change, Some means make the specified change.
 #[derive(Default)]
+#[non_exhaustive]
 pub struct DevSettingsDelta {
     /// Determines whether publishing should be enabled
     pub publish: Option<bool>,

--- a/crates/holochain/src/core/queue_consumer/publish_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/publish_dht_ops_consumer.rs
@@ -29,7 +29,7 @@ pub fn spawn_publish_dht_ops_consumer(
 
             #[cfg(any(test, feature = "test_utils"))]
             {
-                if conductor_handle.should_skip_publish() {
+                if conductor_handle.dev_settings().publish {
                     continue;
                 }
             }

--- a/crates/holochain/tests/sharded_gossip.rs
+++ b/crates/holochain/tests/sharded_gossip.rs
@@ -14,7 +14,9 @@ struct AppString(String);
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
 async fn fullsync_sharded_gossip() -> anyhow::Result<()> {
-    use holochain::test_utils::inline_zomes::simple_create_read_zome;
+    use holochain::{
+        conductor::handle::DevSettingsDelta, test_utils::inline_zomes::simple_create_read_zome,
+    };
 
     let _g = observability::test_run().ok();
     const NUM_CONDUCTORS: usize = 2;
@@ -35,7 +37,10 @@ async fn fullsync_sharded_gossip() -> anyhow::Result<()> {
 
     let mut conductors = SweetConductorBatch::from_config(NUM_CONDUCTORS, config).await;
     for c in conductors.iter() {
-        c.set_skip_publish(true);
+        c.update_dev_settings(DevSettingsDelta {
+            publish: Some(false),
+            ..Default::default()
+        });
     }
 
     let (dna_file, _) = SweetDnaFile::unique_from_inline_zome("zome1", simple_create_read_zome())
@@ -73,7 +78,10 @@ async fn fullsync_sharded_gossip() -> anyhow::Result<()> {
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
 async fn fullsync_sharded_local_gossip() -> anyhow::Result<()> {
-    use holochain::{sweettest::SweetConductor, test_utils::inline_zomes::simple_create_read_zome};
+    use holochain::{
+        conductor::handle::DevSettingsDelta, sweettest::SweetConductor,
+        test_utils::inline_zomes::simple_create_read_zome,
+    };
 
     let _g = observability::test_run().ok();
 
@@ -92,7 +100,10 @@ async fn fullsync_sharded_local_gossip() -> anyhow::Result<()> {
     config.network = Some(network);
 
     let mut conductor = SweetConductor::from_config(config).await;
-    conductor.set_skip_publish(true);
+    conductor.update_dev_settings(DevSettingsDelta {
+        publish: Some(false),
+        ..Default::default()
+    });
 
     let (dna_file, _) = SweetDnaFile::unique_from_inline_zome("zome1", simple_create_read_zome())
         .await


### PR DESCRIPTION
Expands `skip_publish` into a struct with multiple options for enabling/disabling features, which can be added to later.