### PR TITLE
clarify enable app admin request docs

### DIFF
--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -144,8 +144,8 @@ pub enum AdminRequest {
     /// Changes the specified app from a disabled to an enabled state in the conductor.
     ///
     /// It is likely to want to call this after calling [`AdminRequest::InstallApp`], since a freshly
-    /// installed app is not enabled automatically. When an app is enabled,
-    /// zomes can be called and it will be loaded on a reboot of the conductor.
+    /// installed app is not enabled automatically. Once the app is enabled,
+    /// zomes can be immediately called and it will also be loaded and available on any reboot of the conductor.
     ///
     /// # Returns
     ///

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -145,7 +145,7 @@ pub enum AdminRequest {
     ///
     /// It is likely to want to call this after calling [`AdminRequest::InstallApp`], since a freshly
     /// installed app is not enabled automatically. Once the app is enabled,
-    /// zomes can be immediately called and it will also be loaded and available on any reboot of the conductor.
+    /// zomes can be immediately called and it will also be loaded and enabled automatically on any reboot of the conductor.
     ///
     /// # Returns
     ///


### PR DESCRIPTION
it was confusing someone I'm working with on the Unity client. 

The confusion was that the text made it appear that you would need to reboot the conductor anyways

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
