### PR TITLE
Feature flag timestamp deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,12 +2881,10 @@ version = "0.0.7"
 dependencies = [
  "arbitrary",
  "chrono",
- "derive_more",
  "holochain_serialized_bytes",
  "rusqlite",
  "serde",
  "serde_yaml",
- "thiserror",
 ]
 
 [[package]]

--- a/crates/kitsune_p2p/timestamp/CHANGELOG.md
+++ b/crates/kitsune_p2p/timestamp/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- **BREAKING**: All chrono logic is behind the `chrono` feature flag which is on by default. If you are using this crate with `no-default-features` you will no longer have access to any chrono related functionality.
 ## 0.0.7
 
 ## 0.0.6

--- a/crates/kitsune_p2p/timestamp/Cargo.toml
+++ b/crates/kitsune_p2p/timestamp/Cargo.toml
@@ -13,26 +13,23 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+serde = { version = "1.0", features = ["derive"] }
 
-chrono = { version = "0.4.6", features = ["serde"] }
-derive_more = "0.99"
-serde = { version = "1.0", features = [ "derive" ] }
-thiserror = "1"
+# Dependencies not needed for integrity.
+chrono = { version = "0.4.6", features = ["serde"], optional = true }
 
-# arbitrary
-arbitrary = { version = "1.0", features = ["derive"], optional = true }
-
-# rusqlite
+# Dependencies only needed for full.
 rusqlite = { version = "0.26", optional = true }
+
+# Dependencies only needed for testing by downstream crates.
+arbitrary = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 holochain_serialized_bytes = "=0.0.51"
 serde_yaml = "0.8"
 
 [features]
-now = []
+default = ["chrono"]
+now = ["chrono"]
 
-full = [
-  "now",
-  "rusqlite",
-]
+full = ["now", "rusqlite"]

--- a/crates/kitsune_p2p/timestamp/src/chrono_ext.rs
+++ b/crates/kitsune_p2p/timestamp/src/chrono_ext.rs
@@ -1,0 +1,138 @@
+use super::*;
+use std::{convert::TryFrom, fmt, ops::Sub, str::FromStr};
+
+pub(crate) type DateTime = chrono::DateTime<chrono::Utc>;
+
+/// Display as RFC3339 Date+Time for sane value ranges (0000-9999AD).  Beyond that, format
+/// as (seconds, nanoseconds) tuple (output and parsing of large +/- years is unreliable).
+impl fmt::Display for Timestamp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ce = -(62167219200 * MM)..=(253402214400 * MM);
+        if ce.contains(&self.0) {
+            if let Ok(ts) = chrono::DateTime::<chrono::Utc>::try_from(self) {
+                return write!(
+                    f,
+                    "{}",
+                    ts.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)
+                );
+            }
+        }
+        // Outside 0000-01-01 to 9999-12-31; Display raw value tuple, or not a valid DateTime<Utc>;
+        // Display raw value tuple
+        write!(f, "({}μs)", self.0)
+    }
+}
+
+impl fmt::Debug for Timestamp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Timestamp({})", self)
+    }
+}
+
+impl TryFrom<String> for Timestamp {
+    type Error = TimestampError;
+
+    fn try_from(t: String) -> Result<Self, Self::Error> {
+        Timestamp::from_str(t.as_ref())
+    }
+}
+
+impl TryFrom<&String> for Timestamp {
+    type Error = TimestampError;
+
+    fn try_from(t: &String) -> Result<Self, Self::Error> {
+        Timestamp::from_str(t.as_ref())
+    }
+}
+
+impl TryFrom<&str> for Timestamp {
+    type Error = TimestampError;
+
+    fn try_from(t: &str) -> Result<Self, Self::Error> {
+        Timestamp::from_str(t)
+    }
+}
+
+impl From<DateTime> for Timestamp {
+    fn from(t: DateTime) -> Self {
+        std::convert::From::from(&t)
+    }
+}
+
+impl From<&DateTime> for Timestamp {
+    fn from(t: &DateTime) -> Self {
+        let t = t.naive_utc();
+        Timestamp(t.timestamp() * MM + t.timestamp_subsec_nanos() as i64 / 1000)
+    }
+}
+
+// Implementation note: There are *no* infallible conversions from a Timestamp to a DateTime.  These
+// may panic in from_timestamp due to out-of-range secs or nsecs, making all code using/displaying a
+// Timestamp this way dangerously fragile!  Use try_from, and handle any failures.
+
+impl TryFrom<Timestamp> for DateTime {
+    type Error = TimestampError;
+
+    fn try_from(t: Timestamp) -> Result<Self, Self::Error> {
+        std::convert::TryFrom::try_from(&t)
+    }
+}
+
+impl TryFrom<&Timestamp> for DateTime {
+    type Error = TimestampError;
+
+    fn try_from(t: &Timestamp) -> Result<Self, Self::Error> {
+        let (secs, nsecs) = t.as_seconds_and_nanos();
+        let t = chrono::naive::NaiveDateTime::from_timestamp_opt(secs, nsecs)
+            .ok_or(TimestampError::Overflow)?;
+        Ok(chrono::DateTime::from_utc(t, chrono::Utc))
+    }
+}
+
+impl FromStr for Timestamp {
+    type Err = TimestampError;
+
+    fn from_str(t: &str) -> Result<Self, Self::Err> {
+        let t = chrono::DateTime::parse_from_rfc3339(t)?;
+        let t = chrono::DateTime::from_utc(t.naive_utc(), chrono::Utc);
+        Ok(t.into())
+    }
+}
+
+impl Timestamp {
+    /// Returns the current system time as a Timestamp.
+    ///
+    /// This is behind a feature because we need Timestamp to be WASM compatible, and
+    /// chrono doesn't have a now() implementation for WASM.
+    #[cfg(feature = "now")]
+    pub fn now() -> Timestamp {
+        Timestamp::from(chrono::offset::Utc::now())
+    }
+    /// Compute signed difference between two Timestamp, returning `None` if overflow occurred, or
+    /// Some(chrono::Duration).  Produces Duration for differences of up to +/- i64::MIN/MAX
+    /// microseconds.
+    pub fn checked_difference_signed(&self, rhs: &Timestamp) -> Option<chrono::Duration> {
+        Some(chrono::Duration::microseconds(self.0.checked_sub(rhs.0)?))
+    }
+
+    /// Add a signed chrono::Duration{ secs: i64, nanos: i32 } to a Timestamp.
+    pub fn checked_add_signed(&self, rhs: &chrono::Duration) -> Option<Timestamp> {
+        Some(Self(self.0.checked_add(rhs.num_microseconds()?)?))
+    }
+
+    /// Subtracts a chrono::Duration from a Timestamp
+    pub fn checked_sub_signed(&self, rhs: &chrono::Duration) -> Option<Timestamp> {
+        self.checked_add_signed(&-*rhs)
+    }
+}
+/// Distance between two Timestamps as a chrono::Duration (subject to overflow).  A Timestamp
+/// represents a *signed* distance from the UNIX Epoch (1970-01-01T00:00:00Z).  A chrono::Duration
+/// is limited to +/- i64::MIN/MAX microseconds.
+impl Sub<Timestamp> for Timestamp {
+    type Output = TimestampResult<chrono::Duration>;
+
+    fn sub(self, rhs: Timestamp) -> Self::Output {
+        self.checked_difference_signed(&rhs)
+            .ok_or(TimestampError::Overflow)
+    }
+}

