### PR TITLE
db-refactor-11

### DIFF
--- a/crates/holochain/src/core/ribosome/guest_callback/validate.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validate.rs
@@ -7,7 +7,7 @@ use derive_more::Constructor;
 use holo_hash::AnyDhtHash;
 use holochain_p2p::HolochainP2pDna;
 use holochain_serialized_bytes::prelude::*;
-use holochain_state::host_fn_workspace::HostFnWorkspace;
+use holochain_state::host_fn_workspace::HostFnWorkspaceRead;
 use holochain_types::prelude::*;
 use std::sync::Arc;
 
@@ -29,7 +29,7 @@ pub struct ValidateInvocation {
 
 #[derive(Clone, Constructor)]
 pub struct ValidateHostAccess {
-    pub workspace: HostFnWorkspace,
+    pub workspace: HostFnWorkspaceRead,
     pub network: HolochainP2pDna,
 }
 
@@ -383,7 +383,15 @@ mod slow_tests {
 
         // the chain head should be the committed entry header
         let chain_head = tokio_helper::block_forever_on(async move {
-            SourceChainResult::Ok(host_access.workspace.source_chain().chain_head()?.0)
+            SourceChainResult::Ok(
+                host_access
+                    .workspace
+                    .source_chain()
+                    .as_ref()
+                    .unwrap()
+                    .chain_head()?
+                    .0,
+            )
         })
         .unwrap();
 
@@ -400,7 +408,15 @@ mod slow_tests {
 
         // the chain head should be the committed entry header
         let chain_head = tokio_helper::block_forever_on(async move {
-            SourceChainResult::Ok(host_access.workspace.source_chain().chain_head()?.0)
+            SourceChainResult::Ok(
+                host_access
+                    .workspace
+                    .source_chain()
+                    .as_ref()
+                    .unwrap()
+                    .chain_head()?
+                    .0,
+            )
         })
         .unwrap();
 

--- a/crates/holochain/src/core/ribosome/guest_callback/validate_link.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validate_link.rs
@@ -7,7 +7,7 @@ use derive_more::Constructor;
 use holo_hash::AnyDhtHash;
 use holochain_p2p::HolochainP2pDna;
 use holochain_serialized_bytes::prelude::*;
-use holochain_state::host_fn_workspace::HostFnWorkspace;
+use holochain_state::host_fn_workspace::HostFnWorkspaceRead;
 use holochain_types::prelude::*;
 use std::sync::Arc;
 
@@ -76,7 +76,7 @@ impl From<ValidateDeleteLinkInvocation> for ValidateDeleteLinkData {
 }
 #[derive(Clone, Constructor)]
 pub struct ValidateLinkHostAccess {
-    pub workspace: HostFnWorkspace,
+    pub workspace: HostFnWorkspaceRead,
     pub network: HolochainP2pDna,
 }
 
@@ -369,7 +369,15 @@ mod slow_tests {
 
         // the chain head should be the committed entry header
         let chain_head = tokio_helper::block_forever_on(async move {
-            SourceChainResult::Ok(host_access.workspace.source_chain().chain_head()?.0)
+            SourceChainResult::Ok(
+                host_access
+                    .workspace
+                    .source_chain()
+                    .as_ref()
+                    .unwrap()
+                    .chain_head()?
+                    .0,
+            )
         })
         .unwrap();
 
@@ -386,7 +394,15 @@ mod slow_tests {
 
         // the chain head should be the committed entry header
         let chain_head = tokio_helper::block_forever_on(async move {
-            SourceChainResult::Ok(host_access.workspace.source_chain().chain_head()?.0)
+            SourceChainResult::Ok(
+                host_access
+                    .workspace
+                    .source_chain()
+                    .as_ref()
+                    .unwrap()
+                    .chain_head()?
+                    .0,
+            )
         })
         .unwrap();
 

--- a/crates/holochain/src/core/ribosome/guest_callback/validation_package.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validation_package.rs
@@ -7,7 +7,7 @@ use derive_more::Constructor;
 use holo_hash::AnyDhtHash;
 use holochain_p2p::HolochainP2pDna;
 use holochain_serialized_bytes::prelude::*;
-use holochain_state::host_fn_workspace::HostFnWorkspace;
+use holochain_state::host_fn_workspace::HostFnWorkspaceRead;
 use holochain_types::prelude::*;
 
 #[derive(Clone)]
@@ -27,7 +27,7 @@ impl ValidationPackageInvocation {
 
 #[derive(Clone, Constructor)]
 pub struct ValidationPackageHostAccess {
-    pub workspace: HostFnWorkspace,
+    pub workspace: HostFnWorkspaceRead,
     pub network: HolochainP2pDna,
 }
 

--- a/crates/holochain/src/core/ribosome/host_fn/agent_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/agent_info.rs
@@ -1,9 +1,9 @@
 use crate::core::ribosome::CallContext;
+use crate::core::ribosome::HostFnAccess;
 use crate::core::ribosome::RibosomeT;
 use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::WasmError;
 use std::sync::Arc;
-use crate::core::ribosome::HostFnAccess;
 
 #[allow(clippy::extra_unused_lifetimes)]
 pub fn agent_info<'a>(
@@ -12,11 +12,16 @@ pub fn agent_info<'a>(
     _input: (),
 ) -> Result<AgentInfo, WasmError> {
     match HostFnAccess::from(&call_context.host_context()) {
-        HostFnAccess{ agent_info: Permission::Allow, .. } => {
+        HostFnAccess {
+            agent_info: Permission::Allow,
+            ..
+        } => {
             let agent_pubkey = call_context
                 .host_context
                 .workspace()
                 .source_chain()
+                .as_ref()
+                .expect("Must have source chain if agent_info access is given")
                 .agent_pubkey()
                 .clone();
             Ok(AgentInfo {
@@ -26,9 +31,12 @@ pub fn agent_info<'a>(
                     .host_context
                     .workspace()
                     .source_chain()
-                    .chain_head().map_err(|e| WasmError::Host(e.to_string()))?
+                    .as_ref()
+                    .expect("Must have source chain if agent_info access is given")
+                    .chain_head()
+                    .map_err(|e| WasmError::Host(e.to_string()))?,
             })
-        },
+        }
         _ => unreachable!(),
     }
 }
@@ -38,19 +46,19 @@ pub fn agent_info<'a>(
 pub mod test {
     use ::fixt::prelude::*;
 
+    use crate::conductor::ConductorBuilder;
+    use crate::sweettest::SweetConductor;
+    use crate::sweettest::SweetDnaFile;
     use holochain_types::prelude::*;
     use holochain_types::test_utils::fake_agent_pubkey_1;
     use holochain_wasm_test_utils::TestWasm;
-    use crate::sweettest::SweetDnaFile;
-    use crate::sweettest::SweetConductor;
-    use crate::conductor::ConductorBuilder;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn agent_info_test() {
         observability::test_run().ok();
         let (dna_file, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::AgentInfo])
-        .await
-        .unwrap();
+            .await
+            .unwrap();
 
         let alice_pubkey = fixt!(AgentPubKey, Predictable, 0);
         let bob_pubkey = fixt!(AgentPubKey, Predictable, 1);
@@ -66,54 +74,33 @@ pub mod test {
             .expect_get_entry_def()
             .return_const(EntryDef::default_with_id("thing"));
 
-        let mut conductor = SweetConductor::from_builder(ConductorBuilder::with_mock_dna_store(dna_store)).await;
+        let mut conductor =
+            SweetConductor::from_builder(ConductorBuilder::with_mock_dna_store(dna_store)).await;
 
         let apps = conductor
-        .setup_app_for_agents(
-            "app-",
-            &[alice_pubkey.clone(), bob_pubkey.clone()],
-            &[dna_file.into()],
-        )
-        .await
-        .unwrap();
+            .setup_app_for_agents(
+                "app-",
+                &[alice_pubkey.clone(), bob_pubkey.clone()],
+                &[dna_file.into()],
+            )
+            .await
+            .unwrap();
 
         let ((alice,), (bobbo,)) = apps.into_tuples();
         let alice = alice.zome(TestWasm::AgentInfo);
         let _bobbo = bobbo.zome(TestWasm::AgentInfo);
 
-        let call_info: CallInfo = conductor.call(
-            &alice,
-            "call_info",
-            ()
-        ).await;
-        let agent_info: AgentInfo = conductor.call(
-            &alice,
-            "agent_info",
-            ()
-        ).await;
+        let call_info: CallInfo = conductor.call(&alice, "call_info", ()).await;
+        let agent_info: AgentInfo = conductor.call(&alice, "agent_info", ()).await;
         assert_eq!(agent_info.agent_initial_pubkey, fake_agent_pubkey_1(),);
         assert_eq!(agent_info.agent_latest_pubkey, fake_agent_pubkey_1(),);
 
-        assert_eq!(
-            agent_info.chain_head.1,
-            call_info.as_at.1 + 1,
-        );
+        assert_eq!(agent_info.chain_head.1, call_info.as_at.1 + 1,);
 
-        let call_info_1: CallInfo = conductor.call(
-            &alice,
-            "call_info",
-            ()
-        ).await;
-        let agent_info_1: AgentInfo = conductor.call(
-            &alice,
-            "agent_info",
-            ()
-        ).await;
+        let call_info_1: CallInfo = conductor.call(&alice, "call_info", ()).await;
+        let agent_info_1: AgentInfo = conductor.call(&alice, "agent_info", ()).await;
         dbg!(&agent_info_1);
         dbg!(&call_info_1);
-        assert_eq!(
-            agent_info_1.chain_head.1,
-            call_info_1.as_at.1 + 1,
-        );
+        assert_eq!(agent_info_1.chain_head.1, call_info_1.as_at.1 + 1,);
     }
 }

--- a/crates/holochain/src/core/ribosome/host_fn/call.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call.rs
@@ -1,11 +1,11 @@
 use crate::core::ribosome::CallContext;
+use crate::core::ribosome::HostFnAccess;
 use crate::core::ribosome::RibosomeT;
 use crate::core::ribosome::ZomeCall;
+use futures::future::join_all;
 use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::WasmError;
 use std::sync::Arc;
-use crate::core::ribosome::HostFnAccess;
-use futures::future::join_all;
 
 pub fn call(
     _ribosome: Arc<impl RibosomeT>,
@@ -13,10 +13,13 @@ pub fn call(
     inputs: Vec<Call>,
 ) -> Result<Vec<ZomeCallResponse>, WasmError> {
     match HostFnAccess::from(&call_context.host_context()) {
-        HostFnAccess{ write_workspace: Permission::Allow, .. } => {
-            let results: Vec<Result<Result<ZomeCallResponse, _>, _>> = tokio_helper::block_forever_on(async move {
-                join_all(inputs.into_iter().map(|input| {
-                    async {
+        HostFnAccess {
+            write_workspace: Permission::Allow,
+            ..
+        } => {
+            let results: Vec<Result<Result<ZomeCallResponse, _>, _>> =
+                tokio_helper::block_forever_on(async move {
+                    join_all(inputs.into_iter().map(|input| async {
                         let Call {
                             to_cell,
                             zome_name,
@@ -25,7 +28,13 @@ pub fn call(
                             payload,
                             provenance,
                         } = input;
-                        let cell_id = to_cell.unwrap_or_else(|| call_context.host_context().call_zome_handle().cell_id().clone());
+                        let cell_id = to_cell.unwrap_or_else(|| {
+                            call_context
+                                .host_context()
+                                .call_zome_handle()
+                                .cell_id()
+                                .clone()
+                        });
                         let invocation = ZomeCall {
                             cell_id,
                             zome_name,
@@ -34,22 +43,36 @@ pub fn call(
                             cap_secret,
                             provenance,
                         };
-                        call_context.host_context().call_zome_handle().call_zome(
-                            invocation,
-                            call_context.host_context().workspace().clone()
-                        ).await
+                        call_context
+                            .host_context()
+                            .call_zome_handle()
+                            .call_zome(
+                                invocation,
+                                call_context
+                                    .host_context()
+                                    .workspace_write()
+                                    .clone()
+                                    .try_into()
+                                    .expect("Must have source chain to make zome call"),
+                            )
+                            .await
+                    }))
+                    .await
+                });
+            let results: Result<Vec<_>, _> = results
+                .into_iter()
+                .map(|result| match result {
+                    Ok(v) => match v {
+                        Ok(v) => Ok(v),
+                        Err(ribosome_error) => Err(WasmError::Host(ribosome_error.to_string())),
+                    },
+                    Err(conductor_api_error) => {
+                        Err(WasmError::Host(conductor_api_error.to_string()))
                     }
-                })).await
-            });
-            let results: Result<Vec<_>, _> = results.into_iter().map(|result| match result {
-                Ok(v) => match v {
-                    Ok(v) => Ok(v),
-                    Err(ribosome_error) => Err(WasmError::Host(ribosome_error.to_string())),
-                },
-                Err(conductor_api_error) => Err(WasmError::Host(conductor_api_error.to_string())),
-            }).collect();
+                })
+                .collect();
             Ok(results?)
-        },
+        }
         _ => unreachable!(),
     }
 }
@@ -160,9 +183,9 @@ pub mod wasm_test {
                 .unwrap();
 
         // Check alice's source chain contains the new value
-        let has_hash: bool = fresh_reader_test(alice_call_data.env.clone(), |txn| {
+        let has_hash: bool = fresh_reader_test(alice_call_data.authored_env.clone(), |txn| {
             txn.query_row(
-                "SELECT EXISTS(SELECT 1 FROM DhtOp WHERE header_hash = :hash AND is_authored = 1)",
+                "SELECT EXISTS(SELECT 1 FROM DhtOp WHERE header_hash = :hash)",
                 named_params! {
                     ":hash": header_hash
                 },
@@ -209,9 +232,9 @@ pub mod wasm_test {
                 .unwrap();
 
         // Check alice's source chain contains the new value
-        let has_hash: bool = fresh_reader_test(alice_call_data.env.clone(), |txn| {
+        let has_hash: bool = fresh_reader_test(alice_call_data.authored_env.clone(), |txn| {
             txn.query_row(
-                "SELECT EXISTS(SELECT 1 FROM DhtOp WHERE header_hash = :hash AND is_authored = 1)",
+                "SELECT EXISTS(SELECT 1 FROM DhtOp WHERE header_hash = :hash)",
                 named_params! {
                     ":hash": header_hash
                 },

--- a/crates/holochain/src/core/ribosome/host_fn/call_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call_info.rs
@@ -1,10 +1,10 @@
 use crate::core::ribosome::CallContext;
+use crate::core::ribosome::InvocationAuth;
 use crate::core::ribosome::RibosomeT;
-use std::sync::Arc;
+use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::WasmError;
 use holochain_zome_types::info::CallInfo;
-use holochain_types::prelude::*;
-use crate::core::ribosome::InvocationAuth;
+use std::sync::Arc;
 
 pub fn call_info(
     _ribosome: Arc<impl RibosomeT>,
@@ -12,7 +12,10 @@ pub fn call_info(
     _input: (),
 ) -> Result<CallInfo, WasmError> {
     match HostFnAccess::from(&call_context.host_context()) {
-        HostFnAccess{ bindings: Permission::Allow, .. } => {
+        HostFnAccess {
+            bindings: Permission::Allow,
+            ..
+        } => {
             let (provenance, cap_grant) = {
                 match call_context.auth() {
                     InvocationAuth::Cap(provenance, cap_secret) => {
@@ -20,6 +23,8 @@ pub fn call_info(
                             .host_context
                             .workspace()
                             .source_chain()
+                            .as_ref()
+                            .expect("Must have source chain if bindings access is given")
                             .valid_cap_grant(
                                 &(call_context.zome.zome_name().clone(), call_context.function_name().clone()),
                                 &provenance,
@@ -31,9 +36,16 @@ pub fn call_info(
                             // The host must NEVER allow this so `None` is a critical bug.
                             .expect("The host is using an unauthorized cap_secret, which should never happen");
                         (provenance, cap_grant)
-                    },
+                    }
                     InvocationAuth::LocalCallback => {
-                        let author = call_context.host_context.workspace().source_chain().agent_pubkey().clone();
+                        let author = call_context
+                            .host_context
+                            .workspace()
+                            .source_chain()
+                            .as_ref()
+                            .expect("Must have source chain if bindings access is given")
+                            .agent_pubkey()
+                            .clone();
                         (author.clone(), CapGrant::ChainAuthor(author))
                     }
                 }
@@ -44,11 +56,13 @@ pub fn call_info(
                     .host_context
                     .workspace()
                     .source_chain()
+                    .as_ref()
+                    .expect("Must have source chain if bindings access is given")
                     .persisted_chain_head(),
                 provenance,
                 cap_grant,
             })
-        },
+        }
         _ => unreachable!(),
     }
 }
@@ -56,14 +70,14 @@ pub fn call_info(
 #[cfg(test)]
 #[cfg(feature = "slow_tests")]
 pub mod test {
+    use crate::conductor::ConductorBuilder;
+    use crate::core::ribosome::MockDnaStore;
     use crate::fixt::ZomeCallHostAccessFixturator;
+    use crate::sweettest::SweetConductor;
+    use crate::sweettest::SweetDnaFile;
     use ::fixt::prelude::*;
     use holochain_wasm_test_utils::TestWasm;
     use holochain_zome_types::prelude::*;
-    use crate::sweettest::SweetDnaFile;
-    use crate::core::ribosome::MockDnaStore;
-    use crate::sweettest::SweetConductor;
-    use crate::conductor::ConductorBuilder;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn invoke_import_call_info_test() {
@@ -77,8 +91,8 @@ pub mod test {
     async fn call_info_provenance_test() {
         observability::test_run().ok();
         let (dna_file, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::ZomeInfo])
-        .await
-        .unwrap();
+            .await
+            .unwrap();
 
         let alice_pubkey = fixt!(AgentPubKey, Predictable, 0);
         let bob_pubkey = fixt!(AgentPubKey, Predictable, 1);
@@ -94,7 +108,8 @@ pub mod test {
             .expect_get_entry_def()
             .return_const(EntryDef::default_with_id("thing"));
 
-        let mut conductor = SweetConductor::from_builder(ConductorBuilder::with_mock_dna_store(dna_store)).await;
+        let mut conductor =
+            SweetConductor::from_builder(ConductorBuilder::with_mock_dna_store(dna_store)).await;
 
         let apps = conductor
             .setup_app_for_agents(
@@ -114,27 +129,19 @@ pub mod test {
 
         let alice_call_info: CallInfo = conductor.call(&alice, "call_info", ()).await;
         let bobbo_call_info: CallInfo = conductor.call(&bobbo, "call_info", ()).await;
-        let bobbo_call_alice_call_info: CallInfo = conductor.call(&bobbo, "remote_call_info", alice_pubkey.clone()).await;
-        let alice_call_bobbo_call_alice_call_info: CallInfo = conductor.call(&alice, "remote_remote_call_info", bob_pubkey.clone()).await;
+        let bobbo_call_alice_call_info: CallInfo = conductor
+            .call(&bobbo, "remote_call_info", alice_pubkey.clone())
+            .await;
+        let alice_call_bobbo_call_alice_call_info: CallInfo = conductor
+            .call(&alice, "remote_remote_call_info", bob_pubkey.clone())
+            .await;
 
         // direct calls to alice/bob should have their own provenance
-        assert_eq!(
-            alice_call_info.provenance,
-            alice_pubkey
-        );
-        assert_eq!(
-            bobbo_call_info.provenance,
-            bob_pubkey
-        );
+        assert_eq!(alice_call_info.provenance, alice_pubkey);
+        assert_eq!(bobbo_call_info.provenance, bob_pubkey);
         // Bob calling into alice should have bob provenance.
-        assert_eq!(
-            bobbo_call_alice_call_info.provenance,
-            bob_pubkey
-        );
+        assert_eq!(bobbo_call_alice_call_info.provenance, bob_pubkey);
         // Alice calling back into herself via. bob should have bob provenance.
-        assert_eq!(
-            alice_call_bobbo_call_alice_call_info.provenance,
-            bob_pubkey
-        );
+        assert_eq!(alice_call_bobbo_call_alice_call_info.provenance, bob_pubkey);
     }
 }

--- a/crates/holochain/src/core/ribosome/host_fn/call_remote.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call_remote.rs
@@ -34,14 +34,7 @@ pub fn call_remote(
                         call_context
                             .host_context()
                             .network()
-                            .call_remote(
-                                from_agent.clone(),
-                                target_agent,
-                                zome_name,
-                                fn_name,
-                                cap_secret,
-                                payload,
-                            )
+                            .call_remote(from_agent.clone(), target_agent, zome_name, fn_name, cap_secret, payload)
                             .await
                     }))
                     .await

--- a/crates/holochain/src/core/ribosome/host_fn/create.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/create.rs
@@ -29,8 +29,10 @@ pub fn create<'a>(
                 Entry::CounterSign(_, _) => tokio_helper::block_forever_on(async move {
                     call_context
                         .host_context
-                        .workspace()
+                        .workspace_write()
                         .source_chain()
+                        .as_ref()
+                        .expect("Must have source chain if write_workspace access is given")
                         .put_countersigned(Some(call_context.zome.clone()), input.into_entry(), chain_top_ordering)
                         .await
                         .map_err(|source_chain_error| {
@@ -79,8 +81,10 @@ pub fn create<'a>(
                         // push the header and the entry into the source chain
                         call_context
                             .host_context
-                            .workspace()
+                            .workspace_write()
                             .source_chain()
+                            .as_ref()
+                            .expect("Must have source chain if write_workspace access is given")
                             .put(Some(call_context.zome.clone()), header_builder, Some(input.into_entry()), chain_top_ordering)
                             .await
                             .map_err(|source_chain_error| {
@@ -172,7 +176,15 @@ pub mod wasm_test {
 
         // the chain head should be the committed entry header
         let chain_head = tokio_helper::block_forever_on(async move {
-            SourceChainResult::Ok(host_access_2.workspace.source_chain().chain_head()?.0)
+            SourceChainResult::Ok(
+                host_access_2
+                    .workspace
+                    .source_chain()
+                    .as_ref()
+                    .unwrap()
+                    .chain_head()?
+                    .0,
+            )
         })
         .unwrap();
 
@@ -191,7 +203,15 @@ pub mod wasm_test {
         // the chain head should be the committed entry header
         let host_access_2 = host_access.clone();
         let chain_head = tokio_helper::block_forever_on(async move {
-            SourceChainResult::Ok(host_access_2.workspace.source_chain().chain_head()?.0)
+            SourceChainResult::Ok(
+                host_access_2
+                    .workspace
+                    .source_chain()
+                    .as_ref()
+                    .unwrap()
+                    .chain_head()?
+                    .0,
+            )
         })
         .unwrap();
 

--- a/crates/holochain/src/core/ribosome/host_fn/create_link.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/create_link.rs
@@ -1,8 +1,8 @@
 use crate::core::ribosome::CallContext;
+use crate::core::ribosome::HostFnAccess;
 use crate::core::ribosome::RibosomeError;
 use crate::core::ribosome::RibosomeT;
 use holochain_wasmer_host::prelude::WasmError;
-use crate::core::ribosome::HostFnAccess;
 
 use holochain_types::prelude::*;
 use std::sync::Arc;
@@ -14,7 +14,10 @@ pub fn create_link<'a>(
     input: CreateLinkInput,
 ) -> Result<HeaderHash, WasmError> {
     match HostFnAccess::from(&call_context.host_context()) {
-        HostFnAccess{ write_workspace: Permission::Allow, .. } => {
+        HostFnAccess {
+            write_workspace: Permission::Allow,
+            ..
+        } => {
             let CreateLinkInput {
                 base_address,
                 target_address,
@@ -28,27 +31,30 @@ pub fn create_link<'a>(
                 .expect("Failed to get ID for current zome");
 
             // Construct the link add
-            let header_builder = builder::CreateLink::new(base_address, target_address, zome_id, tag);
+            let header_builder =
+                builder::CreateLink::new(base_address, target_address, zome_id, tag);
 
-    let header_hash = tokio_helper::block_forever_on(tokio::task::spawn(async move {
-        // push the header into the source chain
-        let header_hash = call_context
-            .host_context
-            .workspace()
-            .source_chain()
-            .put(Some(call_context.zome.clone()), header_builder, None, chain_top_ordering)
-            .await?;
-        Ok::<HeaderHash, RibosomeError>(header_hash)
-    }))
-    .map_err(|join_error| WasmError::Host(join_error.to_string()))?
-    .map_err(|ribosome_error| WasmError::Host(ribosome_error.to_string()))?;
+            let header_hash = tokio_helper::block_forever_on(tokio::task::spawn(async move {
+                // push the header into the source chain
+                let header_hash = call_context
+                    .host_context
+                    .workspace_write()
+                    .source_chain()
+                    .as_ref()
+                    .expect("Must have source chain if write_workspace access is given")
+                    .put(Some(call_context.zome.clone()), header_builder, None, chain_top_ordering)
+                    .await?;
+                Ok::<HeaderHash, RibosomeError>(header_hash)
+            }))
+            .map_err(|join_error| WasmError::Host(join_error.to_string()))?
+            .map_err(|ribosome_error| WasmError::Host(ribosome_error.to_string()))?;
 
             // return the hash of the committed link
             // note that validation is handled by the workflow
             // if the validation fails this commit will be rolled back by virtue of the DB transaction
             // being atomic
             Ok(header_hash)
-        },
+        }
         _ => unreachable!(),
     }
 }

--- a/crates/holochain/src/core/ribosome/host_fn/delete.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/delete.rs
@@ -5,11 +5,11 @@ use holochain_cascade::error::CascadeError;
 use holochain_cascade::Cascade;
 use holochain_wasmer_host::prelude::WasmError;
 
+use crate::core::ribosome::HostFnAccess;
 use holo_hash::EntryHash;
 use holo_hash::HeaderHash;
 use holochain_types::prelude::*;
 use std::sync::Arc;
-use crate::core::ribosome::HostFnAccess;
 
 #[allow(clippy::extra_unused_lifetimes)]
 pub fn delete<'a>(
@@ -18,15 +18,26 @@ pub fn delete<'a>(
     input: DeleteInput,
 ) -> Result<HeaderHash, WasmError> {
     match HostFnAccess::from(&call_context.host_context()) {
-        HostFnAccess{ write_workspace: Permission::Allow, .. } => {
-            let DeleteInput { deletes_header_address, chain_top_ordering } = input;
-            let deletes_entry_address = get_original_address(call_context.clone(), deletes_header_address.clone())?;
+        HostFnAccess {
+            write_workspace: Permission::Allow,
+            ..
+        } => {
+            let DeleteInput {
+                deletes_header_address,
+                chain_top_ordering,
+            } = input;
+            let deletes_entry_address =
+                get_original_address(call_context.clone(), deletes_header_address.clone())?;
 
             let host_access = call_context.host_context();
 
             // handle timeouts at the source chain layer
             tokio_helper::block_forever_on(async move {
-                let source_chain = host_access.workspace().source_chain();
+                let source_chain = host_access
+                    .workspace_write()
+                    .source_chain()
+                    .as_ref()
+                    .expect("Must have source chain if write_workspace access is given");
                 let header_builder = builder::Delete {
                     deletes_address: deletes_header_address,
                     deletes_entry_address,
@@ -34,10 +45,12 @@ pub fn delete<'a>(
                 let header_hash = source_chain
                     .put(Some(call_context.zome.clone()), header_builder, None, chain_top_ordering)
                     .await
-                    .map_err(|source_chain_error| WasmError::Host(source_chain_error.to_string()))?;
+                    .map_err(|source_chain_error| {
+                        WasmError::Host(source_chain_error.to_string())
+                    })?;
                 Ok(header_hash)
             })
-        },
+        }
         _ => unreachable!(),
     }
 }
@@ -51,7 +64,7 @@ pub(crate) fn get_original_address<'a>(
     let workspace = call_context.host_context.workspace();
 
     tokio_helper::block_forever_on(async move {
-        let mut cascade = Cascade::from_workspace_network(workspace, network);
+        let mut cascade = Cascade::from_workspace_network(&workspace, network);
         // TODO: Think about what options to use here
         let maybe_original_element: Option<SignedHeaderHashed> = cascade
             .get_details(address.clone().into(), GetOptions::content())

--- a/crates/holochain/src/core/ribosome/host_fn/delete_link.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/delete_link.rs
@@ -1,12 +1,12 @@
 use crate::core::ribosome::error::RibosomeError;
 use crate::core::ribosome::CallContext;
+use crate::core::ribosome::HostFnAccess;
 use crate::core::ribosome::RibosomeT;
 use holochain_cascade::error::CascadeResult;
 use holochain_cascade::Cascade;
 use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::WasmError;
 use std::sync::Arc;
-use crate::core::ribosome::HostFnAccess;
 
 #[allow(clippy::extra_unused_lifetimes)]
 pub fn delete_link<'a>(
@@ -15,8 +15,14 @@ pub fn delete_link<'a>(
     input: DeleteLinkInput,
 ) -> Result<HeaderHash, WasmError> {
     match HostFnAccess::from(&call_context.host_context()) {
-        HostFnAccess{ write_workspace: Permission::Allow, .. } => {
-            let DeleteLinkInput { address, chain_top_ordering } = input;
+        HostFnAccess {
+            write_workspace: Permission::Allow,
+            ..
+        } => {
+            let DeleteLinkInput {
+                address,
+                chain_top_ordering,
+            } = input;
             // get the base address from the add link header
             // don't allow the wasm developer to get this wrong
             // it is never valid to have divergent base address for add/remove links
@@ -27,21 +33,24 @@ pub fn delete_link<'a>(
 
             // handle timeouts at the network layer
             let address_2 = address.clone();
-            let maybe_add_link: Option<SignedHeaderHashed> = tokio_helper::block_forever_on(async move {
-                let workspace = call_context_2.host_context.workspace();
-                CascadeResult::Ok(
-                    Cascade::from_workspace_network(workspace, network)
-                        .dht_get(address_2.into(), GetOptions::content())
-                        .await?
-                        .map(|el| el.into_inner().0),
-                )
-            })
-            .map_err(|cascade_error| WasmError::Host(cascade_error.to_string()))?;
+            let maybe_add_link: Option<SignedHeaderHashed> =
+                tokio_helper::block_forever_on(async move {
+                    let workspace = call_context_2.host_context.workspace();
+                    CascadeResult::Ok(
+                        Cascade::from_workspace_network(&workspace, network)
+                            .dht_get(address_2.into(), GetOptions::content())
+                            .await?
+                            .map(|el| el.into_inner().0),
+                    )
+                })
+                .map_err(|cascade_error| WasmError::Host(cascade_error.to_string()))?;
 
             let base_address = match maybe_add_link {
                 Some(add_link_signed_header_hash) => {
                     match add_link_signed_header_hash.header() {
-                        Header::CreateLink(link_add_header) => Ok(link_add_header.base_address.clone()),
+                        Header::CreateLink(link_add_header) => {
+                            Ok(link_add_header.base_address.clone())
+                        }
                         // the add link header hash provided was found but didn't point to an AddLink
                         // header (it is something else) so we cannot proceed
                         _ => Err(RibosomeError::ElementDeps(address.clone().into())),
@@ -56,7 +65,12 @@ pub fn delete_link<'a>(
             }
             .map_err(|ribosome_error| WasmError::Host(ribosome_error.to_string()))?;
 
-            let source_chain = call_context.host_context.workspace().source_chain();
+            let source_chain = call_context
+                .host_context
+                .workspace_write()
+                .source_chain()
+                .as_ref()
+                .expect("Must have source chain if write_workspace access is given");
             let zome = call_context.zome.clone();
 
             // handle timeouts at the source chain layer
@@ -70,10 +84,12 @@ pub fn delete_link<'a>(
                 let header_hash = source_chain
                     .put(Some(zome), header_builder, None, chain_top_ordering)
                     .await
-                    .map_err(|source_chain_error| WasmError::Host(source_chain_error.to_string()))?;
+                    .map_err(|source_chain_error| {
+                        WasmError::Host(source_chain_error.to_string())
+                    })?;
                 Ok(header_hash)
             })
-        },
+        }
         _ => unreachable!(),
     }
 }
@@ -110,7 +126,8 @@ pub mod slow_tests {
 
         // remove a link
         let _: HeaderHash =
-            crate::call_test_ribosome!(host_access, TestWasm::Link, "delete_link", link_one).unwrap();
+            crate::call_test_ribosome!(host_access, TestWasm::Link, "delete_link", link_one)
+                .unwrap();
 
         let links: Vec<Link> = crate::call_test_ribosome!(host_access, TestWasm::Link, "get_links", ()).unwrap();
 
@@ -118,7 +135,8 @@ pub mod slow_tests {
 
         // remove a link
         let _: HeaderHash =
-            crate::call_test_ribosome!(host_access, TestWasm::Link, "delete_link", link_two).unwrap();
+            crate::call_test_ribosome!(host_access, TestWasm::Link, "delete_link", link_two)
+                .unwrap();
 
         let links: Vec<Link> = crate::call_test_ribosome!(host_access, TestWasm::Link, "get_links", ()).unwrap();
 
@@ -134,7 +152,8 @@ pub mod slow_tests {
 
         assert!(links.len() == 2);
 
-        let _: () = crate::call_test_ribosome!(host_access, TestWasm::Link, "delete_all_links", ()).unwrap();
+        let _: () = crate::call_test_ribosome!(host_access, TestWasm::Link, "delete_all_links", ())
+            .unwrap();
 
         // Should be no links left
         let links: Vec<Link> = crate::call_test_ribosome!(host_access, TestWasm::Link, "get_links", ()).unwrap();

--- a/crates/holochain/src/core/ribosome/host_fn/get.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get.rs
@@ -23,7 +23,7 @@ pub fn get<'a>(
                             get_options,
                         } = input;
                         Cascade::from_workspace_network(
-                            call_context.host_context.workspace(),
+                            &call_context.host_context.workspace(),
                             call_context.host_context.network().clone()
                         )
                         .dht_get(any_dht_hash, get_options).await

--- a/crates/holochain/src/core/ribosome/host_fn/get_agent_activity.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_agent_activity.rs
@@ -38,7 +38,7 @@ pub fn get_agent_activity(
     // timeouts must be handled by the network
     tokio_helper::block_forever_on(async move {
         let workspace = call_context.host_context.workspace();
-        let mut cascade = Cascade::from_workspace_network(workspace, network);
+        let mut cascade = Cascade::from_workspace_network(&workspace, network);
         let activity = cascade
             .get_agent_activity(agent_pubkey, chain_query_filter, options)
             .await

--- a/crates/holochain/src/core/ribosome/host_fn/get_details.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_details.rs
@@ -23,7 +23,7 @@ pub fn get_details<'a>(
                             get_options,
                         } = input;
                         Cascade::from_workspace_network(
-                            call_context.host_context.workspace(),
+                            &call_context.host_context.workspace(),
                             call_context.host_context.network().to_owned(),
                         ).get_details(any_dht_hash, get_options).await
                     }

--- a/crates/holochain/src/core/ribosome/host_fn/get_link_details.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_link_details.rs
@@ -32,7 +32,7 @@ pub fn get_link_details<'a>(
                             tag: tag_prefix,
                         };
                         Cascade::from_workspace_network(
-                            call_context.host_context.workspace(),
+                            &call_context.host_context.workspace(),
                             call_context.host_context.network().to_owned(),
                         ).get_link_details(key, GetLinksOptions::default()).await
                     }

--- a/crates/holochain/src/core/ribosome/host_fn/get_links.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_links.rs
@@ -32,7 +32,7 @@ pub fn get_links<'a>(
                             tag: tag_prefix,
                         };
                         Cascade::from_workspace_network(
-                            call_context.host_context.workspace(),
+                            &call_context.host_context.workspace(),
                             call_context.host_context.network().to_owned(),
                         ).dht_get_links(key, GetLinksOptions::default()).await
                     }
@@ -327,7 +327,7 @@ pub mod slow_tests {
         // Plus one length path for the commit existing.
         expected_count += WaitOps::ENTRY + WaitOps::LINK;
 
-        wait_for_integration_1m(&alice_call_data.env, expected_count).await;
+        wait_for_integration_1m(&alice_call_data.dht_env, expected_count).await;
 
         let invocation = new_zome_call(
             &alice_call_data.cell_id,

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_entry.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_entry.rs
@@ -22,7 +22,7 @@ pub fn must_get_entry<'a>(
             // timeouts must be handled by the network
             tokio_helper::block_forever_on(async move {
                 let workspace = call_context.host_context.workspace();
-                let mut cascade = Cascade::from_workspace_network(workspace, network);
+                let mut cascade = Cascade::from_workspace_network(&workspace, network);
                 match cascade
                     .retrieve_entry(entry_hash.clone(),
                     // Set every GetOptions manually here.
@@ -197,7 +197,7 @@ pub mod test {
         validate_invocation.entry_def_id = Some(EntryDefId::App("header_reference".into()));
         let mut validate_host_access = fixt!(ValidateHostAccess);
         validate_host_access.network = host_access.network.clone();
-        validate_host_access.workspace = host_access.workspace.clone();
+        validate_host_access.workspace = host_access.workspace.clone().into();
 
         let header_reference_validate_result = ribosome.run_validate(validate_host_access.clone(), validate_invocation.clone()).unwrap();
 

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_header.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_header.rs
@@ -23,7 +23,7 @@ pub fn must_get_header<'a>(
             // timeouts must be handled by the network
             tokio_helper::block_forever_on(async move {
                 let workspace = call_context.host_context.workspace();
-                let mut cascade = Cascade::from_workspace_network(workspace, network);
+                let mut cascade = Cascade::from_workspace_network(&workspace, network);
                 match cascade
                     .retrieve_header(header_hash.clone(),
                     // Set every GetOptions manually here.

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_valid_element.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_valid_element.rs
@@ -22,7 +22,7 @@ pub fn must_get_valid_element<'a>(
             // timeouts must be handled by the network
             tokio_helper::block_forever_on(async move {
                 let workspace = call_context.host_context.workspace();
-                let mut cascade = Cascade::from_workspace_network(workspace, network);
+                let mut cascade = Cascade::from_workspace_network(&workspace, network);
                 match cascade
                     .get_header_details(header_hash.clone(),
                     GetOptions::content())

--- a/crates/holochain/src/core/ribosome/host_fn/query.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/query.rs
@@ -1,9 +1,9 @@
 use crate::core::ribosome::CallContext;
+use crate::core::ribosome::HostFnAccess;
 use crate::core::ribosome::RibosomeT;
 use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::WasmError;
 use std::sync::Arc;
-use crate::core::ribosome::HostFnAccess;
 
 pub fn query(
     _ribosome: Arc<impl RibosomeT>,
@@ -11,18 +11,21 @@ pub fn query(
     input: ChainQueryFilter,
 ) -> Result<Vec<Element>, WasmError> {
     match HostFnAccess::from(&call_context.host_context()) {
-        HostFnAccess{ read_workspace: Permission::Allow, .. } => {
-            tokio_helper::block_forever_on(async move {
-                let elements: Vec<Element> = call_context
-                    .host_context
-                    .workspace()
-                    .source_chain()
-                    .query(input)
-                    .await
-                    .map_err(|source_chain_error| WasmError::Host(source_chain_error.to_string()))?;
-                Ok(elements)
-            })
-        },
+        HostFnAccess {
+            read_workspace: Permission::Allow,
+            ..
+        } => tokio_helper::block_forever_on(async move {
+            let elements: Vec<Element> = call_context
+                .host_context
+                .workspace()
+                .source_chain()
+                .as_ref()
+                .expect("Must have source chain to query the source chain")
+                .query(input)
+                .await
+                .map_err(|source_chain_error| WasmError::Host(source_chain_error.to_string()))?;
+            Ok(elements)
+        }),
         _ => unreachable!(),
     }
 }
@@ -30,7 +33,7 @@ pub fn query(
 #[cfg(test)]
 #[cfg(feature = "slow_tests")]
 pub mod slow_tests {
-    use crate::{fixt::ZomeCallHostAccessFixturator};
+    use crate::fixt::ZomeCallHostAccessFixturator;
     use ::fixt::prelude::*;
     use hdk::prelude::*;
     use query::ChainQueryFilter;
@@ -42,16 +45,19 @@ pub mod slow_tests {
         let host_access = fixt!(ZomeCallHostAccess, Predictable);
 
         let _hash_a: EntryHash =
-            crate::call_test_ribosome!(host_access, TestWasm::Query, "add_path", "a".to_string()).unwrap();
+            crate::call_test_ribosome!(host_access, TestWasm::Query, "add_path", "a".to_string())
+                .unwrap();
         let _hash_b: EntryHash =
-            crate::call_test_ribosome!(host_access, TestWasm::Query, "add_path", "b".to_string()).unwrap();
+            crate::call_test_ribosome!(host_access, TestWasm::Query, "add_path", "b".to_string())
+                .unwrap();
 
         let elements: Vec<Element> = crate::call_test_ribosome!(
             host_access,
             TestWasm::Query,
             "query",
             ChainQueryFilter::default()
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(elements.len(), 5);
     }

--- a/crates/holochain/src/core/ribosome/host_fn/schedule.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/schedule.rs
@@ -1,8 +1,8 @@
 use crate::core::ribosome::CallContext;
 use crate::core::ribosome::RibosomeT;
-use std::sync::Arc;
-use holochain_wasmer_host::prelude::WasmError;
 use holochain_types::prelude::*;
+use holochain_wasmer_host::prelude::WasmError;
+use std::sync::Arc;
 
 pub fn schedule(
     _ribosome: Arc<impl RibosomeT>,
@@ -10,31 +10,45 @@ pub fn schedule(
     input: String,
 ) -> Result<(), WasmError> {
     match HostFnAccess::from(&call_context.host_context()) {
-        HostFnAccess{ write_workspace: Permission::Allow, .. } => {
-            call_context.host_context().workspace().source_chain().scratch().apply(|scratch| {
-                scratch.add_scheduled_fn(ScheduledFn::new(call_context.zome.zome_name().clone(), input.into()));
-            }).map_err(|e| WasmError::Host(e.to_string()))?;
+        HostFnAccess {
+            write_workspace: Permission::Allow,
+            ..
+        } => {
+            call_context
+                .host_context()
+                .workspace_write()
+                .source_chain()
+                .as_ref()
+                .expect("Must have source chain if write_workspace access is given")
+                .scratch()
+                .apply(|scratch| {
+                    scratch.add_scheduled_fn(ScheduledFn::new(
+                        call_context.zome.zome_name().clone(),
+                        input.into(),
+                    ));
+                })
+                .map_err(|e| WasmError::Host(e.to_string()))?;
             Ok(())
-        },
+        }
         _ => unreachable!(),
     }
 }
 
 #[cfg(test)]
 pub mod tests {
-    use ::fixt::prelude::*;
-    use holochain_wasm_test_utils::TestWasm;
-    use crate::sweettest::SweetDnaFile;
-    use holochain_types::prelude::AgentPubKeyFixturator;
-    use crate::core::ribosome::MockDnaStore;
-    use hdk::prelude::*;
-    use crate::sweettest::SweetConductor;
     use crate::conductor::ConductorBuilder;
-    use holochain_state::schedule::fn_is_scheduled;
+    use crate::core::ribosome::MockDnaStore;
+    use crate::sweettest::SweetConductor;
+    use crate::sweettest::SweetDnaFile;
+    use ::fixt::prelude::*;
+    use hdk::prelude::*;
     use holochain_state::prelude::schedule_fn;
-    use rusqlite::Transaction;
     use holochain_state::prelude::*;
+    use holochain_state::schedule::fn_is_scheduled;
     use holochain_state::schedule::live_scheduled_fns;
+    use holochain_types::prelude::AgentPubKeyFixturator;
+    use holochain_wasm_test_utils::TestWasm;
+    use rusqlite::Transaction;
 
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "test_utils")]
@@ -62,82 +76,100 @@ pub mod tests {
             SweetConductor::from_builder(ConductorBuilder::with_mock_dna_store(dna_store)).await;
 
         let _apps = conductor
-        .setup_app_for_agents(
-            "app-",
-            &[alice_pubkey.clone(), bob_pubkey.clone()],
-            &[dna_file.into()],
-        )
-        .await
-        .unwrap();
+            .setup_app_for_agents(
+                "app-",
+                &[alice_pubkey.clone(), bob_pubkey.clone()],
+                &[dna_file.into()],
+            )
+            .await
+            .unwrap();
 
         let cell_id = conductor.handle().list_cell_ids(None)[0].clone();
-        let cell_env = conductor.handle().get_cell_env(&cell_id).unwrap();
+        let cell_env = conductor
+            .handle()
+            .get_authored_env(cell_id.dna_hash())
+            .unwrap();
+        let author = cell_id.agent_pubkey().clone();
 
-        cell_env.async_commit(move |txn: &mut Transaction| {
-            let now = Timestamp::now();
-            let the_past = (now - std::time::Duration::from_millis(1)).unwrap();
-            let the_future = (now + std::time::Duration::from_millis(1000)).unwrap();
-            let the_distant_future = (now + std::time::Duration::from_millis(2000)).unwrap();
+        cell_env
+            .async_commit(move |txn: &mut Transaction| {
+                let now = Timestamp::now();
+                let the_past = (now - std::time::Duration::from_millis(1)).unwrap();
+                let the_future = (now + std::time::Duration::from_millis(1000)).unwrap();
+                let the_distant_future = (now + std::time::Duration::from_millis(2000)).unwrap();
 
-            let ephemeral_scheduled_fn = ScheduledFn::new("foo".into(), "bar".into());
-            let persisted_scheduled_fn = ScheduledFn::new("1".into(), "2".into());
-            let persisted_schedule = Schedule::Persisted("* * * * * * * ".into());
+                let ephemeral_scheduled_fn = ScheduledFn::new("foo".into(), "bar".into());
+                let persisted_scheduled_fn = ScheduledFn::new("1".into(), "2".into());
+                let persisted_schedule = Schedule::Persisted("* * * * * * * ".into());
 
-            schedule_fn(txn, persisted_scheduled_fn.clone(), Some(persisted_schedule.clone()), now).unwrap();
-            schedule_fn(txn, ephemeral_scheduled_fn.clone(), None, now).unwrap();
+                schedule_fn(
+                    txn,
+                    &author,
+                    persisted_scheduled_fn.clone(),
+                    Some(persisted_schedule.clone()),
+                    now,
+                )
+                .unwrap();
+                schedule_fn(txn, &author, ephemeral_scheduled_fn.clone(), None, now).unwrap();
 
-            assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone()).unwrap());
-            assert!(fn_is_scheduled(txn, ephemeral_scheduled_fn.clone()).unwrap());
+                assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &author).unwrap());
+                assert!(fn_is_scheduled(txn, ephemeral_scheduled_fn.clone(), &author).unwrap());
 
-            // Deleting live ephemeral scheduled fns from now should delete.
-            delete_live_ephemeral_scheduled_fns(txn, now).unwrap();
-            assert!(!fn_is_scheduled(txn, ephemeral_scheduled_fn.clone()).unwrap());
-            assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone()).unwrap());
+                // Deleting live ephemeral scheduled fns from now should delete.
+                delete_live_ephemeral_scheduled_fns(txn, now, &author).unwrap();
+                assert!(!fn_is_scheduled(txn, ephemeral_scheduled_fn.clone(), &author,).unwrap());
+                assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &author,).unwrap());
 
-            schedule_fn(txn, ephemeral_scheduled_fn.clone(), None, now).unwrap();
-            assert!(fn_is_scheduled(txn, ephemeral_scheduled_fn.clone()).unwrap());
-            assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone()).unwrap());
+                schedule_fn(txn, &author, ephemeral_scheduled_fn.clone(), None, now).unwrap();
+                assert!(fn_is_scheduled(txn, ephemeral_scheduled_fn.clone(), &author,).unwrap());
+                assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &author,).unwrap());
 
-            // Deleting live ephemeral fns from a past time should do nothing.
-            delete_live_ephemeral_scheduled_fns(txn, the_past).unwrap();
-            assert!(fn_is_scheduled(txn, ephemeral_scheduled_fn.clone()).unwrap());
-            assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone()).unwrap());
+                // Deleting live ephemeral fns from a past time should do nothing.
+                delete_live_ephemeral_scheduled_fns(txn, the_past, &author).unwrap();
+                assert!(fn_is_scheduled(txn, ephemeral_scheduled_fn.clone(), &author,).unwrap());
+                assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &author,).unwrap());
 
-            // Deleting live ephemeral fns from the future should delete.
-            delete_live_ephemeral_scheduled_fns(txn, the_future).unwrap();
-            assert!(!fn_is_scheduled(txn, ephemeral_scheduled_fn.clone()).unwrap());
-            assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone()).unwrap());
+                // Deleting live ephemeral fns from the future should delete.
+                delete_live_ephemeral_scheduled_fns(txn, the_future, &author).unwrap();
+                assert!(!fn_is_scheduled(txn, ephemeral_scheduled_fn.clone(), &author,).unwrap());
+                assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &author,).unwrap());
 
-            // Deleting all ephemeral fns should delete.
-            schedule_fn(txn, ephemeral_scheduled_fn.clone(), None, now).unwrap();
-            assert!(fn_is_scheduled(txn, ephemeral_scheduled_fn.clone()).unwrap());
-            delete_all_ephemeral_scheduled_fns(txn).unwrap();
-            assert!(!fn_is_scheduled(txn, ephemeral_scheduled_fn.clone()).unwrap());
-            assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone()).unwrap());
+                // Deleting all ephemeral fns should delete.
+                schedule_fn(txn, &author, ephemeral_scheduled_fn.clone(), None, now).unwrap();
+                assert!(fn_is_scheduled(txn, ephemeral_scheduled_fn.clone(), &author,).unwrap());
+                delete_all_ephemeral_scheduled_fns(txn, &author).unwrap();
+                assert!(!fn_is_scheduled(txn, ephemeral_scheduled_fn.clone(), &author,).unwrap());
+                assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &author,).unwrap());
 
-            let ephemeral_future_schedule = Schedule::Ephemeral(std::time::Duration::from_millis(1001));
-            schedule_fn(
-                txn,
-                ephemeral_scheduled_fn.clone(),
-                Some(ephemeral_future_schedule.clone()),
-                now
-            ).unwrap();
-            assert_eq!(
-                vec![
-                    (persisted_scheduled_fn.clone(), Some(persisted_schedule.clone()))
-                ],
-                live_scheduled_fns(txn, the_future).unwrap(),
-            );
-            assert_eq!(
-                vec![
-                    (persisted_scheduled_fn, Some(persisted_schedule)),
-                    (ephemeral_scheduled_fn, Some(ephemeral_future_schedule)),
-                ],
-                live_scheduled_fns(txn, the_distant_future).unwrap(),
-            );
+                let ephemeral_future_schedule =
+                    Schedule::Ephemeral(std::time::Duration::from_millis(1001));
+                schedule_fn(
+                    txn,
+                    &author,
+                    ephemeral_scheduled_fn.clone(),
+                    Some(ephemeral_future_schedule.clone()),
+                    now,
+                )
+                .unwrap();
+                assert_eq!(
+                    vec![(
+                        persisted_scheduled_fn.clone(),
+                        Some(persisted_schedule.clone())
+                    )],
+                    live_scheduled_fns(txn, the_future, &author,).unwrap(),
+                );
+                assert_eq!(
+                    vec![
+                        (persisted_scheduled_fn, Some(persisted_schedule)),
+                        (ephemeral_scheduled_fn, Some(ephemeral_future_schedule)),
+                    ],
+                    live_scheduled_fns(txn, the_distant_future, &author,).unwrap(),
+                );
 
-            Result::<(), DatabaseError>::Ok(())
-        }).await.unwrap();
+                Result::<(), DatabaseError>::Ok(())
+            })
+            .await
+            .unwrap();
         Ok(())
     }
 
@@ -180,83 +212,43 @@ pub mod tests {
         let bobbo = bobbo.zome(TestWasm::Schedule);
 
         // Let's just drive alice to exhaust all ticks.
-        let _schedule: () = conductor
-            .call(
-                &alice,
-                "schedule",
-                ()
-            )
-            .await;
+        let _schedule: () = conductor.call(&alice, "schedule", ()).await;
         let mut i: usize = 0;
         while i < 10 {
             tokio::time::sleep(std::time::Duration::from_millis(2)).await;
             conductor.handle().dispatch_scheduled_fns().await;
             i = i + 1;
         }
-        let query_tick: Vec<Element> = conductor
-        .call(
-            &alice,
-            "query_tick",
-            ()
-        )
-        .await;
+        let query_tick: Vec<Element> = conductor.call(&alice, "query_tick", ()).await;
         assert_eq!(query_tick.len(), 5);
 
         // The persistent schedule should run once in second.
-        let query_tock: Vec<Element> = conductor
-            .call(
-                &alice,
-                "query_tock",
-                ()
-            ).await;
+        let query_tock: Vec<Element> = conductor.call(&alice, "query_tock", ()).await;
         assert!(query_tock.len() < 3);
 
         // If Bob does a few ticks and then calls `start_scheduler` the
         // ephemeral scheduled task will be flushed so the ticks will not be
         // exhaused until the function is rescheduled.
-        let _shedule: () = conductor
-            .call(
-                &bobbo,
-                "schedule",
-                ()
-            ).await;
+        let _shedule: () = conductor.call(&bobbo, "schedule", ()).await;
         conductor.handle().dispatch_scheduled_fns().await;
-        let query1: Vec<Element> = conductor
-            .call(
-                &bobbo,
-                "query_tick",
-                ()
-            ).await;
+        let query1: Vec<Element> = conductor.call(&bobbo, "query_tick", ()).await;
         assert_eq!(query1.len(), 1);
         conductor.handle().dispatch_scheduled_fns().await;
-        let query2: Vec<Element> = conductor
-            .call(
-                &bobbo,
-                "query_tick",
-                ()
-            ).await;
+        let query2: Vec<Element> = conductor.call(&bobbo, "query_tick", ()).await;
         assert_eq!(query2.len(), query1.len() + 1);
 
         // With a fast scheduler bob should clear everything out.
-        let _ = conductor.clone().start_scheduler(std::time::Duration::from_millis(1)).await;
+        let _ = conductor
+            .clone()
+            .start_scheduler(std::time::Duration::from_millis(1))
+            .await;
 
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        let q: Vec<Element> = conductor
-        .call(
-            &bobbo,
-            "query_tick",
-            ()
-        )
-        .await;
+        let q: Vec<Element> = conductor.call(&bobbo, "query_tick", ()).await;
         assert_eq!(q.len(), query2.len());
 
         // Rescheduling will allow bob catch up to alice.
-        let _shedule: () = conductor
-            .call(
-                &bobbo,
-                "schedule",
-                ()
-            ).await;
+        let _shedule: () = conductor.call(&bobbo, "schedule", ()).await;
 
         tokio::time::sleep(std::time::Duration::from_millis(150)).await;
         let q2: Vec<Element> = conductor

--- a/crates/holochain/src/core/ribosome/host_fn/update.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/update.rs
@@ -1,9 +1,9 @@
 use super::create::extract_entry_def;
 use super::delete::get_original_address;
 use crate::core::ribosome::CallContext;
+use crate::core::ribosome::HostFnAccess;
 use crate::core::ribosome::RibosomeT;
 use holochain_wasmer_host::prelude::WasmError;
-use crate::core::ribosome::HostFnAccess;
 
 use holochain_types::prelude::*;
 use std::sync::Arc;
@@ -15,7 +15,10 @@ pub fn update<'a>(
     input: UpdateInput,
 ) -> Result<HeaderHash, WasmError> {
     match HostFnAccess::from(&call_context.host_context()) {
-        HostFnAccess{ write_workspace: Permission::Allow, .. } => {
+        HostFnAccess {
+            write_workspace: Permission::Allow,
+            ..
+        } => {
             // destructure the args out into an app type def id and entry
             let UpdateInput {
                 original_header_address,
@@ -29,26 +32,30 @@ pub fn update<'a>(
 
             // Countersigned entries have different header handling.
             match entry {
-                Entry::CounterSign(_, _) => {
-                    tokio_helper::block_forever_on(async move {
-                        call_context
-                            .host_context
-                            .workspace()
-                            .source_chain()
-                            .put_countersigned(Some(call_context.zome.clone()), entry, chain_top_ordering)
-                            .await
-                            .map_err(|source_chain_error| WasmError::Host(source_chain_error.to_string()))
-                    })
-                },
+                Entry::CounterSign(_, _) => tokio_helper::block_forever_on(async move {
+                    call_context
+                        .host_context
+                        .workspace_write()
+                        .source_chain()
+                        .as_ref()
+                        .expect("Must have source chain if write_workspace access is given")
+                        .put_countersigned(Some(call_context.zome.clone()), entry, chain_top_ordering)
+                        .await
+                        .map_err(|source_chain_error| {
+                            WasmError::Host(source_chain_error.to_string())
+                        })
+                }),
                 _ => {
                     // build the entry hash
-                    let entry_hash =
-                    EntryHash::with_data_sync(&entry);
+                    let entry_hash = EntryHash::with_data_sync(&entry);
 
                     // extract the zome position
-                    let header_zome_id = ribosome
-                    .zome_to_id(&call_context.zome)
-                    .map_err(|source_chain_error| WasmError::Host(source_chain_error.to_string()))?;
+                    let header_zome_id =
+                        ribosome
+                            .zome_to_id(&call_context.zome)
+                            .map_err(|source_chain_error| {
+                                WasmError::Host(source_chain_error.to_string())
+                            })?;
 
                     // extract the entry defs for a zome
                     let entry_type = match entry_def_id {
@@ -58,16 +65,21 @@ pub fn update<'a>(
                                 call_context.clone(),
                                 entry_def_id.into(),
                             )?;
-                            let app_entry_type =
-                                AppEntryType::new(header_entry_def_id, header_zome_id, entry_visibility);
+                            let app_entry_type = AppEntryType::new(
+                                header_entry_def_id,
+                                header_zome_id,
+                                entry_visibility,
+                            );
                             EntryType::App(app_entry_type)
                         }
                         EntryDefId::CapGrant => EntryType::CapGrant,
                         EntryDefId::CapClaim => EntryType::CapClaim,
                     };
 
-                    let original_entry_address =
-                    get_original_address(call_context.clone(), original_header_address.clone())?;
+                    let original_entry_address = get_original_address(
+                        call_context.clone(),
+                        original_header_address.clone(),
+                    )?;
 
                     // build a header for the entry being updated
                     let header_builder = builder::Update {
@@ -76,7 +88,7 @@ pub fn update<'a>(
                         entry_type,
                         entry_hash,
                     };
-                    let workspace = call_context.host_context.workspace();
+                    let workspace = call_context.host_context.workspace_write();
                     let zome = call_context.zome.clone();
 
                     // return the hash of the updated entry
@@ -84,17 +96,22 @@ pub fn update<'a>(
                     // if the validation fails this update will be rolled back by virtue of the DB transaction
                     // being atomic
                     tokio_helper::block_forever_on(async move {
-                        let source_chain = workspace.source_chain();
+                        let source_chain = workspace
+                            .source_chain()
+                            .as_ref()
+                            .expect("Must have source chain if write_workspace access is given");
                         // push the header and the entry into the source chain
                         let header_hash = source_chain
                             .put(Some(zome), header_builder, Some(entry), chain_top_ordering)
                             .await
-                            .map_err(|source_chain_error| WasmError::Host(source_chain_error.to_string()))?;
+                            .map_err(|source_chain_error| {
+                                WasmError::Host(source_chain_error.to_string())
+                            })?;
                         Ok(header_hash)
                     })
                 }
             }
-        },
+        }
         _ => unreachable!(),
     }
 }


### PR DESCRIPTION
- Changes ribosome.
- Changes to host functions for workspaces that are expected to hold a source chain.

- Depends on #1127 
- Followed by #1129 