### PR TITLE
ktest 01: AsTx2ConHnd abstraction for multiple handle impls

### DIFF
--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -338,8 +338,15 @@ impl KitsuneP2pActor {
                                     }) => {
                                         let data: Vec<u8> = data.into();
                                         let data: Box<[u8]> = data.into_boxed_slice();
-                                        if let Err(e) =
-                                            i_s.incoming_gossip(space, con, url, data, module).await
+                                        if let Err(e) = i_s
+                                            .incoming_gossip(
+                                                space,
+                                                Arc::new(con),
+                                                url,
+                                                data,
+                                                module,
+                                            )
+                                            .await
                                         {
                                             tracing::warn!(
                                                 "failed to handle incoming gossip: {:?}",

--- a/crates/kitsune_p2p/proxy/examples/cli-chat.rs
+++ b/crates/kitsune_p2p/proxy/examples/cli-chat.rs
@@ -8,6 +8,7 @@ use kitsune_p2p_types::tx2::tx2_pool_promote::*;
 use kitsune_p2p_types::*;
 use std::collections::HashSet;
 use std::io::Write;
+use std::sync::Arc;
 
 kitsune_p2p_types::write_codec_enum! {
     codec Wire {
@@ -19,9 +20,11 @@ kitsune_p2p_types::write_codec_enum! {
     }
 }
 
+// trait Ch: AsTx2ConHnd<Wire> + PartialEq<RealTx2ConHnd<Wire>> + Eq {}
+
 #[derive(Debug)]
 enum Evt {
-    InCon(Tx2ConHnd<Wire>),
+    InCon(RealTx2ConHnd<Wire>),
     Output(String),
     Key(char),
     Backspace,
@@ -223,7 +226,7 @@ async fn main() {
     while let Some(evt) = evt.next().await {
         match evt {
             Evt::InCon(c) => {
-                con_set.insert(c);
+                con_set.insert(Arc::new(c));
             }
             Evt::Output(o) => pline!("{}", o),
             Evt::Key(evt) => line.push(evt),

--- a/crates/kitsune_p2p/types/src/codec.rs
+++ b/crates/kitsune_p2p/types/src/codec.rs
@@ -61,6 +61,10 @@ pub trait Codec: Clone + Sized {
     }
 }
 
+/// Alias for Codec plus the necessary additional trait bounds
+pub trait CodecBound: Codec + 'static + Send + std::fmt::Debug {}
+impl<T> CodecBound for T where T: Codec + 'static + Send + std::fmt::Debug {}
+
 /// DSL-style macro for generating a serialization protocol message enum.
 ///
 /// DSL:


### PR DESCRIPTION
### INCLUDED CHANGES:
- trait alias `CodecBound` for common `Codec` addons
- make Tx2ConHnd generic wherever possible via `AsTx2ConHnd` trait with associated `Codec` type

Paves the way for a channel-based `TestTx2ConHnd`

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
