### PR TITLE
Prevent concurrent joins

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 - Refactor conductor to use parking lot rw lock instead of tokio rw lock. (Faster and prevents deadlocks.)
+- FIX: Prevent the conductor from trying to join cells to the network that are already in the process of joining.
 
 ### Changed
 

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -84,6 +84,9 @@ pub enum CellStatus {
     /// app status, i.e. if any app has a required Cell with this status,
     /// the app is considered to be in the Paused state.
     PendingJoin,
+
+    /// The Cell is currently in the process of trying to join the network.
+    Joining,
 }
 
 /// Declarative filter for CellStatus
@@ -218,14 +221,16 @@ where
         })
     }
 
-    /// Iterator over only the cells which are pending validation. Used to
-    /// discover which cells need to be joined to the network.
-    pub(super) fn pending_cells(&self) -> Vec<(CellId, Arc<Cell>)> {
-        self.cells.share_ref(|cells| {
+    /// Cells which are pending validation.
+    /// Used to discover which cells need to be joined to the network.
+    /// Cells status are upgraded to `Joining` when this function is called.
+    pub(super) fn pending_to_joining_cells(&self) -> Vec<(CellId, Arc<Cell>)> {
+        self.cells.share_mut(|cells| {
             cells
-                .iter()
+                .iter_mut()
                 .filter_map(|(id, item)| {
                     if item.is_pending() {
+                        item.status = CellStatus::Joining;
                         Some((id.clone(), item.cell.clone()))
                     } else {
                         None

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -1297,7 +1297,7 @@ impl<DS: DnaStore + 'static> ConductorHandleImpl<DS> {
 
         let pending_cells: Vec<(CellId, HolochainP2pCell)> = self
             .conductor
-            .pending_cells()
+            .pending_to_joining_cells()
             .into_iter()
             .map(|(id, cell)| (id, cell.holochain_p2p_cell().clone()))
             .collect();
@@ -1307,13 +1307,13 @@ impl<DS: DnaStore + 'static> ConductorHandleImpl<DS> {
                 match tokio::time::timeout(JOIN_NETWORK_TIMEOUT, network.join()).await {
                     Ok(Err(e)) => {
                         tracing::info!(error = ?e, cell_id = ?cell_id, "Error while trying to join the network");
-                        None
+                        Err(cell_id)
                     }
                     Err(_) => {
                         tracing::info!(cell_id = ?cell_id, "Timed out trying to join the network");
-                        None
+                        Err(cell_id)
                     }
-                    Ok(Ok(_)) => Some(cell_id),
+                    Ok(Ok(_)) => Ok(cell_id),
                 }
             });
 
@@ -1322,12 +1322,20 @@ impl<DS: DnaStore + 'static> ConductorHandleImpl<DS> {
             .collect()
             .await;
 
-        let cell_ids: Vec<_> = maybes.into_iter().flatten().collect();
+        let (cell_ids, failed_joins): (Vec<_>, Vec<_>) =
+            maybes.into_iter().partition(Result::is_ok);
+
+        // These unwraps are both safe because of the partition.
+        let cell_ids: Vec<_> = cell_ids.into_iter().map(Result::unwrap).collect();
+        let failed_joins: Vec<_> = failed_joins.into_iter().map(Result::unwrap_err).collect();
 
         // Update the status of the cells which were able to join the network
         // (may or may not be all cells which were added)
         self.conductor
             .update_cell_status(cell_ids.as_slice(), CellStatus::Joined);
+
+        self.conductor
+            .update_cell_status(failed_joins.as_slice(), CellStatus::PendingJoin);
 
         cell_ids
     }


### PR DESCRIPTION
### INCLUDED CHANGES:
- Prevent the conductor from trying to join cells to the network that are already in the process of joining.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
