### PR TITLE
Db refactor 1

### DIFF
--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -128,6 +128,8 @@ impl Cell {
     pub async fn create(
         id: CellId,
         conductor_handle: ConductorHandle,
+        env: EnvWrite,
+        cache: EnvWrite,
         holochain_p2p_cell: holochain_p2p::HolochainP2pDna,
         managed_task_add_sender: sync::mpsc::Sender<ManagedTaskAdd>,
         managed_task_stop_broadcaster: sync::broadcast::Sender<()>,

--- a/crates/holochain/src/conductor/cell/test.rs
+++ b/crates/holochain/src/conductor/cell/test.rs
@@ -25,7 +25,7 @@ async fn test_cell_handle_publish() {
     let agent = cell_id.agent_pubkey().clone();
 
     let test_network = test_network(Some(dna.clone()), Some(agent.clone())).await;
-    let holochain_p2p_cell = test_network.cell_network();
+    let holochain_p2p_cell = test_network.dna_network();
 
     let mut mock_handle = crate::conductor::handle::MockConductorHandleT::new();
     mock_handle

--- a/crates/holochain/src/conductor/cell/validation_package.rs
+++ b/crates/holochain/src/conductor/cell/validation_package.rs
@@ -5,8 +5,7 @@ use crate::core::workflow::app_validation_workflow::validation_package::get_as_a
 use crate::core::workflow::app_validation_workflow::validation_package::get_as_author_full;
 use crate::core::workflow::app_validation_workflow::validation_package::get_as_author_sub_chain;
 use holochain_cascade::Cascade;
-use holochain_p2p::HolochainP2pCell;
-use holochain_state::source_chain::SourceChain;
+use holochain_p2p::HolochainP2pDna;
 use holochain_types::dna::DnaFile;
 use holochain_zome_types::HeaderHashed;
 
@@ -16,8 +15,7 @@ pub(super) async fn get_as_author(
     env: EnvRead,
     cache: EnvWrite,
     ribosome: &impl RibosomeT,
-    conductor_api: &impl CellConductorApiT,
-    network: &HolochainP2pCell,
+    network: &HolochainP2pDna,
 ) -> CellResult<ValidationPackageResponse> {
     let header = header_hashed.as_content();
 

--- a/crates/holochain/src/conductor/cell/validation_package.rs
+++ b/crates/holochain/src/conductor/cell/validation_package.rs
@@ -6,6 +6,7 @@ use crate::core::workflow::app_validation_workflow::validation_package::get_as_a
 use crate::core::workflow::app_validation_workflow::validation_package::get_as_author_sub_chain;
 use holochain_cascade::Cascade;
 use holochain_p2p::HolochainP2pDna;
+use holochain_state::source_chain::SourceChain;
 use holochain_types::dna::DnaFile;
 use holochain_zome_types::HeaderHashed;
 
@@ -15,6 +16,7 @@ pub(super) async fn get_as_author(
     env: EnvRead,
     cache: EnvWrite,
     ribosome: &impl RibosomeT,
+    conductor_api: &impl CellConductorApiT,
     network: &HolochainP2pDna,
 ) -> CellResult<ValidationPackageResponse> {
     let header = header_hashed.as_content();

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -657,10 +657,8 @@ where
             let managed_task_stop_broadcaster = managed_task_stop_broadcaster.clone();
             let db_sync_level = self.db_sync_level;
             async move {
-                use holochain_p2p::actor::HolochainP2pRefToCell;
-                let holochain_p2p_cell = self
-                    .holochain_p2p
-                    .to_cell(cell_id.dna_hash().clone(), cell_id.agent_pubkey().clone());
+                use holochain_p2p::actor::HolochainP2pRefToDna;
+                let holochain_p2p_cell = self.holochain_p2p.to_dna(cell_id.dna_hash().clone());
 
                 let env = EnvWrite::open_with_sync_level(
                     &root_env_dir,

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -74,10 +74,7 @@ use holochain_keystore::MetaLairClient;
 use holochain_p2p::event::HolochainP2pEvent;
 use holochain_p2p::event::HolochainP2pEvent::*;
 use holochain_p2p::DnaHashExt;
-
-use holochain_p2p::HolochainP2pCellT;
-use holochain_sqlite::db::DbKind;
-use holochain_state::host_fn_workspace::HostFnWorkspace;
+use holochain_p2p::HolochainP2pDnaT;
 use holochain_state::source_chain;
 use holochain_types::prelude::*;
 use kitsune_p2p::agent_store::AgentInfoSigned;
@@ -1397,9 +1394,9 @@ impl<DS: DnaStore + 'static> ConductorHandleImpl<DS> {
             .conductor
             .mark_pending_cells_as_joining()
             .into_iter()
-            .map(|(id, cell)| (id, cell.holochain_p2p_cell().clone()))
+            .map(|(id, cell)| (id, cell.holochain_p2p_dna().clone()))
             .map(|(cell_id, network)| async move {
-                match tokio::time::timeout(JOIN_NETWORK_TIMEOUT, network.join()).await {
+                match tokio::time::timeout(JOIN_NETWORK_TIMEOUT, network.join(cell_id.agent_pubkey().clone())).await {
                     Ok(Err(e)) => {
                         tracing::info!(error = ?e, cell_id = ?cell_id, "Error while trying to join the network");
                         Err(cell_id)

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -75,6 +75,8 @@ use holochain_p2p::event::HolochainP2pEvent;
 use holochain_p2p::event::HolochainP2pEvent::*;
 use holochain_p2p::DnaHashExt;
 use holochain_p2p::HolochainP2pDnaT;
+use holochain_sqlite::db::DbKind;
+use holochain_state::host_fn_workspace::HostFnWorkspace;
 use holochain_state::source_chain;
 use holochain_types::prelude::*;
 use kitsune_p2p::agent_store::AgentInfoSigned;

--- a/crates/holochain/src/core/queue_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer.rs
@@ -49,7 +49,7 @@ use validation_receipt_consumer::*;
 mod validation_receipt_consumer;
 use crate::conductor::{api::CellConductorApiT, error::ConductorError, manager::ManagedTaskResult};
 use crate::conductor::{manager::ManagedTaskAdd, ConductorHandle};
-use holochain_p2p::HolochainP2pCell;
+use holochain_p2p::HolochainP2pDna;
 use holochain_p2p::*;
 use publish_dht_ops_consumer::*;
 
@@ -69,9 +69,8 @@ use super::workflow::error::WorkflowError;
 /// a race condition by trying to run a workflow too soon after cell creation.
 #[allow(clippy::too_many_arguments)]
 pub async fn spawn_queue_consumer_tasks(
-    env: EnvWrite,
-    cache: EnvWrite,
-    cell_network: HolochainP2pCell,
+    cell_id: CellId,
+    network: HolochainP2pDna,
     conductor_handle: ConductorHandle,
     conductor_api: impl CellConductorApiT + 'static,
     task_sender: sync::mpsc::Sender<ManagedTaskAdd>,

--- a/crates/holochain/src/core/queue_consumer/app_validation_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/app_validation_consumer.rs
@@ -25,7 +25,7 @@ pub fn spawn_app_validation_consumer(
     mut stop: sync::broadcast::Receiver<()>,
     trigger_integration: TriggerSender,
     conductor_api: impl CellConductorApiT + 'static,
-    network: HolochainP2pCell,
+    network: HolochainP2pDna,
 ) -> (TriggerSender, JoinHandle<ManagedTaskResult>) {
     let (tx, mut rx) = TriggerSender::new();
     let trigger_self = tx.clone();
@@ -53,7 +53,7 @@ pub fn spawn_app_validation_consumer(
                 Err(err) => {
                     handle_workflow_error(
                         conductor_handle.clone(),
-                        network.cell_id(),
+                        conductor_api.cell_id().clone(),
                         err,
                         "app_validation failure",
                     )

--- a/crates/holochain/src/core/queue_consumer/countersigning_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/countersigning_consumer.rs
@@ -10,13 +10,13 @@ use tokio::task::JoinHandle;
 use tracing::*;
 
 /// Spawn the QueueConsumer for countersigning workflow
-#[instrument(skip(env, stop, conductor_handle, workspace, cell_network, trigger_sys))]
+#[instrument(skip(env, stop, conductor_handle, workspace, dna_network, trigger_sys))]
 pub(crate) fn spawn_countersigning_consumer(
     env: EnvWrite,
     mut stop: sync::broadcast::Receiver<()>,
     conductor_handle: ConductorHandle,
     workspace: CountersigningWorkspace,
-    cell_network: HolochainP2pDna,
+    dna_network: HolochainP2pDna,
     trigger_sys: TriggerSender,
 ) -> (TriggerSender, JoinHandle<ManagedTaskResult>) {
     let (tx, mut rx) = TriggerSender::new();
@@ -38,7 +38,7 @@ pub(crate) fn spawn_countersigning_consumer(
             }
 
             // Run the workflow
-            match countersigning_workflow(&env, &workspace, &cell_network, &trigger_sys).await {
+            match countersigning_workflow(&env, &workspace, &dna_network, &trigger_sys).await {
                 Ok(WorkComplete::Incomplete) => trigger_self.trigger(),
                 Err(err) => {
                     handle_workflow_error(

--- a/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
@@ -7,14 +7,14 @@ use tokio::task::JoinHandle;
 use tracing::*;
 
 /// Spawn the QueueConsumer for DhtOpIntegration workflow
-#[instrument(skip(env, conductor_handle, stop, trigger_receipt, cell_network))]
+#[instrument(skip(env, conductor_handle, stop, trigger_receipt, dna_network))]
 pub fn spawn_integrate_dht_ops_consumer(
     env: EnvWrite,
     conductor_handle: ConductorHandle,
     cell_id: CellId,
     mut stop: sync::broadcast::Receiver<()>,
     trigger_receipt: TriggerSender,
-    cell_network: HolochainP2pDna,
+    dna_network: HolochainP2pDna,
 ) -> (TriggerSender, JoinHandle<ManagedTaskResult>) {
     let (tx, mut rx) = TriggerSender::new();
     let trigger_self = tx.clone();
@@ -32,7 +32,7 @@ pub fn spawn_integrate_dht_ops_consumer(
             match integrate_dht_ops_workflow(
                 env.clone(),
                 trigger_receipt.clone(),
-                cell_network.clone(),
+                dna_network.clone(),
             )
             .await
             {

--- a/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
@@ -14,7 +14,7 @@ pub fn spawn_integrate_dht_ops_consumer(
     cell_id: CellId,
     mut stop: sync::broadcast::Receiver<()>,
     trigger_receipt: TriggerSender,
-    cell_network: HolochainP2pCell,
+    cell_network: HolochainP2pDna,
 ) -> (TriggerSender, JoinHandle<ManagedTaskResult>) {
     let (tx, mut rx) = TriggerSender::new();
     let trigger_self = tx.clone();

--- a/crates/holochain/src/core/queue_consumer/sys_validation_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/sys_validation_consumer.rs
@@ -23,7 +23,7 @@ pub fn spawn_sys_validation_consumer(
     conductor_handle: ConductorHandle,
     mut stop: sync::broadcast::Receiver<()>,
     trigger_app_validation: TriggerSender,
-    network: HolochainP2pCell,
+    network: HolochainP2pDna,
     conductor_api: impl CellConductorApiT + 'static,
 ) -> (TriggerSender, JoinHandle<ManagedTaskResult>) {
     let (tx, mut rx) = TriggerSender::new();
@@ -53,7 +53,7 @@ pub fn spawn_sys_validation_consumer(
                 Err(err) => {
                     handle_workflow_error(
                         conductor_handle.clone(),
-                        network.cell_id(),
+                        conductor_api.cell_id().clone(),
                         err,
                         "sys_validation failure",
                     )

--- a/crates/holochain/src/core/queue_consumer/tests.rs
+++ b/crates/holochain/src/core/queue_consumer/tests.rs
@@ -239,10 +239,7 @@ async fn publish_loop() {
             mutations_helpers::insert_valid_authored_op(txn, op).unwrap();
         })
         .unwrap();
-    let mut cell_network = MockHolochainP2pCellT::new();
-    cell_network
-        .expect_from_agent()
-        .returning(move || author.clone());
+    let mut cell_network = MockHolochainP2pDnaT::new();
     let (tx, mut op_published) = tokio::sync::mpsc::channel(100);
     cell_network
         .expect_publish()
@@ -261,7 +258,7 @@ async fn publish_loop() {
         timer.elapsed() >= Duration::from_secs(60) && timer.elapsed() < Duration::from_secs(61)
     );
 
-    publish_dht_ops_workflow(env.clone(), &cell_network, &ts)
+    publish_dht_ops_workflow(env.clone(), &cell_network, &ts, author.clone())
         .await
         .unwrap();
 
@@ -275,7 +272,7 @@ async fn publish_loop() {
         timer.elapsed() >= Duration::from_secs(60 * 2)
             && timer.elapsed() < Duration::from_secs(60 * 2 + 1)
     );
-    publish_dht_ops_workflow(env.clone(), &cell_network, &ts)
+    publish_dht_ops_workflow(env.clone(), &cell_network, &ts, author.clone())
         .await
         .unwrap();
 
@@ -291,7 +288,7 @@ async fn publish_loop() {
     let timer = tokio::time::Instant::now();
     trigger_recv.listen().await.unwrap();
     assert!(timer.elapsed() < Duration::from_secs(1));
-    publish_dht_ops_workflow(env.clone(), &cell_network, &ts)
+    publish_dht_ops_workflow(env.clone(), &cell_network, &ts, author.clone())
         .await
         .unwrap();
 
@@ -322,7 +319,7 @@ async fn publish_loop() {
         timer.elapsed() >= Duration::from_secs(60) && timer.elapsed() < Duration::from_secs(61)
     );
 
-    publish_dht_ops_workflow(env.clone(), &cell_network, &ts)
+    publish_dht_ops_workflow(env.clone(), &cell_network, &ts, author.clone())
         .await
         .unwrap();
 
@@ -344,7 +341,7 @@ async fn publish_loop() {
         timer.elapsed() >= Duration::from_secs(60 * 2)
             && timer.elapsed() < Duration::from_secs(60 * 2 + 1)
     );
-    publish_dht_ops_workflow(env.clone(), &cell_network, &ts)
+    publish_dht_ops_workflow(env.clone(), &cell_network, &ts, author.clone())
         .await
         .unwrap();
 
@@ -377,7 +374,7 @@ async fn publish_loop() {
     let timer = tokio::time::Instant::now();
     trigger_recv.listen().await.unwrap();
     assert!(timer.elapsed() < Duration::from_secs(1));
-    publish_dht_ops_workflow(env.clone(), &cell_network, &ts)
+    publish_dht_ops_workflow(env.clone(), &cell_network, &ts, author.clone())
         .await
         .unwrap();
 
@@ -391,7 +388,7 @@ async fn publish_loop() {
         timer.elapsed() >= Duration::from_secs(60) && timer.elapsed() < Duration::from_secs(61)
     );
 
-    publish_dht_ops_workflow(env.clone(), &cell_network, &ts)
+    publish_dht_ops_workflow(env.clone(), &cell_network, &ts, author.clone())
         .await
         .unwrap();
     // - The op is not published because of the time interval.

--- a/crates/holochain/src/core/queue_consumer/tests.rs
+++ b/crates/holochain/src/core/queue_consumer/tests.rs
@@ -239,9 +239,9 @@ async fn publish_loop() {
             mutations_helpers::insert_valid_authored_op(txn, op).unwrap();
         })
         .unwrap();
-    let mut cell_network = MockHolochainP2pDnaT::new();
+    let mut dna_network = MockHolochainP2pDnaT::new();
     let (tx, mut op_published) = tokio::sync::mpsc::channel(100);
-    cell_network
+    dna_network
         .expect_publish()
         .returning(move |_, _, _, _, _| {
             tx.try_send(()).unwrap();
@@ -258,7 +258,7 @@ async fn publish_loop() {
         timer.elapsed() >= Duration::from_secs(60) && timer.elapsed() < Duration::from_secs(61)
     );
 
-    publish_dht_ops_workflow(env.clone(), &cell_network, &ts, author.clone())
+    publish_dht_ops_workflow(env.clone(), &dna_network, &ts, author.clone())
         .await
         .unwrap();
 
@@ -272,7 +272,7 @@ async fn publish_loop() {
         timer.elapsed() >= Duration::from_secs(60 * 2)
             && timer.elapsed() < Duration::from_secs(60 * 2 + 1)
     );
-    publish_dht_ops_workflow(env.clone(), &cell_network, &ts, author.clone())
+    publish_dht_ops_workflow(env.clone(), &dna_network, &ts, author.clone())
         .await
         .unwrap();
 
@@ -288,7 +288,7 @@ async fn publish_loop() {
     let timer = tokio::time::Instant::now();
     trigger_recv.listen().await.unwrap();
     assert!(timer.elapsed() < Duration::from_secs(1));
-    publish_dht_ops_workflow(env.clone(), &cell_network, &ts, author.clone())
+    publish_dht_ops_workflow(env.clone(), &dna_network, &ts, author.clone())
         .await
         .unwrap();
 
@@ -319,7 +319,7 @@ async fn publish_loop() {
         timer.elapsed() >= Duration::from_secs(60) && timer.elapsed() < Duration::from_secs(61)
     );
 
-    publish_dht_ops_workflow(env.clone(), &cell_network, &ts, author.clone())
+    publish_dht_ops_workflow(env.clone(), &dna_network, &ts, author.clone())
         .await
         .unwrap();
 
@@ -341,7 +341,7 @@ async fn publish_loop() {
         timer.elapsed() >= Duration::from_secs(60 * 2)
             && timer.elapsed() < Duration::from_secs(60 * 2 + 1)
     );
-    publish_dht_ops_workflow(env.clone(), &cell_network, &ts, author.clone())
+    publish_dht_ops_workflow(env.clone(), &dna_network, &ts, author.clone())
         .await
         .unwrap();
 
@@ -374,7 +374,7 @@ async fn publish_loop() {
     let timer = tokio::time::Instant::now();
     trigger_recv.listen().await.unwrap();
     assert!(timer.elapsed() < Duration::from_secs(1));
-    publish_dht_ops_workflow(env.clone(), &cell_network, &ts, author.clone())
+    publish_dht_ops_workflow(env.clone(), &dna_network, &ts, author.clone())
         .await
         .unwrap();
 
@@ -388,7 +388,7 @@ async fn publish_loop() {
         timer.elapsed() >= Duration::from_secs(60) && timer.elapsed() < Duration::from_secs(61)
     );
 
-    publish_dht_ops_workflow(env.clone(), &cell_network, &ts, author.clone())
+    publish_dht_ops_workflow(env.clone(), &dna_network, &ts, author.clone())
         .await
         .unwrap();
     // - The op is not published because of the time interval.

--- a/crates/holochain/src/core/queue_consumer/validation_receipt_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/validation_receipt_consumer.rs
@@ -3,6 +3,7 @@
 use super::*;
 use crate::conductor::manager::ManagedTaskResult;
 use crate::core::workflow::validation_receipt_workflow::validation_receipt_workflow;
+use holochain_sqlite::db::DbKind;
 use tokio::task::JoinHandle;
 use tracing::*;
 
@@ -12,10 +13,16 @@ pub fn spawn_validation_receipt_consumer(
     env: EnvWrite,
     conductor_handle: ConductorHandle,
     mut stop: sync::broadcast::Receiver<()>,
-    mut cell_network: HolochainP2pCell,
+    cell_network: HolochainP2pDna,
 ) -> (TriggerSender, JoinHandle<ManagedTaskResult>) {
     let (tx, mut rx) = TriggerSender::new();
     let trigger_self = tx.clone();
+    // Temporary workaround until we remove the need for an
+    // cell id in the next PR.
+    let cell_id = match env.kind() {
+        DbKind::Cell(id) => id.clone(),
+        _ => unreachable!(),
+    };
     let handle = tokio::spawn(async move {
         loop {
             // Wait for next job
@@ -27,12 +34,12 @@ pub fn spawn_validation_receipt_consumer(
             }
 
             // Run the workflow
-            match validation_receipt_workflow(env.clone(), &mut cell_network).await {
+            match validation_receipt_workflow(env.clone(), &cell_network).await {
                 Ok(WorkComplete::Incomplete) => trigger_self.trigger(),
                 Err(err) => {
                     handle_workflow_error(
                         conductor_handle.clone(),
-                        cell_network.cell_id(),
+                        cell_id.clone(),
                         err,
                         "validation_receipt_workflow failure",
                     )

--- a/crates/holochain/src/core/queue_consumer/validation_receipt_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/validation_receipt_consumer.rs
@@ -8,12 +8,12 @@ use tokio::task::JoinHandle;
 use tracing::*;
 
 /// Spawn the QueueConsumer for validation receipt workflow
-#[instrument(skip(env, conductor_handle, stop, cell_network))]
+#[instrument(skip(env, conductor_handle, stop, dna_network))]
 pub fn spawn_validation_receipt_consumer(
     env: EnvWrite,
     conductor_handle: ConductorHandle,
     mut stop: sync::broadcast::Receiver<()>,
-    cell_network: HolochainP2pDna,
+    dna_network: HolochainP2pDna,
 ) -> (TriggerSender, JoinHandle<ManagedTaskResult>) {
     let (tx, mut rx) = TriggerSender::new();
     let trigger_self = tx.clone();
@@ -34,7 +34,7 @@ pub fn spawn_validation_receipt_consumer(
             }
 
             // Run the workflow
-            match validation_receipt_workflow(env.clone(), &cell_network).await {
+            match validation_receipt_workflow(env.clone(), &dna_network).await {
                 Ok(WorkComplete::Incomplete) => trigger_self.trigger(),
                 Err(err) => {
                     handle_workflow_error(

--- a/crates/holochain/src/core/ribosome.rs
+++ b/crates/holochain/src/core/ribosome.rs
@@ -589,8 +589,8 @@ pub mod wasm_test {
                     Some(author),
                 )
                 .await;
-                let cell_network = test_network.cell_network();
-                host_access.network = cell_network;
+                let dna_network = test_network.dna_network();
+                host_access.network = dna_network;
 
                 let invocation =
                     $crate::fixt::ZomeCallInvocationFixturator::new($crate::fixt::NamedInvocation(

--- a/crates/holochain/src/core/ribosome.rs
+++ b/crates/holochain/src/core/ribosome.rs
@@ -40,7 +40,7 @@ use guest_callback::validate::ValidateHostAccess;
 use guest_callback::validation_package::ValidationPackageHostAccess;
 use holo_hash::AgentPubKey;
 use holochain_keystore::MetaLairClient;
-use holochain_p2p::HolochainP2pCell;
+use holochain_p2p::HolochainP2pDna;
 use holochain_serialized_bytes::prelude::*;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
 use holochain_types::prelude::*;
@@ -154,7 +154,7 @@ impl HostContext {
     }
 
     /// Get the network, panics if none was provided
-    pub fn network(&self) -> &HolochainP2pCell {
+    pub fn network(&self) -> &HolochainP2pDna {
         match self {
             Self::ZomeCall(ZomeCallHostAccess { network, .. })
             | Self::Init(InitHostAccess { network, .. })
@@ -411,7 +411,7 @@ impl From<ZomeCallInvocation> for ZomeCall {
 pub struct ZomeCallHostAccess {
     pub workspace: HostFnWorkspace,
     pub keystore: MetaLairClient,
-    pub network: HolochainP2pCell,
+    pub network: HolochainP2pDna,
     pub signal_tx: SignalBroadcaster,
     pub call_zome_handle: CellConductorReadHandle,
     // NB: this is kind of an odd place for this, since CellId is not really a special
@@ -571,7 +571,6 @@ pub mod wasm_test {
             let input = $input.clone();
             tokio::task::spawn(async move {
                 use holo_hash::*;
-                use holochain_p2p::HolochainP2pCellT;
                 use $crate::core::ribosome::RibosomeT;
 
                 let ribosome =
@@ -581,7 +580,8 @@ pub mod wasm_test {
                     .next()
                     .unwrap();
 
-                let author = host_access.cell_id.agent_pubkey().clone();
+                let cell_id = host_access.cell_id.clone();
+                let author = cell_id.agent_pubkey().clone();
 
                 // Required because otherwise the network will return routing errors
                 let test_network = crate::test_utils::test_network(
@@ -590,10 +590,6 @@ pub mod wasm_test {
                 )
                 .await;
                 let cell_network = test_network.cell_network();
-                let cell_id = holochain_zome_types::cell::CellId::new(
-                    cell_network.dna_hash(),
-                    cell_network.from_agent(),
-                );
                 host_access.network = cell_network;
 
                 let invocation =

--- a/crates/holochain/src/core/ribosome/guest_callback/init.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/init.rs
@@ -6,7 +6,7 @@ use crate::core::ribosome::ZomesToInvoke;
 use derive_more::Constructor;
 use holo_hash::AnyDhtHash;
 use holochain_keystore::MetaLairClient;
-use holochain_p2p::HolochainP2pCell;
+use holochain_p2p::HolochainP2pDna;
 use holochain_serialized_bytes::prelude::*;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
 use holochain_types::prelude::*;
@@ -26,7 +26,7 @@ impl InitInvocation {
 pub struct InitHostAccess {
     pub workspace: HostFnWorkspace,
     pub keystore: MetaLairClient,
-    pub network: HolochainP2pCell,
+    pub network: HolochainP2pDna,
 }
 
 impl From<InitHostAccess> for HostContext {

--- a/crates/holochain/src/core/ribosome/guest_callback/post_commit.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/post_commit.rs
@@ -6,8 +6,8 @@ use crate::core::ribosome::InvocationAuth;
 use crate::core::ribosome::ZomesToInvoke;
 use derive_more::Constructor;
 use holochain_keystore::MetaLairClient;
-use holochain_p2p::HolochainP2pCell;
-use holochain_p2p::HolochainP2pCellT;
+use holochain_p2p::HolochainP2pDna;
+use holochain_p2p::HolochainP2pDnaT;
 use holochain_serialized_bytes::prelude::*;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
 use holochain_types::prelude::*;
@@ -32,7 +32,7 @@ impl PostCommitInvocation {
 pub struct PostCommitHostAccess {
     pub workspace: HostFnWorkspace,
     pub keystore: MetaLairClient,
-    pub network: HolochainP2pCell,
+    pub network: HolochainP2pDna,
 }
 
 impl From<PostCommitHostAccess> for HostContext {
@@ -78,7 +78,7 @@ impl TryFrom<PostCommitInvocation> for ExternIO {
 pub async fn send_post_commit<C>(
     conductor_api: C,
     workspace: HostFnWorkspace,
-    network: HolochainP2pCell,
+    network: HolochainP2pDna,
     keystore: MetaLairClient,
     zomed_headers: Vec<(Option<Zome>, SignedHeaderHashed)>,
 ) -> Result<(), tokio::sync::mpsc::error::SendError<()>>
@@ -110,7 +110,10 @@ where
                         network: network.clone(),
                     },
                     invocation: PostCommitInvocation::new(zome, headers),
-                    cell_id: CellId::new(network.dna_hash().clone(), network.from_agent().clone()),
+                    cell_id: CellId::new(
+                        network.dna_hash().clone(),
+                        conductor_api.cell_id().agent_pubkey().clone(),
+                    ),
                 });
         }
     }

--- a/crates/holochain/src/core/ribosome/guest_callback/validate.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validate.rs
@@ -5,7 +5,7 @@ use crate::core::ribosome::InvocationAuth;
 use crate::core::ribosome::ZomesToInvoke;
 use derive_more::Constructor;
 use holo_hash::AnyDhtHash;
-use holochain_p2p::HolochainP2pCell;
+use holochain_p2p::HolochainP2pDna;
 use holochain_serialized_bytes::prelude::*;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
 use holochain_types::prelude::*;
@@ -30,7 +30,7 @@ pub struct ValidateInvocation {
 #[derive(Clone, Constructor)]
 pub struct ValidateHostAccess {
     pub workspace: HostFnWorkspace,
-    pub network: HolochainP2pCell,
+    pub network: HolochainP2pDna,
 }
 
 impl From<ValidateHostAccess> for HostContext {

--- a/crates/holochain/src/core/ribosome/guest_callback/validate_link.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validate_link.rs
@@ -5,7 +5,7 @@ use crate::core::ribosome::InvocationAuth;
 use crate::core::ribosome::ZomesToInvoke;
 use derive_more::Constructor;
 use holo_hash::AnyDhtHash;
-use holochain_p2p::HolochainP2pCell;
+use holochain_p2p::HolochainP2pDna;
 use holochain_serialized_bytes::prelude::*;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
 use holochain_types::prelude::*;
@@ -77,7 +77,7 @@ impl From<ValidateDeleteLinkInvocation> for ValidateDeleteLinkData {
 #[derive(Clone, Constructor)]
 pub struct ValidateLinkHostAccess {
     pub workspace: HostFnWorkspace,
-    pub network: HolochainP2pCell,
+    pub network: HolochainP2pDna,
 }
 
 impl From<ValidateLinkHostAccess> for HostContext {

--- a/crates/holochain/src/core/ribosome/guest_callback/validation_package.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validation_package.rs
@@ -5,7 +5,7 @@ use crate::core::ribosome::InvocationAuth;
 use crate::core::ribosome::ZomesToInvoke;
 use derive_more::Constructor;
 use holo_hash::AnyDhtHash;
-use holochain_p2p::HolochainP2pCell;
+use holochain_p2p::HolochainP2pDna;
 use holochain_serialized_bytes::prelude::*;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
 use holochain_types::prelude::*;
@@ -28,7 +28,7 @@ impl ValidationPackageInvocation {
 #[derive(Clone, Constructor)]
 pub struct ValidationPackageHostAccess {
     pub workspace: HostFnWorkspace,
-    pub network: HolochainP2pCell,
+    pub network: HolochainP2pDna,
 }
 
 impl From<ValidationPackageHostAccess> for HostContext {

--- a/crates/holochain/src/core/ribosome/host_fn/call_remote.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call_remote.rs
@@ -2,7 +2,7 @@ use crate::core::ribosome::CallContext;
 use crate::core::ribosome::HostFnAccess;
 use crate::core::ribosome::RibosomeT;
 use futures::future::join_all;
-use holochain_p2p::HolochainP2pCellT;
+use holochain_p2p::HolochainP2pDnaT;
 use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::WasmError;
 use std::sync::Arc;
@@ -15,8 +15,11 @@ pub fn call_remote(
     match HostFnAccess::from(&call_context.host_context()) {
         HostFnAccess {
             write_network: Permission::Allow,
+            agent_info: Permission::Allow,
             ..
         } => {
+            let from_agent = super::agent_info::agent_info(_ribosome, call_context.clone(), ())?
+                .agent_latest_pubkey;
             // it is the network's responsibility to handle timeouts and return an Err result in that case
             let results: Vec<Result<SerializedBytes, _>> =
                 tokio_helper::block_forever_on(async move {
@@ -31,7 +34,14 @@ pub fn call_remote(
                         call_context
                             .host_context()
                             .network()
-                            .call_remote(target_agent, zome_name, fn_name, cap_secret, payload)
+                            .call_remote(
+                                from_agent.clone(),
+                                target_agent,
+                                zome_name,
+                                fn_name,
+                                cap_secret,
+                                payload,
+                            )
                             .await
                     }))
                     .await

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_entry.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_entry.rs
@@ -188,8 +188,8 @@ pub mod test {
             Some(author),
         )
         .await;
-        let cell_network = test_network.cell_network();
-        host_access.network = cell_network;
+        let dna_network = test_network.dna_network();
+        host_access.network = dna_network;
 
         let mut validate_invocation = fixt!(ValidateInvocation);
         validate_invocation.element = Arc::new(header_reference_element.clone());

--- a/crates/holochain/src/core/sys_validate.rs
+++ b/crates/holochain/src/core/sys_validate.rs
@@ -7,7 +7,7 @@ use super::workflow::sys_validation_workflow::SysValidationWorkspace;
 use crate::conductor::api::CellConductorApiT;
 use crate::conductor::entry_def_store::get_entry_def;
 use holochain_keystore::AgentPubKeyExt;
-use holochain_p2p::HolochainP2pCell;
+use holochain_p2p::HolochainP2pDna;
 use holochain_types::prelude::*;
 use holochain_zome_types::countersigning::CounterSigningSessionData;
 use std::convert::TryInto;
@@ -364,7 +364,7 @@ pub fn check_update_reference(
 pub async fn check_and_hold_register_add_link<F>(
     hash: &HeaderHash,
     workspace: &SysValidationWorkspace,
-    network: HolochainP2pCell,
+    network: HolochainP2pDna,
     incoming_dht_ops_sender: Option<IncomingDhtOpSender>,
     f: F,
 ) -> SysValidationResult<()>
@@ -394,7 +394,7 @@ where
 pub async fn check_and_hold_register_agent_activity<F>(
     hash: &HeaderHash,
     workspace: &SysValidationWorkspace,
-    network: HolochainP2pCell,
+    network: HolochainP2pDna,
     incoming_dht_ops_sender: Option<IncomingDhtOpSender>,
     f: F,
 ) -> SysValidationResult<()>
@@ -424,7 +424,7 @@ where
 pub async fn check_and_hold_store_entry<F>(
     hash: &HeaderHash,
     workspace: &SysValidationWorkspace,
-    network: HolochainP2pCell,
+    network: HolochainP2pDna,
     incoming_dht_ops_sender: Option<IncomingDhtOpSender>,
     f: F,
 ) -> SysValidationResult<()>
@@ -457,7 +457,7 @@ where
 pub async fn check_and_hold_any_store_entry<F>(
     hash: &EntryHash,
     workspace: &SysValidationWorkspace,
-    network: HolochainP2pCell,
+    network: HolochainP2pDna,
     incoming_dht_ops_sender: Option<IncomingDhtOpSender>,
     f: F,
 ) -> SysValidationResult<()>
@@ -485,7 +485,7 @@ where
 pub async fn check_and_hold_store_element<F>(
     hash: &HeaderHash,
     workspace: &SysValidationWorkspace,
-    network: HolochainP2pCell,
+    network: HolochainP2pDna,
     incoming_dht_ops_sender: Option<IncomingDhtOpSender>,
     f: F,
 ) -> SysValidationResult<()>
@@ -568,7 +568,7 @@ impl AsRef<Element> for Source {
 async fn check_and_hold<I: Into<AnyDhtHash> + Clone>(
     hash: &I,
     workspace: &SysValidationWorkspace,
-    network: HolochainP2pCell,
+    network: HolochainP2pDna,
 ) -> SysValidationResult<Source> {
     let hash: AnyDhtHash = hash.clone().into();
     // Create a workspace with just the local stores

--- a/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
@@ -4,7 +4,7 @@ use hdk::prelude::EntryType;
 use hdk::prelude::ValidationPackage;
 use holo_hash::HeaderHash;
 use holochain_p2p::actor::GetActivityOptions;
-use holochain_p2p::HolochainP2pCellT;
+use holochain_p2p::HolochainP2pDnaT;
 use holochain_sqlite::fresh_reader_test;
 use holochain_test_wasm_common::AgentActivitySearch;
 use holochain_types::prelude::*;

--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_package.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_package.rs
@@ -1,4 +1,5 @@
 use holochain_p2p::HolochainP2pDna;
+use holochain_state::host_fn_workspace::HostFnWorkspace;
 use holochain_types::prelude::*;
 use holochain_zome_types::HeaderHashed;
 
@@ -46,6 +47,7 @@ pub fn get_as_author_custom(
     header_hashed: &HeaderHashed,
     ribosome: &impl RibosomeT,
     network: &HolochainP2pDna,
+    workspace_lock: HostFnWorkspace,
 ) -> RibosomeResult<Option<ValidationPackageResult>> {
     let header = header_hashed.as_content();
     let access = ValidationPackageHostAccess::new(workspace_lock, network.clone());

--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_package.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_package.rs
@@ -1,5 +1,4 @@
-use holochain_p2p::HolochainP2pCell;
-use holochain_state::host_fn_workspace::HostFnWorkspace;
+use holochain_p2p::HolochainP2pDna;
 use holochain_types::prelude::*;
 use holochain_zome_types::HeaderHashed;
 
@@ -46,8 +45,7 @@ pub async fn get_as_author_full(
 pub fn get_as_author_custom(
     header_hashed: &HeaderHashed,
     ribosome: &impl RibosomeT,
-    network: &HolochainP2pCell,
-    workspace_lock: HostFnWorkspace,
+    network: &HolochainP2pDna,
 ) -> RibosomeResult<Option<ValidationPackageResult>> {
     let header = header_hashed.as_content();
     let access = ValidationPackageHostAccess::new(workspace_lock, network.clone());

--- a/crates/holochain/src/core/workflow/call_zome_workflow.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow.rs
@@ -53,6 +53,8 @@ where
     trigger_publish_dht_ops,
     trigger_integrate_dht_ops
 ))]
+pub async fn call_zome_workflow<Ribosome, C>(
+    workspace: HostFnWorkspace,
     network: HolochainP2pDna,
     keystore: MetaLairClient,
     args: CallZomeWorkflowArgs<Ribosome, C>,
@@ -99,6 +101,8 @@ where
     Ok(result)
 }
 
+async fn call_zome_workflow_inner<Ribosome, C>(
+    workspace: HostFnWorkspace,
     network: HolochainP2pDna,
     keystore: MetaLairClient,
     args: CallZomeWorkflowArgs<Ribosome, C>,
@@ -174,7 +178,10 @@ where
 }
 
 /// Run validation inline and wait for the result.
+pub async fn inline_validation<C, Ribosome>(
+    workspace: HostFnWorkspace,
     network: HolochainP2pDna,
+    conductor_api: C,
     zome: Option<Zome>,
     ribosome: Ribosome,
 ) -> WorkflowResult<()>
@@ -323,6 +330,7 @@ fn map_outcome(outcome: Either<app_validation_workflow::Outcome, Outcome>) -> Wo
 }
 async fn get_zome(
     element: &Element,
+    workspace: &HostFnWorkspace,
     network: HolochainP2pDna,
     dna_def: &DnaDefHashed,
 ) -> WorkflowResult<crate::core::ribosome::ZomesToInvoke> {
@@ -373,7 +381,7 @@ pub mod tests {
         invocation: ZomeCallInvocation,
     ) -> WorkflowResult<ZomeCallResult> {
         let keystore = fixt!(MetaLairClient);
-        let network = fixt!(HolochainP2pCell);
+        let network = fixt!(HolochainP2pDna);
         let cell_id = CellId::new(ribosome.dna_def().as_hash().clone(), fixt!(AgentPubKey));
         let conductor_api = Arc::new(MockConductorHandleT::new());
         let conductor_api = CellConductorApi::new(conductor_api, cell_id);

--- a/crates/holochain/src/core/workflow/call_zome_workflow.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow.rs
@@ -16,7 +16,7 @@ use crate::core::workflow::error::WorkflowError;
 use either::Either;
 use holochain_cascade::Cascade;
 use holochain_keystore::MetaLairClient;
-use holochain_p2p::HolochainP2pCell;
+use holochain_p2p::HolochainP2pDna;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
 use holochain_state::source_chain::SourceChain;
 use holochain_state::source_chain::SourceChainError;
@@ -53,9 +53,7 @@ where
     trigger_publish_dht_ops,
     trigger_integrate_dht_ops
 ))]
-pub async fn call_zome_workflow<Ribosome, C>(
-    workspace: HostFnWorkspace,
-    network: HolochainP2pCell,
+    network: HolochainP2pDna,
     keystore: MetaLairClient,
     args: CallZomeWorkflowArgs<Ribosome, C>,
     trigger_publish_dht_ops: TriggerSender,
@@ -101,9 +99,7 @@ where
     Ok(result)
 }
 
-async fn call_zome_workflow_inner<Ribosome, C>(
-    workspace: HostFnWorkspace,
-    network: HolochainP2pCell,
+    network: HolochainP2pDna,
     keystore: MetaLairClient,
     args: CallZomeWorkflowArgs<Ribosome, C>,
 ) -> WorkflowResult<ZomeCallResult>
@@ -178,10 +174,7 @@ where
 }
 
 /// Run validation inline and wait for the result.
-pub async fn inline_validation<C, Ribosome>(
-    workspace: HostFnWorkspace,
-    network: HolochainP2pCell,
-    conductor_api: C,
+    network: HolochainP2pDna,
     zome: Option<Zome>,
     ribosome: Ribosome,
 ) -> WorkflowResult<()>
@@ -330,8 +323,7 @@ fn map_outcome(outcome: Either<app_validation_workflow::Outcome, Outcome>) -> Wo
 }
 async fn get_zome(
     element: &Element,
-    workspace: &HostFnWorkspace,
-    network: HolochainP2pCell,
+    network: HolochainP2pDna,
     dna_def: &DnaDefHashed,
 ) -> WorkflowResult<crate::core::ribosome::ZomesToInvoke> {
     let mut cascade = Cascade::from_workspace_network(workspace, network);
@@ -361,8 +353,7 @@ pub mod tests {
     use crate::fixt::*;
     use ::fixt::prelude::*;
 
-    use holochain_p2p::HolochainP2pCellFixturator;
-    use holochain_state::prelude::test_cell_env;
+    use holochain_p2p::HolochainP2pDnaFixturator;
     use holochain_types::test_utils::fake_agent_pubkey_1;
     use holochain_wasm_test_utils::TestWasm;
     use holochain_zome_types::cell::CellId;

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -104,6 +104,8 @@ pub(crate) fn incoming_countersigning(
 /// Countersigning workflow that checks for complete sessions and
 /// pushes the complete ops to validation then messages the signers.
 pub(crate) async fn countersigning_workflow(
+    env: &EnvWrite,
+    workspace: &CountersigningWorkspace,
     network: &(dyn HolochainP2pDnaT + Send + Sync),
     sys_validation_trigger: &TriggerSender,
 ) -> WorkflowResult<WorkComplete> {
@@ -135,6 +137,7 @@ pub(crate) async fn countersigning_workflow(
 
 /// An incoming countersigning session success.
 pub(crate) async fn countersigning_success(
+    vault: EnvWrite,
     network: &HolochainP2pDna,
     author: AgentPubKey,
     signed_headers: Vec<SignedHeader>,
@@ -209,7 +212,7 @@ pub(crate) async fn countersigning_success(
 
     // Check which ops we are the authority for and self publish if we are.
     for (op_hash, basis) in this_cell_headers_op_basis_hashes {
-        if network.authority_for_hash(basis).await? {
+        if network.authority_for_hash(author.clone(), basis).await? {
             ops_to_self_publish.push(op_hash);
         }
     }

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use holo_hash::{AgentPubKey, DhtOpHash, HeaderHash};
 use holo_hash::{AnyDhtHash, EntryHash};
 use holochain_keystore::AgentPubKeyExt;
-use holochain_p2p::{HolochainP2pCell, HolochainP2pCellT};
+use holochain_p2p::{HolochainP2pDna, HolochainP2pDnaT};
 use holochain_sqlite::fresh_reader;
 use holochain_state::mutations;
 use holochain_state::prelude::{
@@ -104,9 +104,7 @@ pub(crate) fn incoming_countersigning(
 /// Countersigning workflow that checks for complete sessions and
 /// pushes the complete ops to validation then messages the signers.
 pub(crate) async fn countersigning_workflow(
-    env: &EnvWrite,
-    workspace: &CountersigningWorkspace,
-    network: &(dyn HolochainP2pCellT + Send + Sync),
+    network: &(dyn HolochainP2pDnaT + Send + Sync),
     sys_validation_trigger: &TriggerSender,
 ) -> WorkflowResult<WorkComplete> {
     // Get any complete sessions.
@@ -137,8 +135,7 @@ pub(crate) async fn countersigning_workflow(
 
 /// An incoming countersigning session success.
 pub(crate) async fn countersigning_success(
-    vault: EnvWrite,
-    network: &HolochainP2pCell,
+    network: &HolochainP2pDna,
     author: AgentPubKey,
     signed_headers: Vec<SignedHeader>,
     publish_trigger: TriggerSender,
@@ -285,7 +282,7 @@ pub(crate) async fn countersigning_success(
 /// Publish to entry authorities so they can gather all the signed
 /// headers for this session and respond with a session complete.
 pub async fn countersigning_publish(
-    network: &HolochainP2pCell,
+    network: &HolochainP2pDna,
     op: DhtOp,
 ) -> Result<(), ZomeCallResponse> {
     let basis = op.dht_basis();

--- a/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
+++ b/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
@@ -50,9 +50,7 @@ where
     Ok(result)
 }
 
-async fn initialize_zomes_workflow_inner<Ribosome, C>(
-    workspace: HostFnWorkspace,
-    network: HolochainP2pCell,
+    network: HolochainP2pDna,
     keystore: MetaLairClient,
     args: InitializeZomesWorkflowArgs<Ribosome, C>,
 ) -> WorkflowResult<InitResult>
@@ -108,8 +106,7 @@ pub mod tests {
     use crate::test_utils::fake_genesis;
     use ::fixt::prelude::*;
     use fixt::Unpredictable;
-    use holo_hash::DnaHash;
-    use holochain_p2p::HolochainP2pCellFixturator;
+    use holochain_p2p::HolochainP2pDnaFixturator;
     use holochain_state::prelude::test_cache_env;
     use holochain_state::prelude::test_cell_env;
     use holochain_state::prelude::SourceChain;
@@ -158,7 +155,7 @@ pub mod tests {
             conductor_api,
         };
         let keystore = fixt!(MetaLairClient);
-        let network = fixt!(HolochainP2pCell);
+        let network = fixt!(HolochainP2pDna);
 
         initialize_zomes_workflow_inner(workspace.clone(), network, keystore, args)
             .await

--- a/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
+++ b/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
@@ -7,7 +7,7 @@ use crate::core::ribosome::guest_callback::post_commit::send_post_commit;
 use crate::core::ribosome::RibosomeT;
 use derive_more::Constructor;
 use holochain_keystore::MetaLairClient;
-use holochain_p2p::HolochainP2pCell;
+use holochain_p2p::HolochainP2pDna;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
 use holochain_types::prelude::*;
 use holochain_zome_types::header::builder;
@@ -27,7 +27,7 @@ where
 #[instrument(skip(network, keystore, workspace, args))]
 pub async fn initialize_zomes_workflow<Ribosome, C>(
     workspace: HostFnWorkspace,
-    network: HolochainP2pCell,
+    network: HolochainP2pDna,
     keystore: MetaLairClient,
     args: InitializeZomesWorkflowArgs<Ribosome, C>,
 ) -> WorkflowResult<InitResult>
@@ -50,6 +50,8 @@ where
     Ok(result)
 }
 
+async fn initialize_zomes_workflow_inner<Ribosome, C>(
+    workspace: HostFnWorkspace,
     network: HolochainP2pDna,
     keystore: MetaLairClient,
     args: InitializeZomesWorkflowArgs<Ribosome, C>,
@@ -106,6 +108,7 @@ pub mod tests {
     use crate::test_utils::fake_genesis;
     use ::fixt::prelude::*;
     use fixt::Unpredictable;
+    use holo_hash::DnaHash;
     use holochain_p2p::HolochainP2pDnaFixturator;
     use holochain_state::prelude::test_cache_env;
     use holochain_state::prelude::test_cell_env;

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -16,7 +16,7 @@ mod query_tests;
 #[cfg(feature = "test_utils")]
 mod tests;
 
-#[instrument(skip(vault, trigger_receipt, cell_network))]
+#[instrument(skip(vault, trigger_receipt, network))]
 pub async fn integrate_dht_ops_workflow(
     vault: EnvWrite,
     trigger_receipt: TriggerSender,

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -4,8 +4,8 @@ use super::*;
 use crate::core::queue_consumer::TriggerSender;
 use crate::core::queue_consumer::WorkComplete;
 use error::WorkflowResult;
-use holochain_p2p::HolochainP2pCell;
-use holochain_p2p::HolochainP2pCellT;
+use holochain_p2p::HolochainP2pDna;
+use holochain_p2p::HolochainP2pDnaT;
 use holochain_state::prelude::*;
 use holochain_types::prelude::*;
 
@@ -20,7 +20,7 @@ mod tests;
 pub async fn integrate_dht_ops_workflow(
     vault: EnvWrite,
     trigger_receipt: TriggerSender,
-    cell_network: HolochainP2pCell,
+    network: HolochainP2pDna,
 ) -> WorkflowResult<WorkComplete> {
     let time = holochain_zome_types::Timestamp::now();
     let changed = vault
@@ -46,7 +46,7 @@ pub async fn integrate_dht_ops_workflow(
     tracing::debug!(?changed);
     if changed > 0 {
         trigger_receipt.trigger();
-        cell_network.new_integrated_data().await?;
+        network.new_integrated_data().await?;
         Ok(WorkComplete::Incomplete)
     } else {
         Ok(WorkComplete::Complete)

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/query_tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/query_tests.rs
@@ -43,7 +43,7 @@ async fn integrate_query() {
     let (qt, _rx) = TriggerSender::new();
     // dump_tmp(&env.env());
     let test_network = test_network(None, None).await;
-    let holochain_p2p_cell = test_network.cell_network();
+    let holochain_p2p_cell = test_network.dna_network();
     integrate_dht_ops_workflow(env.env().into(), qt, holochain_p2p_cell)
         .await
         .unwrap();

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
@@ -468,7 +468,7 @@ impl Db {
 async fn call_workflow<'env>(env: EnvWrite) {
     let (qt, _rx) = TriggerSender::new();
     let test_network = test_network(None, None).await;
-    let holochain_p2p_cell = test_network.cell_network();
+    let holochain_p2p_cell = test_network.dna_network();
     integrate_dht_ops_workflow(env.clone(), qt, holochain_p2p_cell)
         .await
         .unwrap();
@@ -899,7 +899,7 @@ async fn get_links(
 
     let mut host_access = fixt!(ZomeCallHostAccess);
     host_access.workspace = workspace_lock;
-    host_access.network = test_network.cell_network();
+    host_access.network = test_network.dna_network();
     call_context.host_context = host_access.into();
     let ribosome = Arc::new(ribosome);
     let call_context = Arc::new(call_context);

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -33,6 +33,7 @@ pub const MIN_PUBLISH_INTERVAL: time::Duration = time::Duration::from_secs(60 * 
 
 #[instrument(skip(env, network, trigger_self))]
 pub async fn publish_dht_ops_workflow(
+    env: EnvWrite,
     network: &(dyn HolochainP2pDnaT + Send + Sync),
     trigger_self: &TriggerSender,
     agent: AgentPubKey,
@@ -223,10 +224,7 @@ mod tests {
     }
 
     /// Call the workflow
-    async fn call_workflow(
-        cell_network: HolochainP2pDna,
-        author: AgentPubKey,
-    ) {
+    async fn call_workflow(env: EnvWrite, cell_network: HolochainP2pDna, author: AgentPubKey) {
         let (trigger_sender, _) = TriggerSender::new();
         publish_dht_ops_workflow(env.clone().into(), &cell_network, &trigger_sender, author)
             .await

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -181,7 +181,7 @@ mod tests {
             test_network_with_events(Some(dna.clone()), Some(author.clone()), filter_events, tx)
                 .await;
         let (tx_complete, rx_complete) = tokio::sync::oneshot::channel();
-        let cell_network = test_network.cell_network();
+        let dna_network = test_network.dna_network();
         let network = test_network.network();
         let mut recv_count: u32 = 0;
         let total_expected = num_agents * num_hash;
@@ -220,13 +220,13 @@ mod tests {
                 .unwrap();
         }
 
-        (test_network, cell_network, author, recv_task, rx_complete)
+        (test_network, dna_network, author, recv_task, rx_complete)
     }
 
     /// Call the workflow
-    async fn call_workflow(env: EnvWrite, cell_network: HolochainP2pDna, author: AgentPubKey) {
+    async fn call_workflow(env: EnvWrite, dna_network: HolochainP2pDna, author: AgentPubKey) {
         let (trigger_sender, _) = TriggerSender::new();
-        publish_dht_ops_workflow(env.clone().into(), &cell_network, &trigger_sender, author)
+        publish_dht_ops_workflow(env.clone().into(), &dna_network, &trigger_sender, author)
             .await
             .unwrap();
     }
@@ -250,10 +250,10 @@ mod tests {
             let env = test_env.env();
 
             // Setup
-            let (_network, cell_network, author, recv_task, rx_complete) =
+            let (_network, dna_network, author, recv_task, rx_complete) =
                 setup(env.clone(), num_agents, num_hash, false).await;
 
-            call_workflow(env.clone().into(), cell_network, author).await;
+            call_workflow(env.clone().into(), dna_network, author).await;
 
             // Wait for expected # of responses, or timeout
             tokio::select! {
@@ -304,7 +304,7 @@ mod tests {
             let env = test_env.env();
 
             // Setup
-            let (_network, cell_network, author, recv_task, _) =
+            let (_network, dna_network, author, recv_task, _) =
                 setup(env.clone(), num_agents, num_hash, true).await;
 
             // Update the authored to have complete receipts
@@ -317,7 +317,7 @@ mod tests {
                 .unwrap();
 
             // Call the workflow
-            call_workflow(env.clone().into(), cell_network, author).await;
+            call_workflow(env.clone().into(), dna_network, author).await;
 
             // If we can wait a while without receiving any publish, we have succeeded
             tokio::time::sleep(Duration::from_millis(
@@ -375,7 +375,7 @@ mod tests {
                     tx,
                 )
                 .await;
-                let cell_network = test_network.cell_network();
+                let dna_network = test_network.dna_network();
 
                 // Setup data
                 let original_entry = fixt!(Entry);
@@ -432,7 +432,7 @@ mod tests {
                     .await
                     .unwrap();
 
-                source_chain.flush(&cell_network).await.unwrap();
+                source_chain.flush(&dna_network).await.unwrap();
                 let (entry_create_header, entry_update_header) = env
                     .conn()
                     .unwrap()
@@ -582,7 +582,7 @@ mod tests {
                     }
                 }
 
-                call_workflow(env.clone().into(), cell_network, author).await;
+                call_workflow(env.clone().into(), dna_network, author).await;
 
                 // Wait for expected # of responses, or timeout
                 tokio::select! {

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -13,6 +13,7 @@ use holo_hash::DhtOpHash;
 use holochain_cascade::Cascade;
 use holochain_p2p::HolochainP2pDna;
 use holochain_p2p::HolochainP2pDnaT;
+use holochain_sqlite::db::ReadManager;
 use holochain_sqlite::prelude::*;
 use holochain_state::host_fn_workspace::HostFnStores;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
@@ -52,6 +53,7 @@ pub async fn sys_validation_workflow(
     sys_validation_trigger: TriggerSender,
     // TODO: Update HolochainP2p to reflect changes to pass through network.
     network: HolochainP2pDna,
+    conductor_api: impl CellConductorApiT,
 ) -> WorkflowResult<WorkComplete> {
     let complete = sys_validation_workflow_inner(
         Arc::new(workspace),
@@ -72,6 +74,7 @@ pub async fn sys_validation_workflow(
 async fn sys_validation_workflow_inner(
     workspace: Arc<SysValidationWorkspace>,
     network: HolochainP2pDna,
+    conductor_api: impl CellConductorApiT,
     sys_validation_trigger: TriggerSender,
 ) -> WorkflowResult<WorkComplete> {
     let env = workspace.vault.clone().into();
@@ -161,6 +164,7 @@ async fn validate_op(
     op: &DhtOp,
     workspace: &SysValidationWorkspace,
     network: HolochainP2pDna,
+    conductor_api: &impl CellConductorApiT,
     incoming_dht_ops_sender: Option<IncomingDhtOpSender>,
 ) -> WorkflowResult<Outcome> {
     match validate_op_inner(
@@ -239,6 +243,7 @@ async fn validate_op_inner(
     op: &DhtOp,
     workspace: &SysValidationWorkspace,
     network: HolochainP2pDna,
+    conductor_api: &impl CellConductorApiT,
     incoming_dht_ops_sender: Option<IncomingDhtOpSender>,
 ) -> SysValidationResult<()> {
     match op {
@@ -373,6 +378,7 @@ pub async fn sys_validate_element(
     element: &Element,
     call_zome_workspace: &HostFnWorkspace,
     network: HolochainP2pDna,
+    conductor_api: &impl CellConductorApiT,
 ) -> SysValidationOutcome<()> {
     trace!(?element);
     // Create a SysValidationWorkspace with the scratches from the CallZomeWorkspace
@@ -397,6 +403,7 @@ async fn sys_validate_element_inner(
     element: &Element,
     workspace: &SysValidationWorkspace,
     network: HolochainP2pDna,
+    conductor_api: &impl CellConductorApiT,
 ) -> SysValidationResult<()> {
     let signature = element.signature();
     let header = element.header();
@@ -408,6 +415,7 @@ async fn sys_validate_element_inner(
         maybe_entry: Option<&Entry>,
         workspace: &SysValidationWorkspace,
         network: HolochainP2pDna,
+        conductor_api: &impl CellConductorApiT,
     ) -> SysValidationResult<()> {
         let incoming_dht_ops_sender = None;
         store_element(header, workspace, network.clone()).await?;

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
@@ -1,5 +1,4 @@
-use holochain_p2p::HolochainP2pCell;
-use holochain_p2p::HolochainP2pCellT;
+use holochain_p2p::HolochainP2pDna;
 use holochain_state::prelude::*;
 use holochain_types::prelude::*;
 use holochain_zome_types::TryInto;
@@ -18,8 +17,7 @@ mod tests;
 /// TODO: Currently still waiting for responses because we don't have a network call
 /// that doesn't.
 pub async fn validation_receipt_workflow(
-    vault: EnvWrite,
-    network: &mut HolochainP2pCell,
+    network: &HolochainP2pDna,
 ) -> WorkflowResult<WorkComplete> {
     // Get the env and keystore
     let keystore = vault.keystore();
@@ -84,8 +82,11 @@ pub async fn validation_receipt_workflow(
         // Send it and don't wait for response.
         // TODO: When networking has a send without response we can use that
         // instead of waiting for response.
-        if let Err(e) = network
-            .send_validation_receipt(author, receipt.try_into()?)
+        if let Err(e) = holochain_p2p::HolochainP2pDnaT::send_validation_receipt(
+            network,
+            author,
+            receipt.try_into()?,
+        )
             .await
         {
             // No one home, they will need to publish again.

--- a/crates/holochain/src/fixt.rs
+++ b/crates/holochain/src/fixt.rs
@@ -377,12 +377,12 @@ fixturator!(
 
 fixturator!(
     ValidateLinkHostAccess;
-    constructor fn new(HostFnWorkspaceReadOnly, HolochainP2pDna);
+    constructor fn new(HostFnWorkspace, HolochainP2pDna);
 );
 
 fixturator!(
     ValidateHostAccess;
-    constructor fn new(HostFnWorkspaceReadOnly, HolochainP2pDna);
+    constructor fn new(HostFnWorkspace, HolochainP2pDna);
 );
 
 fixturator!(
@@ -392,7 +392,7 @@ fixturator!(
 
 fixturator!(
     ValidationPackageHostAccess;
-    constructor fn new(HostFnWorkspaceReadOnly, HolochainP2pDna);
+    constructor fn new(HostFnWorkspace, HolochainP2pDna);
 );
 
 fixturator!(

--- a/crates/holochain/src/fixt.rs
+++ b/crates/holochain/src/fixt.rs
@@ -33,7 +33,7 @@ use ::fixt::prelude::*;
 pub use holo_hash::fixt::*;
 use holo_hash::WasmHash;
 use holochain_keystore::MetaLairClient;
-use holochain_p2p::HolochainP2pCellFixturator;
+use holochain_p2p::HolochainP2pDnaFixturator;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
 use holochain_state::test_utils::test_keystore;
 use holochain_types::prelude::*;
@@ -277,7 +277,7 @@ fixturator!(
 
 fixturator!(
     ZomeCallHostAccess;
-    constructor fn new(HostFnWorkspace, MetaLairClient, HolochainP2pCell, SignalBroadcaster, CellConductorReadHandle, CellId);
+    constructor fn new(HostFnWorkspace, MetaLairClient, HolochainP2pDna, SignalBroadcaster, CellConductorReadHandle, CellId);
 );
 
 fixturator!(
@@ -297,7 +297,7 @@ fixturator!(
 
 fixturator!(
     InitHostAccess;
-    constructor fn new(HostFnWorkspace, MetaLairClient, HolochainP2pCell);
+    constructor fn new(HostFnWorkspace, MetaLairClient, HolochainP2pDna);
 );
 
 fixturator!(
@@ -317,7 +317,7 @@ fixturator!(
 
 fixturator!(
     PostCommitHostAccess;
-    constructor fn new(HostFnWorkspace, MetaLairClient, HolochainP2pCell);
+    constructor fn new(HostFnWorkspace, MetaLairClient, HolochainP2pDna);
 );
 
 fixturator!(
@@ -377,12 +377,12 @@ fixturator!(
 
 fixturator!(
     ValidateLinkHostAccess;
-    constructor fn new(HostFnWorkspace, HolochainP2pCell);
+    constructor fn new(HostFnWorkspaceReadOnly, HolochainP2pDna);
 );
 
 fixturator!(
     ValidateHostAccess;
-    constructor fn new(HostFnWorkspace, HolochainP2pCell);
+    constructor fn new(HostFnWorkspaceReadOnly, HolochainP2pDna);
 );
 
 fixturator!(
@@ -392,7 +392,7 @@ fixturator!(
 
 fixturator!(
     ValidationPackageHostAccess;
-    constructor fn new(HostFnWorkspace, HolochainP2pCell);
+    constructor fn new(HostFnWorkspaceReadOnly, HolochainP2pDna);
 );
 
 fixturator!(

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -18,12 +18,12 @@ use holo_hash::*;
 use holochain_cascade::Cascade;
 use holochain_conductor_api::IntegrationStateDump;
 use holochain_conductor_api::IntegrationStateDumps;
-use holochain_p2p::actor::HolochainP2pRefToCell;
+use holochain_p2p::actor::HolochainP2pRefToDna;
 use holochain_p2p::dht_arc::DhtArc;
 use holochain_p2p::dht_arc::PeerDensity;
 use holochain_p2p::event::HolochainP2pEvent;
 use holochain_p2p::spawn_holochain_p2p;
-use holochain_p2p::HolochainP2pCell;
+use holochain_p2p::HolochainP2pDna;
 use holochain_p2p::HolochainP2pRef;
 use holochain_p2p::HolochainP2pSender;
 use holochain_serialized_bytes::SerializedBytes;
@@ -124,7 +124,7 @@ macro_rules! meta_mock {
 pub struct TestNetwork {
     network: Option<HolochainP2pRef>,
     respond_task: Option<tokio::task::JoinHandle<()>>,
-    cell_network: HolochainP2pCell,
+    cell_network: HolochainP2pDna,
 }
 
 impl TestNetwork {
@@ -132,7 +132,7 @@ impl TestNetwork {
     pub fn new(
         network: HolochainP2pRef,
         respond_task: tokio::task::JoinHandle<()>,
-        cell_network: HolochainP2pCell,
+        cell_network: HolochainP2pDna,
     ) -> Self {
         Self {
             network: Some(network),
@@ -150,7 +150,7 @@ impl TestNetwork {
     }
 
     /// Get the cell network
-    pub fn cell_network(&self) -> HolochainP2pCell {
+    pub fn cell_network(&self) -> HolochainP2pDna {
         self.cell_network.clone()
     }
 }
@@ -240,7 +240,7 @@ where
     let dna = dna_hash.unwrap_or_else(|| fixt!(DnaHash));
     let mut key_fixt = AgentPubKeyFixturator::new(Predictable);
     let agent_key = agent_key.unwrap_or_else(|| key_fixt.next().unwrap());
-    let cell_network = network.to_cell(dna.clone(), agent_key.clone());
+    let cell_network = network.to_dna(dna.clone());
     network.join(dna.clone(), agent_key).await.unwrap();
     TestNetwork::new(network, respond_task, cell_network)
 }

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -124,7 +124,7 @@ macro_rules! meta_mock {
 pub struct TestNetwork {
     network: Option<HolochainP2pRef>,
     respond_task: Option<tokio::task::JoinHandle<()>>,
-    cell_network: HolochainP2pDna,
+    dna_network: HolochainP2pDna,
 }
 
 impl TestNetwork {
@@ -132,12 +132,12 @@ impl TestNetwork {
     pub fn new(
         network: HolochainP2pRef,
         respond_task: tokio::task::JoinHandle<()>,
-        cell_network: HolochainP2pDna,
+        dna_network: HolochainP2pDna,
     ) -> Self {
         Self {
             network: Some(network),
             respond_task: Some(respond_task),
-            cell_network,
+            dna_network,
         }
     }
 
@@ -150,8 +150,8 @@ impl TestNetwork {
     }
 
     /// Get the cell network
-    pub fn cell_network(&self) -> HolochainP2pDna {
-        self.cell_network.clone()
+    pub fn dna_network(&self) -> HolochainP2pDna {
+        self.dna_network.clone()
     }
 }
 
@@ -240,9 +240,9 @@ where
     let dna = dna_hash.unwrap_or_else(|| fixt!(DnaHash));
     let mut key_fixt = AgentPubKeyFixturator::new(Predictable);
     let agent_key = agent_key.unwrap_or_else(|| key_fixt.next().unwrap());
-    let cell_network = network.to_dna(dna.clone());
+    let dna_network = network.to_dna(dna.clone());
     network.join(dna.clone(), agent_key).await.unwrap();
-    TestNetwork::new(network, respond_task, cell_network)
+    TestNetwork::new(network, respond_task, dna_network)
 }
 
 /// Do what's necessary to install an app

--- a/crates/holochain/src/test_utils/conductor_setup.rs
+++ b/crates/holochain/src/test_utils/conductor_setup.rs
@@ -12,8 +12,8 @@ use crate::core::ribosome::real_ribosome::RealRibosome;
 use holo_hash::AgentPubKey;
 use holo_hash::DnaHash;
 use holochain_keystore::MetaLairClient;
-use holochain_p2p::actor::HolochainP2pRefToCell;
-use holochain_p2p::HolochainP2pCell;
+use holochain_p2p::actor::HolochainP2pRefToDna;
+use holochain_p2p::HolochainP2pDna;
 use holochain_serialized_bytes::SerializedBytes;
 use holochain_state::{prelude::test_environments, test_utils::TestEnvs};
 use holochain_types::prelude::*;
@@ -29,7 +29,7 @@ pub struct CellHostFnCaller {
     pub env: EnvWrite,
     pub cache: EnvWrite,
     pub ribosome: RealRibosome,
-    pub network: HolochainP2pCell,
+    pub network: HolochainP2pDna,
     pub keystore: MetaLairClient,
     pub signal_tx: SignalBroadcaster,
     pub triggers: QueueTriggers,
@@ -40,10 +40,7 @@ impl CellHostFnCaller {
     pub async fn new(cell_id: &CellId, handle: &ConductorHandle, dna_file: &DnaFile) -> Self {
         let env = handle.get_cell_env(cell_id).unwrap();
         let cache = handle.get_cache_env(cell_id).unwrap();
-        let keystore = env.keystore().clone();
-        let network = handle
-            .holochain_p2p()
-            .to_cell(cell_id.dna_hash().clone(), cell_id.agent_pubkey().clone());
+        let network = handle.holochain_p2p().to_dna(cell_id.dna_hash().clone());
         let triggers = handle.get_cell_triggers(cell_id).unwrap();
         let cell_conductor_api = CellConductorApi::new(handle.clone(), cell_id.clone());
 

--- a/crates/holochain/src/test_utils/conductor_setup.rs
+++ b/crates/holochain/src/test_utils/conductor_setup.rs
@@ -40,6 +40,7 @@ impl CellHostFnCaller {
     pub async fn new(cell_id: &CellId, handle: &ConductorHandle, dna_file: &DnaFile) -> Self {
         let env = handle.get_cell_env(cell_id).unwrap();
         let cache = handle.get_cache_env(cell_id).unwrap();
+        let keystore = env.keystore().clone();
         let network = handle.holochain_p2p().to_dna(cell_id.dna_hash().clone());
         let triggers = handle.get_cell_triggers(cell_id).unwrap();
         let cell_conductor_api = CellConductorApi::new(handle.clone(), cell_id.clone());

--- a/crates/holochain/src/test_utils/host_fn_caller.rs
+++ b/crates/holochain/src/test_utils/host_fn_caller.rs
@@ -20,8 +20,8 @@ use holo_hash::EntryHash;
 use holo_hash::HeaderHash;
 use holochain_keystore::MetaLairClient;
 use holochain_p2p::actor::GetLinksOptions;
-use holochain_p2p::actor::HolochainP2pRefToCell;
-use holochain_p2p::HolochainP2pCell;
+use holochain_p2p::actor::HolochainP2pRefToDna;
+use holochain_p2p::HolochainP2pDna;
 use holochain_serialized_bytes::prelude::*;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
 use holochain_types::prelude::*;
@@ -88,7 +88,7 @@ pub struct HostFnCaller {
     pub cache: EnvWrite,
     pub ribosome: RealRibosome,
     pub zome_path: ZomePath,
-    pub network: HolochainP2pCell,
+    pub network: HolochainP2pDna,
     pub keystore: MetaLairClient,
     pub signal_tx: SignalBroadcaster,
     pub call_zome_handle: CellConductorReadHandle,
@@ -114,10 +114,7 @@ impl HostFnCaller {
     ) -> HostFnCaller {
         let env = handle.get_cell_env(cell_id).unwrap();
         let cache = handle.get_cache_env(cell_id).unwrap();
-        let keystore = env.keystore().clone();
-        let network = handle
-            .holochain_p2p()
-            .to_cell(cell_id.dna_hash().clone(), cell_id.agent_pubkey().clone());
+        let network = handle.holochain_p2p().to_dna(cell_id.dna_hash().clone());
 
         let zome_path = (
             cell_id.clone(),

--- a/crates/holochain/src/test_utils/host_fn_caller.rs
+++ b/crates/holochain/src/test_utils/host_fn_caller.rs
@@ -114,6 +114,7 @@ impl HostFnCaller {
     ) -> HostFnCaller {
         let env = handle.get_cell_env(cell_id).unwrap();
         let cache = handle.get_cache_env(cell_id).unwrap();
+        let keystore = env.keystore().clone();
         let network = handle.holochain_p2p().to_dna(cell_id.dna_hash().clone());
 
         let zome_path = (

--- a/crates/holochain/tests/network_tests.rs
+++ b/crates/holochain/tests/network_tests.rs
@@ -481,7 +481,7 @@ async fn run_fixt_network(
     meta_fixt_store: BTreeMap<AnyDhtHash, TimedHeaderHash>,
 ) -> (HolochainP2pDna, Shutdown) {
     // Create the network
-    let (network, mut recv, cell_network) = test_network(None, None).await;
+    let (network, mut recv, dna_network) = test_network(None, None).await;
     let (kill, killed) = tokio::sync::oneshot::channel();
 
     // Return fixt store data to gets
@@ -545,7 +545,7 @@ async fn run_fixt_network(
         }
     });
     (
-        cell_network,
+        dna_network,
         Shutdown {
             handle,
             kill,

--- a/crates/holochain/tests/network_tests.rs
+++ b/crates/holochain/tests/network_tests.rs
@@ -22,7 +22,7 @@ use holochain::test_utils::test_network;
 use holochain_cascade::integrate_single_metadata;
 use holochain_p2p::actor::GetLinksOptions;
 use holochain_p2p::actor::GetMetaOptions;
-use holochain_p2p::HolochainP2pCell;
+use holochain_p2p::HolochainP2pDna;
 use holochain_p2p::HolochainP2pRef;
 use holochain_serialized_bytes::SerializedBytes;
 use holochain_sqlite::db::ReadManager;
@@ -479,7 +479,7 @@ impl Shutdown {
 async fn run_fixt_network(
     element_fixt_store: BTreeMap<HeaderHash, Element>,
     meta_fixt_store: BTreeMap<AnyDhtHash, TimedHeaderHash>,
-) -> (HolochainP2pCell, Shutdown) {
+) -> (HolochainP2pDna, Shutdown) {
     // Create the network
     let (network, mut recv, cell_network) = test_network(None, None).await;
     let (kill, killed) = tokio::sync::oneshot::channel();

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -13,8 +13,8 @@ use holo_hash::HeaderHash;
 use holochain_p2p::actor::GetActivityOptions;
 use holochain_p2p::actor::GetLinksOptions;
 use holochain_p2p::actor::GetOptions as NetworkGetOptions;
-use holochain_p2p::HolochainP2pCell;
-use holochain_p2p::HolochainP2pCellT;
+use holochain_p2p::HolochainP2pDna;
+use holochain_p2p::HolochainP2pDnaT;
 use holochain_sqlite::rusqlite::Transaction;
 use holochain_state::host_fn_workspace::HostFnStores;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
@@ -65,16 +65,14 @@ macro_rules! ok_or_return {
 }
 
 #[derive(Clone)]
-pub struct Cascade<Network = HolochainP2pCell> {
-    vault: Option<EnvRead>,
-    cache: Option<EnvWrite>,
+pub struct Cascade<Network = HolochainP2pDna> {
     scratch: Option<SyncScratch>,
     network: Option<Network>,
 }
 
 impl<Network> Cascade<Network>
 where
-    Network: HolochainP2pCellT + Clone + 'static + Send,
+    Network: HolochainP2pDnaT + Clone + 'static + Send,
 {
     /// Add the vault to the cascade.
     pub fn with_vault(self, vault: EnvRead) -> Self {
@@ -104,7 +102,7 @@ where
     }
 
     /// Add the network and cache to the cascade.
-    pub fn with_network<N: HolochainP2pCellT + Clone>(
+    pub fn with_network<N: HolochainP2pDnaT + Clone>(
         self,
         network: N,
         cache_env: EnvWrite,
@@ -117,7 +115,7 @@ where
         }
     }
 }
-impl Cascade<HolochainP2pCell> {
+impl Cascade<HolochainP2pDna> {
     /// Constructs an empty [Cascade].
     pub fn empty() -> Self {
         Self {
@@ -131,7 +129,9 @@ impl Cascade<HolochainP2pCell> {
     pub fn from_workspace_network<N: HolochainP2pCellT + Clone>(
         workspace: &HostFnWorkspace,
         network: N,
-    ) -> Cascade<N> {
+    ) -> Cascade<N>
+    where
+        N: HolochainP2pDnaT + Clone,
         let HostFnStores {
             vault,
             cache,
@@ -161,7 +161,7 @@ impl Cascade<HolochainP2pCell> {
 
 impl<Network> Cascade<Network>
 where
-    Network: HolochainP2pCellT + Clone + 'static + Send,
+    Network: HolochainP2pDnaT + Clone + 'static + Send,
 {
     fn insert_rendered_op(txn: &mut Transaction, op: RenderedOp) -> CascadeResult<()> {
         let RenderedOp {

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -66,6 +66,8 @@ macro_rules! ok_or_return {
 
 #[derive(Clone)]
 pub struct Cascade<Network = HolochainP2pDna> {
+    vault: Option<EnvRead>,
+    cache: Option<EnvWrite>,
     scratch: Option<SyncScratch>,
     network: Option<Network>,
 }
@@ -126,12 +128,10 @@ impl Cascade<HolochainP2pDna> {
         }
     }
 
-    pub fn from_workspace_network<N: HolochainP2pCellT + Clone>(
-        workspace: &HostFnWorkspace,
-        network: N,
-    ) -> Cascade<N>
+    pub fn from_workspace_network<N>(workspace: &HostFnWorkspace, network: N) -> Cascade<N>
     where
         N: HolochainP2pDnaT + Clone,
+    {
         let HostFnStores {
             vault,
             cache,
@@ -775,6 +775,14 @@ where
 
     async fn am_i_an_authority(&mut self, hash: AnyDhtHash) -> CascadeResult<bool> {
         let network = ok_or_return!(self.network.as_mut(), false);
-        Ok(network.authority_for_hash(hash).await?)
+
+        // Temporary workaround until we remove the need to pass the
+        // author to `authority_for_hash` in the next PR.
+        let env = ok_or_return!(self.vault.as_ref(), false);
+        let author = match env.kind() {
+            DbKind::Cell(id) => id.agent_pubkey().clone(),
+            _ => unreachable!(),
+        };
+        Ok(network.authority_for_hash(author, hash).await?)
     }
 }

--- a/crates/holochain_cascade/src/test_utils.rs
+++ b/crates/holochain_cascade/src/test_utils.rs
@@ -165,6 +165,7 @@ impl HolochainP2pDnaT for PassThroughNetwork {
 
     async fn authority_for_hash(
         &self,
+        _agent: AgentPubKey,
         _dht_hash: holo_hash::AnyDhtHash,
     ) -> actor::HolochainP2pResult<bool> {
         Ok(self.authority)
@@ -219,7 +220,7 @@ impl HolochainP2pDnaT for PassThroughNetwork {
 
     async fn join(&self, _agent: AgentPubKey) -> actor::HolochainP2pResult<()> {
         todo!()
-}
+    }
 
     async fn leave(&self, _agent: AgentPubKey) -> actor::HolochainP2pResult<()> {
         todo!()
@@ -237,6 +238,8 @@ impl HolochainP2pDnaT for PassThroughNetwork {
         todo!()
     }
 }
+
+pub fn fill_db(env: &EnvWrite, op: DhtOpHashed) {
     env.conn()
         .unwrap()
         .with_commit_sync(|txn| {
@@ -337,9 +340,14 @@ impl HolochainP2pDnaT for MockNetwork {
 
     async fn authority_for_hash(
         &self,
+        agent: AgentPubKey,
         dht_hash: holo_hash::AnyDhtHash,
     ) -> actor::HolochainP2pResult<bool> {
-        self.0.lock().await.authority_for_hash(dht_hash).await
+        self.0
+            .lock()
+            .await
+            .authority_for_hash(agent, dht_hash)
+            .await
     }
 
     fn dna_hash(&self) -> holo_hash::DnaHash {

--- a/crates/holochain_cascade/src/test_utils.rs
+++ b/crates/holochain_cascade/src/test_utils.rs
@@ -8,9 +8,9 @@ use holo_hash::EntryHash;
 use holo_hash::HasHash;
 use holo_hash::HeaderHash;
 use holochain_p2p::actor;
-use holochain_p2p::HolochainP2pCellT;
+use holochain_p2p::HolochainP2pDnaT;
 use holochain_p2p::HolochainP2pError;
-use holochain_p2p::MockHolochainP2pCellT;
+use holochain_p2p::MockHolochainP2pDnaT;
 use holochain_sqlite::db::WriteManager;
 use holochain_sqlite::prelude::DatabaseResult;
 use holochain_sqlite::rusqlite::Transaction;
@@ -69,16 +69,16 @@ impl PassThroughNetwork {
 }
 
 #[derive(Clone)]
-pub struct MockNetwork(std::sync::Arc<tokio::sync::Mutex<MockHolochainP2pCellT>>);
+pub struct MockNetwork(std::sync::Arc<tokio::sync::Mutex<MockHolochainP2pDnaT>>);
 
 impl MockNetwork {
-    pub fn new(mock: MockHolochainP2pCellT) -> Self {
+    pub fn new(mock: MockHolochainP2pDnaT) -> Self {
         Self(std::sync::Arc::new(tokio::sync::Mutex::new(mock)))
     }
 }
 
 #[async_trait::async_trait]
-impl HolochainP2pCellT for PassThroughNetwork {
+impl HolochainP2pDnaT for PassThroughNetwork {
     async fn get_validation_package(
         &self,
         _request_from: AgentPubKey,
@@ -174,31 +174,9 @@ impl HolochainP2pCellT for PassThroughNetwork {
         todo!()
     }
 
-    fn from_agent(&self) -> AgentPubKey {
-        todo!()
-    }
-
-    async fn join(&self) -> actor::HolochainP2pResult<()> {
-        todo!()
-    }
-
-    async fn leave(&self) -> actor::HolochainP2pResult<()> {
-        todo!()
-    }
-
-    async fn call_remote(
-        &self,
-        _to_agent: AgentPubKey,
-        _zome_name: holochain_zome_types::ZomeName,
-        _fn_name: holochain_zome_types::FunctionName,
-        _cap_secret: Option<holochain_zome_types::CapSecret>,
-        _payload: holochain_zome_types::ExternIO,
-    ) -> actor::HolochainP2pResult<holochain_serialized_bytes::SerializedBytes> {
-        todo!()
-    }
-
     async fn remote_signal(
         &self,
+        _from_agent: AgentPubKey,
         _to_agent_list: Vec<AgentPubKey>,
         _zome_name: holochain_zome_types::ZomeName,
         _fn_name: holochain_zome_types::FunctionName,
@@ -238,9 +216,27 @@ impl HolochainP2pCellT for PassThroughNetwork {
     async fn new_integrated_data(&self) -> actor::HolochainP2pResult<()> {
         todo!()
     }
+
+    async fn join(&self, _agent: AgentPubKey) -> actor::HolochainP2pResult<()> {
+        todo!()
 }
 
-pub fn fill_db(env: &EnvWrite, op: DhtOpHashed) {
+    async fn leave(&self, _agent: AgentPubKey) -> actor::HolochainP2pResult<()> {
+        todo!()
+    }
+
+    async fn call_remote(
+        &self,
+        _from_agent: AgentPubKey,
+        _to_agent: AgentPubKey,
+        _zome_name: holochain_zome_types::ZomeName,
+        _fn_name: holochain_zome_types::FunctionName,
+        _cap: Option<holochain_zome_types::CapSecret>,
+        _payload: holochain_zome_types::ExternIO,
+    ) -> actor::HolochainP2pResult<holochain_serialized_bytes::SerializedBytes> {
+        todo!()
+    }
+}
     env.conn()
         .unwrap()
         .with_commit_sync(|txn| {
@@ -289,7 +285,7 @@ pub fn fill_db_as_author(env: &EnvWrite, op: DhtOpHashed) {
 }
 
 #[async_trait::async_trait]
-impl HolochainP2pCellT for MockNetwork {
+impl HolochainP2pDnaT for MockNetwork {
     async fn get_validation_package(
         &self,
         request_from: AgentPubKey,
@@ -350,31 +346,9 @@ impl HolochainP2pCellT for MockNetwork {
         todo!()
     }
 
-    fn from_agent(&self) -> AgentPubKey {
-        todo!()
-    }
-
-    async fn join(&self) -> actor::HolochainP2pResult<()> {
-        todo!()
-    }
-
-    async fn leave(&self) -> actor::HolochainP2pResult<()> {
-        todo!()
-    }
-
-    async fn call_remote(
-        &self,
-        _to_agent: AgentPubKey,
-        _zome_name: holochain_zome_types::ZomeName,
-        _fn_name: holochain_zome_types::FunctionName,
-        _cap_secret: Option<holochain_zome_types::CapSecret>,
-        _payload: holochain_zome_types::ExternIO,
-    ) -> actor::HolochainP2pResult<holochain_serialized_bytes::SerializedBytes> {
-        todo!()
-    }
-
     async fn remote_signal(
         &self,
+        _from_agent: AgentPubKey,
         _to_agent_list: Vec<AgentPubKey>,
         _zome_name: holochain_zome_types::ZomeName,
         _fn_name: holochain_zome_types::FunctionName,
@@ -412,6 +386,26 @@ impl HolochainP2pCellT for MockNetwork {
     }
 
     async fn new_integrated_data(&self) -> actor::HolochainP2pResult<()> {
+        todo!()
+    }
+
+    async fn join(&self, _agent: AgentPubKey) -> actor::HolochainP2pResult<()> {
+        todo!()
+    }
+
+    async fn leave(&self, _agent: AgentPubKey) -> actor::HolochainP2pResult<()> {
+        todo!()
+    }
+
+    async fn call_remote(
+        &self,
+        _from_agent: AgentPubKey,
+        _to_agent: AgentPubKey,
+        _zome_name: holochain_zome_types::ZomeName,
+        _fn_name: holochain_zome_types::FunctionName,
+        _cap: Option<holochain_zome_types::CapSecret>,
+        _payload: holochain_zome_types::ExternIO,
+    ) -> actor::HolochainP2pResult<holochain_serialized_bytes::SerializedBytes> {
         todo!()
     }
 }

--- a/crates/holochain_cascade/tests/get_entry.rs
+++ b/crates/holochain_cascade/tests/get_entry.rs
@@ -3,8 +3,8 @@ use ghost_actor::dependencies::observability;
 use holo_hash::HasHash;
 use holochain_cascade::test_utils::*;
 use holochain_cascade::Cascade;
-use holochain_p2p::HolochainP2pCellT;
-use holochain_p2p::MockHolochainP2pCellT;
+use holochain_p2p::HolochainP2pDnaT;
+use holochain_p2p::MockHolochainP2pDnaT;
 use holochain_state::mutations::insert_op_scratch;
 use holochain_state::prelude::test_cell_env;
 use holochain_state::scratch::Scratch;
@@ -17,7 +17,7 @@ use holochain_zome_types::GetOptions;
 use holochain_zome_types::ValidationStatus;
 use holochain_zome_types::ZomeFixturator;
 
-async fn assert_can_get<N: HolochainP2pCellT + Clone + Send + 'static>(
+async fn assert_can_get<N: HolochainP2pDnaT + Clone + Send + 'static>(
     td_entry: &EntryTestData,
     td_element: &ElementTestData,
     cascade: &mut Cascade<N>,
@@ -81,7 +81,7 @@ async fn assert_can_get<N: HolochainP2pCellT + Clone + Send + 'static>(
     assert_eq!(r, expected);
 }
 
-async fn assert_is_none<N: HolochainP2pCellT + Clone + Send + 'static>(
+async fn assert_is_none<N: HolochainP2pDnaT + Clone + Send + 'static>(
     td_entry: &EntryTestData,
     td_element: &ElementTestData,
     cascade: &mut Cascade<N>,
@@ -120,7 +120,7 @@ async fn assert_is_none<N: HolochainP2pCellT + Clone + Send + 'static>(
     assert!(r.is_none());
 }
 
-async fn assert_rejected<N: HolochainP2pCellT + Clone + Send + 'static>(
+async fn assert_rejected<N: HolochainP2pDnaT + Clone + Send + 'static>(
     td_entry: &EntryTestData,
     td_element: &ElementTestData,
     cascade: &mut Cascade<N>,
@@ -182,7 +182,7 @@ async fn assert_rejected<N: HolochainP2pCellT + Clone + Send + 'static>(
     assert_eq!(r, expected);
 }
 
-async fn assert_can_retrieve<N: HolochainP2pCellT + Clone + Send + 'static>(
+async fn assert_can_retrieve<N: HolochainP2pDnaT + Clone + Send + 'static>(
     td_entry: &EntryTestData,
     cascade: &mut Cascade<N>,
     options: GetOptions,
@@ -278,7 +278,7 @@ async fn entry_authoring() {
 
     // Network
     // - Not expecting any calls to the network.
-    let mut mock = MockHolochainP2pCellT::new();
+    let mut mock = MockHolochainP2pDnaT::new();
     mock.expect_authority_for_hash().returning(|_| Ok(false));
     let mock = MockNetwork::new(mock);
 
@@ -306,7 +306,7 @@ async fn entry_authority() {
 
     // Network
     // - Not expecting any calls to the network.
-    let mut mock = MockHolochainP2pCellT::new();
+    let mut mock = MockHolochainP2pDnaT::new();
     mock.expect_authority_for_hash().returning(|_| Ok(true));
     let mock = MockNetwork::new(mock);
 
@@ -334,7 +334,7 @@ async fn content_not_authority_or_authoring() {
 
     // Network
     // - Not expecting any calls to the network.
-    let mut mock = MockHolochainP2pCellT::new();
+    let mut mock = MockHolochainP2pDnaT::new();
     mock.expect_authority_for_hash().returning(|_| Ok(false));
     let mock = MockNetwork::new(mock);
 
@@ -375,7 +375,7 @@ async fn content_authoring() {
 
     // Network
     // - Not expecting any calls to the network.
-    let mut mock = MockHolochainP2pCellT::new();
+    let mut mock = MockHolochainP2pDnaT::new();
     mock.expect_authority_for_hash().returning(|_| Ok(false));
     let mock = MockNetwork::new(mock);
 
@@ -401,7 +401,7 @@ async fn content_authority() {
 
     // Network
     // - Not expecting any calls to the network.
-    let mut mock = MockHolochainP2pCellT::new();
+    let mut mock = MockHolochainP2pDnaT::new();
     mock.expect_authority_for_hash().returning(|_| Ok(true));
     let mock = MockNetwork::new(mock);
 

--- a/crates/holochain_cascade/tests/get_entry.rs
+++ b/crates/holochain_cascade/tests/get_entry.rs
@@ -279,7 +279,7 @@ async fn entry_authoring() {
     // Network
     // - Not expecting any calls to the network.
     let mut mock = MockHolochainP2pDnaT::new();
-    mock.expect_authority_for_hash().returning(|_| Ok(false));
+    mock.expect_authority_for_hash().returning(|_, _| Ok(false));
     let mock = MockNetwork::new(mock);
 
     // Cascade
@@ -307,7 +307,7 @@ async fn entry_authority() {
     // Network
     // - Not expecting any calls to the network.
     let mut mock = MockHolochainP2pDnaT::new();
-    mock.expect_authority_for_hash().returning(|_| Ok(true));
+    mock.expect_authority_for_hash().returning(|_, _| Ok(true));
     let mock = MockNetwork::new(mock);
 
     // Cascade
@@ -335,7 +335,7 @@ async fn content_not_authority_or_authoring() {
     // Network
     // - Not expecting any calls to the network.
     let mut mock = MockHolochainP2pDnaT::new();
-    mock.expect_authority_for_hash().returning(|_| Ok(false));
+    mock.expect_authority_for_hash().returning(|_, _| Ok(false));
     let mock = MockNetwork::new(mock);
 
     // Cascade
@@ -376,7 +376,7 @@ async fn content_authoring() {
     // Network
     // - Not expecting any calls to the network.
     let mut mock = MockHolochainP2pDnaT::new();
-    mock.expect_authority_for_hash().returning(|_| Ok(false));
+    mock.expect_authority_for_hash().returning(|_, _| Ok(false));
     let mock = MockNetwork::new(mock);
 
     // Cascade
@@ -402,7 +402,7 @@ async fn content_authority() {
     // Network
     // - Not expecting any calls to the network.
     let mut mock = MockHolochainP2pDnaT::new();
-    mock.expect_authority_for_hash().returning(|_| Ok(true));
+    mock.expect_authority_for_hash().returning(|_, _| Ok(true));
     let mock = MockNetwork::new(mock);
 
     // Cascade

--- a/crates/holochain_cascade/tests/get_links.rs
+++ b/crates/holochain_cascade/tests/get_links.rs
@@ -2,7 +2,7 @@ use fixt::prelude::*;
 use ghost_actor::dependencies::observability;
 use holochain_cascade::test_utils::*;
 use holochain_cascade::Cascade;
-use holochain_p2p::MockHolochainP2pCellT;
+use holochain_p2p::MockHolochainP2pDnaT;
 use holochain_state::mutations::insert_op_scratch;
 use holochain_state::prelude::test_cell_env;
 use holochain_state::scratch::Scratch;
@@ -81,7 +81,7 @@ async fn links_authority() {
 
     // Network
     // - Not expecting any calls to the network.
-    let mut mock = MockHolochainP2pCellT::new();
+    let mut mock = MockHolochainP2pDnaT::new();
     mock.expect_authority_for_hash().returning(|_| Ok(true));
     let mock = MockNetwork::new(mock);
 
@@ -135,7 +135,7 @@ async fn links_authoring() {
 
     // Network
     // - Not expecting any calls to the network.
-    let mut mock = MockHolochainP2pCellT::new();
+    let mut mock = MockHolochainP2pDnaT::new();
     mock.expect_authority_for_hash().returning(|_| Ok(false));
     mock.expect_get_links().returning(|_, _| {
         Ok(vec![WireLinkOps {

--- a/crates/holochain_cascade/tests/get_links.rs
+++ b/crates/holochain_cascade/tests/get_links.rs
@@ -82,7 +82,7 @@ async fn links_authority() {
     // Network
     // - Not expecting any calls to the network.
     let mut mock = MockHolochainP2pDnaT::new();
-    mock.expect_authority_for_hash().returning(|_| Ok(true));
+    mock.expect_authority_for_hash().returning(|_, _| Ok(true));
     let mock = MockNetwork::new(mock);
 
     // Cascade
@@ -136,7 +136,7 @@ async fn links_authoring() {
     // Network
     // - Not expecting any calls to the network.
     let mut mock = MockHolochainP2pDnaT::new();
-    mock.expect_authority_for_hash().returning(|_| Ok(false));
+    mock.expect_authority_for_hash().returning(|_, _| Ok(false));
     mock.expect_get_links().returning(|_, _| {
         Ok(vec![WireLinkOps {
             creates: vec![],

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- BREAKING: Wire message `CallRemote` Takes `from_agent`. [#1091](https://github.com/holochain/holochain/pull/1091)
+
 ## 0.0.14
 
 ## 0.0.13

--- a/crates/holochain_p2p/src/lib.rs
+++ b/crates/holochain_p2p/src/lib.rs
@@ -117,6 +117,7 @@ pub trait HolochainP2pDnaT {
     /// Check if an agent is an authority for a hash.
     async fn authority_for_hash(
         &self,
+        from_agent: AgentPubKey,
         dht_hash: holo_hash::AnyDhtHash,
     ) -> actor::HolochainP2pResult<bool>;
 
@@ -302,14 +303,11 @@ impl HolochainP2pDnaT for HolochainP2pDna {
     /// Check if an agent is an authority for a hash.
     async fn authority_for_hash(
         &self,
+        from_agent: AgentPubKey,
         dht_hash: holo_hash::AnyDhtHash,
     ) -> actor::HolochainP2pResult<bool> {
         self.sender
-            .authority_for_hash(
-                (*self.dna_hash).clone(),
-                (*self.from_agent).clone(),
-                dht_hash,
-            )
+            .authority_for_hash((*self.dna_hash).clone(), from_agent, dht_hash)
             .await
     }
 

--- a/crates/holochain_p2p/src/lib.rs
+++ b/crates/holochain_p2p/src/lib.rs
@@ -17,7 +17,7 @@ use ghost_actor::dependencies::tracing;
 use ghost_actor::dependencies::tracing_futures::Instrument;
 pub use spawn::*;
 pub use test::stub_network;
-pub use test::HolochainP2pCellFixturator;
+pub use test::HolochainP2pDnaFixturator;
 
 pub use kitsune_p2p;
 
@@ -25,27 +25,20 @@ pub use kitsune_p2p;
 #[async_trait::async_trait]
 /// A wrapper around HolochainP2pSender that partially applies the dna_hash / agent_pub_key.
 /// I.e. a sender that is tied to a specific cell.
-pub trait HolochainP2pCellT {
+pub trait HolochainP2pDnaT {
     /// owned getter
     fn dna_hash(&self) -> DnaHash;
 
-    /// owned getter
-    fn from_agent(&self) -> AgentPubKey;
-
-    /// Construct the CellId from the defined DnaHash and AgentPubKey
-    fn cell_id(&self) -> CellId {
-        CellId::new(self.dna_hash(), self.from_agent())
-    }
-
     /// The p2p module must be informed at runtime which dna/agent pairs it should be tracking.
-    async fn join(&self) -> actor::HolochainP2pResult<()>;
+    async fn join(&self, agent: AgentPubKey) -> actor::HolochainP2pResult<()>;
 
     /// If a cell is disabled, we'll need to \"leave\" the network module as well.
-    async fn leave(&self) -> actor::HolochainP2pResult<()>;
+    async fn leave(&self, agent: AgentPubKey) -> actor::HolochainP2pResult<()>;
 
     /// Invoke a zome function on a remote node (if you have been granted the capability).
     async fn call_remote(
         &self,
+        from_agent: AgentPubKey,
         to_agent: AgentPubKey,
         zome_name: ZomeName,
         fn_name: FunctionName,
@@ -59,6 +52,7 @@ pub trait HolochainP2pCellT {
     /// it may decide not to deliver some of the signals.
     async fn remote_signal(
         &self,
+        from_agent: AgentPubKey,
         to_agent_list: Vec<AgentPubKey>,
         zome_name: ZomeName,
         fn_name: FunctionName,
@@ -141,41 +135,32 @@ pub trait HolochainP2pCellT {
 /// A wrapper around HolochainP2pSender that partially applies the dna_hash / agent_pub_key.
 /// I.e. a sender that is tied to a specific cell.
 #[derive(Clone)]
-pub struct HolochainP2pCell {
+pub struct HolochainP2pDna {
     sender: ghost_actor::GhostSender<actor::HolochainP2p>,
     dna_hash: Arc<DnaHash>,
-    from_agent: Arc<AgentPubKey>,
 }
 
 #[async_trait::async_trait]
-impl HolochainP2pCellT for HolochainP2pCell {
+impl HolochainP2pDnaT for HolochainP2pDna {
     /// owned getter
     fn dna_hash(&self) -> DnaHash {
         (*self.dna_hash).clone()
     }
 
-    /// owned getter
-    fn from_agent(&self) -> AgentPubKey {
-        (*self.from_agent).clone()
-    }
-
     /// The p2p module must be informed at runtime which dna/agent pairs it should be tracking.
-    async fn join(&self) -> actor::HolochainP2pResult<()> {
-        self.sender
-            .join((*self.dna_hash).clone(), (*self.from_agent).clone())
-            .await
+    async fn join(&self, agent: AgentPubKey) -> actor::HolochainP2pResult<()> {
+        self.sender.join((*self.dna_hash).clone(), agent).await
     }
 
     /// If a cell is disabled, we'll need to \"leave\" the network module as well.
-    async fn leave(&self) -> actor::HolochainP2pResult<()> {
-        self.sender
-            .leave((*self.dna_hash).clone(), (*self.from_agent).clone())
-            .await
+    async fn leave(&self, agent: AgentPubKey) -> actor::HolochainP2pResult<()> {
+        self.sender.leave((*self.dna_hash).clone(), agent).await
     }
 
     /// Invoke a zome function on a remote node (if you have been granted the capability).
     async fn call_remote(
         &self,
+        from_agent: AgentPubKey,
         to_agent: AgentPubKey,
         zome_name: ZomeName,
         fn_name: FunctionName,
@@ -185,7 +170,7 @@ impl HolochainP2pCellT for HolochainP2pCell {
         self.sender
             .call_remote(
                 (*self.dna_hash).clone(),
-                (*self.from_agent).clone(),
+                from_agent,
                 to_agent,
                 zome_name,
                 fn_name,
@@ -201,6 +186,7 @@ impl HolochainP2pCellT for HolochainP2pCell {
     /// it may decide not to deliver some of the signals.
     async fn remote_signal(
         &self,
+        from_agent: AgentPubKey,
         to_agent_list: Vec<AgentPubKey>,
         zome_name: ZomeName,
         fn_name: FunctionName,
@@ -210,7 +196,7 @@ impl HolochainP2pCellT for HolochainP2pCell {
         self.sender
             .remote_signal(
                 (*self.dna_hash).clone(),
-                (*self.from_agent).clone(),
+                from_agent,
                 to_agent_list,
                 zome_name,
                 fn_name,
@@ -232,7 +218,6 @@ impl HolochainP2pCellT for HolochainP2pCell {
         self.sender
             .publish(
                 (*self.dna_hash).clone(),
-                (*self.from_agent).clone(),
                 request_validation_receipt,
                 countersigning_session,
                 dht_hash,
@@ -251,7 +236,6 @@ impl HolochainP2pCellT for HolochainP2pCell {
         self.sender
             .get_validation_package(actor::GetValidationPackage {
                 dna_hash: (*self.dna_hash).clone(),
-                agent_pub_key: (*self.from_agent).clone(),
                 request_from,
                 header_hash,
             })
@@ -265,12 +249,7 @@ impl HolochainP2pCellT for HolochainP2pCell {
         options: actor::GetOptions,
     ) -> actor::HolochainP2pResult<Vec<WireOps>> {
         self.sender
-            .get(
-                (*self.dna_hash).clone(),
-                (*self.from_agent).clone(),
-                dht_hash,
-                options,
-            )
+            .get((*self.dna_hash).clone(), dht_hash, options)
             .instrument(tracing::debug_span!("HolochainP2p::get"))
             .await
     }
@@ -282,12 +261,7 @@ impl HolochainP2pCellT for HolochainP2pCell {
         options: actor::GetMetaOptions,
     ) -> actor::HolochainP2pResult<Vec<MetadataSet>> {
         self.sender
-            .get_meta(
-                (*self.dna_hash).clone(),
-                (*self.from_agent).clone(),
-                dht_hash,
-                options,
-            )
+            .get_meta((*self.dna_hash).clone(), dht_hash, options)
             .await
     }
 
@@ -298,12 +272,7 @@ impl HolochainP2pCellT for HolochainP2pCell {
         options: actor::GetLinksOptions,
     ) -> actor::HolochainP2pResult<Vec<WireLinkOps>> {
         self.sender
-            .get_links(
-                (*self.dna_hash).clone(),
-                (*self.from_agent).clone(),
-                link_key,
-                options,
-            )
+            .get_links((*self.dna_hash).clone(), link_key, options)
             .await
     }
 
@@ -315,13 +284,7 @@ impl HolochainP2pCellT for HolochainP2pCell {
         options: actor::GetActivityOptions,
     ) -> actor::HolochainP2pResult<Vec<AgentActivityResponse<HeaderHash>>> {
         self.sender
-            .get_agent_activity(
-                (*self.dna_hash).clone(),
-                (*self.from_agent).clone(),
-                agent,
-                query,
-                options,
-            )
+            .get_agent_activity((*self.dna_hash).clone(), agent, query, options)
             .await
     }
 
@@ -332,12 +295,7 @@ impl HolochainP2pCellT for HolochainP2pCell {
         receipt: SerializedBytes,
     ) -> actor::HolochainP2pResult<()> {
         self.sender
-            .send_validation_receipt(
-                (*self.dna_hash).clone(),
-                to_agent,
-                (*self.from_agent).clone(),
-                receipt,
-            )
+            .send_validation_receipt((*self.dna_hash).clone(), to_agent, receipt)
             .await
     }
 
@@ -361,12 +319,7 @@ impl HolochainP2pCellT for HolochainP2pCell {
         response: Vec<SignedHeader>,
     ) -> actor::HolochainP2pResult<()> {
         self.sender
-            .countersigning_authority_response(
-                (*self.dna_hash).clone(),
-                (*self.from_agent).clone(),
-                agents,
-                response,
-            )
+            .countersigning_authority_response((*self.dna_hash).clone(), agents, response)
             .await
     }
 

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -191,14 +191,13 @@ impl WrapEvtSender {
     fn publish(
         &self,
         dna_hash: DnaHash,
-        to_agent: AgentPubKey,
         request_validation_receipt: bool,
         countersigning_session: bool,
         ops: Vec<(holo_hash::DhtOpHash, holochain_types::dht_op::DhtOp)>,
     ) -> impl Future<Output = HolochainP2pResult<()>> + 'static + Send {
         let op_count = ops.len();
         timing_trace!({
-            self.0.publish(dna_hash, to_agent, request_validation_receipt, countersigning_session, ops)
+            self.0.publish(dna_hash, request_validation_receipt, countersigning_session, ops)
         }, %op_count, "(hp2p:handle) publish")
     }
 
@@ -506,7 +505,6 @@ impl HolochainP2pActor {
     fn handle_incoming_publish(
         &mut self,
         dna_hash: DnaHash,
-        to_agent: AgentPubKey,
         request_validation_receipt: bool,
         countersigning_session: bool,
         ops: Vec<(holo_hash::DhtOpHash, holochain_types::dht_op::DhtOp)>,
@@ -516,7 +514,6 @@ impl HolochainP2pActor {
             evt_sender
                 .publish(
                     dna_hash,
-                    to_agent,
                     request_validation_receipt,
                     countersigning_session,
                     ops,
@@ -746,17 +743,15 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
         )
     }
 
-    #[tracing::instrument(skip(self, space, to_agent, from_agent, payload), level = "trace")]
+    #[tracing::instrument(skip(self, space, to_agent, payload), level = "trace")]
     fn handle_call(
         &mut self,
         space: Arc<kitsune_p2p::KitsuneSpace>,
         to_agent: Arc<kitsune_p2p::KitsuneAgent>,
-        from_agent: Arc<kitsune_p2p::KitsuneAgent>,
         payload: Vec<u8>,
     ) -> kitsune_p2p::event::KitsuneP2pEventHandlerResult<Vec<u8>> {
         let space = DnaHash::from_kitsune(&space);
         let to_agent = AgentPubKey::from_kitsune(&to_agent);
-        let from_agent = AgentPubKey::from_kitsune(&from_agent);
 
         let request =
             crate::wire::WireMessage::decode(payload.as_ref()).map_err(HolochainP2pError::from)?;
@@ -767,6 +762,7 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
                 fn_name,
                 cap_secret,
                 data,
+                from_agent,
             } => self.handle_incoming_call_remote(
                 space, to_agent, from_agent, zome_name, fn_name, cap_secret, data,
             ),
@@ -814,12 +810,10 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
         &mut self,
         space: Arc<kitsune_p2p::KitsuneSpace>,
         to_agent: Arc<kitsune_p2p::KitsuneAgent>,
-        from_agent: Arc<kitsune_p2p::KitsuneAgent>,
         payload: Vec<u8>,
     ) -> kitsune_p2p::event::KitsuneP2pEventHandlerResult<()> {
         let space = DnaHash::from_kitsune(&space);
         let to_agent = AgentPubKey::from_kitsune(&to_agent);
-        let from_agent = AgentPubKey::from_kitsune(&from_agent);
 
         let request =
             crate::wire::WireMessage::decode(payload.as_ref()).map_err(HolochainP2pError::from)?;
@@ -840,6 +834,7 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
             crate::wire::WireMessage::CallRemote {
                 zome_name,
                 fn_name,
+                from_agent,
                 cap_secret,
                 data,
             } => {
@@ -860,7 +855,6 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
                 ops,
             } => self.handle_incoming_publish(
                 space,
-                to_agent,
                 request_validation_receipt,
                 countersigning_session,
                 ops,
@@ -874,11 +868,9 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
     fn handle_gossip(
         &mut self,
         space: Arc<kitsune_p2p::KitsuneSpace>,
-        to_agent: Arc<kitsune_p2p::KitsuneAgent>,
         ops: Vec<(Arc<kitsune_p2p::KitsuneOpHash>, Vec<u8>)>,
     ) -> kitsune_p2p::event::KitsuneP2pEventHandlerResult<()> {
         let space = DnaHash::from_kitsune(&space);
-        let to_agent = AgentPubKey::from_kitsune(&to_agent);
         let ops = ops
             .into_iter()
             .map(|(op_hash, op_data)| {
@@ -889,7 +881,7 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
                 Ok((op_hash, op_data))
             })
             .collect::<Result<_, HolochainP2pError>>()?;
-        self.handle_incoming_publish(space, to_agent, false, false, ops)
+        self.handle_incoming_publish(space, false, false, ops)
     }
 
     #[tracing::instrument(skip(self), level = "trace")]
@@ -948,17 +940,17 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
         Ok(async move {
             let mut out = vec![];
             for agent in agents {
-                for (op_hash, dht_op) in evt_sender
+            for (op_hash, dht_op) in evt_sender
                     .fetch_op_data(space.clone(), agent.clone(), op_hashes.clone())
-                    .await?
-                {
-                    out.push((
-                        op_hash.into_kitsune(),
-                        crate::wire::WireDhtOpData { op_data: dht_op }
-                            .encode()
-                            .map_err(kitsune_p2p::KitsuneP2pError::other)?,
-                    ));
-                }
+                .await?
+            {
+                out.push((
+                    op_hash.into_kitsune(),
+                    crate::wire::WireDhtOpData { op_data: dht_op }
+                        .encode()
+                        .map_err(kitsune_p2p::KitsuneP2pError::other)?,
+                ));
+            }
             }
             Ok(out)
         }
@@ -1031,16 +1023,15 @@ impl HolochainP2pHandler for HolochainP2pActor {
     ) -> HolochainP2pHandlerResult<SerializedBytes> {
         let space = dna_hash.into_kitsune();
         let to_agent = to_agent.into_kitsune();
-        let from_agent = from_agent.into_kitsune();
 
-        let req = crate::wire::WireMessage::call_remote(zome_name, fn_name, cap_secret, payload)
-            .encode()?;
+        let req = crate::wire::WireMessage::call_remote(
+            zome_name, fn_name, from_agent, cap_secret, payload,
+        )
+        .encode()?;
 
         let kitsune_p2p = self.kitsune_p2p.clone();
         Ok(async move {
-            let result: Vec<u8> = kitsune_p2p
-                .rpc_single(space, to_agent, from_agent, req, None)
-                .await?;
+            let result: Vec<u8> = kitsune_p2p.rpc_single(space, to_agent, req, None).await?;
             Ok(UnsafeBytes::from(result).into())
         }
         .boxed()
@@ -1063,17 +1054,17 @@ impl HolochainP2pHandler for HolochainP2pActor {
             .into_iter()
             .map(|a| a.into_kitsune())
             .collect();
-        let from_agent = from_agent.into_kitsune();
 
         let req =
-            crate::wire::WireMessage::call_remote(zome_name, fn_name, cap, payload).encode()?;
+            crate::wire::WireMessage::call_remote(zome_name, fn_name, from_agent, cap, payload)
+                .encode()?;
 
         let timeout = self.tuning_params.implicit_timeout();
 
         let kitsune_p2p = self.kitsune_p2p.clone();
         Ok(async move {
             kitsune_p2p
-                .targeted_broadcast(space, from_agent, to_agent_list, timeout, req, true)
+                .targeted_broadcast(space, to_agent_list, timeout, req, true)
                 .await?;
             Ok(())
         }
@@ -1085,7 +1076,6 @@ impl HolochainP2pHandler for HolochainP2pActor {
     fn handle_publish(
         &mut self,
         dna_hash: DnaHash,
-        _from_agent: AgentPubKey,
         request_validation_receipt: bool,
         countersigning_session: bool,
         dht_hash: holo_hash::AnyDhtHash,
@@ -1127,15 +1117,12 @@ impl HolochainP2pHandler for HolochainP2pActor {
     ) -> HolochainP2pHandlerResult<ValidationPackageResponse> {
         let space = input.dna_hash.into_kitsune();
         let to_agent = input.request_from.into_kitsune();
-        let from_agent = input.agent_pub_key.into_kitsune();
 
         let req = crate::wire::WireMessage::get_validation_package(input.header_hash).encode()?;
 
         let kitsune_p2p = self.kitsune_p2p.clone();
         Ok(async move {
-            let response = kitsune_p2p
-                .rpc_single(space, to_agent, from_agent, req, None)
-                .await?;
+            let response = kitsune_p2p.rpc_single(space, to_agent, req, None).await?;
             let response = SerializedBytes::from(UnsafeBytes::from(response)).try_into()?;
             Ok(response)
         }
@@ -1143,16 +1130,14 @@ impl HolochainP2pHandler for HolochainP2pActor {
         .into())
     }
 
-    #[tracing::instrument(skip(self, dna_hash, from_agent, dht_hash, options), level = "trace")]
+    #[tracing::instrument(skip(self, dna_hash, dht_hash, options), level = "trace")]
     fn handle_get(
         &mut self,
         dna_hash: DnaHash,
-        from_agent: AgentPubKey,
         dht_hash: holo_hash::AnyDhtHash,
         options: actor::GetOptions,
     ) -> HolochainP2pHandlerResult<Vec<WireOps>> {
         let space = dna_hash.into_kitsune();
-        let from_agent = from_agent.into_kitsune();
         let basis = dht_hash.to_kitsune();
         let r_options: event::GetOptions = (&options).into();
 
@@ -1161,13 +1146,7 @@ impl HolochainP2pHandler for HolochainP2pActor {
         let kitsune_p2p = self.kitsune_p2p.clone();
         let tuning_params = self.tuning_params.clone();
         Ok(async move {
-            let input = kitsune_p2p::actor::RpcMulti::new(
-                &tuning_params,
-                space,
-                from_agent,
-                basis,
-                payload,
-            );
+            let input = kitsune_p2p::actor::RpcMulti::new(&tuning_params, space, basis, payload);
             let result = kitsune_p2p
                 .rpc_multi(input)
                 .instrument(tracing::debug_span!("rpc_multi"))
@@ -1189,12 +1168,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
     fn handle_get_meta(
         &mut self,
         dna_hash: DnaHash,
-        from_agent: AgentPubKey,
         dht_hash: holo_hash::AnyDhtHash,
         options: actor::GetMetaOptions,
     ) -> HolochainP2pHandlerResult<Vec<MetadataSet>> {
         let space = dna_hash.into_kitsune();
-        let from_agent = from_agent.into_kitsune();
         let basis = dht_hash.to_kitsune();
         let r_options: event::GetMetaOptions = (&options).into();
 
@@ -1203,13 +1180,7 @@ impl HolochainP2pHandler for HolochainP2pActor {
         let kitsune_p2p = self.kitsune_p2p.clone();
         let tuning_params = self.tuning_params.clone();
         Ok(async move {
-            let input = kitsune_p2p::actor::RpcMulti::new(
-                &tuning_params,
-                space,
-                from_agent,
-                basis,
-                payload,
-            );
+            let input = kitsune_p2p::actor::RpcMulti::new(&tuning_params, space, basis, payload);
             let result = kitsune_p2p.rpc_multi(input).await?;
 
             let mut out = Vec::new();
@@ -1228,12 +1199,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
     fn handle_get_links(
         &mut self,
         dna_hash: DnaHash,
-        from_agent: AgentPubKey,
         link_key: WireLinkKey,
         options: actor::GetLinksOptions,
     ) -> HolochainP2pHandlerResult<Vec<WireLinkOps>> {
         let space = dna_hash.into_kitsune();
-        let from_agent = from_agent.into_kitsune();
         let basis = AnyDhtHash::from(link_key.base.clone()).to_kitsune();
         let r_options: event::GetLinksOptions = (&options).into();
 
@@ -1242,13 +1211,8 @@ impl HolochainP2pHandler for HolochainP2pActor {
         let kitsune_p2p = self.kitsune_p2p.clone();
         let tuning_params = self.tuning_params.clone();
         Ok(async move {
-            let mut input = kitsune_p2p::actor::RpcMulti::new(
-                &tuning_params,
-                space,
-                from_agent,
-                basis,
-                payload,
-            );
+            let mut input =
+                kitsune_p2p::actor::RpcMulti::new(&tuning_params, space, basis, payload);
             // TODO - We're just targeting a single remote node for now
             //        without doing any pagination / etc...
             //        Setting up RpcMulti to act like RpcSingle
@@ -1271,13 +1235,11 @@ impl HolochainP2pHandler for HolochainP2pActor {
     fn handle_get_agent_activity(
         &mut self,
         dna_hash: DnaHash,
-        from_agent: AgentPubKey,
         agent: AgentPubKey,
         query: ChainQueryFilter,
         options: actor::GetActivityOptions,
     ) -> HolochainP2pHandlerResult<Vec<AgentActivityResponse<HeaderHash>>> {
         let space = dna_hash.into_kitsune();
-        let from_agent = from_agent.into_kitsune();
         // Convert the agent key to an any dht hash so it can be used
         // as the basis for sending this request
         let agent_hash: AnyDhtHash = agent.clone().into();
@@ -1290,13 +1252,8 @@ impl HolochainP2pHandler for HolochainP2pActor {
         let kitsune_p2p = self.kitsune_p2p.clone();
         let tuning_params = self.tuning_params.clone();
         Ok(async move {
-            let mut input = kitsune_p2p::actor::RpcMulti::new(
-                &tuning_params,
-                space,
-                from_agent,
-                basis,
-                payload,
-            );
+            let mut input =
+                kitsune_p2p::actor::RpcMulti::new(&tuning_params, space, basis, payload);
             // TODO - We're just targeting a single remote node for now
             //        without doing any pagination / etc...
             //        Setting up RpcMulti to act like RpcSingle
@@ -1320,20 +1277,16 @@ impl HolochainP2pHandler for HolochainP2pActor {
         &mut self,
         dna_hash: DnaHash,
         to_agent: AgentPubKey,
-        from_agent: AgentPubKey,
         receipt: SerializedBytes,
     ) -> HolochainP2pHandlerResult<()> {
         let space = dna_hash.into_kitsune();
         let to_agent = to_agent.into_kitsune();
-        let from_agent = from_agent.into_kitsune();
 
         let req = crate::wire::WireMessage::validation_receipt(receipt).encode()?;
 
         let kitsune_p2p = self.kitsune_p2p.clone();
         Ok(async move {
-            kitsune_p2p
-                .rpc_single(space, to_agent, from_agent, req, None)
-                .await?;
+            kitsune_p2p.rpc_single(space, to_agent, req, None).await?;
             Ok(())
         }
         .boxed()
@@ -1375,12 +1328,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
     fn handle_countersigning_authority_response(
         &mut self,
         dna_hash: DnaHash,
-        from_agent: AgentPubKey,
         agents: Vec<AgentPubKey>,
         response: Vec<SignedHeader>,
     ) -> HolochainP2pHandlerResult<()> {
         let space = dna_hash.into_kitsune();
-        let from_agent = from_agent.into_kitsune();
         let agents = agents.into_iter().map(|a| a.into_kitsune()).collect();
 
         let timeout = self.tuning_params.implicit_timeout();
@@ -1391,7 +1342,7 @@ impl HolochainP2pHandler for HolochainP2pActor {
         let kitsune_p2p = self.kitsune_p2p.clone();
         Ok(async move {
             kitsune_p2p
-                .targeted_broadcast(space, from_agent, agents, timeout, payload, false)
+                .targeted_broadcast(space, agents, timeout, payload, false)
                 .await?;
             Ok(())
         }

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -940,17 +940,17 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
         Ok(async move {
             let mut out = vec![];
             for agent in agents {
-            for (op_hash, dht_op) in evt_sender
+                for (op_hash, dht_op) in evt_sender
                     .fetch_op_data(space.clone(), agent.clone(), op_hashes.clone())
-                .await?
-            {
-                out.push((
-                    op_hash.into_kitsune(),
-                    crate::wire::WireDhtOpData { op_data: dht_op }
-                        .encode()
-                        .map_err(kitsune_p2p::KitsuneP2pError::other)?,
-                ));
-            }
+                    .await?
+                {
+                    out.push((
+                        op_hash.into_kitsune(),
+                        crate::wire::WireDhtOpData { op_data: dht_op }
+                            .encode()
+                            .map_err(kitsune_p2p::KitsuneP2pError::other)?,
+                    ));
+                }
             }
             Ok(out)
         }

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -152,7 +152,7 @@ fixturator!(
     curve Empty {
         tokio_helper::block_forever_on(async {
             let holochain_p2p = crate::test::stub_network().await;
-            holochain_p2p.to_cell(
+            holochain_p2p.to_dna(
                 DnaHashFixturator::new(Empty).next().unwrap(),
             )
         })

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -1,8 +1,7 @@
 use crate::actor::*;
-use crate::HolochainP2pCell;
+use crate::HolochainP2pDna;
 use crate::*;
 use ::fixt::prelude::*;
-use holo_hash::fixt::AgentPubKeyFixturator;
 use holo_hash::fixt::DnaHashFixturator;
 use holo_hash::AgentPubKey;
 use holo_hash::DnaHash;
@@ -55,7 +54,6 @@ impl HolochainP2pHandler for StubNetwork {
     fn handle_publish(
         &mut self,
         dna_hash: DnaHash,
-        from_agent: AgentPubKey,
         request_validation_receipt: bool,
         countersigning_session: bool,
         dht_hash: holo_hash::AnyDhtHash,
@@ -73,7 +71,6 @@ impl HolochainP2pHandler for StubNetwork {
     fn handle_get(
         &mut self,
         dna_hash: DnaHash,
-        from_agent: AgentPubKey,
         dht_hash: holo_hash::AnyDhtHash,
         options: actor::GetOptions,
     ) -> HolochainP2pHandlerResult<Vec<WireOps>> {
@@ -82,7 +79,6 @@ impl HolochainP2pHandler for StubNetwork {
     fn handle_get_meta(
         &mut self,
         dna_hash: DnaHash,
-        from_agent: AgentPubKey,
         dht_hash: holo_hash::AnyDhtHash,
         options: actor::GetMetaOptions,
     ) -> HolochainP2pHandlerResult<Vec<MetadataSet>> {
@@ -91,7 +87,6 @@ impl HolochainP2pHandler for StubNetwork {
     fn handle_get_links(
         &mut self,
         dna_hash: DnaHash,
-        from_agent: AgentPubKey,
         link_key: WireLinkKey,
         options: actor::GetLinksOptions,
     ) -> HolochainP2pHandlerResult<Vec<WireLinkOps>> {
@@ -100,7 +95,6 @@ impl HolochainP2pHandler for StubNetwork {
     fn handle_get_agent_activity(
         &mut self,
         dna_hash: DnaHash,
-        from_agent: AgentPubKey,
         agent: AgentPubKey,
         query: ChainQueryFilter,
         options: actor::GetActivityOptions,
@@ -111,7 +105,6 @@ impl HolochainP2pHandler for StubNetwork {
         &mut self,
         dna_hash: DnaHash,
         to_agent: AgentPubKey,
-        from_agent: AgentPubKey,
         receipt: SerializedBytes,
     ) -> HolochainP2pHandlerResult<()> {
         Err("stub".into())
@@ -130,7 +123,6 @@ impl HolochainP2pHandler for StubNetwork {
     fn handle_countersigning_authority_response(
         &mut self,
         dna_hash: DnaHash,
-        from_agent: AgentPubKey,
         agents: Vec<AgentPubKey>,
         response: Vec<SignedHeader>,
     ) -> HolochainP2pHandlerResult<()> {
@@ -156,21 +148,20 @@ pub async fn stub_network() -> ghost_actor::GhostSender<HolochainP2p> {
 }
 
 fixturator!(
-    HolochainP2pCell;
+    HolochainP2pDna;
     curve Empty {
         tokio_helper::block_forever_on(async {
             let holochain_p2p = crate::test::stub_network().await;
             holochain_p2p.to_cell(
                 DnaHashFixturator::new(Empty).next().unwrap(),
-                AgentPubKeyFixturator::new(Empty).next().unwrap(),
             )
         })
     };
     curve Unpredictable {
-        HolochainP2pCellFixturator::new(Empty).next().unwrap()
+        HolochainP2pDnaFixturator::new(Empty).next().unwrap()
     };
     curve Predictable {
-        HolochainP2pCellFixturator::new(Empty).next().unwrap()
+        HolochainP2pDnaFixturator::new(Empty).next().unwrap()
     };
 );
 
@@ -181,6 +172,7 @@ mod tests {
     use futures::future::FutureExt;
     use ghost_actor::GhostControlSender;
 
+    use crate::HolochainP2pSender;
     use holochain_zome_types::ValidationStatus;
     use kitsune_p2p::dependencies::kitsune_p2p_proxy::TlsConfig;
     use kitsune_p2p::KitsuneP2pConfig;
@@ -267,7 +259,7 @@ mod tests {
     async fn test_send_validation_receipt_workflow() {
         let (dna, a1, a2, _) = test_setup();
 
-        let (p2p, mut evt) = spawn_holochain_p2p(
+        let (p2p, mut evt): (HolochainP2pRef, _) = spawn_holochain_p2p(
             KitsuneP2pConfig::default(),
             TlsConfig::new_ephemeral().await.unwrap(),
         )
@@ -300,14 +292,9 @@ mod tests {
         p2p.join(dna.clone(), a1.clone()).await.unwrap();
         p2p.join(dna.clone(), a2.clone()).await.unwrap();
 
-        p2p.send_validation_receipt(
-            dna,
-            a2,
-            a1,
-            UnsafeBytes::from(b"receipt-test".to_vec()).into(),
-        )
-        .await
-        .unwrap();
+        p2p.send_validation_receipt(dna, a1, UnsafeBytes::from(b"receipt-test".to_vec()).into())
+            .await
+            .unwrap();
 
         p2p.ghost_actor_shutdown().await.unwrap();
         r_task.await.unwrap();
@@ -362,7 +349,7 @@ mod tests {
         // this will fail because we can't reach any remote nodes
         // but, it still published locally, so our test will work
         let _ = p2p
-            .publish(dna, a1, true, false, header_hash, vec![], Some(200))
+            .publish(dna, true, false, header_hash, vec![], Some(200))
             .await;
 
         assert_eq!(3, recv_count.load(std::sync::atomic::Ordering::SeqCst));
@@ -441,7 +428,7 @@ mod tests {
 
         tracing::info!("test - get");
         let res = p2p
-            .get(dna, a1, hash, actor::GetOptions::default())
+            .get(dna, hash, actor::GetOptions::default())
             .await
             .unwrap();
 
@@ -518,7 +505,7 @@ mod tests {
         };
 
         let res = p2p
-            .get_links(dna, a1, link_key, actor::GetLinksOptions::default())
+            .get_links(dna, link_key, actor::GetLinksOptions::default())
             .await
             .unwrap();
 

--- a/crates/holochain_p2p/src/types/event.rs
+++ b/crates/holochain_p2p/src/types/event.rs
@@ -154,7 +154,6 @@ ghost_actor::ghost_chan! {
         /// A remote node is publishing data in a range we claim to be holding.
         fn publish(
             dna_hash: DnaHash,
-            to_agent: AgentPubKey,
             request_validation_receipt: bool,
             countersigning_session: bool,
             ops: Vec<(holo_hash::DhtOpHash, holochain_types::dht_op::DhtOp)>,
@@ -253,7 +252,6 @@ macro_rules! match_p2p_evt {
     ($h:ident => |$i:ident| { $($t:tt)* }, { $($t2:tt)* }) => {
         match $h {
             HolochainP2pEvent::CallRemote { $i, .. } => { $($t)* }
-            HolochainP2pEvent::Publish { $i, .. } => { $($t)* }
             HolochainP2pEvent::GetValidationPackage { $i, .. } => { $($t)* }
             HolochainP2pEvent::Get { $i, .. } => { $($t)* }
             HolochainP2pEvent::GetMeta { $i, .. } => { $($t)* }
@@ -275,6 +273,7 @@ impl HolochainP2pEvent {
     /// The dna_hash associated with this network p2p event.
     pub fn dna_hash(&self) -> &DnaHash {
         match_p2p_evt!(self => |dna_hash| { dna_hash }, {
+            HolochainP2pEvent::Publish { dna_hash, .. } => { dna_hash }
             HolochainP2pEvent::QueryOpHashes { dna_hash, .. } => { dna_hash }
             HolochainP2pEvent::QueryAgentInfoSigned { dna_hash, .. } => { dna_hash }
             HolochainP2pEvent::QueryAgentInfoSignedNearBasis { dna_hash, .. } => { dna_hash }
@@ -287,6 +286,7 @@ impl HolochainP2pEvent {
     /// The agent_pub_key associated with this network p2p event.
     pub fn target_agents(&self) -> &AgentPubKey {
         match_p2p_evt!(self => |to_agent| { to_agent }, {
+            HolochainP2pEvent::Publish { .. } => { unimplemented!("There is no single agent target for Publish") }
             HolochainP2pEvent::QueryOpHashes { .. } => { unimplemented!("There is no single agent target for QueryOpHashes") }
             HolochainP2pEvent::QueryAgentInfoSigned { .. } => { unimplemented!("There is no single agent target for QueryAgentInfoSigned") },
             HolochainP2pEvent::QueryAgentInfoSignedNearBasis { .. } => { unimplemented!("There is no single agent target for QueryAgentInfoSignedNearBasis") },

--- a/crates/holochain_p2p/src/types/mock_network.rs
+++ b/crates/holochain_p2p/src/types/mock_network.rs
@@ -90,8 +90,6 @@ pub enum HolochainP2pMockMsg {
     Wire {
         /// The agent this message is addressed to.
         to_agent: AgentPubKey,
-        /// The agent this message is from if there is one.
-        from_agent: Option<AgentPubKey>,
         /// The dna space this message is for.
         dna: DnaHash,
         /// The actual wire message.
@@ -355,10 +353,7 @@ impl HolochainP2pMockMsg {
     fn into_wire_msg(self) -> kwire::Wire {
         match self {
             HolochainP2pMockMsg::Wire {
-                to_agent,
-                msg,
-                from_agent,
-                dna,
+                to_agent, msg, dna, ..
             } => {
                 let call = match &msg {
                     crate::wire::WireMessage::CallRemote { .. }
@@ -375,10 +370,8 @@ impl HolochainP2pMockMsg {
                 let space = dna.to_kitsune();
                 let data = msg.encode().unwrap().into();
                 if call {
-                    let from_agent = from_agent.unwrap().to_kitsune();
                     kwire::Wire::Call(kwire::Call {
                         space,
-                        from_agent,
                         to_agent,
                         data,
                     })
@@ -422,17 +415,14 @@ impl HolochainP2pMockMsg {
                 to_agent,
                 data,
                 space,
-                from_agent,
             }) => {
                 let to_agent = holo_hash::AgentPubKey::from_kitsune(&to_agent);
-                let from_agent = holo_hash::AgentPubKey::from_kitsune(&from_agent);
                 let dna = holo_hash::DnaHash::from_kitsune(&space);
                 let msg = crate::wire::WireMessage::decode(data.as_ref()).unwrap();
                 HolochainP2pMockMsg::Wire {
                     to_agent,
                     msg,
                     dna,
-                    from_agent: Some(from_agent),
                 }
             }
             kwire::Wire::Broadcast(kwire::Broadcast {
@@ -454,7 +444,6 @@ impl HolochainP2pMockMsg {
                     to_agent,
                     msg,
                     dna,
-                    from_agent: None,
                 }
             }
             kwire::Wire::Gossip(kwire::Gossip {

--- a/crates/holochain_p2p/src/types/mock_network.rs
+++ b/crates/holochain_p2p/src/types/mock_network.rs
@@ -419,11 +419,7 @@ impl HolochainP2pMockMsg {
                 let to_agent = holo_hash::AgentPubKey::from_kitsune(&to_agent);
                 let dna = holo_hash::DnaHash::from_kitsune(&space);
                 let msg = crate::wire::WireMessage::decode(data.as_ref()).unwrap();
-                HolochainP2pMockMsg::Wire {
-                    to_agent,
-                    msg,
-                    dna,
-                }
+                HolochainP2pMockMsg::Wire { to_agent, msg, dna }
             }
             kwire::Wire::Broadcast(kwire::Broadcast {
                 to_agent,
@@ -440,11 +436,7 @@ impl HolochainP2pMockMsg {
                 let to_agent = holo_hash::AgentPubKey::from_kitsune(&to_agent);
                 let dna = holo_hash::DnaHash::from_kitsune(&space);
                 let msg = crate::wire::WireMessage::decode(data.as_ref()).unwrap();
-                HolochainP2pMockMsg::Wire {
-                    to_agent,
-                    msg,
-                    dna,
-                }
+                HolochainP2pMockMsg::Wire { to_agent, msg, dna }
             }
             kwire::Wire::Gossip(kwire::Gossip {
                 data,

--- a/crates/holochain_p2p/src/types/wire.rs
+++ b/crates/holochain_p2p/src/types/wire.rs
@@ -28,6 +28,7 @@ pub enum WireMessage {
     CallRemote {
         zome_name: ZomeName,
         fn_name: FunctionName,
+        from_agent: holo_hash::AgentPubKey,
         cap_secret: Option<CapSecret>,
         #[serde(with = "serde_bytes")]
         data: Vec<u8>,
@@ -80,12 +81,14 @@ impl WireMessage {
     pub fn call_remote(
         zome_name: ZomeName,
         fn_name: FunctionName,
+        from_agent: holo_hash::AgentPubKey,
         cap_secret: Option<CapSecret>,
         payload: ExternIO,
     ) -> WireMessage {
         Self::CallRemote {
             zome_name,
             fn_name,
+            from_agent,
             cap_secret,
             data: payload.into_vec(),
         }

--- a/crates/holochain_state/src/host_fn_workspace.rs
+++ b/crates/holochain_state/src/host_fn_workspace.rs
@@ -1,5 +1,5 @@
 use holo_hash::AgentPubKey;
-use holochain_p2p::HolochainP2pCellT;
+use holochain_p2p::HolochainP2pDnaT;
 use holochain_types::env::EnvRead;
 use holochain_types::env::EnvWrite;
 use holochain_zome_types::SignedHeaderHashed;
@@ -40,7 +40,7 @@ impl HostFnWorkspace {
 
     pub async fn flush(
         self,
-        network: &(dyn HolochainP2pCellT + Send + Sync),
+        network: &(dyn HolochainP2pDnaT + Send + Sync),
     ) -> SourceChainResult<Vec<(Option<Zome>, SignedHeaderHashed)>> {
         self.source_chain.flush(network).await
     }

--- a/crates/kitsune_p2p/direct/src/handle_ws.rs
+++ b/crates/kitsune_p2p/direct/src/handle_ws.rs
@@ -393,7 +393,6 @@ async fn handle_ws_recv(
                 if let KdApi::MessageRecvEvt {
                     root,
                     to_agent,
-                    from_agent,
                     content,
                     binary,
                 } = api
@@ -402,7 +401,6 @@ async fn handle_ws_recv(
                         .emit(KdHndEvt::Message {
                             root,
                             to_agent,
-                            from_agent,
                             content,
                             binary,
                         })

--- a/crates/kitsune_p2p/direct/src/types/handle.rs
+++ b/crates/kitsune_p2p/direct/src/types/handle.rs
@@ -20,9 +20,6 @@ pub enum KdHndEvt {
         /// the destination agent
         to_agent: KdHash,
 
-        /// the source agent
-        from_agent: KdHash,
-
         /// the structured content for this message
         content: serde_json::Value,
 

--- a/crates/kitsune_p2p/direct/src/v1.rs
+++ b/crates/kitsune_p2p/direct/src/v1.rs
@@ -671,9 +671,9 @@ async fn handle_events(
                     ..
                 } => {
                     respond.r(Ok(handle_call(kdirect.clone(), space, to_agent, payload)
-                    .map_err(KitsuneP2pError::other)
-                    .boxed()
-                    .into()));
+                        .map_err(KitsuneP2pError::other)
+                        .boxed()
+                        .into()));
                 }
                 event::KitsuneP2pEvent::Notify {
                     respond,

--- a/crates/kitsune_p2p/direct_api/src/kdapi.rs
+++ b/crates/kitsune_p2p/direct_api/src/kdapi.rs
@@ -273,10 +273,6 @@ pub enum KdApi {
         #[serde(rename = "toAgent")]
         to_agent: KdHash,
 
-        /// the agent authoring this message
-        #[serde(rename = "fromAgent")]
-        from_agent: KdHash,
-
         /// the structured content for this message
         #[serde(rename = "content")]
         content: serde_json::Value,

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- BREAKING: Wire message `Call` no longer takes `from_agent`. [#1091](https://github.com/holochain/holochain/pull/1091)
+
 ## 0.0.12
 
 - BREAKING: Return `ShardedGossipWire::Busy` if we are overloaded with incoming gossip. [\#1076](https://github.com/holochain/holochain/pull/1076)

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/store.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/store.rs
@@ -172,7 +172,7 @@ pub(super) async fn put_ops(
     // If there's only a single agent in the space we
     // can avoid cloning the ops which could be large.
     if agent_arcs.len() == 1 {
-        let (agent, arc) = agent_arcs
+        let (_agent, arc) = agent_arcs
             .into_iter()
             .next()
             .expect("Can't be none due to len check");
@@ -180,14 +180,14 @@ pub(super) async fn put_ops(
             return Ok(());
         }
         evt_sender
-            .gossip(space.clone(), agent, ops)
+            .gossip(space.clone(), ops)
             .await
             .map_err(KitsuneError::other)?;
     } else {
-        for (agent, arc) in agent_arcs {
+        for (_agent, arc) in agent_arcs {
             if !arc.is_empty() {
                 evt_sender
-                    .gossip(space.clone(), agent, ops.clone())
+                    .gossip(space.clone(), ops.clone())
                     .await
                     .map_err(KitsuneError::other)?;
             }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -67,7 +67,7 @@ async fn standard_responses(
     }
     evt_handler
         .expect_handle_gossip()
-        .returning(|_, _, _| Ok(async { Ok(()) }.boxed().into()));
+        .returning(|_, _| Ok(async { Ok(()) }.boxed().into()));
     evt_handler
 }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/handler_builder.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/handler_builder.rs
@@ -33,7 +33,7 @@ impl HandlerBuilder {
     pub fn with_noop_gossip(mut self, agent_data: MockAgentPersistence) -> Self {
         self.0
             .expect_handle_gossip()
-            .returning(|_, _, _| Ok(async { Ok(()) }.boxed().into()));
+            .returning(|_, _| Ok(async { Ok(()) }.boxed().into()));
 
         self
     }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/simple_bloom/step_2_local_sync_inner.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/simple_bloom/step_2_local_sync_inner.rs
@@ -130,7 +130,7 @@ impl Inner {
                     }
                 }
                 evt_sender
-                    .gossip(space.clone(), new_agent.clone(), to_send)
+                    .gossip(space.clone(), to_send)
                     .await
                     .map_err(KitsuneError::other)?;
             }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/simple_bloom/step_4_com_loop_inner.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/simple_bloom/step_4_com_loop_inner.rs
@@ -157,54 +157,49 @@ pub(crate) async fn step_4_com_loop_inner_incoming(
             );
 
             // parse/integrate the chunks
-            let futs =
-                bloom.inner.share_mut(move |i, _| {
-                    if let Some(endpoint) = i.initiate_tgt.clone() {
-                        if finished && con.peer_cert() == *endpoint.cert() {
-                            i.initiate_tgt = None;
+            let futs = bloom.inner.share_mut(move |i, _| {
+                if let Some(endpoint) = i.initiate_tgt.clone() {
+                    if finished && con.peer_cert() == *endpoint.cert() {
+                        i.initiate_tgt = None;
+                    }
+                }
+
+                let mut futs = Vec::new();
+
+                // Locally sync the newly received data
+                let mut to_send_ops = Vec::new();
+                let mut to_send_peer_data = Vec::new();
+                for chunk in &chunks {
+                    match &**chunk {
+                        MetaOpData::Op(key, data) => {
+                            to_send_ops.push((key.clone(), data.clone()));
+                        }
+                        MetaOpData::Agent(agent_info_signed) => {
+                            // TODO - we actually only need to do this
+                            // once, since the agent store is shared...
+                            to_send_peer_data.push(agent_info_signed.clone());
                         }
                     }
+                    let key = chunk.key();
+                    i.local_bloom.set(&key);
+                    i.local_data_map.insert(key, chunk.clone());
+                }
+                if !to_send_ops.is_empty() {
+                    futs.push(bloom.evt_sender.gossip(bloom.space.clone(), to_send_ops));
+                }
+                if !to_send_peer_data.is_empty() {
+                    futs.push(
+                        bloom
+                            .evt_sender
+                            .put_agent_info_signed(PutAgentInfoSignedEvt {
+                                space: bloom.space.clone(),
+                                peer_data: to_send_peer_data,
+                            }),
+                    );
+                }
 
-                    let mut futs = Vec::new();
-
-                    // Locally sync the newly received data
-                    for agent in i.local_agents.iter() {
-                        let mut to_send_ops = Vec::new();
-                        let mut to_send_peer_data = Vec::new();
-                        for chunk in &chunks {
-                            match &**chunk {
-                                MetaOpData::Op(key, data) => {
-                                    to_send_ops.push((key.clone(), data.clone()));
-                                }
-                                MetaOpData::Agent(agent_info_signed) => {
-                                    // TODO - we actually only need to do this
-                                    // once, since the agent store is shared...
-                                    to_send_peer_data.push(agent_info_signed.clone());
-                                }
-                            }
-                            let key = chunk.key();
-                            i.local_bloom.set(&key);
-                            i.local_data_map.insert(key, chunk.clone());
-                        }
-                        if !to_send_ops.is_empty() {
-                            futs.push(bloom.evt_sender.gossip(
-                                bloom.space.clone(),
-                                agent.clone(),
-                                to_send_ops,
-                            ));
-                        }
-                        if !to_send_peer_data.is_empty() {
-                            futs.push(bloom.evt_sender.put_agent_info_signed(
-                                PutAgentInfoSignedEvt {
-                                    space: bloom.space.clone(),
-                                    peer_data: to_send_peer_data,
-                                },
-                            ));
-                        }
-                    }
-
-                    Ok(futs)
-                })?;
+                Ok(futs)
+            })?;
 
             if !futs.is_empty() {
                 futures::future::try_join_all(futs)

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -238,13 +238,12 @@ impl KitsuneP2pActor {
                                 match data {
                                     wire::Wire::Call(wire::Call {
                                         space,
-                                        from_agent,
                                         to_agent,
                                         data,
                                         ..
                                     }) => {
                                         let res = match evt_sender
-                                            .call(space, to_agent, from_agent, data.into())
+                                            .call(space, to_agent, data.into())
                                             .await
                                         {
                                             Err(err) => {
@@ -330,9 +329,8 @@ impl KitsuneP2pActor {
                                         data,
                                         ..
                                     }) => {
-                                        if let Err(err) = evt_sender
-                                            .notify(space, to_agent.clone(), to_agent, data.into())
-                                            .await
+                                        if let Err(err) =
+                                            evt_sender.notify(space, to_agent, data.into()).await
                                         {
                                             tracing::warn!(
                                                 ?err,
@@ -524,29 +522,26 @@ impl KitsuneP2pEventHandler for KitsuneP2pActor {
         &mut self,
         space: Arc<KitsuneSpace>,
         to_agent: Arc<KitsuneAgent>,
-        from_agent: Arc<KitsuneAgent>,
         payload: Vec<u8>,
     ) -> KitsuneP2pEventHandlerResult<Vec<u8>> {
-        Ok(self.evt_sender.call(space, to_agent, from_agent, payload))
+        Ok(self.evt_sender.call(space, to_agent, payload))
     }
 
     fn handle_notify(
         &mut self,
         space: Arc<KitsuneSpace>,
         to_agent: Arc<KitsuneAgent>,
-        from_agent: Arc<KitsuneAgent>,
         payload: Vec<u8>,
     ) -> KitsuneP2pEventHandlerResult<()> {
-        Ok(self.evt_sender.notify(space, to_agent, from_agent, payload))
+        Ok(self.evt_sender.notify(space, to_agent, payload))
     }
 
     fn handle_gossip(
         &mut self,
         space: Arc<KitsuneSpace>,
-        to_agent: Arc<KitsuneAgent>,
         ops: Vec<(Arc<KitsuneOpHash>, Vec<u8>)>,
     ) -> KitsuneP2pEventHandlerResult<()> {
-        Ok(self.evt_sender.gossip(space, to_agent, ops))
+        Ok(self.evt_sender.gossip(space, ops))
     }
 
     fn handle_fetch_op_data(
@@ -642,7 +637,6 @@ impl KitsuneP2pHandler for KitsuneP2pActor {
         &mut self,
         space: Arc<KitsuneSpace>,
         to_agent: Arc<KitsuneAgent>,
-        from_agent: Arc<KitsuneAgent>,
         payload: Vec<u8>,
         timeout_ms: Option<u64>,
     ) -> KitsuneP2pHandlerResult<Vec<u8>> {
@@ -653,7 +647,7 @@ impl KitsuneP2pHandler for KitsuneP2pActor {
         Ok(async move {
             let (space_sender, _) = space_sender.await;
             space_sender
-                .rpc_single(space, to_agent, from_agent, payload, timeout_ms)
+                .rpc_single(space, to_agent, payload, timeout_ms)
                 .await
         }
         .boxed()
@@ -699,7 +693,6 @@ impl KitsuneP2pHandler for KitsuneP2pActor {
     fn handle_targeted_broadcast(
         &mut self,
         space: Arc<KitsuneSpace>,
-        from_agent: Arc<KitsuneAgent>,
         agents: Vec<Arc<KitsuneAgent>>,
         timeout: KitsuneTimeout,
         payload: Vec<u8>,
@@ -712,7 +705,7 @@ impl KitsuneP2pHandler for KitsuneP2pActor {
         Ok(async move {
             let (space_sender, _) = space_sender.await;
             space_sender
-                .targeted_broadcast(space, from_agent, agents, timeout, payload, drop_at_limit)
+                .targeted_broadcast(space, agents, timeout, payload, drop_at_limit)
                 .await
         }
         .boxed()
@@ -793,7 +786,6 @@ mockall::mock! {
             &mut self,
             space: Arc<KitsuneSpace>,
             to_agent: Arc<KitsuneAgent>,
-            from_agent: Arc<KitsuneAgent>,
             payload: Vec<u8>,
         ) -> KitsuneP2pEventHandlerResult<Vec<u8>>;
 
@@ -801,14 +793,12 @@ mockall::mock! {
             &mut self,
             space: Arc<KitsuneSpace>,
             to_agent: Arc<KitsuneAgent>,
-            from_agent: Arc<KitsuneAgent>,
             payload: Vec<u8>,
         ) -> KitsuneP2pEventHandlerResult<()> ;
 
         fn handle_gossip(
             &mut self,
             space: Arc<KitsuneSpace>,
-            to_agent: Arc<KitsuneAgent>,
             ops: Vec<(Arc<KitsuneOpHash>, Vec<u8>)>,
         ) -> KitsuneP2pEventHandlerResult<()>;
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -251,12 +251,9 @@ impl SpaceInternalHandler for Space {
         for agent in self.local_joined_agents.iter().cloned() {
             if let Some(arc) = self.agent_arcs.get(&agent) {
                 if arc.contains(basis.get_loc()) {
-                    let fut = self.evt_sender.notify(
-                        space.clone(),
-                        agent.clone(),
-                        agent.clone(),
-                        data.clone().into(),
-                    );
+                    let fut =
+                        self.evt_sender
+                            .notify(space.clone(), agent.clone(), data.clone().into());
                     local_events.push(async move {
                         if let Err(err) = fut.await {
                             tracing::warn!(?err, "failed local broadcast");
@@ -560,7 +557,6 @@ impl KitsuneP2pHandler for Space {
         &mut self,
         space: Arc<KitsuneSpace>,
         to_agent: Arc<KitsuneAgent>,
-        from_agent: Arc<KitsuneAgent>,
         payload: Vec<u8>,
         timeout_ms: Option<u64>,
     ) -> KitsuneP2pHandlerResult<Vec<u8>> {
@@ -582,15 +578,10 @@ impl KitsuneP2pHandler for Space {
             match discover_fut.await {
                 discover::PeerDiscoverResult::OkShortcut => {
                     // reflect this request locally
-                    evt_sender.call(space, to_agent, from_agent, payload).await
+                    evt_sender.call(space, to_agent, payload).await
                 }
                 discover::PeerDiscoverResult::OkRemote { con_hnd, .. } => {
-                    let payload = wire::Wire::call(
-                        space.clone(),
-                        from_agent.clone(),
-                        to_agent.clone(),
-                        payload.into(),
-                    );
+                    let payload = wire::Wire::call(space.clone(), to_agent.clone(), payload.into());
                     let res = con_hnd.request(&payload, timeout).await?;
                     match res {
                         wire::Wire::Failure(wire::Failure { reason }) => Err(reason.into()),
@@ -640,12 +631,9 @@ impl KitsuneP2pHandler for Space {
         for agent in self.local_joined_agents.iter().cloned() {
             if let Some(arc) = self.agent_arcs.get(&agent) {
                 if arc.contains(basis.get_loc()) {
-                    let fut = self.evt_sender.notify(
-                        space.clone(),
-                        agent.clone(),
-                        agent.clone(),
-                        payload.clone(),
-                    );
+                    let fut = self
+                        .evt_sender
+                        .notify(space.clone(), agent.clone(), payload.clone());
                     local_events.push(async move {
                         if let Err(err) = fut.await {
                             tracing::warn!(?err, "failed local broadcast");
@@ -762,7 +750,6 @@ impl KitsuneP2pHandler for Space {
     fn handle_targeted_broadcast(
         &mut self,
         space: Arc<KitsuneSpace>,
-        from_agent: Arc<KitsuneAgent>,
         agents: Vec<Arc<KitsuneAgent>>,
         timeout: KitsuneTimeout,
         payload: Vec<u8>,
@@ -793,7 +780,6 @@ impl KitsuneP2pHandler for Space {
                         .ok()
                 };
                 let space = space.clone();
-                let from_agent = from_agent.clone();
                 let payload = payload.clone();
                 let evt_sender = evt_sender.clone();
                 let ro_inner = ro_inner.clone();
@@ -808,7 +794,7 @@ impl KitsuneP2pHandler for Space {
                         discover::PeerDiscoverResult::OkShortcut => {
                             // reflect this request locally
                             evt_sender
-                                .notify(space, agent, from_agent, payload)
+                                .notify(space, agent, payload)
                                 .map(|r| {
                                     if let Err(e) = r {
                                         tracing::error!(

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
@@ -154,7 +154,6 @@ async fn test_rpc_multi_logic_mocked() {
                                 let resp = match wire {
                                     wire::Wire::Call(wire::Call {
                                         space: _,
-                                        from_agent: _,
                                         to_agent: _,
                                         data,
                                     }) => {
@@ -243,14 +242,12 @@ async fn test_rpc_multi_logic_mocked() {
         config,
     });
 
-    let agent = Arc::new(KitsuneAgent(vec![0; 36]));
     let basis = Arc::new(KitsuneBasis(vec![0; 36]));
 
     // excercise the rpc multi logic
     let res = handle_rpc_multi(
         actor::RpcMulti {
             space,
-            from_agent: agent.clone(),
             basis,
             payload: b"test".to_vec(),
             max_remote_agent_count: 3,

--- a/crates/kitsune_p2p/kitsune_p2p/src/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test.rs
@@ -21,12 +21,12 @@ mod tests {
         harness.magic_peer_info_exchange().await.unwrap();
 
         let r1 = p2p1
-            .rpc_single(space.clone(), a2.clone(), a1.clone(), b"m1".to_vec(), None)
+            .rpc_single(space.clone(), a1.clone(), b"m1".to_vec(), None)
             .await
             .unwrap();
         let s = std::time::Instant::now();
         let r2 = match p2p2
-            .rpc_single(space.clone(), a1, a2, b"m2".to_vec(), None)
+            .rpc_single(space.clone(), a2, b"m2".to_vec(), None)
             .await
         {
             Err(_) => {
@@ -58,7 +58,6 @@ mod tests {
         let mut input = actor::RpcMulti::new(
             &Default::default(),
             space,
-            a1.clone(),
             TestVal::test_val(),
             b"test-multi-request".to_vec(),
         );
@@ -146,9 +145,7 @@ mod tests {
         let a2: Arc<KitsuneAgent> = TestVal::test_val();
         p2p.join(space.clone(), a2.clone()).await?;
 
-        let res = p2p
-            .rpc_single(space, a2, a1, b"hello".to_vec(), None)
-            .await?;
+        let res = p2p.rpc_single(space, a1, b"hello".to_vec(), None).await?;
         assert_eq!(b"echo: hello".to_vec(), res);
 
         harness.ghost_actor_shutdown().await?;
@@ -173,7 +170,6 @@ mod tests {
         let mut input = actor::RpcMulti::new(
             &Default::default(),
             space,
-            a1.clone(),
             TestVal::test_val(),
             b"test-multi-request".to_vec(),
         );
@@ -205,7 +201,6 @@ mod tests {
         let mut input = actor::RpcMulti::new(
             &Default::default(),
             space,
-            a1.clone(),
             TestVal::test_val(),
             b"test-multi-request".to_vec(),
         );

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
@@ -232,14 +232,12 @@ impl KitsuneP2pEventHandler for AgentHarness {
         &mut self,
         space: Arc<super::KitsuneSpace>,
         to_agent: Arc<super::KitsuneAgent>,
-        from_agent: Arc<super::KitsuneAgent>,
         payload: Vec<u8>,
     ) -> KitsuneP2pEventHandlerResult<Vec<u8>> {
         let data = String::from_utf8_lossy(&payload);
         self.harness_chan.publish(HarnessEventType::Call {
             space: space.into(),
             to_agent: to_agent.into(),
-            from_agent: from_agent.into(),
             payload: data.to_string(),
         });
         let data = format!("echo: {}", data);
@@ -251,14 +249,12 @@ impl KitsuneP2pEventHandler for AgentHarness {
         &mut self,
         space: Arc<super::KitsuneSpace>,
         to_agent: Arc<super::KitsuneAgent>,
-        from_agent: Arc<super::KitsuneAgent>,
         payload: Vec<u8>,
     ) -> KitsuneP2pEventHandlerResult<()> {
         let data = String::from_utf8_lossy(&payload);
         self.harness_chan.publish(HarnessEventType::Notify {
             space: space.into(),
             to_agent: to_agent.into(),
-            from_agent: from_agent.into(),
             payload: data.to_string(),
         });
         Ok(async move { Ok(()) }.boxed().into())
@@ -267,7 +263,6 @@ impl KitsuneP2pEventHandler for AgentHarness {
     fn handle_gossip(
         &mut self,
         _space: Arc<super::KitsuneSpace>,
-        _to_agent: Arc<super::KitsuneAgent>,
         ops: Vec<(Arc<super::KitsuneOpHash>, Vec<u8>)>,
     ) -> KitsuneP2pEventHandlerResult<()> {
         for (op_hash, op_data) in ops {

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_event.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_event.rs
@@ -58,13 +58,11 @@ pub enum HarnessEventType {
     Call {
         space: Slug,
         to_agent: Slug,
-        from_agent: Slug,
         payload: String,
     },
     Notify {
         space: Slug,
         to_agent: Slug,
-        from_agent: Slug,
         payload: String,
     },
     Gossip {

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
@@ -9,7 +9,7 @@ use crate::types::event::{KitsuneP2pEvent, KitsuneP2pEventHandler, KitsuneP2pEve
 use kitsune_p2p_types::bin_types::*;
 use kitsune_p2p_types::*;
 
-use super::switchboard_state::{AgentOpEntry, NodeEp, OpEntry, Switchboard};
+use super::switchboard_state::{NodeEp, OpEntry, Switchboard};
 
 type KSpace = Arc<KitsuneSpace>;
 type KAgent = Arc<KitsuneAgent>;
@@ -119,7 +119,6 @@ impl KitsuneP2pEventHandler for SwitchboardEventHandler {
         &mut self,
         space: Arc<KitsuneSpace>,
         to_agent: Arc<KitsuneAgent>,
-        from_agent: Arc<KitsuneAgent>,
         payload: Vec<u8>,
     ) -> KitsuneP2pEventHandlerResult<Vec<u8>> {
         todo!()
@@ -129,7 +128,6 @@ impl KitsuneP2pEventHandler for SwitchboardEventHandler {
         &mut self,
         space: Arc<KitsuneSpace>,
         to_agent: Arc<KitsuneAgent>,
-        from_agent: Arc<KitsuneAgent>,
         payload: Vec<u8>,
     ) -> KitsuneP2pEventHandlerResult<()> {
         todo!()
@@ -137,27 +135,27 @@ impl KitsuneP2pEventHandler for SwitchboardEventHandler {
 
     fn handle_gossip(
         &mut self,
-        space: Arc<KitsuneSpace>,
-        to_agent: Arc<KitsuneAgent>,
-        ops: Vec<(Arc<KitsuneOpHash>, Vec<u8>)>,
+        _space: Arc<KitsuneSpace>,
+        _ops: Vec<(Arc<KitsuneOpHash>, Vec<u8>)>,
     ) -> KitsuneP2pEventHandlerResult<()> {
-        ok_fut(Ok(self.sb.share(|sb| {
-            let agent = sb
-                .node_for_local_agent_hash_mut(&*to_agent)
-                .unwrap()
-                .local_agent_by_hash_mut(&*to_agent)
-                .unwrap();
-            for (hash, op_data) in ops {
-                let loc8 = hash.get_loc().as_loc8();
-                // TODO: allow setting integration status
-                agent.ops.insert(
-                    loc8,
-                    AgentOpEntry {
-                        is_integrated: true,
-                    },
-                );
-            }
-        })))
+        todo!()
+        // ok_fut(Ok(self.sb.share(|sb| {
+        //     let agent = sb
+        //         .node_for_local_agent_hash_mut(&*to_agent)
+        //         .unwrap()
+        //         .local_agent_by_hash_mut(&*to_agent)
+        //         .unwrap();
+        //     for (hash, op_data) in ops {
+        //         let loc8 = hash.get_loc().as_loc8();
+        //         // TODO: allow setting integration status
+        //         agent.ops.insert(
+        //             loc8,
+        //             AgentOpEntry {
+        //                 is_integrated: true,
+        //             },
+        //         );
+        //     }
+        // })))
     }
 
     fn handle_query_op_hashes(

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/actor.rs
@@ -12,9 +12,6 @@ pub struct RpcMulti {
     /// The "space" context.
     pub space: Arc<super::KitsuneSpace>,
 
-    /// The agent making the request.
-    pub from_agent: Arc<super::KitsuneAgent>,
-
     /// The "basis" hash/coordinate of destination neigborhood.
     pub basis: Arc<super::KitsuneBasis>,
 
@@ -40,13 +37,11 @@ impl RpcMulti {
     pub fn new(
         tuning_params: &KitsuneP2pTuningParams,
         space: Arc<super::KitsuneSpace>,
-        from_agent: Arc<super::KitsuneAgent>,
         basis: Arc<super::KitsuneBasis>,
         payload: Vec<u8>,
     ) -> Self {
         Self {
             space,
-            from_agent,
             basis,
             payload,
             max_remote_agent_count: tuning_params.default_rpc_multi_remote_agent_count,
@@ -86,7 +81,7 @@ ghost_actor::ghost_chan! {
 
         /// Make a request of a single remote agent, expecting a response.
         /// The remote side will receive a "Call" event.
-        fn rpc_single(space: KSpace, to_agent: KAgent, from_agent: KAgent, payload: Payload, timeout_ms: OptU64) -> Vec<u8>;
+        fn rpc_single(space: KSpace, to_agent: KAgent, payload: Payload, timeout_ms: OptU64) -> Vec<u8>;
 
         /// Make a request to multiple destination agents - awaiting/aggregating the responses.
         /// The remote sides will see these messages as "Call" events.
@@ -110,7 +105,6 @@ ghost_actor::ghost_chan! {
         /// least one connection with a node in the agent set.
         fn targeted_broadcast(
             space: KSpace,
-            from_agent: KAgent,
             agents: KAgents,
             timeout: KitsuneTimeout,
             payload: Payload,

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
@@ -233,13 +233,13 @@ ghost_actor::ghost_chan! {
         fn query_metrics(query: MetricQuery) -> MetricQueryAnswer;
 
         /// We are receiving a request from a remote node.
-        fn call(space: KSpace, to_agent: KAgent, from_agent: KAgent, payload: Payload) -> Vec<u8>;
+        fn call(space: KSpace, to_agent: KAgent, payload: Payload) -> Vec<u8>;
 
         /// We are receiving a notification from a remote node.
-        fn notify(space: KSpace, to_agent: KAgent, from_agent: KAgent, payload: Payload) -> ();
+        fn notify(space: KSpace, to_agent: KAgent, payload: Payload) -> ();
 
         /// We are receiving a dht op we may need to hold distributed via gossip.
-        fn gossip(space: KSpace, to_agent: KAgent, ops: Ops) -> ();
+        fn gossip(space: KSpace, ops: Ops) -> ();
 
         /// Gather a list of op-hashes from our implementor that meet criteria.
         /// Get the oldest and newest times for ops within a time window and max number of ops.

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/wire.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/wire.rs
@@ -23,9 +23,8 @@ kitsune_p2p_types::write_codec_enum! {
         /// "Call" to the remote.
         Call(0x010) {
             space.0: Arc<KitsuneSpace>,
-            from_agent.1: Arc<KitsuneAgent>,
-            to_agent.2: Arc<KitsuneAgent>,
-            data.3: WireData,
+            to_agent.1: Arc<KitsuneAgent>,
+            data.2: WireData,
         },
 
         /// "Call" response from the remote.


### PR DESCRIPTION
### Summary
This is the first PR in the db refactor series.
- Remove from_agent from places that doesn't make sense once we merge dbs.
- Change `HolochainP2pCell` to HolochailP2pDna`.

There's a few little work arounds just to make this PR work until the next which will remove them.
I will post the next PR once this is merged due to the size and potential for conflicts.

Overall there's a lot of noise from name changes but it's a pretty simple PR.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
