### PR TITLE
Make OpBasis AnyLinkableHash instead of AnyDhtHash

### DIFF
--- a/crates/holo_hash/src/aliases.rs
+++ b/crates/holo_hash/src/aliases.rs
@@ -41,6 +41,9 @@ pub type AnyDhtHash = HoloHash<hash_type::AnyDht>;
 /// The hash of anything linkable.
 pub type AnyLinkableHash = HoloHash<hash_type::AnyLinkable>;
 
+/// Alias for AnyLinkableHash. This hash forms the notion of the "basis hash" of an op.
+pub type OpBasis = AnyLinkableHash;
+
 /// The primitive hash types represented by this composite hash
 pub enum AnyDhtHashPrimitive {
     /// This is an EntryHash
@@ -133,9 +136,10 @@ impl AnyDhtHash {
     }
 }
 
-impl From<AnyLinkableHash> for AnyDhtHash {
-    fn from(hash: AnyLinkableHash) -> Self {
-        hash.retype(hash_type::AnyDht::Entry)
+impl From<AnyDhtHash> for AnyLinkableHash {
+    fn from(hash: AnyDhtHash) -> Self {
+        let t = hash.hash_type().clone().into();
+        hash.retype(t)
     }
 }
 

--- a/crates/holo_hash/src/aliases.rs
+++ b/crates/holo_hash/src/aliases.rs
@@ -138,7 +138,7 @@ impl AnyDhtHash {
 
 impl From<AnyDhtHash> for AnyLinkableHash {
     fn from(hash: AnyDhtHash) -> Self {
-        let t = hash.hash_type().clone().into();
+        let t = (*hash.hash_type()).into();
         hash.retype(t)
     }
 }

--- a/crates/holo_hash/src/hash_type/composite.rs
+++ b/crates/holo_hash/src/hash_type/composite.rs
@@ -160,3 +160,12 @@ impl From<AnyLinkableSerial> for AnyLinkable {
         }
     }
 }
+
+impl From<AnyDht> for AnyLinkable {
+    fn from(t: AnyDht) -> Self {
+        match t {
+            AnyDht::Entry => AnyLinkable::Entry,
+            AnyDht::Action => AnyLinkable::Action,
+        }
+    }
+}

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use holo_hash::{ActionHash, AgentPubKey, DhtOpHash};
-use holo_hash::{AnyDhtHash, EntryHash};
+use holo_hash::{ActionHash, AgentPubKey, DhtOpHash, EntryHash, OpBasis};
 use holochain_keystore::AgentPubKeyExt;
 use holochain_p2p::{HolochainP2pDna, HolochainP2pDnaT};
 use holochain_state::integrate::authored_ops_to_dht_db;
@@ -205,7 +204,7 @@ pub(crate) async fn countersigning_success(
                             },
                             |row| {
                                 let hash: DhtOpHash = row.get("hash")?;
-                                let basis: AnyDhtHash = row.get("basis_hash")?;
+                                let basis: OpBasis = row.get("basis_hash")?;
                                 Ok((hash, basis))
                             },
                         )?
@@ -216,7 +215,7 @@ pub(crate) async fn countersigning_success(
             StateMutationResult::Ok(Vec::with_capacity(0))
         }
     };
