### PR TITLE
Unidirection arcs pt. 3: Rename AgentInfoEncodeMeta field to affect breaking change

### DIFF
--- a/crates/holochain/src/test_utils/network_simulation.rs
+++ b/crates/holochain/src/test_utils/network_simulation.rs
@@ -432,7 +432,7 @@ async fn reset_peer_data(peers: Vec<AgentInfoSigned>, dna_hash: &DnaHash) -> Vec
         let info = AgentInfoSigned::sign(
             space_hash.clone(),
             peer.agent.clone(),
-            ((u32::MAX / 2) as f64 * coverage) as u32,
+            (u32::MAX as f64 * coverage) as u64,
             vec![url2::url2!(
                 "kitsune-proxy://CIW6PxKxs{}MSmB7kLD8xyyj4mqcw/kitsune-quic/h/localhost/p/5778/-",
                 rand_string

--- a/crates/holochain_sqlite/src/db/p2p_agent_store/p2p_test.rs
+++ b/crates/holochain_sqlite/src/db/p2p_agent_store/p2p_test.rs
@@ -48,17 +48,17 @@ async fn rand_insert(
         signed_at_ms + rng.gen_range(100, 200)
     };
 
-    let half_len = match rng.gen_range(0_u8, 9_u8) {
+    let len = match rng.gen_range(0_u8, 9_u8) {
         0 => 0,
         1 => u32::MAX,
         2 => rng.gen_range(0, u32::MAX / 2),
         _ => rng.gen_range(0, u32::MAX / 1000),
-    };
+    } as u64;
 
     let signed = AgentInfoSigned::sign(
         space.clone(),
         agent.clone(),
-        half_len,
+        len,
         vec!["fake:".into()],
         signed_at_ms,
         expires_at_ms,
@@ -177,7 +177,7 @@ async fn test_p2p_agent_store_gossip_query_sanity() {
         .p2p_gossip_query_agents(
             u64::MIN,
             u64::MAX,
-            DhtArc::from_bounds(0, u32::MAX / 4).into(),
+            DhtArc::from_bounds(0, u32::MAX as u64 / 4).into(),
         )
         .unwrap();
     // NOTE - not sure this is right with <= num_nonzero... but it breaks

--- a/crates/kitsune_p2p/bootstrap/benches/bench.rs
+++ b/crates/kitsune_p2p/bootstrap/benches/bench.rs
@@ -59,7 +59,7 @@ fn bootstrap(bench: &mut Criterion) {
                 let info = AgentInfoSigned::sign(
                     space.clone(),
                     Arc::new(fixt!(KitsuneAgent, Unpredictable)),
-                    u32::MAX / 4,
+                    u32::MAX as u64 / 4,
                     fixt!(UrlList, Empty),
                     0,
                     std::time::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64 + 60_000_000,

--- a/crates/kitsune_p2p/bootstrap/src/clear.rs
+++ b/crates/kitsune_p2p/bootstrap/src/clear.rs
@@ -37,7 +37,7 @@ mod tests {
             let info = AgentInfoSigned::sign(
                 space.clone(),
                 Arc::new(fixt!(KitsuneAgent, Unpredictable)),
-                u32::MAX / 4,
+                u32::MAX as u64 / 4,
                 fixt!(UrlList, Empty),
                 0,
                 std::time::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64 + 60_000_000,

--- a/crates/kitsune_p2p/bootstrap/src/put.rs
+++ b/crates/kitsune_p2p/bootstrap/src/put.rs
@@ -55,7 +55,7 @@ mod tests {
         let info = AgentInfoSigned::sign(
             Arc::new(fixt!(KitsuneSpace, Unpredictable)),
             Arc::new(fixt!(KitsuneAgent, Unpredictable)),
-            u32::MAX / 4,
+            u32::MAX as u64 / 4,
             fixt!(UrlList, Empty),
             0,
             std::time::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64 + 60_000_000,

--- a/crates/kitsune_p2p/bootstrap/src/random.rs
+++ b/crates/kitsune_p2p/bootstrap/src/random.rs
@@ -63,7 +63,7 @@ mod tests {
             let info = AgentInfoSigned::sign(
                 space.clone(),
                 Arc::new(fixt!(KitsuneAgent, Unpredictable)),
-                u32::MAX / 4,
+                u32::MAX as u64 / 4,
                 vec!["fake:".into()],
                 0,
                 std::time::UNIX_EPOCH.elapsed().unwrap().as_millis() as u64 + 60_000_000,

--- a/crates/kitsune_p2p/kitsune_p2p/src/fixt.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/fixt.rs
@@ -73,7 +73,7 @@ fixturator!(
             AgentInfoSigned::sign(
                 Arc::new(fixt!(KitsuneSpace, Empty)),
                 Arc::new(fixt!(KitsuneAgent, Empty)),
-                u32::MAX / 4,
+                u32::MAX as u64 / 4,
                 fixt!(UrlList, Empty),
                 0,
                 0,
@@ -88,7 +88,7 @@ fixturator!(
             AgentInfoSigned::sign(
                 Arc::new(fixt!(KitsuneSpace, Unpredictable)),
                 Arc::new(fixt!(KitsuneAgent, Unpredictable)),
-                u32::MAX / 4,
+                u32::MAX as u64 / 4,
                 fixt!(UrlList, Empty),
                 0,
                 0,
@@ -103,7 +103,7 @@ fixturator!(
             AgentInfoSigned::sign(
                 Arc::new(fixt!(KitsuneSpace, Predictable)),
                 Arc::new(fixt!(KitsuneAgent, Predictable)),
-                u32::MAX / 4,
+                u32::MAX as u64 / 4,
                 fixt!(UrlList, Empty),
                 0,
                 0,

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -123,7 +123,7 @@ pub async fn agent_info(agent: Arc<KitsuneAgent>) -> AgentInfoSigned {
     AgentInfoSigned::sign(
         Arc::new(fixt!(KitsuneSpace)),
         agent,
-        u32::MAX / 2,
+        u32::MAX as u64 / 2,
         vec![url2::url2!(
             "kitsune-proxy://CIW6PxKxs{}cKwUpaMSmB7kLD8xyyj4mqcw/kitsune-quic/h/localhost/p/5778/-",
             rand_string

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/bootstrap.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/bootstrap.rs
@@ -211,7 +211,7 @@ mod tests {
         let agent_info_signed = AgentInfoSigned::sign(
             Arc::new(space),
             Arc::new(agent),
-            u32::MAX,
+            u32::MAX as u64,
             urls,
             signed_at_ms,
             expires_at_ms,
@@ -303,7 +303,7 @@ mod tests {
             let agent_info_signed = AgentInfoSigned::sign(
                 Arc::new(space.clone()),
                 Arc::new(kitsune_agent.clone()),
-                u32::MAX,
+                u32::MAX as u64,
                 fixt!(UrlList),
                 signed_at_ms,
                 expires_at_ms,

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -501,7 +501,7 @@ async fn update_single_agent_info(
     let agent_info_signed = AgentInfoSigned::sign(
         space.clone(),
         agent.clone(),
-        arc.half_length(),
+        arc.length(),
         urls.clone(),
         signed_at_ms,
         expires_at_ms,

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
@@ -14,7 +14,7 @@ fn make_agent(c: u8) -> AgentInfoSigned {
     futures::executor::block_on(AgentInfoSigned::sign(
         space,
         agent,
-        u32::MAX,
+        u32::MAX as u64,
         vec![format!("fake://{}", c).into()],
         42,
         69,

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_state.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_state.rs
@@ -689,7 +689,7 @@ fn fake_agent_info(
     use crate::fixt::*;
     let url_list = vec![node.local_addr().unwrap()];
     let meta_info = AgentMetaInfoEncode {
-        dht_storage_arc_half_length: 0,
+        dht_storage_arc_full_length: 0,
     };
     let mut buf = Vec::new();
     kitsune_p2p_types::codec::rmp_encode(&mut buf, meta_info).unwrap();

--- a/crates/kitsune_p2p/types/src/agent_info.rs
+++ b/crates/kitsune_p2p/types/src/agent_info.rs
@@ -19,7 +19,7 @@ pub mod agent_info_helper {
     #[allow(missing_docs)]
     #[derive(Debug, serde::Serialize, serde::Deserialize)]
     pub struct AgentMetaInfoEncode {
-        pub dht_storage_arc_half_length: u32,
+        pub dht_storage_arc_full_length: u64,
     }
 
     #[allow(missing_docs)]
@@ -164,8 +164,7 @@ impl<'de> serde::Deserialize<'de> for AgentInfoSigned {
         }
 
         let start_loc = agent.get_loc();
-        let storage_arc =
-            DhtArc::from_start_and_half_len(start_loc, meta.dht_storage_arc_half_length);
+        let storage_arc = DhtArc::from_start_and_len(start_loc, meta.dht_storage_arc_full_length);
 
         let AgentInfoEncode {
             space,
@@ -196,7 +195,7 @@ impl AgentInfoSigned {
     pub async fn sign<'a, R, F>(
         space: Arc<KitsuneSpace>,
         agent: Arc<KitsuneAgent>,
-        dht_storage_arc_half_length: u32,
+        dht_storage_arc_full_length: u64,
         url_list: UrlList,
         signed_at_ms: u64,
         expires_at_ms: u64,
@@ -207,7 +206,7 @@ impl AgentInfoSigned {
         F: FnOnce(&[u8]) -> R,
     {
         let meta = AgentMetaInfoEncode {
-            dht_storage_arc_half_length,
+            dht_storage_arc_full_length,
         };
         let mut buf = Vec::new();
         crate::codec::rmp_encode(&mut buf, meta).map_err(KitsuneError::other)?;
@@ -231,7 +230,7 @@ impl AgentInfoSigned {
         let inner = AgentInfoInner {
             space,
             agent,
-            storage_arc: DhtArc::from_start_and_half_len(start_loc, dht_storage_arc_half_length),
+            storage_arc: DhtArc::from_start_and_len(start_loc, dht_storage_arc_full_length),
             url_list,
             signed_at_ms,
             expires_at_ms,


### PR DESCRIPTION
### Summary

The work so far causes no breaking change, but will lead to some weird unexpected behavior for nodes before and after the update to unidirectional arcs, since each version will interpret the arcs differently (old nodes use the agent loc as centerpoint, new nodes use it as the left edge).

This just renames a field to affect a breaking change, and is also a step in a more sensible direction since it is more natural to talk about full lengths rather than half lengths now.

(Even though half lengths are still convenient since we can use a u32 instead of a u64, and we don't care about such fine resolution, especially with quantized arcs on the way)

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
