### PR TITLE
Quantized gossip pt. 1: New `kitsune_p2p_dht` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,6 +1113,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,7 +1267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
 dependencies = [
  "byteorder",
- "quick-error",
+ "quick-error 1.2.3",
 ]
 
 [[package]]
@@ -2767,6 +2789,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitsune_p2p_dht"
+version = "0.0.1"
+dependencies = [
+ "colored",
+ "derivative",
+ "derive_more",
+ "futures",
+ "gcollections",
+ "intervallum",
+ "kitsune_p2p_dht",
+ "kitsune_p2p_dht_arc",
+ "kitsune_p2p_timestamp",
+ "maplit",
+ "must_future",
+ "num-traits",
+ "observability",
+ "once_cell",
+ "pretty_assertions 0.7.2",
+ "proptest",
+ "rand 0.8.5",
+ "serde",
+ "statrs",
+ "test-case",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "kitsune_p2p_dht_arc"
 version = "0.0.10"
 dependencies = [
@@ -3069,7 +3119,7 @@ dependencies = [
  "if-addrs 0.6.7",
  "log",
  "multimap",
- "quick-error",
+ "quick-error 1.2.3",
  "rand 0.8.5",
  "socket2 0.3.19",
  "tokio",
@@ -3426,7 +3476,7 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "quick-error",
+ "quick-error 1.2.3",
  "rand 0.8.5",
  "safemem",
  "tempfile",
@@ -4308,6 +4358,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift 0.3.0",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4342,6 +4412,12 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4464,7 +4540,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg 0.1.2",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi",
 ]
 
@@ -4644,6 +4720,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -5016,6 +5101,18 @@ name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
   "crates/holochain_util",
   "crates/holochain_zome_types",
 
+  "crates/kitsune_p2p/dht",
   "crates/kitsune_p2p/dht_arc",
   "crates/kitsune_p2p/bootstrap",
   "crates/kitsune_p2p/direct",

--- a/crates/holochain/tests/dht_arc/mod.rs
+++ b/crates/holochain/tests/dht_arc/mod.rs
@@ -38,8 +38,8 @@ async fn test_arc_redundancy() {
             for i in 0..peers.len() {
                 let p = peers.clone();
                 let arc = peers.get_mut(i).unwrap();
-                let view = PeerStratAlpha::default().view(*arc, p.as_slice());
-                arc.update_length(view);
+                let view = PeerStratAlpha::default().view(*arc, p.as_slice()).into();
+                arc.update_length(&view);
             }
 
             assert!(!check_for_gaps(peers.clone()));
@@ -86,8 +86,8 @@ async fn test_arc_redundancy_all() {
             for i in 0..peers.len() {
                 let p = peers.clone();
                 let arc = peers.get_mut(i).unwrap();
-                let view = PeerStratAlpha::default().view(*arc, p.as_slice());
-                arc.update_length(view);
+                let view = PeerStratAlpha::default().view(*arc, p.as_slice()).into();
+                arc.update_length(&view);
             }
 
             let r = check_redundancy(peers.clone());
@@ -151,8 +151,10 @@ async fn test_join_leave() {
         for i in 0..peers.len() {
             let p = peers.clone();
             let arc = peers.get_mut(i).unwrap();
-            let view = PeerStratAlpha::default().view(arc.clone(), p.as_slice());
-            arc.update_length(view);
+            let view = PeerStratAlpha::default()
+                .view(arc.clone(), p.as_slice())
+                .into();
+            arc.update_length(&view);
         }
     };
     let mut peers = get_peers(num_peers, &coverages, keystore.clone()).await;

--- a/crates/kitsune_p2p/dht/.gitignore
+++ b/crates/kitsune_p2p/dht/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/crates/kitsune_p2p/dht/Cargo.toml
+++ b/crates/kitsune_p2p/dht/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "kitsune_p2p_dht"
+version = "0.0.1"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+colored = { version = "2", optional = true }
+derivative = "2.2.0"
+derive_more = "0.99"
+futures = "0.3"
+gcollections = "1.5"
+kitsune_p2p_dht_arc = { path = "../dht_arc"}
+kitsune_p2p_timestamp = { path = "../timestamp", features = ["now"]}
+intervallum = "1.4"
+# kitsune_p2p_types = { path = "../types"}
+must_future = "0.1"
+num-traits = "0.2.14"
+once_cell = "1.8"
+rand = "0.8.4"
+serde = { version = "1.0", features = [ "derive" ] }
+statrs = "0.15"
+thiserror = "1.0"
+tracing = "0.1.29"
+
+[dev-dependencies]
+kitsune_p2p_dht = { path = ".", features = ["test_utils"]}
+kitsune_p2p_dht_arc = { path = "../dht_arc", features = ["test_utils"]}
+maplit = "1"
+observability = "0.1"
+pretty_assertions = "0.7.2"
+proptest = "1"
+rand = "0.8"
+test-case = "1.2"
+
+[features]
+test_utils = [
+  "colored"
+]
+default = ["test_utils"]

--- a/crates/kitsune_p2p/dht/proptest-regressions/arq.txt
+++ b/crates/kitsune_p2p/dht/proptest-regressions/arq.txt
@@ -1,0 +1,16 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 86f86d813d6b9bfc7b9121bcd1ec79e5186593a147cbbc4a07fb75ac56d7f589 # shrinks to center = 0, pow = 93, count = 240266593
+cc 82adecb24fea474a946f1a5fe059c8150bf0f88bf259c2184c861a3e7a1e164e # shrinks to center = 0, pow = 29, count = 9
+cc 8b613f39f49019b5b85ac888e442fc78a4a3c5b08d4a6ac552f25f43532feb34 # shrinks to center = 0, pow = 0, count = 0
+cc 28d4acd22890773cf8c2251c3998e960f26e2773472b96cf15bb69705b6caaca # shrinks to center = 0, pow = 1, count = 0
+cc 0189bf01f9c65a3d3763c95921689f5a1ac1f57152e94d9ecb866fcbfbf6971b # shrinks to center = 0, pow = 1, count = 1
+cc 4ff091d2c68ae13cbb50704d7e1b7ce09d5dd8eb0a18a9e330060ead9922908e # shrinks to center = 0, pow = 2, count = 1
+cc 2114cf98e01fc238006b6570d03c3cd3929d5883606c763dc4b149aad6a0b75a # shrinks to center = 0, pow = 3, count = 1
+cc 90bdeafe40d63355ed1b0f165443968553acc1a3bdc2090eae8b4cae7035cd8d # shrinks to center = 0, pow = 4, count = 1
+cc 66cdbfa73902d7a834f8548740171d678f3f190c1da2eabaa445adc55783b61f # shrinks to center = 0, pow = 3, count = 3
+cc 7576fd018881c41bb07d294439b3b806f29bfa1544c00952e79a22e859d41462 # shrinks to center = 0, pow = 11, count = 3

--- a/crates/kitsune_p2p/dht/proptest-regressions/coords.txt
+++ b/crates/kitsune_p2p/dht/proptest-regressions/coords.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc f6d5cb1b1ba9986417608c23f37ccc72fc0d9b43f73cb00eefdece231401d3df # shrinks to now = 0

--- a/crates/kitsune_p2p/dht/proptest-regressions/quantum.txt
+++ b/crates/kitsune_p2p/dht/proptest-regressions/quantum.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 07bc33e9a92991ff0c17c3dd45cdaf4e62c03eb75e35328a3f6ecda54f2f8955 # shrinks to now = 5

--- a/crates/kitsune_p2p/dht/proptest-regressions/test_utils.txt
+++ b/crates/kitsune_p2p/dht/proptest-regressions/test_utils.txt
@@ -1,0 +1,13 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc f3a78399f776e21823c32d69968c22bed68a705ed91975088257822e37584b75 # shrinks to min_coverage = 40.0, buffer = 0.1
+cc a16b08b7b7657e6654ce6428892eee99ce8aafd9db3096f6e96d15cb71502bc0 # shrinks to min_coverage = 40.0, buffer = 0.24312421515429483, num_peers = 134
+cc b0a45edf9a8bfbf14d1d4da6fa5947dbe2909fce3ee0222f5315b5f492084709 # shrinks to center = 0.0, len = 0.9903702803455133
+cc 5a470257bf951809b9797ccdec1e7b47547083f678454f99d25e6708d452416a # shrinks to min_coverage = 46.654015826773346, buffer = 0.49587848817064173, num_peers = 117
+cc 2c9fb936731be40577ea0773108bc28c9550b403bada03e55695d20d885a4b6e # shrinks to min_coverage = 76.78284244250997, buffer = 0.21370848915762652, num_peers = 171
+cc c71eb7f1059c4a1c394c1ed165ccb822314cda0ef5d9050cde33307000217fbd # shrinks to min_coverage = 72.73102186324675, buffer = 0.22155720182450622, num_peers = 141
+cc 353592e63f0b6696d9696fbe44d7110c234cbbc8744155a3cdcbd79ef84ab1ac # shrinks to min_coverage = 89.6003555072335, buffer = 0.41911123197780786, num_peers = 100

--- a/crates/kitsune_p2p/dht/src/arq.rs
+++ b/crates/kitsune_p2p/dht/src/arq.rs
@@ -1,0 +1,677 @@
+//! The Quantized DHT Arc type
+//!
+//! Arq coordinates are expressed in terms of powers-of-two, representing
+//! the "chunk" or "segment" size to work with. The actual extent of the Arq
+//! is expressed as a `start` and an `offset`, in terms of the chunk size.
+//! So, Arq boundaries can only ever fall on a quantized grid which is determined
+//! by the `power` setting.
+
+mod arq_set;
+mod peer_view;
+mod strat;
+
+#[cfg(feature = "test_utils")]
+pub mod ascii;
+
+pub use arq_set::*;
+
+pub use peer_view::*;
+pub use strat::*;
+
+use kitsune_p2p_dht_arc::{DhtArc, DhtArcRange};
+
+use crate::{op::Loc, quantum::*};
+
+/// Convenience method for taking the power of 2 in u32
+pub fn pow2(p: u8) -> u32 {
+    debug_assert!(p < 32);
+    2u32.pow((p as u32).min(31))
+}
+
+/// Convenience method for taking the power of 2 in f64
+pub fn pow2f(p: u8) -> f64 {
+    debug_assert!(p < 32);
+    2f64.powf(p as f64)
+}
+
+/// Maximum number of values that a u32 can represent.
+pub(crate) const U32_LEN: u64 = u32::MAX as u64 + 1;
+
+/// Represents the start point or "left edge" of an Arq.
+///
+/// This helps us generalize over the two use cases of Arq:
+/// 1. An Arq which is defined at a definite absolute DhtLocation corresponding
+///    to an Agent's location, and which can be requantized, resized, etc.
+/// 2. An Arq which has no absolute location defined, and which simply represents
+///    a (quantized) range.
+pub trait ArqStart: Sized + Copy + std::fmt::Debug {
+    /// Get the DhtLocation representation
+    fn to_loc(&self, topo: &Topology, power: u8) -> Loc;
+    /// Get the exponential Offset representation
+    fn to_offset(&self, topo: &Topology, power: u8) -> Offset;
+}
+
+impl ArqStart for Loc {
+    fn to_loc(&self, _topo: &Topology, _power: u8) -> Loc {
+        *self
+    }
+
+    fn to_offset(&self, topo: &Topology, power: u8) -> Offset {
+        Offset::from_loc_rounded(*self, topo, power)
+    }
+}
+
+impl ArqStart for Offset {
+    fn to_loc(&self, topo: &Topology, power: u8) -> Loc {
+        self.to_loc(topo, power)
+    }
+    fn to_offset(&self, _topo: &Topology, _power: u8) -> Offset {
+        *self
+    }
+}
+
+/// A quantized DHT arc.
+///
+/// ## Coordinates
+///
+/// Arq coordinates are expressed in terms of powers-of-two, representing
+/// the "chunk" or "segment" size to work with.
+/// The chunk size is determined by the [`Topology`] of the space it is in,
+/// as well as the `power` of the Arq. The actual chunk size is given by:
+///
+/// `chunk size = topology.space.quantum * 2^power`
+///
+/// So, the `power` represents the amount of quantization *on top* of the quantum
+/// size set by the Topology, not the total quantization level.
+///
+/// The `start` is generic, because there are actually two flavors of Arq:
+/// - one which has a definite starting DhtLocation associated with it,
+/// - and one which does not.
+///
+/// The first flavor is significant
+#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Arq<S: ArqStart = Loc> {
+    /// Location around which this coverage is centered
+    pub start: S,
+    /// The level of quantization. Total ArqBounds length is `2^power * count`.
+    /// The power must be between 0 and 31, inclusive.
+    pub power: u8,
+    /// The number of unit lengths.
+    /// We never expect the count to be less than 4 or so, and not much larger
+    /// than 32.
+    pub count: Offset,
+}
+
+/// Alias for Arq with an Loc start
+pub type ArqLocated = Arq<Loc>;
+
+/// Alias for Arq with an Offset start
+pub type ArqBounds = Arq<Offset>;
+
+impl<S: ArqStart> Arq<S> {
+    /// Constructor from individual parts
+    pub fn new(power: u8, start: S, count: Offset) -> Self {
+        Self {
+            power,
+            start,
+            count,
+        }
+    }
+
+    /// The number of quanta to use for each segment
+    #[inline]
+    fn quantum_chunk_width(&self) -> u32 {
+        pow2(self.power)
+    }
+
+    /// The absolute length of each segment, the "chunk size"
+    #[inline]
+    pub(crate) fn absolute_chunk_width(&self, topo: &Topology) -> u32 {
+        let len = self
+            .quantum_chunk_width()
+            .saturating_mul(topo.space.quantum)
+            .min(u32::MAX / 2);
+        // this really shouldn't ever be larger than MAX / 8
+        debug_assert!(
+            len < u32::MAX / 4,
+            "chunk width is much larger than expected: {}",
+            len
+        );
+        len
+    }
+
+    /// The absolute length of the entire arq.
+    pub fn absolute_length(&self, topo: &Topology) -> u64 {
+        let len = (self.absolute_chunk_width(topo) as u64 * (*self.count as u64)).min(U32_LEN);
+        debug_assert_eq!(
+            len,
+            self.to_dht_arc_range(topo).length(),
+            "lengths don't match {:?}",
+            self
+        );
+        len
+    }
+
+    /// Convert to [`DhtArcRange`]
+    pub fn to_dht_arc_range(&self, topo: &Topology) -> DhtArcRange {
+        if is_full(topo, self.power, *self.count) {
+            DhtArcRange::Full
+        } else if *self.count == 0 {
+            DhtArcRange::Empty
+        } else {
+            let (a, b) = self.to_edge_locs(topo);
+            DhtArcRange::from_bounds(a, b)
+        }
+    }
+
+    /// Determine the edges of this Arq in absolute coordinates ([`Loc`])
+    pub fn to_edge_locs(&self, topo: &Topology) -> (Loc, Loc) {
+        let start = self.start.to_offset(topo, self.power);
+        let left = start.to_loc(topo, self.power);
+        let right = (start + self.count).to_loc(topo, self.power) - Loc::from(1);
+        (left, right)
+    }
+
+    /// Accessor
+    pub fn power(&self) -> u8 {
+        self.power
+    }
+
+    /// Accessor
+    pub fn count(&self) -> u32 {
+        self.count.into()
+    }
+
+    /// What portion of the whole circle does this arq cover?
+    pub fn coverage(&self, topo: &Topology) -> f64 {
+        self.absolute_length(topo) as f64 / 2f64.powf(32.0)
+    }
+
+    /// Requantize to a different power. If requantizing to a higher power,
+    /// only requantize if there is no information loss due to rounding.
+    /// Otherwise, return None.
+    pub fn requantize(&self, power: u8) -> Option<Self> {
+        requantize(self.power, *self.count, power).map(|(power, count)| Self {
+            start: self.start,
+            power,
+            count: count.into(),
+        })
+    }
+
+    /// This arq has full coverage
+    pub fn is_full(&self, topo: &Topology) -> bool {
+        is_full(topo, self.power(), self.count())
+    }
+
+    /// This arq has zero coverage
+    pub fn is_empty(&self) -> bool {
+        self.count() == 0
+    }
+}
+
+impl Arq<Loc> {
+    /// Construct a full arq at the given power.
+    /// The `count` is calculated accordingly.
+    pub fn new_full(topo: &Topology, start: Loc, power: u8) -> Self {
+        let count = pow2(32u8.saturating_sub(power + topo.space.quantum_power));
+        assert!(is_full(topo, power, count));
+        Self {
+            start,
+            power,
+            count: count.into(),
+        }
+    }
+
+    /// Reduce the power by 1
+    pub fn downshift(&self) -> Self {
+        Self {
+            start: self.start,
+            power: self.power - 1,
+            count: self.count * 2,
+        }
+    }
+
+    /// Increase the power by 1. If this results in rounding, return None,
+    /// unless `force` is true, in which case always return Some.
+    pub fn upshift(&self, force: bool) -> Option<Self> {
+        let count = if force && *self.count % 2 == 1 {
+            self.count + Offset(1)
+        } else {
+            self.count
+        };
+        (*count % 2 == 0).then(|| Self {
+            start: self.start,
+            power: self.power + 1,
+            count: count / 2,
+        })
+    }
+
+    /// Convert to the [`ArqBounds`] representation, which forgets about the
+    /// [`Loc`] associate with this arq.
+    pub fn to_bounds(&self, topo: &Topology) -> ArqBounds {
+        ArqBounds {
+            start: Offset::from(self.start.as_u32() / self.absolute_chunk_width(topo)),
+            power: self.power,
+            count: self.count,
+        }
+    }
+
+    /// Get a reference to the arq's left edge in absolute coordinates.
+    pub fn start_loc(&self) -> Loc {
+        self.start
+    }
+
+    /// Get a mutable reference to the arq's count.
+    pub fn count_mut(&mut self) -> &mut u32 {
+        &mut self.count
+    }
+
+    /// Convert to [`DhtArc`]
+    pub fn to_dht_arc(&self, topo: &Topology) -> DhtArc {
+        let len = self.absolute_length(topo);
+        DhtArc::from_start_and_len(self.start, len)
+    }
+
+    /// Computes the Arq which most closely matches the given [`DhtArc`]
+    pub fn from_dht_arc_approximate(topo: &Topology, strat: &ArqStrat, dht_arc: &DhtArc) -> Self {
+        approximate_arq(topo, strat, dht_arc.start_loc(), dht_arc.length())
+    }
+
+    /// The two arqs represent the same interval despite having potentially different terms
+    pub fn equivalent(topo: &Topology, a: &Self, b: &Self) -> bool {
+        let qa = a.absolute_chunk_width(topo);
+        let qb = b.absolute_chunk_width(topo);
+        a.start == b.start && (a.count.wrapping_mul(qa) == b.count.wrapping_mul(qb))
+    }
+}
+
+impl From<&ArqBounds> for ArqBounds {
+    fn from(a: &ArqBounds) -> Self {
+        *a
+    }
+}
+
+impl ArqBounds {
+    /// The two arqs represent the same interval despite having potentially different terms
+    pub fn equivalent(topo: &Topology, a: &Self, b: &Self) -> bool {
+        let qa = a.absolute_chunk_width(topo);
+        let qb = b.absolute_chunk_width(topo);
+        *a.count == 0 && *b.count == 0
+            || (a.start.wrapping_mul(qa) == b.start.wrapping_mul(qb)
+                && a.count.wrapping_mul(qa) == b.count.wrapping_mul(qb))
+    }
+
+    /// Return the ArqBounds which most closely matches the given [`DhtArcRange`]
+    pub fn from_interval_rounded(topo: &Topology, power: u8, interval: DhtArcRange) -> Self {
+        Self::from_interval_inner(&topo.space, power, interval, true).unwrap()
+    }
+
+    /// Return the ArqBounds which is equivalent to the given [`DhtArcRange`] if it exists.
+    pub fn from_interval(topo: &Topology, power: u8, interval: DhtArcRange) -> Option<Self> {
+        Self::from_interval_inner(&topo.space, power, interval, false)
+    }
+
+    /// Upcast this ArqBounds to an Arq that has knowledge of its [`Loc`]
+    #[cfg(any(test, feature = "test_utils"))]
+    pub fn to_arq<F: FnOnce(Loc) -> Loc>(&self, topo: &Topology, f: F) -> Arq {
+        Arq {
+            start: f(self.start.to_loc(topo, self.power)),
+            power: self.power,
+            count: self.count,
+        }
+    }
+
+    /// An arbitrary zero-coverage arq.
+    pub fn empty(topo: &Topology, power: u8) -> Self {
+        Self::from_interval(topo, power, DhtArcRange::Empty).unwrap()
+    }
+
+    fn from_interval_inner(
+        dim: &Dimension,
+        power: u8,
+        interval: DhtArcRange,
+        rounded: bool,
+    ) -> Option<Self> {
+        match interval {
+            DhtArcRange::Empty => Some(Self {
+                start: 0.into(),
+                power,
+                count: 0.into(),
+            }),
+            DhtArcRange::Full => {
+                assert!(power > 0);
+                let full_count = 2u32.pow(32 - power as u32 - dim.quantum_power as u32);
+                Some(Self {
+                    start: 0.into(),
+                    power,
+                    count: full_count.into(),
+                })
+            }
+            DhtArcRange::Bounded(lo, hi) => {
+                let lo = lo.as_u32();
+                let hi = hi.as_u32();
+                let q = dim.quantum;
+                let s = 2u32.pow(power as u32) * q;
+                let offset = lo / s;
+                let len = if lo <= hi {
+                    hi - lo + 1
+                } else {
+                    (2u64.pow(32) - (lo as u64) + (hi as u64) + 1) as u32
+                };
+                let count = len / s;
+                // XXX: this is kinda wrong. The right bound of the interval
+                // should be 1 less, but we'll accept if it bleeds over by 1 too.
+                if rounded || lo == offset * s && (len % s <= 1) {
+                    Some(Self {
+                        start: offset.into(),
+                        power,
+                        count: count.into(),
+                    })
+                } else {
+                    tracing::warn!("{} =?= {} == {} * {}", lo, offset * s, offset, s);
+                    tracing::warn!("{} =?= {} == {} * {}", len, count * s, count, s);
+                    None
+                }
+            }
+        }
+    }
+
+    /// Iterate over each segment (chunk) in the Arq
+    pub fn segments(&self) -> impl Iterator<Item = SpaceSegment> + '_ {
+        (0..*self.count).map(|c| SpaceSegment::new(self.power, c.wrapping_add(*self.start)))
+    }
+
+    /// Get a reference to the arq bounds's offset.
+    pub fn offset(&self) -> Offset {
+        self.start
+    }
+}
+
+/// Calculate whether a given combination of power and count corresponds to
+/// full DHT coverage.
+///
+/// e.g. if the space quantum is 2^12, and the power is 14,
+/// then the max power is (32 - 12) = 24. Any power 24 or greater implies fullness,
+/// since even a count of 1 would be greater than 2^32.
+/// Any power lower than 24 will result in full coverage with
+/// count >= 2^(32 - 12 - 14) = 2^6 = 64, since it would take 64 chunks of
+/// size 2^(12 + 14) to cover the full space.
+pub fn is_full(topo: &Topology, power: u8, count: u32) -> bool {
+    let max = 32u8.saturating_sub(topo.space.quantum_power);
+    if power == 0 {
+        false
+    } else if power >= 32 {
+        true
+    } else {
+        count >= pow2(max.saturating_sub(power))
+    }
+}
+
+/// Helper for requantizing arq data
+pub fn requantize(old_power: u8, old_count: u32, new_power: u8) -> Option<(u8, u32)> {
+    if old_power < new_power {
+        let factor = 2u32.pow((new_power - old_power) as u32);
+        let count = old_count / factor;
+        if old_count == count * factor {
+            Some((new_power, count))
+        } else {
+            None
+        }
+    } else {
+        let count = old_count * 2u32.pow((old_power - new_power) as u32);
+        Some((new_power, count))
+    }
+}
+
+/// Calculate the unique pairing of power and count implied by a given length
+/// and max number of chunks
+pub fn power_and_count_from_length(dim: &Dimension, len: u64, max_chunks: u32) -> (u8, u32) {
+    assert!(len <= U32_LEN);
+    let mut power = 0;
+    let mut count = (len / dim.quantum as u64) as f64;
+    let max = max_chunks as f64;
+
+    while count.round() > max {
+        power += 1;
+        count /= 2.0;
+    }
+    let count = count.round() as u32;
+    (power, count)
+}
+
+/// Given a center and a length, give Arq which matches most closely given the provided strategy
+pub fn approximate_arq(topo: &Topology, strat: &ArqStrat, start: Loc, len: u64) -> Arq {
+    if len == 0 {
+        Arq::new(topo.min_space_power(), start, 0.into())
+    } else {
+        let (power, count) = power_and_count_from_length(&topo.space, len, strat.max_chunks());
+
+        let min = strat.min_chunks() as f64;
+        let max = strat.max_chunks() as f64;
+
+        debug_assert!(
+            power == 0 || count >= min as u32,
+            "count < min: {} < {}",
+            count,
+            min
+        );
+        debug_assert!(
+            power == 0 || count <= max as u32,
+            "count > max: {} > {}",
+            count,
+            max
+        );
+        debug_assert!(count == 0 || count - 1 <= u32::MAX / topo.space.quantum);
+        debug_assert!(
+            power <= topo.max_space_power(strat),
+            "power too large: {}",
+            power
+        );
+        Arq::new(power as u8, start, count.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use test_case::test_case;
+
+    #[test]
+    fn test_is_full() {
+        {
+            let topo = Topology::unit_zero();
+            assert!(!is_full(&topo, 31, 1));
+            assert!(is_full(&topo, 31, 2));
+            assert!(is_full(&topo, 31, 3));
+
+            assert!(!is_full(&topo, 30, 3));
+            assert!(is_full(&topo, 30, 4));
+            assert!(is_full(&topo, 29, 8));
+
+            assert!(is_full(&topo, 1, 2u32.pow(31)));
+            assert!(!is_full(&topo, 1, 2u32.pow(31) - 1));
+            assert!(is_full(&topo, 2, 2u32.pow(30)));
+            assert!(!is_full(&topo, 2, 2u32.pow(30) - 1));
+        }
+        {
+            let topo = Topology::standard_epoch();
+            assert!(!is_full(&topo, 31 - 12, 1));
+            assert!(is_full(&topo, 31 - 12, 2));
+
+            // power too high, doesn't panic
+            assert!(is_full(&topo, 31, 2));
+            // power too low, doesn't panic
+            assert!(!is_full(&topo, 1, 2));
+        }
+    }
+
+    #[test]
+    fn test_full_intervals() {
+        let topo = Topology::unit_zero();
+        let full1 = Arq::new_full(&topo, 0u32.into(), 29);
+        let full2 = Arq::new_full(&topo, 2u32.pow(31).into(), 25);
+        assert!(matches!(full1.to_dht_arc_range(&topo), DhtArcRange::Full));
+        assert!(matches!(full2.to_dht_arc_range(&topo), DhtArcRange::Full));
+    }
+
+    #[test]
+    fn arq_requantize() {
+        let c = Arq {
+            start: Loc::from(42u32),
+            power: 20,
+            count: Offset(10),
+        };
+
+        let rq = |c: &Arq, p| (*c).requantize(p);
+
+        assert_eq!(rq(&c, 18).map(|c| *c.count), Some(40));
+        assert_eq!(rq(&c, 19).map(|c| *c.count), Some(20));
+        assert_eq!(rq(&c, 20).map(|c| *c.count), Some(10));
+        assert_eq!(rq(&c, 21).map(|c| *c.count), Some(5));
+        assert_eq!(rq(&c, 22).map(|c| *c.count), None);
+        assert_eq!(rq(&c, 23).map(|c| *c.count), None);
+        assert_eq!(rq(&c, 24).map(|c| *c.count), None);
+
+        let c = Arq {
+            start: Loc::from(42u32),
+            power: 20,
+            count: Offset(256),
+        };
+
+        assert_eq!(rq(&c, 12).map(|c| *c.count), Some(256 * 256));
+        assert_eq!(rq(&c, 28).map(|c| *c.count), Some(1));
+        assert_eq!(rq(&c, 29).map(|c| *c.count), None);
+    }
+
+    #[test]
+    fn test_to_bounds() {
+        let topo = Topology::unit_zero();
+        let pow: u8 = 4;
+        {
+            let a = Arq::new(pow, (2u32.pow(pow.into()) - 1).into(), 16.into());
+            let b = a.to_bounds(&topo);
+            assert_eq!(b.offset(), Offset(0));
+            assert_eq!(b.count(), 16);
+        }
+        {
+            let a = Arq::new(pow, 4u32.into(), 18.into());
+            let b = a.to_bounds(&topo);
+            assert_eq!(b.count(), 18);
+        }
+    }
+
+    #[test]
+    fn from_interval_regression() {
+        let topo = Topology::unit_zero();
+        let i = DhtArcRange::Bounded(4294967040u32.into(), 511.into());
+        assert!(ArqBounds::from_interval(&topo, 8, i).is_some());
+    }
+
+    #[test_case(2u64.pow(30), (14, 16))]
+    #[test_case(2u64.pow(31), (15, 16))]
+    #[test_case(2u64.pow(32), (16, 16))]
+    #[test_case(128 * 2u64.pow(24), (15, 16))]
+    #[test_case((128 + 16) * 2u64.pow(24), (16, 9))]
+    fn test_power_and_count_from_length(len: u64, expected: (u8, u32)) {
+        let topo = Topology::standard_epoch();
+        let (p, c) = power_and_count_from_length(&topo.space, len, 16);
+        assert_eq!((p, c), expected);
+        assert_eq!(
+            2u64.pow(p as u32 + topo.space.quantum_power as u32) * c as u64,
+            len
+        );
+    }
+
+    proptest::proptest! {
+
+        #[test]
+        fn test_to_edge_locs(power in 0u8..16, count in 8u32..16, loc: u32) {
+            // We use powers from 0 to 16 because with standard space topology,
+            // the quantum size is 2^12, and the max count is 16 which is 2^4,
+            // so any power greater than 16 could result in an overflow.
+            let topo = Topology::standard_epoch();
+            let a = Arq::new(power, Loc::from(loc), Offset(count));
+            let (left, right) = a.to_edge_locs(&topo);
+            let p = pow2(power);
+            assert_eq!(left.as_u32() % p, 0);
+            assert_eq!(right.as_u32().wrapping_add(1) % p, 0);
+
+            assert_eq!(a.absolute_length(&topo), (right - left).as_u32() as u64 + 1);
+        }
+
+        #[test]
+        fn test_preserve_ordering_for_bounds(mut centers: Vec<u32>, count in 0u32..8, power in 0u8..16) {
+            let topo = Topology::standard_epoch();
+
+            // given a list of sorted centerpoints
+            centers.sort();
+
+            // build identical arqs at each centerpoint and convert them to ArqBounds
+            let arqs: Vec<_> = centers.into_iter().map(|c| Arq::new(power, c.into(), count.into())).collect();
+            let mut bounds: Vec<_> = arqs.into_iter().map(|a| a.to_bounds(&topo)).enumerate().collect();
+
+            // Ensure the list of ArqBounds also grows monotonically.
+            // However, there may be one point at which monotonicity is broken,
+            // corresponding to the left edge wrapping around.
+            bounds.sort_by_key(|(_, b)| b.to_edge_locs(&topo).0);
+
+            let mut prev = 0;
+            let mut split = None;
+            for (i, (ix, _)) in bounds.iter().enumerate() {
+                if prev > *ix {
+                    split = Some(i);
+                    break;
+                }
+                prev = *ix;
+            }
+
+            // Split the list of bounds in two, if a discontinuity was found,
+            // and check the monotonicity of each piece separately.
+            let (b1, b2) = bounds.split_at(split.unwrap_or(0));
+            let ix1: Vec<_> = b1.iter().map(|(i, _)| i).collect();
+            let ix2: Vec<_> = b2.iter().map(|(i, _)| i).collect();
+            let mut ix1s = ix1.clone();
+            let mut ix2s = ix2.clone();
+            ix1s.sort();
+            ix2s.sort();
+            assert_eq!(ix1, ix1s);
+            assert_eq!(ix2, ix2s);
+        }
+
+        #[test]
+        fn dht_arc_roundtrip_unit_topo(center: u32, pow in 4..29u8, count in 0..8u32) {
+            let topo = Topology::unit_zero();
+            let length = count as u64 * 2u64.pow(pow as u32) / 2 * 2;
+            let strat = ArqStrat::default();
+            let arq = approximate_arq(&topo, &strat, center.into(), length);
+            let dht_arc = arq.to_dht_arc(&topo);
+            assert_eq!(arq.absolute_length(&topo), dht_arc.length());
+            let arq2 = Arq::from_dht_arc_approximate(&topo, &strat, &dht_arc);
+            assert_eq!(arq, arq2);
+        }
+
+        #[test]
+        fn dht_arc_roundtrip_standard_topo(center: u32, pow in 0..16u8, count in 0..8u32) {
+            let topo = Topology::standard_epoch();
+            let length = count as u64 * 2u64.pow(pow as u32) / 2 * 2;
+            let strat = ArqStrat::default();
+            let arq = approximate_arq(&topo, &strat, center.into(), length);
+            let dht_arc = arq.to_dht_arc(&topo);
+            assert_eq!(arq.absolute_length(&topo), dht_arc.length());
+            let arq2 = Arq::from_dht_arc_approximate(&topo, &strat, &dht_arc);
+            assert!(Arq::<Loc>::equivalent(&topo, &arq, &arq2));
+        }
+
+        #[test]
+        fn arc_interval_roundtrip(center: u32, pow in 0..16u8, count in 0..8u32) {
+            let topo = Topology::standard_epoch();
+            let length = count as u64 * 2u64.pow(pow as u32) / 2 * 2;
+            let strat = ArqStrat::default();
+            let arq = approximate_arq(&topo, &strat, center.into(), length).to_bounds(&topo);
+            let interval = arq.to_dht_arc_range(&topo);
+            let arq2 = ArqBounds::from_interval(&topo, arq.power(), interval.clone()).unwrap();
+            assert!(ArqBounds::equivalent(&topo, &arq, &arq2));
+        }
+    }
+}

--- a/crates/kitsune_p2p/dht/src/arq/arq_set.rs
+++ b/crates/kitsune_p2p/dht/src/arq/arq_set.rs
@@ -1,0 +1,238 @@
+//! Types representing a set of Arqs all of the same "power".
+
+use kitsune_p2p_dht_arc::DhtArcSet;
+
+use crate::{
+    arq::ArqBounds,
+    quantum::{Offset, Topology},
+    ArqStrat, Loc,
+};
+
+use super::{power_and_count_from_length, Arq, ArqStart};
+
+/// Alias for a set of [`Arq`]
+pub type ArqSet = ArqSetImpl<Loc>;
+/// Alias for a set of [`ArqBounds`]
+pub type ArqBoundsSet = ArqSetImpl<Offset>;
+
+/// A collection of ArqBounds.
+/// All bounds are guaranteed to be quantized to the same power
+/// (the lowest common power).
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    derive_more::Deref,
+    derive_more::DerefMut,
+    derive_more::IntoIterator,
+    derive_more::Index,
+    derive_more::IndexMut,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct ArqSetImpl<S: ArqStart> {
+    #[into_iterator]
+    #[deref]
+    #[deref_mut]
+    #[index]
+    #[index_mut]
+    #[serde(bound(deserialize = "S: serde::de::DeserializeOwned"))]
+    pub(crate) arqs: Vec<Arq<S>>,
+    power: u8,
+}
+
+impl<S: ArqStart> ArqSetImpl<S> {
+    /// Normalize all arqs to be of the same power (use the minimum power)
+    pub fn new(arqs: Vec<Arq<S>>) -> Self {
+        if let Some(pow) = arqs.iter().map(|a| a.power()).min() {
+            Self {
+                arqs: arqs
+                    .into_iter()
+                    .map(|a| a.requantize(pow).unwrap())
+                    .collect(),
+                power: pow,
+            }
+        } else {
+            Self {
+                arqs: vec![],
+                power: 1,
+            }
+        }
+    }
+
+    /// Empty set
+    pub fn empty() -> Self {
+        Self::new(vec![])
+    }
+
+    /// Singleton set
+    pub fn single(arq: Arq<S>) -> Self {
+        Self::new(vec![arq])
+    }
+
+    /// Get a reference to the arq set's power.
+    pub fn power(&self) -> u8 {
+        self.power
+    }
+
+    /// Get a reference to the arq set's arqs.
+    pub fn arqs(&self) -> &[Arq<S>] {
+        self.arqs.as_ref()
+    }
+
+    /// Convert to a set of "continuous" arcs
+    pub fn to_dht_arc_set(&self, topo: &Topology) -> DhtArcSet {
+        DhtArcSet::from(
+            self.arqs
+                .iter()
+                .map(|a| a.to_dht_arc_range(topo))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Requantize each arq in the set.
+    pub fn requantize(&self, power: u8) -> Option<Self> {
+        self.arqs
+            .iter()
+            .map(|a| a.requantize(power))
+            .collect::<Option<Vec<_>>>()
+            .map(|arqs| Self { arqs, power })
+    }
+
+    /// Intersection of all arqs contained within
+    pub fn intersection(&self, topo: &Topology, other: &Self) -> ArqSetImpl<Offset> {
+        let power = self.power.min(other.power());
+        let a1 = self.requantize(power).unwrap().to_dht_arc_set(topo);
+        let a2 = other.requantize(power).unwrap().to_dht_arc_set(topo);
+        ArqSetImpl {
+            arqs: DhtArcSet::intersection(&a1, &a2)
+                .intervals()
+                .into_iter()
+                .map(|interval| {
+                    ArqBounds::from_interval(topo, power, interval).expect("cannot fail")
+                })
+                .collect(),
+            power,
+        }
+    }
+
+    /// View ascii for all arq bounds
+    pub fn print_arqs(&self, topo: &Topology, len: usize) {
+        println!("{} arqs, power: {}", self.arqs().len(), self.power());
+        for (i, arq) in self.arqs().iter().enumerate() {
+            println!("|{}| {:>3}:\t{:3}", arq.to_ascii(topo, len), i, arq.count(),);
+        }
+    }
+}
+
+impl ArqBoundsSet {
+    /// Convert back from a continuous arc set to a quantized one.
+    /// If any information is lost, return None.
+    pub fn from_dht_arc_set(
+        topo: &Topology,
+        strat: &ArqStrat,
+        dht_arc_set: &DhtArcSet,
+    ) -> Option<Self> {
+        let max_chunks = strat.max_chunks();
+        Some(Self::new(
+            dht_arc_set
+                .intervals()
+                .into_iter()
+                .map(|i| {
+                    let len = i.length();
+                    let (pow, _) = power_and_count_from_length(&topo.space, len, max_chunks);
+                    ArqBounds::from_interval(topo, pow, i)
+                })
+                .collect::<Option<Vec<_>>>()?,
+        ))
+    }
+}
+
+/// Print ascii for arq bounds
+pub fn print_arq<S: ArqStart>(topo: &Topology, arq: &Arq<S>, len: usize) {
+    println!(
+        "|{}| {} *2^{}",
+        arq.to_ascii(topo, len),
+        arq.count(),
+        arq.power()
+    );
+}
+
+/// Print a collection of arqs
+pub fn print_arqs<S: ArqStart>(topo: &Topology, arqs: &[Arq<S>], len: usize) {
+    for (i, arq) in arqs.iter().enumerate() {
+        println!(
+            "|{}| {}:\t{} +{} *2^{}",
+            arq.to_ascii(topo, len),
+            i,
+            *arq.start.to_offset(topo, arq.power()),
+            arq.count(),
+            arq.power()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn intersect_arqs() {
+        observability::test_run().ok();
+        let topo = Topology::unit_zero();
+        let a = Arq::new(27, 536870912u32.into(), 11.into());
+        let b = Arq::new(27, 805306368u32.into(), 11.into());
+        dbg!(a.to_bounds(&topo).offset());
+
+        let a = ArqSet::single(a);
+        let b = ArqSet::single(b);
+        let c = a.intersection(&topo, &b);
+        print_arqs(&topo, &a, 64);
+        print_arqs(&topo, &b, 64);
+        print_arqs(&topo, &c, 64);
+    }
+
+    #[test]
+    fn normalize_arqs() {
+        let s = ArqSetImpl::new(vec![
+            ArqBounds {
+                start: 0.into(),
+                power: 10,
+                count: Offset(10),
+            },
+            ArqBounds {
+                start: 0.into(),
+                power: 8,
+                count: Offset(40),
+            },
+            ArqBounds {
+                start: 0.into(),
+                power: 12,
+                count: Offset(3),
+            },
+        ]);
+
+        assert_eq!(
+            s.arqs,
+            vec![
+                ArqBounds {
+                    start: 0.into(),
+                    power: 8,
+                    count: Offset(4 * 10)
+                },
+                ArqBounds {
+                    start: 0.into(),
+                    power: 8,
+                    count: Offset(40)
+                },
+                ArqBounds {
+                    start: 0.into(),
+                    power: 8,
+                    count: Offset(3 * 16)
+                },
+            ]
+        );
+    }
+}

--- a/crates/kitsune_p2p/dht/src/arq/ascii.rs
+++ b/crates/kitsune_p2p/dht/src/arq/ascii.rs
@@ -1,0 +1,99 @@
+//! Methods to help with ascii representations of Arqs
+
+use kitsune_p2p_dht_arc::DhtArcRange;
+
+use crate::{quantum::Topology, Loc};
+
+use super::{Arq, ArqStart};
+
+/// Scale a number in a smaller space (specified by `len`) up into the `u32` space.
+/// The number to scale can be negative, which is wrapped to a positive value via modulo
+pub(crate) fn loc_upscale(len: usize, v: i32) -> u32 {
+    let max = 2f64.powi(32);
+    let lenf = len as f64;
+    let vf = v as f64;
+    (max / lenf * vf) as i64 as u32
+}
+
+/// Scale a u32 Loc down into a smaller space (specified by `len`)
+pub(crate) fn loc_downscale(len: usize, d: Loc) -> usize {
+    let max = 2f64.powi(32);
+    let lenf = len as f64;
+    ((lenf / max * (d.as_u32() as f64)) as usize) % len
+}
+
+/// Add a hex character [0-f] to represent the number of ops at each position
+/// in the ascii representation fo the arc
+pub fn add_location_ascii(mut s: String, locs: Vec<Loc>) -> String {
+    let len = s.len();
+
+    let mut buf = vec![0; len];
+    for loc in locs {
+        let loc = loc_downscale(len, loc);
+        buf[loc] += 1;
+    }
+    for (i, v) in buf.into_iter().enumerate() {
+        if v > 0 {
+            // add hex representation of number of ops in this bucket
+            let c = format!("{:x}", v.min(0xf));
+            s.replace_range(i..i + 1, &c);
+        }
+    }
+    s
+}
+
+impl<S: ArqStart> Arq<S> {
+    /// Handy ascii representation of an arc, especially useful when
+    /// looking at several arcs at once to get a sense of their overlap
+    pub fn to_ascii(&self, topo: &Topology, len: usize) -> String {
+        let empty = || " ".repeat(len);
+        let full = || "-".repeat(len);
+
+        // If lo and hi are less than one bucket's width apart when scaled down,
+        // decide whether to interpret this as empty or full
+        let decide = |lo: &Loc, hi: &Loc| {
+            let mid = loc_upscale(len, (len / 2) as i32);
+            if lo < hi {
+                if hi.as_u32() - lo.as_u32() < mid {
+                    empty()
+                } else {
+                    full()
+                }
+            } else if lo.as_u32() - hi.as_u32() < mid {
+                full()
+            } else {
+                empty()
+            }
+        };
+
+        match self.to_dht_arc_range(topo) {
+            DhtArcRange::Full => full(),
+            DhtArcRange::Empty => empty(),
+            DhtArcRange::Bounded(lo0, hi0) => {
+                let lo = loc_downscale(len, lo0);
+                let hi = loc_downscale(len, hi0);
+
+                if lo0 <= hi0 {
+                    if lo >= hi {
+                        vec![decide(&lo0, &hi0)]
+                    } else {
+                        vec![
+                            " ".repeat(lo),
+                            "-".repeat(hi - lo + 1),
+                            " ".repeat((len - hi).saturating_sub(1)),
+                        ]
+                    }
+                } else if lo <= hi {
+                    vec![decide(&lo0, &hi0)]
+                } else {
+                    vec![
+                        "-".repeat(hi + 1),
+                        " ".repeat((lo - hi).saturating_sub(1)),
+                        "-".repeat(len - lo),
+                    ]
+                }
+                .join("")
+            }
+        }
+    }
+}

--- a/crates/kitsune_p2p/dht/src/arq/peer_view.rs
+++ b/crates/kitsune_p2p/dht/src/arq/peer_view.rs
@@ -1,4 +1,4 @@
-use kitsune_p2p_dht_arc::{DhtArc, PeerViewAlpha, PeerViewBeta};
+use kitsune_p2p_dht_arc::{DhtArc, PeerView as LegacyPeerView, PeerViewAlpha, PeerViewBeta};
 use num_traits::Zero;
 
 use crate::quantum::{Offset, Topology};
@@ -27,14 +27,26 @@ impl PeerView {
     /// this returns the next step to take in reaching the ideal coverage.
     pub fn update_arc(&self, dht_arc: &mut DhtArc) -> bool {
         match self {
-            Self::Alpha(v) => v.update_arc(dht_arc),
-            Self::Beta(v) => v.update_arc(dht_arc),
+            Self::Alpha(_) | Self::Beta(_) => {
+                let view = self.to_legacy_peer_view().unwrap();
+                dht_arc.update_length(&view);
+                true
+            }
             Self::Quantized(v) => {
                 let mut arq = Arq::from_dht_arc_approximate(&v.topo, &v.strat, dht_arc);
                 let updated = v.update_arq(&v.topo, &mut arq);
                 *dht_arc = arq.to_dht_arc(&v.topo);
                 updated
             }
+        }
+    }
+
+    /// Convert to the corresponding PeerView enum used in the `kitsune_p2p_dht_arc` crate
+    pub fn to_legacy_peer_view(&self) -> Option<LegacyPeerView> {
+        match self {
+            Self::Alpha(v) => Some(LegacyPeerView::Alpha(v.clone())),
+            Self::Beta(v) => Some(LegacyPeerView::Beta(v.clone())),
+            Self::Quantized(_) => None,
         }
     }
 }

--- a/crates/kitsune_p2p/dht/src/arq/peer_view.rs
+++ b/crates/kitsune_p2p/dht/src/arq/peer_view.rs
@@ -1,0 +1,489 @@
+use kitsune_p2p_dht_arc::{DhtArc, PeerViewAlpha, PeerViewBeta};
+use num_traits::Zero;
+
+use crate::quantum::{Offset, Topology};
+
+use super::{is_full, Arq, ArqStrat};
+
+/// A "view" of the peers in a neighborhood. The view consists of a few
+/// observations about the distribution of peers within a particular arc, used
+/// to make inferences about the rest of the (out-of-view) DHT, ultimately
+/// enabling the calculation of the target arc size for the agent who has this View.
+///
+/// The enum allows us to add different views (and different calculations of
+/// target arc length) over time.
+#[derive(derive_more::From)]
+pub enum PeerView {
+    /// The "alpha" PeerView
+    Alpha(PeerViewAlpha),
+    /// The "beta" PeerView
+    Beta(PeerViewBeta),
+    /// The quantized PeerView
+    Quantized(PeerViewQ),
+}
+
+impl PeerView {
+    /// Given the current view of a peer and the peer's current coverage,
+    /// this returns the next step to take in reaching the ideal coverage.
+    pub fn update_arc(&self, dht_arc: &mut DhtArc) -> bool {
+        match self {
+            Self::Alpha(v) => v.update_arc(dht_arc),
+            Self::Beta(v) => v.update_arc(dht_arc),
+            Self::Quantized(v) => {
+                let mut arq = Arq::from_dht_arc_approximate(&v.topo, &v.strat, dht_arc);
+                let updated = v.update_arq(&v.topo, &mut arq);
+                *dht_arc = arq.to_dht_arc(&v.topo);
+                updated
+            }
+        }
+    }
+}
+
+/// The Quantized PeerView
+pub struct PeerViewQ {
+    /// The strategy which generated this view
+    strat: ArqStrat,
+
+    /// The topology of the network space
+    pub topo: Topology,
+
+    /// The peers in this view (TODO: replace with calculated values)
+    peers: Vec<Arq>,
+
+    #[cfg(feature = "test_utils")]
+    /// Omit the arq at this index from all peer considerations.
+    /// Useful for tests which update all arqs, without needing to
+    /// construct a new PeerView for each arq needing to be updated
+    pub skip_index: Option<usize>,
+}
+
+impl PeerViewQ {
+    /// Constructor
+    pub fn new(topo: Topology, strat: ArqStrat, peers: Vec<Arq>) -> Self {
+        Self {
+            strat,
+            topo,
+            peers,
+            #[cfg(feature = "test_utils")]
+            skip_index: None,
+        }
+    }
+
+    /// The actual coverage of all arcs in this view.
+    /// TODO: this only makes sense when the view contains all agents in the DHT.
+    ///       So, it's more useful for testing. Probably want to tease out some
+    ///       concept of a test DHT from this.
+    pub fn actual_coverage(&self) -> f64 {
+        actual_coverage(&self.topo, self.peers.iter())
+    }
+
+    /// Extrapolate the coverage of the entire network from our local view.
+    pub fn extrapolated_coverage(&self, filter: &Arq) -> f64 {
+        self.extrapolated_coverage_and_filtered_count(filter).0
+    }
+
+    /// Return the extrapolated coverage and the number of arqs which match the filter.
+    /// These two are complected together simply for efficiency's sake, to
+    /// minimize computation
+    ///
+    /// TODO: this probably will be rewritten when PeerView is rewritten to
+    /// have the filter baked in.
+    pub fn extrapolated_coverage_and_filtered_count(&self, filter: &Arq) -> (f64, usize) {
+        let filter = filter.to_dht_arc(&self.topo);
+        if filter.is_empty() {
+            // More accurately this would be 0, but it's handy to not have
+            // divide-by-zero crashes
+            return (1.0, 1);
+        }
+        let filter_len = filter.length();
+
+        let initial = (0, 0);
+
+        // FIXME: We can't just filter arcs on the fly here, because we might be
+        // trying to get coverage info for an area we don't have arcs for
+        // (because we don't store arcs for agents outside of our arc).
+        // So, we need to extrapolate the arcs we do have to extend into the
+        // unknown area outside the filter.
+        // For now though, just filter arcs on the fly so we have something to test.
+        // But, this means that the behavior for growing arcs is going to be a bit
+        // different in the future.
+        let (sum, count) = self
+            .filtered_arqs(filter)
+            .fold(initial, |(sum, count), arq| {
+                (sum + arq.absolute_length(&self.topo), count + 1)
+            });
+        let cov = sum as f64 / filter_len as f64;
+        (cov, count)
+    }
+
+    /// Compute the total coverage observed within the filter interval.
+    pub fn raw_coverage(&self, filter: &Arq) -> f64 {
+        self.extrapolated_coverage(filter) * filter.to_dht_arc_range(&self.topo).length() as f64
+            / 2f64.powf(32.0)
+    }
+
+    /// Mutate the arq to its ideal target
+    pub fn update_arq(&self, topo: &Topology, arq: &mut Arq) -> bool {
+        self.update_arq_with_stats(topo, arq).changed
+    }
+
+    fn is_slacking(&self, cov: f64, num_peers: usize) -> bool {
+        num_peers as f64 <= cov * self.strat.slacker_ratio
+    }
+
+    /// The "slacker" factor. If our observed coverage is significantly
+    /// greater than the number of peers we see, it's an indication
+    /// that we may need to pick up more slack.
+    ///
+    /// This check helps balance out stable but unequitable situations where
+    /// all peers have a similar estimated coverage, but some peers are
+    /// holding much more than others.
+    pub fn slack_factor(&self, cov: f64, num_peers: usize) -> f64 {
+        if self.is_slacking(cov, num_peers) {
+            if num_peers.is_zero() {
+                // Prevent a NaN.
+                // This value gets clamped anyway, so it will never actually
+                // lead to an infinite value.
+                f64::INFINITY
+            } else {
+                cov / num_peers as f64
+            }
+        } else {
+            1.0
+        }
+    }
+
+    fn growth_factor(&self, cov: f64, num_peers: usize, median_power_diff: i8) -> f64 {
+        let np = num_peers as f64;
+        let under = cov < self.strat.min_coverage;
+        let over = cov > self.strat.max_coverage();
+
+        // The ratio of ideal coverage vs actual observed coverage.
+        // A ratio > 1 indicates undersaturation and a need to grow.
+        // A ratio < 1 indicates oversaturation and a need to shrink.
+        let cov_diff = if over || under {
+            let ratio = self.strat.midline_coverage() / cov;
+
+            // We want to know which of our peers are likely to be making a similar
+            // update to us, because that will affect the overall coverage more
+            // than the drop in the bucket that we can provide.
+            //
+            // If all peers have seen the same change as us since their last update,
+            // they will on average move similarly to us, and so we should only make
+            // a small step in the direction of the target, trusting that our peers
+            // will do the same.
+            //
+            // Conversely, if all peers are stable, e.g. if we just came online to
+            // find a situation where all peers around us are under-representing,
+            // but stable, then we want to make a much bigger leap.
+            let peer_dampening_factor = 1.0 / (1.0 + np);
+
+            (ratio - 1.0) * peer_dampening_factor + 1.0
+        } else {
+            1.0
+        };
+
+        // The "slacker" factor. If our observed coverage is significantly
+        // greater than the number of peers we see, it's an indication
+        // that we may need to pick up more slack.
+        //
+        // This check helps balance out stable but unequitable situations where
+        // all peers have a similar estimated coverage, but some peers are
+        // holding much more than others.
+        let slack_factor = self.slack_factor(cov, num_peers);
+
+        let unbounded_growth = cov_diff * slack_factor;
+
+        // The difference between the median power and the arq's power helps
+        // determine some limits on growth.
+        // If we are at the median growth, then it makes sense to cap
+        // our movement by 2x in either direction (1/2 to 2)
+        //
+        // If we are 1 below the median, then our range is (1/2 to 4)
+        // If we are 2 below the median, then our range is (1/2 to 8)
+        // If we are 1 above the median, then our range is (1/4 to 2)
+        // If we are 2 above the median, then our range is (1/8 to 2)
+        //
+        // Note that there is also a hard limit on growth described by
+        // ArqStrat::max_power_diff, enforced elsewhere.
+        let mpd = median_power_diff as f64;
+        let min = 2f64.powf(mpd).min(0.5);
+        let max = 2f64.powf(mpd).max(2.0);
+        unbounded_growth.clamp(min, max)
+    }
+
+    /// Take an arq and potentially resize and requantize it based on this view.
+    ///
+    /// This represents an iterative step towards the ideal coverage, based on
+    /// the observed coverage.
+    /// This makes many assumptions, including:
+    /// - this arc resizing algorithm is a good one, namely that the coverage
+    ///     at any point of the DHT is close to the target range
+    /// - all other peers are following the same algorithm
+    /// - if we see a change that we need to make, we assume that a number of
+    ///     peers are about to make a similar change, and that number is on
+    ///     average the same as our target coverage
+    ///
+    /// More detail on these assumptions here:
+    /// https://hackmd.io/@hololtd/r1IAIbr5Y/https%3A%2F%2Fhackmd.io%2FK_fkBj6XQO2rCUZRRL9n2g
+    pub fn update_arq_with_stats(&self, topo: &Topology, arq: &mut Arq) -> UpdateArqStats {
+        let (cov, num_peers) = self.extrapolated_coverage_and_filtered_count(arq);
+
+        let old_count = arq.count();
+        let old_power = arq.power();
+
+        let power_stats = self.power_stats(topo, arq);
+        let PowerStats {
+            median: median_power,
+            ..
+        } = power_stats;
+
+        let median_power_diff = median_power as i8 - arq.power() as i8;
+        let growth_factor = self.growth_factor(cov, num_peers, median_power_diff);
+
+        let new_count = if growth_factor < 1.0 {
+            // Ensure we shrink by at least 1
+            (old_count as f64 * growth_factor).floor() as u32
+        } else {
+            // Ensure we grow by at least 1 (if there is any growth at all)
+            (old_count as f64 * growth_factor).ceil() as u32
+        };
+
+        if new_count != old_count {
+            let mut tentative = *arq;
+            tentative.count = Offset(new_count);
+
+            // If shrinking caused us to go below the target coverage,
+            // or to start "slacking" (not seeing enough peers), then
+            // don't update. This happens when we shrink too much and
+            // lose sight of peers.
+            let (new_cov, new_num_peers) =
+                self.extrapolated_coverage_and_filtered_count(&tentative);
+            if new_count < old_count
+                && (new_cov < self.strat.min_coverage
+                    || (!self.is_slacking(cov, num_peers)
+                        && self.is_slacking(new_cov, new_num_peers)))
+            {
+                return UpdateArqStats {
+                    changed: false,
+                    desired_delta: new_count as i32 - old_count as i32,
+                    power: None,
+                    num_peers,
+                };
+            }
+        }
+
+        // Commit the change to the count
+        arq.count = Offset(new_count);
+
+        let power_above_min = |pow| {
+            // not already at the minimum
+            pow > topo.min_space_power()
+             // don't power down if power is already too low
+             && (median_power as i8 - pow as i8) < self.strat.max_power_diff as i8
+        };
+
+        loop {
+            // check for power downshift opportunity
+            if *arq.count < self.strat.min_chunks() {
+                if power_above_min(arq.power) {
+                    *arq = arq.downshift();
+                } else {
+                    // If we could not downshift due to other constraints, then we cannot
+                    // shrink any smaller than the min_chunks.
+                    arq.count = Offset(self.strat.min_chunks());
+                }
+            } else {
+                break;
+            }
+        }
+
+        let power_below_max = |pow| {
+            // not already at the maximum
+            pow < topo.max_space_power(&self.strat)
+            // don't power up if power is already too high
+            && (pow as i8 - median_power as i8) < self.strat.max_power_diff as i8
+        };
+
+        loop {
+            // check for power upshift opportunity
+            if *arq.count > self.strat.max_chunks() {
+                if power_below_max(arq.power) {
+                    // Attempt to requantize to the next higher power.
+                    // If we only grew by one chunk, into an odd count, then don't
+                    // force upshifting, because that would either require undoing
+                    // the growth, or growing by 2 instead of 1. In this case, skip
+                    // upshifting, and we'll upshift on the next update.
+                    let force = new_count as i32 - old_count as i32 > 1;
+                    if let Some(a) = arq.upshift(force) {
+                        *arq = a
+                    } else {
+                        break;
+                    }
+                } else {
+                    // If we could not upshift due to other constraints, then we cannot
+                    // grow any larger than the max_chunks.
+                    arq.count = Offset(self.strat.max_chunks());
+                }
+            } else {
+                break;
+            }
+        }
+
+        if is_full(topo, arq.power(), arq.count()) {
+            *arq = Arq::new_full(topo, arq.start_loc(), arq.power());
+        }
+
+        // check if anything changed
+        let changed = !(arq.power() == old_power && arq.count() == old_count);
+
+        UpdateArqStats {
+            changed,
+            desired_delta: new_count as i32 - old_count as i32,
+            power: Some(power_stats),
+            num_peers,
+        }
+    }
+
+    /// Gather statistics about the power levels of all arqs in this view.
+    /// Used to make inferences about what your neighbors are up to.
+    pub fn power_stats(&self, topo: &Topology, filter: &Arq) -> PowerStats {
+        use statrs::statistics::*;
+        let mut powers: Vec<_> = self
+            .filtered_arqs(filter.to_dht_arc(topo))
+            .filter(|a| *a.count > 0)
+            .map(|a| a.power as f64)
+            .collect();
+        powers.push(filter.power() as f64);
+        let powers = statrs::statistics::Data::new(powers);
+        let median = powers.median() as u8;
+        let std_dev = powers.std_dev().unwrap_or_default();
+        if std_dev > self.strat.power_std_dev_threshold {
+            // tracing::warn!("Large power std dev: {}", std_dev);
+        }
+        PowerStats { median, std_dev }
+    }
+
+    fn filtered_arqs(&self, filter: DhtArc) -> impl Iterator<Item = &Arq> {
+        let it = self.peers.iter();
+
+        #[cfg(feature = "test_utils")]
+        let it = it
+            .enumerate()
+            .filter(|(i, _)| self.skip_index.as_ref() != Some(i))
+            .map(|(_, arq)| arq);
+
+        it.filter(move |arq| filter.contains(&arq.start_loc()))
+    }
+}
+
+/// A summary of what happened while updating an Arq
+#[derive(Debug, Clone)]
+pub struct UpdateArqStats {
+    /// Did the arq change?
+    pub changed: bool,
+    /// How much did the arq "want" to change?
+    pub desired_delta: i32,
+    /// PowerStats, if calculated.
+    pub power: Option<PowerStats>,
+    /// Number of peers initially visible from this arq.
+    pub num_peers: usize,
+}
+
+/// The actual coverage provided by these peers. Assumes that this is the
+/// entire view of the DHT, all peers are accounted for here.
+pub fn actual_coverage<'a, P: Iterator<Item = &'a Arq>>(topo: &Topology, peers: P) -> f64 {
+    peers
+        .map(|a| a.absolute_length(topo) as f64 / 2f64.powf(32.0))
+        .sum()
+}
+
+/// Statistics about the power levels of all arqs in a view.
+/// Used to make inferences about what your neighbors are up to.
+#[derive(Debug, Clone)]
+pub struct PowerStats {
+    /// The median power level
+    pub median: u8,
+    /// The standard deviation of power levels
+    pub std_dev: f64,
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::convert::identity;
+
+    use kitsune_p2p_dht_arc::DhtArcRange;
+
+    use crate::arq::{pow2, print_arqs};
+    use crate::quantum::Topology;
+    use crate::ArqBounds;
+
+    use super::*;
+
+    fn make_arq(topo: &Topology, pow: u8, lo: u32, hi: u32) -> Arq {
+        let a = ArqBounds::from_interval_rounded(
+            topo,
+            pow,
+            DhtArcRange::from_bounds(
+                pow2(pow) * lo,
+                ((pow2(pow) as u64 * hi as u64) as u32).wrapping_sub(1),
+            ),
+        );
+        a.to_arq(topo, identity)
+    }
+
+    #[test]
+    fn test_filtered_arqs() {
+        let topo = Topology::unit_zero();
+        let pow = 25;
+        let a = make_arq(&topo, pow, 0, 0x20);
+        let b = make_arq(&topo, pow, 0x10, 0x30);
+        let c = make_arq(&topo, pow, 0x20, 0x40);
+
+        let arqs = vec![a, b, c];
+        print_arqs(&topo, &arqs, 64);
+        let view = PeerViewQ::new(topo.clone(), Default::default(), arqs);
+
+        let get = |b: Arq| {
+            view.filtered_arqs(b.to_dht_arc(&topo))
+                .cloned()
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(get(make_arq(&topo, pow, 0, 0x10)), vec![a]);
+        assert_eq!(get(make_arq(&topo, pow, 0, 0x20)), vec![a, b]);
+        assert_eq!(get(make_arq(&topo, pow, 0, 0x40)), vec![a, b, c]);
+        assert_eq!(get(make_arq(&topo, pow, 0x10, 0x20)), vec![b]);
+    }
+
+    #[test]
+    fn test_coverage() {
+        let topo = Topology::unit_zero();
+        let pow = 24;
+        let arqs: Vec<_> = (0..0x100)
+            .step_by(0x10)
+            .map(|x| make_arq(&topo, pow, x, x + 0x20))
+            .collect();
+        print_arqs(&topo, &arqs, 64);
+        let view = PeerViewQ::new(topo.clone(), Default::default(), arqs);
+        assert_eq!(
+            view.extrapolated_coverage_and_filtered_count(&make_arq(&topo, pow, 0, 0x10)),
+            (2.0, 1)
+        );
+        assert_eq!(
+            view.extrapolated_coverage_and_filtered_count(&make_arq(&topo, pow, 0, 0x20)),
+            (2.0, 2)
+        );
+        assert_eq!(
+            view.extrapolated_coverage_and_filtered_count(&make_arq(&topo, pow, 0, 0x40)),
+            (2.0, 4)
+        );
+
+        // TODO: when changing PeerView logic to bake in the filter,
+        // this will probably change
+        assert_eq!(
+            view.extrapolated_coverage_and_filtered_count(&make_arq(&topo, pow, 0x10, 0x20)),
+            (2.0, 1)
+        );
+    }
+}

--- a/crates/kitsune_p2p/dht/src/arq/strat.rs
+++ b/crates/kitsune_p2p/dht/src/arq/strat.rs
@@ -1,0 +1,198 @@
+use kitsune_p2p_dht_arc::{DhtArc, PeerStratAlpha, PeerStratBeta};
+
+use crate::quantum::Topology;
+
+use super::{Arq, PeerView, PeerViewQ};
+
+/// A Strategy for generating PeerViews.
+/// The enum allows us to add new strategies over time.
+#[derive(Debug, Clone, derive_more::From)]
+pub enum PeerStrat {
+    /// The "alpha" peer strat
+    Alpha(PeerStratAlpha),
+    /// The "beta" peer strat
+    Beta(PeerStratBeta),
+    /// The quantized peer strat
+    Quantized(ArqStrat),
+}
+
+impl Default for PeerStrat {
+    fn default() -> Self {
+        ArqStrat::default().into()
+    }
+}
+
+impl PeerStrat {
+    /// Generate a view using this strategy.
+    /// Ensures that only peers which are visible from `arc` are included.
+    pub fn view(&self, topo: Topology, arc: DhtArc, peers: &[DhtArc]) -> PeerView {
+        match self {
+            Self::Alpha(s) => s.view(arc, peers).into(),
+            Self::Beta(s) => s.view(arc, peers).into(),
+            Self::Quantized(s) => {
+                let peers = peers
+                    .iter()
+                    .map(|p| Arq::from_dht_arc_approximate(&topo, s, p))
+                    .collect();
+                PeerViewQ::new(topo, s.clone(), peers).into()
+            }
+        }
+    }
+
+    /// Generate a view using this strategy.
+    /// Assumes that out-of-sight peers have already been filtered out.
+    pub fn view_unchecked(&self, topo: Topology, arc: DhtArc, peers: &[DhtArc]) -> PeerView {
+        match self {
+            Self::Alpha(s) => s.view_unchecked(arc, peers).into(),
+            Self::Beta(s) => s.view_unchecked(arc, peers).into(),
+            Self::Quantized(s) => {
+                // TODO: differentiate checked vs unchecked
+                let peers = peers
+                    .iter()
+                    .map(|p| Arq::from_dht_arc_approximate(&topo, s, p))
+                    .collect();
+                PeerViewQ::new(topo, s.clone(), peers).into()
+            }
+        }
+    }
+}
+
+/// "Arq Resizing Strategy". Defines all parameters necessary to run the arq
+/// resizing algorithm.
+#[derive(Debug, Clone)]
+pub struct ArqStrat {
+    /// The minimum coverage the DHT seeks to maintain.
+    ///
+    /// This is the whole purpose for arc resizing.
+    pub min_coverage: f64,
+
+    /// A multiplicative factor of the min coverage which defines a max.
+    /// coverage. We want coverage to be between the min and max coverage.
+    /// This is expressed in terms of a value > 0 and < 1. For instance,
+    /// a min coverage of 50 with a buffer of 0.2 implies a max coverage of 60.
+    pub buffer: f64,
+
+    /// If the difference between the arq's power and the median power of all
+    /// peer arqs (including this one) is greater than this diff,
+    /// then don't requantize:
+    /// just keep growing or shrinking past the min/max chunks value.
+    ///
+    /// This parameter determines how likely it is for there to be a difference in
+    /// chunk sizes between two agents' arqs. It establishes the tradeoff between
+    /// the size of payloads that must be sent and the extra depth of Fenwick
+    /// tree data that must be stored (to accomodate agents whose power is
+    /// lower than ours).
+    ///
+    /// This parameter is also what allows an arq to shrink to zero in a
+    /// reasonable number of steps. Without this limit on power diff, we would
+    /// keep requantizing until the power was 0 before shrinking to the empty arc.
+    /// We may shrink to zero if our neighborhood is significantly over-covered,
+    /// which can happen if a number of peers decide to keep their coverage
+    /// higher than the ideal equilibrium value.
+    ///
+    /// Note that this parameter does not guarantee that any agent's arq
+    /// will have a power +/- this diff from our power, but we may decide to
+    /// choose not to gossip with agents whose power falls outside the range
+    /// defined by this diff. TODO: do this.
+    pub max_power_diff: u8,
+
+    /// If at any time the number of peers seen by a node is less than the
+    /// extrapolated coverage scaled by this factor, then we assume that we need
+    /// to grow our arc so that we can see more peers.
+    /// In other words, we are "slacking" if at any time:
+    ///     num_peers < extrapolated_coverage * slack_factor
+    ///
+    /// If this is set too high, it may prevent arcs from legitimately shrinking.
+    /// If set too low, it will hamper the ability for extremely small arcs to
+    /// reach a proper size
+    pub slacker_ratio: f64,
+
+    /// If the standard deviation of the powers of each arq in this view is
+    /// greater than this threshold, then we might do something different when
+    /// it comes to our decision to requantize. For now, just print a warning.
+    ///
+    /// TODO: this can probably be expressed in terms of `max_power_diff`.
+    pub power_std_dev_threshold: f64,
+}
+
+impl Default for ArqStrat {
+    fn default() -> Self {
+        Self {
+            min_coverage: 50.0,
+            // this buffer implies min-max chunk count of 8-16
+            buffer: 0.143,
+            power_std_dev_threshold: 1.0,
+            max_power_diff: 2,
+            slacker_ratio: 0.75,
+        }
+    }
+}
+
+impl ArqStrat {
+    /// The midline between min and max coverage
+    pub fn midline_coverage(&self) -> f64 {
+        (self.min_coverage + self.max_coverage()) / 2.0
+    }
+
+    /// The max coverage as expressed by the min coverage and the buffer
+    pub fn max_coverage(&self) -> f64 {
+        (self.min_coverage * (self.buffer + 1.0)).ceil()
+    }
+
+    /// The width of the buffer range
+    pub fn buffer_width(&self) -> f64 {
+        self.min_coverage * self.buffer
+    }
+
+    /// The lower bound of number of chunks to maintain in an arq.
+    /// When the chunk count falls below this number, halve the chunk size.
+    pub fn min_chunks(&self) -> u32 {
+        self.chunk_count_threshold().ceil() as u32
+    }
+
+    /// The upper bound of number of chunks to maintain in an arq.
+    /// When the chunk count exceeds this number, double the chunk size.
+    ///
+    /// This is expressed in terms of min_chunks because we want this value
+    /// to always be odd -- this is because when growing the arq, we need to
+    /// downshift the power, and we can only downshift losslessly if the count
+    /// is even, and the most common case of exceeding the max_chunks is
+    /// is to exceed the max_chunks by 1, which would be an even number.
+    pub fn max_chunks(&self) -> u32 {
+        let max_chunks = self.min_chunks() * 2 - 1;
+        assert!(max_chunks % 2 == 1);
+        max_chunks
+    }
+
+    /// The floor of the log2 of the max_chunks.
+    /// For the default of 15, floor(log2(15)) = 3
+    pub fn max_chunks_log2(&self) -> u8 {
+        (self.max_chunks() as f64).log2().floor() as u8
+    }
+
+    /// The chunk count which gives us the quantization resolution appropriate
+    /// for maintaining the buffer when adding/removing single chunks.
+    /// Used in `min_chunks` and `max_chunks`.
+    ///
+    /// See this doc for rationale:
+    /// https://hackmd.io/@hololtd/r1IAIbr5Y/https%3A%2F%2Fhackmd.io%2FK_fkBj6XQO2rCUZRRL9n2g
+    fn chunk_count_threshold(&self) -> f64 {
+        (self.buffer + 1.0) / self.buffer
+    }
+
+    /// Get a summary report of this strat in string format
+    pub fn summary(&self) -> String {
+        format!(
+            "
+        min coverage: {}
+        max coverage: {}
+        min chunks:   {}
+        max chunks:   {}
+        ",
+            self.min_coverage,
+            self.max_coverage(),
+            self.min_chunks(),
+            self.max_chunks()
+        )
+    }
+}

--- a/crates/kitsune_p2p/dht/src/error.rs
+++ b/crates/kitsune_p2p/dht/src/error.rs
@@ -1,0 +1,15 @@
+#![allow(missing_docs)]
+
+#[derive(Debug, thiserror::Error)]
+pub enum GossipError {
+    #[error("The fundamental parameters of Op region spacetime are mismatched between nodes.")]
+    TopologyMismatch,
+    #[error("System times between nodes are too far apart to be able to gossip.")]
+    TimesOutOfSync,
+    #[error("Attempting to gossip with too large a discrepancy in chunk size")]
+    ArqPowerDiffTooLarge,
+    #[error("Attempting to gossip with a mismatch in the common arc set")]
+    ArqSetMismatchForDiff,
+}
+
+pub type GossipResult<T> = Result<T, GossipError>;

--- a/crates/kitsune_p2p/dht/src/hash.rs
+++ b/crates/kitsune_p2p/dht/src/hash.rs
@@ -1,0 +1,85 @@
+//! Simple hash types.
+//!
+//! TODO: unify with hashes from `kitsune_p2p_types::bin_types`
+
+/// 32 bytes
+pub type Hash32 = [u8; 32];
+
+/// Get a fake hash, for testing only.
+#[cfg(feature = "test_utils")]
+pub fn fake_hash() -> Hash32 {
+    use rand::distributions::*;
+
+    let mut rng = rand::thread_rng();
+    let uni = Uniform::from(u8::MIN..=u8::MAX);
+    let bytes: Vec<u8> = uni.sample_iter(&mut rng).take(32).collect();
+    let bytes: [u8; 32] = bytes.try_into().unwrap();
+    bytes
+}
+
+/// The hash of an Op
+#[derive(
+    Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, derive_more::Constructor, derive_more::From,
+)]
+pub struct OpHash(pub Hash32);
+
+/// The hash of an Agent
+#[derive(
+    Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, derive_more::Constructor, derive_more::From,
+)]
+pub struct AgentKey(pub Hash32);
+
+/// The hash of a Region, which is the XOR of all OpHashes contained in this region.
+#[derive(
+    Copy,
+    Clone,
+    PartialEq,
+    Eq,
+    derive_more::Constructor,
+    derive_more::Deref,
+    derive_more::DerefMut,
+    derive_more::From,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct RegionHash(pub Hash32);
+
+impl RegionHash {
+    /// If the Vec is 32 long, construct a RegionHash from it
+    pub fn from_vec(v: Vec<u8>) -> Option<Self> {
+        v.try_into().map(Self).ok()
+    }
+}
+
+impl std::fmt::Debug for OpHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{}(0x", "OpHash"))?;
+        for byte in &self.0 {
+            f.write_fmt(format_args!("{:02x}", byte))?;
+        }
+        f.write_fmt(format_args!(")"))?;
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for AgentKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{}(0x", "AgentKey"))?;
+        for byte in &self.0 {
+            f.write_fmt(format_args!("{:02x}", byte))?;
+        }
+        f.write_fmt(format_args!(")"))?;
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for RegionHash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{}(0x", "RegionHash"))?;
+        for byte in &self.0 {
+            f.write_fmt(format_args!("{:02x}", byte))?;
+        }
+        f.write_fmt(format_args!(")"))?;
+        Ok(())
+    }
+}

--- a/crates/kitsune_p2p/dht/src/lib.rs
+++ b/crates/kitsune_p2p/dht/src/lib.rs
@@ -1,0 +1,37 @@
+//! Defines the structure of the DHT and the operations which can be performed
+//! in and on it.
+
+#![warn(missing_docs)]
+
+pub mod arq;
+pub mod error;
+pub mod hash;
+pub mod op;
+pub mod quantum;
+pub mod region;
+pub mod region_set;
+
+pub use arq::{actual_coverage, Arq, ArqBounds, ArqStrat, PeerStrat, PeerView, PeerViewQ};
+
+// The persistence traits are currently unused except for test implementations of
+// a kitsune host. If we ever use them in actual host implementations, we can
+// take the feature flag off.
+#[cfg(feature = "test_utils")]
+pub mod persistence;
+
+#[cfg(feature = "test_utils")]
+pub mod test_utils;
+
+pub use kitsune_p2p_dht_arc::DhtLocation as Loc;
+
+/// Common exports
+pub mod prelude {
+    pub use super::arq::*;
+    pub use super::error::*;
+    pub use super::hash::*;
+    pub use super::op::*;
+    pub use super::persistence::*;
+    pub use super::quantum::*;
+    pub use super::region::*;
+    pub use super::region_set::*;
+}

--- a/crates/kitsune_p2p/dht/src/op.rs
+++ b/crates/kitsune_p2p/dht/src/op.rs
@@ -1,0 +1,32 @@
+//! Defines the trait which represents everything Kitsune needs to know about Ops
+
+use crate::quantum::{SpacetimeQuantumCoords, Topology};
+
+pub use kitsune_p2p_dht_arc::DhtLocation as Loc;
+
+pub use kitsune_p2p_timestamp::Timestamp;
+
+/// Everything that Kitsune needs to know about an Op.
+/// Intended to be implemented by the host.
+pub trait OpRegion<D>: PartialOrd + Ord + Send + Sync {
+    /// The op's Location
+    fn loc(&self) -> Loc;
+    /// The op's Timestamp
+    fn timestamp(&self) -> Timestamp;
+    /// The RegionData that would be produced if this op were the only op
+    /// in the region. The sum of these produces the RegionData for the whole
+    /// region.
+    fn region_data(&self) -> D;
+
+    /// The quantized space and time coordinates, based on the location and timestamp.
+    fn coords(&self, topo: &Topology) -> SpacetimeQuantumCoords {
+        SpacetimeQuantumCoords {
+            space: topo.space_quantum(self.loc()),
+            time: topo.time_quantum(self.timestamp()),
+        }
+    }
+
+    /// Create an Op with arbitrary data but that has the given timestamp and location.
+    /// Used for bounded range queries based on the PartialOrd impl of the op.
+    fn bound(timestamp: Timestamp, loc: Loc) -> Self;
+}

--- a/crates/kitsune_p2p/dht/src/persistence.rs
+++ b/crates/kitsune_p2p/dht/src/persistence.rs
@@ -1,0 +1,93 @@
+//! Represents data structures outside of kitsune, on the "host" side,
+//! i.e. methods which would be called via ghost_actors, i.e. Holochain.
+//!
+//! XXX: These traits are an artifact of the original prototype of the quantized gossip
+//! algorithm, which started as its own crate separate from the rest of Kitsune,
+//! and created these traits to build up a suitable interface from scratch.
+//! Eventually these should be better integrated with the existing KitsuneP2pEvent
+//! interface, and the KitsuneHost interface: the integration of those two is
+//! still a work in progress, and these traits should be considered as part of
+//! that work.
+
+use std::sync::Arc;
+
+use must_future::MustBoxFuture;
+
+use crate::{
+    arq::ArqBoundsSet,
+    hash::AgentKey,
+    op::*,
+    quantum::{GossipParams, TelescopingTimes, TimeQuantum, Topology},
+    region::*,
+    region_set::*,
+    test_utils::OpData,
+    Arq,
+};
+
+/// All methods involved in accessing the op store, to be implemented by the host.
+// TODO: make async
+pub trait AccessOpStore<O: OpRegion<D>, D: RegionDataConstraints = RegionData>: Send {
+    /// Query the actual ops inside a region
+    fn query_op_data(&self, region: &RegionCoords) -> Vec<Arc<O>>;
+
+    /// Query the RegionData of a region, including the hash of all ops, size, and count
+    fn query_region_data(&self, region: &RegionCoords) -> D;
+
+    /// Fetch a set of Regions (the coords and the data) given the set of coords
+    fn fetch_region_set(
+        &self,
+        coords: RegionCoordSetLtcs,
+    ) -> MustBoxFuture<Result<RegionSetLtcs<D>, ()>>;
+
+    /// Integrate incoming ops, updating the necessary stores
+    fn integrate_ops<Ops: Clone + Iterator<Item = Arc<O>>>(&mut self, ops: Ops);
+
+    /// Integrate a single op
+    fn integrate_op(&mut self, op: Arc<O>) {
+        self.integrate_ops([op].into_iter())
+    }
+
+    /// Get the GossipParams associated with this store
+    fn gossip_params(&self) -> GossipParams;
+
+    /// Get the Topology associated with this store
+    fn topo(&self) -> &Topology;
+
+    /// Get the RegionSet for this node, suitable for gossiping
+    fn region_set(&self, arq_set: ArqBoundsSet, now: TimeQuantum) -> RegionSet<D> {
+        let coords = RegionCoordSetLtcs::new(TelescopingTimes::new(now), arq_set);
+        let data = coords
+            .region_coords_nested()
+            .map(|columns| {
+                columns
+                    .map(|(_, coords)| self.query_region_data(&coords))
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        RegionSetLtcs::from_data(coords, data).into()
+    }
+}
+
+/// All methods involved in accessing the peer store, to be implemented by the host.
+// TODO: make async
+pub trait AccessPeerStore {
+    /// Get the arq for an agent
+    fn get_agent_arq(&self, agent: AgentKey) -> Arq;
+
+    /// Get the set of all arqs for this node
+    fn get_arq_set(&self) -> ArqBoundsSet;
+}
+
+/// Represents all methods implemented by the host.
+pub trait HostAccess<O: OpRegion<D>, D: RegionDataConstraints = RegionData>:
+    AccessOpStore<O, D> + AccessPeerStore
+{
+}
+impl<T, O: OpRegion<D>, D: RegionDataConstraints> HostAccess<O, D> for T where
+    T: AccessOpStore<O, D> + AccessPeerStore
+{
+}
+
+/// Represents all methods implemented by the host.
+pub trait HostAccessTest: HostAccess<OpData, RegionData> {}
+impl<T> HostAccessTest for T where T: HostAccess<OpData, RegionData> {}

--- a/crates/kitsune_p2p/dht/src/quantum.rs
+++ b/crates/kitsune_p2p/dht/src/quantum.rs
@@ -1,0 +1,901 @@
+//! Data types representing the various ways space and time can be quantized.
+//!
+//! Kitsune thinks of space-time coordinates on three different levels:
+//!
+//! ### Absolute coordinates
+//!
+//! At the absolute level, space coordinates are represented by `u32` (via `DhtLocation`),
+//! and time coordinates by `i64` (via `Timestamp`). The timestamp and DHT location
+//! of each op is measured in absolute coordinates, as well as the DHT locations of
+//! agents
+//!
+//! ### Quantized coordinates
+//!
+//! Some data types represent quantized space/time. The `Topology` for a network
+//! determines the quantum size for both the time and space dimensions, meaning
+//! that any absolute coordinate will always be a multiple of this quantum size.
+//! Hence, quantized coordinates are expressed in terms of multiples of the
+//! quantum size.
+//!
+//! `SpaceQuantum` and `TimeQuantum` express quantized coordinates. They refer
+//! to a specific quantum-sized portion of space/time.
+//!
+//! Note that any transformation between Absolute and Quantized coordinates
+//! requires the information contained in the `Topology` of the network.
+//!
+//! ### Segment coordinates (or, Exponential coordinates)
+//!
+//! The spacetime we are interested in has dimensions that are not only quantized,
+//! but are also hierarchically organized into non-overlapping segments.
+//! When expressing segments of space larger than a single quantum, we only ever talk about
+//! groupings of 2, 4, 8, 16, etc. quanta at a time, and these groupings are
+//! always aligned so that no two segments of a given size ever overlap. Moreover,
+//! any two segments of different sizes either overlap completely (one is a strict
+//! superset of the other), or they don't overlap at all (they are disjoint sets).
+//!
+//! Segment coordinates are expressed in terms of:
+//! - a *power* (exponent of 2) which determines the length of the segment *expressed as a Quantized coordinate*
+//! - an *offset*, which is a multiple of the length of this segment to determine
+//!   the "left" edge's distance from the origin *as a Quantized coordinate*
+//!
+//! You must still convert from these Quantized coordinates to get to the actual
+//! Absolute coordinates.
+//!
+//! The pairing of any `SpaceSegment` with any `TimeSegment` forms a `Region`,
+//! a bounded rectangle of spacetime.
+//!
+
+use std::{marker::PhantomData, ops::AddAssign};
+
+use crate::{
+    op::{Loc, Timestamp},
+    prelude::pow2,
+    ArqStrat,
+};
+use derivative::Derivative;
+
+/// Represents some particular quantum area of space. The actual DhtLocation that this
+/// coordinate corresponds to depends upon the space quantum size specified
+/// in the Topology
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    derive_more::Add,
+    derive_more::Sub,
+    derive_more::Display,
+    derive_more::From,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct SpaceQuantum(u32);
+
+impl SpaceQuantum {
+    /// The locations at either end of this quantum
+    pub fn to_loc_bounds(&self, topo: &Topology) -> (Loc, Loc) {
+        let (a, b): (u32, u32) = bounds(&topo.space, 0, self.0.into(), 1);
+        (Loc::from(a), Loc::from(b))
+    }
+}
+
+/// Represents some particular quantum area of time . The actual Timestamp that this
+/// coordinate corresponds to depends upon the time quantum size specified
+/// in the Topology
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    derive_more::Add,
+    derive_more::Sub,
+    derive_more::Display,
+    derive_more::From,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct TimeQuantum(u32);
+
+impl TimeQuantum {
+    /// The quantum which contains this timestamp
+    pub fn from_timestamp(topo: &Topology, timestamp: Timestamp) -> Self {
+        topo.time_quantum(timestamp)
+    }
+
+    /// The timestamps at either end of this quantum
+    pub fn to_timestamp_bounds(&self, topo: &Topology) -> (Timestamp, Timestamp) {
+        let (a, b): (i64, i64) = bounds64(&topo.time, 0, self.0.into(), 1);
+        (
+            Timestamp::from_micros(a + topo.time_origin.as_micros()),
+            Timestamp::from_micros(b + topo.time_origin.as_micros()),
+        )
+    }
+}
+
+/// A quantum in the physical sense: the smallest possible amount of something.
+/// Here, we are talking about Time and Space quanta.
+pub trait Quantum: From<u32> + PartialEq + Eq + PartialOrd + Ord + std::fmt::Debug {
+    /// The absolute coordinate which this quantum corresponds to (time or space)
+    type Absolute;
+
+    /// The u32 representation
+    fn inner(&self) -> u32;
+
+    /// Return the proper dimension (time or space) from the topology
+    fn dimension(topo: &Topology) -> &Dimension;
+
+    /// If this coord is beyond the max value for its dimension, wrap it around
+    /// the max value
+    fn normalized(self, topo: &Topology) -> Self;
+
+    /// The maximum quantum for this dimension
+    fn max_value(topo: &Topology) -> Self {
+        Self::from((2u64.pow(Self::dimension(topo).bit_depth as u32) - 1) as u32)
+    }
+
+    /// Convert to the absolute u32 coordinate space, wrapping if needed
+    fn exp_wrapping(&self, topo: &Topology, pow: u8) -> u32 {
+        (self.inner() as u64 * Self::dimension(topo).quantum as u64 * 2u64.pow(pow as u32)) as u32
+    }
+
+    /// Exposes wrapping addition for the u32
+    fn wrapping_add(self, other: u32) -> Self {
+        Self::from((self.inner()).wrapping_add(other))
+    }
+
+    /// Exposes wrapping subtraction for the u32
+    fn wrapping_sub(self, other: u32) -> Self {
+        Self::from((self.inner()).wrapping_sub(other))
+    }
+}
+
+impl Quantum for SpaceQuantum {
+    type Absolute = Loc;
+
+    fn inner(&self) -> u32 {
+        self.0
+    }
+
+    fn dimension(topo: &Topology) -> &Dimension {
+        &topo.space
+    }
+
+    fn normalized(self, topo: &Topology) -> Self {
+        let depth = topo.space.bit_depth;
+        if depth >= 32 {
+            self
+        } else {
+            Self(self.0 % pow2(depth))
+        }
+    }
+}
+
+impl Quantum for TimeQuantum {
+    type Absolute = Timestamp;
+
+    fn inner(&self) -> u32 {
+        self.0
+    }
+
+    fn dimension(topo: &Topology) -> &Dimension {
+        &topo.time
+    }
+
+    // Time coordinates do not wrap, so normalization is an identity
+    fn normalized(self, _topo: &Topology) -> Self {
+        self
+    }
+}
+
+/// A SpaceQuantum and a TimeQuantum form a quantum of spacetime
+#[derive(Debug)]
+pub struct SpacetimeQuantumCoords {
+    /// The space quantum coordinate
+    pub space: SpaceQuantum,
+    /// The time quantum coordinate
+    pub time: TimeQuantum,
+}
+
+impl SpacetimeQuantumCoords {
+    /// Unpack the space and time coordinates
+    pub fn to_tuple(&self) -> (u32, u32) {
+        (self.space.0, self.time.0)
+    }
+}
+
+fn bounds<N: From<u32>>(dim: &Dimension, power: u8, offset: Offset, count: u32) -> (N, N) {
+    let q = dim.quantum.wrapping_mul(pow2(power));
+    let start = offset.wrapping_mul(q);
+    let len = count.wrapping_mul(q);
+    (start.into(), start.wrapping_add(len).wrapping_sub(1).into())
+}
+
+fn bounds64<N: From<i64>>(dim: &Dimension, power: u8, offset: Offset, count: u32) -> (N, N) {
+    let q = dim.quantum as i64 * 2i64.pow(power.into());
+    let start = (*offset as i64).wrapping_mul(q);
+    let len = (count as i64).wrapping_mul(q);
+    (start.into(), start.wrapping_add(len).wrapping_sub(1).into())
+}
+
+/// An Offset represents the position of the left edge of some Segment.
+/// The absolute DhtLocation of the offset is determined by the "power" of its
+/// context, and topology of the space, by:
+///
+///   dht location = offset * 2^pow * topology.space.quantum
+///
+/// Currently we only discuss offsets in Space. TODO: do we need to talk about
+/// Time Offsets as well?
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    derive_more::Add,
+    derive_more::Sub,
+    derive_more::Mul,
+    derive_more::Div,
+    derive_more::Deref,
+    derive_more::DerefMut,
+    derive_more::From,
+    derive_more::Into,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[serde(transparent)]
+pub struct Offset(pub u32);
+
+impl Offset {
+    /// Get the absolute coordinate for this Offset
+    pub fn to_loc(&self, topo: &Topology, power: u8) -> Loc {
+        self.wrapping_mul(topo.space.quantum)
+            .wrapping_mul(pow2(power))
+            .into()
+    }
+
+    /// Get the quantum coordinate for this Offset
+    pub fn to_quantum(&self, power: u8) -> SpaceQuantum {
+        self.wrapping_mul(pow2(power)).into()
+    }
+
+    /// Get the nearest rounded-down Offset for the given Loc
+    pub fn from_loc_rounded(loc: Loc, topo: &Topology, power: u8) -> Offset {
+        (loc.as_u32() / topo.space.quantum / pow2(power)).into()
+    }
+}
+
+/// Any interval in space or time is represented by a node in a tree, so our
+/// way of describing intervals uses tree coordinates as well:
+/// The length of an interval is 2^(power), and the position of its left edge
+/// is at (offset * length).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Segment<Q: Quantum> {
+    /// The exponent, where length = 2^power
+    pub power: u8,
+    /// The offset from the origin, measured in number of lengths
+    pub offset: Offset,
+    phantom: PhantomData<Q>,
+}
+
+impl<Q: Quantum> Segment<Q> {
+    /// Constructor
+    pub fn new<O: Into<Offset>>(power: u8, offset: O) -> Self {
+        Self {
+            power,
+            offset: offset.into(),
+            phantom: PhantomData,
+        }
+    }
+
+    /// How many quanta does this segment cover?
+    pub fn num_quanta(&self) -> u64 {
+        // If power is 32, this overflows a u32
+        2u64.pow(self.power.into())
+    }
+
+    /// The length, in absolute terms (Location or microseconds of time)
+    pub fn absolute_length(&self, topo: &Topology) -> u64 {
+        let q = Q::dimension(topo).quantum as u64;
+        // If power is 32, this overflows a u32
+        self.num_quanta() * q
+    }
+
+    /// Get the quanta which bound this segment
+    pub fn quantum_bounds(&self, topo: &Topology) -> (Q, Q) {
+        let n = self.num_quanta();
+        let a = (n * u64::from(*self.offset)) as u32;
+        (
+            Q::from(a).normalized(topo),
+            Q::from(a.wrapping_add(n as u32).wrapping_sub(1)).normalized(topo),
+        )
+    }
+
+    /// The segment contains the given quantum coord
+    pub fn contains_quantum(&self, topo: &Topology, coord: Q) -> bool {
+        let (lo, hi) = self.quantum_bounds(topo);
+        let coord = coord.normalized(topo);
+        if lo <= hi {
+            lo <= coord && coord <= hi
+        } else {
+            lo <= coord || coord <= hi
+        }
+    }
+
+    /// Halving an interval is equivalent to taking the child nodes of the node
+    /// which represents this interval
+    pub fn halve(self) -> Option<(Self, Self)> {
+        if self.power == 0 {
+            // Can't split a quantum value (a leaf has no children)
+            None
+        } else {
+            let power = self.power - 1;
+            Some((
+                Segment::new(power, Offset(*self.offset * 2)),
+                Segment::new(power, Offset(*self.offset * 2 + 1)),
+            ))
+        }
+    }
+}
+
+impl SpaceSegment {
+    /// Get the start and end bounds, in absolute Loc coordinates, for this segment
+    pub fn loc_bounds(&self, topo: &Topology) -> (Loc, Loc) {
+        let (a, b): (u32, u32) = bounds(&topo.space, self.power, self.offset, 1);
+        (Loc::from(a), Loc::from(b))
+    }
+}
+
+impl TimeSegment {
+    /// Get the start and end bounds, in absolute Timestamp coordinates, for this segment
+    pub fn timestamp_bounds(&self, topo: &Topology) -> (Timestamp, Timestamp) {
+        let (a, b): (i64, i64) = bounds64(&topo.time, self.power, self.offset, 1);
+        let o = topo.time_origin.as_micros();
+        (Timestamp::from_micros(a + o), Timestamp::from_micros(b + o))
+    }
+}
+
+/// Alias
+pub type SpaceSegment = Segment<SpaceQuantum>;
+/// Alias
+pub type TimeSegment = Segment<TimeQuantum>;
+
+/// Defines the quantization of a dimension of spacetime.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Dimension {
+    /// The smallest possible length in this dimension.
+    /// Determines the interval represented by the leaf of a tree.
+    pub quantum: u32,
+
+    /// The smallest power of 2 which is larger than the quantum.
+    /// Needed for various calculations.
+    pub quantum_power: u8,
+
+    /// The log2 size of this dimension, so that 2^bit_depth is the number of
+    /// possible values that can be represented.
+    bit_depth: u8,
+}
+
+impl Dimension {
+    /// No quantization.
+    /// Used for testing, making it easier to construct values without thinking
+    /// of unit conversions.
+    #[cfg(feature = "test_utils")]
+    pub fn unit() -> Self {
+        Dimension {
+            quantum: 1,
+            quantum_power: 0,
+            bit_depth: 32,
+        }
+    }
+
+    /// The standard space quantum size is 2^12
+    pub const fn standard_space() -> Self {
+        let quantum_power = 12;
+        Dimension {
+            // if a network has 1 million peers,
+            // the average spacing between them is ~4,300
+            // so at a target coverage of 100,
+            // each arc will be ~430,000 in length
+            // which divided by 16 (max chunks) is ~2700, which is about 2^15.
+            // So, we'll go down to 2^12 just to be extra safe.
+            // This means we only need 20 bits to represent any location.
+            quantum: 2u32.pow(quantum_power as u32),
+            quantum_power,
+            bit_depth: 32 - quantum_power,
+        }
+    }
+
+    /// The standard time quantum size is 5 minutes (300 million microseconds)
+    pub const fn standard_time() -> Self {
+        Dimension {
+            // 5 minutes in microseconds = 1mil * 60 * 5 = 300,000,000
+            // log2 of this is 28.16, FYI
+            quantum: 1_000_000 * 60 * 5,
+            quantum_power: 29,
+
+            // 12 quanta = 1 hour.
+            // If we set the max lifetime for a network to ~100 years, which
+            // is 12 * 24 * 365 * 1000 = 105,120,000 time quanta,
+            // the log2 of which is 26.64,
+            // then we can store any time coordinate in that range using 27 bits.
+            //
+            // BTW, the log2 of 100 years in microseconds is 54.81
+            bit_depth: 27,
+        }
+    }
+}
+
+/// Topology defines the structure of spacetime, in particular how space and
+/// time are quantized.
+///
+/// Any calculation which requires converting from absolute coordinates to
+/// quantized coordinates must refer to the topology. Therefore, this type is
+/// ubiquitous! More functions than not take it as a parameter. This may seem
+/// cumbersome, but there are a few reasons why this is helpful:
+/// - We currently use a "standard" quantization for all networks, but we may
+///   find it beneficial in the future to let each network specify its own
+///   quantization levels, based on its own traffic and longevity needs.
+/// - It is confusing to be working with three different coordinate systems in
+///   this codebase, and the presence of a `&topo` param in a function is a
+///   helpful reminder to be extra mindful about the unit conversions that are
+///   happening
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Topology {
+    /// The quantization of space
+    pub space: Dimension,
+    /// The quantization of time
+    pub time: Dimension,
+    /// The origin of time, meaning the 0th quantum contains this Timestamp.
+    pub time_origin: Timestamp,
+}
+
+impl Topology {
+    /// Unit dimensions with the given time origin
+    #[cfg(feature = "test_utils")]
+    pub fn unit(time_origin: Timestamp) -> Self {
+        Self {
+            space: Dimension::unit(),
+            time: Dimension::unit(),
+            time_origin,
+        }
+    }
+
+    /// Unit dimensions with a zero time origin
+    #[cfg(feature = "test_utils")]
+    pub fn unit_zero() -> Self {
+        Self {
+            space: Dimension::unit(),
+            time: Dimension::unit(),
+            time_origin: Timestamp::from_micros(0),
+        }
+    }
+
+    /// Standard dimensions with the given time origin
+    pub fn standard(time_origin: Timestamp) -> Self {
+        Self {
+            space: Dimension::standard_space(),
+            time: Dimension::standard_time(),
+            time_origin,
+        }
+    }
+
+    /// Standard dimensions with the [`HOLOCHAIN_EPOCH`] as the time origin
+    pub fn standard_epoch() -> Self {
+        Self::standard(Timestamp::HOLOCHAIN_EPOCH)
+    }
+
+    /// Standard dimensions with a zero time origin
+    #[cfg(feature = "test_utils")]
+    pub fn standard_zero() -> Self {
+        Self::standard(Timestamp::ZERO)
+    }
+
+    /// Returns the space quantum which contains this location
+    pub fn space_quantum(&self, x: Loc) -> SpaceQuantum {
+        (x.as_u32() / self.space.quantum).into()
+    }
+
+    /// Returns the time quantum which contains this timestamp
+    pub fn time_quantum(&self, t: Timestamp) -> TimeQuantum {
+        let t = (t.as_micros() - self.time_origin.as_micros()).max(0);
+        ((t / self.time.quantum as i64) as u32).into()
+    }
+
+    /// The minimum power to use in "exponentional coordinates".
+    pub fn min_space_power(&self) -> u8 {
+        // if space quantum power is 0, then min has to be at least 1.
+        // otherwise, it can be 0
+        1u8.saturating_sub(self.space.quantum_power)
+    }
+
+    /// The maximum power to use in "exponentional coordinates".
+    /// This is 17 for standard space topology. (32 - 12 - 3)
+    pub fn max_space_power(&self, strat: &ArqStrat) -> u8 {
+        32 - self.space.quantum_power - strat.max_chunks_log2()
+    }
+}
+
+/// A type which generates a list of exponentially expanding time windows
+/// which fit into a tree structure. See [this document](https://hackmd.io/@hololtd/r1IAIbr5Y)
+/// for the full understanding.
+///
+/// TODO: add this documentation to the codebase
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Derivative, serde::Serialize, serde::Deserialize)]
+#[derivative(PartialOrd, Ord)]
+pub struct TelescopingTimes {
+    time: TimeQuantum,
+
+    #[derivative(PartialOrd = "ignore")]
+    #[derivative(Ord = "ignore")]
+    limit: Option<u32>,
+}
+
+impl TelescopingTimes {
+    /// An empty set of times
+    pub fn empty() -> Self {
+        Self {
+            time: 0.into(),
+            limit: None,
+        }
+    }
+
+    /// Constructor,
+    pub fn new(time: TimeQuantum) -> Self {
+        Self { time, limit: None }
+    }
+
+    /// Calculate the exponentially expanding time segments using the binary
+    /// representation of the current timestamp.
+    ///
+    /// The intuition for this algorithm is that the position of the most
+    /// significant 1 represents the power of the largest, leftmost time segment,
+    /// and subsequent bits represent the powers of 2 below that one.
+    /// After the MSB, a 0 represents a single value of the power represented
+    /// by that bit, and a 1 represents two values of the power at that bit.
+    ///
+    /// See the test below which has the first 16 time segments, alongside
+    /// the binary representation of the timestamp (+1) which generated,
+    /// which illustrates this pattern.
+    pub fn segments(&self) -> Vec<TimeSegment> {
+        let mut now: u32 = self.time.inner() + 1;
+        if now == 1 {
+            return vec![];
+        }
+        let zs = now.leading_zeros() as u8;
+        now <<= zs;
+        let iters = 32 - zs - 1;
+        let mut max = self.limit.unwrap_or(u32::from(iters) * 2);
+        if max == 0 {
+            return vec![];
+        }
+        let mut seg = TimeSegment::new(iters, 0);
+        let mut times = vec![];
+        let mask = 1u32.rotate_right(1); // 0b100000...
+        for _ in 0..iters {
+            seg.power -= 1;
+            *seg.offset *= 2;
+
+            // remove the leading zero and shift left
+            now &= !mask;
+            now <<= 1;
+
+            times.push(seg);
+            *seg.offset += 1;
+            max -= 1;
+            if max == 0 {
+                break;
+            }
+            if now & mask > 0 {
+                // if the MSB is 1, duplicate the segment
+                times.push(seg);
+                *seg.offset += 1;
+                max -= 1;
+                if max == 0 {
+                    break;
+                }
+            }
+        }
+        if self.limit.is_none() {
+            // Should be all zeroes at this point
+            debug_assert_eq!(now & !mask, 0)
+        }
+        times
+    }
+
+    /// Set a limit
+    pub fn limit(&self, limit: u32) -> Self {
+        Self {
+            time: self.time,
+            limit: Some(limit),
+        }
+    }
+
+    /// Modify the region data associated with two different TelescopingTimes
+    /// of different lengths, so that both data vectors are referring to
+    /// the same regions.
+    ///
+    /// In general, when one TelescopingTimes sequence is longer than another,
+    /// the longer sequence will have larger TimeSegments than the shorter one.
+    /// To rectify them, the shorter sequence needs to merge some of its earlier
+    /// data until it has a segment large enough to match the larger segment
+    /// of the other sequence. This continues until all segments of the smaller
+    /// sequence are exhausted. Then, the longer sequence is truncated to match
+    /// the shorter one.
+    pub fn rectify<T: AddAssign>(a: (&Self, &mut Vec<T>), b: (&Self, &mut Vec<T>)) {
+        let (left, right) = if a.0.time > b.0.time { (b, a) } else { (a, b) };
+        let (lt, ld) = left;
+        let (rt, rd) = right;
+        let mut lt: Vec<_> = lt.segments().iter().map(TimeSegment::num_quanta).collect();
+        let rt: Vec<_> = rt.segments().iter().map(TimeSegment::num_quanta).collect();
+        assert_eq!(lt.len(), ld.len());
+        assert_eq!(rt.len(), rd.len());
+        let mut i = 0;
+        while i < lt.len() - 1 {
+            while lt[i] < rt[i] && i < lt.len() - 1 {
+                lt[i] += lt.remove(i + 1);
+                let d = ld.remove(i + 1);
+                ld[i] += d;
+            }
+            i += 1;
+        }
+        rd.truncate(ld.len());
+    }
+}
+
+/// Node-specific parameters for gossip.
+/// While the [`Topology`] must be the same for every node in a network, each
+/// node is free to choose its own GossipParams.
+///
+/// Choosing smaller values for these offsets can lead to less resource usage,
+/// at the expense of reducing opportunities to gossip with other nodes.
+/// This is also largely dependent on the characteristcs of the network,
+/// since if almost all nodes are operating with the same current timestamp
+/// and Arq power level, there will be very little need for reconciliation.
+///
+/// In networks where nodes are offline for long periods of time, or latency
+/// is very high (sneakernet), it could be helpful to increase these values.
+#[derive(Copy, Clone, Debug, derive_more::Constructor)]
+pub struct GossipParams {
+    /// What +/- coordinate offset will you accept for timestamps?
+    /// e.g. if the time quantum is 5 min,
+    /// a time buffer of 2 will allow +/- 10 min.
+    ///
+    /// This, along with `max_space_power_offset`, determines what range of
+    /// region resolution gets stored in the 2D Fenwick tree
+    pub max_time_offset: TimeQuantum,
+
+    /// What difference in power will you accept for other agents' Arqs?
+    /// e.g. if the power I use in my arq is 22, and this offset is 2,
+    /// I won't talk to anyone whose arq is expressed with a power lower
+    /// than 20 or greater than 24
+    ///
+    /// This, along with `max_time_offset`, determines what range of
+    /// region resolution gets stored in the 2D Fenwick tree
+    pub max_space_power_offset: u8,
+}
+
+impl GossipParams {
+    /// Zero-tolerance gossip params
+    pub fn zero() -> Self {
+        Self {
+            max_time_offset: 0.into(),
+            max_space_power_offset: 0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_bounds_unit_topo() {
+        let topo = Topology::unit_zero();
+
+        assert_eq!(
+            SpaceQuantum::from(12).to_loc_bounds(&topo),
+            (12.into(), 12.into())
+        );
+        assert_eq!(
+            SpaceQuantum::max_value(&topo).to_loc_bounds(&topo),
+            (u32::MAX.into(), u32::MAX.into())
+        );
+
+        assert_eq!(
+            TimeQuantum::from(12).to_timestamp_bounds(&topo),
+            (Timestamp::from_micros(12), Timestamp::from_micros(12))
+        );
+
+        assert_eq!(
+            TimeQuantum::max_value(&topo).to_timestamp_bounds(&topo),
+            (
+                Timestamp::from_micros(u32::MAX as i64),
+                Timestamp::from_micros(u32::MAX as i64),
+            )
+        );
+    }
+
+    #[test]
+    fn to_bounds_standard_topo() {
+        let origin = Timestamp::ZERO;
+        let topo = Topology::standard(origin.clone());
+        let epoch = origin.as_micros();
+        let xq = topo.space.quantum;
+        let tq = topo.time.quantum as i64;
+
+        assert_eq!(
+            SpaceQuantum::from(12).to_loc_bounds(&topo),
+            ((12 * xq).into(), (13 * xq - 1).into())
+        );
+        assert_eq!(
+            SpaceQuantum::max_value(&topo).to_loc_bounds(&topo),
+            ((u32::MAX - xq + 1).into(), u32::MAX.into())
+        );
+
+        assert_eq!(
+            TimeQuantum::from(12).to_timestamp_bounds(&topo),
+            (
+                Timestamp::from_micros(epoch + 12 * tq),
+                Timestamp::from_micros(epoch + 13 * tq - 1)
+            )
+        );
+
+        // just ensure this doesn't panic
+        let _ = TimeQuantum::max_value(&topo).to_timestamp_bounds(&topo);
+    }
+
+    #[test]
+    fn test_contains() {
+        let topo = Topology::unit_zero();
+        let s = TimeSegment::new(31, 0);
+        assert_eq!(s.quantum_bounds(&topo), (0.into(), (u32::MAX / 2).into()));
+        assert!(s.contains_quantum(&topo, 0.into()));
+        assert!(!s.contains_quantum(&topo, (u32::MAX / 2 + 2).into()));
+    }
+
+    #[test]
+    fn test_contains_normalized() {
+        let topo = Topology::standard_epoch();
+        let m = pow2(topo.space.bit_depth);
+        let s = SpaceSegment::new(2, m + 5);
+        let bounds = s.quantum_bounds(&topo);
+        // The quantum bounds are normalized (wrapped)
+        assert_eq!(bounds, SpaceSegment::new(2, 5).quantum_bounds(&topo));
+        assert_eq!(bounds, (20.into(), 23.into()));
+
+        assert!(s.contains_quantum(&topo, 20.into()));
+        assert!(s.contains_quantum(&topo, 23.into()));
+        assert!(s.contains_quantum(&topo, (m * 2 + 20).into()));
+        assert!(s.contains_quantum(&topo, (m * 3 + 23).into()));
+        assert!(!s.contains_quantum(&topo, (m * 4 + 24).into()));
+    }
+
+    #[test]
+    fn segment_length() {
+        let s = TimeSegment::new(31, 0);
+        assert_eq!(s.num_quanta(), 2u64.pow(31));
+    }
+
+    fn lengths(t: TimeQuantum) -> Vec<u32> {
+        TelescopingTimes::new(t)
+            .segments()
+            .into_iter()
+            .map(|i| i.num_quanta() as u32)
+            .collect()
+    }
+
+    #[test]
+    fn test_telescoping_times_limit() {
+        let tt = TelescopingTimes::new(64.into());
+        assert_eq!(tt.segments().len(), 7);
+        assert_eq!(tt.limit(6).segments().len(), 6);
+        assert_eq!(tt.limit(4).segments().len(), 4);
+        assert_eq!(
+            tt.segments().into_iter().take(6).collect::<Vec<_>>(),
+            tt.limit(6).segments()
+        );
+    }
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_telescoping_times_first_16() {
+        let ts = TimeQuantum::from;
+
+                                                             // n+1
+        assert_eq!(lengths(ts(0)),  Vec::<u32>::new());      // 0001
+        assert_eq!(lengths(ts(1)),  vec![1]);                // 0010
+        assert_eq!(lengths(ts(2)),  vec![1, 1]);             // 0011
+        assert_eq!(lengths(ts(3)),  vec![2, 1]);             // 0100
+        assert_eq!(lengths(ts(4)),  vec![2, 1, 1]);          // 0101
+        assert_eq!(lengths(ts(5)),  vec![2, 2, 1]);          // 0110
+        assert_eq!(lengths(ts(6)),  vec![2, 2, 1, 1]);       // 0111
+        assert_eq!(lengths(ts(7)),  vec![4, 2, 1]);          // 1000
+        assert_eq!(lengths(ts(8)),  vec![4, 2, 1, 1]);       // 1001
+        assert_eq!(lengths(ts(9)),  vec![4, 2, 2, 1]);       // 1010
+        assert_eq!(lengths(ts(10)), vec![4, 2, 2, 1, 1]);    // 1011
+        assert_eq!(lengths(ts(11)), vec![4, 4, 2, 1]);       // 1100
+        assert_eq!(lengths(ts(12)), vec![4, 4, 2, 1, 1]);    // 1101
+        assert_eq!(lengths(ts(13)), vec![4, 4, 2, 2, 1]);    // 1110
+        assert_eq!(lengths(ts(14)), vec![4, 4, 2, 2, 1, 1]); // 1111
+        assert_eq!(lengths(ts(15)), vec![8, 4, 2, 1]);      // 10000
+    }
+
+    /// Test that data generated by two different telescoping time sets can be
+    /// rectified.
+    ///
+    /// The data used in this test are simple vecs of integers, but in the real
+    /// world, the data would be the region data (which has an AddAssign impl).
+    #[test]
+    fn test_rectify_telescoping_times() {
+        {
+            let a = TelescopingTimes::new(5.into());
+            let b = TelescopingTimes::new(8.into());
+
+            // the actual integers used here don't matter,
+            // they're just picked so that sums look distinct
+            let mut da = vec![16, 8, 4];
+            let mut db = vec![32, 16, 8, 4];
+            TelescopingTimes::rectify((&a, &mut da), (&b, &mut db));
+            assert_eq!(da, vec![16 + 8, 4]);
+            assert_eq!(db, vec![32, 16]);
+        }
+        {
+            let a = TelescopingTimes::new(14.into());
+            let b = TelescopingTimes::new(16.into());
+            let mut da = vec![128, 64, 32, 16, 8, 4];
+            let mut db = vec![32, 16, 8, 4, 1];
+            TelescopingTimes::rectify((&a, &mut da), (&b, &mut db));
+            assert_eq!(da, vec![128 + 64, 32 + 16, 8 + 4]);
+            assert_eq!(db, vec![32, 16, 8]);
+        }
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn telescoping_times_cover_total_time_span(now in 0u32..u32::MAX) {
+            let topo = Topology::unit_zero();
+            let ts = TelescopingTimes::new(now.into()).segments();
+            let total = ts.iter().fold(0u64, |len, t| {
+                assert_eq!(t.quantum_bounds(&topo).0.inner(), len as u32, "t = {:?}, len = {}", t, len);
+                len + t.num_quanta()
+            });
+            assert_eq!(total, now as u64);
+        }
+
+        #[test]
+        fn telescoping_times_end_with_1(now: u32) {
+            if let Some(last) = TelescopingTimes::new(now.into()).segments().pop() {
+                assert_eq!(last.power, 0);
+            }
+        }
+
+        #[test]
+        fn telescoping_times_are_fractal(now: u32) {
+            let a = lengths(now.into());
+            let b = lengths((now - a[0]).into());
+            assert_eq!(b.as_slice(), &a[1..]);
+        }
+
+        #[test]
+        fn rectification_doesnt_panic(a: u32, b: u32) {
+            let (a, b) = if a < b { (a, b)} else {(b, a)};
+            let a = TelescopingTimes::new(a.into());
+            let b = TelescopingTimes::new(b.into());
+            let mut da = vec![1; a.segments().len()];
+            let mut db = vec![1; b.segments().len()];
+            TelescopingTimes::rectify((&a, &mut da), (&b, &mut db));
+            assert_eq!(da.len(), db.len());
+        }
+    }
+}

--- a/crates/kitsune_p2p/dht/src/region.rs
+++ b/crates/kitsune_p2p/dht/src/region.rs
@@ -1,0 +1,68 @@
+//! A Region is a bounded section of spacetime containing zero or more Ops.
+//!
+//! It consists of a [`RegionCoords`] object which defines the space and time
+//! boundaries of the region, and some [`RegionData`] which contains a summary
+//! of what is inside that region, including:
+//! - the number of ops
+//! - the total size of op data
+//! - the XOR of all OpHashes within this region.
+//!
+//! The actual [`Region`] struct is generic over the data type, but in all
+//! cases, we simply use RegionData, the default. (The type is generic for
+//! the possibility of simpler testing in the future.)
+//!
+//! RegionData is composable: The sum of the RegionData of two *disjoint* (nonoverlapping)
+//! Regions represents the union of those two Regions. The sum of hashes is defined
+//! as the XOR of hashes, which allows this compatibility.
+
+mod region_coords;
+mod region_data;
+
+pub use region_coords::*;
+pub use region_data::*;
+
+use num_traits::Zero;
+use std::ops::{AddAssign, Sub};
+
+/// The constant size in bytes of a region, used for calculating bandwidth usage during
+/// gossip. All regions require the same number of bytes.
+pub const REGION_MASS: u32 = std::mem::size_of::<Region<RegionData>>() as u32;
+
+/// The coordinates defining the Region, along with the calculated [`RegionData`]
+#[derive(Debug, derive_more::Constructor)]
+pub struct Region<D: RegionDataConstraints = RegionData> {
+    /// The coords
+    pub coords: RegionCoords,
+    /// The data
+    pub data: D,
+}
+
+impl<D: RegionDataConstraints> Region<D> {}
+
+/// The constraints necessary for any RegionData
+pub trait RegionDataConstraints:
+    Eq
+    + Zero
+    + AddAssign
+    + Sub<Output = Self>
+    + Copy
+    + Send
+    + Sync
+    + std::fmt::Debug
+    + serde::Serialize
+    + serde::de::DeserializeOwned
+{
+}
+impl<T> RegionDataConstraints for T where
+    T: Eq
+        + Zero
+        + AddAssign
+        + Sub<Output = T>
+        + Copy
+        + Send
+        + Sync
+        + std::fmt::Debug
+        + serde::Serialize
+        + serde::de::DeserializeOwned
+{
+}

--- a/crates/kitsune_p2p/dht/src/region/region_coords.rs
+++ b/crates/kitsune_p2p/dht/src/region/region_coords.rs
@@ -1,0 +1,89 @@
+use crate::Loc;
+use kitsune_p2p_dht_arc::DhtArc;
+use kitsune_p2p_timestamp::Timestamp;
+
+use crate::quantum::{SpaceSegment, SpacetimeQuantumCoords, TimeSegment, Topology};
+
+/// The cross product of a space segment and at time segment forms a Region.
+/// Hence, these two segments are the coordinates which define a Region of spacetime.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, derive_more::Constructor)]
+pub struct RegionCoords {
+    /// The space segment
+    pub space: SpaceSegment,
+    /// The time segment
+    pub time: TimeSegment,
+}
+
+impl RegionCoords {
+    /// Map the quantized coordinates into the actual Timestamp and DhtLocation
+    /// bounds specifying the region
+    pub fn to_bounds(&self, topo: &Topology) -> RegionBounds {
+        RegionBounds {
+            x: self.space.loc_bounds(topo),
+            t: self.time.timestamp_bounds(topo),
+        }
+    }
+
+    /// Does the region contain this spacetime quantum?
+    pub fn contains(&self, topo: &Topology, coords: &SpacetimeQuantumCoords) -> bool {
+        self.space.contains_quantum(topo, coords.space)
+            && self.time.contains_quantum(topo, coords.time)
+    }
+}
+
+/// A region specified in absolute coords, rather than quantum coords.
+/// This type should only be used in the host, which deals in absolute coords.
+/// Kitsune itself should only use [`RegionCoords`] to ensure proper quantum
+/// alignment.
+#[derive(Debug)]
+pub struct RegionBounds {
+    /// The min and max locations
+    pub x: (Loc, Loc),
+    /// The min and max timestamps
+    pub t: (Timestamp, Timestamp),
+}
+
+impl RegionBounds {
+    /// Constructor from extrema
+    pub fn new<L: Into<Loc>>((a, b): (L, L), t: (Timestamp, Timestamp)) -> Self {
+        Self {
+            x: (a.into(), b.into()),
+            t,
+        }
+    }
+
+    /// Does this region contain this point?
+    pub fn contains(&self, x: &Loc, t: &Timestamp) -> bool {
+        self.arc_interval().contains(x) && self.time_range().contains(t)
+    }
+
+    fn arc_interval(&self) -> DhtArc {
+        DhtArc::from_bounds(self.x.0, self.x.1)
+    }
+
+    fn time_range(&self) -> std::ops::RangeInclusive<Timestamp> {
+        self.t.0..=self.t.1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn region_bounds_regressions() {
+        use std::str::FromStr;
+        let topo = Topology::standard_epoch();
+        let b =
+            RegionCoords::new(SpaceSegment::new(12, 100), TimeSegment::new(4, 12)).to_bounds(&topo);
+
+        dbg!(&b);
+        assert_eq!(b.x.0, 1677721600.into());
+        assert_eq!(b.x.1, 1694498815.into());
+        assert_eq!(b.t.0, Timestamp::from_str("2022-01-01T16:00:00Z").unwrap());
+        assert_eq!(
+            b.t.1,
+            Timestamp::from_str("2022-01-01T17:19:59.999999Z").unwrap()
+        );
+    }
+}

--- a/crates/kitsune_p2p/dht/src/region/region_data.rs
+++ b/crates/kitsune_p2p/dht/src/region/region_data.rs
@@ -1,0 +1,114 @@
+use crate::hash::{OpHash, RegionHash};
+
+/// Take bitwise XOR of each element of both arrays
+pub fn array_xor<const N: usize>(a: &mut [u8; N], b: &[u8; N]) {
+    for i in 0..N {
+        a[i] ^= b[i];
+    }
+}
+
+impl RegionHash {
+    /// Any null node hashes just get ignored.
+    pub fn xor(&mut self, other: &Self) {
+        array_xor(&mut *self, other);
+    }
+}
+
+impl std::ops::Add for RegionHash {
+    type Output = Self;
+
+    fn add(mut self, rhs: Self) -> Self::Output {
+        Self::xor(&mut self, &rhs);
+        self
+    }
+}
+
+impl num_traits::Zero for RegionHash {
+    fn zero() -> Self {
+        Self::new([0; 32])
+    }
+
+    fn is_zero(&self) -> bool {
+        *self == Self::zero()
+    }
+}
+
+impl From<OpHash> for RegionHash {
+    fn from(h: OpHash) -> Self {
+        Self::new(h.0)
+    }
+}
+
+/// The pertinent data that we care about for each Region. This is what gets
+/// sent over gossip so that nodes can discover which Regions are different
+/// between them.
+///
+/// The size and count data can also act as heuristics to help us fine-tune the
+/// gossip algorithm, although currently they are unused (except for the purpose
+/// of disambiguation in the rare case of an XOR hash collision).
+#[derive(Copy, Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct RegionData {
+    /// The XOR of hashes of all Ops in this Region
+    pub hash: RegionHash,
+    /// The total size of Op data contains in this Region
+    pub size: u32,
+    /// The number of Ops in this Region.
+    pub count: u32,
+}
+
+impl num_traits::Zero for RegionData {
+    fn zero() -> Self {
+        Self {
+            hash: RegionHash::zero(),
+            size: 0,
+            count: 0,
+        }
+    }
+
+    fn is_zero(&self) -> bool {
+        if self.count == 0 {
+            debug_assert_eq!(self.size, 0);
+            debug_assert_eq!(self.hash, RegionHash::zero());
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl std::ops::AddAssign for RegionData {
+    fn add_assign(&mut self, other: Self) {
+        // dbg!("add regions", &self, &other);
+        self.hash.xor(&other.hash);
+        self.size += other.size;
+        self.count += other.count;
+    }
+}
+
+impl std::ops::Add for RegionData {
+    type Output = Self;
+
+    fn add(mut self, other: Self) -> Self::Output {
+        self += other;
+        self
+    }
+}
+
+impl std::ops::SubAssign for RegionData {
+    fn sub_assign(&mut self, other: Self) {
+        // XOR works as both addition and subtraction
+        // dbg!("subtract regions", &self, &other);
+        self.hash.xor(&other.hash);
+        self.size -= other.size;
+        self.count -= other.count;
+    }
+}
+
+impl std::ops::Sub for RegionData {
+    type Output = Self;
+
+    fn sub(mut self, other: Self) -> Self::Output {
+        self -= other;
+        self
+    }
+}

--- a/crates/kitsune_p2p/dht/src/region_set.rs
+++ b/crates/kitsune_p2p/dht/src/region_set.rs
@@ -1,0 +1,313 @@
+//! A RegionSet is a compact representation of a set of Regions -- the [`RegionCoords`]
+//! defining the regions, and their associated [`RegionData`].
+//!
+//! Currently we have only one scheme for specifying RegionSets, called "LTCS".
+//! "LTCS" is an acronym standing for "Logarithmic Time, Constant Space",
+//! and it refers to our current scheme of partitioning spacetime during gossip, which
+//! is to use a constant number of SpaceSegments (8..16) and a logarithmically
+//! growing number of TimeSegments, with larger segments to cover older times.
+//! In the future we may have other schemes.
+
+mod ltcs;
+
+pub use ltcs::*;
+
+use crate::{error::GossipResult, quantum::*};
+
+use crate::region::{Region, RegionBounds, RegionCoords, RegionData, RegionDataConstraints};
+
+/// The generic definition of a set of Regions.
+/// The current representation is very specific to our current algorithm,
+/// but this is an enum to make room for a more generic representation, e.g.
+/// a simple Vec<Region>, if we want a more intricate algorithm later.
+#[derive(Debug, derive_more::From)]
+#[cfg_attr(feature = "test_utils", derive(Clone))]
+pub enum RegionSet<T: RegionDataConstraints = RegionData> {
+    /// Logarithmic Time, Constant Space.
+    Ltcs(RegionSetLtcs<T>),
+}
+
+impl<D: RegionDataConstraints> RegionSet<D> {
+    /// The number of regions specified
+    pub fn count(&self) -> usize {
+        match self {
+            Self::Ltcs(set) => set.count(),
+        }
+    }
+
+    /// can be used to pair the generated coords with stored data.
+    pub fn region_coords(&self) -> impl Iterator<Item = RegionCoords> + '_ {
+        match self {
+            Self::Ltcs(set) => set.coords.region_coords_flat().map(|(_, coords)| coords),
+        }
+    }
+
+    /// Iterator over all Regions
+    pub fn regions(&self) -> impl Iterator<Item = Region<D>> + '_ {
+        match self {
+            Self::Ltcs(set) => set.regions(),
+        }
+    }
+
+    /// The RegionSet can be used to answer questions about more regions than
+    /// just the ones specified: If a larger region is queried, and this set contains
+    /// a set of regions which over that larger region, then the larger region
+    /// can be dynamically constructed.
+    ///
+    /// This allows agents with differently computed RegionSets to still engage
+    /// in gossip without needing to recompute regions.
+    pub fn query(&self, _bounds: &RegionBounds) -> ! {
+        unimplemented!("only implement after trying naive database-only approach")
+    }
+
+    /// In order for this RegionSet to be queryable, new data needs to be
+    /// integrated into it to avoid needing to recompute it from the database
+    /// on each query.
+    pub fn update(&self, _c: SpacetimeQuantumCoords, _d: D) -> ! {
+        unimplemented!("only implement after trying naive database-only approach")
+    }
+
+    /// Find a set of Regions which represents the intersection of the two
+    /// input RegionSets.
+    pub fn diff(self, other: Self) -> GossipResult<Vec<Region<D>>> {
+        match (self, other) {
+            (Self::Ltcs(left), Self::Ltcs(right)) => left.diff(right),
+        }
+        // Notes on a generic algorithm for the diff of generic regions:
+        // can we use a Fenwick tree to look up regions?
+        // idea:
+        // sort the regions by power (problem, there are two power)
+        // lookup the region to see if there's already a direct hit (most efficient if the sorting guarantees that larger regions get looked up later)
+        // PROBLEM: we *can't* resolve rectangles where one is not a subset of the other
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "test_utils")]
+mod tests {
+
+    use kitsune_p2p_timestamp::Timestamp;
+
+    use crate::{
+        op::*,
+        persistence::*,
+        prelude::{ArqBoundsSet, ArqLocated, ArqStart},
+        test_utils::{Op, OpData, OpStore},
+        Arq, Loc,
+    };
+
+    use super::*;
+
+    /// Create a uniform grid of ops:
+    /// - one gridline per arq segment
+    /// - one gridline per time specified in the iterator
+    ///
+    /// Only works for arqs that don't span `u32::MAX / 2`
+    fn op_grid<S: ArqStart>(
+        topo: &Topology,
+        arq: &Arq<S>,
+        trange: impl Iterator<Item = i64> + Clone,
+    ) -> Vec<Op> {
+        let (left, right) = arq.to_edge_locs(topo);
+        let left = left.as_u32();
+        let right = right.as_u32();
+        let mid = u32::MAX / 2;
+        assert!(
+            !(left < mid && right > mid),
+            "This hacky logic does not work for arqs which span `u32::MAX / 2`"
+        );
+        let xstep = (arq.absolute_length(topo) / arq.count() as u64) as usize;
+        (left as i32..=right as i32)
+            .step_by(xstep)
+            .flat_map(|x| {
+                trange.clone().map(move |t| {
+                    let x = SpaceQuantum::from(x as u32).to_loc_bounds(topo).0;
+                    let t = TimeQuantum::from(t as u32).to_timestamp_bounds(topo).0;
+                    OpData::fake(x, t, 10)
+                })
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_regions() {
+        let topo = Topology::unit(Timestamp::from_micros(1000));
+        let pow = 8;
+        let arq = Arq::new(pow, 0u32.into(), 4.into());
+        assert_eq!(
+            arq.to_edge_locs(&topo),
+            (Loc::from(0u32), Loc::from(1023u32))
+        );
+
+        let mut store = OpStore::new(topo.clone(), GossipParams::zero());
+
+        // Create a nx by nt grid of ops and integrate into the store
+        let nx = 8;
+        let nt = 10;
+        let ops = op_grid(
+            &topo,
+            &ArqLocated::new(pow, 0u32.into(), 8.into()),
+            (1000..11000 as i64).step_by(1000),
+        );
+        assert_eq!(ops.len(), nx * nt);
+        store.integrate_ops(ops.into_iter());
+
+        // Calculate region data for all ops.
+        // The total count should be half of what's in the op store,
+        // since the arq covers exactly half of the ops
+        let times = TelescopingTimes::new(TimeQuantum::from(11000));
+        let coords = RegionCoordSetLtcs::new(times, ArqBoundsSet::single(arq.to_bounds(&topo)));
+        let rset = RegionSetLtcs::from_store(&store, coords);
+        assert_eq!(
+            rset.data.concat().iter().map(|r| r.count).sum::<u32>() as usize,
+            nx * nt / 2
+        );
+    }
+
+    #[test]
+    fn test_rectify() {
+        let topo = Topology::unit_zero();
+        let arq = Arq::new(8, 0u32.into(), 4.into()).to_bounds(&topo);
+        let mut store = OpStore::new(topo.clone(), GossipParams::zero());
+        store.integrate_ops(op_grid(&topo, &arq, 10..20).into_iter());
+
+        let tt_a = TelescopingTimes::new(TimeQuantum::from(20));
+        let tt_b = TelescopingTimes::new(TimeQuantum::from(30));
+        let coords_a = RegionCoordSetLtcs::new(tt_a, ArqBoundsSet::single(arq.clone()));
+        let coords_b = RegionCoordSetLtcs::new(tt_b, ArqBoundsSet::single(arq.clone()));
+
+        let mut rset_a = RegionSetLtcs::from_store(&store, coords_a);
+        let mut rset_b = RegionSetLtcs::from_store(&store, coords_b);
+        assert_ne!(rset_a.data, rset_b.data);
+
+        rset_a.rectify(&mut rset_b).unwrap();
+
+        assert_eq!(rset_a, rset_b);
+
+        let coords: Vec<Vec<_>> = rset_a
+            .coords
+            .region_coords_nested()
+            .map(|col| col.collect())
+            .collect();
+
+        assert_eq!(coords.len(), arq.count() as usize);
+        for col in coords.iter() {
+            assert_eq!(col.len(), rset_a.coords.times.segments().len());
+        }
+        let nt = coords[0].len();
+        assert_eq!(tt_b.segments()[0..nt], rset_a.coords.times.segments());
+        assert_eq!(tt_b.segments()[0..nt], rset_b.coords.times.segments());
+    }
+
+    #[test]
+    fn test_diff() {
+        let topo = Topology::unit_zero();
+        let arq = Arq::new(8, Loc::from(-512i32 as u32), 4.into()).to_bounds(&topo);
+        dbg!(&arq, arq.to_dht_arc_range(&topo));
+
+        let mut store1 = OpStore::new(topo.clone(), GossipParams::zero());
+        store1.integrate_ops(op_grid(&topo, &arq, 10..20).into_iter());
+
+        let extra_ops = [
+            OpData::fake(Loc::from(-300i32), Timestamp::from_micros(18), 4),
+            OpData::fake(Loc::from(12u32), Timestamp::from_micros(12), 4),
+        ];
+        let mut store2 = store1.clone();
+        store2.integrate_ops(extra_ops.clone().into_iter());
+
+        let coords_a = RegionCoordSetLtcs::new(
+            TelescopingTimes::new(TimeQuantum::from(20)),
+            ArqBoundsSet::single(arq.clone()),
+        );
+        let coords_b = RegionCoordSetLtcs::new(
+            TelescopingTimes::new(TimeQuantum::from(21)),
+            ArqBoundsSet::single(arq.clone()),
+        );
+
+        let rset_a = RegionSetLtcs::from_store(&store1, coords_a);
+        let rset_b = RegionSetLtcs::from_store(&store2, coords_b);
+        assert_ne!(rset_a.data, rset_b.data);
+
+        let diff = rset_a.clone().diff(rset_b.clone()).unwrap();
+        dbg!(&diff, &extra_ops);
+        assert_eq!(diff.len(), 2);
+
+        assert!(diff[0].coords.contains(&topo, &extra_ops[0].coords(&topo)));
+        assert!(diff[1].coords.contains(&topo, &extra_ops[1].coords(&topo)));
+
+        // Adding the region data from each extra op to the region data of the
+        // diff which was missing those ops should be the same as the query
+        // of the store which contains the extra ops over the same region
+        // TODO: proptest this
+        assert_eq!(
+            diff[0].data + extra_ops[0].region_data(),
+            store2.query_region_data(&diff[0].coords)
+        );
+        assert_eq!(
+            diff[1].data + extra_ops[1].region_data(),
+            store2.query_region_data(&diff[1].coords)
+        );
+    }
+
+    #[test]
+    fn test_diff_standard_topo() {
+        let topo = Topology::standard_zero();
+        let pow: u8 = 4;
+        // This arq goes from -2^17 to 2^17, with a chunk size of 2^16
+        let left_edge = Loc::from(-(2i32.pow(pow as u32 + 12 + 1)));
+        let arq = Arq::new(pow, left_edge, 4.into()).to_bounds(&topo);
+        dbg!(&arq, arq.to_dht_arc_range(&topo));
+
+        let mut store1 = OpStore::new(topo.clone(), GossipParams::zero());
+        store1.integrate_ops(op_grid(&topo, &arq, 10..20).into_iter());
+
+        let extra_ops = [
+            OpData::fake(
+                left_edge,
+                TimeQuantum::from(18).to_timestamp_bounds(&topo).0,
+                13,
+            ),
+            OpData::fake(
+                Loc::from(11111u32),
+                TimeQuantum::from(12).to_timestamp_bounds(&topo).0,
+                11,
+            ),
+        ];
+        // Store 2 has everything store 1 has, plus 2 extra ops
+        let mut store2 = store1.clone();
+        store2.integrate_ops(extra_ops.clone().into_iter());
+
+        let coords_a = RegionCoordSetLtcs::new(
+            TelescopingTimes::new(TimeQuantum::from(20)),
+            ArqBoundsSet::single(arq.clone()),
+        );
+        let coords_b = RegionCoordSetLtcs::new(
+            TelescopingTimes::new(TimeQuantum::from(21)),
+            ArqBoundsSet::single(arq.clone()),
+        );
+
+        let rset_a = RegionSetLtcs::from_store(&store1, coords_a);
+        let rset_b = RegionSetLtcs::from_store(&store2, coords_b);
+        assert_ne!(rset_a.data, rset_b.data);
+
+        let diff = rset_a.clone().diff(rset_b.clone()).unwrap();
+        dbg!(&diff, &extra_ops);
+        assert_eq!(diff.len(), 2);
+
+        assert!(diff[0].coords.contains(&topo, &extra_ops[0].coords(&topo)));
+        assert!(diff[1].coords.contains(&topo, &extra_ops[1].coords(&topo)));
+
+        // Adding the region data from each extra op to the region data of the
+        // diff which was missing those ops should be the same as the query
+        // of the store which contains the extra ops over the same region
+        // TODO: proptest this
+        assert_eq!(
+            diff[0].data + extra_ops[0].region_data(),
+            store2.query_region_data(&diff[0].coords)
+        );
+        assert_eq!(
+            diff[1].data + extra_ops[1].region_data(),
+            store2.query_region_data(&diff[1].coords)
+        );
+    }
+}

--- a/crates/kitsune_p2p/dht/src/region_set/ltcs.rs
+++ b/crates/kitsune_p2p/dht/src/region_set/ltcs.rs
@@ -1,0 +1,194 @@
+use once_cell::sync::OnceCell;
+
+use crate::{
+    arq::*,
+    error::{GossipError, GossipResult},
+    op::OpRegion,
+    quantum::*,
+};
+use derivative::Derivative;
+
+use super::{Region, RegionCoords, RegionData, RegionDataConstraints};
+
+/// A compact representation of a set of [`RegionCoords`].
+/// The [`TelescopingTimes`] generates all relevant [`TimeSegment`]s, and the
+/// [`SpaceSegment`]s are implied by the [`ArqBoundsSet`].
+///
+/// LTCS stands for Logarithmic Time, Constant Space.
+#[derive(Debug, PartialEq, Eq, derive_more::Constructor, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "test_utils", derive(Clone))]
+pub struct RegionCoordSetLtcs {
+    pub(super) times: TelescopingTimes,
+    pub(super) arq_set: ArqBoundsSet,
+}
+
+impl RegionCoordSetLtcs {
+    /// Generate the LTCS region coords given the generating parameters.
+    /// Each RegionCoords is paired with the relative spacetime coords, which
+    /// can be used to pair the generated coords with stored data.
+    pub fn region_coords_flat(&self) -> impl Iterator<Item = ((u32, u32), RegionCoords)> + '_ {
+        self.region_coords_nested().flatten()
+    }
+
+    /// Iterate over the coords in the same structure in which they are stored:
+    /// An outer Vec corresponding to space segments,
+    /// and inner Vecs corresponding to time segments.
+    pub fn region_coords_nested(
+        &self,
+    ) -> impl Iterator<Item = impl Iterator<Item = ((u32, u32), RegionCoords)>> + '_ {
+        self.arq_set.arqs().iter().flat_map(move |arq| {
+            arq.segments().enumerate().map(move |(ix, x)| {
+                self.times
+                    .segments()
+                    .into_iter()
+                    .enumerate()
+                    .map(move |(it, t)| ((ix as u32, it as u32), RegionCoords::new(x, t)))
+            })
+        })
+    }
+
+    /// Generate data for each coord in the set, creating the corresponding [`RegionSetLtcs`].
+    pub fn into_region_set<D, E, F>(self, mut f: F) -> Result<RegionSetLtcs<D>, E>
+    where
+        D: RegionDataConstraints,
+        F: FnMut(((u32, u32), RegionCoords)) -> Result<D, E>,
+    {
+        let data = self
+            .region_coords_nested()
+            .map(move |column| column.map(&mut f).collect::<Result<Vec<D>, E>>())
+            .collect::<Result<Vec<Vec<D>>, E>>()?;
+        Ok(RegionSetLtcs::from_data(self, data))
+    }
+
+    /// An empty set of coords
+    pub fn empty() -> Self {
+        Self {
+            times: TelescopingTimes::empty(),
+            arq_set: ArqBoundsSet::empty(),
+        }
+    }
+}
+
+/// Implementation for the compact LTCS region set format which gets sent over the wire.
+/// The coordinates for the regions are specified by a few values.
+/// The data to match the coordinates are specified in a 2D vector which must
+/// correspond to the generated coordinates.
+#[derive(Debug, serde::Serialize, serde::Deserialize, Derivative)]
+#[derivative(PartialEq, Eq)]
+#[cfg_attr(feature = "test_utils", derive(Clone))]
+pub struct RegionSetLtcs<D: RegionDataConstraints = RegionData> {
+    /// The generator for the coordinates
+    pub coords: RegionCoordSetLtcs,
+
+    /// the actual coordinates as generated
+    #[derivative(PartialEq = "ignore")]
+    #[serde(skip)]
+    pub(crate) _region_coords: OnceCell<Vec<RegionCoords>>,
+
+    /// The outer vec corresponds to the spatial segments;
+    /// the inner vecs are the time segments.
+    #[serde(bound(deserialize = "D: serde::de::DeserializeOwned"))]
+    pub data: Vec<Vec<D>>,
+}
+
+impl<D: RegionDataConstraints> RegionSetLtcs<D> {
+    /// An empty LTCS region set
+    pub fn empty() -> Self {
+        Self {
+            coords: RegionCoordSetLtcs::empty(),
+            data: vec![],
+            _region_coords: OnceCell::new(),
+        }
+    }
+
+    /// Construct the region set from existing data.
+    /// The data must match the coords!
+    pub fn from_data(coords: RegionCoordSetLtcs, data: Vec<Vec<D>>) -> Self {
+        Self {
+            coords,
+            data,
+            _region_coords: OnceCell::new(),
+        }
+    }
+
+    /// The total number of regions represented in this region set
+    pub fn count(&self) -> usize {
+        if self.data.is_empty() {
+            0
+        } else {
+            self.data.len() * self.data[0].len()
+        }
+    }
+
+    /// Iterate over each region in the set
+    pub fn regions(&self) -> impl Iterator<Item = Region<D>> + '_ {
+        self.coords
+            .region_coords_flat()
+            .map(|((ix, it), coords)| Region::new(coords, self.data[ix as usize][it as usize]))
+    }
+
+    /// Reshape the two region sets so that both match, omitting or merging
+    /// regions as needed
+    pub fn rectify(&mut self, other: &mut Self) -> GossipResult<()> {
+        if self.coords.arq_set != other.coords.arq_set {
+            return Err(GossipError::ArqSetMismatchForDiff);
+        }
+        if self.coords.times > other.coords.times {
+            std::mem::swap(self, other);
+        }
+        let mut len = 0;
+        for (da, db) in self.data.iter_mut().zip(other.data.iter_mut()) {
+            TelescopingTimes::rectify((&self.coords.times, da), (&other.coords.times, db));
+            len = da.len();
+        }
+        let times = other.coords.times.limit(len as u32);
+        self.coords.times = times;
+        other.coords.times = times;
+        Ok(())
+    }
+
+    /// Given two region sets, return only the ones which are different between
+    /// the two
+    pub fn diff(mut self, mut other: Self) -> GossipResult<Vec<Region<D>>> {
+        self.rectify(&mut other)?;
+
+        let regions = self
+            .regions()
+            .into_iter()
+            .zip(other.regions().into_iter())
+            .filter_map(|(a, b)| (a.data != b.data).then(|| a))
+            .collect();
+
+        Ok(regions)
+    }
+}
+
+#[cfg(feature = "test_utils")]
+impl<D: RegionDataConstraints> RegionSetLtcs<D> {
+    /// Query the specified OpStore for each coord in the set, constructing
+    /// the full RegionSet. Purely for convenience.
+    pub fn from_store<O: OpRegion<D>, S: crate::persistence::AccessOpStore<O, D>>(
+        store: &S,
+        coords: RegionCoordSetLtcs,
+    ) -> Self {
+        coords
+            .into_region_set(|(_, coords)| {
+                Result::<_, std::convert::Infallible>::Ok(store.query_region_data(&coords))
+            })
+            .unwrap()
+    }
+}
+
+#[cfg(feature = "test_utils")]
+impl RegionSetLtcs {
+    /// Return only the regions which have ops in them. Useful for testing
+    /// sparse scenarios.
+    pub fn nonzero_regions(
+        &self,
+    ) -> impl '_ + Iterator<Item = ((u32, u32), RegionCoords, RegionData)> {
+        self.coords.region_coords_flat().filter_map(|((i, j), c)| {
+            let d = &self.data[i as usize][j as usize];
+            (d.count > 0).then(|| ((i, j), c, *d))
+        })
+    }
+}

--- a/crates/kitsune_p2p/dht/src/test_utils.rs
+++ b/crates/kitsune_p2p/dht/src/test_utils.rs
@@ -1,0 +1,286 @@
+//! Utils for testing
+
+mod gossip_direct;
+mod min_redundancy;
+mod op_data;
+mod op_store;
+mod test_node;
+
+pub use gossip_direct::*;
+pub use min_redundancy::*;
+pub use op_data::*;
+pub use op_store::*;
+pub use test_node::*;
+
+use crate::arq::*;
+use crate::quantum::Topology;
+
+use kitsune_p2p_dht_arc::DhtLocation as Loc;
+use rand::prelude::StdRng;
+use rand::thread_rng;
+use rand::Rng;
+use rand::SeedableRng;
+
+/// Wait for input, to slow down overwhelmingly large iterations
+pub fn get_input() {
+    let mut input_string = String::new();
+    std::io::stdin()
+        .read_line(&mut input_string)
+        .expect("Failed to read line");
+}
+
+/// A RNG suitable for testing, if no seed is passed, uses standard random seed.
+pub fn seeded_rng(seed: Option<u64>) -> StdRng {
+    let seed = seed.unwrap_or_else(|| thread_rng().gen());
+    tracing::info!("RNG seed: {}", seed);
+    StdRng::seed_from_u64(seed)
+}
+
+fn full_len() -> f64 {
+    2f64.powf(32.0)
+}
+
+#[allow(dead_code)]
+type DataVec = statrs::statistics::Data<Vec<f64>>;
+
+/// Your peers just look like a bunch of Arqs
+pub type Peers = Vec<Arq>;
+
+/// Construct an arq from start and length specified in the interval [0, 1]
+pub fn unit_arq(topo: &Topology, strat: &ArqStrat, unit_start: f64, unit_len: f64) -> Arq {
+    assert!(
+        (0.0..1.0).contains(&unit_start),
+        "center out of bounds {}",
+        unit_start
+    );
+    assert!(
+        (0.0..=1.0).contains(&unit_len),
+        "len out of bounds {}",
+        unit_len
+    );
+
+    approximate_arq(
+        topo,
+        strat,
+        Loc::from((unit_start * full_len()) as u32),
+        (unit_len * full_len()) as u64,
+    )
+}
+
+/// Each agent is perfectly evenly spaced around the DHT (+/- some jitter),
+/// with stable arc lengths that are sized to meet the minimum coverage target
+pub fn generate_ideal_coverage(
+    topo: &Topology,
+    rng: &mut StdRng,
+    strat: &ArqStrat,
+    cov: Option<f64>,
+    n: u32,
+    jitter: f64,
+) -> Peers {
+    tracing::info!("N = {}, J = {}", n, jitter);
+    tracing::info!("ArqStrat: = {:#?}", strat);
+
+    let nf = n as f64;
+    // aim for the middle of the coverage target range
+    let target = cov.unwrap_or_else(|| strat.midline_coverage());
+    let len = (target / nf).min(1.0);
+
+    let peers: Vec<_> = (0..n)
+        .map(|i| {
+            let center =
+                ((i as f64 / nf) + (2.0 * jitter * rng.gen::<f64>()) - jitter).rem_euclid(1.0);
+
+            unit_arq(topo, strat, center, len)
+        })
+        .collect();
+
+    let cov = actual_coverage(topo, peers.iter());
+    let min = (target / (strat.buffer / 2.0 + 1.0)).floor();
+    let max = (min * (strat.buffer + 1.0)).ceil();
+    assert!(
+        min <= cov && cov <= max,
+        "Ideal coverage was generated incorrectly: !({} <= {} <= {})",
+        min,
+        cov,
+        max
+    );
+    peers
+}
+
+/// Generates arqs with lengths according to a standard distribution, to test
+/// wildly unbalanced initial conditions
+pub fn generate_messy_coverage(
+    topo: &Topology,
+    rng: &mut StdRng,
+    strat: &ArqStrat,
+    len_mean: f64,
+    len_std: f64,
+    n: u32,
+    jitter: f64,
+) -> Peers {
+    use rand::distributions::*;
+
+    tracing::info!("N = {}, J = {}", n, jitter);
+    tracing::info!("ArqStrat: = {:#?}", strat);
+
+    let len_dist = statrs::distribution::Normal::new(len_mean, len_std).unwrap();
+
+    let nf = n as f64;
+
+    let peers: Vec<_> = (0..n)
+        .map(|i| {
+            let center =
+                ((i as f64 / nf) + (2.0 * jitter * rng.gen::<f64>()) - jitter).rem_euclid(1.0);
+            let len = len_dist.sample(rng).clamp(0.0, 1.0);
+            unit_arq(topo, strat, center, len)
+        })
+        .collect();
+
+    peers
+}
+
+#[test]
+fn test_unit_arc() {
+    let topo = Topology::unit_zero();
+    let strat = ArqStrat {
+        min_coverage: 10.0,
+        buffer: 0.2,
+        ..Default::default()
+    };
+    let expected_chunks = 8;
+
+    {
+        let a = unit_arq(&topo, &strat, 0.0, 0.0);
+        assert_eq!(a.power(), topo.min_space_power());
+        assert_eq!(a.count(), 0);
+    }
+    {
+        let a = unit_arq(&topo, &strat, 0.0, 1.0);
+        assert_eq!(a.power(), topo.max_space_power(&strat));
+        assert_eq!(a.count(), 8);
+    }
+    {
+        let a = unit_arq(&topo, &strat, 0.0, 1.0 / 2.0);
+        assert_eq!(a.power(), 28);
+        assert_eq!(a.count(), expected_chunks);
+    }
+    {
+        let a = unit_arq(&topo, &strat, 0.0, 1.0 / 4.0);
+        assert_eq!(a.power(), 27);
+        assert_eq!(a.count(), expected_chunks);
+    }
+    {
+        let a = unit_arq(&topo, &strat, 0.0, 1.0 / 8.0);
+        assert_eq!(a.power(), 26);
+        assert_eq!(a.count(), expected_chunks);
+    }
+    {
+        let a = unit_arq(&topo, &strat, 0.0, 1.0 / 16.0);
+        assert_eq!(a.power(), 25);
+        assert_eq!(a.count(), expected_chunks);
+    }
+    {
+        let a = unit_arq(&topo, &strat, 0.0, 1.0 / 32.0);
+        assert_eq!(a.power(), 24);
+        assert_eq!(a.count(), expected_chunks);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::arq::PeerViewQ;
+
+    use super::*;
+    use proptest::proptest;
+    use test_case::test_case;
+
+    #[test_case(21.62, 0.1, 100)]
+    #[test_case(89.6, 0.25, 100)]
+    fn test_ideal_coverage_cases(min_coverage: f64, buffer: f64, num_peers: u32) {
+        let topo = Topology::unit_zero();
+
+        let strat = ArqStrat {
+            min_coverage,
+            buffer,
+            ..Default::default()
+        };
+
+        let mut rng = seeded_rng(None);
+        let peers = generate_ideal_coverage(&topo, &mut rng, &strat, None, num_peers, 0.0);
+
+        let view = PeerViewQ::new(topo, strat.clone(), peers);
+        let cov = view.actual_coverage();
+
+        let min = strat.min_coverage;
+        let max = strat.max_coverage();
+        assert!(min <= cov);
+        assert!(cov <= max);
+    }
+
+    proptest! {
+        /// Ensure that something close to the ideal coverage is generated under a
+        /// range of ArqStrat parameters.
+        /// NOTE: this is not perfect. The final assertion has to be fudged a bit,
+        /// so this test asserts that the extrapolated coverage falls within the
+        /// range.
+        #[test]
+        fn test_ideal_coverage(min_coverage in 40f64..100.0, buffer in 0.1f64..0.25, num_peers in 100u32..200) {
+            let topo = Topology::unit_zero();
+            let strat = ArqStrat {
+                min_coverage,
+                buffer,
+                ..Default::default()
+            };
+            let mut rng = seeded_rng(None);
+            let peers = generate_ideal_coverage(&topo, &mut rng, &strat, None, num_peers, 0.0);
+            let view = PeerViewQ::new(topo, strat.clone(), peers);
+            let cov = view.actual_coverage();
+
+            let min = strat.min_coverage;
+            let max = strat.max_coverage();
+            assert!(min <= cov, "extrapolated less than min {} <= {}", min, cov);
+            assert!(cov <= max, "extrapolated greater than max {} <= {}", cov, max);
+        }
+
+        #[test]
+        fn chunk_count_is_always_within_bounds(center in 0.0f64..0.999, len in 0.001f64..1.0) {
+            let topo = Topology::unit_zero();
+            let strat = ArqStrat {
+                min_coverage: 10.0,
+                buffer: 0.144,
+                ..Default::default()
+            };
+            let a = unit_arq(&topo, &strat, center, len);
+
+            assert!(a.count() >= strat.min_chunks());
+            assert!(a.count() <= strat.max_chunks());
+        }
+
+        #[test]
+        fn power_is_always_within_bounds(center in 0.0f64..0.999, len in 0.001f64..1.0) {
+            let topo = Topology::unit_zero();
+            let strat = ArqStrat {
+                min_coverage: 10.0,
+                buffer: 0.144,
+                ..Default::default()
+            };
+            let a = unit_arq(&topo, &strat, center, len);
+            assert!(a.power() >= topo.min_space_power());
+            assert!(a.power() <= topo.max_space_power(&strat));
+        }
+
+        #[test]
+        fn length_is_always_close(center in 0.0f64..0.999, len in 0.001f64..1.0) {
+            let topo = Topology::unit_zero();
+            let strat = ArqStrat {
+                min_coverage: 10.0,
+                buffer: 0.144,
+                ..Default::default()
+            };
+            let a = unit_arq(&topo, &strat, center, len);
+            let target_len = (len * 2f64.powf(32.0)) as i64;
+            let true_len = a.to_dht_arc_range(&topo).length() as i64;
+            assert!((true_len - target_len).abs() < a.absolute_chunk_width(&topo) as i64);
+        }
+    }
+}

--- a/crates/kitsune_p2p/dht/src/test_utils/gossip_direct.rs
+++ b/crates/kitsune_p2p/dht/src/test_utils/gossip_direct.rs
@@ -1,0 +1,125 @@
+use crate::{
+    error::{GossipError, GossipResult},
+    persistence::HostAccessTest,
+    quantum::{Quantum, TimeQuantum},
+    region::REGION_MASS,
+};
+
+/// Do [`gossip_direct`], with both nodes at the same current time
+pub fn gossip_direct_at<Peer: HostAccessTest>(
+    left: &mut Peer,
+    right: &mut Peer,
+    now: TimeQuantum,
+) -> GossipResult<TestNodeGossipRoundStats> {
+    gossip_direct((left, now), (right, now))
+}
+
+/// Quick 'n dirty simulation of a gossip round. Mutates both nodes as if
+/// they were exchanging gossip messages, without the rigmarole of a real protocol
+pub fn gossip_direct<Peer: HostAccessTest>(
+    (left, time_left): (&mut Peer, TimeQuantum),
+    (right, time_right): (&mut Peer, TimeQuantum),
+) -> GossipResult<TestNodeGossipRoundStats> {
+    let mut stats = TestNodeGossipRoundStats::default();
+
+    // - ensure identical topologies (especially the time_origin)
+    if left.topo() != right.topo() {
+        return Err(GossipError::TopologyMismatch);
+    }
+    let topo = left.topo();
+
+    let common_arqs = {
+        // ROUND I: Initial handshake, exchange ArqSets and as-at timestamps
+
+        let gpl = left.gossip_params();
+        let gpr = right.gossip_params();
+
+        // - ensure compatible as-at timestamps
+        let tl = time_left.inner() as i64;
+        let tr = time_right.inner() as i64;
+        if (tl - tr).abs() as u32
+            > u32::min(gpl.max_time_offset.inner(), gpr.max_time_offset.inner())
+        {
+            return Err(GossipError::TimesOutOfSync);
+        }
+
+        // - calculate common arqset
+        let al = left.get_arq_set();
+        let ar = right.get_arq_set();
+        if (al.power() as i8 - ar.power() as i8).abs() as u8
+            > u8::min(gpl.max_space_power_offset, gpr.max_space_power_offset)
+        {
+            return Err(GossipError::ArqPowerDiffTooLarge);
+        }
+        al.intersection(topo, &ar)
+    };
+
+    {
+        // ROUND II: Send Agents (not shown)
+    }
+
+    let (regions_left, regions_right) = {
+        // ROUND III: Calculate and send Region data
+
+        // - calculate regions
+        let regions_left = left.region_set(common_arqs.clone(), time_left);
+        let regions_right = right.region_set(common_arqs, time_right);
+        stats.regions_sent += regions_left.count() as u32;
+        stats.regions_rcvd += regions_right.count() as u32;
+        (regions_left, regions_right)
+    };
+    {
+        // ROUND IV: Calculate diffs and send missing ops
+
+        // - calculate diffs
+        let diff_left = regions_left.clone().diff(regions_right.clone())?;
+        let diff_right = regions_right.diff(regions_left)?;
+
+        // - fetch ops
+        let ops_left: Vec<_> = diff_left
+            .iter()
+            .flat_map(|r| left.query_op_data(&r.coords))
+            .collect();
+        let ops_right: Vec<_> = diff_right
+            .iter()
+            .flat_map(|r| right.query_op_data(&r.coords))
+            .collect();
+
+        // - "send" missing ops
+        for op in ops_right {
+            stats.ops_rcvd += 1;
+            stats.op_data_rcvd += op.size as u64;
+            left.integrate_op(op);
+        }
+        for op in ops_left {
+            stats.ops_sent += 1;
+            stats.op_data_sent += op.size as u64;
+            right.integrate_op(op);
+        }
+    }
+    Ok(stats)
+}
+
+/// Stats about what was sent and received during the gossip round
+#[derive(Clone, Debug, Default, derive_more::Add)]
+#[allow(missing_docs)]
+pub struct TestNodeGossipRoundStats {
+    pub regions_sent: u32,
+    pub regions_rcvd: u32,
+    pub ops_sent: u32,
+    pub ops_rcvd: u32,
+    pub op_data_sent: u64,
+    pub op_data_rcvd: u64,
+}
+
+impl TestNodeGossipRoundStats {
+    /// The total bytes sent
+    pub fn total_sent(&self) -> u64 {
+        (self.regions_sent * REGION_MASS) as u64 + self.op_data_sent
+    }
+
+    /// The total bytes received
+    pub fn total_rcvd(&self) -> u64 {
+        (self.regions_rcvd * REGION_MASS) as u64 + self.op_data_rcvd
+    }
+}

--- a/crates/kitsune_p2p/dht/src/test_utils/min_redundancy.rs
+++ b/crates/kitsune_p2p/dht/src/test_utils/min_redundancy.rs
@@ -1,0 +1,142 @@
+use std::num::Wrapping;
+
+use crate::{arq::*, quantum::Topology};
+
+/// Margin of error for floating point comparisons
+const ERROR_MARGIN: f64 = 0.0000000001;
+
+/// Check a set of peers the actual redundancy across all peers.
+/// This can tell if there is bad distribution.
+/// Note this function is only used for verification in tests at this time.
+pub fn calc_min_redundancy(topo: &Topology, peers: Vec<Arq>) -> u32 {
+    use std::collections::HashSet;
+    #[derive(Clone, Copy, Debug)]
+    enum Side {
+        Left,
+        Right,
+    }
+    #[derive(Clone, Copy, Debug)]
+    struct Arm {
+        id: usize,
+        side: Side,
+        pos: u32,
+    }
+
+    // Turn each arc into a side with a unique id that is
+    // shared by both sides.
+    let mut id = 0;
+    let mut sides = |arq: &Arq| {
+        let (left, right) = arq.to_edge_locs(topo);
+        let i = id;
+        let l = Arm {
+            id: i,
+            side: Side::Left,
+            pos: left.as_u32(),
+        };
+        let r = Arm {
+            id: i,
+            side: Side::Right,
+            pos: right.as_u32(),
+        };
+        id += 1;
+        vec![l, r]
+    };
+
+    // Record and remove any full redundancy arcs as we only
+    // need to measure that stack of partial coverage.
+    let mut full_r = 0;
+    let peers: Vec<_> = peers
+        .into_iter()
+        .filter(|a| {
+            if (a.coverage(topo) - 1.0).abs() < ERROR_MARGIN {
+                full_r += 1;
+                false
+            } else {
+                // Also remove any bounds that don't include some coverage.
+                !a.is_empty()
+            }
+        })
+        .collect();
+
+    // If we are empty at this stage then return any full coverage.
+    if peers.is_empty() {
+        return full_r;
+    }
+
+    // Turn the rest of the partial arcs into their sides.
+    let mut peers = peers
+        .into_iter()
+        .flat_map(|p| sides(&p).into_iter())
+        .collect::<Vec<_>>();
+
+    // Sort the sides by their positions.
+    peers.sort_unstable_by_key(|p| p.pos);
+
+    // Fold over the sides tracking the stack of arcs that have been entered but not exited.
+    // The minimal stack height at any given point is the minimum redundancy on the network.
+    let stack_fold = |(mut stack, r, mut started, mut last_remove): (
+        HashSet<usize>,
+        usize,
+        bool,
+        Option<u32>,
+    ),
+                      arm: &Arm| {
+        let mut connected = false;
+        let mut this_remove = None;
+        match arm.side {
+            Side::Left => {
+                // We must have added at least one arc otherwise
+                // our minimum stack height will always be one.
+                started = true;
+
+                // Check if we are inserting an arc just one location
+                // past a remove because that actually counts as covered.
+                connected = last_remove
+                    .as_ref()
+                    .map(|l| (Wrapping(arm.pos) - Wrapping(*l)).0 <= 1)
+                    .unwrap_or(false);
+
+                // Add this id to the stack.
+                stack.insert(arm.id);
+            }
+            Side::Right => {
+                // Set the last removed.
+                this_remove = Some(arm.pos);
+
+                // Remove this id.
+                stack.remove(&arm.id);
+            }
+        }
+        // Get the current stack height.
+        let len = stack.len();
+
+        // If we have started and the length has dropped then set a
+        // lower redundancy.
+        let mut r = if len < r && started {
+            // Only record removes that actually change the r level.
+            last_remove = this_remove;
+            len
+        } else {
+            r
+        };
+
+        // If this was actually a connected insert then undo the last remove.
+        if connected {
+            r += 1
+        }
+        (stack, r, started, last_remove)
+    };
+
+    // Run through the list once to find the stack remaining at the end of the run.
+    let (stack, _, started, last_removed) = peers
+        .iter()
+        .fold((HashSet::new(), usize::MAX, false, None), stack_fold);
+
+    // Now use that as the starting stack for the "real" run.
+    let (_, r, _, _) = peers
+        .iter()
+        .fold((stack, usize::MAX, started, last_removed), stack_fold);
+
+    // Our redundancy is whatever partial + any full redundancy
+    r as u32 + full_r
+}

--- a/crates/kitsune_p2p/dht/src/test_utils/op_data.rs
+++ b/crates/kitsune_p2p/dht/src/test_utils/op_data.rs
@@ -1,0 +1,85 @@
+use std::{borrow::Borrow, sync::Arc};
+
+use kitsune_p2p_timestamp::Timestamp;
+
+use crate::{hash::OpHash, prelude::OpRegion, region::RegionData, Loc};
+
+/// TODO: mark this as for testing only.
+/// This is indeed the type that Holochain provides.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct OpData {
+    /// The DhtLocation
+    pub loc: Loc,
+    /// The hash of the op
+    pub hash: OpHash,
+    /// The size in bytes of the op data
+    pub size: u32,
+    /// The timestamp that the op was created
+    pub timestamp: Timestamp,
+}
+
+impl OpData {
+    /// Accessor
+    pub fn loc(&self) -> Loc {
+        self.loc
+    }
+
+    /// Obviously only for testing
+    pub fn fake(loc: Loc, timestamp: Timestamp, size: u32) -> Op {
+        use crate::hash::fake_hash;
+        Op::new(Self {
+            loc,
+            timestamp,
+            size,
+            hash: fake_hash().into(),
+        })
+    }
+}
+
+impl Borrow<Timestamp> for OpData {
+    fn borrow(&self) -> &Timestamp {
+        &self.timestamp
+    }
+}
+
+impl PartialOrd for OpData {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for OpData {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (&self.timestamp, &self.loc).cmp(&(&other.timestamp, &other.loc))
+    }
+}
+
+impl OpRegion<RegionData> for OpData {
+    fn loc(&self) -> Loc {
+        self.loc
+    }
+
+    fn timestamp(&self) -> Timestamp {
+        self.timestamp
+    }
+
+    fn region_data(&self) -> RegionData {
+        RegionData {
+            hash: self.hash.into(),
+            size: self.size,
+            count: 1,
+        }
+    }
+
+    fn bound(timestamp: Timestamp, loc: Loc) -> Self {
+        Self {
+            loc,
+            timestamp,
+            size: 0,
+            hash: [0; 32].into(),
+        }
+    }
+}
+
+/// Alias for op
+pub type Op = Arc<OpData>;

--- a/crates/kitsune_p2p/dht/src/test_utils/op_store.rs
+++ b/crates/kitsune_p2p/dht/src/test_utils/op_store.rs
@@ -1,0 +1,96 @@
+use crate::{
+    op::OpRegion,
+    persistence::AccessOpStore,
+    prelude::{RegionCoords, RegionSet, RegionSetLtcs},
+    quantum::{GossipParams, Topology},
+    region::{RegionData, RegionDataConstraints},
+};
+use futures::future::FutureExt;
+use std::{collections::BTreeSet, ops::Bound, sync::Arc};
+
+use super::op_data::OpData;
+
+/// An in-memory implementation of a node's op store
+#[derive(Clone)]
+pub struct OpStore<O: OpRegion<D> = OpData, D: RegionDataConstraints = RegionData> {
+    pub(crate) topo: Topology,
+    pub(crate) ops: BTreeSet<Arc<O>>,
+    pub(crate) _region_set: RegionSet<D>,
+    pub(crate) gossip_params: GossipParams,
+}
+
+impl<D: RegionDataConstraints, O: OpRegion<D>> OpStore<O, D> {
+    /// Construct an empty store
+    pub fn new(topo: Topology, gossip_params: GossipParams) -> Self {
+        Self {
+            topo,
+            ops: Default::default(),
+            _region_set: RegionSetLtcs::empty().into(),
+            gossip_params,
+        }
+    }
+}
+
+impl<D: RegionDataConstraints, O: OpRegion<D>> AccessOpStore<O, D> for OpStore<O, D> {
+    fn query_op_data(&self, region: &RegionCoords) -> Vec<Arc<O>> {
+        let region = region.to_bounds(self.topo());
+        let (x0, x1) = region.x;
+        let (t0, t1) = region.t;
+        let op0 = O::bound(t0, x0);
+        let op1 = O::bound(t1, x0);
+        self.ops
+            .range((Bound::Included(op0), Bound::Included(op1)))
+            .filter(|o| x0 <= o.loc() && o.loc() <= x1)
+            .cloned()
+            .collect()
+    }
+
+    fn query_region_data(&self, region: &RegionCoords) -> D {
+        self.query_op_data(region)
+            .into_iter()
+            .map(|o| o.region_data())
+            .fold(D::zero(), |d, o| d + o)
+    }
+
+    fn fetch_region_set(
+        &self,
+        coords: crate::prelude::RegionCoordSetLtcs,
+    ) -> must_future::MustBoxFuture<Result<crate::prelude::RegionSetLtcs<D>, ()>> {
+        async move { coords.into_region_set(|(_, coords)| Ok(self.query_region_data(&coords))) }
+            .boxed()
+            .into()
+    }
+
+    fn integrate_ops<Ops: Clone + Iterator<Item = Arc<O>>>(&mut self, ops: Ops) {
+        // for op in ops.clone() {
+        //     self.region_set.add(op.region_tuple(self.region_set.topo()));
+        // }
+        self.ops.extend(ops);
+    }
+
+    fn topo(&self) -> &Topology {
+        &self.topo
+    }
+
+    fn gossip_params(&self) -> GossipParams {
+        self.gossip_params
+    }
+}
+
+// impl OpStore<RegionData> {
+//     fn integrate_ops<O: Iterator<Item = Op>>(&mut self, ops: O) {
+//         for op in ops {
+//             self.tree.add_op(op);
+//         }
+//         self.ops.extend(ops);
+//     }
+// }
+
+// fn op_bound(timestamp: Timestamp, loc: Loc) -> OpData {
+//     OpData {
+//         loc,
+//         timestamp,
+//         size: 0,
+//         hash: [0; 32].into(),
+//     }
+// }

--- a/crates/kitsune_p2p/dht/src/test_utils/test_node.rs
+++ b/crates/kitsune_p2p/dht/src/test_utils/test_node.rs
@@ -1,0 +1,188 @@
+use must_future::MustBoxFuture;
+
+use crate::{
+    arq::{ascii::add_location_ascii, *},
+    hash::{fake_hash, AgentKey},
+    persistence::{AccessOpStore, AccessPeerStore},
+    prelude::RegionCoordSetLtcs,
+    quantum::{GossipParams, TelescopingTimes, TimeQuantum, Topology},
+    region::*,
+    region_set::*,
+};
+
+use super::{
+    op_data::{Op, OpData},
+    op_store::OpStore,
+};
+
+/// A "node", with test-worthy implementation of the host interface
+pub struct TestNode {
+    _agent: AgentKey,
+    agent_arq: Arq,
+    store: OpStore,
+}
+
+impl TestNode {
+    /// Constructor
+    pub fn new(topo: Topology, gopa: GossipParams, arq: Arq) -> Self {
+        Self {
+            _agent: AgentKey(fake_hash()),
+            agent_arq: arq,
+            store: OpStore::new(topo, gopa),
+        }
+    }
+
+    /// The Arq to use when gossiping
+    pub fn arq(&self) -> Arq {
+        self.agent_arq
+    }
+
+    /// The ArqBounds to use when gossiping
+    pub fn arq_bounds(&self) -> ArqBounds {
+        self.agent_arq.to_bounds(self.topo())
+    }
+
+    /// Get the RegionSet for this node, suitable for gossiping
+    pub fn region_set(&self, arq_set: ArqBoundsSet, now: TimeQuantum) -> RegionSet {
+        let coords = RegionCoordSetLtcs::new(TelescopingTimes::new(now), arq_set);
+        let data = coords
+            .region_coords_nested()
+            .map(|columns| {
+                columns
+                    .map(|(_, coords)| self.query_region_data(&coords))
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        RegionSetLtcs::from_data(coords, data).into()
+    }
+
+    /// Print an ascii representation of the node's arq and all ops held
+    pub fn ascii_arq_and_ops(&self, topo: &Topology, i: usize, len: usize) -> String {
+        let arq = self.arq();
+        format!(
+            "|{}| {}: {}/{} @ {}",
+            add_location_ascii(
+                arq.to_ascii(topo, len),
+                self.store.ops.iter().map(|o| o.loc).collect()
+            ),
+            i,
+            arq.power(),
+            arq.count(),
+            arq.start_loc()
+        )
+    }
+}
+
+impl AccessOpStore<OpData> for TestNode {
+    fn query_op_data(&self, region: &RegionCoords) -> Vec<Op> {
+        self.store.query_op_data(region)
+    }
+
+    fn query_region_data(&self, region: &RegionCoords) -> RegionData {
+        self.store.query_region_data(region)
+    }
+
+    fn fetch_region_set(
+        &self,
+        coords: RegionCoordSetLtcs,
+    ) -> MustBoxFuture<Result<RegionSetLtcs, ()>> {
+        self.store.fetch_region_set(coords)
+    }
+
+    fn integrate_ops<Ops: Clone + Iterator<Item = Op>>(&mut self, ops: Ops) {
+        self.store.integrate_ops(ops)
+    }
+
+    fn topo(&self) -> &Topology {
+        self.store.topo()
+    }
+
+    fn gossip_params(&self) -> GossipParams {
+        self.store.gossip_params()
+    }
+}
+
+impl AccessPeerStore for TestNode {
+    fn get_agent_arq(&self, _agent: AgentKey) -> crate::arq::Arq {
+        self.agent_arq.clone()
+    }
+
+    fn get_arq_set(&self) -> ArqBoundsSet {
+        ArqBoundsSet::single(self.arq_bounds())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use kitsune_p2p_timestamp::Timestamp;
+
+    use crate::quantum::*;
+
+    use super::*;
+
+    #[test]
+    fn integrate_and_query_ops() {
+        let topo = Topology::unit_zero();
+        let gopa = GossipParams::zero();
+        let arq = Arq::new(8, 0u32.into(), 4.into());
+        let mut node = TestNode::new(topo, gopa, arq);
+
+        node.integrate_ops(
+            [
+                OpData::fake(0u32.into(), Timestamp::from_micros(10), 1234),
+                OpData::fake(1000u32.into(), Timestamp::from_micros(20), 2345),
+                OpData::fake(2000u32.into(), Timestamp::from_micros(15), 3456),
+            ]
+            .into_iter(),
+        );
+        {
+            let data = node.query_region_data(&RegionCoords {
+                space: SpaceSegment::new(7, 0),
+                time: TimeSegment::new(5, 0),
+            });
+            assert_eq!(data.count, 1);
+            assert_eq!(data.size, 1234);
+        }
+        {
+            let data = node.query_region_data(&RegionCoords {
+                space: SpaceSegment::new(10, 0),
+                time: TimeSegment::new(5, 0),
+            });
+            assert_eq!(data.count, 2);
+            assert_eq!(data.size, 1234 + 2345);
+        }
+        {
+            let data = node.query_region_data(&RegionCoords {
+                space: SpaceSegment::new(7, 1),
+                time: TimeSegment::new(5, 0),
+            });
+            assert_eq!(data.count, 1);
+            assert_eq!(data.size, 2345);
+        }
+    }
+
+    #[test]
+    #[cfg(obsolete)]
+    fn gossip_regression() {
+        let topo = Topology::unit_zero();
+        let gopa = GossipParams::zero();
+        let alice_arq = Arq::new(0u32.into(), 8, 4);
+        let bobbo_arq = Arq::new(128.into(), 8, 4);
+        let mut alice = TestNode::new(topo.clone(), gopa, alice_arq);
+        let mut bobbo = TestNode::new(topo.clone(), gopa, bobbo_arq);
+
+        alice.integrate_ops([OpData::fake(0.into(), Timestamp::from_micros(10), 4321)].into_iter());
+        bobbo.integrate_ops(
+            [OpData::fake(128.into(), Timestamp::from_micros(20), 1234)].into_iter(),
+        );
+
+        // dbg!(&alice.tree.tree);
+        let b = (4294967295, 71);
+        let a = (4294967040, 64);
+
+        let ne = alice.store.tree.tree.prefix_sum(b);
+        let sw = alice.store.tree.tree.prefix_sum(a);
+        assert_eq!(ne, sw);
+        // alice.tree.tree.query((4294967040, 64), (4294967295, 71));
+    }
+}

--- a/crates/kitsune_p2p/dht/tests/SPEC.md
+++ b/crates/kitsune_p2p/dht/tests/SPEC.md
@@ -1,0 +1,15 @@
+# Arc resizing
+
+TODO: write about data generation
+
+
+## Redundancy
+
+- Ensure that minimum redundancy is maintained for 80 iterations...
+  - [ ] ...TODO
+
+
+## Stability
+
+- Ensure that arcs become stable within 80 resizing iterations...
+  - [ ] ...TODO

--- a/crates/kitsune_p2p/dht/tests/arc_resizing.rs
+++ b/crates/kitsune_p2p/dht/tests/arc_resizing.rs
@@ -1,0 +1,265 @@
+//! Tests of arq resizing behavior.
+
+#![cfg(feature = "test_utils")]
+
+mod common;
+
+use kitsune_p2p_dht::arq::print_arq;
+use kitsune_p2p_dht::quantum::Topology;
+use kitsune_p2p_dht::*;
+
+use kitsune_p2p_dht::test_utils::generate_ideal_coverage;
+use kitsune_p2p_dht::test_utils::seeded_rng;
+use kitsune_p2p_dht_arc::DhtArcRange;
+
+fn resize_to_equilibrium(view: &PeerViewQ, arq: &mut Arq) {
+    while view.update_arq(&view.topo, arq) {}
+}
+
+#[test]
+/// If extrapolated coverage remains above the maximum coverage threshold even
+/// when shrinking towards empty, let the arq be resized as small as possible
+/// before losing peers.
+fn test_shrink_towards_empty() {
+    let topo = Topology::unit_zero();
+    let mut rng = seeded_rng(None);
+
+    // aim for coverage between 10 and 12
+    let strat = ArqStrat {
+        min_coverage: 10.0,
+        buffer: 0.2,
+        max_power_diff: 2,
+        ..Default::default()
+    };
+    let jitter = 0.01;
+
+    // generate peers with a bit too much coverage (14 > 12)
+    let peers: Vec<_> = generate_ideal_coverage(&topo, &mut rng, &strat, Some(14.5), 100, jitter);
+    let peer_power = peers.iter().map(|p| p.power()).min().unwrap();
+    let view = PeerViewQ::new(topo.clone(), strat.clone(), peers);
+
+    // start with a full arq at max power
+    let mut arq = Arq::new_full(&topo, 0u32.into(), topo.max_space_power(&strat));
+    resize_to_equilibrium(&view, &mut arq);
+    // test that the arc gets reduced in power to match those of its peers
+    assert!(
+        arq.power() <= peer_power,
+        "{} <= {}",
+        arq.power(),
+        peer_power
+    );
+}
+
+#[test]
+/// If extrapolated coverage remains below the minimum coverage threshold even
+/// when growing to full, let the arq be resized as large as it can be under
+/// the constraints of the ArqStrat.
+fn test_grow_towards_full() {
+    let topo = Topology::unit_zero();
+    let mut rng = seeded_rng(None);
+
+    // aim for coverage between 10 and 12, with no limit on power diff
+    let strat = ArqStrat {
+        min_coverage: 10.0,
+        buffer: 0.2,
+        max_power_diff: 2,
+        ..Default::default()
+    };
+    println!("{}", strat.summary());
+    strat.max_chunks();
+    let jitter = 0.01;
+
+    // generate peers with deficient coverage
+    let peers: Vec<_> = generate_ideal_coverage(&topo, &mut rng, &strat, Some(7.0), 1000, jitter);
+    let peer_power = peers.iter().map(|p| p.power()).min().unwrap();
+    let view = PeerViewQ::new(topo.clone(), strat.clone(), peers);
+
+    // start with an arq comparable to one's peers
+    let mut arq = Arq::new(peer_power, 0u32.into(), 12.into());
+    loop {
+        let stats = view.update_arq_with_stats(&topo, &mut arq);
+        if !stats.changed {
+            break;
+        }
+    }
+    // ensure that the arq grows to full size
+    assert_eq!(arq.power(), peer_power + 2);
+    assert_eq!(arq.count(), strat.max_chunks());
+}
+
+#[test]
+/// If extrapolated coverage remains below the minimum coverage threshold even
+/// when growing to full, let the arq be resized to full when the max_power_diff
+/// is not a constraint
+fn test_grow_to_full() {
+    let topo = Topology::unit_zero();
+    let mut rng = seeded_rng(None);
+
+    // aim for coverage between 10 and 12, with no limit on power diff
+    let strat = ArqStrat {
+        min_coverage: 10.0,
+        buffer: 0.2,
+        max_power_diff: 32,
+        ..Default::default()
+    };
+    let jitter = 0.01;
+    dbg!(strat.max_chunks());
+
+    // generate peers with deficient coverage
+    let peers: Vec<_> = generate_ideal_coverage(&topo, &mut rng, &strat, Some(7.0), 1000, jitter);
+    let peer_power = peers.iter().map(|p| p.power()).min().unwrap();
+    let view = PeerViewQ::new(topo.clone(), strat.clone(), peers);
+
+    // start with an arq comparable to one's peers
+    let mut arq = Arq::new(peer_power, 0u32.into(), 12.into());
+    print_arq(&topo, &arq, 64);
+    while view.update_arq(&topo, &mut arq) {
+        print_arq(&topo, &arq, 64);
+    }
+    // ensure that the arq grows to full size
+    assert_eq!(arq.power(), topo.max_space_power(&strat));
+    assert_eq!(arq.count(), 8);
+    assert!(arq::is_full(&topo, arq.power(), arq.count()));
+}
+
+#[test]
+// XXX: We only want to do this if other peers have not moved. But currently
+//      we have no way of determining this.
+//
+/// If the current coverage is far from the target, growing can occur in
+/// multiple chunks
+fn test_grow_by_multiple_chunks() {
+    let topo = Topology::unit_zero();
+    let mut rng = seeded_rng(None);
+
+    // aim for coverage between 10 and 12
+    let strat = ArqStrat {
+        min_coverage: 10.0,
+        buffer: 0.2,
+        ..Default::default()
+    };
+    let jitter = 0.01;
+
+    // generate peers with far too little coverage
+    let peers: Vec<_> = generate_ideal_coverage(&topo, &mut rng, &strat, Some(5.0), 1000, jitter);
+    let peer_power = peers.iter().map(|p| p.power()).min().unwrap();
+    let view = PeerViewQ::new(topo.clone(), strat.clone(), peers);
+
+    let arq = Arq::new(peer_power - 1, 0u32.into(), 6.into());
+    let mut resized = arq.clone();
+    view.update_arq(&topo, &mut resized);
+    assert!(resized.power() > arq.power() || resized.count() > arq.count() + 1);
+}
+
+#[test]
+/// If the space to our left is oversaturated by double,
+/// and the space to our right is completely empty,
+/// we should not resize
+///
+/// (not a very good test, probably)
+fn test_degenerate_asymmetrical_coverage() {
+    observability::test_run().ok();
+    let topo = Topology::unit_zero();
+    let other = ArqBounds::from_interval(&topo, 4, DhtArcRange::from_bounds(0x0u32, 0x80))
+        .unwrap()
+        .to_arq(&topo, |l| l);
+    let others = vec![other; 10];
+    // aim for coverage between 5 and 6.
+    let strat = ArqStrat {
+        min_coverage: 5.0,
+        buffer: 0.1,
+        ..Default::default()
+    };
+    let view = PeerViewQ::new(topo.clone(), strat, others);
+
+    let arq = Arq::new(
+        4, // log2 of 0x10
+        Loc::new(0),
+        0x10.into(),
+    );
+
+    let extrapolated = view.extrapolated_coverage(&arq);
+    assert_eq!(extrapolated, 5.0);
+    let old = arq.clone();
+    let mut new = arq.clone();
+    let resized = view.update_arq(&topo, &mut new);
+    assert_eq!(old, new);
+    assert!(!resized);
+}
+
+#[test]
+/// Test resizing across several quantization levels to get a feel for how
+/// it should work.
+fn test_scenario() {
+    let mut rng = seeded_rng(None);
+    let topo = Topology::unit_zero();
+
+    // aim for coverage between 10 and 12.
+    let strat = ArqStrat {
+        min_coverage: 10.0,
+        buffer: 0.2,
+        max_power_diff: 2,
+        ..Default::default()
+    };
+    let jitter = 0.000;
+
+    {
+        // start with a full arq
+        let mut arq = Arq::new_full(&topo, Loc::new(0x0), topo.max_space_power(&strat));
+        // create 10 peers, all with full arcs, fully covering the DHT
+        let peers: Vec<_> = generate_ideal_coverage(&topo, &mut rng, &strat, None, 10, jitter);
+        let view = PeerViewQ::new(topo.clone(), strat.clone(), peers);
+        let extrapolated = view.extrapolated_coverage(&arq);
+        assert_eq!(extrapolated, 10.0);
+
+        // expect that the arq remains full under these conditions
+        let resized = view.update_arq(&topo, &mut arq);
+        assert!(!resized);
+    }
+
+    {
+        // start with a full arq again
+        let mut arq = Arq::new_full(&topo, Loc::new(0x0), topo.max_space_power(&strat));
+        // create 100 peers, with arcs at about 10%,
+        // covering a bit more than they need to
+        let peers = generate_ideal_coverage(&topo, &mut rng, &strat, Some(13.0), 100, jitter);
+
+        {
+            let peer_power = peers.iter().map(|p| p.power()).min().unwrap();
+            assert_eq!(peer_power, 26);
+
+            let view = PeerViewQ::new(topo.clone(), strat.clone(), peers.clone());
+            let extrapolated = view.extrapolated_coverage(&arq);
+            assert!(extrapolated > strat.max_coverage());
+            // assert!(strat.min_coverage <= extrapolated && extrapolated <= strat.max_coverage());
+
+            // update the arq until there is no change
+            while view.update_arq(&topo, &mut arq) {}
+
+            // expect that the arq shrinks to at least the ballpark of the peers
+            assert_eq!(arq.power(), peer_power);
+        }
+        {
+            // create the same view but with all arcs cut in half, so that the
+            // coverage is uniformly undersaturated.
+            let peers: Vec<_> = peers
+                .clone()
+                .iter_mut()
+                .map(|arq| {
+                    let mut arq = arq.downshift();
+                    *arq.count_mut() = arq.count() / 2;
+                    arq
+                })
+                .collect();
+            let peer_power = peers.iter().map(|p| p.power()).min().unwrap();
+            let view = PeerViewQ::new(topo.clone(), strat.clone(), peers);
+            print_arq(&topo, &arq, 64);
+            // assert that our arc will grow as large as it can to pick up the slack.
+            while view.update_arq(&topo, &mut arq) {
+                print_arq(&topo, &arq, 64);
+            }
+            assert_eq!(arq.power(), peer_power + strat.max_power_diff);
+            assert!(arq.count() == strat.max_chunks());
+        }
+    }
+}

--- a/crates/kitsune_p2p/dht/tests/arc_stability.proptest-regressions
+++ b/crates/kitsune_p2p/dht/tests/arc_stability.proptest-regressions
@@ -1,0 +1,11 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc cae5edf9ef853466f36d60db25aac7876ff4770f5b76dd550ce5b161228bb9f6 # shrinks to num_peers = 169, min_coverage = 5.217987342470106, j = 0.6050556078416869
+cc 6303700e80b02a015a9407a3c1ff81baf2c6fcf07f8fe545ddac6dfd25d7f77c # shrinks to num_peers = 178, min_coverage = 39.85385430206192, j = 0.9042918388873882
+cc 9860586077761354c04d518cfc0a5ac143a9aab8d1117ed21f0c0cf55a21e074 # shrinks to num_peers = 252, min_coverage = 83.5397361841111, j = 0.6320501880340919
+cc cab2a01968f25e90e0fd0b6cdca2b142284f62170aa9dc7d9319d4d014921f5f # shrinks to num_peers = 100, min_coverage = 50.0, j = 0.63266649805623
+cc ab2e7ff50d481f96e51c0417d6a676692d5990e25e348d4ea52968d0d0557dcd # shrinks to num_peers = 183, min_coverage = 64.8751034867194, j = 0.23164834987464333

--- a/crates/kitsune_p2p/dht/tests/arc_stability.rs
+++ b/crates/kitsune_p2p/dht/tests/arc_stability.rs
@@ -1,0 +1,151 @@
+mod common;
+
+use common::quantized::*;
+use kitsune_p2p_dht::{
+    quantum::Topology,
+    test_utils::{generate_ideal_coverage, generate_messy_coverage, seeded_rng},
+    *,
+};
+
+fn pass_report(report: &RunReport, redundancy_target: f64) {
+    match &report.outcome {
+        RunReportOutcome::Convergent { redundancy_stats } => {
+            pass_redundancy(redundancy_stats, redundancy_target)
+        }
+        _ => panic!("Divergent outcome is a failure"),
+    }
+}
+
+/// Check if the min redundancy is "close enough" to the target for the given
+/// Stats.
+/// Currently this does not assert a very strong guarantee. Over time we want
+/// to reduce the margins closer to zero.
+fn pass_redundancy(stats: &Stats, redundancy_target: f64) {
+    let rf = redundancy_target as f64;
+
+    let margin_min = 0.40;
+    let margin_median_lo = 0.40;
+
+    assert!(
+        stats.median >= rf * (1.0 - margin_median_lo),
+        "median min redundancy too low: {}",
+        stats.median
+    );
+    assert!(
+        stats.min >= rf * (1.0 - margin_min),
+        "minimum min redundancy too low: {}",
+        stats.min
+    );
+}
+
+/// Equilibrium test for a single distribution
+#[test]
+fn stability_test_case_near_ideal() {
+    std::env::set_var("RUST_LOG", "debug");
+    observability::test_run().ok();
+
+    let topo = Topology::standard_zero();
+    let detail = false;
+    let mut rng = seeded_rng(None);
+    let n = 150;
+    let j = 0.1;
+    let cov = 50.0;
+
+    let strat = ArqStrat {
+        min_coverage: cov,
+        ..Default::default()
+    };
+    println!("{}", strat.summary());
+
+    let peers = generate_ideal_coverage(&topo, &mut rng, &strat, Some(cov * 2.0), n, j);
+    parameterized_stability_test(&topo, &strat, peers, detail);
+}
+
+#[test]
+fn stability_test_case_messy() {
+    std::env::set_var("RUST_LOG", "debug");
+    observability::test_run().ok();
+
+    let topo = Topology::standard_zero();
+    let detail = true;
+
+    let mut rng = seeded_rng(None);
+    let n = 300;
+    let j = 0.01;
+    let len_mean = 0.50;
+    let len_std = 0.35;
+    let cov = 100.0;
+    let strat = ArqStrat {
+        min_coverage: cov,
+        ..Default::default()
+    };
+    let peers = generate_messy_coverage(&topo, &mut rng, &strat, len_mean, len_std, n, j);
+    parameterized_stability_test(&topo, &strat, peers, detail);
+}
+
+proptest::proptest! {
+
+    #[test]
+    #[ignore = "takes a very long time. run sparingly."]
+    fn stability_test(num_peers in 100u32..300, min_coverage in 50.0f64..100.0, j in 0.0..1.0) {
+        std::env::set_var("RUST_LOG", "debug");
+        observability::test_run().ok();
+
+        let topo = Topology::unit_zero();
+        let detail = false;
+
+        let mut rng = seeded_rng(None);
+
+        let len_mean = 0.50;
+        let len_std = 0.35;
+
+        let strat = ArqStrat {
+            min_coverage,
+            ..Default::default()
+        };
+
+        let peers = generate_messy_coverage(&topo, &mut rng, &strat, len_mean, len_std, num_peers, j);
+        parameterized_stability_test(&topo, &strat, peers, detail);
+    }
+}
+
+fn parameterized_stability_test(topo: &Topology, strat: &ArqStrat, peers: Vec<Arq>, detail: bool) {
+    println!("{}", strat.summary());
+
+    if detail {
+        println!("INITIAL CONDITIONS:");
+        for (i, arq) in peers.iter().enumerate() {
+            println!(
+                "|{}| #{:<3} {:>3} {:>3}",
+                arq.to_dht_arc_range(topo).to_ascii(64),
+                i,
+                arq.count(),
+                arq.power()
+            );
+        }
+    }
+
+    tracing::debug!("{}", EpochStats::oneline_header());
+    let eq = determine_equilibrium(1, peers.clone(), |peers| {
+        let (peers, stats) = run_one_epoch(topo, strat, peers, None, detail);
+        tracing::debug!("{}", stats.oneline());
+        (peers, stats)
+    });
+    let report = eq.report();
+    report.log();
+    pass_report(&report, strat.min_coverage);
+
+    let actual_cov = actual_coverage(topo, eq.runs()[0].peers.iter());
+    assert!(
+        actual_cov >= strat.min_coverage,
+        "{} < {}",
+        actual_cov,
+        strat.min_coverage
+    );
+    assert!(
+        actual_cov <= strat.max_coverage() + 1.0,
+        "{} > {}",
+        actual_cov,
+        strat.max_coverage() + 1.0
+    );
+}

--- a/crates/kitsune_p2p/dht/tests/common/continuous.rs
+++ b/crates/kitsune_p2p/dht/tests/common/continuous.rs
@@ -1,0 +1,433 @@
+#![allow(dead_code)]
+#![cfg(feature = "test_utils")]
+
+use kitsune_p2p_dht::arq::PeerStrat;
+use kitsune_p2p_dht::quantum::Topology;
+use kitsune_p2p_dht::test_utils::get_input;
+use kitsune_p2p_dht_arc::*;
+use rand::prelude::StdRng;
+use rand::thread_rng;
+use rand::Rng;
+use rand::SeedableRng;
+use statrs::statistics::*;
+use std::collections::HashSet;
+use std::iter;
+
+/// Maximum number of iterations. If we iterate this much, we assume the
+/// system is divergent (unable to reach equilibrium).
+const DIVERGENCE_ITERS: usize = 40;
+
+/// Number of consecutive rounds of no movement before declaring convergence.
+const CONVERGENCE_WINDOW: usize = 3;
+
+/// Level of detail in reporting.
+pub const DETAIL: u8 = 1;
+
+type DataVec = statrs::statistics::Data<Vec<f64>>;
+
+pub type Peers = Vec<DhtArc>;
+
+pub fn seeded_rng(seed: Option<u64>) -> StdRng {
+    let seed = seed.unwrap_or_else(|| thread_rng().gen());
+    tracing::info!("RNG seed: {}", seed);
+    StdRng::seed_from_u64(seed)
+}
+
+pub fn determine_equilibrium<'a, F>(iters: usize, peers: Peers, step: F) -> RunBatch
+where
+    F: 'a + Clone + Fn(Peers) -> (Peers, EpochStats),
+{
+    use Vergence::*;
+    let mut runs = vec![];
+    for i in 1..=iters {
+        tracing::debug!("----- Running equilibrium iteration {} -----", i);
+        let run = seek_convergence(peers.clone(), |peers| step(peers));
+        let vergence = run.vergence;
+        runs.push(run);
+        if vergence == Divergent {
+            break;
+        }
+    }
+    RunBatch(runs)
+}
+
+/// Run iterations until there is no movement of any arc
+/// TODO: this may be unreasonable, and we may need to just ensure that arcs
+/// settle down into a reasonable level of oscillation
+pub fn seek_convergence<'a, F>(peers: Peers, step: F) -> Run
+where
+    F: Fn(Peers) -> (Peers, EpochStats),
+{
+    let converged = |convergence| convergence >= CONVERGENCE_WINDOW;
+    let (peers, history, convergence) = (1..=DIVERGENCE_ITERS).fold(
+        (peers, vec![], 0),
+        |(peers, mut history, mut convergence), _i| {
+            if !converged(convergence) {
+                let (peers, stats) = step(peers);
+                if stats.gross_delta_avg == 0.0 {
+                    convergence += 1;
+                } else if convergence > 0 {
+                    panic!(
+                        "we don't expect a system in equilibirum to suddenly start moving again."
+                    )
+                } else {
+                    history.push(stats);
+                }
+                (peers, history, convergence)
+            } else {
+                (peers, history, convergence)
+            }
+        },
+    );
+
+    let vergence = if converged(convergence) {
+        Vergence::Convergent
+    } else {
+        Vergence::Divergent
+    };
+    Run {
+        vergence,
+        history,
+        peers,
+    }
+}
+
+/// Resize every arc based on neighbors' arcs, and compute stats about this iteration
+/// strat: The resizing strategy to use
+/// peers: The list of peers in this epoch
+/// dynamic_peer_indices: Indices of peers who should be updated. If None, all peers will be updated.
+/// detail: Level of output detail. More is more verbose. detail: u8,
+pub fn run_one_epoch(
+    topo: &Topology,
+    strat: &PeerStrat,
+    mut peers: Peers,
+    dynamic_peer_indices: Option<&HashSet<usize>>,
+    detail: u8,
+) -> (Peers, EpochStats) {
+    let mut net = 0.0;
+    let mut gross = 0.0;
+    let mut delta_min = FULL_LEN_F;
+    let mut delta_max = -FULL_LEN_F;
+    let mut index_min = peers.len();
+    let mut index_max = peers.len();
+    for i in 0..peers.len() {
+        if let Some(dynamic) = dynamic_peer_indices {
+            if !dynamic.contains(&i) {
+                continue;
+            }
+        }
+        let p = peers.clone();
+        let mut arc = peers.get_mut(i).unwrap();
+        let view = strat.view(topo.clone(), *arc, p.as_slice());
+        let before = arc.length() as f64;
+        view.update_arc(&mut arc);
+        let after = arc.length() as f64;
+        let delta = after - before;
+        // dbg!(&before, &after, &delta);
+        net += delta;
+        gross += delta.abs();
+        if delta < delta_min {
+            delta_min = delta;
+            index_min = i;
+        }
+        if delta > delta_max {
+            delta_max = delta;
+            index_max = i;
+        }
+    }
+
+    if detail >= 2 {
+        tracing::info!("min: |{}| {}", peers[index_min].to_ascii(64), index_min);
+        tracing::info!("max: |{}| {}", peers[index_max].to_ascii(64), index_max);
+        tracing::info!("");
+    } else if detail >= 3 {
+        print_arcs(&peers);
+        get_input();
+    }
+
+    let tot = peers.len() as f64;
+    let min_redundancy = check_redundancy(peers.clone());
+    let stats = EpochStats {
+        net_delta_avg: net / tot / FULL_LEN_F,
+        gross_delta_avg: gross / tot / FULL_LEN_F,
+        min_redundancy: min_redundancy,
+        delta_min: delta_min / FULL_LEN_F,
+        delta_max: delta_max / FULL_LEN_F,
+    };
+    (peers, stats)
+}
+
+/// Generate a list of DhtArcs based on 3 parameters:
+/// N: total # of peers
+/// J: random jitter of peer locations
+/// S: strategy for generating arc lengths
+pub fn simple_parameterized_generator(
+    rng: &mut StdRng,
+    n: usize,
+    j: f64,
+    s: ArcLenStrategy,
+) -> Peers {
+    tracing::info!("N = {}, J = {}", n, j);
+    tracing::info!("Arc len generation: {:?}", s);
+    let halflens = s.gen(rng, n);
+    generate_evenly_spaced_with_half_lens_and_jitter(rng, j, halflens)
+}
+
+/// Define arcs by start location and halflen in the unit interval [0.0, 1.0]
+pub fn unit_arcs<H: Iterator<Item = (f64, f64)>>(arcs: H) -> Peers {
+    let fc = FULL_LEN_F;
+    let fh = MAX_HALF_LENGTH as f64;
+    arcs.map(|(s, h)| {
+        DhtArc::from_start_and_half_len((s * fc).min(u32::MAX as f64) as u32, (h * fh) as u32)
+    })
+    .collect()
+}
+
+/// Each agent is perfect evenly spaced around the DHT,
+/// with the halflens specified by the iterator.
+pub fn generate_evenly_spaced_with_half_lens_and_jitter(
+    rng: &mut StdRng,
+    jitter: f64,
+    hs: Vec<f64>,
+) -> Peers {
+    let n = hs.len() as f64;
+    unit_arcs(hs.into_iter().enumerate().map(|(i, h)| {
+        (
+            (i as f64 / n) + (2.0 * jitter * rng.gen::<f64>()) - jitter,
+            h,
+        )
+    }))
+}
+
+#[derive(Debug)]
+pub struct RunBatch(Vec<Run>);
+
+#[derive(Clone, Debug)]
+pub struct Stats {
+    pub min: f64,
+    pub max: f64,
+    pub mean: f64,
+    pub median: f64,
+    pub variance: f64,
+}
+
+impl Stats {
+    pub fn new(xs: DataVec) -> Self {
+        Self {
+            min: xs.min(),
+            max: xs.max(),
+            mean: xs.mean().unwrap(),
+            median: xs.median(),
+            variance: xs.variance().unwrap(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RunReport {
+    pub iteration_stats: Stats,
+    pub overall_redundancy_stats: Stats,
+    pub outcome: RunReportOutcome,
+    pub total_runs: usize,
+}
+
+impl RunReport {
+    pub fn is_convergent(&self) -> bool {
+        match self.outcome {
+            RunReportOutcome::Convergent { .. } => true,
+            RunReportOutcome::Divergent { .. } => false,
+        }
+    }
+
+    pub fn log(&self) -> &Self {
+        tracing::info!("{:#?}", self);
+        if self.is_convergent() {
+            tracing::info!(
+                "Reached equilibrium in {} mean iterations (variance {})",
+                self.iteration_stats.mean,
+                self.iteration_stats.variance
+            );
+        } else {
+            tracing::warn!(
+                "Divergent run found on attempt #{}. Failed to reach equilibrium in {} iterations",
+                self.total_runs,
+                DIVERGENCE_ITERS
+            );
+        }
+        self
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum RunReportOutcome {
+    /// The redundancy stats across just the last epoch of each run
+    Convergent { redundancy_stats: Stats },
+    /// The redundancy stats across the last N epochs of each run, all combined
+    Divergent {
+        redundancy_stats: Stats,
+        num_epochs: usize,
+    },
+}
+
+#[allow(dead_code)]
+impl RunBatch {
+    pub fn report(&self) -> RunReport {
+        let num_epochs = 10;
+        let iterations = DataVec::new(self.histories().map(|h| h.len() as f64).collect());
+        let redundancies = DataVec::new(
+            self.histories()
+                .flatten()
+                .map(|h| h.min_redundancy as f64)
+                .collect(),
+        );
+        let outcome = match self.vergence() {
+            Vergence::Convergent => RunReportOutcome::Convergent {
+                redundancy_stats: Stats::new(DataVec::new(
+                    self.histories()
+                        .map(|hs| {
+                            hs.last()
+                                .map(|l| l.min_redundancy as f64)
+                                .unwrap_or_default()
+                        })
+                        .collect(),
+                )),
+            },
+            Vergence::Divergent => RunReportOutcome::Divergent {
+                num_epochs,
+                redundancy_stats: Stats::new(DataVec::new(
+                    self.histories()
+                        .map(|hs| {
+                            let mut hs = hs.clone();
+                            hs.reverse();
+                            hs.into_iter()
+                                .take(num_epochs)
+                                .map(|e| e.min_redundancy as f64)
+                                .collect::<Vec<_>>()
+                        })
+                        .flatten()
+                        .collect(),
+                )),
+            },
+        };
+        RunReport {
+            iteration_stats: Stats::new(iterations),
+            overall_redundancy_stats: Stats::new(redundancies),
+            outcome,
+            total_runs: self.histories().count(),
+        }
+    }
+
+    pub fn vergence(&self) -> Vergence {
+        if self.0.iter().all(|r| r.vergence.is_convergent()) {
+            Vergence::Convergent
+        } else {
+            Vergence::Divergent
+        }
+    }
+
+    pub fn runs(&self) -> &Vec<Run> {
+        &self.0
+    }
+
+    pub fn histories(&self) -> impl Iterator<Item = &Vec<EpochStats>> + '_ {
+        self.0.iter().map(|r| &r.history)
+    }
+}
+
+#[derive(Debug)]
+pub struct Run {
+    pub vergence: Vergence,
+    pub history: Vec<EpochStats>,
+    /// the final state of the peers at the last iteration
+    pub peers: Peers,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Vergence {
+    Convergent,
+    Divergent,
+}
+
+impl Vergence {
+    pub fn is_convergent(&self) -> bool {
+        *self == Vergence::Convergent
+    }
+}
+
+impl PartialOrd for Vergence {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Vergence {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use Vergence::*;
+        match (self, other) {
+            (Divergent, Convergent) => std::cmp::Ordering::Less,
+            (Convergent, Divergent) => std::cmp::Ordering::Greater,
+            _ => std::cmp::Ordering::Equal,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EpochStats {
+    pub net_delta_avg: f64,
+    pub gross_delta_avg: f64,
+    pub delta_max: f64,
+    pub delta_min: f64,
+    // pub delta_variance: f64,
+    pub min_redundancy: u32,
+}
+
+impl EpochStats {
+    pub fn oneline_header() -> String {
+        format!("rdun   net Δ%   gross Δ%   min Δ%   max Δ%")
+    }
+
+    pub fn oneline(&self) -> String {
+        format!(
+            "{:4}   {:>+6.3}   {:>8.3}   {:>6.3}   {:>6.3}",
+            self.min_redundancy,
+            self.net_delta_avg * 100.0,
+            self.gross_delta_avg * 100.0,
+            self.delta_min * 100.0,
+            self.delta_max * 100.0,
+        )
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub enum ArcLenStrategy {
+    Random,
+    Ideal { target_coverage: f64 },
+    Constant(f64),
+    HalfAndHalf(f64, f64),
+}
+
+impl ArcLenStrategy {
+    pub fn gen(&self, rng: &mut StdRng, num: usize) -> Vec<f64> {
+        match self {
+            Self::Random => iter::repeat_with(|| rng.gen()).take(num).collect(),
+            Self::Ideal { target_coverage } => {
+                iter::repeat((target_coverage / num as f64).min(1.0))
+                    .take(num)
+                    .collect()
+            }
+            Self::Constant(v) => iter::repeat(*v).take(num).collect(),
+            Self::HalfAndHalf(a, b) => iter::repeat(*a)
+                .take(num / 2)
+                .chain(iter::repeat(*b).take(num / 2))
+                .collect(),
+        }
+    }
+}
+
+/// View ascii for all arcs
+pub fn print_arcs(arcs: &Peers) {
+    for (i, arc) in arcs.into_iter().enumerate() {
+        println!("|{}| {}", arc.to_ascii(64), i);
+    }
+}

--- a/crates/kitsune_p2p/dht/tests/common/mod.rs
+++ b/crates/kitsune_p2p/dht/tests/common/mod.rs
@@ -1,0 +1,2 @@
+pub mod continuous;
+pub mod quantized;

--- a/crates/kitsune_p2p/dht/tests/common/quantized.rs
+++ b/crates/kitsune_p2p/dht/tests/common/quantized.rs
@@ -1,0 +1,474 @@
+#![allow(dead_code)]
+#![cfg(feature = "test_utils")]
+
+use kitsune_p2p_dht::arq::*;
+use kitsune_p2p_dht::quantum::Topology;
+use kitsune_p2p_dht::test_utils::calc_min_redundancy;
+use rand::prelude::StdRng;
+use rand::thread_rng;
+use rand::Rng;
+use rand::SeedableRng;
+use statrs::statistics::*;
+use std::collections::HashSet;
+use std::iter;
+
+use colored::*;
+
+/// Maximum number of iterations. If we iterate this much, we assume the
+/// system is divergent (unable to reach equilibrium).
+const DIVERGENCE_ITERS: usize = 60;
+
+/// Number of consecutive rounds of no movement before declaring convergence.
+const CONVERGENCE_WINDOW: usize = 1;
+
+/// Level of detail in reporting.
+pub const DETAIL: u8 = 1;
+
+type DataVec = statrs::statistics::Data<Vec<f64>>;
+
+pub type Peers = Vec<Arq>;
+
+fn full_len() -> f64 {
+    2f64.powi(32)
+}
+
+pub fn seeded_rng(seed: Option<u64>) -> StdRng {
+    let seed = seed.unwrap_or_else(|| thread_rng().gen());
+    tracing::info!("RNG seed: {}", seed);
+    StdRng::seed_from_u64(seed)
+}
+
+pub fn determine_equilibrium<'a, F>(iters: usize, peers: Peers, step: F) -> RunBatch
+where
+    F: 'a + Clone + Fn(Peers) -> (Peers, EpochStats),
+{
+    use Vergence::*;
+    let mut runs = vec![];
+    for i in 1..=iters {
+        tracing::debug!("----- Running equilibrium iteration {} -----", i);
+        let run = seek_convergence(peers.clone(), |peers| step(peers));
+        let vergence = run.vergence;
+        runs.push(run);
+        if vergence == Divergent {
+            break;
+        }
+    }
+    RunBatch(runs)
+}
+
+/// Run iterations until there is no movement of any arc
+/// TODO: this may be unreasonable, and we may need to just ensure that arcs
+/// settle down into a reasonable level of oscillation
+pub fn seek_convergence<'a, F>(peers: Peers, step: F) -> Run
+where
+    F: Fn(Peers) -> (Peers, EpochStats),
+{
+    let converged = |convergence| convergence >= CONVERGENCE_WINDOW;
+    let (peers, history, convergence) = (1..=DIVERGENCE_ITERS).fold(
+        (peers, vec![], 0),
+        |(peers, mut history, mut convergence), _i| {
+            if !converged(convergence) {
+                let (peers, stats) = step(peers);
+                if stats.gross_delta_avg == 0.0 {
+                    convergence += 1;
+                } else if convergence > 0 {
+                    panic!(
+                        "we don't expect a system in equilibirum to suddenly start moving again."
+                    )
+                } else {
+                    history.push(stats);
+                }
+                (peers, history, convergence)
+            } else {
+                (peers, history, convergence)
+            }
+        },
+    );
+
+    let vergence = if converged(convergence) {
+        Vergence::Convergent
+    } else {
+        Vergence::Divergent
+    };
+    Run {
+        vergence,
+        history,
+        peers,
+    }
+}
+
+/// Resize every arc based on neighbors' arcs, and compute stats about this iteration
+/// strat: The resizing strategy to use
+/// peers: The list of peers in this epoch
+/// dynamic_peer_indices: Indices of peers who should be updated. If None, all peers will be updated.
+/// detail: Level of output detail. More is more verbose. detail: u8,
+pub fn run_one_epoch(
+    topo: &Topology,
+    strat: &ArqStrat,
+    mut peers: Peers,
+    dynamic_peer_indices: Option<&HashSet<usize>>,
+    detail: bool,
+) -> (Peers, EpochStats) {
+    let mut cov_total = 0.0;
+    let mut cov_min = full_len();
+    let mut cov_max = 0.0;
+    let mut power_min = 32;
+    let mut power_max = 0;
+    let mut power_total = 0.0;
+    let mut delta_net = 0.0;
+    let mut delta_gross = 0.0;
+
+    let mut delta_min = full_len();
+    let mut delta_max = -full_len();
+
+    // TODO: update the continuous test framework to only use one view per epoch
+    let mut view = PeerViewQ::new(topo.clone(), strat.clone(), peers.clone());
+
+    if detail {
+        println!(
+            "|{: ^64}|  {:<3} {:>3} {:>3} {:>3} {:>4} {:>6} {:>3} {:>4}",
+            "<arc>", "idx", "cnt", "pwr", "mp", "Δ", "cov", "#p", "slk",
+        )
+    }
+
+    for i in 0..peers.len() {
+        view.skip_index = Some(i);
+
+        if let Some(dynamic) = dynamic_peer_indices {
+            if !dynamic.contains(&i) {
+                continue;
+            }
+        }
+        let mut arq = peers.get_mut(i).unwrap();
+        let before = arq.absolute_length(topo) as f64;
+        let before_pow = arq.power();
+
+        let stats = view.update_arq_with_stats(topo, &mut arq);
+
+        let after = arq.absolute_length(topo) as f64;
+        let delta = (after - before) / topo.space.quantum as f64;
+
+        if detail {
+            let d = delta as i64 / 2i64.pow(before_pow as u32);
+            let delta_str = if d == 0 {
+                "    ".into()
+            } else if d > 0 {
+                format!("{:>+4}", d).green()
+            } else {
+                format!("{:>+4}", d).red()
+            };
+            let delta_str = if d.abs() > strat.max_chunks() as i64 {
+                delta_str.bold()
+            } else {
+                delta_str
+            };
+
+            let cov = view.extrapolated_coverage(&arq);
+            let slack_factor = view.slack_factor(cov, stats.num_peers);
+
+            let slack_str = if slack_factor == 1.0 {
+                "    ".into()
+            } else if slack_factor > 3.0 {
+                format!("{:4.2}", slack_factor).bold()
+            } else {
+                format!("{:4.2}", slack_factor).normal()
+            };
+
+            let cov_str = format!("{: >6.2}", cov);
+
+            let power_str = stats
+                .power
+                .map(|p| format!("{:2}", p.median).normal())
+                .unwrap_or("??".magenta());
+            println!(
+                "|{}| #{:<3} {:>3} {:>3} {:>3} {} {} {: >3} {}",
+                arq.to_dht_arc_range(topo).to_ascii(64),
+                i,
+                arq.count(),
+                arq.power(),
+                power_str,
+                delta_str,
+                cov_str,
+                stats.num_peers,
+                slack_str,
+            );
+        }
+
+        power_total += arq.power() as f64;
+        cov_total += after;
+        delta_net += delta;
+        delta_gross += delta.abs();
+        if after < cov_min {
+            cov_min = after;
+        }
+        if after > cov_max {
+            cov_max = after;
+        }
+
+        if arq.power() > power_max {
+            power_max = arq.power();
+        }
+        if arq.power() < power_min {
+            power_min = arq.power();
+        }
+
+        if delta < delta_min {
+            delta_min = delta;
+        }
+        if delta > delta_max {
+            delta_max = delta;
+        }
+        view.skip_index = None;
+    }
+
+    let tot = peers.len() as f64;
+    let min_redundancy = calc_min_redundancy(topo, peers.clone());
+    let stats = EpochStats {
+        net_delta_avg: delta_net / tot / full_len(),
+        gross_delta_avg: delta_gross / tot / full_len(),
+        min_redundancy,
+        delta_min: delta_min / full_len(),
+        delta_max: delta_max / full_len(),
+        min_coverage: cov_min / full_len(),
+        max_coverage: cov_max / full_len(),
+        avg_redundancy: cov_total / full_len(),
+        min_power: power_min,
+        max_power: power_max,
+        mean_power: power_total / tot,
+    };
+    (peers, stats)
+}
+
+#[derive(Debug)]
+pub struct RunBatch(Vec<Run>);
+
+#[derive(Clone, Debug)]
+pub struct Stats {
+    pub min: f64,
+    pub max: f64,
+    pub mean: f64,
+    pub median: f64,
+    pub variance: f64,
+}
+
+impl Stats {
+    pub fn new(xs: DataVec) -> Self {
+        Self {
+            min: xs.min(),
+            max: xs.max(),
+            mean: xs.mean().unwrap(),
+            median: xs.median(),
+            variance: xs.variance().unwrap(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RunReport {
+    pub iteration_stats: Stats,
+    pub overall_redundancy_stats: Stats,
+    pub outcome: RunReportOutcome,
+    pub total_runs: usize,
+}
+
+impl RunReport {
+    pub fn is_convergent(&self) -> bool {
+        match self.outcome {
+            RunReportOutcome::Convergent { .. } => true,
+            RunReportOutcome::Divergent { .. } => false,
+        }
+    }
+
+    pub fn log(&self) -> &Self {
+        tracing::info!("{:#?}", self);
+        if self.is_convergent() {
+            tracing::info!(
+                "Reached equilibrium in {} mean iterations (variance {})",
+                self.iteration_stats.mean,
+                self.iteration_stats.variance
+            );
+        } else {
+            tracing::warn!(
+                "Divergent run found on attempt #{}. Failed to reach equilibrium in {} iterations",
+                self.total_runs,
+                DIVERGENCE_ITERS
+            );
+        }
+        self
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum RunReportOutcome {
+    /// The redundancy stats across just the last epoch of each run
+    Convergent { redundancy_stats: Stats },
+    /// The redundancy stats across the last N epochs of each run, all combined
+    Divergent {
+        redundancy_stats: Stats,
+        num_epochs: usize,
+    },
+}
+
+#[allow(dead_code)]
+impl RunBatch {
+    pub fn report(&self) -> RunReport {
+        let num_epochs = 10;
+        let iterations = DataVec::new(self.histories().map(|h| h.len() as f64).collect());
+        let redundancies = DataVec::new(
+            self.histories()
+                .flatten()
+                .map(|h| h.min_redundancy as f64)
+                .collect(),
+        );
+        let outcome = match self.vergence() {
+            Vergence::Convergent => RunReportOutcome::Convergent {
+                redundancy_stats: Stats::new(DataVec::new(
+                    self.histories()
+                        .filter_map(|hs| hs.last().map(|h| h.min_redundancy as f64))
+                        .collect(),
+                )),
+            },
+            Vergence::Divergent => RunReportOutcome::Divergent {
+                num_epochs,
+                redundancy_stats: Stats::new(DataVec::new(
+                    self.histories()
+                        .map(|hs| {
+                            let mut hs = hs.clone();
+                            hs.reverse();
+                            hs.into_iter()
+                                .take(num_epochs)
+                                .map(|e| e.min_redundancy as f64)
+                                .collect::<Vec<_>>()
+                        })
+                        .flatten()
+                        .collect(),
+                )),
+            },
+        };
+        RunReport {
+            iteration_stats: Stats::new(iterations),
+            overall_redundancy_stats: Stats::new(redundancies),
+            outcome,
+            total_runs: self.histories().count(),
+        }
+    }
+
+    pub fn vergence(&self) -> Vergence {
+        if self.0.iter().all(|r| r.vergence.is_convergent()) {
+            Vergence::Convergent
+        } else {
+            Vergence::Divergent
+        }
+    }
+
+    pub fn runs(&self) -> &Vec<Run> {
+        &self.0
+    }
+
+    pub fn histories(&self) -> impl Iterator<Item = &Vec<EpochStats>> + '_ {
+        self.0.iter().map(|r| &r.history)
+    }
+}
+
+#[derive(Debug)]
+pub struct Run {
+    pub vergence: Vergence,
+    pub history: Vec<EpochStats>,
+    /// the final state of the peers at the last iteration
+    pub peers: Peers,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Vergence {
+    Convergent,
+    Divergent,
+}
+
+impl Vergence {
+    pub fn is_convergent(&self) -> bool {
+        *self == Vergence::Convergent
+    }
+}
+
+impl PartialOrd for Vergence {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Vergence {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use Vergence::*;
+        match (self, other) {
+            (Divergent, Convergent) => std::cmp::Ordering::Less,
+            (Convergent, Divergent) => std::cmp::Ordering::Greater,
+            _ => std::cmp::Ordering::Equal,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EpochStats {
+    pub net_delta_avg: f64,
+    pub gross_delta_avg: f64,
+    pub delta_max: f64,
+    pub delta_min: f64,
+    // pub delta_variance: f64,
+    pub min_redundancy: u32,
+    pub min_coverage: f64,
+    pub max_coverage: f64,
+    pub avg_redundancy: f64,
+    pub min_power: u8,
+    pub max_power: u8,
+    pub mean_power: f64,
+}
+
+impl EpochStats {
+    pub fn oneline_header() -> String {
+        format!(
+            "rdun   net Δ%   gross Δ%   min Δ%   max Δ%   avg cov   min pow   avg pow   max pow"
+        )
+    }
+
+    pub fn oneline(&self) -> String {
+        format!(
+            "{:4}   {:>+6.3}   {:>8.3}   {:>6.3}   {:>6.3}   {:>7.2}   {:>7}   {:>7.2}   {:>7}",
+            self.min_redundancy,
+            self.net_delta_avg * 100.0,
+            self.gross_delta_avg * 100.0,
+            self.delta_min * 100.0,
+            self.delta_max * 100.0,
+            self.avg_redundancy,
+            self.min_power,
+            self.mean_power,
+            self.max_power,
+        )
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub enum ArcLenStrategy {
+    Random,
+    Ideal { target_coverage: f64 },
+    Constant(f64),
+    HalfAndHalf(f64, f64),
+}
+
+impl ArcLenStrategy {
+    pub fn gen(&self, rng: &mut StdRng, num: usize) -> Vec<f64> {
+        match self {
+            Self::Random => iter::repeat_with(|| rng.gen()).take(num).collect(),
+            Self::Ideal { target_coverage } => {
+                iter::repeat((target_coverage / num as f64).min(1.0))
+                    .take(num)
+                    .collect()
+            }
+            Self::Constant(v) => iter::repeat(*v).take(num).collect(),
+            Self::HalfAndHalf(a, b) => iter::repeat(*a)
+                .take(num / 2)
+                .chain(iter::repeat(*b).take(num / 2))
+                .collect(),
+        }
+    }
+}

--- a/crates/kitsune_p2p/dht/tests/gossip.rs
+++ b/crates/kitsune_p2p/dht/tests/gossip.rs
@@ -1,0 +1,159 @@
+#![cfg(feature = "test_utils")]
+
+use kitsune_p2p_dht::{
+    arq::*,
+    op::*,
+    persistence::*,
+    quantum::*,
+    region::*,
+    test_utils::{
+        generate_ideal_coverage, gossip_direct, gossip_direct_at, seeded_rng, OpData, TestNode,
+    },
+};
+use kitsune_p2p_timestamp::Timestamp;
+use rand::Rng;
+
+#[test]
+fn test_basic() {
+    let topo = Topology::unit_zero();
+    let gopa = GossipParams::new(1.into(), 0);
+    let ts = |t: u32| TimeQuantum::from(t).to_timestamp_bounds(&topo).0;
+
+    let alice_arq = Arq::new(8, (-128i32 as u32).into(), 4.into());
+    let bobbo_arq = Arq::new(8, 0u32.into(), 4.into());
+    let mut alice = TestNode::new(topo.clone(), gopa, alice_arq);
+    let mut bobbo = TestNode::new(topo.clone(), gopa, bobbo_arq);
+
+    alice.integrate_op(OpData::fake(0.into(), ts(10), 4321));
+    bobbo.integrate_op(OpData::fake(128.into(), ts(20), 1234));
+
+    let ta = TimeQuantum::from(30);
+    let tb = TimeQuantum::from(31);
+    let nta = TelescopingTimes::new(ta).segments().len() as u32;
+    let ntb = TelescopingTimes::new(tb).segments().len() as u32;
+
+    let stats = gossip_direct((&mut alice, ta), (&mut bobbo, tb)).unwrap();
+
+    assert_eq!(stats.regions_sent, 3 * nta);
+    assert_eq!(stats.regions_rcvd, 3 * ntb);
+    assert_eq!(stats.op_data_sent, 4321);
+    assert_eq!(stats.op_data_rcvd, 1234);
+}
+
+#[test]
+fn gossip_scenario_full_sync() {
+    observability::test_run().ok();
+    let topo = Topology::standard_zero();
+    let gopa = GossipParams::new(1.into(), 0);
+
+    let mut rng = seeded_rng(None);
+
+    // must be a power of 2.
+    let pow = 4;
+    let n = 2usize.pow(pow);
+    let ops_per_node = 10;
+
+    let strat = ArqStrat {
+        min_coverage: n as f64,
+        ..Default::default()
+    };
+
+    let expected_num_space_chunks: u32 = 8;
+    let expected_num_time_chunks: u32 = 22;
+
+    let max_time = TimeQuantum::from(525600 / 12).to_timestamp_bounds(&topo).0; // 1 year
+    assert_eq!(
+        TelescopingTimes::new(topo.time_quantum(max_time))
+            .segments()
+            .len() as u32,
+        expected_num_time_chunks
+    );
+
+    // these arqs will all be Full coverage
+    let arqs = generate_ideal_coverage(&topo, &mut rng, &strat, None, n as u32, 0.0);
+
+    let mut nodes: Vec<_> = arqs
+        .iter()
+        .map(|a| {
+            assert_eq!(a.count(), expected_num_space_chunks);
+            TestNode::new(topo.clone(), gopa, *a)
+        })
+        .collect();
+
+    let num_ops = ops_per_node * n;
+    let ops = std::iter::repeat_with(|| {
+        OpData::fake(
+            Loc::new(rng.gen()),
+            Timestamp::from_micros(rng.gen_range(0..max_time.as_micros())),
+            rng.gen_range(1..16_000_000),
+        )
+    })
+    .take(num_ops);
+
+    for (i, op) in ops.enumerate() {
+        nodes[i % n].integrate_op(op);
+    }
+
+    let full_region = RegionCoords {
+        space: SpaceSegment::new(31, 0),
+        time: TimeSegment::new(31, 0),
+    };
+
+    // Assert that each node has the expected number of ops to start with,
+    // and print each arq at the same time.
+    assert_eq!(
+        nodes
+            .iter()
+            .enumerate()
+            .map(|(i, n)| {
+                let ops = n.query_op_data(&full_region);
+                println!("{}", n.ascii_arq_and_ops(&topo, i, 64));
+                ops.len()
+            })
+            .collect::<Vec<_>>(),
+        vec![ops_per_node; n]
+    );
+
+    // Do a bunch of gossip such that node 0 will be exposed to all ops created
+    for p in 0..pow {
+        let x: usize = 2usize.pow(p + 1);
+        for i in (0..n).step_by(x) {
+            let a = i;
+            let b = i + x / 2;
+            let (n1, n2) = get_two_mut(nodes.as_mut_slice(), a, b);
+            let stats = gossip_direct_at(n1, n2, topo.time_quantum(max_time)).unwrap();
+
+            // Something is wrong if we're sending tons of regions
+            assert_eq!(
+                stats.regions_sent,
+                expected_num_space_chunks * expected_num_time_chunks
+            );
+            assert_eq!(
+                stats.regions_rcvd,
+                expected_num_space_chunks * expected_num_time_chunks
+            );
+            println!(
+                "{:>2} <-> {:<2}  regions sent/rcvd: {}/{}, ops sent/rcvd: {:3}/{:3}, bytes sent/rcvd: {}/{}",
+                a, b, stats.regions_sent, stats.regions_rcvd, stats.ops_sent, stats.ops_rcvd, stats.op_data_sent, stats.op_data_rcvd
+            );
+        }
+    }
+
+    for (i, n) in nodes.iter().enumerate() {
+        println!("{}", n.ascii_arq_and_ops(&topo, i, 64));
+    }
+
+    assert_eq!(nodes[0].query_op_data(&full_region).len(), num_ops);
+}
+
+/// from https://www.reddit.com/r/rust/comments/7dep46/multiple_references_to_a_vectors_elements/
+fn get_two_mut<T>(slice: &mut [T], index1: usize, index2: usize) -> (&mut T, &mut T) {
+    assert!(index1 != index2 && index1 < slice.len() && index2 < slice.len());
+    if index1 < index2 {
+        let (start, end) = slice.split_at_mut(index2);
+        (&mut start[index1], &mut end[0])
+    } else {
+        let (start, end) = slice.split_at_mut(index1);
+        (&mut end[0], &mut start[index2])
+    }
+}

--- a/crates/kitsune_p2p/dht/tests/legacy_arc_stability.rs
+++ b/crates/kitsune_p2p/dht/tests/legacy_arc_stability.rs
@@ -1,0 +1,242 @@
+#![cfg(feature = "test_utils")]
+#![cfg(feature = "NORUN")]
+
+mod common;
+
+use std::collections::HashSet;
+
+use common::continuous::*;
+use kitsune_p2p_dht::arq::PeerStrat;
+use kitsune_p2p_dht_arc::*;
+
+fn pass_report(report: &RunReport, redundancy_target: f64) -> bool {
+    match &report.outcome {
+        RunReportOutcome::Convergent { redundancy_stats } => {
+            pass_redundancy(redundancy_stats, redundancy_target)
+        }
+        RunReportOutcome::Divergent {
+            redundancy_stats, ..
+        } => pass_redundancy(redundancy_stats, redundancy_target),
+    }
+}
+
+/// Check if the min redundancy is "close enough" to the target for the given
+/// Stats.
+/// Currently this does not assert a very strong guarantee. Over time we want
+/// to reduce the margins closer to zero.
+fn pass_redundancy(stats: &Stats, redundancy_target: f64) -> bool {
+    let rf = redundancy_target as f64;
+
+    let margin_min = 0.40;
+    let margin_median_lo = 0.40;
+    let margin_median_hi = 0.20;
+    stats.median >= rf * (1.0 - margin_median_lo)
+        && stats.median <= rf * (1.0 + margin_median_hi)
+        && stats.min >= rf * (1.0 - margin_min)
+}
+
+#[test]
+#[ignore = "Not suitable for ci"]
+fn single_agent_convergence_debug() {
+    std::env::set_var("RUST_LOG", "debug");
+    observability::test_run().ok();
+
+    let n = 1000;
+    let redundancy = 100;
+    let j = 0.1;
+    let check_gaps = false;
+
+    let mut rng = seeded_rng(None);
+    // let mut rng = seeded_rng(Some(5181023930453438019));
+
+    let strat = PeerStratAlpha {
+        check_gaps,
+        redundancy_target: redundancy / 2,
+        ..Default::default()
+    }
+    .into();
+
+    let s = ArcLenStrategy::Constant(redundancy as f64 / n as f64);
+
+    let mut peers = simple_parameterized_generator(&mut rng, n, j, s);
+    peers[0] = DhtArc::full(peers[0].start_loc());
+    tracing::debug!("{}", EpochStats::oneline_header());
+    let runs = determine_equilibrium(1, peers, |peers| {
+        let dynamic = Some(maplit::hashset![0]);
+        let (peers, stats) = run_one_epoch(&strat, peers, dynamic.as_ref(), DETAIL);
+
+        tracing::debug!("{}", stats.oneline());
+        // tracing::debug!("{}", peers[0].coverage());
+        (peers, stats)
+    });
+    // print_arcs(&runs.runs()[0].peers);
+    let report = runs.report();
+    report.log();
+    assert!(report.is_convergent());
+}
+
+pub fn run_report(
+    strat: &PeerStrat,
+    indices: &Option<HashSet<usize>>,
+    iters: usize,
+    n: usize,
+    j: f64,
+    s: ArcLenStrategy,
+) -> RunReport {
+    tracing::info!("");
+    tracing::info!("------------------------");
+
+    // let seed = None;
+    let seed = Some(7532095396949412554);
+    let mut rng = seeded_rng(seed);
+
+    let mut peers = simple_parameterized_generator(&mut rng, n, j, s);
+    peers[0] = DhtArc::full(peers[0].start_loc());
+    let runs = determine_equilibrium(iters, peers, |peers| {
+        let (peers, stats) = run_one_epoch(strat, peers, indices.as_ref(), DETAIL);
+        tracing::debug!("{}", peers[0].coverage());
+        (peers, stats)
+    });
+    let report = runs.report();
+    if DETAIL >= 2 {
+        print_arcs(&runs.runs()[0].peers);
+    }
+    if DETAIL >= 1 {
+        report.log();
+    }
+    report
+}
+
+/// Test if various distributions of agents can converge
+#[test]
+#[cfg(feature = "slow_tests")]
+fn parameterized_battery() {
+    std::env::set_var("RUST_LOG", "info");
+    observability::test_run().ok();
+    use std::collections::HashSet;
+
+    let n = 100;
+    let r = 50;
+    let rf = r as f64;
+    let s = ArcLenStrategy::Constant(1.0);
+    let its = 3;
+
+    let pass = |report: RunReport| pass_report(&report, rf);
+    let pass_convergent = |report: RunReport| report.is_convergent() && pass_report(&report, rf);
+    let _pass_divergent = |report: RunReport| !report.is_convergent() && pass_report(&report, rf);
+
+    let strat_alpha_0: PeerStrat = PeerStratAlpha {
+        check_gaps: false,
+        redundancy_target: r / 2,
+        ..Default::default()
+    }
+    .into();
+
+    let strat_alpha_1: PeerStrat = PeerStratAlpha {
+        check_gaps: true,
+        redundancy_target: r / 2,
+        ..Default::default()
+    }
+    .into();
+
+    let strat_beta: PeerStrat = PeerStratBeta {
+        min_sample_size: r / 2,
+        ..Default::default()
+    }
+    .into();
+
+    // If None, resize all arcs. If Some, only resize the specified indices.
+    let ixs: Option<HashSet<usize>> = None;
+
+    // beta
+    assert!(pass(run_report(&strat_beta, &ixs, its, n, 0.0, s)));
+    assert!(pass(run_report(&strat_beta, &ixs, its, n, 0.01, s)));
+    assert!(pass(run_report(&strat_beta, &ixs, its, n, 0.05, s)));
+    assert!(pass(run_report(&strat_beta, &ixs, its, n, 0.1, s)));
+    assert!(pass(run_report(&strat_beta, &ixs, its, n, 0.25, s)));
+    assert!(pass(run_report(&strat_beta, &ixs, its, n, 0.5, s)));
+
+    // alpha, gap_check == true
+    pass_convergent(run_report(&strat_alpha_1, &ixs, its, n, 0.0, s));
+    pass_convergent(run_report(&strat_alpha_1, &ixs, its, n, 0.001, s));
+    pass_convergent(run_report(&strat_alpha_1, &ixs, its, n, 0.01, s));
+
+    // alpha, gap_check == false
+    pass_convergent(run_report(&strat_alpha_0, &ixs, its, n, 0.0, s));
+    pass_convergent(run_report(&strat_alpha_0, &ixs, its, n, 0.001, s));
+    pass_convergent(run_report(&strat_alpha_0, &ixs, its, n, 0.01, s));
+    // Note that the following cases fail with gap_check
+    pass(run_report(&strat_alpha_0, &ixs, its, n, 0.1, s));
+    pass(run_report(&strat_alpha_0, &ixs, its, n, 0.5, s));
+    pass(run_report(&strat_alpha_0, &ixs, its, n, 1.0, s));
+}
+
+/// Equilibrium test for a single distribution
+#[test]
+#[ignore = "Not suitable for ci"]
+fn parameterized_stability_test() {
+    std::env::set_var("RUST_LOG", "debug");
+    observability::test_run().ok();
+
+    let mut rng = seeded_rng(None);
+
+    let n = 1000;
+    let j = 10.0 / n as f64;
+    let s = ArcLenStrategy::Constant(0.1);
+
+    let r = 50;
+    let rf = r as f64;
+
+    let strat = PeerStratAlpha {
+        redundancy_target: r,
+        ..Default::default()
+    }
+    .into();
+
+    let peers = simple_parameterized_generator(&mut rng, n, j, s);
+    tracing::info!("");
+    tracing::debug!("{}", EpochStats::oneline_header());
+    print_arcs(&peers);
+    let eq = determine_equilibrium(2, peers, |peers| {
+        let (peers, stats) = run_one_epoch(&strat, peers, None, DETAIL);
+        tracing::debug!("{}", stats.oneline());
+        print_arcs(&peers);
+        (peers, stats)
+    });
+    let report = eq.report();
+    report.log();
+    assert!(pass_report(&report, rf * 2.0));
+}
+
+/// Equilibrium test for a single distribution
+#[test]
+#[ignore = "Not suitable for ci"]
+fn test_peer_view_beta() {
+    observability::test_run().ok();
+
+    let mut rng = seeded_rng(None);
+
+    let n = 1000;
+    let j = 10.0 / n as f64;
+    let s = ArcLenStrategy::Constant(0.1);
+
+    let r = 50;
+    let strat = PeerStratBeta {
+        min_sample_size: r,
+        ..Default::default()
+    };
+
+    let target_redundancy = r as f64 / strat.default_uptime;
+    let error_buffer = target_redundancy as f64 * strat.total_coverage_buffer;
+    let min_r = target_redundancy - error_buffer;
+
+    let peers = simple_parameterized_generator(&mut rng, n, j, s);
+    tracing::debug!("{}", EpochStats::oneline_header());
+    let runs = determine_equilibrium(2, peers, |peers| {
+        let (peers, stats) = run_one_epoch(&strat.into(), peers, None, DETAIL);
+        tracing::debug!("{}", stats.oneline());
+        (peers, stats)
+    });
+    dbg!(min_r);
+    assert!(pass_report(runs.report().log(), min_r));
+}

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
@@ -100,8 +100,8 @@ impl DhtArc {
     /// This will converge on a new target instead of jumping directly
     /// to the new target and is designed to be called at a given rate
     /// with more recent peer views.
-    pub fn update_length<V: Into<PeerView>>(&mut self, view: V) {
-        let new_length = (U32_LEN as f64 * view.into().next_coverage(self.coverage())) as u64;
+    pub fn update_length(&mut self, view: &PeerView) {
+        let new_length = (U32_LEN as f64 * view.next_coverage(self.coverage())) as u64;
         *self = Self::from_start_and_len(self.start_loc(), new_length)
     }
 

--- a/crates/kitsune_p2p/dht_arc/src/test/test_peer_view_alpha.rs
+++ b/crates/kitsune_p2p/dht_arc/src/test/test_peer_view_alpha.rs
@@ -170,7 +170,7 @@ fn test_peer_gaps() {
                 let p = peers.clone();
                 let arc = peers.get_mut(i).unwrap();
                 let view = strat.view(*arc, p.as_slice());
-                arc.update_length(view);
+                arc.update_length(&view);
             }
             if gaps {
                 gaps = check_for_gaps(peers.clone());

--- a/crates/kitsune_p2p/dht_arc/src/test/test_peer_view_beta.rs
+++ b/crates/kitsune_p2p/dht_arc/src/test/test_peer_view_beta.rs
@@ -8,14 +8,14 @@ fn test_peer_coverage() {
     let strat = PeerStratBeta::default();
     let arc = |c, n, h| {
         let mut arc = DhtArc::from_start_and_half_len(0u32, h);
-        arc.update_length(PeerViewBeta::new(Default::default(), arc, c, n));
+        arc.update_length(&PeerViewBeta::new(Default::default(), arc, c, n).into());
         (arc.coverage() * 10000.0).round() / 10000.0
     };
 
     let converge = |arc: &mut DhtArc, peers: &Vec<DhtArc>| {
         for _ in 0..40 {
-            let view = strat.view(*arc, peers.as_slice());
-            arc.update_length(view);
+            let view = strat.view(*arc, peers.as_slice()).into();
+            arc.update_length(&view);
         }
     };
 

--- a/crates/kitsune_p2p/dht_arc/tests/common/mod.rs
+++ b/crates/kitsune_p2p/dht_arc/tests/common/mod.rs
@@ -111,9 +111,9 @@ pub fn run_one_epoch(
         }
         let p = peers.clone();
         let arc = peers.get_mut(i).unwrap();
-        let view = strat.view(*arc, p.as_slice());
+        let view = strat.view(*arc, p.as_slice()).into();
         let before = arc.length() as f64;
-        arc.update_length(view);
+        arc.update_length(&view);
         let after = arc.length() as f64;
         let delta = after - before;
         // dbg!(&before, &after, &delta);

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -462,8 +462,11 @@ async fn update_arc_length(
     space: Arc<KitsuneSpace>,
     arc: &mut DhtArc,
 ) -> KitsuneP2pResult<()> {
-    let density = evt_sender.query_peer_density(space.clone(), *arc).await?;
-    arc.update_length(density);
+    let density = evt_sender
+        .query_peer_density(space.clone(), *arc)
+        .await?
+        .into();
+    arc.update_length(&density);
     Ok(())
 }
 

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hdk"
-version = "0.0.124"
+version = "0.0.126"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "holochain_zome_types",
  "paste",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.0.24"
+version = "0.0.26"
 dependencies = [
  "hdk",
  "serde",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.0.26"
+version = "0.0.27"
 dependencies = [
  "chrono",
  "fixt",


### PR DESCRIPTION
### Summary

Adds a new crate, `kitsune_p2p_dht`. I am hoping to combine `dht` and `dht_arc` at some point. I wrote this crate as a standalone when first prototyping the quantized gossip algorithm, and it was easier for design to just bring in a whole new crate and tie it into the existing codebase where needed.

There are some rough edges of integration (which will be apparent in follow-up PRs). For instance, there are currently two parallel versions of `PeerView`. Also, this crate defines a quantized version of DhtArc, but gossip still happens with the existing "continuous" DhtArc, and conversion happens between the two. Eventually it may be good to gossip with the quantized version, and perhaps remove the continuous version altogether.

There are a LOT of new concepts in this PR. It may help to refer to the [HackMD book](https://hackmd.io/@hololtd/r1IAIbr5Y/https%3A%2F%2Fhackmd.io%2F%40hololtd%2FByr2SWrcF) I wrote a while back. It's a bit out of date in terms of actual implementation -- in particular I am *not* using Fenwick trees at all anymore -- but it contains the underlying theory and motivation for this work.

I will be recording a walkthrough video.

#### Note on reading

This is all new code, so I figured there is no need to chunk it up. I documented it fully and extensively, so please read the module-level docs, and there is plenty of documentation for each function to guide you. This PR also contains some minor changes to the rest of the codebase just to ensure that things compile.

The follow-up PRs will be the changes to the rest of the codebase.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
