### PR TITLE
use latest upstream nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,7 +10,7 @@ status-level = "all"
 # Treat a test that takes longer than this period as slow, and print a message.
 # Given a non-zero positive integer, shutdown the tests when the number periods
 # have passed.
-slow-timeout = { period = "30s", shutdown-after = 2 }
+slow-timeout = { period = "30s", terminate-after = 2 }
 
 # * "immediate-final": output failures as soon as they happen and at the end of
 #   the test run

--- a/default.nix
+++ b/default.nix
@@ -46,13 +46,18 @@ let
         fi
       '';
 
+      rustPlatform = self.makeRustPlatform {
+        rustc = holonix.pkgs.custom_rustc;
+        cargo = holonix.pkgs.custom_rustc;
+      };
+
       crate2nix = import sources.crate2nix.outPath { };
 
       cargo-nextest = self.rustPlatform.buildRustPackage {
         name = "cargo-nextest";
 
         src = sources.nextest.outPath;
-        cargoSha256 = "sha256-8zJxGSlGp65BwLGEm5lb38CJZd1thAAKIKBQXMUaKRA=";
+        cargoSha256 = "sha256-E25P/vasIBQp4m3zGii7ZotzJ7b2kT6ma9glvmQXcnM=";
 
         cargoTestFlags = [
           # TODO: investigate some more why these tests fail in nix

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -24,15 +24,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nextest": {
-        "branch": "terminate_slow_tests",
+        "branch": "main",
         "description": "A next-generation test runner for Rust.",
         "homepage": "https://nexte.st",
-        "owner": "steveej-forks",
+        "owner": "nextest-rs",
         "repo": "nextest",
-        "rev": "a54bbc6ad7caa65908e42491e3f55d7b426385aa",
-        "sha256": "1cvj3ksqxlx0nv8d0xia7kff5p2ajww5nksmhk5z0l8iaq6pnkg1",
+        "rev": "cc1ebea104e5705097c9f8da69023bf80d03dd6a",
+        "sha256": "1in972hzhy2zrf18v7a5m2pgll4znk9ipyzv1nih9vp5m2sg5nlx",
         "type": "tarball",
-        "url": "https://github.com/steveej-forks/nextest/archive/a54bbc6ad7caa65908e42491e3f55d7b426385aa.tar.gz",
+        "url": "https://github.com/nextest-rs/nextest/archive/cc1ebea104e5705097c9f8da69023bf80d03dd6a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixos-unstable": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "8242e5148fab82c6259af93d4aac9267a4eac6ba",
-        "sha256": "131rch1923xvgdixyr71k4dk6z2a3x53ms5zd168brf95w9g69j4",
+        "rev": "2b874668324ae5a7804066f61afbed913ac0cb9c",
+        "sha256": "1brdayg4kaf0ybmgjli6z8v137apyyknq1w9i3cswy9n4yq5mqcv",
         "type": "tarball",
-        "url": "https://github.com/holochain/holonix/archive/8242e5148fab82c6259af93d4aac9267a4eac6ba.tar.gz",
+        "url": "https://github.com/holochain/holonix/archive/2b874668324ae5a7804066f61afbed913ac0cb9c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nextest": {


### PR DESCRIPTION
### Summary

- [x] release dry-run succeeds
  - https://github.com/holochain/holochain/actions/runs/2468797170