### PR TITLE
release-automation/changelog: add release-notes subcmd

### DIFF
--- a/crates/release-automation/src/main.rs
+++ b/crates/release-automation/src/main.rs
@@ -123,9 +123,27 @@ pub(crate) mod cli {
         pub(crate) output_path: PathBuf,
     }
 
+    /// Generate the release notes for a given release.
+    #[derive(StructOpt, Debug)]
+    pub(crate) struct ChangelogReleaseNotesArgs {
+        /// Name of the release for which to generate the release notes.
+        /// Defaults to the latest release.
+        // #[structopt(long)]
+        // pub(crate) release_name: Option<String>,
+
+        //
+
+        /// Where to output the release notes.
+        /// If a path is given at which a file exists it will be overwritten.
+        /// Defaults to stdout.
+        #[structopt(long)]
+        pub(crate) output: Option<PathBuf>,
+    }
+
     #[derive(Debug, StructOpt)]
     pub(crate) enum ChangelogCommands {
         Aggregate(ChangelogAggregateArgs),
+        ReleaseNotes(ChangelogReleaseNotesArgs),
     }
 
     #[derive(StructOpt, Debug)]


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
