### PR TITLE
Add `Element::privatized`

### DIFF
--- a/crates/holochain_zome_types/src/element.rs
+++ b/crates/holochain_zome_types/src/element.rs
@@ -71,6 +71,28 @@ impl Element {
         }
     }
 
+    /// If the Element contains private entry data, set the ElementEntry
+    /// to Hidden so that it cannot be leaked
+    pub fn privatized(self) -> Self {
+        let entry = if let Some(EntryVisibility::Private) = self
+            .signed_header
+            .header()
+            .entry_data()
+            .map(|(_, entry_type)| entry_type.visibility())
+        {
+            match self.entry {
+                ElementEntry::Present(_) => ElementEntry::Hidden,
+                other => other,
+            }
+        } else {
+            self.entry
+        };
+        Self {
+            signed_header: self.signed_header,
+            entry,
+        }
+    }
+
     /// Break this element into its components
     pub fn into_inner(self) -> (SignedHeaderHashed, ElementEntry) {
         (self.signed_header, self.entry)


### PR DESCRIPTION
### Summary

An alternate way to fix the private entries leak in #1104

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
