### PR TITLE
reduce build-parallelity on github CI and nix-shell size; extend free space on github CI

### DIFF
--- a/.github/actions/extend-space/action.yml
+++ b/.github/actions/extend-space/action.yml
@@ -16,6 +16,8 @@ runs:
         remove-android: true
         remove-haskell: true
         build-mount-path: /mnt/extended
+        root-reserve-mb: 512
+        swap-size-mb: 1024
 
     # after we've got the extended space mounted, we can use overlayfs and bind
     # mounts as appropriate to make this space available to all paths that are

--- a/.github/actions/extend-space/action.yml
+++ b/.github/actions/extend-space/action.yml
@@ -51,3 +51,5 @@ runs:
           -o lowerdir=${HOME}_lower,upperdir=$EXTENDED_PATH/home/upper,workdir=$EXTENDED_PATH/home/work \
           $HOME
         sudo chown $(id -u):$(id -g) $HOME
+
+        df -h

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,7 @@ jobs:
               nix-shell \
                 --keep CARGO_NEXTEST_ARGS \
                 --keep CARGO_TEST_ARGS \
+                --keep CARGO_BUILD_JOBS \
                 --fallback --pure --argstr flavor "coreDev" --run hc-test-standard-nextest
 
           - name: cargo-test-slow
@@ -203,6 +204,7 @@ jobs:
               nix-shell \
               --keep CARGO_NEXTEST_ARGS \
               --keep CARGO_TEST_ARGS \
+              --keep CARGO_BUILD_JOBS \
               --fallback --pure --argstr flavor "coreDev" --run hc-test-slow-nextest
 
           - name: cargo-test-static
@@ -216,6 +218,7 @@ jobs:
             run: |
               nix-shell \
                 --keep CARGO_TEST_ARGS \
+                --keep CARGO_BUILD_JOBS \
                 --fallback --pure --argstr flavor "coreDev" --run hc-static-checks
 
           - name: cargo-test-wasm
@@ -229,6 +232,7 @@ jobs:
             run: |
               nix-shell \
                 --keep CARGO_TEST_ARGS \
+                --keep CARGO_BUILD_JOBS \
                 --fallback --pure --argstr flavor "coreDev" --run hc-test-wasm
 
           - name: nix-test
@@ -364,7 +368,8 @@ jobs:
         if: ${{ matrix.testCommand.restoresCargoCache == true && needs.vars.outputs.skip_test != 'true' }}
         env:
           CARGO_TEST_ARGS: "--no-run"
-          CARGO_NEXTEST_ARGS: "list"
+          CARGO_NEXTEST_ARGS: "list --build-jobs=1"
+          CARGO_BUILD_JOBS: "1"
         run: |
           set -e
           source "${HOLOCHAIN_RELEASE_SH}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # \[Unreleased\]
 
+- nix-shell: exclude most holonix components by default to reduce shell size [\#1498](https://github.com/holochain/holochain/pull/1498)
+
 # 20220713.013021
 
 - **BREAKING**: the `holochain_deterministic_integrity` crate has been renamed to `hdi`

--- a/config.nix
+++ b/config.nix
@@ -10,6 +10,10 @@
     includeHolochainBinaries = false;
     includeScaffolding = false;
     includeTest = false;
+    includeNode = false;
+    includeDocs = false;
+    includeHapps = false;
+    includeRelease = false;
 
     # configuration for when use-github = false
     local = {
@@ -27,6 +31,11 @@
         scaffolding = args.include.scaffolding or includeScaffolding;
         test = args.include.test or includeTest;
         holochainBinaries = args.include.holochainBinaries or includeHolochainBinaries;
+
+        node = args.include.node or includeScaffolding;
+        docs = args.include.docs or includeDocs;
+        happs = args.include.happs or includeHapps;
+        release = args.include.release or includeRelease;
       };
     }));
   };

--- a/default.nix
+++ b/default.nix
@@ -4,9 +4,7 @@
     version = "1.60.0";
   }
 
-, holonixArgs ? {
-    inherit rustVersion;
-  }
+, holonixArgs ? { }
 }:
 
 # This is an example of what downstream consumers of holonix should do
@@ -20,7 +18,7 @@ let
 
   # START HOLONIX IMPORT BOILERPLATE
   holonixPath = config.holonix.pathFn { };
-  holonix = config.holonix.importFn holonixArgs;
+  holonix = config.holonix.importFn ({ inherit rustVersion; } // holonixArgs);
   # END HOLONIX IMPORT BOILERPLATE
 
   overlays = [


### PR DESCRIPTION
### Summary



### TODO:
- [x] [dry-run](https://github.com/holochain/holochain/runs/7557807562?check_suite_focus=true)
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
