### PR TITLE
Use single InlineZome instead of InlineZomeSet where possible

### DIFF
--- a/crates/holochain/src/conductor/cell/gossip_test.rs
+++ b/crates/holochain/src/conductor/cell/gossip_test.rs
@@ -71,9 +71,10 @@ async fn agent_info_test() {
             ..Default::default()
         });
     }
-    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_create_read_zome())
-        .await
-        .unwrap();
+    let (dna_file, _, _) =
+        SweetDnaFile::unique_from_inline_zomes(("zome", simple_create_read_zome()))
+            .await
+            .unwrap();
 
     let apps = conductors.setup_app("app", &[dna_file]).await.unwrap();
     let ((cell_1,), (cell_2,)) = apps.into_tuples();

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -159,7 +159,7 @@ async fn test_list_running_apps_for_cell_id() {
 
     let mk_dna = |name: &'static str| async move {
         let zome = InlineIntegrityZome::new_unique(Vec::new(), 0);
-        SweetDnaFile::unique_from_inline_zomes((name, zome).into())
+        SweetDnaFile::unique_from_inline_zomes((name, zome))
             .await
             .unwrap()
     };
@@ -435,24 +435,21 @@ async fn test_signing_error_during_genesis_doesnt_bork_interfaces() {
     assert_matches!(response, AppResponse::ZomeCall(_));
 }
 
