### PR TITLE
circle-ci: introduce catch-all job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,28 +53,28 @@ jobs:
               name: Install Nix
               no_output_timeout: 30m
               command: |
-                # fix for "too many open files" that breaks tokio
-                ulimit -n 10240
-                # workaround a bug in the Nix installer
-                echo " #" >> /Users/distiller/.bash_profile
-                # catalina nixos install
-                sh <(curl -L https://releases.nixos.org/nix/nix-2.3.8/install) --darwin-use-unencrypted-nix-store-volume
+                 # fix for "too many open files" that breaks tokio
+                 ulimit -n 10240
+                 # workaround a bug in the Nix installer
+                 echo " #" >> /Users/distiller/.bash_profile
+                 # catalina nixos install
+                 sh <(curl -L https://releases.nixos.org/nix/nix-2.3.8/install) --darwin-use-unencrypted-nix-store-volume
          - run:
               name: Set up Nix cache
               command: |
-                $(nix-build . --fallback --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
+                 $(nix-build . --fallback --no-link -A pkgs.ci.ciSetupNixConf)/bin/hc-ci-setup-nix-conf.sh
          - run:
               name: PR release tests
               no_output_timeout: 30m
               command: |
-                ./scripts/ci_merge-release-test.sh
+                 ./scripts/ci_merge-release-test.sh
 
    hc-static-checks:
       docker:
          - image: holochain/holochain:circle.build.develop
            auth:
-            username: $DOCKER_USER
-            password: $DOCKER_PASS
+              username: $DOCKER_USER
+              password: $DOCKER_PASS
       resource_class: xlarge
       environment:
          CACHIX_NAME: holochain-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,14 @@ jobs:
          - build-docker:
               box: circle.build
 
+   all-jobs-succeed:
+      docker:
+         - image: bash
+      steps:
+         - run:
+              name: echo
+              command: echo
+
 workflows:
    version: 2.1
    tests:
@@ -208,6 +216,13 @@ workflows:
          - slow-test
          - wasm-test
          # - merge-test-mac
+         - all-jobs-succeed:
+              requires:
+                 - standard-test
+                 - hc-static-checks
+                 - slow-test
+                 - wasm-test
+                 - merge-release-test
 
    docker-builds:
       triggers:


### PR DESCRIPTION
### Summary
this job can be configured as the only required status-check which allows subsequent management of the required status checks in code.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
