### PR TITLE
DhtArc stability 01: initial tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3285,6 +3285,7 @@ dependencies = [
  "intervallum",
  "num-traits",
  "pretty_assertions 0.7.2",
+ "rand 0.8.4",
  "rusqlite",
  "serde",
 ]

--- a/crates/holochain/src/conductor/p2p_agent_store.rs
+++ b/crates/holochain/src/conductor/p2p_agent_store.rs
@@ -6,7 +6,7 @@ use holochain_conductor_api::AgentInfoDump;
 use holochain_conductor_api::P2pAgentsDump;
 use holochain_p2p::dht_arc::DhtArc;
 use holochain_p2p::dht_arc::DhtArcBucket;
-use holochain_p2p::dht_arc::PeerDensity;
+use holochain_p2p::dht_arc::PeerViewAlpha;
 use holochain_p2p::kitsune_p2p::agent_store::AgentInfoSigned;
 use holochain_p2p::AgentPubKeyExt;
 use holochain_sqlite::prelude::*;
@@ -160,7 +160,7 @@ pub fn query_peer_density(
     env: EnvWrite,
     kitsune_space: Arc<kitsune_p2p::KitsuneSpace>,
     dht_arc: DhtArc,
-) -> ConductorResult<PeerDensity> {
+) -> ConductorResult<PeerViewAlpha> {
     let now = now();
     let arcs = env.conn()?.p2p_list_agents()?;
     let arcs = arcs
@@ -181,7 +181,7 @@ pub fn query_peer_density(
     // contains is already checked in the iterator
     let bucket = DhtArcBucket::new_unchecked(dht_arc, arcs);
 
-    Ok(bucket.density())
+    Ok(bucket.peer_view_alpha())
 }
 
 /// Put single agent info into store

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -20,7 +20,7 @@ use holochain_conductor_api::IntegrationStateDump;
 use holochain_conductor_api::IntegrationStateDumps;
 use holochain_p2p::actor::HolochainP2pRefToCell;
 use holochain_p2p::dht_arc::DhtArc;
-use holochain_p2p::dht_arc::PeerDensity;
+use holochain_p2p::dht_arc::PeerViewAlpha;
 use holochain_p2p::event::HolochainP2pEvent;
 use holochain_p2p::spawn_holochain_p2p;
 use holochain_p2p::HolochainP2pCell;
@@ -227,11 +227,11 @@ where
                     respond.r(Ok(async move { Ok(vec![]) }.boxed().into()));
                 }
                 QueryPeerDensity { respond, .. } => {
-                    respond.r(Ok(
-                        async move { Ok(PeerDensity::new(DhtArc::full(0), 1.0, 1)) }
-                            .boxed()
-                            .into(),
-                    ));
+                    respond.r(Ok(async move {
+                        Ok(PeerViewAlpha::new(DhtArc::full(0), 1.0, 1))
+                    }
+                    .boxed()
+                    .into()));
                 }
                 _ => {}
             }

--- a/crates/holochain/tests/dht_arc.rs
+++ b/crates/holochain/tests/dht_arc.rs
@@ -40,7 +40,7 @@ async fn test_arc_coverage() {
                 let p = peers.clone();
                 let arc = peers.get_mut(i).unwrap();
                 let bucket = DhtArcBucket::new(*arc, p.clone());
-                let density = bucket.density();
+                let density = bucket.peer_view_alpha();
                 arc.update_length(density);
             }
             let bucket = DhtArcBucket::new(
@@ -89,7 +89,7 @@ async fn test_arc_redundancy() {
                 let p = peers.clone();
                 let arc = peers.get_mut(i).unwrap();
                 let bucket = DhtArcBucket::new(*arc, p.clone());
-                let density = bucket.density();
+                let density = bucket.peer_view_alpha();
                 arc.update_length(density);
             }
 
@@ -138,7 +138,7 @@ async fn test_arc_redundancy_all() {
                 let p = peers.clone();
                 let arc = peers.get_mut(i).unwrap();
                 let bucket = DhtArcBucket::new(*arc, p.clone());
-                let density = bucket.density();
+                let density = bucket.peer_view_alpha();
                 arc.update_length(density);
             }
 
@@ -204,7 +204,7 @@ async fn test_join_leave() {
             let p = peers.clone();
             let arc = peers.get_mut(i).unwrap();
             let bucket = DhtArcBucket::new(*arc, p.clone());
-            let density = bucket.density();
+            let density = bucket.peer_view_alpha();
             arc.update_length(density);
         }
     };

