### PR TITLE
Remove get_cached_remotes_near_basis from add_remote_fetch

### DIFF
--- a/crates/kitsune_p2p/types/src/tx2/tx2_pool_promote.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_pool_promote.rs
@@ -210,7 +210,7 @@ async fn in_chan_recv_logic(
         }
     }
 
-    tracing::warn!(?local_cert, ?peer_cert, "channel logic end");
+    tracing::info!(?local_cert, ?peer_cert, "channel logic end");
 
     Ok(())
 }


### PR DESCRIPTION
- Remove get_cached_remotes_near_basis from add_remote_fetch as it's not needed.
- Downgrade channel logic end to info from warning.