### PR TITLE
Refactor and test metrics / choosing the next node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3255,6 +3255,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "shrinkwraprs",
+ "test-case",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -46,6 +46,7 @@ arbitrary = { version = "1.0", features = ["derive"]}
 maplit = "1"
 matches = "0.1"
 mockall = "0.10.2"
+test-case = "1.0.0"
 tracing-subscriber = "0.2"
 
 [features]

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/accept.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/accept.rs
@@ -46,6 +46,15 @@ impl ShardedGossipLocal {
             // a stale accept comes in for the same peer cert?
             // Maybe we need to check timestamps on messages or have unique round ids?
             inner.round_map.insert(peer_cert.clone(), state);
+            // If this is not the target we are accepting
+            // then record it as a remote round.
+            if inner
+                .initiate_tgt
+                .as_ref()
+                .map_or(true, |tgt| *tgt.0.cert() != peer_cert)
+            {
+                inner.metrics.record_remote_round(peer_cert);
+            }
             Ok(())
         })?;
         Ok(gossip)

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/metrics.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/metrics.rs
@@ -1,0 +1,140 @@
+use std::time::Instant;
+
+use super::*;
+
+/// Maximum amount of history we will track
+/// per remote node.
+const MAX_HISTORY: usize = 10;
+
+#[derive(Debug, Clone, Default)]
+/// Information about a remote node.
+struct Info {
+    /// Times we recorded errors for this node.
+    errors: VecDeque<Instant>,
+    /// Times we recorded initiates to this node.
+    initiates: VecDeque<Instant>,
+    /// Times we recorded remote rounds from this node.
+    remote_rounds: VecDeque<Instant>,
+    /// Times we recorded complete rounds for this node.
+    complete_rounds: VecDeque<Instant>,
+    /// Is this node currently in an active round?
+    current_round: bool,
+}
+
+#[derive(Debug, Default)]
+/// Metrics tracking for remote nodes to help
+/// choose which remote node to initiate the next round with.
+pub(super) struct Metrics {
+    /// Map of remote nodes.
+    map: HashMap<StateKey, Info>,
+    // Number of times we need to force initiate
+    // the next round.
+    force_initiates: u8,
+}
+
+/// Outcome of a gossip round.
+pub(super) enum Outcome {
+    Success(Instant),
+    Error(Instant),
+}
+
+impl Metrics {
+    #[cfg(test)]
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a gossip round has been initiated by us.
+    pub(super) fn record_initiate(&mut self, key: StateKey) {
+        let info = self.map.entry(key).or_default();
+        info.initiates.push_back(Instant::now());
+        if info.initiates.len() > MAX_HISTORY {
+            info.initiates.pop_front();
+        }
+        info.current_round = true;
+    }
+
+    /// Record a remote gossip round has started.
+    pub(super) fn record_remote_round(&mut self, key: StateKey) {
+        let info = self.map.entry(key).or_default();
+        info.remote_rounds.push_back(Instant::now());
+        if info.remote_rounds.len() > MAX_HISTORY {
+            info.remote_rounds.pop_front();
+        }
+        info.current_round = true;
+    }
+
+    /// Record a gossip round has completed successfully.
+    pub(super) fn record_success(&mut self, key: StateKey) {
+        let info = self.map.entry(key).or_default();
+        info.complete_rounds.push_back(Instant::now());
+        if info.complete_rounds.len() > MAX_HISTORY {
+            info.complete_rounds.pop_front();
+        }
+        info.current_round = false;
+        if info.is_initiate_round() {
+            self.force_initiates = self.force_initiates.saturating_sub(1);
+        }
+    }
+
+    /// Record a gossip round has finished with an error.
+    pub(super) fn record_error(&mut self, key: StateKey) {
+        let info = self.map.entry(key).or_default();
+        info.errors.push_back(Instant::now());
+        if info.errors.len() > MAX_HISTORY {
+            info.errors.pop_front();
+        }
+        info.current_round = false;
+    }
+
+    /// Record that we should force initiate the next few rounds.
+    pub(super) fn record_force_initiate(&mut self) {
+        self.force_initiates = MAX_TRIGGERS;
+    }
+
+    /// Get the last successful round time.
+    pub(super) fn last_success(&self, key: &StateKey) -> Option<&Instant> {
+        self.map
+            .get(key)
+            .and_then(|info| info.complete_rounds.back())
+    }
+
+    /// Is this node currently in an active round?
+    pub(super) fn is_current_round(&self, key: &StateKey) -> bool {
+        self.map.get(key).map_or(false, |info| info.current_round)
+    }
+
+    /// What was the last outcome for this nodes gossip round?
+    pub(super) fn last_outcome(&self, key: &StateKey) -> Option<Outcome> {
+        self.map.get(key).and_then(
+            |info| match (info.errors.back(), info.complete_rounds.back()) {
+                (Some(error), Some(success)) => {
+                    if dbg!(error) > dbg!(success) {
+                        Some(Outcome::Error(*error))
+                    } else {
+                        Some(Outcome::Success(*success))
+                    }
+                }
+                (Some(error), None) => Some(Outcome::Error(*error)),
+                (None, Some(success)) => Some(Outcome::Success(*success)),
+                (None, None) => None,
+            },
+        )
+    }
+
+    /// Should we force initiate the next round?
+    pub(super) fn forced_initiate(&self) -> bool {
+        self.force_initiates > 0
+    }
+}
+
+impl Info {
+    /// Was the last round for this node initiated by us?
+    fn is_initiate_round(&self) -> bool {
+        match (self.remote_rounds.back(), self.initiates.back()) {
+            (None, None) | (Some(_), None) => false,
+            (None, Some(_)) => true,
+            (Some(remote), Some(initiate)) => initiate > remote,
+        }
+    }
+}

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/metrics.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/metrics.rs
@@ -8,7 +8,7 @@ const MAX_HISTORY: usize = 10;
 
 #[derive(Debug, Clone, Default)]
 /// Information about a remote node.
