### PR TITLE
hdk/CHANGELOG: insert missing 0.0.127 section

### DIFF
--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - hdk: Adds compound hash type for linkable hashes [#1308](https://github.com/holochain/holochain/pull/1308)
 - hdk: Missing dependencies are fetched async for validation [#1268](https://github.com/holochain/holochain/pull/1268)
 
+## 0.0.127
+
 ## 0.0.126
 
 - Docs: Explain how hashes in Holochain are composed and its components on the module page for `hdk::hash` [\#1299](https://github.com/holochain/holochain/pull/1299).

--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -6,7 +6,7 @@ default_unreleasable: true
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/holochain/holochain/compare/hdk-v0.0.100...HEAD)
+## Unreleased
 
 - hdk: Adds external hash type for data that has a DHT location but does not exist on the DHT [#1298](https://github.com/holochain/holochain/pull/1298)
 - hdk: Adds compound hash type for linkable hashes [#1308](https://github.com/holochain/holochain/pull/1308)


### PR DESCRIPTION
### Summary
i suspect that this missing headline has caused today's release to fail.
please help me double-check that i moved the correct items into the 0.0.127 section.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
