### PR TITLE
remove unused deps to speed up compile times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,19 +1708,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
 dependencies = [
  "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2 1.0.30",
- "quote 1.0.10",
- "syn 1.0.80",
- "synstructure",
 ]
 
 [[package]]
@@ -2014,15 +2001,6 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -2423,7 +2401,6 @@ dependencies = [
  "unwrap_to",
  "url 1.7.2",
  "url2",
- "url_serde",
  "uuid 0.7.4",
  "xsalsa20poly1305",
 ]
@@ -2439,8 +2416,6 @@ dependencies = [
  "fixt",
  "futures",
  "ghost_actor 0.3.0-alpha.4",
- "hdk",
- "hdk_derive",
  "holo_hash",
  "holochain_p2p",
  "holochain_serialized_bytes",
@@ -2504,7 +2479,6 @@ dependencies = [
  "assert_cmd",
  "chrono",
  "futures",
- "holochain_cli_bundle",
  "holochain_conductor_api",
  "holochain_p2p",
  "holochain_types",
@@ -2540,7 +2514,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_yaml",
- "structopt 0.3.23",
  "thiserror",
  "tracing",
  "url2",
@@ -2631,13 +2604,11 @@ dependencies = [
  "chrono",
  "derive_more",
  "either",
- "failure",
  "fallible-iterator",
  "fixt",
  "futures",
  "holo_hash",
  "holochain_serialized_bytes",
- "holochain_util",
  "holochain_zome_types",
  "kitsune_p2p",
  "lazy_static",
@@ -2646,7 +2617,6 @@ dependencies = [
  "num_cpus",
  "observability",
  "once_cell",
- "page_size",
  "parking_lot 0.10.2",
  "pretty_assertions 0.7.2",
  "r2d2",
@@ -2773,7 +2743,6 @@ version = "0.0.4"
 dependencies = [
  "backtrace",
  "cfg-if 0.1.10",
- "derive_more",
  "dunce",
  "futures",
  "num_cpus",
@@ -2861,7 +2830,6 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite 0.13.0",
  "tracing",
- "tracing-futures",
  "tungstenite 0.12.0",
  "unwrap_to",
  "url2",
@@ -3438,7 +3406,6 @@ dependencies = [
  "sysinfo",
  "thiserror",
  "tokio",
- "tokio-stream",
  "tracing-subscriber",
  "url 2.2.2",
  "url2",
@@ -3927,8 +3894,6 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "bytes",
- "derive_more",
- "either",
  "flate2",
  "futures",
  "holochain_util",
@@ -3937,7 +3902,6 @@ dependencies = [
  "reqwest",
  "rmp-serde",
  "serde",
- "serde_bytes",
  "serde_derive",
  "serde_yaml",
  "tempdir",
@@ -4395,16 +4359,6 @@ name = "owning_ref"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d52571ddcb42e9c900c901a18d8d67e393df723fcd51dd59c5b1a85d0acb6cc"
-
-[[package]]
-name = "page_size"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "parking"
@@ -4898,18 +4852,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulldown-cmark"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
-dependencies = [
- "bitflags",
- "getopts",
- "memchr",
- "unicase",
-]
-
-[[package]]
 name = "quanta"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5384,7 +5326,6 @@ dependencies = [
  "env_logger 0.8.4",
  "fancy-regex",
  "git2",
- "holochain_util",
  "indoc",
  "linked-hash-map",
  "linked_hash_set",
@@ -5392,7 +5333,6 @@ dependencies = [
  "once_cell",
  "predicates 1.0.8",
  "prettydiff",
- "pulldown-cmark",
  "regex",
  "rustfix 0.6.0",
  "semver 0.10.0",
@@ -6949,16 +6889,6 @@ checksum = "c89cd13f1de9862d363308f5ffdadcd2b64b2a4a812fb296a80b7d3e80011b1e"
 dependencies = [
  "serde",
  "url 2.2.2",
-]
-
-[[package]]
-name = "url_serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e7d099f1ee52f823d4bdd60c93c3602043c728f5db3b97bdb548467f7bddea"
-dependencies = [
- "serde",
- "url 1.7.2",
 ]
 
 [[package]]

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -20,7 +20,6 @@ ansi_term = "0.12"
 chrono = "0.4.6"
 futures = "0.3"
 lazy_static = "1.4.0"
-holochain_cli_bundle = { path = "../hc_bundle", version = "0.0.12"}
 holochain_conductor_api = { path = "../holochain_conductor_api", version = "0.0.14"}
 holochain_types = { path = "../holochain_types", version = "0.0.14"}
 holochain_websocket = { path = "../holochain_websocket", version = "0.0.14"}

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -62,7 +62,7 @@ strum = "0.18.0"
 tempdir = "0.3.7"
 thiserror = "1.0.22"
 tokio = { version = "1.11", features = [ "full"] }
-tokio-stream = "0.1"
+tokio-stream = { version = "0.1", features = [ "sync", "net" ] }
 holochain_util = { version = "0.0.4", path = "../holochain_util" }
 toml = "0.5.6"
 tracing = "0.1.26"
@@ -70,7 +70,6 @@ tracing-futures = "0.2.5"
 tracing-subscriber = "0.2.19"
 url = "1.7.2"
 url2 = "0.0.6"
-url_serde = "0.2.0"
 uuid = { version = "0.7", features = [ "serde", "v4" ] }
 xsalsa20poly1305 = "0.6.0"
 holochain_wasm_test_utils = { version = "0.0.14", path = "../test_utils/wasm" }
@@ -78,7 +77,6 @@ holochain_wasm_test_utils = { version = "0.0.14", path = "../test_utils/wasm" }
 # Dependencies for test_utils: keep in sync with below
 hdk = { version = "0.0.114", path = "../hdk", optional = true }
 matches = {version = "0.1.8", optional = true }
-holochain_test_wasm_common = { version = "0.0.14", path = "../test_utils/wasm_common", optional = true  }
 unwrap_to = { version = "0.1.0", optional = true }
 itertools = { version = "0.10", optional = false }
 
@@ -134,7 +132,6 @@ test_utils = [
   "kitsune_p2p/test_utils",
   "holochain_p2p/mock_network",
   "matches",
-  "holochain_test_wasm_common",
   "unwrap_to"
 ]
 

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -15,8 +15,6 @@ fallible-iterator = "0.2"
 fixt = { version = "0.0.7", path = "../fixt" }
 futures = "0.3"
 ghost_actor = "=0.3.0-alpha.4"
-hdk = { version = "0.0.114", path = "../hdk" }
-hdk_derive = { version = "0.0.16", path = "../hdk_derive" }
 holo_hash = { version = "0.0.12", path = "../holo_hash", features = ["full"] }
 holochain_sqlite = { version = "0.0.14", path = "../holochain_sqlite" }
 holochain_p2p = { version = "0.0.14", path = "../holochain_p2p" }

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -21,7 +21,6 @@ holochain_zome_types = { version = "0.0.16", path = "../holochain_zome_types" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_yaml = "0.8"
-structopt = "0.3"
 tracing = "0.1.26"
 thiserror = "1.0.22"
 url2 = "0.0.6"

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -19,7 +19,6 @@ chrono = "0.4.6"
 derive_more = "0.99.3"
 either = "1.5.0"
 fallible-iterator = "0.2.0"
-failure = "0.1.6"
 fixt = { version = "0.0.7", path = "../fixt" }
 futures = "0.3.1"
 holo_hash = { path = "../holo_hash", features = ["rusqlite"], version = "0.0.12"}
@@ -31,7 +30,6 @@ once_cell = "1.4.1"
 must_future = "0.1.1"
 nanoid = "0.3.0"
 num_cpus = "1.13.0"
-page_size = "0.4.2"
 parking_lot = "0.10"
 rand = "0.7"
 r2d2 = "0.8"
@@ -45,7 +43,6 @@ shrinkwraprs = "0.3.0"
 tempdir = "0.3.7"
 thiserror = "1.0.22"
 tokio = { version = "1.11", features = [ "macros", "rt-multi-thread", "io-util", "sync" ] }
-holochain_util = { version = "0.0.4", path = "../holochain_util" }
 tracing = "0.1.18"
 tracing-futures = "0.2"
 

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -21,7 +21,6 @@ holochain_serialized_bytes = "=0.0.51"
 holochain_p2p = { version = "0.0.14", path = "../holochain_p2p" }
 holochain_types = { version = "0.0.14", path = "../holochain_types" }
 holochain_util = { version = "0.0.4", path = "../holochain_util" }
-holochain_wasm_test_utils = { path = "../test_utils/wasm", optional = true, version = "0.0.14"}
 holochain_zome_types = { version = "0.0.16", path = "../holochain_zome_types", features = [ "full" ] }
 kitsune_p2p = { version = "0.0.12", path = "../kitsune_p2p/kitsune_p2p" }
 mockall = "0.10.2"
@@ -60,7 +59,6 @@ default = ["test_utils"]
 test_utils = [
     "holochain_types/test_utils",
     "holochain_zome_types/test_utils",
-    "holochain_wasm_test_utils",
     "base64",
     "contrafact",
     "tempdir",

--- a/crates/holochain_util/Cargo.toml
+++ b/crates/holochain_util/Cargo.toml
@@ -15,7 +15,6 @@ num_cpus = "1.8"
 futures = "0.3"
 backtrace = { version = "0.3", optional = true }
 cfg-if = "0.1"
-derive_more = "0.99"
 dunce = "1.0"
 
 [features]

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -23,7 +23,6 @@ tokio = { version = "1", features = [ "full" ] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio-tungstenite = { version = "0.13", features = [ "tls" ] }
 tracing = "0.1"
-tracing-futures = "0.2"
 tungstenite = "0.12"
 url2 = "0.0.6"
 

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -42,7 +42,6 @@ observability = "0.1.3"
 # arbitrary could be made optional
 arbitrary = { version = "1.0", features = ["derive"] }
 
-maplit = { version = "1", optional = true }
 mockall = { version = "0.10.2", optional = true }
 
 [dev-dependencies]
@@ -59,7 +58,6 @@ test_utils = [
   "tokio/test-util",
   "ghost_actor/test_utils",
   "kitsune_p2p_types/test_utils",
-  "maplit",
   "mockall",
   "kitsune_p2p_timestamp/now",
   "kitsune_p2p_timestamp/arbitrary",

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -34,7 +34,6 @@ shrinkwraprs = "0.3.0"
 sysinfo = "0.15.9"
 thiserror = "1.0.22"
 tokio = { version = "1.11", features = [ "full" ] }
-tokio-stream = { version = "0.1", features = [ "sync", "net" ] }
 url = "2"
 url2 = "0.0.6"
 webpki = "0.21.2"

--- a/crates/mr_bundle/Cargo.toml
+++ b/crates/mr_bundle/Cargo.toml
@@ -10,15 +10,12 @@ documentation = "https://docs.rs/mr_bundle"
 
 [dependencies]
 bytes = "1.0"
-derive_more = "0.99"
-either = "1.5"
 flate2 = "1.0"
 holochain_util = { path = "../holochain_util", version = "0.0.4"}
 futures = "0.3"
 reqwest = "0.11"
 rmp-serde = "0.15"
 serde = { version = "1.0", features = [ "serde_derive", "derive" ] }
-serde_bytes = "0.11"
 serde_derive = "1.0"
 thiserror = "1.0"
 

--- a/crates/release-automation/Cargo.toml
+++ b/crates/release-automation/Cargo.toml
@@ -11,7 +11,6 @@ documentation = "https://docs.rs/release-automation"
 comrak = "0.10"
 yaml-rust = "0.4.5"
 structopt = "0.3"
-pulldown-cmark = "0.8"
 bstr = "0.2"
 cargo = "0.53"
 once_cell = "1.7"
@@ -37,13 +36,11 @@ toml_edit = "0.2"
 thiserror = "1"
 regex = "1.5"
 crates_io_api = "0.7"
-holochain_util = { path = "../holochain_util" ,version = "0.0.4"}
 crates-index = "0.16"
 
 # used for the example clippy fix-json
 rustfix = "0.6"
 serde_json = "1.0"
-serde_with = "1.9.4"
 
 [dev-dependencies]
 ctor = "0.1"
@@ -52,3 +49,4 @@ tempfile = "3"
 cargo-test-support = { git = "https://github.com/rust-lang/cargo", branch = "rust-1.53.0" }
 assert_cmd = "1.0"
 predicates = "1.0"
+serde_with = "1.9.4"


### PR DESCRIPTION
Just removes deps that showed up as unused with [cargo-udeps](https://github.com/est31/cargo-udeps). Should speed up compile times a little.
