### PR TITLE
release-automation: extract ensure-crate-owners as subcommand and add github action test

### DIFF
--- a/crates/release-automation/src/crate_.rs
+++ b/crates/release-automation/src/crate_.rs
@@ -97,7 +97,7 @@ pub(crate) struct CrateCheckArgs {
 }
 
 pub(crate) const MINIMUM_CRATE_OWNERS: &str =
-    "github:holochain:core-dev,holochain-release-automation,zippy";
+    "github:holochain:core-dev,holochain-release-automation,holochain-release-automation2,zippy,steveej";
 
 #[derive(Debug, StructOpt)]
 pub(crate) struct EnsureCrateOwnersArgs {


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
