### PR TITLE
[D-01415] fix instant subtract bug

### DIFF
--- a/crates/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/CHANGELOG.md
@@ -3,3 +3,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- Fixes D-01415 holochain panic on startup [#1206](https://github.com/holochain/holochain/pull/1206)

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/metric_exchange.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/metric_exchange.rs
@@ -6,11 +6,11 @@ use tokio::time::Instant;
 
 struct ShouldTrigger {
     last_sync: Option<Instant>,
-    freq: u128,
+    freq: Duration,
 }
 
 impl ShouldTrigger {
-    pub fn new(freq: u128) -> Self {
+    pub fn new(freq: Duration) -> Self {
         Self {
             last_sync: None,
             freq,
@@ -21,7 +21,7 @@ impl ShouldTrigger {
         let now = Instant::now();
         if self
             .last_sync
-            .map(|s| now.saturating_duration_since(s).as_millis() > self.freq)
+            .map(|s| now.saturating_duration_since(s) > self.freq)
             .unwrap_or(true)
         {
             self.last_sync = Some(now);

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/metric_exchange.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/metric_exchange.rs
@@ -10,8 +10,8 @@ const EXTRAP_COV_CHECK_FREQ_US: i64 = 1000 * 1000 * 60;
 const METRIC_EXCHANGE_FREQ_US: i64 = 1000 * 1000 * 60;
 
 fn get_runtime_micros() -> i64 {
-    use tokio::time::Instant;
     use once_cell::sync::Lazy;
+    use tokio::time::Instant;
     static MARKER: Lazy<Instant> = Lazy::new(Instant::now);
     MARKER.elapsed().as_micros() as i64
 }


### PR DESCRIPTION
### Summary

- checked sub works fine on linux, but alas, panics on other systems, switch to deriving a pseudo runtime via single lazy instant elasped converted into an i64 that can be subtracted safely.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
