### PR TITLE
add hdi_version_req to BUILD_INFO

### DIFF
--- a/crates/hdi/src/lib.rs
+++ b/crates/hdi/src/lib.rs
@@ -75,6 +75,9 @@
 //! <https://github.com/holochain/holochain/blob/develop/crates/test_utils/wasm/wasm_workspace/validate/src/integrity.rs>.
 //! Many more validation examples can be browsed in that very workspace.
 
+/// Current HDI rust crate version.
+pub const HDI_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub use hdk_derive::hdk_entry_defs;
 pub use hdk_derive::hdk_entry_helper;
 pub use hdk_derive::hdk_extern;

--- a/crates/hdk/src/lib.rs
+++ b/crates/hdk/src/lib.rs
@@ -259,6 +259,11 @@
 //!
 //! [`hdk_extern!`]: hdk_derive::hdk_extern
 
+pub use hdi::HDI_VERSION;
+
+/// Current HDK rust crate version.
+pub const HDK_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 const ERAND_INTERNAL: u32 = getrandom::Error::CUSTOM_START + 1;
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Revert: "Add the `hdi_version_req` key:value field to the output of the `--build-info` argument" because it broke. [\#1521](https://github.com/holochain/holochain/pull/1521)
 
   Reason: it causes a build failure of the _holochain_  crate on crates.io
+- New solution for adding `hdi_version_req` field to the output of `--build-info` argument. [\#1523](https://github.com/holochain/holochain/pull/1523)
 
 ## 0.0.153
 

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -110,6 +110,7 @@ unwrap_to = { version = "0.1.0", optional = false }
 arbitrary = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
+hdk = { version = "0.0.145", path = "../hdk"}
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0.51" }
 toml = "0.5.6"

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -110,7 +110,7 @@ unwrap_to = { version = "0.1.0", optional = false }
 arbitrary = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-hdk = { version = "0.0.145", path = "../hdk"}
+hdk = { version = "0.0.146", path = "../hdk"}
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0.51" }
 toml = "0.5.6"

--- a/crates/holochain/src/lib.rs
+++ b/crates/holochain/src/lib.rs
@@ -5,6 +5,15 @@
 // We have a lot of usages of type aliases to `&String`, which clippy objects to.
 #![allow(clippy::ptr_arg)]
 
+#[cfg(feature = "hdk")]
+pub use hdk::HDI_VERSION;
+
+#[cfg(feature = "hdk")]
+pub use hdk::HDK_VERSION;
+
+/// Current Holochain Conductor rust crate version.
+pub const HC_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub mod conductor;
 #[allow(missing_docs)]
 pub mod core;


### PR DESCRIPTION
### Summary

- New solution for adding `hdi_version_req` field to the output of `--build-info` argument.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
