### PR TITLE
Enforce source chain query ordering

### DIFF
--- a/crates/hdk/src/chain.rs
+++ b/crates/hdk/src/chain.rs
@@ -17,7 +17,7 @@ pub fn get_agent_activity(
     })
 }
 
-/// Walks the source chain in reverse (latest to oldest) filtering by header and/or entry type
+/// Walks the source chain in ascending order (oldest to latest) filtering by header and/or entry type
 ///
 /// Given a header and entry type, returns an [ `Vec<Element>` ]
 ///

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -3,6 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## \[Unreleased\]
+- BREAKING CHANGE. Source chain `query` will now return results in header sequence order ascending.
 
 ## 0.0.7
 


### PR DESCRIPTION
### INCLUDED CHANGES:
- This enforces the source chain query order as header sequence ascending.
I'm open to it being the other way around but it was probably defaulting to this but wasn't actually enforced.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