-    let this_cell_actions_op_basis_hashes: Vec<(DhtOpHash, AnyDhtHash)> =
+    let this_cell_actions_op_basis_hashes: Vec<(DhtOpHash, OpBasis)> =
         authored_db.async_reader(reader_closure).await?;
 
     // If there is no active session then we can short circuit.

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -94,7 +94,7 @@ pub async fn publish_dht_ops_workflow(
 pub async fn publish_dht_ops_workflow_inner(
     db: DbRead<DbKindAuthored>,
     agent: AgentPubKey,
-) -> WorkflowResult<HashMap<AnyDhtHash, Vec<(DhtOpHash, DhtOp)>>> {
+) -> WorkflowResult<HashMap<OpBasis, Vec<(DhtOpHash, DhtOp)>>> {
     // Ops to publish by basis
     let mut to_publish = HashMap::new();
 

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -1060,7 +1060,7 @@ where
     async fn am_i_an_authority(&mut self, hash: OpBasis) -> CascadeResult<bool> {
         let network = some_or_return!(self.network.as_mut(), false);
 
-        Ok(network.authority_for_hash(hash.into()).await?)
+        Ok(network.authority_for_hash(hash).await?)
     }
 
     /// Construct a query with private data access if this cascade has been

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -842,7 +842,7 @@ where
         key: WireLinkKey,
         options: GetLinksOptions,
     ) -> CascadeResult<Vec<Link>> {
-        let authority = self.am_i_an_authority(key.base.clone().into()).await?;
+        let authority = self.am_i_an_authority(key.base.clone()).await?;
         if !authority {
             self.fetch_links(key.clone(), options).await?;
         }
@@ -859,7 +859,7 @@ where
         key: WireLinkKey,
         options: GetLinksOptions,
     ) -> CascadeResult<Vec<(SignedActionHashed, Vec<SignedActionHashed>)>> {
-        let authority = self.am_i_an_authority(key.base.clone().into()).await?;
+        let authority = self.am_i_an_authority(key.base.clone()).await?;
         if !authority {
             self.fetch_links(key.clone(), options).await?;
         }
@@ -1057,10 +1057,10 @@ where
         Ok(scratch.apply_and_then(|scratch| scratch.contains_hash(hash))?)
     }
 
-    async fn am_i_an_authority(&mut self, hash: AnyDhtHash) -> CascadeResult<bool> {
+    async fn am_i_an_authority(&mut self, hash: OpBasis) -> CascadeResult<bool> {
         let network = some_or_return!(self.network.as_mut(), false);
 
-        Ok(network.authority_for_hash(hash).await?)
+        Ok(network.authority_for_hash(hash.into()).await?)
     }
 
     /// Construct a query with private data access if this cascade has been

--- a/crates/holochain_cascade/src/test_utils.rs
+++ b/crates/holochain_cascade/src/test_utils.rs
@@ -199,7 +199,7 @@ impl HolochainP2pDnaT for PassThroughNetwork {
 
     async fn authority_for_hash(
         &self,
-        _dht_hash: holo_hash::AnyDhtHash,
+        _dht_hash: holo_hash::OpBasis,
     ) -> actor::HolochainP2pResult<bool> {
         Ok(self.authority)
     }
@@ -224,7 +224,7 @@ impl HolochainP2pDnaT for PassThroughNetwork {
         &self,
         _request_validation_receipt: bool,
         _countersigning_session: bool,
-        _dht_hash: holo_hash::AnyDhtHash,
+        _basis_hash: holo_hash::OpBasis,
         _ops: Vec<holochain_types::dht_op::DhtOp>,
         _timeout_ms: Option<u64>,
     ) -> actor::HolochainP2pResult<usize> {
@@ -385,7 +385,7 @@ impl HolochainP2pDnaT for MockNetwork {
 
     async fn authority_for_hash(
         &self,
-        dht_hash: holo_hash::AnyDhtHash,
+        dht_hash: holo_hash::OpBasis,
     ) -> actor::HolochainP2pResult<bool> {
         self.0.lock().await.authority_for_hash(dht_hash).await
     }
@@ -410,7 +410,7 @@ impl HolochainP2pDnaT for MockNetwork {
         &self,
         _request_validation_receipt: bool,
         _countersigning_session: bool,
-        _dht_hash: holo_hash::AnyDhtHash,
+        _basis_hash: holo_hash::OpBasis,
         _ops: Vec<holochain_types::dht_op::DhtOp>,
         _timeout_ms: Option<u64>,
     ) -> actor::HolochainP2pResult<usize> {

--- a/crates/holochain_p2p/src/lib.rs
+++ b/crates/holochain_p2p/src/lib.rs
@@ -70,7 +70,7 @@ pub trait HolochainP2pDnaT {
         &self,
         request_validation_receipt: bool,
         countersigning_session: bool,
-        dht_hash: holo_hash::AnyDhtHash,
+        basis_hash: holo_hash::OpBasis,
         ops: Vec<holochain_types::dht_op::DhtOp>,
         timeout_ms: Option<u64>,
     ) -> actor::HolochainP2pResult<usize>;
@@ -121,7 +121,7 @@ pub trait HolochainP2pDnaT {
     /// Check if an agent is an authority for a hash.
     async fn authority_for_hash(
         &self,
-        dht_hash: holo_hash::AnyDhtHash,
+        basis: holo_hash::OpBasis,
     ) -> actor::HolochainP2pResult<bool>;
 
     /// Messages between agents driving a countersigning session.
@@ -227,7 +227,7 @@ impl HolochainP2pDnaT for HolochainP2pDna {
         &self,
         request_validation_receipt: bool,
         countersigning_session: bool,
-        dht_hash: holo_hash::AnyDhtHash,
+        basis_hash: holo_hash::OpBasis,
         ops: Vec<holochain_types::dht_op::DhtOp>,
         timeout_ms: Option<u64>,
     ) -> actor::HolochainP2pResult<usize> {
@@ -236,7 +236,7 @@ impl HolochainP2pDnaT for HolochainP2pDna {
                 (*self.dna_hash).clone(),
                 request_validation_receipt,
                 countersigning_session,
-                dht_hash,
+                basis_hash,
                 ops,
                 timeout_ms,
             )
@@ -313,7 +313,7 @@ impl HolochainP2pDnaT for HolochainP2pDna {
     /// Check if an agent is an authority for a hash.
     async fn authority_for_hash(
         &self,
-        dht_hash: holo_hash::AnyDhtHash,
+        dht_hash: holo_hash::OpBasis,
     ) -> actor::HolochainP2pResult<bool> {
         self.sender
             .authority_for_hash((*self.dna_hash).clone(), dht_hash)

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -758,7 +758,7 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
             crate::wire::WireMessage::Publish {
                 request_validation_receipt,
                 countersigning_session,
-                dht_hash: _,
+                basis_hash: _,
                 ops,
             } => self.handle_incoming_publish(
                 space,
@@ -971,14 +971,14 @@ impl HolochainP2pHandler for HolochainP2pActor {
         dna_hash: DnaHash,
         request_validation_receipt: bool,
         countersigning_session: bool,
-        dht_hash: holo_hash::AnyDhtHash,
+        basis_hash: holo_hash::OpBasis,
         ops: Vec<holochain_types::dht_op::DhtOp>,
         timeout_ms: Option<u64>,
     ) -> HolochainP2pHandlerResult<usize> {
         use kitsune_p2p_types::KitsuneTimeout;
 
         let space = dna_hash.into_kitsune();
-        let basis = dht_hash.to_kitsune();
+        let basis = basis_hash.to_kitsune();
         let timeout = match timeout_ms {
             Some(ms) => KitsuneTimeout::from_millis(ms),
             None => self.tuning_params.implicit_timeout(),
@@ -987,7 +987,7 @@ impl HolochainP2pHandler for HolochainP2pActor {
         let payload = crate::wire::WireMessage::publish(
             request_validation_receipt,
             countersigning_session,
-            dht_hash,
+            basis_hash,
             ops,
         )
         .encode()?;
@@ -1077,7 +1077,7 @@ impl HolochainP2pHandler for HolochainP2pActor {
         options: actor::GetLinksOptions,
     ) -> HolochainP2pHandlerResult<Vec<WireLinkOps>> {
         let space = dna_hash.into_kitsune();
-        let basis = AnyDhtHash::from(link_key.base.clone()).to_kitsune();
+        let basis = link_key.base.clone().to_kitsune();
         let r_options: event::GetLinksOptions = (&options).into();
 
         let payload = crate::wire::WireMessage::get_links(link_key, r_options).encode()?;
@@ -1221,10 +1221,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
     fn handle_authority_for_hash(
         &mut self,
         dna_hash: DnaHash,
-        dht_hash: AnyDhtHash,
+        basis_hash: OpBasis,
     ) -> HolochainP2pHandlerResult<bool> {
         let space = dna_hash.into_kitsune();
-        let basis = dht_hash.to_kitsune();
+        let basis = basis_hash.to_kitsune();
 
         let kitsune_p2p = self.kitsune_p2p.clone();
         Ok(

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -1077,7 +1077,7 @@ impl HolochainP2pHandler for HolochainP2pActor {
         options: actor::GetLinksOptions,
     ) -> HolochainP2pHandlerResult<Vec<WireLinkOps>> {
         let space = dna_hash.into_kitsune();
-        let basis = link_key.base.clone().to_kitsune();
+        let basis = link_key.base.to_kitsune();
         let r_options: event::GetLinksOptions = (&options).into();
 
         let payload = crate::wire::WireMessage::get_links(link_key, r_options).encode()?;

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -61,7 +61,7 @@ impl HolochainP2pHandler for StubNetwork {
         dna_hash: DnaHash,
         request_validation_receipt: bool,
         countersigning_session: bool,
-        dht_hash: holo_hash::AnyDhtHash,
+        basis_hash: holo_hash::OpBasis,
         ops: Vec<holochain_types::dht_op::DhtOp>,
         timeout_ms: Option<u64>,
     ) -> HolochainP2pHandlerResult<usize> {
@@ -130,7 +130,7 @@ impl HolochainP2pHandler for StubNetwork {
     fn handle_authority_for_hash(
         &mut self,
         dna_hash: DnaHash,
-        dht_hash: AnyDhtHash,
+        basis_hash: OpBasis,
     ) -> HolochainP2pHandlerResult<bool> {
         Err("stub".into())
     }
@@ -380,9 +380,9 @@ mod tests {
         p2p.join(dna.clone(), a2.clone(), None).await.unwrap();
         p2p.join(dna.clone(), a3.clone(), None).await.unwrap();
 
-        let action_hash = holo_hash::AnyDhtHash::from_raw_36_and_type(
+        let action_hash = holo_hash::OpBasis::from_raw_36_and_type(
             b"eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee".to_vec(),
-            holo_hash::hash_type::AnyDht::Action,
+            holo_hash::hash_type::AnyLinkable::Action,
         );
 
         // this will fail because we can't reach any remote nodes

--- a/crates/holochain_p2p/src/types.rs
+++ b/crates/holochain_p2p/src/types.rs
@@ -198,4 +198,5 @@ macro_rules! to_kitsune {
 
 to_kitsune! {
     AnyDhtHashExt<holo_hash::AnyDhtHash> -> kitsune_p2p::KitsuneBasis,
+    AnyLinkableHashExt<holo_hash::AnyLinkableHash> -> kitsune_p2p::KitsuneBasis,
 }

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -243,7 +243,7 @@ ghost_actor::ghost_chan! {
             dna_hash: DnaHash,
             request_validation_receipt: bool,
             countersigning_session: bool,
-            dht_hash: holo_hash::AnyDhtHash,
+            basis_hash: holo_hash::OpBasis,
             ops: Vec<holochain_types::dht_op::DhtOp>,
             timeout_ms: Option<u64>,
         ) -> usize;
@@ -291,7 +291,7 @@ ghost_actor::ghost_chan! {
         fn new_integrated_data(dna_hash: DnaHash) -> ();
 
         /// Check if any local agent in this space is an authority for a hash.
-        fn authority_for_hash(dna_hash: DnaHash, dht_hash: AnyDhtHash) -> bool;
+        fn authority_for_hash(dna_hash: DnaHash, basis: OpBasis) -> bool;
 
         /// Messages between agents negotiation a countersigning session.
         fn countersigning_session_negotiation(

--- a/crates/holochain_p2p/src/types/wire.rs
+++ b/crates/holochain_p2p/src/types/wire.rs
@@ -36,7 +36,7 @@ pub enum WireMessage {
     Publish {
         request_validation_receipt: bool,
         countersigning_session: bool,
-        dht_hash: holo_hash::AnyDhtHash,
+        basis_hash: holo_hash::OpBasis,
         ops: Vec<holochain_types::dht_op::DhtOp>,
     },
     ValidationReceipt {
@@ -98,13 +98,13 @@ impl WireMessage {
     pub fn publish(
         request_validation_receipt: bool,
         countersigning_session: bool,
-        dht_hash: holo_hash::AnyDhtHash,
+        basis_hash: holo_hash::OpBasis,
         ops: Vec<holochain_types::dht_op::DhtOp>,
     ) -> WireMessage {
         Self::Publish {
             request_validation_receipt,
             countersigning_session,
-            dht_hash,
+            basis_hash,
             ops,
         }
     }

--- a/crates/holochain_state/src/integrate.rs
+++ b/crates/holochain_state/src/integrate.rs
@@ -1,4 +1,4 @@
-use holo_hash::{AnyDhtHash, DhtOpHash, HasHash};
+use holo_hash::{AnyLinkableHash, DhtOpHash, HasHash};
 use holochain_p2p::HolochainP2pDnaT;
 use holochain_sqlite::rusqlite::Transaction;
 use holochain_types::{
@@ -16,7 +16,7 @@ use crate::{prelude::*, query::get_public_op_from_db};
 /// of any local agents.
 pub async fn authored_ops_to_dht_db(
     network: &(dyn HolochainP2pDnaT + Send + Sync),
-    hashes: Vec<(DhtOpHash, AnyDhtHash)>,
+    hashes: Vec<(DhtOpHash, AnyLinkableHash)>,
     authored_db: &DbRead<DbKindAuthored>,
     dht_db: &DbWrite<DbKindDht>,
     dht_db_cache: &DhtDbQueryCache,

--- a/crates/holochain_state/tests/cache_tests/mod.rs
+++ b/crates/holochain_state/tests/cache_tests/mod.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 fn insert_action_and_op(txn: &mut Transaction, u: &mut Unstructured, action: &Action) -> DhtOpHash {
     let timestamp = Timestamp::arbitrary(u).unwrap();
     let op_order = OpOrder::new(DhtOpType::RegisterAgentActivity, timestamp);
-    let any_hash: AnyDhtHash = EntryHash::arbitrary(u).unwrap().into();
+    let basis_hash: OpBasis = EntryHash::arbitrary(u).unwrap().into();
     let action = SignedActionHashed::with_presigned(
         ActionHashed::from_content_sync(action.clone()),
         Signature::arbitrary(u).unwrap(),
@@ -28,7 +28,7 @@ fn insert_action_and_op(txn: &mut Transaction, u: &mut Unstructured, action: &Ac
     mutations::insert_action(txn, &action).unwrap();
     mutations::insert_op_lite(
         txn,
-        &DhtOpLight::RegisterAgentActivity(hash, any_hash.clone()),
+        &DhtOpLight::RegisterAgentActivity(hash, basis_hash.clone()),
         &op_hash,
         &op_order,
         &timestamp,

--- a/crates/holochain_types/src/dht_op.rs
+++ b/crates/holochain_types/src/dht_op.rs
@@ -609,8 +609,8 @@ impl<'a> UniqueForm<'a> {
             UniqueForm::RegisterDeletedEntryAction(action) => {
                 action.deletes_entry_address.clone().into()
             }
-            UniqueForm::RegisterAddLink(action) => action.base_address.clone().into(),
-            UniqueForm::RegisterRemoveLink(action) => action.base_address.clone().into(),
+            UniqueForm::RegisterAddLink(action) => action.base_address.clone(),
+            UniqueForm::RegisterRemoveLink(action) => action.base_address.clone(),
         }
     }
 

--- a/crates/holochain_types/src/dht_op.rs
+++ b/crates/holochain_types/src/dht_op.rs
@@ -131,32 +131,29 @@ impl kitsune_p2p_dht::prelude::OpRegion for DhtOp {
     }
 }
 
-/// Show that this type is used as the basis
-type DhtBasis = AnyDhtHash;
-
 /// A type for storing in databases that don't need the actual
 /// data. Everything is a hash of the type except the signatures.
 #[allow(missing_docs)]
 #[derive(Clone, Debug, Serialize, Deserialize, derive_more::Display)]
 pub enum DhtOpLight {
     #[display(fmt = "StoreRecord")]
-    StoreRecord(ActionHash, Option<EntryHash>, DhtBasis),
+    StoreRecord(ActionHash, Option<EntryHash>, OpBasis),
     #[display(fmt = "StoreEntry")]
-    StoreEntry(ActionHash, EntryHash, DhtBasis),
+    StoreEntry(ActionHash, EntryHash, OpBasis),
     #[display(fmt = "RegisterAgentActivity")]
-    RegisterAgentActivity(ActionHash, DhtBasis),
+    RegisterAgentActivity(ActionHash, OpBasis),
     #[display(fmt = "RegisterUpdatedContent")]
-    RegisterUpdatedContent(ActionHash, EntryHash, DhtBasis),
+    RegisterUpdatedContent(ActionHash, EntryHash, OpBasis),
     #[display(fmt = "RegisterUpdatedRecord")]
-    RegisterUpdatedRecord(ActionHash, EntryHash, DhtBasis),
+    RegisterUpdatedRecord(ActionHash, EntryHash, OpBasis),
     #[display(fmt = "RegisterDeletedBy")]
-    RegisterDeletedBy(ActionHash, DhtBasis),
+    RegisterDeletedBy(ActionHash, OpBasis),
     #[display(fmt = "RegisterDeletedEntryAction")]
-    RegisterDeletedEntryAction(ActionHash, DhtBasis),
+    RegisterDeletedEntryAction(ActionHash, OpBasis),
     #[display(fmt = "RegisterAddLink")]
-    RegisterAddLink(ActionHash, DhtBasis),
+    RegisterAddLink(ActionHash, OpBasis),
     #[display(fmt = "RegisterRemoveLink")]
-    RegisterRemoveLink(ActionHash, DhtBasis),
+    RegisterRemoveLink(ActionHash, OpBasis),
 }
 
 impl PartialEq for DhtOpLight {
@@ -253,7 +250,7 @@ impl DhtOp {
     }
 
     /// Returns the basis hash which determines which agents will receive this DhtOp
-    pub fn dht_basis(&self) -> AnyDhtHash {
+    pub fn dht_basis(&self) -> OpBasis {
         self.as_unique_form().basis()
     }
 
@@ -461,7 +458,7 @@ impl Ord for DhtOp {
 
 impl DhtOpLight {
     /// Get the dht basis for where to send this op
-    pub fn dht_basis(&self) -> &AnyDhtHash {
+    pub fn dht_basis(&self) -> &OpBasis {
         match self {
             DhtOpLight::StoreRecord(_, _, b)
             | DhtOpLight::StoreEntry(_, _, b)
@@ -566,14 +563,14 @@ impl DhtOpLight {
                     Action::CreateLink(create_link) => create_link.base_address.clone(),
                     _ => return Err(DhtOpError::OpActionMismatch(op_type, action.action_type())),
                 };
-                Self::RegisterAddLink(action_hash, basis.into())
+                Self::RegisterAddLink(action_hash, basis)
             }
             DhtOpType::RegisterRemoveLink => {
                 let basis = match action {
                     Action::DeleteLink(delete_link) => delete_link.base_address.clone(),
                     _ => return Err(DhtOpError::OpActionMismatch(op_type, action.action_type())),
                 };
-                Self::RegisterRemoveLink(action_hash, basis.into())
+                Self::RegisterRemoveLink(action_hash, basis)
             }
         };
         Ok(op)
@@ -597,7 +594,7 @@ pub enum UniqueForm<'a> {
 }
 
 impl<'a> UniqueForm<'a> {
-    fn basis(&'a self) -> AnyDhtHash {
+    fn basis(&'a self) -> OpBasis {
         match self {
             UniqueForm::StoreRecord(action) => ActionHash::with_data_sync(*action).into(),
             UniqueForm::StoreEntry(action) => action.entry().clone().into(),

--- a/crates/holochain_types/src/dht_op/tests.rs
+++ b/crates/holochain_types/src/dht_op/tests.rs
@@ -19,6 +19,8 @@ use holochain_zome_types::Entry;
 use observability;
 use tracing::*;
 
+use super::OpBasis;
+
 struct RecordTest {
     entry_type: EntryType,
     entry_hash: EntryHash,
@@ -239,7 +241,7 @@ async fn test_all_ops() {
 async fn test_dht_basis() {
     // Create an action that points to an entry
     let original_action = fixt!(Create);
-    let expected_entry_hash: AnyDhtHash = original_action.entry_hash.clone().into();
+    let expected_entry_hash: OpBasis = original_action.entry_hash.clone().into();
 
     let original_action_hash =
         ActionHashed::from_content_sync(Action::Create(original_action.clone()));
@@ -367,21 +369,27 @@ fn test_all_ops_basis() {
         let ops = produce_ops_from_record(&record).unwrap();
         let check_basis = |op: DhtOp| match (op.get_type(), op.dht_basis()) {
             (DhtOpType::StoreRecord, basis) => {
-                assert_eq!(basis, AnyDhtHash::from(record.action_address().clone()))
+                assert_eq!(
+                    basis,
+                    AnyLinkableHash::from(record.action_address().clone())
+                )
             }
             (DhtOpType::StoreEntry, basis) => {
                 assert_eq!(
                     basis,
-                    AnyDhtHash::from(record.action().entry_hash().unwrap().clone())
+                    AnyLinkableHash::from(record.action().entry_hash().unwrap().clone())
                 )
             }
             (DhtOpType::RegisterAgentActivity, basis) => {
-                assert_eq!(basis, AnyDhtHash::from(record.action().author().clone()))
+                assert_eq!(
+                    basis,
+                    AnyLinkableHash::from(record.action().author().clone())
+                )
             }
             (DhtOpType::RegisterUpdatedContent, basis) => {
                 assert_eq!(
                     basis,
-                    AnyDhtHash::from(
+                    AnyLinkableHash::from(
                         Update::try_from(record.action().clone())
                             .unwrap()
                             .original_entry_address
@@ -392,7 +400,7 @@ fn test_all_ops_basis() {
             (DhtOpType::RegisterUpdatedRecord, basis) => {
                 assert_eq!(
                     basis,
-                    AnyDhtHash::from(
+                    AnyLinkableHash::from(
                         Update::try_from(record.action().clone())
                             .unwrap()
                             .original_action_address
@@ -403,7 +411,7 @@ fn test_all_ops_basis() {
             (DhtOpType::RegisterDeletedBy, basis) => {
                 assert_eq!(
                     basis,
-                    AnyDhtHash::from(
+                    AnyLinkableHash::from(
                         Delete::try_from(record.action().clone())
                             .unwrap()
                             .deletes_address
@@ -414,7 +422,7 @@ fn test_all_ops_basis() {
             (DhtOpType::RegisterDeletedEntryAction, basis) => {
                 assert_eq!(
                     basis,
-                    AnyDhtHash::from(
+                    AnyLinkableHash::from(
                         Delete::try_from(record.action().clone())
                             .unwrap()
                             .deletes_entry_address
@@ -425,7 +433,7 @@ fn test_all_ops_basis() {
             (DhtOpType::RegisterAddLink, basis) => {
                 assert_eq!(
                     basis,
-                    AnyDhtHash::from(
+                    AnyLinkableHash::from(
                         CreateLink::try_from(record.action().clone())
                             .unwrap()
                             .base_address
@@ -436,7 +444,7 @@ fn test_all_ops_basis() {
             (DhtOpType::RegisterRemoveLink, basis) => {
                 assert_eq!(
                     basis,
-                    AnyDhtHash::from(
+                    AnyLinkableHash::from(
                         DeleteLink::try_from(record.action().clone())
                             .unwrap()
                             .base_address


### PR DESCRIPTION
### Summary

Since `RegisterAddLink` and `RegisterRemoveLink` are ops, and the link base is the op's basis, and link bases are `AnyLinkableHash`, then it follows that the op basis is actually that, not `AnyDhtHash`, which excludes the External hash type. This adjusts the code accordingly.

There was also a `From<AnyLinkableHash> for AnyDhtHash`, which is invalid because the External variant has no mapping in AnyDhtHash, so I removed it. It is also no longer needed, since the places it was used are no longer relevant with the type change.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
