### PR TITLE
release automation milestone 3 part 1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,24 @@ commands:
               command: ./docker/push.sh << parameters.box >> $CIRCLE_BRANCH
 
 jobs:
+   merge-release-test:
+      docker:
+         - image: nixos/nix:latest
+           auth:
+              username: $DOCKER_USER
+              password: $DOCKER_PASS
+      environment:
+         CACHIX_NAME: holochain-ci
+         NIXPKGS_ALLOW_UNFREE: 1
+      steps:
+         - checkout
+         - run:
+              name: Set up Hydra cache
+              command: $(nix-build . --fallback --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
+         - run:
+              name: PR release tests
+              no_output_timeout: 30m
+              command: ./scripts/ci_merge-release-test.sh
    merge-test:
       docker:
          - image: holochain/holochain:circle.build.develop
@@ -34,7 +52,7 @@ jobs:
               command: git config --global --unset "url.ssh://git@github.com.insteadof"
          - run:
               name: Set up Hydra cache
-              command: $(nix-build . --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
+              command: $(nix-build . --fallback --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
          - run:
               name: Run the merge tests
               no_output_timeout: 30m
@@ -78,6 +96,7 @@ workflows:
    version: 2.1
    tests:
       jobs:
+         - merge-release-test
          - merge-test
          # - merge-test-mac
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5307,7 +5307,7 @@ dependencies = [
 
 [[package]]
 name = "release-automation"
-version = "0.1.0"
+version = "0.2.0-alpha.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/crates/release-automation/Cargo.toml
+++ b/crates/release-automation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "release-automation"
-version = "0.1.0"
+version = "0.2.0-alpha.0"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
 edition = "2018"
 

--- a/crates/release-automation/src/crate_selection/mod.rs
+++ b/crates/release-automation/src/crate_selection/mod.rs
@@ -1005,15 +1005,38 @@ impl<'a> ReleaseWorkspace<'a> {
         self.changelog.as_ref()
     }
 
-    pub(crate) fn cargo_check(&'a self) -> Fallible<()> {
+    pub(crate) fn update_lockfile(&'a self, dry_run: bool) -> Fallible<()> {
+        let mut cmd = std::process::Command::new("cargo");
+        cmd.current_dir(self.root()).args(
+            &[
+                vec!["update", "--workspace", "--offline", "--verbose"],
+                if dry_run { vec!["--dry-run"] } else { vec![] },
+            ]
+            .concat(),
+        );
+        debug!("running command: {:?}", cmd);
+
+        if !dry_run {
+            let mut cmd = cmd.spawn()?;
+            let cmd_status = cmd.wait()?;
+            if !cmd_status.success() {
+                bail!("running {:?} failed: \n{:?}", cmd, cmd.stderr);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn cargo_check(&'a self, offline: bool) -> Fallible<()> {
         let mut cmd = std::process::Command::new("cargo")
-            .args(&[
-                "check",
-                "--manifest-path",
-                &self.cargo_workspace()?.root_manifest().to_string_lossy(),
-                "--all-targets",
-                "--all-features",
-            ])
+            .current_dir(self.root())
+            .args(
+                &[
+                    vec!["check", "--workspace", "--all-targets", "--all-features"],
+                    if offline { vec!["--offline"] } else { vec![] },
+                ]
+                .concat(),
+            )
             .spawn()?;
 
         let cmd_status = cmd.wait()?;

--- a/crates/release-automation/src/main.rs
+++ b/crates/release-automation/src/main.rs
@@ -255,6 +255,11 @@ pub(crate) mod cli {
         /// The dependencies that are allowed to be missing at the search location despite not being released.
         #[structopt(long, default_value="", parse(from_str = parse_string_set))]
         pub(crate) allowed_missing_dependencies: HashSet<String>,
+
+        /// Set a custom CARGO_TARGET_DIR when shelling out to `cargo`.
+        /// Currently only used for `cargo publish`.
+        #[structopt(long)]
+        pub(crate) cargo_target_dir: Option<PathBuf>,
     }
 
     /// Parses a commad separated input string to a set of strings.

--- a/crates/release-automation/src/tests/cli.rs
+++ b/crates/release-automation/src/tests/cli.rs
@@ -19,6 +19,10 @@ fn release_createreleasebranch() {
     let cmd = cmd.args(&[
         &format!("--workspace-path={}", workspace.root().display()),
         "release",
+        &format!(
+            "--cargo-target-dir={}",
+            workspace.root().join("target").display()
+        ),
         "--steps=CreateReleaseBranch",
     ]);
     cmd.assert().success();
@@ -47,6 +51,10 @@ fn release_createreleasebranch_fails_on_dirty_repo() {
         &format!("--workspace-path={}", workspace.root().display()),
         "--log-level=debug",
         "release",
+        &format!(
+            "--cargo-target-dir={}",
+            workspace.root().join("target").display()
+        ),
         "--steps=CreateReleaseBranch",
     ]);
 
@@ -113,11 +121,16 @@ fn bump_versions_on_selection() {
         &format!("--workspace-path={}", workspace.root().display()),
         "--log-level=trace",
         "release",
+        &format!(
+            "--cargo-target-dir={}",
+            workspace.root().join("target").display()
+        ),
         "--disallowed-version-reqs=>=0.1",
         "--allowed-matched-blockers=UnreleasableViaChangelogFrontmatter,DisallowedVersionReqViolated",
         "--steps=CreateReleaseBranch,BumpReleaseVersions",
         "--allowed-missing-dependencies=crate_b",
-    ]);
+    ])
+    ;
 
     let output = assert_cmd_success!(cmd);
     println!("stderr:\n'{}'\n---\nstdout:\n'{}'\n---", output.0, output.1,);
@@ -353,6 +366,7 @@ fn release_publish() {
         &format!("--workspace-path={}", workspace.root().display()),
         "--log-level=trace",
         "release",
+        &format!("--cargo-target-dir={}", workspace.root().join("target").display()),
         "--disallowed-version-reqs=>=0.1",
         "--allowed-matched-blockers=UnreleasableViaChangelogFrontmatter,DisallowedVersionReqViolated",
         "--steps=CreateReleaseBranch,BumpReleaseVersions",
@@ -368,6 +382,10 @@ fn release_publish() {
         "release",
         // todo: set up a custom registry and actually publish the crates
         "--dry-run",
+        &format!(
+            "--cargo-target-dir={}",
+            workspace.root().join("target").display()
+        ),
         "--steps=PublishToCratesIo",
     ]);
     let output = assert_cmd_success!(cmd);
@@ -389,6 +407,10 @@ fn post_release_version_bumps() {
         &format!("--workspace-path={}", workspace.root().display()),
         "--log-level=trace",
         "release",
+        &format!(
+            "--cargo-target-dir={}",
+            workspace.root().join("target").display()
+        ),
         "--disallowed-version-reqs=>=0.1",
         "--allowed-matched-blockers=UnreleasableViaChangelogFrontmatter,DisallowedVersionReqViolated",
         "--steps=CreateReleaseBranch,BumpReleaseVersions",
@@ -402,6 +424,10 @@ fn post_release_version_bumps() {
         &format!("--workspace-path={}", workspace.root().display()),
         "--log-level=trace",
         "release",
+        &format!(
+            "--cargo-target-dir={}",
+            workspace.root().join("target").display()
+        ),
         "--steps=BumpPostReleaseVersions",
     ]);
     let output = assert_cmd_success!(cmd);
@@ -588,6 +614,7 @@ fn multiple_subsequent_releases() {
                 &format!("--workspace-path={}", workspace.root().display()),
                 "--log-level=debug",
                 "release",
+                &format!("--cargo-target-dir={}", workspace.root().join("target").display()),
                 "--disallowed-version-reqs=>=0.1",
                 "--allowed-matched-blockers=UnreleasableViaChangelogFrontmatter,DisallowedVersionReqViolated",
                 "--steps=CreateReleaseBranch,BumpReleaseVersions",

--- a/scripts/ci_merge-release-test.sh
+++ b/scripts/ci_merge-release-test.sh
@@ -1,0 +1,10 @@
+#! /usr/bin/env nix-shell
+#! nix-shell ../shell.nix
+#! nix-shell --fallback
+#! nix-shell --pure
+#! nix-shell --argstr flavor "coreDev"
+#! nix-shell -i bash
+set +e
+git diff --exit-code
+hc-ra --log-level=debug --workspace-path=$PWD crate apply-dev-versions --commit
+hc-release-test


### PR DESCRIPTION
### INCLUDED CHANGES:

(copy and paste from teh commit)

change to the release-automation crate:

- add `crate fixup-release`s command

  this command queries crates.io for all crate versions in the most
  recent release. it will print every crate that hasn't been published
  and optionally bump their version to a develop version to indicate a
  re-release is necessary.

- rework checking behavior

  this separates the lockfile update from the consistency check.  the
  advantage is that this lets use use the `--offline` argument in the
  lockfile update step.

- custom cargo-target-dir nested cargo

  the main use-case for this are the CLI tests. if they run
  concurrently, which is the default in rust tests, they will create
  conflicts if they share a target directory. hence the tests require
  setting a custom target dir for each test workspace.

- readd separate check command

  i erroneously removed this command. we do need this after all since
  the `cargo publish --dry-run` sometimes doesn't reach the verification
  when some crates have already bumped to their dev versions.

- output some stats on publishing

- lower version to prepare for releases

changes to CI:

- extract and extend release tests into a separate job and

  as a job in parallel to `merge-test` introduce `merge-release-test`,
  which ensures that the code remains releasable. by using a parallel
  job we don't extend wall-time for developers who are waiting on CI.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info

---

Demonstrates the failure that's fixed in #974