### PR TITLE
create a release from branch release-20210825.101130

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,61 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # \[Unreleased\]
 
+# 20210825.101130
+
+## [holochain-0.0.104](crates/holochain/CHANGELOG.md#0.0.104)
+
+- Updates lair to 0.0.4 which pins rcgen to 0.8.11 to work around [https://github.com/est31/rcgen/issues/63](https://github.com/est31/rcgen/issues/63)
+
+## [holochain\_test\_wasm\_common-0.0.4](crates/holochain_test_wasm_common/CHANGELOG.md#0.0.4)
+
+## [holochain\_cascade-0.0.4](crates/holochain_cascade/CHANGELOG.md#0.0.4)
+
+## [holochain\_cli-0.0.5](crates/holochain_cli/CHANGELOG.md#0.0.5)
+
+## [holochain\_cli\_sandbox-0.0.5](crates/holochain_cli_sandbox/CHANGELOG.md#0.0.5)
+
+## [holochain\_websocket-0.0.4](crates/holochain_websocket/CHANGELOG.md#0.0.4)
+
+## [holochain\_conductor\_api-0.0.4](crates/holochain_conductor_api/CHANGELOG.md#0.0.4)
+
+## [holochain\_state-0.0.4](crates/holochain_state/CHANGELOG.md#0.0.4)
+
+## [holochain\_wasm\_test\_utils-0.0.4](crates/holochain_wasm_test_utils/CHANGELOG.md#0.0.4)
+
+## [holochain\_p2p-0.0.4](crates/holochain_p2p/CHANGELOG.md#0.0.4)
+
+## [holochain\_cli\_bundle-0.0.4](crates/holochain_cli_bundle/CHANGELOG.md#0.0.4)
+
+## [holochain\_types-0.0.4](crates/holochain_types/CHANGELOG.md#0.0.4)
+
+## [holochain\_keystore-0.0.4](crates/holochain_keystore/CHANGELOG.md#0.0.4)
+
+## [holochain\_sqlite-0.0.4](crates/holochain_sqlite/CHANGELOG.md#0.0.4)
+
+## [kitsune\_p2p-0.0.4](crates/kitsune_p2p/CHANGELOG.md#0.0.4)
+
+## [kitsune\_p2p\_proxy-0.0.4](crates/kitsune_p2p_proxy/CHANGELOG.md#0.0.4)
+
+## [kitsune\_p2p\_transport\_quic-0.0.4](crates/kitsune_p2p_transport_quic/CHANGELOG.md#0.0.4)
+
+## [kitsune\_p2p\_types-0.0.4](crates/kitsune_p2p_types/CHANGELOG.md#0.0.4)
+
+## [hdk-0.0.104](crates/hdk/CHANGELOG.md#0.0.104)
+
+## [hdk\_derive-0.0.6](crates/hdk_derive/CHANGELOG.md#0.0.6)
+
+## [holochain\_zome\_types-0.0.6](crates/holochain_zome_types/CHANGELOG.md#0.0.6)
+
+### Changed
+
+- `CreateInput`, `DeleteInput`, `DeleteLinkInput` structs invented for zome io
+- `EntryDefId` merged into `CreateInput`
+
+### Added
+
+- `ChainTopOrdering` enum added to define chain top ordering behaviour on write
+
 # 20210817.185301
 
 ## [holochain-0.0.103](crates/holochain/CHANGELOG.md#0.0.103)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.0.103"
+version = "0.0.104"
 dependencies = [
  "fixt",
  "hdk_derive",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "holochain_zome_types",
  "paste",
@@ -2369,7 +2369,7 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.0.104-dev.0"
+version = "0.0.104"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli"
-version = "0.0.5-dev.0"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "futures",
@@ -2497,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_bundle"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_sandbox"
-version = "0.0.5-dev.0"
+version = "0.0.5"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 dependencies = [
  "derive_more",
  "directories 2.0.2",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 dependencies = [
  "ghost_actor 0.3.0-alpha.3",
  "holo_hash",
@@ -2588,7 +2588,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_p2p"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 dependencies = [
  "async-trait",
  "fixt",
@@ -2639,7 +2639,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "hdk",
  "serde",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_test_utils"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 dependencies = [
  "fixt",
  "holo_hash",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 dependencies = [
  "criterion",
  "futures",
@@ -2883,7 +2883,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -3227,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 dependencies = [
  "arbitrary",
  "arrayref",
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_proxy"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_transport_quic"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 dependencies = [
  "blake2b_simd",
  "futures",
@@ -3407,7 +3407,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_types"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 dependencies = [
  "arbitrary",
  "base64",

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.0.5
+
 ## 0.0.4
 
 ## 0.0.3

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli"
-version = "0.0.5-dev.0"
+version = "0.0.5"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://github.com/holochain/holochain"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
@@ -21,8 +21,8 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0"
 futures = "0.3"
-holochain_cli_bundle = { path = "../hc_bundle", version = "0.0.4-dev.0"}
-holochain_cli_sandbox = { path = "../hc_sandbox", version = "0.0.5-dev.0"}
+holochain_cli_bundle = { path = "../hc_bundle", version = "0.0.4"}
+holochain_cli_sandbox = { path = "../hc_sandbox", version = "0.0.5"}
 observability = "0.1.3"
 structopt = "0.3"
 tokio = { version = "1.3", features = [ "full" ] }

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 ## 0.0.2

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_bundle"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 description = "DNA and hApp bundling functionality for the `hc` Holochain CLI utility"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -22,7 +22,7 @@ path = "src/bin/hc-dna.rs"
 anyhow = "1.0"
 holochain_util = { path = "../holochain_util", features = ["backtrace"], version = "0.0.3"}
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "0.0.4-dev.0", path = "../holochain_types" }
+holochain_types = { version = "0.0.4", path = "../holochain_types" }
 mr_bundle = {version = "0.0.3", path = "../mr_bundle"}
 serde = { version = "1.0", features = [ "derive" ] }
 serde_bytes = "0.11"

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.5
+
 ## 0.0.4
 
 ## 0.0.3

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_sandbox"
-version = "0.0.5-dev.0"
+version = "0.0.5"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://github.com/holochain/holochain"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
@@ -20,11 +20,11 @@ ansi_term = "0.12"
 chrono = "0.4.6"
 futures = "0.3"
 lazy_static = "1.4.0"
-holochain_cli_bundle = { path = "../hc_bundle", version = "0.0.4-dev.0"}
-holochain_conductor_api = { path = "../holochain_conductor_api", version = "0.0.4-dev.0"}
-holochain_types = { path = "../holochain_types", version = "0.0.4-dev.0"}
-holochain_websocket = { path = "../holochain_websocket", version = "0.0.4-dev.0"}
-holochain_p2p = { path = "../holochain_p2p", version = "0.0.4-dev.0"}
+holochain_cli_bundle = { path = "../hc_bundle", version = "0.0.4"}
+holochain_conductor_api = { path = "../holochain_conductor_api", version = "0.0.4"}
+holochain_types = { path = "../holochain_types", version = "0.0.4"}
+holochain_websocket = { path = "../holochain_websocket", version = "0.0.4"}
+holochain_p2p = { path = "../holochain_p2p", version = "0.0.4"}
 nanoid = "0.3"
 observability = "0.1.3"
 serde_yaml = "0.8"

--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/holochain/holochain/compare/hdk-v0.0.100...HEAD)
 
+## 0.0.104
+
 ## 0.0.103
 
 ### Changed

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk"
-version = "0.0.103"
+version = "0.0.104"
 description = "The Holochain HDK"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain/tree/develop/crates/hdk"
@@ -21,12 +21,12 @@ fixturators = [ "holochain_zome_types/fixturators", "holo_hash/fixturators" ]
 test_utils = [ "fixturators", "holochain_zome_types/test_utils", "holo_hash/test_utils" ]
 
 [dependencies]
-hdk_derive = { version = "0.0.5", path = "../hdk_derive" }
+hdk_derive = { version = "0.0.6", path = "../hdk_derive" }
 holo_hash = { version = "0.0.5", path = "../holo_hash", default-features = false }
 holochain_wasmer_guest = "=0.0.73"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
-holochain_zome_types = { version = "0.0.5", path = "../holochain_zome_types", default-features = false }
+holochain_zome_types = { version = "0.0.6", path = "../holochain_zome_types", default-features = false }
 paste = "=1.0.5"
 serde = "1.0"
 serde_bytes = "0.11"

--- a/crates/hdk_derive/CHANGELOG.md
+++ b/crates/hdk_derive/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.6
+
 ## 0.0.5
 
 ## 0.0.4

--- a/crates/hdk_derive/Cargo.toml
+++ b/crates/hdk_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk_derive"
-version = "0.0.5"
+version = "0.0.6"
 description = "derive macros for the holochain hdk"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -20,7 +20,7 @@ proc-macro2 = "1"
 paste = "=1.0.5"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdk, to reduce code bloat
-holochain_zome_types = { version = "0.0.5", path = "../holochain_zome_types", default-features = false }
+holochain_zome_types = { version = "0.0.6", path = "../holochain_zome_types", default-features = false }
 
 [features]
 default = []

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.0.104
+
 - Updates lair to 0.0.4 which pins rcgen to 0.8.11 to work around [https://github.com/est31/rcgen/issues/63](https://github.com/est31/rcgen/issues/63)
 
 ## 0.0.103

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain"
-version = "0.0.104-dev.0"
+version = "0.0.104"
 description = "Holochain, a framework for distributed applications"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -23,20 +23,20 @@ fixt = { version = "0.0.5", path = "../fixt" }
 futures = "0.3.1"
 ghost_actor = "0.3.0-alpha.3"
 holo_hash = { version = "0.0.5", path = "../holo_hash", features = ["full"] }
-holochain_cascade = { version = "0.0.4-dev.0", path = "../holochain_cascade" }
-holochain_conductor_api = { version = "0.0.4-dev.0", path = "../holochain_conductor_api" }
-holochain_keystore = { version = "0.0.4-dev.0", path = "../holochain_keystore" }
-holochain_p2p = { version = "0.0.4-dev.0", path = "../holochain_p2p" }
-holochain_sqlite = { version = "0.0.4-dev.0", path = "../holochain_sqlite" }
+holochain_cascade = { version = "0.0.4", path = "../holochain_cascade" }
+holochain_conductor_api = { version = "0.0.4", path = "../holochain_conductor_api" }
+holochain_keystore = { version = "0.0.4", path = "../holochain_keystore" }
+holochain_p2p = { version = "0.0.4", path = "../holochain_p2p" }
+holochain_sqlite = { version = "0.0.4", path = "../holochain_sqlite" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_state = { version = "0.0.4-dev.0", path = "../holochain_state" }
-holochain_types = { version = "0.0.4-dev.0", path = "../holochain_types" }
+holochain_state = { version = "0.0.4", path = "../holochain_state" }
+holochain_types = { version = "0.0.4", path = "../holochain_types" }
 holochain_wasmer_host = "=0.0.73"
-holochain_websocket = { version = "0.0.4-dev.0", path = "../holochain_websocket" }
-holochain_zome_types = { version = "0.0.5", path = "../holochain_zome_types" }
+holochain_websocket = { version = "0.0.4", path = "../holochain_websocket" }
+holochain_zome_types = { version = "0.0.6", path = "../holochain_zome_types" }
 human-panic = "1.0.3"
-kitsune_p2p = { version = "0.0.4-dev.0", path = "../kitsune_p2p/kitsune_p2p" }
-kitsune_p2p_types = { version = "0.0.4-dev.0", path = "../kitsune_p2p/types" }
+kitsune_p2p = { version = "0.0.4", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p_types = { version = "0.0.4", path = "../kitsune_p2p/types" }
 lazy_static = "1.4.0"
 mockall = "0.10.2"
 mr_bundle = { version = "0.0.3", path = "../mr_bundle" }
@@ -71,12 +71,12 @@ url2 = "0.0.6"
 url_serde = "0.2.0"
 uuid = { version = "0.7", features = [ "serde", "v4" ] }
 xsalsa20poly1305 = "0.6.0"
-holochain_wasm_test_utils = { version = "0.0.4-dev.0", path = "../test_utils/wasm" }
+holochain_wasm_test_utils = { version = "0.0.4", path = "../test_utils/wasm" }
 
 # Dependencies for test_utils: keep in sync with below
-hdk = { version = "0.0.103", path = "../hdk", optional = true }
+hdk = { version = "0.0.104", path = "../hdk", optional = true }
 matches = {version = "0.1.8", optional = true }
-holochain_test_wasm_common = { version = "0.0.3", path = "../test_utils/wasm_common", optional = true  }
+holochain_test_wasm_common = { version = "0.0.4", path = "../test_utils/wasm_common", optional = true  }
 unwrap_to = { version = "0.1.0", optional = true }
 itertools = { version = "0.10", optional = true }
 
@@ -94,9 +94,9 @@ serial_test = "0.4.0"
 test-case = "1.0.0"
 
 # Dependencies for test_utils: keep in sync with above
-hdk = { version = "0.0.103", path = "../hdk", optional = false }
+hdk = { version = "0.0.104", path = "../hdk", optional = false }
 matches = {version = "0.1.8", optional = false }
-holochain_test_wasm_common = { version = "0.0.3", path = "../test_utils/wasm_common", optional = false  }
+holochain_test_wasm_common = { version = "0.0.4", path = "../test_utils/wasm_common", optional = false  }
 unwrap_to = { version = "0.1.0", optional = false }
 arbitrary = { version = "1.0", features = ["derive"] }
 

--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 ## 0.0.2

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cascade"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 description = "Logic for cascading updates to Holochain state and network interaction"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -15,17 +15,17 @@ fallible-iterator = "0.2"
 fixt = { version = "0.0.5", path = "../fixt" }
 futures = "0.3"
 ghost_actor = "=0.3.0-alpha.3"
-hdk = { version = "0.0.103", path = "../hdk" }
-hdk_derive = { version = "0.0.5", path = "../hdk_derive" }
+hdk = { version = "0.0.104", path = "../hdk" }
+hdk_derive = { version = "0.0.6", path = "../hdk_derive" }
 holo_hash = { version = "0.0.5", path = "../holo_hash", features = ["full"] }
-holochain_sqlite = { version = "0.0.4-dev.0", path = "../holochain_sqlite" }
-holochain_p2p = { version = "0.0.4-dev.0", path = "../holochain_p2p" }
+holochain_sqlite = { version = "0.0.4", path = "../holochain_sqlite" }
+holochain_p2p = { version = "0.0.4", path = "../holochain_p2p" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_state = { version = "0.0.4-dev.0", path = "../holochain_state" }
-holochain_types = { version = "0.0.4-dev.0", path = "../holochain_types" }
-holochain_zome_types = { version = "0.0.5", path = "../holochain_zome_types" }
+holochain_state = { version = "0.0.4", path = "../holochain_state" }
+holochain_types = { version = "0.0.4", path = "../holochain_types" }
+holochain_zome_types = { version = "0.0.6", path = "../holochain_zome_types" }
 observability = "0.1.3"
-kitsune_p2p = { version = "0.0.4-dev.0", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "0.0.4", path = "../kitsune_p2p/kitsune_p2p" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 tokio = { version = "1.3", features = [ "full" ] }

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 - BREAKING: CONDUCTOR CONFIG CHANGE–related to update to lair 0.0.3

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_conductor_api"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 description = "Message types for Holochain admin and app interface protocols"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -11,13 +11,13 @@ edition = "2018"
 [dependencies]
 directories = "2.0.2"
 derive_more = "0.99.3"
-kitsune_p2p = { version = "0.0.4-dev.0", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "0.0.4", path = "../kitsune_p2p/kitsune_p2p" }
 holo_hash = { version = "0.0.5", path = "../holo_hash", features = ["full"] }
-holochain_p2p = { version = "0.0.4-dev.0", path = "../holochain_p2p" }
-holochain_state = { version = "0.0.4-dev.0", path = "../holochain_state" }
+holochain_p2p = { version = "0.0.4", path = "../holochain_p2p" }
+holochain_state = { version = "0.0.4", path = "../holochain_state" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "0.0.4-dev.0", path = "../holochain_types" }
-holochain_zome_types = { version = "0.0.5", path = "../holochain_zome_types" }
+holochain_types = { version = "0.0.4", path = "../holochain_types" }
+holochain_zome_types = { version = "0.0.6", path = "../holochain_zome_types" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_yaml = "0.8"

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 - Updated to lair 0.0.3

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_keystore"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 description = "keystore for libsodium keypairs"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -14,7 +14,7 @@ edition = "2018"
 ghost_actor = "=0.3.0-alpha.3"
 holo_hash = { version = "0.0.5", path = "../holo_hash", features = ["full"] }
 holochain_serialized_bytes = "=0.0.51"
-holochain_zome_types = { path = "../holochain_zome_types", version = "0.0.5"}
+holochain_zome_types = { path = "../holochain_zome_types", version = "0.0.6"}
 lair_keystore_api = "=0.0.4"
 lair_keystore_client = "=0.0.4"
 serde = { version = "1.0", features = [ "derive" ] }
@@ -26,4 +26,4 @@ tracing = "0.1"
 
 # This is a redundant dependency.
 # It's included only to set the proper feature flag for database encryption.
-holochain_sqlite = { version = "0.0.4-dev.0", path = "../holochain_sqlite" }
+holochain_sqlite = { version = "0.0.4", path = "../holochain_sqlite" }

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 ## 0.0.2

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_p2p"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 description = "holochain specific wrapper around more generic p2p module"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -16,12 +16,12 @@ fixt = { path = "../fixt", version = "0.0.5"}
 futures = "0.3"
 ghost_actor = "=0.3.0-alpha.3"
 holo_hash = { version = "0.0.5", path = "../holo_hash" }
-holochain_keystore = { version = "0.0.4-dev.0", path = "../holochain_keystore" }
+holochain_keystore = { version = "0.0.4", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "0.0.4-dev.0", path = "../holochain_types" }
-holochain_zome_types = { version = "0.0.5", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "0.0.4-dev.0", path = "../kitsune_p2p/kitsune_p2p" }
-kitsune_p2p_types = { version = "0.0.4-dev.0", path = "../kitsune_p2p/types" }
+holochain_types = { version = "0.0.4", path = "../holochain_types" }
+holochain_zome_types = { version = "0.0.6", path = "../holochain_zome_types" }
+kitsune_p2p = { version = "0.0.4", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p_types = { version = "0.0.4", path = "../kitsune_p2p/types" }
 mockall = "0.10.2"
 observability = "0.1.3"
 serde = { version = "1.0", features = [ "derive" ] }

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 ## 0.0.2

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_sqlite"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 description = "Abstractions for persistence of Holochain state via SQLite"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -22,8 +22,8 @@ fixt = { version = "0.0.5", path = "../fixt" }
 futures = "0.3.1"
 holo_hash = { path = "../holo_hash", features = ["rusqlite"], version = "0.0.5"}
 holochain_serialized_bytes = "=0.0.51"
-holochain_zome_types = { version = "0.0.5", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "0.0.4-dev.0", path = "../kitsune_p2p/kitsune_p2p" }
+holochain_zome_types = { version = "0.0.6", path = "../holochain_zome_types" }
+kitsune_p2p = { version = "0.0.4", path = "../kitsune_p2p/kitsune_p2p" }
 lazy_static = "1.4.0"
 once_cell = "1.4.1"
 must_future = "0.1.1"

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 ## 0.0.2

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_state"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 description = "TODO minimize deps"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -13,17 +13,17 @@ byteorder = "1.3.4"
 chrono = "0.4.6"
 derive_more = "0.99.3"
 either = "1.5"
-holochain_sqlite = { version = "0.0.4-dev.0", path = "../holochain_sqlite" }
+holochain_sqlite = { version = "0.0.4", path = "../holochain_sqlite" }
 holo_hash = { version = "0.0.5", path = "../holo_hash", features = ["full"] }
 fallible-iterator = "0.2.0"
-holochain_keystore = { version = "0.0.4-dev.0", path = "../holochain_keystore" }
+holochain_keystore = { version = "0.0.4", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_p2p = { version = "0.0.4-dev.0", path = "../holochain_p2p" }
-holochain_types = { version = "0.0.4-dev.0", path = "../holochain_types" }
+holochain_p2p = { version = "0.0.4", path = "../holochain_p2p" }
+holochain_types = { version = "0.0.4", path = "../holochain_types" }
 holochain_util = { version = "0.0.3", path = "../holochain_util" }
-holochain_wasm_test_utils = { path = "../test_utils/wasm", optional = true, version = "0.0.4-dev.0"}
-holochain_zome_types = { version = "0.0.5", path = "../holochain_zome_types", features = [ "full" ] }
-kitsune_p2p = { version = "0.0.4-dev.0", path = "../kitsune_p2p/kitsune_p2p" }
+holochain_wasm_test_utils = { path = "../test_utils/wasm", optional = true, version = "0.0.4"}
+holochain_zome_types = { version = "0.0.6", path = "../holochain_zome_types", features = [ "full" ] }
+kitsune_p2p = { version = "0.0.4", path = "../kitsune_p2p/kitsune_p2p" }
 mockall = "0.10.2"
 parking_lot = "0.10"
 shrinkwraprs = "0.3.0"
@@ -43,8 +43,8 @@ contrafact = { version = "0.1.0-dev.1", optional = true }
 [dev-dependencies]
 anyhow = "1.0.26"
 fixt = { version = "0.0.5", path = "../fixt" }
-hdk = { version = "0.0.103", path = "../hdk" }
-holochain_wasm_test_utils = { path = "../test_utils/wasm", version = "0.0.4-dev.0"}
+hdk = { version = "0.0.104", path = "../hdk" }
+holochain_wasm_test_utils = { path = "../test_utils/wasm", version = "0.0.4"}
 matches = "0.1.8"
 observability = "0.1.3"
 pretty_assertions = "0.6.1"

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 ## 0.0.2

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_types"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 description = "Holochain common types"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -25,10 +25,10 @@ fixt = { path = "../fixt", version = "0.0.5"}
 flate2 = "1.0.14"
 futures = "0.3"
 holo_hash = { version = "0.0.5", path = "../holo_hash", features = ["string-encoding"] }
-holochain_keystore = { version = "0.0.4-dev.0", path = "../holochain_keystore" }
+holochain_keystore = { version = "0.0.4", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_sqlite = { path = "../holochain_sqlite", version = "0.0.4-dev.0"}
-holochain_zome_types = { path = "../holochain_zome_types", version = "0.0.5"}
+holochain_sqlite = { path = "../holochain_sqlite", version = "0.0.4"}
+holochain_zome_types = { path = "../holochain_zome_types", version = "0.0.6"}
 itertools = { version = "0.10" }
 lazy_static = "1.4.0"
 mockall = "0.10.2"

--- a/crates/holochain_websocket/CHANGELOG.md
+++ b/crates/holochain_websocket/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 ## 0.0.2

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_websocket"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 description = "Holochain utilities for serving and connection with websockets"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -28,7 +28,7 @@ tungstenite = "0.12"
 url2 = "0.0.6"
 
 [dev-dependencies]
-holochain_types = { version = "0.0.4-dev.0", path = "../holochain_types" }
+holochain_types = { version = "0.0.4", path = "../holochain_types" }
 linefeed = "0.6"
 unwrap_to = "0.1.0"
 observability = "0.1.3"

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/holochain/holochain/holochain_zome_types-v0.0.2-alpha.1...HEAD)
 
+## 0.0.6
+
 ### Changed
 
 - `CreateInput`, `DeleteInput`, `DeleteLinkInput` structs invented for zome io

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_zome_types"
-version = "0.0.5"
+version = "0.0.6"
 description = "Holochain zome types"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/bootstrap/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.15"
-kitsune_p2p_types = { version = "0.0.4-dev.0", path = "../types" }
+kitsune_p2p_types = { version = "0.0.4", path = "../types" }
 once_cell = "1.7.2"
 parking_lot = "0.11"
 rand = "0.7"
@@ -26,7 +26,7 @@ tokio = { version = "1", features = ["full"] }
 warp = "0.3"
 
 [dev-dependencies]
-kitsune_p2p = { version = "0.0.4-dev.0", path = "../kitsune_p2p" }
+kitsune_p2p = { version = "0.0.4", path = "../kitsune_p2p" }
 fixt = { path = "../../fixt" ,version = "0.0.5"}
 criterion = "0.3"
 reqwest = "0.11.2"

--- a/crates/kitsune_p2p/direct/Cargo.toml
+++ b/crates/kitsune_p2p/direct/Cargo.toml
@@ -19,10 +19,10 @@ hyper = { version = "0.14", features = ["server","http1","http2","tcp"] }
 if-addrs = "0.6"
 kitsune_p2p_bootstrap = { version = "0.0.1", path = "../bootstrap" }
 kitsune_p2p_direct_api = { version = "0.0.1", path = "../direct_api" }
-kitsune_p2p_types = { version = "0.0.4-dev.0", path = "../types" }
-kitsune_p2p = { version = "0.0.4-dev.0", path = "../kitsune_p2p" }
-kitsune_p2p_transport_quic = { version = "0.0.4-dev.0", path = "../transport_quic" }
-kitsune_p2p_proxy = { version = "0.0.4-dev.0", path = "../proxy" }
+kitsune_p2p_types = { version = "0.0.4", path = "../types" }
+kitsune_p2p = { version = "0.0.4", path = "../kitsune_p2p" }
+kitsune_p2p_transport_quic = { version = "0.0.4", path = "../transport_quic" }
+kitsune_p2p_proxy = { version = "0.0.4", path = "../proxy" }
 rand = "0.8.3"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/crates/kitsune_p2p/direct_test/Cargo.toml
+++ b/crates/kitsune_p2p/direct_test/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 
 [dependencies]
 kitsune_p2p_direct = { version = "0.0.1", path = "../direct" }
-kitsune_p2p_transport_quic = { version = "0.0.4-dev.0", path = "../transport_quic" }
-kitsune_p2p_proxy = { version = "0.0.4-dev.0", path = "../proxy" }
+kitsune_p2p_transport_quic = { version = "0.0.4", path = "../transport_quic" }
+kitsune_p2p_proxy = { version = "0.0.4", path = "../proxy" }
 rand = "0.8.4"
 structopt = "0.3.21"
 tokio = { version = "1.5", features = ["full"] }

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 ## 0.0.2

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 description = "p2p / dht communication framework"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -20,9 +20,9 @@ ghost_actor = "=0.3.0-alpha.3"
 governor = "0.3.2"
 itertools = "0.10"
 kitsune_p2p_mdns = { version = "0.0.1", path = "../mdns" }
-kitsune_p2p_types = { version = "0.0.4-dev.0", path = "../types" }
-kitsune_p2p_proxy = { version = "0.0.4-dev.0", path = "../proxy" }
-kitsune_p2p_transport_quic = { version = "0.0.4-dev.0", path = "../transport_quic" }
+kitsune_p2p_types = { version = "0.0.4", path = "../types" }
+kitsune_p2p_proxy = { version = "0.0.4", path = "../proxy" }
+kitsune_p2p_transport_quic = { version = "0.0.4", path = "../transport_quic" }
 lair_keystore_api = "=0.0.4"
 mockall = { version = "0.10.2", optional = true }
 parking_lot = "0.11.1"

--- a/crates/kitsune_p2p/proxy/CHANGELOG.md
+++ b/crates/kitsune_p2p/proxy/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 ## 0.0.2

--- a/crates/kitsune_p2p/proxy/Cargo.toml
+++ b/crates/kitsune_p2p/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_proxy"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 description = "Proxy transport module for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -15,8 +15,8 @@ base64 = "0.13"
 blake2b_simd = "0.5.10"
 derive_more = "0.99.7"
 futures = "0.3"
-kitsune_p2p_types = { version = "0.0.4-dev.0", path = "../types" }
-kitsune_p2p_transport_quic = { version = "0.0.4-dev.0", path = "../transport_quic" }
+kitsune_p2p_types = { version = "0.0.4", path = "../types" }
+kitsune_p2p_transport_quic = { version = "0.0.4", path = "../transport_quic" }
 lair_keystore_api = "=0.0.4"
 nanoid = "0.3"
 observability = "0.1.3"

--- a/crates/kitsune_p2p/transport_quic/CHANGELOG.md
+++ b/crates/kitsune_p2p/transport_quic/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 ## 0.0.2

--- a/crates/kitsune_p2p/transport_quic/Cargo.toml
+++ b/crates/kitsune_p2p/transport_quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_transport_quic"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 description = "QUIC transport module for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -14,7 +14,7 @@ edition = "2018"
 blake2b_simd = "0.5.10"
 futures = "0.3"
 if-addrs = "0.6"
-kitsune_p2p_types = { version = "0.0.4-dev.0", path = "../types" }
+kitsune_p2p_types = { version = "0.0.4", path = "../types" }
 lair_keystore_api = "=0.0.4"
 nanoid = "0.3"
 once_cell = "1.5.2"

--- a/crates/kitsune_p2p/types/CHANGELOG.md
+++ b/crates/kitsune_p2p/types/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 ## 0.0.2

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_types"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 description = "types subcrate for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/test_utils/wasm/CHANGELOG.md
+++ b/crates/test_utils/wasm/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 ## 0.0.2

--- a/crates/test_utils/wasm/Cargo.toml
+++ b/crates/test_utils/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_wasm_test_utils"
-version = "0.0.4-dev.0"
+version = "0.0.4"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2018"
 description = "Utilities for Wasm testing for Holochain"
@@ -20,8 +20,8 @@ only_check = []
 [dependencies]
 fixt = { path = "../../fixt", version = "0.0.5"}
 holo_hash = { path = "../../holo_hash", version = "0.0.5"}
-holochain_types = { path = "../../holochain_types", version = "0.0.4-dev.0"}
-holochain_zome_types = { path = "../../holochain_zome_types", version = "0.0.5"}
+holochain_types = { path = "../../holochain_types", version = "0.0.4"}
+holochain_zome_types = { path = "../../holochain_zome_types", version = "0.0.6"}
 rand = "0.7"
 strum = "0.18.0"
 strum_macros = "0.18.0"

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -281,7 +281,7 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hdk"
-version = "0.0.103"
+version = "0.0.104"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "holochain_zome_types",
  "paste",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "hdk",
  "serde",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "chrono",
  "fixt",

--- a/crates/test_utils/wasm_common/CHANGELOG.md
+++ b/crates/test_utils/wasm_common/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.4
+
 ## 0.0.3
 
 ## 0.0.2

--- a/crates/test_utils/wasm_common/Cargo.toml
+++ b/crates/test_utils/wasm_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_test_wasm_common"
-version = "0.0.3"
+version = "0.0.4"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2018"
 description = "Common code for Wasm testing for Holochain"
@@ -12,5 +12,5 @@ crate-type = [ "cdylib", "rlib" ]
 path = "src/lib.rs"
 
 [dependencies]
-hdk = { path = "../../hdk", version = "0.0.103"}
+hdk = { path = "../../hdk", version = "0.0.104"}
 serde = "1.0"


### PR DESCRIPTION
the following crates are part of this release:

- holochain_zome_types-0.0.6
- hdk_derive-0.0.6
- hdk-0.0.104
- kitsune_p2p_types-0.0.4
- kitsune_p2p_transport_quic-0.0.4
- kitsune_p2p_proxy-0.0.4
- kitsune_p2p-0.0.4
- holochain_sqlite-0.0.4
- holochain_keystore-0.0.4
- holochain_types-0.0.4
- holochain_cli_bundle-0.0.4
- holochain_p2p-0.0.4
- holochain_wasm_test_utils-0.0.4
- holochain_state-0.0.4
- holochain_conductor_api-0.0.4
- holochain_websocket-0.0.4
- holochain_cli_sandbox-0.0.5
- holochain_cli-0.0.5
- holochain_cascade-0.0.4
- holochain_test_wasm_common-0.0.4
- holochain-0.0.104