### PR TITLE
release-automation: detect invalid manifest keyword conditions

### DIFF
--- a/crates/holochain_deterministic_integrity/Cargo.toml
+++ b/crates/holochain_deterministic_integrity/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain/tree/develop/crates/holochain_deterministic_integrity"
 documentation = "https://docs.rs/holochain_deterministic_integrity"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
-keywords = ["holochain", "holo", "holochain_deterministic_integrity"]
+keywords = ["holochain", "holo", "integrity"]
 categories = ["cryptography"]
 edition = "2021"
 

--- a/crates/release-automation/src/crate_selection/mod.rs
+++ b/crates/release-automation/src/crate_selection/mod.rs
@@ -14,6 +14,7 @@ use enumflags2::{bitflags, BitFlags};
 use linked_hash_map::LinkedHashMap;
 use linked_hash_set::LinkedHashSet;
 use once_cell::unsync::{Lazy, OnceCell};
+use regex::Regex;
 use semver::Version;
 use std::cell::Cell;
 use std::collections::{BTreeSet, HashMap, HashSet};
@@ -260,7 +261,7 @@ pub(crate) struct SelectionCriteria {
 
 /// Defines detailed crate's state in terms of the release process.
 #[bitflags]
-#[repr(u16)]
+#[repr(u32)]
 #[derive(enum_utils::FromStr, Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum CrateStateFlags {
     /// matches a package filter
@@ -292,6 +293,10 @@ pub(crate) enum CrateStateFlags {
     MissingLicense,
     /// Has a dependency that contains '*'
     HasWildcardDependency,
+    /// One of the manifest keywords is too long
+    ManifestKeywordExceeds20Chars,
+    ManifestKeywordContainsInvalidChar,
+    ManifestKeywordsMoreThan5,
 }
 
 /// Defines the meta states that can be derived from the more detailed `CrateStateFlags`.
@@ -331,6 +336,9 @@ impl CrateState {
             | MissingDescription
             | MissingLicense
             | HasWildcardDependency
+            | ManifestKeywordExceeds20Chars
+            | ManifestKeywordContainsInvalidChar
+            | ManifestKeywordsMoreThan5
     });
 
     pub(crate) fn new(
@@ -593,6 +601,8 @@ impl<'a> ReleaseWorkspace<'a> {
                 ..Default::default()
             };
 
+            let keyword_validation_re = Regex::new("^[a-zA-Z][a-zA-Z_\\-0-9]+$").unwrap();
+
             for member in self.members()? {
 
                 // helper macros to access the desired state
@@ -619,6 +629,18 @@ impl<'a> ReleaseWorkspace<'a> {
 
                     if metadata.description.is_none() {
                         insert_state!(CrateStateFlags::MissingDescription);
+                    }
+
+                    // see https://doc.rust-lang.org/cargo/reference/manifest.html?highlight=keywords#the-keywords-field
+                    // Note: crates.io has a maximum of 5 keywords. Each keyword must be ASCII text, start with a letter, and only contain letters, numbers, _ or -, and have at most 20 characters.
+                    if metadata.keywords.iter().any(|keyword| keyword.len() > 20) {
+                        insert_state!(CrateStateFlags::ManifestKeywordExceeds20Chars);
+                    }
+                    if metadata.keywords.iter().any(|keyword| !keyword_validation_re.is_match(keyword)) {
+                        insert_state!(CrateStateFlags::ManifestKeywordContainsInvalidChar);
+                    }
+                    if metadata.keywords.len() > 5 {
+                        insert_state!(CrateStateFlags::ManifestKeywordsMoreThan5);
                     }
                 }
 

--- a/crates/release-automation/src/tests/cli.rs
+++ b/crates/release-automation/src/tests/cli.rs
@@ -757,6 +757,11 @@ fn release_dry_run_fails_on_unallowed_conditions() {
             "#,
             },
         );
+
+        workspace
+            .update_lockfile(false, std::iter::empty())
+            .unwrap();
+
         workspace.git_add_all_and_commit("msg", None).unwrap();
 
         let mut cmd = assert_cmd::Command::cargo_bin("release-automation").unwrap();

--- a/crates/release-automation/src/tests/workspace_mocker.rs
+++ b/crates/release-automation/src/tests/workspace_mocker.rs
@@ -667,7 +667,9 @@ pub(crate) fn example_workspace_4<'a>() -> Fallible<WorkspaceMocker> {
             name: "wildcard_dependency".to_string(),
             version: "0.0.1".to_string(),
             dependencies: vec![],
-            dev_dependencies: vec![r#"criterion = '*'"#.to_string()],
+            dev_dependencies: vec![
+                r#"wildcard_dependency = {path = ".", version = '*'}"#.to_string()
+            ],
             excluded: false,
             ty: workspace_mocker::MockProjectType::Bin,
             changelog: Some(indoc::formatdoc!(

--- a/crates/release-automation/src/tests/workspace_mocker.rs
+++ b/crates/release-automation/src/tests/workspace_mocker.rs
@@ -37,6 +37,7 @@ pub(crate) struct MockProject {
     pub(crate) description: Option<String>,
     #[educe(Default(expression = r##"Some("Apache-2.0".to_string())"##))]
     pub(crate) license: Option<String>,
+    pub(crate) keywords: Vec<String>,
 }
 
 pub(crate) struct WorkspaceMocker {
@@ -125,6 +126,13 @@ impl WorkspaceMocker {
                         },
                     );
 
+                    let keywords = project
+                        .keywords
+                        .iter()
+                        .map(|keyword| format!(r#""{}""#, keyword))
+                        .collect::<Vec<_>>()
+                        .join(",");
+
                     let project_builder = project_builder
                         .file(
                             format!("crates/{}/Cargo.toml", &name),
@@ -138,6 +146,7 @@ impl WorkspaceMocker {
                                 {license}
                                 homepage = "https://github.com/holochain/holochain"
                                 documentation = "https://github.com/holochain/holochain"
+                                keywords = [{keywords}]
 
                                 [dependencies]
                                 {dependencies}
@@ -159,6 +168,7 @@ impl WorkspaceMocker {
                                     .unwrap_or_default(),
                                 dependencies = dependencies,
                                 dev_dependencies = dev_dependencies,
+                                keywords = keywords,
                             ),
                         )
                         .file(
@@ -705,6 +715,55 @@ pub(crate) fn example_workspace_4<'a>() -> Fallible<WorkspaceMocker> {
                 "#
             )),
             license: None,
+            ..Default::default()
+        },
+        MockProject {
+            name: "keyword_invalid_char".to_string(),
+            version: "0.0.1".to_string(),
+            dependencies: vec![],
+            excluded: false,
+            ty: workspace_mocker::MockProjectType::Bin,
+            changelog: Some(indoc::formatdoc!(
+                r#"
+                # Changelog
+                "#
+            )),
+            keywords: vec!["1nvalid".to_string()],
+            ..Default::default()
+        },
+        MockProject {
+            name: "keyword_toolong".to_string(),
+            version: "0.0.1".to_string(),
+            dependencies: vec![],
+            excluded: false,
+            ty: workspace_mocker::MockProjectType::Bin,
+            changelog: Some(indoc::formatdoc!(
+                r#"
+                # Changelog
+                "#
+            )),
+            keywords: vec!["toolongtoolongtoolongtoolongtoolong".to_string()],
+            ..Default::default()
+        },
+        MockProject {
+            name: "keyword_toomany".to_string(),
+            version: "0.0.1".to_string(),
+            dependencies: vec![],
+            excluded: false,
+            ty: workspace_mocker::MockProjectType::Bin,
+            changelog: Some(indoc::formatdoc!(
+                r#"
+                # Changelog
+                "#
+            )),
+            keywords: vec![
+                "one".to_string(),
+                "two".to_string(),
+                "three".to_string(),
+                "four".to_string(),
+                "five".to_string(),
+                "many".to_string(),
+            ],
             ..Default::default()
         },
     ];


### PR DESCRIPTION
### Summary
this undetected condition caused the previous release to fail at the publish step.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
