### PR TITLE
[TK-10153] sharding compatible peer consistency

### DIFF
--- a/crates/kitsune_p2p/direct/src/handle_ws.rs
+++ b/crates/kitsune_p2p/direct/src/handle_ws.rs
@@ -234,6 +234,29 @@ impl AsKdHnd for Hnd {
         .boxed()
     }
 
+    fn is_authority(
+        &self,
+        root: KdHash,
+        agent: KdHash,
+        basis: KdHash,
+    ) -> BoxFuture<'static, KdResult<bool>> {
+        let msg_id = new_msg_id();
+        let api = KdApi::IsAuthorityReq {
+            msg_id,
+            root,
+            agent,
+            basis,
+        };
+        let api = self.request(api);
+        async move {
+            match api.await {
+                Ok(KdApi::IsAuthorityRes { is_authority, .. }) => Ok(is_authority),
+                oth => Err(format!("unexpected: {:?}", oth).into()),
+            }
+        }
+        .boxed()
+    }
+
     fn message_send(
         &self,
         root: KdHash,

--- a/crates/kitsune_p2p/direct/src/types/handle.rs
+++ b/crates/kitsune_p2p/direct/src/types/handle.rs
@@ -67,6 +67,14 @@ pub trait AsKdHnd: 'static + Send + Sync {
     /// query a list of agent_info records from the store
     fn agent_info_query(&self, root: KdHash) -> BoxFuture<'static, KdResult<Vec<KdAgentInfo>>>;
 
+    /// check if an agent is an authority for a given hash
+    fn is_authority(
+        &self,
+        root: KdHash,
+        agent: KdHash,
+        basis: KdHash,
+    ) -> BoxFuture<'static, KdResult<bool>>;
+
     /// Send a message to a remote app/agent
     fn message_send(
         &self,
@@ -181,6 +189,16 @@ impl KdHnd {
         root: KdHash,
     ) -> impl Future<Output = KdResult<Vec<KdAgentInfo>>> + 'static + Send {
         AsKdHnd::agent_info_query(&*self.0, root)
+    }
+
+    /// check if an agent is an authority for a given hash
+    pub fn is_authority(
+        &self,
+        root: KdHash,
+        agent: KdHash,
+        basis: KdHash,
+    ) -> impl Future<Output = KdResult<bool>> {
+        AsKdHnd::is_authority(&*self.0, root, agent, basis)
     }
 
     /// Send a message to a remote app/agent

--- a/crates/kitsune_p2p/direct/src/v1.rs
+++ b/crates/kitsune_p2p/direct/src/v1.rs
@@ -453,6 +453,26 @@ async fn handle_srv_events(
                                     })
                                 }.boxed()).await;
                             }
