### PR TITLE
fix MacOS hdk not compiling since 0.0.101

### DIFF
--- a/crates/hdk_derive/Cargo.toml
+++ b/crates/hdk_derive/Cargo.toml
@@ -18,7 +18,7 @@ syn = { version = "1", features = [ "full", "extra-traits" ] }
 quote = "1"
 proc-macro2 = "1"
 paste = "=1.0.5"
-holochain_zome_types = { version = "0.0.4", path = "../holochain_zome_types" }
+holochain_zome_types = { version = "0.0.4", path = "../holochain_zome_types", default-features = false }
 
 [features]
 default = []


### PR DESCRIPTION
the solution proposed by @maackle to the problem worked. PRing the solution
fixes https://github.com/holochain/holochain/issues/891'

better make sure that sqlite deps don't sneak into stuff that actually has to get built to WASM in future

if we could rush this through it'd be ideal cause this is big blocker