### PR TITLE
fix(nix-shell): set DYLD_FALLBACK_LIBRARY_PATH on darwin

### DIFF
--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -28,7 +28,13 @@ let
 
           export HC_WASM_CACHE_PATH="$CARGO_TARGET_DIR/.wasm_cache"
           mkdir -p $HC_WASM_CACHE_PATH
-        '';
+        ''
+        # workaround to make cargo-nextest work on darwin
+        # see: https://github.com/nextest-rs/nextest/issues/267
+        + (lib.strings.optionalString stdenv.isDarwin ''
+          export DYLD_FALLBACK_LIBRARY_PATH="$(rustc --print sysroot)/lib"
+        '')
+        ;
       }
 
       input


### PR DESCRIPTION
this is required for cargo-nextest to work. without this, binaries
cannot find rust's libtest as it's not in their rpath.

### Summary



### TODO:
- [x] check if a release dry-run gets beyond the previous issue with cargo-nextest on macos. (this doesn't mean tests pass there, just that they're actually executed)
  - https://github.com/holochain/holochain/actions/runs/2475493768
- [ ] ~~CHANGELOG(s) updated with appropriate info~~
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
