### PR TITLE
macos: add merge-release-test-mac and fix openssl build issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,8 @@ jobs:
    merge-release-test-mac:
       macos:
          xcode: "13.2.1"
-      resource_class: xlarge
+      # todo: use "large" which is currently blocked on our plan
+      resource_class: medium
       environment:
          CACHIX_NAME: holochain-ci
          NIXPKGS_ALLOW_UNFREE: 1
@@ -93,7 +94,8 @@ jobs:
    merge-test-mac:
       macos:
          xcode: "12.0.0"
-      resource_class: xlarge
+      # todo: use "large" which is currently blocked on our plan
+      resource_class: medium
       environment:
          CACHIX_NAME: holochain-ci
          NIXPKGS_ALLOW_UNFREE: 1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ workflows:
    tests:
       jobs:
          - merge-release-test
-         - merge-release-test-mac
+         # - merge-release-test-mac
          - merge-test
          # - merge-test-mac
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,43 @@ jobs:
       steps:
          - checkout
          - run:
-              name: Set up Hydra cache
+              name: Set up Nix cache
               command: $(nix-build . --fallback --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
          - run:
               name: PR release tests
               no_output_timeout: 30m
               command: ./scripts/ci_merge-release-test.sh
+   merge-release-test-mac:
+      macos:
+         xcode: "13.2.1"
+      resource_class: xlarge
+      environment:
+         CACHIX_NAME: holochain-ci
+         NIXPKGS_ALLOW_UNFREE: 1
+      steps:
+         - checkout
+         - run:
+              name: Unset CircleCI's forced conversion of HTTPS->SSH
+              command: git config --global --unset "url.ssh://git@github.com.insteadof"
+         - run:
+              name: Install Nix
+              no_output_timeout: 30m
+              command: |
+                # fix for "too many open files" that breaks tokio
+                ulimit -n 10240
+                # workaround a bug in the Nix installer
+                echo " #" >> /Users/distiller/.bash_profile
+                # catalina nixos install
+                sh <(curl -L https://releases.nixos.org/nix/nix-2.3.8/install) --darwin-use-unencrypted-nix-store-volume
+         - run:
+              name: Set up Nix cache
+              command: |
+                $(nix-build . --fallback --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
+         - run:
+              name: PR release tests
+              no_output_timeout: 30m
+              command: |
+                ./scripts/ci_merge-release-test.sh
    merge-test:
       docker:
          - image: holochain/holochain:circle.build.develop
@@ -99,6 +130,7 @@ workflows:
    tests:
       jobs:
          - merge-release-test
+         - merge-release-test-mac
          - merge-test
          # - merge-test-mac
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
               password: $DOCKER_PASS
       resource_class: xlarge
       environment:
+         CACHIX_NAME: holochain-ci
          NIXPKGS_ALLOW_UNFREE: 1
       steps:
          - checkout
@@ -51,7 +52,7 @@ jobs:
               name: Unset CircleCI's forced conversion of HTTPS->SSH
               command: git config --global --unset "url.ssh://git@github.com.insteadof"
          - run:
-              name: Set up Hydra cache
+              name: Set up Nix cache
               command: $(nix-build . --fallback --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
          - run:
               name: Run the merge tests
@@ -63,6 +64,7 @@ jobs:
          xcode: "12.0.0"
       resource_class: xlarge
       environment:
+         CACHIX_NAME: holochain-ci
          NIXPKGS_ALLOW_UNFREE: 1
       steps:
          - checkout

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4338,9 +4338,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-src"
-version = "111.16.0+1.1.1l"
+version = "111.17.0+1.1.1m"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2173f69416cf3ec12debb5823d244127d23a9b127d5a5189aa97c5fa2859f"
+checksum = "05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4"
 dependencies = [
  "cc",
 ]


### PR DESCRIPTION
### Summary



### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
