### PR TITLE
Kitsune sharded tests 02: More precise DhtArc <-> ArcInterval conversions and more flexible Loc8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3221,6 +3221,7 @@ dependencies = [
  "arrayref",
  "base64",
  "bloomfilter",
+ "contrafact",
  "derive_more",
  "fixt",
  "futures",
@@ -3249,6 +3250,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tracing",
  "tracing-subscriber",
  "url2",
 ]
@@ -3282,6 +3284,7 @@ dependencies = [
  "gcollections",
  "intervallum",
  "num-traits",
+ "pretty_assertions 0.7.2",
  "rusqlite",
  "serde",
 ]

--- a/crates/kitsune_p2p/dht_arc/Cargo.toml
+++ b/crates/kitsune_p2p/dht_arc/Cargo.toml
@@ -19,6 +19,9 @@ serde = {version = "1.0", features = ["derive"]}
 
 rusqlite = { version = "0.26", optional = true }
 
+[dev-dependencies]
+pretty_assertions = "0.7.2"
+
 [features]
 sqlite = ["rusqlite"]
 test_utils = []

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
@@ -13,7 +13,11 @@ use std::ops::RangeInclusive;
 #[cfg(test)]
 mod tests;
 
+#[cfg(test)]
+mod test_ascii;
+
 mod dht_arc_set;
+pub(crate) use dht_arc_set::{loc_downscale, loc_upscale};
 pub use dht_arc_set::{ArcInterval, DhtArcSet};
 
 mod dht_arc_bucket;
@@ -50,6 +54,11 @@ impl DhtLocation {
 
     pub fn as_u32(&self) -> u32 {
         self.0 .0
+    }
+
+    #[cfg(any(test, feature = "test_utils"))]
+    pub fn as_i32(&self) -> i32 {
+        self.0 .0 as i32
     }
 }
 
@@ -273,7 +282,7 @@ impl DhtArc {
             }
         // In order to make sure the arc covers the full range we need some overlap at the
         // end to account for division rounding.
