### PR TITLE
ci(release): add arg to skip integration testsuite

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,6 +189,7 @@ jobs:
             restoresCargoCache: true
             savesCargoCache: true
             ignoreErrorOnNonUbuntu: true
+            maxBuildSpace: true
             timeout_minutes: 12
             max_attempts:
               ubuntu-latest: 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ on:
         required: false
         default: "true"
         type: string
+      skip_test:
+        description: "skip the integration test suite"
+        required: false
+        default: "false"
+        type: string
 
   pull_request: {}
 
@@ -68,6 +73,7 @@ jobs:
       holochain_source_branch: ${{ steps.eval.outputs.holochain_source_branch }}
       dry_run: ${{ steps.eval.outputs.dry_run }}
       debug: ${{ steps.eval.outputs.debug }}
+      skip_test: ${{ steps.eval.outputs.skip_test }}
     steps:
       - name: evaluate variables
         id: eval
@@ -80,6 +86,7 @@ jobs:
           input_holochain_source_branch: ${{ github.event.inputs.holochain_source_branch }}
           input_dry_run: ${{ github.event.inputs.dry_run}}
           input_debug: ${{ github.event.inputs.debug }}
+          input_skip_test: ${{ github.event.inputs.skip_test }}
         run: |
           set -x
 
@@ -123,6 +130,12 @@ jobs:
             echo "::set-output name=debug::false"
           else
             echo "::set-output name=debug::true"
+          fi
+
+          if [[ ${input_skip_test} != "" ]]; then
+            echo "::set-output name=skip_test::${input_skip_test}"
+          else
+            echo "::set-output name=skip_test::false"
           fi
 
           echo "::set-output name=HOLOCHAIN_REPO::/tmp/holochain_repo"
@@ -279,7 +292,7 @@ jobs:
       - name: Maximize build space
         # uses: easimon/maximize-build-space@master
         uses: AdityaGarg8/remove-unwanted-software@v1
-        if: ${{ matrix.platform == 'ubuntu-latest' && matrix.testCommand.maxBuildSpace == true }}
+        if: ${{ matrix.platform == 'ubuntu-latest' && matrix.testCommand.maxBuildSpace == true && needs.vars.outputs.skip_test != 'true' }}
         with:
           remove-dotnet: true
           remove-android: true
@@ -346,7 +359,7 @@ jobs:
             '
 
       - name: ${{ matrix.testCommand.name }} (build only)
-        if: ${{ matrix.testCommand.restoresCargoCache == true }}
+        if: ${{ matrix.testCommand.restoresCargoCache == true && needs.vars.outputs.skip_test != 'true' }}
         env:
           CARGO_TEST_ARGS: "--no-run"
           CARGO_NEXTEST_ARGS: "list"
@@ -361,6 +374,7 @@ jobs:
         continue-on-error: ${{ matrix.platform != 'ubuntu-latest' && matrix.testCommand.ignoreErrorOnNonUbuntu == true }}
 
       - name: ${{ matrix.testCommand.name }} (run)
+        if: ${{ needs.vars.outputs.skip_test != 'true' }}
         uses: nick-fields/retry@v2
         env:
           HOLOCHAIN_NIXPKGS_SOURCE_BRANCH: ${{ needs.vars.outputs.holochain_nixpkgs_source_branch }}
@@ -377,7 +391,7 @@ jobs:
         continue-on-error: ${{ matrix.platform != 'ubuntu-latest' && matrix.testCommand.ignoreErrorOnNonUbuntu == true }}
 
       - name: Garbage-collect cache
-        if: ${{ always() && matrix.testCommand.savesCargoCache == true }}
+        if: ${{ always() && matrix.testCommand.savesCargoCache == true && needs.vars.outputs.skip_test != 'true' }}
         run: |
           set -e
           source "${HOLOCHAIN_RELEASE_SH}"
@@ -388,7 +402,7 @@ jobs:
 
       - name: Cache cargo related build files
         uses: steveeJ-forks/actions-cache/save@main
-        if: ${{ always() && matrix.testCommand.savesCargoCache == true }}
+        if: ${{ always() && matrix.testCommand.savesCargoCache == true && needs.vars.outputs.skip_test != 'true' }}
         with:
           path: |
             /tmp/holochain_repo/.cargo/bin/


### PR DESCRIPTION
this can be useful when testing workflow changes that are unrelated to
the integration testsuite.

### Summary



### TODO:
- [ ] ~~CHANGELOG(s) updated with appropriate info~~
- [ ] pass release dry-run
  - [x] `skip_test=false` (not specified): https://github.com/holochain/holochain/actions/runs/2498474830
  - [ ] `skip_test=false` (explicit): https://github.com/holochain/holochain/actions/runs/2502793582
  - [x] `skip_test=true`: https://github.com/holochain/holochain/actions/runs/2498476989
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
