### PR TITLE
Exposed UninstallApp

### DIFF
--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Added `UninstallApp` command.
+
 ## 0.0.5
 
 ## 0.0.4

--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -302,7 +302,7 @@ async fn call_inner(cmd: &mut CmdRunner, call: AdminRequestCli) -> anyhow::Resul
         }
         AdminRequestCli::UninstallApp(args) => {
             let app_id = args.app_id.clone();
-            let app = uninstall_app(cmd, args).await?;
+            uninstall_app(cmd, args).await?;
             msg!("Uninstalled App: {}", app_id,);
         }
         AdminRequestCli::ListDnas => {
@@ -535,7 +535,12 @@ pub async fn uninstall_app(cmd: &mut CmdRunner, args: UninstallApp) -> anyhow::R
             installed_app_id: args.app_id,
         })
         .await?;
-    Ok(expect_match!(resp => AdminResponse::AppUninstalled, "Failed to uninstall app"))
+
+    assert!(
+        matches!(resp, AdminResponse::AppUninstalled),
+        "Failed to uninstall app"
+    );
+    Ok(())
 }
 
 /// Calls [`AdminRequest::ListAppInterfaces`].

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Exposes `UninstallApp` in the conductor admin API.
+
 ## 0.0.104
 
 - Updates lair to 0.0.4 which pins rcgen to 0.8.11 to work around [https://github.com/est31/rcgen/issues/63](https://github.com/est31/rcgen/issues/63)

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -200,6 +200,13 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     InstalledAppInfo::from_installed_app(&app),
                 ))
             }
+            UninstallApp { installed_app_id } => {
+                self.conductor_handle
+                    .clone()
+                    .uninstall_app(&installed_app_id)
+                    .await?;
+                Ok(AdminResponse::AppUninstalled)
+            }
             ListDnas => {
                 let dna_list = self.conductor_handle.list_dnas().await?;
                 Ok(AdminResponse::DnasListed(dna_list))

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -92,6 +92,19 @@ pub enum AdminRequest {
     /// [`AdminResponse::Error`]: enum.AppResponse.html#variant.Error
     InstallAppBundle(Box<InstallAppBundlePayload>),
 
+    /// Uninstalls the `App` specified by argument `installed_app_id` from the conductor,
+    /// meaning that all its cells will be disabled and removed, and all persistent state removed.
+    ///
+    /// Will be responded to with an [`AdminResponse::AppUninstalled`]
+    /// or an [`AdminResponse::Error`]
+    ///
+    /// [`AdminResponse::AppUninstalled`]: enum.AdminResponse.html#variant.AppUninstalled
+    /// [`AdminResponse::Error`]: enum.AppResponse.html#variant.Error
+    UninstallApp {
+        /// The InstalledAppId to uninstall
+        installed_app_id: InstalledAppId,
+    },
+
     /// List the hashes of all installed `Dna`s.
     /// Takes no arguments.
     ///
@@ -309,6 +322,13 @@ pub enum AdminResponse {
     /// [`CellNick`]: ../../../holochain_types/app/type.CellNick.html
     /// [`CellId`]: ../../../holochain_types/cell/struct.CellId.html
     AppBundleInstalled(InstalledAppInfo),
+
+    /// The succesful response to an [`AdminRequest::UninstallApp`].
+    ///
+    /// It means the `App` was uninstalled successfully.
+    ///
+    /// [`AdminRequest::UninstallApp`]: enum.AdminRequest.html#variant.UninstallApp
+    AppUninstalled,
 
     /// The successful response to an [`AdminRequest::CreateCloneCell`].
     ///

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -95,7 +95,7 @@ pub enum AdminRequest {
     /// Uninstalls the `App` specified by argument `installed_app_id` from the conductor,
     /// meaning that the app will be removed from the list of installed apps, and any Cells
     /// which were referenced only by this app will be disabled and removed, clearing up
-    /// any persisted data. 
+    /// any persisted data.
     /// Cells which are still referenced by other installed apps will not be removed.
     ///
     /// Will be responded to with an [`AdminResponse::AppUninstalled`]

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -93,7 +93,10 @@ pub enum AdminRequest {
     InstallAppBundle(Box<InstallAppBundlePayload>),
 
     /// Uninstalls the `App` specified by argument `installed_app_id` from the conductor,
-    /// meaning that all its cells will be disabled and removed, and all persistent state removed.
+    /// meaning that the app will be removed from the list of installed apps, and any Cells
+    /// which were referenced only by this app will be disabled and removed, clearing up
+    /// any persisted data. 
+    /// Cells which are still referenced by other installed apps will not be removed.
     ///
     /// Will be responded to with an [`AdminResponse::AppUninstalled`]
     /// or an [`AdminResponse::Error`]

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -281,7 +281,7 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hdk"
-version = "0.0.104"
+version = "0.0.105-dev.0"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.0.6"
+version = "0.0.7-dev.0"
 dependencies = [
  "holochain_zome_types",
  "paste",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.0.4"
+version = "0.0.5-dev.0"
 dependencies = [
  "hdk",
  "serde",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.0.6"
+version = "0.0.7-dev.0"
 dependencies = [
  "chrono",
  "fixt",


### PR DESCRIPTION
### INCLUDED CHANGES:
- Exposed `uninstall_app` from conductor handle in the external conductor api.

This is needed by the launcher to actually uninstall apps.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
