### PR TITLE
Add origin_time to DnaDef

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2785,9 +2785,11 @@ version = "0.0.5"
 dependencies = [
  "arbitrary",
  "chrono",
+ "derive_more",
  "holochain_serialized_bytes",
  "rusqlite",
  "serde",
+ "serde_yaml",
  "thiserror",
 ]
 

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## \[Unreleased\]
 
 - BREAKING: The DNA manifest now requires an `origin_time` Timestamp field, which will be used in the forthcoming gossip optimization.
+  - There is a new system validation rule that all Header timestamps (including the initial Dna header) must come after the DNA's `origin_time` field.
+  - `hc dna init` injects the current system time as *microseconds* for the `origin_time` field of the DNA manifest
 
 ## 0.0.21
 

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -4,9 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
-- BREAKING: The DNA manifest now requires an `origin_time` Timestamp field, which will be used in the forthcoming gossip optimization.
+- The DNA manifest now requires an `origin_time` Timestamp field, which will be used in the forthcoming gossip optimization.
   - There is a new system validation rule that all Header timestamps (including the initial Dna header) must come after the DNA's `origin_time` field.
   - `hc dna init` injects the current system time as *microseconds* for the `origin_time` field of the DNA manifest
+  - Since this field is not actually hooked up to anything at the moment, if the field is not present in a DNA manifest, a default `origin_time` of `January 1, 2022 12:00:00 AM` will be used instead. Once the new gossip algorithm lands, this default will be removed, and this will become a breaking change for DNA manifests which have not yet added an `origin_time`.
 
 ## 0.0.22
 

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- BREAKING: The DNA manifest now requires an `origin_time` Timestamp field, which will be used in the forthcoming gossip optimization.
+
 ## 0.0.21
 
 ## 0.0.20

--- a/crates/hc_bundle/src/init.rs
+++ b/crates/hc_bundle/src/init.rs
@@ -46,7 +46,7 @@ fn prompt_dna_init(root_dir: PathBuf) -> anyhow::Result<DnaBundle> {
         "uid:",
         "00000000-0000-0000-0000-000000000000",
     )?);
-    let manifest = DnaManifest::current(name, uid, None, Timestamp::now(), vec![]);
+    let manifest = DnaManifest::current(name, uid, None, Timestamp::now().into(), vec![]);
     Ok(DnaBundle::new(manifest, vec![], root_dir)?)
 }
 

--- a/crates/hc_bundle/src/init.rs
+++ b/crates/hc_bundle/src/init.rs
@@ -3,6 +3,7 @@ use std::{io, path::PathBuf};
 
 use holochain_types::prelude::{
     AppBundle, AppManifest, AppManifestCurrentBuilder, AppRoleManifest, DnaBundle, DnaManifest,
+    Timestamp,
 };
 use holochain_types::web_app::{WebAppBundle, WebAppManifest};
 
@@ -45,7 +46,7 @@ fn prompt_dna_init(root_dir: PathBuf) -> anyhow::Result<DnaBundle> {
         "uid:",
         "00000000-0000-0000-0000-000000000000",
     )?);
-    let manifest = DnaManifest::current(name, uid, None, vec![]);
+    let manifest = DnaManifest::current(name, uid, None, Timestamp::now(), vec![]);
     Ok(DnaBundle::new(manifest, vec![], root_dir)?)
 }
 

--- a/crates/hc_bundle/src/packing.rs
+++ b/crates/hc_bundle/src/packing.rs
@@ -94,6 +94,7 @@ mod tests {
 manifest_version: "1"
 name: test_dna
 uid: blablabla
+origin_time: 2022-02-11T23:29:00.789576Z
 properties:
   some: 42
   props: yay

--- a/crates/hc_bundle/tests/fixtures/my-app/dnas/dna1/dna.yaml
+++ b/crates/hc_bundle/tests/fixtures/my-app/dnas/dna1/dna.yaml
@@ -3,6 +3,7 @@ manifest_version: "1"
 name: a dna
 uid: 00000000-0000-0000-0000-000000000000
 properties: ~
+origin_time: 2022-02-11T23:29:00.789576Z
 zomes:
   - name: zome1
     bundled: ./zomes/zome1.wasm

--- a/crates/hc_bundle/tests/fixtures/my-app/dnas/dna2/dna.yaml
+++ b/crates/hc_bundle/tests/fixtures/my-app/dnas/dna2/dna.yaml
@@ -3,7 +3,6 @@ manifest_version: "1"
 name: another dna
 uid: 00000000-0000-0000-0000-000000000000
 properties: ~
-origin_time: 2022-02-11T23:29:00.789576Z
 zomes:
   - name: zome1
     bundled: ./zome1.wasm

--- a/crates/hc_bundle/tests/fixtures/my-app/dnas/dna2/dna.yaml
+++ b/crates/hc_bundle/tests/fixtures/my-app/dnas/dna2/dna.yaml
@@ -3,6 +3,7 @@ manifest_version: "1"
 name: another dna
 uid: 00000000-0000-0000-0000-000000000000
 properties: ~
+origin_time: 2022-02-11T23:29:00.789576Z
 zomes:
   - name: zome1
     bundled: ./zome1.wasm

--- a/crates/holochain/src/conductor/api/api_cell.rs
+++ b/crates/holochain/src/conductor/api/api_cell.rs
@@ -79,12 +79,12 @@ impl CellConductorApiT for CellConductorApi {
     }
 
     fn get_dna(&self, dna_hash: &DnaHash) -> Option<DnaFile> {
-        self.conductor_handle.get_dna(dna_hash)
+        self.conductor_handle.get_dna_file(dna_hash)
     }
 
     fn get_this_dna(&self) -> ConductorApiResult<DnaFile> {
         self.conductor_handle
-            .get_dna(self.cell_id.dna_hash())
+            .get_dna_file(self.cell_id.dna_hash())
             .ok_or_else(|| ConductorApiError::DnaMissing(self.cell_id.dna_hash().clone()))
     }
 

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -91,12 +91,13 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                                     .to_string(),
                             ));
                         }
