### PR TITLE
Fix deadlock in MetricsSync

### DIFF
--- a/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
@@ -605,9 +605,14 @@ impl MetricsSync {
         match self.0.try_read_for(std::time::Duration::from_millis(100)) {
             Some(g) => g,
             // This won't block if a writer is waiting.
+            // NOTE: This is a bit of a hack to work around a lock somewhere that is errant-ly 
+            // held over another call to lock. Really we should fix that error,
+            // potentially by using a closure pattern here to ensure the lock cannot
+            // be held beyond the access logic.
             None => self.0.read_recursive(),
         }
     }
+    
     /// Get a write lock for the metrics store.
     pub fn write(&self) -> parking_lot::RwLockWriteGuard<Metrics> {
         match self.0.try_write_for(std::time::Duration::from_secs(100)) {

--- a/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
@@ -605,14 +605,14 @@ impl MetricsSync {
         match self.0.try_read_for(std::time::Duration::from_millis(100)) {
             Some(g) => g,
             // This won't block if a writer is waiting.
-            // NOTE: This is a bit of a hack to work around a lock somewhere that is errant-ly 
+            // NOTE: This is a bit of a hack to work around a lock somewhere that is errant-ly
             // held over another call to lock. Really we should fix that error,
             // potentially by using a closure pattern here to ensure the lock cannot
             // be held beyond the access logic.
             None => self.0.read_recursive(),
         }
     }
-    
+
     /// Get a write lock for the metrics store.
     pub fn write(&self) -> parking_lot::RwLockWriteGuard<Metrics> {
         match self.0.try_write_for(std::time::Duration::from_secs(100)) {


### PR DESCRIPTION
Was deadlocking see gdb output:
Holochain test is frozen with no threads doing anything.
Two threads have a backtrace like this:
```
#2  0x0000558264feb378 in parking_lot::raw_rwlock::{impl#0}::lock_shared (self=0x7f2e743025b0) at /home/freesig/holochain/otherchain/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot-0.11.2/src/raw_rwlock.rs:110
#3  0x0000558264f8c653 in lock_api::rwlock::RwLock<parking_lot::raw_rwlock::RawRwLock, kitsune_p2p::metrics::Metrics>::read<parking_lot::raw_rwlock::RawRwLock, kitsune_p2p::metrics::Metrics> (self=0x7f2e743025b0) at /home
/freesig/holochain/otherchain/.cargo/registry/src/github.com-1ecc6299db9ec823/lock_api-0.4.5/src/rwlock.rs:436
#4  0x000055826509df1a in kitsune_p2p::gossip::sharded_gossip::next_target::next_remote_node::{closure#0} (a=0x7f2d6c036338, b=0x7f2d6c036310) at crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/next_target.rs:114
#5  0x000055826501b2ef in core::slice::{impl#0}::sort_unstable_by::{closure#0}<kitsune_p2p::gossip::sharded_gossip::next_target::Node, kitsune_p2p::gossip::sharded_gossip::next_target::next_remote_node::{closure#0}> (a=0x
7f2d6c036338, b=0x7f2d6c036310) at /rustc/f1edd0429582dd29cccacaf50fd134b05593bd9c/library/core/src/slice/mod.rs:2394
```
Another looks like:
```
#1  0x0000558265815c4d in parking_lot::raw_rwlock::RawRwLock::wait_for_readers ()
#2  0x0000558262e9b929 in parking_lot::raw_rwlock::RawRwLock::lock_exclusive_slow ()                                                                                                                                         #3  0x0000558264feb499 in parking_lot::raw_rwlock::{impl#0}::lock_exclusive (self=0x7f2e743025b0) at /home/freesig/holochain/otherchain/.cargo/registry/src/github.com-1ecc6299db9ec823/parking_lot-0.11.2/src/raw_rwlock.rs:
74
#4  0x0000558264f8c6b3 in lock_api::rwlock::RwLock<parking_lot::raw_rwlock::RawRwLock, kitsune_p2p::metrics::Metrics>::write<parking_lot::raw_rwlock::RawRwLock, kitsune_p2p::metrics::Metrics> (self=0x7f2e743025b0) at /hom
e/freesig/holochain/otherchain/.cargo/registry/src/github.com-1ecc6299db9ec823/lock_api-0.4.5/src/rwlock.rs:468
```
Which leads to a deadlock because readers are not allowed to take the lock while a writer is waiting to avoid starving. `read_recursive` avoids this but can starve readers so I try a normal read first in my solution.