### PR TITLE
Fix bug with null status on must_get

### DIFF
--- a/crates/holochain_state/src/query/element_details.rs
+++ b/crates/holochain_state/src/query/element_details.rs
@@ -57,7 +57,7 @@ impl Query for GetElementDetailsQuery {
             let header = HeaderHashed::from_content_sync(header);
             let shh = SignedHeaderHashed::with_presigned(header, signature);
             let status = row.get(row.column_index("status")?)?;
-            let r = Judged::new(shh, status);
+            let r = Judged::raw(shh, status);
             Ok(r)
         };
         Arc::new(f)


### PR DESCRIPTION
### INCLUDED CHANGES:
- Fix issue where `must_get_valid_element` could return `Err(WasmError::Host("Invalid column type Null at index: 1, name: status"))` by removing an assumption that `status` in non-nullable

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
