### PR TITLE
Unify 3 agent queries into 1

### DIFF
--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -558,13 +558,6 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
                 let res = env
                     .conn()?
                     .p2p_gossip_query_agents(since_ms, until_ms, (*arc_set).clone())
-                    // FIXME: This sucks we have to iterate through the whole vec just to add Arcs.
-                    // Are arcs really saving us that much?
-                    .map(|r| {
-                        r.into_iter()
-                            .map(|(agent, arc)| (Arc::new(agent), arc))
-                            .collect()
-                    })
                     .map_err(holochain_p2p::HolochainP2pError::other);
                 respond.respond(Ok(async move { res }.boxed().into()));
             }

--- a/crates/holochain/src/conductor/p2p_agent_store.rs
+++ b/crates/holochain/src/conductor/p2p_agent_store.rs
@@ -83,7 +83,7 @@ pub fn list_all_agent_info_signed_near_basis(
     environ: EnvWrite,
     _kitsune_space: Arc<kitsune_p2p::KitsuneSpace>,
     basis_loc: u32,
-    limit: usize,
+    limit: u32,
 ) -> ConductorResult<Vec<AgentInfoSigned>> {
     Ok(environ.conn()?.p2p_query_near_basis(basis_loc, limit)?)
 }

--- a/crates/holochain/src/conductor/p2p_agent_store.rs
+++ b/crates/holochain/src/conductor/p2p_agent_store.rs
@@ -83,7 +83,7 @@ pub fn list_all_agent_info_signed_near_basis(
     environ: EnvWrite,
     _kitsune_space: Arc<kitsune_p2p::KitsuneSpace>,
     basis_loc: u32,
-    limit: u32,
+    limit: usize,
 ) -> ConductorResult<Vec<AgentInfoSigned>> {
     Ok(environ.conn()?.p2p_query_near_basis(basis_loc, limit)?)
 }

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -115,7 +115,7 @@ impl WrapEvtSender {
         dna_hash: DnaHash,
         kitsune_space: Arc<kitsune_p2p::KitsuneSpace>,
         basis_loc: u32,
-        limit: usize,
+        limit: u32,
     ) -> impl Future<Output = HolochainP2pResult<Vec<AgentInfoSigned>>> + 'static + Send {
         timing_trace!(
             {

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -4,6 +4,7 @@ use crate::event::*;
 use crate::*;
 
 use futures::future::FutureExt;
+use kitsune_p2p::event::full_time_range;
 use kitsune_p2p::event::MetricDatum;
 use kitsune_p2p::event::MetricKind;
 use kitsune_p2p::event::MetricQuery;

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -655,8 +655,9 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
                     .query_agent_info_signed_near_basis(h_space, space, basis.as_u32(), limit)
                     .await?),
 
-                // If window and arc_set are set, this is a "gossip agents" query
-                (agents, Some(window), Some(arc_set), None, None) => {
+                // If arc_set is set, this is a "gossip agents" query
+                (agents, window, Some(arc_set), None, None) => {
+                    let window = window.unwrap_or_else(full_time_range);
                     let h_agents =
                         agents.map(|agents| agents.iter().map(AgentPubKey::from_kitsune).collect());
                     let since_ms = (window.start.as_micros() / 1000) as u64;
@@ -666,7 +667,7 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
                         .await?)
                 }
                 // Otherwise, do a simple agent query with optional agent filter
-                (agents, None, None, None, _) => Ok(evt_sender
+                (agents, None, None, None, None) => Ok(evt_sender
                     .query_agent_info_signed(h_space, agents, space)
                     .await?),
 

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -78,16 +78,7 @@ impl WrapEvtSender {
         since_ms: u64,
         until_ms: u64,
         arc_set: Arc<kitsune_p2p_types::dht_arc::DhtArcSet>,
-    ) -> impl Future<
-        Output = HolochainP2pResult<
-            Vec<(
-                Arc<kitsune_p2p::KitsuneAgent>,
-                kitsune_p2p_types::dht_arc::ArcInterval,
-            )>,
-        >,
-    >
-           + 'static
-           + Send {
+    ) -> impl Future<Output = HolochainP2pResult<Vec<AgentInfoSigned>>> + 'static + Send {
         timing_trace!(
             {
                 self.0.query_gossip_agents(
@@ -123,7 +114,7 @@ impl WrapEvtSender {
         dna_hash: DnaHash,
         kitsune_space: Arc<kitsune_p2p::KitsuneSpace>,
         basis_loc: u32,
-        limit: u32,
+        limit: usize,
     ) -> impl Future<Output = HolochainP2pResult<Vec<AgentInfoSigned>>> + 'static + Send {
         timing_trace!(
             {
@@ -635,67 +626,47 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
         .into())
     }
 
-    /// We need to get previously stored agent info.
+    /// We need to get previously stored agent info. A single kitusne agent query
+    /// can take one of three Holochain agent query paths. We do "duck typing"
+    /// on the query object to determine which query path to take. The reason for
+    /// this is that Holochain is optimized for these three query types, while
+    /// kitsune has a more general interface.
     #[tracing::instrument(skip(self), level = "trace")]
-    fn handle_query_agent_info_signed(
+    fn handle_query_agents(
         &mut self,
-        input: kitsune_p2p::event::QueryAgentInfoSignedEvt,
+        input: kitsune_p2p::event::QueryAgentsEvt,
     ) -> kitsune_p2p::event::KitsuneP2pEventHandlerResult<Vec<AgentInfoSigned>> {
-        let kitsune_p2p::event::QueryAgentInfoSignedEvt { space, agents } = input;
-        let h_space = DnaHash::from_kitsune(&space);
-        let evt_sender = self.evt_sender.clone();
-        Ok(async move {
-            Ok(evt_sender
-                .query_agent_info_signed(h_space, agents, space)
-                .await?)
-        }
-        .boxed()
-        .into())
-    }
-
-    /// We need to get previously stored agent info.
-    #[tracing::instrument(skip(self), level = "trace")]
-    fn handle_query_gossip_agents(
-        &mut self,
-        input: kitsune_p2p::event::QueryGossipAgentsEvt,
-    ) -> kitsune_p2p::event::KitsuneP2pEventHandlerResult<
-        Vec<(
-            Arc<kitsune_p2p::KitsuneAgent>,
-            kitsune_p2p_types::dht_arc::ArcInterval,
-        )>,
-    > {
-        let kitsune_p2p::event::QueryGossipAgentsEvt {
+        let kitsune_p2p::event::QueryAgentsEvt {
             space,
             agents,
-            since_ms,
-            until_ms,
+            window,
             arc_set,
+            near_basis,
+            limit,
         } = input;
-        let h_space = DnaHash::from_kitsune(&space);
-        let h_agents = agents.map(|agents| agents.iter().map(AgentPubKey::from_kitsune).collect());
-        let evt_sender = self.evt_sender.clone();
-        Ok(async move {
-            Ok(evt_sender
-                .query_gossip_agents(h_space, h_agents, space, since_ms, until_ms, arc_set)
-                .await?)
-        }
-        .boxed()
-        .into())
-    }
 
-    #[tracing::instrument(skip(self), level = "trace")]
-    fn handle_query_agent_info_signed_near_basis(
-        &mut self,
-        space: Arc<kitsune_p2p::KitsuneSpace>,
-        basis_loc: u32,
-        limit: u32,
-    ) -> kitsune_p2p::event::KitsuneP2pEventHandlerResult<Vec<AgentInfoSigned>> {
         let h_space = DnaHash::from_kitsune(&space);
         let evt_sender = self.evt_sender.clone();
+
         Ok(async move {
-            Ok(evt_sender
-                .query_agent_info_signed_near_basis(h_space, space, basis_loc, limit)
-                .await?)
+            match (agents, window, arc_set, near_basis, limit) {
+                (None, None, None, Some(basis), Some(limit)) => Ok(evt_sender
+                    .query_agent_info_signed_near_basis(h_space, space, basis.as_u32(), limit)
+                    .await?),
+                (agents, Some(window), Some(arc_set), None, None) => {
+                    let h_agents =
+                        agents.map(|agents| agents.iter().map(AgentPubKey::from_kitsune).collect());
+                    let since_ms = (window.start.as_micros() / 1000) as u64;
+                    let until_ms = (window.end.as_micros() / 1000) as u64;
+                    Ok(evt_sender
+                        .query_gossip_agents(h_space, h_agents, space, since_ms, until_ms, arc_set)
+                        .await?)
+                }
+                (agents, None, None, None, _) => Ok(evt_sender
+                    .query_agent_info_signed(h_space, agents, space)
+                    .await?),
+                _ => todo!(),
+            }
         }
         .boxed()
         .into())

--- a/crates/holochain_p2p/src/types/event.rs
+++ b/crates/holochain_p2p/src/types/event.rs
@@ -126,10 +126,10 @@ ghost_actor::ghost_chan! {
             since_ms: u64,
             until_ms: u64,
             arc_set: Arc<kitsune_p2p_types::dht_arc::DhtArcSet>,
-        ) -> Vec<(Arc<kitsune_p2p::KitsuneAgent>, kitsune_p2p_types::dht_arc::ArcInterval)>;
+        ) -> Vec<AgentInfoSigned>;
 
         /// query agent info in order of closeness to a basis location.
-        fn query_agent_info_signed_near_basis(dna_hash: DnaHash, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>, basis_loc: u32, limit: u32) -> Vec<AgentInfoSigned>;
+        fn query_agent_info_signed_near_basis(dna_hash: DnaHash, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>, basis_loc: u32, limit: usize) -> Vec<AgentInfoSigned>;
 
         /// Query the peer density of a space for a given [`DhtArc`].
         fn query_peer_density(dna_hash: DnaHash, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>, dht_arc: kitsune_p2p_types::dht_arc::DhtArc) -> kitsune_p2p_types::dht_arc::PeerDensity;

--- a/crates/holochain_p2p/src/types/event.rs
+++ b/crates/holochain_p2p/src/types/event.rs
@@ -129,7 +129,7 @@ ghost_actor::ghost_chan! {
         ) -> Vec<AgentInfoSigned>;
 
         /// query agent info in order of closeness to a basis location.
-        fn query_agent_info_signed_near_basis(dna_hash: DnaHash, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>, basis_loc: u32, limit: usize) -> Vec<AgentInfoSigned>;
+        fn query_agent_info_signed_near_basis(dna_hash: DnaHash, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>, basis_loc: u32, limit: u32) -> Vec<AgentInfoSigned>;
 
         /// Query the peer density of a space for a given [`DhtArc`].
         fn query_peer_density(dna_hash: DnaHash, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>, dht_arc: kitsune_p2p_types::dht_arc::DhtArc) -> kitsune_p2p_types::dht_arc::PeerDensity;

--- a/crates/holochain_sqlite/src/db/p2p_agent_store.rs
+++ b/crates/holochain_sqlite/src/db/p2p_agent_store.rs
@@ -189,6 +189,8 @@ impl AsP2pStateTxExt for Transaction<'_> {
         let mut out = Vec::new();
         for r in stmt.query_map(
             named_params! {
+                // TODO: just take i64 so we don't need to clamp (probably
+                //       should just do more Timestamp refactor)
                 ":since_ms": clamp64(since_ms),
                 ":until_ms": clamp64(until_ms),
                 // we filter by arc in memory, not in the db query
@@ -206,6 +208,7 @@ impl AsP2pStateTxExt for Transaction<'_> {
         )? {
             let info = r?;
             let interval = info.storage_arc.interval();
+            dbg!(&arcset, &interval);
             if arcset.overlap(&interval.into()) {
                 out.push(info);
             }

--- a/crates/holochain_sqlite/src/db/p2p_agent_store.rs
+++ b/crates/holochain_sqlite/src/db/p2p_agent_store.rs
@@ -29,7 +29,7 @@ pub trait AsP2pAgentStoreConExt {
     fn p2p_query_near_basis(
         &mut self,
         basis: u32,
-        limit: usize,
+        limit: u32,
     ) -> DatabaseResult<Vec<AgentInfoSigned>>;
 }
 
@@ -51,11 +51,7 @@ pub trait AsP2pStateTxExt {
     ) -> DatabaseResult<Vec<AgentInfoSigned>>;
 
     /// Query agents sorted by nearness to basis loc
-    fn p2p_query_near_basis(
-        &self,
-        basis: u32,
-        limit: usize,
-    ) -> DatabaseResult<Vec<AgentInfoSigned>>;
+    fn p2p_query_near_basis(&self, basis: u32, limit: u32) -> DatabaseResult<Vec<AgentInfoSigned>>;
 }
 
 impl AsP2pAgentStoreConExt for crate::db::PConn {
@@ -79,7 +75,7 @@ impl AsP2pAgentStoreConExt for crate::db::PConn {
     fn p2p_query_near_basis(
         &mut self,
         basis: u32,
-        limit: usize,
+        limit: u32,
     ) -> DatabaseResult<Vec<AgentInfoSigned>> {
         self.with_reader(move |reader| reader.p2p_query_near_basis(basis, limit))
     }
@@ -217,11 +213,7 @@ impl AsP2pStateTxExt for Transaction<'_> {
         Ok(out)
     }
 
-    fn p2p_query_near_basis(
-        &self,
-        basis: u32,
-        limit: usize,
-    ) -> DatabaseResult<Vec<AgentInfoSigned>> {
+    fn p2p_query_near_basis(&self, basis: u32, limit: u32) -> DatabaseResult<Vec<AgentInfoSigned>> {
         let mut stmt = self
             .prepare(sql_p2p_agent_store::QUERY_NEAR_BASIS)
             .map_err(|e| rusqlite::Error::ToSqlConversionFailure(e.into()))?;

--- a/crates/holochain_sqlite/src/sql/p2p_agent_store/gossip_query.sql
+++ b/crates/holochain_sqlite/src/sql/p2p_agent_store/gossip_query.sql
@@ -1,7 +1,5 @@
 SELECT
-  agent,
-  storage_start_loc,
-  storage_end_loc
+  encoded
 FROM
   p2p_agent_store
 WHERE

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
@@ -26,6 +26,16 @@ pub mod gaps;
 /// a u32 dht arc
 pub struct DhtLocation(pub Wrapping<u32>);
 
+impl DhtLocation {
+    pub fn new(loc: u32) -> Self {
+        Self(Wrapping(loc))
+    }
+
+    pub fn as_u32(&self) -> u32 {
+        self.0 .0
+    }
+}
+
 /// The maximum you can hold either side of the hash location
 /// is half the circle.
 /// This is half of the furthest index you can hold

--- a/crates/kitsune_p2p/direct/src/v1.rs
+++ b/crates/kitsune_p2p/direct/src/v1.rs
@@ -632,34 +632,11 @@ async fn handle_events(
                         .boxed()
                         .into()));
                 }
-                event::KitsuneP2pEvent::QueryAgentInfoSigned { respond, input, .. } => {
-                    respond.r(Ok(handle_query_agent_info_signed(kdirect.clone(), input)
+                event::KitsuneP2pEvent::QueryAgents { respond, input, .. } => {
+                    respond.r(Ok(handle_query_agents(kdirect.clone(), input)
                         .map_err(KitsuneP2pError::other)
                         .boxed()
                         .into()));
-                }
-                event::KitsuneP2pEvent::QueryGossipAgents { respond, input, .. } => {
-                    respond.r(Ok(handle_query_gossip_agents(kdirect.clone(), input)
-                        .map_err(KitsuneP2pError::other)
-                        .boxed()
-                        .into()));
-                }
-                event::KitsuneP2pEvent::QueryAgentInfoSignedNearBasis {
-                    respond,
-                    space,
-                    basis_loc,
-                    limit,
-                    ..
-                } => {
-                    respond.r(Ok(handle_query_agent_info_signed_near_basis(
-                        kdirect.clone(),
-                        space,
-                        basis_loc,
-                        limit,
-                    )
-                    .map_err(KitsuneP2pError::other)
-                    .boxed()
-                    .into()));
                 }
                 event::KitsuneP2pEvent::QueryPeerDensity {
                     respond,
@@ -796,41 +773,15 @@ async fn handle_get_agent_info_signed(
     })
 }
 
-async fn handle_query_gossip_agents(
-    _kdirect: Arc<Kd1>,
-    _input: kitsune_p2p::event::QueryGossipAgentsEvt,
-) -> KdResult<
-    Vec<(
-        Arc<kitsune_p2p::KitsuneAgent>,
-        kitsune_p2p_types::dht_arc::ArcInterval,
-    )>,
-> {
-    todo!()
-}
-
-async fn handle_query_agent_info_signed(
+async fn handle_query_agents(
     kdirect: Arc<Kd1>,
-    input: QueryAgentInfoSignedEvt,
+    input: QueryAgentsEvt,
 ) -> KdResult<Vec<AgentInfoSigned>> {
-    let QueryAgentInfoSignedEvt { space, .. } = input;
+    let QueryAgentsEvt { space, .. } = input;
 
     let root = KdHash::from_kitsune_space(&space);
 
     let map = kdirect.persist.query_agent_info(root).await?;
-    Ok(map.into_iter().map(|a| a.to_kitsune()).collect())
-}
-
-async fn handle_query_agent_info_signed_near_basis(
-    kdirect: Arc<Kd1>,
-    space: Arc<KitsuneSpace>,
-    basis_loc: u32,
-    limit: u32,
-) -> KdResult<Vec<AgentInfoSigned>> {
-    let root = KdHash::from_kitsune_space(&space);
-    let map = kdirect
-        .persist
-        .query_agent_info_near_basis(root, basis_loc, limit)
-        .await?;
     Ok(map.into_iter().map(|a| a.to_kitsune()).collect())
 }
 

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+### Changed
+
+- `query_gossip_agents`, `query_agent_info_signed`, and `query_agent_info_signed_near_basis` are now unified into a single `query_agents` call in `KitsuneP2pEvent`
+
 ## 0.0.6
 
 ## 0.0.5

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -20,23 +20,21 @@ async fn standard_responses(
 ) -> MockKitsuneP2pEventHandler {
     let mut evt_handler = MockKitsuneP2pEventHandler::new();
     let agents: Vec<_> = agents_with_arcs.iter().map(|(a, _)| a.clone()).collect();
-    evt_handler
-        .expect_handle_query_agent_info_signed()
-        .returning({
+    evt_handler.expect_handle_query_agents().returning({
+        let agents = agents.clone();
+        move |_| {
             let agents = agents.clone();
-            move |_| {
-                let agents = agents.clone();
-                Ok(async move {
-                    let mut infos = Vec::new();
-                    for agent in agents {
-                        infos.push(agent_info(agent).await);
-                    }
-                    Ok(infos)
+            Ok(async move {
+                let mut infos = Vec::new();
+                for agent in agents {
+                    infos.push(agent_info(agent).await);
                 }
-                .boxed()
-                .into())
+                Ok(infos)
             }
-        });
+            .boxed()
+            .into())
+        }
+    });
     evt_handler
         .expect_handle_get_agent_info_signed()
         .returning({
@@ -49,12 +47,7 @@ async fn standard_responses(
                     .into())
             }
         });
-    evt_handler.expect_handle_query_gossip_agents().returning({
-        move |_| {
-            let agents_with_arcs = agents_with_arcs.clone();
-            Ok(async move { Ok(agents_with_arcs) }.boxed().into())
-        }
-    });
+
     if with_data {
         evt_handler.expect_handle_query_op_hashes().returning(|_| {
             Ok(async {

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/handler_builder.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/handler_builder.rs
@@ -46,12 +46,8 @@ impl HandlerBuilder {
     pub fn with_agent_persistence(mut self, agent_data: MockAgentPersistence) -> Self {
         let info_only: Vec<_> = agent_data.iter().map(|(info, _)| info.clone()).collect();
         let agents_only: Vec<_> = info_only.iter().map(|info| info.agent.clone()).collect();
-        let agents_arcs: Vec<_> = agent_data
-            .iter()
-            .map(|(info, _)| (info.agent.clone(), info.storage_arc.interval()))
-            .collect();
 
-        self.0.expect_handle_query_agent_info_signed().returning({
+        self.0.expect_handle_query_agents().returning({
             let info_only = info_only.clone();
             move |_| {
                 let info_only = info_only.clone();
@@ -67,13 +63,6 @@ impl HandlerBuilder {
                 Ok(async move { Ok(Some(agent_info(agent).await)) }
                     .boxed()
                     .into())
-            }
-        });
-
-        self.0.expect_handle_query_gossip_agents().returning({
-            move |_| {
-                let agents_arcs = agents_arcs.clone();
-                Ok(async move { Ok(agents_arcs) }.boxed().into())
             }
         });
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/simple_bloom/step_2_local_sync_inner.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/simple_bloom/step_2_local_sync_inner.rs
@@ -79,10 +79,7 @@ impl Inner {
         // agent store is shared between agents in one space
         // we only have to query it once for all local_agents
         if let Ok(agent_infos) = evt_sender
-            .query_agent_info_signed(QueryAgentInfoSignedEvt {
-                space: space.clone(),
-                agents: Some(local_agents.clone().into_iter().collect()),
-            })
+            .query_agents(QueryAgentsEvt::new(space.clone()).by_agents(local_agents.clone()))
             .await
         {
             for agent_info in agent_infos {

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -265,13 +265,11 @@ impl KitsuneP2pActor {
                                     wire::Wire::PeerQuery(wire::PeerQuery { space, basis_loc }) => {
                                         // this *does* go over the network...
                                         // so we don't want it to be too many
-                                        const LIMIT: u32 = 8;
-                                        match evt_sender
-                                            .query_agent_info_signed_near_basis(
-                                                space, basis_loc, LIMIT,
-                                            )
-                                            .await
-                                        {
+                                        const LIMIT: usize = 8;
+                                        let query = QueryAgentsEvt::new(space)
+                                            .near_basis(basis_loc)
+                                            .limit(LIMIT);
+                                        match evt_sender.query_agents(query).await {
                                             Ok(list) if !list.is_empty() => {
                                                 let resp = wire::Wire::peer_query_resp(list);
                                                 resp!(respond, resp);
@@ -485,34 +483,11 @@ impl KitsuneP2pEventHandler for KitsuneP2pActor {
         Ok(self.evt_sender.get_agent_info_signed(input))
     }
 
-    fn handle_query_agent_info_signed(
+    fn handle_query_agents(
         &mut self,
-        input: crate::event::QueryAgentInfoSignedEvt,
+        input: crate::event::QueryAgentsEvt,
     ) -> KitsuneP2pEventHandlerResult<Vec<crate::types::agent_store::AgentInfoSigned>> {
-        Ok(self.evt_sender.query_agent_info_signed(input))
-    }
-
-    fn handle_query_gossip_agents(
-        &mut self,
-        input: crate::event::QueryGossipAgentsEvt,
-    ) -> KitsuneP2pEventHandlerResult<
-        Vec<(
-            Arc<crate::KitsuneAgent>,
-            kitsune_p2p_types::dht_arc::ArcInterval,
-        )>,
-    > {
-        Ok(self.evt_sender.query_gossip_agents(input))
-    }
-
-    fn handle_query_agent_info_signed_near_basis(
-        &mut self,
-        space: Arc<KitsuneSpace>,
-        basis_loc: u32,
-        limit: u32,
-    ) -> KitsuneP2pEventHandlerResult<Vec<crate::types::agent_store::AgentInfoSigned>> {
-        Ok(self
-            .evt_sender
-            .query_agent_info_signed_near_basis(space, basis_loc, limit))
+        Ok(self.evt_sender.query_agents(input))
     }
 
     fn handle_query_peer_density(
@@ -784,26 +759,9 @@ mockall::mock! {
             input: crate::event::GetAgentInfoSignedEvt,
         ) -> KitsuneP2pEventHandlerResult<Option<crate::types::agent_store::AgentInfoSigned>>;
 
-        fn handle_query_agent_info_signed(
+        fn handle_query_agents(
             &mut self,
-            input: crate::event::QueryAgentInfoSignedEvt,
-        ) -> KitsuneP2pEventHandlerResult<Vec<crate::types::agent_store::AgentInfoSigned>>;
-
-        fn handle_query_gossip_agents(
-            &mut self,
-            input: crate::event::QueryGossipAgentsEvt,
-        ) -> KitsuneP2pEventHandlerResult<
-            Vec<(
-                Arc<crate::KitsuneAgent>,
-                kitsune_p2p_types::dht_arc::ArcInterval,
-            )>,
-        >;
-
-        fn handle_query_agent_info_signed_near_basis(
-            &mut self,
-            space: Arc<KitsuneSpace>,
-            basis_loc: u32,
-            limit: u32,
+            input: crate::event::QueryAgentsEvt,
         ) -> KitsuneP2pEventHandlerResult<Vec<crate::types::agent_store::AgentInfoSigned>>;
 
         fn handle_put_metric_datum(&mut self, datum: MetricDatum) -> KitsuneP2pEventHandlerResult<()>;

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -265,7 +265,7 @@ impl KitsuneP2pActor {
                                     wire::Wire::PeerQuery(wire::PeerQuery { space, basis_loc }) => {
                                         // this *does* go over the network...
                                         // so we don't want it to be too many
-                                        const LIMIT: usize = 8;
+                                        const LIMIT: u32 = 8;
                                         let query = QueryAgentsEvt::new(space)
                                             .near_basis(basis_loc)
                                             .limit(LIMIT);

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/discover.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/discover.rs
@@ -239,16 +239,15 @@ pub(crate) fn get_cached_remotes_near_basis(
 ) -> impl Future<Output = KitsuneP2pResult<Vec<AgentInfoSigned>>> + 'static + Send {
     // as this is a local request, there isn't much cost to getting more
     // results than we strictly need
-    const LIMIT: u32 = 20;
+    const LIMIT: usize = 20;
 
     async move {
         let mut nodes = Vec::new();
 
-        for node in inner
-            .evt_sender
-            .query_agent_info_signed_near_basis(inner.space.clone(), basis_loc, LIMIT)
-            .await?
-        {
+        let query = QueryAgentsEvt::new(inner.space.clone())
+            .near_basis(basis_loc)
+            .limit(LIMIT);
+        for node in inner.evt_sender.query_agents(query).await? {
             if !inner
                 .i_s
                 .is_agent_local(node.agent.clone())

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/discover.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/discover.rs
@@ -239,7 +239,7 @@ pub(crate) fn get_cached_remotes_near_basis(
 ) -> impl Future<Output = KitsuneP2pResult<Vec<AgentInfoSigned>>> + 'static + Send {
     // as this is a local request, there isn't much cost to getting more
     // results than we strictly need
-    const LIMIT: usize = 20;
+    const LIMIT: u32 = 20;
 
     async move {
         let mut nodes = Vec::new();

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -109,10 +109,7 @@ impl SpaceInternalHandler for Space {
             self.local_joined_agents.iter().cloned().collect();
         let all_peers_fut = self
             .evt_sender
-            .query_agent_info_signed(QueryAgentInfoSignedEvt {
-                space: self.space.clone(),
-                agents: None,
-            });
+            .query_agents(QueryAgentsEvt::new(self.space.clone()));
         Ok(async move {
             for peer in all_peers_fut.await? {
                 res.insert(peer.agent.clone());

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
@@ -96,18 +96,17 @@ async fn test_rpc_multi_logic_mocked() {
     let mut m = MockKitsuneP2pEventHandler::new();
     let start = tokio::time::Instant::now();
     // don't return any infos to start, then return 4 to test our loops
-    m.expect_handle_query_agent_info_signed_near_basis()
-        .returning(move |_, _, _| {
-            println!("QUERY: {}", start.elapsed().as_secs_f64());
-            let mut out = Vec::new();
-            if start.elapsed().as_secs_f64() > 1.0 {
-                out.push(A1.clone());
-                out.push(A2.clone());
-                out.push(A3.clone());
-                out.push(A4.clone());
-            }
-            Ok(async move { Ok(out) }.boxed().into())
-        });
+    m.expect_handle_query_agents().returning(move |_| {
+        println!("QUERY: {}", start.elapsed().as_secs_f64());
+        let mut out = Vec::new();
+        if start.elapsed().as_secs_f64() > 1.0 {
+            out.push(A1.clone());
+            out.push(A2.clone());
+            out.push(A3.clone());
+            out.push(A4.clone());
+        }
+        Ok(async move { Ok(out) }.boxed().into())
+    });
     let evt_sender = build_event_handler(m).await;
 
     let config = Arc::new(KitsuneP2pConfig::default());

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
@@ -97,7 +97,6 @@ async fn test_rpc_multi_logic_mocked() {
     let start = tokio::time::Instant::now();
     // don't return any infos to start, then return 4 to test our loops
     m.expect_handle_query_agents().returning(move |_| {
-        println!("QUERY: {}", start.elapsed().as_secs_f64());
         let mut out = Vec::new();
         if start.elapsed().as_secs_f64() > 1.0 {
             out.push(A1.clone());

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
@@ -184,7 +184,7 @@ impl KitsuneP2pEventHandler for AgentHarness {
             })
             .filter(|(_, i)| arc_set.contains(i.agent.get_loc()))
             .filter(|(_, i)| window.contains(&Timestamp::from_micros(i.signed_at_ms as i64 * 1000)))
-            .take(limit.unwrap_or(usize::MAX))
+            .take(limit.unwrap_or(u32::MAX) as usize)
             .map(|(_, i)| (**i).clone())
             .collect();
         Ok(async move { Ok(out) }.boxed().into())

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
@@ -57,6 +57,8 @@ pub(crate) async fn spawn_test_agent(
     Ok((agent, p2p, control))
 }
 
+use kitsune_p2p_timestamp::Timestamp;
+use kitsune_p2p_types::dht_arc::DhtArcSet;
 use lair_keystore_api::entry::EntrySignEd25519;
 use lair_keystore_api::internal::sign_ed25519::*;
 
@@ -157,59 +159,33 @@ impl KitsuneP2pEventHandler for AgentHarness {
         Ok(async move { Ok(res) }.boxed().into())
     }
 
-    fn handle_query_gossip_agents(
+    fn handle_query_agents(
         &mut self,
-        input: crate::event::QueryGossipAgentsEvt,
-    ) -> KitsuneP2pEventHandlerResult<
-        Vec<(
-            Arc<crate::KitsuneAgent>,
-            kitsune_p2p_types::dht_arc::ArcInterval,
-        )>,
-    > {
-        let crate::event::QueryGossipAgentsEvt {
+        QueryAgentsEvt {
+            space: _,
             agents,
-            since_ms,
-            until_ms,
+            window,
             arc_set,
-            ..
-        } = input;
-        let res = self
-            .agent_store
-            .iter()
-            .filter(|(a, _)| match agents {
-                Some(ref agents) => agents.contains(a),
-                None => true,
-            })
-            .filter(|(_, i)| {
-                arc_set.contains(i.agent.get_loc())
-                    && i.signed_at_ms >= since_ms
-                    && i.signed_at_ms <= until_ms
-            })
-            .map(|(k, v)| (k.clone(), v.storage_arc.interval()))
-            .collect();
-        Ok(async move { Ok(res) }.boxed().into())
-    }
-
-    fn handle_query_agent_info_signed(
-        &mut self,
-        _input: QueryAgentInfoSignedEvt,
+            near_basis: _,
+            limit,
+        }: QueryAgentsEvt,
     ) -> KitsuneP2pEventHandlerResult<Vec<crate::types::agent_store::AgentInfoSigned>> {
-        let out = self.agent_store.values().map(|a| (**a).clone()).collect();
-        Ok(async move { Ok(out) }.boxed().into())
-    }
-
-    fn handle_query_agent_info_signed_near_basis(
-        &mut self,
-        _space: Arc<KitsuneSpace>,
-        _basis_loc: u32,
-        limit: u32,
-    ) -> KitsuneP2pEventHandlerResult<Vec<crate::types::agent_store::AgentInfoSigned>> {
-        // TODO - sort these?
+        let arc_set = arc_set.unwrap_or(Arc::new(DhtArcSet::Full));
+        let window = window.unwrap_or(full_time_range());
+        // TODO - sort by near_basis if set
         let out = self
             .agent_store
-            .values()
-            .map(|a| (**a).clone())
-            .take(limit as usize)
+            .iter()
+            .filter(|(a, _)| {
+                agents
+                    .as_ref()
+                    .map(|agents| agents.contains(*a))
+                    .unwrap_or(true)
+            })
+            .filter(|(_, i)| arc_set.contains(i.agent.get_loc()))
+            .filter(|(_, i)| window.contains(&Timestamp::from_micros(i.signed_at_ms as i64 * 1000)))
+            .take(limit.unwrap_or(usize::MAX))
+            .map(|(_, i)| (**i).clone())
             .collect();
         Ok(async move { Ok(out) }.boxed().into())
     }

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
@@ -2,7 +2,7 @@
 
 use crate::types::agent_store::AgentInfoSigned;
 use kitsune_p2p_timestamp::Timestamp;
-use kitsune_p2p_types::dht_arc::DhtArcSet;
+use kitsune_p2p_types::dht_arc::{DhtArcSet, DhtLocation};
 use std::{collections::HashSet, sync::Arc, time::SystemTime};
 
 /// Gather a list of op-hashes from our implementor that meet criteria.
@@ -65,26 +65,64 @@ pub struct GetAgentInfoSignedEvt {
 
 /// Get agent info which satisfies a query.
 #[derive(Debug)]
-pub struct QueryAgentInfoSignedEvt {
+pub struct QueryAgentsEvt {
     /// The "space" context.
     pub space: KSpace,
-    /// The optional list of agents to filter by.
+    /// Optional set of agents to filter by.
     pub agents: Option<HashSet<KAgent>>,
+    /// Optional time range to filter by.
+    pub window: Option<TimeWindow>,
+    /// Optional arcset to intersect by.
+    pub arc_set: Option<Arc<DhtArcSet>>,
+    /// If set, results are ordered by proximity to the specified location
+    pub near_basis: Option<DhtLocation>,
+    /// Limit to the number of results returned
+    pub limit: Option<usize>,
 }
 
-/// Get agent info which satisfies a query.
-#[derive(Debug)]
-pub struct QueryGossipAgentsEvt {
-    /// The "space" context.
-    pub space: KSpace,
-    /// The optional list of agents to filter by.
-    pub agents: Option<Vec<KAgent>>,
-    /// Start of the time window.
-    pub since_ms: u64,
-    /// End of the time window.
-    pub until_ms: u64,
-    /// The set that we need agents to fit into.
-    pub arc_set: Arc<kitsune_p2p_types::dht_arc::DhtArcSet>,
+impl QueryAgentsEvt {
+    /// Constructor. Every query needs to know what space it's for.
+    pub fn new(space: KSpace) -> Self {
+        Self {
+            space,
+            agents: None,
+            window: None,
+            arc_set: None,
+            near_basis: None,
+            limit: None,
+        }
+    }
+
+    /// Add in an agent list query
+    pub fn by_agents<A: IntoIterator<Item = KAgent>>(mut self, agents: A) -> Self {
+        self.agents = Some(agents.into_iter().collect());
+        self
+    }
+
+    /// Add in an a time window query
+    pub fn by_window(mut self, window: TimeWindow) -> Self {
+        self.window = Some(window);
+        self
+    }
+
+    /// Add in an an arcset query
+    pub fn by_arc_set(mut self, arc_set: Arc<DhtArcSet>) -> Self {
+        self.arc_set = Some(arc_set);
+        self
+    }
+
+    /// Specify that the results should be ordered by proximity to this basis
+    // TODO: make it take a DhtLocation
+    pub fn near_basis(mut self, basis: u32) -> Self {
+        self.near_basis = Some(DhtLocation::new(basis));
+        self
+    }
+
+    /// Limit the number of results
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.limit = Some(limit);
+        self
+    }
 }
 
 /// A single datum of metric info about an Agent, to be recorded by the client.
@@ -180,13 +218,7 @@ ghost_actor::ghost_chan! {
         fn get_agent_info_signed(input: GetAgentInfoSignedEvt) -> Option<crate::types::agent_store::AgentInfoSigned>;
 
         /// We need to get previously stored agent info.
-        fn query_agent_info_signed(input: QueryAgentInfoSignedEvt) -> Vec<crate::types::agent_store::AgentInfoSigned>;
-
-        /// We need to get agents that fit into an arc set for gossip.
-        fn query_gossip_agents(input: QueryGossipAgentsEvt) -> Vec<(KAgent, kitsune_p2p_types::dht_arc::ArcInterval)>;
-
-        /// query agent info in order of closeness to a basis location.
-        fn query_agent_info_signed_near_basis(space: KSpace, basis_loc: u32, limit: u32) -> Vec<crate::types::agent_store::AgentInfoSigned>;
+        fn query_agents(input: QueryAgentsEvt) -> Vec<crate::types::agent_store::AgentInfoSigned>;
 
         /// Query the peer density of a space for a given [`DhtArc`].
         fn query_peer_density(space: KSpace, dht_arc: kitsune_p2p_types::dht_arc::DhtArc) -> kitsune_p2p_types::dht_arc::PeerDensity;

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
@@ -80,6 +80,10 @@ pub struct QueryAgentsEvt {
     pub limit: Option<usize>,
 }
 
+// NB: if we want to play it safer, rather than providing these fine-grained
+//     builder methods, we could provide only the three "flavors" of query that
+//     Holochain supports, which would still provide us the full expressivity to
+//     implement Kitsune.
 impl QueryAgentsEvt {
     /// Constructor. Every query needs to know what space it's for.
     pub fn new(space: KSpace) -> Self {

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
@@ -77,7 +77,7 @@ pub struct QueryAgentsEvt {
     /// If set, results are ordered by proximity to the specified location
     pub near_basis: Option<DhtLocation>,
     /// Limit to the number of results returned
-    pub limit: Option<usize>,
+    pub limit: Option<u32>,
 }
 
 // NB: if we want to play it safer, rather than providing these fine-grained
@@ -123,7 +123,7 @@ impl QueryAgentsEvt {
     }
 
     /// Limit the number of results
-    pub fn limit(mut self, limit: usize) -> Self {
+    pub fn limit(mut self, limit: u32) -> Self {
         self.limit = Some(limit);
         self
     }

--- a/crates/kitsune_p2p/timestamp/src/lib.rs
+++ b/crates/kitsune_p2p/timestamp/src/lib.rs
@@ -200,6 +200,11 @@ impl Timestamp {
         self.0
     }
 
+    /// Access time as milliseconds since UNIX epoch
+    pub fn as_millis(&self) -> i64 {
+        self.0 / 1000
+    }
+
     /// Access seconds since UNIX epoch plus nanosecond offset
     pub fn as_seconds_and_nanos(&self) -> (i64, u32) {
         let secs = self.0 / MM;


### PR DESCRIPTION
### INCLUDED CHANGES:
- The following API messages have been consolidated into a single `query_agents`:
    - `query_gossip_agents`
    - `handle_query_agent_info_signed`
    - `handle_query_agent_info_signed_near_basis`
- The holochain side is unchanged. The single query gets split into 3 paths by duck typing on the single query object to infer the intent.
    - Ideally at some point we could unify this on the Holochain side too, but it's not so important.
    - This is a kind of dubious thing I did, because we have to be a bit careful about changes on the Kitsune side which could caues the Holochain side to panic (though these panics will not be rare, we'll know about them immediately if they happen)
- I had to change the return type of `query_gossip_agents` to return a full `AgentInfoSigned` instead of the subset of data it was returning, to be able to unify the results with the other two queries.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
