### PR TITLE
Use const time hex encoding for secure_primitive Debug

### DIFF
--- a/crates/holochain_integrity_types/src/lib.rs
+++ b/crates/holochain_integrity_types/src/lib.rs
@@ -155,11 +155,12 @@ macro_rules! secure_primitive {
         /// It seems better to never try to encode secrets.
         impl std::fmt::Debug for $t {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                f.write_fmt(format_args!("{}(0x", stringify!($t)))?;
+                f.write_str(stringify!($t))?;
+                f.write_str("(0x"))?;
                 for byte in &self.0 {
                     f.write_fmt(format_args!("{:02x}", byte))?;
                 }
-                f.write_fmt(format_args!(")"))?;
+                f.write_str(")")?;
                 Ok(())
             }
         }

--- a/crates/holochain_integrity_types/src/lib.rs
+++ b/crates/holochain_integrity_types/src/lib.rs
@@ -153,12 +153,14 @@ macro_rules! secure_primitive {
         /// Also, encodings like base64 are not constant time so debugging could open some weird
         /// side channel issue trying to be 'human friendly'.
         /// It seems better to never try to encode secrets.
-        ///
-        /// @todo maybe we want something like **HIDDEN** by default and putting the actual bytes
-        ///       behind a feature flag?
         impl std::fmt::Debug for $t {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                std::fmt::Debug::fmt(&self.0.to_vec(), f)
+                f.write_fmt(format_args!("{}(0x", stringify!($t)))?;
+                for byte in &self.0 {
+                    f.write_fmt(format_args!("{:02x}", byte))?;
+                }
+                f.write_fmt(format_args!(")"))?;
+                Ok(())
             }
         }
 

--- a/crates/holochain_integrity_types/src/lib.rs
+++ b/crates/holochain_integrity_types/src/lib.rs
@@ -156,7 +156,7 @@ macro_rules! secure_primitive {
         impl std::fmt::Debug for $t {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 f.write_str(stringify!($t))?;
-                f.write_str("(0x"))?;
+                f.write_str("(0x")?;
                 for byte in &self.0 {
                     f.write_fmt(format_args!("{:02x}", byte))?;
                 }


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
