### PR TITLE
create a release from branch release-20211117.094411

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # \[Unreleased\]
 
+# 20211117.094411
+
+## [holochain-0.0.116](crates/holochain/CHANGELOG.md#0.0.116)
+
+## [holochain\_cascade-0.0.16](crates/holochain_cascade/CHANGELOG.md#0.0.16)
+
+## [holochain\_cli-0.0.17](crates/holochain_cli/CHANGELOG.md#0.0.17)
+
+## [holochain\_websocket-0.0.16](crates/holochain_websocket/CHANGELOG.md#0.0.16)
+
+## [holochain\_conductor\_api-0.0.16](crates/holochain_conductor_api/CHANGELOG.md#0.0.16)
+
+## [holochain\_state-0.0.16](crates/holochain_state/CHANGELOG.md#0.0.16)
+
+## [holochain\_wasm\_test\_utils-0.0.16](crates/holochain_wasm_test_utils/CHANGELOG.md#0.0.16)
+
+## [holochain\_p2p-0.0.16](crates/holochain_p2p/CHANGELOG.md#0.0.16)
+
+## [holochain\_types-0.0.16](crates/holochain_types/CHANGELOG.md#0.0.16)
+
+## [holochain\_keystore-0.0.16](crates/holochain_keystore/CHANGELOG.md#0.0.16)
+
+## [holochain\_sqlite-0.0.16](crates/holochain_sqlite/CHANGELOG.md#0.0.16)
+
+## [kitsune\_p2p-0.0.14](crates/kitsune_p2p/CHANGELOG.md#0.0.14)
+
+## [kitsune\_p2p\_proxy-0.0.13](crates/kitsune_p2p_proxy/CHANGELOG.md#0.0.13)
+
+## [kitsune\_p2p\_transport\_quic-0.0.13](crates/kitsune_p2p_transport_quic/CHANGELOG.md#0.0.13)
+
+## [kitsune\_p2p\_types-0.0.13](crates/kitsune_p2p_types/CHANGELOG.md#0.0.13)
+
+## [mr\_bundle-0.0.5](crates/mr_bundle/CHANGELOG.md#0.0.5)
+
+## [holochain\_util-0.0.5](crates/holochain_util/CHANGELOG.md#0.0.5)
+
 # 20211110.083530
 
 ## [holochain-0.0.115](crates/holochain/CHANGELOG.md#0.0.115)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.0.115"
