### PR TITLE
Filter out private entries from incoming ops sender

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix [issue](https://github.com/holochain/holochain/issues/1100) where private dht ops were being leaked through the incoming ops sender. [1104](https://github.com/holochain/holochain/pull/1104).
 - Kitsune now attempts to rebind the network interface in the event of endpoint shutdown. Note, it's still recommended to bind to `0.0.0.0` as the OS provides additional resiliency for interfaces coming and going.
 - **BREAKING CHANGE** current chain head including recent writes available in agent info [#1079](https://github.com/holochain/holochain/pull/1079)
 - **BREAKING (If using new lair)** If you are using the new (non-legacy) `lair_server` keystore, you will need to rebuild your keystore, we now pre-hash the passphrase used to access it to mitigate some information leakage. [#1094](https://github.com/holochain/holochain/pull/1094)

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -497,7 +497,6 @@ impl Cell {
                 // and should reset the publish back off loop to its minimum.
                 self.queue_triggers.publish_dht_ops.reset_back_off();
             }
-
             FetchOpData {
                 span_context: _,
                 respond,


### PR DESCRIPTION
### Summary
Fixes #1100


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
