### PR TITLE
holochain: add build-info cli flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2380,6 +2380,7 @@ dependencies = [
  "holochain_wasmer_host",
  "holochain_websocket",
  "holochain_zome_types",
+ "hostname",
  "human-panic",
  "itertools 0.10.1",
  "kitsune_p2p",

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **BREAKING CHANGE** Removed `app_info` from HDK [1108](https://github.com/holochain/holochain/pull/1108)
 - Permissions on host functions now return an error instead of panicking [1141](https://github.com/holochain/holochain/pull/1141)
-
+- Add `--build-info` CLI flag for displaying various information in JSON format. [\#1163](https://github.com/holochain/holochain/pull/1163)
 
 ## 0.0.120
 

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -106,7 +106,7 @@ arbitrary = { version = "1.0", features = ["derive"] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0.51" }
 toml = "0.5.6"
-chrono = "0.4.6"
+chrono = { version = "0.4.6", features = [ "serde" ] }
 hostname = "0.3.1"
 
 [[bench]]

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -102,6 +102,13 @@ holochain_test_wasm_common = { version = "0.0.16", path = "../test_utils/wasm_co
 unwrap_to = { version = "0.1.0", optional = false }
 arbitrary = { version = "1.0", features = ["derive"] }
 
+[build-dependencies]
+serde = { version = "1.0", features = [ "derive" ] }
+serde_json = { version = "1.0.51" }
+toml = "0.5.6"
+chrono = "0.4.6"
+hostname = "0.3.1"
+
 [[bench]]
 name = "bench"
 harness = false

--- a/crates/holochain/build.rs
+++ b/crates/holochain/build.rs
@@ -1,0 +1,142 @@
+mod version_info {
+    use chrono::{offset::Utc, DateTime};
+    use serde::Serialize;
+    use std::{process::Command, time::SystemTime};
+
+    #[derive(Serialize, Debug)]
+    struct BuildInfo {
+        git_info: Option<GitInfo>,
+        cargo_pkg_version: String,
+        hdk_version_req: String,
+
+        timestamp: DateTime<Utc>,
+        hostname: String,
+
+        host: String,
+        target: String,
+        rustc_version: String,
+        rustflags: String,
+        profile: String,
+    }
+    #[derive(Serialize, Debug)]
+    struct GitInfo {
+        rev: String,
+        dirty: bool,
+    }
+
+    impl GitInfo {
+        fn maybe_retrieve() -> Option<Self> {
+            let git_available = Command::new("git")
+                .arg("status")
+                .output()
+                .map(|output| output.status.code().unwrap_or(1))
+                .unwrap_or(1)
+                == 0;
+
+            if !git_available {
+                None
+            } else {
+                let git_rev = String::from_utf8_lossy(
+                    &Command::new("git")
+                        .arg("rev-parse")
+                        .arg("HEAD")
+                        .output()
+                        .unwrap()
+                        .stdout,
+                )
+                .trim()
+                .to_string();
+
+                let git_dirty = Command::new("git")
+                    .arg("diff")
+                    .arg("--quiet")
+                    .arg("--exit-code")
+                    .spawn()
+                    .unwrap()
+                    .wait()
+                    .unwrap()
+                    .code()
+                    .unwrap()
+                    != 0;
+
+                Some(Self {
+                    rev: git_rev,
+                    dirty: git_dirty,
+                })
+            }
+        }
+    }
+
+    fn hdk_version_req() -> String {
+        use std::str::FromStr;
+        use toml::Value;
+
+        let manifest_path = std::path::PathBuf::from_str(env!("CARGO_MANIFEST_DIR"))
+            .unwrap()
+            .join("Cargo.toml");
+        let manifest = std::fs::read_to_string(&manifest_path)
+            .unwrap_or_else(|e| panic!("reading {:?}: {}", &manifest_path, e));
+
+        let manifest_toml = Value::from_str(&manifest).expect("parsing manifest");
+
+        let table = manifest_toml.as_table().unwrap();
+        let hdk_dep = &table["dependencies"]["hdk"];
+
+        match hdk_dep {
+            Value::Table(hdk) => hdk["version"].to_string(),
+            Value::String(hdk_version) => hdk_version.to_string(),
+            other => panic!("unexpected hdk_dep {:?}", other),
+        }
+        .replace('"', "")
+    }
+
+    impl BuildInfo {
+        fn retrieve() -> Self {
+            let rustc_version = Command::new(option_env!("RUSTC").unwrap_or("rustc"))
+                .arg("--version")
+                .output()
+                .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+                .unwrap_or_default();
+
+            let hostname = hostname::get()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+
+            BuildInfo {
+                cargo_pkg_version: std::env::var("CARGO_PKG_VERSION").unwrap_or_default(),
+                git_info: GitInfo::maybe_retrieve(),
+                hdk_version_req: hdk_version_req(),
+
+                timestamp: SystemTime::now().into(),
+                hostname,
+
+                host: std::env::var("HOST").unwrap_or_default(),
+                target: std::env::var("TARGET").unwrap_or_default(),
+                rustc_version,
+                rustflags: std::env::var("RUSTFLAGS")
+                    .ok()
+                    .or_else(|| option_env!("RUSTFLAGS").map(|s| s.to_string()))
+                    .unwrap_or_default(),
+                profile: std::env::var("PROFILE").unwrap_or_default(),
+            }
+        }
+
+        fn as_json_string(&self) -> String {
+            serde_json::to_string(&self).unwrap()
+        }
+    }
+
+    /// This will be used populate the VERSION_INFO environment variable,
+    /// which will be displayed as JSON when `holochain --version-info` is called.
+    pub(crate) fn populate_env() {
+        println!(
+            "cargo:rustc-env=BUILD_INFO={}",
+            BuildInfo::retrieve().as_json_string()
+        );
+    }
+}
+
+fn main() {
+    version_info::populate_env();
+}

--- a/crates/holochain/src/bin/holochain/main.rs
+++ b/crates/holochain/src/bin/holochain/main.rs
@@ -55,6 +55,12 @@ struct Opt {
     useful when running a conductor for the first time"
     )]
     interactive: bool,
+
+    #[structopt(
+        long,
+        help = "Display version information such as git revision and HDK version"
+    )]
+    build_info: bool,
 }
 
 fn main() {
@@ -69,6 +75,11 @@ async fn async_main() {
     human_panic::setup_panic!();
 
     let opt = Opt::from_args();
+
+    if opt.build_info {
+        println!("{}", option_env!("BUILD_INFO").unwrap_or("{}"));
+        return;
+    }
 
     observability::init_fmt(opt.structured.clone()).expect("Failed to start contextual logging");
     debug!("observability initialized");


### PR DESCRIPTION
holochain: add build-info cli flag

when `--build-info` is passed, display build information such as the git
tree status, hdk dependency version, etc., in the JSON format. this can
be useful for scaffolding and updating happs or collect debug
information in real-world environments.

prettified example:

```json
{
  "git_info": {
    "rev": "f55106c6097c0dcb142f1d7387efb7f8444eee52",
    "dirty": false
  },
  "cargo_pkg_version": "0.0.120",
  "hdk_version_req": "0.0.116",
  "timestamp": "2021-12-16T21:03:19.692523855Z",
  "hostname": "steveej-t14",
  "host": "x86_64-unknown-linux-gnu",
  "target": "x86_64-unknown-linux-gnu",
  "rustc_version": "rustc 1.55.0 (c8dfcfe04 2021-09-06)",
  "rustflags": "-D warnings -C codegen-units=10",
  "profile": "debug"
}
```


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