-struct Info {
+struct NodeInfo {
     /// Times we recorded errors for this node.
     errors: VecDeque<Instant>,
     /// Times we recorded initiates to this node.
@@ -26,14 +26,14 @@ struct Info {
 /// choose which remote node to initiate the next round with.
 pub(super) struct Metrics {
     /// Map of remote nodes.
-    map: HashMap<StateKey, Info>,
+    map: HashMap<StateKey, NodeInfo>,
     // Number of times we need to force initiate
     // the next round.
     force_initiates: u8,
 }
 
 /// Outcome of a gossip round.
-pub(super) enum Outcome {
+pub(super) enum RoundOutcome {
     Success(Instant),
     Error(Instant),
 }
@@ -47,30 +47,21 @@ impl Metrics {
     /// Record a gossip round has been initiated by us.
     pub(super) fn record_initiate(&mut self, key: StateKey) {
         let info = self.map.entry(key).or_default();
-        info.initiates.push_back(Instant::now());
-        if info.initiates.len() > MAX_HISTORY {
-            info.initiates.pop_front();
-        }
+        record_instant(&mut info.initiates);
         info.current_round = true;
     }
 
     /// Record a remote gossip round has started.
     pub(super) fn record_remote_round(&mut self, key: StateKey) {
         let info = self.map.entry(key).or_default();
-        info.remote_rounds.push_back(Instant::now());
-        if info.remote_rounds.len() > MAX_HISTORY {
-            info.remote_rounds.pop_front();
-        }
+        record_instant(&mut info.remote_rounds);
         info.current_round = true;
     }
 
     /// Record a gossip round has completed successfully.
     pub(super) fn record_success(&mut self, key: StateKey) {
         let info = self.map.entry(key).or_default();
-        info.complete_rounds.push_back(Instant::now());
-        if info.complete_rounds.len() > MAX_HISTORY {
-            info.complete_rounds.pop_front();
-        }
+        record_instant(&mut info.complete_rounds);
         info.current_round = false;
         if info.is_initiate_round() {
             self.force_initiates = self.force_initiates.saturating_sub(1);
@@ -80,10 +71,7 @@ impl Metrics {
     /// Record a gossip round has finished with an error.
     pub(super) fn record_error(&mut self, key: StateKey) {
         let info = self.map.entry(key).or_default();
-        info.errors.push_back(Instant::now());
-        if info.errors.len() > MAX_HISTORY {
-            info.errors.pop_front();
-        }
+        record_instant(&mut info.errors);
         info.current_round = false;
     }
 
@@ -105,18 +93,18 @@ impl Metrics {
     }
 
     /// What was the last outcome for this nodes gossip round?
-    pub(super) fn last_outcome(&self, key: &StateKey) -> Option<Outcome> {
+    pub(super) fn last_outcome(&self, key: &StateKey) -> Option<RoundOutcome> {
         self.map.get(key).and_then(
             |info| match (info.errors.back(), info.complete_rounds.back()) {
                 (Some(error), Some(success)) => {
                     if dbg!(error) > dbg!(success) {
-                        Some(Outcome::Error(*error))
+                        Some(RoundOutcome::Error(*error))
                     } else {
-                        Some(Outcome::Success(*success))
+                        Some(RoundOutcome::Success(*success))
                     }
                 }
-                (Some(error), None) => Some(Outcome::Error(*error)),
-                (None, Some(success)) => Some(Outcome::Success(*success)),
+                (Some(error), None) => Some(RoundOutcome::Error(*error)),
+                (None, Some(success)) => Some(RoundOutcome::Success(*success)),
                 (None, None) => None,
             },
         )
@@ -128,7 +116,7 @@ impl Metrics {
     }
 }
 
-impl Info {
+impl NodeInfo {
     /// Was the last round for this node initiated by us?
     fn is_initiate_round(&self) -> bool {
         match (self.remote_rounds.back(), self.initiates.back()) {
@@ -137,4 +125,11 @@ impl Info {
             (Some(remote), Some(initiate)) => initiate > remote,
         }
     }
+}
+
+fn record_instant(buffer: &mut VecDeque<Instant>) {
+    if buffer.len() > MAX_HISTORY {
+        buffer.pop_front();
+    }
+    buffer.push_back(Instant::now());
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/next_target.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/next_target.rs
@@ -1,0 +1,725 @@
+use std::cmp::Ordering;
+
+use super::metrics::Metrics;
+use super::*;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// A remote node we can connect to.
+/// Note that a node can contain many agents.
+struct Node {
+    target: GossipTgt,
+    url: TxUrl,
+}
+
+impl ShardedGossipLocal {
+    /// Find a remote endpoint from agents within arc set.
+    pub(super) async fn find_remote_agent_within_arcset(
+        &self,
+        arc_set: Arc<DhtArcSet>,
+        local_agents: &HashSet<Arc<KitsuneAgent>>,
+    ) -> KitsuneResult<Option<(GossipTgt, TxUrl)>> {
+        let mut remote_nodes: HashMap<Tx2Cert, Node> = HashMap::new();
+
+        // Get all the remote nodes in this arc set.
+        let remote_agents_within_arc_set: HashSet<_> =
+            store::agents_within_arcset(&self.evt_sender, &self.space, arc_set.clone())
+                .await?
+                .into_iter()
+                .filter(|(a, _)| !local_agents.contains(a))
+                .map(|(a, _)| a)
+                .collect();
+
+        // Get all the agent info for these remote nodes.
+        for info in store::all_agent_info(&self.evt_sender, &self.space)
+            .await?
+            .into_iter()
+            .filter(|a| remote_agents_within_arc_set.contains(&a.agent))
+        {
+            // Get an address if there is one.
+            let info = info
+                .url_list
+                .iter()
+                .filter_map(|url| {
+                    kitsune_p2p_proxy::ProxyUrl::from_full(url.as_str())
+                        .map_err(|e| tracing::error!("Failed to parse url {:?}", e))
+                        .ok()
+                        .map(|purl| {
+                            (
+                                info.agent.clone(),
+                                Tx2Cert::from(purl.digest()),
+                                TxUrl::from(url.as_str()),
+                            )
+                        })
+                })
+                .next();
+
+            // If we found a remote address add this agent to the node
+            // or create the node if it doesn't exist.
+            if let Some((agent, cert, url)) = info {
+                match remote_nodes.get_mut(&cert) {
+                    // Add the agent to the node.
+                    Some(node) => node.target.agents.push(agent),
+                    None => {
+                        // This is a new node.
+                        remote_nodes.insert(
+                            cert.clone(),
+                            Node {
+                                target: GossipTgt {
+                                    agents: vec![agent],
+                                    cert,
+                                },
+                                url,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+
+        let remote_nodes = remote_nodes.into_iter().map(|(_, v)| v).collect();
+        let tuning_params = self.tuning_params.clone();
+        // We could clone the metrics store out of the lock here but I don't think
+        // the next_remote_node will be that slow so we can just choose the next node inline.
+        self.inner.share_mut(|i, _| {
+            let node = next_remote_node(remote_nodes, &i.metrics, tuning_params)
+                .map(|n| (n.target, n.url));
+            Ok(node)
+        })
+    }
+}
+
+/// Find the next remote node to sync with.
+fn next_remote_node(
+    mut remote_nodes: Vec<Node>,
+    metrics: &Metrics,
+    tuning_params: KitsuneP2pTuningParams,
+) -> Option<Node> {
+    use rand::prelude::*;
+    let mut rng = thread_rng();
+
+    // Sort the nodes by longest time since we last successfully gossiped with them.
+    // Randomly break ties between nodes we haven't successfully gossiped with.
+    // Note the smaller an Instant the longer it is in the past.
+    remote_nodes.sort_unstable_by(|a, b| {
+        match (
+            metrics.last_success(a.cert()),
+            metrics.last_success(b.cert()),
+        ) {
+            // Choose the smallest (oldest) Instant.
+            (Some(a), Some(b)) => a.cmp(&b),
+            // Put a behind b that hasn't been gossiped with.
+            (Some(_), None) => Ordering::Greater,
+            // Put b behind a that hasn't been gossiped with.
+            (None, Some(_)) => Ordering::Less,
+            // Randomly break ties.
+            (None, None) => {
+                if rng.gen() {
+                    Ordering::Less
+                } else {
+                    Ordering::Greater
+                }
+            }
+        }
+    });
+
+    remote_nodes
+        .into_iter()
+        // Don't initiate with nodes we are currently gossiping with.
+        .filter(|n| !metrics.is_current_round(n.cert()))
+        .find(|n| {
+            // If we should force initiate then find all remaining nodes.
+            if metrics.forced_initiate() {
+                true
+            } else {
+                // Otherwise only find with nodes that have not been gossiped with too recently.
+                match metrics.last_outcome(n.cert()) {
+                    Some(metrics::Outcome::Success(when)) => {
+                        when.elapsed().as_millis() as u32
+                            >= tuning_params.gossip_peer_on_success_next_gossip_delay_ms
+                    }
+                    Some(metrics::Outcome::Error(when)) => {
+                        when.elapsed().as_millis() as u32
+                            >= tuning_params.gossip_peer_on_error_next_gossip_delay_ms
+                    }
+                    _ => true,
+                }
+            }
+        })
+}
+
+impl Node {
+    /// Get the cert for this node.
+    fn cert(&self) -> &Tx2Cert {
+        self.target.cert()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{fixt::*, gossip::sharded_gossip::metrics::Metrics};
+    use fixt::prelude::*;
+    use rand::distributions::Alphanumeric;
+    use test_case::test_case;
+
+    use super::*;
+
+    /// Generate a random valid proxy url.
+    fn random_url(rng: &mut ThreadRng) -> url2::Url2 {
+        let cert_string: String = rng
+            .sample_iter(&Alphanumeric)
+            .take(39)
+            .map(char::from)
+            .collect();
+        let port = rng.gen_range(5000, 6000);
+
+        url2::url2!(
+            "kitsune-proxy://{}mqcw/kitsune-quic/h/localhost/p/{}/-",
+            cert_string,
+            port
+        )
+    }
+
+    /// Tuning params with no delay on recently gossiped to nodes.
+    fn tuning_params_no_delay() -> KitsuneP2pTuningParams {
+        let mut t = tuning_params_struct::KitsuneP2pTuningParams::default();
+        t.gossip_peer_on_success_next_gossip_delay_ms = 0;
+        t.gossip_peer_on_error_next_gossip_delay_ms = 0;
+        Arc::new(t)
+    }
+
+    /// Tuning params with a delay on recently gossiped to nodes.
+    fn tuning_params_delay(success: u32, error: u32) -> KitsuneP2pTuningParams {
+        let mut t = tuning_params_struct::KitsuneP2pTuningParams::default();
+        t.gossip_peer_on_success_next_gossip_delay_ms = success;
+        t.gossip_peer_on_error_next_gossip_delay_ms = error;
+        Arc::new(t)
+    }
+
+    #[test]
+    /// Test that we can find a remote node to sync with
+    /// when there is only one to choose from.
+    fn next_remote_node_sanity() {
+        let agent = Arc::new(fixt!(KitsuneAgent));
+
+        let mut rng = thread_rng();
+
+        // - Create one remote node.
+        let url = random_url(&mut rng);
+        let expected_url = TxUrl::from(url.as_str());
+        let purl = kitsune_p2p_proxy::ProxyUrl::from_full(url.as_str()).unwrap();
+        let expected_tgt = GossipTgt::new(vec![agent], Tx2Cert::from(purl.digest()));
+        let expected_tgt = Node {
+            target: expected_tgt,
+            url: expected_url,
+        };
+        let remote_nodes = vec![expected_tgt.clone()];
+
+        let r = next_remote_node(remote_nodes, &Default::default(), tuning_params_no_delay());
+
+        // - That node is chosen.
+        assert_eq!(r, Some(expected_tgt));
+    }
+
+    /// Test that given N remote nodes we choose the one
+    /// we talked to the least recently.
+    #[test_case(1)]
+    #[test_case(2)]
+    #[test_case(10)]
+    #[test_case(100)]
+    fn next_remote_node_least_recently(n: usize) {
+        let mut rng = thread_rng();
+
+        // - Create N remote nodes.
+        let mut remote_nodes: Vec<_> = (0..n)
+            .map(|_| {
+                let url = random_url(&mut rng);
+                let url = TxUrl::from(url.as_str());
+                let purl = kitsune_p2p_proxy::ProxyUrl::from_full(url.as_str()).unwrap();
+                let target = GossipTgt::new(vec![], Tx2Cert::from(purl.digest()));
+                Node { target, url }
+            })
+            .collect();
+
+        let mut metrics = Metrics::new();
+
+        // - Pop the last node off the list.
+        let last = remote_nodes.pop().unwrap();
+        let cert = last.cert().clone();
+
+        // - Record a successful initiate round for the last node at the earliest time.
+        metrics.record_initiate(cert.clone());
+        metrics.record_success(cert);
+
+        // - Record successful initiate rounds for the rest of the nodes at later times.
+        for node in remote_nodes.iter() {
+            let cert = node.cert().clone();
+            metrics.record_initiate(cert.clone());
+            metrics.record_success(cert);
+        }
+
+        // - Push the last node back into the remote nodes.
+        remote_nodes.push(last);
+
+        let r = next_remote_node(remote_nodes.clone(), &metrics, tuning_params_no_delay());
+
+        // - Expect the last node to be chosen because it was the least recently gossiped with.
+        assert_eq!(r, remote_nodes.last().cloned());
+    }
+
+    /// Test that given N remote nodes we choose the one
+    /// we've never talked to before over all others.
+    #[test_case(1)]
+    #[test_case(2)]
+    #[test_case(10)]
+    #[test_case(100)]
+    fn next_remote_node_never_talked_to(n: usize) {
+        let mut rng = thread_rng();
+
+        // - Create N remote nodes.
+        let mut remote_nodes: Vec<_> = (0..n)
+            .map(|_| {
+                let url = random_url(&mut rng);
+                let url = TxUrl::from(url.as_str());
+                let purl = kitsune_p2p_proxy::ProxyUrl::from_full(url.as_str()).unwrap();
+                let target = GossipTgt::new(vec![], Tx2Cert::from(purl.digest()));
+                Node { target, url }
+            })
+            .collect();
+
+        let mut metrics = Metrics::new();
+
+        // - Pop the last node off the list.
+        let last = remote_nodes.pop().unwrap();
+
+        // - Record successful initiate rounds for the rest of the nodes.
+        for node in remote_nodes.iter() {
+            let cert = node.cert().clone();
+            metrics.record_initiate(cert.clone());
+            metrics.record_success(cert);
+        }
+
+        // - Push the last node back into the remote nodes.
+        remote_nodes.push(last);
+
+        let r = next_remote_node(remote_nodes.clone(), &metrics, tuning_params_no_delay());
+
+        // - Expect the last node to be chosen because it was never gossiped with.
+        assert_eq!(r, remote_nodes.last().cloned());
+    }
+
+    #[test]
+    /// Test we break ties between never talked
+    /// to nodes by randomly choosing one.
+    fn randomly_break_ties() {
+        let mut rng = thread_rng();
+
+        // - Create 100 remote nodes.
+        let mut remote_nodes: Vec<_> = (0..100)
+            .map(|_| {
+                let url = random_url(&mut rng);
+                let url = TxUrl::from(url.as_str());
+                let purl = kitsune_p2p_proxy::ProxyUrl::from_full(url.as_str()).unwrap();
+                let target = GossipTgt::new(vec![], Tx2Cert::from(purl.digest()));
+                Node { target, url }
+            })
+            .collect();
+
+        let mut metrics = Metrics::new();
+
+        // - Pop the last two nodes off the list.
+        let last = remote_nodes.pop().unwrap();
+        let second_last = remote_nodes.pop().unwrap();
+
+        // - Record successful initiate rounds for the rest of the nodes.
+        for node in remote_nodes.iter() {
+            let cert = node.cert().clone();
+            metrics.record_initiate(cert.clone());
+            metrics.record_success(cert);
+        }
+
+        // - Push the last two nodes back into the remote nodes.
+        remote_nodes.push(second_last.clone());
+        remote_nodes.push(last);
+
+        // - Check we don't always get the second last node.
+        // The second last is returned always when not randomly breaking ties.
+        let mut always_the_last = true;
+        for _ in 0..100 {
+            let r =
+                next_remote_node(remote_nodes.clone(), &metrics, tuning_params_no_delay()).unwrap();
+            if r != second_last {
+                always_the_last = false;
+            }
+        }
+        assert!(!always_the_last);
+    }
+
+    /// Test that given N remote nodes we never choose a current round.
+    #[test_case(1)]
+    #[test_case(2)]
+    #[test_case(10)]
+    #[test_case(100)]
+    fn dont_choose_current_rounds(n: usize) {
+        let mut rng = thread_rng();
+
+        // - Create N remote nodes.
+        let mut remote_nodes: Vec<_> = (0..n)
+            .map(|_| {
+                let url = random_url(&mut rng);
+                let url = TxUrl::from(url.as_str());
+                let purl = kitsune_p2p_proxy::ProxyUrl::from_full(url.as_str()).unwrap();
+                let target = GossipTgt::new(vec![], Tx2Cert::from(purl.digest()));
+                Node { target, url }
+            })
+            .collect();
+
+        let mut metrics = Metrics::new();
+
+        // - Pop the last node off the list.
+        let last = remote_nodes.pop().unwrap();
+
+        // - Record remote rounds for the rest of the nodes
+        // but don't record any successes.
+        for node in remote_nodes.iter() {
+            let cert = node.cert().clone();
+            metrics.record_remote_round(cert);
+        }
+
+        let r = next_remote_node(remote_nodes.clone(), &metrics, tuning_params_no_delay());
+
+        // - Without the last node we expect no nodes to be chosen.
+        assert!(r.is_none());
+
+        // - Record the last node as a successful round and push it into the list.
+        let cert = last.cert().clone();
+        metrics.record_initiate(cert.clone());
+        metrics.record_success(cert);
+        remote_nodes.push(last);
+
+        let r = next_remote_node(remote_nodes.clone(), &metrics, tuning_params_no_delay());
+
+        // - Now we expect the last node to be chosen.
+        assert_eq!(r, remote_nodes.last().cloned());
+    }
+
+    #[test]
+    /// Test we don't choose nodes we've seen too recently.
+    fn dont_choose_very_recent_rounds() {
+        let mut rng = thread_rng();
+
+        // - Create 100 remote nodes.
+        let remote_nodes: Vec<_> = (0..100)
+            .map(|_| {
+                let url = random_url(&mut rng);
+                let url = TxUrl::from(url.as_str());
+                let purl = kitsune_p2p_proxy::ProxyUrl::from_full(url.as_str()).unwrap();
+                let target = GossipTgt::new(vec![], Tx2Cert::from(purl.digest()));
+                Node { target, url }
+            })
+            .collect();
+
+        let mut metrics = Metrics::new();
+
+        // - Record successful initiate rounds for the all of the nodes.
+        for node in remote_nodes.iter() {
+            let cert = node.cert().clone();
+            metrics.record_initiate(cert.clone());
+            metrics.record_success(cert);
+        }
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(1000 * 60, 0),
+        );
+
+        // - Expect no nodes to be chosen.
+        assert!(r.is_none());
+
+        // - Use up 10 ms.
+        std::thread::sleep(Duration::from_millis(10));
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(1000 * 60, 0),
+        );
+
+        // - Still no result.
+        assert!(r.is_none());
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a 9 ms after the successful round.
+            tuning_params_delay(9, 0),
+        );
+
+        // - Now we should get a result.
+        assert!(r.is_some());
+
+        // - Record error outcomes for every node.
+        for node in remote_nodes.iter() {
+            let cert = node.cert().clone();
+            metrics.record_initiate(cert.clone());
+            metrics.record_error(cert);
+        }
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(0, 1000 * 60),
+        );
+
+        // - Expect no nodes to be chosen.
+        assert!(r.is_none());
+
+        // - Use up 10ms.
+        std::thread::sleep(Duration::from_millis(10));
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(0, 1000 * 60),
+        );
+
+        // - Still no result.
+        assert!(r.is_none());
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a 9 ms after an error round.
+            tuning_params_delay(1000 * 60, 9),
+        );
+
+        // - Now we should get a result.
+        assert!(r.is_some());
+    }
+
+    /// Test that given N remote nodes and a force initiate trigger
+    /// we will choose the least recent node even if it's too recent.
+    #[test_case(1)]
+    #[test_case(2)]
+    #[test_case(10)]
+    #[test_case(100)]
+    fn force_initiate(n: usize) {
+        let mut rng = thread_rng();
+
+        // - Create N remote nodes.
+        let mut remote_nodes: Vec<_> = (0..n)
+            .map(|_| {
+                let url = random_url(&mut rng);
+                let url = TxUrl::from(url.as_str());
+                let purl = kitsune_p2p_proxy::ProxyUrl::from_full(url.as_str()).unwrap();
+                let target = GossipTgt::new(vec![], Tx2Cert::from(purl.digest()));
+                Node { target, url }
+            })
+            .collect();
+
+        let mut metrics = Metrics::new();
+
+        // - Pop the last node off the list.
+        let last = remote_nodes.pop().unwrap();
+        let cert = last.cert().clone();
+
+        // - Record a successful initiate round for the last node before the other nodes.
+        metrics.record_initiate(cert.clone());
+        metrics.record_success(cert);
+
+        // - Record successful initiate rounds for the rest of the nodes.
+        for node in remote_nodes.iter() {
+            let cert = node.cert().clone();
+            metrics.record_initiate(cert.clone());
+            metrics.record_success(cert);
+        }
+
+        // - Push the last node back on the list.
+        remote_nodes.push(last);
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(1000 * 60, 0),
+        );
+
+        // - Expect no nodes to be chosen.
+        assert!(r.is_none());
+
+        // - First force initiate.
+        metrics.record_force_initiate();
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(1000 * 60, 0),
+        );
+
+        // - Expect the last node to be chosen because it was successfully gossiped
+        // with the lest recently and we are force initiating.
+        assert_eq!(r, remote_nodes.last().cloned());
+
+        // - Record this successful initiate round.
+        let cert = remote_nodes.last().unwrap().cert().clone();
+        metrics.record_initiate(cert.clone());
+        metrics.record_success(cert);
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(1000 * 60, 0),
+        );
+
+        // - Now the first node is the least recently gossiped with.
+        assert_eq!(r, remote_nodes.first().cloned());
+
+        // - Record this successful initiate round.
+        let cert = remote_nodes.first().unwrap().cert().clone();
+        metrics.record_initiate(cert.clone());
+        metrics.record_success(cert);
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(1000 * 60, 0),
+        );
+        // - Force initiate only forces 2 nodes so now we expect no nodes
+        // to be chosen because they are all more recent then the tuning params delay.
+        assert!(r.is_none());
+
+        // - Second force initiate.
+        metrics.record_force_initiate();
+
+        // Helper function to get the next expected node.
+        let expected_node = |i| {
+            match n {
+                // - Only one node so the first will always be chosen.
+                1 => remote_nodes.first(),
+                // Two nodes so it will alternate between the first and last.
+                2 => {
+                    if i % 2 == 0 {
+                        remote_nodes.first()
+                    } else {
+                        remote_nodes.last()
+                    }
+                }
+                // All other tests will climb in the order they recorded success.
+                _ => remote_nodes.get(i),
+            }
+        };
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(1000 * 60, 0),
+        );
+
+        // - Now we expect node 1 to be chosen (unless there is only one node).
+        assert_eq!(r, expected_node(1).cloned());
+
+        // - Record the successful initiate round for this node.
+        let node = expected_node(1).unwrap();
+        let cert = node.cert().clone();
+        metrics.record_initiate(cert.clone());
+        metrics.record_success(cert);
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(1000 * 60, 0),
+        );
+
+        // - Now we expect node 2 to be chosen (unless there is only one node).
+        assert_eq!(r, expected_node(2).cloned());
+
+        // - Record the successful initiate round for this node.
+        let node = expected_node(2).unwrap();
+        let cert = node.cert().clone();
+        metrics.record_initiate(cert.clone());
+        metrics.record_success(cert);
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(1000 * 60, 0),
+        );
+
+        // - We expect no nodes to be chosen because the forced initiate has run out.
+        assert!(r.is_none());
+
+        // - Third force initiate.
+        metrics.record_force_initiate();
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(1000 * 60, 0),
+        );
+
+        // - Now we expect node 3 to be chosen (unless there is only one or two nodes).
+        assert_eq!(r, expected_node(3).cloned());
+
+        // - Record the successful initiate round for this node.
+        let node = expected_node(3).unwrap();
+        let cert = node.cert().clone();
+        metrics.record_initiate(cert.clone());
+        metrics.record_success(cert);
+
+        // - Forth force initiate overlaps with third so it resets.
+        metrics.record_force_initiate();
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(1000 * 60, 0),
+        );
+
+        // - Now we expect node 4 to be chosen (unless there is only one or two nodes).
+        assert_eq!(r, expected_node(4).cloned());
+
+        // - Record the successful initiate round for this node.
+        let node = expected_node(4).unwrap();
+        let cert = node.cert().clone();
+        metrics.record_initiate(cert.clone());
+        metrics.record_success(cert);
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(1000 * 60, 0),
+        );
+
+        // - We expect the 5 node to be chosen because the forced initiate was reset.
+        assert_eq!(r, expected_node(5).cloned());
+
+        // - Record the successful initiate round for this node.
+        let node = expected_node(5).unwrap();
+        let cert = node.cert().clone();
+        metrics.record_initiate(cert.clone());
+        metrics.record_success(cert);
+
+        let r = next_remote_node(
+            remote_nodes.clone(),
+            &metrics,
+            // - Set the tuning params to a delay in the future.
+            tuning_params_delay(1000 * 60, 0),
+        );
+
+        // - Now the reset has run out we get no nodes.
+        assert!(r.is_none());
+    }
+}

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/store.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/store.rs
@@ -4,8 +4,8 @@
 use std::{collections::HashSet, ops::Range, sync::Arc};
 
 use crate::event::{
-    FetchOpDataEvt, GetAgentInfoSignedEvt, PutAgentInfoSignedEvt, QueryAgentInfoSignedEvt,
-    QueryGossipAgentsEvt, QueryOpHashesEvt, TimeWindowMs,
+    FetchOpDataEvt, PutAgentInfoSignedEvt, QueryAgentInfoSignedEvt, QueryGossipAgentsEvt,
+    QueryOpHashesEvt, TimeWindowMs,
 };
 use crate::types::event::KitsuneP2pEventSender;
 use kitsune_p2p_types::{
@@ -26,21 +26,6 @@ pub(super) async fn all_agent_info(
         .query_agent_info_signed(QueryAgentInfoSignedEvt {
             space: space.clone(),
             agents: None,
-        })
-        .await
-        .map_err(KitsuneError::other)?)
-}
-
-/// Get a single agent info.
-pub(super) async fn get_agent_info(
-    evt_sender: &EventSender,
-    space: &Arc<KitsuneSpace>,
-    agent: &Arc<KitsuneAgent>,
-) -> KitsuneResult<Option<AgentInfoSigned>> {
-    Ok(evt_sender
-        .get_agent_info_signed(GetAgentInfoSignedEvt {
-            space: space.clone(),
-            agent: agent.clone(),
         })
         .await
         .map_err(KitsuneError::other)?)

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/gossip.rs
@@ -87,9 +87,9 @@ pub struct GossipTgt {
     /// In the current full-sync case, it makes sense to address gossip to all
     /// known agents on a node, but after sharding, we may make this a single
     /// agent target.
-    agents: Vec<Arc<KitsuneAgent>>,
+    pub agents: Vec<Arc<KitsuneAgent>>,
     /// The cert which represents the remote node to talk to.
-    cert: Tx2Cert,
+    pub cert: Tx2Cert,
 }
 
 impl GossipTgt {


### PR DESCRIPTION
This refactors and tests the in memory metrics for the gossip module.
This is not the same as the metrics database although we probably will flush from this in memory to the database in a future pr.
The aim of the in memory metrics is to help the gossip module make the better choices when choosing the next node to gossip with.
This is definitely easier to understand then before and much easier to test.
It also appears to be faster because there are less poor choices that result in gossip rounds with node data exchanged although I will confirm this in a future PR.