--- a/crates/kitsune_p2p/timestamp/src/error.rs
+++ b/crates/kitsune_p2p/timestamp/src/error.rs
@@ -1,11 +1,41 @@
+#[cfg(feature = "chrono")]
 use chrono::ParseError;
 
-#[derive(thiserror::Error, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TimestampError {
-    #[error("Overflow in adding/subtracting a Duration")]
     Overflow,
-    #[error(transparent)]
-    ParseError(#[from] ParseError),
+    #[cfg(feature = "chrono")]
+    ParseError(ParseError),
 }
 
 pub type TimestampResult<T> = Result<T, TimestampError>;
+
+impl std::error::Error for TimestampError {
+    #[cfg(feature = "chrono")]
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            TimestampError::Overflow => None,
+            TimestampError::ParseError(e) => e.source(),
+        }
+    }
+}
+
+#[cfg(feature = "chrono")]
+impl From<ParseError> for TimestampError {
+    fn from(e: ParseError) -> Self {
+        Self::ParseError(e)
+    }
+}
+
+impl core::fmt::Display for TimestampError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TimestampError::Overflow => write!(
+                f,
+                "Overflow in adding, subtracting or creating from a Duration"
+            ),
+            #[cfg(feature = "chrono")]
+            TimestampError::ParseError(s) => s.fmt(f),
+        }
+    }
+}

--- a/crates/kitsune_p2p/timestamp/src/human.rs
+++ b/crates/kitsune_p2p/timestamp/src/human.rs
@@ -8,7 +8,9 @@ use std::convert::TryFrom;
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum HumanTimestamp {
+    /// A microsecond resolution [`Timestamp`].
     Micros(Timestamp),
+    /// A RFC3339 [`DateTime`].
     RFC3339(DateTime),
 }
 

--- a/crates/kitsune_p2p/timestamp/src/lib.rs
+++ b/crates/kitsune_p2p/timestamp/src/lib.rs
@@ -1,21 +1,25 @@
 //! A microsecond-precision UTC timestamp for use in Holochain's headers.
+#![deny(missing_docs)]
 
 #[allow(missing_docs)]
 mod error;
