### PR TITLE
Quantized rounding

### DIFF
--- a/crates/holochain/src/conductor/kitsune_host_impl/query_region_set.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl/query_region_set.rs
@@ -37,8 +37,10 @@ pub async fn query_region_set(
                     dht_arc_set,
                     arq_set
                 );
+                Some(now.as_millis())
+            } else {
+                None
             }
-            it_is_time.then(|| now.as_millis())
         });
     }
 

--- a/crates/holochain/src/conductor/kitsune_host_impl/query_region_set.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl/query_region_set.rs
@@ -1,10 +1,16 @@
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicI64, Ordering},
+    Arc,
+};
 
 use holochain_p2p::{dht::prelude::*, dht_arc::DhtArcSet};
 use holochain_sqlite::prelude::*;
 use rusqlite::named_params;
 
 use crate::conductor::error::ConductorResult;
+
+static LAST_LOG_MS: AtomicI64 = AtomicI64::new(0);
+const LOG_RATE_MS: i64 = 1000;
 
 /// The network module needs info about various groupings ("regions") of ops
 pub async fn query_region_set(
@@ -15,6 +21,15 @@ pub async fn query_region_set(
 ) -> ConductorResult<RegionSetLtcs> {
     let (arq_set, rounded) = ArqBoundsSet::from_dht_arc_set_rounded(&topology, strat, &dht_arc_set);
     if rounded {
+        // If an arq was rounded, emit a warning, but throttle it to once every LOG_RATE_MS
+        // so we don't get slammed.
+        let _ = LAST_LOG_MS.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |t| {
+            let now = Timestamp::now();
+            now.checked_difference_signed(&Timestamp::from_micros(t * 1000))
+                .map(|d| d > chrono::Duration::milliseconds(LOG_RATE_MS))
+                .unwrap_or(false)
+                .then(|| now.as_millis())
+        });
         tracing::warn!(
             "A continuous arc set could not be properly quantized.
         Original:  {:?}

--- a/crates/kitsune_p2p/dht/proptest-regressions/arq/arq_set.txt
+++ b/crates/kitsune_p2p/dht/proptest-regressions/arq/arq_set.txt
@@ -1,0 +1,10 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc c5a173f602e7a0da8b012678a4220f89c56bea3af116d5a7a58d35c16cc0a1eb # shrinks to p1 = 0, s1 = 0, c1 = 0, p2 = 18, s2 = 0, c2 = 0
+cc b2f3015c667472b6a68829a61e0cec05dc6fb8400f4a5253160f35cb7c0a1201 # shrinks to mut p1 = 0, s1 = 0, c1 = 1, mut p2 = 0, s2 = 3560210432, c2 = 3089284281
+cc 759f52a1b22a74e7693990c215ee5f69e6fa93beb1a212663c080692c7b81bae # shrinks to mut p1 = 0, s1 = 0, c1 = 0, mut p2 = 94, s2 = 0, c2 = 0
+cc e4718d3feed040cb3aaf7b6e4e3bf5e288c3739ab4ee8f89ad0fb831d14a7073 # shrinks to p1 = 11, s1 = 3992977408, c1 = 36, p2 = 14, s2 = 2952790016, c2 = 20

--- a/crates/kitsune_p2p/dht/src/arq/arq_set.rs
+++ b/crates/kitsune_p2p/dht/src/arq/arq_set.rs
@@ -305,4 +305,23 @@ mod tests {
             ]
         );
     }
+
+    proptest::proptest! {
+        #[test]
+        fn rounded_arcset_intersections(p1 in 0u8..15, s1: u32, c1 in 8u32..64, p2 in 0u8..15, s2: u32, c2 in 8u32..64) {
+            let topo = Topology::standard_epoch_full();
+            let arq1 = Arq::new(p1, Loc::from(s1), c1.into());
+            let arq2 = Arq::new(p2, Loc::from(s2), c2.into());
+            let arcset1: DhtArcSet = arq1.to_bounds(&topo).to_dht_arc_range(&topo).into();
+            let arcset2: DhtArcSet = arq2.to_bounds(&topo).to_dht_arc_range(&topo).into();
+            let common = arcset1.intersection(&arcset2);
+            let ii = common.intervals();
+            for i in ii {
+                let p = p1.min(p2);
+                dbg!(&p, &i);
+                let (_, rounded) = ArqBounds::from_interval_rounded(&topo, p, i);
+                assert!(!rounded);
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Summary

"Fixes" the rounding logic so that it accepts a margin of +/- 1 for rounding error, rather than only +1.

Throttles the warning which says when rounding occurs, so the logs don't get slammed in case this happens, but we still get visibility into the problem if it shows up in the wild.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
