### PR TITLE
feat: add the `hdi_version_req` to build-info

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Add the `hdi_version_req` key:value field to the output of the `--build-info` argument
+
 ## 0.0.152
 
 - Adds `AdminRequest::UpdateCoordinators` that allows swapping coordinator zomes for a running happ.
@@ -163,7 +165,7 @@ network:
 - **BREAKING CHANGE** `entry_defs` added to `zome_info` and referenced by macros [PR1055](https://github.com/holochain/holochain/pull/1055)
 
 - **BREAKING CHANGE**: The notion of “cell nicknames” (“nicks”) and “app slots” has been unified into the notion of “app roles”. This introduces several breaking changes. In general, you will need to rebuild any app bundles you are using, and potentially update some usages of the admin interface. In particular:
-  
+
   - The `slots` field in App manifests is now called `roles`
   - The `InstallApp` admin method now takes a `role_id` field instead of a `nick` field
   - In the return value for any admin method which lists installed apps, e.g. `ListEnabledApps`, any reference to `"slots"` is now named `"roles"`
@@ -193,7 +195,7 @@ network:
 - `call_info` is now implemented [1047](https://github.com/holochain/holochain/pull/1047)
 
 - `dna_info` now returns `DnaInfo` correctly [\#1044](https://github.com/holochain/holochain/pull/1044)
-  
+
   - `ZomeInfo` no longer includes what is now on `DnaInfo`
   - `ZomeInfo` renames `zome_name` and `zome_id` to `name` and `id`
   - `DnaInfo` includes `name`, `hash`, `properties`

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -21,7 +21,7 @@ let
 
       {
         shellHook = ''
-          echo Using "$NIX_ENV_PREFIX" as target prefix...
+          >&2 echo Using "$NIX_ENV_PREFIX" as target prefix...
 
           export HC_TEST_WASM_DIR="$CARGO_TARGET_DIR/.wasm_target"
           mkdir -p $HC_TEST_WASM_DIR


### PR DESCRIPTION
### Summary



### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
