### PR TITLE
feat(release-automation): implement pre-release version increments

### DIFF
--- a/crates/release-automation/src/lib/changelog.rs
+++ b/crates/release-automation/src/lib/changelog.rs
@@ -343,10 +343,8 @@ where
 
             // we're only interested in the frontmatter here
             if let NodeValue::FrontMatter(ref fm) = &mut node.data.borrow_mut().value {
-                let fm_str = String::from_utf8(fm.to_vec())?
-                    .replace("---", "")
-                    .trim()
-                    .to_owned();
+                let fm_str_raw = String::from_utf8(fm.to_vec())?;
+                let fm_str = fm_str_raw.replace("---", "").trim().to_owned();
 
                 let fm: Frontmatter = if fm_str.is_empty() {
                     Frontmatter::default()
@@ -358,7 +356,7 @@ where
                     "[{}] found a YAML front matter: {:#?}\nsource string: \n'{}'",
                     i,
                     fm,
-                    fm_str
+                    fm_str_raw
                 );
 
                 return Ok(Some(fm));

--- a/crates/release-automation/src/lib/changelog.rs
+++ b/crates/release-automation/src/lib/changelog.rs
@@ -16,6 +16,9 @@ use std::path::{Path, PathBuf};
 use std::{cell::RefCell, convert::TryFrom};
 use std::{collections::HashSet, convert::TryInto};
 
+/// This data structure helps implement the YAML-type frontmatter for `ChangelogT`.
+/// Please see the [serde_yaml docs](https://docs.rs/serde_yaml/0.9.11/serde_yaml/index.html#using-serde-derive)
+/// for several syntax examples.
 #[derive(Clone, Default, Debug, PartialEq, Deserialize, Serialize)]
 pub(crate) struct Frontmatter {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/release-automation/src/lib/changelog.rs
+++ b/crates/release-automation/src/lib/changelog.rs
@@ -1403,12 +1403,7 @@ mod tests {
             (
                 "crate_b",
                 workspace_mocker.root().join("crates/crate_b/CHANGELOG.md"),
-                vec![
-                    ChangeT::Unreleased,
-                    ChangeT::Release(ReleaseChange::CrateReleaseChange(
-                        "0.0.0-alpha.1".to_string(),
-                    )),
-                ],
+                vec![ChangeT::Unreleased],
             ),
             (
                 "crate_c",

--- a/crates/release-automation/src/lib/changelog.rs
+++ b/crates/release-automation/src/lib/changelog.rs
@@ -461,7 +461,7 @@ impl<'a> ChangelogT<'a, CrateChangelog> {
         Ok(())
     }
 
-    fn erase_front_matter(&'a self, write_file: bool) -> Fallible<String> {
+    pub(crate) fn erase_front_matter(&'a self, write_file: bool) -> Fallible<String> {
         let frontmatter_re = regex::Regex::new(r"(?ms)^---$.*^---$\w*").unwrap();
         let cl = sanitize(std::fs::read_to_string(self.path())?);
 
@@ -477,7 +477,7 @@ impl<'a> ChangelogT<'a, CrateChangelog> {
     }
 
     /// Writes the given Frontmatter back to the changelog file
-    fn set_front_matter(&'a self, fm: &Frontmatter) -> Fallible<()> {
+    pub(crate) fn set_front_matter(&'a self, fm: &Frontmatter) -> Fallible<()> {
         let cl_str = if self.front_matter()?.is_some() {
             self.erase_front_matter(false)?
         } else {

--- a/crates/release-automation/src/lib/common.rs
+++ b/crates/release-automation/src/lib/common.rs
@@ -3,6 +3,7 @@ use std::{
     path::Path,
 };
 
+use cargo::util::VersionExt;
 use semver::VersionReq;
 use serde::{Deserialize, Serialize};
 
@@ -140,11 +141,15 @@ fn load_from_file(path: &Path) -> Fallible<String> {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub(crate) enum SemverIncrementMode {
     Major,
     Minor,
     Patch,
+    Pre(String),
+    PreMajor(String),
+    PreMinor(String),
+    PrePatch(String),
 }
 
 impl Default for SemverIncrementMode {
@@ -153,25 +158,137 @@ impl Default for SemverIncrementMode {
     }
 }
 
-/// Increment the given Version according to the given `SemVerIncrementMode`.
-pub(crate) fn increment_semver(v: &mut semver::Version, mode: SemverIncrementMode) {
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub(crate) enum SemverIncrementError {
+    #[error("resulting version ({result}) is lower than on entry ({entry})")]
+    ResultingVersionLower {
+        result: semver::Version,
+        entry: semver::Version,
+    },
+
+    #[error("pre-release increment requested but none found on entry ({entry})")]
+    MissingPreRelease { entry: semver::Version },
+}
+
+fn evaluate_suffix<'a>(suffix_requested: &'a str, pre: &'a semver::Prerelease) -> (&'a str, usize) {
+    let (suffix, counter) = match pre.rsplit_once('.') {
+        Some((suffix, maybe_number)) => {
+            if let Ok(number) = maybe_number.parse::<usize>() {
+                (suffix, number + 1)
+            } else {
+                (pre.as_str(), 0)
+            }
+        }
+
+        None => (pre.as_str(), 0),
+    };
+
+    if suffix != suffix_requested {
+        (suffix_requested, 0)
+    } else {
+        (suffix, counter)
+    }
+}
+
+/// Implements version incrementation as specified in [SemVer 2.0.0](https://semver.org/spec/v2.0.0.html)
+/// Currently resets [Build metadata](https://semver.org/spec/v2.0.0.html#spec-item-10).
+pub(crate) fn increment_semver<'a>(
+    v: &'a mut semver::Version,
+    mode: SemverIncrementMode,
+) -> Fallible<()> {
+    use SemverIncrementMode::*;
+
+    v.build = semver::BuildMetadata::EMPTY;
+
+    let entry_version = v.clone();
+
     match mode {
-        SemverIncrementMode::Major => {
-            v.major += 1;
-            v.minor = 0;
-            v.patch = 0;
+        Major => {
+            if !v.pre.is_empty() && v.patch == 0 && v.minor == 0 {
+                v.pre = semver::Prerelease::EMPTY;
+            } else {
+                v.major += 1;
+                v.minor = 0;
+                v.patch = 0;
+                v.pre = semver::Prerelease::EMPTY;
+            }
         }
-        SemverIncrementMode::Minor => {
-            v.minor += 1;
-            v.patch = 0;
+        Minor => {
+            if !v.pre.is_empty() && v.patch == 0 {
+                v.pre = semver::Prerelease::EMPTY;
+            } else {
+                v.minor += 1;
+                v.patch = 0;
+                v.pre = semver::Prerelease::EMPTY;
+            }
         }
-        SemverIncrementMode::Patch => {
-            v.patch += 1;
+        Patch => {
+            if !v.pre.is_empty() {
+                v.pre = semver::Prerelease::EMPTY;
+            } else {
+                v.patch += 1;
+                v.pre = semver::Prerelease::EMPTY;
+            }
+        }
+
+        pre_modes => {
+            let (suffix, counter) = match &pre_modes {
+                Major | Minor | Patch => unreachable!(
+                    r"
+                        this arm is already fully covered in the surrounding match statement.
+                        i'm surprised the compiler doesn't understand this ¯\_(ツ)_/¯
+                    "
+                ),
+
+                Pre(suffix_requested) => {
+                    if !v.is_prerelease() {
+                        bail!(SemverIncrementError::MissingPreRelease { entry: v.clone() });
+                    }
+
+                    evaluate_suffix(&suffix_requested, &v.pre)
+                }
+
+                PreMajor(suffix_requested) => {
+                    if v.minor == 0 && v.patch == 0 && v.is_prerelease() {
+                        evaluate_suffix(suffix_requested.as_str(), &v.pre)
+                    } else {
+                        increment_semver(v, SemverIncrementMode::Major)?;
+                        (suffix_requested.as_str(), 0)
+                    }
+                }
+
+                PreMinor(suffix_requested) => {
+                    if v.patch == 0 && v.is_prerelease() {
+                        evaluate_suffix(suffix_requested.as_str(), &v.pre)
+                    } else {
+                        increment_semver(v, SemverIncrementMode::Minor)?;
+                        (suffix_requested.as_str(), 0)
+                    }
+                }
+
+                PrePatch(suffix_requested) => {
+                    if v.is_prerelease() {
+                        evaluate_suffix(suffix_requested.as_str(), &v.pre)
+                    } else {
+                        increment_semver(v, SemverIncrementMode::Patch)?;
+                        (suffix_requested.as_str(), 0)
+                    }
+                }
+            };
+
+            let final_pre = format!("{}.{}", suffix, counter);
+            v.pre = semver::Prerelease::new(&final_pre)?;
         }
     }
 
-    v.pre = semver::Prerelease::EMPTY;
-    v.build = semver::BuildMetadata::EMPTY;
+    if &entry_version >= &v {
+        bail!(SemverIncrementError::ResultingVersionLower {
+            result: v.clone(),
+            entry: entry_version,
+        });
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -183,23 +300,100 @@ mod test {
         SemverIncrementMode::{self, *},
     };
 
-    #[test_case("0.0.1", "0.0.2", Patch; "patch version bump")]
-    #[test_case("0.0.1", "0.1.0", Minor; "minor version bump")]
-    #[test_case("0.0.1", "1.0.0", Major; "major version bump")]
-    #[test_case("0.0.1-dev.0", "0.0.2", Patch; "patch version bump from pre-release")]
-    #[test_case("0.0.1-dev.0", "0.1.0", Minor; "minor version bump from pre-release")]
-    #[test_case("0.0.1-dev.0", "1.0.0", Major; "major version bump from pre-release")]
-    #[test_case("0.1.1-dev.0", "0.2.0", Minor; "non-zero minor version bump from pre-release")]
-    #[test_case("1.0.1-dev.0", "2.0.0", Major; "non-zero major version bump from pre-release")]
+    use super::SemverIncrementError;
+
+    //
+    // Major
+    //
+    #[test_case(Major, "0.0.0-dev.0", "0.0.0")]
+    #[test_case(Major, "0.0.1-dev.0", "1.0.0")]
+    #[test_case(Major, "0.0.1", "1.0.0")]
+    #[test_case(Major, "1.0.0-dev.0", "1.0.0")]
+    #[test_case(Major, "1.0.0", "2.0.0")]
+    #[test_case(Major, "1.0.1-dev.0", "2.0.0")]
+    #[test_case(Major, "1.1.1-dev.0", "2.0.0")]
+    #[test_case(Major, "1.1.1", "2.0.0")]
+    //
+    // Minor
+    //
+    #[test_case(Minor, "0.0.1", "0.1.0")]
+    #[test_case(Minor, "0.0.1-dev.0", "0.1.0")]
+    #[test_case(Minor, "0.1.1-dev.0", "0.2.0")]
+    //
+    // Patch
+    //
+    #[test_case(Patch, "0.0.0-dev.0", "0.0.0")]
+    #[test_case(Patch, "0.0.1-dev.0", "0.0.1")]
+    #[test_case(Patch, "0.0.1", "0.0.2")]
+    #[test_case(Patch, "0.1.1", "0.1.2")]
+    #[test_case(Patch, "1.1.1", "1.1.2")]
+    //
+    // Pre
+    //
+    #[test_case(Pre("rc".to_string()), "0.0.1-dev.0", "0.0.1-rc.0")]
+    #[test_case(Pre("rc".to_string()), "0.0.1-rc.0", "0.0.1-rc.1")]
+    //
+    // PreMajor
+    //
+    #[test_case(PreMajor("rc".to_string()), "0.0.0", "1.0.0-rc.0")]
+    #[test_case(PreMajor("rc".to_string()), "0.0.1", "1.0.0-rc.0")]
+    #[test_case(PreMajor("rc".to_string()), "0.1.0", "1.0.0-rc.0")]
+    #[test_case(PreMajor("rc".to_string()), "0.1.1", "1.0.0-rc.0")]
+    // TODO: check with someone else if this seems counter-intuitive
+    #[test_case(PreMajor("rc".to_string()), "1.0.0-rc", "1.0.0-rc.0")]
+    // TODO: check with someone else if this seems counter-intuitive
+    #[test_case(PreMajor("rc".to_string()), "1.0.0-rc.0", "1.0.0-rc.1")]
+    //
+    // PreMinor
+    //
+    #[test_case(PreMinor("rc".to_string()), "0.0.0", "0.1.0-rc.0")]
+    #[test_case(PreMinor("rc".to_string()), "0.0.1-rc.0", "0.1.0-rc.0")]
+    // TODO: check with someone else if this seems counter-intuitive
+    #[test_case(PreMinor("rc".to_string()), "0.1.0-rc", "0.1.0-rc.0")]
+    // TODO: check with someone else if this seems counter-intuitive
+    #[test_case(PreMinor("rc".to_string()), "0.1.0-rc.0", "0.1.0-rc.1")]
+    //
+    // PrePatch
+    //
+    #[test_case(PrePatch("rc".to_string()), "0.0.0", "0.0.1-rc.0")]
+    #[test_case(PrePatch("rc".to_string()), "0.0.1", "0.0.2-rc.0")]
+    #[test_case(PrePatch("rc".to_string()), "0.1.1", "0.1.2-rc.0")]
+    #[test_case(PrePatch("rc".to_string()), "1.1.0", "1.1.1-rc.0")]
+    #[test_case(PrePatch("rc".to_string()), "1.1.1-rc", "1.1.1-rc.0")]
+    #[test_case(PrePatch("rc".to_string()), "1.1.1-rc.0", "1.1.1-rc.1")]
+    #[test_case(PrePatch("rc".to_string()), "1.0.0", "1.0.1-rc.0")]
+    // TODO: check with someone else if this seems counter-intuitive
+    #[test_case(PrePatch("rc".to_string()), "0.0.0-rc", "0.0.0-rc.0")]
+    // TODO: check with someone else if this seems counter-intuitive
+    #[test_case(PrePatch("rc".to_string()), "0.0.0-rc.0", "0.0.0-rc.1")]
     fn increment_semver_consistency(
+        increment_mode: SemverIncrementMode,
         input_version: &str,
         expected_version: &str,
-        increment_mode: SemverIncrementMode,
     ) {
         let mut working_version = semver::Version::parse(input_version).unwrap();
-        increment_semver(&mut working_version, increment_mode);
+        increment_semver(&mut working_version, increment_mode).unwrap();
 
         let expected_version = semver::Version::parse(expected_version).unwrap();
         assert_eq!(expected_version, working_version);
+    }
+
+    //
+    // errors
+    //
+    #[test_case(Pre("rc".to_string()), "0.0.1", SemverIncrementError::MissingPreRelease { entry:  semver::Version::new(0,0,1)})]
+    #[test_case(Pre("a".to_string()), "0.0.1-b", SemverIncrementError::ResultingVersionLower { result: semver::Version::parse("0.0.1-a.0").unwrap(), entry:  semver::Version::parse("0.0.1-b").unwrap()})]
+    fn increment_semver_consistency_failure(
+        increment_mode: SemverIncrementMode,
+        input_version: &str,
+        expected_error: SemverIncrementError,
+    ) {
+        let mut working_version = semver::Version::parse(input_version).unwrap();
+        let err: SemverIncrementError = increment_semver(&mut working_version, increment_mode)
+            .unwrap_err()
+            .downcast()
+            .unwrap();
+
+        assert_eq!(expected_error, err, "{:?}", err)
     }
 }

--- a/crates/release-automation/src/lib/crate_.rs
+++ b/crates/release-automation/src/lib/crate_.rs
@@ -400,7 +400,7 @@ pub(crate) fn apply_dev_vesrions_to_selection<'a>(
             continue;
         }
 
-        increment_semver(&mut version, SemverIncrementMode::Patch);
+        increment_semver(&mut version, SemverIncrementMode::Patch)?;
         version = semver::Version::parse(&format!("{}-{}", version, dev_suffix))?;
 
         debug!(

--- a/crates/release-automation/src/lib/release.rs
+++ b/crates/release-automation/src/lib/release.rs
@@ -219,7 +219,7 @@ fn bump_release_versions<'a>(
                 bail!("previously documented release version '{}' is greater than this release version '{}'", previous_release_version, current_version);
             }
 
-            increment_semver(&mut previous_release_version, semver_increment_mode);
+            increment_semver(&mut previous_release_version, semver_increment_mode)?;
 
             previous_release_version
         } else {
@@ -227,7 +227,7 @@ fn bump_release_versions<'a>(
             let mut new_version = current_version.clone();
 
             if new_version.is_prerelease() {
-                increment_semver(&mut new_version, semver_increment_mode);
+                increment_semver(&mut new_version, semver_increment_mode)?;
             }
 
             new_version

--- a/crates/release-automation/src/lib/tests/cli.rs
+++ b/crates/release-automation/src/lib/tests/cli.rs
@@ -136,7 +136,7 @@ fn bump_versions_on_selection() {
 
     // set expectations
     let expected_crates = vec!["crate_b", "crate_a", "crate_e"];
-    let expected_release_versions = vec!["0.0.1", "0.1.0", "0.0.1"];
+    let expected_release_versions = vec!["0.0.0", "0.1.0", "0.0.1"];
 
     // check manifests for new release headings
     assert_eq!(
@@ -147,7 +147,7 @@ fn bump_versions_on_selection() {
     // ensure dependants were updated
     // todo: ensure *all* dependants were updated
     assert_eq!(
-        "0.0.1",
+        "0.0.0",
         crate::common::get_dependency_version(
             &workspace
                 .root()
@@ -253,12 +253,11 @@ fn bump_versions_on_selection() {
         - BREAKING:  `InstallAppDnaPayload`
         - BREAKING: `DnaSource(Path)`
 
-        ## [crate_b-0.0.1](crates/crate_b/CHANGELOG.md#0.0.1)
+        ## [crate_b-0.0.0](crates/crate_b/CHANGELOG.md#0.0.0)
 
         ### Changed
 
         - `Signature` is a 64 byte ‘secure primitive’
-
 
         # \[20210304.120604\]
 
@@ -301,7 +300,7 @@ fn bump_versions_on_selection() {
 
         the following crates are part of this release:
 
-        - crate_b-0.0.1
+        - crate_b-0.0.0
         - crate_a-0.1.0
         - crate_e-0.0.1
         "#,
@@ -312,7 +311,7 @@ fn bump_versions_on_selection() {
 
     // TODO: tag creation has been moved to publishing, test it there
     // ensure the git tags for the crate releases were created
-    // for expected_tag in &["crate_b-0.0.1", "crate_a-0.0.2", "crate_e-0.0.1"] {
+    // for expected_tag in &["crate_b-0.0.0", "crate_a-0.0.2", "crate_e-0.0.1"] {
     //     crate::crate_selection::git_lookup_tag(workspace.git_repo(), &expected_tag)
     //         .expect(&format!("git tag '{}' not found", &expected_tag));
     // }
@@ -504,7 +503,7 @@ fn multiple_subsequent_releases() {
         (
             // bump the first time as they're initially released
             // vec!["0.0.2-dev.0", "0.0.3-dev.0", "0.0.2-dev.0"],
-            vec!["0.0.1", "0.1.0", "0.0.1"],
+            vec!["0.0.0", "0.1.0", "0.0.1"],
             vec!["crate_b", "crate_a", "crate_e"],
             // allowed missing dependencies
             Vec::<&str>::new(),
@@ -514,7 +513,7 @@ fn multiple_subsequent_releases() {
         (
             // should not bump the second time without making any changes
             // vec!["0.0.2-dev.0", "0.0.3-dev.0", "0.0.2-dev.0"],
-            vec!["0.0.1", "0.1.0", "0.0.1"],
+            vec!["0.0.0", "0.1.0", "0.0.1"],
             vec!["crate_b", "crate_a", "crate_e"],
             // allowed missing dependencies
             Vec::<&str>::new(),
@@ -523,7 +522,7 @@ fn multiple_subsequent_releases() {
         ),
         (
             // only crate_a and crate_e have changed, expect these to be bumped
-            vec!["0.0.1", "0.1.1", "0.0.2"],
+            vec!["0.0.0", "0.1.1", "0.0.2"],
             vec!["crate_b", "crate_a", "crate_e"],
             // crate_b won't be part of the release so we allow it to be missing as we're not publishing
             vec!["crate_b"],
@@ -549,7 +548,7 @@ fn multiple_subsequent_releases() {
         ),
         (
             // change crate_b, and as crate_a depends on crate_b it'll be bumped as well
-            vec!["0.0.2", "0.1.2", "0.0.2"],
+            vec!["0.0.1", "0.1.2", "0.0.2"],
             vec!["crate_b", "crate_a", "crate_e"],
             // allowed missing dependencies
             vec![],

--- a/crates/release-automation/src/lib/tests/workspace_mocker.rs
+++ b/crates/release-automation/src/lib/tests/workspace_mocker.rs
@@ -386,8 +386,6 @@ pub(crate) fn example_workspace_1<'a>() -> Fallible<WorkspaceMocker> {
                 ### Changed
                 - `Signature` is a 64 byte 'secure primitive'
 
-                ## 0.0.0-alpha.1
-
                 [Unreleased]: https://duckduckgo.com/?q=version&t=hd&va=u
                 "#
             )),
@@ -519,7 +517,6 @@ pub(crate) fn example_workspace_1<'a>() -> Fallible<WorkspaceMocker> {
     workspace_mocker.commit(None);
 
     // todo: derive the tag from a function
-    workspace_mocker.tag("crate_b-0.0.1-alpha.1");
     workspace_mocker.add_or_replace_file(
         "crates/crate_b/README.md",
         indoc::indoc! {r#"


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
- [x] dry run without pre
    - [x] https://github.com/holochain/holochain/actions/runs/3038151467
- [x] dry run with pre via [the pr_release_automation_support_prerelease_testing branch](https://github.com/holochain/holochain/compare/pr_release_automation_support_prerelease...pr_release_automation_support_prerelease_testing?expand=1)
    - [x] https://github.com/holochain/holochain/actions/runs/3038172189
