### PR TITLE
Add placeholder for alternate FetchOpData by Region

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,6 +2016,7 @@ name = "holochain_p2p"
 version = "0.0.26"
 dependencies = [
  "async-trait",
+ "derive_more",
  "fixt",
  "futures",
  "ghost_actor 0.3.0-alpha.4",

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -790,7 +790,7 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
             }
             FetchOpData {
                 respond,
-                op_hashes,
+                query,
                 dna_hash,
                 ..
             } => {
@@ -798,7 +798,7 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
                     let res = self
                         .conductor
                         .spaces
-                        .handle_fetch_op_data(&dna_hash, op_hashes)
+                        .handle_fetch_op_data(&dna_hash, query)
                         .await
                         .map_err(holochain_p2p::HolochainP2pError::other);
                     respond.respond(Ok(async move { res }.boxed().into()));

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -6,7 +6,10 @@ use std::{collections::HashMap, sync::Arc};
 
 use holo_hash::{DhtOpHash, DnaHash};
 use holochain_conductor_api::conductor::EnvironmentRootPath;
-use holochain_p2p::dht_arc::{ArcInterval, DhtArcSet};
+use holochain_p2p::{
+    dht_arc::{ArcInterval, DhtArcSet},
+    event::FetchOpDataQuery,
+};
 use holochain_sqlite::{
     conn::{DbSyncLevel, DbSyncStrategy},
     db::{DbKindAuthored, DbKindCache, DbKindDht, DbWrite},
@@ -244,9 +247,38 @@ impl Spaces {
         Ok(results)
     }
 
-    #[instrument(skip(self, op_hashes))]
+    #[instrument(skip(self, query))]
     /// The network module is requesting the content for dht ops
     pub async fn handle_fetch_op_data(
+        &self,
+        dna_hash: &DnaHash,
+        query: FetchOpDataQuery,
+    ) -> ConductorResult<Vec<(holo_hash::DhtOpHash, holochain_types::dht_op::DhtOp)>> {
+        match query {
+            FetchOpDataQuery::Hashes(op_hashes) => {
+                self.handle_fetch_op_data_by_hashes(dna_hash, op_hashes)
+                    .await
+            }
+            FetchOpDataQuery::Region { .. } => {
+                self.handle_fetch_op_data_by_region(dna_hash, ()).await
+            }
+        }
+    }
+
+    #[instrument(skip(self, _region))]
+    /// The network module is requesting the content for dht ops
+    pub async fn handle_fetch_op_data_by_region(
+        &self,
+        dna_hash: &DnaHash,
+        // This type will become something real.
+        _region: (),
+    ) -> ConductorResult<Vec<(holo_hash::DhtOpHash, holochain_types::dht_op::DhtOp)>> {
+        unimplemented!("Will be implemented as part of quantized-gossip")
+    }
+
+    #[instrument(skip(self, op_hashes))]
+    /// The network module is requesting the content for dht ops
+    pub async fn handle_fetch_op_data_by_hashes(
         &self,
         dna_hash: &DnaHash,
         op_hashes: Vec<holo_hash::DhtOpHash>,

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1"
+derive_more = "0.99"
 fixt = { path = "../fixt", version = "0.0.8"}
 futures = "0.3"
 ghost_actor = "=0.3.0-alpha.4"

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -295,16 +295,14 @@ impl WrapEvtSender {
     fn fetch_op_data(
         &self,
         dna_hash: DnaHash,
-        op_hashes: Vec<holo_hash::DhtOpHash>,
+        query: FetchOpDataQuery,
     ) -> impl Future<
         Output = HolochainP2pResult<Vec<(holo_hash::DhtOpHash, holochain_types::dht_op::DhtOp)>>,
     >
            + 'static
            + Send {
-        let op_count = op_hashes.len();
         timing_trace!(
-            { self.0.fetch_op_data(dna_hash, op_hashes) },
-            %op_count,
+            { self.0.fetch_op_data(dna_hash, query) },
             "(hp2p:handle) fetch_op_data",
         )
     }
@@ -885,7 +883,7 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
         Ok(async move {
             let mut out = vec![];
             for (op_hash, dht_op) in evt_sender
-                .fetch_op_data(space.clone(), op_hashes.clone())
+                .fetch_op_data(space.clone(), op_hashes.clone().into())
                 .await?
             {
                 out.push((


### PR DESCRIPTION
### Summary

In quantized-gossip, we need to be able to FetchOpData not only by list of hashes (for recent gossip) but also by location and timestamp bounds (for historical gossip). This adds an enum which allows for both types of op data query.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
