### PR TITLE
Docs/fix item links

### DIFF
--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fixed broken links in Rust docs [#1284](https://github.com/holochain/holochain/pull/1284)
+
 ## 0.0.30
 
 ## 0.0.29

--- a/crates/hc/src/lib.rs
+++ b/crates/hc/src/lib.rs
@@ -66,7 +66,7 @@
 //!  hc r -n 5 ./elemental-chat.dna gen -a "my-app" network quic
 //! ```
 //! #### Call
-//! Allows calling the [`AdminRequest`] api.
+//! Allows calling the [`AdminRequest`](https://docs.rs/holochain_conductor_api/latest/holochain_conductor_api/enum.AdminRequest.html) api.
 //! If the conductors are not already running they
 //! will be run to make the call.
 //!

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Fixed broken links in Rust docs [#1284](https://github.com/holochain/holochain/pull/1284)
+
 ## 0.0.26
 
 ## 0.0.25

--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -76,7 +76,7 @@ pub enum AdminRequestCli {
     DisableApp(DisableApp),
     DumpState(DumpState),
     /// Calls AdminRequest::AddAgentInfo.
-    /// [Unimplemented].
+    /// _Unimplemented_.
     AddAgents,
     ListAgents(ListAgents),
 }

--- a/crates/hc_sandbox/src/sandbox.rs
+++ b/crates/hc_sandbox/src/sandbox.rs
@@ -9,7 +9,7 @@ use crate::cmds::*;
 use crate::run::run_async;
 use crate::CmdRunner;
 
-/// Generates a new sandbox with a default [`ConductorConfig`]
+/// Generates a new sandbox with a default [`ConductorConfig`](holochain_conductor_api::config::conductor::ConductorConfig)
 /// and optional network.
 /// Then installs the dnas with a new app per dna.
 pub async fn default_with_network(

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fixed broken links in Rust docs [#1284](https://github.com/holochain/holochain/pull/1284)
+
 ## 0.0.129
 
 ## 0.0.128

--- a/crates/holochain/src/conductor/api.rs
+++ b/crates/holochain/src/conductor/api.rs
@@ -1,13 +1,13 @@
 #![deny(missing_docs)]
 
 //! Defines the three Conductor APIs by which other code can communicate
-//! with a [Conductor]:
+//! with a [`Conductor`](super::Conductor):
 //!
-//! - [CellConductorApi], for Cells to communicate with their Conductor
-//! - [AppInterfaceApi], for external UIs to e.g. call zome functions on a Conductor
-//! - [AdminInterfaceApi], for external processes to e.g. modify ConductorState
+//! - [`CellConductorApi`], for Cells to communicate with their Conductor
+//! - [`AppInterfaceApi`], for external UIs to e.g. call zome functions on a Conductor
+//! - [`AdminInterfaceApi`], for external processes to e.g. modify ConductorState
 //!
-//! Each type of API uses a [ConductorHandle] as its exclusive means of conductor access
+//! Each type of API uses a [`ConductorHandle`](super::ConductorHandle) as its exclusive means of conductor access
 
 mod api_cell;
 mod api_external;

--- a/crates/holochain/src/conductor/api/api_cell.rs
+++ b/crates/holochain/src/conductor/api/api_cell.rs
@@ -134,16 +134,16 @@ pub trait CellConductorApiT: Clone + Send + Sync + Sized {
     /// attached app interface
     async fn signal_broadcaster(&self) -> SignalBroadcaster;
 
-    /// Get a [Dna] from the [DnaStore]
+    /// Get a [`Dna`](holochain_types::prelude::Dna) from the [`DnaStore`](crate::conductor::dna_store::DnaStore)
     fn get_dna(&self, dna_hash: &DnaHash) -> Option<DnaFile>;
 
-    /// Get the [Dna] of this cell from the [DnaStore]
+    /// Get the [`Dna`](holochain_types::prelude::Dna) of this cell from the [`DnaStore`](crate::conductor::dna_store::DnaStore)
     fn get_this_dna(&self) -> ConductorApiResult<DnaFile>;
 
-    /// Get a [Zome] from this cell's Dna
+    /// Get a [`Zome`](holochain_types::prelude::Zome) from this cell's Dna
     fn get_zome(&self, dna_hash: &DnaHash, zome_name: &ZomeName) -> ConductorApiResult<Zome>;
 
-    /// Get a [EntryDef] from the [EntryDefBuf]
+    /// Get a [`EntryDef`](holochain_zome_types::EntryDef) from the [`EntryDefBufferKey`](holochain_types::dna::EntryDefBufferKey)
     fn get_entry_def(&self, key: &EntryDefBufferKey) -> Option<EntryDef>;
 
     /// Turn this into a call zome handle

--- a/crates/holochain/src/conductor/api/api_cell.rs
+++ b/crates/holochain/src/conductor/api/api_cell.rs
@@ -17,9 +17,8 @@ use holochain_types::prelude::*;
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::mpsc::OwnedPermit;
 use tracing::*;
-
-/// The concrete implementation of [CellConductorApiT], which is used to give
-/// Cells an API for calling back to their [Conductor].
+/// The concrete implementation of [`CellConductorApiT`], which is used to give
+/// Cells an API for calling back to their [`Conductor`](crate::conductor::Conductor).
 #[derive(Clone)]
 pub struct CellConductorApi {
     conductor_handle: ConductorHandle,

--- a/crates/holochain/src/conductor/api/error.rs
+++ b/crates/holochain/src/conductor/api/error.rs
@@ -1,5 +1,4 @@
-//! Errors occurring during a [CellConductorApi] or [InterfaceApi] call
-
+//! Errors occurring during a [`CellConductorApi`](super::CellConductorApi) or [`InterfaceApi`](super::InterfaceApi) call
 use crate::conductor::error::ConductorError;
 use crate::conductor::interface::error::InterfaceError;
 use crate::conductor::CellError;
@@ -14,7 +13,7 @@ use holochain_zome_types::cell::CellId;
 use mr_bundle::error::MrBundleError;
 use thiserror::Error;
 
-/// Errors occurring during a [CellConductorApi] or [InterfaceApi] call
+/// Errors occurring during a [`CellConductorApi`](super::CellConductorApi) or [`InterfaceApi`](super::InterfaceApi) call
 #[derive(Error, Debug)]
 pub enum ConductorApiError {
     /// The Dna for this Cell is not installed in the conductor.

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -90,9 +90,9 @@ impl PartialEq for Cell {
 /// A Cell is guaranteed to contain a Source Chain which has undergone
 /// Genesis.
 ///
-/// The [Conductor] manages a collection of Cells, and will call functions
+/// The [`Conductor`](super::Conductor) manages a collection of Cells, and will call functions
 /// on the Cell when a Conductor API method is called (either a
-/// [CellConductorApi] or an [AppInterfaceApi])
+/// [`CellConductorApi`](super::api::CellConductorApi) or an [`AppInterfaceApi`](super::api::AppInterfaceApi))
 pub struct Cell<Api = CellConductorApi, P2pCell = holochain_p2p::HolochainP2pDna>
 where
     Api: CellConductorApiT,

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -2,15 +2,14 @@
 //! A Conductor is a dynamically changing group of [Cell]s.
 //!
 //! A Conductor can be managed:
-//! - externally, via a [AppInterfaceApi]
-//! - from within a [Cell], via [CellConductorApi]
+//! - externally, via an [`AppInterfaceApi`](super::api::AppInterfaceApi)
+//! - from within a [`Cell`](super::Cell), via [`CellConductorApi`](super::api::CellConductorApi)
 //!
 //! In normal use cases, a single Holochain user runs a single Conductor in a single process.
 //! However, there's no reason we can't have multiple Conductors in a single process, simulating multiple
 //! users in a testing environment.
 
 pub use self::share::RwShare;
-
 use super::api::RealAppInterfaceApi;
 use super::config::AdminInterfaceConfig;
 use super::config::InterfaceDriver;

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -1,7 +1,7 @@
-//! Defines [ConductorHandle], a lightweight cloneable reference to a Conductor
+//! Defines [`ConductorHandle`], a lightweight cloneable reference to a Conductor
 //! with a limited public interface.
 //!
-//! A ConductorHandle can be produced via [Conductor::into_handle]
+//! A ConductorHandle can be produced via [`ConductorBuilder`](crate::conductor::ConductorBuilder)
 //!
 //! ```rust, no_run
 //! async fn async_main () {
@@ -26,7 +26,7 @@
 //!
 //! First, it specifies how to synchronize
 //! read/write access to a single Conductor across multiple references. The various
-//! Conductor APIs - [CellConductorApi], [AdminInterfaceApi], and [AppInterfaceApi],
+//! Conductor APIs - [CellConductorApi](super::api::CellConductorApi), [AdminInterfaceApi](super::api::AdminInterfaceApi), and [AppInterfaceApi](super::api::AppInterfaceApi),
 //! use a ConductorHandle as their sole method of interaction with a Conductor.
 //!
 //! Secondly, it hides the concrete type of the Conductor behind a dyn Trait.
@@ -133,25 +133,25 @@ pub trait ConductorHandleT: Send + Sync {
     /// List the app interfaces currently install.
     async fn list_app_interfaces(&self) -> ConductorResult<Vec<u16>>;
 
-    /// Install a [DnaFile] in this Conductor
+    /// Install a [`DnaFile`](holochain_types::dna::DnaFile) in this Conductor
     async fn register_dna(&self, dna: DnaFile) -> ConductorResult<()>;
 
     /// Get the list of hashes of installed Dnas in this Conductor
     fn list_dnas(&self) -> Vec<DnaHash>;
 
-    /// Get a [DnaDef] from the [DnaStore]
+    /// Get a [`DnaDef`](holochain_types::prelude::DnaDef) from the [`DnaStore`](crate::conductor::dna_store::DnaStore)
     fn get_dna_def(&self, hash: &DnaHash) -> Option<DnaDef>;
 
-    /// Get a [DnaFile] from the [DnaStore]
+    /// Get a [`DnaFile`](holochain_types::dna::DnaFile) from the [`DnaStore`](crate::conductor::dna_store::DnaStore)
     fn get_dna_file(&self, hash: &DnaHash) -> Option<DnaFile>;
 
-    /// Get an instance of a [RealRibosome] for the DnaHash
+    /// Get an instance of a [`RealRibosome`](crate::core::ribosome::real_ribosome::RealRibosome) for the DnaHash
     fn get_ribosome(&self, dna_hash: &DnaHash) -> ConductorResult<RealRibosome>;
 
-    /// Get a [EntryDef] from the [EntryDefBuffer]
+    /// Get an [`EntryDef`](holochain_zome_types::EntryDef) from the [`EntryDefBufferKey`](holochain_types::dna::EntryDefBufferKey)
     fn get_entry_def(&self, key: &EntryDefBufferKey) -> Option<EntryDef>;
 
-    /// Add the [DnaFile]s from the wasm and dna_def databases into memory
+    /// Add the [`DnaFile`](holochain_types::dna::DnaFile)s from the wasm and dna_def databases into memory
     async fn load_dnas(&self) -> ConductorResult<()>;
 
     /// Dispatch a network event to the correct cell.

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -1,7 +1,6 @@
 //! This module contains data and functions for running operations
 //! at the level of a [`DnaHash`] space.
-//! Multiple [`Cell`]'s could share the same space.
-
+//! Multiple [`Cell`](crate::conductor::Cell)'s could share the same space.
 use std::{collections::HashMap, sync::Arc};
 
 use holo_hash::{DhtOpHash, DnaHash};

--- a/crates/holochain/src/core/ribosome.rs
+++ b/crates/holochain/src/core/ribosome.rs
@@ -1,6 +1,6 @@
 //! A Ribosome is a structure which knows how to execute hApp code.
 //!
-//! We have only one instance of this: [RealRibosome]. The abstract trait exists
+//! We have only one instance of this: [crate::core::ribosome::real_ribosome::RealRibosome]. The abstract trait exists
 //! so that we can write mocks against the `RibosomeT` interface, as well as
 //! opening the possiblity that we might support applications written in other
 //! languages and environments.
@@ -441,7 +441,7 @@ impl From<&ZomeCallHostAccess> for HostFnAccess {
 }
 
 /// Interface for a Ribosome. Currently used only for mocking, as our only
-/// real concrete type is [RealRibosome]
+/// real concrete type is [`RealRibosome`](crate::core::ribosome::real_ribosome::RealRibosome)
 #[automock]
 pub trait RibosomeT: Sized + std::fmt::Debug {
     fn dna_def(&self) -> &DnaDefHashed;
@@ -538,9 +538,8 @@ pub trait RibosomeT: Sized + std::fmt::Debug {
         invocation: PostCommitInvocation,
     ) -> RibosomeResult<()>;
 
-    /// Helper function for running a validation callback. Just calls
-    /// [`run_callback`][] under the hood.
-    /// [`run_callback`]: #method.run_callback
+    /// Helper function for running a validation callback. Calls
+    /// [`do_callback!`] under the hood.
     fn run_validate(
         &self,
         access: ValidateHostAccess,

--- a/crates/holochain/src/core/ribosome/error.rs
+++ b/crates/holochain/src/core/ribosome/error.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs)]
-//! Errors occurring during a [Ribosome] call
+//! Errors occurring during a [`RealRibosome`](crate::core::ribosome::real_ribosome::RealRibosome) call
 
 use crate::conductor::api::error::ConductorApiError;
 use crate::conductor::interface::error::InterfaceError;
@@ -13,7 +13,7 @@ use holochain_zome_types::inline_zome::error::InlineZomeError;
 use thiserror::Error;
 use tokio::task::JoinError;
 
-/// Errors occurring during a [Ribosome] call
+/// Errors occurring during a [`RealRibosome`](crate::core::ribosome::real_ribosome::RealRibosome) call
 #[derive(Error, Debug)]
 pub enum RibosomeError {
     /// Dna error while working with Ribosome.

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validation_query.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validation_query.rs
@@ -12,14 +12,14 @@ use crate::core::workflow::error::WorkflowResult;
 
 /// Get all ops that need to sys or app validated in order.
 /// - Sys validated or awaiting app dependencies.
-/// - Ordered by type then timestamp (See [`DhtOpOrder`])
+/// - Ordered by type then timestamp (See [`DhtOpOrder`](crate::core::validation::DhtOpOrder))
 pub async fn get_ops_to_app_validate(db: &DbRead<DbKindDht>) -> WorkflowResult<Vec<DhtOpHashed>> {
     get_ops_to_validate(db, false).await
 }
 
 /// Get all ops that need to sys or app validated in order.
 /// - Pending or awaiting sys dependencies.
-/// - Ordered by type then timestamp (See [`DhtOpOrder`])
+/// - Ordered by type then timestamp (See [`DhtOpOrder`](crate::core::validation::DhtOpOrder))
 pub async fn get_ops_to_sys_validate(db: &DbRead<DbKindDht>) -> WorkflowResult<Vec<DhtOpHashed>> {
     get_ops_to_validate(db, true).await
 }

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -586,7 +586,7 @@ impl ExternalApiWireError {
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, SerializedBytes, Clone)]
-/// Filter for `ListApps`.
+/// Filter for [`ListApps`].
 pub enum AppStatusFilter {
     Enabled,
     Disabled,

--- a/crates/holochain_util/src/ffs/mod.rs
+++ b/crates/holochain_util/src/ffs/mod.rs
@@ -38,7 +38,7 @@ macro_rules! impl_ffs {
         )*
 
         /// Wrap dunce::canonicalize, since std::fs::canonicalize has problems for Windows
-        /// (see https://docs.rs/dunce/1.0.1/dunce/index.html)
+        /// (see <https://docs.rs/dunce/1.0.1/dunce/index.html>)
         pub async fn canonicalize<P: Clone + AsRef<std::path::Path>>(path: P) -> IoResult<PathBuf> {
             dunce::canonicalize(path.clone()).map_err(mapper(path))
         }


### PR DESCRIPTION
### Summary

- Fixed broken item links in Rust docs for crates:
  - holochain
  - hc
  - hc_sandbox


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