-        } else if self.half_length == MAX_HALF_LENGTH || self.half_length == MAX_HALF_LENGTH - 1 {
+        } else if self.half_length >= MAX_HALF_LENGTH - 1 {
             ArcRange {
                 start: Bound::Included(
                     (self.center_loc.0 - DhtLocation::from(MAX_HALF_LENGTH - 1).0).0,
@@ -540,10 +549,9 @@ impl std::fmt::Display for DhtArc {
     }
 }
 
-#[cfg(any(test, feature = "test_utils"))]
 impl DhtArc {
     pub fn from_interval(interval: ArcInterval) -> Self {
-        match interval {
+        match interval.quantized() {
             ArcInterval::Empty => Self::empty(0),
             ArcInterval::Full => Self::full(0),
             ArcInterval::Bounded(start, end) => {
@@ -553,7 +561,7 @@ impl DhtArc {
                     // this should be +2 instead of +3, but we want to round up
                     // so that the arc covers the interval
                     let half_length = ((end as f64 - start as f64 + 3f64) / 2f64) as u32;
-                    let center = ((start as f64 + end as f64) / 2f64) as u32;
+                    let center = ((start as f64 + end as f64) / 2f64).round() as u32;
                     Self::new(center, half_length)
                 } else {
                     let half_length = MAX_HALF_LENGTH - ((start - end) / 2);
@@ -566,7 +574,55 @@ impl DhtArc {
 }
 
 #[test]
-fn dht_arc_interval_roundtrip() {
+fn arc_interval_center_loc() {
+    use pretty_assertions::assert_eq;
+
+    let intervals = vec![
+        // singleton
+        (ArcInterval::<i32>::new(0, 0), 0),
+        (ArcInterval::<i32>::new(2, 2), 2),
+        (ArcInterval::<i32>::new(3, 3), 3),
+        // non-wrapping
+        (ArcInterval::<i32>::new(2, 4), 3),
+        (ArcInterval::<i32>::new(2, 5), 4),
+        (ArcInterval::<i32>::new(2, 6), 4),
+        (ArcInterval::<i32>::new(0, 8), 4),
+        (ArcInterval::<i32>::new(1, 8), 5),
+        (ArcInterval::<i32>::new(2, 8), 5),
+        (ArcInterval::<i32>::new(3, 5), 4),
+        (ArcInterval::<i32>::new(3, 6), 5),
+        (ArcInterval::<i32>::new(3, 7), 5),
+        // wrapping
+        (ArcInterval::<i32>::new(-3, 3), 0),
+        (ArcInterval::<i32>::new(-4, 3), 0),
+        (ArcInterval::<i32>::new(-4, 4), 0),
+        (ArcInterval::<i32>::new(-5, 4), 0),
+        (ArcInterval::<i32>::new(-4, 2), -1i32),
+        (ArcInterval::<i32>::new(-5, 2), -1i32),
+        (ArcInterval::<i32>::new(-5, 3), -1i32),
+    ];
+    let expected: Vec<_> = intervals
+        .iter()
+        .map(|(_, c)| DhtLocation::from(*c))
+        .collect();
+    let actual: Vec<_> = intervals
+        .into_iter()
+        .map(|(i, _)| i.canonical().center_loc())
+        .collect();
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn interval_dht_arc_roundtrip() {
+    use pretty_assertions::assert_eq;
+
+    // a big number: 1073741823
+    const A: u32 = u32::MAX / 4;
+    // another big number: 3221225469
+    const B: u32 = A * 3;
+    // the biggest number: 4294967295
+    const M: u32 = u32::MAX;
+
     let intervals = vec![
         ArcInterval::<u32>::new(0, 0).canonical(),
         ArcInterval::<u32>::new(2, 2).canonical(),
@@ -576,23 +632,67 @@ fn dht_arc_interval_roundtrip() {
         ArcInterval::<u32>::new(3, 6).canonical(),
         ArcInterval::<u32>::new(3, 7).canonical(),
         ArcInterval::<u32>::new(3, 8).canonical(),
-        // these wind up becoming FULL for some reason
-        // ArcInterval::<u32>::new(1, u32::MAX).canonical(),
-        // ArcInterval::<u32>::new(2, u32::MAX).canonical(),
-        // ArcInterval::<u32>::new(3, u32::MAX).canonical(),
-        // ArcInterval::<u32>::new(3, u32::MAX - 1).canonical(),
-        // ArcInterval::<u32>::new(3, u32::MAX - 2).canonical(),
-        ArcInterval::<u32>::new(u32::MAX, u32::MAX).canonical(),
-        ArcInterval::<u32>::new(u32::MAX / 4 * 3, u32::MAX / 4).canonical(),
-        ArcInterval::<u32>::new(u32::MAX / 4 * 3 + 1, u32::MAX / 4).canonical(),
-        ArcInterval::<u32>::new(u32::MAX / 4 * 3 - 1, u32::MAX / 4).canonical(),
-        ArcInterval::<u32>::new(u32::MAX / 4 * 3 - 1, u32::MAX / 4 + 1).canonical(),
-        ArcInterval::<u32>::new(u32::MAX / 4 * 3 + 1, u32::MAX / 4 - 1).canonical(),
+        ArcInterval::<u32>::new(M, M).canonical(),
+        ArcInterval::<u32>::new(A, B).canonical(),
+        ArcInterval::<u32>::new(B, A).canonical(),
+        ArcInterval::<u32>::new(B + 1, A).canonical(),
+        ArcInterval::<u32>::new(B - 1, A).canonical(),
+        ArcInterval::<u32>::new(B - 1, A + 1).canonical(),
+        ArcInterval::<u32>::new(B + 1, A - 1).canonical(),
+        ArcInterval::<u32>::new(1, M).canonical(),
+        ArcInterval::<u32>::new(2, M).canonical(),
+        ArcInterval::<u32>::new(3, M).canonical(),
+        ArcInterval::<u32>::new(3, M - 1).canonical(),
+        ArcInterval::<u32>::new(3, M - 2).canonical(),
     ];
+    // Show that roundtrips of quantized intervals produce no change
+    // (roundtrips of unquantized intervals only result in quantization)
     let quantized: Vec<_> = intervals.iter().map(|i| i.quantized()).collect();
     let roundtrips: Vec<_> = intervals
         .iter()
         .map(|i| DhtArc::from_interval(i.to_owned()).interval())
         .collect();
+
+    // Show that roundtrips don't alter the centerpoints at all
+    let original_centers: Vec<_> = intervals.iter().map(|i| i.center_loc()).collect();
+    let quantized_centers: Vec<_> = quantized.iter().map(|i| i.center_loc()).collect();
+    let roundtrip_centers: Vec<_> = roundtrips.iter().map(|i| i.center_loc()).collect();
+    let dht_arc_centers: Vec<_> = quantized
+        .iter()
+        .map(|i| DhtArc::from_interval(i.clone()).center_loc())
+        .collect();
     assert_eq!(quantized, roundtrips);
+    assert_eq!(original_centers, quantized_centers);
+    assert_eq!(original_centers, roundtrip_centers);
+    assert_eq!(original_centers, dht_arc_centers);
+}
+
+#[test]
+fn dht_arc_interval_roundtrip() {
+    use pretty_assertions::assert_eq;
+
+    // ignore empty ArcIntervals, which can't map back to DhtArc
+    let arcs = vec![
+        // DhtArc::new(1, 0),
+        DhtArc::new(1, 1),
+        DhtArc::new(1, 2),
+        DhtArc::new(1, 3),
+        // DhtArc::new(0, 0),
+        DhtArc::new(0, 1),
+        DhtArc::new(0, 2),
+        DhtArc::new(0, 3),
+        // DhtArc::new(-1, 0),
+        DhtArc::new(-1, 1),
+        DhtArc::new(-1, 2),
+        DhtArc::new(-1, 3),
+        // DhtArc::new(-2, 0),
+        DhtArc::new(-2, 1),
+        DhtArc::new(-2, 2),
+        DhtArc::new(-2, 3),
+    ];
+    let roundtrips: Vec<_> = arcs
+        .iter()
+        .map(|arc| DhtArc::from_interval(arc.interval()))
+        .collect();
+    assert_eq!(arcs, roundtrips);
 }

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
@@ -574,6 +574,7 @@ impl DhtArc {
 }
 
 #[test]
+/// Test the center_loc calculation for a variety of ArcIntervals
 fn arc_interval_center_loc() {
     use pretty_assertions::assert_eq;
 
@@ -613,6 +614,9 @@ fn arc_interval_center_loc() {
 }
 
 #[test]
+/// Test ArcInterval -> DhtArc -> ArcInterval roundtrips
+/// Note that the intervals must be "quantized" to have an odd length 
+/// to be representable as DhtArc, so true roundtrips are not possible in general
 fn interval_dht_arc_roundtrip() {
     use pretty_assertions::assert_eq;
 
@@ -668,6 +672,7 @@ fn interval_dht_arc_roundtrip() {
 }
 
 #[test]
+/// Test DhtArc -> ArcInterval -> DhtArc roundtrips
 fn dht_arc_interval_roundtrip() {
     use pretty_assertions::assert_eq;
 

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc/dht_arc_set.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc/dht_arc_set.rs
@@ -369,6 +369,8 @@ impl ArcInterval<DhtLocation> {
     }
 
     #[cfg(any(test, feature = "test_utils"))]
+    /// Handy ascii representation of an arc, especially useful when
+    /// looking at several arcs at once to get a sense of their overlap
     pub fn to_ascii(&self, len: usize) -> String {
         match self {
             Self::Full => "-".repeat(len),
@@ -398,6 +400,10 @@ impl ArcInterval<DhtLocation> {
     }
 
     #[cfg(any(test, feature = "test_utils"))]
+    /// Ascii representation of an arc, with a histogram of op locations superimposed.
+    /// Each character of the string, if an op falls in that "bucket", will be represented
+    /// by a hexadecimal digit representing the number of ops in that bucket,
+    /// with a max of 0xF (15)
     pub fn to_ascii_with_ops<L: Into<crate::loc8::Loc8>, I: IntoIterator<Item = L>>(
         &self,
         len: usize,
@@ -433,6 +439,8 @@ fn is_full(start: u32, end: u32) -> bool {
     (start == MIN && end >= MAX) || end == start.wrapping_sub(1)
 }
 
+/// Scale a number in a smaller space (specified by `len`) up into the `u32` space.
+/// The number to scale can be negative, which is wrapped to a positive value via modulo
 pub(crate) fn loc_upscale(len: usize, v: i32) -> u32 {
     let max = 2f64.powi(32);
     let lenf = len as f64;
@@ -440,6 +448,7 @@ pub(crate) fn loc_upscale(len: usize, v: i32) -> u32 {
     (max / lenf * vf).round() as i64 as u32
 }
 
+/// Scale a u32 DhtLocation down into a smaller space (specified by `len`)
 pub(crate) fn loc_downscale(len: usize, d: DhtLocation) -> usize {
     let max = 2f64.powi(32);
     let lenf = len as f64;

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc/test_ascii.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc/test_ascii.rs
@@ -1,0 +1,44 @@
+use crate::dht_arc::dht_arc_set::loc_upscale;
+
+use super::*;
+use pretty_assertions::assert_eq;
+
+#[test]
+fn correct_ascii() {
+    test_cases(
+        16,
+        [
+            (0, 8, "----@----       "),
+            (1, 8, " ----@---       "),
+            (2, 8, "  ---@---       "),
+            (8, 0, "-       ----@---"),
+            (8, 1, "--      -----@--"),
+            (8, 2, "---     -----@--"),
+            (9, 5, "------   ------@"),
+            (9, 6, "@------  -------"),
+            (9, 7, "@------- -------"),
+        ],
+    );
+}
+
+fn test_cases<'a>(len: usize, cases: impl IntoIterator<Item = (i32, i32, &'a str)> + Clone) {
+    let fmt_bounds = |lo, hi| format!("({:+}, {:+})", lo, hi);
+
+    let expected: Vec<_> = cases
+        .clone()
+        .into_iter()
+        .map(|(lo, hi, ascii)| (fmt_bounds(lo, hi), ascii.to_string()))
+        .collect();
+
+    let actual: Vec<_> = cases
+        .into_iter()
+        .map(|(lo, hi, _)| {
+            let ascii = ArcInterval::new(loc_upscale(len, lo), loc_upscale(len, hi)).to_ascii(len);
+            let bounds = fmt_bounds(lo, hi);
+            assert_eq!(ascii.len(), len, "Wrong length for case {}", bounds);
+            (bounds, ascii)
+        })
+        .collect();
+
+    assert_eq!(expected, actual);
+}

--- a/crates/kitsune_p2p/dht_arc/src/loc8.rs
+++ b/crates/kitsune_p2p/dht_arc/src/loc8.rs
@@ -1,47 +1,112 @@
-use crate::DhtLocation;
+use std::collections::BTreeSet;
 
-/// F == 2^32 / 2^8
-const F: u32 = 16777216;
+use crate::{loc_downscale, loc_upscale, ArcInterval, DhtLocation};
 
-#[derive(
-    Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, derive_more::From, derive_more::Display,
-)]
-#[display(fmt = "{}", _0)]
-pub struct Loc8(i8);
+#[derive(Copy, Clone)]
+pub struct Loc8 {
+    val: u8,
+    sign: bool,
+}
+
+impl From<i32> for Loc8 {
+    fn from(i: i32) -> Self {
+        if i >= 0 {
+            Self {
+                val: i as u8,
+                sign: false,
+            }
+        } else {
+            Self {
+                val: i as i8 as u8,
+                sign: true,
+            }
+        }
+    }
+}
+
+impl PartialEq for Loc8 {
+    fn eq(&self, other: &Self) -> bool {
+        self.val == other.val
+    }
+}
+
+impl Eq for Loc8 {}
+
+impl PartialOrd for Loc8 {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.val.partial_cmp(&other.val)
+    }
+}
+
+impl Ord for Loc8 {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.val.cmp(&other.val)
+    }
+}
+
+impl std::hash::Hash for Loc8 {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.val.hash(state);
+    }
+}
+
+impl std::fmt::Display for Loc8 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.as_i32().fmt(f)
+    }
+}
 
 impl std::fmt::Debug for Loc8 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+        self.as_i32().fmt(f)
     }
 }
 
 impl Loc8 {
     pub fn as_i8(&self) -> i8 {
-        self.0
+        self.as_u8() as i8
     }
 
     pub fn as_u8(&self) -> u8 {
-        self.0 as u8
+        self.val
     }
 
-    pub fn vec<L: Into<Loc8>, I: IntoIterator<Item = L>>(it: I) -> Vec<Self> {
+    pub fn as_i32(&self) -> i32 {
+        if self.sign {
+            self.as_i8() as i32
+        } else {
+            self.as_u8() as u32 as i32
+        }
+    }
+
+    pub fn set<L: Into<Loc8>, I: IntoIterator<Item = L>>(it: I) -> BTreeSet<Self> {
         it.into_iter().map(Into::into).collect()
+    }
+
+    pub fn upscale<L: Into<Loc8>>(v: L) -> u32 {
+        let v: Loc8 = v.into();
+        loc_upscale(256, v.as_i32())
+    }
+
+    pub fn downscale(v: u32) -> u8 {
+        loc_downscale(256, DhtLocation::from(v)) as u8
     }
 }
 
 impl From<Loc8> for DhtLocation {
     fn from(i: Loc8) -> Self {
-        DhtLocation::new(i.0 as u8 as u32 * F)
+        DhtLocation::from(Loc8::upscale(i))
     }
 }
 
 impl DhtLocation {
     pub fn as_loc8(&self) -> Loc8 {
-        Loc8((self.as_u32() / F) as u8 as i8)
+        Loc8 {
+            val: Loc8::downscale(self.as_u32()),
+            sign: false,
+        }
     }
-}
 
-impl DhtLocation {
     /// Turn this location into a "representative" 36 byte vec,
     /// suitable for use as a hash type.
     #[cfg(feature = "test_utils")]
@@ -54,4 +119,40 @@ impl DhtLocation {
             .copied()
             .collect()
     }
+}
+
+impl ArcInterval {
+    pub fn as_loc8(&self) -> ArcInterval<Loc8> {
+        match self {
+            Self::Empty => ArcInterval::Empty,
+            Self::Full => ArcInterval::Full,
+            Self::Bounded(lo, hi) => ArcInterval::Bounded(lo.as_loc8(), hi.as_loc8()),
+        }
+    }
+}
+
+impl<L> ArcInterval<L>
+where
+    Loc8: From<L>,
+{
+    pub fn canonical(self) -> ArcInterval {
+        match self {
+            ArcInterval::Empty => ArcInterval::Empty,
+            ArcInterval::Full => ArcInterval::Full,
+            ArcInterval::Bounded(lo, hi) => ArcInterval::new(
+                DhtLocation::from(Loc8::from(lo)),
+                DhtLocation::from(Loc8::from(hi)),
+            ),
+        }
+    }
+}
+
+#[test]
+fn scaling() {
+    let f = 16777216i32;
+    assert_eq!(Loc8::upscale(4) as i32, f * 4);
+    assert_eq!(Loc8::upscale(-4) as i32, f * -4);
+
+    assert_eq!(Loc8::downscale((f * 4) as u32), 4);
+    assert_eq!(Loc8::downscale((f * -4) as u32) as i8, -4);
 }

--- a/crates/kitsune_p2p/dht_arc/src/loc8.rs
+++ b/crates/kitsune_p2p/dht_arc/src/loc8.rs
@@ -2,9 +2,19 @@ use std::collections::BTreeSet;
 
 use crate::{loc_downscale, loc_upscale, ArcInterval, DhtLocation};
 
+/// A representation of DhtLocation in the u8 space. Useful for writing tests
+/// that test the full range of possible locations while still working with small numbers.
+/// A Loc8 can be constructed `From<i8>` within `-128 <= n <= 255`.
+/// A negative number is wrapped to a positive number internally, and the `sign` is preserved
+/// for display purposes.
+///
+/// Loc8 has custom `Eq`, `Ord`, and other impls which disregard the `sign`.
 #[derive(Copy, Clone)]
 pub struct Loc8 {
+    /// The unsigned value
     val: u8,
+    /// Designates whether this value was constructed with a negative number or not,
+    /// so that it can be displayed as positive or negative accordingly.
     sign: bool,
 }
 

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -47,10 +47,12 @@ maplit = { version = "1", optional = true }
 mockall = { version = "0.10.2", optional = true }
 
 [dev-dependencies]
+contrafact = { version = "0.1.0-dev.1" }
 maplit = "1"
 mockall = "0.10.2"
 pretty_assertions = "0.7"
 test-case = "1.0.0"
+tracing = "0.1"
 tracing-subscriber = "0.2"
 
 [features]
@@ -60,7 +62,8 @@ test_utils = [
   "kitsune_p2p_types/test_utils",
   "maplit",
   "mockall",
-  "kitsune_p2p_timestamp/now"
+  "kitsune_p2p_timestamp/now",
+  "kitsune_p2p_timestamp/arbitrary",
 ]
 mock_network = [
   "kitsune_p2p_types/test_utils",

--- a/crates/kitsune_p2p/kitsune_p2p/src/lib.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/lib.rs
@@ -34,7 +34,12 @@ pub mod fixt;
 #[cfg(any(test, feature = "test_utils"))]
 pub static NOISE: once_cell::sync::Lazy<Vec<u8>> = once_cell::sync::Lazy::new(|| {
     use rand::Rng;
+
     let mut rng = rand::thread_rng();
+
+    // use rand::SeedableRng;
+    // let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+
     std::iter::repeat_with(|| rng.gen())
         .take(10_000_000)
         .collect()

--- a/crates/kitsune_p2p/types/src/tx2/tx2_pool_promote.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_pool_promote.rs
@@ -111,7 +111,8 @@ async fn in_chan_recv_logic(
                     }
                     Ok(c) => c,
                 };
-                tracing::debug!(?local_cert, ?peer_cert, "accepted incoming channel");
+                // TODO: ask david.b if it was ok to downgrade this from debug to trace
+                tracing::trace!(?local_cert, ?peer_cert, "accepted incoming channel");
                 loop {
                     let r = chan.read(tuning_params.implicit_timeout()).await;
 
@@ -197,7 +198,8 @@ async fn in_chan_recv_logic(
                 writer,
             });
 
-            tracing::debug!(?local_cert, ?peer_cert, "established outgoing channel");
+            // TODO: ask david.b if it was ok to downgrade this from debug to trace
+            tracing::trace!(?local_cert, ?peer_cert, "established outgoing channel");
         }
         tracing::debug!(?local_cert, ?peer_cert, "channel create loop end");
     };

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -308,7 +308,7 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hdk"
-version = "0.0.112-dev.0"
+version = "0.0.112"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -326,11 +326,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-<<<<<<< HEAD
-version = "0.0.13"
-=======
-version = "0.0.14-dev.0"
->>>>>>> origin/develop
+version = "0.0.14"
 dependencies = [
  "holochain_zome_types",
  "paste",
@@ -393,11 +389,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-<<<<<<< HEAD
-version = "0.0.11"
-=======
-version = "0.0.12-dev.0"
->>>>>>> origin/develop
+version = "0.0.12"
 dependencies = [
  "hdk",
  "serde",
@@ -430,11 +422,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-<<<<<<< HEAD
-version = "0.0.13"
-=======
-version = "0.0.14-dev.0"
->>>>>>> origin/develop
+version = "0.0.14"
 dependencies = [
  "chrono",
  "fixt",


### PR DESCRIPTION
### Summary

Mainly more groundwork. Previously, DhtArc <-> ArcInterval conversions were a little loosey-goosey, and this tightens them up to be precisely interchangeable.

It also makes `Loc8` more flexible, allowing it to be constructed from any number in the range `-128 <= n <= 255`, rather than only allowing the `i8` range of `-128 <= n <= 127`. It turned out to be really inconvenient to use only negative numbers, but sometimes it is useful, so now both are allowed.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
