### PR TITLE
fix(restore-clone): find clone in archived clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [holochain-0.0.165](crates/holochain/CHANGELOG.md#0.0.165)
 
+- Revert requiring DNA modifiers when registering a DNA. These modifiers were optional before and were made mandatory by accident.
+
 ## [holochain\_conductor\_api-0.0.62](crates/holochain_conductor_api/CHANGELOG.md#0.0.62)
 
 ## [holochain\_wasm\_test\_utils-0.0.61](crates/holochain_wasm_test_utils/CHANGELOG.md#0.0.61)

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix restore clone cell by cell id. This used to fail with a "CloneCellNotFound" error. [\#1603](https://github.com/holochain/holochain/pull/1603)
+
 ## 0.0.165
 
 ## 0.0.164

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.0.165
 
+- Revert requiring DNA modifiers when registering a DNA. These modifiers were optional before and were made mandatory by accident.
+
 ## 0.0.164
 
 - Add App API call to archive an existing clone cell. [\#1578](https://github.com/holochain/holochain/pull/1578)

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -862,7 +862,7 @@ impl Conductor {
                 let clone_cell_id = clone_cell_id.to_owned();
                 move |mut state| {
                     let app = state.get_app_mut(&app_id)?;
-                    let clone_id = app.get_clone_id(&clone_cell_id)?;
+                    let clone_id = app.get_archived_clone_id(&clone_cell_id)?;
                     let restored_cell = app.restore_clone_cell(&clone_id)?;
                     Ok((state, restored_cell))
                 }

--- a/crates/holochain/src/conductor/tests/cell_cloning.rs
+++ b/crates/holochain/src/conductor/tests/cell_cloning.rs
@@ -231,7 +231,7 @@ async fn clone_cell_deletion() {
         .await;
     assert!(zome_call_response.is_err());
 
-    // restore the archived clone cell
+    // restore the archived clone cell by clone id
     let restored_cell = conductor
         .inner_handle()
         .restore_archived_clone_cell(ArchiveCloneCellPayload {
@@ -259,6 +259,31 @@ async fn clone_cell_deletion() {
         .call_fallible(&zome, "call_create_entry", ())
         .await;
     assert!(zome_call_response.is_ok());
+
+    // archive clone cell again
+    conductor
+        .inner_handle()
+        .archive_clone_cell(ArchiveCloneCellPayload {
+            app_id: app_id.to_string(),
+            clone_cell_id: CloneCellId::CloneId(
+                CloneId::try_from(installed_clone_cell.clone().into_role_id()).unwrap(),
+            ),
+        })
+        .await
+        .unwrap();
+
+    // restore clone cell by cell id
+    let restored_cell = conductor
+        .inner_handle()
+        .restore_archived_clone_cell(ArchiveCloneCellPayload {
+            app_id: app_id.into(),
+            clone_cell_id: CloneCellId::CellId(installed_clone_cell.as_id().clone()),
+        })
+        .await
+        .unwrap();
+
+    // assert the restored clone cell is the previously created clone cell
+    assert_eq!(restored_cell, installed_clone_cell);
 
     // archive and delete clone cell
     conductor

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -573,6 +573,22 @@ impl InstalledAppCommon {
         Ok(clone_id.clone())
     }
 
+    /// Get the clone id from either clone or cell id.
+    pub fn get_archived_clone_id(&self, clone_cell_id: &CloneCellId) -> AppResult<CloneId> {
+        let clone_id = match clone_cell_id {
+            CloneCellId::CloneId(id) => id.clone(),
+            CloneCellId::CellId(id) => {
+                self.role_assignments
+                    .iter()
+                    .flat_map(|(_, role_assignment)| role_assignment.archived_clones.clone())
+                    .find(|(_, cell_id)| cell_id == id)
+                    .ok_or_else(|| AppError::CloneCellNotFound(CloneCellId::CellId(id.clone())))?
+                    .0
+            }
+        };
+        Ok(clone_id)
+    }
+
     /// Archive a clone cell.
     ///
     /// Removes the cell from the list of clones and it is not accessible any


### PR DESCRIPTION
### Summary

Fix D-01649 where clone cells cannot be restored by cell id. The problem was that cell ids are removed from the cell list when archived, and therefore cannot be found in the cell list when trying to find them for restoration.

This is changed now to find the cell in the list of archived clones.

Add retrospectively to previous version's changelog the DNA modifier fix.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
