### PR TITLE
Expose `AppManifestV1` to be used by downstream dependencies

### DIFF
--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Exposed `AppManifestV1` to be used from downstream dependencies.
+
 ## 0.0.59
 
 ## 0.0.58

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## \[Unreleased\]
 
 - Exposed `AppManifestV1` to be used from downstream dependencies.
+- Exposed `WebAppManifestV1` to be used from downstream dependencies.
 
 ## 0.0.59
 

--- a/crates/holochain_types/src/app/app_manifest.rs
+++ b/crates/holochain_types/src/app/app_manifest.rs
@@ -6,7 +6,7 @@ use holochain_zome_types::NetworkSeed;
 use mr_bundle::{Location, Manifest};
 use std::path::PathBuf;
 
-pub(crate) mod app_manifest_v1;
+pub mod app_manifest_v1;
 pub mod app_manifest_validated;
 mod current;
 mod error;

--- a/crates/holochain_types/src/web_app/web_app_manifest.rs
+++ b/crates/holochain_types/src/web_app/web_app_manifest.rs
@@ -6,7 +6,7 @@ use mr_bundle::{Location, Manifest};
 use std::path::PathBuf;
 
 mod current;
-pub(crate) mod web_app_manifest_v1;
+pub mod web_app_manifest_v1;
 
 pub use current::*;
 


### PR DESCRIPTION
### Summary

 - Expose `AppManifestV1` to be used by downstream dependencies

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
