### PR TITLE
Add trace feature to hdk dep of hdi

### DIFF
--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fixed hdk dependency which disabled tracing by default. If you have not seen output from HDK's `trace` in a while, this is why, and now it is fixed.
+
 ## 0.0.133
 
 ## 0.0.132

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -27,7 +27,7 @@ test_utils = [
 properties = ["holochain_zome_types/properties"]
 
 [dependencies]
-holochain_deterministic_integrity = { version = "0.0.6", path = "../holochain_deterministic_integrity" }
+holochain_deterministic_integrity = { version = "0.0.6", path = "../holochain_deterministic_integrity", features = ["trace"] }
 hdk_derive = { version = "0.0.33", path = "../hdk_derive" }
 holo_hash = { version = "0.0.25", path = "../holo_hash" }
 holochain_wasmer_guest = "=0.0.77"

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -153,7 +153,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "fixt"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -301,7 +301,7 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hdk"
-version = "0.0.130"
+version = "0.0.133"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.0.31"
+version = "0.0.33"
 dependencies = [
  "holochain_integrity_types",
  "paste",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.0.23"
+version = "0.0.25"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_deterministic_integrity"
-version = "0.0.3"
+version = "0.0.6"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -366,11 +366,13 @@ dependencies = [
  "paste",
  "serde",
  "serde_bytes",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.0.3"
+version = "0.0.5"
 dependencies = [
  "holo_hash",
  "holochain_serialized_bytes",
@@ -416,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.0.31"
+version = "0.0.34"
 dependencies = [
  "hdk",
  "serde",
@@ -449,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.0.31"
+version = "0.0.33"
 dependencies = [
  "fixt",
  "holo_hash",
@@ -528,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_timestamp"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "chrono",
  "serde",


### PR DESCRIPTION
### Summary

The trace feature was turned off for the hdk, making `trace` a no-op

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
