### PR TITLE
Fix some deprecations

### DIFF
--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -579,8 +579,8 @@ pub async fn list_cell_ids(cmd: &mut CmdRunner) -> anyhow::Result<Vec<CellId>> {
 
 /// Calls [`AdminRequest::ListActiveApps`].
 pub async fn list_running_apps(cmd: &mut CmdRunner) -> anyhow::Result<Vec<String>> {
-    let resp = cmd.command(AdminRequest::ListActiveApps).await?;
-    Ok(expect_match!(resp => AdminResponse::ActiveAppsListed, "Failed to list active apps"))
+    let resp = cmd.command(AdminRequest::ListEnabledApps).await?;
+    Ok(expect_match!(resp => AdminResponse::EnabledAppsListed, "Failed to list active apps"))
 }
 
 /// Calls [`AdminRequest::ListApps`].

--- a/crates/hc_sandbox/src/lib.rs
+++ b/crates/hc_sandbox/src/lib.rs
@@ -108,8 +108,6 @@
 //! ```
 //! and the examples.
 
-#![allow(deprecated)]
-
 use std::path::Path;
 use std::path::PathBuf;
 

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -318,22 +318,6 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                 let r = self.conductor_handle.get_agent_infos(cell_id).await?;
                 Ok(AdminResponse::AgentInfoRequested(r))
             }
-
-            // deprecated aliases
-            ListActiveApps => {
-                tracing::warn!("Admin method ListActiveApps is deprecated: use ListApps instead.");
-                self.handle_admin_request_inner(ListEnabledApps).await
-            }
-            ActivateApp { installed_app_id } => {
-                tracing::warn!("Admin method ActivateApp is deprecated: use EnableApp instead (functionality is identical).");
-                self.handle_admin_request_inner(EnableApp { installed_app_id })
-                    .await
-            }
-            DeactivateApp { installed_app_id } => {
-                tracing::warn!("Admin method DeactivateApp is deprecated: use DisableApp instead (functionality is identical).");
-                self.handle_admin_request_inner(DisableApp { installed_app_id })
-                    .await
-            }
             GraftRecords {
                 cell_id,
                 validate,
@@ -344,6 +328,25 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     .graft_records_onto_source_chain(cell_id, validate, records)
                     .await?;
                 Ok(AdminResponse::RecordsGrafted)
+            }
+
+            // deprecated aliases
+            #[allow(deprecated)]
+            ListActiveApps => {
+                tracing::warn!("Admin method ListActiveApps is deprecated: use ListApps instead.");
+                self.handle_admin_request_inner(ListEnabledApps).await
+            }
+            #[allow(deprecated)]
+            ActivateApp { installed_app_id } => {
+                tracing::warn!("Admin method ActivateApp is deprecated: use EnableApp instead (functionality is identical).");
+                self.handle_admin_request_inner(EnableApp { installed_app_id })
+                    .await
+            }
+            #[allow(deprecated)]
+            DeactivateApp { installed_app_id } => {
+                tracing::warn!("Admin method DeactivateApp is deprecated: use DisableApp instead (functionality is identical).");
+                self.handle_admin_request_inner(DisableApp { installed_app_id })
+                    .await
             }
         }
     }

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -63,6 +63,7 @@ impl AppInterfaceApi for RealAppInterfaceApi {
                     .get_app_info(&installed_app_id)
                     .await?,
             )),
