### PR TITLE
unique tls per conductor

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Updates TLS certificate handling so that multiple conductors can share the same lair, but use different TLS certificates by storing a "tag" in the conductor state database. This should not be a breaking change, but *will* result in a new TLS certificate being used per conductor. [\#1519](https://github.com/holochain/holochain/pull/1519)
 - **BREAKING CHANGE** - Removes legacy lair. You must now use lair-keystore >= 0.2.0 with holochain. It is recommended to abandon your previous holochain agents, as there is not a straight forward migration path. To migrate: [dump the old keys](https://github.com/holochain/lair/blob/v0.0.11/crates/lair_keystore/src/bin/lair-keystore/main.rs#L38) -> [write a utility to re-encode them](https://github.com/holochain/lair/tree/hc_seed_bundle-v0.1.2/crates/hc_seed_bundle) -> [then import them to the new lair](https://github.com/holochain/lair/tree/lair_keystore-v0.2.0/crates/lair_keystore#lair-keystore-import-seed---help) -- [\#1518](https://github.com/holochain/holochain/pull/1518)
 
 ## 0.0.154

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -64,13 +64,12 @@ use holochain_keystore::test_keystore::spawn_test_keystore;
 use holochain_keystore::MetaLairClient;
 use holochain_sqlite::prelude::*;
 use holochain_sqlite::sql::sql_cell::state_dump;
-use holochain_state::mutations;
 use holochain_state::prelude::from_blob;
 use holochain_state::prelude::StateMutationResult;
 use holochain_state::prelude::StateQueryResult;
 use holochain_types::prelude::*;
 pub use holochain_types::share;
-use rusqlite::{OptionalExtension, Transaction};
+use rusqlite::Transaction;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
@@ -1321,29 +1320,7 @@ impl Conductor {
     }
 
     pub(super) async fn get_state(&self) -> ConductorResult<ConductorState> {
-        let state = self
-            .spaces
-            .conductor_db
-            .async_reader(|txn| {
-                let state = txn
-                    .query_row("SELECT blob FROM ConductorState WHERE id = 1", [], |row| {
-                        row.get("blob")
-                    })
-                    .optional()?;
-                match state {
-                    Some(state) => ConductorResult::Ok(Some(from_blob(state)?)),
-                    None => ConductorResult::Ok(None),
-                }
-            })
-            .await?;
-
-        match state {
-            Some(state) => Ok(state),
-            // update_state will again try to read the state. It's a little
-            // inefficient in the infrequent case where we haven't saved the
-            // state yet, but more atomic, so worth it.
-            None => self.update_state(Ok).await,
-        }
+        self.spaces.get_state().await
     }
 
     /// Update the internal state with a pure function mapping old state to new
@@ -1351,8 +1328,7 @@ impl Conductor {
     where
         F: FnOnce(ConductorState) -> ConductorResult<ConductorState> + 'static,
     {
-        let (state, _) = self.update_state_prime(|s| Ok((f(s)?, ()))).await?;
-        Ok(state)
+        self.spaces.update_state(f).await
     }
 
     /// Update the internal state with a pure function mapping old state to new,
@@ -1364,25 +1340,7 @@ impl Conductor {
         O: Send + 'static,
     {
         self.check_running()?;
-        let output = self
-            .spaces
-            .conductor_db
-            .async_commit(move |txn| {
-                let state = txn
-                    .query_row("SELECT blob FROM ConductorState WHERE id = 1", [], |row| {
-                        row.get("blob")
-                    })
-                    .optional()?;
-                let state = match state {
-                    Some(state) => from_blob(state)?,
-                    None => ConductorState::default(),
-                };
-                let (new_state, output) = f(state)?;
-                mutations::insert_conductor_state(txn, (&new_state).try_into()?)?;
-                Result::<_, ConductorError>::Ok((new_state, output))
-            })
-            .await?;
-        Ok(output)
+        self.spaces.update_state_prime(f).await
     }
 
     fn add_admin_port(&self, port: u16) {
@@ -1495,9 +1453,12 @@ mod builder {
 
             let ribosome_store = RwShare::new(ribosome_store);
 
+            let spaces = Spaces::new(&config)?;
+            let tag = spaces.get_state().await?.tag().clone();
+
             let network_config = config.network.clone().unwrap_or_default();
             let (cert_digest, cert, cert_priv_key) =
-                keystore.get_or_create_first_tls_cert().await?;
+                keystore.get_or_create_tls_cert_by_tag(tag.0).await?;
             let tls_config =
                 holochain_p2p::kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig {
                     cert,
@@ -1507,7 +1468,6 @@ mod builder {
             let strat =
                 ArqStrat::from_params(network_config.tuning_params.gossip_redundancy_target);
 
-            let spaces = Spaces::new(&config)?;
             let host = KitsuneHostImpl::new(
                 spaces.clone(),
                 ribosome_store.clone(),

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -48,7 +48,9 @@ async fn can_update_state() {
     .await
     .unwrap();
     let state = conductor.get_state().await.unwrap();
-    assert_eq!(state, ConductorState::default());
+    let mut expect_state = ConductorState::default();
+    expect_state.set_tag(state.tag().clone());
+    assert_eq!(state, expect_state);
 
     let cell_id = fake_cell_id(1);
     let installed_cell = InstalledCell::new(cell_id.clone(), "role_id".to_string());

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -27,6 +27,7 @@ use holochain_sqlite::{
     prelude::{DatabaseError, DatabaseResult},
 };
 use holochain_state::{
+    mutations,
     prelude::{from_blob, StateQueryResult},
     query::{map_sql_dht_op_common, StateQueryError},
 };
@@ -39,9 +40,10 @@ use kitsune_p2p::{
     event::{TimeWindow, TimeWindowInclusive},
     KitsuneP2pConfig,
 };
-use rusqlite::named_params;
+use rusqlite::{named_params, OptionalExtension};
 use tracing::instrument;
 
+use crate::conductor::{error::ConductorError, state::ConductorState};
 use crate::core::{
     queue_consumer::QueueConsumerMap,
     workflow::{
@@ -154,6 +156,69 @@ impl Spaces {
             wasm_db,
             network_config: config.network.clone().unwrap_or_default(),
         })
+    }
+
+    /// Get the holochain conductor state
+    pub async fn get_state(&self) -> ConductorResult<ConductorState> {
+        let state = self
+            .conductor_db
+            .async_reader(|txn| {
+                let state = txn
+                    .query_row("SELECT blob FROM ConductorState WHERE id = 1", [], |row| {
+                        row.get("blob")
+                    })
+                    .optional()?;
+                match state {
+                    Some(state) => ConductorResult::Ok(Some(from_blob(state)?)),
+                    None => ConductorResult::Ok(None),
+                }
+            })
+            .await?;
+
+        match state {
+            Some(state) => Ok(state),
+            // update_state will again try to read the state. It's a little
+            // inefficient in the infrequent case where we haven't saved the
+            // state yet, but more atomic, so worth it.
+            None => self.update_state(Ok).await,
+        }
+    }
+
+    /// Update the internal state with a pure function mapping old state to new
+    pub async fn update_state<F: Send>(&self, f: F) -> ConductorResult<ConductorState>
+    where
+        F: FnOnce(ConductorState) -> ConductorResult<ConductorState> + 'static,
+    {
+        let (state, _) = self.update_state_prime(|s| Ok((f(s)?, ()))).await?;
+        Ok(state)
+    }
+
+    /// Update the internal state with a pure function mapping old state to new,
+    /// which may also produce an output value which will be the output of
+    /// this function
+    pub async fn update_state_prime<F, O>(&self, f: F) -> ConductorResult<(ConductorState, O)>
+    where
+        F: FnOnce(ConductorState) -> ConductorResult<(ConductorState, O)> + Send + 'static,
+        O: Send + 'static,
+    {
+        let output = self
+            .conductor_db
+            .async_commit(move |txn| {
+                let state = txn
+                    .query_row("SELECT blob FROM ConductorState WHERE id = 1", [], |row| {
+                        row.get("blob")
+                    })
+                    .optional()?;
+                let state = match state {
+                    Some(state) => from_blob(state)?,
+                    None => ConductorState::default(),
+                };
+                let (new_state, output) = f(state)?;
+                mutations::insert_conductor_state(txn, (&new_state).try_into()?)?;
+                Result::<_, ConductorError>::Ok((new_state, output))
+            })
+            .await?;
+        Ok(output)
     }
 
     /// Get something from every space

--- a/crates/holochain/src/conductor/state.rs
+++ b/crates/holochain/src/conductor/state.rs
@@ -17,7 +17,7 @@ use super::error::{ConductorError, ConductorResult};
 #[serde(transparent)]
 pub struct ConductorStateTag(pub Arc<str>);
 
-impl Default for Tag {
+impl Default for ConductorStateTag {
     fn default() -> Self {
         Self(nanoid::nanoid!().into())
     }
@@ -33,7 +33,7 @@ impl Default for Tag {
 pub struct ConductorState {
     /// Unique conductor tag / identifier.
     #[serde(default)]
-    tag: Tag,
+    tag: ConductorStateTag,
     /// Apps that have been installed, regardless of status.
     #[serde(default)]
     installed_apps: InstalledAppMap,
@@ -76,12 +76,12 @@ impl AppInterfaceId {
 
 impl ConductorState {
     /// A unique identifier for this conductor
-    pub fn tag(&self) -> &Tag {
+    pub fn tag(&self) -> &ConductorStateTag {
         &self.tag
     }
 
     #[cfg(test)]
-    pub fn set_tag(&mut self, tag: Tag) {
+    pub fn set_tag(&mut self, tag: ConductorStateTag) {
         self.tag = tag;
     }
 

--- a/crates/holochain/src/conductor/state.rs
+++ b/crates/holochain/src/conductor/state.rs
@@ -15,7 +15,7 @@ use super::error::{ConductorError, ConductorResult};
 #[derive(Clone, Deserialize, Serialize, Debug, SerializedBytes)]
 #[cfg_attr(test, derive(PartialEq))]
 #[serde(transparent)]
-pub struct Tag(pub Arc<str>);
+pub struct ConductorStateTag(pub Arc<str>);
 
 impl Default for Tag {
     fn default() -> Self {

--- a/crates/holochain/src/conductor/state.rs
+++ b/crates/holochain/src/conductor/state.rs
@@ -7,8 +7,21 @@ use holochain_types::prelude::*;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use super::error::{ConductorError, ConductorResult};
+
+/// Unique conductor tag / identifier.
+#[derive(Clone, Deserialize, Serialize, Debug, SerializedBytes)]
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(transparent)]
+pub struct Tag(pub Arc<str>);
+
+impl Default for Tag {
+    fn default() -> Self {
+        Self(nanoid::nanoid!().into())
+    }
+}
 
 /// Mutable conductor state, stored in a DB and writable only via Admin interface.
 ///
@@ -18,7 +31,10 @@ use super::error::{ConductorError, ConductorResult};
 #[derive(Clone, Deserialize, Serialize, Default, Debug, SerializedBytes)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct ConductorState {
-    /// Apps that have been installed, regardless of status
+    /// Unique conductor tag / identifier.
+    #[serde(default)]
+    tag: Tag,
+    /// Apps that have been installed, regardless of status.
     #[serde(default)]
     installed_apps: InstalledAppMap,
     /// List of interfaces any UI can use to access zome functions.
@@ -59,6 +75,16 @@ impl AppInterfaceId {
 }
 
 impl ConductorState {
+    /// A unique identifier for this conductor
+    pub fn tag(&self) -> &Tag {
+        &self.tag
+    }
+
+    #[cfg(test)]
+    pub fn set_tag(&mut self, tag: Tag) {
+        self.tag = tag;
+    }
+
     /// Immutable access to the inner collection of all apps
     pub fn installed_apps(&self) -> &InstalledAppMap {
         &self.installed_apps


### PR DESCRIPTION
### Summary

DEPENDS ON https://github.com/holochain/holochain/pull/1518

Give each conductor a unique id stored in conductor state. This will allow multiple conductors sharing a single lair instance to each have a unique TLS certificate to avoid conflict.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
