### PR TITLE
db-refactor-6

### DIFF
--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -4,6 +4,8 @@
 //! where as retrieve only checks that where the data was found
 //! the appropriate validation has been run.
 
+use std::sync::Arc;
+
 use error::CascadeResult;
 use holo_hash::hash_type::AnyDht;
 use holo_hash::AgentPubKey;
@@ -66,20 +68,38 @@ macro_rules! ok_or_return {
 
 #[derive(Clone)]
 pub struct Cascade<Network = HolochainP2pDna> {
-    vault: Option<EnvRead>,
-    cache: Option<EnvWrite>,
+    authored: Option<DbRead<DbKindAuthored>>,
+    dht: Option<DbRead<DbKindDht>>,
+    cache: Option<DbWrite<DbKindCache>>,
     scratch: Option<SyncScratch>,
     network: Option<Network>,
+    private_data: Option<Arc<AgentPubKey>>,
 }
 
 impl<Network> Cascade<Network>
 where
     Network: HolochainP2pDnaT + Clone + 'static + Send,
 {
-    /// Add the vault to the cascade.
-    pub fn with_vault(self, vault: EnvRead) -> Self {
+    /// Add the authored env to the cascade.
+    pub fn with_authored(self, authored: DbRead<DbKindAuthored>) -> Self {
         Self {
-            vault: Some(vault),
+            authored: Some(authored),
+            ..self
+        }
+    }
+
+    /// Add the ability to access private entries for this agent.
+    pub fn with_private_data(self, author: Arc<AgentPubKey>) -> Self {
+        Self {
+            private_data: Some(author),
+            ..self
+        }
+    }
+
+    /// Add the dht env to the cascade.
+    pub fn with_dht(self, dht: DbRead<DbKindDht>) -> Self {
+        Self {
+            dht: Some(dht),
             ..self
         }
     }
@@ -88,7 +108,7 @@ where
     // TODO: We do want to be able to use the cache without
     // the network but we always need a cache when we have a
     // network. Perhaps this can be proven at the type level?
-    pub fn with_cache(self, cache: EnvWrite) -> Self {
+    pub fn with_cache(self, cache: DbWrite<DbKindCache>) -> Self {
         Self {
             cache: Some(cache),
             ..self
@@ -107,11 +127,13 @@ where
     pub fn with_network<N: HolochainP2pDnaT + Clone>(
         self,
         network: N,
-        cache_env: EnvWrite,
+        cache_env: DbWrite<DbKindCache>,
     ) -> Cascade<N> {
         Cascade {
-            vault: self.vault,
+            authored: self.authored,
+            dht: self.dht,
             scratch: self.scratch,
+            private_data: self.private_data,
             cache: Some(cache_env),
             network: Some(network),
         }
@@ -121,40 +143,54 @@ impl Cascade<HolochainP2pDna> {
     /// Constructs an empty [Cascade].
     pub fn empty() -> Self {
         Self {
-            vault: None,
+            authored: None,
+            dht: None,
             network: None,
             cache: None,
             scratch: None,
+            private_data: None,
         }
     }
 
-    pub fn from_workspace_network<N>(workspace: &HostFnWorkspace, network: N) -> Cascade<N>
+    pub fn from_workspace_network<N, AuthorDb, DhtDb>(
+        workspace: &HostFnWorkspace<AuthorDb, DhtDb>,
+        network: N,
+    ) -> Cascade<N>
     where
         N: HolochainP2pDnaT + Clone,
+        AuthorDb: ReadAccess<DbKindAuthored>,
+        DhtDb: ReadAccess<DbKindDht>,
     {
         let HostFnStores {
-            vault,
+            authored,
+            dht,
             cache,
             scratch,
         } = workspace.stores();
+        let private_data = workspace.author();
         Cascade::<N> {
-            vault: Some(vault),
+            authored: Some(authored),
+            dht: Some(dht),
             cache: Some(cache),
-            scratch: Some(scratch),
+            private_data,
+            scratch,
             network: Some(network),
         }
     }
-    pub fn from_workspace(workspace: &HostFnWorkspace) -> Self {
+    pub fn from_workspace(stores: HostFnStores, author: Option<Arc<AgentPubKey>>) -> Self {
         let HostFnStores {
-            vault,
+            authored,
+            dht,
             cache,
             scratch,
-        } = workspace.stores();
+        } = stores;
         Self {
-            vault: Some(vault),
+            authored: Some(authored),
+            dht: Some(dht),
             cache: Some(cache),
-            scratch: Some(scratch),
+            scratch,
             network: None,
+            private_data: author,
         }
     }
 }
@@ -173,7 +209,7 @@ where
         let op_order = OpOrder::new(op_light.get_type(), header.header().timestamp());
         let timestamp = header.header().timestamp();
         insert_header(txn, header)?;
-        insert_op_lite(txn, op_light, op_hash.clone(), false, op_order, timestamp)?;
+        insert_op_lite(txn, op_light, op_hash.clone(), op_order, timestamp)?;
         if let Some(status) = validation_status {
             set_validation_status(txn, op_hash.clone(), status)?;
         }
@@ -276,8 +312,11 @@ where
         if let Some(cache) = &mut self.cache {
             conns.push(cache.conn()?);
         }
-        if let Some(vault) = &mut self.vault {
-            conns.push(vault.conn()?);
+        if let Some(dht) = &mut self.dht {
+            conns.push(dht.conn()?);
+        }
+        if let Some(authored) = &mut self.authored {
+            conns.push(authored.conn()?);
         }
         for conn in &mut conns {
             let txn = conn.transaction().map_err(StateQueryError::from)?;
@@ -307,8 +346,17 @@ where
                 return Ok(r);
             }
         }
-        if let Some(vault) = &mut self.vault {
-            let mut conn = vault.conn()?;
+        if let Some(dht) = &mut self.dht {
+            let mut conn = dht.conn()?;
+            let txn = conn.transaction().map_err(StateQueryError::from)?;
+            let txn = Txn::from(&txn);
+            let r = f(&txn)?;
+            if r.is_some() {
+                return Ok(r);
+            }
+        }
+        if let Some(authored) = &mut self.authored {
+            let mut conn = authored.conn()?;
             let txn = conn.transaction().map_err(StateQueryError::from)?;
             let txn = Txn::from(&txn);
             let r = f(&txn)?;
@@ -332,7 +380,11 @@ where
         hash: EntryHash,
         mut options: NetworkGetOptions,
     ) -> CascadeResult<Option<EntryHashed>> {
-        let result = self.find_map(|store| Ok(store.get_entry(&hash)?))?;
+        let private_data = self.private_data.clone();
+        let result = self.find_map(|store| {
+            Ok(store
+                .get_public_or_authored_entry(&hash, private_data.as_ref().map(|a| a.as_ref()))?)
+        })?;
         if result.is_some() {
             return Ok(result.map(EntryHashed::from_content_sync));
         }
@@ -340,7 +392,11 @@ where
         self.fetch_element(hash.clone().into(), options).await?;
 
         // Check if we have the data now after the network call.
-        let result = self.find_map(|store| Ok(store.get_entry(&hash)?))?;
+        let private_data = self.private_data.clone();
+        let result = self.find_map(|store| {
+            Ok(store
+                .get_public_or_authored_entry(&hash, private_data.as_ref().map(|a| a.as_ref()))?)
+        })?;
         Ok(result.map(EntryHashed::from_content_sync))
     }
 
@@ -370,15 +426,23 @@ where
         hash: AnyDhtHash,
         mut options: NetworkGetOptions,
     ) -> CascadeResult<Option<Element>> {
-        let result = self.find_map(|store| Ok(store.get_element(&hash)?))?;
+        let private_data = self.private_data.clone();
+        let result = self.find_map(|store| {
+            Ok(store
+                .get_public_or_authored_element(&hash, private_data.as_ref().map(|a| a.as_ref()))?)
+        })?;
         if result.is_some() {
             return Ok(result);
         }
         options.request_type = holochain_p2p::event::GetRequest::Pending;
         self.fetch_element(hash.clone(), options).await?;
 
+        let private_data = self.private_data.clone();
         // Check if we have the data now after the network call.
-        let result = self.find_map(|store| Ok(store.get_element(&hash)?))?;
+        let result = self.find_map(|store| {
+            Ok(store
+                .get_public_or_authored_element(&hash, private_data.as_ref().map(|a| a.as_ref()))?)
+        })?;
         Ok(result)
     }
 
@@ -390,7 +454,12 @@ where
     ) -> CascadeResult<Option<EntryDetails>> {
         let authoring = self.am_i_authoring(&entry_hash.clone().into())?;
         let authority = self.am_i_an_authority(entry_hash.clone().into()).await?;
-        let query = GetEntryDetailsQuery::new(entry_hash.clone());
+        let query = match self.private_data.clone() {
+            Some(author) => {
+                GetEntryDetailsQuery::with_private_data_access(entry_hash.clone(), author)
+            }
+            None => GetEntryDetailsQuery::new(entry_hash.clone()),
+        };
 
         // We don't need metadata and only need the content
         // so if we have it locally then we can avoid the network.
@@ -427,7 +496,12 @@ where
     ) -> CascadeResult<Option<ElementDetails>> {
         let authoring = self.am_i_authoring(&header_hash.clone().into())?;
         let authority = self.am_i_an_authority(header_hash.clone().into()).await?;
-        let query = GetElementDetailsQuery::new(header_hash.clone());
+        let query = match self.private_data.clone() {
+            Some(author) => {
+                GetElementDetailsQuery::with_private_data_access(header_hash.clone(), author)
+            }
+            None => GetElementDetailsQuery::new(header_hash.clone()),
+        };
 
         // TODO: we can short circuit if we have any local deletes on a header.
         // Is this bad because we will not go back to the network until our
@@ -472,7 +546,12 @@ where
     ) -> CascadeResult<Option<Element>> {
         let authoring = self.am_i_authoring(&header_hash.clone().into())?;
         let authority = self.am_i_an_authority(header_hash.clone().into()).await?;
-        let query = GetLiveElementQuery::new(header_hash.clone());
+        let query = match self.private_data.clone() {
+            Some(author) => {
+                GetLiveElementQuery::with_private_data_access(header_hash.clone(), author)
+            }
+            None => GetLiveElementQuery::new(header_hash.clone()),
+        };
 
         // TODO: we can short circuit if we have any local deletes on a header.
         // Is this bad because we will not go back to the network until our
@@ -515,7 +594,10 @@ where
     ) -> CascadeResult<Option<Element>> {
         let authoring = self.am_i_authoring(&entry_hash.clone().into())?;
         let authority = self.am_i_an_authority(entry_hash.clone().into()).await?;
-        let query = GetLiveEntryQuery::new(entry_hash.clone());
+        let query = match self.private_data.clone() {
+            Some(author) => GetLiveEntryQuery::with_private_data_access(entry_hash.clone(), author),
+            None => GetLiveEntryQuery::new(entry_hash.clone()),
+        };
 
         // We don't need metadata and only need the content
         // so if we have it locally then we can avoid the network.
@@ -660,7 +742,7 @@ where
                 agent_activity::merge_activities(agent.clone(), &options, results)?;
             merged_response
         } else {
-            match self.vault.clone() {
+            match self.dht.clone() {
                 Some(vault) => {
                     authority::handle_get_agent_activity(
                         vault,
@@ -776,13 +858,6 @@ where
     async fn am_i_an_authority(&mut self, hash: AnyDhtHash) -> CascadeResult<bool> {
         let network = ok_or_return!(self.network.as_mut(), false);
 
-        // Temporary workaround until we remove the need to pass the
-        // author to `authority_for_hash` in the next PR.
-        let env = ok_or_return!(self.vault.as_ref(), false);
-        let author = match env.kind() {
-            DbKind::Cell(id) => id.agent_pubkey().clone(),
-            _ => unreachable!(),
-        };
-        Ok(network.authority_for_hash(author, hash).await?)
+        Ok(network.authority_for_hash(hash).await?)
     }
 }

--- a/crates/holochain_cascade/tests/get_activity.rs
+++ b/crates/holochain_cascade/tests/get_activity.rs
@@ -1,7 +1,8 @@
 use ghost_actor::dependencies::observability;
 use holochain_cascade::test_utils::*;
 use holochain_cascade::Cascade;
-use holochain_state::prelude::test_cell_env;
+use holochain_state::prelude::test_cache_env;
+use holochain_state::prelude::test_dht_env;
 use holochain_types::activity::*;
 use holochain_zome_types::ChainStatus;
 use pretty_assertions::assert_eq;
@@ -11,8 +12,8 @@ async fn get_activity() {
     observability::test_run().ok();
 
     // Environments
-    let cache = test_cell_env();
-    let authority = test_cell_env();
+    let cache = test_cache_env();
+    let authority = test_dht_env();
 
     // Data
     let td = ActivityTestData::valid_chain_scenario();

--- a/crates/holochain_cascade/tests/get_entry.rs
+++ b/crates/holochain_cascade/tests/get_entry.rs
@@ -6,7 +6,9 @@ use holochain_cascade::Cascade;
 use holochain_p2p::HolochainP2pDnaT;
 use holochain_p2p::MockHolochainP2pDnaT;
 use holochain_state::mutations::insert_op_scratch;
-use holochain_state::prelude::test_cell_env;
+use holochain_state::prelude::test_authored_env;
+use holochain_state::prelude::test_cache_env;
+use holochain_state::prelude::test_dht_env;
 use holochain_state::scratch::Scratch;
 use holochain_zome_types::ChainTopOrdering;
 use holochain_zome_types::Details;
@@ -231,8 +233,8 @@ async fn entry_not_authority_or_authoring() {
     observability::test_run().ok();
 
     // Environments
-    let cache = test_cell_env();
-    let authority = test_cell_env();
+    let cache = test_cache_env();
+    let authority = test_dht_env();
 
     // Data
     let td_entry = EntryTestData::create();
@@ -254,7 +256,7 @@ async fn entry_authoring() {
     observability::test_run().ok();
 
     // Environments
-    let cache = test_cell_env();
+    let cache = test_cache_env();
     let mut scratch = Scratch::new();
     let zome = fixt!(Zome);
 
@@ -279,7 +281,7 @@ async fn entry_authoring() {
     // Network
     // - Not expecting any calls to the network.
     let mut mock = MockHolochainP2pDnaT::new();
-    mock.expect_authority_for_hash().returning(|_, _| Ok(false));
+    mock.expect_authority_for_hash().returning(|_| Ok(false));
     let mock = MockNetwork::new(mock);
 
     // Cascade
@@ -295,8 +297,8 @@ async fn entry_authority() {
     observability::test_run().ok();
 
     // Environments
-    let cache = test_cell_env();
-    let vault = test_cell_env();
+    let cache = test_cache_env();
+    let vault = test_authored_env();
 
     // Data
     let td_entry = EntryTestData::create();
@@ -307,12 +309,12 @@ async fn entry_authority() {
     // Network
     // - Not expecting any calls to the network.
     let mut mock = MockHolochainP2pDnaT::new();
-    mock.expect_authority_for_hash().returning(|_, _| Ok(true));
+    mock.expect_authority_for_hash().returning(|_| Ok(true));
     let mock = MockNetwork::new(mock);
 
     // Cascade
     let mut cascade = Cascade::empty()
-        .with_vault(vault.env().into())
+        .with_authored(vault.env().into())
         .with_network(mock, cache.env());
 
     assert_can_get(&td_entry, &td_element, &mut cascade, GetOptions::latest()).await;
@@ -323,8 +325,8 @@ async fn content_not_authority_or_authoring() {
     observability::test_run().ok();
 
     // Environments
-    let cache = test_cell_env();
-    let vault = test_cell_env();
+    let cache = test_cache_env();
+    let vault = test_authored_env();
 
     // Data
     let td_entry = EntryTestData::create();
@@ -335,12 +337,12 @@ async fn content_not_authority_or_authoring() {
     // Network
     // - Not expecting any calls to the network.
     let mut mock = MockHolochainP2pDnaT::new();
-    mock.expect_authority_for_hash().returning(|_, _| Ok(false));
+    mock.expect_authority_for_hash().returning(|_| Ok(false));
     let mock = MockNetwork::new(mock);
 
     // Cascade
     let mut cascade = Cascade::empty()
-        .with_vault(vault.env().into())
+        .with_authored(vault.env().into())
         .with_network(mock, cache.env());
 
     assert_can_get(&td_entry, &td_element, &mut cascade, GetOptions::content()).await;
@@ -351,7 +353,7 @@ async fn content_authoring() {
     observability::test_run().ok();
 
     // Environments
-    let cache = test_cell_env();
+    let cache = test_cache_env();
     let mut scratch = Scratch::new();
     let zome = fixt!(Zome);
 
@@ -376,7 +378,7 @@ async fn content_authoring() {
     // Network
     // - Not expecting any calls to the network.
     let mut mock = MockHolochainP2pDnaT::new();
-    mock.expect_authority_for_hash().returning(|_, _| Ok(false));
+    mock.expect_authority_for_hash().returning(|_| Ok(false));
     let mock = MockNetwork::new(mock);
 
     // Cascade
@@ -392,8 +394,8 @@ async fn content_authority() {
     observability::test_run().ok();
 
     // Environments
-    let cache = test_cell_env();
-    let vault = test_cell_env();
+    let cache = test_cache_env();
+    let vault = test_authored_env();
 
     // Data
     let td_entry = EntryTestData::create();
@@ -402,12 +404,12 @@ async fn content_authority() {
     // Network
     // - Not expecting any calls to the network.
     let mut mock = MockHolochainP2pDnaT::new();
-    mock.expect_authority_for_hash().returning(|_, _| Ok(true));
+    mock.expect_authority_for_hash().returning(|_| Ok(true));
     let mock = MockNetwork::new(mock);
 
     // Cascade
     let mut cascade = Cascade::empty()
-        .with_vault(vault.env().into())
+        .with_authored(vault.env().into())
         .with_network(mock, cache.env());
 
     assert_is_none(&td_entry, &td_element, &mut cascade, GetOptions::content()).await;
@@ -418,8 +420,8 @@ async fn rejected_ops() {
     observability::test_run().ok();
 
     // Environments
-    let cache = test_cell_env();
-    let authority = test_cell_env();
+    let cache = test_cache_env();
+    let authority = test_dht_env();
 
     // Data
     let td_entry = EntryTestData::create();
@@ -440,8 +442,8 @@ async fn check_can_handle_rejected_ops_in_cache() {
     observability::test_run().ok();
 
     // Environments
-    let cache = test_cell_env();
-    let authority = test_cell_env();
+    let cache = test_cache_env();
+    let authority = test_dht_env();
 
     // Data
     let td_entry = EntryTestData::create();
@@ -484,9 +486,9 @@ async fn test_pending_data_isnt_returned() {
     observability::test_run().ok();
 
     // Environments
-    let cache = test_cell_env();
-    let authority = test_cell_env();
-    let vault = test_cell_env();
+    let cache = test_cache_env();
+    let authority = test_dht_env();
+    let vault = test_authored_env();
 
     // Data
     let td_entry = EntryTestData::create();


### PR DESCRIPTION
- Final changes to cascade to work with space level databases.
- Adds the ability for cascade to get private entries for a given author.

- Depends on #1120 
- Followed by #1122 