### PR TITLE
ci(release): prevent 'cargo publish' and 'holochain-nixpkgs tags' race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -475,8 +475,6 @@ jobs:
 
           git push origin main
 
-          git push origin main --tags
-
       - name: Push the release branch
         run: |
           source ${HOLOCHAIN_RELEASE_SH}
@@ -534,6 +532,17 @@ jobs:
               release \
                 --steps=PublishToCratesIo,AddOwnersToCratesIo
             '
+
+      - name: Push the tags
+        if: ${{ needs.vars.outputs.dry_run == 'false' }}
+        run: |
+          set -e
+          source ${HOLOCHAIN_RELEASE_SH}
+          cd "${HOLOCHAIN_REPO}"
+
+          git status
+
+          git push origin main --tags
 
       - name: Create a github release
         if: ${{ needs.vars.outputs.dry_run == 'false' }}


### PR DESCRIPTION
the race condition can happen under these conditions:

1. the cron job for the holochain release pushes a new holochain tag to
   github
2. if the cron job on holochain-nixpkgs starts now, it finds this tag
  and fails to find a published version on crates.io. it marks the tag
  as broken from which it will never recover.

to work around this in the holochain release workflow, we can publish to
crates.io first before pushing the tags to github.

### Summary



### TODO:
- [ ] ~~CHANGELOG(s) updated with appropriate info~~
- [ ] release dry-run passes
  - https://github.com/holochain/holochain/runs/6880473074
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
