### PR TITLE
Adjust feature usage in holo_hash so it builds under --no-default-features

### DIFF
--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -22,7 +22,7 @@ test_utils = [ "fixturators", "holochain_zome_types/test_utils", "holo_hash/test
 
 [dependencies]
 hdk_derive = { version = "0.0.8-dev.0", path = "../hdk_derive" }
-holo_hash = { version = "0.0.5", path = "../holo_hash", default-features = false }
+holo_hash = { version = "0.0.5", path = "../holo_hash" }
 holochain_wasmer_guest = "=0.0.73"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat

--- a/crates/holo_hash/CHANGELOG.md
+++ b/crates/holo_hash/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+### Fixed
+
+- Crate now builds with `--no-default-features`
+
 ## 0.0.5
 
 ## 0.0.4

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -14,8 +14,7 @@ documentation = "https://github.com/holochain/holochain"
 normal = ["tracing"]
 
 [dependencies]
-serde = "1"
-serde_bytes = "0.11"
+thiserror = "1.0.22"
 
 arbitrary = {version = "1.0", optional = true}
 base64 = {version = "0.13", optional = true}
@@ -27,19 +26,20 @@ holochain_serialized_bytes = {version = "=0.0.51", optional = true }
 must_future = {version = "0.1", optional = true}
 rand = {version = "0.7", optional = true}
 rusqlite = { version = "0.25", optional = true }
+serde = { version = "1", optional = true }
+serde_bytes = { version = "0.11", optional = true }
 tracing = { version = "0.1", optional = true}
-thiserror = "1.0.22"
 
 [dev-dependencies]
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 
 [features]
 
-default = ["serialized-bytes", "fixturators"]
-full = ["fixturators", "hashing", "string-encoding", "rusqlite"]
+default = ["serialization", "fixturators"]
+full = ["fixturators", "hashing", "encoding", "rusqlite"]
 
-fixturators = ["fixt", "rand", "hashing", "string-encoding"]
-hashing = ["futures", "must_future", "blake2b_simd", "serialized-bytes"]
-serialized-bytes = ["holochain_serialized_bytes"]
-string-encoding = ["base64", "blake2b_simd", "derive_more"]
+fixturators = ["fixt", "rand", "hashing", "encoding"]
+hashing = ["futures", "must_future", "blake2b_simd", "serialization"]
+serialization = ["holochain_serialized_bytes", "serde", "serde_bytes"]
+encoding = ["base64", "blake2b_simd", "derive_more"]
 test_utils = ["fixturators"]

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 
 [features]
 
-default = ["serialization", "fixturators"]
+default = ["encoding", "hashing", "serialization"]
 full = ["fixturators", "hashing", "encoding", "rusqlite"]
 
 fixturators = ["fixt", "rand", "hashing", "encoding"]

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 
 [features]
 
-default = ["encoding", "hashing", "serialization"]
+default = ["serialization"]
 full = ["fixturators", "hashing", "encoding", "rusqlite"]
 
 fixturators = ["fixt", "rand", "hashing", "encoding"]

--- a/crates/holo_hash/src/aliases.rs
+++ b/crates/holo_hash/src/aliases.rs
@@ -63,11 +63,11 @@ impl From<AnyDhtHash> for EntryHash {
     }
 }
 
-#[cfg(feature = "serialized-bytes")]
+#[cfg(feature = "serialization")]
 use holochain_serialized_bytes::prelude::*;
 
 /// A newtype for a collection of EntryHashes, needed for some wasm return types.
-#[cfg(feature = "serialized-bytes")]
+#[cfg(feature = "serialization")]
 #[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, SerializedBytes)]
 #[repr(transparent)]
 #[serde(transparent)]

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -23,11 +23,13 @@
 //!
 //! The complete 39 bytes together are known as the "full" hash
 
-use crate::encode;
 use crate::error::HoloHashResult;
 use crate::has_hash::HasHash;
 use crate::HashType;
 use crate::PrimitiveHashType;
+
+#[cfg(feature = "encoding")]
+use crate::encode;
 
 /// Length of the prefix bytes (3)
 pub const HOLO_HASH_PREFIX_LEN: usize = 3;
@@ -153,6 +155,7 @@ impl<T: HashType> HoloHash<T> {
     }
 }
 
