### PR TITLE
ci: refine catch-all to make the required github job appear successful

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,7 +196,7 @@ jobs:
          - build-docker:
               box: circle.build
 
-   all-jobs-succeed:
+   ci-jobs-succeed:
       docker:
          - image: bash
       steps:
@@ -215,7 +215,7 @@ workflows:
          - slow-test
          - wasm-test
          # - merge-test-mac
-         - all-jobs-succeed:
+         - ci-jobs-succeed:
               requires:
                  - standard-test
                  - hc-static-checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -536,7 +536,14 @@ jobs:
           ## limits ssh access and adds the ssh public keys of the listed GitHub users
           limit-access-to-users: steveeJ,jost-s,freesig,neonphog,thedavidmeister,maackle
 
+  github-actions-ci-jobs-succeed:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: "ubuntu-latest"
+    needs: [vars, prepare]
+    steps: [{ name: "ci-jobs-succeed", run: ":" }]
+
   all-jobs-succeed:
+    if: ${{ github.event_name != 'pull_request' }}
     runs-on: "ubuntu-latest"
     needs: [vars, prepare, test, finalize]
     steps: [{ name: "all-jobs-succeed", run: ":" }]


### PR DESCRIPTION
### Summary



### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
