### PR TITLE
Some extra tracing, and ability to disable publishing from tuning_params

### DIFF
--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -208,7 +208,7 @@ impl Cell {
             .get_queue_consumer_workflows()
             .integration_trigger(Arc::new(id.dna_hash().clone()))
         {
-            trigger.trigger("genesis");
+            trigger.trigger(&"genesis");
         }
         Ok(())
     }

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -208,7 +208,7 @@ impl Cell {
             .get_queue_consumer_workflows()
             .integration_trigger(Arc::new(id.dna_hash().clone()))
         {
-            trigger.trigger();
+            trigger.trigger("genesis");
         }
         Ok(())
     }

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -135,6 +135,9 @@ where
     /// The collection of cells associated with this Conductor
     cells: RwShare<HashMap<CellId, CellItem<CA>>>,
 
+    /// The config used to create this Conductor
+    pub config: ConductorConfig,
+
     /// The map of dna hash spaces.
     pub(super) spaces: Spaces,
 
@@ -1248,6 +1251,7 @@ fn query_dht_ops_from_statement(
 impl Conductor {
     #[allow(clippy::too_many_arguments)]
     async fn new(
+        config: ConductorConfig,
         dna_store: RwShare<DnaStore>,
         keystore: MetaLairClient,
         holochain_p2p: holochain_p2p::HolochainP2pRef,
@@ -1257,6 +1261,7 @@ impl Conductor {
         Ok(Self {
             spaces,
             cells: RwShare::new(HashMap::new()),
+            config,
             shutting_down: Arc::new(AtomicBool::new(false)),
             app_interfaces: RwShare::new(HashMap::new()),
             task_manager: RwShare::new(None),
@@ -1493,6 +1498,7 @@ mod builder {
                 tokio::sync::mpsc::channel(POST_COMMIT_CHANNEL_BOUND);
 
             let conductor = Conductor::new(
+                config.clone(),
                 dna_store,
                 keystore,
                 holochain_p2p,
@@ -1654,6 +1660,7 @@ mod builder {
                 tokio::sync::mpsc::channel(POST_COMMIT_CHANNEL_BOUND);
 
             let conductor = Conductor::new(
+                self.config.clone(),
                 RwShare::new(self.dna_store),
                 keystore,
                 holochain_p2p,

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -35,6 +35,7 @@ async fn can_update_state() {
         tokio::sync::mpsc::channel(POST_COMMIT_CHANNEL_BOUND);
     let spaces = Spaces::new(db_dir.path().to_path_buf().into(), Default::default()).unwrap();
     let conductor = Conductor::new(
+        Default::default(),
         dna_store,
         keystore,
         holochain_p2p,
@@ -83,6 +84,7 @@ async fn can_add_clone_cell_to_app() {
     let spaces = Spaces::new(db_dir.path().to_path_buf().into(), Default::default()).unwrap();
 
     let conductor = Conductor::new(
+        Default::default(),
         dna_store,
         keystore,
         holochain_p2p,
@@ -156,6 +158,7 @@ async fn app_ids_are_unique() {
         tokio::sync::mpsc::channel(POST_COMMIT_CHANNEL_BOUND);
     let spaces = Spaces::new(db_dir.path().to_path_buf().into(), Default::default()).unwrap();
     let conductor = Conductor::new(
+        Default::default(),
         dna_store,
         test_keystore(),
         holochain_p2p,

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -65,6 +65,7 @@ use crate::core::workflow::ZomeCallResult;
 use derive_more::From;
 use futures::future::FutureExt;
 use futures::StreamExt;
+use holochain_conductor_api::conductor::ConductorConfig;
 use holochain_conductor_api::AppStatusFilter;
 use holochain_conductor_api::FullStateDump;
 use holochain_conductor_api::InstalledAppInfo;
@@ -176,6 +177,9 @@ pub trait ConductorHandleT: Send + Sync {
 
     /// Get the running queue consumer workflows per [`DnaHash`] map.
     fn get_queue_consumer_workflows(&self) -> QueueConsumerMap;
+
+    /// Get the conductor config
+    fn get_config(&self) -> &ConductorConfig;
 
     /// Return the JoinHandle for all managed tasks, which when resolved will
     /// signal that the Conductor has completely shut down.
@@ -590,6 +594,10 @@ impl ConductorHandleT for ConductorHandleImpl {
         self.conductor
             .dna_store()
             .share_ref(|ds| ds.get_entry_def(key))
+    }
+
+    fn get_config(&self) -> &ConductorConfig {
+        &self.conductor.config
     }
 
     #[instrument(skip(self))]

--- a/crates/holochain/src/core/queue_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer.rs
@@ -437,18 +437,18 @@ impl InitialQueueTriggers {
 
     /// Initialize all the workflows once.
     pub fn initialize_workflows(self) {
-        self.sys_validation.trigger("init");
-        self.app_validation.trigger("init");
-        self.integrate_dht_ops.trigger("init");
-        self.publish_dht_ops.trigger("init");
-        self.validation_receipt.trigger("init");
+        self.sys_validation.trigger(&"init");
+        self.app_validation.trigger(&"init");
+        self.integrate_dht_ops.trigger(&"init");
+        self.publish_dht_ops.trigger(&"init");
+        self.validation_receipt.trigger(&"init");
     }
 }
 /// The means of nudging a queue consumer to tell it to look for more work
 #[derive(Clone)]
 pub struct TriggerSender {
     /// The actual trigger sender.
-    trigger: broadcast::Sender<String>,
+    trigger: broadcast::Sender<&'static &'static str>,
     /// Reset the back off loop if there is one.
     reset_back_off: Option<Arc<AtomicBool>>,
     /// Pause / resume the back off loop if there is one.
@@ -458,7 +458,7 @@ pub struct TriggerSender {
 /// The receiving end of a queue trigger channel
 pub struct TriggerReceiver {
     /// The actual trigger.
-    rx: broadcast::Receiver<String>,
+    rx: broadcast::Receiver<&'static &'static str>,
     /// If there is a back off loop, should
     /// the trigger reset the back off.
     reset_on_trigger: bool,
@@ -528,8 +528,8 @@ impl TriggerSender {
 
     /// Lazily nudge the consumer task, ignoring the case where the consumer
     /// already has a pending trigger signal
-    pub fn trigger(&self, context: &str) {
-        if self.trigger.send(context.to_string()).is_err() {
+    pub fn trigger(&self, context: &'static &'static str) {
+        if self.trigger.send(context).is_err() {
             tracing::warn!(
                 "Queue consumer trigger was sent while Cell is shutting down: ignoring."
             );
@@ -562,7 +562,7 @@ impl TriggerSender {
     pub fn resume_loop_now(&self) {
         if let Some(pause) = &self.pause_back_off {
             if pause.fetch_and(false, Ordering::AcqRel) {
-                self.trigger("resume_loop_now");
+                self.trigger(&"resume_loop_now");
             }
         }
     }
@@ -655,7 +655,9 @@ impl TriggerReceiver {
 }
 
 /// Create a future that will be ok with either a recv or a lagged.
-async fn rx_fut(rx: &mut broadcast::Receiver<String>) -> Result<(), QueueTriggerClosedError> {
+async fn rx_fut(
+    rx: &mut broadcast::Receiver<&'static &'static str>,
+) -> Result<(), QueueTriggerClosedError> {
     match rx.recv().await {
         Ok(context) => {
             tracing::trace!(msg = "trigger received", ?context);

--- a/crates/holochain/src/core/queue_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer.rs
@@ -437,18 +437,18 @@ impl InitialQueueTriggers {
 
     /// Initialize all the workflows once.
     pub fn initialize_workflows(self) {
-        self.sys_validation.trigger();
-        self.app_validation.trigger();
-        self.integrate_dht_ops.trigger();
-        self.publish_dht_ops.trigger();
-        self.validation_receipt.trigger();
+        self.sys_validation.trigger("init");
+        self.app_validation.trigger("init");
+        self.integrate_dht_ops.trigger("init");
+        self.publish_dht_ops.trigger("init");
+        self.validation_receipt.trigger("init");
     }
 }
 /// The means of nudging a queue consumer to tell it to look for more work
 #[derive(Clone)]
 pub struct TriggerSender {
     /// The actual trigger sender.
-    trigger: broadcast::Sender<()>,
+    trigger: broadcast::Sender<String>,
     /// Reset the back off loop if there is one.
     reset_back_off: Option<Arc<AtomicBool>>,
     /// Pause / resume the back off loop if there is one.
@@ -458,7 +458,7 @@ pub struct TriggerSender {
 /// The receiving end of a queue trigger channel
 pub struct TriggerReceiver {
     /// The actual trigger.
-    rx: broadcast::Receiver<()>,
+    rx: broadcast::Receiver<String>,
     /// If there is a back off loop, should
     /// the trigger reset the back off.
     reset_on_trigger: bool,
@@ -528,8 +528,8 @@ impl TriggerSender {
 
     /// Lazily nudge the consumer task, ignoring the case where the consumer
     /// already has a pending trigger signal
-    pub fn trigger(&self) {
-        if self.trigger.send(()).is_err() {
+    pub fn trigger(&self, context: &str) {
+        if self.trigger.send(context.to_string()).is_err() {
             tracing::warn!(
                 "Queue consumer trigger was sent while Cell is shutting down: ignoring."
             );
@@ -562,7 +562,7 @@ impl TriggerSender {
     pub fn resume_loop_now(&self) {
         if let Some(pause) = &self.pause_back_off {
             if pause.fetch_and(false, Ordering::AcqRel) {
-                self.trigger();
+                self.trigger("resume_loop_now");
             }
         }
     }
@@ -655,9 +655,12 @@ impl TriggerReceiver {
 }
 
 /// Create a future that will be ok with either a recv or a lagged.
-async fn rx_fut(rx: &mut broadcast::Receiver<()>) -> Result<(), QueueTriggerClosedError> {
+async fn rx_fut(rx: &mut broadcast::Receiver<String>) -> Result<(), QueueTriggerClosedError> {
     match rx.recv().await {
-        Ok(_) => Ok(()),
+        Ok(context) => {
+            tracing::trace!(msg = "trigger received", ?context);
+            Ok(())
+        }
         Err(broadcast::error::RecvError::Closed) => Err(QueueTriggerClosedError),
         Err(broadcast::error::RecvError::Lagged(_)) => Ok(()),
     }

--- a/crates/holochain/src/core/queue_consumer/app_validation_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/app_validation_consumer.rs
@@ -53,7 +53,7 @@ pub fn spawn_app_validation_consumer(
             match result {
                 Ok(WorkComplete::Incomplete) => {
                     tracing::debug!("Work incomplete, retriggering workflow");
-                    trigger_self.trigger("retrigger")
+                    trigger_self.trigger(&"retrigger")
                 }
                 Err(err) => handle_workflow_error(err)?,
                 _ => (),

--- a/crates/holochain/src/core/queue_consumer/app_validation_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/app_validation_consumer.rs
@@ -51,7 +51,10 @@ pub fn spawn_app_validation_consumer(
             )
             .await;
             match result {
-                Ok(WorkComplete::Incomplete) => trigger_self.trigger(),
+                Ok(WorkComplete::Incomplete) => {
+                    tracing::debug!("Work incomplete, retriggering workflow");
+                    trigger_self.trigger("retrigger")
+                }
                 Err(err) => handle_workflow_error(err)?,
                 _ => (),
             };

--- a/crates/holochain/src/core/queue_consumer/countersigning_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/countersigning_consumer.rs
@@ -30,7 +30,7 @@ pub(crate) fn spawn_countersigning_consumer(
             match countersigning_workflow(&space, &dna_network, &trigger_sys).await {
                 Ok(WorkComplete::Incomplete) => {
                     tracing::debug!("Work incomplete, retriggering workflow");
-                    trigger_self.trigger("retrigger")
+                    trigger_self.trigger(&"retrigger")
                 }
                 Err(err) => handle_workflow_error(err)?,
                 _ => (),

--- a/crates/holochain/src/core/queue_consumer/countersigning_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/countersigning_consumer.rs
@@ -28,7 +28,10 @@ pub(crate) fn spawn_countersigning_consumer(
 
             // Run the workflow
             match countersigning_workflow(&space, &dna_network, &trigger_sys).await {
-                Ok(WorkComplete::Incomplete) => trigger_self.trigger(),
+                Ok(WorkComplete::Incomplete) => {
+                    tracing::debug!("Work incomplete, retriggering workflow");
+                    trigger_self.trigger("retrigger")
+                }
                 Err(err) => handle_workflow_error(err)?,
                 _ => (),
             };

--- a/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
@@ -38,7 +38,10 @@ pub fn spawn_integrate_dht_ops_consumer(
             )
             .await
             {
-                Ok(WorkComplete::Incomplete) => trigger_self.trigger(),
+                Ok(WorkComplete::Incomplete) => {
+                    tracing::debug!("Work incomplete, retriggering workflow");
+                    trigger_self.trigger("retrigger")
+                }
                 Err(err) => handle_workflow_error(err)?,
                 _ => (),
             };

--- a/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
@@ -40,7 +40,7 @@ pub fn spawn_integrate_dht_ops_consumer(
             {
                 Ok(WorkComplete::Incomplete) => {
                     tracing::debug!("Work incomplete, retriggering workflow");
-                    trigger_self.trigger("retrigger")
+                    trigger_self.trigger(&"retrigger")
                 }
                 Err(err) => handle_workflow_error(err)?,
                 _ => (),

--- a/crates/holochain/src/core/queue_consumer/publish_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/publish_dht_ops_consumer.rs
@@ -50,7 +50,10 @@ pub fn spawn_publish_dht_ops_consumer(
             )
             .await
             {
-                Ok(WorkComplete::Incomplete) => trigger_self.trigger(),
+                Ok(WorkComplete::Incomplete) => {
+                    tracing::debug!("Work incomplete, retriggering workflow");
+                    trigger_self.trigger("retrigger")
+                }
                 Err(err) => handle_workflow_error(err)?,
                 _ => (),
             };

--- a/crates/holochain/src/core/queue_consumer/publish_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/publish_dht_ops_consumer.rs
@@ -62,7 +62,7 @@ pub fn spawn_publish_dht_ops_consumer(
             {
                 Ok(WorkComplete::Incomplete) => {
                     tracing::debug!("Work incomplete, retriggering workflow");
-                    trigger_self.trigger("retrigger")
+                    trigger_self.trigger(&"retrigger")
                 }
                 Err(err) => handle_workflow_error(err)?,
                 _ => (),

--- a/crates/holochain/src/core/queue_consumer/publish_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/publish_dht_ops_consumer.rs
@@ -41,6 +41,16 @@ pub fn spawn_publish_dht_ops_consumer(
                 }
             }
 
+            if conductor_handle
+                .get_config()
+                .network
+                .as_ref()
+                .map(|c| c.tuning_params.disable_publish)
+                .unwrap_or(false)
+            {
+                continue;
+            }
+
             // Run the workflow
             match publish_dht_ops_workflow(
                 env.clone(),

--- a/crates/holochain/src/core/queue_consumer/sys_validation_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/sys_validation_consumer.rs
@@ -49,7 +49,10 @@ pub fn spawn_sys_validation_consumer(
             )
             .await
             {
-                Ok(WorkComplete::Incomplete) => trigger_self.trigger(),
+                Ok(WorkComplete::Incomplete) => {
+                    tracing::debug!("Work incomplete, retriggering workflow");
+                    trigger_self.trigger("retrigger")
+                }
                 Err(err) => handle_workflow_error(err)?,
                 _ => (),
             };

--- a/crates/holochain/src/core/queue_consumer/sys_validation_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/sys_validation_consumer.rs
@@ -51,7 +51,7 @@ pub fn spawn_sys_validation_consumer(
             {
                 Ok(WorkComplete::Incomplete) => {
                     tracing::debug!("Work incomplete, retriggering workflow");
-                    trigger_self.trigger("retrigger")
+                    trigger_self.trigger(&"retrigger")
                 }
                 Err(err) => handle_workflow_error(err)?,
                 _ => (),

--- a/crates/holochain/src/core/queue_consumer/tests.rs
+++ b/crates/holochain/src/core/queue_consumer/tests.rs
@@ -18,7 +18,7 @@ async fn test_trigger() {
 
     let (tx, mut rx) = TriggerSender::new();
     let jh = tokio::spawn(async move { rx.listen().await.unwrap() });
-    tx.trigger("");
+    tx.trigger(&"");
 
     // This should be joined because the trigger was called.
     let r = jh.await;
@@ -33,8 +33,8 @@ async fn test_trigger() {
     });
     // Calling trigger twice before a listen should only
     // cause one listen to progress.
-    tx.trigger("");
-    tx.trigger("");
+    tx.trigger(&"");
+    tx.trigger(&"");
 
     // This should timeout because the second listen should not pass.
     let r = tokio::time::timeout(Duration::from_millis(100), jh).await;
@@ -130,7 +130,7 @@ async fn test_reset_on_trigger() {
             && timer.elapsed() < Duration::from_secs(60 * 2 + 1)
     );
 
-    tx.trigger("");
+    tx.trigger(&"");
 
     // There should be one trigger immediately.
     let timer = tokio::time::Instant::now();
@@ -185,7 +185,7 @@ async fn test_concurrency() {
     let jh = tokio::spawn(async move { rx.listen().await.unwrap() });
     // - Make sure listen has been called already.
     tokio::time::sleep(Duration::from_millis(10)).await;
-    tx.trigger("");
+    tx.trigger(&"");
     jh.await.unwrap();
     assert!(timer.elapsed() < Duration::from_millis(20));
 
@@ -278,7 +278,7 @@ async fn publish_loop() {
     );
 
     // - Triggering publish causes it to run again.
-    ts.trigger("");
+    ts.trigger(&"");
 
     let timer = tokio::time::Instant::now();
     trigger_recv.listen().await.unwrap();
@@ -365,7 +365,7 @@ async fn publish_loop() {
         .unwrap();
 
     // - Publish runs due to a trigger.
-    ts.trigger("");
+    ts.trigger(&"");
     let timer = tokio::time::Instant::now();
     trigger_recv.listen().await.unwrap();
     assert!(timer.elapsed() < Duration::from_secs(1));

--- a/crates/holochain/src/core/queue_consumer/tests.rs
+++ b/crates/holochain/src/core/queue_consumer/tests.rs
@@ -18,7 +18,7 @@ async fn test_trigger() {
 
     let (tx, mut rx) = TriggerSender::new();
     let jh = tokio::spawn(async move { rx.listen().await.unwrap() });
-    tx.trigger();
+    tx.trigger("");
 
     // This should be joined because the trigger was called.
     let r = jh.await;
@@ -33,8 +33,8 @@ async fn test_trigger() {
     });
     // Calling trigger twice before a listen should only
     // cause one listen to progress.
-    tx.trigger();
-    tx.trigger();
+    tx.trigger("");
+    tx.trigger("");
 
     // This should timeout because the second listen should not pass.
     let r = tokio::time::timeout(Duration::from_millis(100), jh).await;
@@ -130,7 +130,7 @@ async fn test_reset_on_trigger() {
             && timer.elapsed() < Duration::from_secs(60 * 2 + 1)
     );
 
-    tx.trigger();
+    tx.trigger("");
 
     // There should be one trigger immediately.
     let timer = tokio::time::Instant::now();
@@ -185,7 +185,7 @@ async fn test_concurrency() {
     let jh = tokio::spawn(async move { rx.listen().await.unwrap() });
     // - Make sure listen has been called already.
     tokio::time::sleep(Duration::from_millis(10)).await;
-    tx.trigger();
+    tx.trigger("");
     jh.await.unwrap();
     assert!(timer.elapsed() < Duration::from_millis(20));
 
@@ -278,7 +278,7 @@ async fn publish_loop() {
     );
 
     // - Triggering publish causes it to run again.
-    ts.trigger();
+    ts.trigger("");
 
     let timer = tokio::time::Instant::now();
     trigger_recv.listen().await.unwrap();
@@ -365,7 +365,7 @@ async fn publish_loop() {
         .unwrap();
 
     // - Publish runs due to a trigger.
-    ts.trigger();
+    ts.trigger("");
     let timer = tokio::time::Instant::now();
     trigger_recv.listen().await.unwrap();
     assert!(timer.elapsed() < Duration::from_secs(1));

--- a/crates/holochain/src/core/queue_consumer/validation_receipt_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/validation_receipt_consumer.rs
@@ -40,7 +40,7 @@ pub fn spawn_validation_receipt_consumer(
             {
                 Ok(WorkComplete::Incomplete) => {
                     tracing::debug!("Work incomplete, retriggering workflow");
-                    trigger_self.trigger("retrigger")
+                    trigger_self.trigger(&"retrigger")
                 }
                 Err(err) => handle_workflow_error(err)?,
                 _ => (),

--- a/crates/holochain/src/core/queue_consumer/validation_receipt_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/validation_receipt_consumer.rs
@@ -38,7 +38,10 @@ pub fn spawn_validation_receipt_consumer(
             )
             .await
             {
-                Ok(WorkComplete::Incomplete) => trigger_self.trigger(),
+                Ok(WorkComplete::Incomplete) => {
+                    tracing::debug!("Work incomplete, retriggering workflow");
+                    trigger_self.trigger("retrigger")
+                }
                 Err(err) => handle_workflow_error(err)?,
                 _ => (),
             };

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -75,7 +75,7 @@ pub async fn app_validation_workflow(
     // --- END OF WORKFLOW, BEGIN FINISHER BOILERPLATE ---
 
     // trigger other workflows
-    trigger_integration.trigger();
+    trigger_integration.trigger("app_validation_workflow");
 
     Ok(complete)
 }

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -75,7 +75,7 @@ pub async fn app_validation_workflow(
     // --- END OF WORKFLOW, BEGIN FINISHER BOILERPLATE ---
 
     // trigger other workflows
-    trigger_integration.trigger("app_validation_workflow");
+    trigger_integration.trigger(&"app_validation_workflow");
 
     Ok(complete)
 }

--- a/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
@@ -379,7 +379,7 @@ async fn get_agent_activity_test() {
     // Commit private messages
     commit_some_data("create_priv_msg", &alice_call_data, &handle).await;
 
-    alice_call_data.triggers.produce_dht_ops.trigger("");
+    alice_call_data.triggers.produce_dht_ops.trigger(&"");
 
     expected_count += NUM_COMMITS * 2;
     wait_for_integration(
@@ -426,7 +426,7 @@ async fn get_agent_activity_test() {
         .clone();
 
     // Wait for alice to integrate the chain as an authority
-    alice_call_data.triggers.produce_dht_ops.trigger("");
+    alice_call_data.triggers.produce_dht_ops.trigger(&"");
     expected_count += NUM_COMMITS * 3;
     wait_for_integration(
         &alice_call_data.db,

--- a/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
@@ -379,7 +379,7 @@ async fn get_agent_activity_test() {
     // Commit private messages
     commit_some_data("create_priv_msg", &alice_call_data, &handle).await;
 
-    alice_call_data.triggers.produce_dht_ops.trigger();
+    alice_call_data.triggers.produce_dht_ops.trigger("");
 
     expected_count += NUM_COMMITS * 2;
     wait_for_integration(
@@ -426,7 +426,7 @@ async fn get_agent_activity_test() {
         .clone();
 
     // Wait for alice to integrate the chain as an authority
-    alice_call_data.triggers.produce_dht_ops.trigger();
+    alice_call_data.triggers.produce_dht_ops.trigger("");
     expected_count += NUM_COMMITS * 3;
     wait_for_integration(
         &alice_call_data.db,

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -421,7 +421,7 @@ async fn commit_invalid(
 
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(&bob_cell_id).unwrap();
-    triggers.publish_dht_ops.trigger("commit_invalid");
+    triggers.publish_dht_ops.trigger(&"commit_invalid");
     (invalid_header_hash, entry_hash)
 }
 
@@ -444,7 +444,7 @@ async fn commit_invalid_post(
 
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(&bob_cell_id).unwrap();
-    triggers.publish_dht_ops.trigger("commit_invalid_post");
+    triggers.publish_dht_ops.trigger(&"commit_invalid_post");
     (invalid_header_hash, entry_hash)
 }
 
@@ -460,6 +460,6 @@ async fn call_zome_directly(
 
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(&bob_cell_id).unwrap();
-    triggers.publish_dht_ops.trigger("call_zome_directly");
+    triggers.publish_dht_ops.trigger(&"call_zome_directly");
     output
 }

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -421,7 +421,7 @@ async fn commit_invalid(
 
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(&bob_cell_id).unwrap();
-    triggers.publish_dht_ops.trigger();
+    triggers.publish_dht_ops.trigger("commit_invalid");
     (invalid_header_hash, entry_hash)
 }
 
@@ -444,7 +444,7 @@ async fn commit_invalid_post(
 
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(&bob_cell_id).unwrap();
-    triggers.publish_dht_ops.trigger();
+    triggers.publish_dht_ops.trigger("commit_invalid_post");
     (invalid_header_hash, entry_hash)
 }
 
@@ -460,6 +460,6 @@ async fn call_zome_directly(
 
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(&bob_cell_id).unwrap();
-    triggers.publish_dht_ops.trigger();
+    triggers.publish_dht_ops.trigger("call_zome_directly");
     output
 }

--- a/crates/holochain/src/core/workflow/call_zome_workflow.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow.rs
@@ -84,8 +84,8 @@ where
                     }
                 }
                 None => {
-                    trigger_publish_dht_ops.trigger();
-                    trigger_integrate_dht_ops.trigger();
+                    trigger_publish_dht_ops.trigger("trigger_publish_dht_ops");
+                    trigger_integrate_dht_ops.trigger("trigger_integrate_dht_ops");
                 }
             }
         }

--- a/crates/holochain/src/core/workflow/call_zome_workflow.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow.rs
@@ -84,8 +84,8 @@ where
                     }
                 }
                 None => {
-                    trigger_publish_dht_ops.trigger("trigger_publish_dht_ops");
-                    trigger_integrate_dht_ops.trigger("trigger_integrate_dht_ops");
+                    trigger_publish_dht_ops.trigger(&"trigger_publish_dht_ops");
+                    trigger_integrate_dht_ops.trigger(&"trigger_integrate_dht_ops");
                 }
             }
         }

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -95,7 +95,7 @@ pub(crate) fn incoming_countersigning(
 
     // Trigger the workflow if we have new ops.
     if should_trigger {
-        trigger.trigger("incoming_countersigning");
+        trigger.trigger(&"incoming_countersigning");
     }
     Ok(())
 }
@@ -259,7 +259,7 @@ pub(crate) async fn countersigning_success(
             &dht_db_cache,
         )
         .await?;
-        integration_trigger.trigger("countersigning_success");
+        integration_trigger.trigger(&"countersigning_success");
         // Publish other signers agent activity ops to their agent activity authorities.
         for SignedHeader(header, signature) in signed_headers {
             if *header.author() == author {
@@ -280,7 +280,7 @@ pub(crate) async fn countersigning_success(
             entry_hash,
         )))?;
 
-        publish_trigger.trigger("publish countersigning_success");
+        publish_trigger.trigger(&"publish countersigning_success");
     }
     Ok(())
 }

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -95,7 +95,7 @@ pub(crate) fn incoming_countersigning(
 
     // Trigger the workflow if we have new ops.
     if should_trigger {
-        trigger.trigger();
+        trigger.trigger("incoming_countersigning");
     }
     Ok(())
 }
@@ -259,7 +259,7 @@ pub(crate) async fn countersigning_success(
             &dht_db_cache,
         )
         .await?;
-        integration_trigger.trigger();
+        integration_trigger.trigger("countersigning_success");
         // Publish other signers agent activity ops to their agent activity authorities.
         for SignedHeader(header, signature) in signed_headers {
             if *header.author() == author {
@@ -280,7 +280,7 @@ pub(crate) async fn countersigning_success(
             entry_hash,
         )))?;
 
-        publish_trigger.trigger();
+        publish_trigger.trigger("publish countersigning_success");
     }
     Ok(())
 }

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
@@ -209,7 +209,7 @@ pub async fn incoming_dht_ops_workflow(
                     }
 
                     // trigger validation of queued ops
-                    sys_validation_trigger.trigger("incoming_dht_ops_workflow");
+                    sys_validation_trigger.trigger(&"incoming_dht_ops_workflow");
 
                     maybe_batch = batch_check_end(&incoming_ops_batch);
                 }

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
@@ -209,7 +209,7 @@ pub async fn incoming_dht_ops_workflow(
                     }
 
                     // trigger validation of queued ops
-                    sys_validation_trigger.trigger();
+                    sys_validation_trigger.trigger("incoming_dht_ops_workflow");
 
                     maybe_batch = batch_check_end(&incoming_ops_batch);
                 }

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -97,7 +97,7 @@ pub async fn integrate_dht_ops_workflow(
     let ops_ps = changed as f64 / start.elapsed().as_micros() as f64 * 1_000_000.0;
     tracing::debug!(?changed, %ops_ps);
     if changed > 0 {
-        trigger_receipt.trigger("integrate_dht_ops_workflow");
+        trigger_receipt.trigger(&"integrate_dht_ops_workflow");
         network.new_integrated_data().await?;
         Ok(WorkComplete::Incomplete)
     } else {

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -97,7 +97,7 @@ pub async fn integrate_dht_ops_workflow(
     let ops_ps = changed as f64 / start.elapsed().as_micros() as f64 * 1_000_000.0;
     tracing::debug!(?changed, %ops_ps);
     if changed > 0 {
-        trigger_receipt.trigger();
+        trigger_receipt.trigger("integrate_dht_ops_workflow");
         network.new_integrated_data().await?;
         Ok(WorkComplete::Incomplete)
     } else {

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -71,7 +71,7 @@ pub async fn sys_validation_workflow(
     // --- END OF WORKFLOW, BEGIN FINISHER BOILERPLATE ---
 
     // trigger other workflows
-    trigger_app_validation.trigger();
+    trigger_app_validation.trigger("sys_validation_workflow");
 
     Ok(complete)
 }

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -71,7 +71,7 @@ pub async fn sys_validation_workflow(
     // --- END OF WORKFLOW, BEGIN FINISHER BOILERPLATE ---
 
     // trigger other workflows
-    trigger_app_validation.trigger("sys_validation_workflow");
+    trigger_app_validation.trigger(&"sys_validation_workflow");
 
     Ok(complete)
 }

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -241,7 +241,9 @@ async fn bob_links_in_a_legit_way(
 
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(&bob_cell_id).unwrap();
-    triggers.publish_dht_ops.trigger("bob_links_in_a_legit_way");
+    triggers
+        .publish_dht_ops
+        .trigger(&"bob_links_in_a_legit_way");
     link_add_address
 }
 
@@ -297,7 +299,7 @@ async fn bob_makes_a_large_link(
 
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(&bob_cell_id).unwrap();
-    triggers.publish_dht_ops.trigger("bob_makes_a_large_link");
+    triggers.publish_dht_ops.trigger(&"bob_makes_a_large_link");
     (bad_update_header, bad_update_entry_hash, link_add_address)
 }
 
@@ -343,7 +345,7 @@ async fn dodgy_bob(bob_cell_id: &CellId, handle: &ConductorHandle, dna_file: &Dn
 
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(&bob_cell_id).unwrap();
-    triggers.publish_dht_ops.trigger("dodgy_bob");
+    triggers.publish_dht_ops.trigger(&"dodgy_bob");
 }
 
 //////////////////////

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -241,7 +241,7 @@ async fn bob_links_in_a_legit_way(
 
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(&bob_cell_id).unwrap();
-    triggers.publish_dht_ops.trigger();
+    triggers.publish_dht_ops.trigger("bob_links_in_a_legit_way");
     link_add_address
 }
 
@@ -297,7 +297,7 @@ async fn bob_makes_a_large_link(
 
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(&bob_cell_id).unwrap();
-    triggers.publish_dht_ops.trigger();
+    triggers.publish_dht_ops.trigger("bob_makes_a_large_link");
     (bad_update_header, bad_update_entry_hash, link_add_address)
 }
 
@@ -343,7 +343,7 @@ async fn dodgy_bob(bob_cell_id: &CellId, handle: &ConductorHandle, dna_file: &Dn
 
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(&bob_cell_id).unwrap();
-    triggers.publish_dht_ops.trigger();
+    triggers.publish_dht_ops.trigger("dodgy_bob");
 }
 
 //////////////////////

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -814,6 +814,6 @@ pub async fn force_publish_dht_ops(
             )?)
         })
         .await?;
-    publish_trigger.trigger("force_publish_dht_ops");
+    publish_trigger.trigger(&"force_publish_dht_ops");
     Ok(())
 }

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -814,6 +814,6 @@ pub async fn force_publish_dht_ops(
             )?)
         })
         .await?;
-    publish_trigger.trigger();
+    publish_trigger.trigger("force_publish_dht_ops");
     Ok(())
 }

--- a/crates/holochain/tests/authored_test/mod.rs
+++ b/crates/holochain/tests/authored_test/mod.rs
@@ -42,7 +42,7 @@ async fn authored_test() {
 
     // publish these commits
     let triggers = handle.get_cell_triggers(&alice_call_data.cell_id).unwrap();
-    triggers.publish_dht_ops.trigger("");
+    triggers.publish_dht_ops.trigger(&"");
 
     // Alice commits the entry
     fresh_reader_test(alice_call_data.authored_db.clone(), |txn| {
@@ -112,7 +112,7 @@ async fn authored_test() {
 
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(&bob_call_data.cell_id).unwrap();
-    triggers.publish_dht_ops.trigger("");
+    triggers.publish_dht_ops.trigger(&"");
 
     fresh_reader_test(bob_call_data.authored_db.clone(), |txn| {
         let basis: AnyDhtHash = entry_hash.clone().into();

--- a/crates/holochain/tests/authored_test/mod.rs
+++ b/crates/holochain/tests/authored_test/mod.rs
@@ -42,7 +42,7 @@ async fn authored_test() {
 
     // publish these commits
     let triggers = handle.get_cell_triggers(&alice_call_data.cell_id).unwrap();
-    triggers.publish_dht_ops.trigger();
+    triggers.publish_dht_ops.trigger("");
 
     // Alice commits the entry
     fresh_reader_test(alice_call_data.authored_db.clone(), |txn| {
@@ -112,7 +112,7 @@ async fn authored_test() {
 
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(&bob_call_data.cell_id).unwrap();
-    triggers.publish_dht_ops.trigger();
+    triggers.publish_dht_ops.trigger("");
 
     fresh_reader_test(bob_call_data.authored_db.clone(), |txn| {
         let basis: AnyDhtHash = entry_hash.clone().into();

--- a/crates/kitsune_p2p/types/src/config.rs
+++ b/crates/kitsune_p2p/types/src/config.rs
@@ -192,6 +192,16 @@ pub mod tuning_params_struct {
         /// by the `SSLKEYLOGFILE` environment variable, or do nothing if
         /// it is not set, or is not writable.
         danger_tls_keylog: String = "no_keylog".to_string(),
+
+        /// Set the cutoff time when gossip switches over from recent
+        /// to historical gossip. This is dangerous, because gossip may not be
+        /// possible with nodes using a different setting for this threshold.
+        /// Do not change this except in testing environments.
+        /// [Default: 1 hour]
+        danger_gossip_recent_threshold_secs: u64 = super::RECENT_THRESHOLD_DEFAULT.as_secs(),
+
+        /// Don't publish ops, only rely on gossip. Useful for testing the efficacy of gossip.
+        disable_publish: bool = false,
     }
 
     impl KitsuneP2pTuningParams {

--- a/crates/kitsune_p2p/types/src/config.rs
+++ b/crates/kitsune_p2p/types/src/config.rs
@@ -193,13 +193,6 @@ pub mod tuning_params_struct {
         /// it is not set, or is not writable.
         danger_tls_keylog: String = "no_keylog".to_string(),
 
-        /// Set the cutoff time when gossip switches over from recent
-        /// to historical gossip. This is dangerous, because gossip may not be
-        /// possible with nodes using a different setting for this threshold.
-        /// Do not change this except in testing environments.
-        /// [Default: 1 hour]
-        danger_gossip_recent_threshold_secs: u64 = super::RECENT_THRESHOLD_DEFAULT.as_secs(),
-
         /// Don't publish ops, only rely on gossip. Useful for testing the efficacy of gossip.
         disable_publish: bool = false,
     }


### PR DESCRIPTION
### Summary

Adds ability to disable publishing from tuning_params. Helps test gossip.

I noticed that sometimes the conductor sometimes gets stuck in a loop of validating 0 ops many times per second, these trace and debug logs may help.

### TODO:
- [ ] ~~CHANGELOG(s) updated with appropriate info~~
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
