### PR TITLE
Zome type check

### DIFF
--- a/crates/hdk/tests/integration.rs
+++ b/crates/hdk/tests/integration.rs
@@ -121,9 +121,9 @@ fn combine_integrity_zomes() {
 
     assert!(matches!(
         EntryZomes::try_from_global_type(0u8, &Entry::try_from(integrity_zomes::A {}).unwrap()),
-        Ok(Some(EntryZomes::A(
+        Ok(EntryCheck::Found(ParseEntry::Valid(EntryZomes::A(
             integrity_zomes::integrity_a::EntryTypes::A(integrity_zomes::A {})
-        )))
+        ))))
     ));
 }
 

--- a/crates/holochain_deterministic_integrity/src/entry.rs
+++ b/crates/holochain_deterministic_integrity/src/entry.rs
@@ -115,12 +115,12 @@ pub fn must_get_valid_element(header_hash: HeaderHash) -> ExternResult<Element> 
 pub trait EntryTypesHelper: Sized {
     /// Check if the [`LocalZomeTypeId`] matches one of the Self [`LocalZomeTypeId`]'s and if
     /// it does deserialize the [`Entry`] into that types.
-    fn try_from_local_type<I>(type_index: I, entry: &Entry) -> Result<Option<Self>, WasmError>
+    fn try_from_local_type<I>(type_index: I, entry: &Entry) -> EntryCheck<Self>
     where
         LocalZomeTypeId: From<I>;
     /// Check if the [`GlobalZomeTypeId`] maps to a [`LocalZomeTypeId`] declared by Self and if
     /// it does deserialize the [`Entry`] into that types.
-    fn try_from_global_type<I>(type_index: I, entry: &Entry) -> Result<Option<Self>, WasmError>
+    fn try_from_global_type<I>(type_index: I, entry: &Entry) -> Result<EntryCheck<Self>, WasmError>
     where
         GlobalZomeTypeId: From<I>;
 }

