### PR TITLE
Fix the gossip bug

### DIFF
--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Fixes a regression where a node can prematurely end a gossip round if their partner signals that they are done sending data, even if the node itself still has more data to send, which can lead to persistent timeouts between the two nodes. [\#1553](https://github.com/holochain/holochain/pull/1553)
+
 ## 0.0.42
 
 ## 0.0.41

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
@@ -339,7 +339,7 @@ impl OpsBatchQueue {
         self.0
             .share_mut(|i, _| {
                 i.queues.retain(|_, q| !q.is_empty());
-                Ok(i.queues.is_empty())
+                Ok(i.queues.is_empty() && i.region_queue.is_empty())
             })
             .unwrap_or(true)
     }


### PR DESCRIPTION
### Summary

This nasty bug was introduced during quantized gossip because of the introduction of a separate queue of region data, alongside the op queue. The function checking whether all queues are empty is used as part of the check to determine if a gossip round is complete. Since this function neglected to check the region queue, a gossip round could be prematurely ended if a node received a final MissingOps batch from their partner, even if the node itself still had more data to send. Correcting this fix seems to fix the problem I was reproducing in `large_entry_test`.

This bug was showing up in the wild when gossiping large amounts of data, in particular when DevHub was trying to gossip all hApp data to another node, which can be tens or hundreds of MB. The reason why this bug would much more likely show up with asymmetric transfer of large amounts of data is because there is 16MB limit on the amount of data that can be sent in a single gossip message. When both peers' op data is less than 16MB in total, both peers can safely end their gossip rounds after sending the single payload of op data. The bug still manifest in that situation, but it's not a problem because even though one node finishes prematurely, they are still ready to finish as soon as they send their own op payload. The problem only manifests when one node has more than one op payload to send, in which case they never actually send any payloads after receiving the final one from their partner.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