-                        let mut dna = self.conductor_handle.get_dna(hash).ok_or_else(|| {
-                            ConductorApiError::DnaReadError(format!(
-                                "Unable to create derived Dna: {} not registered",
-                                hash
-                            ))
-                        })?;
+                        let mut dna =
+                            self.conductor_handle.get_dna_file(hash).ok_or_else(|| {
+                                ConductorApiError::DnaReadError(format!(
+                                    "Unable to create derived Dna: {} not registered",
+                                    hash
+                                ))
+                            })?;
                         if let Some(props) = properties {
                             let properties = SerializedBytes::try_from(props)
                                 .map_err(SerializationError::from)?;

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -798,9 +798,7 @@ impl Cell {
         let invocation =
             ZomeCallInvocation::try_from_interface_call(self.conductor_api.clone(), call).await?;
 
-        let dna_def = conductor_handle
-            .get_dna_def(self.id.dna_hash())
-            .ok_or_else(|| DnaError::DnaMissing(self.id.dna_hash().to_owned()))?;
+        let dna_def = ribosome.dna_def.as_content().clone();
 
         // If there is no existing zome call then this is the root zome call
         let is_root_zome_call = workspace_lock.is_none();

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -798,7 +798,7 @@ impl Cell {
         let invocation =
             ZomeCallInvocation::try_from_interface_call(self.conductor_api.clone(), call).await?;
 
-        let dna_def = ribosome.dna_def.as_content().clone();
+        let dna_def = ribosome.dna_def().as_content().clone();
 
         // If there is no existing zome call then this is the root zome call
         let is_root_zome_call = workspace_lock.is_none();

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -880,14 +880,12 @@ impl Cell {
         let dna_file = conductor_handle
             .get_dna_file(id.dna_hash())
             .ok_or_else(|| DnaError::DnaMissing(id.dna_hash().to_owned()))?;
-        let dna_def = dna_file.dna_def().clone();
 
         // Get the ribosome
         let ribosome = RealRibosome::new(dna_file);
 
         // Run the workflow
         let args = InitializeZomesWorkflowArgs {
-            dna_def,
             ribosome,
             conductor_handle,
         };

--- a/crates/holochain/src/conductor/cell/test.rs
+++ b/crates/holochain/src/conductor/cell/test.rs
@@ -32,7 +32,7 @@ async fn test_cell_handle_publish() {
 
     let mut mock_handle = crate::conductor::handle::MockConductorHandleT::new();
     mock_handle
-        .expect_get_dna()
+        .expect_get_dna_file()
         .return_const(Some(dna_file.clone()));
     mock_handle
         .expect_get_queue_consumer_workflows()

--- a/crates/holochain/src/conductor/cell/test.rs
+++ b/crates/holochain/src/conductor/cell/test.rs
@@ -32,6 +32,9 @@ async fn test_cell_handle_publish() {
 
     let mut mock_handle = crate::conductor::handle::MockConductorHandleT::new();
     mock_handle
+        .expect_get_dna_def()
+        .return_const(Some(dna_file.dna_def().clone()));
+    mock_handle
         .expect_get_dna_file()
         .return_const(Some(dna_file.clone()));
     mock_handle

--- a/crates/holochain/src/conductor/cell/validation_package.rs
+++ b/crates/holochain/src/conductor/cell/validation_package.rs
@@ -93,6 +93,7 @@ pub(super) async fn get_as_author(
                 cache,
                 conductor_handle.keystore().clone(),
                 Some(header.author().clone()),
+                Arc::new(ribosome.dna_def().as_content().clone()),
             )
             .await?;
             let result =

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -494,7 +494,7 @@ where
 
     /// Instantiate a Ribosome for use with a DNA
     pub(crate) fn get_ribosome(&self, dna_hash: &DnaHash) -> ConductorResult<RealRibosome> {
-        self.dna_store.share_ref(|d| match d.get(dna_hash) {
+        self.dna_store.share_ref(|d| match d.get_dna_file(dna_hash) {
             Some(dna) => Ok(RealRibosome::new(dna)),
             None => Err(DnaError::DnaMissing(dna_hash.to_owned()).into()),
         })
@@ -793,7 +793,7 @@ where
             })
             .await?;
         let child_dna = dna_store.share_ref(|ds| {
-            ds.get(&parent_dna_hash)
+            ds.get_dna_file(&parent_dna_hash)
                 .ok_or(DnaError::DnaMissing(parent_dna_hash))?
                 .modify_phenotype(random_uid(), properties)
         })?;

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -494,10 +494,11 @@ where
 
     /// Instantiate a Ribosome for use with a DNA
     pub(crate) fn get_ribosome(&self, dna_hash: &DnaHash) -> ConductorResult<RealRibosome> {
-        self.dna_store.share_ref(|d| match d.get_dna_file(dna_hash) {
-            Some(dna) => Ok(RealRibosome::new(dna)),
-            None => Err(DnaError::DnaMissing(dna_hash.to_owned()).into()),
-        })
+        self.dna_store
+            .share_ref(|d| match d.get_dna_file(dna_hash) {
+                Some(dna) => Ok(RealRibosome::new(dna)),
+                None => Err(DnaError::DnaMissing(dna_hash.to_owned()).into()),
+            })
     }
 
     /// Get a dna space or create it if one doesn't exist.

--- a/crates/holochain/src/conductor/dna_store.rs
+++ b/crates/holochain/src/conductor/dna_store.rs
@@ -23,7 +23,11 @@ impl DnaStore for RealDnaStore {
         self.dnas.keys().cloned().collect()
     }
     #[instrument]
-    fn get(&self, hash: &DnaHash) -> Option<DnaFile> {
+    fn get_dna_def(&self, hash: &DnaHash) -> Option<DnaDef> {
+        self.dnas.get(hash).map(|d| d.dna_def()).cloned()
+    }
+    #[instrument]
+    fn get_dna_file(&self, hash: &DnaHash) -> Option<DnaFile> {
         self.dnas.get(hash).cloned()
     }
     fn add_entry_def(&mut self, k: EntryDefBufferKey, entry_def: EntryDef) {

--- a/crates/holochain/src/conductor/entry_def_store.rs
+++ b/crates/holochain/src/conductor/entry_def_store.rs
@@ -30,7 +30,7 @@ pub(crate) async fn get_entry_def(
     let entry_def = conductor_handle.get_entry_def(&key);
     let dna_hash = dna_def.as_hash();
     let dna_file = conductor_handle
-        .get_dna(dna_hash)
+        .get_dna_file(dna_hash)
         .ok_or_else(|| EntryDefStoreError::DnaFileMissing(dna_hash.clone()))?;
 
     // If it's not found run the ribosome and get the entry defs

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -60,6 +60,7 @@ use crate::conductor::p2p_agent_store::P2pBatch;
 use crate::core::queue_consumer::QueueConsumerMap;
 use crate::core::ribosome::guest_callback::post_commit::PostCommitArgs;
 use crate::core::ribosome::real_ribosome::RealRibosome;
+use crate::core::ribosome::RibosomeT;
 use crate::core::workflow::ZomeCallResult;
 use derive_more::From;
 use futures::future::FutureExt;
@@ -142,8 +143,11 @@ pub trait ConductorHandleT: Send + Sync {
     /// Get the list of hashes of installed Dnas in this Conductor
     fn list_dnas(&self) -> Vec<DnaHash>;
 
-    /// Get a [Dna] from the [DnaStore]
-    fn get_dna(&self, hash: &DnaHash) -> Option<DnaFile>;
+    /// Get a [DnaDef] from the [DnaStore]
+    fn get_dna_def(&self, hash: &DnaHash) -> Option<DnaDef>;
+
+    /// Get a [DnaFile] from the [DnaStore]
+    fn get_dna_file(&self, hash: &DnaHash) -> Option<DnaFile>;
 
     /// Get an instance of a [RealRibosome] for the DnaHash
     fn get_ribosome(&self, dna_hash: &DnaHash) -> ConductorResult<RealRibosome>;
@@ -572,8 +576,16 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
         self.conductor.dna_store().share_ref(|ds| ds.list())
     }
 
-    fn get_dna(&self, hash: &DnaHash) -> Option<DnaFile> {
-        self.conductor.dna_store().share_ref(|ds| ds.get(hash))
+    fn get_dna_def(&self, hash: &DnaHash) -> Option<DnaDef> {
+        self.conductor
+            .dna_store()
+            .share_ref(|ds| ds.get_dna_def(hash))
+    }
+
+    fn get_dna_file(&self, hash: &DnaHash) -> Option<DnaFile> {
+        self.conductor
+            .dna_store()
+            .share_ref(|ds| ds.get_dna_file(hash))
     }
 
     fn get_ribosome(&self, dna_hash: &DnaHash) -> ConductorResult<RealRibosome> {
@@ -1292,6 +1304,12 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
 
         // Validate the elements.
         if validate {
+            // Create the ribosome.
+            let ribosome = self
+                .get_dna_file(cell_id.dna_hash())
+                .map(RealRibosome::new)
+                .ok_or_else(|| DnaError::DnaMissing(cell_id.dna_hash().to_owned()))?;
+
             // Create a raw source chain to validate against because
             // genesis may not have been run yet.
             let workspace = SourceChainWorkspace::raw_empty(
@@ -1300,14 +1318,9 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
                 space.cache.clone(),
                 self.keystore.clone(),
                 cell_id.agent_pubkey().clone(),
+                Arc::new(ribosome.dna_def().as_content().clone()),
             )
             .await?;
-
-            // Create the ribosome.
-            let ribosome = self
-                .get_dna(cell_id.dna_hash())
-                .map(RealRibosome::new)
-                .ok_or_else(|| DnaError::DnaMissing(cell_id.dna_hash().to_owned()))?;
 
             let sc = workspace.source_chain();
 

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -485,9 +485,13 @@ pub mod test {
             .map(|hash| (CellId::from((hash, agent_key.clone())), None))
             .collect::<Vec<_>>();
         let mut dna_store = MockDnaStore::new();
+        let dna_map_clone = dna_map.clone();
         dna_store
             .expect_get_dna_file()
-            .returning(move |hash| dna_map.get(&hash).cloned());
+            .returning(move |hash| dna_map_clone.get(&hash).cloned());
+        dna_store
+            .expect_get_dna_def()
+            .returning(move |hash| dna_map.get(&hash).map(|d| d.dna_def()).cloned());
         dna_store
             .expect_add_dnas::<Vec<_>>()
             .times(1)

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -305,7 +305,6 @@ pub mod test {
     use kitsune_p2p::fixt::AgentInfoSignedFixturator;
     use kitsune_p2p::{KitsuneAgent, KitsuneSpace};
     use matches::assert_matches;
-    use mockall::predicate;
     use observability;
     use std::collections::{HashMap, HashSet};
     use std::convert::TryInto;
@@ -433,20 +432,7 @@ pub mod test {
         let cell_id = CellId::from((dna_hash.clone(), fake_agent_pubkey_1()));
         let installed_cell = InstalledCell::new(cell_id.clone(), "handle".into());
 
-        let mut dna_store = MockDnaStore::new();
-
-        dna_store
-            .expect_get_dna_file()
-            .with(predicate::eq(dna_hash))
-            .returning(move |_| Some(dna.clone()));
-        dna_store
-            .expect_add_dnas::<Vec<_>>()
-            .times(1)
-            .return_const(());
-        dna_store
-            .expect_add_entry_defs::<Vec<_>>()
-            .times(1)
-            .return_const(());
+        let dna_store = MockDnaStore::single_dna(dna, 1, 1);
 
         let (_tmpdir, app_api, handle) = setup_app(vec![(installed_cell, None)], dna_store).await;
         let mut request: ZomeCall =
@@ -641,18 +627,7 @@ pub mod test {
         );
         let cell_id = CellId::from((dna.dna_hash().clone(), fake_agent_pubkey_1()));
 
-        let mut dna_store = MockDnaStore::new();
-        dna_store
-            .expect_get_dna_file()
-            .returning(move |_| Some(dna.clone()));
-        dna_store
-            .expect_add_dnas::<Vec<_>>()
-            .times(1)
-            .return_const(());
-        dna_store
-            .expect_add_entry_defs::<Vec<_>>()
-            .times(1)
-            .return_const(());
+        let dna_store = MockDnaStore::single_dna(dna, 1, 1);
 
         let (_tmpdir, conductor_handle) =
             setup_admin_fake_cells(vec![(cell_id.clone(), None)], dna_store).await;

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -685,6 +685,7 @@ pub mod test {
                 name: "conductor_test".to_string(),
                 uid: uid.to_string(),
                 properties: SerializedBytes::try_from(()).unwrap(),
+                origin_time: Timestamp::now(),
                 zomes: zomes.clone().into_iter().map(Into::into).collect(),
             },
             zomes.into_iter().map(Into::into),

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -436,7 +436,7 @@ pub mod test {
         let mut dna_store = MockDnaStore::new();
 
         dna_store
-            .expect_get()
+            .expect_get_dna_file()
             .with(predicate::eq(dna_hash))
             .returning(move |_| Some(dna.clone()));
         dna_store
@@ -500,7 +500,7 @@ pub mod test {
             .collect::<Vec<_>>();
         let mut dna_store = MockDnaStore::new();
         dna_store
-            .expect_get()
+            .expect_get_dna_file()
             .returning(move |hash| dna_map.get(&hash).cloned());
         dna_store
             .expect_add_dnas::<Vec<_>>()
@@ -642,7 +642,9 @@ pub mod test {
         let cell_id = CellId::from((dna.dna_hash().clone(), fake_agent_pubkey_1()));
 
         let mut dna_store = MockDnaStore::new();
-        dna_store.expect_get().returning(move |_| Some(dna.clone()));
+        dna_store
+            .expect_get_dna_file()
+            .returning(move |_| Some(dna.clone()));
         dna_store
             .expect_add_dnas::<Vec<_>>()
             .times(1)

--- a/crates/holochain/src/core/queue_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer.rs
@@ -158,6 +158,10 @@ pub async fn spawn_queue_consumer_tasks(
             .expect("Failed to manage workflow handle");
     }
 
+    let dna_def = conductor_handle
+        .get_dna_def(&*dna_hash)
+        .expect("Dna must be in store");
+
     // App validation
     // One per space.
     let (tx_app, handle) = queue_consumer_map.spawn_once_app_validation(dna_hash.clone(), || {
@@ -168,6 +172,7 @@ pub async fn spawn_queue_consumer_tasks(
                 dht_env.clone(),
                 cache.clone(),
                 keystore.clone(),
+                Arc::new(dna_def),
             ),
             conductor_handle.clone(),
             stop.subscribe(),
@@ -186,6 +191,10 @@ pub async fn spawn_queue_consumer_tasks(
             .expect("Failed to manage workflow handle");
     }
 
+    let dna_def = conductor_handle
+        .get_dna_def(&*dna_hash)
+        .expect("Dna must be in store");
+
     // Sys validation
     // One per space.
     let (tx_sys, handle) = queue_consumer_map.spawn_once_sys_validation(dna_hash.clone(), || {
@@ -194,6 +203,7 @@ pub async fn spawn_queue_consumer_tasks(
                 authored_env.clone().into(),
                 dht_env.clone().into(),
                 cache.clone(),
+                Arc::new(dna_def),
             ),
             space.clone(),
             conductor_handle.clone(),

--- a/crates/holochain/src/core/ribosome/host_fn/dna_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/dna_info.rs
@@ -42,8 +42,6 @@ pub fn dna_info(
 #[cfg(test)]
 #[cfg(feature = "slow_tests")]
 pub mod test {
-    use crate::conductor::ConductorBuilder;
-    use crate::core::ribosome::MockDnaStore;
     use crate::sweettest::SweetConductor;
     use crate::sweettest::SweetDnaFile;
     use crate::sweettest::SweetZome;
@@ -60,19 +58,7 @@ pub mod test {
         let alice_pubkey = fixt!(AgentPubKey, Predictable, 0);
         let bob_pubkey = fixt!(AgentPubKey, Predictable, 1);
 
-        let mut dna_store = MockDnaStore::new();
-        dna_store.expect_add_dnas::<Vec<_>>().return_const(());
-        dna_store.expect_add_entry_defs::<Vec<_>>().return_const(());
-        dna_store.expect_add_dna().return_const(());
-        dna_store
-            .expect_get_dna_file()
-            .return_const(Some(dna_file.clone().into()));
-        dna_store
-            .expect_get_entry_def()
-            .return_const(EntryDef::default_with_id("thing"));
-
-        let mut conductor =
-            SweetConductor::from_builder(ConductorBuilder::with_mock_dna_store(dna_store)).await;
+        let mut conductor = SweetConductor::from_standard_config().await;
         let apps = conductor
             .setup_app_for_agents(
                 "app-",

--- a/crates/holochain/src/core/ribosome/host_fn/dna_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/dna_info.rs
@@ -42,14 +42,14 @@ pub fn dna_info(
 #[cfg(test)]
 #[cfg(feature = "slow_tests")]
 pub mod test {
+    use crate::conductor::ConductorBuilder;
+    use crate::core::ribosome::MockDnaStore;
+    use crate::sweettest::SweetConductor;
+    use crate::sweettest::SweetDnaFile;
+    use crate::sweettest::SweetZome;
+    use ::fixt::prelude::*;
     use holochain_wasm_test_utils::TestWasm;
     use holochain_zome_types::prelude::*;
-    use ::fixt::prelude::*;
-    use crate::sweettest::SweetConductor;
-    use crate::sweettest::SweetZome;
-    use crate::sweettest::SweetDnaFile;
-    use crate::core::ribosome::MockDnaStore;
-    use crate::conductor::ConductorBuilder;
 
     async fn test_conductor(properties: SerializedBytes) -> (SweetConductor, SweetZome) {
         let (dna_file, _) =
@@ -65,7 +65,7 @@ pub mod test {
         dna_store.expect_add_entry_defs::<Vec<_>>().return_const(());
         dna_store.expect_add_dna().return_const(());
         dna_store
-            .expect_get()
+            .expect_get_dna_file()
             .return_const(Some(dna_file.clone().into()));
         dna_store
             .expect_get_entry_def()

--- a/crates/holochain/src/core/ribosome/real_ribosome.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome.rs
@@ -679,8 +679,6 @@ impl RibosomeT for RealRibosome {
 #[cfg(test)]
 #[cfg(feature = "slow_tests")]
 pub mod wasm_test {
-    use crate::conductor::ConductorBuilder;
-    use crate::core::ribosome::MockDnaStore;
     use crate::core::ribosome::ZomeCall;
     use crate::sweettest::SweetConductor;
     use crate::sweettest::SweetDnaFile;
@@ -701,16 +699,7 @@ pub mod wasm_test {
         let alice_pubkey = fixt!(AgentPubKey, Predictable, 0);
         let bob_pubkey = fixt!(AgentPubKey, Predictable, 1);
 
-        let mut dna_store = MockDnaStore::new();
-        dna_store.expect_add_dnas::<Vec<_>>().return_const(());
-        dna_store.expect_add_entry_defs::<Vec<_>>().return_const(());
-        dna_store.expect_add_dna().return_const(());
-        dna_store
-            .expect_get_dna_file()
-            .return_const(Some(dna_file.clone().into()));
-
-        let mut conductor =
-            SweetConductor::from_builder(ConductorBuilder::with_mock_dna_store(dna_store)).await;
+        let mut conductor = SweetConductor::from_standard_config().await;
 
         let apps = conductor
             .setup_app_for_agents(

--- a/crates/holochain/src/core/ribosome/real_ribosome.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome.rs
@@ -706,7 +706,7 @@ pub mod wasm_test {
         dna_store.expect_add_entry_defs::<Vec<_>>().return_const(());
         dna_store.expect_add_dna().return_const(());
         dna_store
-            .expect_get()
+            .expect_get_dna_file()
             .return_const(Some(dna_file.clone().into()));
 
         let mut conductor =

--- a/crates/holochain/src/core/sys_validate.rs
+++ b/crates/holochain/src/core/sys_validate.rs
@@ -179,7 +179,11 @@ pub async fn check_valid_if_dna(
 ) -> SysValidationResult<()> {
     match header {
         Header::Dna(_) => {
-            if workspace.is_chain_empty(header.author().clone()).await? {
+            let chain_empty = workspace.is_chain_empty(header.author().clone()).await?;
+            // If the Dna timestamp is ahead of the origin time, every other header
+            // will be inductively so also due to the prev_header check
+            let timestamp_valid = header.timestamp() >= workspace.dna_def().origin_time;
+            if chain_empty && timestamp_valid {
                 Ok(())
             } else {
                 Err(PrevHeaderError::InvalidRoot).map_err(|e| ValidationOutcome::from(e).into())
@@ -262,7 +266,7 @@ pub async fn check_app_entry_type(
     // We want to be careful about holding locks open to the conductor api
     // so calls are made in blocks
     let dna_file = conductor
-        .get_dna(dna_hash)
+        .get_dna_file(dna_hash)
         .ok_or_else(|| SysValidationError::DnaMissing(dna_hash.clone()))?;
 
     // Check if the zome is found

--- a/crates/holochain/src/core/sys_validate/error.rs
+++ b/crates/holochain/src/core/sys_validate/error.rs
@@ -156,6 +156,8 @@ pub enum PrevHeaderError {
     HashMismatch,
     #[error("Root of source chain must be Dna")]
     InvalidRoot,
+    #[error("Root of source chain must have a timestamp greater than the Dna's origin_time")]
+    InvalidRootOriginTime,
     #[error("Previous header sequence number {1} != ({0} - 1)")]
     InvalidSeq(u32, u32),
     #[error("Previous header was missing from the metadata store")]

--- a/crates/holochain/src/core/sys_validate/tests.rs
+++ b/crates/holochain/src/core/sys_validate/tests.rs
@@ -86,7 +86,6 @@ async fn check_valid_if_dna_test() {
     );
     let mut header = fixt!(Dna);
 
-    dna_def.origin_time = Timestamp::MIN;
     assert_matches!(
         check_valid_if_dna(&header.clone().into(), &workspace).await,
         Ok(())

--- a/crates/holochain/src/core/sys_validate/tests.rs
+++ b/crates/holochain/src/core/sys_validate/tests.rs
@@ -98,7 +98,9 @@ async fn check_valid_if_dna_test() {
     workspace.dna_def = Arc::new(dna_def);
     assert_matches!(
         check_valid_if_dna(&header.clone().into(), &workspace).await,
-        Ok(())
+        Err(SysValidationError::ValidationOutcome(
+            ValidationOutcome::PrevHeaderError(PrevHeaderError::InvalidRootOriginTime)
+        ))
     );
     workspace.dna_def = dna_def_original;
 

--- a/crates/holochain/src/core/sys_validate/tests.rs
+++ b/crates/holochain/src/core/sys_validate/tests.rs
@@ -297,6 +297,7 @@ async fn check_app_entry_type_test() {
             name: "app_entry_type_test".to_string(),
             uid: "ba1d046d-ce29-4778-914b-47e6010d2faf".to_string(),
             properties: SerializedBytes::try_from(()).unwrap(),
+            origin_time: Timestamp::now(),
             zomes: vec![TestWasm::EntryDefs.into()].into(),
         },
         vec![TestWasm::EntryDefs.into()],

--- a/crates/holochain/src/core/sys_validate/tests.rs
+++ b/crates/holochain/src/core/sys_validate/tests.rs
@@ -68,20 +68,39 @@ async fn check_valid_if_dna_test() {
     // Test data
     let _activity_return = vec![fixt!(HeaderHash)];
 
+    let mut dna_def = fixt!(DnaDef);
+    dna_def.origin_time = Timestamp::MIN;
+
     // Empty store not dna
     let header = fixt!(CreateLink);
-    let workspace =
-        SysValidationWorkspace::new(env.clone().into(), tmp_dht.env().into(), tmp_cache.env());
+    let mut workspace = SysValidationWorkspace::new(
+        env.clone().into(),
+        tmp_dht.env().into(),
+        tmp_cache.env(),
+        Arc::new(dna_def.clone()),
+    );
 
     assert_matches!(
         check_valid_if_dna(&header.clone().into(), &workspace).await,
         Ok(())
     );
     let mut header = fixt!(Dna);
+
+    dna_def.origin_time = Timestamp::MIN;
     assert_matches!(
         check_valid_if_dna(&header.clone().into(), &workspace).await,
         Ok(())
     );
+
+    // - Test that an origin_time in the future leads to invalid Dna header commit
+    let dna_def_original = workspace.dna_def();
+    dna_def.origin_time = Timestamp::MAX;
+    workspace.dna_def = Arc::new(dna_def);
+    assert_matches!(
+        check_valid_if_dna(&header.clone().into(), &workspace).await,
+        Ok(())
+    );
+    workspace.dna_def = dna_def_original;
 
     fake_genesis(env.clone().into(), tmp_dht.env(), keystore)
         .await
@@ -312,7 +331,7 @@ async fn check_app_entry_type_test() {
     let mut conductor_handle = MockConductorHandleT::new();
     // # No dna or entry def
     conductor_handle.expect_get_entry_def().return_const(None);
-    conductor_handle.expect_get_dna().return_const(None);
+    conductor_handle.expect_get_dna_file().return_const(None);
 
     // ## Dna is missing
     let aet = AppEntryType::new(0.into(), 0.into(), EntryVisibility::Public);
@@ -326,7 +345,7 @@ async fn check_app_entry_type_test() {
     conductor_handle.checkpoint();
     conductor_handle.expect_get_entry_def().return_const(None);
     conductor_handle
-        .expect_get_dna()
+        .expect_get_dna_file()
         .return_const(Some(dna_file.clone()));
     let aet = AppEntryType::new(0.into(), 1.into(), EntryVisibility::Public);
     assert_matches!(

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -241,7 +241,7 @@ async fn validate_op(
 
     // Get the dna file
     let dna_file = conductor_handle
-        .get_dna(dna_hash.as_ref())
+        .get_dna_file(dna_hash.as_ref())
         .ok_or_else(|| AppValidationError::DnaMissing((*dna_hash).clone()))?;
 
     // Get the EntryDefId associated with this Element if there is one
@@ -921,6 +921,7 @@ pub struct AppValidationWorkspace {
     dht_env: DbWrite<DbKindDht>,
     cache: DbWrite<DbKindCache>,
     keystore: MetaLairClient,
+    dna_def: Arc<DnaDef>,
 }
 
 impl AppValidationWorkspace {
@@ -929,12 +930,14 @@ impl AppValidationWorkspace {
         dht_env: DbWrite<DbKindDht>,
         cache: DbWrite<DbKindCache>,
         keystore: MetaLairClient,
+        dna_def: Arc<DnaDef>,
     ) -> Self {
         Self {
             authored_env,
             dht_env,
             cache,
             keystore,
+            dna_def,
         }
     }
 
@@ -945,6 +948,7 @@ impl AppValidationWorkspace {
             self.cache.clone(),
             self.keystore.clone(),
             None,
+            self.dna_def.clone(),
         )
         .await?)
     }

--- a/crates/holochain/src/core/workflow/call_zome_workflow/validation_test.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow/validation_test.rs
@@ -20,6 +20,7 @@ async fn direct_validation_test() {
             name: "direct_validation_test".to_string(),
             uid: "ba1d046d-ce29-4778-914b-47e6010d2faf".to_string(),
             properties: SerializedBytes::try_from(()).unwrap(),
+            origin_time: Timestamp::now(),
             zomes: vec![TestWasm::Update.into()].into(),
         },
         vec![TestWasm::Update.into()],

--- a/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
+++ b/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
@@ -19,9 +19,17 @@ pub struct InitializeZomesWorkflowArgs<Ribosome>
 where
     Ribosome: RibosomeT + Send + 'static,
 {
-    pub dna_def: DnaDef,
     pub ribosome: Ribosome,
     pub conductor_handle: ConductorHandle,
+}
+
+impl<Ribosome> InitializeZomesWorkflowArgs<Ribosome>
+where
+    Ribosome: RibosomeT + Send + 'static,
+{
+    pub fn dna_def(&self) -> &DnaDef {
+        self.ribosome.dna_def().as_content()
+    }
 }
 
 #[instrument(skip(network, keystore, workspace, args))]
@@ -67,8 +75,8 @@ async fn initialize_zomes_workflow_inner<Ribosome>(
 where
     Ribosome: RibosomeT + Send + 'static,
 {
+    let dna_def = args.dna_def().clone();
     let InitializeZomesWorkflowArgs {
-        dna_def,
         ribosome,
         conductor_handle,
     } = args;
@@ -159,7 +167,7 @@ pub mod tests {
             test_cache.env(),
             keystore,
             author.clone(),
-            Arc::new(dna_def.clone()),
+            Arc::new(dna_def),
         )
         .await
         .unwrap();
@@ -174,7 +182,6 @@ pub mod tests {
         let conductor_handle = Arc::new(MockConductorHandleT::new());
         let args = InitializeZomesWorkflowArgs {
             ribosome,
-            dna_def,
             conductor_handle,
         };
         let keystore = fixt!(MetaLairClient);

--- a/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
+++ b/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
@@ -150,18 +150,21 @@ pub mod tests {
             .await
             .unwrap();
 
+        let dna_def = DnaDefFixturator::new(Unpredictable).next().unwrap();
+        let dna_def_hashed = DnaDefHashed::from_content_sync(dna_def.clone());
+
         let workspace = SourceChainWorkspace::new(
             env.clone(),
             test_dht.env(),
             test_cache.env(),
             keystore,
             author.clone(),
+            Arc::new(dna_def.clone()),
         )
         .await
         .unwrap();
         let mut ribosome = MockRibosomeT::new();
-        let dna_def = DnaDefFixturator::new(Unpredictable).next().unwrap();
-        let dna_def_hashed = DnaDefHashed::from_content_sync(dna_def.clone());
+
         // Setup the ribosome mock
         ribosome
             .expect_run_init()

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -801,6 +801,7 @@ pub struct SysValidationWorkspace {
     authored_env: DbRead<DbKindAuthored>,
     dht_env: DbRead<DbKindDht>,
     cache: DbWrite<DbKindCache>,
+    pub(crate) dna_def: Arc<DnaDef>,
 }
 
 impl SysValidationWorkspace {
@@ -808,11 +809,13 @@ impl SysValidationWorkspace {
         authored_env: DbRead<DbKindAuthored>,
         dht_env: DbRead<DbKindDht>,
         cache: DbWrite<DbKindCache>,
+        dna_def: Arc<DnaDef>,
     ) -> Self {
         Self {
             authored_env,
             dht_env,
             cache,
+            dna_def,
             scratch: None,
         }
     }
@@ -929,6 +932,11 @@ impl SysValidationWorkspace {
     fn dna_hash(&self) -> &DnaHash {
         self.dht_env.kind().dna_hash()
     }
+
+    /// Get a reference to the sys validation workspace's dna def.
+    pub fn dna_def(&self) -> Arc<DnaDef> {
+        self.dna_def.clone()
+    }
 }
 
 fn put_validation_limbo(
@@ -976,6 +984,7 @@ impl From<&HostFnWorkspace> for SysValidationWorkspace {
             authored_env: authored,
             dht_env: dht,
             cache,
+            dna_def: h.dna_def(),
         }
     }
 }

--- a/crates/holochain/src/fixt.rs
+++ b/crates/holochain/src/fixt.rs
@@ -245,7 +245,14 @@ fixturator!(
         let keystore = holochain_state::test_utils::test_keystore();
         tokio_helper::block_forever_on(async {
             fake_genesis(authored_env.env(), dht_env.env(), keystore.clone()).await.unwrap();
-            HostFnWorkspace::new(authored_env.env(), dht_env.env(), cache.env(), keystore, Some(fixt!(AgentPubKey, Predictable, get_fixt_index!()))).await.unwrap()
+            HostFnWorkspace::new(
+                authored_env.env(),
+                dht_env.env(),
+                cache.env(),
+                keystore,
+                Some(fixt!(AgentPubKey, Predictable, get_fixt_index!())),
+                Arc::new(fixt!(DnaDef))
+            ).await.unwrap()
         })
     };
     curve Unpredictable {
@@ -255,7 +262,14 @@ fixturator!(
         let keystore = holochain_state::test_utils::test_keystore();
         tokio_helper::block_forever_on(async {
             fake_genesis(authored_env.env(), dht_env.env(), keystore.clone()).await.unwrap();
-            HostFnWorkspace::new(authored_env.env(), dht_env.env(), cache.env(), keystore, Some(fixt!(AgentPubKey, Predictable, get_fixt_index!()))).await.unwrap()
+            HostFnWorkspace::new(
+                authored_env.env(),
+                dht_env.env(),
+                cache.env(),
+                keystore,
+                Some(fixt!(AgentPubKey, Predictable, get_fixt_index!())),
+                Arc::new(fixt!(DnaDef))
+            ).await.unwrap()
         })
     };
     curve Predictable {
@@ -266,7 +280,14 @@ fixturator!(
         let keystore = holochain_state::test_utils::test_keystore();
         tokio_helper::block_forever_on(async {
             crate::test_utils::fake_genesis_for_agent(authored_env.env(), dht_env.env(), agent.clone(), keystore.clone()).await.unwrap();
-            HostFnWorkspace::new(authored_env.env(), dht_env.env(), cache.env(), keystore, Some(agent)).await.unwrap()
+            HostFnWorkspace::new(
+                authored_env.env(),
+                dht_env.env(),
+                cache.env(),
+                keystore,
+                Some(agent),
+                Arc::new(fixt!(DnaDef))
+            ).await.unwrap()
         })
     };
 );
@@ -280,7 +301,14 @@ fixturator!(
         let keystore = holochain_state::test_utils::test_keystore();
         tokio_helper::block_forever_on(async {
             fake_genesis(authored_env.env(), dht_env.env(), keystore.clone()).await.unwrap();
-            HostFnWorkspaceRead::new(authored_env.env().into(), dht_env.env().into(), cache.env(), keystore, Some(fixt!(AgentPubKey, Predictable, get_fixt_index!()))).await.unwrap()
+            HostFnWorkspaceRead::new(
+                authored_env.env().into(),
+                dht_env.env().into(),
+                cache.env(),
+                keystore,
+                Some(fixt!(AgentPubKey, Predictable, get_fixt_index!())),
+                Arc::new(fixt!(DnaDef))
+            ).await.unwrap()
         })
     };
     curve Unpredictable {
@@ -290,7 +318,14 @@ fixturator!(
         let keystore = holochain_state::test_utils::test_keystore();
         tokio_helper::block_forever_on(async {
             fake_genesis(authored_env.env(), dht_env.env(), keystore.clone()).await.unwrap();
-            HostFnWorkspaceRead::new(authored_env.env().into(), dht_env.env().into(), cache.env(), keystore, Some(fixt!(AgentPubKey, Predictable, get_fixt_index!()))).await.unwrap()
+            HostFnWorkspaceRead::new(
+                authored_env.env().into(),
+                dht_env.env().into(),
+                cache.env(),
+                keystore,
+                Some(fixt!(AgentPubKey, Predictable, get_fixt_index!())),
+                Arc::new(fixt!(DnaDef))
+            ).await.unwrap()
         })
     };
     curve Predictable {
@@ -301,7 +336,14 @@ fixturator!(
         let keystore = holochain_state::test_utils::test_keystore();
         tokio_helper::block_forever_on(async {
             crate::test_utils::fake_genesis_for_agent(authored_env.env(), dht_env.env(), agent.clone(), keystore.clone()).await.unwrap();
-            HostFnWorkspaceRead::new(authored_env.env().into(), dht_env.env().into(), cache.env(), keystore, Some(agent)).await.unwrap()
+            HostFnWorkspaceRead::new(
+                authored_env.env().into(),
+                dht_env.env().into(),
+                cache.env(),
+                keystore,
+                Some(agent),
+                Arc::new(fixt!(DnaDef))
+            ).await.unwrap()
         })
     };
 );

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -452,6 +452,7 @@ async fn setup(
             name: "conductor_test".to_string(),
             uid,
             properties: SerializedBytes::try_from(()).unwrap(),
+            origin_time: Timestamp::now(),
             zomes: zomes.clone().into_iter().map(Into::into).collect(),
         },
         zomes.into_iter().map(Into::into),

--- a/crates/holochain/src/sweettest/sweet_dna.rs
+++ b/crates/holochain/src/sweettest/sweet_dna.rs
@@ -44,6 +44,7 @@ impl SweetDnaFile {
             .uid(uid)
             .zomes(zomes.clone())
             .properties(properties.clone())
+            .origin_time(Timestamp::now())
             .build()
             .unwrap();
 

--- a/crates/holochain/src/test_utils/conductor_setup.rs
+++ b/crates/holochain/src/test_utils/conductor_setup.rs
@@ -170,6 +170,7 @@ impl ConductorTestData {
                 name: "conductor_test".to_string(),
                 uid: "ba1d046d-ce29-4778-914b-47e6010d2faf".to_string(),
                 properties: SerializedBytes::try_from(()).unwrap(),
+                origin_time: Timestamp::now(),
                 zomes: zomes.clone().into_iter().map(Into::into).collect(),
             },
             zomes.into_iter().map(Into::into),

--- a/crates/holochain/src/test_utils/host_fn_caller.rs
+++ b/crates/holochain/src/test_utils/host_fn_caller.rs
@@ -170,6 +170,7 @@ impl HostFnCaller {
             cache,
             keystore.clone(),
             Some(cell_id.agent_pubkey().clone()),
+            Arc::new(ribosome.dna_def().as_content().clone()),
         )
         .await
         .unwrap();

--- a/crates/holochain/tests/network_tests/mod.rs
+++ b/crates/holochain/tests/network_tests/mod.rs
@@ -187,17 +187,7 @@ async fn get_from_another_agent() {
     let bob_cell_id = CellId::new(dna_file.dna_hash().to_owned(), bob_agent_id.clone());
     let bob_installed_cell = InstalledCell::new(bob_cell_id.clone(), "bob_handle".into());
 
-    let mut dna_store = MockDnaStore::new();
-
-    dna_store.expect_get().return_const(Some(dna_file.clone()));
-    dna_store
-        .expect_add_dnas::<Vec<_>>()
-        .times(2)
-        .return_const(());
-    dna_store
-        .expect_add_entry_defs::<Vec<_>>()
-        .times(2)
-        .return_const(());
+    let mut dna_store = MockDnaStore::single_dna(dna_file, 2, 2);
     dna_store.expect_get_entry_def().return_const(None);
 
     let (_tmpdir, _app_api, handle) = setup_app(
@@ -331,17 +321,7 @@ async fn get_links_from_another_agent() {
     let bob_cell_id = CellId::new(dna_file.dna_hash().to_owned(), bob_agent_id.clone());
     let bob_installed_cell = InstalledCell::new(bob_cell_id.clone(), "bob_handle".into());
 
-    let mut dna_store = MockDnaStore::new();
-
-    dna_store.expect_get().return_const(Some(dna_file.clone()));
-    dna_store
-        .expect_add_dnas::<Vec<_>>()
-        .times(2)
-        .return_const(());
-    dna_store
-        .expect_add_entry_defs::<Vec<_>>()
-        .times(2)
-        .return_const(());
+    let mut dna_store = MockDnaStore::single_dna(dna_file, 2, 2);
     dna_store.expect_get_entry_def().return_const(None);
 
     let (_tmpdir, _app_api, handle) = setup_app(

--- a/crates/holochain/tests/ser_regression/mod.rs
+++ b/crates/holochain/tests/ser_regression/mod.rs
@@ -92,19 +92,7 @@ async fn ser_regression_test() {
     // START CONDUCTOR
     // ///////////////
 
-    let mut dna_store = MockDnaStore::new();
-
-    dna_store
-        .expect_get_dna_file()
-        .return_const(Some(dna_file.clone()));
-    dna_store
-        .expect_add_dnas::<Vec<_>>()
-        .times(2)
-        .return_const(());
-    dna_store
-        .expect_add_entry_defs::<Vec<_>>()
-        .times(2)
-        .return_const(());
+    let mut dna_store = MockDnaStore::single_dna(dna_file, 2, 2);
     dna_store.expect_get_entry_def().return_const(None);
 
     let (_tmpdir, app_api, handle) = setup_app(

--- a/crates/holochain/tests/ser_regression/mod.rs
+++ b/crates/holochain/tests/ser_regression/mod.rs
@@ -94,7 +94,9 @@ async fn ser_regression_test() {
 
     let mut dna_store = MockDnaStore::new();
 
-    dna_store.expect_get_dna_file().return_const(Some(dna_file.clone()));
+    dna_store
+        .expect_get_dna_file()
+        .return_const(Some(dna_file.clone()));
     dna_store
         .expect_add_dnas::<Vec<_>>()
         .times(2)

--- a/crates/holochain/tests/ser_regression/mod.rs
+++ b/crates/holochain/tests/ser_regression/mod.rs
@@ -94,7 +94,7 @@ async fn ser_regression_test() {
 
     let mut dna_store = MockDnaStore::new();
 
-    dna_store.expect_get().return_const(Some(dna_file.clone()));
+    dna_store.expect_get_dna_file().return_const(Some(dna_file.clone()));
     dna_store
         .expect_add_dnas::<Vec<_>>()
         .times(2)

--- a/crates/holochain/tests/ser_regression/mod.rs
+++ b/crates/holochain/tests/ser_regression/mod.rs
@@ -52,6 +52,7 @@ async fn ser_regression_test() {
             name: "ser_regression_test".to_string(),
             uid: "ba1d046d-ce29-4778-914b-47e6010d2faf".to_string(),
             properties: SerializedBytes::try_from(()).unwrap(),
+            origin_time: Timestamp::now(),
             zomes: vec![TestWasm::SerRegression.into()].into(),
         },
         vec![TestWasm::SerRegression.into()],

--- a/crates/holochain/tests/speed_tests/mod.rs
+++ b/crates/holochain/tests/speed_tests/mod.rs
@@ -171,7 +171,9 @@ async fn speed_test(n: Option<usize>) -> TestEnvs {
 
     let mut dna_store = MockDnaStore::new();
 
-    dna_store.expect_get_dna_file().return_const(Some(dna_file.clone()));
+    dna_store
+        .expect_get_dna_file()
+        .return_const(Some(dna_file.clone()));
     dna_store
         .expect_add_dnas::<Vec<_>>()
         .times(2)

--- a/crates/holochain/tests/speed_tests/mod.rs
+++ b/crates/holochain/tests/speed_tests/mod.rs
@@ -129,6 +129,7 @@ async fn speed_test(n: Option<usize>) -> TestEnvs {
             name: "need_for_speed_test".to_string(),
             uid: "ba1d046d-ce29-4778-914b-47e6010d2faf".to_string(),
             properties: SerializedBytes::try_from(()).unwrap(),
+            origin_time: Timestamp::now(),
             zomes: vec![TestWasm::Anchor.into()].into(),
         },
         vec![TestWasm::Anchor.into()],

--- a/crates/holochain/tests/speed_tests/mod.rs
+++ b/crates/holochain/tests/speed_tests/mod.rs
@@ -171,7 +171,7 @@ async fn speed_test(n: Option<usize>) -> TestEnvs {
 
     let mut dna_store = MockDnaStore::new();
 
-    dna_store.expect_get().return_const(Some(dna_file.clone()));
+    dna_store.expect_get_dna_file().return_const(Some(dna_file.clone()));
     dna_store
         .expect_add_dnas::<Vec<_>>()
         .times(2)

--- a/crates/holochain/tests/speed_tests/mod.rs
+++ b/crates/holochain/tests/speed_tests/mod.rs
@@ -169,19 +169,7 @@ async fn speed_test(n: Option<usize>) -> TestEnvs {
     // START CONDUCTOR
     // ///////////////
 
-    let mut dna_store = MockDnaStore::new();
-
-    dna_store
-        .expect_get_dna_file()
-        .return_const(Some(dna_file.clone()));
-    dna_store
-        .expect_add_dnas::<Vec<_>>()
-        .times(2)
-        .return_const(());
-    dna_store
-        .expect_add_entry_defs::<Vec<_>>()
-        .times(2)
-        .return_const(());
+    let mut dna_store = MockDnaStore::single_dna(dna_file, 2, 2);
     dna_store.expect_get_entry_def().return_const(None);
 
     let (test_env, _app_api, handle) = setup_app(

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -42,7 +42,7 @@ pub enum DnaSource {
     /// register the dna loaded from a bundle file on disk
     Path(PathBuf),
     /// register the dna as provided in the DnaBundle data structure
-    Bundle(DnaBundle),
+    Bundle(Box<DnaBundle>),
     /// register the dna from an existing registered DNA (assumes properties will be set)
     Hash(DnaHash),
 }

--- a/crates/holochain_types/src/dna/dna_bundle.rs
+++ b/crates/holochain_types/src/dna/dna_bundle.rs
@@ -127,7 +127,7 @@ impl DnaBundle {
                     properties: SerializedBytes::try_from(
                         manifest.properties.clone().unwrap_or_default(),
                     )?,
-                    origin_time: manifest.origin_time,
+                    origin_time: manifest.origin_time.into(),
                     zomes,
                 };
 
@@ -197,7 +197,7 @@ impl DnaBundle {
                     e
                 ))
             })?),
-            origin_time: dna_def.origin_time,
+            origin_time: dna_def.origin_time.into(),
             zomes,
         }
         .into())
@@ -222,7 +222,7 @@ mod tests {
             name: "name".into(),
             uid: Some("original uid".to_string()),
             properties: Some(serde_yaml::Value::Null.into()),
-            origin_time: Timestamp::now(),
+            origin_time: Timestamp::now().into(),
             zomes: vec![
                 ZomeManifest {
                     name: "zome1".into(),

--- a/crates/holochain_types/src/dna/dna_bundle.rs
+++ b/crates/holochain_types/src/dna/dna_bundle.rs
@@ -127,6 +127,7 @@ impl DnaBundle {
                     properties: SerializedBytes::try_from(
                         manifest.properties.clone().unwrap_or_default(),
                     )?,
+                    origin_time: manifest.origin_time,
                     zomes,
                 };
 
@@ -196,6 +197,7 @@ impl DnaBundle {
                     e
                 ))
             })?),
+            origin_time: dna_def.origin_time,
             zomes,
         }
         .into())
@@ -220,6 +222,7 @@ mod tests {
             name: "name".into(),
             uid: Some("original uid".to_string()),
             properties: Some(serde_yaml::Value::Null.into()),
+            origin_time: Timestamp::now(),
             zomes: vec![
                 ZomeManifest {
                     name: "zome1".into(),

--- a/crates/holochain_types/src/dna/dna_manifest.rs
+++ b/crates/holochain_types/src/dna/dna_manifest.rs
@@ -40,9 +40,10 @@ impl DnaManifest {
         name: String,
         uid: Option<String>,
         properties: Option<YamlProperties>,
+        origin_time: Timestamp,
         zomes: Vec<ZomeManifest>,
     ) -> Self {
-        DnaManifestCurrent::new(name, uid, properties, zomes).into()
+        DnaManifestCurrent::new(name, uid, properties, origin_time, zomes).into()
     }
 
     /// Getter for properties

--- a/crates/holochain_types/src/dna/dna_manifest.rs
+++ b/crates/holochain_types/src/dna/dna_manifest.rs
@@ -40,7 +40,7 @@ impl DnaManifest {
         name: String,
         uid: Option<String>,
         properties: Option<YamlProperties>,
-        origin_time: Timestamp,
+        origin_time: HumanTimestamp,
         zomes: Vec<ZomeManifest>,
     ) -> Self {
         DnaManifestCurrent::new(name, uid, properties, origin_time, zomes).into()

--- a/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
+++ b/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
@@ -29,11 +29,17 @@ pub struct DnaManifestV1 {
     /// The time used to denote the origin of the network, used to calculate
     /// time windows during gossip.
     /// All Header timestamps must come after this time.
+    #[serde(default = "default_origin_time")]
     pub origin_time: HumanTimestamp,
 
     /// An array of zomes associated with your DNA.
     /// The order is significant: it determines initialization order.
     pub zomes: Vec<ZomeManifest>,
+}
+
+fn default_origin_time() -> HumanTimestamp {
+    // Jan 1, 2022, 12:00:00 AM UTC
+    Timestamp::from_micros(1640995200000000).into()
 }
 
 /// Manifest for an individual Zome

--- a/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
+++ b/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
@@ -17,28 +17,38 @@ use holochain_zome_types::ZomeName;
 #[serde(rename_all = "snake_case")]
 pub struct DnaManifestV1 {
     /// The friendly "name" of a Holochain DNA.
-    pub(crate) name: String,
+    pub name: String,
 
     /// A UID for uniquifying this Dna.
     // TODO: consider Vec<u8> instead (https://github.com/holochain/holochain/pull/86#discussion_r412689085)
-    pub(crate) uid: Option<String>,
+    pub uid: Option<String>,
 
     /// Any arbitrary application properties can be included in this object.
-    pub(crate) properties: Option<YamlProperties>,
+    pub properties: Option<YamlProperties>,
+
+    /// The time used to denote the origin of the network, used to calculate
+    /// time windows during gossip.
+    /// All Header timestamps must come after this time.
+    pub origin_time: Timestamp,
 
     /// An array of zomes associated with your DNA.
     /// The order is significant: it determines initialization order.
-    pub(crate) zomes: Vec<ZomeManifest>,
+    pub zomes: Vec<ZomeManifest>,
 }
 
 /// Manifest for an individual Zome
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub struct ZomeManifest {
-    pub(crate) name: ZomeName,
-    pub(crate) hash: Option<WasmHashB64>,
+    /// Just a friendly name, no semantic meaning.
+    pub name: ZomeName,
+
+    /// The hash of the wasm which defines this zome
+    pub hash: Option<WasmHashB64>,
+
+    /// The location of the wasm for this zome
     #[serde(flatten)]
-    pub(crate) location: ZomeLocation,
+    pub location: ZomeLocation,
 }
 
 /// Alias for a suitable representation of zome location

--- a/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
+++ b/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
@@ -29,7 +29,7 @@ pub struct DnaManifestV1 {
     /// The time used to denote the origin of the network, used to calculate
     /// time windows during gossip.
     /// All Header timestamps must come after this time.
-    pub origin_time: Timestamp,
+    pub origin_time: HumanTimestamp,
 
     /// An array of zomes associated with your DNA.
     /// The order is significant: it determines initialization order.

--- a/crates/holochain_types/src/dna/dna_store.rs
+++ b/crates/holochain_types/src/dna/dna_store.rs
@@ -17,8 +17,10 @@ pub trait DnaStore: Default + Send + Sync {
     /// List all DNAs in the store
     // TODO: FAST: Make this return an iterator to avoid allocating
     fn list(&self) -> Vec<DnaHash>;
+    /// Get a particular DnaDef
+    fn get_dna_def(&self, hash: &DnaHash) -> Option<DnaDef>;
     /// Get a particular DnaFile
-    fn get(&self, hash: &DnaHash) -> Option<DnaFile>;
+    fn get_dna_file(&self, hash: &DnaHash) -> Option<DnaFile>;
     /// Get a particular EntryDef
     fn get_entry_def(&self, k: &EntryDefBufferKey) -> Option<EntryDef>;
 }
@@ -27,8 +29,10 @@ pub trait DnaStore: Default + Send + Sync {
 pub trait DnaStoreRead: Default + Send + Sync {
     /// List all DNAs in the store
     fn list(&self) -> Vec<DnaHash>;
+    /// Get a particular DnaDef
+    fn get_dna_def(&self, hash: &DnaHash) -> Option<DnaDef>;
     /// Get a particular DnaFile
-    fn get(&self, hash: &DnaHash) -> Option<DnaFile>;
+    fn get_dna_file(&self, hash: &DnaHash) -> Option<DnaFile>;
 }
 
 impl<DS: DnaStore> DnaStoreRead for DS {
@@ -36,8 +40,12 @@ impl<DS: DnaStore> DnaStoreRead for DS {
         DS::list(self)
     }
 
-    fn get(&self, hash: &DnaHash) -> Option<DnaFile> {
-        DS::get(self, hash)
+    fn get_dna_def(&self, hash: &DnaHash) -> Option<DnaDef> {
+        DS::get_dna_def(self, hash)
+    }
+
+    fn get_dna_file(&self, hash: &DnaHash) -> Option<DnaFile> {
+        DS::get_dna_file(self, hash)
     }
 }
 

--- a/crates/holochain_types/src/test_utils.rs
+++ b/crates/holochain_types/src/test_utils.rs
@@ -37,6 +37,7 @@ pub fn fake_dna_zomes_named(uid: &str, name: &str, zomes: Vec<(ZomeName, DnaWasm
             .try_into()
             .unwrap(),
         uid: uid.to_string(),
+        origin_time: Timestamp::now(),
         zomes: Vec::new(),
     };
     tokio_helper::block_forever_on(async move {

--- a/crates/holochain_zome_types/src/dna_def.rs
+++ b/crates/holochain_zome_types/src/dna_def.rs
@@ -42,6 +42,11 @@ pub struct DnaDef {
     #[cfg_attr(feature = "full-dna-def", builder(default = "().try_into().unwrap()"))]
     pub properties: SerializedBytes,
 
+    /// The time used to denote the origin of the network, used to calculate
+    /// time windows during gossip.
+    /// All Header timestamps must come after this time.
+    pub origin_time: Timestamp,
+
     /// A vector of zomes associated with your DNA.
     pub zomes: Zomes,
 }

--- a/crates/holochain_zome_types/src/dna_def.rs
+++ b/crates/holochain_zome_types/src/dna_def.rs
@@ -43,7 +43,7 @@ pub struct DnaDef {
     /// The time used to denote the origin of the network, used to calculate
     /// time windows during gossip.
     /// All Header timestamps must come after this time.
-    #[builder(default = "Timestamp::now()")]
+    #[cfg_attr(feature = "full-dna-def", builder(default = "Timestamp::now()"))]
     pub origin_time: Timestamp,
 
     /// A vector of zomes associated with your DNA.

--- a/crates/holochain_zome_types/src/dna_def.rs
+++ b/crates/holochain_zome_types/src/dna_def.rs
@@ -19,10 +19,8 @@ pub type Uid = String;
 /// Historical note: This struct was written before `DnaManifest` appeared.
 /// It is included as part of a `DnaFile`. There is still a lot of code that uses
 /// this type, but in function, it has mainly been superseded by `DnaManifest`.
-///
-/// TODO: after removing the `InstallApp` admin method, we can remove the Serialize
-///       impl on this type, and document it/rename it to show that it is
-///       basically a fully validated, normalized DnaManifest
+/// Hence, this type can basically be thought of as a fully validated, normalized
+/// `DnaManifest`
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, SerializedBytes)]
 #[cfg_attr(feature = "full-dna-def", derive(derive_builder::Builder))]
 #[cfg_attr(feature = "full-dna-def", builder(public))]

--- a/crates/holochain_zome_types/src/dna_def.rs
+++ b/crates/holochain_zome_types/src/dna_def.rs
@@ -43,6 +43,7 @@ pub struct DnaDef {
     /// The time used to denote the origin of the network, used to calculate
     /// time windows during gossip.
     /// All Header timestamps must come after this time.
+    #[builder(default = "Timestamp::now()")]
     pub origin_time: Timestamp,
 
     /// A vector of zomes associated with your DNA.

--- a/crates/holochain_zome_types/src/fixt.rs
+++ b/crates/holochain_zome_types/src/fixt.rs
@@ -693,9 +693,7 @@ fixturator!(
         properties: SerializedBytesFixturator::new_indexed(Empty, get_fixt_index!())
             .next()
             .unwrap(),
-        origin_time: TimestampFixturator::new_indexed(Empty, get_fixt_index!())
-            .next()
-            .unwrap(),
+        origin_time: Timestamp::from_micros(0),
         zomes: ZomesFixturator::new_indexed(Empty, get_fixt_index!())
             .next()
             .unwrap(),
@@ -711,9 +709,7 @@ fixturator!(
         properties: SerializedBytesFixturator::new_indexed(Unpredictable, get_fixt_index!())
             .next()
             .unwrap(),
-        origin_time: TimestampFixturator::new_indexed(Empty, get_fixt_index!())
-            .next()
-            .unwrap(),
+        origin_time: Timestamp::from_micros(0),
         zomes: ZomesFixturator::new_indexed(Unpredictable, get_fixt_index!())
             .next()
             .unwrap(),
@@ -729,9 +725,7 @@ fixturator!(
         properties: SerializedBytesFixturator::new_indexed(Predictable, get_fixt_index!())
             .next()
             .unwrap(),
-        origin_time: TimestampFixturator::new_indexed(Empty, get_fixt_index!())
-            .next()
-            .unwrap(),
+        origin_time: Timestamp::from_micros(0),
         zomes: ZomesFixturator::new_indexed(Predictable, get_fixt_index!())
             .next()
             .unwrap(),

--- a/crates/holochain_zome_types/src/fixt.rs
+++ b/crates/holochain_zome_types/src/fixt.rs
@@ -693,6 +693,9 @@ fixturator!(
         properties: SerializedBytesFixturator::new_indexed(Empty, get_fixt_index!())
             .next()
             .unwrap(),
+        origin_time: TimestampFixturator::new_indexed(Empty, get_fixt_index!())
+            .next()
+            .unwrap(),
         zomes: ZomesFixturator::new_indexed(Empty, get_fixt_index!())
             .next()
             .unwrap(),
@@ -708,6 +711,9 @@ fixturator!(
         properties: SerializedBytesFixturator::new_indexed(Unpredictable, get_fixt_index!())
             .next()
             .unwrap(),
+        origin_time: TimestampFixturator::new_indexed(Empty, get_fixt_index!())
+            .next()
+            .unwrap(),
         zomes: ZomesFixturator::new_indexed(Unpredictable, get_fixt_index!())
             .next()
             .unwrap(),
@@ -721,6 +727,9 @@ fixturator!(
             .next()
             .unwrap(),
         properties: SerializedBytesFixturator::new_indexed(Predictable, get_fixt_index!())
+            .next()
+            .unwrap(),
+        origin_time: TimestampFixturator::new_indexed(Empty, get_fixt_index!())
             .next()
             .unwrap(),
         zomes: ZomesFixturator::new_indexed(Predictable, get_fixt_index!())

--- a/crates/kitsune_p2p/timestamp/Cargo.toml
+++ b/crates/kitsune_p2p/timestamp/Cargo.toml
@@ -14,7 +14,8 @@ edition = "2018"
 
 [dependencies]
 
-chrono = "0.4.6"
+chrono = { version = "0.4.6", features = ["serde"] }
+derive_more = "0.99"
 serde = { version = "1.0", features = [ "derive" ] }
 thiserror = "1"
 
@@ -26,6 +27,7 @@ rusqlite = { version = "0.26", optional = true }
 
 [dev-dependencies]
 holochain_serialized_bytes = "=0.0.51"
+serde_yaml = "0.8"
 
 [features]
 now = []

--- a/crates/kitsune_p2p/timestamp/src/human.rs
+++ b/crates/kitsune_p2p/timestamp/src/human.rs
@@ -2,9 +2,10 @@ use crate::{DateTime, Timestamp};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
-/// A human-readable timestamp which is serialized as an RFC3339 when possible,
-/// and a microsecond integer count otherwise
-#[derive(Clone, Copy, Debug, Hash, Deserialize, Serialize)]
+/// A human-readable timestamp which is represented/serialized as an RFC3339
+/// when possible, and a microsecond integer count otherwise.
+/// Both representations can be deserialized to this type.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum HumanTimestamp {
     Micros(Timestamp),

--- a/crates/kitsune_p2p/timestamp/src/human.rs
+++ b/crates/kitsune_p2p/timestamp/src/human.rs
@@ -1,0 +1,76 @@
+use crate::{DateTime, Timestamp};
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+
+/// A human-readable timestamp which is serialized as an RFC3339 when possible,
+/// and a microsecond integer count otherwise
+#[derive(Clone, Copy, Debug, Hash, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum HumanTimestamp {
+    Micros(Timestamp),
+    RFC3339(DateTime),
+}
+
+impl From<Timestamp> for HumanTimestamp {
+    fn from(t: Timestamp) -> Self {
+        DateTime::try_from(t)
+            .map(Self::RFC3339)
+            .unwrap_or_else(|_| Self::Micros(t))
+    }
+}
+
+impl From<DateTime> for HumanTimestamp {
+    fn from(t: DateTime) -> Self {
+        Self::RFC3339(t)
+    }
+}
+
+impl From<HumanTimestamp> for Timestamp {
+    fn from(h: HumanTimestamp) -> Self {
+        match h {
+            HumanTimestamp::Micros(t) => t,
+            HumanTimestamp::RFC3339(d) => d.into(),
+        }
+    }
+}
+
+impl From<&HumanTimestamp> for Timestamp {
+    fn from(h: &HumanTimestamp) -> Self {
+        match h {
+            HumanTimestamp::Micros(t) => *t,
+            HumanTimestamp::RFC3339(d) => d.into(),
+        }
+    }
+}
+
+impl PartialEq for HumanTimestamp {
+    fn eq(&self, other: &Self) -> bool {
+        Timestamp::from(self) == Timestamp::from(other)
+    }
+}
+
+impl Eq for HumanTimestamp {}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use holochain_serialized_bytes::{holochain_serial, SerializedBytes};
+
+    holochain_serial!(HumanTimestamp);
+
+    #[test]
+    fn human_timestamp_conversions() {
+        let show = |v| format!("{:?}", v);
+        let s = "2022-02-11T23:05:19.470323Z";
+        let t = Timestamp::from_str(s).unwrap();
+        let h = HumanTimestamp::from(t);
+        let sb = SerializedBytes::try_from(h).unwrap();
+        let ser = show(&sb);
+        assert_eq!(ser, format!("\"{}\"", s));
+        let h2 = HumanTimestamp::try_from(sb).unwrap();
+        let t2 = Timestamp::from(h2);
+        assert_eq!(t, t2);
+    }
+}

--- a/crates/kitsune_p2p/timestamp/src/lib.rs
+++ b/crates/kitsune_p2p/timestamp/src/lib.rs
@@ -2,6 +2,9 @@
 
 #[allow(missing_docs)]
 mod error;
+mod human;
+
+pub use human::*;
 
 use std::{
     convert::TryFrom,
@@ -41,6 +44,8 @@ pub struct Timestamp(
     i64, // microseconds from UNIX Epoch, positive or negative
 );
 
+pub(crate) type DateTime = chrono::DateTime<chrono::Utc>;
+
 /// Display as RFC3339 Date+Time for sane value ranges (0000-9999AD).  Beyond that, format
 /// as (seconds, nanoseconds) tuple (output and parsing of large +/- years is unreliable).
 impl fmt::Display for Timestamp {
@@ -67,14 +72,14 @@ impl fmt::Debug for Timestamp {
     }
 }
 
-impl From<chrono::DateTime<chrono::Utc>> for Timestamp {
-    fn from(t: chrono::DateTime<chrono::Utc>) -> Self {
+impl From<DateTime> for Timestamp {
+    fn from(t: DateTime) -> Self {
         std::convert::From::from(&t)
     }
 }
 
-impl From<&chrono::DateTime<chrono::Utc>> for Timestamp {
-    fn from(t: &chrono::DateTime<chrono::Utc>) -> Self {
+impl From<&DateTime> for Timestamp {
+    fn from(t: &DateTime) -> Self {
         let t = t.naive_utc();
         Timestamp(t.timestamp() * MM + t.timestamp_subsec_nanos() as i64 / 1000)
     }
@@ -84,7 +89,7 @@ impl From<&chrono::DateTime<chrono::Utc>> for Timestamp {
 // may panic in from_timestamp due to out-of-range secs or nsecs, making all code using/displaying a
 // Timestamp this way dangerously fragile!  Use try_from, and handle any failures.
 
-impl TryFrom<Timestamp> for chrono::DateTime<chrono::Utc> {
+impl TryFrom<Timestamp> for DateTime {
     type Error = TimestampError;
 
     fn try_from(t: Timestamp) -> Result<Self, Self::Error> {
@@ -92,7 +97,7 @@ impl TryFrom<Timestamp> for chrono::DateTime<chrono::Utc> {
     }
 }
 
-impl TryFrom<&Timestamp> for chrono::DateTime<chrono::Utc> {
+impl TryFrom<&Timestamp> for DateTime {
     type Error = TimestampError;
 
     fn try_from(t: &Timestamp) -> Result<Self, Self::Error> {

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -94,6 +94,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "time",
  "winapi",
 ]
@@ -480,6 +481,7 @@ name = "kitsune_p2p_timestamp"
 version = "0.0.5"
 dependencies = [
  "chrono",
+ "derive_more",
  "serde",
  "thiserror",
 ]


### PR DESCRIPTION
### Summary

The DNA has to specify its origin timestamp for use in the new gossip algorithm.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
