### PR TITLE
Refactor register agent activity op into struct

### DIFF
--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
@@ -7,7 +7,7 @@ use holo_hash::{ActionHash, AgentPubKey};
 use holochain_types::{dht_op::DhtOpType, inline_zome::InlineZomeSet};
 use holochain_zome_types::{
     Action, ActionType, AppEntryType, BoxApi, ChainTopOrdering, CreateInput, Entry, EntryDef,
-    EntryDefIndex, EntryVisibility, Op, TryInto, ZomeId,
+    EntryDefIndex, EntryVisibility, Op, RegisterAgentActivityOp, TryInto, ZomeId,
 };
 
 use crate::{
@@ -255,7 +255,7 @@ async fn app_validation_ops() {
                             with_entry_def_index,
                         }
                     }
-                    Op::RegisterAgentActivity { action } => Event {
+                    Op::RegisterAgentActivity(RegisterAgentActivityOp { action }) => Event {
                         action: ActionLocation::new(action.action().clone(), &agents),
                         op_type: DhtOpType::RegisterAgentActivity,
                         called_zome: zome,

--- a/crates/holochain_integrity_types/src/op.rs
+++ b/crates/holochain_integrity_types/src/op.rs
@@ -130,10 +130,7 @@ pub enum Op {
     /// Registers a new [`Action`] on an agent source chain.
     /// This is the act of creating any [`Action`] and
     /// publishing it to the DHT.
-    RegisterAgentActivity {
-        /// The signed and hashed [`Action`] that is being registered.
-        action: SignedActionHashed,
-    },
+    RegisterAgentActivity(RegisterAgentActivityOp),
     /// Registers a link between two [`Entry`]s.
     /// This is the act of creating a [`Action::CreateLink`] and
     /// publishing it to the DHT.
@@ -152,6 +149,16 @@ pub enum Op {
         /// The link that is being deleted.
         create_link: CreateLink,
     },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes)]
+#[cfg_attr(feature = "test_utils", derive(arbitrary::Arbitrary))]
+/// Registers a new [`Action`] on an agent source chain.
+/// This is the act of creating any [`Action`] and
+/// publishing it to the DHT.
+pub struct RegisterAgentActivityOp {
+    /// The signed and hashed [`Action`] that is being registered.
+    pub action: SignedActionHashed,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes)]


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
