### PR TITLE
KitsuneHostErrorDefault instead of KitsuneHostPanicky

### DIFF
--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -1,6 +1,6 @@
 pub use crate::test_util::spawn_handler;
 use crate::HostStub;
-use crate::{test_util::hash_op_data, KitsuneHostPanicky};
+use crate::{test_util::hash_op_data, KitsuneHostDefaultError};
 use kitsune_p2p_types::box_fut;
 
 use super::*;
@@ -9,7 +9,7 @@ pub struct StandardResponsesHostApi {
     infos: Vec<AgentInfoSigned>,
 }
 
-impl KitsuneHostPanicky for StandardResponsesHostApi {
+impl KitsuneHostDefaultError for StandardResponsesHostApi {
     const NAME: &'static str = "StandardResponsesHostApi";
 
     fn get_agent_info_signed(

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
@@ -43,6 +43,6 @@ mod host_stub;
 pub use host_stub::*;
 
 #[cfg(any(test, feature = "test_utils"))]
-mod host_panicky;
+mod host_default_error;
 #[cfg(any(test, feature = "test_utils"))]
-pub use host_panicky::*;
+pub use host_default_error::*;

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_default_error.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_default_error.rs
@@ -1,10 +1,12 @@
+use kitsune_p2p_types::box_fut;
+
 use super::*;
 
 /// A supertrait of KitsuneHost convenient for defining test handlers.
 /// Allows only specifying the methods you care about, and letting all the rest
-/// panic if called
-pub trait KitsuneHostPanicky: KitsuneHost {
-    /// Name to be printed out on unimplemented panic
+/// throw errors if called
+pub trait KitsuneHostDefaultError: KitsuneHost {
+    /// Name to be printed out on unimplemented error
     const NAME: &'static str;
 
     /// We need to get previously stored agent info.
@@ -12,10 +14,12 @@ pub trait KitsuneHostPanicky: KitsuneHost {
         &self,
         _input: GetAgentInfoSignedEvt,
     ) -> KitsuneHostResult<Option<crate::types::agent_store::AgentInfoSigned>> {
-        unimplemented!(
-            "default panic for unimplemented KitsuneHost test behavior: {}",
+        box_fut(Err(format!(
+            "error for unimplemented KitsuneHost test behavior: method {} of {}",
+            "get_agent_info_signed",
             Self::NAME
         )
+        .into()))
     }
 
     /// Extrapolated Peer Coverage
@@ -24,10 +28,12 @@ pub trait KitsuneHostPanicky: KitsuneHost {
         _space: Arc<KitsuneSpace>,
         _dht_arc_set: DhtArcSet,
     ) -> KitsuneHostResult<Vec<f64>> {
-        unimplemented!(
-            "default panic for unimplemented KitsuneHost test behavior: {}",
+        box_fut(Err(format!(
+            "error for unimplemented KitsuneHost test behavior: method {} of {}",
+            "peer_extrapolated_coverage",
             Self::NAME
         )
+        .into()))
     }
 
     /// Record a set of metric records
@@ -36,19 +42,21 @@ pub trait KitsuneHostPanicky: KitsuneHost {
         _space: Arc<KitsuneSpace>,
         _records: Vec<MetricRecord>,
     ) -> KitsuneHostResult<()> {
-        unimplemented!(
-            "default panic for unimplemented KitsuneHost test behavior: {}",
+        box_fut(Err(format!(
+            "error for unimplemented KitsuneHost test behavior: method {} of {}",
+            "record_metrics",
             Self::NAME
         )
+        .into()))
     }
 }
 
-impl<T: KitsuneHostPanicky> KitsuneHost for T {
+impl<T: KitsuneHostDefaultError> KitsuneHost for T {
     fn get_agent_info_signed(
         &self,
         input: GetAgentInfoSignedEvt,
     ) -> KitsuneHostResult<Option<crate::types::agent_store::AgentInfoSigned>> {
-        KitsuneHostPanicky::get_agent_info_signed(self, input)
+        KitsuneHostDefaultError::get_agent_info_signed(self, input)
     }
 
     fn peer_extrapolated_coverage(
@@ -56,7 +64,7 @@ impl<T: KitsuneHostPanicky> KitsuneHost for T {
         space: Arc<KitsuneSpace>,
         dht_arc_set: DhtArcSet,
     ) -> KitsuneHostResult<Vec<f64>> {
-        KitsuneHostPanicky::peer_extrapolated_coverage(self, space, dht_arc_set)
+        KitsuneHostDefaultError::peer_extrapolated_coverage(self, space, dht_arc_set)
     }
 
     fn record_metrics(
@@ -64,6 +72,6 @@ impl<T: KitsuneHostPanicky> KitsuneHost for T {
         space: Arc<KitsuneSpace>,
         records: Vec<MetricRecord>,
     ) -> KitsuneHostResult<()> {
-        KitsuneHostPanicky::record_metrics(self, space, records)
+        KitsuneHostDefaultError::record_metrics(self, space, records)
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
@@ -1,9 +1,9 @@
-use crate::KitsuneHostPanicky;
+use crate::KitsuneHostDefaultError;
 
 /// Dummy host impl for plumbing
 pub struct HostStub;
 
-impl KitsuneHostPanicky for HostStub {
+impl KitsuneHostDefaultError for HostStub {
     const NAME: &'static str = "HostStub";
 }
 


### PR DESCRIPTION
### Summary

KitsuneHostPanicky was causing tons of panicks during test runs, which don't cause tests to fail, but starves the tokio runtime of threads. This causes errors to be thrown instead of panicking, hoping that the code which uses HostStub doesn't actually care about the result, and will carry on without panicking.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
