### PR TITLE
Add HDK doc example for hdk::entry::get

### DIFF
--- a/crates/hdk/src/entry.rs
+++ b/crates/hdk/src/entry.rs
@@ -210,6 +210,19 @@ where
 ///       contacts on their current network partition, there could always be an older live entry
 ///       on another partition, and of course the oldest live entry could be deleted and no longer
 ///       be live.
+///
+/// e.g.
+/// ```ignore
+/// #[hdk_entry(id = "foo")]
+/// pub struct Foo(u32);
+///
+/// let header_hash = create_entry(Foo(50))?;
+/// let element: Element = get(header_hash, GetOptions::latest())?
+///     .ok_or(WasmError::Guest(String::from("Entry not found")))?;
+/// let foo_option: Option<Foo> = element.entry().to_app_option()?;
+/// let foo: Foo = foo_option.ok_or(WasmError::Guest("Entry is not type Foo".into()))?;
+/// assert_eq!(foo.0, 50);
+/// ```
 pub fn get<H>(hash: H, options: GetOptions) -> ExternResult<Option<Element>>
 where
     AnyDhtHash: From<H>,


### PR DESCRIPTION
### Summary

Add HDK doc example for `hdk::entry::get`.

Note: This was largely created in a Holochain in Action recorded session, where we were demoing adding docs to the HDK, to try to help inspire spreading the work of documentation examples to the Holochain open source community.

Credit to @axhue for writing most of the code!

Note to core team: feel free to improve this directly before merging, or make any requests.  If improving directly, please state the intention to help improve future similar pull requests.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
