### PR TITLE
Puts spaces in query to fix crash

### DIFF
--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -228,7 +228,7 @@ impl Spaces {
         let intervals = dht_arc_set.intervals();
         let sql = if let Some(ArcInterval::Full) = intervals.first() {
             format!(
-                "{}{}{}",
+                "{} {} {}",
                 holochain_sqlite::sql::sql_cell::FETCH_OP_HASHES_P1,
                 include_limbo,
                 holochain_sqlite::sql::sql_cell::FETCH_OP_HASHES_P2,
@@ -255,7 +255,7 @@ impl Spaces {
                 })
                 .collect::<String>();
             format!(
-                "{}{}{}{}",
+                "{} {} {} {}",
                 holochain_sqlite::sql::sql_cell::FETCH_OP_HASHES_P1,
                 include_limbo,
                 sql_ranges,


### PR DESCRIPTION
Simple fix to a query that was crashing when sharding.
