### PR TITLE
ci(release): ignore cachix errors

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -79,6 +79,7 @@ jobs:
         uses: cachix/install-nix-action@v16
       - name: Setup cachix
         uses: cachix/cachix-action@v10
+        continue-on-error: ${{ github.event_name != 'pull_request' }}
         with:
           name: holochain-ci
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
@@ -198,7 +199,6 @@ jobs:
         run: |
           source "${HOLOCHAIN_RELEASE_SH}"
           cd "${HOLOCHAIN_REPO}"
-          
           nix-shell --pure --argstr flavor release --run "./scripts/generate_readmes.sh"
 
       - name: Bump the crate versions for the release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,6 +305,7 @@ jobs:
         uses: cachix/install-nix-action@v16
       - name: Setup cachix
         uses: cachix/cachix-action@v10
+        continue-on-error: ${{ github.event_name != 'pull_request' }}
         with:
           name: holochain-ci
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"


### PR DESCRIPTION
### Summary



### TODO:
- [x] verify that release dry-run mode tolerates cachix failures: https://github.com/holochain/holochain/actions/runs/2508297723
- [x] verify that ci mode does not tolerate cachix failures: https://github.com/holochain/holochain/runs/6916340401?check_suite_focus=true