### PR TITLE
Remove versions from dev dependencies

### DIFF
--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -44,4 +44,4 @@ mockall = { version = "0.11.0", optional = true }
 
 
 [dev-dependencies]
-fixt = { path = "../fixt" ,version = "0.0.11"}
+fixt = { path = "../fixt" }

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -92,7 +92,7 @@ sd-notify = "0.3.0"
 anyhow = "1.0.26"
 assert_cmd = "1.0.1"
 criterion = { version = "0.3", features = [ "async_tokio" ] }
-kitsune_p2p_bootstrap = { version = "0.0.11", path = "../kitsune_p2p/bootstrap" }
+kitsune_p2p_bootstrap = { path = "../kitsune_p2p/bootstrap" }
 maplit = "1"
 pretty_assertions = "0.6.1"
 reqwest = "0.11.2"

--- a/crates/holochain_deterministic_integrity/Cargo.toml
+++ b/crates/holochain_deterministic_integrity/Cargo.toml
@@ -36,4 +36,4 @@ mockall = { version = "0.10.2", optional = true }
 
 
 [dev-dependencies]
-fixt = { path = "../fixt", version = "0.0.11"}
+fixt = { path = "../fixt" }

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -49,9 +49,9 @@ contrafact = { version = "0.1.0-dev.1", optional = true }
 [dev-dependencies]
 anyhow = "1.0.26"
 arbitrary = "1.0"
-fixt = { version = "0.0.11", path = "../fixt" }
-hdk = { version = "0.0.132", path = "../hdk" }
-holochain_wasm_test_utils = { path = "../test_utils/wasm", version = "0.0.38"}
+fixt = { path = "../fixt" }
+hdk = { path = "../hdk" }
+holochain_wasm_test_utils = { path = "../test_utils/wasm" }
 matches = "0.1.8"
 observability = "0.1.3"
 pretty_assertions = "0.6.1"

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -28,7 +28,7 @@ tungstenite = "0.12"
 url2 = "0.0.6"
 
 [dev-dependencies]
-holochain_types = { version = "0.0.37", path = "../holochain_types" }
+holochain_types = { path = "../holochain_types" }
 linefeed = "0.6"
 unwrap_to = "0.1.0"
 observability = "0.1.3"

--- a/crates/kitsune_p2p/bootstrap/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1", features = ["full"] }
 warp = "0.3"
 
 [dev-dependencies]
-kitsune_p2p = { version = "0.0.32", path = "../kitsune_p2p" }
+kitsune_p2p = { path = "../kitsune_p2p" }
 fixt = { path = "../../fixt" ,version = "0.0.11"}
 criterion = "0.3"
 reqwest = "0.11.2"

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -51,8 +51,9 @@ mockall = { version = "0.10.2", optional = true }
 [dev-dependencies]
 kitsune_p2p_bootstrap = { path = "../bootstrap" }
 contrafact = { version = "0.1.0-dev.1" }
-kitsune_p2p_timestamp = { version = "0.0.9", path = "../timestamp", features = ["now", "arbitrary"] }
-kitsune_p2p_types = { version = "0.0.24", path = "../types", features = ["test_utils"] }
+kitsune_p2p_bootstrap = { path = "../bootstrap" }
+kitsune_p2p_timestamp = { path = "../timestamp", features = ["now", "arbitrary"] }
+kitsune_p2p_types = { path = "../types", features = ["test_utils"] }
 maplit = "1"
 mockall = "0.10.2"
 pretty_assertions = "0.7"

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -49,7 +49,6 @@ maplit = { version = "1", optional = true }
 mockall = { version = "0.10.2", optional = true }
 
 [dev-dependencies]
-kitsune_p2p_bootstrap = { path = "../bootstrap" }
 contrafact = { version = "0.1.0-dev.1" }
 kitsune_p2p_bootstrap = { path = "../bootstrap" }
 kitsune_p2p_timestamp = { path = "../timestamp", features = ["now", "arbitrary"] }

--- a/crates/release-automation/src/lib/crate_selection/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/mod.rs
@@ -293,6 +293,8 @@ pub(crate) enum CrateStateFlags {
     MissingLicense,
     /// Has a dependency that contains '*'
     HasWildcardDependency,
+    /// Has a dev-dependency that contains '*'
+    HasWildcardDevDependency,
     /// One of the manifest keywords is too long
     ManifestKeywordExceeds20Chars,
     ManifestKeywordContainsInvalidChar,
@@ -776,7 +778,10 @@ impl<'a> ReleaseWorkspace<'a> {
 
                         for dep in member.package().dependencies() {
                             if dep.version_req().to_string().contains('*') {
-                                insert_state!(CrateStateFlags::HasWildcardDependency);
+                                insert_state!(match dep.kind() {
+                                    CargoDepKind::Normal | CargoDepKind::Build => CrateStateFlags::HasWildcardDependency,
+                                    CargoDepKind::Development => CrateStateFlags::HasWildcardDevDependency,
+                                });
                             }
                         }
                     }


### PR DESCRIPTION
### Summary

Hypothesis: There's no need for versions in dev dependencies: they only create opportunities for forgetting to update one, or missing one in a merge conflict, leading to a confusing or annoying error.

### TODO:
- [ ] ~~CHANGELOG(s) updated with appropriate info~~
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
