### PR TITLE
Kitsune host logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2724,6 +2724,7 @@ dependencies = [
  "kitsune_p2p_types",
  "maplit",
  "mockall",
+ "must_future",
  "num-traits",
  "observability",
  "once_cell",

--- a/crates/holochain/src/conductor.rs
+++ b/crates/holochain/src/conductor.rs
@@ -28,6 +28,7 @@ pub mod error;
 pub mod handle;
 pub mod interactive;
 pub mod interface;
+pub mod kitsune_host_impl;
 pub mod manager;
 pub mod p2p_agent_store;
 pub mod paths;

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -345,8 +345,7 @@ impl Cell {
     ) -> CellResult<()> {
         use holochain_p2p::event::HolochainP2pEvent::*;
         match evt {
-            KGenReq { .. }
-            | PutAgentInfoSigned { .. }
+            PutAgentInfoSigned { .. }
             | GetAgentInfoSigned { .. }
             | QueryAgentInfoSigned { .. }
             | QueryGossipAgents { .. }

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -346,7 +346,6 @@ impl Cell {
         use holochain_p2p::event::HolochainP2pEvent::*;
         match evt {
             PutAgentInfoSigned { .. }
-            | GetAgentInfoSigned { .. }
             | QueryAgentInfoSigned { .. }
             | QueryGossipAgents { .. }
             | QueryOpHashes { .. }

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1629,17 +1629,18 @@ mod builder {
             let keystore = self.keystore.unwrap_or_else(test_keystore);
             self.config.environment_path = env_path.to_path_buf().into();
 
-            let (holochain_p2p, p2p_evt) =
-                holochain_p2p::spawn_test_holochain_p2p(self.config.network.clone().unwrap_or_default(), holochain_p2p::kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig::new_ephemeral().await.unwrap())
-                    .await?;
-
-            let (post_commit_sender, post_commit_receiver) =
-                tokio::sync::mpsc::channel(POST_COMMIT_CHANNEL_BOUND);
-
             let spaces = Spaces::new(
                 self.config.environment_path.clone(),
                 self.config.db_sync_strategy,
             )?;
+            let host = KitsuneHostImpl::new(spaces.clone());
+
+            let (holochain_p2p, p2p_evt) =
+                holochain_p2p::spawn_holochain_p2p(self.config.network.clone().unwrap_or_default(), holochain_p2p::kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig::new_ephemeral().await.unwrap(), host)
+                    .await?;
+
+            let (post_commit_sender, post_commit_receiver) =
+                tokio::sync::mpsc::channel(POST_COMMIT_CHANNEL_BOUND);
 
             let conductor = Conductor::new(
                 self.dna_store,

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1362,6 +1362,7 @@ mod builder {
     use super::*;
     use crate::conductor::dna_store::RealDnaStore;
     use crate::conductor::handle::DevSettings;
+    use crate::conductor::kitsune_host_impl::KitsuneHostImpl;
     use crate::conductor::ConductorHandle;
 
     /// A configurable Builder for Conductor and sometimes ConductorHandle
@@ -1486,8 +1487,10 @@ mod builder {
                 };
 
             let spaces = Spaces::new(env_path, config.db_sync_strategy)?;
+            let host = KitsuneHostImpl::new(spaces.clone());
+
             let (holochain_p2p, p2p_evt) =
-                holochain_p2p::spawn_holochain_p2p(network_config, tls_config).await?;
+                holochain_p2p::spawn_holochain_p2p(network_config, tls_config, host).await?;
 
             let (post_commit_sender, post_commit_receiver) =
                 tokio::sync::mpsc::channel(POST_COMMIT_CHANNEL_BOUND);
@@ -1627,7 +1630,7 @@ mod builder {
             self.config.environment_path = env_path.to_path_buf().into();
 
             let (holochain_p2p, p2p_evt) =
-                holochain_p2p::spawn_holochain_p2p(self.config.network.clone().unwrap_or_default(), holochain_p2p::kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig::new_ephemeral().await.unwrap())
+                holochain_p2p::spawn_test_holochain_p2p(self.config.network.clone().unwrap_or_default(), holochain_p2p::kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig::new_ephemeral().await.unwrap())
                     .await?;
 
             let (post_commit_sender, post_commit_receiver) =

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -46,7 +46,6 @@ use super::manager::TaskManagerClient;
 use super::manager::TaskManagerRunHandle;
 use super::p2p_agent_store;
 use super::p2p_agent_store::all_agent_infos;
-use super::p2p_agent_store::get_agent_info_signed;
 use super::p2p_agent_store::inject_agent_infos;
 use super::p2p_agent_store::list_all_agent_info;
 use super::p2p_agent_store::list_all_agent_info_signed_near_basis;
@@ -606,18 +605,6 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
                     Ok(r) => r.map_err(holochain_p2p::HolochainP2pError::other),
                     Err(e) => Err(holochain_p2p::HolochainP2pError::other(e)),
                 };
-                respond.respond(Ok(async move { res }.boxed().into()));
-            }
-            GetAgentInfoSigned {
-                kitsune_space,
-                kitsune_agent,
-                respond,
-                ..
-            } => {
-                let env = { self.p2p_env(&dna_hash) };
-                let res = get_agent_info_signed(env.into(), kitsune_space, kitsune_agent)
-                    .await
-                    .map_err(holochain_p2p::HolochainP2pError::other);
                 respond.respond(Ok(async move { res }.boxed().into()));
             }
             QueryAgentInfoSigned {

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -84,7 +84,6 @@ use holochain_state::prelude::StateMutationResult;
 use holochain_state::source_chain;
 use holochain_types::prelude::*;
 use kitsune_p2p::agent_store::AgentInfoSigned;
-use kitsune_p2p::event::{KGenReq, KGenRes};
 use kitsune_p2p_types::config::JOIN_NETWORK_TIMEOUT;
 use std::collections::HashMap;
 use std::{collections::HashSet, sync::Arc};
@@ -357,6 +356,10 @@ pub trait ConductorHandleT: Send + Sync {
     #[cfg(any(test, feature = "test_utils"))]
     fn get_p2p_env(&self, space: &DnaHash) -> DbWrite<DbKindP2pAgentStore>;
 
+    /// Retrieve the database for metrics. FOR TESTING ONLY.
+    #[cfg(any(test, feature = "test_utils"))]
+    fn get_p2p_metrics_env(&self, space: &DnaHash) -> DbWrite<DbKindP2pMetrics>;
+
     /// Retrieve the database for networking. FOR TESTING ONLY.
     #[cfg(any(test, feature = "test_utils"))]
     fn get_spaces(&self) -> Spaces;
@@ -588,44 +591,6 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
         let dna_hash = event.dna_hash().clone();
         trace!(dispatch_event = ?event);
         match event {
-            holochain_p2p::event::HolochainP2pEvent::KGenReq { arg, respond, .. } => match arg {
-                KGenReq::PeerExtrapCov { space, dht_arc_set } => {
-                    let env = { self.p2p_env(&DnaHash::from_kitsune(&space)) };
-                    respond.respond(Ok(async move {
-                        use holochain_sqlite::db::AsP2pAgentStoreConExt;
-                        let permit = env.conn_permit().await;
-                        let res = tokio::task::spawn_blocking(move || {
-                            let mut conn = env.from_permit(permit)?;
-                            conn.p2p_extrapolated_coverage(dht_arc_set)
-                        })
-                        .await;
-                        let res = res
-                            .map_err(holochain_p2p::HolochainP2pError::other)
-                            .and_then(|r| r.map_err(holochain_p2p::HolochainP2pError::other))?;
-                        Ok(KGenRes::PeerExtrapCov(res))
-                    }
-                    .boxed()
-                    .into()));
-                }
-                KGenReq::RecordMetrics { space, records } => {
-                    let env = { self.p2p_metrics_env(&DnaHash::from_kitsune(&space)) };
-                    respond.respond(Ok(async move {
-                        use holochain_sqlite::db::AsP2pMetricStoreConExt;
-                        let permit = env.conn_permit().await;
-                        let res = tokio::task::spawn_blocking(move || {
-                            let mut conn = env.from_permit(permit)?;
-                            conn.p2p_log_metrics(records)
-                        })
-                        .await;
-                        let res = res
-                            .map_err(holochain_p2p::HolochainP2pError::other)
-                            .and_then(|r| r.map_err(holochain_p2p::HolochainP2pError::other))?;
-                        Ok(KGenRes::RecordMetrics(res))
-                    }
-                    .boxed()
-                    .into()));
-                }
-            },
             PutAgentInfoSigned {
                 peer_data, respond, ..
             } => {
@@ -1432,6 +1397,11 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
     #[cfg(any(test, feature = "test_utils"))]
     fn get_p2p_env(&self, space: &DnaHash) -> DbWrite<DbKindP2pAgentStore> {
         self.p2p_env(space)
+    }
+
+    #[cfg(any(test, feature = "test_utils"))]
+    fn get_p2p_metrics_env(&self, space: &DnaHash) -> DbWrite<DbKindP2pMetrics> {
+        self.p2p_metrics_env(space)
     }
 
     #[cfg(any(test, feature = "test_utils"))]

--- a/crates/holochain/src/conductor/kitsune_host_impl.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl.rs
@@ -1,0 +1,102 @@
+//! Implementation of the Kitsune Host API
+
+use futures::FutureExt;
+use kitsune_p2p::{KitsuneHost, KitsuneHostResult};
+
+use super::ConductorHandle;
+use holochain_types::env::PermittedConn;
+
+/// Implementation of the Kitsune Host API.
+/// Lets Kitsune make requests of Holochain
+pub struct KitsuneHostImpl {
+    conductor: ConductorHandle,
+}
+
+impl KitsuneHost for KitsuneHostImpl {
+    fn peer_extrapolated_coverage(
+        &self,
+        space: std::sync::Arc<kitsune_p2p::KitsuneSpace>,
+        dht_arc_set: holochain_p2p::dht_arc::DhtArcSet,
+    ) -> KitsuneHostResult<Vec<f64>> {
+        let env = self.conductor.get_p2p_env(space);
+        async move {
+            use holochain_sqlite::db::AsP2pAgentStoreConExt;
+            let permit = env.conn_permit().await;
+            let res = tokio::task::spawn_blocking(move || {
+                let mut conn = env.from_permit(permit)?;
+                conn.p2p_extrapolated_coverage(dht_arc_set)
+            })
+            .await;
+            let res = res
+                .map_err(holochain_p2p::HolochainP2pError::other)
+                .and_then(|r| r.map_err(holochain_p2p::HolochainP2pError::other))?;
+            Ok(res)
+        }
+        .boxed()
+        .into()
+    }
+
+    fn record_metrics(
+        &self,
+        space: std::sync::Arc<kitsune_p2p::KitsuneSpace>,
+        records: Vec<kitsune_p2p::event::MetricRecord>,
+    ) -> KitsuneHostResult<()> {
+        let env = self.conductor.get_p2p_metrics_env(space);
+        async move {
+            use holochain_sqlite::db::AsP2pMetricStoreConExt;
+            let permit = env.conn_permit().await;
+            let res = tokio::task::spawn_blocking(move || {
+                let mut conn = env.from_permit(permit)?;
+                conn.p2p_log_metrics(records)
+            })
+            .await;
+            let res = res
+                .map_err(holochain_p2p::HolochainP2pError::other)
+                .and_then(|r| r.map_err(holochain_p2p::HolochainP2pError::other))?;
+            Ok(res)
+        }
+        .boxed()
+        .into()
+    }
+}
+
+/*
+holochain_p2p::event::HolochainP2pEvent::KGenReq { arg, respond, .. } => match arg {
+    KGenReq::PeerExtrapCov { space, dht_arc_set } => {
+        let env = { self.p2p_env(space) };
+        respond.respond(Ok(async move {
+            use holochain_sqlite::db::AsP2pAgentStoreConExt;
+            let permit = env.conn_permit().await;
+            let res = tokio::task::spawn_blocking(move || {
+                let mut conn = env.from_permit(permit)?;
+                conn.p2p_extrapolated_coverage(dht_arc_set)
+            })
+            .await;
+            let res = res
+                .map_err(holochain_p2p::HolochainP2pError::other)
+                .and_then(|r| r.map_err(holochain_p2p::HolochainP2pError::other))?;
+            Ok(KGenRes::PeerExtrapCov(res))
+        }
+        .boxed()
+        .into()));
+    }
+    KGenReq::RecordMetrics { space, records } => {
+        let env = { self.p2p_metrics_env(space) };
+        respond.respond(Ok(async move {
+            use holochain_sqlite::db::AsP2pMetricStoreConExt;
+            let permit = env.conn_permit().await;
+            let res = tokio::task::spawn_blocking(move || {
+                let mut conn = env.from_permit(permit)?;
+                conn.p2p_log_metrics(records)
+            })
+            .await;
+            let res = res
+                .map_err(holochain_p2p::HolochainP2pError::other)
+                .and_then(|r| r.map_err(holochain_p2p::HolochainP2pError::other))?;
+            Ok(KGenRes::RecordMetrics(res))
+        }
+        .boxed()
+        .into()));
+    }
+},
+*/

--- a/crates/holochain/src/conductor/kitsune_host_impl.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl.rs
@@ -38,9 +38,7 @@ impl KitsuneHost for KitsuneHostImpl {
                 conn.p2p_extrapolated_coverage(dht_arc_set)
             })
             .await;
-            let res = res
-                .map_err(holochain_p2p::HolochainP2pError::other)
-                .and_then(|r| r.map_err(holochain_p2p::HolochainP2pError::other))?;
+            let res = res.map_err(Box::new)?.map_err(Box::new)?;
             Ok(res)
         }
         .boxed()
@@ -63,9 +61,7 @@ impl KitsuneHost for KitsuneHostImpl {
                 conn.p2p_log_metrics(records)
             })
             .await;
-            let res = res
-                .map_err(holochain_p2p::HolochainP2pError::other)
-                .and_then(|r| r.map_err(holochain_p2p::HolochainP2pError::other))?;
+            let res = res.map_err(Box::new)?.map_err(Box::new)?;
             Ok(res)
         }
         .boxed()

--- a/crates/holochain/src/conductor/kitsune_host_impl.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl.rs
@@ -1,15 +1,26 @@
 //! Implementation of the Kitsune Host API
 
+use std::sync::Arc;
+
 use futures::FutureExt;
+use holo_hash::DnaHash;
+use holochain_p2p::DnaHashExt;
 use kitsune_p2p::{KitsuneHost, KitsuneHostResult};
 
-use super::ConductorHandle;
+use super::space::Spaces;
 use holochain_types::env::PermittedConn;
 
 /// Implementation of the Kitsune Host API.
 /// Lets Kitsune make requests of Holochain
 pub struct KitsuneHostImpl {
-    conductor: ConductorHandle,
+    spaces: Spaces,
+}
+
+impl KitsuneHostImpl {
+    /// Constructor
+    pub fn new(spaces: Spaces) -> Arc<Self> {
+        Arc::new(Self { spaces })
+    }
 }
 
 impl KitsuneHost for KitsuneHostImpl {
@@ -18,8 +29,8 @@ impl KitsuneHost for KitsuneHostImpl {
         space: std::sync::Arc<kitsune_p2p::KitsuneSpace>,
         dht_arc_set: holochain_p2p::dht_arc::DhtArcSet,
     ) -> KitsuneHostResult<Vec<f64>> {
-        let env = self.conductor.get_p2p_env(space);
         async move {
+            let env = self.spaces.p2p_env(&DnaHash::from_kitsune(&space))?;
             use holochain_sqlite::db::AsP2pAgentStoreConExt;
             let permit = env.conn_permit().await;
             let res = tokio::task::spawn_blocking(move || {
@@ -41,8 +52,10 @@ impl KitsuneHost for KitsuneHostImpl {
         space: std::sync::Arc<kitsune_p2p::KitsuneSpace>,
         records: Vec<kitsune_p2p::event::MetricRecord>,
     ) -> KitsuneHostResult<()> {
-        let env = self.conductor.get_p2p_metrics_env(space);
         async move {
+            let env = self
+                .spaces
+                .p2p_metrics_env(&DnaHash::from_kitsune(&space))?;
             use holochain_sqlite::db::AsP2pMetricStoreConExt;
             let permit = env.conn_permit().await;
             let res = tokio::task::spawn_blocking(move || {
@@ -59,44 +72,3 @@ impl KitsuneHost for KitsuneHostImpl {
         .into()
     }
 }
-
-/*
-holochain_p2p::event::HolochainP2pEvent::KGenReq { arg, respond, .. } => match arg {
-    KGenReq::PeerExtrapCov { space, dht_arc_set } => {
-        let env = { self.p2p_env(space) };
-        respond.respond(Ok(async move {
-            use holochain_sqlite::db::AsP2pAgentStoreConExt;
-            let permit = env.conn_permit().await;
-            let res = tokio::task::spawn_blocking(move || {
-                let mut conn = env.from_permit(permit)?;
-                conn.p2p_extrapolated_coverage(dht_arc_set)
-            })
-            .await;
-            let res = res
-                .map_err(holochain_p2p::HolochainP2pError::other)
-                .and_then(|r| r.map_err(holochain_p2p::HolochainP2pError::other))?;
-            Ok(KGenRes::PeerExtrapCov(res))
-        }
-        .boxed()
-        .into()));
-    }
-    KGenReq::RecordMetrics { space, records } => {
-        let env = { self.p2p_metrics_env(space) };
-        respond.respond(Ok(async move {
-            use holochain_sqlite::db::AsP2pMetricStoreConExt;
-            let permit = env.conn_permit().await;
-            let res = tokio::task::spawn_blocking(move || {
-                let mut conn = env.from_permit(permit)?;
-                conn.p2p_log_metrics(records)
-            })
-            .await;
-            let res = res
-                .map_err(holochain_p2p::HolochainP2pError::other)
-                .and_then(|r| r.map_err(holochain_p2p::HolochainP2pError::other))?;
-            Ok(KGenRes::RecordMetrics(res))
-        }
-        .boxed()
-        .into()));
-    }
-},
-*/

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -22,7 +22,7 @@ use holochain_p2p::actor::HolochainP2pRefToDna;
 use holochain_p2p::dht_arc::DhtArc;
 use holochain_p2p::dht_arc::PeerViewBeta;
 use holochain_p2p::event::HolochainP2pEvent;
-use holochain_p2p::spawn_holochain_p2p;
+use holochain_p2p::spawn_test_holochain_p2p;
 use holochain_p2p::HolochainP2pDna;
 use holochain_p2p::HolochainP2pRef;
 use holochain_p2p::HolochainP2pSender;
@@ -202,7 +202,7 @@ where
     tuning.tx2_implicit_timeout_ms = 500;
     config.tuning_params = std::sync::Arc::new(tuning);
 
-    let (network, mut recv) = spawn_holochain_p2p(
+    let (network, mut recv) = spawn_test_holochain_p2p(
         config,
         holochain_p2p::kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig::new_ephemeral(
         )

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -22,7 +22,7 @@ use holochain_p2p::actor::HolochainP2pRefToDna;
 use holochain_p2p::dht_arc::DhtArc;
 use holochain_p2p::dht_arc::PeerViewBeta;
 use holochain_p2p::event::HolochainP2pEvent;
-use holochain_p2p::spawn_test_holochain_p2p;
+use holochain_p2p::spawn_holochain_p2p;
 use holochain_p2p::HolochainP2pDna;
 use holochain_p2p::HolochainP2pRef;
 use holochain_p2p::HolochainP2pSender;
@@ -202,12 +202,13 @@ where
     tuning.tx2_implicit_timeout_ms = 500;
     config.tuning_params = std::sync::Arc::new(tuning);
 
-    let (network, mut recv) = spawn_test_holochain_p2p(
+    let (network, mut recv) = spawn_holochain_p2p(
         config,
         holochain_p2p::kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig::new_ephemeral(
         )
         .await
         .unwrap(),
+        kitsune_p2p::HostStub::new(),
     )
     .await
     .unwrap();

--- a/crates/holochain_p2p/src/spawn.rs
+++ b/crates/holochain_p2p/src/spawn.rs
@@ -4,19 +4,8 @@ use crate::event::*;
 mod actor;
 use actor::*;
 
-/// Spawn a new HolochainP2p actor.  Conductor will call this on initialization.
-pub async fn spawn_test_holochain_p2p(
-    config: kitsune_p2p::KitsuneP2pConfig,
-    tls_config: kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig,
-    // host: kitsune_p2p::HostApi,
-) -> HolochainP2pResult<(
-    ghost_actor::GhostSender<HolochainP2p>,
-    HolochainP2pEventReceiver,
-)> {
-    spawn_holochain_p2p(config, tls_config, kitsune_p2p::HostStub::new()).await
-}
-
-/// Spawn a new HolochainP2p actor.  Conductor will call this on initialization.
+/// Spawn a new HolochainP2p actor.
+/// Conductor will call this on initialization.
 pub async fn spawn_holochain_p2p(
     config: kitsune_p2p::KitsuneP2pConfig,
     tls_config: kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig,

--- a/crates/holochain_p2p/src/spawn.rs
+++ b/crates/holochain_p2p/src/spawn.rs
@@ -5,10 +5,22 @@ mod actor;
 use actor::*;
 
 /// Spawn a new HolochainP2p actor.  Conductor will call this on initialization.
-pub async fn spawn_holochain_p2p(
+pub async fn spawn_test_holochain_p2p(
     config: kitsune_p2p::KitsuneP2pConfig,
     tls_config: kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig,
     // host: kitsune_p2p::HostApi,
+) -> HolochainP2pResult<(
+    ghost_actor::GhostSender<HolochainP2p>,
+    HolochainP2pEventReceiver,
+)> {
+    spawn_holochain_p2p(config, tls_config, kitsune_p2p::HostStub::new()).await
+}
+
+/// Spawn a new HolochainP2p actor.  Conductor will call this on initialization.
+pub async fn spawn_holochain_p2p(
+    config: kitsune_p2p::KitsuneP2pConfig,
+    tls_config: kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig,
+    host: kitsune_p2p::HostApi,
 ) -> HolochainP2pResult<(
     ghost_actor::GhostSender<HolochainP2p>,
     HolochainP2pEventReceiver,
@@ -23,14 +35,7 @@ pub async fn spawn_holochain_p2p(
 
     tokio::task::spawn(
         builder.spawn(
-            HolochainP2pActor::new(
-                config,
-                tls_config,
-                channel_factory,
-                evt_send,
-                kitsune_p2p::HostStub::new(),
-            )
-            .await?,
+            HolochainP2pActor::new(config, tls_config, channel_factory, evt_send, host).await?,
         ),
     );
 

--- a/crates/holochain_p2p/src/spawn.rs
+++ b/crates/holochain_p2p/src/spawn.rs
@@ -8,6 +8,7 @@ use actor::*;
 pub async fn spawn_holochain_p2p(
     config: kitsune_p2p::KitsuneP2pConfig,
     tls_config: kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig,
+    // host: kitsune_p2p::HostApi,
 ) -> HolochainP2pResult<(
     ghost_actor::GhostSender<HolochainP2p>,
     HolochainP2pEventReceiver,
@@ -21,7 +22,16 @@ pub async fn spawn_holochain_p2p(
     let sender = channel_factory.create_channel::<HolochainP2p>().await?;
 
     tokio::task::spawn(
-        builder.spawn(HolochainP2pActor::new(config, tls_config, channel_factory, evt_send).await?),
+        builder.spawn(
+            HolochainP2pActor::new(
+                config,
+                tls_config,
+                channel_factory,
+                evt_send,
+                kitsune_p2p::HostStub::new(),
+            )
+            .await?,
+        ),
     );
 
     Ok((sender, evt_recv))

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -576,25 +576,6 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
         )
     }
 
-    /// We need to get previously stored agent info.
-    #[tracing::instrument(skip(self), level = "trace")]
-    fn handle_get_agent_info_signed(
-        &mut self,
-        input: kitsune_p2p::event::GetAgentInfoSignedEvt,
-    ) -> kitsune_p2p::event::KitsuneP2pEventHandlerResult<Option<AgentInfoSigned>> {
-        let kitsune_p2p::event::GetAgentInfoSignedEvt { space, agent } = input;
-        let h_space = DnaHash::from_kitsune(&space);
-        let h_agent = AgentPubKey::from_kitsune(&agent);
-        let evt_sender = self.evt_sender.clone();
-        Ok(async move {
-            Ok(evt_sender
-                .get_agent_info_signed(h_space, h_agent, space, agent)
-                .await?)
-        }
-        .boxed()
-        .into())
-    }
-
     /// We need to get previously stored agent info. A single kitusne agent query
     /// can take one of three Holochain agent query paths. We do "duck typing"
     /// on the query object to determine which query path to take. The reason for

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -52,22 +52,6 @@ impl WrapEvtSender {
         )
     }
 
-    fn get_agent_info_signed(
-        &self,
-        dna_hash: DnaHash,
-        to_agent: AgentPubKey,
-        kitsune_space: Arc<kitsune_p2p::KitsuneSpace>,
-        kitsune_agent: Arc<kitsune_p2p::KitsuneAgent>,
-    ) -> impl Future<Output = HolochainP2pResult<Option<AgentInfoSigned>>> + 'static + Send {
-        timing_trace!(
-            {
-                self.0
-                    .get_agent_info_signed(dna_hash, to_agent, kitsune_space, kitsune_agent)
-            },
-            "(hp2p:handle) get_agent_info_signed",
-        )
-    }
-
     fn query_gossip_agents(
         &self,
         dna_hash: DnaHash,

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -354,10 +354,11 @@ impl HolochainP2pActor {
         tls_config: kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig,
         channel_factory: ghost_actor::actor_builder::GhostActorChannelFactory<Self>,
         evt_sender: futures::channel::mpsc::Sender<HolochainP2pEvent>,
+        host: kitsune_p2p::HostApi,
     ) -> HolochainP2pResult<Self> {
         let tuning_params = config.tuning_params.clone();
         let (kitsune_p2p, kitsune_p2p_events) =
-            kitsune_p2p::spawn_kitsune_p2p(config, tls_config).await?;
+            kitsune_p2p::spawn_kitsune_p2p(config, tls_config, host).await?;
 
         channel_factory.attach_receiver(kitsune_p2p_events).await?;
 

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -208,7 +208,7 @@ mod tests {
     async fn test_call_remote_workflow() {
         let (dna, a1, a2, _) = test_setup();
 
-        let (p2p, mut evt) = spawn_holochain_p2p(
+        let (p2p, mut evt) = spawn_test_holochain_p2p(
             KitsuneP2pConfig::default(),
             TlsConfig::new_ephemeral().await.unwrap(),
         )
@@ -274,7 +274,7 @@ mod tests {
     async fn test_send_validation_receipt_workflow() {
         let (dna, a1, a2, _) = test_setup();
 
-        let (p2p, mut evt): (HolochainP2pRef, _) = spawn_holochain_p2p(
+        let (p2p, mut evt): (HolochainP2pRef, _) = spawn_test_holochain_p2p(
             KitsuneP2pConfig::default(),
             TlsConfig::new_ephemeral().await.unwrap(),
         )
@@ -328,7 +328,7 @@ mod tests {
     async fn test_publish_workflow() {
         let (dna, a1, a2, a3) = test_setup();
 
-        let (p2p, mut evt) = spawn_holochain_p2p(
+        let (p2p, mut evt) = spawn_test_holochain_p2p(
             KitsuneP2pConfig::default(),
             TlsConfig::new_ephemeral().await.unwrap(),
         )
@@ -405,7 +405,7 @@ mod tests {
         params.default_rpc_multi_remote_request_grace_ms = 100;
         let mut config = KitsuneP2pConfig::default();
         config.tuning_params = Arc::new(params);
-        let (p2p, mut evt) = spawn_holochain_p2p(config, cert).await.unwrap();
+        let (p2p, mut evt) = spawn_test_holochain_p2p(config, cert).await.unwrap();
 
         let test_1 = WireOps::Element(WireElementOps {
             header: Some(Judged::valid(SignedHeader(fixt!(Header), fixt!(Signature)))),
@@ -502,9 +502,10 @@ mod tests {
         let mut config = KitsuneP2pConfig::default();
         config.tuning_params = Arc::new(params);
 
-        let (p2p, mut evt) = spawn_holochain_p2p(config, TlsConfig::new_ephemeral().await.unwrap())
-            .await
-            .unwrap();
+        let (p2p, mut evt) =
+            spawn_test_holochain_p2p(config, TlsConfig::new_ephemeral().await.unwrap())
+                .await
+                .unwrap();
 
         let test_1 = WireLinkOps {
             creates: vec![WireCreateLink::condense(

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -208,9 +208,10 @@ mod tests {
     async fn test_call_remote_workflow() {
         let (dna, a1, a2, _) = test_setup();
 
-        let (p2p, mut evt) = spawn_test_holochain_p2p(
+        let (p2p, mut evt) = spawn_holochain_p2p(
             KitsuneP2pConfig::default(),
             TlsConfig::new_ephemeral().await.unwrap(),
+            kitsune_p2p::HostStub::new(),
         )
         .await
         .unwrap();
@@ -274,9 +275,10 @@ mod tests {
     async fn test_send_validation_receipt_workflow() {
         let (dna, a1, a2, _) = test_setup();
 
-        let (p2p, mut evt): (HolochainP2pRef, _) = spawn_test_holochain_p2p(
+        let (p2p, mut evt): (HolochainP2pRef, _) = spawn_holochain_p2p(
             KitsuneP2pConfig::default(),
             TlsConfig::new_ephemeral().await.unwrap(),
+            kitsune_p2p::HostStub::new(),
         )
         .await
         .unwrap();
@@ -328,9 +330,10 @@ mod tests {
     async fn test_publish_workflow() {
         let (dna, a1, a2, a3) = test_setup();
 
-        let (p2p, mut evt) = spawn_test_holochain_p2p(
+        let (p2p, mut evt) = spawn_holochain_p2p(
             KitsuneP2pConfig::default(),
             TlsConfig::new_ephemeral().await.unwrap(),
+            kitsune_p2p::HostStub::new(),
         )
         .await
         .unwrap();
@@ -405,7 +408,9 @@ mod tests {
         params.default_rpc_multi_remote_request_grace_ms = 100;
         let mut config = KitsuneP2pConfig::default();
         config.tuning_params = Arc::new(params);
-        let (p2p, mut evt) = spawn_test_holochain_p2p(config, cert).await.unwrap();
+        let (p2p, mut evt) = spawn_holochain_p2p(config, cert, kitsune_p2p::HostStub::new())
+            .await
+            .unwrap();
 
         let test_1 = WireOps::Element(WireElementOps {
             header: Some(Judged::valid(SignedHeader(fixt!(Header), fixt!(Signature)))),
@@ -502,10 +507,13 @@ mod tests {
         let mut config = KitsuneP2pConfig::default();
         config.tuning_params = Arc::new(params);
 
-        let (p2p, mut evt) =
-            spawn_test_holochain_p2p(config, TlsConfig::new_ephemeral().await.unwrap())
-                .await
-                .unwrap();
+        let (p2p, mut evt) = spawn_holochain_p2p(
+            config,
+            TlsConfig::new_ephemeral().await.unwrap(),
+            kitsune_p2p::HostStub::new(),
+        )
+        .await
+        .unwrap();
 
         let test_1 = WireLinkOps {
             creates: vec![WireCreateLink::condense(

--- a/crates/holochain_p2p/src/types/event.rs
+++ b/crates/holochain_p2p/src/types/event.rs
@@ -109,9 +109,6 @@ ghost_actor::ghost_chan! {
         fn put_agent_info_signed(dna_hash: DnaHash, peer_data: Vec<AgentInfoSigned>) -> ();
 
         /// We need to get previously stored agent info.
-        fn get_agent_info_signed(dna_hash: DnaHash, to_agent: AgentPubKey, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>, kitsune_agent: Arc<kitsune_p2p::KitsuneAgent>) -> Option<AgentInfoSigned>;
-
-        /// We need to get previously stored agent info.
         fn query_agent_info_signed(dna_hash: DnaHash, agents: Option<std::collections::HashSet<Arc<kitsune_p2p::KitsuneAgent>>>, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>) -> Vec<AgentInfoSigned>;
 
         /// We need to get agents that fit into an arc set for gossip.
@@ -248,7 +245,6 @@ macro_rules! match_p2p_evt {
             HolochainP2pEvent::GetAgentActivity { $i, .. } => { $($t)* }
             HolochainP2pEvent::ValidationReceiptReceived { $i, .. } => { $($t)* }
             HolochainP2pEvent::SignNetworkData { $i, .. } => { $($t)* }
-            HolochainP2pEvent::GetAgentInfoSigned { $i, .. } => { $($t)* }
             HolochainP2pEvent::CountersigningAuthorityResponse { $i, .. } => { $($t)* }
             $($t2)*
         }

--- a/crates/holochain_p2p/src/types/event.rs
+++ b/crates/holochain_p2p/src/types/event.rs
@@ -104,8 +104,6 @@ ghost_actor::ghost_chan! {
     /// The HolochainP2pEvent stream allows handling events generated from
     /// the HolochainP2p actor.
     pub chan HolochainP2pEvent<super::HolochainP2pError> {
-        /// Generic Kitsune Request of the implementor
-        fn k_gen_req(dna_hash: DnaHash, arg: KGenReq) -> KGenRes;
 
         /// We need to store signed agent info.
         fn put_agent_info_signed(dna_hash: DnaHash, peer_data: Vec<AgentInfoSigned>) -> ();
@@ -261,7 +259,6 @@ impl HolochainP2pEvent {
     /// The dna_hash associated with this network p2p event.
     pub fn dna_hash(&self) -> &DnaHash {
         match_p2p_evt!(self => |dna_hash| { dna_hash }, {
-            HolochainP2pEvent::KGenReq { dna_hash, .. } => { dna_hash }
             HolochainP2pEvent::Publish { dna_hash, .. } => { dna_hash }
             HolochainP2pEvent::FetchOpData { dna_hash, .. } => { dna_hash }
             HolochainP2pEvent::QueryOpHashes { dna_hash, .. } => { dna_hash }
@@ -276,7 +273,6 @@ impl HolochainP2pEvent {
     /// The agent_pub_key associated with this network p2p event.
     pub fn target_agents(&self) -> &AgentPubKey {
         match_p2p_evt!(self => |to_agent| { to_agent }, {
-            HolochainP2pEvent::KGenReq { .. } => { unimplemented!("There is no single agent target for KGenReq") }
             HolochainP2pEvent::Publish { .. } => { unimplemented!("There is no single agent target for Publish") }
             HolochainP2pEvent::FetchOpData { .. } => { unimplemented!("There is no single agent target for FetchOpData") }
             HolochainP2pEvent::QueryOpHashes { .. } => { unimplemented!("There is no single agent target for QueryOpHashes") }

--- a/crates/holochain_zome_types/src/op.rs
+++ b/crates/holochain_zome_types/src/op.rs
@@ -1,65 +1,4 @@
 //! # Dht Operational Transforms
-//! These are the operational transformations that can be applied to Holochain data.
-//! Every [`Header`] produces a set of operations.
-//! These operations are each sent to an authority for validation.
-//!
-//! ## Producing Operations
-//! The following is a list of the operations that can be produced by each [`Header`]:
-//! - Every [`Header`] produces a [`Op::RegisterAgentActivity`] and a [`Op::StoreElement`].
-//! - [`Header::Create`] also produces a [`Op::StoreEntry`].
-//! - [`Header::Update`] also produces a [`Op::StoreEntry`] and a [`Op::RegisterUpdate`].
-//! - [`Header::Delete`] also produces a [`Op::RegisterDelete`].
-//! - [`Header::CreateLink`] also produces a [`Op::RegisterCreateLink`].
-//! - [`Header::DeleteLink`] also produces a [`Op::RegisterDeleteLink`].
-//!
-//! ## Authorities
-//! There are three types of authorities in Holochain:
-//!
-//! #### The Header Authority
-//! This set of authorities receives the [`Op::StoreElement`].
-//! This is where you can implement your own logic for checking
-//! that it is valid to store any of the [`Header`] variants
-//! according to your own applications rules.
-//!
-//! #### The Entry Authority
-//! This set of authorities receives the [`Op::StoreEntry`].
-//! This is where you can implement your own logic for checking
-//! that it is valid to store an [`Entry`].
-//! You can think of this as the "Create" from the CRUD acronym.
-//!
-//! ##### Metadata
-//! The entry authority is also responsible for storing the metadata for each entry.
-//! They receive the [`Op::RegisterUpdate`] and [`Op::RegisterDelete`].
-//! This is where you can implement your own logic for checking that it is valid to
-//! update or delete any of the [`Entry`] types defined in your application.
-//! You can think of this as the "Update" and "Delete" from the CRUD acronym.
-//!
-//! They receive the [`Op::RegisterCreateLink`] and [`Op::RegisterDeleteLink`].
-//! This is where you can implement your own logic for checking that it is valid to
-//! place a link on a base [`Entry`].
-//!
-//! #### The Chain Authority
-//! This set of authorities receives the [`Op::RegisterAgentActivity`].
-//! This is where you can implement your own logic for checking that it is valid to
-//! add a new [`Header`] to an agent source chain.
-//! You are not validating the individual element but the entire agents source chain.
-//!
-//! ##### Author
-//! When authoring a new [`Header`] to your source chain, the
-//! validation will be run from the perspective of every authority.
-//!
-//! ##### A note on metadata for the Header authority.
-//! Technically speaking the Header authority also receives and validates the
-//! [`Op::RegisterUpdate`] and [`Op::RegisterDelete`] but they run the same callback
-//! as the Entry authority because it would be inconsistent to have two separate
-//! validation outcomes for these ops.
-//!
-//! ## Running Validation
-//! When the `fn validate(op: Op) -> ExternResult<ValidateCallbackResult>` is called
-//! it will be passed the operation variant for the authority that is
-//! actually running the validation.
-//!
-//! For example the entry authority will be passed the [`Op::StoreEntry`] operation.
 
 use crate::{
     AppEntryType, Create, CreateLink, Delete, DeleteLink, Element, Entry, EntryType, Header,
@@ -71,6 +10,68 @@ use kitsune_p2p_timestamp::Timestamp;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes)]
 #[cfg_attr(feature = "test_utils", derive(arbitrary::Arbitrary))]
+/// # Dht Operational Transforms
+/// These are the operational transformations that can be applied to Holochain data.
+/// Every [`Header`] produces a set of operations.
+/// These operations are each sent to an authority for validation.
+///
+/// ## Producing Operations
+/// The following is a list of the operations that can be produced by each [`Header`]:
+/// - Every [`Header`] produces a [`Op::RegisterAgentActivity`] and a [`Op::StoreElement`].
+/// - [`Header::Create`] also produces a [`Op::StoreEntry`].
+/// - [`Header::Update`] also produces a [`Op::StoreEntry`] and a [`Op::RegisterUpdate`].
+/// - [`Header::Delete`] also produces a [`Op::RegisterDelete`].
+/// - [`Header::CreateLink`] also produces a [`Op::RegisterCreateLink`].
+/// - [`Header::DeleteLink`] also produces a [`Op::RegisterDeleteLink`].
+///
+/// ## Authorities
+/// There are three types of authorities in Holochain:
+///
+/// #### The Header Authority
+/// This set of authorities receives the [`Op::StoreElement`].
+/// This is where you can implement your own logic for checking
+/// that it is valid to store any of the [`Header`] variants
+/// according to your own applications rules.
+///
+/// #### The Entry Authority
+/// This set of authorities receives the [`Op::StoreEntry`].
+/// This is where you can implement your own logic for checking
+/// that it is valid to store an [`Entry`].
+/// You can think of this as the "Create" from the CRUD acronym.
+///
+/// ##### Metadata
+/// The entry authority is also responsible for storing the metadata for each entry.
+/// They receive the [`Op::RegisterUpdate`] and [`Op::RegisterDelete`].
+/// This is where you can implement your own logic for checking that it is valid to
+/// update or delete any of the [`Entry`] types defined in your application.
+/// You can think of this as the "Update" and "Delete" from the CRUD acronym.
+///
+/// They receive the [`Op::RegisterCreateLink`] and [`Op::RegisterDeleteLink`].
+/// This is where you can implement your own logic for checking that it is valid to
+/// place a link on a base [`Entry`].
+///
+/// #### The Chain Authority
+/// This set of authorities receives the [`Op::RegisterAgentActivity`].
+/// This is where you can implement your own logic for checking that it is valid to
+/// add a new [`Header`] to an agent source chain.
+/// You are not validating the individual element but the entire agents source chain.
+///
+/// ##### Author
+/// When authoring a new [`Header`] to your source chain, the
+/// validation will be run from the perspective of every authority.
+///
+/// ##### A note on metadata for the Header authority.
+/// Technically speaking the Header authority also receives and validates the
+/// [`Op::RegisterUpdate`] and [`Op::RegisterDelete`] but they run the same callback
+/// as the Entry authority because it would be inconsistent to have two separate
+/// validation outcomes for these ops.
+///
+/// ## Running Validation
+/// When the `fn validate(op: Op) -> ExternResult<ValidateCallbackResult>` is called
+/// it will be passed the operation variant for the authority that is
+/// actually running the validation.
+///
+/// For example the entry authority will be passed the [`Op::StoreEntry`] operation.
 /// The operational transforms that can are applied to Holochain data.
 /// Operations beginning with `Store` are concerned with creating and
 /// storing data.

--- a/crates/kitsune_p2p/direct/src/v1.rs
+++ b/crates/kitsune_p2p/direct/src/v1.rs
@@ -153,7 +153,9 @@ pub fn new_kitsune_direct_v1(
 
         let tls = persist.singleton_tls_config().await?;
 
-        let (p2p, evt) = spawn_kitsune_p2p(sub_config, tls)
+        let host = HostStub::new();
+
+        let (p2p, evt) = spawn_kitsune_p2p(sub_config, tls, host)
             .await
             .map_err(KdError::other)?;
 

--- a/crates/kitsune_p2p/direct/src/v1.rs
+++ b/crates/kitsune_p2p/direct/src/v1.rs
@@ -620,9 +620,6 @@ async fn handle_events(
         tuning_params.concurrent_limit_per_thread,
         move |evt| async move {
             match evt {
-                event::KitsuneP2pEvent::KGenReq { respond, .. } => {
-                    respond.r(Err("unimplemented".into()))
-                }
                 event::KitsuneP2pEvent::PutAgentInfoSigned { respond, input, .. } => {
                     respond.r(Ok(handle_put_agent_info_signed(kdirect.clone(), input)
                         .map_err(KitsuneP2pError::other)

--- a/crates/kitsune_p2p/direct/src/v1.rs
+++ b/crates/kitsune_p2p/direct/src/v1.rs
@@ -626,12 +626,6 @@ async fn handle_events(
                         .boxed()
                         .into()));
                 }
-                event::KitsuneP2pEvent::GetAgentInfoSigned { respond, input, .. } => {
-                    respond.r(Ok(handle_get_agent_info_signed(kdirect.clone(), input)
-                        .map_err(KitsuneP2pError::other)
-                        .boxed()
-                        .into()));
-                }
                 event::KitsuneP2pEvent::QueryAgents { respond, input, .. } => {
                     respond.r(Ok(handle_query_agents(kdirect.clone(), input)
                         .map_err(KitsuneP2pError::other)
@@ -736,21 +730,6 @@ async fn handle_put_agent_info_signed(
     }
 
     Ok(())
-}
-
-async fn handle_get_agent_info_signed(
-    kdirect: Arc<Kd1>,
-    input: GetAgentInfoSignedEvt,
-) -> KdResult<Option<AgentInfoSigned>> {
-    let GetAgentInfoSignedEvt { space, agent } = input;
-
-    let root = KdHash::from_kitsune_space(&space);
-    let agent = KdHash::from_kitsune_agent(&agent);
-
-    Ok(match kdirect.persist.get_agent_info(root, agent).await {
-        Ok(i) => Some(i.to_kitsune()),
-        Err(_) => None,
-    })
 }
 
 async fn handle_query_agents(

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -24,6 +24,7 @@ kitsune_p2p_proxy = { version = "0.0.18", path = "../proxy" }
 kitsune_p2p_timestamp = { version = "0.0.6", path = "../timestamp", features = ["now"] }
 kitsune_p2p_transport_quic = { version = "0.0.18", path = "../transport_quic" }
 kitsune_p2p_types = { version = "0.0.18", path = "../types" }
+must_future = "0.1.1"
 num-traits = "0.2"
 observability = "0.1.3"
 once_cell = "1.4.1"

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -146,6 +146,7 @@ impl Stats {
 
 impl ShardedGossip {
     /// Constructor
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         tuning_params: KitsuneP2pTuningParams,
         space: Arc<KitsuneSpace>,
@@ -163,7 +164,7 @@ impl ShardedGossip {
                 tuning_params,
                 space,
                 evt_sender,
-                host,
+                _host: host,
                 inner: Share::new(ShardedGossipLocalState::new(metrics)),
                 gossip_type,
                 closing: AtomicBool::new(false),
@@ -344,7 +345,7 @@ pub struct ShardedGossipLocal {
     tuning_params: KitsuneP2pTuningParams,
     space: Arc<KitsuneSpace>,
     evt_sender: EventSender,
-    host: HostApi,
+    _host: HostApi,
     inner: Share<ShardedGossipLocalState>,
     closing: AtomicBool,
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests.rs
@@ -25,7 +25,7 @@ impl ShardedGossipLocal {
             tuning_params: Default::default(),
             space,
             evt_sender,
-            host,
+            _host: host,
             inner: Share::new(inner),
             closing: std::sync::atomic::AtomicBool::new(false),
         }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests.rs
@@ -15,6 +15,7 @@ impl ShardedGossipLocal {
     pub fn test(
         gossip_type: GossipType,
         evt_sender: EventSender,
+        host: HostApi,
         inner: ShardedGossipLocalState,
     ) -> Self {
         // TODO: randomize space
@@ -24,6 +25,7 @@ impl ShardedGossipLocal {
             tuning_params: Default::default(),
             space,
             evt_sender,
+            host,
             inner: Share::new(inner),
             closing: std::sync::atomic::AtomicBool::new(false),
         }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/bloom.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/bloom.rs
@@ -4,6 +4,7 @@ use std::slice::SliceIndex;
 use super::common::*;
 use super::*;
 use crate::gossip::sharded_gossip::bloom::Batch;
+use crate::HostStub;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn bloom_windows() {
@@ -234,10 +235,12 @@ async fn make_node_inner(data: Option<(usize, TimeWindow)>) -> ShardedGossipLoca
             Ok(async move { Ok(data) }.boxed().into())
         });
     let (evt_sender, _) = spawn_handler(evt_handler).await;
+    let host = HostStub::new();
 
     ShardedGossipLocal::test(
         GossipType::Historical,
         evt_sender,
+        host,
         ShardedGossipLocalState::default(),
     )
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -9,6 +9,8 @@ pub struct StandardResponsesHostApi {
 }
 
 impl KitsuneHostPanicky for StandardResponsesHostApi {
+    const NAME: &'static str = "StandardResponsesHostApi";
+
     fn get_agent_info_signed(
         &self,
         input: GetAgentInfoSignedEvt,

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -1,6 +1,7 @@
 pub use crate::test_util::spawn_handler;
 use crate::HostStub;
 use crate::{test_util::hash_op_data, KitsuneHostPanicky};
+use kitsune_p2p_types::box_fut;
 
 use super::*;
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -34,7 +34,6 @@ async fn standard_responses(
         infos: infos.clone(),
     };
     evt_handler.expect_handle_query_agents().returning({
-        let infos = infos.clone();
         move |_| {
             let infos = infos.clone();
             Ok(async move { Ok(infos.clone()) }.boxed().into())

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -1,5 +1,6 @@
 use crate::test_util::hash_op_data;
 pub use crate::test_util::spawn_handler;
+use crate::HostStub;
 
 use super::*;
 
@@ -72,7 +73,7 @@ pub async fn setup_player(
 ) -> ShardedGossipLocal {
     let evt_handler = standard_responses(agents, with_data).await;
     let (evt_sender, _) = spawn_handler(evt_handler).await;
-    ShardedGossipLocal::test(GossipType::Historical, evt_sender, state)
+    ShardedGossipLocal::test(GossipType::Historical, evt_sender, HostStub::new(), state)
 }
 
 pub async fn setup_standard_player(
@@ -88,7 +89,7 @@ pub async fn setup_empty_player(
 ) -> ShardedGossipLocal {
     let evt_handler = standard_responses(agents, false).await;
     let (evt_sender, _) = spawn_handler(evt_handler).await;
-    ShardedGossipLocal::test(GossipType::Historical, evt_sender, state)
+    ShardedGossipLocal::test(GossipType::Historical, evt_sender, HostStub::new(), state)
 }
 
 pub async fn agents_with_infos(num_agents: usize) -> Vec<(Arc<KitsuneAgent>, AgentInfoSigned)> {

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -1,16 +1,38 @@
-use crate::test_util::hash_op_data;
 pub use crate::test_util::spawn_handler;
 use crate::HostStub;
+use crate::{test_util::hash_op_data, KitsuneHostPanicky};
 
 use super::*;
+
+pub struct StandardResponsesHostApi {
+    infos: Vec<AgentInfoSigned>,
+}
+
+impl KitsuneHostPanicky for StandardResponsesHostApi {
+    fn get_agent_info_signed(
+        &self,
+        input: GetAgentInfoSignedEvt,
+    ) -> crate::KitsuneHostResult<Option<crate::types::agent_store::AgentInfoSigned>> {
+        let agent = self
+            .infos
+            .clone()
+            .into_iter()
+            .find(|a| a.agent == input.agent)
+            .unwrap();
+        box_fut(Ok(Some(agent)))
+    }
+}
 
 // TODO: integrate with `HandlerBuilder`
 async fn standard_responses(
     agents: Vec<(Arc<KitsuneAgent>, AgentInfoSigned)>,
     with_data: bool,
-) -> MockKitsuneP2pEventHandler {
+) -> (MockKitsuneP2pEventHandler, HostApi) {
     let mut evt_handler = MockKitsuneP2pEventHandler::new();
     let infos = agents.iter().map(|(_, i)| i.clone()).collect::<Vec<_>>();
+    let host = StandardResponsesHostApi {
+        infos: infos.clone(),
+    };
     evt_handler.expect_handle_query_agents().returning({
         let infos = infos.clone();
         move |_| {
@@ -18,18 +40,6 @@ async fn standard_responses(
             Ok(async move { Ok(infos.clone()) }.boxed().into())
         }
     });
-    evt_handler
-        .expect_handle_get_agent_info_signed()
-        .returning({
-            move |input| {
-                let agent = infos
-                    .clone()
-                    .into_iter()
-                    .find(|a| a.agent == input.agent)
-                    .unwrap();
-                Ok(async move { Ok(Some(agent)) }.boxed().into())
-            }
-        });
 
     if with_data {
         let fake_data = KitsuneOpData::new(vec![0]);
@@ -63,7 +73,8 @@ async fn standard_responses(
     evt_handler
         .expect_handle_gossip()
         .returning(|_, _| Ok(async { Ok(()) }.boxed().into()));
-    evt_handler
+
+    (evt_handler, Arc::new(host))
 }
 
 pub async fn setup_player(
@@ -71,9 +82,9 @@ pub async fn setup_player(
     agents: Vec<(Arc<KitsuneAgent>, AgentInfoSigned)>,
     with_data: bool,
 ) -> ShardedGossipLocal {
-    let evt_handler = standard_responses(agents, with_data).await;
+    let (evt_handler, host_api) = standard_responses(agents, with_data).await;
     let (evt_sender, _) = spawn_handler(evt_handler).await;
-    ShardedGossipLocal::test(GossipType::Historical, evt_sender, HostStub::new(), state)
+    ShardedGossipLocal::test(GossipType::Historical, evt_sender, host_api, state)
 }
 
 pub async fn setup_standard_player(
@@ -87,9 +98,9 @@ pub async fn setup_empty_player(
     state: ShardedGossipLocalState,
     agents: Vec<(Arc<KitsuneAgent>, AgentInfoSigned)>,
 ) -> ShardedGossipLocal {
-    let evt_handler = standard_responses(agents, false).await;
+    let (evt_handler, host_api) = standard_responses(agents, false).await;
     let (evt_sender, _) = spawn_handler(evt_handler).await;
-    ShardedGossipLocal::test(GossipType::Historical, evt_sender, HostStub::new(), state)
+    ShardedGossipLocal::test(GossipType::Historical, evt_sender, host_api, state)
 }
 
 pub async fn agents_with_infos(num_agents: usize) -> Vec<(Arc<KitsuneAgent>, AgentInfoSigned)> {

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
@@ -11,7 +11,7 @@ pub type KitsuneHostResult<'a, T> =
 
 /// The interface to be implemented by the host, which handles various requests
 /// for data
-pub trait KitsuneHost {
+pub trait KitsuneHost: 'static + Send + Sync {
     /// We need to get previously stored agent info.
     fn get_agent_info_signed(
         &self,

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
@@ -6,7 +6,8 @@ use kitsune_p2p_types::{bin_types::KitsuneSpace, dht_arc::DhtArcSet};
 use crate::event::MetricRecord;
 
 /// A boxed future result with dynamic error type
-pub type KitsuneHostResult<'a, T> = MustBoxFuture<'a, Result<T, Box<dyn std::error::Error>>>;
+pub type KitsuneHostResult<'a, T> =
+    MustBoxFuture<'a, Result<T, Box<dyn 'a + Send + std::error::Error>>>;
 
 /// The interface to be implemented by the host, which handles various requests
 /// for data
@@ -29,30 +30,8 @@ pub trait KitsuneHost {
 /// Trait object for the host interface
 pub type HostApi = std::sync::Arc<dyn KitsuneHost + Send + Sync>;
 
-/// Dummy host impl for plumbing
-pub struct HostStub;
-
-impl KitsuneHost for HostStub {
-    fn peer_extrapolated_coverage(
-        &self,
-        _space: Arc<crate::KitsuneSpace>,
-        _dht_arc_set: DhtArcSet,
-    ) -> KitsuneHostResult<Vec<f64>> {
-        todo!()
-    }
-
-    fn record_metrics(
-        &self,
-        _space: Arc<crate::KitsuneSpace>,
-        _records: Vec<MetricRecord>,
-    ) -> KitsuneHostResult<()> {
-        todo!()
-    }
-}
-
-impl HostStub {
-    /// Constructor
-    pub fn new() -> std::sync::Arc<Self> {
-        std::sync::Arc::new(Self)
-    }
-}
+// Test-only stub which mostly panics
+#[cfg(any(test, feature = "test_utils"))]
+mod host_stub;
+#[cfg(any(test, feature = "test_utils"))]
+pub use host_stub::*;

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
@@ -3,15 +3,21 @@ use std::sync::Arc;
 
 use kitsune_p2p_types::{bin_types::KitsuneSpace, dht_arc::DhtArcSet};
 
-use crate::event::MetricRecord;
+use crate::event::{GetAgentInfoSignedEvt, MetricRecord};
 
 /// A boxed future result with dynamic error type
 pub type KitsuneHostResult<'a, T> =
-    MustBoxFuture<'a, Result<T, Box<dyn 'a + Send + Sync + std::error::Error>>>;
+    MustBoxFuture<'a, Result<T, Box<dyn Send + Sync + std::error::Error>>>;
 
 /// The interface to be implemented by the host, which handles various requests
 /// for data
 pub trait KitsuneHost {
+    /// We need to get previously stored agent info.
+    fn get_agent_info_signed(
+        &self,
+        input: GetAgentInfoSignedEvt,
+    ) -> KitsuneHostResult<Option<crate::types::agent_store::AgentInfoSigned>>;
+
     /// Extrapolated Peer Coverage
     fn peer_extrapolated_coverage(
         &self,
@@ -35,3 +41,8 @@ pub type HostApi = std::sync::Arc<dyn KitsuneHost + Send + Sync>;
 mod host_stub;
 #[cfg(any(test, feature = "test_utils"))]
 pub use host_stub::*;
+
+#[cfg(any(test, feature = "test_utils"))]
+mod host_panicky;
+#[cfg(any(test, feature = "test_utils"))]
+pub use host_panicky::*;

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
@@ -7,7 +7,7 @@ use crate::event::MetricRecord;
 
 /// A boxed future result with dynamic error type
 pub type KitsuneHostResult<'a, T> =
-    MustBoxFuture<'a, Result<T, Box<dyn 'a + Send + std::error::Error>>>;
+    MustBoxFuture<'a, Result<T, Box<dyn 'a + Send + Sync + std::error::Error>>>;
 
 /// The interface to be implemented by the host, which handles various requests
 /// for data

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_panicky.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_panicky.rs
@@ -1,0 +1,57 @@
+use super::*;
+
+/// A supertrait of KitsuneHost convenient for defining test handlers.
+/// Allows only specifying the methods you care about, and letting all the rest
+/// panic if called
+pub trait KitsuneHostPanicky: KitsuneHost {
+    /// We need to get previously stored agent info.
+    fn get_agent_info_signed(
+        &self,
+        _input: GetAgentInfoSignedEvt,
+    ) -> KitsuneHostResult<Option<crate::types::agent_store::AgentInfoSigned>> {
+        unimplemented!("default panic for unimplemented KitsuneHost test behavior")
+    }
+
+    /// Extrapolated Peer Coverage
+    fn peer_extrapolated_coverage(
+        &self,
+        _space: Arc<KitsuneSpace>,
+        _dht_arc_set: DhtArcSet,
+    ) -> KitsuneHostResult<Vec<f64>> {
+        unimplemented!("default panic for unimplemented KitsuneHost test behavior")
+    }
+
+    /// Record a set of metric records
+    fn record_metrics(
+        &self,
+        _space: Arc<KitsuneSpace>,
+        _records: Vec<MetricRecord>,
+    ) -> KitsuneHostResult<()> {
+        unimplemented!("default panic for unimplemented KitsuneHost test behavior")
+    }
+}
+
+impl<T: KitsuneHostPanicky> KitsuneHost for T {
+    fn get_agent_info_signed(
+        &self,
+        input: GetAgentInfoSignedEvt,
+    ) -> KitsuneHostResult<Option<crate::types::agent_store::AgentInfoSigned>> {
+        KitsuneHostPanicky::get_agent_info_signed(self, input)
+    }
+
+    fn peer_extrapolated_coverage(
+        &self,
+        space: Arc<KitsuneSpace>,
+        dht_arc_set: DhtArcSet,
+    ) -> KitsuneHostResult<Vec<f64>> {
+        KitsuneHostPanicky::peer_extrapolated_coverage(self, space, dht_arc_set)
+    }
+
+    fn record_metrics(
+        &self,
+        space: Arc<KitsuneSpace>,
+        records: Vec<MetricRecord>,
+    ) -> KitsuneHostResult<()> {
+        KitsuneHostPanicky::record_metrics(self, space, records)
+    }
+}

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_panicky.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_panicky.rs
@@ -4,12 +4,18 @@ use super::*;
 /// Allows only specifying the methods you care about, and letting all the rest
 /// panic if called
 pub trait KitsuneHostPanicky: KitsuneHost {
+    /// Name to be printed out on unimplemented panic
+    const NAME: &'static str;
+
     /// We need to get previously stored agent info.
     fn get_agent_info_signed(
         &self,
         _input: GetAgentInfoSignedEvt,
     ) -> KitsuneHostResult<Option<crate::types::agent_store::AgentInfoSigned>> {
-        unimplemented!("default panic for unimplemented KitsuneHost test behavior")
+        unimplemented!(
+            "default panic for unimplemented KitsuneHost test behavior: {}",
+            Self::NAME
+        )
     }
 
     /// Extrapolated Peer Coverage
@@ -18,7 +24,10 @@ pub trait KitsuneHostPanicky: KitsuneHost {
         _space: Arc<KitsuneSpace>,
         _dht_arc_set: DhtArcSet,
     ) -> KitsuneHostResult<Vec<f64>> {
-        unimplemented!("default panic for unimplemented KitsuneHost test behavior")
+        unimplemented!(
+            "default panic for unimplemented KitsuneHost test behavior: {}",
+            Self::NAME
+        )
     }
 
     /// Record a set of metric records
@@ -27,7 +36,10 @@ pub trait KitsuneHostPanicky: KitsuneHost {
         _space: Arc<KitsuneSpace>,
         _records: Vec<MetricRecord>,
     ) -> KitsuneHostResult<()> {
-        unimplemented!("default panic for unimplemented KitsuneHost test behavior")
+        unimplemented!(
+            "default panic for unimplemented KitsuneHost test behavior: {}",
+            Self::NAME
+        )
     }
 }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
@@ -1,0 +1,33 @@
+use std::sync::Arc;
+
+use kitsune_p2p_types::{box_fut, dht_arc::DhtArcSet};
+
+use crate::{event::MetricRecord, KitsuneHost, KitsuneHostResult};
+
+/// Dummy host impl for plumbing
+pub struct HostStub;
+
+impl KitsuneHost for HostStub {
+    fn peer_extrapolated_coverage(
+        &self,
+        _space: Arc<crate::KitsuneSpace>,
+        _dht_arc_set: DhtArcSet,
+    ) -> KitsuneHostResult<Vec<f64>> {
+        unreachable!("function not used in tests")
+    }
+
+    fn record_metrics(
+        &self,
+        _space: Arc<crate::KitsuneSpace>,
+        _records: Vec<MetricRecord>,
+    ) -> KitsuneHostResult<()> {
+        box_fut(Ok(()))
+    }
+}
+
+impl HostStub {
+    /// Constructor
+    pub fn new() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self)
+    }
+}

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
@@ -3,7 +3,9 @@ use crate::KitsuneHostPanicky;
 /// Dummy host impl for plumbing
 pub struct HostStub;
 
-impl KitsuneHostPanicky for HostStub {}
+impl KitsuneHostPanicky for HostStub {
+    const NAME: &'static str = "HostStub";
+}
 
 impl HostStub {
     /// Constructor

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
@@ -1,29 +1,9 @@
-use std::sync::Arc;
-
-use kitsune_p2p_types::{box_fut, dht_arc::DhtArcSet};
-
-use crate::{event::MetricRecord, KitsuneHost, KitsuneHostResult};
+use crate::KitsuneHostPanicky;
 
 /// Dummy host impl for plumbing
 pub struct HostStub;
 
-impl KitsuneHost for HostStub {
-    fn peer_extrapolated_coverage(
-        &self,
-        _space: Arc<crate::KitsuneSpace>,
-        _dht_arc_set: DhtArcSet,
-    ) -> KitsuneHostResult<Vec<f64>> {
-        unreachable!("function not used in tests")
-    }
-
-    fn record_metrics(
-        &self,
-        _space: Arc<crate::KitsuneSpace>,
-        _records: Vec<MetricRecord>,
-    ) -> KitsuneHostResult<()> {
-        box_fut(Ok(()))
-    }
-}
+impl KitsuneHostPanicky for HostStub {}
 
 impl HostStub {
     /// Constructor

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_logic.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_logic.rs
@@ -35,16 +35,16 @@ pub struct HostStub;
 impl KitsuneHost for HostStub {
     fn peer_extrapolated_coverage(
         &self,
-        space: Arc<crate::KitsuneSpace>,
-        dht_arc_set: DhtArcSet,
+        _space: Arc<crate::KitsuneSpace>,
+        _dht_arc_set: DhtArcSet,
     ) -> KitsuneHostResult<Vec<f64>> {
         todo!()
     }
 
     fn record_metrics(
         &self,
-        space: Arc<crate::KitsuneSpace>,
-        records: Vec<MetricRecord>,
+        _space: Arc<crate::KitsuneSpace>,
+        _records: Vec<MetricRecord>,
     ) -> KitsuneHostResult<()> {
         todo!()
     }

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_logic.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_logic.rs
@@ -1,0 +1,27 @@
+use kitsune_p2p_types::bin_types::KitsuneSpace;
+
+/// The interface to be implemented by the host, which handles various requests
+/// for data
+pub trait KitsuneHost {
+    /// Dummy function
+    fn get_foo(&self, space: &KitsuneSpace) -> !;
+}
+
+/// Trait object for the host interface
+pub type HostApi = std::sync::Arc<dyn KitsuneHost + Send + Sync>;
+
+/// Dummy host impl for plumbing
+pub struct HostStub;
+
+impl KitsuneHost for HostStub {
+    fn get_foo(&self, _space: &KitsuneSpace) -> ! {
+        todo!()
+    }
+}
+
+impl HostStub {
+    /// Constructor
+    pub fn new() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self)
+    }
+}

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_logic.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_logic.rs
@@ -1,10 +1,29 @@
-use kitsune_p2p_types::bin_types::KitsuneSpace;
+use must_future::MustBoxFuture;
+use std::sync::Arc;
+
+use kitsune_p2p_types::{bin_types::KitsuneSpace, dht_arc::DhtArcSet};
+
+use crate::event::MetricRecord;
+
+/// A boxed future result with dynamic error type
+pub type KitsuneHostResult<'a, T> = MustBoxFuture<'a, Result<T, Box<dyn std::error::Error>>>;
 
 /// The interface to be implemented by the host, which handles various requests
 /// for data
 pub trait KitsuneHost {
-    /// Dummy function
-    fn get_foo(&self, space: &KitsuneSpace) -> !;
+    /// Extrapolated Peer Coverage
+    fn peer_extrapolated_coverage(
+        &self,
+        space: Arc<KitsuneSpace>,
+        dht_arc_set: DhtArcSet,
+    ) -> KitsuneHostResult<Vec<f64>>;
+
+    /// Record a set of metric records
+    fn record_metrics(
+        &self,
+        space: Arc<KitsuneSpace>,
+        records: Vec<MetricRecord>,
+    ) -> KitsuneHostResult<()>;
 }
 
 /// Trait object for the host interface
@@ -14,7 +33,19 @@ pub type HostApi = std::sync::Arc<dyn KitsuneHost + Send + Sync>;
 pub struct HostStub;
 
 impl KitsuneHost for HostStub {
-    fn get_foo(&self, _space: &KitsuneSpace) -> ! {
+    fn peer_extrapolated_coverage(
+        &self,
+        space: Arc<crate::KitsuneSpace>,
+        dht_arc_set: DhtArcSet,
+    ) -> KitsuneHostResult<Vec<f64>> {
+        todo!()
+    }
+
+    fn record_metrics(
+        &self,
+        space: Arc<crate::KitsuneSpace>,
+        records: Vec<MetricRecord>,
+    ) -> KitsuneHostResult<()> {
         todo!()
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/lib.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/lib.rs
@@ -22,6 +22,9 @@ pub use config::*;
 mod spawn;
 pub use spawn::*;
 
+mod host_logic;
+pub use host_logic::*;
+
 #[allow(missing_docs)]
 #[cfg(any(test, feature = "test_utils"))]
 pub mod test_util;

--- a/crates/kitsune_p2p/kitsune_p2p/src/lib.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/lib.rs
@@ -22,8 +22,8 @@ pub use config::*;
 mod spawn;
 pub use spawn::*;
 
-mod host_logic;
-pub use host_logic::*;
+mod host_api;
+pub use host_api::*;
 
 #[allow(missing_docs)]
 #[cfg(any(test, feature = "test_utils"))]

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn.rs
@@ -1,5 +1,6 @@
 use crate::actor::*;
 use crate::event::*;
+use crate::HostApi;
 
 mod actor;
 use actor::*;
@@ -11,6 +12,7 @@ pub use actor::MockKitsuneP2pEventHandler;
 pub async fn spawn_kitsune_p2p(
     config: crate::KitsuneP2pConfig,
     tls_config: kitsune_p2p_types::tls::TlsConfig,
+    host: HostApi,
 ) -> KitsuneP2pResult<(
     ghost_actor::GhostSender<KitsuneP2p>,
     KitsuneP2pEventReceiver,
@@ -32,6 +34,7 @@ pub async fn spawn_kitsune_p2p(
                 channel_factory,
                 internal_sender,
                 evt_send,
+                host,
             )
             .await?,
         ),

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -222,10 +222,12 @@ impl KitsuneP2pActor {
         let i_s = internal_sender.clone();
         tokio::task::spawn({
             let evt_sender = evt_sender.clone();
+            let host = host.clone();
             let tuning_params = config.tuning_params.clone();
             async move {
                 ep.for_each_concurrent(tuning_params.concurrent_limit_per_thread, move |event| {
                     let evt_sender = evt_sender.clone();
+                    let host = host.clone();
                     let tuning_params = tuning_params.clone();
                     let i_s = i_s.clone();
                     async move {
@@ -283,7 +285,7 @@ impl KitsuneP2pActor {
                                         resp!(respond, resp);
                                     }
                                     wire::Wire::PeerGet(wire::PeerGet { space, agent }) => {
-                                        if let Ok(Some(agent_info_signed)) = evt_sender
+                                        if let Ok(Some(agent_info_signed)) = host
                                             .get_agent_info_signed(GetAgentInfoSignedEvt {
                                                 space,
                                                 agent,
@@ -624,13 +626,6 @@ impl KitsuneP2pEventHandler for KitsuneP2pActor {
         Ok(self.evt_sender.put_agent_info_signed(input))
     }
 
-    fn handle_get_agent_info_signed(
-        &mut self,
-        input: crate::event::GetAgentInfoSignedEvt,
-    ) -> KitsuneP2pEventHandlerResult<Option<crate::types::agent_store::AgentInfoSigned>> {
-        Ok(self.evt_sender.get_agent_info_signed(input))
-    }
-
     fn handle_query_agents(
         &mut self,
         input: crate::event::QueryAgentsEvt,
@@ -918,11 +913,6 @@ mockall::mock! {
             &mut self,
             input: crate::event::PutAgentInfoSignedEvt,
         ) -> KitsuneP2pEventHandlerResult<()>;
-
-        fn handle_get_agent_info_signed(
-            &mut self,
-            input: crate::event::GetAgentInfoSignedEvt,
-        ) -> KitsuneP2pEventHandlerResult<Option<crate::types::agent_store::AgentInfoSigned>>;
 
         fn handle_query_agents(
             &mut self,

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -617,10 +617,6 @@ impl InternalHandler for KitsuneP2pActor {
 impl ghost_actor::GhostHandler<KitsuneP2pEvent> for KitsuneP2pActor {}
 
 impl KitsuneP2pEventHandler for KitsuneP2pActor {
-    fn handle_k_gen_req(&mut self, arg: KGenReq) -> KitsuneP2pEventHandlerResult<KGenRes> {
-        Ok(self.evt_sender.k_gen_req(arg))
-    }
-
     fn handle_put_agent_info_signed(
         &mut self,
         input: crate::event::PutAgentInfoSignedEvt,
@@ -917,10 +913,6 @@ mockall::mock! {
     pub KitsuneP2pEventHandler {}
 
     impl KitsuneP2pEventHandler for KitsuneP2pEventHandler {
-        fn handle_k_gen_req(
-            &mut self,
-            arg: KGenReq,
-        ) -> KitsuneP2pEventHandlerResult<KGenRes>;
 
         fn handle_put_agent_info_signed(
             &mut self,

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -80,6 +80,7 @@ pub(crate) struct KitsuneP2pActor {
     internal_sender: ghost_actor::GhostSender<Internal>,
     evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
     ep_hnd: Tx2EpHnd<wire::Wire>,
+    host: HostApi,
     #[allow(clippy::type_complexity)]
     spaces: HashMap<
         Arc<KitsuneSpace>,
@@ -100,6 +101,7 @@ impl KitsuneP2pActor {
         channel_factory: ghost_actor::actor_builder::GhostActorChannelFactory<Self>,
         internal_sender: ghost_actor::GhostSender<Internal>,
         evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+        host: HostApi,
     ) -> KitsuneP2pResult<Self> {
         crate::types::metrics::init();
 
@@ -450,6 +452,7 @@ impl KitsuneP2pActor {
             internal_sender,
             evt_sender,
             ep_hnd,
+            host,
             spaces: HashMap::new(),
             config: Arc::new(config),
             bandwidth_throttles,
@@ -711,6 +714,7 @@ impl KitsuneP2pHandler for KitsuneP2pActor {
         let internal_sender = self.internal_sender.clone();
         let space2 = space.clone();
         let ep_hnd = self.ep_hnd.clone();
+        let host = self.host.clone();
         let config = Arc::clone(&self.config);
         let bandwidth_throttles = self.bandwidth_throttles.clone();
         let parallel_notify_permit = self.parallel_notify_permit.clone();
@@ -720,6 +724,7 @@ impl KitsuneP2pHandler for KitsuneP2pActor {
                 let (send, send_inner, evt_recv) = spawn_space(
                     space2,
                     ep_hnd,
+                    host,
                     config,
                     bandwidth_throttles,
                     parallel_notify_permit,

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/discover.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/discover.rs
@@ -35,7 +35,7 @@ pub(crate) fn search_and_discover_peer_connect(
 
             // see if we already know how to reach the tgt agent
             if let Ok(Some(agent_info_signed)) = inner
-                .evt_sender
+                .host_api
                 .get_agent_info_signed(GetAgentInfoSignedEvt {
                     space: inner.space.clone(),
                     agent: to_agent.clone(),

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -80,6 +80,7 @@ ghost_actor::ghost_chan! {
 pub(crate) async fn spawn_space(
     space: Arc<KitsuneSpace>,
     ep_hnd: Tx2EpHnd<wire::Wire>,
+    host: HostApi,
     config: Arc<KitsuneP2pConfig>,
     bandwidth_throttles: BandwidthThrottles,
     parallel_notify_permit: Arc<tokio::sync::Semaphore>,
@@ -106,6 +107,7 @@ pub(crate) async fn spawn_space(
         space,
         i_s.clone(),
         evt_send,
+        host,
         ep_hnd,
         config,
         bandwidth_throttles,
@@ -1083,6 +1085,7 @@ impl Space {
         space: Arc<KitsuneSpace>,
         i_s: ghost_actor::GhostSender<SpaceInternal>,
         evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+        host: HostApi,
         ep_hnd: Tx2EpHnd<wire::Wire>,
         config: Arc<KitsuneP2pConfig>,
         bandwidth_throttles: BandwidthThrottles,
@@ -1150,6 +1153,7 @@ impl Space {
                         space.clone(),
                         ep_hnd.clone(),
                         evt_sender.clone(),
+                        host.clone(),
                         metrics.clone(),
                     ),
                 )

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -1114,7 +1114,6 @@ impl Space {
         let metric_exchange = MetricExchangeSync::spawn(
             space.clone(),
             config.tuning_params.clone(),
-            evt_sender.clone(),
             host.clone(),
             metrics.clone(),
         );

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -1055,6 +1055,7 @@ pub(crate) struct SpaceReadOnlyInner {
     #[allow(dead_code)]
     pub(crate) i_s: ghost_actor::GhostSender<SpaceInternal>,
     pub(crate) evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+    pub(crate) host_api: HostApi,
     pub(crate) ep_hnd: Tx2EpHnd<wire::Wire>,
     #[allow(dead_code)]
     pub(crate) config: Arc<KitsuneP2pConfig>,
@@ -1070,6 +1071,7 @@ pub(crate) struct Space {
     pub(crate) space: Arc<KitsuneSpace>,
     pub(crate) i_s: ghost_actor::GhostSender<SpaceInternal>,
     pub(crate) evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+    pub(crate) _host_api: HostApi,
     pub(crate) local_joined_agents: HashSet<Arc<KitsuneAgent>>,
     pub(crate) agent_arcs: HashMap<Arc<KitsuneAgent>, DhtArc>,
     pub(crate) config: Arc<KitsuneP2pConfig>,
@@ -1085,7 +1087,7 @@ impl Space {
         space: Arc<KitsuneSpace>,
         i_s: ghost_actor::GhostSender<SpaceInternal>,
         evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
-        host: HostApi,
+        host_api: HostApi,
         ep_hnd: Tx2EpHnd<wire::Wire>,
         config: Arc<KitsuneP2pConfig>,
         bandwidth_throttles: BandwidthThrottles,
@@ -1096,7 +1098,7 @@ impl Space {
         {
             let space = space.clone();
             let metrics = metrics.clone();
-            let host = host.clone();
+            let host = host_api.clone();
             tokio::task::spawn(async move {
                 loop {
                     tokio::time::sleep(std::time::Duration::from_millis(
@@ -1114,7 +1116,7 @@ impl Space {
         let metric_exchange = MetricExchangeSync::spawn(
             space.clone(),
             config.tuning_params.clone(),
-            host.clone(),
+            host_api.clone(),
             metrics.clone(),
         );
 
@@ -1148,7 +1150,7 @@ impl Space {
                         space.clone(),
                         ep_hnd.clone(),
                         evt_sender.clone(),
-                        host.clone(),
+                        host_api.clone(),
                         metrics.clone(),
                     ),
                 )
@@ -1237,6 +1239,7 @@ impl Space {
             space: space.clone(),
             i_s: i_s.clone(),
             evt_sender: evt_sender.clone(),
+            host_api: host_api.clone(),
             ep_hnd,
             config: config.clone(),
             parallel_notify_permit,
@@ -1249,6 +1252,7 @@ impl Space {
             space,
             i_s,
             evt_sender,
+            _host_api: host_api,
             local_joined_agents: HashSet::new(),
             agent_arcs: HashMap::new(),
             config,

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -1096,7 +1096,7 @@ impl Space {
         {
             let space = space.clone();
             let metrics = metrics.clone();
-            let evt_sender = evt_sender.clone();
+            let host = host.clone();
             tokio::task::spawn(async move {
                 loop {
                     tokio::time::sleep(std::time::Duration::from_millis(
@@ -1106,12 +1106,7 @@ impl Space {
 
                     let records = metrics.read().dump_historical();
 
-                    let _ = evt_sender
-                        .k_gen_req(KGenReq::RecordMetrics {
-                            space: space.clone(),
-                            records,
-                        })
-                        .await;
+                    let _ = host.record_metrics(space.clone(), records).await;
                 }
             });
         }
@@ -1120,6 +1115,7 @@ impl Space {
             space.clone(),
             config.tuning_params.clone(),
             evt_sender.clone(),
+            host.clone(),
             metrics.clone(),
         );
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/metric_exchange.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/metric_exchange.rs
@@ -155,7 +155,6 @@ impl MetricExchangeSync {
     pub fn spawn(
         space: Arc<KitsuneSpace>,
         tuning_params: KitsuneP2pTuningParams,
-        evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
         host: HostApi,
         metrics: MetricsSync,
     ) -> Self {

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/metric_exchange.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/metric_exchange.rs
@@ -156,6 +156,7 @@ impl MetricExchangeSync {
         space: Arc<KitsuneSpace>,
         tuning_params: KitsuneP2pTuningParams,
         evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+        host: HostApi,
         metrics: MetricsSync,
     ) -> Self {
         let out = Self(Arc::new(parking_lot::RwLock::new(MetricExchange::spawn(
@@ -174,11 +175,8 @@ impl MetricExchangeSync {
 
                     if last_extrap_cov.should_trigger() {
                         let arc_set = mx.read().arc_set.clone();
-                        if let Ok(KGenRes::PeerExtrapCov(res)) = evt_sender
-                            .k_gen_req(KGenReq::PeerExtrapCov {
-                                space: space.clone(),
-                                dht_arc_set: arc_set,
-                            })
+                        if let Ok(res) = host
+                            .peer_extrapolated_coverage(space.clone(), arc_set)
                             .await
                         {
                             // MAYBE: ignore outliers?

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
@@ -105,9 +105,9 @@ async fn test_rpc_multi_logic_mocked() {
         }
         ok_fut(Ok(out))
     });
-    m.expect_handle_k_gen_req()
-        .returning(move |_| ok_fut(Ok(KGenRes::RecordMetrics(()))));
+
     let evt_sender = build_event_handler(m).await;
+    let host = HostStub::new();
 
     let config = Arc::new(KitsuneP2pConfig::default());
 
@@ -235,6 +235,7 @@ async fn test_rpc_multi_logic_mocked() {
         space.clone(),
         config.tuning_params.clone(),
         evt_sender.clone(),
+        host.clone(),
         metrics.clone(),
     );
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
@@ -107,7 +107,7 @@ async fn test_rpc_multi_logic_mocked() {
     });
 
     let evt_sender = build_event_handler(m).await;
-    let host = HostStub::new();
+    let host_api = HostStub::new();
 
     let config = Arc::new(KitsuneP2pConfig::default());
 
@@ -234,7 +234,7 @@ async fn test_rpc_multi_logic_mocked() {
     let metric_exchange = MetricExchangeSync::spawn(
         space.clone(),
         config.tuning_params.clone(),
-        host.clone(),
+        host_api.clone(),
         metrics.clone(),
     );
 
@@ -243,6 +243,7 @@ async fn test_rpc_multi_logic_mocked() {
         space: space.clone(),
         i_s,
         evt_sender,
+        host_api,
         ep_hnd,
         parallel_notify_permit: Arc::new(tokio::sync::Semaphore::new(
             config.tuning_params.concurrent_limit_per_thread,

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
@@ -234,7 +234,6 @@ async fn test_rpc_multi_logic_mocked() {
     let metric_exchange = MetricExchangeSync::spawn(
         space.clone(),
         config.tuning_params.clone(),
-        evt_sender.clone(),
         host.clone(),
         metrics.clone(),
     );

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
@@ -155,14 +155,6 @@ impl KitsuneP2pEventHandler for AgentHarness {
         Ok(async move { Ok(()) }.boxed().into())
     }
 
-    fn handle_get_agent_info_signed(
-        &mut self,
-        input: GetAgentInfoSignedEvt,
-    ) -> KitsuneP2pEventHandlerResult<Option<crate::types::agent_store::AgentInfoSigned>> {
-        let res = self.agent_store.get(&input.agent).map(|i| (**i).clone());
-        Ok(async move { Ok(res) }.boxed().into())
-    }
-
     fn handle_query_agents(
         &mut self,
         QueryAgentsEvt {

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
@@ -34,11 +34,13 @@ pub(crate) async fn spawn_test_agent(
     ),
     KitsuneP2pError,
 > {
+    let host = HostStub::new();
     let (p2p, evt) = spawn_kitsune_p2p(
         config,
         kitsune_p2p_types::tls::TlsConfig::new_ephemeral()
             .await
             .unwrap(),
+            host,
     )
     .await?;
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
@@ -140,10 +140,6 @@ impl HarnessAgentControlHandler for AgentHarness {
 impl ghost_actor::GhostHandler<KitsuneP2pEvent> for AgentHarness {}
 
 impl KitsuneP2pEventHandler for AgentHarness {
-    fn handle_k_gen_req(&mut self, _: KGenReq) -> KitsuneP2pEventHandlerResult<KGenRes> {
-        Err("unimplemented".into())
-    }
-
     fn handle_put_agent_info_signed(
         &mut self,
         input: PutAgentInfoSignedEvt,

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
@@ -40,7 +40,7 @@ pub(crate) async fn spawn_test_agent(
         kitsune_p2p_types::tls::TlsConfig::new_ephemeral()
             .await
             .unwrap(),
-            host,
+        host,
     )
     .await?;
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
@@ -57,20 +57,6 @@ impl KitsuneP2pEventHandler for SwitchboardEventHandler {
         ok_fut(Ok(()))
     }
 
-    fn handle_get_agent_info_signed(
-        &mut self,
-        GetAgentInfoSignedEvt { space, agent }: GetAgentInfoSignedEvt,
-    ) -> KitsuneP2pEventHandlerResult<Option<crate::types::agent_store::AgentInfoSigned>> {
-        ok_fut(Ok(self.sb.share(|state| {
-            let node = state.nodes.get_mut(&self.node).unwrap();
-            let loc = agent.get_loc().as_loc8();
-            node.local_agents
-                .get(&loc)
-                .map(|e| e.info.to_owned())
-                .or_else(|| node.remote_agents.get(&loc).cloned())
-        })))
-    }
-
     fn handle_query_agents(
         &mut self,
         QueryAgentsEvt {

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
@@ -4,8 +4,8 @@
 
 use std::sync::Arc;
 
-use crate::event::*;
 use crate::types::event::{KitsuneP2pEvent, KitsuneP2pEventHandler, KitsuneP2pEventHandlerResult};
+use crate::{event::*, KitsuneHost};
 use kitsune_p2p_types::bin_types::*;
 use kitsune_p2p_types::*;
 
@@ -35,6 +35,38 @@ impl SwitchboardEventHandler {
 
 impl ghost_actor::GhostHandler<KitsuneP2pEvent> for SwitchboardEventHandler {}
 impl ghost_actor::GhostControlHandler for SwitchboardEventHandler {}
+
+impl KitsuneHost for SwitchboardEventHandler {
+    fn get_agent_info_signed(
+        &self,
+        GetAgentInfoSignedEvt { agent, space: _ }: GetAgentInfoSignedEvt,
+    ) -> crate::KitsuneHostResult<Option<crate::types::agent_store::AgentInfoSigned>> {
+        box_fut(Ok(self.sb.share(|state| {
+            let node = state.nodes.get_mut(&self.node).unwrap();
+            let loc = agent.get_loc().as_loc8();
+            node.local_agents
+                .get(&loc)
+                .map(|e| e.info.to_owned())
+                .or_else(|| node.remote_agents.get(&loc).cloned())
+        })))
+    }
+
+    fn peer_extrapolated_coverage(
+        &self,
+        _space: Arc<KitsuneSpace>,
+        _dht_arc_set: dht_arc::DhtArcSet,
+    ) -> crate::KitsuneHostResult<Vec<f64>> {
+        unimplemented!()
+    }
+
+    fn record_metrics(
+        &self,
+        _space: Arc<KitsuneSpace>,
+        _records: Vec<MetricRecord>,
+    ) -> crate::KitsuneHostResult<()> {
+        box_fut(Ok(()))
+    }
+}
 
 #[allow(warnings)]
 impl KitsuneP2pEventHandler for SwitchboardEventHandler {

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
@@ -38,10 +38,6 @@ impl ghost_actor::GhostControlHandler for SwitchboardEventHandler {}
 
 #[allow(warnings)]
 impl KitsuneP2pEventHandler for SwitchboardEventHandler {
-    fn handle_k_gen_req(&mut self, _: KGenReq) -> KitsuneP2pEventHandlerResult<KGenRes> {
-        Err("unimplemented".into())
-    }
-
     fn handle_put_agent_info_signed(
         &mut self,
         PutAgentInfoSignedEvt { space, peer_data }: PutAgentInfoSignedEvt,

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_state.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_state.rs
@@ -4,6 +4,7 @@ use crate::gossip::sharded_gossip::{BandwidthThrottle, GossipType, ShardedGossip
 use crate::test_util::spawn_handler;
 use crate::types::gossip::*;
 use crate::types::wire;
+use crate::HostStub;
 use futures::stream::StreamExt;
 use ghost_actor::dependencies::tracing;
 use ghost_actor::GhostResult;
@@ -120,6 +121,7 @@ impl Switchboard {
         let ep_hnd = ep.handle().clone();
 
         let evt_handler = SwitchboardEventHandler::new(ep_hnd.clone(), self.clone());
+        let host = HostStub::new();
         let (evt_sender, handler_task) = spawn_handler(evt_handler.clone()).await;
 
         let bandwidth = Arc::new(BandwidthThrottle::new(1000.0, 1000.0));
@@ -129,6 +131,7 @@ impl Switchboard {
             space.clone(),
             ep_hnd.clone(),
             evt_sender,
+            host,
             self.gossip_type,
             bandwidth,
             Default::default(),

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
@@ -225,9 +225,6 @@ ghost_actor::ghost_chan! {
         fn put_agent_info_signed(input: PutAgentInfoSignedEvt) -> ();
 
         /// We need to get previously stored agent info.
-        fn get_agent_info_signed(input: GetAgentInfoSignedEvt) -> Option<crate::types::agent_store::AgentInfoSigned>;
-
-        /// We need to get previously stored agent info.
         fn query_agents(input: QueryAgentsEvt) -> Vec<crate::types::agent_store::AgentInfoSigned>;
 
         /// Query the peer density of a space for a given [`DhtArc`].

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
@@ -210,37 +210,6 @@ pub struct MetricRecord {
     pub data: serde_json::Value,
 }
 
-/// Generic Kitsune Request of the implementor
-/// This enum may be easier to add variants to for future updates,
-/// rather than adding a full new top-level event message type.
-pub enum KGenReq {
-    /// Extrapolated Peer Coverage
-    PeerExtrapCov {
-        /// The space to extrapolate coverage
-        space: Arc<super::KitsuneSpace>,
-
-        /// Storage arcs of joined agents
-        dht_arc_set: DhtArcSet,
-    },
-
-    /// Record a set of metric records
-    RecordMetrics {
-        /// The space to associate the records with
-        space: Arc<super::KitsuneSpace>,
-
-        /// The records to record
-        records: Vec<MetricRecord>,
-    },
-}
-
-/// Generic Kitsune Respons from the imlementor
-pub enum KGenRes {
-    /// Extrapolated Peer Coverage
-    PeerExtrapCov(Vec<f64>),
-    /// Record a set of metric records
-    RecordMetrics(()),
-}
-
 type KSpace = Arc<super::KitsuneSpace>;
 type KAgent = Arc<super::KitsuneAgent>;
 type KOpHash = Arc<super::KitsuneOpHash>;
@@ -251,8 +220,6 @@ ghost_actor::ghost_chan! {
     /// The KitsuneP2pEvent stream allows handling events generated from the
     /// KitsuneP2p actor.
     pub chan KitsuneP2pEvent<super::KitsuneP2pError> {
-        /// Generic Kitsune Request of the implementor
-        fn k_gen_req(arg: KGenReq) -> KGenRes;
 
         /// We need to store signed agent info.
         fn put_agent_info_signed(input: PutAgentInfoSignedEvt) -> ();

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/gossip.rs
@@ -1,5 +1,6 @@
 use crate::metrics::*;
 use crate::types::*;
+use crate::HostApi;
 use kitsune_p2p_types::config::*;
 use kitsune_p2p_types::tx2::tx2_api::*;
 use kitsune_p2p_types::tx2::tx2_utils::TxUrl;
@@ -76,6 +77,7 @@ pub trait AsGossipModuleFactory: 'static + Send + Sync {
         space: Arc<KitsuneSpace>,
         ep_hnd: Tx2EpHnd<wire::Wire>,
         evt_sender: futures::channel::mpsc::Sender<event::KitsuneP2pEvent>,
+        host: HostApi,
         metrics: MetricsSync,
     ) -> GossipModule;
 }
@@ -89,9 +91,10 @@ impl GossipModuleFactory {
         space: Arc<KitsuneSpace>,
         ep_hnd: Tx2EpHnd<wire::Wire>,
         evt_sender: futures::channel::mpsc::Sender<event::KitsuneP2pEvent>,
+        host: HostApi,
         metrics: MetricsSync,
     ) -> GossipModule {
         self.0
-            .spawn_gossip_task(tuning_params, space, ep_hnd, evt_sender, metrics)
+            .spawn_gossip_task(tuning_params, space, ep_hnd, evt_sender, host, metrics)
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/tests/proxy_list.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/tests/proxy_list.rs
@@ -70,7 +70,9 @@ async fn test_integrated_proxy_list() {
         },
     }];
 
-    let (actor, mut evt) = spawn_kitsune_p2p(kconf, k_tls).await.unwrap();
+    let (actor, mut evt) = spawn_kitsune_p2p(kconf, k_tls, HostStub::new())
+        .await
+        .unwrap();
 
     tokio::task::spawn(async move {
         while let Some(e) = evt.next().await {

--- a/crates/kitsune_p2p/types/src/lib.rs
+++ b/crates/kitsune_p2p/types/src/lib.rs
@@ -47,7 +47,7 @@ pub fn unit_ok_fut<E1, E2>() -> Result<MustBoxFuture<'static, Result<(), E2>>, E
     Ok(async move { Ok(()) }.boxed().into())
 }
 
-/// Helper function for the common case of returning this nested Unit type.
+/// Helper function for the common case of returning this boxed future type.
 pub fn ok_fut<E1, R: Send + 'static>(result: R) -> Result<MustBoxFuture<'static, R>, E1> {
     use futures::FutureExt;
     Ok(async move { result }.boxed().into())

--- a/crates/kitsune_p2p/types/src/lib.rs
+++ b/crates/kitsune_p2p/types/src/lib.rs
@@ -53,6 +53,12 @@ pub fn ok_fut<E1, R: Send + 'static>(result: R) -> Result<MustBoxFuture<'static,
     Ok(async move { result }.boxed().into())
 }
 
+/// Helper function for the common case of returning this boxed future type.
+pub fn box_fut<'a, R: Send + 'a>(result: R) -> MustBoxFuture<'a, R> {
+    use futures::FutureExt;
+    async move { result }.boxed().into()
+}
+
 use ::ghost_actor::dependencies::tracing;
 use ghost_actor::dependencies::must_future::MustBoxFuture;
 

--- a/crates/release-automation/src/crate_.rs
+++ b/crates/release-automation/src/crate_.rs
@@ -1,12 +1,16 @@
-use std::collections::{HashMap, HashSet};
-
-use anyhow::bail;
+use anyhow::{bail, Context};
+use bstr::ByteSlice;
 use cargo::util::VersionExt;
 use log::{debug, info, warn};
 use semver::Version;
+use std::collections::{HashMap, HashSet};
 use structopt::StructOpt;
 
-use crate::{crate_selection::Crate, release::ReleaseWorkspace, CommandResult, Fallible};
+use crate::{
+    crate_selection::Crate,
+    release::{crates_index_helper, ReleaseWorkspace},
+    CommandResult, Fallible,
+};
 
 #[derive(StructOpt, Debug)]
 pub(crate) struct CrateArgs {
@@ -92,6 +96,25 @@ pub(crate) struct CrateCheckArgs {
     offline: bool,
 }
 
+pub(crate) const MINIMUM_CRATE_OWNERS: &str =
+    "github:holochain:core-dev,holochain-release-automation,holochain-release-automation2,zippy,steveej";
+
+#[derive(Debug, StructOpt)]
+pub(crate) struct EnsureCrateOwnersArgs {
+    #[structopt(long)]
+    dry_run: bool,
+
+    /// Assumes the default crate owners that are ensured to be set for each crate in the workspace.
+    #[structopt(
+        long,
+        default_value = MINIMUM_CRATE_OWNERS,
+        use_delimiter = true,
+        multiple = false,
+
+    )]
+    minimum_crate_owners: Vec<String>,
+}
+
 #[derive(Debug, StructOpt)]
 pub(crate) enum CrateCommands {
     SetVersion(CrateSetVersionArgs),
@@ -101,6 +124,7 @@ pub(crate) enum CrateCommands {
     FixupReleases(CrateFixupReleases),
 
     Check(CrateCheckArgs),
+    EnsureCrateOwners(EnsureCrateOwnersArgs),
 }
 
 pub(crate) fn cmd(args: &crate::cli::Args, cmd_args: &CrateArgs) -> CommandResult {
@@ -138,6 +162,21 @@ pub(crate) fn cmd(args: &crate::cli::Args, cmd_args: &CrateArgs) -> CommandResul
 
         CrateCommands::Check(subcmd_args) => {
             ws.cargo_check(subcmd_args.offline, std::iter::empty::<&str>())?;
+
+            Ok(())
+        }
+        CrateCommands::EnsureCrateOwners(subcmd_args) => {
+            ensure_crate_io_owners(
+                &ws,
+                subcmd_args.dry_run,
+                ws.members()?,
+                subcmd_args
+                    .minimum_crate_owners
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            )?;
 
             Ok(())
         }
@@ -353,6 +392,78 @@ pub(crate) fn fixup_releases<'a>(
 
             if commit {
                 ws.git_add_all_and_commit(&commit_msg, None)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Ensures that the given crates have at least sent an invite to the given crate.io usernames.
+pub(crate) fn ensure_crate_io_owners<'a>(
+    _ws: &'a ReleaseWorkspace<'a>,
+    dry_run: bool,
+    crates: &[&Crate],
+    minimum_crate_owners: &[&str],
+) -> Fallible<()> {
+    let desired_owners = minimum_crate_owners
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<HashSet<_>>();
+
+    for crt in crates {
+        if !crates_index_helper::is_version_published(crt, false)? {
+            warn!("{} is not published, skipping..", crt.name());
+            continue;
+        }
+
+        let mut cmd = std::process::Command::new("cargo");
+        cmd.args(&["owner", "--list", &crt.name()]);
+
+        debug!("[{}] running command: {:?}", crt.name(), cmd);
+        let output = cmd.output().context("process exitted unsuccessfully")?;
+        if !output.status.success() {
+            warn!(
+                "[{}] failed list owners: {}",
+                crt.name(),
+                String::from_utf8_lossy(&output.stderr)
+            );
+
+            continue;
+        }
+
+        let current_owners = output
+            .stdout
+            .lines()
+            .map(|line| {
+                line.words_with_breaks()
+                    .take_while(|item| *item != " ")
+                    .collect::<String>()
+            })
+            .collect::<HashSet<_>>();
+        let diff = desired_owners.difference(&current_owners);
+        info!(
+            "[{}] current owners {:?}, missing owners: {:?}",
+            crt.name(),
+            current_owners,
+            diff
+        );
+
+        for owner in diff {
+            let mut cmd = std::process::Command::new("cargo");
+            cmd.args(&["owner", "--add", owner, &crt.name()]);
+
+            debug!("[{}] running command: {:?}", crt.name(), cmd);
+            if !dry_run {
+                let output = cmd.output().context("process exitted unsuccessfully")?;
+                if !output.status.success() {
+                    warn!(
+                        "[{}] failed to add owner '{}': {}",
+                        crt.name(),
+                        owner,
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
### Summary

Add a trait-based way for kitsune to make requests of its host, rather than ghost_actor.

Converts both KGenReq sub-methods, as well as get_agent_info_signed (chosen somewhat at random) to this new method, to prove that it works. The rest of the methods can be converted at another time.

### TODO:
- [x] Replace HostStub with actual handler suitable for testing
- [ ] Move more methods over from the ghost_actor
- [ ] ~~CHANGELOG(s) updated with appropriate info~~
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