+#[cfg(feature = "chrono")]
 mod human;
 
+#[cfg(feature = "chrono")]
 pub use human::*;
 
-use std::{
-    convert::TryFrom,
-    fmt,
-    ops::{Add, Sub},
-    str::FromStr,
-};
-
+use core::ops::{Add, Sub};
 use serde::{Deserialize, Serialize};
+use std::convert::{TryFrom, TryInto};
 
 pub use crate::error::{TimestampError, TimestampResult};
+
+#[cfg(feature = "chrono")]
+pub(crate) use chrono_ext::*;
+
+#[cfg(feature = "chrono")]
+mod chrono_ext;
 
 /// One million
 pub const MM: i64 = 1_000_000;
@@ -40,107 +44,11 @@ pub const MM: i64 = 1_000_000;
 /// supported by WASM; however, holochain_types provides a Timestamp::now() method.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(not(feature = "chrono"), derive(Debug))]
 pub struct Timestamp(
-    i64, // microseconds from UNIX Epoch, positive or negative
+    /// Microseconds from UNIX Epoch, positive or negative
+    pub i64,
 );
-
-pub(crate) type DateTime = chrono::DateTime<chrono::Utc>;
-
-/// Display as RFC3339 Date+Time for sane value ranges (0000-9999AD).  Beyond that, format
-/// as (seconds, nanoseconds) tuple (output and parsing of large +/- years is unreliable).
-impl fmt::Display for Timestamp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let ce = -(62167219200 * MM)..=(253402214400 * MM);
-        if ce.contains(&self.0) {
-            if let Ok(ts) = chrono::DateTime::<chrono::Utc>::try_from(self) {
-                return write!(
-                    f,
-                    "{}",
-                    ts.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)
-                );
-            }
-        }
-        // Outside 0000-01-01 to 9999-12-31; Display raw value tuple, or not a valid DateTime<Utc>;
-        // Display raw value tuple
-        write!(f, "({}μs)", self.0)
-    }
-}
-
-impl fmt::Debug for Timestamp {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Timestamp({})", self)
-    }
-}
-
-impl From<DateTime> for Timestamp {
-    fn from(t: DateTime) -> Self {
-        std::convert::From::from(&t)
-    }
-}
-
-impl From<&DateTime> for Timestamp {
-    fn from(t: &DateTime) -> Self {
-        let t = t.naive_utc();
-        Timestamp(t.timestamp() * MM + t.timestamp_subsec_nanos() as i64 / 1000)
-    }
-}
-
-// Implementation note: There are *no* infallible conversions from a Timestamp to a DateTime.  These
-// may panic in from_timestamp due to out-of-range secs or nsecs, making all code using/displaying a
-// Timestamp this way dangerously fragile!  Use try_from, and handle any failures.
-
-impl TryFrom<Timestamp> for DateTime {
-    type Error = TimestampError;
-
-    fn try_from(t: Timestamp) -> Result<Self, Self::Error> {
-        std::convert::TryFrom::try_from(&t)
-    }
-}
-
-impl TryFrom<&Timestamp> for DateTime {
-    type Error = TimestampError;
-
-    fn try_from(t: &Timestamp) -> Result<Self, Self::Error> {
-        let (secs, nsecs) = t.as_seconds_and_nanos();
-        let t = chrono::naive::NaiveDateTime::from_timestamp_opt(secs, nsecs)
-            .ok_or(TimestampError::Overflow)?;
-        Ok(chrono::DateTime::from_utc(t, chrono::Utc))
-    }
-}
-
-impl FromStr for Timestamp {
-    type Err = TimestampError;
-
-    fn from_str(t: &str) -> Result<Self, Self::Err> {
-        let t = chrono::DateTime::parse_from_rfc3339(t)?;
-        let t = chrono::DateTime::from_utc(t.naive_utc(), chrono::Utc);
-        Ok(t.into())
-    }
-}
-
-impl TryFrom<String> for Timestamp {
-    type Error = TimestampError;
-
-    fn try_from(t: String) -> Result<Self, Self::Error> {
-        Timestamp::from_str(t.as_ref())
-    }
-}
-
-impl TryFrom<&String> for Timestamp {
-    type Error = TimestampError;
-
-    fn try_from(t: &String) -> Result<Self, Self::Error> {
-        Timestamp::from_str(t.as_ref())
-    }
-}
-
-impl TryFrom<&str> for Timestamp {
-    type Error = TimestampError;
-
-    fn try_from(t: &str) -> Result<Self, Self::Error> {
-        Timestamp::from_str(t)
-    }
-}
 
 /// Timestamp +/- Into<core::time::Duration>: Anything that can be converted into a
 /// core::time::Duration can be used as an overflow-checked offset (unsigned) for a Timestamp.  A