+            #[allow(deprecated)]
             AppRequest::ZomeCallInvocation(call) => {
                 tracing::warn!(
                     "AppRequest::ZomeCallInvocation is deprecated, use AppRequest::ZomeCall (TODO: update conductor-api)"

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -517,6 +517,7 @@ impl Conductor {
         let running_cells: HashSet<CellId> = self.running_cell_ids();
         let (_, delta) = self
             .update_state_prime(move |mut state| {
+                #[allow(deprecated)]
                 let apps = state.installed_apps_mut().iter_mut().filter(|(id, _)| {
                     app_ids
                         .as_ref()

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -397,11 +397,11 @@ pub mod test {
             .unwrap()
             .into();
         request.cell_id = cell_id;
-        let msg = AppRequest::ZomeCallInvocation(Box::new(request));
+        let msg = AppRequest::ZomeCall(Box::new(request));
         let msg = msg.try_into().unwrap();
         let respond = |bytes: SerializedBytes| {
             let response: AppResponse = bytes.try_into().unwrap();
-            assert_matches!(response, AppResponse::ZomeCallInvocation { .. });
+            assert_matches!(response, AppResponse::ZomeCall { .. });
             async { Ok(()) }.boxed().into()
         };
         let respond = Respond::Request(Box::new(respond));
@@ -494,7 +494,7 @@ pub mod test {
         }
 
         // Now deactivate app
-        let msg = AdminRequest::DeactivateApp {
+        let msg = AdminRequest::DisableApp {
             installed_app_id: app_id.clone(),
         };
         let msg = msg.try_into().unwrap();

--- a/crates/holochain/src/core/ribosome.rs
+++ b/crates/holochain/src/core/ribosome.rs
@@ -339,13 +339,13 @@ impl ZomeCallInvocation {
 
 mockall::mock! {
     Invocation {}
-    trait Invocation {
+    impl Invocation for Invocation {
         fn zomes(&self) -> ZomesToInvoke;
         fn fn_components(&self) -> FnComponents;
         fn host_input(self) -> Result<ExternIO, SerializedBytesError>;
         fn auth(&self) -> InvocationAuth;
     }
-    trait Clone {
+    impl Clone for Invocation {
         fn clone(&self) -> Self;
     }
 }

--- a/crates/holochain/src/core/sys_validate/error.rs
+++ b/crates/holochain/src/core/sys_validate/error.rs
@@ -59,7 +59,7 @@ impl From<CounterSigningError> for SysValidationError {
     }
 }
 
-#[deprecated = "This will be replaced with SysValidationOutcome as we shouldn't treat outcomes as errors"]
+// #[deprecated = "This will be replaced with SysValidationOutcome as we shouldn't treat outcomes as errors"]
 pub type SysValidationResult<T> = Result<T, SysValidationError>;
 
 /// Return either:

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -1,5 +1,4 @@
 //! The workflow and queue consumer for sys validation
-#![allow(deprecated)]
 
 use super::*;
 use crate::conductor::handle::ConductorHandleT;

--- a/crates/holochain/src/lib.rs
+++ b/crates/holochain/src/lib.rs
@@ -1,7 +1,5 @@
 //! All the components you need to build a Holochain Conductor
 
-// Toggle this to see what needs to be eventually refactored (as warnings).
-#![allow(deprecated)]
 // We have a lot of usages of type aliases to `&String`, which clippy objects to.
 #![allow(clippy::ptr_arg)]
 

--- a/crates/holochain/src/test_utils/network_simulation.rs
+++ b/crates/holochain/src/test_utils/network_simulation.rs
@@ -145,7 +145,7 @@ impl MockNetworkData {
 
     /// Hashes that an agent is an authority for.
     pub fn hashes_authority_for(&self, agent: &AgentPubKey) -> Vec<Arc<DhtOpHash>> {
-        let arc = self.agent_to_arc[agent].interval();
+        let arc = self.agent_to_arc[agent].inner();
         match arc {
             DhtArcRange::Empty => Vec::with_capacity(0),
             DhtArcRange::Full => self.ops_by_loc.values().flatten().cloned().collect(),

--- a/crates/holochain/tests/network_tests/mod.rs
+++ b/crates/holochain/tests/network_tests/mod.rs
@@ -2,7 +2,6 @@
 #![cfg(todo_redo_old_tests)]
 #![allow(unused_imports)]
 #![allow(dead_code)]
-#![allow(deprecated)]
 use ::fixt::prelude::*;
 use fallible_iterator::FallibleIterator;
 use futures::future::Either;

--- a/crates/holochain/tests/ser_regression/mod.rs
+++ b/crates/holochain/tests/ser_regression/mod.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 use ::fixt::prelude::*;
 use hdk::prelude::*;
 

--- a/crates/holochain/tests/speed_tests/mod.rs
+++ b/crates/holochain/tests/speed_tests/mod.rs
@@ -15,8 +15,6 @@
 //! hard to automate piping from tests stderr.
 //!
 
-#![allow(deprecated)]
-
 use std::sync::Arc;
 
 use ::fixt::prelude::*;

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use holo_hash::*;
 use holochain_types::prelude::*;
 use holochain_zome_types::cell::CellId;

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use crate::{signal_subscription::SignalSubscription, ExternalApiWireError};
 use holo_hash::AgentPubKey;
 use holochain_types::prelude::*;

--- a/crates/holochain_conductor_api/src/lib.rs
+++ b/crates/holochain_conductor_api/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 mod admin_interface;
 mod app_interface;
 pub mod config;

--- a/crates/holochain_state/src/lib.rs
+++ b/crates/holochain_state/src/lib.rs
@@ -24,8 +24,6 @@
 //! The Query trait allows combining arbitrary database SQL queries with
 //! the scratch space so reads can union across the database and in-memory data.
 
-#![allow(deprecated)]
-
 pub mod chain_lock;
 #[allow(missing_docs)]
 pub mod dna_def;

--- a/crates/holochain_state/src/query.rs
+++ b/crates/holochain_state/src/query.rs
@@ -260,7 +260,7 @@ impl<'stmt> Store for Txn<'stmt, '_> {
     }
 
     fn contains_entry(&self, hash: &EntryHash) -> StateQueryResult<bool> {
-        let exists = self.txn.query_row_named(
+        let exists = self.txn.query_row(
             "
             SELECT
             EXISTS(
@@ -288,7 +288,7 @@ impl<'stmt> Store for Txn<'stmt, '_> {
     }
 
     fn contains_action(&self, hash: &ActionHash) -> StateQueryResult<bool> {
-        let exists = self.txn.query_row_named(
+        let exists = self.txn.query_row(
             "
             SELECT
             EXISTS(
@@ -316,7 +316,7 @@ impl<'stmt> Store for Txn<'stmt, '_> {
     }
 
     fn get_action(&self, hash: &ActionHash) -> StateQueryResult<Option<SignedActionHashed>> {
-        let shh = self.txn.query_row_named(
+        let shh = self.txn.query_row(
             "
             SELECT
             Action.blob, Action.hash
@@ -388,7 +388,7 @@ impl<'stmt> Store for Txn<'stmt, '_> {
 
 impl<'stmt> Txn<'stmt, '_> {
     fn get_exact_record(&self, hash: &ActionHash) -> StateQueryResult<Option<Record>> {
-        let record = self.txn.query_row_named(
+        let record = self.txn.query_row(
             "
             SELECT
             Action.blob AS action_blob, Action.hash, Entry.blob as entry_blob
@@ -425,7 +425,7 @@ impl<'stmt> Txn<'stmt, '_> {
         }
     }
     fn get_any_record(&self, hash: &EntryHash) -> StateQueryResult<Option<Record>> {
-        let record = self.txn.query_row_named(
+        let record = self.txn.query_row(
             "
             SELECT
             Action.blob AS action_blob, Action.hash, Entry.blob as entry_blob
@@ -463,7 +463,7 @@ impl<'stmt> Txn<'stmt, '_> {
     }
 
     fn get_any_public_record(&self, hash: &EntryHash) -> StateQueryResult<Option<Record>> {
-        let record = self.txn.query_row_named(
+        let record = self.txn.query_row(
             "
             SELECT
             Action.blob AS action_blob, Action.hash, Entry.blob as entry_blob
@@ -507,7 +507,7 @@ impl<'stmt> Txn<'stmt, '_> {
         hash: &EntryHash,
         author: &AgentPubKey,
     ) -> StateQueryResult<Option<Record>> {
-        let record = self.txn.query_row_named(
+        let record = self.txn.query_row(
             "
             SELECT
             Action.blob AS action_blob, Action.hash, Entry.blob as entry_blob
@@ -832,7 +832,7 @@ impl<'stmt, 'iter, Q: Query> QueryStmt<'stmt, Q> {
                 if params.is_empty() {
                     Ok(Box::new(fallible_iterator::convert(std::iter::empty())) as StmtIter<T>)
                 } else {
-                    let iter = stmt.query_and_then_named(params, move |r| map_fn(r))?;
+                    let iter = stmt.query_and_then(params, move |r| map_fn(r))?;
                     Ok(Box::new(fallible_iterator::convert(iter)) as StmtIter<T>)
                 }
             }
@@ -882,7 +882,7 @@ pub fn get_entry_from_db(
     txn: &Transaction,
     entry_hash: &EntryHash,
 ) -> StateQueryResult<Option<Entry>> {
-    let entry = txn.query_row_named(
+    let entry = txn.query_row(
         "
         SELECT Entry.blob AS entry_blob FROM Entry
         WHERE hash = :entry_hash
@@ -908,7 +908,7 @@ pub fn get_public_entry_from_db(
     txn: &Transaction,
     entry_hash: &EntryHash,
 ) -> StateQueryResult<Option<Entry>> {
-    let entry = txn.query_row_named(
+    let entry = txn.query_row(
         "
         SELECT Entry.blob AS entry_blob FROM Entry
         JOIN Action ON Action.entry_hash = Entry.hash

--- a/crates/holochain_state/src/query/tests.rs
+++ b/crates/holochain_state/src/query/tests.rs
@@ -2,8 +2,8 @@ use crate::prelude::mutations_helpers::insert_valid_integrated_op;
 use crate::scratch::Scratch;
 use ::fixt::prelude::*;
 use holo_hash::*;
+use holochain_sqlite::rusqlite::Transaction;
 use holochain_sqlite::rusqlite::TransactionBehavior;
-use holochain_sqlite::rusqlite::{Transaction, NO_PARAMS};
 use holochain_sqlite::{rusqlite::Connection, schema::SCHEMA_CELL};
 use holochain_types::dht_op::DhtOpHashed;
 use holochain_types::dht_op::OpOrder;
@@ -232,24 +232,24 @@ async fn insert_op_equivalence() {
 
     // Query the DB on conn1
     let entries1: Vec<u8> = conn1
-        .query_row("SELECT * FROM Entry", NO_PARAMS, |row| row.get("hash"))
+        .query_row("SELECT * FROM Entry", [], |row| row.get("hash"))
         .unwrap();
     let actions1: Vec<u8> = conn1
-        .query_row("SELECT * FROM Action", NO_PARAMS, |row| row.get("hash"))
+        .query_row("SELECT * FROM Action", [], |row| row.get("hash"))
         .unwrap();
     let ops1: Vec<u8> = conn1
-        .query_row("SELECT * FROM DhtOp", NO_PARAMS, |row| row.get("hash"))
+        .query_row("SELECT * FROM DhtOp", [], |row| row.get("hash"))
         .unwrap();
 
     // Query the DB on conn2
     let entries2: Vec<u8> = conn2
-        .query_row("SELECT * FROM Entry", NO_PARAMS, |row| row.get("hash"))
+        .query_row("SELECT * FROM Entry", [], |row| row.get("hash"))
         .unwrap();
     let actions2: Vec<u8> = conn2
-        .query_row("SELECT * FROM Action", NO_PARAMS, |row| row.get("hash"))
+        .query_row("SELECT * FROM Action", [], |row| row.get("hash"))
         .unwrap();
     let ops2: Vec<u8> = conn2
-        .query_row("SELECT * FROM DhtOp", NO_PARAMS, |row| row.get("hash"))
+        .query_row("SELECT * FROM DhtOp", [], |row| row.get("hash"))
         .unwrap();
 
     assert_eq!(entries1, entries2);

--- a/crates/holochain_state/src/scratch.rs
+++ b/crates/holochain_state/src/scratch.rs
@@ -352,11 +352,11 @@ CREATE TABLE mytable (
 );
     ";
 
-    m1.execute(schema, NO_PARAMS).unwrap();
-    m2.execute(schema, NO_PARAMS).unwrap();
+    m1.execute(schema, []).unwrap();
+    m2.execute(schema, []).unwrap();
 
     let num = m1
-        .execute("INSERT INTO mytable (x) VALUES (1)", NO_PARAMS)
+        .execute("INSERT INTO mytable (x) VALUES (1)", [])
         .unwrap();
     assert_eq!(num, 1);
 
@@ -365,7 +365,7 @@ CREATE TABLE mytable (
         .unwrap()
         .prepare_cached("SELECT x FROM mytable")
         .unwrap()
-        .query_map(NO_PARAMS, |row| row.get(0))
+        .query_map([], |row| row.get(0))
         .unwrap()
         .collect::<Result<Vec<_>, _>>()
         .unwrap();
@@ -375,7 +375,7 @@ CREATE TABLE mytable (
         .unwrap()
         .prepare_cached("SELECT * FROM mytable")
         .unwrap()
-        .query_map(NO_PARAMS, |row| row.get(0))
+        .query_map([], |row| row.get(0))
         .unwrap()
         .collect::<Result<Vec<_>, _>>()
         .unwrap();

--- a/crates/holochain_types/src/app/app_bundle.rs
+++ b/crates/holochain_types/src/app/app_bundle.rs
@@ -193,7 +193,6 @@ impl AppBundle {
 
 /// This function is called in places where it will be necessary to rework that
 /// area after use_existing has been implemented
-#[deprecated = "Raising visibility into a change that needs to happen after `use_existing` is implemented"]
 pub fn we_must_remember_to_rework_cell_panic_handling_after_implementing_use_existing_cell_resolution(
 ) {
 }

--- a/crates/holochain_types/src/app/dna_gamut.rs
+++ b/crates/holochain_types/src/app/dna_gamut.rs
@@ -46,7 +46,6 @@ impl DnaGamut {
         Self(map)
     }
 
-    #[deprecated = "Stop using the placeholder"]
     #[allow(missing_docs)]
     pub fn placeholder() -> Self {
         Self::new(std::iter::empty())

--- a/crates/holochain_types/src/lib.rs
+++ b/crates/holochain_types/src/lib.rs
@@ -7,8 +7,6 @@
 //! itself depends on.
 
 #![deny(missing_docs)]
-// Toggle this to see what needs to be eventually refactored (as warnings).
-#![allow(deprecated)]
 // We have a lot of usages of type aliases to `&String`, which clippy objects to.
 #![allow(clippy::ptr_arg)]
 

--- a/crates/holochain_types/src/link.rs
+++ b/crates/holochain_types/src/link.rs
@@ -2,7 +2,6 @@
 
 use holo_hash::ActionHash;
 use holo_hash::AgentPubKey;
-use holo_hash::AnyDhtHash;
 use holo_hash::AnyLinkableHash;
 use holo_hash::EntryHash;
 use holochain_serialized_bytes::prelude::*;
@@ -21,20 +20,6 @@ pub struct Link {
     base: EntryHash,
     target: EntryHash,
     tag: LinkTag,
-}
-
-/// Owned link key for sending across networks
-#[deprecated = "This is being replaced by WireLinkKey"]
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes)]
-pub enum WireLinkMetaKey {
-    /// Search for all links on a base
-    Base(EntryHash),
-    /// Search for all links on a base, for a zome
-    BaseZome(EntryHash, ZomeId),
-    /// Search for all links on a base, for a zome and with a tag
-    BaseZomeTag(EntryHash, ZomeId, LinkTag),
-    /// This will match only the link created with a certain [CreateLink] hash
-    Full(EntryHash, ZomeId, LinkTag, ActionHash),
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes)]
@@ -221,16 +206,6 @@ pub struct GetLinksResponse {
     pub link_adds: Vec<(CreateLink, Signature)>,
     /// All the link removes on the key you searched for
     pub link_removes: Vec<(DeleteLink, Signature)>,
-}
-
-impl WireLinkMetaKey {
-    /// Get the basis of this key
-    pub fn basis(&self) -> AnyDhtHash {
-        use WireLinkMetaKey::*;
-        match self {
-            Base(b) | BaseZome(b, _) | BaseZomeTag(b, _, _) | Full(b, _, _, _) => b.clone().into(),
-        }
-    }
 }
 
 impl Link {

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
@@ -212,11 +212,6 @@ impl<T> DhtArcRange<T> {
             Self::Bounded(lo, hi) => DhtArcRange::Bounded(f(lo), f(hi)),
         }
     }
-
-    #[deprecated = "left over from refactor"]
-    pub fn interval(self) -> Self {
-        self
-    }
 }
 
 impl<T: num_traits::AsPrimitive<u32>> DhtArcRange<T> {

--- a/crates/kitsune_p2p/direct/src/lib.rs
+++ b/crates/kitsune_p2p/direct/src/lib.rs
@@ -2,7 +2,6 @@
 #![deny(warnings)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
-#![allow(deprecated)]
 
 pub use kitsune_p2p_direct_api::{KdError, KdResult};
 use kitsune_p2p_types::dependencies::ghost_actor::dependencies::tracing;


### PR DESCRIPTION
### Summary

Doesn't remove anything public-facing, just removes the need for `allow(deprecated)` in a bunch of places, and makes some other `allows` more targeted.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
