### PR TITLE
bump rusqlite to 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,7 +2619,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "pretty_assertions 0.7.2",
  "r2d2",
- "r2d2_sqlite",
+ "r2d2_sqlite_neonphog",
  "rand 0.7.3",
  "rmp-serde",
  "rusqlite",
@@ -3417,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8728ad4b1541470fec2ede33a57d710004f2fb15937ffda4734045b92257b2"
+checksum = "a25c9fa16214ffe482d7daa84246c04a553d70ba18d52cd5a8d43150111d7d2a"
 dependencies = [
  "arbitrary",
  "blake2b_simd",
@@ -3449,9 +3449,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_client"
-version = "0.0.6"
+version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a89867e50be651a26b4b089c41e41bcd56dc5492c61a8dde6c7ae954575c44"
+checksum = "c2a7dd6f048af058c76bb15f7060aa997a34e15fd1fddc47fb96d57949a00ee4"
 dependencies = [
  "futures",
  "ghost_actor 0.3.0-alpha.4",
@@ -3552,11 +3552,12 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.22.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d"
+checksum = "c4ecc4273169aeb654a26ba8c7e087947caad92c9d121886eafa6446d4ebe138"
 dependencies = [
  "cc",
+ "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
@@ -4262,6 +4263,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
+name = "openssl-src"
+version = "111.16.0+1.1.1l"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ab2173f69416cf3ec12debb5823d244127d23a9b127d5a5189aa97c5fa2859f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4270,6 +4280,7 @@ dependencies = [
  "autocfg 1.0.1",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -4920,10 +4931,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "r2d2_sqlite"
+name = "r2d2_sqlite_neonphog"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d24607049214c5e42d3df53ac1d8a23c34cc6a5eefe3122acb2c72174719959"
+checksum = "75681c1503fca52049c7236548026c156b51a452440bfa4be2074dc06fe5ce6f"
 dependencies = [
  "r2d2",
  "rusqlite",
@@ -5438,9 +5449,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.25.3"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57adcf67c8faaf96f3248c2a7b419a0dbc52ebe36ba83dd57fe83827c1ea4eb3"
+checksum = "6e2aebd07fccf5c0d3f1458219965b0861d45f5db9f9b2617277fa7f85179213"
 dependencies = [
  "bitflags",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,3 +69,4 @@ codegen-units = 16
 # lair_keystore_api = { path = "../lair/crates/lair_keystore_api" }
 # lair_keystore_client = { path = "../lair/crates/lair_keystore_client" }
 # observability = { path = "../../rust/observability" }
+# r2d2_sqlite = { path = "../r2d2-sqlite" }

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -25,7 +25,7 @@ futures = {version = "0.3", optional = true}
 holochain_serialized_bytes = {version = "=0.0.51", optional = true }
 must_future = {version = "0.1", optional = true}
 rand = {version = "0.7", optional = true}
-rusqlite = { version = "0.25", optional = true }
+rusqlite = { version = "0.26", optional = true }
 serde = { version = "1", optional = true }
 serde_bytes = { version = "0.11", optional = true }
 tracing = { version = "0.1", optional = true}

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -49,7 +49,7 @@ parking_lot = "0.10"
 predicates = "1.0.4"
 rand = "0.7"
 ring = "0.16"
-rusqlite = { version = "0.25" }
+rusqlite = { version = "0.26" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 serde_yaml = "0.8"

--- a/crates/holochain_cascade/src/authority/get_element_query.rs
+++ b/crates/holochain_cascade/src/authority/get_element_query.rs
@@ -69,9 +69,10 @@ impl Query for GetElementOpsQuery {
 
     fn as_map(&self) -> Arc<dyn Fn(&Row) -> StateQueryResult<Self::Item>> {
         let f = |row: &Row| {
-            let header = from_blob::<SignedHeader>(row.get(row.column_index("header_blob")?)?)?;
-            let op_type = row.get(row.column_index("dht_type")?)?;
-            let validation_status = row.get(row.column_index("status")?)?;
+            let header =
+                from_blob::<SignedHeader>(row.get(row.as_ref().column_index("header_blob")?)?)?;
+            let op_type = row.get(row.as_ref().column_index("dht_type")?)?;
+            let validation_status = row.get(row.as_ref().column_index("status")?)?;
             Ok(Judged::raw(Item { op_type, header }, validation_status))
         };
         Arc::new(f)

--- a/crates/holochain_cascade/src/authority/get_entry_ops_query.rs
+++ b/crates/holochain_cascade/src/authority/get_entry_ops_query.rs
@@ -96,9 +96,10 @@ impl Query for GetEntryOpsQuery {
 
     fn as_map(&self) -> Arc<dyn Fn(&Row) -> StateQueryResult<Self::Item>> {
         let f = |row: &Row| {
-            let header = from_blob::<SignedHeader>(row.get(row.column_index("header_blob")?)?)?;
-            let op_type = row.get(row.column_index("dht_type")?)?;
-            let validation_status = row.get(row.column_index("status")?)?;
+            let header =
+                from_blob::<SignedHeader>(row.get(row.as_ref().column_index("header_blob")?)?)?;
+            let op_type = row.get(row.as_ref().column_index("dht_type")?)?;
+            let validation_status = row.get(row.as_ref().column_index("status")?)?;
             Ok(Judged::raw(Item { op_type, header }, validation_status))
         };
         Arc::new(f)

--- a/crates/holochain_cascade/src/authority/get_links_ops_query.rs
+++ b/crates/holochain_cascade/src/authority/get_links_ops_query.rs
@@ -109,9 +109,10 @@ impl Query for GetLinksOpsQuery {
 
     fn as_map(&self) -> Arc<dyn Fn(&Row) -> StateQueryResult<Self::Item>> {
         let f = |row: &Row| {
-            let header = from_blob::<SignedHeader>(row.get(row.column_index("header_blob")?)?)?;
-            let op_type = row.get(row.column_index("dht_type")?)?;
-            let validation_status = row.get(row.column_index("status")?)?;
+            let header =
+                from_blob::<SignedHeader>(row.get(row.as_ref().column_index("header_blob")?)?)?;
+            let op_type = row.get(row.as_ref().column_index("dht_type")?)?;
+            let validation_status = row.get(row.as_ref().column_index("status")?)?;
             Ok(Judged::raw(Item { header, op_type }, validation_status))
         };
         Arc::new(f)

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Update to lair 0.0.7 which updates to rusqlite 0.26.0 [#1023](https://github.com/holochain/holochain/pull/1023)
+  - provides `bundled-sqlcipher-vendored-openssl` to ease build process on non-windows systems (windows is still using `bundled` which doesn't provide at-rest encryption).
+
 ## 0.0.8
 
 ## 0.0.7

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -16,7 +16,7 @@ holo_hash = { version = "0.0.7", path = "../holo_hash", features = ["full"] }
 holochain_serialized_bytes = "=0.0.51"
 holochain_zome_types = { path = "../holochain_zome_types", version = "0.0.10"}
 kitsune_p2p_types = { version = "0.0.7", path = "../kitsune_p2p/types" }
-legacy_lair_client = { version = "=0.0.6", package = "lair_keystore_client" }
+legacy_lair_client = { version = "=0.0.7", package = "lair_keystore_client" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_bytes = "0.11"
 sodoken = "=0.0.1-alpha.21"

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Update to rusqlite 0.26.0 [#1023](https://github.com/holochain/holochain/pull/1023)
+  - provides `bundled-sqlcipher-vendored-openssl` to ease build process on non-windows systems (windows is still using `bundled` which doesn't provide at-rest encryption).
+
 ## 0.0.8
 
 ## 0.0.7

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -35,7 +35,8 @@ page_size = "0.4.2"
 parking_lot = "0.10"
 rand = "0.7"
 r2d2 = "0.8"
-r2d2_sqlite = "0.18"
+# neonphog fork for updated rusqlite dependency
+r2d2_sqlite = { version = "0.18", package = "r2d2_sqlite_neonphog" }
 rmp-serde = "0.15"
 scheduled-thread-pool = "0.2"
 serde = "1.0"
@@ -48,7 +49,7 @@ holochain_util = { version = "0.0.4", path = "../holochain_util" }
 tracing = "0.1.18"
 tracing-futures = "0.2"
 
-rusqlite = { version = "0.25", features = [
+rusqlite = { version = "0.26", features = [
   "blob",        # better integration with blob types (Read, Write, etc)
   "backup",
   "trace",
@@ -73,7 +74,7 @@ default = [ "test_utils", "no-deps" ]
 test_utils = [ ]
 
 # Use at-rest encryption of databases
-db-encryption = ["rusqlite/sqlcipher"]
+db-encryption = ["rusqlite/bundled-sqlcipher-vendored-openssl"]
 
 # Compile SQLite from source rather than depending on a library
 no-deps = ['rusqlite/bundled']

--- a/crates/holochain_state/src/query.rs
+++ b/crates/holochain_state/src/query.rs
@@ -270,10 +270,11 @@ impl<'stmt> Store for Txn<'stmt, '_> {
                 ":hash": hash,
             },
             |row| {
-                let header = from_blob::<SignedHeader>(row.get(row.column_index("blob")?)?);
+                let header =
+                    from_blob::<SignedHeader>(row.get(row.as_ref().column_index("blob")?)?);
                 Ok(header.and_then(|header| {
                     let SignedHeader(header, signature) = header;
-                    let hash: HeaderHash = row.get(row.column_index("hash")?)?;
+                    let hash: HeaderHash = row.get(row.as_ref().column_index("hash")?)?;
                     let header = HeaderHashed::with_pre_hashed(header, hash);
                     let shh = SignedHeaderHashed::with_presigned(header, signature);
                     Ok(shh)
@@ -310,13 +311,15 @@ impl<'stmt> Txn<'stmt, '_> {
                 ":hash": hash,
             },
             |row| {
-                let header = from_blob::<SignedHeader>(row.get(row.column_index("header_blob")?)?);
+                let header =
+                    from_blob::<SignedHeader>(row.get(row.as_ref().column_index("header_blob")?)?);
                 Ok(header.and_then(|header| {
                     let SignedHeader(header, signature) = header;
-                    let hash: HeaderHash = row.get(row.column_index("hash")?)?;
+                    let hash: HeaderHash = row.get(row.as_ref().column_index("hash")?)?;
                     let header = HeaderHashed::with_pre_hashed(header, hash);
                     let shh = SignedHeaderHashed::with_presigned(header, signature);
-                    let entry: Option<Vec<u8>> = row.get(row.column_index("entry_blob")?)?;
+                    let entry: Option<Vec<u8>> =
+                        row.get(row.as_ref().column_index("entry_blob")?)?;
                     let entry = match entry {
                         Some(entry) => Some(from_blob::<Entry>(entry)?),
                         None => None,
@@ -345,13 +348,15 @@ impl<'stmt> Txn<'stmt, '_> {
                 ":hash": hash,
             },
             |row| {
-                let header = from_blob::<SignedHeader>(row.get(row.column_index("header_blob")?)?);
+                let header =
+                    from_blob::<SignedHeader>(row.get(row.as_ref().column_index("header_blob")?)?);
                 Ok(header.and_then(|header| {
                     let SignedHeader(header, signature) = header;
-                    let hash: HeaderHash = row.get(row.column_index("hash")?)?;
+                    let hash: HeaderHash = row.get(row.as_ref().column_index("hash")?)?;
                     let header = HeaderHashed::with_pre_hashed(header, hash);
                     let shh = SignedHeaderHashed::with_presigned(header, signature);
-                    let entry: Option<Vec<u8>> = row.get(row.column_index("entry_blob")?)?;
+                    let entry: Option<Vec<u8>> =
+                        row.get(row.as_ref().column_index("entry_blob")?)?;
                     let entry = match entry {
                         Some(entry) => Some(from_blob::<Entry>(entry)?),
                         None => None,
@@ -612,7 +617,7 @@ pub fn row_blob_and_hash_to_header(
     move |row| {
         let header = from_blob::<SignedHeader>(row.get(blob_index)?)?;
         let SignedHeader(header, signature) = header;
-        let hash: HeaderHash = row.get(row.column_index(hash_index)?)?;
+        let hash: HeaderHash = row.get(row.as_ref().column_index(hash_index)?)?;
         let header = HeaderHashed::with_pre_hashed(header, hash);
         let shh = SignedHeaderHashed::with_presigned(header, signature);
         Ok(shh)
@@ -656,7 +661,7 @@ pub fn get_entry_from_db(
         },
         |row| {
             Ok(from_blob::<Entry>(
-                row.get(row.column_index("entry_blob")?)?,
+                row.get(row.as_ref().column_index("entry_blob")?)?,
             ))
         },
     );

--- a/crates/holochain_state/src/query/element_details.rs
+++ b/crates/holochain_state/src/query/element_details.rs
@@ -52,11 +52,12 @@ impl Query for GetElementDetailsQuery {
 
     fn as_map(&self) -> Arc<dyn Fn(&Row) -> StateQueryResult<Self::Item>> {
         let f = |row: &Row| {
-            let header = from_blob::<SignedHeader>(row.get(row.column_index("header_blob")?)?)?;
+            let header =
+                from_blob::<SignedHeader>(row.get(row.as_ref().column_index("header_blob")?)?)?;
             let SignedHeader(header, signature) = header;
             let header = HeaderHashed::from_content_sync(header);
             let shh = SignedHeaderHashed::with_presigned(header, signature);
-            let status = row.get(row.column_index("status")?)?;
+            let status = row.get(row.as_ref().column_index("status")?)?;
             let r = Judged::new(shh, status);
             Ok(r)
         };

--- a/crates/holochain_state/src/query/entry_details.rs
+++ b/crates/holochain_state/src/query/entry_details.rs
@@ -52,11 +52,12 @@ impl Query for GetEntryDetailsQuery {
 
     fn as_map(&self) -> Arc<dyn Fn(&Row) -> StateQueryResult<Self::Item>> {
         let f = |row: &Row| {
-            let header = from_blob::<SignedHeader>(row.get(row.column_index("header_blob")?)?)?;
+            let header =
+                from_blob::<SignedHeader>(row.get(row.as_ref().column_index("header_blob")?)?)?;
             let SignedHeader(header, signature) = header;
             let header = HeaderHashed::from_content_sync(header);
             let shh = SignedHeaderHashed::with_presigned(header, signature);
-            let status = row.get(row.column_index("status")?)?;
+            let status = row.get(row.as_ref().column_index("status")?)?;
             let r = Judged::new(shh, status);
             Ok(r)
         };

--- a/crates/holochain_state/src/test_utils.rs
+++ b/crates/holochain_state/src/test_utils.rs
@@ -324,7 +324,7 @@ pub fn dump_db(txn: &Transaction) {
     let dump = |mut stmt: Statement| {
         let mut rows = stmt.query([]).unwrap();
         while let Some(row) = rows.next().unwrap() {
-            for column in row.column_names() {
+            for column in row.as_ref().column_names() {
                 let row = row.get_ref_unwrap(column);
                 match row {
                     holochain_sqlite::rusqlite::types::ValueRef::Null

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -38,7 +38,7 @@ nanoid = "0.3"
 observability = "0.1.3"
 rand = "0.7"
 regex = "1.4"
-rusqlite = { version = "0.25"}
+rusqlite = { version = "0.26" }
 serde = { version = "1.0", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"
 serde_derive = "1.0"

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -30,7 +30,7 @@ strum = { version = "0.18.0", optional = true }
 rand = {version = "0.7", optional = true}
 
 # sqlite dependencies
-rusqlite = { version = "0.25", optional = true }
+rusqlite = { version = "0.26", optional = true }
 num_enum = { version = "0.5", optional = true }
 
 # full-dna-def dependencies

--- a/crates/kitsune_p2p/timestamp/Cargo.toml
+++ b/crates/kitsune_p2p/timestamp/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1"
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 
 # rusqlite
-rusqlite = { version = "0.25", optional = true }
+rusqlite = { version = "0.26", optional = true }
 
 [dev-dependencies]
 holochain_serialized_bytes = "=0.0.51"

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -11,7 +11,7 @@ categories = [ "network-programming" ]
 edition = "2018"
 
 [dependencies]
-legacy_lair_api = { version = "=0.0.6", package = "lair_keystore_api" }
+legacy_lair_api = { version = "=0.0.7", package = "lair_keystore_api" }
 base64 = "0.13"
 derive_more = "0.99.7"
 futures = "0.3"


### PR DESCRIPTION
CLOSES https://github.com/holochain/lair/issues/56

### INCLUDED CHANGES:
- update to lair 0.0.7 which updates to rusqlite 0.26.0
- update rusqlite to 0.26.0
- on non-windows systems, switch to `rusqlite/bundled-sqlcipher-vendored-openssl` to ease build issues
- adjusts to some unexpected [rusqlite api changes](https://github.com/rusqlite/rusqlite/issues/1024)

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
