### PR TITLE
Remove dylib config in Cargo.tomls

### DIFF
--- a/crates/hdi/Cargo.toml
+++ b/crates/hdi/Cargo.toml
@@ -10,10 +10,6 @@ keywords = ["holochain", "holo", "integrity"]
 categories = ["cryptography"]
 edition = "2021"
 
-[lib]
-crate-type = ["cdylib", "rlib"]
-path = "src/lib.rs"
-
 [features]
 default = []
 trace = ["tracing", "tracing-core", "holochain_integrity_types/tracing"]

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -10,10 +10,6 @@ keywords = [ "holochain", "holo", "hdk" ]
 categories = [ "cryptography" ]
 edition = "2021"
 
-[lib]
-crate-type = ["cdylib", "rlib"]
-path = "src/lib.rs"
-
 [features]
 default = []
 mock = ["hdk_derive/mock", "mockall"]

--- a/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
@@ -116,13 +116,13 @@ pub mod wasm_test {
     use crate::core::ribosome::error::RibosomeError;
     use crate::core::ribosome::wasm_test::RibosomeTestFixture;
     use crate::core::workflow::error::WorkflowError;
+    use crate::sweettest::SweetConductorBatch;
+    use crate::sweettest::SweetDnaFile;
     use crate::test_utils::consistency_10s;
     use hdk::prelude::*;
     use holochain_state::source_chain::SourceChainError;
     use holochain_wasm_test_utils::TestWasm;
     use holochain_wasmer_host::prelude::*;
-    use crate::sweettest::SweetConductorBatch;
-    use crate::sweettest::SweetDnaFile;
 
     /// Allow ChainLocked error, panic on anything else
     fn expect_chain_locked(


### PR DESCRIPTION
### Summary

I have found that before this change, every change to the `holochain` crate would trigger a re-check of `hdi` and `hdk`. Post this change, I can update `holochain` and only `holochain` gets compiled.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
