### PR TITLE
Fix holo hash features

### DIFF
--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -48,5 +48,5 @@ full = [
 fixturators = ["fixt", "rand", "hashing", "encoding"]
 hashing = ["futures", "must_future", "blake2b_simd", "serialization"]
 serialization = ["holochain_serialized_bytes", "serde", "serde_bytes"]
-encoding = ["base64", "blake2b_simd", "derive_more"]
+encoding = ["base64", "derive_more"]
 test_utils = ["fixturators"]

--- a/crates/holo_hash/src/encode.rs
+++ b/crates/holo_hash/src/encode.rs
@@ -3,11 +3,13 @@ use crate::error::HoloHashError;
 use crate::HashType;
 use crate::HoloHash;
 use crate::PrimitiveHashType;
-use crate::HOLO_HASH_CORE_LEN;
 use crate::HOLO_HASH_FULL_LEN;
 use crate::HOLO_HASH_PREFIX_LEN;
 use std::convert::TryFrom;
 use std::convert::TryInto;
+
+#[cfg(feature = "hashing")]
+pub use crate::hash_ext::{blake2b_128, blake2b_256, blake2b_n, holo_dht_location_bytes};
 
 impl<P: PrimitiveHashType> TryFrom<&str> for HoloHash<P> {
     type Error = HoloHashError;
@@ -47,22 +49,19 @@ pub fn holo_hash_decode_unchecked(s: &str) -> Result<Vec<u8>, HoloHashError> {
     if &s[..1] != "u" {
         return Err(HoloHashError::NoU);
     }
-    let s = match base64::decode_config(&s[1..], base64::URL_SAFE_NO_PAD) {
+    let decoded = match base64::decode_config(&s[1..], base64::URL_SAFE_NO_PAD) {
         Err(_) => return Err(HoloHashError::BadBase64),
-        Ok(s) => s,
+        Ok(decoded) => decoded,
     };
-    if s.len() != HOLO_HASH_FULL_LEN {
-        return Err(HoloHashError::BadSize);
-    }
-    let loc_bytes = holo_dht_location_bytes(
-        &s[HOLO_HASH_PREFIX_LEN..HOLO_HASH_PREFIX_LEN + HOLO_HASH_CORE_LEN],
-    );
-    let loc_bytes: &[u8] = &loc_bytes;
-    if loc_bytes != &s[HOLO_HASH_PREFIX_LEN + HOLO_HASH_CORE_LEN..] {
+    let hash_bytes: &[u8; HOLO_HASH_FULL_LEN] = decoded
+        .as_slice()
+        .try_into()
+        .map_err(|_| HoloHashError::BadSize)?;
+    if !has_valid_checksum(&hash_bytes) {
         return Err(HoloHashError::BadChecksum);
     }
-    assert_length!(HOLO_HASH_FULL_LEN, &s);
-    Ok(s.to_vec())
+    assert_length!(HOLO_HASH_FULL_LEN, &decoded);
+    Ok(decoded)
 }
 
 /// internal PARSE for holo hash REPR
@@ -70,68 +69,42 @@ pub fn holo_hash_decode(prefix: &[u8], s: &str) -> Result<Vec<u8>, HoloHashError
     if &s[..1] != "u" {
         return Err(HoloHashError::NoU);
     }
-    let s = match base64::decode_config(&s[1..], base64::URL_SAFE_NO_PAD) {
+    let decoded = match base64::decode_config(&s[1..], base64::URL_SAFE_NO_PAD) {
         Err(_) => return Err(HoloHashError::BadBase64),
-        Ok(s) => s,
+        Ok(decoded) => decoded,
     };
-    if s.len() != HOLO_HASH_FULL_LEN {
-        return Err(HoloHashError::BadSize);
-    }
-    let actual_prefix: [u8; HOLO_HASH_PREFIX_LEN] = s[..HOLO_HASH_PREFIX_LEN].try_into().unwrap();
+    let hash_bytes: &[u8; HOLO_HASH_FULL_LEN] = decoded
+        .as_slice()
+        .try_into()
+        .map_err(|_| HoloHashError::BadSize)?;
+    let actual_prefix = &hash_bytes[..HOLO_HASH_PREFIX_LEN];
     if actual_prefix != prefix {
         return Err(HoloHashError::BadPrefix(
             format!("{:?}", prefix),
-            actual_prefix,
+            actual_prefix.try_into().unwrap(),
         ));
     }
-    let loc_bytes = holo_dht_location_bytes(
-        &s[HOLO_HASH_PREFIX_LEN..HOLO_HASH_PREFIX_LEN + HOLO_HASH_CORE_LEN],
-    );
-    let loc_bytes: &[u8] = &loc_bytes;
-    if loc_bytes != &s[HOLO_HASH_PREFIX_LEN + HOLO_HASH_CORE_LEN..] {
+    if !has_valid_checksum(hash_bytes) {
         return Err(HoloHashError::BadChecksum);
     }
-    assert_length!(HOLO_HASH_FULL_LEN, &s);
-    Ok(s.to_vec())
+    assert_length!(HOLO_HASH_FULL_LEN, &decoded);
+    Ok(decoded)
 }
 
-/// internal compute the holo dht location u32
-pub fn holo_dht_location_bytes(data: &[u8]) -> Vec<u8> {
-    // Assert the data size is relatively small so we are
-    // comfortable executing this synchronously / blocking tokio thread.
-    assert_eq!(32, data.len(), "only 32 byte hashes supported");
+#[cfg(feature = "hashing")]
+fn has_valid_checksum(hash: &[u8; HOLO_HASH_FULL_LEN]) -> bool {
+    use crate::HOLO_HASH_CORE_LEN;
 
-    let hash = blake2b_128(data);
-    let mut out = vec![hash[0], hash[1], hash[2], hash[3]];
-    for i in (4..16).step_by(4) {
-        out[0] ^= hash[i];
-        out[1] ^= hash[i + 1];
-        out[2] ^= hash[i + 2];
-        out[3] ^= hash[i + 3];
-    }
-    out
+    let expected = holo_dht_location_bytes(
+        &hash[HOLO_HASH_PREFIX_LEN..HOLO_HASH_PREFIX_LEN + HOLO_HASH_CORE_LEN],
+    );
+    let actual = &hash[HOLO_HASH_PREFIX_LEN + HOLO_HASH_CORE_LEN..];
+    expected == actual
 }
 
-/// Arbitrary (within limits) output length blake2b
-pub fn blake2b_n(data: &[u8], length: usize) -> Result<Vec<u8>, HoloHashError> {
-    // blake2b_simd does an assert on the hash length and we allow happ devs
-    // to set this so we have to put a result guarding against the bounds.
-    if length < 1 || blake2b_simd::OUTBYTES < length {
-        return Err(HoloHashError::BadHashSize);
-    }
-    Ok(blake2b_simd::Params::new()
-        .hash_length(length)
-        .hash(data)
-        .as_bytes()
-        .to_vec())
-}
-
-/// internal compute a 32 byte blake2b hash
-pub fn blake2b_256(data: &[u8]) -> Vec<u8> {
-    blake2b_n(data, 32).unwrap()
-}
-
-/// internal compute a 16 byte blake2b hash
-pub fn blake2b_128(data: &[u8]) -> Vec<u8> {
-    blake2b_n(data, 16).unwrap()
+#[cfg(not(feature = "hashing"))]
+fn has_valid_checksum(_hash: &[u8; HOLO_HASH_FULL_LEN]) -> bool {
+    // Do not verify checksums if hashing is not enabled.
+    // This is necessary so that we don't include blake2b in Wasm
+    true
 }

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -30,9 +30,6 @@ use crate::has_hash::HasHash;
 use crate::HashType;
 use crate::PrimitiveHashType;
 
-#[cfg(feature = "hashing")]
-use crate::encode;
-
 /// Length of the prefix bytes (3)
 pub const HOLO_HASH_PREFIX_LEN: usize = 3;
 
@@ -169,7 +166,7 @@ impl<T: HashType> HoloHash<T> {
     /// the location bytes will used as provided, not computed.
     pub fn from_raw_32_and_type(mut hash: Vec<u8>, hash_type: T) -> Self {
         if hash.len() == HOLO_HASH_CORE_LEN {
-            hash.append(&mut encode::holo_dht_location_bytes(&hash));
+            hash.append(&mut crate::hash_ext::holo_dht_location_bytes(&hash));
         }
 
         assert_length!(HOLO_HASH_UNTYPED_LEN, &hash);
@@ -254,18 +251,18 @@ fn bytes_to_loc(bytes: &[u8]) -> u32 {
 mod tests {
     use crate::*;
 
-    #[cfg(not(feature = "encoding"))]
-    fn assert_type<T: HashType>(t: &str, h: HoloHash<T>) {
-        assert_eq!(3_688_618_971, h.get_loc());
-        assert_eq!(
-            "[219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219]",
-            format!("{:?}", h.get_raw_32()),
-        );
-    }
-
     #[test]
     #[cfg(not(feature = "encoding"))]
     fn test_enum_types() {
+        fn assert_type<T: HashType>(t: &str, h: HoloHash<T>) {
+            assert_eq!(3_688_618_971, h.get_loc().as_u32());
+            assert_eq!(
+                "[219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219]",
+                format!("{:?}", h.get_raw_32()),
+            );
+            assert_eq!(t, h.hash_type().hash_name())
+        }
+
         assert_type(
             "DnaHash",
             DnaHash::from_raw_36(vec![0xdb; HOLO_HASH_UNTYPED_LEN]),


### PR DESCRIPTION
### Summary

- Currently, Wasm is including blake2b, which we explicitly wanted to avoid
- Also holo_hash when used with no features, or just hashing does not compile

This fixes those two problems


### TODO:
- [ ] Add test that bad checksums are caught by the host
  - I ran into some difficulty was this, so I'm pausing working on this PR
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