@@ -190,15 +98,6 @@ impl Timestamp {
     /// Jan 1, 2022, 12:00:00 AM UTC
     pub const HOLOCHAIN_EPOCH: Timestamp = Timestamp(1640995200000000);
 
-    /// Returns the current system time as a Timestamp.
-    ///
-    /// This is behind a feature because we need Timestamp to be WASM compatible, and
-    /// chrono doesn't have a now() implementation for WASM.
-    #[cfg(feature = "now")]
-    pub fn now() -> Timestamp {
-        Timestamp::from(chrono::offset::Utc::now())
-    }
-
     /// Largest possible Timestamp.
     pub fn max() -> Timestamp {
         Timestamp(i64::MAX)
@@ -224,23 +123,6 @@ impl Timestamp {
         let secs = self.0 / MM;
         let nsecs = (self.0 % 1_000_000) * 1000;
         (secs, nsecs as u32)
-    }
-
-    /// Compute signed difference between two Timestamp, returning `None` if overflow occurred, or
-    /// Some(chrono::Duration).  Produces Duration for differences of up to +/- i64::MIN/MAX
-    /// microseconds.
-    pub fn checked_difference_signed(&self, rhs: &Timestamp) -> Option<chrono::Duration> {
-        Some(chrono::Duration::microseconds(self.0.checked_sub(rhs.0)?))
-    }
-
-    /// Add a signed chrono::Duration{ secs: i64, nanos: i32 } to a Timestamp.
-    pub fn checked_add_signed(&self, rhs: &chrono::Duration) -> Option<Timestamp> {
-        Some(Self(self.0.checked_add(rhs.num_microseconds()?)?))
-    }
-
-    /// Subtracts a chrono::Duration from a Timestamp
-    pub fn checked_sub_signed(&self, rhs: &chrono::Duration) -> Option<Timestamp> {
-        self.checked_add_signed(&-*rhs)
     }
 
     /// Add unsigned core::time::Duration{ secs: u64, nanos: u32 } to a Timestamp.  See:
@@ -274,6 +156,11 @@ impl Timestamp {
         self.checked_sub(rhs).unwrap_or(Self::MIN)
     }
 
+    /// Create a [`Timestamp`] from a [`core::time::Duration`] saturating at i64::MAX.
+    pub fn saturating_from_dur(duration: &core::time::Duration) -> Self {
+        Timestamp(std::cmp::min(duration.as_micros(), i64::MAX as u128) as i64)
+    }
+
     /// Convert this timestamp to fit into a SQLite integer which is an i64.
     /// The value will be clamped to the valid range supported by SQLite
     pub fn into_sql_lossy(self) -> Self {
@@ -281,15 +168,16 @@ impl Timestamp {
     }
 }
 
-/// Distance between two Timestamps as a chrono::Duration (subject to overflow).  A Timestamp
-/// represents a *signed* distance from the UNIX Epoch (1970-01-01T00:00:00Z).  A chrono::Duration
-/// is limited to +/- i64::MIN/MAX microseconds.
-impl Sub<Timestamp> for Timestamp {
-    type Output = TimestampResult<chrono::Duration>;
+impl TryFrom<core::time::Duration> for Timestamp {
+    type Error = error::TimestampError;
 
-    fn sub(self, rhs: Timestamp) -> Self::Output {
-        self.checked_difference_signed(&rhs)
-            .ok_or(TimestampError::Overflow)
+    fn try_from(value: core::time::Duration) -> Result<Self, Self::Error> {
+        Ok(Timestamp(
+            value
+                .as_micros()
+                .try_into()
+                .map_err(|_| error::TimestampError::Overflow)?,
+        ))
     }
 }
 

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hdk"
-version = "0.0.124"
+version = "0.0.125"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "holochain_zome_types",
  "paste",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.0.24"
+version = "0.0.25"
 dependencies = [
  "hdk",
  "serde",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "chrono",
  "fixt",
@@ -481,9 +481,7 @@ name = "kitsune_p2p_timestamp"
 version = "0.0.7"
 dependencies = [
  "chrono",
- "derive_more",
  "serde",
- "thiserror",
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary
This is part of the work to stabilize the integrity zomes dependencies. Removing dependencies that we don't really need means there is less opportunity for bugs or security problems to pop up and force us into a corner.
[chrono already has security issues](https://github.com/chronotope/chrono/pull/578) and is not actively maintained. 
- move `chrono` related features behind a default feature flag for kitsune_p2p_timestamp.
- Remove `derive_more` dependency.
- Remove `thiserror` dependency and manually implement `std::error::Error`.

**Keep in mind** that integrity types will be using this crate as `no-default-features` so anything under any feature flag will **not** be available to integrity zomes. If you see anything that you think really is needed for writing validation please flag it. We do have to balance convenience for stability though.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
