### PR TITLE
db-refactor-8

### DIFF
--- a/crates/holochain/src/conductor.rs
+++ b/crates/holochain/src/conductor.rs
@@ -32,6 +32,7 @@ pub mod manager;
 pub mod p2p_agent_store;
 pub mod p2p_metrics;
 pub mod paths;
+pub mod space;
 pub mod state;
 
 pub use cell::error::CellError;

--- a/crates/holochain/src/conductor/api/api_cell.rs
+++ b/crates/holochain/src/conductor/api/api_cell.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use holo_hash::DnaHash;
 use holochain_conductor_api::ZomeCall;
 use holochain_keystore::MetaLairClient;
-use holochain_state::host_fn_workspace::HostFnWorkspace;
+use holochain_state::host_fn_workspace::SourceChainWorkspace;
 use holochain_types::prelude::*;
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::OwnedPermit;
@@ -164,7 +164,7 @@ pub trait CellConductorReadHandleT: Send + Sync {
     async fn call_zome(
         &self,
         call: ZomeCall,
-        workspace_lock: HostFnWorkspace,
+        workspace_lock: SourceChainWorkspace,
     ) -> ConductorApiResult<ZomeCallResult>;
 
     /// Get a zome from this cell's Dna
@@ -180,7 +180,7 @@ impl CellConductorReadHandleT for CellConductorApi {
     async fn call_zome(
         &self,
         call: ZomeCall,
-        workspace_lock: HostFnWorkspace,
+        workspace_lock: SourceChainWorkspace,
     ) -> ConductorApiResult<ZomeCallResult> {
         if self.cell_id == call.cell_id {
             self.conductor_handle

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -7,6 +7,7 @@
 use super::api::ZomeCall;
 use super::interface::SignalBroadcaster;
 use super::manager::ManagedTaskAdd;
+use super::space::Space;
 use crate::conductor::api::CellConductorApi;
 use crate::conductor::api::CellConductorApiT;
 use crate::conductor::cell::error::CellResult;
@@ -20,11 +21,7 @@ use crate::core::ribosome::real_ribosome::RealRibosome;
 use crate::core::ribosome::ZomeCallInvocation;
 use crate::core::workflow::call_zome_workflow;
 use crate::core::workflow::countersigning_workflow::countersigning_success;
-use crate::core::workflow::countersigning_workflow::incoming_countersigning;
-use crate::core::workflow::countersigning_workflow::CountersigningWorkspace;
 use crate::core::workflow::genesis_workflow::genesis_workflow;
-use crate::core::workflow::incoming_dht_ops_workflow::incoming_dht_ops_workflow;
-use crate::core::workflow::incoming_dht_ops_workflow::IncomingOpHashes;
 use crate::core::workflow::initialize_zomes_workflow;
 use crate::core::workflow::CallZomeWorkflowArgs;
 use crate::core::workflow::GenesisWorkflowArgs;
@@ -38,20 +35,18 @@ use hash_type::AnyDht;
 use holo_hash::*;
 use holochain_cascade::authority;
 use holochain_cascade::Cascade;
-use holochain_p2p::dht_arc::ArcInterval;
-use holochain_p2p::dht_arc::DhtArcSet;
 use holochain_serialized_bytes::SerializedBytes;
 use holochain_sqlite::prelude::*;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
+use holochain_state::host_fn_workspace::SourceChainWorkspace;
 use holochain_state::prelude::*;
 use holochain_state::schedule::live_scheduled_fns;
 use holochain_types::prelude::*;
-use kitsune_p2p::event::TimeWindow;
-use observability::OpenSpanExt;
 use rusqlite::OptionalExtension;
 use rusqlite::Transaction;
 use std::hash::Hash;
 use std::hash::Hasher;
+use std::sync::Arc;
 use tokio::sync;
 use tracing::*;
 use tracing_futures::Instrument;
@@ -105,15 +100,11 @@ where
 {
     id: CellId,
     conductor_api: Api,
-    env: EnvWrite,
-    cache: EnvWrite,
+    conductor_handle: ConductorHandle,
+    space: Space,
     holochain_p2p_cell: P2pCell,
     queue_triggers: QueueTriggers,
     init_mutex: tokio::sync::Mutex<()>,
-    /// Countersigning workspace that is shared across this cell.
-    countersigning_workspace: CountersigningWorkspace,
-    /// Incoming op hashes that are queued for processing.
-    incoming_op_hashes: IncomingOpHashes,
 }
 
 impl Cell {
@@ -128,8 +119,7 @@ impl Cell {
     pub async fn create(
         id: CellId,
         conductor_handle: ConductorHandle,
-        env: EnvWrite,
-        cache: EnvWrite,
+        space: Space,
         holochain_p2p_cell: holochain_p2p::HolochainP2pDna,
         managed_task_add_sender: sync::mpsc::Sender<ManagedTaskAdd>,
         managed_task_stop_broadcaster: sync::broadcast::Sender<()>,
@@ -139,21 +129,18 @@ impl Cell {
         // check if genesis has been run
         let has_genesis = {
             // check if genesis ran.
-            GenesisWorkspace::new(env.clone())?.has_genesis(id.agent_pubkey())?
+            GenesisWorkspace::new(space.authored_env.clone(), space.dht_env.clone())?
+                .has_genesis(id.agent_pubkey())?
         };
 
         if has_genesis {
-            let incoming_op_hashes = IncomingOpHashes::default();
-            let countersigning_workspace = CountersigningWorkspace::new();
             let (queue_triggers, initial_queue_triggers) = spawn_queue_consumer_tasks(
-                env.clone(),
-                cache.clone(),
+                id.clone(),
                 holochain_p2p_cell.clone(),
+                &space,
                 conductor_handle.clone(),
-                conductor_api.clone(),
                 managed_task_add_sender,
                 managed_task_stop_broadcaster,
-                countersigning_workspace.clone(),
             )
             .await;
 
@@ -161,13 +148,11 @@ impl Cell {
                 Self {
                     id,
                     conductor_api,
-                    env,
-                    cache,
+                    conductor_handle,
+                    space,
                     holochain_p2p_cell,
                     queue_triggers,
                     init_mutex: Default::default(),
-                    countersigning_workspace,
-                    incoming_op_hashes,
                 },
                 initial_queue_triggers,
             ))
@@ -182,7 +167,8 @@ impl Cell {
     pub async fn genesis<Ribosome>(
         id: CellId,
         conductor_handle: ConductorHandle,
-        cell_env: EnvWrite,
+        authored_env: DbWrite<DbKindAuthored>,
+        dht_env: DbWrite<DbKindDht>,
         ribosome: Ribosome,
         membrane_proof: Option<SerializedBytes>,
     ) -> CellResult<()>
@@ -194,10 +180,10 @@ impl Cell {
             .get_dna(id.dna_hash())
             .ok_or_else(|| DnaError::DnaMissing(id.dna_hash().to_owned()))?;
 
-        let conductor_api = CellConductorApi::new(conductor_handle, id.clone());
+        let conductor_api = CellConductorApi::new(conductor_handle.clone(), id.clone());
 
         // run genesis
-        let workspace = GenesisWorkspace::new(cell_env.clone())
+        let workspace = GenesisWorkspace::new(authored_env, dht_env)
             .map_err(ConductorApiError::from)
             .map_err(Box::new)?;
 
@@ -213,6 +199,13 @@ impl Cell {
             .map_err(Box::new)
             .map_err(ConductorApiError::from)
             .map_err(Box::new)?;
+
+        if let Some(trigger) = conductor_handle
+            .get_queue_consumer_workflows()
+            .integration_trigger(Arc::new(id.dna_hash().clone()))
+        {
+            trigger.trigger();
+        }
         Ok(())
     }
 
@@ -240,25 +233,31 @@ impl Cell {
     }
 
     pub(super) async fn delete_all_ephemeral_scheduled_fns(self: Arc<Self>) -> CellResult<()> {
+        let author = self.id.agent_pubkey().clone();
         Ok(self
-            .env
-            .async_commit(move |txn: &mut Transaction| delete_all_ephemeral_scheduled_fns(txn))
+            .space
+            .authored_env
+            .async_commit(move |txn: &mut Transaction| {
+                delete_all_ephemeral_scheduled_fns(txn, &author)
+            })
             .await?)
     }
 
     pub(super) async fn dispatch_scheduled_fns(self: Arc<Self>) {
         let now = Timestamp::now();
+        let author = self.id.agent_pubkey().clone();
         let lives = self
-            .env
+            .space
+            .authored_env
             .async_commit(move |txn: &mut Transaction| {
                 // Rescheduling should not fail as the data in the database
                 // should be valid schedules only.
-                reschedule_expired(txn, now)?;
-                let lives = live_scheduled_fns(txn, now);
+                reschedule_expired(txn, now, &author)?;
+                let lives = live_scheduled_fns(txn, now, &author);
                 // We know what to run so we can delete the ephemerals.
                 if lives.is_ok() {
                     // Failing to delete should rollback this attempt.
-                    delete_live_ephemeral_scheduled_fns(txn, now)?;
+                    delete_live_ephemeral_scheduled_fns(txn, now, &author)?;
                 }
                 lives
             })
@@ -294,9 +293,11 @@ impl Cell {
                 let results: Vec<CellResult<ZomeCallResult>> =
                     futures::future::join_all(tasks).await;
 
+                let author = self.id.agent_pubkey().clone();
                 // We don't do anything with errors in here.
                 let _ = self
-                    .env
+                    .space
+                    .authored_env
                     .async_commit(move |txn: &mut Transaction| {
                         for ((scheduled_fn, _), result) in lives.iter().zip(results.iter()) {
                             match result {
@@ -316,6 +317,7 @@ impl Cell {
                                     // For example if a zome returns a bad cron.
                                     if let Err(e) = schedule_fn(
                                         txn,
+                                        &author,
                                         scheduled_fn.clone(),
                                         Some(next_schedule),
                                         now,
@@ -349,7 +351,9 @@ impl Cell {
             | QueryOpHashes { .. }
             | QueryAgentInfoSignedNearBasis { .. }
             | QueryPeerDensity { .. }
+            | Publish { .. }
             | PutMetricDatum { .. }
+            | FetchOpData { .. }
             | QueryMetrics { .. } => {
                 // These events are aggregated over a set of cells, so need to be handled at the conductor level.
                 unreachable!()
@@ -372,25 +376,6 @@ impl Cell {
                     respond.respond(Ok(async move { res }.boxed().into()));
                 }
                 .instrument(debug_span!("call_remote"))
-                .await;
-            }
-            Publish {
-                span_context,
-                respond,
-                request_validation_receipt,
-                countersigning_session,
-                ops,
-                ..
-            } => {
-                async {
-                    tracing::Span::set_current_context(span_context);
-                    let res = self
-                        .handle_publish(request_validation_receipt, countersigning_session, ops)
-                        .await
-                        .map_err(holochain_p2p::HolochainP2pError::other);
-                    respond.respond(Ok(async move { res }.boxed().into()));
-                }
-                .instrument(debug_span!("cell_handle_publish"))
                 .await;
             }
             GetValidationPackage {
@@ -497,23 +482,6 @@ impl Cell {
                 // and should reset the publish back off loop to its minimum.
                 self.queue_triggers.publish_dht_ops.reset_back_off();
             }
-
-            FetchOpData {
-                span_context: _,
-                respond,
-                op_hashes,
-                ..
-            } => {
-                async {
-                    let res = self
-                        .handle_fetch_op_data(op_hashes)
-                        .await
-                        .map_err(holochain_p2p::HolochainP2pError::other);
-                    respond.respond(Ok(async move { res }.boxed().into()));
-                }
-                .instrument(debug_span!("cell_handle_fetch_op_data"))
-                .await;
-            }
             SignNetworkData {
                 span_context: _,
                 respond,
@@ -548,41 +516,6 @@ impl Cell {
         Ok(())
     }
 
-    #[instrument(skip(self, request_validation_receipt, ops))]
-    /// we are receiving a "publish" event from the network
-    async fn handle_publish(
-        &self,
-        request_validation_receipt: bool,
-        countersigning_session: bool,
-        ops: Vec<(holo_hash::DhtOpHash, holochain_types::dht_op::DhtOp)>,
-    ) -> CellResult<()> {
-        // If this is a countersigning session then
-        // send it to the countersigning workflow otherwise
-        // send it to the incoming ops workflow.
-        if countersigning_session {
-            incoming_countersigning(
-                ops,
-                &self.countersigning_workspace,
-                self.queue_triggers.countersigning.clone(),
-            )
-            .map_err(Box::new)
-            .map_err(ConductorApiError::from)
-            .map_err(Box::new)?;
-        } else {
-            incoming_dht_ops_workflow(
-                &self.env,
-                Some(&self.incoming_op_hashes),
-                self.queue_triggers.sys_validation.clone(),
-                ops,
-                request_validation_receipt,
-            )
-            .await
-            .map_err(Box::new)
-            .map_err(ConductorApiError::from)
-            .map_err(Box::new)?;
-        }
-        Ok(())
-    }
     #[instrument(skip(self, signed_headers))]
     /// we are receiving a response from a countersigning authority
     async fn handle_countersigning_authority_response(
@@ -590,11 +523,12 @@ impl Cell {
         signed_headers: Vec<SignedHeader>,
     ) -> CellResult<()> {
         Ok(countersigning_success(
-            self.env.clone(),
+            self.space.authored_env.clone(),
+            self.space.dht_env.clone(),
             &self.holochain_p2p_cell,
             self.id.agent_pubkey().clone(),
             signed_headers,
-            self.queue_triggers.publish_dht_ops.clone(),
+            self.queue_triggers.clone(),
             self.conductor_api.signal_broadcaster().await,
         )
         .await
@@ -608,10 +542,10 @@ impl Cell {
         &self,
         header_hash: HeaderHash,
     ) -> CellResult<ValidationPackageResponse> {
-        let env: EnvRead = self.env.clone().into();
+        let env: DbRead<DbKindDht> = self.dht_env().clone().into();
 
         // Get the header
-        let mut cascade = Cascade::empty().with_vault(env.clone());
+        let mut cascade = Cascade::empty().with_dht(env.clone());
         let header = match cascade
             .retrieve_header(header_hash, Default::default())
             .await?
@@ -626,10 +560,11 @@ impl Cell {
         if header.author() == self.id.agent_pubkey() {
             validation_package::get_as_author(
                 header,
-                env,
-                self.cache.clone(),
+                self.space.authored_env.clone().into(),
+                self.dht_env().clone().into(),
+                self.space.cache.clone(),
                 &ribosome,
-                &self.conductor_api,
+                &(*self.conductor_handle),
                 &self.holochain_p2p_cell,
             )
             .await
@@ -638,7 +573,7 @@ impl Cell {
                 header,
                 env,
                 &ribosome.dna_file,
-                &self.conductor_api,
+                self.conductor_handle.as_ref(),
             )
             .await
         }
@@ -678,7 +613,7 @@ impl Cell {
         hash: EntryHash,
         options: holochain_p2p::event::GetOptions,
     ) -> CellResult<WireEntryOps> {
-        let env = self.env.clone();
+        let env = self.space.dht_env.clone();
         authority::handle_get_entry(env.into(), hash, options)
             .await
             .map_err(Into::into)
@@ -690,7 +625,7 @@ impl Cell {
         hash: HeaderHash,
         options: holochain_p2p::event::GetOptions,
     ) -> CellResult<WireElementOps> {
-        let env = self.env.clone();
+        let env = self.space.dht_env.clone();
         authority::handle_get_element(env.into(), hash, options)
             .await
             .map_err(Into::into)
@@ -717,7 +652,7 @@ impl Cell {
         options: holochain_p2p::event::GetLinksOptions,
     ) -> CellResult<WireLinkOps> {
         debug!(id = ?self.id());
-        let env = self.env.clone();
+        let env = self.space.dht_env.clone();
         authority::handle_get_links(env.into(), link_key, options)
             .await
             .map_err(Into::into)
@@ -730,7 +665,7 @@ impl Cell {
         query: ChainQueryFilter,
         options: holochain_p2p::event::GetActivityOptions,
     ) -> CellResult<AgentActivityResponse<HeaderHash>> {
-        let env = self.env.clone();
+        let env = self.space.dht_env.clone();
         authority::handle_get_agent_activity(env.into(), agent, query, options)
             .await
             .map_err(Into::into)
@@ -740,10 +675,10 @@ impl Cell {
     #[tracing::instrument(skip(self, receipt))]
     async fn handle_validation_receipt(&self, receipt: SerializedBytes) -> CellResult<()> {
         let receipt: SignedValidationReceipt = receipt.try_into()?;
-        tracing::debug!(from = ?receipt.receipt.validator, to = ?self.id.agent_pubkey(), hash = ?receipt.receipt.dht_op_hash);
+        tracing::debug!(from = ?receipt.receipt.validators, to = ?self.id.agent_pubkey(), hash = ?receipt.receipt.dht_op_hash);
 
         // Get the header for this op so we can check the entry type.
-        let header: Option<SignedHeader> = fresh_reader!(self.env, |txn| {
+        let header: Option<SignedHeader> = fresh_reader!(self.space.authored_env, |txn| {
             let h: Option<Vec<u8>> = txn
                 .query_row(
                     "SELECT Header.blob as header_blob
@@ -785,7 +720,8 @@ impl Cell {
             crate::core::workflow::publish_dht_ops_workflow::DEFAULT_RECEIPT_BUNDLE_SIZE,
         );
 
-        self.env
+        self.space
+            .dht_env
             .async_commit(move |txn| {
                 // Get the current count for this dhtop.
                 let receipt_count: usize = txn.query_row(
@@ -807,142 +743,6 @@ impl Cell {
             .await?;
 
         Ok(())
-    }
-
-    #[instrument(skip(self))]
-    /// the network module is requesting a list of dht op hashes
-    /// Get the [`DhtOpHash`]es and authored timestamps for a given time window.
-    pub(super) async fn handle_query_op_hashes(
-        &self,
-        dht_arc_set: DhtArcSet,
-        window: TimeWindow,
-        include_limbo: bool,
-    ) -> CellResult<Vec<(DhtOpHash, Timestamp)>> {
-        let mut results = Vec::new();
-
-        // The exclusive window bounds.
-        let start = window.start;
-        let end = window.end;
-
-        let full = if include_limbo {
-            holochain_sqlite::sql::sql_cell::any::FETCH_OP_HASHES_FULL
-        } else {
-            holochain_sqlite::sql::sql_cell::integrated::FETCH_OP_HASHES_FULL
-        };
-
-        let continuous = if include_limbo {
-            holochain_sqlite::sql::sql_cell::any::FETCH_OP_HASHES_CONTINUOUS
-        } else {
-            holochain_sqlite::sql::sql_cell::integrated::FETCH_OP_HASHES_CONTINUOUS
-        };
-
-        let wrapped = if include_limbo {
-            holochain_sqlite::sql::sql_cell::any::FETCH_OP_HASHES_WRAPPED
-        } else {
-            holochain_sqlite::sql::sql_cell::integrated::FETCH_OP_HASHES_WRAPPED
-        };
-
-        // For each interval in the set, fetch the hashes and timestamps.
-        for interval in dht_arc_set.intervals() {
-            let result = self
-                .env()
-                .async_reader(move |txn| {
-                    DatabaseResult::Ok(match interval {
-                        ArcInterval::Full => txn
-                            .prepare_cached(full)?
-                            .query_map(
-                                named_params! {
-                                    ":from": start,
-                                    ":to": end,
-                                },
-                                |row| Ok((row.get("hash")?, row.get("authored_timestamp")?)),
-                            )?
-                            .collect::<rusqlite::Result<Vec<_>>>()?,
-                        ArcInterval::Bounded(start_loc, end_loc) => {
-                            let sql = if start_loc <= end_loc {
-                                continuous
-                            } else {
-                                wrapped
-                            };
-                            txn.prepare_cached(sql)?
-                                .query_map(
-                                    named_params! {
-                                        ":from": start,
-                                        ":to": end,
-                                        ":storage_start_loc": start_loc,
-                                        ":storage_end_loc": end_loc,
-                                    },
-                                    |row| Ok((row.get("hash")?, row.get("authored_timestamp")?)),
-                                )?
-                                .collect::<rusqlite::Result<Vec<_>>>()?
-                        }
-                        ArcInterval::Empty => Vec::new(),
-                    })
-                })
-                .await?;
-            results.extend(result);
-        }
-        Ok(results)
-    }
-
-    #[instrument(skip(self, op_hashes))]
-    /// The network module is requesting the content for dht ops
-    async fn handle_fetch_op_data(
-        &self,
-        op_hashes: Vec<holo_hash::DhtOpHash>,
-    ) -> CellResult<Vec<(holo_hash::DhtOpHash, holochain_types::dht_op::DhtOp)>> {
-        // FIXME: Test this query.
-        // TODO: SQL_PERF: Really on the fence about this query.
-        // It has the potential to be slow if data density is very high
-        // but this is ideally not the case for most apps so is it
-        // worth everyone paying the cost of asyncifying?
-        let results = self
-            .env()
-            .async_reader(move |txn| {
-                let mut positions = "?,".repeat(op_hashes.len());
-                positions.pop();
-                let sql = format!(
-                    "
-                SELECT DhtOp.hash, DhtOp.type AS dht_type,
-                Header.blob AS header_blob, Entry.blob AS entry_blob
-                FROM DHtOp
-                JOIN Header ON DhtOp.header_hash = Header.hash
-                LEFT JOIN Entry ON Header.entry_hash = Entry.hash
-                WHERE
-                DhtOp.when_integrated IS NOT NULL
-                AND
-                DhtOp.hash in ({})
-                ",
-                    positions
-                );
-                let mut stmt = txn.prepare(&sql)?;
-                let r = stmt
-                    .query_and_then(rusqlite::params_from_iter(op_hashes.into_iter()), |row| {
-                        let header = from_blob::<SignedHeader>(row.get("header_blob")?)?;
-                        let op_type: DhtOpType = row.get("dht_type")?;
-                        let hash: DhtOpHash = row.get("hash")?;
-                        // Check the entry isn't private before gossiping it.
-                        let mut entry: Option<Entry> = None;
-                        if header
-                            .0
-                            .entry_type()
-                            .filter(|et| *et.visibility() == EntryVisibility::Public)
-                            .is_some()
-                        {
-                            let e: Option<Vec<u8>> = row.get("entry_blob")?;
-                            entry = match e {
-                                Some(entry) => Some(from_blob::<Entry>(entry)?),
-                                None => None,
-                            };
-                        }
-                        let op = DhtOp::from_type(op_type, header, entry)?;
-                        StateQueryResult::Ok((hash, op))
-                    })?
-                    .collect::<StateQueryResult<Vec<_>>>()?;
-                StateQueryResult::Ok(r)
-            })
-            .await?;
-        Ok(results)
     }
 
     /// the network module would like this cell/agent to sign some data
@@ -980,38 +780,41 @@ impl Cell {
     pub async fn call_zome(
         &self,
         call: ZomeCall,
-        workspace_lock: Option<HostFnWorkspace>,
+        workspace_lock: Option<SourceChainWorkspace>,
     ) -> CellResult<ZomeCallResult> {
         // Check if init has run if not run it
         self.check_or_run_zome_init().await?;
 
-        let arc = self.env();
-        let keystore = arc.keystore().clone();
+        let keystore = self.conductor_api.keystore().clone();
 
         // If there is no existing zome call then this is the root zome call
         let is_root_zome_call = workspace_lock.is_none();
         let workspace_lock = match workspace_lock {
             Some(l) => l,
             None => {
-                HostFnWorkspace::new(
-                    self.env().clone(),
+                SourceChainWorkspace::new(
+                    self.authored_env().clone(),
+                    self.dht_env().clone(),
                     self.cache().clone(),
+                    keystore.clone(),
                     self.id.agent_pubkey().clone(),
                 )
                 .await?
             }
         };
 
-        let conductor_api = self.conductor_api.clone();
+        let conductor_handle = self.conductor_handle.clone();
         let signal_tx = self.signal_broadcaster().await;
         let ribosome = self.get_ribosome().await?;
-        let invocation = ZomeCallInvocation::from_interface_call(conductor_api.clone(), call).await;
+        let invocation =
+            ZomeCallInvocation::from_interface_call(self.conductor_api.clone(), call).await;
 
         let args = CallZomeWorkflowArgs {
+            cell_id: self.id.clone(),
             ribosome,
             invocation,
             signal_tx,
-            conductor_api,
+            conductor_handle,
             is_root_zome_call,
         };
         Ok(call_zome_workflow(
@@ -1038,14 +841,15 @@ impl Cell {
         .map_err(|_| CellError::InitTimeout)?;
 
         // If not run it
-        let env = self.env.clone();
-        let keystore = env.keystore().clone();
+        let keystore = self.conductor_api.keystore().clone();
         let id = self.id.clone();
-        let conductor_api = self.conductor_api.clone();
+        let conductor_handle = self.conductor_handle.clone();
         // Create the workspace
-        let workspace = HostFnWorkspace::new(
-            self.env().clone(),
+        let workspace = SourceChainWorkspace::new(
+            self.authored_env().clone(),
+            self.dht_env().clone(),
             self.cache().clone(),
+            keystore.clone(),
             id.agent_pubkey().clone(),
         )
         .await?;
@@ -1057,7 +861,7 @@ impl Cell {
         trace!("running init");
 
         // get the dna
-        let dna_file = conductor_api
+        let dna_file = conductor_handle
             .get_dna(id.dna_hash())
             .ok_or_else(|| DnaError::DnaMissing(id.dna_hash().to_owned()))?;
         let dna_def = dna_file.dna_def().clone();
@@ -1069,7 +873,7 @@ impl Cell {
         let args = InitializeZomesWorkflowArgs {
             dna_def,
             ribosome,
-            conductor_api,
+            conductor_handle,
         };
         let init_result =
             initialize_zomes_workflow(workspace, self.holochain_p2p_cell.clone(), keystore, args)
@@ -1110,12 +914,13 @@ impl Cell {
     #[tracing::instrument(skip(self))]
     pub async fn destroy(self) -> CellResult<()> {
         self.cleanup().await?;
-        let path = self.env.path().clone();
-        // Delete directory
-        self.env
-            .remove()
-            .await
-            .map_err(|e| CellError::Cleanup(e.to_string(), path))?;
+        //TODO "This will need to be reference counted if we really want to delete it"
+        // let path = self.authored_env.path().clone();
+        // // Delete directory
+        // self.authored_env
+        //     .remove()
+        //     .await
+        //     .map_err(|e| CellError::Cleanup(e.to_string(), path))?;
         Ok(())
     }
 
@@ -1128,14 +933,19 @@ impl Cell {
         }
     }
 
-    /// Accessor for the database backing this Cell
+    /// Accessor for the authored database backing this Cell
     // TODO: reevaluate once Workflows are fully implemented (after B-01567)
-    pub(crate) fn env(&self) -> &EnvWrite {
-        &self.env
+    pub(crate) fn authored_env(&self) -> &DbWrite<DbKindAuthored> {
+        &self.space.authored_env
     }
 
-    pub(crate) fn cache(&self) -> &EnvWrite {
-        &self.cache
+    /// Accessor for the authored database backing this Cell
+    pub(crate) fn dht_env(&self) -> &DbWrite<DbKindDht> {
+        &self.space.dht_env
+    }
+
+    pub(crate) fn cache(&self) -> &DbWrite<DbKindCache> {
+        &self.space.cache
     }
 
     #[cfg(any(test, feature = "test_utils"))]

--- a/crates/holochain/src/conductor/cell/error.rs
+++ b/crates/holochain/src/conductor/cell/error.rs
@@ -53,6 +53,12 @@ pub enum CellError {
     InitTimeout,
     #[error("Failed to get or create the cache for this dna {0:?}")]
     FailedToCreateCache(Box<ConductorError>),
+    #[error("Failed to get or create the authored db for this dna {0:?}")]
+    FailedToCreateAuthoredDb(Box<ConductorError>),
+    #[error("Failed to get or create the DHT db for this dna {0:?}")]
+    FailedToCreateDhtDb(Box<ConductorError>),
+    #[error("Failed to get or create the dna space {0:?}")]
+    FailedToCreateDnaSpace(Box<ConductorError>),
     #[error(transparent)]
     HolochainP2pError(#[from] HolochainP2pError),
     #[error(transparent)]

--- a/crates/holochain/src/conductor/cell/gossip_test.rs
+++ b/crates/holochain/src/conductor/cell/gossip_test.rs
@@ -46,10 +46,19 @@ async fn gossip_test() {
     const NUM_ATTEMPTS: usize = 200;
     const DELAY_PER_ATTEMPT: std::time::Duration = std::time::Duration::from_millis(100);
 
-    let all_cell_envs = vec![&bob_call_data.env, &conductor_test.alice_call_data().env];
+    let all_cell_envs = vec![
+        (
+            bob_call_data.cell_id.agent_pubkey(),
+            &bob_call_data.authored_env,
+            &bob_call_data.dht_env,
+        ),
+        (
+            conductor_test.alice_call_data().cell_id.agent_pubkey(),
+            &conductor_test.alice_call_data().authored_env,
+            &conductor_test.alice_call_data().dht_env,
+        ),
+    ];
     consistency_envs(&all_cell_envs, NUM_ATTEMPTS, DELAY_PER_ATTEMPT).await;
-
-    dump_tmp(&bob_call_data.env);
 
     // Bob list anchors
     let invocation = new_zome_call(

--- a/crates/holochain/src/conductor/cell/test.rs
+++ b/crates/holochain/src/conductor/cell/test.rs
@@ -1,4 +1,5 @@
 use crate::conductor::manager::spawn_task_manager;
+use crate::conductor::space::TestSpaces;
 use crate::core::ribosome::guest_callback::genesis_self_check::GenesisSelfCheckResult;
 use crate::core::ribosome::MockRibosomeT;
 use crate::core::workflow::incoming_dht_ops_workflow::op_exists;
@@ -6,7 +7,6 @@ use crate::fixt::DnaFileFixturator;
 use crate::test_utils::test_network;
 use ::fixt::prelude::*;
 use holo_hash::HasHash;
-use holochain_state::prelude::*;
 use holochain_state::test_utils::test_keystore;
 use holochain_types::prelude::*;
 use holochain_zome_types::header;
@@ -15,14 +15,17 @@ use tokio::sync;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_cell_handle_publish() {
-    let cell_env = test_cell_env();
-    let cache_env = test_cache_env();
-    let env = cell_env.env();
-    let cache = cache_env.env();
+    let keystore = test_keystore();
 
-    let cell_id = fake_cell_id(1);
+    let agent_key = keystore.new_sign_keypair_random().await.unwrap();
+    let dna_file = fixt!(DnaFile);
+    let cell_id = CellId::new(dna_file.dna_hash().clone(), agent_key);
     let dna = cell_id.dna_hash().clone();
     let agent = cell_id.agent_pubkey().clone();
+
+    let spaces = TestSpaces::new([dna.clone()]);
+    let env = spaces.test_spaces[&dna].space.authored_env.clone();
+    let dht_env = spaces.test_spaces[&dna].space.dht_env.clone();
 
     let test_network = test_network(Some(dna.clone()), Some(agent.clone())).await;
     let holochain_p2p_cell = test_network.dna_network();
@@ -30,7 +33,11 @@ async fn test_cell_handle_publish() {
     let mut mock_handle = crate::conductor::handle::MockConductorHandleT::new();
     mock_handle
         .expect_get_dna()
-        .returning(|_| Some(fixt!(DnaFile)));
+        .return_const(Some(dna_file.clone()));
+    mock_handle
+        .expect_get_queue_consumer_workflows()
+        .return_const(spaces.queue_consumer_map.clone());
+    mock_handle.expect_keystore().return_const(keystore.clone());
 
     let mock_handle: crate::conductor::handle::ConductorHandle = Arc::new(mock_handle);
     let mut mock_ribosome = MockRibosomeT::new();
@@ -42,6 +49,7 @@ async fn test_cell_handle_publish() {
         cell_id.clone(),
         mock_handle.clone(),
         env.clone(),
+        dht_env.clone(),
         mock_ribosome,
         None,
     )
@@ -51,11 +59,10 @@ async fn test_cell_handle_publish() {
     let (add_task_sender, shutdown) = spawn_task_manager(mock_handle.clone());
     let (stop_tx, _) = sync::broadcast::channel(1);
 
-    let (cell, _) = super::Cell::create(
+    let (_cell, _) = super::Cell::create(
         cell_id,
         mock_handle,
-        env.clone(),
-        cache.clone(),
+        spaces.test_spaces[&dna].space.clone(),
         holochain_p2p_cell,
         add_task_sender,
         stop_tx.clone(),
@@ -63,7 +70,6 @@ async fn test_cell_handle_publish() {
     .await
     .unwrap();
 
-    let keystore = test_keystore();
     let header = header::Header::Dna(header::Dna {
         author: agent.clone(),
         timestamp: Timestamp::now().into(),
@@ -74,11 +80,13 @@ async fn test_cell_handle_publish() {
     let op = DhtOp::StoreElement(shh.signature().clone(), header.clone(), None);
     let op_hash = DhtOpHashed::from_content_sync(op.clone()).into_hash();
 
-    cell.handle_publish(true, false, vec![(op_hash.clone(), op.clone())])
+    spaces
+        .spaces
+        .handle_publish(&dna, true, false, vec![(op_hash.clone(), op.clone())])
         .await
         .unwrap();
 
-    op_exists(&cell.env, &op_hash).unwrap();
+    op_exists(&dht_env, &op_hash).unwrap();
 
     stop_tx.send(()).unwrap();
     shutdown.await.unwrap().unwrap();

--- a/crates/holochain/src/conductor/cell/validation_package.rs
+++ b/crates/holochain/src/conductor/cell/validation_package.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::conductor::handle::ConductorHandleT;
 use crate::core::ribosome::guest_callback::validation_package::ValidationPackageResult;
 use crate::core::ribosome::RibosomeT;
 use crate::core::workflow::app_validation_workflow::validation_package::get_as_author_custom;
@@ -6,17 +7,25 @@ use crate::core::workflow::app_validation_workflow::validation_package::get_as_a
 use crate::core::workflow::app_validation_workflow::validation_package::get_as_author_sub_chain;
 use holochain_cascade::Cascade;
 use holochain_p2p::HolochainP2pDna;
-use holochain_state::source_chain::SourceChain;
 use holochain_types::dna::DnaFile;
 use holochain_zome_types::HeaderHashed;
 
-#[instrument(skip(header_hashed, env, cache, ribosome, conductor_api, network))]
+#[instrument(skip(
+    header_hashed,
+    authored_env,
+    dht_env,
+    cache,
+    ribosome,
+    conductor_handle,
+    network
+))]
 pub(super) async fn get_as_author(
     header_hashed: HeaderHashed,
-    env: EnvRead,
-    cache: EnvWrite,
+    authored_env: DbRead<DbKindAuthored>,
+    dht_env: DbRead<DbKindDht>,
+    cache: DbWrite<DbKindCache>,
     ribosome: &impl RibosomeT,
-    conductor_api: &impl CellConductorApiT,
+    conductor_handle: &dyn ConductorHandleT,
     network: &HolochainP2pDna,
 ) -> CellResult<ValidationPackageResponse> {
     let header = header_hashed.as_content();
@@ -24,7 +33,13 @@ pub(super) async fn get_as_author(
     // Get the source chain with public data only
     // TODO: evaluate if we even need to use a source chain here
     // vs directly querying the database.
-    let mut source_chain = SourceChain::new(env.clone().into(), header.author().clone()).await?;
+    let mut source_chain = SourceChainRead::new(
+        authored_env.clone(),
+        dht_env.clone(),
+        conductor_handle.keystore().clone(),
+        header.author().clone(),
+    )
+    .await?;
     source_chain.public_only();
 
     // Get the header data
@@ -42,7 +57,7 @@ pub(super) async fn get_as_author(
         app_entry_type.zome_id(),
         app_entry_type.id(),
         ribosome.dna_def(),
-        conductor_api,
+        conductor_handle,
     )
     .await?;
 
@@ -66,16 +81,18 @@ pub(super) async fn get_as_author(
             Ok(Some(get_as_author_full(header_seq, &source_chain).await?).into())
         }
         RequiredValidationType::Custom => {
-            let cascade = Cascade::empty().with_vault(env.clone());
+            let cascade = Cascade::empty().with_authored(authored_env.clone());
 
             if let Some(elements) = cascade.get_validation_package_local(header_hashed.as_hash())? {
                 return Ok(Some(ValidationPackage::new(elements)).into());
             }
 
             let workspace_lock = HostFnWorkspace::new(
-                env.into(),
+                authored_env.clone(),
+                dht_env,
                 cache,
-                conductor_api.cell_id().agent_pubkey().clone(),
+                conductor_handle.keystore().clone(),
+                Some(header.author().clone()),
             )
             .await?;
             let result =
@@ -119,9 +136,9 @@ pub(super) async fn get_as_author(
 
 pub(super) async fn get_as_authority(
     header: HeaderHashed,
-    env: EnvRead,
+    env: DbRead<DbKindDht>,
     dna_file: &DnaFile,
-    conductor_api: &impl CellConductorApiT,
+    conductor_api: &dyn ConductorHandleT,
 ) -> CellResult<ValidationPackageResponse> {
     // Get author and hash
     let (header, header_hash) = header.into_inner();
@@ -151,7 +168,7 @@ pub(super) async fn get_as_authority(
         None => return Ok(None.into()),
     };
 
-    let cascade = Cascade::empty().with_vault(env.clone());
+    let cascade = Cascade::empty().with_dht(env.clone());
 
     // Gather the package
     match required_validation_type {

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -8,7 +8,8 @@
 //! In normal use cases, a single Holochain user runs a single Conductor in a single process.
 //! However, there's no reason we can't have multiple Conductors in a single process, simulating multiple
 //! users in a testing environment.
-use self::share::RwShare;
+
+pub use self::share::RwShare;
 
 use super::api::RealAppInterfaceApi;
 use super::config::AdminInterfaceConfig;
@@ -28,6 +29,8 @@ use super::manager::ManagedTaskAdd;
 use super::manager::ManagedTaskHandle;
 use super::manager::TaskManagerRunHandle;
 use super::paths::EnvironmentRootPath;
+use super::space::Space;
+use super::space::Spaces;
 use super::state::AppInterfaceId;
 use super::state::ConductorState;
 use super::CellError;
@@ -39,6 +42,7 @@ use crate::conductor::config::ConductorConfig;
 use crate::conductor::error::ConductorResult;
 use crate::conductor::handle::ConductorHandle;
 use crate::core::queue_consumer::InitialQueueTriggers;
+use crate::core::queue_consumer::QueueConsumerMap;
 use crate::core::ribosome::guest_callback::post_commit::PostCommitArgs;
 use crate::core::ribosome::guest_callback::post_commit::POST_COMMIT_CHANNEL_BOUND;
 use crate::core::ribosome::guest_callback::post_commit::POST_COMMIT_CONCURRENT_LIMIT;
@@ -61,7 +65,7 @@ use holochain_keystore::lair_keystore::spawn_new_lair_keystore;
 use holochain_keystore::test_keystore::spawn_legacy_test_keystore;
 use holochain_keystore::test_keystore::spawn_test_keystore;
 use holochain_keystore::MetaLairClient;
-use holochain_sqlite::db::DbKind;
+use holochain_sqlite::conn::DbSyncStrategy;
 use holochain_sqlite::prelude::*;
 use holochain_sqlite::sql::sql_cell::state_dump;
 use holochain_state::mutations;
@@ -71,7 +75,6 @@ use holochain_state::prelude::StateQueryResult;
 use holochain_types::prelude::*;
 use rusqlite::{OptionalExtension, Transaction};
 use std::collections::{HashMap, HashSet};
-use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use tokio::sync::mpsc::error::SendError;
@@ -137,14 +140,13 @@ where
     cells: RwShare<HashMap<CellId, CellItem<CA>>>,
 
     /// The database for persisting state related to this Conductor
-    conductor_env: EnvWrite,
+    conductor_env: DbWrite<DbKindConductor>,
 
     /// A database for storing wasm
-    wasm_env: EnvWrite,
+    wasm_env: DbWrite<DbKindWasm>,
 
-    /// The caches databases. These are shared across cells.
-    /// There is one per unique Dna.
-    caches: RwShare<HashMap<DnaHash, EnvWrite>>,
+    /// The map of dna hash spaces.
+    pub(super) spaces: Spaces,
 
     /// Set to true when `conductor.shutdown()` has been called, so that other
     /// tasks can check on the shutdown status
@@ -174,8 +176,11 @@ where
     /// Handle to the network actor.
     holochain_p2p: holochain_p2p::HolochainP2pRef,
 
-    /// Database sync level
-    db_sync_level: DbSyncLevel,
+    /// Database sync strategy
+    db_sync_level: DbSyncStrategy,
+
+    /// The map of running queue consumer workflows.
+    queue_consumer_map: QueueConsumerMap,
 
     post_commit: tokio::sync::mpsc::Sender<PostCommitArgs>,
 }
@@ -463,6 +468,10 @@ where
         self.dna_store.share_mut(|d| d.add_dna(dna));
     }
 
+    pub(super) fn get_queue_consumer_workflows(&self) -> QueueConsumerMap {
+        self.queue_consumer_map.clone()
+    }
+
     /// Start all app interfaces currently in state.
     /// This should only be run at conductor initialization.
     #[allow(irrefutable_let_patterns)]
@@ -494,23 +503,22 @@ where
         })
     }
 
-    fn get_or_create_cache(&self, dna_hash: &DnaHash) -> ConductorResult<EnvWrite> {
-        let dir = &self.root_env_dir;
-        let keystore = &self.keystore;
-        let db_sync_level = self.db_sync_level;
-        self.caches.share_mut(|caches| match caches.get(dna_hash) {
-            Some(env) => Ok(env.clone()),
-            None => {
-                let env = EnvWrite::open_with_sync_level(
-                    dir.as_ref(),
-                    DbKind::Cache(dna_hash.clone()),
-                    keystore.clone(),
-                    db_sync_level,
-                )?;
-                caches.insert(dna_hash.clone(), env.clone());
-                Ok(env)
-            }
-        })
+    fn get_or_create_space(&self, dna_hash: &DnaHash) -> ConductorResult<Space> {
+        self.spaces.get_or_create_space(dna_hash)
+    }
+
+    pub(super) fn get_or_create_authored_env(
+        &self,
+        dna_hash: &DnaHash,
+    ) -> ConductorResult<DbWrite<DbKindAuthored>> {
+        self.spaces.authored_env(dna_hash)
+    }
+
+    pub(super) fn get_or_create_dht_env(
+        &self,
+        dna_hash: &DnaHash,
+    ) -> ConductorResult<DbWrite<DbKindDht>> {
+        self.spaces.dht_env(dna_hash)
     }
 
     /// Adjust app statuses (via state transitions) to match the current
@@ -622,8 +630,6 @@ where
         conductor_handle: ConductorHandle,
     ) -> ConductorResult<Vec<Result<(Cell, InitialQueueTriggers), (CellId, CellError)>>> {
         // Data required to create apps
-        let root_env_dir = PathBuf::from(self.root_env_dir.clone());
-        let keystore = self.keystore.clone();
         let (managed_task_add_sender, managed_task_stop_broadcaster) =
             self.task_manager.share_ref(|tm| {
                 let tm = tm.as_ref().expect("Task manager not initialized");
@@ -650,34 +656,22 @@ where
         let on_cells: HashSet<CellId> = self.cells.share_ref(|c| c.keys().cloned().collect());
 
         let tasks = app_cells.difference(&on_cells).map(|cell_id| {
-            let root_env_dir = root_env_dir.clone();
-            let keystore = keystore.clone();
             let conductor_handle = conductor_handle.clone();
             let managed_task_add_sender = managed_task_add_sender.clone();
             let managed_task_stop_broadcaster = managed_task_stop_broadcaster.clone();
-            let db_sync_level = self.db_sync_level;
             async move {
                 use holochain_p2p::actor::HolochainP2pRefToDna;
                 let holochain_p2p_cell = self.holochain_p2p.to_dna(cell_id.dna_hash().clone());
 
-                let env = EnvWrite::open_with_sync_level(
-                    &root_env_dir,
-                    DbKind::Cell(cell_id.clone()),
-                    keystore.clone(),
-                    db_sync_level,
-                )
-                .map_err(|err| (cell_id.clone(), err.into()))?;
-
-                let cache = self
-                    .get_or_create_cache(cell_id.dna_hash())
-                    .map_err(|e| CellError::FailedToCreateCache(e.into()))
+                let space = self
+                    .get_or_create_space(cell_id.dna_hash())
+                    .map_err(|e| CellError::FailedToCreateDnaSpace(e.into()))
                     .map_err(|err| (cell_id.clone(), err))?;
 
                 Cell::create(
                     cell_id.clone(),
                     conductor_handle,
-                    env,
-                    cache,
+                    space,
                     holochain_p2p_cell,
                     managed_task_add_sender,
                     managed_task_stop_broadcaster,
@@ -1042,6 +1036,20 @@ where
             .collect())
     }
 
+    pub(super) async fn list_running_apps_for_dna_hash(
+        &self,
+        dna_hash: &DnaHash,
+    ) -> ConductorResult<HashSet<InstalledAppId>> {
+        Ok(self
+            .get_state()
+            .await?
+            .running_apps()
+            .filter(|(_, v)| v.all_cells().any(|i| i.dna_hash() == dna_hash))
+            .map(|(k, _)| k)
+            .cloned()
+            .collect())
+    }
+
     pub(super) fn print_setup(&self) {
         use std::fmt::Write;
         let mut out = String::new();
@@ -1089,36 +1097,42 @@ where
 /// If genesis fails for any cell, this entire function fails, and all other
 /// partial or complete successes are rolled back.
 /// Note this function takes read locks so should not be called from within a read lock.
-pub(super) async fn genesis_cells(
-    root_env_dir: PathBuf,
-    keystore: MetaLairClient,
+pub(super) async fn genesis_cells<DS: DnaStore + 'static>(
+    conductor: &Conductor<DS>,
     cell_ids_with_proofs: Vec<(CellId, Option<MembraneProof>)>,
     conductor_handle: ConductorHandle,
-    db_sync_level: DbSyncLevel,
 ) -> ConductorResult<()> {
-    let cells_tasks = cell_ids_with_proofs
-        .into_iter()
-        .map(|(cell_id, proof)| async {
-            let root_env_dir = root_env_dir.clone();
-            let keystore = keystore.clone();
+    let cells_tasks = cell_ids_with_proofs.into_iter().map(|(cell_id, proof)| {
+        let authored_env = conductor
+            .get_or_create_authored_env(cell_id.dna_hash())
+            .map_err(|e| CellError::FailedToCreateAuthoredDb(e.into()));
+        let dht_env = conductor
+            .get_or_create_dht_env(cell_id.dna_hash())
+            .map_err(|e| CellError::FailedToCreateDhtDb(e.into()));
+        async {
+            let authored_env = authored_env?;
+            let dht_env = dht_env?;
             let conductor_handle = conductor_handle.clone();
             let cell_id_inner = cell_id.clone();
             let ribosome = conductor_handle
                 .get_ribosome(cell_id.dna_hash())
                 .map_err(Box::new)?;
             tokio::spawn(async move {
-                let env = EnvWrite::open_with_sync_level(
-                    &root_env_dir,
-                    DbKind::Cell(cell_id_inner.clone()),
-                    keystore.clone(),
-                    db_sync_level,
-                )?;
-                Cell::genesis(cell_id_inner, conductor_handle, env, ribosome, proof).await
+                Cell::genesis(
+                    cell_id_inner,
+                    conductor_handle,
+                    authored_env,
+                    dht_env,
+                    ribosome,
+                    proof,
+                )
+                .await
             })
             .map_err(CellError::from)
             .and_then(|result| async move { result.map(|_| cell_id) })
             .await
-        });
+        }
+    });
     let (success, errors): (Vec<_>, Vec<_>) = futures::future::join_all(cells_tasks)
         .await
         .into_iter()
@@ -1129,11 +1143,6 @@ pub(super) async fn genesis_cells(
 
     // If there were errors, cleanup and return the errors
     if !errors.is_empty() {
-        for cell_id in success {
-            let db =
-                DbWrite::open_with_sync_level(&root_env_dir, DbKind::Cell(cell_id), db_sync_level)?;
-            db.remove().await?;
-        }
 
         // match needed to avoid Debug requirement on unwrap_err
         let errors = errors
@@ -1152,7 +1161,9 @@ pub(super) async fn genesis_cells(
 }
 
 /// Dump the integration json state.
-pub async fn integration_dump(vault: &EnvRead) -> ConductorApiResult<IntegrationStateDump> {
+pub async fn integration_dump(
+    vault: &DbRead<DbKindDht>,
+) -> ConductorApiResult<IntegrationStateDump> {
     vault
         .async_reader(move |txn| {
             let integrated = txn.query_row(
@@ -1169,11 +1180,8 @@ pub async fn integration_dump(vault: &EnvRead) -> ConductorApiResult<Integration
                 "
                 SELECT count(hash) FROM DhtOp
                 WHERE when_integrated IS NULL
-                AND (
-                    (is_authored = 1 AND validation_stage IS NOT NULL AND validation_stage < 3)
-                    OR
-                    (is_authored = 0 AND (validation_stage IS NULL OR validation_stage < 3))
-                )
+                AND
+                (validation_stage IS NULL OR validation_stage < 3)
                 ",
                 [],
                 |row| row.get(0),
@@ -1190,7 +1198,7 @@ pub async fn integration_dump(vault: &EnvRead) -> ConductorApiResult<Integration
 /// Dump the full integration json state.
 /// Careful! This will return a lot of data.
 pub async fn full_integration_dump(
-    vault: &EnvRead,
+    vault: &DbRead<DbKindDht>,
     dht_ops_cursor: Option<u64>,
 ) -> ConductorApiResult<FullIntegrationStateDump> {
     vault
@@ -1264,19 +1272,24 @@ where
 {
     #[allow(clippy::too_many_arguments)]
     async fn new(
-        env: EnvWrite,
-        wasm_env: EnvWrite,
+        conductor_env: DbWrite<DbKindConductor>,
+        wasm_env: DbWrite<DbKindWasm>,
         dna_store: DS,
         keystore: MetaLairClient,
         root_env_dir: EnvironmentRootPath,
         holochain_p2p: holochain_p2p::HolochainP2pRef,
-        db_sync_level: DbSyncLevel,
+        db_sync_level: DbSyncStrategy,
         post_commit: tokio::sync::mpsc::Sender<PostCommitArgs>,
     ) -> ConductorResult<Self> {
+        let queue_consumer_map = QueueConsumerMap::new();
         Ok(Self {
-            conductor_env: env,
+            conductor_env,
             wasm_env,
-            caches: RwShare::new(HashMap::new()),
+            spaces: Spaces::new(
+                root_env_dir.clone(),
+                db_sync_level,
+                queue_consumer_map.clone(),
+            ),
             cells: RwShare::new(HashMap::new()),
             shutting_down: Arc::new(AtomicBool::new(false)),
             app_interfaces: RwShare::new(HashMap::new()),
@@ -1287,6 +1300,7 @@ where
             root_env_dir,
             holochain_p2p,
             db_sync_level,
+            queue_consumer_map,
             post_commit,
         })
     }
@@ -1368,7 +1382,6 @@ mod builder {
     use crate::conductor::dna_store::RealDnaStore;
     use crate::conductor::handle::DevSettings;
     use crate::conductor::ConductorHandle;
-    use holochain_sqlite::db::DbKind;
     #[cfg(any(test, feature = "test_utils"))]
     use holochain_state::test_utils::TestEnvs;
 
@@ -1476,19 +1489,9 @@ mod builder {
 
             let env_path = self.config.environment_path.clone();
 
-            let environment = EnvWrite::open_with_sync_level(
-                env_path.as_ref(),
-                DbKind::Conductor,
-                keystore.clone(),
-                self.config.db_sync_level,
-            )?;
+            let environment = DbWrite::open(env_path.as_ref(), DbKindConductor)?;
 
-            let wasm_environment = EnvWrite::open_with_sync_level(
-                env_path.as_ref(),
-                DbKind::Wasm,
-                keystore.clone(),
-                self.config.db_sync_level,
-            )?;
+            let wasm_environment = DbWrite::open(env_path.as_ref(), DbKindWasm)?;
 
             #[cfg(any(test, feature = "test_utils"))]
             let state = self.state;
@@ -1522,7 +1525,7 @@ mod builder {
                 keystore,
                 env_path,
                 holochain_p2p,
-                config.db_sync_level,
+                config.db_sync_strategy,
                 post_commit_sender,
             )
             .await?;
@@ -1540,7 +1543,8 @@ mod builder {
                 conductor,
                 keystore,
                 holochain_p2p,
-                db_sync_level: config.db_sync_level,
+                db_sync_strategy: config.db_sync_strategy,
+
                 p2p_env: Arc::new(parking_lot::Mutex::new(HashMap::new())),
                 p2p_batch_senders: Arc::new(parking_lot::Mutex::new(HashMap::new())),
                 p2p_metrics_env: Arc::new(parking_lot::Mutex::new(HashMap::new())),
@@ -1660,7 +1664,7 @@ mod builder {
             envs: &TestEnvs,
             extra_dnas: &[DnaFile],
         ) -> ConductorResult<ConductorHandle> {
-            let keystore = envs.conductor().keystore().clone();
+            let keystore = envs.keystore().clone();
 
             self.config.environment_path = envs.path().to_path_buf().into();
 
@@ -1678,7 +1682,7 @@ mod builder {
                 keystore,
                 self.config.environment_path.clone(),
                 holochain_p2p,
-                self.config.db_sync_level,
+                self.config.db_sync_strategy,
                 post_commit_sender,
             )
             .await?;
@@ -1698,8 +1702,7 @@ mod builder {
                 p2p_env: envs.p2p(),
                 p2p_batch_senders: Arc::new(parking_lot::Mutex::new(HashMap::new())),
                 p2p_metrics_env: envs.p2p_metrics(),
-                db_sync_level: self.config.db_sync_level,
-
+                db_sync_strategy: self.config.db_sync_strategy,
                 #[cfg(any(test, feature = "test_utils"))]
                 dev_settings: parking_lot::RwLock::new(DevSettings::default()),
             });

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -27,7 +27,7 @@ use matches::assert_matches;
 async fn can_update_state() {
     let envs = test_environments();
     let dna_store = MockDnaStore::new();
-    let keystore = envs.conductor().keystore().clone();
+    let keystore = envs.keystore().clone();
     let holochain_p2p = holochain_p2p::stub_network().await;
     let (post_commit_sender, _post_commit_receiver) =
         tokio::sync::mpsc::channel(POST_COMMIT_CHANNEL_BOUND);
@@ -38,7 +38,7 @@ async fn can_update_state() {
         keystore,
         envs.path().to_path_buf().into(),
         holochain_p2p,
-        DbSyncLevel::default(),
+        DbSyncStrategy::default(),
         post_commit_sender,
     )
     .await
@@ -70,7 +70,7 @@ async fn can_update_state() {
 #[tokio::test(flavor = "multi_thread")]
 async fn can_add_clone_cell_to_app() {
     let envs = test_environments();
-    let keystore = envs.conductor().keystore().clone();
+    let keystore = envs.keystore().clone();
     let holochain_p2p = holochain_p2p::stub_network().await;
 
     let agent = fixt!(AgentPubKey);
@@ -87,7 +87,7 @@ async fn can_add_clone_cell_to_app() {
         keystore,
         envs.path().to_path_buf().into(),
         holochain_p2p,
-        DbSyncLevel::default(),
+        DbSyncStrategy::default(),
         post_commit_sender,
     )
     .await
@@ -162,7 +162,7 @@ async fn app_ids_are_unique() {
         environments.keystore().clone(),
         environments.path().to_path_buf().into(),
         holochain_p2p,
-        DbSyncLevel::default(),
+        DbSyncStrategy::default(),
         post_commit_sender,
     )
     .await

--- a/crates/holochain/src/conductor/entry_def_store.rs
+++ b/crates/holochain/src/conductor/entry_def_store.rs
@@ -6,13 +6,14 @@ use crate::core::ribosome::guest_callback::entry_defs::EntryDefsResult;
 use crate::core::ribosome::real_ribosome::RealRibosome;
 use crate::core::ribosome::RibosomeT;
 
-use super::api::CellConductorApiT;
 use error::EntryDefStoreError;
 use error::EntryDefStoreResult;
 use holo_hash::*;
 use holochain_serialized_bytes::prelude::*;
 use holochain_types::prelude::*;
 use std::collections::HashMap;
+
+use super::handle::ConductorHandleT;
 
 pub mod error;
 
@@ -22,7 +23,7 @@ pub(crate) async fn get_entry_def(
     entry_def_index: EntryDefIndex,
     zome: ZomeDef,
     dna_def: &DnaDefHashed,
-    conductor_api: &impl CellConductorApiT,
+    conductor_api: &dyn ConductorHandleT,
 ) -> EntryDefStoreResult<Option<EntryDef>> {
     // Try to get the entry def from the entry def store
     let key = EntryDefBufferKey::new(zome, entry_def_index);
@@ -45,7 +46,7 @@ pub(crate) async fn get_entry_def_from_ids(
     zome_id: ZomeId,
     entry_def_index: EntryDefIndex,
     dna_def: &DnaDefHashed,
-    conductor_api: &impl CellConductorApiT,
+    conductor_api: &dyn ConductorHandleT,
 ) -> EntryDefStoreResult<Option<EntryDef>> {
     match dna_def.zomes.get(zome_id.index()) {
         Some((_, zome)) => {

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -59,6 +59,7 @@ use crate::conductor::p2p_agent_store::query_peer_density;
 use crate::conductor::p2p_agent_store::P2pBatch;
 use crate::conductor::p2p_metrics::put_metric_datum;
 use crate::conductor::p2p_metrics::query_metrics;
+use crate::core::queue_consumer::QueueConsumerMap;
 use crate::core::ribosome::guest_callback::post_commit::PostCommitArgs;
 use crate::core::ribosome::real_ribosome::RealRibosome;
 use crate::core::workflow::ZomeCallResult;
@@ -75,8 +76,8 @@ use holochain_p2p::event::HolochainP2pEvent;
 use holochain_p2p::event::HolochainP2pEvent::*;
 use holochain_p2p::DnaHashExt;
 use holochain_p2p::HolochainP2pDnaT;
-use holochain_sqlite::db::DbKind;
-use holochain_state::host_fn_workspace::HostFnWorkspace;
+use holochain_sqlite::conn::DbSyncStrategy;
+use holochain_state::host_fn_workspace::SourceChainWorkspace;
 use holochain_state::source_chain;
 use holochain_types::prelude::*;
 use kitsune_p2p::agent_store::AgentInfoSigned;
@@ -163,11 +164,14 @@ pub trait ConductorHandleT: Send + Sync {
     async fn call_zome_with_workspace(
         &self,
         invocation: ZomeCall,
-        workspace_lock: HostFnWorkspace,
+        workspace_lock: SourceChainWorkspace,
     ) -> ConductorApiResult<ZomeCallResult>;
 
     /// Get a Websocket port which will
     fn get_arbitrary_admin_websocket_port(&self) -> Option<u16>;
+
+    /// Get the running queue consumer workflows per [`DnaHash`] map.
+    fn get_queue_consumer_workflows(&self) -> QueueConsumerMap;
 
     /// Return the JoinHandle for all managed tasks, which when resolved will
     /// signal that the Conductor has completely shut down.
@@ -277,6 +281,12 @@ pub trait ConductorHandleT: Send + Sync {
         cell_id: &CellId,
     ) -> ConductorResult<HashSet<InstalledAppId>>;
 
+    /// Get the IDs of all active installed Apps which use this Dna
+    async fn list_running_apps_for_required_dna_hash(
+        &self,
+        dna_hash: &DnaHash,
+    ) -> ConductorResult<HashSet<InstalledAppId>>;
+
     /// Dump the cells state
     async fn dump_cell_state(&self, cell_id: &CellId) -> ConductorApiResult<String>;
 
@@ -309,24 +319,25 @@ pub trait ConductorHandleT: Send + Sync {
     /// Print the current setup in a machine readable way.
     fn print_setup(&self);
 
-    /// Retrieve the environment for this cell.
-    fn get_cell_env_readonly(&self, cell_id: &CellId) -> ConductorApiResult<EnvRead>;
-
     /// Manually remove some cells. Should only be used when handling errors in Cells,
     /// allowing individual Cells to be shut down.
     async fn remove_cells(&self, cell_ids: &[CellId]);
 
-    /// Retrieve the environment for this cell. FOR TESTING ONLY.
+    /// Retrieve the authored environment for this dna. FOR TESTING ONLY.
     #[cfg(any(test, feature = "test_utils"))]
-    fn get_cell_env(&self, cell_id: &CellId) -> ConductorApiResult<EnvWrite>;
+    fn get_authored_env(&self, cell_id: &DnaHash) -> ConductorApiResult<DbWrite<DbKindAuthored>>;
+
+    /// Retrieve the dht environment for this dna. FOR TESTING ONLY.
+    #[cfg(any(test, feature = "test_utils"))]
+    fn get_dht_env(&self, cell_id: &DnaHash) -> ConductorApiResult<DbWrite<DbKindDht>>;
 
     /// Retrieve the database for this cell. FOR TESTING ONLY.
     #[cfg(any(test, feature = "test_utils"))]
-    fn get_cache_env(&self, cell_id: &CellId) -> ConductorApiResult<EnvWrite>;
+    fn get_cache_env(&self, cell_id: &CellId) -> ConductorApiResult<DbWrite<DbKindCache>>;
 
     /// Retrieve the database for networking. FOR TESTING ONLY.
     #[cfg(any(test, feature = "test_utils"))]
-    fn get_p2p_env(&self, space: Arc<KitsuneSpace>) -> EnvWrite;
+    fn get_p2p_env(&self, space: Arc<KitsuneSpace>) -> DbWrite<DbKindP2pAgentStore>;
 
     /// Retrieve Senders for triggering workflows. FOR TESTING ONLY.
     #[cfg(any(test, feature = "test_utils"))]
@@ -444,13 +455,15 @@ pub struct ConductorHandleImpl<DS: DnaStore + 'static> {
     pub(super) root_env_dir: EnvironmentRootPath,
 
     /// The database for storing AgentInfoSigned
-    pub(super) p2p_env: Arc<parking_lot::Mutex<HashMap<Arc<KitsuneSpace>, EnvWrite>>>,
+    pub(super) p2p_env:
+        Arc<parking_lot::Mutex<HashMap<Arc<KitsuneSpace>, DbWrite<DbKindP2pAgentStore>>>>,
 
     /// The database for storing p2p MetricDatum(s)
-    pub(super) p2p_metrics_env: Arc<parking_lot::Mutex<HashMap<Arc<KitsuneSpace>, EnvWrite>>>,
+    pub(super) p2p_metrics_env:
+        Arc<parking_lot::Mutex<HashMap<Arc<KitsuneSpace>, DbWrite<DbKindP2pMetrics>>>>,
 
     /// Database sync level
-    pub(super) db_sync_level: DbSyncLevel,
+    pub(super) db_sync_strategy: DbSyncStrategy,
 
     /// The batch sender for writes to the p2p database.
     pub(super) p2p_batch_senders:
@@ -681,17 +694,58 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
             }
             HolochainP2pEvent::CallRemote { .. }
             | CountersigningAuthorityResponse { .. }
-            | Publish { .. }
             | GetValidationPackage { .. }
             | Get { .. }
             | GetMeta { .. }
             | GetLinks { .. }
             | GetAgentActivity { .. }
-            | ValidationReceiptReceived { .. }
-            | FetchOpData { .. } => {
+            | ValidationReceiptReceived { .. } => {
                 let cell_id = CellId::new(event.dna_hash().clone(), event.target_agents().clone());
                 let cell = self.cell_by_id(&cell_id)?;
                 cell.handle_holochain_p2p_event(event).await?;
+            }
+            Publish {
+                dna_hash,
+                respond,
+                request_validation_receipt,
+                countersigning_session,
+                ops,
+                ..
+            } => {
+                async {
+                    let res = self
+                        .conductor
+                        .spaces
+                        .handle_publish(
+                            &dna_hash,
+                            request_validation_receipt,
+                            countersigning_session,
+                            ops,
+                        )
+                        .await
+                        .map_err(holochain_p2p::HolochainP2pError::other);
+                    respond.respond(Ok(async move { res }.boxed().into()));
+                }
+                .instrument(debug_span!("handle_publish"))
+                .await;
+            }
+            FetchOpData {
+                respond,
+                op_hashes,
+                dna_hash,
+                ..
+            } => {
+                async {
+                    let res = self
+                        .conductor
+                        .spaces
+                        .handle_fetch_op_data(&dna_hash, op_hashes)
+                        .await
+                        .map_err(holochain_p2p::HolochainP2pError::other);
+                    respond.respond(Ok(async move { res }.boxed().into()));
+                }
+                .instrument(debug_span!("handle_fetch_op_data"))
+                .await;
             }
 
             // This event does not have a single Cell as a target, so we handle
@@ -700,71 +754,21 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
             //       is meant for a single Cell, i.e. allow batching in general
             HolochainP2pEvent::QueryOpHashes {
                 dna_hash,
-                to_agents,
                 window,
                 max_ops,
                 include_limbo,
+                arc_set,
                 respond,
                 ..
             } => {
-                let mut hashes_and_times = Vec::with_capacity(to_agents.len());
+                let res = self
+                    .conductor
+                    .spaces
+                    .handle_query_op_hashes(&dna_hash, arc_set, window, max_ops, include_limbo)
+                    .await
+                    .map_err(holochain_p2p::HolochainP2pError::other);
 
-                // For each cell collect the hashes and times that fit within the
-                // agents interval and time window.
-                for (agent, arc_set) in to_agents {
-                    let cell_id = CellId::new(dna_hash.clone(), agent);
-                    let cell = self.cell_by_id(&cell_id)?;
-                    match cell
-                        .handle_query_op_hashes(arc_set, window.clone(), include_limbo)
-                        .await
-                    {
-                        Ok(t) => hashes_and_times.extend(t),
-                        Err(e) => {
-                            // If there's an error for any cell we want to fail the whole call.
-                            respond.respond(Ok(async move {
-                                Err(holochain_p2p::HolochainP2pError::other(e))
-                            }
-                            .boxed()
-                            .into()));
-                            return Ok(());
-                        }
-                    }
-                }
-                // Remove any duplicate hashes.
-                // Note vec must be sorted to remove duplicates.
-                hashes_and_times.sort_unstable_by(|a, b| a.0.cmp(&b.0));
-                hashes_and_times.dedup_by(|a, b| a.0 == b.0);
-
-                // Now sort by time so we can take up to max_ops.
-                hashes_and_times.sort_unstable_by_key(|(_, t)| *t);
-
-                // The start time bound if there is one.
-                let start = hashes_and_times.first().map(|(_, t)| *t);
-
-                // The end time bound if there is one.
-                let end = hashes_and_times
-                    .get(max_ops)
-                    .or_else(|| hashes_and_times.last())
-                    .map(|(_, t)| *t);
-
-                // Extract the hashes.
-                let hashes: Vec<_> = hashes_and_times
-                    .into_iter()
-                    .take(max_ops)
-                    .map(|(h, _)| h)
-                    .collect();
-
-                // The range is exclusive so we add one to the end.
-                let range = start.and_then(|s| {
-                    end.map(|e| {
-                        (
-                            hashes,
-                            s..(e.saturating_add(&std::time::Duration::from_millis(1))),
-                        )
-                    })
-                });
-
-                respond.respond(Ok(async move { Ok(range) }.boxed().into()));
+                respond.respond(Ok(async move { res }.boxed().into()));
             }
         }
         Ok(())
@@ -778,7 +782,7 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
     async fn call_zome_with_workspace(
         &self,
         call: ZomeCall,
-        workspace_lock: HostFnWorkspace,
+        workspace_lock: SourceChainWorkspace,
     ) -> ConductorApiResult<ZomeCallResult> {
         debug!(cell_id = ?call.cell_id);
         let cell = self.cell_by_id(&call.cell_id)?;
@@ -791,6 +795,10 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
 
     fn get_arbitrary_admin_websocket_port(&self) -> Option<u16> {
         self.conductor.get_arbitrary_admin_websocket_port()
+    }
+
+    fn get_queue_consumer_workflows(&self) -> QueueConsumerMap {
+        self.conductor.get_queue_consumer_workflows()
     }
 
     fn shutdown(&self) {
@@ -820,18 +828,8 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
         let cell_id = CellId::new(dna_hash, agent_key);
         let cells = vec![(cell_id.clone(), membrane_proof)];
 
-        // Gather the directory and keystore to avoid holding the conductor read lock.
-        let root_env_dir = std::path::PathBuf::from(self.conductor.root_env_dir().clone());
-        let keystore = self.conductor.keystore().clone();
         // Run genesis on cells.
-        crate::conductor::conductor::genesis_cells(
-            root_env_dir,
-            keystore,
-            cells,
-            self.clone(),
-            self.db_sync_level,
-        )
-        .await?;
+        crate::conductor::conductor::genesis_cells(&self.conductor, cells, self.clone()).await?;
 
         let properties = properties.unwrap_or_else(|| ().into());
         let cell_id = self
@@ -850,19 +848,13 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
         installed_app_id: InstalledAppId,
         cell_data: Vec<(InstalledCell, Option<MembraneProof>)>,
     ) -> ConductorResult<()> {
-        // Gather the directory and keystore to avoid holding the conductor read lock.
-        let root_env_dir = std::path::PathBuf::from(self.conductor.root_env_dir().clone());
-        let keystore = self.conductor.keystore().clone();
-
         crate::conductor::conductor::genesis_cells(
-            root_env_dir,
-            keystore,
+            &self.conductor,
             cell_data
                 .iter()
                 .map(|(c, p)| (c.as_id().clone(), p.clone()))
                 .collect(),
             self.clone(),
-            self.db_sync_level,
         )
         .await?;
 
@@ -910,18 +902,8 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
             self.clone().register_dna(dna).await?;
         }
 
-        // Gather the directory and keystore to avoid holding the conductor read lock.
-        let root_env_dir = std::path::PathBuf::from(self.conductor.root_env_dir().clone());
-        let keystore = self.conductor.keystore().clone();
-
-        crate::conductor::conductor::genesis_cells(
-            root_env_dir,
-            keystore,
-            cells_to_create,
-            self.clone(),
-            self.db_sync_level,
-        )
-        .await?;
+        crate::conductor::conductor::genesis_cells(&self.conductor, cells_to_create, self.clone())
+            .await?;
 
         let roles = ops.role_assignments;
         let app = InstalledAppCommon::new(installed_app_id, agent_key, roles);
@@ -1102,9 +1084,19 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
         self.conductor.list_running_apps_for_cell_id(cell_id).await
     }
 
+    async fn list_running_apps_for_required_dna_hash(
+        &self,
+        dna_hash: &DnaHash,
+    ) -> ConductorResult<HashSet<InstalledAppId>> {
+        self.conductor
+            .list_running_apps_for_dna_hash(dna_hash)
+            .await
+    }
+
     async fn dump_cell_state(&self, cell_id: &CellId) -> ConductorApiResult<String> {
         let cell = self.conductor.cell_by_id(cell_id)?;
-        let arc = cell.env();
+        let authored_env = cell.authored_env();
+        let dht_env = cell.dht_env();
         let space = cell_id.dna_hash().to_kitsune();
         let p2p_env = self
             .p2p_env
@@ -1115,12 +1107,13 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
 
         let peer_dump = p2p_agent_store::dump_state(p2p_env.into(), Some(cell_id.clone()))?;
         let source_chain_dump =
-            source_chain::dump_state(arc.clone().into(), cell_id.agent_pubkey().clone()).await?;
+            source_chain::dump_state(authored_env.clone().into(), cell_id.agent_pubkey().clone())
+                .await?;
 
         let out = JsonDump {
             peer_dump,
             source_chain_dump,
-            integration_dump: integration_dump(&arc.clone().into()).await?,
+            integration_dump: integration_dump(&dht_env.clone().into()).await?,
         };
         // Add summary
         let summary = out.to_string();
@@ -1133,8 +1126,10 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
         cell_id: &CellId,
         dht_ops_cursor: Option<u64>,
     ) -> ConductorApiResult<FullStateDump> {
-        let cell = self.conductor.cell_by_id(cell_id)?;
-        let arc = cell.env();
+        let authored_env = self
+            .conductor
+            .get_or_create_authored_env(cell_id.dna_hash())?;
+        let dht_env = self.conductor.get_or_create_dht_env(cell_id.dna_hash())?;
         let space = cell_id.dna_hash().to_kitsune();
         let p2p_env = self
             .p2p_env
@@ -1145,12 +1140,12 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
 
         let peer_dump = p2p_agent_store::dump_state(p2p_env.into(), Some(cell_id.clone()))?;
         let source_chain_dump =
-            source_chain::dump_state(arc.clone().into(), cell_id.agent_pubkey().clone()).await?;
+            source_chain::dump_state(authored_env.into(), cell_id.agent_pubkey().clone()).await?;
 
         let out = FullStateDump {
             peer_dump,
             source_chain_dump,
-            integration_dump: full_integration_dump(&arc.clone().into(), dht_ops_cursor).await?,
+            integration_dump: full_integration_dump(&dht_env, dht_ops_cursor).await?,
         };
         Ok(out)
     }
@@ -1215,29 +1210,28 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
         self.conductor.print_setup()
     }
 
-    fn get_cell_env_readonly(&self, cell_id: &CellId) -> ConductorApiResult<EnvRead> {
-        let cell = self.cell_by_id(cell_id)?;
-        Ok(cell.env().clone().into())
-    }
-
     async fn remove_cells(&self, cell_ids: &[CellId]) {
         self.conductor.remove_cells(cell_ids.to_vec()).await
     }
 
     #[cfg(any(test, feature = "test_utils"))]
-    fn get_cell_env(&self, cell_id: &CellId) -> ConductorApiResult<EnvWrite> {
-        let cell = self.cell_by_id(cell_id)?;
-        Ok(cell.env().clone())
+    fn get_authored_env(&self, dna_hash: &DnaHash) -> ConductorApiResult<DbWrite<DbKindAuthored>> {
+        Ok(self.conductor.get_or_create_authored_env(dna_hash)?)
     }
 
     #[cfg(any(test, feature = "test_utils"))]
-    fn get_cache_env(&self, cell_id: &CellId) -> ConductorApiResult<EnvWrite> {
+    fn get_dht_env(&self, dna_hash: &DnaHash) -> ConductorApiResult<DbWrite<DbKindDht>> {
+        Ok(self.conductor.get_or_create_dht_env(dna_hash)?)
+    }
+
+    #[cfg(any(test, feature = "test_utils"))]
+    fn get_cache_env(&self, cell_id: &CellId) -> ConductorApiResult<DbWrite<DbKindCache>> {
         let cell = self.cell_by_id(cell_id)?;
         Ok(cell.cache().clone())
     }
 
     #[cfg(any(test, feature = "test_utils"))]
-    fn get_p2p_env(&self, space: Arc<KitsuneSpace>) -> EnvWrite {
+    fn get_p2p_env(&self, space: Arc<KitsuneSpace>) -> DbWrite<DbKindP2pAgentStore> {
         self.p2p_env(space)
     }
 
@@ -1434,19 +1428,20 @@ impl<DS: DnaStore + 'static> ConductorHandleImpl<DS> {
         cell_ids
     }
 
-    pub(super) fn p2p_env(&self, space: Arc<KitsuneSpace>) -> EnvWrite {
+    pub(super) fn p2p_env(&self, space: Arc<KitsuneSpace>) -> DbWrite<DbKindP2pAgentStore> {
         let mut p2p_env = self.p2p_env.lock();
-        let db_sync_level = self.db_sync_level;
+        let db_sync_strategy = self.db_sync_strategy;
         p2p_env
             .entry(space.clone())
             .or_insert_with(move || {
                 let root_env_dir = self.root_env_dir.as_ref();
-                let keystore = self.keystore.clone();
-                EnvWrite::open_with_sync_level(
+                DbWrite::open_with_sync_level(
                     root_env_dir,
-                    DbKind::P2pAgentStore(space),
-                    keystore,
-                    db_sync_level,
+                    DbKindP2pAgentStore(space),
+                    match db_sync_strategy {
+                        DbSyncStrategy::Fast => DbSyncLevel::Off,
+                        DbSyncStrategy::Resilient => DbSyncLevel::Normal,
+                    },
                 )
                 .expect("failed to open p2p_agent_store database")
             })
@@ -1469,19 +1464,20 @@ impl<DS: DnaStore + 'static> ConductorHandleImpl<DS> {
             .clone()
     }
 
-    pub(super) fn p2p_metrics_env(&self, space: Arc<KitsuneSpace>) -> EnvWrite {
+    pub(super) fn p2p_metrics_env(&self, space: Arc<KitsuneSpace>) -> DbWrite<DbKindP2pMetrics> {
         let mut p2p_metrics_env = self.p2p_metrics_env.lock();
-        let db_sync_level = self.db_sync_level;
+        let db_sync_strategy = self.db_sync_strategy;
         p2p_metrics_env
             .entry(space.clone())
             .or_insert_with(move || {
                 let root_env_dir = self.root_env_dir.as_ref();
-                let keystore = self.keystore.clone();
-                EnvWrite::open_with_sync_level(
+                DbWrite::open_with_sync_level(
                     root_env_dir,
-                    DbKind::P2pMetrics(space),
-                    keystore,
-                    db_sync_level,
+                    DbKindP2pMetrics(space),
+                    match db_sync_strategy {
+                        DbSyncStrategy::Fast => DbSyncLevel::Off,
+                        DbSyncStrategy::Resilient => DbSyncLevel::Normal,
+                    },
                 )
                 .expect("failed to open p2p_metrics database")
             })

--- a/crates/holochain/src/conductor/manager/mod.rs
+++ b/crates/holochain/src/conductor/manager/mod.rs
@@ -12,6 +12,7 @@ use futures::stream::FuturesUnordered;
 use holochain_types::prelude::*;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
 use tokio::sync::broadcast;
@@ -42,6 +43,9 @@ pub enum TaskKind {
     /// If the task returns an error, "freeze" the cell which caused the error,
     /// but continue running the rest of the conductor and other managed tasks.
     CellCritical(CellId),
+    /// If the task returns an error, "freeze" all cells with this dna hash,
+    /// but continue running the rest of the conductor and other managed tasks.
+    DnaCritical(Arc<DnaHash>),
     /// A generic callback for handling the result
     // TODO: B-01455: reevaluate whether this should be a callback
     Generic(OnDeath),
@@ -77,6 +81,11 @@ impl ManagedTaskAdd {
     /// If this task fails, only the Cell which it runs under must be stopped
     pub fn cell_critical(handle: ManagedTaskHandle, cell_id: CellId, name: &str) -> Self {
         Self::new(handle, TaskKind::CellCritical(cell_id), name)
+    }
+
+    /// If this task fails, only the Cells with this DnaHash must be stopped
+    pub fn dna_critical(handle: ManagedTaskHandle, dna_hash: Arc<DnaHash>, name: &str) -> Self {
+        Self::new(handle, TaskKind::DnaCritical(dna_hash), name)
     }
 
     /// Handle a task's completion with a generic callback
@@ -120,6 +129,9 @@ pub enum TaskOutcome {
     /// Either pause or disable all apps which contain the problematic Cell,
     /// depending upon the specific error.
     StopApps(CellId, Box<ManagedTaskError>, String),
+    /// Either pause or disable all apps which contain the problematic Dna,
+    /// depending upon the specific error.
+    StopAppsWithDna(Arc<DnaHash>, Box<ManagedTaskError>, String),
 }
 
 struct TaskManager {
@@ -230,6 +242,45 @@ async fn run(
                         tracing::error!("Apps disabled.");
                     }
                 },
+                Some(TaskOutcome::StopAppsWithDna(dna_hash, error, context)) => {
+                    tracing::error!("About to automatically stop apps with dna {}", dna_hash);
+                    let app_ids = conductor.list_running_apps_for_required_dna_hash(dna_hash.as_ref()).await.map_err(TaskManagerError::internal)?;
+                    if error.is_recoverable() {
+                        let cells_with_same_dna: Vec<_> = conductor.list_cell_ids(None).into_iter().filter(|id| id.dna_hash() == dna_hash.as_ref()).collect();
+                        conductor.remove_cells(&cells_with_same_dna).await;
+
+                        // The following message assumes that only the app_ids calculated will be paused, but other apps
+                        // may have been paused as well.
+                        tracing::error!(
+                            "PAUSING the following apps due to a recoverable error: {:?}\nError: {:?}\nContext: {}",
+                            app_ids,
+                            error,
+                            context
+                        );
+
+                        // TODO: it could be helpful to modify this function so that when providing Some(app_ids),
+                        //   you can also pass in a PausedAppReason override, so that the reason for the apps being paused
+                        //   can be set to the specific error message encountered here, rather than having to read it from
+                        //   the logs.
+                        let delta = conductor.reconcile_app_status_with_cell_status(None).await.map_err(TaskManagerError::internal)?;
+                        tracing::debug!(delta = ?delta);
+
+                        tracing::error!("Apps paused.");
+                    } else {
+                        // Since the error is unrecoverable, we don't expect to be able to use this Cell anymore.
+                        // Therefore, we disable every app which requires that cell.
+                        tracing::error!(
+                            "DISABLING the following apps due to an unrecoverable error: {:?}\nError: {:?}\nContext: {}",
+                            app_ids,
+                            error,
+                            context
+                        );
+                        for app_id in app_ids.iter() {
+                            conductor.clone().disable_app(app_id.to_string(), DisabledAppReason::Error(error.to_string())).await.map_err(TaskManagerError::internal)?;
+                        }
+                        tracing::error!("Apps disabled.");
+                    }
+                },
                 None => return Ok(()),
             }}
         };
@@ -251,6 +302,10 @@ fn handle_completed_task(kind: &TaskKind, result: ManagedTaskResult, name: Strin
         TaskKind::CellCritical(cell_id) => match result {
             Ok(_) => LogInfo(name),
             Err(err) => StopApps(cell_id.to_owned(), Box::new(err), name),
+        },
+        TaskKind::DnaCritical(dna_hash) => match result {
+            Ok(_) => LogInfo(name),
+            Err(err) => StopAppsWithDna(dna_hash.to_owned(), Box::new(err), name),
         },
         TaskKind::Generic(f) => f(result),
     }

--- a/crates/holochain/src/conductor/p2p_metrics.rs
+++ b/crates/holochain/src/conductor/p2p_metrics.rs
@@ -11,7 +11,7 @@ use std::time::SystemTime;
 
 /// Record a p2p metric datum
 pub async fn put_metric_datum(
-    env: EnvWrite,
+    env: DbWrite<DbKindP2pMetrics>,
     agent: AgentPubKey,
     metric: MetricKind,
     timestamp: SystemTime,
@@ -25,7 +25,7 @@ pub async fn put_metric_datum(
 
 /// Query the p2p_metrics database in a variety of ways
 pub async fn query_metrics(
-    env: EnvWrite,
+    env: DbWrite<DbKindP2pMetrics>,
     query: MetricQuery,
 ) -> ConductorResult<MetricQueryAnswer> {
     Ok(env

--- a/crates/holochain/src/fixt.rs
+++ b/crates/holochain/src/fixt.rs
@@ -35,6 +35,7 @@ use holo_hash::WasmHash;
 use holochain_keystore::MetaLairClient;
 use holochain_p2p::HolochainP2pDnaFixturator;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
+use holochain_state::host_fn_workspace::HostFnWorkspaceRead;
 use holochain_state::test_utils::test_keystore;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
@@ -238,32 +239,72 @@ fixturator!(
 fixturator!(
     HostFnWorkspace;
     curve Empty {
-        let vault = holochain_state::test_utils::test_cell_env_with_id(get_fixt_index!() as u8);
-        let cache = holochain_state::test_utils::test_cell_env();
+        let authored_env = holochain_state::test_utils::test_authored_env_with_id(get_fixt_index!() as u8);
+        let dht_env = holochain_state::test_utils::test_dht_env_with_id(get_fixt_index!() as u8);
+        let cache = holochain_state::test_utils::test_cache_env();
+        let keystore = holochain_state::test_utils::test_keystore();
         tokio_helper::block_forever_on(async {
-            fake_genesis(vault.env()).await.unwrap();
-            HostFnWorkspace::new(vault.env(), cache.env(), fixt!(AgentPubKey, Predictable, get_fixt_index!())).await.unwrap()
+            fake_genesis(authored_env.env(), dht_env.env(), keystore.clone()).await.unwrap();
+            HostFnWorkspace::new(authored_env.env(), dht_env.env(), cache.env(), keystore, Some(fixt!(AgentPubKey, Predictable, get_fixt_index!()))).await.unwrap()
         })
     };
     curve Unpredictable {
-        let vault = holochain_state::test_utils::test_cell_env_with_id(get_fixt_index!() as u8);
-        let cache = holochain_state::test_utils::test_cell_env();
+        let authored_env = holochain_state::test_utils::test_authored_env_with_id(get_fixt_index!() as u8);
+        let dht_env = holochain_state::test_utils::test_dht_env_with_id(get_fixt_index!() as u8);
+        let cache = holochain_state::test_utils::test_cache_env();
+        let keystore = holochain_state::test_utils::test_keystore();
         tokio_helper::block_forever_on(async {
-            fake_genesis(vault.env()).await.unwrap();
-            HostFnWorkspace::new(vault.env(), cache.env(), fixt!(AgentPubKey, Predictable, get_fixt_index!())).await.unwrap()
+            fake_genesis(authored_env.env(), dht_env.env(), keystore.clone()).await.unwrap();
+            HostFnWorkspace::new(authored_env.env(), dht_env.env(), cache.env(), keystore, Some(fixt!(AgentPubKey, Predictable, get_fixt_index!()))).await.unwrap()
         })
     };
     curve Predictable {
-        let vault = holochain_state::test_utils::test_cell_env_with_id(get_fixt_index!() as u8);
+        let authored_env = holochain_state::test_utils::test_authored_env_with_id(get_fixt_index!() as u8);
+        let dht_env = holochain_state::test_utils::test_dht_env_with_id(get_fixt_index!() as u8);
         let cache = holochain_state::test_utils::test_cache_env_with_id(get_fixt_index!() as u8);
         let agent = fixt!(AgentPubKey, Predictable, get_fixt_index!());
+        let keystore = holochain_state::test_utils::test_keystore();
         tokio_helper::block_forever_on(async {
-            crate::test_utils::fake_genesis_for_agent(vault.env(), agent.clone()).await.unwrap();
-            HostFnWorkspace::new(vault.env(), cache.env(), agent).await.unwrap()
+            crate::test_utils::fake_genesis_for_agent(authored_env.env(), dht_env.env(), agent.clone(), keystore.clone()).await.unwrap();
+            HostFnWorkspace::new(authored_env.env(), dht_env.env(), cache.env(), keystore, Some(agent)).await.unwrap()
         })
     };
 );
 
+fixturator!(
+    HostFnWorkspaceRead;
+    curve Empty {
+        let authored_env = holochain_state::test_utils::test_authored_env_with_id(get_fixt_index!() as u8);
+        let dht_env = holochain_state::test_utils::test_dht_env_with_id(get_fixt_index!() as u8);
+        let cache = holochain_state::test_utils::test_cache_env();
+        let keystore = holochain_state::test_utils::test_keystore();
+        tokio_helper::block_forever_on(async {
+            fake_genesis(authored_env.env(), dht_env.env(), keystore.clone()).await.unwrap();
+            HostFnWorkspaceRead::new(authored_env.env().into(), dht_env.env().into(), cache.env(), keystore, Some(fixt!(AgentPubKey, Predictable, get_fixt_index!()))).await.unwrap()
+        })
+    };
+    curve Unpredictable {
+        let authored_env = holochain_state::test_utils::test_authored_env_with_id(get_fixt_index!() as u8);
+        let dht_env = holochain_state::test_utils::test_dht_env_with_id(get_fixt_index!() as u8);
+        let cache = holochain_state::test_utils::test_cache_env();
+        let keystore = holochain_state::test_utils::test_keystore();
+        tokio_helper::block_forever_on(async {
+            fake_genesis(authored_env.env(), dht_env.env(), keystore.clone()).await.unwrap();
+            HostFnWorkspaceRead::new(authored_env.env().into(), dht_env.env().into(), cache.env(), keystore, Some(fixt!(AgentPubKey, Predictable, get_fixt_index!()))).await.unwrap()
+        })
+    };
+    curve Predictable {
+        let authored_env = holochain_state::test_utils::test_authored_env_with_id(get_fixt_index!() as u8);
+        let dht_env = holochain_state::test_utils::test_dht_env_with_id(get_fixt_index!() as u8);
+        let cache = holochain_state::test_utils::test_cache_env_with_id(get_fixt_index!() as u8);
+        let agent = fixt!(AgentPubKey, Predictable, get_fixt_index!());
+        let keystore = holochain_state::test_utils::test_keystore();
+        tokio_helper::block_forever_on(async {
+            crate::test_utils::fake_genesis_for_agent(authored_env.env(), dht_env.env(), agent.clone(), keystore.clone()).await.unwrap();
+            HostFnWorkspaceRead::new(authored_env.env().into(), dht_env.env().into(), cache.env(), keystore, Some(agent)).await.unwrap()
+        })
+    };
+);
 fn make_call_zome_handle(cell_id: CellId) -> CellConductorReadHandle {
     let handle = Arc::new(MockConductorHandleT::new());
     let cell_conductor_api = CellConductorApi::new(handle, cell_id);

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -448,13 +448,13 @@ async fn check_gossip(
 
     let mut others = Vec::with_capacity(all_handles.len());
     for other in all_handles {
-        let other = other.get_cell_env(&other.cell_id).unwrap();
+        let other = other.get_dht_env(other.cell_id.dna_hash()).unwrap().into();
         others.push(other);
     }
     let others_ref = others.iter().collect::<Vec<_>>();
 
     wait_for_integration_with_others(
-        &handle.get_cell_env(&handle.cell_id).unwrap(),
+        &handle.get_dht_env(handle.cell_id.dna_hash()).unwrap(),
         &others_ref,
         expected_count,
         NUM_ATTEMPTS,
@@ -478,7 +478,7 @@ async fn check_gossip(
 }
 
 #[tracing::instrument(skip(envs))]
-fn check_peers(envs: Vec<EnvWrite>) {
+fn check_peers(envs: Vec<DbWrite<DbKindP2pAgentStore>>) {
     for (i, a) in envs.iter().enumerate() {
         let peers = all_agent_infos(a.clone().into()).unwrap();
         let num_peers = peers.len();

--- a/crates/holochain/src/sweettest/sweet_cell.rs
+++ b/crates/holochain/src/sweettest/sweet_cell.rs
@@ -1,13 +1,15 @@
 use super::SweetZome;
 use hdk::prelude::*;
 use holo_hash::DnaHash;
-use holochain_types::env::EnvWrite;
+use holochain_sqlite::db::{DbKindAuthored, DbKindDht};
+use holochain_types::env::DbWrite;
 /// A reference to a Cell created by a SweetConductor installation function.
 /// It has very concise methods for calling a zome on this cell
 #[derive(Clone, derive_more::Constructor)]
 pub struct SweetCell {
     pub(super) cell_id: CellId,
-    pub(super) cell_env: EnvWrite,
+    pub(super) cell_authored_env: DbWrite<DbKindAuthored>,
+    pub(super) cell_dht_env: DbWrite<DbKindDht>,
 }
 
 impl SweetCell {
@@ -16,9 +18,14 @@ impl SweetCell {
         &self.cell_id
     }
 
-    /// Get the environment for this cell
-    pub fn env(&self) -> &EnvWrite {
-        &self.cell_env
+    /// Get the authored environment for this cell
+    pub fn authored_env(&self) -> &DbWrite<DbKindAuthored> {
+        &self.cell_authored_env
+    }
+
+    /// Get the dht environment for this cell
+    pub fn dht_env(&self) -> &DbWrite<DbKindDht> {
+        &self.cell_dht_env
     }
 
     /// Accessor for AgentPubKey


### PR DESCRIPTION
- Changes to cell to allow space level databases.
- Some functions are moved to the `space.rs` file as they don't make sense at the cell level any more.

- Depends on #1122 
- Followed by #1126 