### PR TITLE
join initializes arc size to last set value if known

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -3,11 +3,11 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- When joining the network set arc size to previous value if available instead of full to avoid network load [1287](https://github.com/holochain/holochain/pull/1287)
 
 ## 0.0.130
 
 - Workflow errors generally now log rather than abort the current app [1279](https://github.com/holochain/holochain/pull/1279/files)
-- When joining the network set arc size to previous value if available instead of full to avoid network load [1287](https://github.com/holochain/holochain/pull/1287)
 
 ## 0.0.129
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Workflow errors generally now log rather than abort the current app [1279](https://github.com/holochain/holochain/pull/1279/files)
+- When joining the network set arc size to previous value if available instead of full to avoid network load [1287](https://github.com/holochain/holochain/pull/1287)
 
 ## 0.0.129
 

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -934,6 +934,11 @@ impl Cell {
         }
     }
 
+    /// Accessor for the p2p_agents_db backing this Cell
+    pub(crate) fn p2p_agents_db(&self) -> &DbWrite<DbKindP2pAgents> {
+        &self.space.p2p_agents_db
+    }
+
     /// Accessor for the authored database backing this Cell
     pub(crate) fn authored_db(&self) -> &DbWrite<DbKindAuthored> {
         &self.space.authored_db

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1269,7 +1269,6 @@ impl Conductor {
         })
     }
 
-    #[allow(dead_code)]
     pub(crate) async fn prune_p2p_agents_db(&self) -> ConductorResult<()> {
         use holochain_p2p::AgentPubKeyExt;
 

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -215,7 +215,7 @@ mod tests {
         // Join some agents onto the network
         // Skip the first agent as it has already joined
         for agent in agents.into_iter().skip(1) {
-            HolochainP2pRef::join(&network, dna.clone(), agent)
+            HolochainP2pRef::join(&network, dna.clone(), agent, None)
                 .await
                 .unwrap();
         }
@@ -585,7 +585,7 @@ mod tests {
                 {
                     let network = test_network.network();
                     for agent in agents {
-                        HolochainP2pRef::join(&network, dna.clone(), agent)
+                        HolochainP2pRef::join(&network, dna.clone(), agent, None)
                             .await
                             .unwrap()
                     }

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -254,7 +254,7 @@ where
     let mut key_fixt = AgentPubKeyFixturator::new(Predictable);
     let agent_key = agent_key.unwrap_or_else(|| key_fixt.next().unwrap());
     let dna_network = network.to_dna(dna.clone());
-    network.join(dna.clone(), agent_key).await.unwrap();
+    network.join(dna.clone(), agent_key, None).await.unwrap();
     TestNetwork::new(network, respond_task, dna_network)
 }
 

--- a/crates/holochain_cascade/src/test_utils.rs
+++ b/crates/holochain_cascade/src/test_utils.rs
@@ -8,6 +8,7 @@ use holo_hash::EntryHash;
 use holo_hash::HasHash;
 use holo_hash::HeaderHash;
 use holochain_p2p::actor;
+use holochain_p2p::dht_arc::DhtArc;
 use holochain_p2p::HolochainP2pDnaT;
 use holochain_p2p::HolochainP2pError;
 use holochain_p2p::MockHolochainP2pDnaT;
@@ -221,7 +222,11 @@ impl HolochainP2pDnaT for PassThroughNetwork {
         todo!()
     }
 
-    async fn join(&self, _agent: AgentPubKey) -> actor::HolochainP2pResult<()> {
+    async fn join(
+        &self,
+        _agent: AgentPubKey,
+        _initial_arc: Option<DhtArc>,
+    ) -> actor::HolochainP2pResult<()> {
         todo!()
     }
 
@@ -395,7 +400,11 @@ impl HolochainP2pDnaT for MockNetwork {
         todo!()
     }
 
-    async fn join(&self, _agent: AgentPubKey) -> actor::HolochainP2pResult<()> {
+    async fn join(
+        &self,
+        _agent: AgentPubKey,
+        _initial_arc: Option<DhtArc>,
+    ) -> actor::HolochainP2pResult<()> {
         todo!()
     }
 

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -36,4 +36,5 @@ holochain_util = { version = "0.0.8", path = "../holochain_util" }
 [features]
 mock_network = [
   "kitsune_p2p/mock_network",
+  "kitsune_p2p/test_utils",
 ]

--- a/crates/holochain_p2p/src/lib.rs
+++ b/crates/holochain_p2p/src/lib.rs
@@ -30,7 +30,11 @@ pub trait HolochainP2pDnaT {
     fn dna_hash(&self) -> DnaHash;
 
     /// The p2p module must be informed at runtime which dna/agent pairs it should be tracking.
-    async fn join(&self, agent: AgentPubKey) -> actor::HolochainP2pResult<()>;
+    async fn join(
+        &self,
+        agent: AgentPubKey,
+        initial_arc: Option<crate::dht_arc::DhtArc>,
+    ) -> actor::HolochainP2pResult<()>;
 
     /// If a cell is disabled, we'll need to \"leave\" the network module as well.
     async fn leave(&self, agent: AgentPubKey) -> actor::HolochainP2pResult<()>;
@@ -148,8 +152,14 @@ impl HolochainP2pDnaT for HolochainP2pDna {
     }
 
     /// The p2p module must be informed at runtime which dna/agent pairs it should be tracking.
-    async fn join(&self, agent: AgentPubKey) -> actor::HolochainP2pResult<()> {
-        self.sender.join((*self.dna_hash).clone(), agent).await
+    async fn join(
+        &self,
+        agent: AgentPubKey,
+        initial_arc: Option<crate::dht_arc::DhtArc>,
+    ) -> actor::HolochainP2pResult<()> {
+        self.sender
+            .join((*self.dna_hash).clone(), agent, initial_arc)
+            .await
     }
 
     /// If a cell is disabled, we'll need to \"leave\" the network module as well.

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -872,14 +872,17 @@ impl HolochainP2pHandler for HolochainP2pActor {
         &mut self,
         dna_hash: DnaHash,
         agent_pub_key: AgentPubKey,
+        initial_arc: Option<crate::dht_arc::DhtArc>,
     ) -> HolochainP2pHandlerResult<()> {
         let space = dna_hash.into_kitsune();
         let agent = agent_pub_key.into_kitsune();
 
         let kitsune_p2p = self.kitsune_p2p.clone();
-        Ok(async move { Ok(kitsune_p2p.join(space, agent).await?) }
-            .boxed()
-            .into())
+        Ok(
+            async move { Ok(kitsune_p2p.join(space, agent, initial_arc).await?) }
+                .boxed()
+                .into(),
+        )
     }
 
     #[tracing::instrument(skip(self), level = "trace")]

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -249,8 +249,8 @@ mod tests {
             }
         });
 
-        p2p.join(dna.clone(), a1.clone()).await.unwrap();
-        p2p.join(dna.clone(), a2.clone()).await.unwrap();
+        p2p.join(dna.clone(), a1.clone(), None).await.unwrap();
+        p2p.join(dna.clone(), a2.clone(), None).await.unwrap();
 
         let res = p2p
             .call_remote(
@@ -316,8 +316,8 @@ mod tests {
             }
         });
 
-        p2p.join(dna.clone(), a1.clone()).await.unwrap();
-        p2p.join(dna.clone(), a2.clone()).await.unwrap();
+        p2p.join(dna.clone(), a1.clone(), None).await.unwrap();
+        p2p.join(dna.clone(), a2.clone(), None).await.unwrap();
 
         p2p.send_validation_receipt(dna, a1, UnsafeBytes::from(b"receipt-test".to_vec()).into())
             .await
@@ -374,9 +374,9 @@ mod tests {
             }
         });
 
-        p2p.join(dna.clone(), a1.clone()).await.unwrap();
-        p2p.join(dna.clone(), a2.clone()).await.unwrap();
-        p2p.join(dna.clone(), a3.clone()).await.unwrap();
+        p2p.join(dna.clone(), a1.clone(), None).await.unwrap();
+        p2p.join(dna.clone(), a2.clone(), None).await.unwrap();
+        p2p.join(dna.clone(), a3.clone(), None).await.unwrap();
 
         let header_hash = holo_hash::AnyDhtHash::from_raw_36_and_type(
             b"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".to_vec(),
@@ -468,9 +468,9 @@ mod tests {
         });
 
         tracing::info!("test - join1");
-        p2p.join(dna.clone(), a1.clone()).await.unwrap();
+        p2p.join(dna.clone(), a1.clone(), None).await.unwrap();
         tracing::info!("test - join2");
-        p2p.join(dna.clone(), a2.clone()).await.unwrap();
+        p2p.join(dna.clone(), a2.clone(), None).await.unwrap();
 
         let hash = holo_hash::AnyDhtHash::from_raw_36_and_type(
             b"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".to_vec(),
@@ -559,8 +559,8 @@ mod tests {
             }
         });
 
-        p2p.join(dna.clone(), a1.clone()).await.unwrap();
-        p2p.join(dna.clone(), a2.clone()).await.unwrap();
+        p2p.join(dna.clone(), a1.clone(), None).await.unwrap();
+        p2p.join(dna.clone(), a2.clone(), None).await.unwrap();
 
         let hash = holo_hash::EntryHash::from_raw_36_and_type(
             b"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".to_vec(),

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -17,6 +17,7 @@ impl HolochainP2pHandler for StubNetwork {
         &mut self,
         dna_hash: DnaHash,
         agent_pub_key: AgentPubKey,
+        initial_arc: Option<crate::dht_arc::DhtArc>,
     ) -> HolochainP2pHandlerResult<()> {
         Err("stub".into())
     }

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -190,7 +190,7 @@ ghost_actor::ghost_chan! {
     /// actor instance.
     pub chan HolochainP2p<HolochainP2pError> {
         /// The p2p module must be informed at runtime which dna/agent pairs it should be tracking.
-        fn join(dna_hash: DnaHash, agent_pub_key: AgentPubKey) -> ();
+        fn join(dna_hash: DnaHash, agent_pub_key: AgentPubKey, initial_arc: Option<crate::dht_arc::DhtArc>) -> ();
 
         /// If a cell is disabled, we'll need to \"leave\" the network module as well.
         fn leave(dna_hash: DnaHash, agent_pub_key: AgentPubKey) -> ();

--- a/crates/holochain_sqlite/src/db/p2p_agent_store/p2p_test.rs
+++ b/crates/holochain_sqlite/src/db/p2p_agent_store/p2p_test.rs
@@ -238,7 +238,7 @@ async fn test_p2p_agent_store_gossip_query_sanity() {
     }
 
     // prune everything by expires time
-    p2p_prune(&db).await.unwrap();
+    p2p_prune(&db, vec![]).await.unwrap();
 
     // after prune, make sure all are pruned
     let all = con.p2p_list_agents().unwrap();

--- a/crates/holochain_sqlite/src/sql/p2p_agent_store/prune.sql
+++ b/crates/holochain_sqlite/src/sql/p2p_agent_store/prune.sql
@@ -1,5 +1,5 @@
 -- it's hard to construct queries with input arrays
--- we're taking the strategy here of concatonating a bunch of
+-- we're taking the strategy here of concatenating a bunch of
 -- local agent ids together, and extracting them here
 WITH RECURSIVE split(src, cur_idx, slice) AS (
   -- we have to manually configure the first seed row

--- a/crates/holochain_sqlite/src/sql/p2p_agent_store/prune.sql
+++ b/crates/holochain_sqlite/src/sql/p2p_agent_store/prune.sql
@@ -1,5 +1,30 @@
--- delete all expired entries from the p2p_agent_store
+-- it's hard to construct queries with input arrays
+-- we're taking the strategy here of concatonating a bunch of
+-- local agent ids together, and extracting them here
+WITH RECURSIVE split(src, cur_idx, slice) AS (
+  -- we have to manually configure the first seed row
+  SELECT
+    :agent_list,
+    37,
+    substr(:agent_list, 1, 36)
+  UNION
+  ALL
+  SELECT
+    src,
+    cur_idx + 36,
+    substr(src, cur_idx, 36)
+  FROM
+    split
+  WHERE
+    cur_idx < length(src)
+) -- delete all expired entries from the p2p_agent_store
 DELETE FROM
   p2p_agent_store
 WHERE
-  expires_at_ms <= :now;
+  expires_at_ms <= :now
+  AND agent NOT IN (
+    SELECT
+      slice AS agent
+    FROM
+      split
+  );

--- a/crates/kitsune_p2p/direct/src/v1.rs
+++ b/crates/kitsune_p2p/direct/src/v1.rs
@@ -395,7 +395,7 @@ async fn handle_srv_events(
                             } => {
                                 exec(msg_id.clone(), async {
                                     kdirect.inner.share_mut(|i, _| {
-                                        Ok(i.p2p.join(root.to_kitsune_space(), agent.to_kitsune_agent()))
+                                        Ok(i.p2p.join(root.to_kitsune_space(), agent.to_kitsune_agent(), None))
                                     }).map_err(KdError::other)?.await.map_err(KdError::other)?;
                                     Ok(KdApi::AppJoinRes {
                                         msg_id,

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -701,6 +701,7 @@ impl KitsuneP2pHandler for KitsuneP2pActor {
         &mut self,
         space: Arc<KitsuneSpace>,
         agent: Arc<KitsuneAgent>,
+        initial_arc: Option<crate::dht_arc::DhtArc>,
     ) -> KitsuneP2pHandlerResult<()> {
         let internal_sender = self.internal_sender.clone();
         let space2 = space.clone();
@@ -732,7 +733,7 @@ impl KitsuneP2pHandler for KitsuneP2pActor {
         let space_sender = space_sender.get();
         Ok(async move {
             let (space_sender, _) = space_sender.await;
-            space_sender.join(space, agent).await
+            space_sender.join(space, agent, initial_arc).await
         }
         .boxed()
         .into())

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -594,7 +594,11 @@ impl KitsuneP2pHandler for Space {
         &mut self,
         space: Arc<KitsuneSpace>,
         agent: Arc<KitsuneAgent>,
+        initial_arc: Option<DhtArc>,
     ) -> KitsuneP2pHandlerResult<()> {
+        if let Some(initial_arc) = initial_arc {
+            self.agent_arcs.insert(agent.clone(), initial_arc);
+        }
         self.local_joined_agents.insert(agent.clone());
         for module in self.gossip_mod.values() {
             module.local_agent_join(agent.clone());
@@ -1356,6 +1360,9 @@ impl Space {
         } else {
             // TODO: We are simply setting the initial arc to full.
             // In the future we may want to do something more intelligent.
+            //
+            // In the case an initial_arc is passend into the join request,
+            // handle_join will initialize this agent_arcs map to that value.
             self.agent_arcs
                 .get(agent)
                 .cloned()

--- a/crates/kitsune_p2p/kitsune_p2p/src/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test.rs
@@ -107,7 +107,7 @@ mod tests {
         // TODO when networking works, just add_*_agent again...
         // but for now, we need the two agents to be on the same node:
         let a2: Arc<KitsuneAgent> = TestVal::test_val();
-        p2p.join(space.clone(), a2.clone()).await?;
+        p2p.join(space.clone(), a2.clone(), None).await?;
 
         let res = p2p.rpc_single(space, a1, b"hello".to_vec(), None).await?;
         assert_eq!(b"echo: hello".to_vec(), res);
@@ -127,9 +127,9 @@ mod tests {
         // TODO when networking works, just add_*_agent again...
         // but for now, we need the two agents to be on the same node:
         let a2: Arc<KitsuneAgent> = TestVal::test_val();
-        p2p.join(space.clone(), a2.clone()).await?;
+        p2p.join(space.clone(), a2.clone(), None).await?;
         let a3: Arc<KitsuneAgent> = TestVal::test_val();
-        p2p.join(space.clone(), a3.clone()).await?;
+        p2p.join(space.clone(), a3.clone(), None).await?;
 
         let mut input = actor::RpcMulti::new(
             &Default::default(),
@@ -194,7 +194,7 @@ mod tests {
         // TODO when networking works, just add_*_agent again...
         // but for now, we need the two agents to be on the same node:
         let a2: Arc<KitsuneAgent> = TestVal::test_val();
-        p2p.join(space.clone(), a2.clone()).await?;
+        p2p.join(space.clone(), a2.clone(), None).await?;
 
         let op1 = harness
             .inject_gossip_data(a1.clone(), "agent-1-data".to_string())
@@ -238,7 +238,7 @@ mod tests {
         assert_eq!(num_agent_info, 1);
 
         let a2: Arc<KitsuneAgent> = TestVal::test_val();
-        p2p.join(space.clone(), a2.clone()).await?;
+        p2p.join(space.clone(), a2.clone(), None).await?;
 
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_actor.rs
@@ -189,7 +189,7 @@ impl HarnessInnerHandler for HarnessActor {
         let space_list = self.space_list.clone();
         Ok(async move {
             for space in space_list {
-                p2p.join(space.clone(), agent.clone()).await?;
+                p2p.join(space.clone(), agent.clone(), None).await?;
 
                 harness_chan.publish(HarnessEventType::Join {
                     agent: (&agent).into(),
@@ -211,7 +211,7 @@ impl HarnessControlApiHandler for HarnessActor {
         self.space_list.push(space.clone());
         let mut all = Vec::new();
         for (agent, (p2p, _)) in self.agents.iter() {
-            all.push(p2p.join(space.clone(), agent.clone()));
+            all.push(p2p.join(space.clone(), agent.clone(), None));
         }
         Ok(async move {
             futures::future::try_join_all(all).await?;

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/actor.rs
@@ -76,6 +76,7 @@ type KAgents = Vec<Arc<super::KitsuneAgent>>;
 type KBasis = Arc<super::KitsuneBasis>;
 type Payload = Vec<u8>;
 type OptU64 = Option<u64>;
+type OptArc = Option<crate::dht_arc::DhtArc>;
 
 ghost_actor::ghost_chan! {
     /// The KitsuneP2pSender allows async remote-control of the KitsuneP2p actor.
@@ -84,7 +85,7 @@ ghost_actor::ghost_chan! {
         fn list_transport_bindings() -> Vec<Url2>;
 
         /// Announce a space/agent pair on this network.
-        fn join(space: KSpace, agent: KAgent) -> ();
+        fn join(space: KSpace, agent: KAgent, initial_arc: OptArc) -> ();
 
         /// Withdraw this space/agent pair from this network.
         fn leave(space: KSpace, agent: KAgent) -> ();


### PR DESCRIPTION
### Summary

- actually run p2p_agents_db prune once per minute
- set up prune to not delete local agents (so we can look at their last arc size on reboot)
- configure kitsune join to take an initial arc size
- configure holochain to pass in an initial arc size from the p2p_agents_db if there is one

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
