### PR TITLE
github-actions: explicitly set exit code in catch-all job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -568,13 +568,21 @@ jobs:
           limit-access-to-users: steveeJ,jost-s,freesig,neonphog,thedavidmeister,maackle
 
   github-actions-ci-jobs-succeed:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ always() && github.event_name == 'pull_request' }}
     runs-on: "ubuntu-latest"
     needs: [vars, prepare]
-    steps: [{ name: "ci-jobs-succeed", run: ":" }]
+    steps:
+      - name: Check status
+        env:
+          RESULTS: "${{ toJSON(needs.*.result) }}"
+        run: "[[ $(jq -n 'env.RESULTS | fromjson | unique == [\"success\"]') == \"true\" ]]\n"
 
   all-jobs-succeed:
-    if: ${{ github.event_name != 'pull_request' }}
+    if: ${{ always() && github.event_name != 'pull_request' }}
     runs-on: "ubuntu-latest"
     needs: [vars, prepare, test, finalize]
-    steps: [{ name: "all-jobs-succeed", run: ":" }]
+    steps:
+      - name: Check status
+        env:
+          RESULTS: "${{ toJSON(needs.*.result) }}"
+        run: "[[ $(jq -n 'env.RESULTS | fromjson | unique == [\"success\"]') == \"true\" ]]\n"


### PR DESCRIPTION
this is an unfortuante workaround that seems necessary by a bug on
github actions. the bug shows itself under the following conditions

1. github branch protection is set up to require a status check for a job that 'needs' other jobs
2. auto-merge is enabled a PR
3. the workflow run gets cancelled
4. BUG: the PR gets merged despite the required status check being
   'cancelled'

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