+                            KdApi::IsAuthorityReq {
+                                msg_id,
+                                root,
+                                agent,
+                                basis,
+                                ..
+                            } => {
+                                exec(msg_id.clone(), async {
+                                    let space = root.to_kitsune_space();
+                                    let agent = agent.to_kitsune_agent();
+                                    let basis = basis.to_kitsune_basis();
+                                    let is_authority = kdirect.inner.share_mut(move |i, _| {
+                                        Ok(i.p2p.authority_for_hash(space, agent, basis))
+                                    }).map_err(KdError::other)?.await.map_err(KdError::other)?;
+                                    Ok(KdApi::IsAuthorityRes {
+                                        msg_id,
+                                        is_authority,
+                                    })
+                                }.boxed()).await;
+                            }
                             KdApi::MessageSendReq {
                                 msg_id,
                                 root,
@@ -566,6 +586,7 @@ async fn handle_srv_events(
                             oth @ KdApi::AgentInfoStoreRes { .. } |
                             oth @ KdApi::AgentInfoGetRes { .. } |
                             oth @ KdApi::AgentInfoQueryRes { .. } |
+                            oth @ KdApi::IsAuthorityRes { .. } |
                             oth @ KdApi::MessageSendRes { .. } |
                             oth @ KdApi::MessageRecvEvt { .. } |
                             oth @ KdApi::EntryAuthorRes { .. } |

--- a/crates/kitsune_p2p/direct_api/src/kdapi.rs
+++ b/crates/kitsune_p2p/direct_api/src/kdapi.rs
@@ -194,6 +194,38 @@ pub enum KdApi {
         agent_info_list: Vec<KdAgentInfo>,
     },
 
+    /// check if an agent is an authority for a given hash
+    #[serde(rename = "isAuthorityReq")]
+    IsAuthorityReq {
+        /// message id
+        #[serde(rename = "msgId")]
+        msg_id: String,
+
+        /// root app hash
+        #[serde(rename = "root")]
+        root: KdHash,
+
+        /// agent hash
+        #[serde(rename = "agent")]
+        agent: KdHash,
+
+        /// basis hash
+        #[serde(rename = "basis")]
+        basis: KdHash,
+    },
+
+    /// check if an agent is an authority for a given hash
+    #[serde(rename = "isAuthorityRes")]
+    IsAuthorityRes {
+        /// message id
+        #[serde(rename = "msgId")]
+        msg_id: String,
+
+        /// is authority
+        #[serde(rename = "isAuthority")]
+        is_authority: bool,
+    },
+
     /// Send a message to a remote app/agent
     #[serde(rename = "messageSendReq")]
     MessageSendReq {
@@ -399,6 +431,8 @@ impl KdApi {
             Self::AgentInfoGetRes { msg_id, .. } => msg_id,
             Self::AgentInfoQueryReq { msg_id, .. } => msg_id,
             Self::AgentInfoQueryRes { msg_id, .. } => msg_id,
+            Self::IsAuthorityReq { msg_id, .. } => msg_id,
+            Self::IsAuthorityRes { msg_id, .. } => msg_id,
             Self::MessageSendReq { msg_id, .. } => msg_id,
             Self::MessageSendRes { msg_id, .. } => msg_id,
             Self::MessageRecvEvt { .. } => "",
@@ -423,6 +457,7 @@ impl KdApi {
             Self::AgentInfoStoreRes { .. } => true,
             Self::AgentInfoGetRes { .. } => true,
             Self::AgentInfoQueryRes { .. } => true,
+            Self::IsAuthorityRes { .. } => true,
             Self::MessageSendRes { .. } => true,
             Self::EntryAuthorRes { .. } => true,
             Self::EntryGetRes { .. } => true,

--- a/crates/kitsune_p2p/direct_test/src/consistency_stress.rs
+++ b/crates/kitsune_p2p/direct_test/src/consistency_stress.rs
@@ -255,10 +255,10 @@ struct TestNode {
 struct State {
     /// the total agent node count processed for averaging purposes
     agent_tot_cnt: usize,
-    
+
     /// the total calculated target number of agents that should be held across the system
     agent_tot_tgt: usize,
-    
+
     /// the total calculated number of agents currently held across the system
     agent_tot_cur: usize,
 

--- a/crates/kitsune_p2p/direct_test/src/consistency_stress.rs
+++ b/crates/kitsune_p2p/direct_test/src/consistency_stress.rs
@@ -241,10 +241,21 @@ pub fn run(
 
 // -- private -- //
 
+use std::collections::HashMap;
+
 struct TestNode {
     kdirect: KitsuneDirect,
     kdhnd: KdHnd,
     agents: Vec<KdHash>,
+    agents_holding: HashMap<KdHash, (usize, usize)>,
+}
+
+struct State {
+    agent_tot_cnt: usize,
+    agent_tot_tgt: usize,
+    agent_tot_cur: usize,
+
+    avg_total_op_count: usize,
 }
 
 struct Test {
@@ -265,7 +276,6 @@ struct Test {
     #[allow(dead_code)]
     time_round_start: std::time::Instant,
 
-    target_agent_count: usize,
     target_total_op_count: usize,
 }
 
@@ -323,7 +333,6 @@ impl Test {
             time_test_start,
             time_round_start: std::time::Instant::now(),
 
-            target_agent_count: node_count * agents_per_node,
             target_total_op_count: 1, // 1 for app_entry
         }
     }
@@ -377,6 +386,7 @@ impl Test {
             kdirect,
             kdhnd,
             agents: Vec::new(),
+            agents_holding: HashMap::new(),
         });
 
         let node_idx = self.nodes.len() - 1;
@@ -388,8 +398,6 @@ impl Test {
 
     async fn inject_bad_agent_info(&mut self) {
         for _ in 0..self.bad_agent_count {
-            self.target_agent_count += 1;
-
             let info = gen_bad_agent_info(
                 self.tuning_params.clone(),
                 self.root.clone(),
@@ -421,32 +429,70 @@ impl Test {
                 .await
                 .unwrap();
             self.add_agent_to_node(node_idx).await;
-            // we don't remove the old one, because the agent info is
-            // still going to be in the db / gossiped
-            self.target_agent_count += 1;
             println!("Turned Over Agent in NODE {}", node_idx);
         }
     }
 
-    async fn calc_avgs(&mut self) -> (usize, usize) {
-        let mut avg_agent_count = 0;
+    async fn calc_avgs(&mut self) -> State {
+        let mut out = State {
+            agent_tot_cnt: 0,
+            agent_tot_tgt: 0,
+            agent_tot_cur: 0,
 
+            avg_total_op_count: 0,
+        };
+
+        // gather the list of all agents we care about
+        let mut all_agents = Vec::new();
         for node in self.nodes.iter() {
-            avg_agent_count += node
-                .kdirect
-                .get_persist()
-                .query_agent_info(self.root.clone())
-                .await
-                .unwrap()
-                .len();
+            for agent in node.agents.iter() {
+                all_agents.push(agent.clone());
+            }
         }
-        avg_agent_count /= self.nodes.len();
 
-        let mut avg_total_op_count = 0;
+        // check each agent for which agents they *should* be holding
+        // then also count the agents that they *are* holding
+        for node in self.nodes.iter_mut() {
+            // clear previous data, otherwise we have stale stuff from turnover
+            node.agents_holding.clear();
+
+            let agents_in_node = node.agents.clone();
+            for agent in agents_in_node.iter() {
+                let mut should_hold_count = 0;
+                for hold_agent in all_agents.iter() {
+                    let should_hold = node
+                        .kdhnd
+                        .is_authority(self.root.clone(), agent.clone(), hold_agent.clone())
+                        .await
+                        .unwrap();
+                    if should_hold {
+                        should_hold_count += 1;
+                    }
+                }
+                let does_hold_count = node
+                    .kdirect
+                    .get_persist()
+                    .query_agent_info(self.root.clone())
+                    .await
+                    .unwrap()
+                    .len();
+                node.agents_holding
+                    .insert(agent.clone(), (should_hold_count, does_hold_count));
+            }
+        }
+
+        // see how our agent collecting progress is going
+        for node in self.nodes.iter() {
+            for (_, (tgt, cur)) in node.agents_holding.iter() {
+                out.agent_tot_cnt += 1;
+                out.agent_tot_tgt += tgt;
+                out.agent_tot_cur += cur;
+            }
+        }
 
         for node in self.nodes.iter() {
             for agent in node.agents.iter() {
-                avg_total_op_count += node
+                out.avg_total_op_count += node
                     .kdirect
                     .get_persist()
                     .query_entries(
@@ -460,9 +506,9 @@ impl Test {
                     .len();
             }
         }
-        avg_total_op_count /= self.node_count * self.agents_per_node;
+        out.avg_total_op_count /= self.node_count * self.agents_per_node;
 
-        (avg_agent_count, avg_total_op_count)
+        out
     }
 
     fn new_round(&mut self) {
@@ -484,37 +530,40 @@ impl Test {
             .unwrap();
     }
 
-    async fn emit_interim(&mut self, avg_agent_count: usize, avg_total_op_count: usize) {
+    async fn emit_interim(&mut self, state: State) {
+        let agent_avg_cur = state.agent_tot_cur / state.agent_tot_cnt;
+        let agent_avg_tgt = state.agent_tot_tgt / state.agent_tot_cnt;
         self.p_send
             .send(Progress::InterimState {
                 run_time_s: self.time_test_start.elapsed().as_secs_f64(),
                 round_elapsed_s: self.time_round_start.elapsed().as_secs_f64(),
-                target_agent_count: self.target_agent_count,
-                avg_agent_count,
+                target_agent_count: agent_avg_tgt,
+                avg_agent_count: agent_avg_cur,
                 target_total_op_count: self.target_total_op_count,
-                avg_total_op_count,
+                avg_total_op_count: state.avg_total_op_count,
             })
             .await
             .unwrap();
     }
 
-    async fn emit_agent_consistent(&mut self, agent_count: usize) {
+    async fn emit_agent_consistent(&mut self, state: State) {
+        let agent_avg_cur = state.agent_tot_cur / state.agent_tot_cnt;
         self.p_send
             .send(Progress::AgentConsistent {
                 run_time_s: self.time_test_start.elapsed().as_secs_f64(),
-                agent_count,
+                agent_count: agent_avg_cur,
             })
             .await
             .unwrap();
     }
 
-    async fn emit_op_consistent(&mut self, total_op_count: usize) {
+    async fn emit_op_consistent(&mut self, _state: State) {
         self.p_send
             .send(Progress::OpConsistent {
                 run_time_s: self.time_test_start.elapsed().as_secs_f64(),
                 round_elapsed_s: self.time_round_start.elapsed().as_secs_f64(),
                 new_ops_added_count: self.node_count * self.agents_per_node,
-                total_op_count,
+                total_op_count: self.target_total_op_count,
             })
             .await
             .unwrap();
@@ -575,14 +624,14 @@ async fn test(
     loop {
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
-        let (avg_agent_count, avg_total_op_count) = test.calc_avgs().await;
+        let state = test.calc_avgs().await;
 
-        if avg_agent_count >= test.target_agent_count {
-            test.emit_agent_consistent(avg_agent_count).await;
+        if state.agent_tot_cur >= state.agent_tot_tgt {
+            test.emit_agent_consistent(state).await;
             break;
         }
 
-        test.emit_interim(avg_agent_count, avg_total_op_count).await;
+        test.emit_interim(state).await;
     }
 
     // this loop publishes ops, and waits for them to be synced
@@ -622,14 +671,14 @@ async fn test(
         loop {
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
-            let (avg_agent_count, avg_total_op_count) = test.calc_avgs().await;
+            let state = test.calc_avgs().await;
 
-            if avg_total_op_count >= test.target_total_op_count {
-                test.emit_op_consistent(avg_total_op_count).await;
+            if state.avg_total_op_count >= test.target_total_op_count {
+                test.emit_op_consistent(state).await;
                 break;
             }
 
-            test.emit_interim(avg_agent_count, avg_total_op_count).await;
+            test.emit_interim(state).await;
         }
     }
 }

--- a/crates/kitsune_p2p/direct_test/src/consistency_stress.rs
+++ b/crates/kitsune_p2p/direct_test/src/consistency_stress.rs
@@ -247,12 +247,19 @@ struct TestNode {
     kdirect: KitsuneDirect,
     kdhnd: KdHnd,
     agents: Vec<KdHash>,
+    /// The pair of usizes here represents the number of agents
+    /// this agent *should* hold vs the number that they *do* hold
     agents_holding: HashMap<KdHash, (usize, usize)>,
 }
 
 struct State {
+    /// the total agent node count processed for averaging purposes
     agent_tot_cnt: usize,
+    
+    /// the total calculated target number of agents that should be held across the system
     agent_tot_tgt: usize,
+    
+    /// the total calculated number of agents currently held across the system
     agent_tot_cur: usize,
 
     avg_total_op_count: usize,


### PR DESCRIPTION
This only does the agent_info side! Next PR will have the same thing for ops.

- plumbs `authority_for_hash` call up through kitsune direct
- consistency test makes use of `is_authority` call to determite *which* agents each agent should hold before claiming consistency reached.