### PR TITLE
FIX: redundant use of AppBundleSource prevented large apps from being installed

### DIFF
--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -499,8 +499,6 @@ pub async fn install_app_bundle(
         uid,
     } = args;
 
-    let bundle = AppBundleSource::Path(path).resolve().await?;
-
     let agent_key = match agent_key {
         Some(agent) => agent,
         None => generate_agent_pub_key(cmd).await?,
@@ -509,7 +507,7 @@ pub async fn install_app_bundle(
     let payload = InstallAppBundlePayload {
         installed_app_id: app_id,
         agent_key,
-        source: AppBundleSource::Bundle(bundle),
+        source: AppBundleSource::Path(path),
         membrane_proofs: Default::default(),
         uid,
     };


### PR DESCRIPTION
### Summary
Using `AppBundleSource::Bundled` means being liable to experiencing 'websocket message too large' error, while using `hc sandbox` to install a happ. 

There is a related issue in Holochain Launcher: https://github.com/holochain/launcher/issues/46

### Background
https://github.com/holochain/holochain/issues/966#issuecomment-1087842900


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