+version = "0.0.116"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2407,7 +2407,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli"
-version = "0.0.16"
+version = "0.0.17"
 dependencies = [
  "anyhow",
  "futures",
@@ -2498,7 +2498,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "derive_more",
  "directories 2.0.2",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "base64",
  "ghost_actor 0.3.0-alpha.4",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_p2p"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "async-trait",
  "fixt",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2688,7 +2688,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "backtrace",
  "cfg-if 0.1.10",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_test_utils"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "fixt",
  "holo_hash",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "criterion",
  "futures",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p"
-version = "0.0.13"
+version = "0.0.14"
 dependencies = [
  "arbitrary",
  "arrayref",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_proxy"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -3361,7 +3361,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_transport_quic"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "blake2b_simd",
  "futures",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_types"
-version = "0.0.12"
+version = "0.0.13"
 dependencies = [
  "arbitrary",
  "base64",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "mr_bundle"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.0.17
+
 ## 0.0.16
 
 ## 0.0.15

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli"
-version = "0.0.16"
+version = "0.0.17"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -20,10 +20,10 @@ path = "src/bin/hc-dna.rs"
 
 [dependencies]
 anyhow = "1.0"
-holochain_util = { path = "../holochain_util", features = ["backtrace"], version = "0.0.4"}
+holochain_util = { path = "../holochain_util", features = ["backtrace"], version = "0.0.5"}
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "0.0.15", path = "../holochain_types" }
-mr_bundle = {version = "0.0.4", path = "../mr_bundle"}
+holochain_types = { version = "0.0.16", path = "../holochain_types" }
+mr_bundle = {version = "0.0.5", path = "../mr_bundle"}
 serde = { version = "1.0", features = [ "derive" ] }
 serde_bytes = "0.11"
 serde_yaml = "0.8"

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -20,10 +20,10 @@ ansi_term = "0.12"
 chrono = "0.4.6"
 futures = "0.3"
 lazy_static = "1.4.0"
-holochain_conductor_api = { path = "../holochain_conductor_api", version = "0.0.15"}
-holochain_types = { path = "../holochain_types", version = "0.0.15"}
-holochain_websocket = { path = "../holochain_websocket", version = "0.0.15"}
-holochain_p2p = { path = "../holochain_p2p", version = "0.0.15"}
+holochain_conductor_api = { path = "../holochain_conductor_api", version = "0.0.16"}
+holochain_types = { path = "../holochain_types", version = "0.0.16"}
+holochain_websocket = { path = "../holochain_websocket", version = "0.0.16"}
+holochain_p2p = { path = "../holochain_p2p", version = "0.0.16"}
 nanoid = "0.3"
 observability = "0.1.3"
 serde_yaml = "0.8"

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.0.116
+
 ## 0.0.115
 
 - Fix [issue](https://github.com/holochain/holochain/issues/1100) where private dht ops were being leaked through the incoming ops sender. [1104](https://github.com/holochain/holochain/pull/1104).

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain"
-version = "0.0.115"
+version = "0.0.116"
 description = "Holochain, a framework for distributed applications"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -23,23 +23,23 @@ fixt = { version = "0.0.7", path = "../fixt" }
 futures = "0.3.1"
 ghost_actor = "0.3.0-alpha.4"
 holo_hash = { version = "0.0.12", path = "../holo_hash", features = ["full"] }
-holochain_cascade = { version = "0.0.15", path = "../holochain_cascade" }
-holochain_conductor_api = { version = "0.0.15", path = "../holochain_conductor_api" }
-holochain_keystore = { version = "0.0.15", path = "../holochain_keystore" }
-holochain_p2p = { version = "0.0.15", path = "../holochain_p2p" }
-holochain_sqlite = { version = "0.0.15", path = "../holochain_sqlite" }
+holochain_cascade = { version = "0.0.16", path = "../holochain_cascade" }
+holochain_conductor_api = { version = "0.0.16", path = "../holochain_conductor_api" }
+holochain_keystore = { version = "0.0.16", path = "../holochain_keystore" }
+holochain_p2p = { version = "0.0.16", path = "../holochain_p2p" }
+holochain_sqlite = { version = "0.0.16", path = "../holochain_sqlite" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_state = { version = "0.0.15", path = "../holochain_state" }
-holochain_types = { version = "0.0.15", path = "../holochain_types" }
+holochain_state = { version = "0.0.16", path = "../holochain_state" }
+holochain_types = { version = "0.0.16", path = "../holochain_types" }
 holochain_wasmer_host = "=0.0.73"
-holochain_websocket = { version = "0.0.15", path = "../holochain_websocket" }
+holochain_websocket = { version = "0.0.16", path = "../holochain_websocket" }
 holochain_zome_types = { version = "0.0.17", path = "../holochain_zome_types", features = ["full"] }
 human-panic = "1.0.3"
-kitsune_p2p = { version = "0.0.13", path = "../kitsune_p2p/kitsune_p2p" }
-kitsune_p2p_types = { version = "0.0.12", path = "../kitsune_p2p/types" }
+kitsune_p2p = { version = "0.0.14", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p_types = { version = "0.0.13", path = "../kitsune_p2p/types" }
 lazy_static = "1.4.0"
 mockall = "0.10.2"
-mr_bundle = { version = "0.0.4", path = "../mr_bundle" }
+mr_bundle = { version = "0.0.5", path = "../mr_bundle" }
 must_future = "0.1.1"
 nanoid = "0.3"
 num_cpus = "1.8"
@@ -63,7 +63,7 @@ tempdir = "0.3.7"
 thiserror = "1.0.22"
 tokio = { version = "1.11", features = [ "full"] }
 tokio-stream = { version = "0.1", features = [ "sync", "net" ] }
-holochain_util = { version = "0.0.4", path = "../holochain_util" }
+holochain_util = { version = "0.0.5", path = "../holochain_util" }
 toml = "0.5.6"
 tracing = "0.1.26"
 tracing-futures = "0.2.5"
@@ -72,7 +72,7 @@ url = "1.7.2"
 url2 = "0.0.6"
 uuid = { version = "0.7", features = [ "serde", "v4" ] }
 xsalsa20poly1305 = "0.6.0"
-holochain_wasm_test_utils = { version = "0.0.15", path = "../test_utils/wasm" }
+holochain_wasm_test_utils = { version = "0.0.16", path = "../test_utils/wasm" }
 
 # Dependencies for test_utils: keep in sync with below
 hdk = { version = "0.0.115", path = "../hdk", optional = true }

--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.16
+
 ## 0.0.15
 
 ## 0.0.14

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cascade"
-version = "0.0.15"
+version = "0.0.16"
 description = "Logic for cascading updates to Holochain state and network interaction"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -16,14 +16,14 @@ fixt = { version = "0.0.7", path = "../fixt" }
 futures = "0.3"
 ghost_actor = "=0.3.0-alpha.4"
 holo_hash = { version = "0.0.12", path = "../holo_hash", features = ["full"] }
-holochain_sqlite = { version = "0.0.15", path = "../holochain_sqlite" }
-holochain_p2p = { version = "0.0.15", path = "../holochain_p2p" }
+holochain_sqlite = { version = "0.0.16", path = "../holochain_sqlite" }
+holochain_p2p = { version = "0.0.16", path = "../holochain_p2p" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_state = { version = "0.0.15", path = "../holochain_state" }
-holochain_types = { version = "0.0.15", path = "../holochain_types" }
+holochain_state = { version = "0.0.16", path = "../holochain_state" }
+holochain_types = { version = "0.0.16", path = "../holochain_types" }
 holochain_zome_types = { version = "0.0.17", path = "../holochain_zome_types" }
 observability = "0.1.3"
-kitsune_p2p = { version = "0.0.13", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "0.0.14", path = "../kitsune_p2p/kitsune_p2p" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 tokio = { version = "1.11", features = [ "full" ] }

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.16
+
 ## 0.0.15
 
 ## 0.0.14

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_conductor_api"
-version = "0.0.15"
+version = "0.0.16"
 description = "Message types for Holochain admin and app interface protocols"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -11,12 +11,12 @@ edition = "2018"
 [dependencies]
 directories = "2.0.2"
 derive_more = "0.99.3"
-kitsune_p2p = { version = "0.0.13", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "0.0.14", path = "../kitsune_p2p/kitsune_p2p" }
 holo_hash = { version = "0.0.12", path = "../holo_hash", features = ["full"] }
-holochain_p2p = { version = "0.0.15", path = "../holochain_p2p" }
-holochain_state = { version = "0.0.15", path = "../holochain_state" }
+holochain_p2p = { version = "0.0.16", path = "../holochain_p2p" }
+holochain_state = { version = "0.0.16", path = "../holochain_state" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "0.0.15", path = "../holochain_types" }
+holochain_types = { version = "0.0.16", path = "../holochain_types" }
 holochain_zome_types = { version = "0.0.17", path = "../holochain_zome_types" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.16
+
 ## 0.0.15
 
 ## 0.0.14

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_keystore"
-version = "0.0.15"
+version = "0.0.16"
 description = "keystore for libsodium keypairs"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -16,7 +16,7 @@ ghost_actor = "=0.3.0-alpha.4"
 holo_hash = { version = "0.0.12", path = "../holo_hash", features = ["full"] }
 holochain_serialized_bytes = "=0.0.51"
 holochain_zome_types = { path = "../holochain_zome_types", version = "0.0.17"}
-kitsune_p2p_types = { version = "0.0.12", path = "../kitsune_p2p/types" }
+kitsune_p2p_types = { version = "0.0.13", path = "../kitsune_p2p/types" }
 lair_keystore_client_0_0 = { version = "=0.0.9", package = "lair_keystore_client" }
 nanoid = "0.4.0"
 one_err = "0.0.5"
@@ -29,4 +29,4 @@ tracing = "0.1"
 
 # This is a redundant dependency.
 # It's included only to set the proper feature flag for database encryption.
-holochain_sqlite = { version = "0.0.15", path = "../holochain_sqlite" }
+holochain_sqlite = { version = "0.0.16", path = "../holochain_sqlite" }

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.16
+
 ## 0.0.15
 
 ## 0.0.14

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_p2p"
-version = "0.0.15"
+version = "0.0.16"
 description = "holochain specific wrapper around more generic p2p module"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -16,12 +16,12 @@ fixt = { path = "../fixt", version = "0.0.7"}
 futures = "0.3"
 ghost_actor = "=0.3.0-alpha.4"
 holo_hash = { version = "0.0.12", path = "../holo_hash" }
-holochain_keystore = { version = "0.0.15", path = "../holochain_keystore" }
+holochain_keystore = { version = "0.0.16", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "0.0.15", path = "../holochain_types" }
+holochain_types = { version = "0.0.16", path = "../holochain_types" }
 holochain_zome_types = { version = "0.0.17", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "0.0.13", path = "../kitsune_p2p/kitsune_p2p" }
-kitsune_p2p_types = { version = "0.0.12", path = "../kitsune_p2p/types" }
+kitsune_p2p = { version = "0.0.14", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p_types = { version = "0.0.13", path = "../kitsune_p2p/types" }
 mockall = "0.10.2"
 observability = "0.1.3"
 rand = "0.7"
@@ -30,7 +30,7 @@ serde_bytes = "0.11"
 thiserror = "1.0.22"
 tokio = { version = "1.11", features = [ "full" ] }
 tokio-stream = "0.1"
-holochain_util = { version = "0.0.4", path = "../holochain_util" }
+holochain_util = { version = "0.0.5", path = "../holochain_util" }
 
 [features]
 mock_network = [

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.16
+
 ## 0.0.15
 
 - Fixes: Bug where database connections would timeout and return `DatabaseError(DbConnectionPoolError(Error(None)))`. [\#1097](https://github.com/holochain/holochain/pull/1097).

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_sqlite"
-version = "0.0.15"
+version = "0.0.16"
 description = "Abstractions for persistence of Holochain state via SQLite"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -24,7 +24,7 @@ futures = "0.3.1"
 holo_hash = { path = "../holo_hash", features = ["rusqlite"], version = "0.0.12"}
 holochain_serialized_bytes = "=0.0.51"
 holochain_zome_types = { version = "0.0.17", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "0.0.13", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "0.0.14", path = "../kitsune_p2p/kitsune_p2p" }
 lazy_static = "1.4.0"
 once_cell = "1.4.1"
 must_future = "0.1.1"

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.16
+
 ## 0.0.15
 
 ## 0.0.14

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_state"
-version = "0.0.15"
+version = "0.0.16"
 description = "TODO minimize deps"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -13,16 +13,16 @@ byteorder = "1.3.4"
 chrono = "0.4.6"
 derive_more = "0.99.3"
 either = "1.5"
-holochain_sqlite = { version = "0.0.15", path = "../holochain_sqlite" }
+holochain_sqlite = { version = "0.0.16", path = "../holochain_sqlite" }
 holo_hash = { version = "0.0.12", path = "../holo_hash", features = ["full"] }
 fallible-iterator = "0.2.0"
-holochain_keystore = { version = "0.0.15", path = "../holochain_keystore" }
+holochain_keystore = { version = "0.0.16", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_p2p = { version = "0.0.15", path = "../holochain_p2p" }
-holochain_types = { version = "0.0.15", path = "../holochain_types" }
-holochain_util = { version = "0.0.4", path = "../holochain_util" }
+holochain_p2p = { version = "0.0.16", path = "../holochain_p2p" }
+holochain_types = { version = "0.0.16", path = "../holochain_types" }
+holochain_util = { version = "0.0.5", path = "../holochain_util" }
 holochain_zome_types = { version = "0.0.17", path = "../holochain_zome_types", features = [ "full" ] }
-kitsune_p2p = { version = "0.0.13", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "0.0.14", path = "../kitsune_p2p/kitsune_p2p" }
 mockall = "0.10.2"
 one_err = "0.0.5"
 parking_lot = "0.10"
@@ -46,7 +46,7 @@ contrafact = { version = "0.1.0-dev.1", optional = true }
 anyhow = "1.0.26"
 fixt = { version = "0.0.7", path = "../fixt" }
 hdk = { version = "0.0.115", path = "../hdk" }
-holochain_wasm_test_utils = { path = "../test_utils/wasm", version = "0.0.15"}
+holochain_wasm_test_utils = { path = "../test_utils/wasm", version = "0.0.16"}
 matches = "0.1.8"
 observability = "0.1.3"
 pretty_assertions = "0.6.1"

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.16
+
 ## 0.0.15
 
 - FIX: [Bug](https://github.com/holochain/holochain/issues/1101) that was allowing `HeaderWithoutEntry` to shutdown apps. [\#1105](https://github.com/holochain/holochain/pull/1105)

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_types"
-version = "0.0.15"
+version = "0.0.16"
 description = "Holochain common types"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -25,14 +25,14 @@ fixt = { path = "../fixt", version = "0.0.7"}
 flate2 = "1.0.14"
 futures = "0.3"
 holo_hash = { version = "0.0.12", path = "../holo_hash", features = ["encoding"] }
-holochain_keystore = { version = "0.0.15", path = "../holochain_keystore" }
+holochain_keystore = { version = "0.0.16", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_sqlite = { path = "../holochain_sqlite", version = "0.0.15"}
+holochain_sqlite = { path = "../holochain_sqlite", version = "0.0.16"}
 holochain_zome_types = { path = "../holochain_zome_types", version = "0.0.17", features = ["full"] }
 itertools = { version = "0.10" }
 lazy_static = "1.4.0"
 mockall = "0.10.2"
-mr_bundle = { path = "../mr_bundle", features = ["packing"], version = "0.0.4"}
+mr_bundle = { path = "../mr_bundle", features = ["packing"], version = "0.0.5"}
 must_future = "0.1.1"
 nanoid = "0.3"
 observability = "0.1.3"
@@ -49,7 +49,7 @@ strum_macros = "0.18.0"
 tempdir = "0.3.7"
 thiserror = "1.0.22"
 tokio = { version = "1.11", features = [ "rt" ] }
-holochain_util = { version = "0.0.4", path = "../holochain_util", features = ["backtrace"] }
+holochain_util = { version = "0.0.5", path = "../holochain_util", features = ["backtrace"] }
 tracing = "0.1.26"
 derive_builder = "0.9.0"
 

--- a/crates/holochain_util/CHANGELOG.md
+++ b/crates/holochain_util/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.5
+
 ## 0.0.4
 
 ## 0.0.3

--- a/crates/holochain_util/Cargo.toml
+++ b/crates/holochain_util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_util"
-version = "0.0.4"
+version = "0.0.5"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
 edition = "2018"
 description = "This crate is a collection of various utility functions that are used in the other crates in the holochain repository."

--- a/crates/holochain_websocket/CHANGELOG.md
+++ b/crates/holochain_websocket/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.16
+
 ## 0.0.15
 
 ## 0.0.14

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_websocket"
-version = "0.0.15"
+version = "0.0.16"
 description = "Holochain utilities for serving and connection with websockets"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -27,7 +27,7 @@ tungstenite = "0.12"
 url2 = "0.0.6"
 
 [dev-dependencies]
-holochain_types = { version = "0.0.15", path = "../holochain_types" }
+holochain_types = { version = "0.0.16", path = "../holochain_types" }
 linefeed = "0.6"
 unwrap_to = "0.1.0"
 observability = "0.1.3"

--- a/crates/kitsune_p2p/bootstrap/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 futures = "0.3.15"
-kitsune_p2p_types = { version = "0.0.12", path = "../types" }
+kitsune_p2p_types = { version = "0.0.13", path = "../types" }
 once_cell = "1.7.2"
 parking_lot = "0.11"
 rand = "0.7"
@@ -26,7 +26,7 @@ tokio = { version = "1", features = ["full"] }
 warp = "0.3"
 
 [dev-dependencies]
-kitsune_p2p = { version = "0.0.13", path = "../kitsune_p2p" }
+kitsune_p2p = { version = "0.0.14", path = "../kitsune_p2p" }
 fixt = { path = "../../fixt" ,version = "0.0.7"}
 criterion = "0.3"
 reqwest = "0.11.2"

--- a/crates/kitsune_p2p/direct/Cargo.toml
+++ b/crates/kitsune_p2p/direct/Cargo.toml
@@ -19,10 +19,10 @@ hyper = { version = "0.14", features = ["server","http1","http2","tcp"] }
 if-addrs = "0.6"
 kitsune_p2p_bootstrap = { version = "0.0.1", path = "../bootstrap" }
 kitsune_p2p_direct_api = { version = "0.0.1", path = "../direct_api" }
-kitsune_p2p_types = { version = "0.0.12", path = "../types" }
-kitsune_p2p = { version = "0.0.13", path = "../kitsune_p2p" }
-kitsune_p2p_transport_quic = { version = "0.0.12", path = "../transport_quic" }
-kitsune_p2p_proxy = { version = "0.0.12", path = "../proxy" }
+kitsune_p2p_types = { version = "0.0.13", path = "../types" }
+kitsune_p2p = { version = "0.0.14", path = "../kitsune_p2p" }
+kitsune_p2p_transport_quic = { version = "0.0.13", path = "../transport_quic" }
+kitsune_p2p_proxy = { version = "0.0.13", path = "../proxy" }
 rand = "0.8.3"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/crates/kitsune_p2p/direct_test/Cargo.toml
+++ b/crates/kitsune_p2p/direct_test/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 
 [dependencies]
 kitsune_p2p_direct = { version = "0.0.1", path = "../direct" }
-kitsune_p2p_transport_quic = { version = "0.0.12", path = "../transport_quic" }
-kitsune_p2p_proxy = { version = "0.0.12", path = "../proxy" }
+kitsune_p2p_transport_quic = { version = "0.0.13", path = "../transport_quic" }
+kitsune_p2p_proxy = { version = "0.0.13", path = "../proxy" }
 rand = "0.8.4"
 structopt = "0.3.21"
 tokio = { version = "1.11", features = ["full"] }

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.14
+
 ## 0.0.13
 
 ## 0.0.12

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p"
-version = "0.0.13"
+version = "0.0.14"
 description = "p2p / dht communication framework"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -20,10 +20,10 @@ ghost_actor = "=0.3.0-alpha.4"
 governor = "0.3.2"
 itertools = "0.10"
 kitsune_p2p_mdns = { version = "0.0.2", path = "../mdns" }
-kitsune_p2p_proxy = { version = "0.0.12", path = "../proxy" }
+kitsune_p2p_proxy = { version = "0.0.13", path = "../proxy" }
 kitsune_p2p_timestamp = { version = "0.0.5", path = "../timestamp" }
-kitsune_p2p_transport_quic = { version = "0.0.12", path = "../transport_quic" }
-kitsune_p2p_types = { version = "0.0.12", path = "../types" }
+kitsune_p2p_transport_quic = { version = "0.0.13", path = "../transport_quic" }
+kitsune_p2p_types = { version = "0.0.13", path = "../types" }
 num-traits = "0.2"
 parking_lot = "0.11.1"
 rand = "0.7"

--- a/crates/kitsune_p2p/proxy/CHANGELOG.md
+++ b/crates/kitsune_p2p/proxy/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.13
+
 ## 0.0.12
 
 ## 0.0.11

--- a/crates/kitsune_p2p/proxy/Cargo.toml
+++ b/crates/kitsune_p2p/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_proxy"
-version = "0.0.12"
+version = "0.0.13"
 description = "Proxy transport module for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -15,8 +15,8 @@ base64 = "0.13"
 blake2b_simd = "0.5.10"
 derive_more = "0.99.7"
 futures = "0.3"
-kitsune_p2p_types = { version = "0.0.12", path = "../types" }
-kitsune_p2p_transport_quic = { version = "0.0.12", path = "../transport_quic" }
+kitsune_p2p_types = { version = "0.0.13", path = "../types" }
+kitsune_p2p_transport_quic = { version = "0.0.13", path = "../transport_quic" }
 nanoid = "0.3"
 observability = "0.1.3"
 parking_lot = "0.11"

--- a/crates/kitsune_p2p/transport_quic/CHANGELOG.md
+++ b/crates/kitsune_p2p/transport_quic/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.13
+
 ## 0.0.12
 
 ## 0.0.11

--- a/crates/kitsune_p2p/transport_quic/Cargo.toml
+++ b/crates/kitsune_p2p/transport_quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_transport_quic"
-version = "0.0.12"
+version = "0.0.13"
 description = "QUIC transport module for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -14,7 +14,7 @@ edition = "2018"
 blake2b_simd = "0.5.10"
 futures = "0.3"
 if-addrs = "0.6"
-kitsune_p2p_types = { version = "0.0.12", path = "../types" }
+kitsune_p2p_types = { version = "0.0.13", path = "../types" }
 nanoid = "0.3"
 once_cell = "1.5.2"
 quinn = "0.7"

--- a/crates/kitsune_p2p/types/CHANGELOG.md
+++ b/crates/kitsune_p2p/types/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.13
+
 ## 0.0.12
 
 ## 0.0.11

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_types"
-version = "0.0.12"
+version = "0.0.13"
 description = "types subcrate for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/mr_bundle/CHANGELOG.md
+++ b/crates/mr_bundle/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.5
+
 ## 0.0.4
 
 ## 0.0.3

--- a/crates/mr_bundle/Cargo.toml
+++ b/crates/mr_bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mr_bundle"
-version = "0.0.4"
+version = "0.0.5"
 authors = ["Michael Dougherty <maackle.d@gmail.com>"]
 edition = "2018"
 description = "Implements the un-/packing of bundles that either embed or reference a set of resources"
@@ -11,7 +11,7 @@ documentation = "https://docs.rs/mr_bundle"
 [dependencies]
 bytes = "1.0"
 flate2 = "1.0"
-holochain_util = { path = "../holochain_util", version = "0.0.4"}
+holochain_util = { path = "../holochain_util", version = "0.0.5"}
 futures = "0.3"
 reqwest = "0.11"
 rmp-serde = "0.15"

--- a/crates/test_utils/wasm/CHANGELOG.md
+++ b/crates/test_utils/wasm/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.0.16
+
 ## 0.0.15
 
 ## 0.0.14

--- a/crates/test_utils/wasm/Cargo.toml
+++ b/crates/test_utils/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_wasm_test_utils"
-version = "0.0.15"
+version = "0.0.16"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2018"
 description = "Utilities for Wasm testing for Holochain"
@@ -21,12 +21,12 @@ only_check = []
 [dependencies]
 fixt = { path = "../../fixt", version = "0.0.7"}
 holo_hash = { path = "../../holo_hash", version = "0.0.12"}
-holochain_types = { path = "../../holochain_types", version = "0.0.15"}
+holochain_types = { path = "../../holochain_types", version = "0.0.16"}
 holochain_zome_types = { path = "../../holochain_zome_types", version = "0.0.17"}
 rand = "0.7"
 strum = "0.18.0"
 strum_macros = "0.18.0"
-holochain_util = { version = "0.0.4", path = "../../holochain_util" }
+holochain_util = { version = "0.0.5", path = "../../holochain_util" }
 
 [build-dependencies]
 toml = "0.5"


### PR DESCRIPTION
the following crates are part of this release:

- holochain_util-0.0.5
- mr_bundle-0.0.5
- kitsune_p2p_types-0.0.13
- kitsune_p2p_transport_quic-0.0.13
- kitsune_p2p_proxy-0.0.13
- kitsune_p2p-0.0.14
- holochain_sqlite-0.0.16
- holochain_keystore-0.0.16
- holochain_types-0.0.16
- holochain_p2p-0.0.16
- holochain_wasm_test_utils-0.0.16
- holochain_state-0.0.16
- holochain_conductor_api-0.0.16
- holochain_websocket-0.0.16
- holochain_cli-0.0.17
- holochain_cascade-0.0.16
- holochain-0.0.116

### Summary



### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