+#[cfg(feature = "encoding")]
 impl<T: HashType> HoloHash<T> {
     /// Construct a HoloHash from a 32-byte hash.
     /// The 3 prefix bytes will be added based on the provided HashType,
@@ -177,6 +180,8 @@ impl<P: PrimitiveHashType> HoloHash<P> {
         assert_length!(HOLO_HASH_UNTYPED_LEN, &hash);
         Self::from_raw_36_and_type(hash, P::new())
     }
+
+    #[cfg(feature = "encoding")]
     /// Construct a HoloHash from a prehashed raw 32-byte slice.
     /// The location bytes will be calculated.
     pub fn from_raw_32(hash: Vec<u8>) -> Self {
@@ -245,7 +250,7 @@ fn bytes_to_loc(bytes: &[u8]) -> u32 {
 mod tests {
     use crate::*;
 
-    #[cfg(not(feature = "string-encoding"))]
+    #[cfg(not(feature = "encoding"))]
     fn assert_type<T: HashType>(t: &str, h: HoloHash<T>) {
         assert_eq!(3_688_618_971, h.get_loc());
         assert_eq!(
@@ -255,7 +260,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "string-encoding"))]
+    #[cfg(not(feature = "encoding"))]
     fn test_enum_types() {
         assert_type(
             "DnaHash",

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -155,7 +155,7 @@ impl<T: HashType> HoloHash<T> {
     }
 }
 
-#[cfg(feature = "encoding")]
+#[cfg(feature = "hashing")]
 impl<T: HashType> HoloHash<T> {
     /// Construct a HoloHash from a 32-byte hash.
     /// The 3 prefix bytes will be added based on the provided HashType,
@@ -181,7 +181,7 @@ impl<P: PrimitiveHashType> HoloHash<P> {
         Self::from_raw_36_and_type(hash, P::new())
     }
 
-    #[cfg(feature = "encoding")]
+    #[cfg(feature = "hashing")]
     /// Construct a HoloHash from a prehashed raw 32-byte slice.
     /// The location bytes will be calculated.
     pub fn from_raw_32(hash: Vec<u8>) -> Self {

--- a/crates/holo_hash/src/hash_type/composite.rs
+++ b/crates/holo_hash/src/hash_type/composite.rs
@@ -2,15 +2,16 @@ use super::*;
 use crate::error::HoloHashError;
 use std::convert::TryInto;
 
-#[cfg(all(test, feature = "serialized-bytes"))]
+#[cfg(feature = "serialization")]
 use holochain_serialized_bytes::prelude::*;
 
 /// The AnyDht (composite) HashType
-#[derive(
-    Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, serde::Deserialize, serde::Serialize,
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Deserialize, serde::Serialize, SerializedBytes),
+    serde(from = "AnyDhtSerial", into = "AnyDhtSerial")
 )]
-#[cfg_attr(all(test, feature = "serialized-bytes"), derive(SerializedBytes))]
-#[serde(from = "AnyDhtSerial", into = "AnyDhtSerial")]
 pub enum AnyDht {
     /// The hash of an Entry
     Entry,
@@ -44,7 +45,10 @@ impl HashType for AnyDht {
 
 impl HashTypeAsync for AnyDht {}
 
-#[derive(serde::Deserialize, serde::Serialize)]
+#[cfg_attr(
+    feature = "serialization",
+    derive(serde::Deserialize, serde::Serialize)
+)]
 enum AnyDhtSerial {
     /// The hash of an Entry of EntryType::Agent
     Header(Header),

--- a/crates/holo_hash/src/hash_type/primitive.rs
+++ b/crates/holo_hash/src/hash_type/primitive.rs
@@ -86,6 +86,7 @@ macro_rules! primitive_hash_type {
             }
         }
 
+        #[cfg(feature = "serialization")]
         impl serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -95,6 +96,7 @@ macro_rules! primitive_hash_type {
             }
         }
 
+        #[cfg(feature = "serialization")]
         impl<'de> serde::Deserialize<'de> for $name {
             fn deserialize<D>(deserializer: D) -> Result<$name, D::Error>
             where
@@ -104,8 +106,10 @@ macro_rules! primitive_hash_type {
             }
         }
 
+        #[cfg(feature = "serialization")]
         struct $visitor;
 
+        #[cfg(feature = "serialization")]
         impl<'de> serde::de::Visitor<'de> for $visitor {
             type Value = $name;
 

--- a/crates/holo_hash/src/hashed.rs
+++ b/crates/holo_hash/src/hashed.rs
@@ -1,6 +1,8 @@
 use crate::HasHash;
 use crate::HashableContent;
 use crate::HoloHashOf;
+
+#[cfg(feature = "serialization")]
 use holochain_serialized_bytes::prelude::*;
 
 #[cfg(feature = "arbitrary")]
@@ -10,7 +12,7 @@ use crate::PrimitiveHashType;
 /// hashes need not be calculated multiple times.
 /// Provides an easy constructor which consumes the content.
 // TODO: consider making lazy with OnceCell
-#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "serialization", derive(Debug, Serialize, Deserialize))]
 pub struct HoloHashed<C: HashableContent> {
     /// Whatever type C is as data.
     pub(crate) content: C,

--- a/crates/holo_hash/src/lib.rs
+++ b/crates/holo_hash/src/lib.rs
@@ -9,23 +9,26 @@ mod hash;
 pub mod hash_type;
 
 pub use aliases::*;
-pub use encode::{holo_hash_decode, holo_hash_decode_unchecked, holo_hash_encode};
 pub use has_hash::HasHash;
 pub use hash::*;
-pub use hash_b64::*;
 pub use hash_type::HashType;
 pub use hash_type::PrimitiveHashType;
 
+#[cfg(feature = "encoding")]
+pub use encode::{holo_hash_decode, holo_hash_decode_unchecked, holo_hash_encode};
+
 /// By default, disable string encoding and just display raw bytes
-#[cfg(not(feature = "string-encoding"))]
+#[cfg(not(feature = "encoding"))]
 pub mod encode_raw;
 
 /// Include nice string encoding methods and From impls
-#[cfg(feature = "string-encoding")]
+#[cfg(feature = "encoding")]
 pub mod encode;
 
-#[cfg(feature = "string-encoding")]
-pub mod hash_b64;
+#[cfg(feature = "encoding")]
+mod hash_b64;
+#[cfg(feature = "encoding")]
+pub use hash_b64::*;
 
 #[cfg(feature = "fixturators")]
 pub mod fixt;
@@ -33,21 +36,21 @@ pub mod fixt;
 #[cfg(feature = "hashing")]
 mod hash_ext;
 
-#[cfg(feature = "serialized-bytes")]
+#[cfg(feature = "hashing")]
 mod hashable_content;
-#[cfg(feature = "serialized-bytes")]
+#[cfg(feature = "hashing")]
 mod hashed;
-#[cfg(feature = "serialized-bytes")]
+#[cfg(feature = "serialization")]
 mod ser;
 
 #[cfg(feature = "hashing")]
 pub use hash_ext::*;
-#[cfg(feature = "serialized-bytes")]
+#[cfg(feature = "hashing")]
 pub use hashable_content::*;
-#[cfg(feature = "serialized-bytes")]
+#[cfg(feature = "hashing")]
 pub use hashed::*;
 
 /// A convenience type, for specifying a hash by HashableContent rather than
 /// by its HashType
-#[cfg(feature = "serialized-bytes")]
+#[cfg(feature = "hashing")]
 pub type HoloHashOf<C> = HoloHash<<C as HashableContent>::HashType>;

--- a/crates/holo_hash/src/lib.rs
+++ b/crates/holo_hash/src/lib.rs
@@ -14,6 +14,30 @@ pub use hash::*;
 pub use hash_type::HashType;
 pub use hash_type::PrimitiveHashType;
 
+// feature: serialization (enabled by default)
+// (serde, SerializedBytes)
+
+#[cfg(feature = "serialization")]
+mod hashed;
+#[cfg(feature = "serialization")]
+pub use hashed::*;
+
+#[cfg(feature = "serialization")]
+mod hashable_content;
+#[cfg(feature = "serialization")]
+pub use hashable_content::*;
+
+#[cfg(feature = "serialization")]
+mod ser;
+
+#[cfg(feature = "serialization")]
+/// A convenience type, for specifying a hash by HashableContent rather than
+/// by its HashType
+pub type HoloHashOf<C> = HoloHash<<C as HashableContent>::HashType>;
+
+// feature: encoding
+// (string encoding)
+
 #[cfg(feature = "encoding")]
 pub use encode::{holo_hash_decode, holo_hash_decode_unchecked, holo_hash_encode};
 
@@ -30,27 +54,16 @@ mod hash_b64;
 #[cfg(feature = "encoding")]
 pub use hash_b64::*;
 
-#[cfg(feature = "fixturators")]
-pub mod fixt;
+// feature: hashing
+// (blake2b hashing for hash generation and DHT location calculation)
 
 #[cfg(feature = "hashing")]
 mod hash_ext;
 
 #[cfg(feature = "hashing")]
-mod hashable_content;
-#[cfg(feature = "hashing")]
-mod hashed;
-#[cfg(feature = "serialization")]
-mod ser;
-
-#[cfg(feature = "hashing")]
 pub use hash_ext::*;
-#[cfg(feature = "hashing")]
-pub use hashable_content::*;
-#[cfg(feature = "hashing")]
-pub use hashed::*;
 
-/// A convenience type, for specifying a hash by HashableContent rather than
-/// by its HashType
-#[cfg(feature = "hashing")]
-pub type HoloHashOf<C> = HoloHash<<C as HashableContent>::HashType>;
+// feature: fixturators
+// provides fixturators for all hash types
+#[cfg(feature = "fixturators")]
+pub mod fixt;

--- a/crates/holo_hash/src/ser.rs
+++ b/crates/holo_hash/src/ser.rs
@@ -60,7 +60,7 @@ impl<'de, T: HashType> serde::de::Visitor<'de> for HoloHashVisitor<T> {
         self.visit_bytes(&vec)
     }
 
-    #[cfg(feature = "string-encoding")]
+    #[cfg(feature = "encoding")]
     fn visit_str<E>(self, b64: &str) -> Result<Self::Value, E>
     where
         E: serde::de::Error,
@@ -116,7 +116,7 @@ mod tests {
     struct TestByteArray(#[serde(with = "serde_bytes")] Vec<u8>);
 
     #[test]
-    #[cfg(feature = "serialized-bytes")]
+    #[cfg(feature = "serialization")]
     fn test_serialized_bytes_roundtrip() {
         use holochain_serialized_bytes::SerializedBytes;
         use std::convert::TryInto;

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -28,7 +28,7 @@ holo_hash = { version = "0.0.5", path = "../holo_hash", features = ["encoding"] 
 holochain_keystore = { version = "0.0.6-dev.0", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
 holochain_sqlite = { path = "../holochain_sqlite", version = "0.0.6-dev.0"}
-holochain_zome_types = { path = "../holochain_zome_types", version = "0.0.7"}
+holochain_zome_types = { path = "../holochain_zome_types", version = "0.0.7", features = ["full"] }
 itertools = { version = "0.10" }
 lazy_static = "1.4.0"
 mockall = "0.10.2"

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -24,7 +24,7 @@ either = "1.5"
 fixt = { path = "../fixt", version = "0.0.5"}
 flate2 = "1.0.14"
 futures = "0.3"
-holo_hash = { version = "0.0.5", path = "../holo_hash", features = ["string-encoding"] }
+holo_hash = { version = "0.0.5", path = "../holo_hash", features = ["encoding"] }
 holochain_keystore = { version = "0.0.6-dev.0", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
 holochain_sqlite = { path = "../holochain_sqlite", version = "0.0.6-dev.0"}

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [dependencies]
 chrono = "0.4.6"
 kitsune_p2p_timestamp = { version = "0.0.1-dev.0", path = "../kitsune_p2p/timestamp" }
-holo_hash = { version = "0.0.5", path = "../holo_hash", default-features = false }
+holo_hash = { version = "0.0.5", path = "../holo_hash" }
 holochain_serialized_bytes = "=0.0.51"
 paste = "=1.0.5"
 serde = { version = "1.0", features = [ "derive" ] }


### PR DESCRIPTION
### INCLUDED CHANGES:
- holo_hash now builds with --no-default-features
- some features renamed
- "serialization" feature now includes serde, not just holochain_serialized_bytes
- holo_hash is expected to be used *with* default features by the HDK

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
