### PR TITLE
changelogs: add back missing release headings

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -172,6 +172,21 @@ jobs:
             git branch -D ${obsolete_branches}
           fi
 
+      - name: Detect missing release headings
+        run: |
+          set -ex
+          source "${HOLOCHAIN_RELEASE_SH}"
+          cd "${HOLOCHAIN_REPO}"
+
+          nix-shell --argstr flavor release --pure --run '
+            set -e
+
+            release-automation \
+              --workspace-path=$PWD \
+              --log-level=debug \
+              crate detect-missing-releaseheadings
+            '
+
       - name: Bump the crate versions for the release
         id: bump-versions
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1931,8 +1931,6 @@ This will include the hdk-0.0.100 release.
 
 # 20210226.155101
 
-## Global
-
 This release was initiated for publishing the HDK at version *0.0.100-alpha.1*. We are in the process of redefining the release process around this repository so rough edges are still expected at this point.
 
 ### Added

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixed broken links in Rust docs [#1284](https://github.com/holochain/holochain/pull/1284)
 
+## 0.0.31
+
 ## 0.0.30
 
 ## 0.0.29

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `hc sandbox` command for installing happs was limited to 16mb websocket message limit and would error if given a large happ bundle. now it won't.  [#1322](https://github.com/holochain/holochain/pull/1322)
 - Fixed broken links in Rust docs [#1284](https://github.com/holochain/holochain/pull/1284)
 
+## 0.0.27
+
 ## 0.0.26
 
 ## 0.0.25

--- a/crates/release-automation/Cargo.lock
+++ b/crates/release-automation/Cargo.lock
@@ -2088,6 +2088,7 @@ dependencies = [
  "fancy-regex",
  "git2",
  "indoc",
+ "itertools",
  "linked-hash-map",
  "linked_hash_set",
  "log",

--- a/crates/release-automation/Cargo.nix
+++ b/crates/release-automation/Cargo.nix
@@ -5686,6 +5686,10 @@ rec {
             packageId = "indoc";
           }
           {
+            name = "itertools";
+            packageId = "itertools";
+          }
+          {
             name = "linked-hash-map";
             packageId = "linked-hash-map";
           }

--- a/crates/release-automation/Cargo.toml
+++ b/crates/release-automation/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = "1"
 regex = "1.5"
 crates_io_api = "0.7"
 crates-index = "0.18"
+itertools = "0.10"
 
 # used for the example clippy fix-json
 rustfix = "0.6"

--- a/crates/release-automation/src/crate_.rs
+++ b/crates/release-automation/src/crate_.rs
@@ -73,7 +73,7 @@ pub(crate) fn parse_fixup_releases(input: &str) -> Fallible<FixupReleases> {
 }
 
 #[derive(Debug, StructOpt)]
-pub(crate) struct CrateFixupReleases {
+pub(crate) struct CrateFixupUnpublishedReleases {
     #[structopt(long, default_value = DEFAULT_DEV_SUFFIX)]
     pub(crate) dev_suffix: String,
 
@@ -122,7 +122,7 @@ pub(crate) enum CrateCommands {
     ApplyDevVersions(CrateApplyDevVersionsArgs),
 
     /// check the latest (or given) release for crates that aren't published, remove their tags, and bump their version.
-    FixupReleases(CrateFixupReleases),
+    FixupUnpublishedReleases(CrateFixupUnpublishedReleases),
 
     Check(CrateCheckArgs),
     EnsureCrateOwners(EnsureCrateOwnersArgs),
@@ -152,7 +152,7 @@ pub(crate) fn cmd(args: &crate::cli::Args, cmd_args: &CrateArgs) -> CommandResul
             subcmd_args.no_verify,
         ),
 
-        CrateCommands::FixupReleases(subcmd_args) => fixup_releases(
+        CrateCommands::FixupUnpublishedReleases(subcmd_args) => fixup_unpublished_releases(
             &ws,
             &subcmd_args.dev_suffix,
             &subcmd_args.fixup_releases,
@@ -292,7 +292,7 @@ pub(crate) fn increment_patch(v: &mut semver::Version) {
     v.build = semver::BuildMetadata::EMPTY;
 }
 
-pub(crate) fn fixup_releases<'a>(
+pub(crate) fn fixup_unpublished_releases<'a>(
     ws: &'a ReleaseWorkspace<'a>,
     dev_suffix: &str,
     fixup: &FixupReleases,

--- a/crates/release-automation/src/main.rs
+++ b/crates/release-automation/src/main.rs
@@ -100,7 +100,7 @@ pub(crate) mod cli {
         #[structopt(long, default_value = "warn")]
         pub(crate) log_level: log::Level,
 
-        #[structopt(long, default_value = "release_automation=info")]
+        #[structopt(long, default_value = "")]
         pub(crate) log_filters: String,
     }
 

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -47,13 +47,13 @@ rec {
       gh
       nixpkgs-fmt
       cargo-sweep
+      crate2nix
     ]);
   };
 
   release = coreDev.overrideAttrs (attrs: {
     nativeBuildInputs = attrs.nativeBuildInputs ++ (with holonix.pkgs; [
       niv
-      crate2nix
       (import ../crates/release-automation/default.nix { })
     ]);
   });


### PR DESCRIPTION
### Summary
these headings are present in the toplevel CHANGELOG but not in the
crate's ones. a separate change has enabled the detection of this
circumstance on CI so this won't go unnoticed again.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 

---

incorporates #1336 
