### PR TITLE
parallel tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,30 @@ jobs:
               no_output_timeout: 30m
               command: |
                 ./scripts/ci_merge-release-test.sh
+
+   static-test:
+      docker:
+         - image: holochain/holochain:circle.build.develop
+           auth:
+            username: $DOCKER_USER
+            password: $DOCKER_PASS
+      resource_class: xlarge
+      environment:
+         CACHIX_NAME: holochain-ci
+         NIXPKGS_ALLOW_UNFREE: 1
+      steps:
+         - checkout
+         - run:
+              name: Unset CircleCI's forced conversion of HTTPS->SSH
+              command: git config --global --unset "url.ssh://git@github.com.insteadof"
+         - run:
+              name: Set up Nix cache
+              command: $(nix-build . --fallback --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
+         - run:
+              name: Run the standard tests
+              no_output_timeout: 30m
+              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-static-test
+
    standard-test:
       docker:
          - image: holochain/holochain:circle.build.develop
@@ -90,6 +114,52 @@ jobs:
               name: Run the standard tests
               no_output_timeout: 30m
               command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-standard-test
+
+   slow-test:
+      docker:
+         - image: holochain/holochain:circle.build.develop
+           auth:
+              username: $DOCKER_USER
+              password: $DOCKER_PASS
+      resource_class: xlarge
+      environment:
+         CACHIX_NAME: holochain-ci
+         NIXPKGS_ALLOW_UNFREE: 1
+      steps:
+         - checkout
+         - run:
+              name: Unset CircleCI's forced conversion of HTTPS->SSH
+              command: git config --global --unset "url.ssh://git@github.com.insteadof"
+         - run:
+              name: Set up Nix cache
+              command: $(nix-build . --fallback --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
+         - run:
+              name: Run the standard tests
+              no_output_timeout: 30m
+              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-slow-test
+
+   wasm-test:
+      docker:
+         - image: holochain/holochain:circle.build.develop
+           auth:
+              username: $DOCKER_USER
+              password: $DOCKER_PASS
+      resource_class: xlarge
+      environment:
+         CACHIX_NAME: holochain-ci
+         NIXPKGS_ALLOW_UNFREE: 1
+      steps:
+         - checkout
+         - run:
+              name: Unset CircleCI's forced conversion of HTTPS->SSH
+              command: git config --global --unset "url.ssh://git@github.com.insteadof"
+         - run:
+              name: Set up Nix cache
+              command: $(nix-build . --fallback --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
+         - run:
+              name: Run the standard tests
+              no_output_timeout: 30m
+              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-wasm-test
 
    merge-test-mac:
       macos:
@@ -134,6 +204,9 @@ workflows:
          - merge-release-test
          # - merge-release-test-mac
          - standard-test
+         - static-test
+         - slow-test
+         - wasm-test
          # - merge-test-mac
 
    docker-builds:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
               command: |
                 ./scripts/ci_merge-release-test.sh
 
-   static-test:
+   hc-static-checks:
       docker:
          - image: holochain/holochain:circle.build.develop
            auth:
@@ -90,7 +90,7 @@ jobs:
          - run:
               name: Run the standard tests
               no_output_timeout: 30m
-              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-static-test
+              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-static-checks
 
    standard-test:
       docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
          - run:
               name: Run the standard tests
               no_output_timeout: 30m
-              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-standard-test
+              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-test-test
 
    slow-test:
       docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -204,7 +204,7 @@ workflows:
          - merge-release-test
          # - merge-release-test-mac
          - standard-test
-         - static-test
+         - hc-static-checks
          - slow-test
          - wasm-test
          # - merge-test-mac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,7 @@ jobs:
          - run:
               name: Run the standard tests
               no_output_timeout: 30m
-              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-test-test
+              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-test-standard
 
    slow-test:
       docker:
@@ -136,7 +136,7 @@ jobs:
          - run:
               name: Run the slow tests
               no_output_timeout: 30m
-              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-slow-test
+              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-test-slow
 
    wasm-test:
       docker:
@@ -159,7 +159,7 @@ jobs:
          - run:
               name: Run the wasm tests
               no_output_timeout: 30m
-              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-wasm-test
+              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-test-wasm
 
    merge-test-mac:
       macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ workflows:
       jobs:
          - merge-release-test
          # - merge-release-test-mac
-         - merge-test
+         - standard-test
          # - merge-test-mac
 
    docker-builds:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
               name: Set up Nix cache
               command: $(nix-build . --fallback --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
          - run:
-              name: Run the standard tests
+              name: Run the static checks
               no_output_timeout: 30m
               command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-static-checks
 
@@ -134,7 +134,7 @@ jobs:
               name: Set up Nix cache
               command: $(nix-build . --fallback --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
          - run:
-              name: Run the standard tests
+              name: Run the slow tests
               no_output_timeout: 30m
               command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-slow-test
 
@@ -157,7 +157,7 @@ jobs:
               name: Set up Nix cache
               command: $(nix-build . --fallback --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
          - run:
-              name: Run the standard tests
+              name: Run the wasm tests
               no_output_timeout: 30m
               command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-wasm-test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
               no_output_timeout: 30m
               command: |
                 ./scripts/ci_merge-release-test.sh
-   merge-test:
+   standard-test:
       docker:
          - image: holochain/holochain:circle.build.develop
            auth:
@@ -87,9 +87,9 @@ jobs:
               name: Set up Nix cache
               command: $(nix-build . --fallback --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
          - run:
-              name: Run the merge tests
+              name: Run the standard tests
               no_output_timeout: 30m
-              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-merge-test
+              command: nix-shell --fallback --pure --argstr flavor "coreDev" --run hc-standard-test
 
    merge-test-mac:
       macos:

--- a/nix/pkgs/core.nix
+++ b/nix/pkgs/core.nix
@@ -28,7 +28,7 @@ rec {
     export CARGO_BUILD_JOBS=8
 
     # run all the non-slow cargo tests
-    cargo check --all-features --all-targets --workspace --exclude holochain --exclude release-automation
+    # cargo check --all-features --all-targets --workspace --exclude holochain --exclude release-automation
     cargo test --workspace --exclude holochain --exclude release-automation --lib --tests --profile fast-test -- --nocapture
   '';
 
@@ -42,7 +42,7 @@ rec {
 
     # alas, we cannot specify --features in the virtual workspace
     # run the specific slow tests in the holochain crate
-    cargo check --all-features --all-targets --manifest-path=crates/holochain/Cargo.toml
+    # cargo check --all-features --all-targets --manifest-path=crates/holochain/Cargo.toml
     cargo test --manifest-path=crates/holochain/Cargo.toml --features slow_tests,test_utils,build_wasms,db-encryption --profile fast-test -- --nocapture
   '';
 
@@ -55,7 +55,7 @@ rec {
     export CARGO_BUILD_JOBS=8
 
     # run all the wasm tests (within wasm) with the conductor mocked
-    cargo check --all-targets --lib --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml --all-features
+    # cargo check --all-targets --lib --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml --all-features
     cargo test --lib --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml --all-features -- --nocapture
   '';
 

--- a/nix/pkgs/core.nix
+++ b/nix/pkgs/core.nix
@@ -28,7 +28,6 @@ rec {
     export CARGO_BUILD_JOBS=8
 
     # run all the non-slow cargo tests
-    # cargo check --all-features --all-targets --workspace --exclude holochain --exclude release-automation
     cargo build --features 'build_wasms' --manifest-path=crates/holochain/Cargo.toml
     cargo test --workspace --exclude holochain --exclude release-automation --lib --tests --profile fast-test -- --nocapture
   '';
@@ -43,7 +42,6 @@ rec {
 
     # alas, we cannot specify --features in the virtual workspace
     # run the specific slow tests in the holochain crate
-    # cargo check --all-features --all-targets --manifest-path=crates/holochain/Cargo.toml
     cargo test --manifest-path=crates/holochain/Cargo.toml --features slow_tests,test_utils,build_wasms,db-encryption --profile fast-test -- --nocapture
   '';
 
@@ -56,7 +54,6 @@ rec {
     export CARGO_BUILD_JOBS=8
 
     # run all the wasm tests (within wasm) with the conductor mocked
-    # cargo check --all-targets --lib --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml --all-features
     cargo test --lib --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml --all-features -- --nocapture
   '';
 

--- a/nix/pkgs/core.nix
+++ b/nix/pkgs/core.nix
@@ -14,12 +14,12 @@ rec {
     set -euxo pipefail
     export RUST_BACKTRACE=1
 
-    hc-standard-test
-    hc-slow-test
-    hc-wasm-test
+    hc-test-standard
+    hc-test-slow
+    hc-test-wasm
   '';
 
-  hcStandardTests = writeShellScriptBin "hc-standard-test" ''
+  hcStandardTests = writeShellScriptBin "hc-test-standard" ''
     set -euxo pipefail
     export RUST_BACKTRACE=1
 
@@ -32,7 +32,7 @@ rec {
     cargo test --workspace --exclude holochain --exclude release-automation --lib --tests --profile fast-test -- --nocapture
   '';
 
-  hcSlowTests = writeShellScriptBin "hc-slow-test" ''
+  hcSlowTests = writeShellScriptBin "hc-test-slow" ''
     set -euxo pipefail
     export RUST_BACKTRACE=1
 
@@ -45,7 +45,7 @@ rec {
     cargo test --manifest-path=crates/holochain/Cargo.toml --features slow_tests,test_utils,build_wasms,db-encryption --profile fast-test -- --nocapture
   '';
 
-  hcWasmTests = writeShellScriptBin "hc-wasm-test" ''
+  hcWasmTests = writeShellScriptBin "hc-test-wasm" ''
     set -euxo pipefail
     export RUST_BACKTRACE=1
 

--- a/nix/pkgs/core.nix
+++ b/nix/pkgs/core.nix
@@ -14,6 +14,28 @@ rec {
     set -euxo pipefail
     export RUST_BACKTRACE=1
 
+    hc-standard-test
+    hc-slow-test
+    hc-wasm-test
+  '';
+
+  hcStandardTests = writeShellScriptBin "hc-standard-test" ''
+    set -euxo pipefail
+    export RUST_BACKTRACE=1
+
+    # limit parallel jobs to reduce memory consumption
+    export NUM_JOBS=8
+    export CARGO_BUILD_JOBS=8
+
+    # run all the non-slow cargo tests
+    cargo check --all-features --all-targets --workspace --exclude holochain --exclude release-automation
+    cargo test --workspace --exclude holochain --exclude release-automation --lib --tests --profile fast-test -- --nocapture
+  '';
+
+  hcSlowTests = writeShellScriptBin "hc-slow-test" ''
+    set -euxo pipefail
+    export RUST_BACKTRACE=1
+
     # limit parallel jobs to reduce memory consumption
     export NUM_JOBS=8
     export CARGO_BUILD_JOBS=8
@@ -22,9 +44,16 @@ rec {
     # run the specific slow tests in the holochain crate
     cargo check --all-features --all-targets --manifest-path=crates/holochain/Cargo.toml
     cargo test --manifest-path=crates/holochain/Cargo.toml --features slow_tests,test_utils,build_wasms,db-encryption --profile fast-test -- --nocapture
-    # run all the remaining cargo tests
-    cargo check --all-features --all-targets --workspace --exclude holochain --exclude release-automation
-    cargo test --workspace --exclude holochain --exclude release-automation --lib --tests --profile fast-test -- --nocapture
+  '';
+
+  hcWasmTests = writeShellScriptBin "hc-wasm-test" ''
+    set -euxo pipefail
+    export RUST_BACKTRACE=1
+
+    # limit parallel jobs to reduce memory consumption
+    export NUM_JOBS=8
+    export CARGO_BUILD_JOBS=8
+
     # run all the wasm tests (within wasm) with the conductor mocked
     cargo check --all-targets --lib --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml --all-features
     cargo test --lib --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml --all-features -- --nocapture

--- a/nix/pkgs/core.nix
+++ b/nix/pkgs/core.nix
@@ -28,7 +28,7 @@ rec {
     export CARGO_BUILD_JOBS=8
 
     # run all the non-slow cargo tests
-    cargo build --features 'build_wasms' -p holochain_wasm_test_utils
+    cargo build --features 'build' -p holochain_wasm_test_utils
     cargo test --workspace --exclude holochain --exclude release-automation --lib --tests --profile fast-test -- --nocapture
   '';
 

--- a/nix/pkgs/core.nix
+++ b/nix/pkgs/core.nix
@@ -28,7 +28,7 @@ rec {
     export CARGO_BUILD_JOBS=8
 
     # run all the non-slow cargo tests
-    cargo build --features 'build_wasms' --manifest-path=crates/holochain/Cargo.toml
+    cargo build --features 'build_wasms' -p holochain_wasm_test_utils
     cargo test --workspace --exclude holochain --exclude release-automation --lib --tests --profile fast-test -- --nocapture
   '';
 

--- a/nix/pkgs/core.nix
+++ b/nix/pkgs/core.nix
@@ -29,6 +29,7 @@ rec {
 
     # run all the non-slow cargo tests
     # cargo check --all-features --all-targets --workspace --exclude holochain --exclude release-automation
+    cargo build --features 'build_wasms' --manifest-path=crates/holochain/Cargo.toml
     cargo test --workspace --exclude holochain --exclude release-automation --lib --tests --profile fast-test -- --nocapture
   '';
 


### PR DESCRIPTION
### Summary

CI takes about 28 mins to run in series and often wasm issues fail right at the end

splitting out our ci into 4x groups:

- static checks
- standard tests
- slow tests
- wasm tests

gets everything cleared in about 16 mins wall time with wasm and static checks happening in about half that

also, looking at what is taking a long time, seems like if we get incremental compliation working properly like it used to, we'd have sub 10 minute builds again, but that's a separate PR

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
