### PR TITLE
fix(hdi): pin the hdi where it's a direct dependency; feat(release-automation): respect version operators when bumping versions

### DIFF
--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+* Pin the _hdi_ dependency version. [\#1605](https://github.com/holochain/holochain/pull/1605)
+
 ## 0.0.156
 
 ## 0.0.155

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -23,7 +23,7 @@ test_utils = [
 properties = ["holochain_zome_types/properties"]
 
 [dependencies]
-hdi = { version = "0.1.5", path = "../hdi", features = ["trace"] }
+hdi = { version = "=0.1.5", path = "../hdi", features = ["trace"] }
 hdk_derive = { version = "0.0.51", path = "../hdk_derive" }
 holo_hash = { version = "0.0.34", path = "../holo_hash" }
 holochain_wasmer_guest = "=0.0.80"

--- a/crates/release-automation/src/lib/common.rs
+++ b/crates/release-automation/src/lib/common.rs
@@ -39,9 +39,14 @@ pub(crate) fn set_version<'a>(
         "setting version to {} in manifest at {:?}",
         release_version, cargo_toml_path
     );
+
+    let version = release_version.to_string();
+
     if !dry_run {
-        cargo_next::set_version(&cargo_toml_path, release_version.to_string())?;
+        cargo_next::set_version(&cargo_toml_path, version.as_str())?;
     }
+
+    let version_req = format!("={}", release_version);
 
     let dependants = crt
         .dependants_in_workspace_filtered(|(_dep_name, deps)| {
@@ -54,19 +59,15 @@ pub(crate) fn set_version<'a>(
         let target_manifest = dependant.manifest_path();
 
         debug!(
-            "[{}] updating dependency version from dependant {} to version {} in manifest {:?}",
+            "[{}] updating dependency version from dependant {} to version requirement {} in manifest {:?}",
             crt.name(),
             dependant.name(),
-            release_version.to_string().as_str(),
+            &version_req,
             &target_manifest,
         );
 
         if !dry_run {
-            set_dependency_version(
-                target_manifest,
-                &crt.name(),
-                release_version.to_string().as_str(),
-            )?;
+            set_dependency_version(target_manifest, &crt.name(), &version_req)?;
         }
     }
 

--- a/crates/release-automation/src/lib/release.rs
+++ b/crates/release-automation/src/lib/release.rs
@@ -243,7 +243,7 @@ fn bump_release_versions<'a>(
 
         let greater_release = release_version > current_version;
         if greater_release {
-            common::set_version(cmd_args.dry_run, crt, &release_version.clone())?;
+            crt.set_version(cmd_args.dry_run, &release_version.clone())?;
         }
 
         let crate_release_heading_name = format!("{}", release_version);

--- a/crates/release-automation/src/lib/tests/cli.rs
+++ b/crates/release-automation/src/lib/tests/cli.rs
@@ -149,7 +149,7 @@ fn bump_versions_on_selection() {
     // ensure dependants were updated
     // todo: ensure *all* dependants were updated
     assert_eq!(
-        "0.0.0",
+        "=0.0.0",
         crate::common::get_dependency_version(
             &workspace
                 .root()

--- a/crates/release-automation/src/lib/tests/cli.rs
+++ b/crates/release-automation/src/lib/tests/cli.rs
@@ -146,23 +146,25 @@ fn bump_versions_on_selection() {
         get_crate_versions(&expected_crates, &workspace),
     );
 
-    // ensure dependants were updated
-    // todo: ensure *all* dependants were updated
-    assert_eq!(
-        "=0.0.0",
-        crate::common::get_dependency_version(
-            &workspace
-                .root()
-                .join("crates")
-                .join("crate_a")
-                .join("Cargo.toml"),
-            "crate_b"
-        )
-        .unwrap()
-        .replace("\"", "")
-        .replace("\\", "")
-        .replace(" ", ""),
-    );
+    // ensure *all* dependants were updated
+    // alas, after refactoring the code into a loop i noticed there's only one dependency in this example workspace
+    for (name, dep_name, expected_crate_version) in &[("crate_a", "crate_b", "=0.0.0")] {
+        assert_eq!(
+            expected_crate_version,
+            &crate::common::get_dependency_version(
+                &workspace
+                    .root()
+                    .join("crates")
+                    .join(name)
+                    .join("Cargo.toml"),
+                dep_name
+            )
+            .unwrap()
+            .replace("\"", "")
+            .replace("\\", "")
+            .replace(" ", ""),
+        );
+    }
 
     // check changelogs for new release headings
     assert_eq!(

--- a/crates/release-automation/src/lib/tests/workspace_mocker.rs
+++ b/crates/release-automation/src/lib/tests/workspace_mocker.rs
@@ -328,7 +328,7 @@ pub(crate) fn example_workspace_1<'a>() -> Fallible<WorkspaceMocker> {
             name: "crate_a".to_string(),
             version: "0.0.1".to_string(),
             dependencies: vec![
-                r#"crate_b = { path = "../crate_b", version = "0.0.0-alpha.1" }"#.to_string(),
+                r#"crate_b = { path = "../crate_b", version = "=0.0.0-alpha.1" }"#.to_string(),
             ],
             excluded: false,
             ty: workspace_mocker::MockProjectType::Bin,


### PR DESCRIPTION
### Summary

closes #1596.



### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
