### PR TITLE
ci(release): crank up slow-test retry count

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,9 +176,9 @@ jobs:
             restoresCargoCache: true
             savesCargoCache: true
             ignoreErrorOnNonUbuntu: true
-            timeout_minutes: 60
+            timeout_minutes: 30
             max_attempts:
-              ubuntu-latest: 5
+              ubuntu-latest: 30
               macos-latest: 1
             run: |
               nix-shell \


### PR DESCRIPTION
this is a temporary stop-gap as this test has been timing out a lot on
github CI specifically.

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
