### PR TITLE
More gossip fixes 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This file conveniently consolidates all of the crates individual CHANGELOG.md fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # \[Unreleased\]
-
+- Adds experimental feature for one storage agent per space.
 # 20210825.101130
 
 ## [holochain-0.0.104](crates/holochain/CHANGELOG.md#0.0.104)

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -149,3 +149,8 @@ db-encryption = ['holochain_sqlite/db-encryption']
 # Compile SQLite from source rather than depending on a library.
 # Incompatible with "db-encryption"
 no-deps = ['holochain_sqlite/no-deps']
+
+# An experimental feature that enables only one cell to gossip 
+# per dna space. This should not be used in production unless 
+# you know what you're doing.
+space_gossip = ['holochain_p2p/space_gossip']

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -24,6 +24,7 @@ use crate::core::workflow::countersigning_workflow::incoming_countersigning;
 use crate::core::workflow::countersigning_workflow::CountersigningWorkspace;
 use crate::core::workflow::genesis_workflow::genesis_workflow;
 use crate::core::workflow::incoming_dht_ops_workflow::incoming_dht_ops_workflow;
+use crate::core::workflow::incoming_dht_ops_workflow::IncomingOpHashes;
 use crate::core::workflow::initialize_zomes_workflow;
 use crate::core::workflow::CallZomeWorkflowArgs;
 use crate::core::workflow::GenesisWorkflowArgs;
@@ -109,6 +110,8 @@ where
     init_mutex: tokio::sync::Mutex<()>,
     /// Countersigning workspace that is shared across this cell.
     countersigning_workspace: CountersigningWorkspace,
