### PR TITLE
fix(docker): use nix image instead of outdated holonix image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ commands:
          - run: ./docker/login.sh
          - run:
               no_output_timeout: 45m
+              environment:
+                 CACHIX_NAME: holochain-ci
+                 NIX_CONFIG: "extra-experimental-features = nix-command"
               command: ./docker/build.sh << parameters.box >> $CIRCLE_BRANCH
          - run:
               no_output_timeout: 30m

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -301,7 +301,7 @@ checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hdk"
-version = "0.0.133"
+version = "0.0.134"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "holochain_integrity_types",
  "paste",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.0.25"
+version = "0.0.26"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_deterministic_integrity"
-version = "0.0.6"
+version = "0.0.7"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "holo_hash",
  "holochain_serialized_bytes",
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.0.34"
+version = "0.0.35"
 dependencies = [
  "hdk",
  "serde",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.0.33"
+version = "0.0.34"
 dependencies = [
  "fixt",
  "holo_hash",

--- a/docker/Dockerfile.circle.build
+++ b/docker/Dockerfile.circle.build
@@ -2,4 +2,4 @@ ARG DOCKER_BRANCH=develop
 FROM holochain/holochain:latest.${DOCKER_BRANCH}
 
 RUN `nix-build . --no-link -A pkgs.ci.ciSetupNixConf`/bin/hc-ci-setup-nix-conf.sh
-RUN nix-shell --pure --argstr flavor coreDev --run hc-merge-test || echo WARNING: merge tests failed
+RUN nix-shell --pure --argstr flavor coreDev --run 'env CARGO_TEST_ARGS="--no-run" hc-merge-test' || echo WARNING: merge tests failed

--- a/docker/Dockerfile.latest
+++ b/docker/Dockerfile.latest
@@ -5,6 +5,11 @@ ENV NIX_ENV_PREFIX /holochain/build
 ENV NIXPKGS_ALLOW_UNFREE 1
 
 ARG DOCKER_BRANCH=develop
+ARG CACHIX_NAME=holochain-ci
+ARG NIX_CONFIG="extra-experimental-features = nix-command"
+
+ENV CACHIX_NAME=$CACHIX_NAME
+ENV NIX_CONFIG=$NIX_CONFIG
 
 ADD https://github.com/holochain/holochain/archive/$DOCKER_BRANCH.tar.gz /holochain/build/$DOCKER_BRANCH.tar.gz
 RUN tar --strip-components=1 -zxvf $DOCKER_BRANCH.tar.gz

--- a/docker/Dockerfile.latest
+++ b/docker/Dockerfile.latest
@@ -1,4 +1,4 @@
-FROM holochain/holonix:latest
+FROM nixos/nix:latest
 
 WORKDIR /holochain/build
 ENV NIX_ENV_PREFIX /holochain/build

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -8,4 +8,8 @@ box=${1:-latest}
 branch=${2:-$( git rev-parse --abbrev-ref HEAD )}
 tag="$owner/$repo:$box.$branch"
 
-docker build ./docker --build-arg DOCKER_BRANCH=$branch -f ./docker/Dockerfile.$box -t $tag --no-cache
+docker build ./docker \
+    --build-arg DOCKER_BRANCH=$branch \
+    --build-arg CACHIX_NAME="${CACHIX_NAME}" \
+    --build-arg NIX_CONFIG="${NIX_CONFIG}" \
+    -f ./docker/Dockerfile.$box -t $tag --no-cache


### PR DESCRIPTION
### Summary

using this command

```shell
curl -u ${CIRCLE_API_USER_TOKEN}: \
     -d 'build_parameters[CIRCLE_JOB]=docker-build-circle-build' \
     https://circleci.com/api/v1.1/project/github/holochain/holochain/tree/pr_attempt_fix_dockerbuilds
```

i manually triggered [a build job for the docker image on this branch](https://app.circleci.com/pipelines/github/holochain/holochain/11378/workflows/4778a779-92fe-4d88-8061-79415c29a351/jobs/22242), which succeeded.



