### PR TITLE
feat(github-workflows/release): enable autoupdate for release PR

### DIFF
--- a/.github/workflows/autorebase.yml
+++ b/.github/workflows/autorebase.yml
@@ -1,3 +1,5 @@
+name: autorebase
+
 on:
     # Run on every push on every branch
     push:

--- a/.github/workflows/autorebase.yml
+++ b/.github/workflows/autorebase.yml
@@ -5,7 +5,6 @@ on:
     pull_request:
         types: [labeled, opened, ready_for_review, reopened]
         branches:
-            - "release-**"
             - "develop"
 
 jobs:

--- a/.github/workflows/autoupdate.yaml
+++ b/.github/workflows/autoupdate.yaml
@@ -1,0 +1,21 @@
+name: autoupdate
+on:
+  # Run on every push on every branch
+  push: {}
+  # Run when pull requests get labeled
+  pull_request:
+    types: [labeled, opened, ready_for_review, reopened]
+    branches:
+      - "develop"
+jobs:
+  autoupdate:
+    name: autoupdate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker://chinthakagodawita/autoupdate-action:v1
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          PR_FILTER: "labelled"
+          PR_LABELS: "autoupdate:opt-in"
+          MERGE_CONFLICT_ACTION: "fail"
+          MERGE_MSG: "Branch was auto-updated."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -505,6 +505,7 @@ jobs:
           gh pr create \
             --title "Merge ${RELEASE_BRANCH} back into ${HOLOCHAIN_SOURCE_BRANCH}" \
             --label release \
+            --label "autoupdate:opt-in" \
             --base ${HOLOCHAIN_SOURCE_BRANCH} --head "${RELEASE_BRANCH}" \
             --body 'Please double-check the consistency of the CHANGELOG.md files' 2>&1 | tee gh-pr-create.log
             # --reviewer "holochain/core-dev" \


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