+    /// Incoming op hashes that are queued for processing.
+    incoming_op_hashes: IncomingOpHashes,
 }
 
 impl Cell {
@@ -138,6 +141,7 @@ impl Cell {
         };
 
         if has_genesis {
+            let incoming_op_hashes = IncomingOpHashes::default();
             let countersigning_workspace = CountersigningWorkspace::new();
             let (queue_triggers, initial_queue_triggers) = spawn_queue_consumer_tasks(
                 env.clone(),
@@ -161,6 +165,7 @@ impl Cell {
                     queue_triggers,
                     init_mutex: Default::default(),
                     countersigning_workspace,
+                    incoming_op_hashes,
                 },
                 initial_queue_triggers,
             ))
@@ -467,6 +472,7 @@ impl Cell {
         } else {
             incoming_dht_ops_workflow(
                 &self.env,
+                Some(&self.incoming_op_hashes),
                 self.queue_triggers.sys_validation.clone(),
                 ops,
                 request_validation_receipt,

--- a/crates/holochain/src/core/sys_validate.rs
+++ b/crates/holochain/src/core/sys_validate.rs
@@ -516,15 +516,9 @@ impl IncomingDhtOpSender {
     ) -> SysValidationResult<()> {
         if let Some(op) = make_op(element) {
             let ops = vec![op];
-            incoming_dht_ops_workflow(
-                &self.env,
-                None,
-                self.sys_validation_trigger,
-                ops,
-                false,
-            )
-            .await
-            .map_err(Box::new)?;
+            incoming_dht_ops_workflow(&self.env, None, self.sys_validation_trigger, ops, false)
+                .await
+                .map_err(Box::new)?;
         }
         Ok(())
     }

--- a/crates/holochain/src/core/sys_validate.rs
+++ b/crates/holochain/src/core/sys_validate.rs
@@ -516,9 +516,15 @@ impl IncomingDhtOpSender {
     ) -> SysValidationResult<()> {
         if let Some(op) = make_op(element) {
             let ops = vec![op];
-            incoming_dht_ops_workflow(&self.env, self.sys_validation_trigger, ops, false)
-                .await
-                .map_err(Box::new)?;
+            incoming_dht_ops_workflow(
+                &self.env,
+                None,
+                self.sys_validation_trigger,
+                ops,
+                false,
+            )
+            .await
+            .map_err(Box::new)?;
         }
         Ok(())
     }

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -115,8 +115,7 @@ pub(crate) async fn countersigning_workflow(
 
     // For each complete session send the ops to validation.
     for (agents, ops, headers) in complete_sessions {
-        incoming_dht_ops_workflow(&env, None, sys_validation_trigger.clone(), ops, false)
-            .await?;
+        incoming_dht_ops_workflow(&env, None, sys_validation_trigger.clone(), ops, false).await?;
         notify_agents.push((agents, headers));
     }
 

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -115,7 +115,8 @@ pub(crate) async fn countersigning_workflow(
 
     // For each complete session send the ops to validation.
     for (agents, ops, headers) in complete_sessions {
-        incoming_dht_ops_workflow(&env, sys_validation_trigger.clone(), ops, false).await?;
+        incoming_dht_ops_workflow(&env, None, sys_validation_trigger.clone(), ops, false)
+            .await?;
         notify_agents.push((agents, headers));
     }
 

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow/test.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow/test.rs
@@ -31,7 +31,7 @@ async fn incoming_ops_to_limbo() {
         let env = env.clone();
         all.push(tokio::task::spawn(async move {
             let start = std::time::Instant::now();
-            incoming_dht_ops_workflow(&env, sys_validation_trigger, vec![op], false)
+            incoming_dht_ops_workflow(&env, None, sys_validation_trigger, vec![op], false)
                 .await
                 .unwrap();
             println!("IN OP in {} s", start.elapsed().as_secs_f64());

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -30,3 +30,9 @@ thiserror = "1.0.22"
 tokio = { version = "1.3", features = [ "full" ] }
 tokio-stream = "0.1"
 holochain_util = { version = "0.0.3", path = "../holochain_util" }
+
+[features]
+# An experimental feature that enables only one cell to gossip 
+# per dna space. This should not be used in production unless 
+# you know what you're doing.
+space_gossip = ["kitsune_p2p/space_gossip"]

--- a/crates/holochain_sqlite/src/db.rs
+++ b/crates/holochain_sqlite/src/db.rs
@@ -218,7 +218,6 @@ pub trait WriteManager<'e> {
     /// transaction, and commit the transaction after the closure has run.
     /// If there is a SQLite error, recover from it and re-run the closure.
     // FIXME: B-01566: implement write failure detection
-    #[cfg(feature = "test_utils")]
     fn with_commit_sync<E, R, F>(&'e mut self, f: F) -> Result<R, E>
     where
         E: From<DatabaseError>,

--- a/crates/holochain_sqlite/src/db/p2p_agent_store.rs
+++ b/crates/holochain_sqlite/src/db/p2p_agent_store.rs
@@ -203,8 +203,7 @@ impl AsP2pStateTxExt for Transaction<'_> {
                     let end: Option<u32> = r.get(2)?;
                     let interval = match (start, end) {
                         (Some(start), Some(end)) => Some(ArcInterval::new(start, end)),
-                        // (None, None) => None,
-                        (None, None) => Some(ArcInterval::new_empty()),
+                        (None, None) => None,
                         _ => {
                             tracing::warn!(
                             "Mismatch in arc bounds for an agent, treating as zero arc ({:?}, {:?})",
@@ -219,12 +218,12 @@ impl AsP2pStateTxExt for Transaction<'_> {
             )?;
         query.fold(Ok(vec![]), |out, maybe_pair| {
             if let Some((agent, interval)) = maybe_pair? {
-                // if arcset.overlap(&interval.clone().into()) {
+                if arcset.overlap(&interval.clone().into()) {
                     return out.map(|mut out| {
                         out.push((agent, interval));
                         out
                     });
-                // }
+                }
             }
             out
         })

--- a/crates/holochain_sqlite/src/db/p2p_agent_store.rs
+++ b/crates/holochain_sqlite/src/db/p2p_agent_store.rs
@@ -203,7 +203,8 @@ impl AsP2pStateTxExt for Transaction<'_> {
                     let end: Option<u32> = r.get(2)?;
                     let interval = match (start, end) {
                         (Some(start), Some(end)) => Some(ArcInterval::new(start, end)),
-                        (None, None) => None,
+                        // (None, None) => None,
+                        (None, None) => Some(ArcInterval::new_empty()),
                         _ => {
                             tracing::warn!(
                             "Mismatch in arc bounds for an agent, treating as zero arc ({:?}, {:?})",
@@ -218,12 +219,12 @@ impl AsP2pStateTxExt for Transaction<'_> {
             )?;
         query.fold(Ok(vec![]), |out, maybe_pair| {
             if let Some((agent, interval)) = maybe_pair? {
-                if arcset.overlap(&interval.clone().into()) {
+                // if arcset.overlap(&interval.clone().into()) {
                     return out.map(|mut out| {
                         out.push((agent, interval));
                         out
                     });
-                }
+                // }
             }
             out
         })

--- a/crates/holochain_state/src/test_utils.rs
+++ b/crates/holochain_state/src/test_utils.rs
@@ -28,6 +28,10 @@ pub fn test_cell_env_with_id(id: u8) -> TestEnv {
     test_env(DbKind::Cell(fake_cell_id(id)))
 }
 
+pub fn test_cell_env_with_cell_id(id: CellId) -> TestEnv {
+    test_env(DbKind::Cell(id))
+}
+
 /// Create a [TestEnv] of [DbKind::Cache], backed by a temp directory.
 pub fn test_cache_env() -> TestEnv {
     test_cache_env_with_id(1)

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc/dht_arc_set.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc/dht_arc_set.rs
@@ -287,6 +287,11 @@ impl ArcInterval {
             .unwrap_or_default()
     }
 
+    /// Check if this arc is empty.
+    pub fn is_empty(&self) -> bool {
+        matches!(self, Self::Empty)
+    }
+
     #[cfg(any(test, feature = "test_utils"))]
     pub fn to_ascii(&self, len: usize) -> String {
         match self {

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -56,3 +56,7 @@ test_utils = [
   "kitsune_p2p_types/test_utils",
   "mockall",
 ]
+# An experimental feature that enables only one cell to gossip 
+# per dna space. This should not be used in production unless 
+# you know what you're doing.
+space_gossip = []

--- a/crates/kitsune_p2p/kitsune_p2p/src/fixt.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/fixt.rs
@@ -5,6 +5,7 @@ use crate::agent_store::UrlList;
 use crate::dependencies::url2;
 use crate::KitsuneAgent;
 use crate::KitsuneBinType;
+use crate::KitsuneOpHash;
 use crate::KitsuneSignature;
 use crate::KitsuneSpace;
 use ::fixt::prelude::*;
@@ -43,6 +44,11 @@ fixturator!(
 
 fixturator!(
     KitsuneSpace;
+    constructor fn new(ThirtySixBytes);
+);
+
+fixturator!(
+    KitsuneOpHash;
     constructor fn new(ThirtySixBytes);
 );
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -320,6 +320,7 @@ pub struct ShardedGossipLocalState {
     /// Metrics that track remote node states and help guide
     /// the next node to gossip with.
     metrics: Metrics,
+    #[allow(dead_code)]
     /// Last moment we locally synced.
     last_local_sync: Option<std::time::Instant>,
     /// Trigger local sync to run on the next iteration.
@@ -632,6 +633,7 @@ impl ShardedGossipLocal {
         Ok(())
     }
 
+    #[cfg(not(feature = "space_gossip"))]
     /// Check if we should locally sync
     fn should_local_sync(&self) -> KitsuneResult<bool> {
         // Historical gossip should not locally sync.
@@ -663,6 +665,11 @@ impl ShardedGossipLocal {
         };
 
         self.inner.share_mut(update_last_sync)
+    }
+
+    #[cfg(feature = "space_gossip")]
+    fn should_local_sync(&self) -> KitsuneResult<bool> {
+        Ok(false)
     }
 
     /// Record all timed out rounds into metrics

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -56,6 +56,9 @@ const MAX_SEND_BUF_BYTES: usize = 16000;
 /// gossiped with if gossip is triggered.
 const MAX_TRIGGERS: u8 = 2;
 
+/// The timeout for a gossip round if there is no contact. Five minutes.
+const ROUND_TIMEOUT_MS: u32 = 1000 * 60 * 5;
+
 type BloomFilter = bloomfilter::Bloom<Arc<MetaOpKey>>;
 type EventSender = futures::channel::mpsc::Sender<event::KitsuneP2pEvent>;
 
@@ -98,6 +101,26 @@ pub struct ShardedGossip {
     bandwidth: Arc<BandwidthThrottle>,
 }
 
+/// Basic statistic for gossip loop processing performance.
+struct Stats {
+    start: std::time::Instant,
+    avg_processing_time: std::time::Duration,
+    max_processing_time: std::time::Duration,
+    count: u32,
+}
+
+impl Stats {
+    /// Reset the stats.
+    fn reset() -> Self {
+        Stats {
+            start: std::time::Instant::now(),
+            avg_processing_time: std::time::Duration::default(),
+            max_processing_time: std::time::Duration::default(),
+            count: 0,
+        }
+    }
+}
+
 impl ShardedGossip {
     /// Constructor
     pub fn new(
@@ -125,6 +148,7 @@ impl ShardedGossip {
             let this = this.clone();
 
             async move {
+                let mut stats = Stats::reset();
                 while !this
                     .gossip
                     .closing
@@ -132,6 +156,7 @@ impl ShardedGossip {
                 {
                     tokio::time::sleep(std::time::Duration::from_millis(10)).await;
                     this.run_one_iteration().await;
+                    this.stats(&mut stats);
                 }
                 KitsuneResult::Ok(())
             }
@@ -238,6 +263,28 @@ impl ShardedGossip {
             let outgoing = inner.outgoing.pop_front();
             Ok((incoming, outgoing))
         })
+    }
+
+    /// Log the statistics for the gossip loop.
+    fn stats(&self, stats: &mut Stats) {
+        if let GossipType::Recent = self.gossip.gossip_type {
+            let elapsed = stats.start.elapsed();
+            stats.avg_processing_time += elapsed;
+            stats.max_processing_time = std::cmp::max(stats.max_processing_time, elapsed);
+            stats.count += 1;
+            if elapsed.as_secs() > 5 {
+                stats.avg_processing_time = stats
+                    .avg_processing_time
+                    .checked_div(stats.count)
+                    .unwrap_or_default();
+                let _ = self.gossip.inner.share_mut(|i, _| {
+                    let s = tracing::trace_span!("gossip_metrics");
+                    s.in_scope(|| tracing::trace!("{}\nStats over last 5s:\n\tAverage processing time {:?}\n\tIteration count: {}\n\tMax gossip processing time: {:?}", i.metrics, stats.avg_processing_time, stats.count, stats.max_processing_time));
+                    Ok(())
+                });
+                *stats = Stats::reset();
+            }
+        }
     }
 }
 
@@ -349,6 +396,8 @@ pub struct RoundState {
     received_all_incoming_ops_blooms: bool,
     /// Round start time
     created_at: std::time::Instant,
+    /// Last moment we had any contact for this round.
+    last_touch: std::time::Instant,
     /// Amount of time before a round is considered expired.
     round_timeout: u32,
 }
@@ -388,12 +437,8 @@ impl ShardedGossipLocal {
             num_sent_ops_blooms: 0,
             received_all_incoming_ops_blooms: false,
             created_at: std::time::Instant::now(),
-            // TODO: Check if the node is a successful peer or not and set the timeout accordingly.
-            // TODO: Actually I think this is the wrong time out? This is
-            // how long we wait to timeout a round.
-            round_timeout: self
-                .tuning_params
-                .gossip_peer_on_success_next_gossip_delay_ms,
+            last_touch: std::time::Instant::now(),
+            round_timeout: ROUND_TIMEOUT_MS,
         })
     }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/agents.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/agents.rs
@@ -13,18 +13,17 @@ impl ShardedGossipLocal {
 
         // Get all agents within common arc and filter out
         // the ones in the remote bloom.
-        let missing: Vec<_> =
-            store::agent_info_within_arc_set(&self.evt_sender, &self.space, common_arc_set)
-                .await?
-                .filter(|info| {
-                    // Check them against the bloom
-                    !remote_bloom.check(&Arc::new(MetaOpKey::Agent(
-                        info.agent.clone(),
-                        info.signed_at_ms,
-                    )))
-                })
-                .map(Arc::new)
-                .collect();
+        let missing: Vec<_> = get_agent_info(&self.evt_sender, &self.space, common_arc_set)
+            .await?
+            .filter(|info| {
+                // Check them against the bloom
+                !remote_bloom.check(&Arc::new(MetaOpKey::Agent(
+                    info.agent.clone(),
+                    info.signed_at_ms,
+                )))
+            })
+            .map(Arc::new)
+            .collect();
 
         // Send any missing.
         Ok(if !missing.is_empty() {
@@ -72,4 +71,22 @@ impl ShardedGossipLocal {
 
         Ok(())
     }
+}
+
+#[cfg(feature = "space_gossip")]
+async fn get_agent_info(
+    evt_sender: &EventSender,
+    space: &Arc<KitsuneSpace>,
+    _arc_set: Arc<DhtArcSet>,
+) -> KitsuneResult<impl Iterator<Item = AgentInfoSigned>> {
+    Ok(store::all_agent_info(evt_sender, space).await?.into_iter())
+}
+
+#[cfg(not(feature = "space_gossip"))]
+async fn get_agent_info(
+    evt_sender: &EventSender,
+    space: &Arc<KitsuneSpace>,
+    arc_set: Arc<DhtArcSet>,
+) -> KitsuneResult<impl Iterator<Item = AgentInfoSigned>> {
+    store::agent_info_within_arc_set(evt_sender, space, arc_set).await
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/bloom.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/bloom.rs
@@ -63,6 +63,7 @@ impl ShardedGossipLocal {
                     .await?
                     .into_iter()
                     .filter(|(a, _)| local_agents.contains(a))
+                    .filter(|(_, i)| !i.is_empty())
                     .collect();
 
             // Get the op hashes which fit within the common arc set from these local agents.

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/next_target.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/next_target.rs
@@ -34,6 +34,7 @@ impl ShardedGossipLocal {
             .await?
             .into_iter()
             .filter(|a| remote_agents_within_arc_set.contains(&a.agent))
+            .filter(|a| !a.storage_arc.interval().is_empty())
         {
             // Get an address if there is one.
             let info = info

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/store.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/store.rs
@@ -72,6 +72,7 @@ pub(super) async fn local_arcs(
         .collect())
 }
 
+#[allow(dead_code)]
 /// Get `AgentInfoSigned` for all agents within a `DhtArcSet`.
 pub(super) async fn agent_info_within_arc_set(
     evt_sender: &EventSender,

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/test_two_nodes.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/test_two_nodes.rs
@@ -136,6 +136,7 @@ async fn partial_missing_doesnt_finish() {
                 num_sent_ops_blooms: 1,
                 received_all_incoming_ops_blooms: true,
                 created_at: std::time::Instant::now(),
+                last_touch: std::time::Instant::now(),
                 round_timeout: u32::MAX,
             }
         }
@@ -178,6 +179,7 @@ async fn missing_ops_finishes() {
                 num_sent_ops_blooms: 1,
                 received_all_incoming_ops_blooms: true,
                 created_at: std::time::Instant::now(),
+                last_touch: std::time::Instant::now(),
                 round_timeout: u32::MAX,
             }
         }
@@ -221,6 +223,7 @@ async fn missing_ops_doesnt_finish_awaiting_bloom_responses() {
                 num_sent_ops_blooms: 1,
                 received_all_incoming_ops_blooms: false,
                 created_at: std::time::Instant::now(),
+                last_touch: std::time::Instant::now(),
                 round_timeout: u32::MAX,
             }
         }
@@ -264,6 +267,7 @@ async fn bloom_response_finishes() {
                 num_sent_ops_blooms: 0,
                 received_all_incoming_ops_blooms: false,
                 created_at: std::time::Instant::now(),
+                last_touch: std::time::Instant::now(),
                 round_timeout: u32::MAX,
             }
         }
@@ -307,6 +311,7 @@ async fn bloom_response_doesnt_finish_outstanding_incoming() {
                 num_sent_ops_blooms: 1,
                 received_all_incoming_ops_blooms: false,
                 created_at: std::time::Instant::now(),
+                last_touch: std::time::Instant::now(),
                 round_timeout: u32::MAX,
             }
         }
@@ -353,6 +358,7 @@ async fn no_data_still_finishes() {
                 num_sent_ops_blooms: 0,
                 received_all_incoming_ops_blooms: false,
                 created_at: std::time::Instant::now(),
+                last_touch: std::time::Instant::now(),
                 round_timeout: u32::MAX,
             }
         }
@@ -370,6 +376,7 @@ async fn no_data_still_finishes() {
                 num_sent_ops_blooms: 1,
                 received_all_incoming_ops_blooms: true,
                 created_at: std::time::Instant::now(),
+                last_touch: std::time::Instant::now(),
                 round_timeout: u32::MAX,
             }
         }


### PR DESCRIPTION
This adds an experimental feature flag that allows the space to assign the first agent to join as a full storage are and the rest as zero size storage arcs. This doesn't handle restarts as a new agent will probably be chosen. This feature is to unblock holo and will most likely be removed in the future in favor of a better solution (like moving the vault database to the space level instead of the agent level).
It does result in a huge speed increase. (I can easily run 10000 cells in the elemental chat tests vs only about 200 without this).
Note that this disables local sync because it is not needed. 
Also there is a hacky work around that allows zero length agent arcs to be gossiped. This is mostly to get around the elemental chat tests as they require all agents holding all agent infos. If this turns out to not be needed then we should remove the hack.

Everything to do with the actual arc size change is behind the feature flag `space_gossip` which can be enabled from holochain.

There is also a few performance fixes that are not behind the flag.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