--- a/crates/holochain_deterministic_integrity/tests/integration.rs
+++ b/crates/holochain_deterministic_integrity/tests/integration.rs
@@ -323,15 +323,21 @@ fn entry_defs_to_entry_type_index() {
 
     assert!(matches!(
         integrity_a::EntryTypes::try_from_global_type(0u8, &Entry::try_from(A {}).unwrap()),
-        Ok(Some(integrity_a::EntryTypes::A(A {})))
+        Ok(EntryCheck::Found(ParseEntry::Valid(
+            integrity_a::EntryTypes::A(A {})
+        )))
     ));
     assert!(matches!(
         integrity_a::EntryTypes::try_from_global_type(1u8, &Entry::try_from(B {}).unwrap()),
-        Ok(Some(integrity_a::EntryTypes::B(B {})))
+        Ok(EntryCheck::Found(ParseEntry::Valid(
+            integrity_a::EntryTypes::B(B {})
+        )))
     ));
     assert!(matches!(
         integrity_a::EntryTypes::try_from_global_type(2u8, &Entry::try_from(C {}).unwrap()),
-        Ok(Some(integrity_a::EntryTypes::C(C {})))
+        Ok(EntryCheck::Found(ParseEntry::Valid(
+            integrity_a::EntryTypes::C(C {})
+        )))
     ));
 
     // Set the integrity_b scope.
@@ -373,15 +379,21 @@ fn entry_defs_to_entry_type_index() {
 
     assert!(matches!(
         integrity_b::EntryTypes::try_from_global_type(3u8, &Entry::try_from(A {}).unwrap()),
-        Ok(Some(integrity_b::EntryTypes::A(A {})))
+        Ok(EntryCheck::Found(ParseEntry::Valid(
+            integrity_b::EntryTypes::A(A {})
+        )))
     ));
     assert!(matches!(
         integrity_b::EntryTypes::try_from_global_type(4u8, &Entry::try_from(B {}).unwrap()),
-        Ok(Some(integrity_b::EntryTypes::B(B {})))
+        Ok(EntryCheck::Found(ParseEntry::Valid(
+            integrity_b::EntryTypes::B(B {})
+        )))
     ));
     assert!(matches!(
         integrity_b::EntryTypes::try_from_global_type(5u8, &Entry::try_from(C {}).unwrap()),
-        Ok(Some(integrity_b::EntryTypes::C(C {})))
+        Ok(EntryCheck::Found(ParseEntry::Valid(
+            integrity_b::EntryTypes::C(C {})
+        )))
     ));
 }
 

--- a/crates/holochain_integrity_types/CHANGELOG.md
+++ b/crates/holochain_integrity_types/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Adds ZomeTypeCheck and ParseEntry.
 - KeyRef (opaque reference to a secretbox shared secret) is now an unsized byte slice [\#1410](https://github.com/holochain/holochain/pull/1410)
 
 ### Integrity / Coordinator Changes [\#1325](https://github.com/holochain/holochain/pull/1325) 

--- a/crates/holochain_integrity_types/src/entry.rs
+++ b/crates/holochain_integrity_types/src/entry.rs
@@ -9,6 +9,7 @@ use crate::capability::CapClaim;
 use crate::capability::CapGrant;
 use crate::capability::ZomeCallCapGrant;
 use crate::countersigning::CounterSigningSessionData;
+use crate::ZomeTypeCheck;
 use holo_hash::hash_type;
 use holo_hash::AgentPubKey;
 use holo_hash::EntryHash;
@@ -63,6 +64,17 @@ pub enum Entry {
     /// capabilities
     CapGrant(CapGrantEntry),
 }
+
+/// The outcome of deserializing [`Entry`] bytes to a user defined type.
+pub enum ParseEntry<T> {
+    /// The bytes successfully deserialized into `T`.
+    Valid(T),
+    /// The bytes failed to parse because of the given reason.
+    Failed(String),
+}
+
+/// The outcome of type checking and parsing a header and entry.
+pub type EntryCheck<T> = ZomeTypeCheck<ParseEntry<T>>;
 
 impl Entry {
     /// If this entry represents a capability grant, return a `CapGrant`.

--- a/crates/holochain_integrity_types/src/zome.rs
+++ b/crates/holochain_integrity_types/src/zome.rs
@@ -15,6 +15,16 @@ use holochain_serialized_bytes::prelude::*;
 #[repr(transparent)]
 pub struct ZomeName(pub Cow<'static, str>);
 
+/// Type for checking if zome types are in scope
+/// and match a given user defined type.
+pub enum ZomeTypeCheck<T = ()> {
+    /// The type does not match any global
+    /// type that is in scope for this zome.
+    NotInScope,
+    /// Found the type.
+    Found(T),
+}
+
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for ZomeName {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {

--- a/crates/test_utils/wasm/wasm_workspace/countersigning/src/integrity.rs
+++ b/crates/test_utils/wasm/wasm_workspace/countersigning/src/integrity.rs
@@ -35,16 +35,14 @@ fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
                 EntryType::App(AppEntryType { id, .. }) => Some(id),
                 _ => None,
             }) {
-                Some(id) => match EntryTypes::try_from_global_type(*id, &entry) {
-                    Ok(Some(EntryTypes::Thing(thing))) => Ok(thing.into()),
-                    Ok(None) => Ok(ValidateCallbackResult::Valid),
-                    Err(WasmError {
-                        error: WasmErrorInner::Deserialize(_),
-                        ..
-                    }) => Ok(ValidateCallbackResult::Invalid(
-                        "Failed to deserialize entry".to_string(),
-                    )),
-                    Err(e) => Err(e),
+                Some(id) => match EntryTypes::try_from_global_type(*id, &entry)? {
+                    EntryCheck::Found(ParseEntry::Valid(EntryTypes::Thing(thing))) => {
+                        Ok(thing.into())
+                    }
+                    EntryCheck::NotInScope => Ok(ValidateCallbackResult::Valid),
+                    EntryCheck::Found(ParseEntry::Failed(error)) => Ok(
+                        ValidateCallbackResult::Invalid("Failed to deserialize entry".to_string()),
+                    ),
                 },
                 None => Ok(ValidateCallbackResult::Valid),
             }

--- a/crates/test_utils/wasm/wasm_workspace/countersigning/src/integrity.rs
+++ b/crates/test_utils/wasm/wasm_workspace/countersigning/src/integrity.rs
@@ -40,7 +40,7 @@ fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
                         Ok(thing.into())
                     }
                     EntryCheck::NotInScope => Ok(ValidateCallbackResult::Valid),
-                    EntryCheck::Found(ParseEntry::Failed(error)) => Ok(
+                    EntryCheck::Found(ParseEntry::Failed(_)) => Ok(
                         ValidateCallbackResult::Invalid("Failed to deserialize entry".to_string()),
                     ),
                 },

--- a/crates/test_utils/wasm/wasm_workspace/create_entry/src/integrity.rs
+++ b/crates/test_utils/wasm/wasm_workspace/create_entry/src/integrity.rs
@@ -44,7 +44,9 @@ pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
             .map_or(
                 Ok(ValidateCallbackResult::Valid),
                 |id| match EntryTypes::try_from_global_type(*id, &entry)? {
-                    Some(EntryTypes::Post(post)) if post.0 == "Banana" => {
+                    EntryCheck::Found(ParseEntry::Valid(EntryTypes::Post(post)))
+                        if post.0 == "Banana" =>
+                    {
                         Ok(ValidateCallbackResult::Invalid("No Bananas!".to_string()))
                     }
                     _ => Ok(ValidateCallbackResult::Valid),

--- a/crates/test_utils/wasm/wasm_workspace/integrity_zome/src/lib.rs
+++ b/crates/test_utils/wasm/wasm_workspace/integrity_zome/src/lib.rs
@@ -53,11 +53,12 @@ fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
                 .to_local_scope(*entry_def_index)
             {
                 Some(local_type_index) => {
-                    match EntryTypes::try_from_local_type(local_type_index, &entry)? {
-                        Some(EntryTypes::Post(_)) => (),
-                        Some(EntryTypes::Msg(_)) => (),
-                        Some(EntryTypes::PrivMsg(_)) => (),
-                        None => (),
+                    match EntryTypes::try_from_local_type(local_type_index, &entry) {
+                        EntryCheck::Found(ParseEntry::Valid(EntryTypes::Post(_))) => (),
+                        EntryCheck::Found(ParseEntry::Valid(EntryTypes::Msg(_))) => (),
+                        EntryCheck::Found(ParseEntry::Valid(EntryTypes::PrivMsg(_))) => (),
+                        EntryCheck::Found(ParseEntry::Failed(_)) => (),
+                        EntryCheck::NotInScope => (),
                     }
                 }
                 None => (),
@@ -74,16 +75,18 @@ fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
                 None => (),
             }
             match EntryTypes::try_from_global_type(*entry_def_index, &entry)? {
-                Some(EntryTypes::Post(_)) => (),
-                Some(EntryTypes::Msg(_)) => (),
-                Some(EntryTypes::PrivMsg(_)) => (),
-                None => (),
+                EntryCheck::Found(ParseEntry::Valid(EntryTypes::Post(_))) => (),
+                EntryCheck::Found(ParseEntry::Valid(EntryTypes::Msg(_))) => (),
+                EntryCheck::Found(ParseEntry::Valid(EntryTypes::PrivMsg(_))) => (),
+                EntryCheck::Found(ParseEntry::Failed(_)) => (),
+                EntryCheck::NotInScope => (),
             }
-            match EntryTypes::try_from_local_type(UnitEntryTypes::Post, &entry)? {
-                Some(EntryTypes::Post(_)) => (),
-                Some(EntryTypes::Msg(_)) => (),
-                Some(EntryTypes::PrivMsg(_)) => (),
-                None => (),
+            match EntryTypes::try_from_local_type(UnitEntryTypes::Post, &entry) {
+                EntryCheck::Found(ParseEntry::Valid(EntryTypes::Post(_))) => (),
+                EntryCheck::Found(ParseEntry::Valid(EntryTypes::Msg(_))) => (),
+                EntryCheck::Found(ParseEntry::Valid(EntryTypes::PrivMsg(_))) => (),
+                EntryCheck::Found(ParseEntry::Failed(_)) => (),
+                EntryCheck::NotInScope => (),
             }
         }
     }

--- a/crates/test_utils/wasm/wasm_workspace/update_entry/src/integrity.rs
+++ b/crates/test_utils/wasm/wasm_workspace/update_entry/src/integrity.rs
@@ -26,23 +26,21 @@ pub fn msg() -> EntryTypes {
 #[hdk_extern]
 fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
     match op {
-        Op::StoreEntry { header, entry } => {
-            match header.hashed.app_entry_type() {
-                Some(AppEntryType {
-                    id: entry_def_index,
-                    ..
-                }) => match EntryTypes::try_from_global_type(*entry_def_index, &entry)? {
-                    Some(EntryTypes::Post(Post(p))) => {
-                        if p != "foo" {
-                            return Ok(ValidateCallbackResult::Invalid("because".into()));
-                        }
+        Op::StoreEntry { header, entry } => match header.hashed.app_entry_type() {
+            Some(AppEntryType {
+                id: entry_def_index,
+                ..
+            }) => match EntryTypes::try_from_global_type(*entry_def_index, &entry)? {
+                EntryCheck::Found(ParseEntry::Valid(EntryTypes::Post(Post(p)))) => {
+                    if p != "foo" {
+                        return Ok(ValidateCallbackResult::Invalid("because".into()));
                     }
-                    Some(EntryTypes::Msg(_)) => (),
-                    None => (),
-                },
+                }
+                EntryCheck::Found(ParseEntry::Valid(EntryTypes::Msg(_))) => (),
                 _ => (),
-            }
-        }
+            },
+            _ => (),
+        },
         _ => (),
     }
     Ok(ValidateCallbackResult::Valid)


### PR DESCRIPTION
### Summary
Small PR that adds ZomeTypeCheck and ParseEntry for checking type id's then deserializing in validation.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
