### PR TITLE
Conductor refactor 2: remove lots of TestEnv usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2724,6 +2724,7 @@ dependencies = [
  "kitsune_p2p_types",
  "maplit",
  "mockall",
+ "must_future",
  "num-traits",
  "observability",
  "once_cell",

--- a/crates/holochain/src/conductor.rs
+++ b/crates/holochain/src/conductor.rs
@@ -28,6 +28,7 @@ pub mod error;
 pub mod handle;
 pub mod interactive;
 pub mod interface;
+pub mod kitsune_host_impl;
 pub mod manager;
 pub mod p2p_agent_store;
 pub mod paths;

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -415,8 +415,8 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn register_list_dna_app() -> Result<()> {
         observability::test_run().ok();
-        let envs = test_environments();
-        let handle = Conductor::builder().test(&envs.into(), &[]).await?;
+        let env_dir = test_env_dir();
+        let handle = Conductor::builder().test(env_dir.path(), &[]).await?;
         let shutdown = handle.take_shutdown_handle().unwrap();
         let admin_api = RealAdminInterfaceApi::new(handle.clone());
         let uid = Uuid::new_v4();
@@ -548,7 +548,7 @@ mod test {
     async fn install_list_dna_app() {
         observability::test_run().ok();
         let envs = test_environments();
-        let handle = Conductor::builder().test(&envs.into(), &[]).await.unwrap();
+        let handle = Conductor::builder().test(envs.path(), &[]).await.unwrap();
         let shutdown = handle.take_shutdown_handle().unwrap();
         let admin_api = RealAdminInterfaceApi::new(handle.clone());
         let uid = Uuid::new_v4();

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -547,7 +547,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn install_list_dna_app() {
         observability::test_run().ok();
-        let envs = test_environments();
+        let envs = test_env_dir();
         let handle = Conductor::builder().test(envs.path(), &[]).await.unwrap();
         let shutdown = handle.take_shutdown_handle().unwrap();
         let admin_api = RealAdminInterfaceApi::new(handle.clone());

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -345,9 +345,7 @@ impl Cell {
     ) -> CellResult<()> {
         use holochain_p2p::event::HolochainP2pEvent::*;
         match evt {
-            KGenReq { .. }
-            | PutAgentInfoSigned { .. }
-            | GetAgentInfoSigned { .. }
+            PutAgentInfoSigned { .. }
             | QueryAgentInfoSigned { .. }
             | QueryGossipAgents { .. }
             | QueryOpHashes { .. }

--- a/crates/holochain/src/conductor/cell/gossip_test.rs
+++ b/crates/holochain/src/conductor/cell/gossip_test.rs
@@ -118,14 +118,15 @@ async fn agent_info_test() {
     let p2p_envs: Vec<_> = conductors
         .iter()
         .filter_map(|c| {
-            let lock = c.envs().p2p();
-            let env = lock.lock().values().cloned().next();
-            env
+            c.spaces
+                .get_from_spaces(|s| s.p2p_env.clone())
+                .first()
+                .cloned()
         })
         .collect();
 
     consistency_10s(&[&cell_1, &cell_2]).await;
-    for p2p_env in &p2p_envs {
+    for p2p_env in p2p_envs {
         let len = fresh_reader_test(p2p_env.clone(), |txn| txn.p2p_list_agents().unwrap().len());
         assert_eq!(len, 2);
     }

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1371,8 +1371,6 @@ mod builder {
     use crate::conductor::dna_store::RealDnaStore;
     use crate::conductor::handle::DevSettings;
     use crate::conductor::ConductorHandle;
-    #[cfg(any(test, feature = "test_utils"))]
-    use holochain_state::test_utils::TestEnvs;
 
     /// A configurable Builder for Conductor and sometimes ConductorHandle
     #[derive(Default)]
@@ -1641,7 +1639,7 @@ mod builder {
             env_path: &std::path::Path,
             extra_dnas: &[DnaFile],
         ) -> ConductorResult<ConductorHandle> {
-            let keystore = test_keystore();
+            let keystore = self.keystore.unwrap_or_else(test_keystore);
             self.config.environment_path = env_path.to_path_buf().into();
 
             let (holochain_p2p, p2p_evt) =
@@ -1686,7 +1684,6 @@ mod builder {
             // the ones with InlineZomes will not be registered in the Wasm DB
             // and cannot be automatically loaded on conductor restart.
 
-            use std::path::Path;
             for dna_file in extra_dnas {
                 handle
                     .register_dna(dna_file.clone())

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1656,12 +1656,11 @@ mod builder {
 
             let conductor = Conductor::new(
                 DbWrite::test(
-                    &self.config.environment_path.as_ref().as_path(),
+                    self.config.environment_path.as_ref().as_path(),
                     DbKindConductor,
                 )
                 .unwrap(),
-                DbWrite::test(&self.config.environment_path.as_ref().as_path(), DbKindWasm)
-                    .unwrap(),
+                DbWrite::test(self.config.environment_path.as_ref().as_path(), DbKindWasm).unwrap(),
                 self.dna_store,
                 keystore,
                 holochain_p2p,

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -33,10 +33,8 @@ async fn can_update_state() {
     let holochain_p2p = holochain_p2p::stub_network().await;
     let (post_commit_sender, _post_commit_receiver) =
         tokio::sync::mpsc::channel(POST_COMMIT_CHANNEL_BOUND);
-    let spaces = Spaces::new(envs.path().to_path_buf().into(), Default::default());
+    let spaces = Spaces::new(envs.path().to_path_buf().into(), Default::default()).unwrap();
     let conductor = Conductor::new(
-        DbWrite::test(envs.path(), DbKindConductor).unwrap(),
-        DbWrite::test(envs.path(), DbKindWasm).unwrap(),
         dna_store,
         keystore,
         holochain_p2p,
@@ -82,11 +80,9 @@ async fn can_add_clone_cell_to_app() {
     let dna_store = RealDnaStore::new();
     let (post_commit_sender, _post_commit_receiver) =
         tokio::sync::mpsc::channel(POST_COMMIT_CHANNEL_BOUND);
-    let spaces = Spaces::new(envs.path().to_path_buf().into(), Default::default());
+    let spaces = Spaces::new(envs.path().to_path_buf().into(), Default::default()).unwrap();
 
     let conductor = Conductor::new(
-        DbWrite::open(envs.path(), DbKindConductor).unwrap(),
-        DbWrite::open(envs.path(), DbKindWasm).unwrap(),
         dna_store,
         keystore,
         holochain_p2p,
@@ -158,10 +154,8 @@ async fn app_ids_are_unique() {
     let holochain_p2p = holochain_p2p::stub_network().await;
     let (post_commit_sender, _post_commit_receiver) =
         tokio::sync::mpsc::channel(POST_COMMIT_CHANNEL_BOUND);
-    let spaces = Spaces::new(envs.path().to_path_buf().into(), Default::default());
+    let spaces = Spaces::new(envs.path().to_path_buf().into(), Default::default()).unwrap();
     let conductor = Conductor::new(
-        DbWrite::test(envs.path(), DbKindConductor).unwrap(),
-        DbWrite::test(envs.path(), DbKindWasm).unwrap(),
         dna_store,
         test_keystore(),
         holochain_p2p,

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -27,7 +27,7 @@ use matches::assert_matches;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_update_state() {
-    let envs = test_environments();
+    let envs = test_env_dir();
     let dna_store = MockDnaStore::new();
     let keystore = test_keystore();
     let holochain_p2p = holochain_p2p::stub_network().await;
@@ -71,7 +71,7 @@ async fn can_update_state() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_add_clone_cell_to_app() {
-    let envs = test_environments();
+    let envs = test_env_dir();
     let keystore = test_keystore();
     let holochain_p2p = holochain_p2p::stub_network().await;
 
@@ -153,7 +153,7 @@ async fn can_add_clone_cell_to_app() {
 /// same InstalledAppId
 #[tokio::test(flavor = "multi_thread")]
 async fn app_ids_are_unique() {
-    let envs = test_environments();
+    let envs = test_env_dir();
     let dna_store = MockDnaStore::new();
     let holochain_p2p = holochain_p2p::stub_network().await;
     let (post_commit_sender, _post_commit_receiver) =
@@ -217,7 +217,7 @@ async fn app_role_ids_are_unique() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_set_fake_state() {
-    let envs = test_environments();
+    let envs = test_env_dir();
     let state = ConductorState::default();
     let conductor = ConductorBuilder::new()
         .fake_state(state.clone())

--- a/crates/holochain/src/conductor/entry_def_store.rs
+++ b/crates/holochain/src/conductor/entry_def_store.rs
@@ -115,7 +115,7 @@ mod tests {
     use super::EntryDefBufferKey;
     use crate::conductor::Conductor;
     use holo_hash::HasHash;
-    use holochain_state::prelude::test_environments;
+    use holochain_state::prelude::test_env_dir;
     use holochain_types::prelude::*;
     use holochain_types::test_utils::fake_dna_zomes;
     use holochain_wasm_test_utils::TestWasm;
@@ -125,7 +125,7 @@ mod tests {
         observability::test_run().ok();
 
         // all the stuff needed to have a WasmBuf
-        let envs = test_environments();
+        let envs = test_env_dir();
         let handle = Conductor::builder().test(envs.path(), &[]).await.unwrap();
 
         let dna = fake_dna_zomes(

--- a/crates/holochain/src/conductor/entry_def_store.rs
+++ b/crates/holochain/src/conductor/entry_def_store.rs
@@ -126,7 +126,7 @@ mod tests {
 
         // all the stuff needed to have a WasmBuf
         let envs = test_environments();
-        let handle = Conductor::builder().test(&envs, &[]).await.unwrap();
+        let handle = Conductor::builder().test(envs.path(), &[]).await.unwrap();
 
         let dna = fake_dna_zomes(
             "",
@@ -172,7 +172,7 @@ mod tests {
         std::mem::drop(handle);
 
         // Restart conductor and check defs are still here
-        let handle = Conductor::builder().test(&envs.into(), &[]).await.unwrap();
+        let handle = Conductor::builder().test(envs.path(), &[]).await.unwrap();
 
         assert_eq!(handle.get_entry_def(&post_def_key), Some(post_def));
         assert_eq!(

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -5,11 +5,11 @@
 //!
 //! ```rust, no_run
 //! async fn async_main () {
-//! use holochain_state::test_utils::test_environments;
+//! use holochain_state::test_utils::test_env_dir;
 //! use holochain::conductor::{Conductor, ConductorBuilder, ConductorHandle};
-//! let envs = test_environments();
+//! let env_dir = test_env_dir();
 //! let handle: ConductorHandle = ConductorBuilder::new()
-//!    .test(&envs, &[])
+//!    .test(env_dir.path(), &[])
 //!    .await
 //!    .unwrap();
 //!

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -50,6 +50,7 @@ use super::p2p_agent_store::get_agent_info_signed;
 use super::p2p_agent_store::inject_agent_infos;
 use super::p2p_agent_store::list_all_agent_info;
 use super::p2p_agent_store::list_all_agent_info_signed_near_basis;
+use super::space::Spaces;
 use super::Cell;
 use super::CellError;
 use super::Conductor;
@@ -355,6 +356,10 @@ pub trait ConductorHandleT: Send + Sync {
     /// Retrieve the database for networking. FOR TESTING ONLY.
     #[cfg(any(test, feature = "test_utils"))]
     fn get_p2p_env(&self, space: &DnaHash) -> DbWrite<DbKindP2pAgentStore>;
+
+    /// Retrieve the database for networking. FOR TESTING ONLY.
+    #[cfg(any(test, feature = "test_utils"))]
+    fn get_spaces(&self) -> Spaces;
 
     /// Retrieve Senders for triggering workflows. FOR TESTING ONLY.
     #[cfg(any(test, feature = "test_utils"))]
@@ -1427,6 +1432,11 @@ impl<DS: DnaStore + 'static> ConductorHandleT for ConductorHandleImpl<DS> {
     #[cfg(any(test, feature = "test_utils"))]
     fn get_p2p_env(&self, space: &DnaHash) -> DbWrite<DbKindP2pAgentStore> {
         self.p2p_env(space)
+    }
+
+    #[cfg(any(test, feature = "test_utils"))]
+    fn get_spaces(&self) -> Spaces {
+        self.conductor.spaces.clone()
     }
 
     #[cfg(any(test, feature = "test_utils"))]

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -234,7 +234,7 @@ pub mod test_utils {
         cell_data: Vec<(InstalledCell, Option<SerializedBytes>)>,
         dna_store: MockDnaStore,
     ) -> (Arc<TempDir>, RealAppInterfaceApi, ConductorHandle) {
-        let envs = test_environments();
+        let envs = test_env_dir();
 
         let conductor_handle = ConductorBuilder::with_mock_dna_store(dna_store)
             .test(envs.path(), &[])
@@ -290,7 +290,7 @@ pub mod test {
     use holochain_p2p::{AgentPubKeyExt, DnaHashExt};
     use holochain_serialized_bytes::prelude::*;
     use holochain_sqlite::prelude::*;
-    use holochain_state::prelude::test_environments;
+    use holochain_state::prelude::test_env_dir;
     use holochain_types::prelude::*;
     use holochain_types::test_utils::fake_agent_pubkey_1;
     use holochain_types::test_utils::fake_dna_hash;
@@ -319,7 +319,7 @@ pub mod test {
     }
 
     async fn setup_admin() -> (Arc<TempDir>, ConductorHandle) {
-        let envs = test_environments();
+        let envs = test_env_dir();
         let conductor_handle = Conductor::builder().test(envs.path(), &[]).await.unwrap();
         (Arc::new(envs), conductor_handle)
     }
@@ -328,7 +328,7 @@ pub mod test {
         cell_ids_with_proofs: Vec<(CellId, Option<SerializedBytes>)>,
         dna_store: MockDnaStore,
     ) -> (Arc<TempDir>, ConductorHandle) {
-        let envs = test_environments();
+        let envs = test_env_dir();
         let conductor_handle = ConductorBuilder::with_mock_dna_store(dna_store)
             .test(envs.path(), &[])
             .await
@@ -680,7 +680,7 @@ pub mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn add_agent_info_via_admin() {
         observability::test_run().ok();
-        let test_envs = test_environments();
+        let test_envs = test_env_dir();
         let agents = vec![fake_agent_pubkey_1(), fake_agent_pubkey_2()];
         let dnas = vec![
             make_dna("1", vec![TestWasm::Anchor]).await,

--- a/crates/holochain/src/conductor/kitsune_host_impl.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl.rs
@@ -1,0 +1,83 @@
+//! Implementation of the Kitsune Host API
+
+use std::sync::Arc;
+
+use futures::FutureExt;
+use holo_hash::DnaHash;
+use holochain_p2p::DnaHashExt;
+use kitsune_p2p::{
+    agent_store::AgentInfoSigned, event::GetAgentInfoSignedEvt, KitsuneHost, KitsuneHostResult,
+};
+
+use super::space::Spaces;
+use holochain_types::env::PermittedConn;
+
+/// Implementation of the Kitsune Host API.
+/// Lets Kitsune make requests of Holochain
+pub struct KitsuneHostImpl {
+    spaces: Spaces,
+}
+
+impl KitsuneHostImpl {
+    /// Constructor
+    pub fn new(spaces: Spaces) -> Arc<Self> {
+        Arc::new(Self { spaces })
+    }
+}
+
+impl KitsuneHost for KitsuneHostImpl {
+    fn peer_extrapolated_coverage(
+        &self,
+        space: std::sync::Arc<kitsune_p2p::KitsuneSpace>,
+        dht_arc_set: holochain_p2p::dht_arc::DhtArcSet,
+    ) -> KitsuneHostResult<Vec<f64>> {
+        async move {
+            let env = self.spaces.p2p_env(&DnaHash::from_kitsune(&space))?;
+            use holochain_sqlite::db::AsP2pAgentStoreConExt;
+            let permit = env.conn_permit().await;
+            let task = tokio::task::spawn_blocking(move || {
+                let mut conn = env.from_permit(permit)?;
+                conn.p2p_extrapolated_coverage(dht_arc_set)
+            })
+            .await;
+            Ok(task??)
+        }
+        .boxed()
+        .into()
+    }
+
+    fn record_metrics(
+        &self,
+        space: std::sync::Arc<kitsune_p2p::KitsuneSpace>,
+        records: Vec<kitsune_p2p::event::MetricRecord>,
+    ) -> KitsuneHostResult<()> {
+        async move {
+            let env = self
+                .spaces
+                .p2p_metrics_env(&DnaHash::from_kitsune(&space))?;
+            use holochain_sqlite::db::AsP2pMetricStoreConExt;
+            let permit = env.conn_permit().await;
+            let task = tokio::task::spawn_blocking(move || {
+                let mut conn = env.from_permit(permit)?;
+                conn.p2p_log_metrics(records)
+            })
+            .await;
+            Ok(task??)
+        }
+        .boxed()
+        .into()
+    }
+
+    fn get_agent_info_signed(
+        &self,
+        GetAgentInfoSignedEvt { space, agent }: GetAgentInfoSignedEvt,
+    ) -> KitsuneHostResult<Option<AgentInfoSigned>> {
+        let dna_hash = DnaHash::from_kitsune(&space);
+        let env = self.spaces.p2p_env(&dna_hash);
+        async move {
+            Ok(super::p2p_agent_store::get_agent_info_signed(env?.into(), space, agent).await?)
+        }
+        .boxed()
+        .into()
+    }
+}

--- a/crates/holochain/src/core/queue_consumer/tests.rs
+++ b/crates/holochain/src/core/queue_consumer/tests.rs
@@ -221,7 +221,7 @@ async fn publish_loop() {
         .prefix("holochain-test-environments")
         .tempdir()
         .unwrap();
-    let env = DbWrite::test(&tmpdir, kind).expect("Couldn't create test database");
+    let env = DbWrite::test(tmpdir.path(), kind).expect("Couldn't create test database");
     let header = Header::arbitrary(&mut u).unwrap();
     let author = header.author().clone();
     let signature = Signature::arbitrary(&mut u).unwrap();

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -16,13 +16,13 @@ use holo_hash::AgentPubKey;
 use holo_hash::HeaderHash;
 use holochain_keystore::AgentPubKeyExt;
 use holochain_serialized_bytes::SerializedBytes;
-use holochain_state::prelude::TestEnvs;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
 use holochain_zome_types::ZomeCallResponse;
 use kitsune_p2p::KitsuneP2pConfig;
 use matches::assert_matches;
 use shrinkwraprs::Shrinkwrap;
+use tempfile::TempDir;
 use test_case::test_case;
 use tokio_helper;
 use tracing::debug_span;
@@ -423,7 +423,7 @@ struct TestHandle {
     #[shrinkwrap(main_field)]
     handle: ConductorHandle,
     cell_id: CellId,
-    _envs: Arc<TestEnvs>,
+    _envs: Arc<TempDir>,
 }
 
 impl TestHandle {

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -81,7 +81,7 @@ impl SweetConductor {
         // to actually access those databases.
         // As a TODO, we can remove the need for TestEnvs in sweettest or have
         // some other better integration between the two.
-        let spaces = Spaces::new(env_dir.path().to_path_buf().into(), Default::default());
+        let spaces = Spaces::new(env_dir.path().to_path_buf().into(), Default::default()).unwrap();
 
         let keystore = handle.keystore().clone();
 

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -10,7 +10,7 @@ use hdk::prelude::*;
 use holo_hash::DnaHash;
 use holochain_conductor_api::{AdminInterfaceConfig, InterfaceDriver};
 use holochain_keystore::MetaLairClient;
-use holochain_state::{prelude::test_env_dir, test_utils::test_environments};
+use holochain_state::prelude::test_env_dir;
 use holochain_types::prelude::*;
 use holochain_websocket::*;
 use kitsune_p2p::KitsuneP2pConfig;
@@ -83,7 +83,7 @@ impl SweetConductor {
         // some other better integration between the two.
         let spaces = Spaces::new(env_dir.path().to_path_buf().into(), Default::default());
 
-        let keystore = test_keystore();
+        let keystore = handle.keystore().clone();
 
         Self {
             handle: Some(SweetConductorHandle(handle)),
@@ -99,7 +99,7 @@ impl SweetConductor {
     /// Create a SweetConductor with a new set of TestEnvs from the given config
     pub async fn from_config(config: ConductorConfig) -> SweetConductor {
         let dir = test_env_dir();
-        let handle = Self::handle_from_existing(&dir.path(), test_keystore(), &config, &[]).await;
+        let handle = Self::handle_from_existing(dir.path(), test_keystore(), &config, &[]).await;
         Self::new(handle, dir, config).await
     }
 
@@ -107,7 +107,7 @@ impl SweetConductor {
     pub async fn from_builder<DS: DnaStore + 'static>(
         builder: ConductorBuilder<DS>,
     ) -> SweetConductor {
-        let envs = test_environments();
+        let envs = test_env_dir();
         let config = builder.config.clone();
         let handle = builder.test(envs.path(), &[]).await.unwrap();
         Self::new(handle, envs, config).await

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -135,7 +135,7 @@ impl SweetConductor {
 
     /// Access the TestEnvs for this conductor
     pub fn envs(&self) -> &Path {
-        &self.env_dir.path()
+        self.env_dir.path()
     }
 
     /// Access the MetaLairClient for this conductor

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -103,7 +103,7 @@ impl SweetConductor {
     ) -> SweetConductor {
         let envs = test_environments();
         let config = builder.config.clone();
-        let handle = builder.test(&envs, &[]).await.unwrap();
+        let handle = builder.test(envs.path(), &[]).await.unwrap();
         Self::new(handle, envs, config).await
     }
 

--- a/crates/holochain/src/sweettest/sweet_conductor_batch.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor_batch.rs
@@ -109,7 +109,7 @@ impl SweetConductorBatch {
     pub async fn exchange_peer_info(&self) {
         let mut all = Vec::new();
         for c in self.0.iter() {
-            for env in c.envs().p2p().lock().values() {
+            for env in c.spaces.get_from_spaces(|s| s.p2p_env.clone()) {
                 all.push(env.clone());
             }
         }

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -322,7 +322,7 @@ pub async fn setup_app_inner(
             network,
             ..Default::default()
         })
-        .test(&envs, &[])
+        .test(envs.path(), &[])
         .await
         .unwrap();
 

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -208,6 +208,7 @@ where
         )
         .await
         .unwrap(),
+        kitsune_p2p::HostStub::new(),
     )
     .await
     .unwrap();

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -30,17 +30,18 @@ use holochain_serialized_bytes::SerializedBytes;
 use holochain_serialized_bytes::SerializedBytesError;
 use holochain_sqlite::prelude::DatabaseResult;
 use holochain_state::prelude::from_blob;
-use holochain_state::prelude::test_environments;
+use holochain_state::prelude::test_env_dir;
 use holochain_state::prelude::SourceChainResult;
 use holochain_state::prelude::StateQueryResult;
 use holochain_state::source_chain;
 use holochain_state::test_utils::fresh_reader_test;
-use holochain_state::test_utils::TestEnvs;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
 use kitsune_p2p::KitsuneP2pConfig;
 use rusqlite::named_params;
+use std::path::Path;
 use std::time::Duration;
+use tempfile::TempDir;
 use tokio::sync::mpsc;
 
 pub use itertools;
@@ -293,8 +294,10 @@ pub type InstalledCellsWithProofs = Vec<(InstalledCell, Option<SerializedBytes>)
 pub async fn setup_app(
     apps_data: Vec<(&str, InstalledCellsWithProofs)>,
     dnas: Vec<DnaFile>,
-) -> (TestEnvs, RealAppInterfaceApi, ConductorHandle) {
-    setup_app_inner(test_environments(), apps_data, dnas, None).await
+) -> (TempDir, RealAppInterfaceApi, ConductorHandle) {
+    let dir = test_env_dir();
+    let (iface, handle) = setup_app_inner(dir.path(), apps_data, dnas, None).await;
+    (dir, iface, handle)
 }
 
 /// Setup an app with a custom network config for testing
@@ -303,17 +306,19 @@ pub async fn setup_app_with_network(
     apps_data: Vec<(&str, InstalledCellsWithProofs)>,
     dnas: Vec<DnaFile>,
     network: KitsuneP2pConfig,
-) -> (TestEnvs, RealAppInterfaceApi, ConductorHandle) {
-    setup_app_inner(test_environments(), apps_data, dnas, Some(network)).await
+) -> (TempDir, RealAppInterfaceApi, ConductorHandle) {
+    let dir = test_env_dir();
+    let (iface, handle) = setup_app_inner(dir.path(), apps_data, dnas, Some(network)).await;
+    (dir, iface, handle)
 }
 
 /// Setup an app with full configurability
 pub async fn setup_app_inner(
-    envs: TestEnvs,
+    envs: &Path,
     apps_data: Vec<(&str, InstalledCellsWithProofs)>,
     dnas: Vec<DnaFile>,
     network: Option<KitsuneP2pConfig>,
-) -> (TestEnvs, RealAppInterfaceApi, ConductorHandle) {
+) -> (RealAppInterfaceApi, ConductorHandle) {
     let conductor_handle = ConductorBuilder::new()
         .config(ConductorConfig {
             admin_interfaces: Some(vec![AdminInterfaceConfig {
@@ -322,7 +327,7 @@ pub async fn setup_app_inner(
             network,
             ..Default::default()
         })
-        .test(envs.path(), &[])
+        .test(envs, &[])
         .await
         .unwrap();
 
@@ -332,7 +337,7 @@ pub async fn setup_app_inner(
 
     let handle = conductor_handle.clone();
 
-    (envs, RealAppInterfaceApi::new(conductor_handle), handle)
+    (RealAppInterfaceApi::new(conductor_handle), handle)
 }
 
 /// If HC_WASM_CACHE_PATH is set warm the cache

--- a/crates/holochain/src/test_utils/conductor_setup.rs
+++ b/crates/holochain/src/test_utils/conductor_setup.rs
@@ -15,7 +15,7 @@ use holochain_keystore::MetaLairClient;
 use holochain_p2p::actor::HolochainP2pRefToDna;
 use holochain_p2p::HolochainP2pDna;
 use holochain_serialized_bytes::SerializedBytes;
-use holochain_state::prelude::test_environments;
+use holochain_state::prelude::test_env_dir;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
 use kitsune_p2p::KitsuneP2pConfig;
@@ -185,7 +185,7 @@ impl ConductorTestData {
         }
 
         let (this, _) = Self::new(
-            test_environments(),
+            test_env_dir(),
             vec![dna_file],
             agents,
             network.unwrap_or_default(),

--- a/crates/holochain/src/test_utils/conductor_setup.rs
+++ b/crates/holochain/src/test_utils/conductor_setup.rs
@@ -15,13 +15,14 @@ use holochain_keystore::MetaLairClient;
 use holochain_p2p::actor::HolochainP2pRefToDna;
 use holochain_p2p::HolochainP2pDna;
 use holochain_serialized_bytes::SerializedBytes;
-use holochain_state::{prelude::test_environments, test_utils::TestEnvs};
+use holochain_state::prelude::test_environments;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
 use kitsune_p2p::KitsuneP2pConfig;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use tempfile::TempDir;
 
 /// A "factory" for HostFnCaller, which will produce them when given a ZomeName
 pub struct CellHostFnCaller {
@@ -85,14 +86,14 @@ impl CellHostFnCaller {
 /// Everything you need to run a test that uses the conductor
 // TODO: rewrite as sweettests if possible
 pub struct ConductorTestData {
-    _envs: TestEnvs,
+    _envs: TempDir,
     handle: ConductorHandle,
     cell_apis: BTreeMap<CellId, CellHostFnCaller>,
 }
 
 impl ConductorTestData {
     pub async fn new(
-        envs: TestEnvs,
+        envs: TempDir,
         dna_files: Vec<DnaFile>,
         agents: Vec<AgentPubKey>,
         network_config: KitsuneP2pConfig,
@@ -114,8 +115,8 @@ impl ConductorTestData {
             cell_id_by_dna_file.push((dna_file, cell_ids));
         }
 
-        let (_envs, _app_api, handle) = setup_app_inner(
-            envs,
+        let (_app_api, handle) = setup_app_inner(
+            envs.path(),
             vec![("test_app", cells)],
             dna_files.clone(),
             Some(network_config),
@@ -134,7 +135,7 @@ impl ConductorTestData {
         }
 
         let this = Self {
-            _envs,
+            _envs: envs,
             // app_api,
             handle,
             cell_apis,

--- a/crates/holochain/tests/ser_regression/mod.rs
+++ b/crates/holochain/tests/ser_regression/mod.rs
@@ -12,11 +12,11 @@ use holochain::conductor::ConductorBuilder;
 use holochain::conductor::ConductorHandle;
 
 use holochain_state::prelude::test_environments;
-use holochain_state::prelude::TestEnvs;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
 pub use holochain_zome_types::capability::CapSecret;
 use observability;
+use tempfile::TempDir;
 
 #[derive(Serialize, Deserialize, SerializedBytes, Debug)]
 struct CreateMessageInput {
@@ -171,10 +171,10 @@ async fn ser_regression_test() {
 pub async fn setup_app(
     cell_data: Vec<(InstalledCell, Option<SerializedBytes>)>,
     dna_store: MockDnaStore,
-) -> (TestEnvs, RealAppInterfaceApi, ConductorHandle) {
+) -> (TempDir, RealAppInterfaceApi, ConductorHandle) {
     let envs = test_environments();
     let conductor_handle = ConductorBuilder::with_mock_dna_store(dna_store)
-        .test(&envs, &[])
+        .test(envs.path(), &[])
         .await
         .unwrap();
 

--- a/crates/holochain/tests/ser_regression/mod.rs
+++ b/crates/holochain/tests/ser_regression/mod.rs
@@ -11,7 +11,7 @@ use holochain::conductor::api::ZomeCall;
 use holochain::conductor::ConductorBuilder;
 use holochain::conductor::ConductorHandle;
 
-use holochain_state::prelude::test_environments;
+use holochain_state::prelude::test_env_dir;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
 pub use holochain_zome_types::capability::CapSecret;
@@ -172,7 +172,7 @@ pub async fn setup_app(
     cell_data: Vec<(InstalledCell, Option<SerializedBytes>)>,
     dna_store: MockDnaStore,
 ) -> (TempDir, RealAppInterfaceApi, ConductorHandle) {
-    let envs = test_environments();
+    let envs = test_env_dir();
     let conductor_handle = ConductorBuilder::with_mock_dna_store(dna_store)
         .test(envs.path(), &[])
         .await

--- a/crates/holochain/tests/speed_tests/mod.rs
+++ b/crates/holochain/tests/speed_tests/mod.rs
@@ -34,7 +34,7 @@ use tempfile::TempDir;
 
 use super::test_utils::*;
 use holochain::sweettest::*;
-use holochain_state::prelude::test_environments;
+use holochain_state::prelude::test_env_dir;
 use holochain_test_wasm_common::AnchorInput;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
@@ -299,7 +299,7 @@ pub async fn setup_app(
     cell_data: Vec<(InstalledCell, Option<SerializedBytes>)>,
     dna_store: MockDnaStore,
 ) -> (TempDir, RealAppInterfaceApi, ConductorHandle) {
-    let envs = test_environments();
+    let envs = test_env_dir();
 
     let conductor_handle = ConductorBuilder::with_mock_dna_store(dna_store)
         .config(ConductorConfig {

--- a/crates/holochain/tests/speed_tests/mod.rs
+++ b/crates/holochain/tests/speed_tests/mod.rs
@@ -30,10 +30,11 @@ use holochain::conductor::config::ConductorConfig;
 use holochain::conductor::config::InterfaceDriver;
 use holochain::conductor::ConductorBuilder;
 use holochain::conductor::ConductorHandle;
+use tempfile::TempDir;
 
 use super::test_utils::*;
 use holochain::sweettest::*;
-use holochain_state::{prelude::test_environments, test_utils::TestEnvs};
+use holochain_state::prelude::test_environments;
 use holochain_test_wasm_common::AnchorInput;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
@@ -97,7 +98,7 @@ async fn speed_test_normal() {
 async fn speed_test_persisted() {
     observability::test_run().unwrap();
     let envs = speed_test(None).await;
-    let path = envs.into_tempdir().into_path();
+    let path = envs.path();
     println!("Run the following to see info about the test that just ran,");
     println!("with the correct cell env dir appended to the path:");
     println!();
@@ -117,7 +118,7 @@ fn speed_test_all(n: usize) {
 }
 
 #[instrument]
-async fn speed_test(n: Option<usize>) -> TestEnvs {
+async fn speed_test(n: Option<usize>) -> TempDir {
     let num = n.unwrap_or(DEFAULT_NUM);
 
     // ////////////
@@ -297,7 +298,7 @@ async fn speed_test(n: Option<usize>) -> TestEnvs {
 pub async fn setup_app(
     cell_data: Vec<(InstalledCell, Option<SerializedBytes>)>,
     dna_store: MockDnaStore,
-) -> (TestEnvs, RealAppInterfaceApi, ConductorHandle) {
+) -> (TempDir, RealAppInterfaceApi, ConductorHandle) {
     let envs = test_environments();
 
     let conductor_handle = ConductorBuilder::with_mock_dna_store(dna_store)
@@ -307,7 +308,7 @@ pub async fn setup_app(
             }]),
             ..Default::default()
         })
-        .test(&envs, &[])
+        .test(envs.path(), &[])
         .await
         .unwrap();
 

--- a/crates/holochain_conductor_api/src/config/conductor/paths.rs
+++ b/crates/holochain_conductor_api/src/config/conductor/paths.rs
@@ -5,6 +5,7 @@ use derive_more::Display;
 use derive_more::From;
 use derive_more::FromStr;
 use derive_more::Into;
+use std::path::Path;
 use std::path::PathBuf;
 
 const QUALIFIER: &str = "org";
@@ -32,6 +33,12 @@ pub struct EnvironmentRootPath(PathBuf);
 impl Default for EnvironmentRootPath {
     fn default() -> Self {
         Self(data_root().join(PathBuf::from(DATABASES_DIRECTORY)))
+    }
+}
+
+impl<'a> From<&'a Path> for EnvironmentRootPath {
+    fn from(p: &'a Path) -> Self {
+        p.to_owned().into()
     }
 }
 

--- a/crates/holochain_p2p/src/spawn.rs
+++ b/crates/holochain_p2p/src/spawn.rs
@@ -4,10 +4,12 @@ use crate::event::*;
 mod actor;
 use actor::*;
 
-/// Spawn a new HolochainP2p actor.  Conductor will call this on initialization.
+/// Spawn a new HolochainP2p actor.
+/// Conductor will call this on initialization.
 pub async fn spawn_holochain_p2p(
     config: kitsune_p2p::KitsuneP2pConfig,
     tls_config: kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig,
+    host: kitsune_p2p::HostApi,
 ) -> HolochainP2pResult<(
     ghost_actor::GhostSender<HolochainP2p>,
     HolochainP2pEventReceiver,
@@ -21,7 +23,9 @@ pub async fn spawn_holochain_p2p(
     let sender = channel_factory.create_channel::<HolochainP2p>().await?;
 
     tokio::task::spawn(
-        builder.spawn(HolochainP2pActor::new(config, tls_config, channel_factory, evt_send).await?),
+        builder.spawn(
+            HolochainP2pActor::new(config, tls_config, channel_factory, evt_send, host).await?,
+        ),
     );
 
     Ok((sender, evt_recv))

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -41,20 +41,6 @@ macro_rules! timing_trace {
 struct WrapEvtSender(futures::channel::mpsc::Sender<HolochainP2pEvent>);
 
 impl WrapEvtSender {
-    pub fn k_gen_req(
-        &self,
-        arg: KGenReq,
-    ) -> impl Future<Output = HolochainP2pResult<KGenRes>> + 'static + Send {
-        let dna_hash = match &arg {
-            KGenReq::PeerExtrapCov { space, .. } => DnaHash::from_kitsune(space),
-            KGenReq::RecordMetrics { space, .. } => DnaHash::from_kitsune(space),
-        };
-        timing_trace!(
-            { self.0.k_gen_req(dna_hash, arg) },
-            "(hp2p:handle) k_gen_req",
-        )
-    }
-
     pub fn put_agent_info_signed(
         &self,
         dna_hash: DnaHash,
@@ -63,22 +49,6 @@ impl WrapEvtSender {
         timing_trace!(
             { self.0.put_agent_info_signed(dna_hash, peer_data) },
             "(hp2p:handle) put_agent_info_signed",
-        )
-    }
-
-    fn get_agent_info_signed(
-        &self,
-        dna_hash: DnaHash,
-        to_agent: AgentPubKey,
-        kitsune_space: Arc<kitsune_p2p::KitsuneSpace>,
-        kitsune_agent: Arc<kitsune_p2p::KitsuneAgent>,
-    ) -> impl Future<Output = HolochainP2pResult<Option<AgentInfoSigned>>> + 'static + Send {
-        timing_trace!(
-            {
-                self.0
-                    .get_agent_info_signed(dna_hash, to_agent, kitsune_space, kitsune_agent)
-            },
-            "(hp2p:handle) get_agent_info_signed",
         )
     }
 
@@ -354,10 +324,11 @@ impl HolochainP2pActor {
         tls_config: kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig,
         channel_factory: ghost_actor::actor_builder::GhostActorChannelFactory<Self>,
         evt_sender: futures::channel::mpsc::Sender<HolochainP2pEvent>,
+        host: kitsune_p2p::HostApi,
     ) -> HolochainP2pResult<Self> {
         let tuning_params = config.tuning_params.clone();
         let (kitsune_p2p, kitsune_p2p_events) =
-            kitsune_p2p::spawn_kitsune_p2p(config, tls_config).await?;
+            kitsune_p2p::spawn_kitsune_p2p(config, tls_config, host).await?;
 
         channel_factory.attach_receiver(kitsune_p2p_events).await?;
 
@@ -573,16 +544,6 @@ impl HolochainP2pActor {
 impl ghost_actor::GhostHandler<kitsune_p2p::event::KitsuneP2pEvent> for HolochainP2pActor {}
 
 impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
-    fn handle_k_gen_req(
-        &mut self,
-        arg: KGenReq,
-    ) -> kitsune_p2p::event::KitsuneP2pEventHandlerResult<KGenRes> {
-        let evt_sender = self.evt_sender.clone();
-        Ok(async move { Ok(evt_sender.k_gen_req(arg).await?) }
-            .boxed()
-            .into())
-    }
-
     /// We need to store signed agent info.
     #[tracing::instrument(skip(self), level = "trace")]
     fn handle_put_agent_info_signed(
@@ -597,25 +558,6 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
                 .boxed()
                 .into(),
         )
-    }
-
-    /// We need to get previously stored agent info.
-    #[tracing::instrument(skip(self), level = "trace")]
-    fn handle_get_agent_info_signed(
-        &mut self,
-        input: kitsune_p2p::event::GetAgentInfoSignedEvt,
-    ) -> kitsune_p2p::event::KitsuneP2pEventHandlerResult<Option<AgentInfoSigned>> {
-        let kitsune_p2p::event::GetAgentInfoSignedEvt { space, agent } = input;
-        let h_space = DnaHash::from_kitsune(&space);
-        let h_agent = AgentPubKey::from_kitsune(&agent);
-        let evt_sender = self.evt_sender.clone();
-        Ok(async move {
-            Ok(evt_sender
-                .get_agent_info_signed(h_space, h_agent, space, agent)
-                .await?)
-        }
-        .boxed()
-        .into())
     }
 
     /// We need to get previously stored agent info. A single kitusne agent query

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -211,6 +211,7 @@ mod tests {
         let (p2p, mut evt) = spawn_holochain_p2p(
             KitsuneP2pConfig::default(),
             TlsConfig::new_ephemeral().await.unwrap(),
+            kitsune_p2p::HostStub::new(),
         )
         .await
         .unwrap();
@@ -277,6 +278,7 @@ mod tests {
         let (p2p, mut evt): (HolochainP2pRef, _) = spawn_holochain_p2p(
             KitsuneP2pConfig::default(),
             TlsConfig::new_ephemeral().await.unwrap(),
+            kitsune_p2p::HostStub::new(),
         )
         .await
         .unwrap();
@@ -331,6 +333,7 @@ mod tests {
         let (p2p, mut evt) = spawn_holochain_p2p(
             KitsuneP2pConfig::default(),
             TlsConfig::new_ephemeral().await.unwrap(),
+            kitsune_p2p::HostStub::new(),
         )
         .await
         .unwrap();
@@ -405,7 +408,9 @@ mod tests {
         params.default_rpc_multi_remote_request_grace_ms = 100;
         let mut config = KitsuneP2pConfig::default();
         config.tuning_params = Arc::new(params);
-        let (p2p, mut evt) = spawn_holochain_p2p(config, cert).await.unwrap();
+        let (p2p, mut evt) = spawn_holochain_p2p(config, cert, kitsune_p2p::HostStub::new())
+            .await
+            .unwrap();
 
         let test_1 = WireOps::Element(WireElementOps {
             header: Some(Judged::valid(SignedHeader(fixt!(Header), fixt!(Signature)))),
@@ -502,9 +507,13 @@ mod tests {
         let mut config = KitsuneP2pConfig::default();
         config.tuning_params = Arc::new(params);
 
-        let (p2p, mut evt) = spawn_holochain_p2p(config, TlsConfig::new_ephemeral().await.unwrap())
-            .await
-            .unwrap();
+        let (p2p, mut evt) = spawn_holochain_p2p(
+            config,
+            TlsConfig::new_ephemeral().await.unwrap(),
+            kitsune_p2p::HostStub::new(),
+        )
+        .await
+        .unwrap();
 
         let test_1 = WireLinkOps {
             creates: vec![WireCreateLink::condense(

--- a/crates/holochain_p2p/src/types/event.rs
+++ b/crates/holochain_p2p/src/types/event.rs
@@ -104,14 +104,9 @@ ghost_actor::ghost_chan! {
     /// The HolochainP2pEvent stream allows handling events generated from
     /// the HolochainP2p actor.
     pub chan HolochainP2pEvent<super::HolochainP2pError> {
-        /// Generic Kitsune Request of the implementor
-        fn k_gen_req(dna_hash: DnaHash, arg: KGenReq) -> KGenRes;
 
         /// We need to store signed agent info.
         fn put_agent_info_signed(dna_hash: DnaHash, peer_data: Vec<AgentInfoSigned>) -> ();
-
-        /// We need to get previously stored agent info.
-        fn get_agent_info_signed(dna_hash: DnaHash, to_agent: AgentPubKey, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>, kitsune_agent: Arc<kitsune_p2p::KitsuneAgent>) -> Option<AgentInfoSigned>;
 
         /// We need to get previously stored agent info.
         fn query_agent_info_signed(dna_hash: DnaHash, agents: Option<std::collections::HashSet<Arc<kitsune_p2p::KitsuneAgent>>>, kitsune_space: Arc<kitsune_p2p::KitsuneSpace>) -> Vec<AgentInfoSigned>;
@@ -250,7 +245,6 @@ macro_rules! match_p2p_evt {
             HolochainP2pEvent::GetAgentActivity { $i, .. } => { $($t)* }
             HolochainP2pEvent::ValidationReceiptReceived { $i, .. } => { $($t)* }
             HolochainP2pEvent::SignNetworkData { $i, .. } => { $($t)* }
-            HolochainP2pEvent::GetAgentInfoSigned { $i, .. } => { $($t)* }
             HolochainP2pEvent::CountersigningAuthorityResponse { $i, .. } => { $($t)* }
             $($t2)*
         }
@@ -261,7 +255,6 @@ impl HolochainP2pEvent {
     /// The dna_hash associated with this network p2p event.
     pub fn dna_hash(&self) -> &DnaHash {
         match_p2p_evt!(self => |dna_hash| { dna_hash }, {
-            HolochainP2pEvent::KGenReq { dna_hash, .. } => { dna_hash }
             HolochainP2pEvent::Publish { dna_hash, .. } => { dna_hash }
             HolochainP2pEvent::FetchOpData { dna_hash, .. } => { dna_hash }
             HolochainP2pEvent::QueryOpHashes { dna_hash, .. } => { dna_hash }
@@ -276,7 +269,6 @@ impl HolochainP2pEvent {
     /// The agent_pub_key associated with this network p2p event.
     pub fn target_agents(&self) -> &AgentPubKey {
         match_p2p_evt!(self => |to_agent| { to_agent }, {
-            HolochainP2pEvent::KGenReq { .. } => { unimplemented!("There is no single agent target for KGenReq") }
             HolochainP2pEvent::Publish { .. } => { unimplemented!("There is no single agent target for Publish") }
             HolochainP2pEvent::FetchOpData { .. } => { unimplemented!("There is no single agent target for FetchOpData") }
             HolochainP2pEvent::QueryOpHashes { .. } => { unimplemented!("There is no single agent target for QueryOpHashes") }

--- a/crates/holochain_sqlite/src/db.rs
+++ b/crates/holochain_sqlite/src/db.rs
@@ -321,8 +321,8 @@ impl<Kind: DbKindT + Send + Sync + 'static> DbWrite<Kind> {
     /// Create a unique db in a temp dir with no static management of the
     /// connection pool, useful for testing.
     #[cfg(any(test, feature = "test_utils"))]
-    pub fn test(tmpdir: &tempfile::TempDir, kind: Kind) -> DatabaseResult<Self> {
-        Self::new(Some(tmpdir.path()), kind, DbSyncLevel::default())
+    pub fn test(path: &Path, kind: Kind) -> DatabaseResult<Self> {
+        Self::new(Some(path), kind, DbSyncLevel::default())
     }
 
     #[cfg(any(test, feature = "test_utils"))]

--- a/crates/holochain_sqlite/src/db/p2p_agent_store/p2p_test.rs
+++ b/crates/holochain_sqlite/src/db/p2p_agent_store/p2p_test.rs
@@ -80,7 +80,7 @@ async fn test_p2p_agent_store_extrapolated_coverage() {
 
     let space = rand_space();
 
-    let db = DbWrite::test(&tmp_dir, DbKindP2pAgentStore(space.clone())).unwrap();
+    let db = DbWrite::test(tmp_dir.path(), DbKindP2pAgentStore(space.clone())).unwrap();
 
     let mut example_agent = rand_agent();
 
@@ -121,7 +121,7 @@ async fn test_p2p_agent_store_gossip_query_sanity() {
 
     let space = rand_space();
 
-    let db = DbWrite::test(&tmp_dir, DbKindP2pAgentStore(space.clone())).unwrap();
+    let db = DbWrite::test(tmp_dir.path(), DbKindP2pAgentStore(space.clone())).unwrap();
 
     let mut example_agent = rand_agent();
 

--- a/crates/holochain_sqlite/src/db/p2p_metrics/p2p_metrics_test.rs
+++ b/crates/holochain_sqlite/src/db/p2p_metrics/p2p_metrics_test.rs
@@ -30,7 +30,7 @@ async fn test_p2p_metric_store_sanity() {
 
     let space = rand_space();
 
-    let db = DbWrite::test(&tmp_dir, DbKindP2pMetrics(space.clone())).unwrap();
+    let db = DbWrite::test(tmp_dir.path(), DbKindP2pMetrics(space.clone())).unwrap();
 
     let permit = db.conn_permit().await;
     let mut con = db.from_permit(permit).unwrap();

--- a/crates/holochain_state/src/test_utils.rs
+++ b/crates/holochain_state/src/test_utils.rs
@@ -96,7 +96,6 @@ pub fn test_in_mem_db<Kind: DbKindT>(kind: Kind) -> DbWrite<Kind> {
     DbWrite::test_in_mem(kind).expect("Couldn't create test database")
 }
 
-
 /// Create a fresh set of test environments with a new TempDir
 pub fn test_env_dir() -> TempDir {
     tempfile::Builder::new()

--- a/crates/holochain_state/src/test_utils.rs
+++ b/crates/holochain_state/src/test_utils.rs
@@ -107,14 +107,24 @@ pub fn test_envs_with_keystore(keystore: MetaLairClient) -> TestEnvs {
 }
 
 /// Create a fresh set of test environments with a new TempDir
-pub fn test_environments() -> TestEnvs {
-    let tempdir = tempfile::Builder::new()
+pub fn test_env_dir() -> TempDir {
+    tempfile::Builder::new()
         .prefix("holochain-test-environments")
         .suffix(&nanoid::nanoid!())
         .tempdir()
-        .unwrap();
-    TestEnvs::new(tempdir)
+        .unwrap()
 }
+
+/// Create a fresh set of test environments with a new TempDir
+pub fn test_environments() -> TempDir {
+    test_env_dir()
+}
+
+// /// Create a fresh set of test environments with a new TempDir
+// pub fn test_environments() -> TestEnvs {
+//     let tempdir = test_env_dir();
+//     TestEnvs::new(tempdir)
+// }
 
 /// Create a fresh set of test environments with a new TempDir in a given directory.
 pub fn test_environments_in(path: impl AsRef<Path>) -> TestEnvs {

--- a/crates/holochain_state/src/test_utils.rs
+++ b/crates/holochain_state/src/test_utils.rs
@@ -96,15 +96,6 @@ pub fn test_in_mem_db<Kind: DbKindT>(kind: Kind) -> DbWrite<Kind> {
     DbWrite::test_in_mem(kind).expect("Couldn't create test database")
 }
 
-/// Create a fresh set of test environments with a new TempDir and custom MetaLairClient
-pub fn test_envs_with_keystore(keystore: MetaLairClient) -> TestEnvs {
-    let tempdir = tempfile::Builder::new()
-        .prefix("holochain-test-environments")
-        .suffix(&nanoid::nanoid!())
-        .tempdir()
-        .unwrap();
-    TestEnvs::with_keystore(tempdir, keystore)
-}
 
 /// Create a fresh set of test environments with a new TempDir
 pub fn test_env_dir() -> TempDir {
@@ -114,17 +105,6 @@ pub fn test_env_dir() -> TempDir {
         .tempdir()
         .unwrap()
 }
-
-/// Create a fresh set of test environments with a new TempDir
-pub fn test_environments() -> TempDir {
-    test_env_dir()
-}
-
-// /// Create a fresh set of test environments with a new TempDir
-// pub fn test_environments() -> TestEnvs {
-//     let tempdir = test_env_dir();
-//     TestEnvs::new(tempdir)
-// }
 
 /// Create a fresh set of test environments with a new TempDir in a given directory.
 pub fn test_environments_in(path: impl AsRef<Path>) -> TestEnvs {

--- a/crates/holochain_state/src/test_utils.rs
+++ b/crates/holochain_state/src/test_utils.rs
@@ -86,7 +86,7 @@ fn test_env<Kind: DbKindT>(kind: Kind) -> TestEnv<Kind> {
         .tempdir()
         .unwrap();
     TestEnv {
-        env: DbWrite::test(&tmpdir, kind).expect("Couldn't create test database"),
+        env: DbWrite::test(tmpdir.path(), kind).expect("Couldn't create test database"),
         tmpdir,
     }
 }
@@ -241,8 +241,8 @@ pub struct TestEnvs {
 impl TestEnvs {
     /// Create all three non-cell environments at once with a custom keystore
     pub fn with_keystore(tempdir: TempDir, keystore: MetaLairClient) -> Self {
-        let conductor = DbWrite::test(&tempdir, DbKindConductor).unwrap();
-        let wasm = DbWrite::test(&tempdir, DbKindWasm).unwrap();
+        let conductor = DbWrite::test(tempdir.path(), DbKindConductor).unwrap();
+        let wasm = DbWrite::test(tempdir.path(), DbKindWasm).unwrap();
         let p2p = Arc::new(parking_lot::Mutex::new(HashMap::new()));
         let p2p_metrics = Arc::new(parking_lot::Mutex::new(HashMap::new()));
         Self {

--- a/crates/holochain_state/tests/corrupt_db/mod.rs
+++ b/crates/holochain_state/tests/corrupt_db/mod.rs
@@ -26,7 +26,7 @@ async fn corrupt_cache_creates_new_db() {
     let testdir = create_corrupt_db(kind.clone(), &mut u);
 
     // - Try to open it.
-    let env = DbWrite::test(&testdir, kind).unwrap();
+    let env = DbWrite::test(testdir.path(), kind).unwrap();
 
     // - It opens successfully but the data is wiped.
     let n: usize = fresh_reader_test(env, |txn| {
@@ -47,7 +47,7 @@ async fn corrupt_source_chain_panics() {
     let testdir = create_corrupt_db(kind.clone(), &mut u);
 
     // - Try to open it.
-    let result = DbWrite::test(&testdir, kind);
+    let result = DbWrite::test(testdir.path(), kind);
 
     // - It cannot open.
     assert!(result.is_err());

--- a/crates/holochain_zome_types/src/op.rs
+++ b/crates/holochain_zome_types/src/op.rs
@@ -1,65 +1,4 @@
 //! # Dht Operational Transforms
-//! These are the operational transformations that can be applied to Holochain data.
-//! Every [`Header`] produces a set of operations.
-//! These operations are each sent to an authority for validation.
-//!
-//! ## Producing Operations
-//! The following is a list of the operations that can be produced by each [`Header`]:
-//! - Every [`Header`] produces a [`Op::RegisterAgentActivity`] and a [`Op::StoreElement`].
-//! - [`Header::Create`] also produces a [`Op::StoreEntry`].
-//! - [`Header::Update`] also produces a [`Op::StoreEntry`] and a [`Op::RegisterUpdate`].
-//! - [`Header::Delete`] also produces a [`Op::RegisterDelete`].
-//! - [`Header::CreateLink`] also produces a [`Op::RegisterCreateLink`].
-//! - [`Header::DeleteLink`] also produces a [`Op::RegisterDeleteLink`].
-//!
-//! ## Authorities
-//! There are three types of authorities in Holochain:
-//!
-//! #### The Header Authority
-//! This set of authorities receives the [`Op::StoreElement`].
-//! This is where you can implement your own logic for checking
-//! that it is valid to store any of the [`Header`] variants
-//! according to your own applications rules.
-//!
-//! #### The Entry Authority
-//! This set of authorities receives the [`Op::StoreEntry`].
-//! This is where you can implement your own logic for checking
-//! that it is valid to store an [`Entry`].
-//! You can think of this as the "Create" from the CRUD acronym.
-//!
-//! ##### Metadata
-//! The entry authority is also responsible for storing the metadata for each entry.
-//! They receive the [`Op::RegisterUpdate`] and [`Op::RegisterDelete`].
-//! This is where you can implement your own logic for checking that it is valid to
-//! update or delete any of the [`Entry`] types defined in your application.
-//! You can think of this as the "Update" and "Delete" from the CRUD acronym.
-//!
-//! They receive the [`Op::RegisterCreateLink`] and [`Op::RegisterDeleteLink`].
-//! This is where you can implement your own logic for checking that it is valid to
-//! place a link on a base [`Entry`].
-//!
-//! #### The Chain Authority
-//! This set of authorities receives the [`Op::RegisterAgentActivity`].
-//! This is where you can implement your own logic for checking that it is valid to
-//! add a new [`Header`] to an agent source chain.
-//! You are not validating the individual element but the entire agents source chain.
-//!
-//! ##### Author
-//! When authoring a new [`Header`] to your source chain, the
-//! validation will be run from the perspective of every authority.
-//!
-//! ##### A note on metadata for the Header authority.
-//! Technically speaking the Header authority also receives and validates the
-//! [`Op::RegisterUpdate`] and [`Op::RegisterDelete`] but they run the same callback
-//! as the Entry authority because it would be inconsistent to have two separate
-//! validation outcomes for these ops.
-//!
-//! ## Running Validation
-//! When the `fn validate(op: Op) -> ExternResult<ValidateCallbackResult>` is called
-//! it will be passed the operation variant for the authority that is
-//! actually running the validation.
-//!
-//! For example the entry authority will be passed the [`Op::StoreEntry`] operation.
 
 use crate::{
     AppEntryType, Create, CreateLink, Delete, DeleteLink, Element, Entry, EntryType, Header,
@@ -71,6 +10,68 @@ use kitsune_p2p_timestamp::Timestamp;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes)]
 #[cfg_attr(feature = "test_utils", derive(arbitrary::Arbitrary))]
+/// # Dht Operational Transforms
+/// These are the operational transformations that can be applied to Holochain data.
+/// Every [`Header`] produces a set of operations.
+/// These operations are each sent to an authority for validation.
+///
+/// ## Producing Operations
+/// The following is a list of the operations that can be produced by each [`Header`]:
+/// - Every [`Header`] produces a [`Op::RegisterAgentActivity`] and a [`Op::StoreElement`].
+/// - [`Header::Create`] also produces a [`Op::StoreEntry`].
+/// - [`Header::Update`] also produces a [`Op::StoreEntry`] and a [`Op::RegisterUpdate`].
+/// - [`Header::Delete`] also produces a [`Op::RegisterDelete`].
+/// - [`Header::CreateLink`] also produces a [`Op::RegisterCreateLink`].
+/// - [`Header::DeleteLink`] also produces a [`Op::RegisterDeleteLink`].
+///
+/// ## Authorities
+/// There are three types of authorities in Holochain:
+///
+/// #### The Header Authority
+/// This set of authorities receives the [`Op::StoreElement`].
+/// This is where you can implement your own logic for checking
+/// that it is valid to store any of the [`Header`] variants
+/// according to your own applications rules.
+///
+/// #### The Entry Authority
+/// This set of authorities receives the [`Op::StoreEntry`].
+/// This is where you can implement your own logic for checking
+/// that it is valid to store an [`Entry`].
+/// You can think of this as the "Create" from the CRUD acronym.
+///
+/// ##### Metadata
+/// The entry authority is also responsible for storing the metadata for each entry.
+/// They receive the [`Op::RegisterUpdate`] and [`Op::RegisterDelete`].
+/// This is where you can implement your own logic for checking that it is valid to
+/// update or delete any of the [`Entry`] types defined in your application.
+/// You can think of this as the "Update" and "Delete" from the CRUD acronym.
+///
+/// They receive the [`Op::RegisterCreateLink`] and [`Op::RegisterDeleteLink`].
+/// This is where you can implement your own logic for checking that it is valid to
+/// place a link on a base [`Entry`].
+///
+/// #### The Chain Authority
+/// This set of authorities receives the [`Op::RegisterAgentActivity`].
+/// This is where you can implement your own logic for checking that it is valid to
+/// add a new [`Header`] to an agent source chain.
+/// You are not validating the individual element but the entire agents source chain.
+///
+/// ##### Author
+/// When authoring a new [`Header`] to your source chain, the
+/// validation will be run from the perspective of every authority.
+///
+/// ##### A note on metadata for the Header authority.
+/// Technically speaking the Header authority also receives and validates the
+/// [`Op::RegisterUpdate`] and [`Op::RegisterDelete`] but they run the same callback
+/// as the Entry authority because it would be inconsistent to have two separate
+/// validation outcomes for these ops.
+///
+/// ## Running Validation
+/// When the `fn validate(op: Op) -> ExternResult<ValidateCallbackResult>` is called
+/// it will be passed the operation variant for the authority that is
+/// actually running the validation.
+///
+/// For example the entry authority will be passed the [`Op::StoreEntry`] operation.
 /// The operational transforms that can are applied to Holochain data.
 /// Operations beginning with `Store` are concerned with creating and
 /// storing data.

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -24,6 +24,7 @@ kitsune_p2p_proxy = { version = "0.0.18", path = "../proxy" }
 kitsune_p2p_timestamp = { version = "0.0.6", path = "../timestamp", features = ["now"] }
 kitsune_p2p_transport_quic = { version = "0.0.18", path = "../transport_quic" }
 kitsune_p2p_types = { version = "0.0.18", path = "../types" }
+must_future = "0.1.1"
 num-traits = "0.2"
 observability = "0.1.3"
 once_cell = "1.4.1"

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -6,7 +6,7 @@ use crate::agent_store::AgentInfoSigned;
 use crate::gossip::{decode_bloom_filter, encode_bloom_filter};
 use crate::types::event::*;
 use crate::types::gossip::*;
-use crate::types::*;
+use crate::{types::*, HostApi};
 use ghost_actor::dependencies::tracing;
 use governor::clock::DefaultClock;
 use governor::state::{InMemoryState, NotKeyed};
@@ -146,11 +146,13 @@ impl Stats {
 
 impl ShardedGossip {
     /// Constructor
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         tuning_params: KitsuneP2pTuningParams,
         space: Arc<KitsuneSpace>,
         ep_hnd: Tx2EpHnd<wire::Wire>,
         evt_sender: EventSender,
+        host: HostApi,
         gossip_type: GossipType,
         bandwidth: Arc<BandwidthThrottle>,
         metrics: MetricsSync,
@@ -162,6 +164,7 @@ impl ShardedGossip {
                 tuning_params,
                 space,
                 evt_sender,
+                _host: host,
                 inner: Share::new(ShardedGossipLocalState::new(metrics)),
                 gossip_type,
                 closing: AtomicBool::new(false),
@@ -342,6 +345,7 @@ pub struct ShardedGossipLocal {
     tuning_params: KitsuneP2pTuningParams,
     space: Arc<KitsuneSpace>,
     evt_sender: EventSender,
+    _host: HostApi,
     inner: Share<ShardedGossipLocalState>,
     closing: AtomicBool,
 }
@@ -1080,6 +1084,7 @@ impl AsGossipModuleFactory for ShardedRecentGossipFactory {
         space: Arc<KitsuneSpace>,
         ep_hnd: Tx2EpHnd<wire::Wire>,
         evt_sender: futures::channel::mpsc::Sender<event::KitsuneP2pEvent>,
+        host: HostApi,
         metrics: MetricsSync,
     ) -> GossipModule {
         GossipModule(ShardedGossip::new(
@@ -1087,6 +1092,7 @@ impl AsGossipModuleFactory for ShardedRecentGossipFactory {
             space,
             ep_hnd,
             evt_sender,
+            host,
             GossipType::Recent,
             self.bandwidth.clone(),
             metrics,
@@ -1111,6 +1117,7 @@ impl AsGossipModuleFactory for ShardedHistoricalGossipFactory {
         space: Arc<KitsuneSpace>,
         ep_hnd: Tx2EpHnd<wire::Wire>,
         evt_sender: futures::channel::mpsc::Sender<event::KitsuneP2pEvent>,
+        host: HostApi,
         metrics: MetricsSync,
     ) -> GossipModule {
         GossipModule(ShardedGossip::new(
@@ -1118,6 +1125,7 @@ impl AsGossipModuleFactory for ShardedHistoricalGossipFactory {
             space,
             ep_hnd,
             evt_sender,
+            host,
             GossipType::Historical,
             self.bandwidth.clone(),
             metrics,

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests.rs
@@ -15,6 +15,7 @@ impl ShardedGossipLocal {
     pub fn test(
         gossip_type: GossipType,
         evt_sender: EventSender,
+        host: HostApi,
         inner: ShardedGossipLocalState,
     ) -> Self {
         // TODO: randomize space
@@ -24,6 +25,7 @@ impl ShardedGossipLocal {
             tuning_params: Default::default(),
             space,
             evt_sender,
+            _host: host,
             inner: Share::new(inner),
             closing: std::sync::atomic::AtomicBool::new(false),
         }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/bloom.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/bloom.rs
@@ -4,6 +4,7 @@ use std::slice::SliceIndex;
 use super::common::*;
 use super::*;
 use crate::gossip::sharded_gossip::bloom::Batch;
+use crate::HostStub;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn bloom_windows() {
@@ -234,10 +235,12 @@ async fn make_node_inner(data: Option<(usize, TimeWindow)>) -> ShardedGossipLoca
             Ok(async move { Ok(data) }.boxed().into())
         });
     let (evt_sender, _) = spawn_handler(evt_handler).await;
+    let host = HostStub::new();
 
     ShardedGossipLocal::test(
         GossipType::Historical,
         evt_sender,
+        host,
         ShardedGossipLocalState::default(),
     )
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -1,34 +1,47 @@
-use crate::test_util::hash_op_data;
 pub use crate::test_util::spawn_handler;
+use crate::HostStub;
+use crate::{test_util::hash_op_data, KitsuneHostPanicky};
+use kitsune_p2p_types::box_fut;
 
 use super::*;
+
+pub struct StandardResponsesHostApi {
+    infos: Vec<AgentInfoSigned>,
+}
+
+impl KitsuneHostPanicky for StandardResponsesHostApi {
+    const NAME: &'static str = "StandardResponsesHostApi";
+
+    fn get_agent_info_signed(
+        &self,
+        input: GetAgentInfoSignedEvt,
+    ) -> crate::KitsuneHostResult<Option<crate::types::agent_store::AgentInfoSigned>> {
+        let agent = self
+            .infos
+            .clone()
+            .into_iter()
+            .find(|a| a.agent == input.agent)
+            .unwrap();
+        box_fut(Ok(Some(agent)))
+    }
+}
 
 // TODO: integrate with `HandlerBuilder`
 async fn standard_responses(
     agents: Vec<(Arc<KitsuneAgent>, AgentInfoSigned)>,
     with_data: bool,
-) -> MockKitsuneP2pEventHandler {
+) -> (MockKitsuneP2pEventHandler, HostApi) {
     let mut evt_handler = MockKitsuneP2pEventHandler::new();
     let infos = agents.iter().map(|(_, i)| i.clone()).collect::<Vec<_>>();
+    let host = StandardResponsesHostApi {
+        infos: infos.clone(),
+    };
     evt_handler.expect_handle_query_agents().returning({
-        let infos = infos.clone();
         move |_| {
             let infos = infos.clone();
             Ok(async move { Ok(infos.clone()) }.boxed().into())
         }
     });
-    evt_handler
-        .expect_handle_get_agent_info_signed()
-        .returning({
-            move |input| {
-                let agent = infos
-                    .clone()
-                    .into_iter()
-                    .find(|a| a.agent == input.agent)
-                    .unwrap();
-                Ok(async move { Ok(Some(agent)) }.boxed().into())
-            }
-        });
 
     if with_data {
         let fake_data = KitsuneOpData::new(vec![0]);
@@ -62,7 +75,8 @@ async fn standard_responses(
     evt_handler
         .expect_handle_gossip()
         .returning(|_, _| Ok(async { Ok(()) }.boxed().into()));
-    evt_handler
+
+    (evt_handler, Arc::new(host))
 }
 
 pub async fn setup_player(
@@ -70,9 +84,9 @@ pub async fn setup_player(
     agents: Vec<(Arc<KitsuneAgent>, AgentInfoSigned)>,
     with_data: bool,
 ) -> ShardedGossipLocal {
-    let evt_handler = standard_responses(agents, with_data).await;
+    let (evt_handler, host_api) = standard_responses(agents, with_data).await;
     let (evt_sender, _) = spawn_handler(evt_handler).await;
-    ShardedGossipLocal::test(GossipType::Historical, evt_sender, state)
+    ShardedGossipLocal::test(GossipType::Historical, evt_sender, host_api, state)
 }
 
 pub async fn setup_standard_player(
@@ -86,9 +100,9 @@ pub async fn setup_empty_player(
     state: ShardedGossipLocalState,
     agents: Vec<(Arc<KitsuneAgent>, AgentInfoSigned)>,
 ) -> ShardedGossipLocal {
-    let evt_handler = standard_responses(agents, false).await;
+    let (evt_handler, host_api) = standard_responses(agents, false).await;
     let (evt_sender, _) = spawn_handler(evt_handler).await;
-    ShardedGossipLocal::test(GossipType::Historical, evt_sender, state)
+    ShardedGossipLocal::test(GossipType::Historical, evt_sender, host_api, state)
 }
 
 pub async fn agents_with_infos(num_agents: usize) -> Vec<(Arc<KitsuneAgent>, AgentInfoSigned)> {

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
@@ -1,0 +1,48 @@
+use must_future::MustBoxFuture;
+use std::sync::Arc;
+
+use kitsune_p2p_types::{bin_types::KitsuneSpace, dht_arc::DhtArcSet};
+
+use crate::event::{GetAgentInfoSignedEvt, MetricRecord};
+
+/// A boxed future result with dynamic error type
+pub type KitsuneHostResult<'a, T> =
+    MustBoxFuture<'a, Result<T, Box<dyn Send + Sync + std::error::Error>>>;
+
+/// The interface to be implemented by the host, which handles various requests
+/// for data
+pub trait KitsuneHost: 'static + Send + Sync {
+    /// We need to get previously stored agent info.
+    fn get_agent_info_signed(
+        &self,
+        input: GetAgentInfoSignedEvt,
+    ) -> KitsuneHostResult<Option<crate::types::agent_store::AgentInfoSigned>>;
+
+    /// Extrapolated Peer Coverage
+    fn peer_extrapolated_coverage(
+        &self,
+        space: Arc<KitsuneSpace>,
+        dht_arc_set: DhtArcSet,
+    ) -> KitsuneHostResult<Vec<f64>>;
+
+    /// Record a set of metric records
+    fn record_metrics(
+        &self,
+        space: Arc<KitsuneSpace>,
+        records: Vec<MetricRecord>,
+    ) -> KitsuneHostResult<()>;
+}
+
+/// Trait object for the host interface
+pub type HostApi = std::sync::Arc<dyn KitsuneHost + Send + Sync>;
+
+// Test-only stub which mostly panics
+#[cfg(any(test, feature = "test_utils"))]
+mod host_stub;
+#[cfg(any(test, feature = "test_utils"))]
+pub use host_stub::*;
+
+#[cfg(any(test, feature = "test_utils"))]
+mod host_panicky;
+#[cfg(any(test, feature = "test_utils"))]
+pub use host_panicky::*;

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_panicky.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_panicky.rs
@@ -1,0 +1,69 @@
+use super::*;
+
+/// A supertrait of KitsuneHost convenient for defining test handlers.
+/// Allows only specifying the methods you care about, and letting all the rest
+/// panic if called
+pub trait KitsuneHostPanicky: KitsuneHost {
+    /// Name to be printed out on unimplemented panic
+    const NAME: &'static str;
+
+    /// We need to get previously stored agent info.
+    fn get_agent_info_signed(
+        &self,
+        _input: GetAgentInfoSignedEvt,
+    ) -> KitsuneHostResult<Option<crate::types::agent_store::AgentInfoSigned>> {
+        unimplemented!(
+            "default panic for unimplemented KitsuneHost test behavior: {}",
+            Self::NAME
+        )
+    }
+
+    /// Extrapolated Peer Coverage
+    fn peer_extrapolated_coverage(
+        &self,
+        _space: Arc<KitsuneSpace>,
+        _dht_arc_set: DhtArcSet,
+    ) -> KitsuneHostResult<Vec<f64>> {
+        unimplemented!(
+            "default panic for unimplemented KitsuneHost test behavior: {}",
+            Self::NAME
+        )
+    }
+
+    /// Record a set of metric records
+    fn record_metrics(
+        &self,
+        _space: Arc<KitsuneSpace>,
+        _records: Vec<MetricRecord>,
+    ) -> KitsuneHostResult<()> {
+        unimplemented!(
+            "default panic for unimplemented KitsuneHost test behavior: {}",
+            Self::NAME
+        )
+    }
+}
+
+impl<T: KitsuneHostPanicky> KitsuneHost for T {
+    fn get_agent_info_signed(
+        &self,
+        input: GetAgentInfoSignedEvt,
+    ) -> KitsuneHostResult<Option<crate::types::agent_store::AgentInfoSigned>> {
+        KitsuneHostPanicky::get_agent_info_signed(self, input)
+    }
+
+    fn peer_extrapolated_coverage(
+        &self,
+        space: Arc<KitsuneSpace>,
+        dht_arc_set: DhtArcSet,
+    ) -> KitsuneHostResult<Vec<f64>> {
+        KitsuneHostPanicky::peer_extrapolated_coverage(self, space, dht_arc_set)
+    }
+
+    fn record_metrics(
+        &self,
+        space: Arc<KitsuneSpace>,
+        records: Vec<MetricRecord>,
+    ) -> KitsuneHostResult<()> {
+        KitsuneHostPanicky::record_metrics(self, space, records)
+    }
+}

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
@@ -1,0 +1,15 @@
+use crate::KitsuneHostPanicky;
+
+/// Dummy host impl for plumbing
+pub struct HostStub;
+
+impl KitsuneHostPanicky for HostStub {
+    const NAME: &'static str = "HostStub";
+}
+
+impl HostStub {
+    /// Constructor
+    pub fn new() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self)
+    }
+}

--- a/crates/kitsune_p2p/kitsune_p2p/src/lib.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/lib.rs
@@ -22,6 +22,9 @@ pub use config::*;
 mod spawn;
 pub use spawn::*;
 
+mod host_api;
+pub use host_api::*;
+
 #[allow(missing_docs)]
 #[cfg(any(test, feature = "test_utils"))]
 pub mod test_util;

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn.rs
@@ -1,5 +1,6 @@
 use crate::actor::*;
 use crate::event::*;
+use crate::HostApi;
 
 mod actor;
 use actor::*;
@@ -11,6 +12,7 @@ pub use actor::MockKitsuneP2pEventHandler;
 pub async fn spawn_kitsune_p2p(
     config: crate::KitsuneP2pConfig,
     tls_config: kitsune_p2p_types::tls::TlsConfig,
+    host: HostApi,
 ) -> KitsuneP2pResult<(
     ghost_actor::GhostSender<KitsuneP2p>,
     KitsuneP2pEventReceiver,
@@ -32,6 +34,7 @@ pub async fn spawn_kitsune_p2p(
                 channel_factory,
                 internal_sender,
                 evt_send,
+                host,
             )
             .await?,
         ),

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -80,6 +80,7 @@ pub(crate) struct KitsuneP2pActor {
     internal_sender: ghost_actor::GhostSender<Internal>,
     evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
     ep_hnd: Tx2EpHnd<wire::Wire>,
+    host: HostApi,
     #[allow(clippy::type_complexity)]
     spaces: HashMap<
         Arc<KitsuneSpace>,
@@ -100,6 +101,7 @@ impl KitsuneP2pActor {
         channel_factory: ghost_actor::actor_builder::GhostActorChannelFactory<Self>,
         internal_sender: ghost_actor::GhostSender<Internal>,
         evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+        host: HostApi,
     ) -> KitsuneP2pResult<Self> {
         crate::types::metrics::init();
 
@@ -220,10 +222,12 @@ impl KitsuneP2pActor {
         let i_s = internal_sender.clone();
         tokio::task::spawn({
             let evt_sender = evt_sender.clone();
+            let host = host.clone();
             let tuning_params = config.tuning_params.clone();
             async move {
                 ep.for_each_concurrent(tuning_params.concurrent_limit_per_thread, move |event| {
                     let evt_sender = evt_sender.clone();
+                    let host = host.clone();
                     let tuning_params = tuning_params.clone();
                     let i_s = i_s.clone();
                     async move {
@@ -281,7 +285,7 @@ impl KitsuneP2pActor {
                                         resp!(respond, resp);
                                     }
                                     wire::Wire::PeerGet(wire::PeerGet { space, agent }) => {
-                                        if let Ok(Some(agent_info_signed)) = evt_sender
+                                        if let Ok(Some(agent_info_signed)) = host
                                             .get_agent_info_signed(GetAgentInfoSignedEvt {
                                                 space,
                                                 agent,
@@ -450,6 +454,7 @@ impl KitsuneP2pActor {
             internal_sender,
             evt_sender,
             ep_hnd,
+            host,
             spaces: HashMap::new(),
             config: Arc::new(config),
             bandwidth_throttles,
@@ -614,22 +619,11 @@ impl InternalHandler for KitsuneP2pActor {
 impl ghost_actor::GhostHandler<KitsuneP2pEvent> for KitsuneP2pActor {}
 
 impl KitsuneP2pEventHandler for KitsuneP2pActor {
-    fn handle_k_gen_req(&mut self, arg: KGenReq) -> KitsuneP2pEventHandlerResult<KGenRes> {
-        Ok(self.evt_sender.k_gen_req(arg))
-    }
-
     fn handle_put_agent_info_signed(
         &mut self,
         input: crate::event::PutAgentInfoSignedEvt,
     ) -> KitsuneP2pEventHandlerResult<()> {
         Ok(self.evt_sender.put_agent_info_signed(input))
-    }
-
-    fn handle_get_agent_info_signed(
-        &mut self,
-        input: crate::event::GetAgentInfoSignedEvt,
-    ) -> KitsuneP2pEventHandlerResult<Option<crate::types::agent_store::AgentInfoSigned>> {
-        Ok(self.evt_sender.get_agent_info_signed(input))
     }
 
     fn handle_query_agents(
@@ -711,6 +705,7 @@ impl KitsuneP2pHandler for KitsuneP2pActor {
         let internal_sender = self.internal_sender.clone();
         let space2 = space.clone();
         let ep_hnd = self.ep_hnd.clone();
+        let host = self.host.clone();
         let config = Arc::clone(&self.config);
         let bandwidth_throttles = self.bandwidth_throttles.clone();
         let parallel_notify_permit = self.parallel_notify_permit.clone();
@@ -720,6 +715,7 @@ impl KitsuneP2pHandler for KitsuneP2pActor {
                 let (send, send_inner, evt_recv) = spawn_space(
                     space2,
                     ep_hnd,
+                    host,
                     config,
                     bandwidth_throttles,
                     parallel_notify_permit,
@@ -912,20 +908,11 @@ mockall::mock! {
     pub KitsuneP2pEventHandler {}
 
     impl KitsuneP2pEventHandler for KitsuneP2pEventHandler {
-        fn handle_k_gen_req(
-            &mut self,
-            arg: KGenReq,
-        ) -> KitsuneP2pEventHandlerResult<KGenRes>;
 
         fn handle_put_agent_info_signed(
             &mut self,
             input: crate::event::PutAgentInfoSignedEvt,
         ) -> KitsuneP2pEventHandlerResult<()>;
-
-        fn handle_get_agent_info_signed(
-            &mut self,
-            input: crate::event::GetAgentInfoSignedEvt,
-        ) -> KitsuneP2pEventHandlerResult<Option<crate::types::agent_store::AgentInfoSigned>>;
 
         fn handle_query_agents(
             &mut self,

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/discover.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/discover.rs
@@ -35,7 +35,7 @@ pub(crate) fn search_and_discover_peer_connect(
 
             // see if we already know how to reach the tgt agent
             if let Ok(Some(agent_info_signed)) = inner
-                .evt_sender
+                .host_api
                 .get_agent_info_signed(GetAgentInfoSignedEvt {
                     space: inner.space.clone(),
                     agent: to_agent.clone(),

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -80,6 +80,7 @@ ghost_actor::ghost_chan! {
 pub(crate) async fn spawn_space(
     space: Arc<KitsuneSpace>,
     ep_hnd: Tx2EpHnd<wire::Wire>,
+    host: HostApi,
     config: Arc<KitsuneP2pConfig>,
     bandwidth_throttles: BandwidthThrottles,
     parallel_notify_permit: Arc<tokio::sync::Semaphore>,
@@ -106,6 +107,7 @@ pub(crate) async fn spawn_space(
         space,
         i_s.clone(),
         evt_send,
+        host,
         ep_hnd,
         config,
         bandwidth_throttles,
@@ -1053,6 +1055,7 @@ pub(crate) struct SpaceReadOnlyInner {
     #[allow(dead_code)]
     pub(crate) i_s: ghost_actor::GhostSender<SpaceInternal>,
     pub(crate) evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+    pub(crate) host_api: HostApi,
     pub(crate) ep_hnd: Tx2EpHnd<wire::Wire>,
     #[allow(dead_code)]
     pub(crate) config: Arc<KitsuneP2pConfig>,
@@ -1068,6 +1071,7 @@ pub(crate) struct Space {
     pub(crate) space: Arc<KitsuneSpace>,
     pub(crate) i_s: ghost_actor::GhostSender<SpaceInternal>,
     pub(crate) evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+    pub(crate) _host_api: HostApi,
     pub(crate) local_joined_agents: HashSet<Arc<KitsuneAgent>>,
     pub(crate) agent_arcs: HashMap<Arc<KitsuneAgent>, DhtArc>,
     pub(crate) config: Arc<KitsuneP2pConfig>,
@@ -1083,6 +1087,7 @@ impl Space {
         space: Arc<KitsuneSpace>,
         i_s: ghost_actor::GhostSender<SpaceInternal>,
         evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+        host_api: HostApi,
         ep_hnd: Tx2EpHnd<wire::Wire>,
         config: Arc<KitsuneP2pConfig>,
         bandwidth_throttles: BandwidthThrottles,
@@ -1093,7 +1098,7 @@ impl Space {
         {
             let space = space.clone();
             let metrics = metrics.clone();
-            let evt_sender = evt_sender.clone();
+            let host = host_api.clone();
             tokio::task::spawn(async move {
                 loop {
                     tokio::time::sleep(std::time::Duration::from_millis(
@@ -1103,12 +1108,7 @@ impl Space {
 
                     let records = metrics.read().dump_historical();
 
-                    let _ = evt_sender
-                        .k_gen_req(KGenReq::RecordMetrics {
-                            space: space.clone(),
-                            records,
-                        })
-                        .await;
+                    let _ = host.record_metrics(space.clone(), records).await;
                 }
             });
         }
@@ -1116,7 +1116,7 @@ impl Space {
         let metric_exchange = MetricExchangeSync::spawn(
             space.clone(),
             config.tuning_params.clone(),
-            evt_sender.clone(),
+            host_api.clone(),
             metrics.clone(),
         );
 
@@ -1150,6 +1150,7 @@ impl Space {
                         space.clone(),
                         ep_hnd.clone(),
                         evt_sender.clone(),
+                        host_api.clone(),
                         metrics.clone(),
                     ),
                 )
@@ -1238,6 +1239,7 @@ impl Space {
             space: space.clone(),
             i_s: i_s.clone(),
             evt_sender: evt_sender.clone(),
+            host_api: host_api.clone(),
             ep_hnd,
             config: config.clone(),
             parallel_notify_permit,
@@ -1250,6 +1252,7 @@ impl Space {
             space,
             i_s,
             evt_sender,
+            _host_api: host_api,
             local_joined_agents: HashSet::new(),
             agent_arcs: HashMap::new(),
             config,

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/metric_exchange.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/metric_exchange.rs
@@ -155,7 +155,7 @@ impl MetricExchangeSync {
     pub fn spawn(
         space: Arc<KitsuneSpace>,
         tuning_params: KitsuneP2pTuningParams,
-        evt_sender: futures::channel::mpsc::Sender<KitsuneP2pEvent>,
+        host: HostApi,
         metrics: MetricsSync,
     ) -> Self {
         let out = Self(Arc::new(parking_lot::RwLock::new(MetricExchange::spawn(
@@ -174,11 +174,8 @@ impl MetricExchangeSync {
 
                     if last_extrap_cov.should_trigger() {
                         let arc_set = mx.read().arc_set.clone();
-                        if let Ok(KGenRes::PeerExtrapCov(res)) = evt_sender
-                            .k_gen_req(KGenReq::PeerExtrapCov {
-                                space: space.clone(),
-                                dht_arc_set: arc_set,
-                            })
+                        if let Ok(res) = host
+                            .peer_extrapolated_coverage(space.clone(), arc_set)
                             .await
                         {
                             // MAYBE: ignore outliers?

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
@@ -105,9 +105,9 @@ async fn test_rpc_multi_logic_mocked() {
         }
         ok_fut(Ok(out))
     });
-    m.expect_handle_k_gen_req()
-        .returning(move |_| ok_fut(Ok(KGenRes::RecordMetrics(()))));
+
     let evt_sender = build_event_handler(m).await;
+    let host_api = HostStub::new();
 
     let config = Arc::new(KitsuneP2pConfig::default());
 
@@ -234,7 +234,7 @@ async fn test_rpc_multi_logic_mocked() {
     let metric_exchange = MetricExchangeSync::spawn(
         space.clone(),
         config.tuning_params.clone(),
-        evt_sender.clone(),
+        host_api.clone(),
         metrics.clone(),
     );
 
@@ -243,6 +243,7 @@ async fn test_rpc_multi_logic_mocked() {
         space: space.clone(),
         i_s,
         evt_sender,
+        host_api,
         ep_hnd,
         parallel_notify_permit: Arc::new(tokio::sync::Semaphore::new(
             config.tuning_params.concurrent_limit_per_thread,

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
@@ -34,11 +34,13 @@ pub(crate) async fn spawn_test_agent(
     ),
     KitsuneP2pError,
 > {
+    let host = HostStub::new();
     let (p2p, evt) = spawn_kitsune_p2p(
         config,
         kitsune_p2p_types::tls::TlsConfig::new_ephemeral()
             .await
             .unwrap(),
+        host,
     )
     .await?;
 
@@ -138,10 +140,6 @@ impl HarnessAgentControlHandler for AgentHarness {
 impl ghost_actor::GhostHandler<KitsuneP2pEvent> for AgentHarness {}
 
 impl KitsuneP2pEventHandler for AgentHarness {
-    fn handle_k_gen_req(&mut self, _: KGenReq) -> KitsuneP2pEventHandlerResult<KGenRes> {
-        Err("unimplemented".into())
-    }
-
     fn handle_put_agent_info_signed(
         &mut self,
         input: PutAgentInfoSignedEvt,
@@ -155,14 +153,6 @@ impl KitsuneP2pEventHandler for AgentHarness {
             });
         }
         Ok(async move { Ok(()) }.boxed().into())
-    }
-
-    fn handle_get_agent_info_signed(
-        &mut self,
-        input: GetAgentInfoSignedEvt,
-    ) -> KitsuneP2pEventHandlerResult<Option<crate::types::agent_store::AgentInfoSigned>> {
-        let res = self.agent_store.get(&input.agent).map(|i| (**i).clone());
-        Ok(async move { Ok(res) }.boxed().into())
     }
 
     fn handle_query_agents(

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_state.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_state.rs
@@ -4,6 +4,7 @@ use crate::gossip::sharded_gossip::{BandwidthThrottle, GossipType, ShardedGossip
 use crate::test_util::spawn_handler;
 use crate::types::gossip::*;
 use crate::types::wire;
+use crate::HostStub;
 use futures::stream::StreamExt;
 use ghost_actor::dependencies::tracing;
 use ghost_actor::GhostResult;
@@ -120,6 +121,7 @@ impl Switchboard {
         let ep_hnd = ep.handle().clone();
 
         let evt_handler = SwitchboardEventHandler::new(ep_hnd.clone(), self.clone());
+        let host = HostStub::new();
         let (evt_sender, handler_task) = spawn_handler(evt_handler.clone()).await;
 
         let bandwidth = Arc::new(BandwidthThrottle::new(1000.0, 1000.0));
@@ -129,6 +131,7 @@ impl Switchboard {
             space.clone(),
             ep_hnd.clone(),
             evt_sender,
+            host,
             self.gossip_type,
             bandwidth,
             Default::default(),

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
@@ -210,37 +210,6 @@ pub struct MetricRecord {
     pub data: serde_json::Value,
 }
 
-/// Generic Kitsune Request of the implementor
-/// This enum may be easier to add variants to for future updates,
-/// rather than adding a full new top-level event message type.
-pub enum KGenReq {
-    /// Extrapolated Peer Coverage
-    PeerExtrapCov {
-        /// The space to extrapolate coverage
-        space: Arc<super::KitsuneSpace>,
-
-        /// Storage arcs of joined agents
-        dht_arc_set: DhtArcSet,
-    },
-
-    /// Record a set of metric records
-    RecordMetrics {
-        /// The space to associate the records with
-        space: Arc<super::KitsuneSpace>,
-
-        /// The records to record
-        records: Vec<MetricRecord>,
-    },
-}
-
-/// Generic Kitsune Respons from the imlementor
-pub enum KGenRes {
-    /// Extrapolated Peer Coverage
-    PeerExtrapCov(Vec<f64>),
-    /// Record a set of metric records
-    RecordMetrics(()),
-}
-
 type KSpace = Arc<super::KitsuneSpace>;
 type KAgent = Arc<super::KitsuneAgent>;
 type KOpHash = Arc<super::KitsuneOpHash>;
@@ -251,14 +220,9 @@ ghost_actor::ghost_chan! {
     /// The KitsuneP2pEvent stream allows handling events generated from the
     /// KitsuneP2p actor.
     pub chan KitsuneP2pEvent<super::KitsuneP2pError> {
-        /// Generic Kitsune Request of the implementor
-        fn k_gen_req(arg: KGenReq) -> KGenRes;
 
         /// We need to store signed agent info.
         fn put_agent_info_signed(input: PutAgentInfoSignedEvt) -> ();
-
-        /// We need to get previously stored agent info.
-        fn get_agent_info_signed(input: GetAgentInfoSignedEvt) -> Option<crate::types::agent_store::AgentInfoSigned>;
 
         /// We need to get previously stored agent info.
         fn query_agents(input: QueryAgentsEvt) -> Vec<crate::types::agent_store::AgentInfoSigned>;

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/gossip.rs
@@ -1,5 +1,6 @@
 use crate::metrics::*;
 use crate::types::*;
+use crate::HostApi;
 use kitsune_p2p_types::config::*;
 use kitsune_p2p_types::tx2::tx2_api::*;
 use kitsune_p2p_types::tx2::tx2_utils::TxUrl;
@@ -76,6 +77,7 @@ pub trait AsGossipModuleFactory: 'static + Send + Sync {
         space: Arc<KitsuneSpace>,
         ep_hnd: Tx2EpHnd<wire::Wire>,
         evt_sender: futures::channel::mpsc::Sender<event::KitsuneP2pEvent>,
+        host: HostApi,
         metrics: MetricsSync,
     ) -> GossipModule;
 }
@@ -89,9 +91,10 @@ impl GossipModuleFactory {
         space: Arc<KitsuneSpace>,
         ep_hnd: Tx2EpHnd<wire::Wire>,
         evt_sender: futures::channel::mpsc::Sender<event::KitsuneP2pEvent>,
+        host: HostApi,
         metrics: MetricsSync,
     ) -> GossipModule {
         self.0
-            .spawn_gossip_task(tuning_params, space, ep_hnd, evt_sender, metrics)
+            .spawn_gossip_task(tuning_params, space, ep_hnd, evt_sender, host, metrics)
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/tests/proxy_list.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/tests/proxy_list.rs
@@ -70,7 +70,9 @@ async fn test_integrated_proxy_list() {
         },
     }];
 
-    let (actor, mut evt) = spawn_kitsune_p2p(kconf, k_tls).await.unwrap();
+    let (actor, mut evt) = spawn_kitsune_p2p(kconf, k_tls, HostStub::new())
+        .await
+        .unwrap();
 
     tokio::task::spawn(async move {
         while let Some(e) = evt.next().await {

--- a/crates/kitsune_p2p/types/src/lib.rs
+++ b/crates/kitsune_p2p/types/src/lib.rs
@@ -47,10 +47,16 @@ pub fn unit_ok_fut<E1, E2>() -> Result<MustBoxFuture<'static, Result<(), E2>>, E
     Ok(async move { Ok(()) }.boxed().into())
 }
 
-/// Helper function for the common case of returning this nested Unit type.
+/// Helper function for the common case of returning this boxed future type.
 pub fn ok_fut<E1, R: Send + 'static>(result: R) -> Result<MustBoxFuture<'static, R>, E1> {
     use futures::FutureExt;
     Ok(async move { result }.boxed().into())
+}
+
+/// Helper function for the common case of returning this boxed future type.
+pub fn box_fut<'a, R: Send + 'a>(result: R) -> MustBoxFuture<'a, R> {
+    use futures::FutureExt;
+    async move { result }.boxed().into()
 }
 
 use ::ghost_actor::dependencies::tracing;

--- a/crates/release-automation/src/crate_.rs
+++ b/crates/release-automation/src/crate_.rs
@@ -1,12 +1,16 @@
-use std::collections::{HashMap, HashSet};
-
-use anyhow::bail;
+use anyhow::{bail, Context};
+use bstr::ByteSlice;
 use cargo::util::VersionExt;
 use log::{debug, info, warn};
 use semver::Version;
+use std::collections::{HashMap, HashSet};
 use structopt::StructOpt;
 
-use crate::{crate_selection::Crate, release::ReleaseWorkspace, CommandResult, Fallible};
+use crate::{
+    crate_selection::Crate,
+    release::{crates_index_helper, ReleaseWorkspace},
+    CommandResult, Fallible,
+};
 
 #[derive(StructOpt, Debug)]
 pub(crate) struct CrateArgs {
@@ -92,6 +96,25 @@ pub(crate) struct CrateCheckArgs {
     offline: bool,
 }
 
+pub(crate) const MINIMUM_CRATE_OWNERS: &str =
+    "github:holochain:core-dev,holochain-release-automation,holochain-release-automation2,zippy,steveej";
+
+#[derive(Debug, StructOpt)]
+pub(crate) struct EnsureCrateOwnersArgs {
+    #[structopt(long)]
+    dry_run: bool,
+
+    /// Assumes the default crate owners that are ensured to be set for each crate in the workspace.
+    #[structopt(
+        long,
+        default_value = MINIMUM_CRATE_OWNERS,
+        use_delimiter = true,
+        multiple = false,
+
+    )]
+    minimum_crate_owners: Vec<String>,
+}
+
 #[derive(Debug, StructOpt)]
 pub(crate) enum CrateCommands {
     SetVersion(CrateSetVersionArgs),
@@ -101,6 +124,7 @@ pub(crate) enum CrateCommands {
     FixupReleases(CrateFixupReleases),
 
     Check(CrateCheckArgs),
+    EnsureCrateOwners(EnsureCrateOwnersArgs),
 }
 
 pub(crate) fn cmd(args: &crate::cli::Args, cmd_args: &CrateArgs) -> CommandResult {
@@ -138,6 +162,21 @@ pub(crate) fn cmd(args: &crate::cli::Args, cmd_args: &CrateArgs) -> CommandResul
 
         CrateCommands::Check(subcmd_args) => {
             ws.cargo_check(subcmd_args.offline, std::iter::empty::<&str>())?;
+
+            Ok(())
+        }
+        CrateCommands::EnsureCrateOwners(subcmd_args) => {
+            ensure_crate_io_owners(
+                &ws,
+                subcmd_args.dry_run,
+                ws.members()?,
+                subcmd_args
+                    .minimum_crate_owners
+                    .iter()
+                    .map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            )?;
 
             Ok(())
         }
@@ -353,6 +392,78 @@ pub(crate) fn fixup_releases<'a>(
 
             if commit {
                 ws.git_add_all_and_commit(&commit_msg, None)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Ensures that the given crates have at least sent an invite to the given crate.io usernames.
+pub(crate) fn ensure_crate_io_owners<'a>(
+    _ws: &'a ReleaseWorkspace<'a>,
+    dry_run: bool,
+    crates: &[&Crate],
+    minimum_crate_owners: &[&str],
+) -> Fallible<()> {
+    let desired_owners = minimum_crate_owners
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<HashSet<_>>();
+
+    for crt in crates {
+        if !crates_index_helper::is_version_published(crt, false)? {
+            warn!("{} is not published, skipping..", crt.name());
+            continue;
+        }
+
+        let mut cmd = std::process::Command::new("cargo");
+        cmd.args(&["owner", "--list", &crt.name()]);
+
+        debug!("[{}] running command: {:?}", crt.name(), cmd);
+        let output = cmd.output().context("process exitted unsuccessfully")?;
+        if !output.status.success() {
+            warn!(
+                "[{}] failed list owners: {}",
+                crt.name(),
+                String::from_utf8_lossy(&output.stderr)
+            );
+
+            continue;
+        }
+
+        let current_owners = output
+            .stdout
+            .lines()
+            .map(|line| {
+                line.words_with_breaks()
+                    .take_while(|item| *item != " ")
+                    .collect::<String>()
+            })
+            .collect::<HashSet<_>>();
+        let diff = desired_owners.difference(&current_owners);
+        info!(
+            "[{}] current owners {:?}, missing owners: {:?}",
+            crt.name(),
+            current_owners,
+            diff
+        );
+
+        for owner in diff {
+            let mut cmd = std::process::Command::new("cargo");
+            cmd.args(&["owner", "--add", owner, &crt.name()]);
+
+            debug!("[{}] running command: {:?}", crt.name(), cmd);
+            if !dry_run {
+                let output = cmd.output().context("process exitted unsuccessfully")?;
+                if !output.status.success() {
+                    warn!(
+                        "[{}] failed to add owner '{}': {}",
+                        crt.name(),
+                        owner,
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
### Summary

The previous PR #1260 had some problems with the existing use of a HashMap of test dbs within `TestEnvs` which got out of sync with the HashMap of Spaces (with its own db references) in `Spaces`. To reconcile that, I removed many uses of `TestEnvs` (which is getting increasingly outdated and should probably be removed eventually) opting to pass around a `TempDir`/`Path` directly.

### TODO:
- [ ] Change Fn to FnMut per [previous PR comment](https://github.com/holochain/holochain/pull/1260#discussion_r817925517)
- [ ] ~~CHANGELOG(s) updated with appropriate info~~
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
