### PR TITLE
bump to lair 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1775,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "hc_seed_bundle"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae01760e90dcdb62fb1b82ac79c8cf8da5cf727fc72efc771c59491d9a96a6bf"
+checksum = "0cd58bbdef35b067ac8628d1aefab03083f95c976a592f3fb4c57afa8ab392eb"
 dependencies = [
  "futures",
  "one_err",
@@ -2982,7 +2982,7 @@ dependencies = [
  "ghost_actor 0.3.0-alpha.4",
  "kitsune_p2p_dht_arc",
  "lair_keystore_api 0.0.10",
- "lair_keystore_api 0.1.1",
+ "lair_keystore_api 0.1.3",
  "lru",
  "mockall 0.10.2",
  "nanoid 0.3.0",
@@ -3049,9 +3049,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600142edf1ab2ca63e5606cc88b30611c9adc51748d7d12e94410abacd3c750a"
+checksum = "31d52f8d74a3a7c50667fd881e3ea8e7efd8c44774280afdeb0541fc71c13cbe"
 dependencies = [
  "base64",
  "dunce",

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Udpate lair to 0.1.3 - largely just documentation updates, but also re-introduces some dependency pinning to fix mismatch client/server version check [\#1377](https://github.com/holochain/holochain/pull/1377)
+
 ## 0.0.138
 
 ## 0.0.137

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 lair_keystore_api_0_0 = { version = "=0.0.10", package = "lair_keystore_api" }
-lair_keystore_api = "=0.1.1"
+lair_keystore_api = "=0.1.3"
 base64 = "0.13"
 derive_more = "0.99.7"
 futures = "0.3"


### PR DESCRIPTION
### Summary

- bump to lair 0.1.3 - which is largely just documentation updates, but also re-introduces some dependency pinning to fix mismatch client/server version check

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
