### PR TITLE
ci(hc-test-slow): build in retry loop

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -179,6 +179,17 @@ jobs:
             git branch -D ${obsolete_branches}
           fi
 
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+        if: ${{ failure() && needs.vars.outputs.debug == 'true' }}
+        env:
+          HRA_GITHUB_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
+        with:
+          ## limits ssh access and adds the ssh public key for the user which triggered the workflow
+          limit-access-to-actor: true
+          ## limits ssh access and adds the ssh public keys of the listed GitHub users
+          limit-access-to-users: steveeJ,jost-s,freesig,neonphog,thedavidmeister,maackle
+
       - name: Detect missing release headings
         run: |
           set -ex

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -33,6 +33,8 @@ on:
         type: string
         required: true
     secrets:
+      HRA_GITHUB_TOKEN:
+        required: true
       CACHIX_SIGNING_KEY:
         required: true
       CACHIX_AUTH_TOKEN:
@@ -142,6 +144,8 @@ jobs:
           cat ${HOLOCHAIN_RELEASE_SH}
 
       - name: Prepare the holochain repository
+        env:
+          HRA_GITHUB_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
         run: |
           set -eE -o pipefail
           source "${HOLOCHAIN_RELEASE_SH}"
@@ -159,6 +163,9 @@ jobs:
           fi
 
           cp -v $HOME/work/holochain/holochain/.git/config .git/config
+
+          # use our custom token for more permissions, e.g. "workflow" which is needed to push workflow files
+          git config --local "http.https://github.com/.extraheader" "AUTHORIZATION: basic $(echo -n pat:${HRA_GITHUB_TOKEN} | base64)"
 
           git fetch --all --tags --prune --prune-tags --force
           git checkout --force -B ${HOLOCHAIN_SOURCE_BRANCH} remotes/origin/${HOLOCHAIN_SOURCE_BRANCH}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,8 +167,6 @@ jobs:
               macos-latest: 10
             run: |
               nix-shell \
-                --keep NUM_JOBS \
-                --keep CARGO_BUILD_JOBS \
                 --keep CARGO_TEST_ARGS \
                 --fallback --pure --argstr flavor "coreDev" --run hc-test-standard
 
@@ -182,10 +180,7 @@ jobs:
               macos-latest: 1
             run: |
               nix-shell \
-              --keep NUM_JOBS \
-              --keep CARGO_BUILD_JOBS \
               --keep CARGO_TEST_ARGS \
-              --keep RUST_TEST_THREADS \
               --fallback --pure --argstr flavor "coreDev" --run hc-test-slow
 
           - name: cargo-test-static
@@ -198,8 +193,6 @@ jobs:
               macos-latest: 1
             run: |
               nix-shell \
-                --keep NUM_JOBS \
-                --keep CARGO_BUILD_JOBS \
                 --keep CARGO_TEST_ARGS \
                 --fallback --pure --argstr flavor "coreDev" --run hc-static-checks
 
@@ -213,8 +206,6 @@ jobs:
               macos-latest: 1
             run: |
               nix-shell \
-                --keep NUM_JOBS \
-                --keep CARGO_BUILD_JOBS \
                 --keep CARGO_TEST_ARGS \
                 --fallback --pure --argstr flavor "coreDev" --run hc-test-wasm
 
@@ -354,8 +345,6 @@ jobs:
       - name: ${{ matrix.testCommand.name }} (build only)
         if: ${{ matrix.testCommand.restoresCargoCache == true }}
         env:
-          # NUM_JOBS: ""
-          # CARGO_BUILD_JOBS: ""
           CARGO_TEST_ARGS: "--no-run"
         run: |
           set -e
@@ -369,8 +358,6 @@ jobs:
       - name: ${{ matrix.testCommand.name }} (run)
         uses: nick-fields/retry@v2
         env:
-          # NUM_JOBS: ""
-          # CARGO_BUILD_JOBS: ""
           HOLOCHAIN_NIXPKGS_SOURCE_BRANCH: ${{ needs.vars.outputs.holochain_nixpkgs_source_branch }}
           HOLONIX_SOURCE_BRANCH: ${{ needs.vars.outputs.holonix_source_branch }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,9 +176,9 @@ jobs:
             restoresCargoCache: true
             savesCargoCache: true
             ignoreErrorOnNonUbuntu: true
-            timeout_minutes: 30
+            timeout_minutes: 15
             max_attempts:
-              ubuntu-latest: 30
+              ubuntu-latest: 60
               macos-latest: 1
             run: |
               nix-shell \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,6 +141,7 @@ jobs:
     secrets:
       CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_AUTH_TOKEN }}
       CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      HRA_GITHUB_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN}}
 
   test:
     if: ${{ github.event_name != 'pull_request' }}

--- a/nix/pkgs/core.nix
+++ b/nix/pkgs/core.nix
@@ -42,7 +42,15 @@ rec {
 
     # alas, we cannot specify --features in the virtual workspace
     # run the specific slow tests in the holochain crate
-    cargo test ''${CARGO_TEST_ARGS:-} --manifest-path=crates/holochain/Cargo.toml --features slow_tests,test_utils,build_wasms,db-encryption --profile fast-test -- --nocapture
+    for i in $(((RANDOM % NUM_JOBS) + 1)) $NUM_JOBS 1 ; do
+      if env \
+        RUST_TEST_THREADS=$i \
+        cargo test ''${CARGO_TEST_ARGS:-} --manifest-path=crates/holochain/Cargo.toml --features slow_tests,test_utils,build_wasms,db-encryption --profile fast-test -- --nocapture
+      then
+        echo succeeded with RUST_TEST_THREADS=$i
+        exit 0
+      fi
+    done
   '';
 
   hcWasmTests = writeShellScriptBin "hc-test-wasm" ''


### PR DESCRIPTION
this test suite has been problematic on CI for a while.
this is a stop-gap attempt to smoothen the experience so that we can dig
for the root cause with less pressure.

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
