### PR TITLE
Allow backward-compatible DeleteInput for delete hdk functions

### DIFF
--- a/crates/hdk/src/capability.rs
+++ b/crates/hdk/src/capability.rs
@@ -142,8 +142,12 @@ pub fn create_cap_grant(cap_grant_entry: CapGrantEntry) -> ExternResult<HeaderHa
 ///
 /// The input to [ `delete_cap_grant` ] is the [ `HeaderHash` ] of the [ `CapGrant` ] element to delete.
 /// Deletes can reference both [ `CapGrant` ] creates and updates.
-pub fn delete_cap_grant(hash: HeaderHash) -> ExternResult<HeaderHash> {
-    delete(hash)
+pub fn delete_cap_grant<I, E>(delete_input: I) -> ExternResult<HeaderHash>
+where
+    DeleteInput: TryFrom<I, Error = E>,
+    WasmError: From<E>,
+{
+    delete(delete_input)
 }
 
 /// Generate secrets for capability grants.

--- a/crates/hdk/src/entry.rs
+++ b/crates/hdk/src/entry.rs
@@ -36,13 +36,12 @@ pub fn update(hash: HeaderHash, create_input: CreateInput) -> ExternResult<Heade
 ///
 /// Usually you don't need to use this function directly; it is the most general way to update an
 /// entry and standardises the internals of higher level create functions.
-pub fn delete(deletes_header_address: HeaderHash) -> ExternResult<HeaderHash> {
-    HDK.with(|h| {
-        h.borrow().delete(DeleteInput::new(
-            deletes_header_address,
-            ChainTopOrdering::default(),
-        ))
-    })
+pub fn delete<I, E>(delete_input: I) -> ExternResult<HeaderHash>
+where
+    DeleteInput: TryFrom<I, Error = E>,
+    WasmError: From<E>,
+{
+    HDK.with(|h| h.borrow().delete(DeleteInput::try_from(delete_input)?))
 }
 
 /// Create an app entry.
@@ -78,8 +77,12 @@ where
 /// ```ignore
 /// delete_entry(entry_hash(foo_entry)?)?;
 /// ```
-pub fn delete_entry(hash: HeaderHash) -> ExternResult<HeaderHash> {
-    delete(hash)
+pub fn delete_entry<I, E>(delete_input: I) -> ExternResult<HeaderHash>
+where
+    DeleteInput: TryFrom<I, Error = E>,
+    WasmError: From<E>,
+{
+    delete(delete_input)
 }
 
 /// Hash anything that that implements [ `TryInto<Entry>` ].

--- a/crates/holochain_zome_types/src/entry.rs
+++ b/crates/holochain_zome_types/src/entry.rs
@@ -341,3 +341,12 @@ impl DeleteInput {
         }
     }
 }
+
+impl From<holo_hash::HeaderHash> for DeleteInput {
+    fn from(deletes_header_address: holo_hash::HeaderHash) -> Self {
+        Self {
+            deletes_header_address,
+            chain_top_ordering: ChainTopOrdering::default(),
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Just plumbs the already extant DeleteInput through the 3 hdk functions that involve deletes, with a From impl for backward compatibility for existing zome code that just used a HeaderHash.

Closes #1071

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
