### PR TITLE
 chore: bump rust to 1.66.0 

### DIFF
--- a/crates/holochain_integrity_types/src/countersigning.rs
+++ b/crates/holochain_integrity_types/src/countersigning.rs
@@ -523,7 +523,7 @@ impl CounterSigningSessionData {
             .iter()
             .position(|(pubkey, _)| pubkey == agent)
         {
-            Some(agent_index) => match self.responses.get(agent_index as usize) {
+            Some(agent_index) => match self.responses.get(agent_index) {
                 Some((agent_state, _)) => Ok(agent_state),
                 None => Err(CounterSigningError::AgentIndexOutOfBounds),
             },

--- a/crates/holochain_integrity_types/src/info.rs
+++ b/crates/holochain_integrity_types/src/info.rs
@@ -146,7 +146,7 @@ where
         T: PartialEq,
     {
         iter.into_iter()
-            .find_map(|key| (self.get(key)? == scoped_type).then(|| key))
+            .find_map(|key| (self.get(key)? == scoped_type).then_some(key))
     }
 
     /// Find the [`ZomeTypesKey`] for this [`ScopedZomeType`].

--- a/crates/kitsune_p2p/bootstrap/src/clear.rs
+++ b/crates/kitsune_p2p/bootstrap/src/clear.rs
@@ -5,7 +5,8 @@ use warp::Filter;
 
 pub(crate) fn clear(
     store: Store,
-) -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone
+{
     warp::post()
         .and(warp::header::exact("X-Op", "clear"))
         .and(with_store(store))

--- a/crates/kitsune_p2p/bootstrap/src/clear.rs
+++ b/crates/kitsune_p2p/bootstrap/src/clear.rs
@@ -5,7 +5,7 @@ use warp::Filter;
 
 pub(crate) fn clear(
     store: Store,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone {
     warp::post()
         .and(warp::header::exact("X-Op", "clear"))
         .and(with_store(store))

--- a/crates/kitsune_p2p/bootstrap/src/now.rs
+++ b/crates/kitsune_p2p/bootstrap/src/now.rs
@@ -1,7 +1,7 @@
 use super::*;
 use warp::Filter;
 
-pub(crate) fn now() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+pub(crate) fn now() -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone {
     warp::post()
         .and(warp::header::exact("X-Op", "now"))
         .and_then(time)

--- a/crates/kitsune_p2p/bootstrap/src/now.rs
+++ b/crates/kitsune_p2p/bootstrap/src/now.rs
@@ -1,7 +1,9 @@
 use super::*;
 use warp::Filter;
 
-pub(crate) fn now() -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone {
+pub(crate) fn now(
+) -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone
+{
     warp::post()
         .and(warp::header::exact("X-Op", "now"))
         .and_then(time)

--- a/crates/kitsune_p2p/bootstrap/src/proxy_list.rs
+++ b/crates/kitsune_p2p/bootstrap/src/proxy_list.rs
@@ -5,7 +5,7 @@ use warp::Filter;
 
 pub(crate) fn proxy_list(
     store: Store,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone {
     warp::post()
         .and(warp::header::exact("X-Op", "proxy_list"))
         .and(with_store(store))

--- a/crates/kitsune_p2p/bootstrap/src/proxy_list.rs
+++ b/crates/kitsune_p2p/bootstrap/src/proxy_list.rs
@@ -5,7 +5,8 @@ use warp::Filter;
 
 pub(crate) fn proxy_list(
     store: Store,
-) -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone
+{
     warp::post()
         .and(warp::header::exact("X-Op", "proxy_list"))
         .and(with_store(store))

--- a/crates/kitsune_p2p/bootstrap/src/put.rs
+++ b/crates/kitsune_p2p/bootstrap/src/put.rs
@@ -6,7 +6,8 @@ use warp::Filter;
 
 pub(crate) fn put(
     store: Store,
-) -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone
+{
     warp::post()
         .and(warp::header::exact("X-Op", "put"))
         .and(warp::body::content_length_limit(SIZE_LIMIT))

--- a/crates/kitsune_p2p/bootstrap/src/put.rs
+++ b/crates/kitsune_p2p/bootstrap/src/put.rs
@@ -6,7 +6,7 @@ use warp::Filter;
 
 pub(crate) fn put(
     store: Store,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone {
     warp::post()
         .and(warp::header::exact("X-Op", "put"))
         .and(warp::body::content_length_limit(SIZE_LIMIT))

--- a/crates/kitsune_p2p/bootstrap/src/random.rs
+++ b/crates/kitsune_p2p/bootstrap/src/random.rs
@@ -6,7 +6,8 @@ use warp::Filter;
 
 pub(crate) fn random(
     store: Store,
-) -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone
+{
     warp::post()
         .and(warp::header::exact("X-Op", "random"))
         .and(warp::body::content_length_limit(SIZE_LIMIT))

--- a/crates/kitsune_p2p/bootstrap/src/random.rs
+++ b/crates/kitsune_p2p/bootstrap/src/random.rs
@@ -6,7 +6,7 @@ use warp::Filter;
 
 pub(crate) fn random(
     store: Store,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = impl warp::Reply + warp::generic::Tuple, Error = warp::Rejection> + Clone {
     warp::post()
         .and(warp::header::exact("X-Op", "random"))
         .and(warp::body::content_length_limit(SIZE_LIMIT))

--- a/crates/kitsune_p2p/dht/src/arq.rs
+++ b/crates/kitsune_p2p/dht/src/arq.rs
@@ -511,7 +511,7 @@ pub fn approximate_arq(topo: &Topology, strat: &ArqStrat, start: Loc, len: u64) 
             "power too large: {}",
             power
         );
-        Arq::new(power as u8, start, count.into())
+        Arq::new(power, start, count.into())
     }
 }
 

--- a/crates/kitsune_p2p/dht/src/arq/peer_view.rs
+++ b/crates/kitsune_p2p/dht/src/arq/peer_view.rs
@@ -368,7 +368,7 @@ impl PeerViewQ {
             .filter(|(i, _)| self.skip_index.as_ref() != Some(i))
             .map(|(_, arq)| arq);
 
-        it.filter(move |arq| filter.contains(&arq.start_loc()))
+        it.filter(move |arq| filter.contains(arq.start_loc()))
     }
 }
 

--- a/crates/kitsune_p2p/dht/src/region_set/ltcs.rs
+++ b/crates/kitsune_p2p/dht/src/region_set/ltcs.rs
@@ -178,7 +178,7 @@ impl<D: RegionDataConstraints> RegionSetLtcs<D> {
         self.coords
             .region_coords_flat()
             .map(|((ia, ix, it), coords)| {
-                Region::new(coords, self.data[ia][ix as usize][it as usize].clone())
+                Region::new(coords, self.data[ia][ix][it].clone())
             })
     }
 
@@ -213,7 +213,7 @@ impl<D: RegionDataConstraints> RegionSetLtcs<D> {
             .regions()
             .into_iter()
             .zip(other.regions().into_iter())
-            .filter_map(|(a, b)| (a.data != b.data).then(|| a))
+            .filter_map(|(a, b)| (a.data != b.data).then_some(a))
             .collect();
 
         Ok(regions)

--- a/crates/kitsune_p2p/dht/src/region_set/ltcs.rs
+++ b/crates/kitsune_p2p/dht/src/region_set/ltcs.rs
@@ -177,9 +177,7 @@ impl<D: RegionDataConstraints> RegionSetLtcs<D> {
     pub fn regions(&self) -> impl Iterator<Item = Region<D>> + '_ {
         self.coords
             .region_coords_flat()
-            .map(|((ia, ix, it), coords)| {
-                Region::new(coords, self.data[ia][ix][it].clone())
-            })
+            .map(|((ia, ix, it), coords)| Region::new(coords, self.data[ia][ix][it].clone()))
     }
 
     /// Reshape the two region sets so that both match, omitting or merging

--- a/crates/kitsune_p2p/dht/src/test_utils/test_node.rs
+++ b/crates/kitsune_p2p/dht/src/test_utils/test_node.rs
@@ -104,7 +104,9 @@ impl AccessPeerStore for TestNode {
 
     fn get_arq_set(&self) -> ArqBoundsSet {
         ArqBoundsSet::new(
-            self.arqs.values().map(|arq| arq.to_bounds(&self.store.topo))
+            self.arqs
+                .values()
+                .map(|arq| arq.to_bounds(&self.store.topo))
                 .collect(),
         )
     }

--- a/crates/kitsune_p2p/dht/src/test_utils/test_node.rs
+++ b/crates/kitsune_p2p/dht/src/test_utils/test_node.rs
@@ -104,9 +104,7 @@ impl AccessPeerStore for TestNode {
 
     fn get_arq_set(&self) -> ArqBoundsSet {
         ArqBoundsSet::new(
-            self.arqs
-                .iter()
-                .map(|(_, arq)| arq.to_bounds(&self.store.topo))
+            self.arqs.values().map(|arq| arq.to_bounds(&self.store.topo))
                 .collect(),
         )
     }

--- a/crates/kitsune_p2p/direct_api/src/kdentry.rs
+++ b/crates/kitsune_p2p/direct_api/src/kdentry.rs
@@ -104,7 +104,7 @@ pub mod kd_entry {
             D: serde::Deserializer<'de>,
         {
             let s = String::deserialize(deserializer).map_err(serde::de::Error::custom)?;
-            let d = base64::decode(&s).map_err(serde::de::Error::custom)?;
+            let d = base64::decode(s).map_err(serde::de::Error::custom)?;
             Ok(Self(d.into_boxed_slice()))
         }
     }

--- a/crates/kitsune_p2p/types/src/lib.rs
+++ b/crates/kitsune_p2p/types/src/lib.rs
@@ -186,7 +186,7 @@ impl From<Arc<Vec<u8>>> for Tx2Cert {
 
 impl From<CertDigest> for Tx2Cert {
     fn from(c: CertDigest) -> Self {
-        let b64 = base64::encode_config(&*c, base64::URL_SAFE_NO_PAD);
+        let b64 = base64::encode_config(*c, base64::URL_SAFE_NO_PAD);
         let nick = {
             let (start, _) = b64.split_at(6);
             let (_, end) = b64.split_at(b64.len() - 6);

--- a/crates/kitsune_p2p/types/src/tx2/tx2_pool_promote.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_pool_promote.rs
@@ -660,7 +660,7 @@ fn close_promote_ep_hnd(
 
         *c = true;
         i.con_limit.close();
-        let cons = i.cons.iter().map(|(_, c)| c.clone()).collect::<Vec<_>>();
+        let cons = i.cons.values().cloned().collect::<Vec<_>>();
         let ep_close_fut = i.sub_ep.close(code, reason);
         Ok((cons, ep_close_fut, i.logic_hnd.clone()))
     }) {
@@ -835,7 +835,7 @@ impl AsEpFactory for PromoteFactory {
         timeout: KitsuneTimeout,
     ) -> BoxFuture<'static, KitsuneResult<Ep>> {
         let tuning_params = self.tuning_params.clone();
-        let max_cons = tuning_params.tx2_pool_max_connection_count as usize;
+        let max_cons = tuning_params.tx2_pool_max_connection_count;
         let con_limit = Arc::new(Semaphore::new(max_cons));
         let pair_fut = self.adapter.bind(bind_spec, timeout);
         timeout

--- a/crates/kitsune_p2p/types/src/tx2/tx2_utils/tx_url.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_utils/tx_url.rs
@@ -58,7 +58,7 @@ impl From<url2::Url2> for TxUrl {
 
 impl From<String> for TxUrl {
     fn from(r: String) -> Self {
-        Self(Arc::new(url2::Url2::parse(&r)))
+        Self(Arc::new(url2::Url2::parse(r)))
     }
 }
 

--- a/crates/mr_bundle/src/location.rs
+++ b/crates/mr_bundle/src/location.rs
@@ -31,7 +31,7 @@ impl Location {
         if let Location::Path(path) = self {
             if path.is_relative() {
                 if let Some(dir) = root_dir {
-                    Ok(Location::Path(ffs::sync::canonicalize(dir.join(&path))?))
+                    Ok(Location::Path(ffs::sync::canonicalize(dir.join(path))?))
                 } else {
                     Err(BundleError::RelativeLocalPath(path.to_owned()).into())
                 }

--- a/crates/mr_bundle/src/packing.rs
+++ b/crates/mr_bundle/src/packing.rs
@@ -87,7 +87,7 @@ async fn unpack_yaml<M: serde::Serialize>(
     }
     ffs::create_dir_all(&base_path).await?;
     for (relative_path, resource) in resources {
-        let path = base_path.join(&relative_path);
+        let path = base_path.join(relative_path);
         let path_clone = path.clone();
         let parent = path_clone
             .parent()

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { nixpkgs ? null
 , rustVersion ? {
     track = "stable";
-    version = "1.66.0";
+    version = "1.65.0";
   }
 
 , holonixArgs ? { }

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { nixpkgs ? null
 , rustVersion ? {
     track = "stable";
-    version = "1.60.0";
+    version = "1.66.0";
   }
 
 , holonixArgs ? { }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "2b874668324ae5a7804066f61afbed913ac0cb9c",
-        "sha256": "1brdayg4kaf0ybmgjli6z8v137apyyknq1w9i3cswy9n4yq5mqcv",
+        "rev": "35cbc55c4f34ac824445b58ad7feb991e767646b",
+        "sha256": "0rrj8cf6gzva924yync6z4rjmx6jflwcfkk80m2s7dbrlyk53fsn",
         "type": "tarball",
-        "url": "https://github.com/holochain/holonix/archive/2b874668324ae5a7804066f61afbed913ac0cb9c.tar.gz",
+        "url": "https://github.com/holochain/holonix/archive/35cbc55c4f34ac824445b58ad7feb991e767646b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nextest": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "35cbc55c4f34ac824445b58ad7feb991e767646b",
-        "sha256": "0rrj8cf6gzva924yync6z4rjmx6jflwcfkk80m2s7dbrlyk53fsn",
+        "rev": "dc10c098c43cffafdc1e9a8dcc33b731a8c01bff",
+        "sha256": "154ay3gf3c6z9qyf6gdfphmnbcvrb1vbr25jgd5mrf118f9a3khn",
         "type": "tarball",
-        "url": "https://github.com/holochain/holonix/archive/35cbc55c4f34ac824445b58ad7feb991e767646b.tar.gz",
+        "url": "https://github.com/holochain/holonix/archive/dc10c098c43cffafdc1e9a8dcc33b731a8c01bff.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nextest": {

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -31,8 +31,28 @@ let
           if spec ? branch then "refs/heads/${spec.branch}" else
             if spec ? tag then "refs/tags/${spec.tag}" else
               abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+      submodules = if spec ? submodules then spec.submodules else false;
+      submoduleArg =
+        let
+          nixSupportsSubmodules = builtins.compareVersions builtins.nixVersion "2.4" >= 0;
+          emptyArgWithWarning =
+            if submodules == true
+            then
+              builtins.trace
+                (
+                  "The niv input \"${name}\" uses submodules "
+                  + "but your nix's (${builtins.nixVersion}) builtins.fetchGit "
+                  + "does not support them"
+                )
+                {}
+            else {};
+        in
+          if nixSupportsSubmodules
+          then { inherit submodules; }
+          else emptyArgWithWarning;
     in
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
+      builtins.fetchGit
+        ({ url = spec.repo; inherit (spec) rev; inherit ref; } // submoduleArg);
 
   fetch_local = spec: spec.path;
 


### PR DESCRIPTION
### Summary




### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] wait until 1.64.0 has appeared at https://github.com/oxalica/rust-overlay/blob/master/manifests/stable/default.nix#L52 and then bump holonix again
- [ ] fix clippy lints
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