--- a/crates/holochain/tests/dht_arc.rs
+++ b/crates/holochain/tests/dht_arc.rs
@@ -48,7 +48,7 @@ async fn test_arc_coverage() {
                 peers.clone(),
             );
             println!("{}", bucket);
-            std::thread::sleep(std::time::Duration::from_millis(200));
+            // std::thread::sleep(std::time::Duration::from_millis(200));
         }
     };
 

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -131,8 +131,9 @@ impl WrapEvtSender {
         dna_hash: DnaHash,
         kitsune_space: Arc<kitsune_p2p::KitsuneSpace>,
         dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
-    ) -> impl Future<Output = HolochainP2pResult<kitsune_p2p_types::dht_arc::PeerDensity>> + 'static + Send
-    {
+    ) -> impl Future<Output = HolochainP2pResult<kitsune_p2p_types::dht_arc::PeerViewAlpha>>
+           + 'static
+           + Send {
         timing_trace!(
             { self.0.query_peer_density(dna_hash, kitsune_space, dht_arc) },
             "(hp2p:handle) query_peer_density",
@@ -695,7 +696,7 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
         &mut self,
         space: Arc<kitsune_p2p::KitsuneSpace>,
         dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
-    ) -> kitsune_p2p::event::KitsuneP2pEventHandlerResult<kitsune_p2p_types::dht_arc::PeerDensity>
+    ) -> kitsune_p2p::event::KitsuneP2pEventHandlerResult<kitsune_p2p_types::dht_arc::PeerViewAlpha>
     {
         let h_space = DnaHash::from_kitsune(&space);
         let evt_sender = self.evt_sender.clone();

--- a/crates/holochain_p2p/src/types/event.rs
+++ b/crates/holochain_p2p/src/types/event.rs
@@ -132,7 +132,7 @@ ghost_actor::ghost_chan! {
         fn query_agent_info_signed_near_basis(dna_hash: DnaHash, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>, basis_loc: u32, limit: u32) -> Vec<AgentInfoSigned>;
 
         /// Query the peer density of a space for a given [`DhtArc`].
-        fn query_peer_density(dna_hash: DnaHash, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>, dht_arc: kitsune_p2p_types::dht_arc::DhtArc) -> kitsune_p2p_types::dht_arc::PeerDensity;
+        fn query_peer_density(dna_hash: DnaHash, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>, dht_arc: kitsune_p2p_types::dht_arc::DhtArc) -> kitsune_p2p_types::dht_arc::PeerViewAlpha;
 
         /// We need to store some metric data on behalf of kitsune.
         fn put_metric_datum(dna_hash: DnaHash, to_agent: AgentPubKey, agent: AgentPubKey, metric: MetricKind, timestamp: SystemTime) -> ();

--- a/crates/kitsune_p2p/dht_arc/Cargo.toml
+++ b/crates/kitsune_p2p/dht_arc/Cargo.toml
@@ -21,6 +21,7 @@ rusqlite = { version = "0.26", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "0.7.2"
+rand = "0.8"
 
 [features]
 sqlite = ["rusqlite"]

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc/dht_arc_set.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc/dht_arc_set.rs
@@ -372,26 +372,56 @@ impl ArcInterval<DhtLocation> {
     /// Handy ascii representation of an arc, especially useful when
     /// looking at several arcs at once to get a sense of their overlap
     pub fn to_ascii(&self, len: usize) -> String {
-        use crate::loc_downscale;
+        use crate::{loc_downscale, loc_upscale};
+
+        let empty = || " ".repeat(len);
+        let full = || "-".repeat(len);
+
+        // If lo and hi are less than one bucket's width apart when scaled down,
+        // decide whether to interpret this as empty or full
+        let decide = |lo: &DhtLocation, hi: &DhtLocation| {
+            let mid = loc_upscale(len, (len / 2) as i32);
+            if lo < hi {
+                if hi.as_u32() - lo.as_u32() < mid {
+                    empty()
+                } else {
+                    full()
+                }
+            } else {
+                if lo.as_u32() - hi.as_u32() < mid {
+                    full()
+                } else {
+                    empty()
+                }
+            }
+        };
 
         match self {
-            Self::Full => "-".repeat(len),
-            Self::Empty => " ".repeat(len),
-            Self::Bounded(lo, hi) => {
-                let lo = loc_downscale(len, *lo);
-                let hi = loc_downscale(len, *hi);
-                let mut s = if lo <= hi {
-                    vec![
-                        " ".repeat(lo),
-                        "-".repeat(hi - lo + 1),
-                        " ".repeat(len - hi - 1),
-                    ]
+            Self::Full => full(),
+            Self::Empty => empty(),
+            Self::Bounded(lo0, hi0) => {
+                let lo = loc_downscale(len, *lo0);
+                let hi = loc_downscale(len, *hi0);
+                let mut s = if lo0 <= hi0 {
+                    if lo >= hi {
+                        vec![decide(lo0, hi0)]
+                    } else {
+                        vec![
+                            " ".repeat(lo),
+                            "-".repeat(hi - lo + 1),
+                            " ".repeat((len - hi).saturating_sub(1)),
+                        ]
+                    }
                 } else {
-                    vec![
-                        "-".repeat(hi + 1),
-                        " ".repeat(lo - hi - 1),
-                        "-".repeat(len - lo),
-                    ]
+                    if lo <= hi {
+                        vec![decide(lo0, hi0)]
+                    } else {
+                        vec![
+                            "-".repeat(hi + 1),
+                            " ".repeat((lo - hi).saturating_sub(1)),
+                            "-".repeat(len - lo),
+                        ]
+                    }
                 }
                 .join("");
                 let center = loc_downscale(len, self.center_loc());

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc/gaps.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc/gaps.rs
@@ -52,7 +52,7 @@ pub fn check_for_gaps(peers: Vec<DhtArc>) -> bool {
 /// Check a set of peers the actual redundancy across all peers.
 /// This can tell if there is bad distribution.
 /// Note this function is only used for verification in tests at this time.
-pub fn check_redundancy(peers: Vec<DhtArc>) -> usize {
+pub fn check_redundancy(peers: Vec<DhtArc>) -> u32 {
     use std::collections::HashSet;
     #[derive(Clone, Copy, Debug)]
     enum Side {
@@ -189,5 +189,5 @@ pub fn check_redundancy(peers: Vec<DhtArc>) -> usize {
         .fold((stack, usize::MAX, started, last_removed), stack_fold);
 
     // Our redundancy is whatever partial + any full redundancy
-    r + full_r
+    r as u32 + full_r
 }

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc/test_ascii.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc/test_ascii.rs
@@ -1,5 +1,3 @@
-use crate::dht_arc::loc_upscale;
-
 use super::*;
 use pretty_assertions::assert_eq;
 

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc/test_ascii.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc/test_ascii.rs
@@ -71,7 +71,7 @@ fn test_cases_scaled<'a>(len: usize, cases: impl IntoIterator<Item = (i32, i32, 
     let actual: Vec<_> = cases
         .into_iter()
         .map(|(lo, hi, _)| {
-            let ascii = ArcInterval::new(loc_upscale(len, lo), loc_upscale(len, hi)).to_ascii(len);
+            let ascii = ArcInterval::new(lo, hi).to_ascii(len);
             let bounds = fmt_bounds(lo, hi);
             assert_eq!(ascii.len(), len, "Wrong length for case {}", bounds);
             (bounds, ascii)

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc/tests.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc/tests.rs
@@ -233,14 +233,14 @@ fn test_arc_len() {
 fn test_peer_density() {
     let arc = |c, n, h| {
         let mut arc = DhtArc::new(0, h);
-        arc.update_length(PeerDensity::new(arc, c, n));
+        arc.update_length(PeerViewAlpha::new(arc, c, n));
         (arc.coverage() * 10000.0).round() / 10000.0
     };
 
     let converge = |arc: &mut DhtArc, peers: &Vec<DhtArc>| {
         for _ in 0..40 {
             let bucket = DhtArcBucket::new(*arc, peers.clone());
-            let density = bucket.density();
+            let density = bucket.peer_view_alpha();
             arc.update_length(density);
         }
     };
@@ -284,22 +284,22 @@ fn test_peer_density() {
 fn test_converge() {
     let min_online_peers = MIN_PEERS;
     let bucket = DhtArc::new(0, MAX_HALF_LENGTH);
-    assert_eq!(converge(1.0, PeerDensity::new(bucket, 1.0, 1)), 1.0);
+    assert_eq!(converge(1.0, PeerViewAlpha::new(bucket, 1.0, 1)), 1.0);
     assert_eq!(
-        converge(1.0, PeerDensity::new(bucket, 1.0, min_online_peers)),
+        converge(1.0, PeerViewAlpha::new(bucket, 1.0, min_online_peers)),
         1.0
     );
     assert_eq!(
-        converge(1.0, PeerDensity::new(bucket, 1.0, min_online_peers * 2)),
+        converge(1.0, PeerViewAlpha::new(bucket, 1.0, min_online_peers * 2)),
         0.9
     );
     assert_eq!(
-        converge(0.5, PeerDensity::new(bucket, 1.0, min_online_peers)),
+        converge(0.5, PeerViewAlpha::new(bucket, 1.0, min_online_peers)),
         0.6
     );
     let mut coverage = 0.5;
     for _ in 0..20 {
-        coverage = converge(coverage, PeerDensity::new(bucket, 1.0, 1));
+        coverage = converge(coverage, PeerViewAlpha::new(bucket, 1.0, 1));
     }
     assert_eq!(coverage, 1.0);
 
@@ -307,7 +307,7 @@ fn test_converge() {
     for _ in 0..20 {
         coverage = converge(
             coverage,
-            PeerDensity::new(bucket, 1.0, min_online_peers * 2),
+            PeerViewAlpha::new(bucket, 1.0, min_online_peers * 2),
         );
     }
     assert_eq!(coverage, 0.5);
@@ -322,7 +322,7 @@ fn test_multiple() {
                 let p = peers.clone();
                 let arc = peers.get_mut(i).unwrap();
                 let bucket = DhtArcBucket::new(*arc, p.clone());
-                let density = bucket.density();
+                let density = bucket.peer_view_alpha();
                 arc.update_length(density);
             }
             let r = check_redundancy(peers.clone());
@@ -484,7 +484,7 @@ fn test_peer_gaps() {
                 let p = peers.clone();
                 let arc = peers.get_mut(i).unwrap();
                 let bucket = DhtArcBucket::new(*arc, p.clone());
-                let density = bucket.density();
+                let density = bucket.peer_view_alpha();
                 arc.update_length(density);
             }
             if gaps {

--- a/crates/kitsune_p2p/dht_arc/src/test/arc_stability.rs
+++ b/crates/kitsune_p2p/dht_arc/src/test/arc_stability.rs
@@ -1,0 +1,16 @@
+use crate::DhtArc;
+
+#[test]
+fn a_test() {
+    // todo
+}
+
+struct EpochStats {
+    net_change: f64,
+    gross_change: f64,
+    min_redundancy: u32,
+}
+
+fn one_epoch(mut arcs: Vec<DhtArc>) -> EpochStats {
+    todo!()
+}

--- a/crates/kitsune_p2p/dht_arc/src/test/arc_stability.rs
+++ b/crates/kitsune_p2p/dht_arc/src/test/arc_stability.rs
@@ -1,16 +1,224 @@
-use crate::DhtArc;
+use crate::{gaps::check_redundancy, DhtArc, DhtArcBucket, MAX_HALF_LENGTH};
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use rand::Rng;
+use std::iter;
 
-#[test]
-fn a_test() {
-    // todo
+/// Maximum number of iterations. If we iterate this much, we assume the
+/// system will never converge on equilibrium.
+const MAX_ITERS: usize = 80;
+
+/// Number of consecutive rounds of no movement before considering equilibrium
+/// achieved.
+const STEADY_WINDOW: usize = 3;
+
+const DETAIL: u8 = 0;
+
+fn full_len() -> f64 {
+    2f64.powi(32)
 }
 
+#[test]
+fn parameterized_stability_test() {
+    let n = 500;
+    let j = 1f64 / n as f64 / 3.0;
+
+    let peers = simple_parameterized_generator(n, j, ArcLenStrategy::Constant(0.1));
+    report(peers);
+}
+
+fn report(mut peers: Vec<DhtArc>) {
+    if let Some(mut stats) = seek_equilibrium(&mut peers) {
+        let total = stats.len();
+        // print_arcs(&peers);
+        println!("{:?}", stats.pop().unwrap());
+        println!("Reached equilibrium in {} iterations", total);
+    } else {
+        // print_arcs(&peers);
+        panic!("failed to reach equilibrium in {} iterations", MAX_ITERS);
+    }
+}
+
+/// Run iterations until there is no movement of any arc
+/// TODO: this may be unreasonable, and we may need to just ensure that arcs
+/// settle down into a reasonable level of oscillation
+fn seek_equilibrium(peers: &mut Vec<DhtArc>) -> Option<Vec<EpochStats>> {
+    let mut n_delta_count = 0;
+    let mut stats_history = vec![];
+    println!("{}", EpochStats::oneline_header());
+    for i in 1..=MAX_ITERS {
+        if n_delta_count >= STEADY_WINDOW {
+            println!("Converged in {} iterations", i - STEADY_WINDOW);
+            break;
+        }
+
+        // print_arcs(&peers);
+        let stats = run_one_epoch(peers, DETAIL);
+        println!("{}", stats.oneline());
+        // get_input();
+        if stats.gross_delta_avg == 0.0 {
+            n_delta_count += 1;
+        } else if n_delta_count > 0 {
+            panic!("we don't expect a system in equilibirum to suddenly start moving again!")
+        } else {
+            stats_history.push(stats);
+        }
+    }
+    if n_delta_count == 0 {
+        None
+    } else {
+        Some(stats_history)
+    }
+}
+
+/// Resize every arc based on neighbors' arcs, and compute stats about this iteration
+fn run_one_epoch(peers: &mut Vec<DhtArc>, detail: u8) -> EpochStats {
+    let mut net = 0.0;
+    let mut gross = 0.0;
+    let mut delta_min = full_len() / 2.0;
+    let mut delta_max = -full_len() / 2.0;
+    let mut index_min = peers.len();
+    let mut index_max = peers.len();
+    for i in 0..peers.len() {
+        let p = peers.clone();
+        let arc = peers.get_mut(i).unwrap();
+        let bucket = DhtArcBucket::new(*arc, p.clone());
+        let density = bucket.density();
+        let before = arc.absolute_length() as f64;
+        arc.update_length(density);
+        let after = arc.absolute_length() as f64;
+        let delta = after - before;
+        net += delta;
+        gross += delta.abs();
+        if delta < delta_min {
+            delta_min = delta;
+            index_min = i;
+        }
+        if delta > delta_max {
+            delta_max = delta;
+            index_max = i;
+        }
+    }
+
+    if detail == 1 {
+        println!("min: |{}| {}", peers[index_min].to_ascii(64), index_min);
+        println!("max: |{}| {}", peers[index_max].to_ascii(64), index_max);
+        println!("");
+    } else if detail == 2 {
+        print_arcs(peers);
+        get_input();
+    }
+
+    let tot = peers.len() as f64;
+    let min_redundancy = check_redundancy(peers.clone());
+    EpochStats {
+        net_delta_avg: net / tot / full_len(),
+        gross_delta_avg: gross / tot / full_len(),
+        min_redundancy: min_redundancy,
+        delta_min: delta_min / full_len(),
+        delta_max: delta_max / full_len(),
+    }
+}
+
+/// Generate a list of DhtArcs based on 3 parameters:
+/// N: total # of peers
+/// J: random jitter of peer locations
+/// S: strategy for generating arc lengths
+fn simple_parameterized_generator(n: usize, j: f64, s: ArcLenStrategy) -> Vec<DhtArc> {
+    println!("N = {}, J = {}", n, j);
+    println!("Arc len generation: {:?}", s);
+    let halflens = s.gen(n);
+    generate_evenly_spaced_with_half_lens_and_jitter(j, halflens)
+}
+
+/// Define arcs by centerpoint and halflen in the unit interval [0.0, 1.0]
+fn unit_arcs<H: Iterator<Item = (f64, f64)>>(arcs: H) -> Vec<DhtArc> {
+    let fc = full_len();
+    let fh = MAX_HALF_LENGTH as f64;
+    arcs.map(|(c, h)| DhtArc::new((c * fc).min(u32::MAX as f64) as u32, (h * fh) as u32))
+        .collect()
+}
+
+/// Each agent is perfect evenly spaced around the DHT,
+/// with the halflens specified by the iterator.
+fn generate_evenly_spaced_with_half_lens_and_jitter<H: Iterator<Item = f64>>(
+    jitter: f64,
+    hs: H,
+) -> Vec<DhtArc> {
+    let mut rng = thread_rng();
+    let hs: Vec<_> = hs.collect();
+    let n = hs.len() as f64;
+    unit_arcs(hs.into_iter().enumerate().map(|(i, h)| {
+        (
+            (i as f64 / n) + (2.0 * jitter * rng.gen::<f64>()) - jitter,
+            h,
+        )
+    }))
+}
+
+#[derive(Debug)]
 struct EpochStats {
-    net_change: f64,
-    gross_change: f64,
+    net_delta_avg: f64,
+    gross_delta_avg: f64,
+    delta_max: f64,
+    delta_min: f64,
+    // delta_variance: f64,
     min_redundancy: u32,
 }
 
-fn one_epoch(mut arcs: Vec<DhtArc>) -> EpochStats {
-    todo!()
+impl EpochStats {
+    pub fn oneline_header() -> String {
+        format!("rdun   net Δ%   gross Δ%   min Δ%   max Δ%")
+    }
+
+    pub fn oneline(&self) -> String {
+        format!(
+            "{:4}   {:>+6.3}   {:>8.3}   {:>6.3}   {:>6.3}",
+            self.min_redundancy,
+            self.net_delta_avg * 100.0,
+            self.gross_delta_avg * 100.0,
+            self.delta_min * 100.0,
+            self.delta_max * 100.0,
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+enum ArcLenStrategy {
+    Random,
+    Constant(f64),
+    HalfAndHalf(f64, f64),
+}
+
+impl ArcLenStrategy {
+    pub fn gen(&self, num: usize) -> Box<dyn Iterator<Item = f64>> {
+        match self {
+            Self::Random => {
+                let mut rng = thread_rng();
+                Box::new(iter::repeat_with(move || rng.gen()).take(num))
+            }
+            Self::Constant(v) => Box::new(iter::repeat(*v).take(num)),
+            Self::HalfAndHalf(a, b) => Box::new(
+                iter::repeat(*a)
+                    .take(num / 2)
+                    .chain(iter::repeat(*b).take(num / 2)),
+            ),
+        }
+    }
+}
+
+/// View ascii for all arcs
+fn print_arcs(arcs: &Vec<DhtArc>) {
+    for (i, arc) in arcs.into_iter().enumerate() {
+        println!("|{}| {}", arc.to_ascii(64), i);
+    }
+}
+
+/// Wait for input, to slow down overwhelmingly large iterations
+fn get_input() {
+    let mut input_string = String::new();
+    std::io::stdin()
+        .read_line(&mut input_string)
+        .ok()
+        .expect("Failed to read line");
 }

--- a/crates/kitsune_p2p/dht_arc/src/test/mod.rs
+++ b/crates/kitsune_p2p/dht_arc/src/test/mod.rs
@@ -1,5 +1,6 @@
 mod ascii;
 pub use ascii::ascii;
 
+mod arc_stability;
 mod intersection;
 mod union;

--- a/crates/kitsune_p2p/direct/src/lib.rs
+++ b/crates/kitsune_p2p/direct/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
+#![allow(deprecated)]
 
 pub use kitsune_p2p_direct_api::{KdError, KdResult};
 use kitsune_p2p_types::dependencies::ghost_actor::dependencies::tracing;

--- a/crates/kitsune_p2p/direct/src/persist_mem.rs
+++ b/crates/kitsune_p2p/direct/src/persist_mem.rs
@@ -391,7 +391,7 @@ impl AsKdPersist for PersistMem {
         &self,
         root: KdHash,
         dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
-    ) -> BoxFuture<'static, KdResult<kitsune_p2p_types::dht_arc::PeerDensity>> {
+    ) -> BoxFuture<'static, KdResult<kitsune_p2p_types::dht_arc::PeerViewAlpha>> {
         let store = self.0.share_mut(move |i, _| match i.agent_info.get(&root) {
             Some(store) => Ok(store.clone()),
             None => Err("root not found".into()),
@@ -416,7 +416,7 @@ impl AsKdPersist for PersistMem {
             // contains is already checked in the iterator
             let bucket = kitsune_p2p::dht_arc::DhtArcBucket::new_unchecked(dht_arc, arcs);
 
-            Ok(bucket.density())
+            Ok(bucket.peer_view_alpha())
         }
         .boxed()
     }

--- a/crates/kitsune_p2p/direct/src/types/persist.rs
+++ b/crates/kitsune_p2p/direct/src/types/persist.rs
@@ -56,7 +56,7 @@ pub trait AsKdPersist: 'static + Send + Sync {
         &self,
         root: KdHash,
         dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
-    ) -> BoxFuture<'static, KdResult<kitsune_p2p_types::dht_arc::PeerDensity>>;
+    ) -> BoxFuture<'static, KdResult<kitsune_p2p_types::dht_arc::PeerViewAlpha>>;
 
     /// Store agent info
     fn put_metric_datum(&self, datum: MetricDatum) -> BoxFuture<'static, KdResult<()>>;
@@ -185,7 +185,7 @@ impl KdPersist {
         &self,
         root: KdHash,
         dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
-    ) -> impl Future<Output = KdResult<kitsune_p2p_types::dht_arc::PeerDensity>> + 'static + Send
+    ) -> impl Future<Output = KdResult<kitsune_p2p_types::dht_arc::PeerViewAlpha>> + 'static + Send
     {
         AsKdPersist::query_peer_density(&*self.0, root, dht_arc)
     }

--- a/crates/kitsune_p2p/direct/src/v1.rs
+++ b/crates/kitsune_p2p/direct/src/v1.rs
@@ -789,7 +789,7 @@ async fn handle_query_peer_density(
     kdirect: Arc<Kd1>,
     space: Arc<KitsuneSpace>,
     dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
-) -> KdResult<kitsune_p2p_types::dht_arc::PeerDensity> {
+) -> KdResult<kitsune_p2p_types::dht_arc::PeerViewAlpha> {
     let root = KdHash::from_kitsune_space(&space);
     let density = kdirect.persist.query_peer_density(root, dht_arc).await?;
     Ok(density)

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -505,7 +505,7 @@ impl KitsuneP2pEventHandler for KitsuneP2pActor {
         &mut self,
         space: Arc<KitsuneSpace>,
         dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
-    ) -> KitsuneP2pEventHandlerResult<kitsune_p2p_types::dht_arc::PeerDensity> {
+    ) -> KitsuneP2pEventHandlerResult<kitsune_p2p_types::dht_arc::PeerViewAlpha> {
         Ok(self.evt_sender.query_peer_density(space, dht_arc))
     }
 
@@ -787,7 +787,7 @@ mockall::mock! {
             &mut self,
             space: Arc<KitsuneSpace>,
             dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
-        ) -> KitsuneP2pEventHandlerResult<kitsune_p2p_types::dht_arc::PeerDensity>;
+        ) -> KitsuneP2pEventHandlerResult<kitsune_p2p_types::dht_arc::PeerViewAlpha>;
 
         fn handle_call(
             &mut self,

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
@@ -196,7 +196,7 @@ impl KitsuneP2pEventHandler for AgentHarness {
         &mut self,
         _space: Arc<KitsuneSpace>,
         dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
-    ) -> KitsuneP2pEventHandlerResult<kitsune_p2p_types::dht_arc::PeerDensity> {
+    ) -> KitsuneP2pEventHandlerResult<kitsune_p2p_types::dht_arc::PeerViewAlpha> {
         let arcs = self
             .agent_store
             .values()
@@ -212,7 +212,7 @@ impl KitsuneP2pEventHandler for AgentHarness {
         // contains is already checked in the iterator
         let bucket = DhtArcBucket::new_unchecked(dht_arc, arcs);
 
-        Ok(async move { Ok(bucket.density()) }.boxed().into())
+        Ok(async move { Ok(bucket.peer_view_alpha()) }.boxed().into())
     }
 
     fn handle_put_metric_datum(&mut self, datum: MetricDatum) -> KitsuneP2pEventHandlerResult<()> {

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
@@ -100,7 +100,7 @@ impl KitsuneP2pEventHandler for SwitchboardEventHandler {
         &mut self,
         space: Arc<KitsuneSpace>,
         dht_arc: kitsune_p2p_types::dht_arc::DhtArc,
-    ) -> KitsuneP2pEventHandlerResult<kitsune_p2p_types::dht_arc::PeerDensity> {
+    ) -> KitsuneP2pEventHandlerResult<kitsune_p2p_types::dht_arc::PeerViewAlpha> {
         todo!()
     }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
@@ -224,7 +224,7 @@ ghost_actor::ghost_chan! {
         fn query_agents(input: QueryAgentsEvt) -> Vec<crate::types::agent_store::AgentInfoSigned>;
 
         /// Query the peer density of a space for a given [`DhtArc`].
-        fn query_peer_density(space: KSpace, dht_arc: kitsune_p2p_types::dht_arc::DhtArc) -> kitsune_p2p_types::dht_arc::PeerDensity;
+        fn query_peer_density(space: KSpace, dht_arc: kitsune_p2p_types::dht_arc::DhtArc) -> kitsune_p2p_types::dht_arc::PeerViewAlpha;
 
         /// Record a metric datum about an agent.
         fn put_metric_datum(datum: MetricDatum) -> ();


### PR DESCRIPTION
### Summary

Adds some tests which test for arc resizing stability: a basic check of convergence vs. divergence. These all live in `arc_stability.rc`

Mostly other changes are just a bunch of renames from `PeerDensity` to `PeerViewAlpha`, paving the way for having multiple different methods of calculating ideal target coverage.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
