### PR TITLE
Fix `hc dna pack` to be deterministic and always create same DNA hashes

### DIFF
--- a/crates/hc_bundle/tests/test_cli.rs
+++ b/crates/hc_bundle/tests/test_cli.rs
@@ -54,6 +54,33 @@ async fn roundtrip() {
 }
 
 #[tokio::test]
+async fn test_packed_hash_consistency() {
+    let mut i = 0;
+    let mut hash = None;
+    while i < 5 {
+        let mut cmd = Command::cargo_bin("hc-dna").unwrap();
+        let cmd = cmd.args(&["pack", "tests/fixtures/my-app/dnas/dna1"]);
+        cmd.assert().success();
+
+        let cmd = Command::new("sha256sum")
+            .args([r"./tests/fixtures/my-app/dnas/dna1/a dna.dna"])
+            .unwrap();
+        let sha_result = std::str::from_utf8(&cmd.stdout).unwrap().to_string();
+        let sha_result = sha_result.split(" ").collect::<Vec<_>>();
+        let new_hash = sha_result.first().unwrap().to_owned().to_owned();
+
+        match hash {
+            Some(prev_hash) => {
+                assert_eq!(prev_hash, new_hash);
+                hash = Some(new_hash)
+            }
+            None => hash = Some(new_hash),
+        }
+        i += 1;
+    }
+}
+
+#[tokio::test]
 async fn test_integrity() {
     let pack_dna = |path| async move {
         let mut cmd = Command::cargo_bin("hc-dna").unwrap();

--- a/crates/mr_bundle/CHANGELOG.md
+++ b/crates/mr_bundle/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Fix inconsistent bundle writting due to unordered map of bundle resources
+  
 ## 0.0.13
 
 ## 0.0.12

--- a/crates/mr_bundle/src/bundle.rs
+++ b/crates/mr_bundle/src/bundle.rs
@@ -8,11 +8,11 @@ use holochain_util::ffs;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::{
     borrow::Cow,
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
-pub type ResourceMap = HashMap<PathBuf, ResourceBytes>;
+pub type ResourceMap = BTreeMap<PathBuf, ResourceBytes>;
 
 /// A Manifest bundled together, optionally, with the Resources that it describes.
 /// This is meant to be serialized for standalone distribution, and deserialized


### PR DESCRIPTION
As per @jdeepee's PR https://github.com/holochain/holochain/pull/1479 (testing hypothesis that CI workflows fail because of PR from external repo) 

Summary
Fixes https://github.com/holochain/holochain/issues/1475 by storing bundle resources as a BTreeMap vs Map. Before when writing out the bundle the resources were written in an inconsistent order, causing the hash of result .dna files to differ.

TODO:
 - [x] CHANGELOG(s) updated with appropriate info
 - [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the UNRELEASED heading