### PR TITLE
bump lair version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,9 +2221,9 @@ dependencies = [
 
 [[package]]
 name = "hc_seed_bundle"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6a2239e3f209ac27aae8fc9c14a8aa4efc7e2ff2c106dc901a28b04e5a1c5af"
+checksum = "ae01760e90dcdb62fb1b82ac79c8cf8da5cf727fc72efc771c59491d9a96a6bf"
 dependencies = [
  "futures",
  "one_err",
@@ -3233,7 +3233,6 @@ dependencies = [
  "kitsune_p2p_timestamp",
  "kitsune_p2p_transport_quic",
  "kitsune_p2p_types",
- "lair_keystore_api 0.1.0-alpha.4",
  "maplit",
  "mockall",
  "num-traits",
@@ -3421,8 +3420,8 @@ dependencies = [
  "futures",
  "ghost_actor 0.3.0-alpha.4",
  "kitsune_p2p_dht_arc",
- "lair_keystore_api 0.0.8",
- "lair_keystore_api 0.1.0-alpha.4",
+ "lair_keystore_api 0.0.9",
+ "lair_keystore_api 0.1.0",
  "lru",
  "mockall",
  "nanoid 0.3.0",
@@ -3457,9 +3456,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.0.8"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893dc7c66b3f2abd1d05f4df4fda3d28615249c6254e0a6120d38d80f98a4343"
+checksum = "5cc95edf9f8d54feace7ee5189e3c58d71435208afea4abda0c4b0b0a5c78c65"
 dependencies = [
  "arbitrary",
  "blake2b_simd",
@@ -3489,9 +3488,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64360d4a4bba538d467162455177d2e26063d1ea86b4bc3159068af878d35ab7"
+checksum = "821c3eed9a5a27a9e225fcd0ecb340ef810a4078b6b0207bb26daee0744d963c"
 dependencies = [
  "base64",
  "dunce",
@@ -3513,13 +3512,13 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_client"
-version = "0.0.8"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6a3807675e92606f82a5c4c489b06fb5d07fe543999c7e06173200bb0737b0"
+checksum = "30c0525d3a00010803a6074d6df24d602813b93598b547c9d55f7b43620da458"
 dependencies = [
  "futures",
  "ghost_actor 0.3.0-alpha.4",
- "lair_keystore_api 0.0.8",
+ "lair_keystore_api 0.0.9",
  "sodoken",
  "tempfile",
  "tokio",
@@ -3546,9 +3545,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.103"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8f7255a17a627354f321ef0055d63b898c6fb27eff628af4d1b66b7331edf6"
+checksum = "a60553f9a9e039a333b4e9b20573b9e9b9c0bb3a11e201ccc48ef4283456d673"
 
 [[package]]
 name = "libgit2-sys"
@@ -6127,9 +6126,9 @@ dependencies = [
 
 [[package]]
 name = "sodoken"
-version = "0.0.1-alpha.21"
+version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4289c6852b505c8b6b8c6ec7de150de002694e5bb021e9a9b769e20427d1d0de"
+checksum = "f90aae9dabf2f1cd20959dc73124a1f5da613a197a222cef94723c72653b13ca"
 dependencies = [
  "libc",
  "libsodium-sys",

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - **BREAKING CHANGE** current chain head including recent writes available in agent info [#1079](https://github.com/holochain/holochain/pull/1079)
+- **BREAKING (If using new lair)** If you are using the new (non-legacy) `lair_server` keystore, you will need to rebuild your keystore, we now pre-hash the passphrase used to access it to mitigate some information leakage. [#1094](https://github.com/holochain/holochain/pull/1094)
+- Better lair signature fallback child process management. The child process will now be properly restarted if it exits. (Note this can take a few millis on Windows, and may result in some signature errors.)
 
 ## 0.0.114
 

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -56,7 +56,7 @@ serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 serde_yaml = "0.8"
 shrinkwraprs = "0.3.0"
-sodoken = "=0.0.1-alpha.21"
+sodoken = "=0.0.1"
 structopt = "0.3.11"
 strum = "0.18.0"
 tempdir = "0.3.7"

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -17,12 +17,12 @@ holo_hash = { version = "0.0.12", path = "../holo_hash", features = ["full"] }
 holochain_serialized_bytes = "=0.0.51"
 holochain_zome_types = { path = "../holochain_zome_types", version = "0.0.16"}
 kitsune_p2p_types = { version = "0.0.11", path = "../kitsune_p2p/types" }
-lair_keystore_client_0_0 = { version = "=0.0.8", package = "lair_keystore_client" }
+lair_keystore_client_0_0 = { version = "=0.0.9", package = "lair_keystore_client" }
 nanoid = "0.4.0"
 one_err = "0.0.5"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_bytes = "0.11"
-sodoken = "=0.0.1-alpha.21"
+sodoken = "=0.0.1"
 thiserror = "1.0.22"
 tokio = { version = "1.11", features = [ "full" ] }
 tracing = "0.1"

--- a/crates/kitsune_p2p/direct/Cargo.toml
+++ b/crates/kitsune_p2p/direct/Cargo.toml
@@ -27,7 +27,7 @@ rand = "0.8.3"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 structopt = "0.3.21"
-sodoken = "=0.0.1-alpha.21"
+sodoken = "=0.0.1"
 tokio = { version = "1.11", features = ["full"] }
 tokio-tungstenite = "0.14"
 tungstenite = "0.13"

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -24,7 +24,6 @@ kitsune_p2p_proxy = { version = "0.0.11", path = "../proxy" }
 kitsune_p2p_timestamp = { version = "0.0.5", path = "../timestamp" }
 kitsune_p2p_transport_quic = { version = "0.0.11", path = "../transport_quic" }
 kitsune_p2p_types = { version = "0.0.11", path = "../types" }
-lair_keystore_api = "=0.1.0-alpha.4"
 num-traits = "0.2"
 parking_lot = "0.11.1"
 rand = "0.7"

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -11,8 +11,8 @@ categories = [ "network-programming" ]
 edition = "2018"
 
 [dependencies]
-lair_keystore_api_0_0 = { version = "=0.0.8", package = "lair_keystore_api" }
-lair_keystore_api = "=0.1.0-alpha.4"
+lair_keystore_api_0_0 = { version = "=0.0.9", package = "lair_keystore_api" }
+lair_keystore_api = "=0.1.0"
 base64 = "0.13"
 derive_more = "0.99.7"
 futures = "0.3"


### PR DESCRIPTION
### Summary

- sodoken: `0.0.1`
- legacy lair: `0.0.9`
- new lair: `0.1.0`

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
