### PR TITLE
Limit concurrent gets

### DIFF
--- a/crates/holochain/src/core/ribosome/host_fn/get.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get.rs
@@ -1,47 +1,71 @@
 use crate::core::ribosome::CallContext;
+use crate::core::ribosome::HostFnAccess;
+use crate::core::ribosome::RibosomeError;
 use crate::core::ribosome::RibosomeT;
+use futures::StreamExt;
 use holochain_cascade::Cascade;
 use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::WasmError;
 use std::sync::Arc;
-use crate::core::ribosome::HostFnAccess;
-use futures::future::join_all;
-use crate::core::ribosome::RibosomeError;
 
 #[allow(clippy::extra_unused_lifetimes)]
+#[tracing::instrument(skip(_ribosome, call_context), fields(?call_context.zome, function = ?call_context.function_name))]
 pub fn get<'a>(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,
     inputs: Vec<GetInput>,
 ) -> Result<Vec<Option<Element>>, WasmError> {
+    let num_requests = inputs.len();
+    tracing::debug!("Starting with {} requests.", num_requests);
     match HostFnAccess::from(&call_context.host_context()) {
-        HostFnAccess{ read_workspace: Permission::Allow, .. } => {
-            let results: Vec<Result<Option<Element>, _>> = tokio_helper::block_forever_on(async move {
-                join_all(inputs.into_iter().map(|input| {
-                    async {
+        HostFnAccess {
+            read_workspace: Permission::Allow,
+            ..
+        } => {
+            let results: Vec<Result<Option<Element>, _>> =
+                tokio_helper::block_forever_on(async move {
+                    futures::stream::iter(inputs.into_iter().map(|input| async {
                         let GetInput {
                             any_dht_hash,
                             get_options,
                         } = input;
                         Cascade::from_workspace_network(
                             &call_context.host_context.workspace(),
-                            call_context.host_context.network().clone()
+                            call_context.host_context.network().clone(),
                         )
-                        .dht_get(any_dht_hash, get_options).await
-                    }
-                })).await
-            });
-            let results: Result<Vec<_>, _> = results.into_iter().map(|result| match result {
-                Ok(v) => Ok(v),
-                Err(cascade_error) => Err(WasmError::Host(cascade_error.to_string())),
-            }).collect();
-            Ok(results?)
-        },
-        _ => Err(WasmError::Host(RibosomeError::HostFnPermissions(
-            call_context.zome.zome_name().clone(),
-            call_context.function_name().clone(),
-            "get".into()
-        ).to_string()))
+                        .dht_get(any_dht_hash, get_options)
+                        .await
+                    }))
+                    // Limit concurrent calls to 10 as each call
+                    // can spawn multiple connections.
+                    .buffered(10)
+                    .collect()
+                    .await
+                });
+            let results: Result<Vec<_>, _> = results
+                .into_iter()
+                .map(|result| match result {
+                    Ok(v) => Ok(v),
+                    Err(cascade_error) => Err(WasmError::Host(cascade_error.to_string())),
+                })
+                .collect();
+            let results = results?;
+            tracing::debug!(
+                "Ending with {} out of {} results and {} total responses.",
+                results.iter().filter(|r| r.is_some()).count(),
+                num_requests,
+                results.len(),
+            );
+            Ok(results)
+        }
+        _ => Err(WasmError::Host(
+            RibosomeError::HostFnPermissions(
+                call_context.zome.zome_name().clone(),
+                call_context.function_name().clone(),
+                "get".into(),
+            )
+            .to_string(),
+        )),
     }
 }
 


### PR DESCRIPTION
Limit concurrent get and get_links calls to prevent spawning too many background tasks.
Each call may spawn up to the max remote agents which leads to cpu starvation if these concurrent futures are unbounded.
I also added some debugging to help with tracking the behavior of gets / get_links. 
I found this very helpful in recent work but it may be too much and I'm happy to remove if others think so. 