-pub(crate) fn simple_create_entry_zome() -> InlineZomeSet {
+pub(crate) fn simple_create_entry_zome() -> InlineIntegrityZome {
     let unit_entry_def = EntryDef::default_with_id("unit");
-    InlineZomeSet::new_unique_single(
-        "integrity_create_entry",
-        "create_entry",
-        vec![unit_entry_def.clone()],
-        0,
+    InlineIntegrityZome::new_unique(vec![unit_entry_def.clone()], 0).function(
+        "create",
+        move |api, ()| {
+            let entry = Entry::app(().try_into().unwrap()).unwrap();
+            let hash = api.create(CreateInput::new(
+                InlineZomeSet::get_entry_location(&api, EntryDefIndex(0)),
+                EntryVisibility::Public,
+                entry,
+                ChainTopOrdering::default(),
+            ))?;
+            Ok(hash)
+        },
     )
-    .function("create_entry", "create", move |api, ()| {
-        let entry = Entry::app(().try_into().unwrap()).unwrap();
-        let hash = api.create(CreateInput::new(
-            InlineZomeSet::get_entry_location(&api, EntryDefIndex(0)),
-            EntryVisibility::Public,
-            entry,
-            ChainTopOrdering::default(),
-        ))?;
-        Ok(hash)
-    })
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -460,7 +457,9 @@ async fn test_reenable_app() {
     observability::test_run().ok();
     let zome = simple_create_entry_zome();
     let mut conductor = SweetConductor::from_standard_config().await;
-    let app = common_genesis_test_app(&mut conductor, zome).await.unwrap();
+    let app = common_genesis_test_app(&mut conductor, ("zome", zome))
+        .await
+        .unwrap();
 
     let all_apps = conductor.list_apps(None).await.unwrap();
     assert_eq!(all_apps.len(), 1);
@@ -512,7 +511,7 @@ async fn test_reenable_app() {
 
     // - We can still make a zome call after reactivation
     let _: ActionHash = conductor
-        .call_fallible(&cell.zome("create_entry"), "create", ())
+        .call_fallible(&cell.zome("zome"), "create", ())
         .await
         .unwrap();
 
@@ -673,7 +672,9 @@ async fn test_app_status_states() {
     observability::test_run().ok();
     let zome = simple_create_entry_zome();
     let mut conductor = SweetConductor::from_standard_config().await;
-    common_genesis_test_app(&mut conductor, zome).await.unwrap();
+    common_genesis_test_app(&mut conductor, ("zome", zome))
+        .await
+        .unwrap();
 
     let all_apps = conductor.list_apps(None).await.unwrap();
     assert_eq!(all_apps.len(), 1);

--- a/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
+++ b/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
@@ -146,6 +146,7 @@ pub mod tests {
     use holochain_state::prelude::test_dht_db;
     use holochain_state::prelude::SourceChain;
     use holochain_types::db_cache::DhtDbQueryCache;
+    use holochain_types::inline_zome::InlineZomeSet;
     use holochain_types::prelude::DnaDefHashed;
     use holochain_wasm_test_utils::TestWasm;
     use holochain_zome_types::fake_agent_pubkey_1;
@@ -303,8 +304,11 @@ pub mod tests {
             ))?;
             Ok(InitCallbackResult::Fail("reason".into()))
         });
-        let zomes =
-            crate::conductor::conductor::tests::simple_create_entry_zome().merge(zome_fail.0);
+        let zomes = InlineZomeSet::from((
+            "create_entry",
+            crate::conductor::conductor::tests::simple_create_entry_zome(),
+        ))
+        .merge(zome_fail.0);
 
         let (dna, _, _) = SweetDnaFile::unique_from_inline_zomes(zomes).await.unwrap();
 

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
@@ -14,9 +14,10 @@ async fn sys_validation_agent_activity_test() {
 
     let mut conductors = SweetConductorBatch::from_standard_config(2).await;
 
-    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_create_read_zome())
-        .await
-        .unwrap();
+    let (dna_file, _, _) =
+        SweetDnaFile::unique_from_inline_zomes(("simple", simple_create_read_zome()))
+            .await
+            .unwrap();
 
     let apps = conductors.setup_app("app", &[dna_file]).await.unwrap();
     let ((cell_1,), (cell_2,)) = apps.into_tuples();

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -17,9 +17,10 @@ async fn test_validation_receipt() {
 
     let mut conductors = SweetConductorBatch::from_standard_config(NUM_CONDUCTORS).await;
 
-    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_create_read_zome())
-        .await
-        .unwrap();
+    let (dna_file, _, _) =
+        SweetDnaFile::unique_from_inline_zomes(("simple", simple_create_read_zome()))
+            .await
+            .unwrap();
 
     let apps = conductors.setup_app("app", &[dna_file]).await.unwrap();
     conductors.exchange_peer_info().await;

--- a/crates/holochain/src/sweettest/sweet_dna.rs
+++ b/crates/holochain/src/sweettest/sweet_dna.rs
@@ -160,8 +160,9 @@ impl SweetDnaFile {
     /// Create a DnaFile from a collection of InlineZomes (no Wasm)
     pub async fn from_inline_zomes(
         network_seed: String,
-        mut zomes: InlineZomeSet,
+        zomes: impl Into<InlineZomeSet>,
     ) -> DnaResult<(DnaFile, Vec<IntegrityZome>, Vec<CoordinatorZome>)> {
+        let mut zomes = zomes.into();
         let coordinator_zomes: Vec<CoordinatorZome> = zomes
             .coordinator_zomes
             .into_iter()
@@ -193,7 +194,7 @@ impl SweetDnaFile {
     /// Create a DnaFile from a collection of InlineZomes (no Wasm),
     /// with a random network seed
     pub async fn unique_from_inline_zomes(
-        zomes: InlineZomeSet,
+        zomes: impl Into<InlineZomeSet>,
     ) -> DnaResult<(DnaFile, Vec<IntegrityZome>, Vec<CoordinatorZome>)> {
         Self::from_inline_zomes(random_network_seed(), zomes).await
     }

--- a/crates/holochain/src/sweettest/sweet_zome.rs
+++ b/crates/holochain/src/sweettest/sweet_zome.rs
@@ -27,7 +27,8 @@ impl SweetZome {
 pub type SweetEasyInline = SweetInlineZomes;
 
 #[derive(Default)]
-/// A helper for creating [`InlineZomeSet`]
+/// A helper for creating an [`InlineZomeSet`] consisting of a single
+/// integrity zome and a single coordinator zome.
 pub struct SweetInlineZomes(pub InlineZomeSet);
 
 impl SweetInlineZomes {

--- a/crates/holochain/tests/agent_scaling/mod.rs
+++ b/crates/holochain/tests/agent_scaling/mod.rs
@@ -13,25 +13,20 @@ use holochain_zome_types::inline_zome::BoxApi;
 #[derive(serde::Serialize, serde::Deserialize, Debug, SerializedBytes, derive_more::From)]
 struct BaseTarget(AnyLinkableHash, AnyLinkableHash);
 
-fn links_zome() -> InlineZomeSet {
-    InlineZomeSet::new_unique([("integrity_links", vec![], 1)], ["links"])
+fn links_zome() -> InlineIntegrityZome {
+    InlineIntegrityZome::new_unique(vec![], 1)
+        .function("create_link", move |api, base_target: BaseTarget| {
+            let hash = api.create_link(CreateLinkInput::new(
+                base_target.0,
+                base_target.1,
+                ZomeId(0),
+                LinkType::new(0),
+                ().into(),
+                ChainTopOrdering::default(),
+            ))?;
+            Ok(hash)
+        })
         .function(
-            "links",
-            "create_link",
-            move |api, base_target: BaseTarget| {
-                let hash = api.create_link(CreateLinkInput::new(
-                    base_target.0,
-                    base_target.1,
-                    ZomeId(0),
-                    LinkType::new(0),
-                    ().into(),
-                    ChainTopOrdering::default(),
-                ))?;
-                Ok(hash)
-            },
-        )
-        .function(
-            "links",
             "get_links",
             move |api: BoxApi, base: AnyLinkableHash| -> InlineZomeResult<Vec<Vec<Link>>> {
                 Ok(api.get_links(vec![GetLinksInput::new(
@@ -51,7 +46,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
     observability::test_run().ok();
     const NUM_AGENTS: usize = 20;
 
-    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(links_zome())
+    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(("links", links_zome()))
         .await
         .unwrap();
 

--- a/crates/holochain/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/multi_conductor/mod.rs
@@ -36,9 +36,10 @@ async fn test_publish() -> anyhow::Result<()> {
     config.network = Some(network);
     let mut conductors = SweetConductorBatch::from_config(NUM_CONDUCTORS, config).await;
 
-    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_create_read_zome())
-        .await
-        .unwrap();
+    let (dna_file, _, _) =
+        SweetDnaFile::unique_from_inline_zomes(("simple", simple_create_read_zome()))
+            .await
+            .unwrap();
 
     let apps = conductors.setup_app("app", &[dna_file]).await.unwrap();
     conductors.exchange_peer_info().await;
@@ -79,9 +80,10 @@ async fn multi_conductor() -> anyhow::Result<()> {
 
     let mut conductors = SweetConductorBatch::from_standard_config(NUM_CONDUCTORS).await;
 
-    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_create_read_zome())
-        .await
-        .unwrap();
+    let (dna_file, _, _) =
+        SweetDnaFile::unique_from_inline_zomes(("simple", simple_create_read_zome()))
+            .await
+            .unwrap();
 
     let apps = conductors.setup_app("app", &[dna_file]).await.unwrap();
     conductors.exchange_peer_info().await;
@@ -152,9 +154,10 @@ async fn sharded_consistency() {
     };
     let mut conductors = SweetConductorBatch::from_config(NUM_CONDUCTORS, config).await;
 
-    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_create_read_zome())
-        .await
-        .unwrap();
+    let (dna_file, _, _) =
+        SweetDnaFile::unique_from_inline_zomes(("simple", simple_create_read_zome()))
+            .await
+            .unwrap();
     let dnas = vec![dna_file];
 
     let apps = conductors.setup_app("app", &dnas).await.unwrap();

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -61,9 +61,10 @@ async fn fullsync_sharded_gossip() -> anyhow::Result<()> {
         });
     }
 
-    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_create_read_zome())
-        .await
-        .unwrap();
+    let (dna_file, _, _) =
+        SweetDnaFile::unique_from_inline_zomes(("simple", simple_create_read_zome()))
+            .await
+            .unwrap();
 
     let apps = conductors.setup_app("app", &[dna_file]).await.unwrap();
     conductors.exchange_peer_info().await;
@@ -114,7 +115,7 @@ async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
         });
     }
 
-    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(batch_create_zome())
+    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(("zome", batch_create_zome()))
         .await
         .unwrap();
 
@@ -128,11 +129,7 @@ async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
 
     // Call the "create" zome fn on Alice's app
     let hashes: Vec<ActionHash> = conductors[0]
-        .call(
-            &alice.zome(holochain::sweettest::SweetInlineZomes::COORDINATOR),
-            "create_batch",
-            NUM_OPS,
-        )
+        .call(&alice.zome("zome"), "create_batch", NUM_OPS)
         .await;
     let all_cells = vec![&alice, &bobbo, &carol];
 
@@ -167,11 +164,7 @@ async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let element: Option<Record> = conductors[1]
-        .call(
-            &bobbo.zome(holochain::sweettest::SweetInlineZomes::COORDINATOR),
-            "read",
-            hashes[0].clone(),
-        )
+        .call(&bobbo.zome("zome"), "read", hashes[0].clone())
         .await;
     let element = element.expect("Record was None: bobbo couldn't `get` it");
 
@@ -354,9 +347,10 @@ async fn fullsync_sharded_local_gossip() -> anyhow::Result<()> {
         ..Default::default()
     });
 
-    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_create_read_zome())
-        .await
-        .unwrap();
+    let (dna_file, _, _) =
+        SweetDnaFile::unique_from_inline_zomes(("simple", simple_create_read_zome()))
+            .await
+            .unwrap();
 
     let alice = conductor
         .setup_app("app", &[dna_file.clone()])

--- a/crates/holochain_zome_types/src/zome/inline_zome.rs
+++ b/crates/holochain_zome_types/src/zome/inline_zome.rs
@@ -25,20 +25,18 @@ pub struct CoordinatorZomeMarker;
 pub type InlineIntegrityZome = InlineZome<IntegrityZomeMarker>;
 pub type InlineCoordinatorZome = InlineZome<CoordinatorZomeMarker>;
 
-/// An InlineZome, which consists
-pub struct InlineZome<T> {
+/// An "inline" zome definition in pure Rust, as opposed to a zome defined in Wasm.
+pub struct InlineZome<T = IntegrityZomeMarker> {
     /// Inline zome type marker.
     _t: PhantomData<T>,
-    /// Since closures cannot be serialized, we include a network seed which
+
+    /// Since closures cannot be serialized, we include a UUID which
     /// is the only part of an InlineZome that gets serialized.
-    /// This uuid becomes part of the determination of the DnaHash
+    /// This UUID becomes part of the determination of the DnaHash
     /// that it is a part of.
     /// Think of it as a stand-in for the WasmHash of a WasmZome.
     pub(super) uuid: String,
 
-    // /// The EntryDefs returned by the `entry_defs` callback function,
-    // /// which will be automatically provided
-    // pub(super) entry_defs: EntryDefs,
     /// The collection of closures which define this zome.
     /// These functions are directly called by the Ribosome.
     pub(super) functions: HashMap<FunctionName, InlineZomeFn>,


### PR DESCRIPTION
### Summary

It's unnecessary and needlessly complicated to use InlineZomeSet for a single zome. Changes some of these instances back to a single InlineIntegrityZome where possible, so we don't proliferate a more complex pattern than needed.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
