### PR TITLE
release: don't use squash merge when updating develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -544,7 +544,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN}}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}
-          merge-method: squash
+          merge-method: merge
       - name: Auto approve Pull Request
         if: ${{ needs.vars.outputs.dry_run == 'false' }}
         uses: juliangruber/approve-pull-request-action@v1


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
