### PR TITLE
Release exp simulate ci failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,27 +194,12 @@ jobs:
       steps:
          - run:
               name: echo
-              command: echo
+              command: exit 1
 
 workflows:
    tests:
       jobs:
-         - merge-release-test
-         # - merge-release-test-mac
-         - standard-test
-         - rustdoc-build-test
-         - hc-static-checks
-         - slow-test
-         - wasm-test
-         # - merge-test-mac
-         - ci-jobs-succeed:
-              requires:
-                 - standard-test
-                 - rustdoc-build-test
-                 - hc-static-checks
-                 - slow-test
-                 - wasm-test
-                 - merge-release-test
+         - ci-jobs-succeed
 
    docker-builds:
       triggers:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,12 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  uneeded:
+    runs-on: ubuntu-latest
+    steps:
+      - name: fail
+        run: |
+          exit 1
   vars:
     runs-on: ubuntu-latest
     outputs:
@@ -128,6 +134,9 @@ jobs:
           echo "::set-output name=HOLOCHAIN_REPO::/tmp/holochain_repo"
           echo "::set-output name=HOLOCHAIN_RELEASE_SH::/tmp/holochain_release.sh"
           echo "::set-output name=CACHIX_REV::master"
+      - name: fail
+        run: |
+          exit 1
   prepare:
     needs: [vars]
     uses: ./.github/workflows/release-prepare.yml


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
