### PR TITLE
Allow deterministic bindings to the genesis self check

### DIFF
--- a/crates/holochain/src/core/ribosome/guest_callback/genesis_self_check.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/genesis_self_check.rs
@@ -27,6 +27,7 @@ impl From<&GenesisSelfCheckHostAccess> for HostFnAccess {
     fn from(_: &GenesisSelfCheckHostAccess) -> Self {
         let mut access = Self::none();
         access.keystore_deterministic = Permission::Allow;
+        access.bindings_deterministic = Permission::Allow;
         access
     }
 }


### PR DESCRIPTION
If this isn't added, then we can't call dna_info() from inside the genesis_self_check to get the dna properties, like the progenitor. Which makes it impossible to write apps with progenitors right now.

### Summary

- Added deterministic bindings to genesis self check.


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
