### PR TITLE
Scoped conductor logs

### DIFF
--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -7,7 +7,6 @@
 use super::api::CellConductorHandle;
 use super::api::ZomeCall;
 use super::interface::SignalBroadcaster;
-use super::manager::ManagedTaskAdd;
 use super::space::Space;
 use super::ConductorHandle;
 use crate::conductor::api::CellConductorApi;
@@ -49,7 +48,6 @@ use rusqlite::Transaction;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::Arc;
-use tokio::sync;
 use tracing::*;
 use tracing_futures::Instrument;
 
@@ -117,8 +115,6 @@ impl Cell {
         conductor_handle: ConductorHandle,
         space: Space,
         holochain_p2p_cell: holochain_p2p::HolochainP2pDna,
-        managed_task_add_sender: sync::mpsc::Sender<ManagedTaskAdd>,
-        managed_task_stop_broadcaster: sync::broadcast::Sender<()>,
     ) -> CellResult<(Self, InitialQueueTriggers)> {
         let conductor_api = Arc::new(CellConductorApi::new(conductor_handle.clone(), id.clone()));
 
@@ -136,8 +132,6 @@ impl Cell {
                 holochain_p2p_cell.clone(),
                 &space,
                 conductor_handle.clone(),
-                managed_task_add_sender,
-                managed_task_stop_broadcaster,
             )
             .await;
 

--- a/crates/holochain/src/conductor/cell/test.rs
+++ b/crates/holochain/src/conductor/cell/test.rs
@@ -50,7 +50,7 @@ async fn test_cell_handle_publish() {
     .await
     .unwrap();
 
-    let (add_task_sender, shutdown) = spawn_task_manager(handle.clone());
+    let (_, shutdown) = spawn_task_manager(handle.clone());
     let (stop_tx, _) = sync::broadcast::channel(1);
 
     let (_cell, _) = super::Cell::create(
@@ -58,8 +58,6 @@ async fn test_cell_handle_publish() {
         handle,
         spaces.test_spaces[&dna].space.clone(),
         holochain_p2p_cell,
-        add_task_sender,
-        stop_tx.clone(),
     )
     .await
     .unwrap();

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -207,10 +207,6 @@ pub struct Conductor {
     holochain_p2p: holochain_p2p::HolochainP2pRef,
 
     post_commit: tokio::sync::mpsc::Sender<PostCommitArgs>,
-
-    /// A tag that gets added to trace logs, to differentiate this from other
-    /// conductors which may be running in the same process
-    tracing_scope: String,
 }
 
 impl Conductor {
@@ -253,7 +249,6 @@ impl Conductor {
         holochain_p2p: holochain_p2p::HolochainP2pRef,
         spaces: Spaces,
         post_commit: tokio::sync::mpsc::Sender<PostCommitArgs>,
-        tracing_scope: String,
     ) -> Self {
         Self {
             spaces,
@@ -267,7 +262,6 @@ impl Conductor {
             keystore,
             holochain_p2p,
             post_commit,
-            tracing_scope,
         }
     }
 
@@ -904,7 +898,7 @@ impl Conductor {
                 ..
             } => {
                 let cutoff = self
-                    .get_config()
+                    .config()
                     .network
                     .clone()
                     .unwrap_or_default()
@@ -2059,13 +2053,13 @@ impl Conductor {
     }
 
     /// Get the conductor config
-    pub fn get_config(&self) -> &ConductorConfig {
+    pub fn config(&self) -> &ConductorConfig {
         &self.config
     }
 
     /// Get the tracing_scope
     pub(crate) fn tracing_scope(&self) -> &str {
-        self.tracing_scope.as_ref()
+        self.config.tracing_scope.as_ref()
     }
 }
 

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -98,8 +98,9 @@ impl ConductorBuilder {
         let tag = spaces.get_state().await?.tag().clone();
 
         let network_config = config.network.clone().unwrap_or_default();
-        let (cert_digest, cert, cert_priv_key) =
-            keystore.get_or_create_tls_cert_by_tag(tag.0).await?;
+        let (cert_digest, cert, cert_priv_key) = keystore
+            .get_or_create_tls_cert_by_tag(tag.0.clone())
+            .await?;
         let tls_config =
             holochain_p2p::kitsune_p2p::dependencies::kitsune_p2p_types::tls::TlsConfig {
                 cert,
@@ -128,6 +129,7 @@ impl ConductorBuilder {
             holochain_p2p,
             spaces,
             post_commit_sender,
+            format!("scope-{}", tag.0),
         );
 
         let shutting_down = conductor.shutting_down.clone();
@@ -278,6 +280,7 @@ impl ConductorBuilder {
             holochain_p2p,
             spaces,
             post_commit_sender,
+            nanoid::nanoid!(),
         );
 
         let conductor = Self::update_fake_state(self.state, conductor).await?;

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -129,7 +129,6 @@ impl ConductorBuilder {
             holochain_p2p,
             spaces,
             post_commit_sender,
-            format!("scope-{}", tag.0),
         );
 
         let shutting_down = conductor.shutting_down.clone();
@@ -280,7 +279,6 @@ impl ConductorBuilder {
             holochain_p2p,
             spaces,
             post_commit_sender,
-            nanoid::nanoid!(),
         );
 
         let conductor = Self::update_fake_state(self.state, conductor).await?;

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -43,7 +43,6 @@ async fn can_update_state() {
         holochain_p2p,
         spaces,
         post_commit_sender,
-        "".to_string(),
     );
     let state = conductor.get_state().await.unwrap();
     let mut expect_state = ConductorState::default();
@@ -92,7 +91,6 @@ async fn app_ids_are_unique() {
         holochain_p2p,
         spaces,
         post_commit_sender,
-        "".to_string(),
     );
 
     let cell_id = fake_cell_id(1);

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -43,6 +43,7 @@ async fn can_update_state() {
         holochain_p2p,
         spaces,
         post_commit_sender,
+        "".to_string(),
     );
     let state = conductor.get_state().await.unwrap();
     let mut expect_state = ConductorState::default();
@@ -91,6 +92,7 @@ async fn app_ids_are_unique() {
         holochain_p2p,
         spaces,
         post_commit_sender,
+        "".to_string(),
     );
 
     let cell_id = fake_cell_id(1);

--- a/crates/holochain/src/conductor/error.rs
+++ b/crates/holochain/src/conductor/error.rs
@@ -125,6 +125,9 @@ pub enum ConductorError {
     #[error(transparent)]
     RibosomeError(#[from] crate::core::ribosome::error::RibosomeError),
 
+    #[error(transparent)]
+    TaskAddError(#[from] super::manager::TaskAddError),
+
     /// Other
     #[error("Other: {0}")]
     Other(Box<dyn std::error::Error + Send + Sync>),

--- a/crates/holochain/src/conductor/interface/error.rs
+++ b/crates/holochain/src/conductor/interface/error.rs
@@ -25,6 +25,8 @@ pub enum InterfaceError {
     Closed,
     #[error(transparent)]
     WebsocketError(#[from] holochain_websocket::WebsocketError),
+    #[error(transparent)]
+    TaskAddError(#[from] crate::conductor::manager::TaskAddError),
     #[error("Failed to find free port")]
     PortError,
 }

--- a/crates/holochain/src/conductor/manager/error.rs
+++ b/crates/holochain/src/conductor/manager/error.rs
@@ -35,6 +35,9 @@ pub enum ManagedTaskError {
     Conductor(#[from] Box<ConductorError>),
 
     #[error(transparent)]
+    TaskAdd(#[from] super::TaskAddError),
+
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 
     #[error(transparent)]
@@ -52,7 +55,7 @@ impl ManagedTaskError {
         use ManagedTaskError::*;
         #[allow(clippy::match_like_matches_macro)]
         match self {
-            Io(_) | Join(_) | Recv(_) => false,
+            Io(_) | Join(_) | Recv(_) | TaskAdd(_) => false,
             Conductor(err) => match **err {
                 C::ShuttingDown => true,
                 // TODO: identify all recoverable cases

--- a/crates/holochain/src/core/queue_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer.rs
@@ -100,7 +100,7 @@ pub async fn spawn_queue_consumer_tasks(
         Box::new(network.clone()),
     );
     task_adder
-        .cell_critical("publish_dht_ops_consumer", cell_id.clone(), task)
+        .cell_critical_task("publish_dht_ops_consumer", cell_id.clone(), task)
         .await
         .expect("Failed to manage workflow task");
 
@@ -118,7 +118,7 @@ pub async fn spawn_queue_consumer_tasks(
 
     if let Some(task) = task {
         task_adder
-            .cell_critical("validation_receipt_consumer", cell_id.clone(), task)
+            .cell_critical_task("validation_receipt_consumer", cell_id.clone(), task)
             .await
             .expect("Failed to manage workflow task");
     }
@@ -139,7 +139,7 @@ pub async fn spawn_queue_consumer_tasks(
 
     if let Some(task) = task {
         task_adder
-            .cell_critical("integrate_dht_ops_consumer", cell_id.clone(), task)
+            .cell_critical_task("integrate_dht_ops_consumer", cell_id.clone(), task)
             .await
             .expect("Failed to manage workflow task");
     }
@@ -169,7 +169,7 @@ pub async fn spawn_queue_consumer_tasks(
     });
     if let Some(task) = task {
         task_adder
-            .cell_critical("app_validation_consumer", cell_id.clone(), task)
+            .cell_critical_task("app_validation_consumer", cell_id.clone(), task)
             .await
             .expect("Failed to manage workflow task");
     }
@@ -198,7 +198,7 @@ pub async fn spawn_queue_consumer_tasks(
 
     if let Some(task) = task {
         task_adder
-            .cell_critical("sys_validation_consumer", cell_id.clone(), task)
+            .cell_critical_task("sys_validation_consumer", cell_id.clone(), task)
             .await
             .expect("Failed to manage workflow task");
     }
@@ -213,7 +213,7 @@ pub async fn spawn_queue_consumer_tasks(
     });
     if let Some(task) = task {
         task_adder
-            .cell_critical("countersigning_consumer", cell_id.clone(), task)
+            .cell_critical_task("countersigning_consumer", cell_id.clone(), task)
             .await
             .expect("Failed to manage workflow task");
     }

--- a/crates/holochain/src/core/queue_consumer/app_validation_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/app_validation_consumer.rs
@@ -1,19 +1,16 @@
 //! The workflow and queue consumer for sys validation
 
 use super::*;
-use crate::conductor::manager::ManagedTaskResult;
 use crate::core::workflow::app_validation_workflow::app_validation_workflow;
 use crate::core::workflow::app_validation_workflow::AppValidationWorkspace;
 use holochain_p2p::*;
 use holochain_types::db_cache::DhtDbQueryCache;
-use tokio::task::JoinHandle;
 use tracing::*;
 
 /// Spawn the QueueConsumer for AppValidation workflow
 #[instrument(skip(
     workspace,
     conductor_handle,
-    stop,
     trigger_integration,
     network,
     dht_query_cache
@@ -22,15 +19,15 @@ pub fn spawn_app_validation_consumer(
     dna_hash: Arc<DnaHash>,
     workspace: AppValidationWorkspace,
     conductor_handle: ConductorHandle,
-    mut stop: sync::broadcast::Receiver<()>,
     trigger_integration: TriggerSender,
     network: HolochainP2pDna,
     dht_query_cache: DhtDbQueryCache,
-) -> (TriggerSender, JoinHandle<ManagedTaskResult>) {
+) -> (TriggerSender, impl ManagedTaskFut) {
     let (tx, mut rx) = TriggerSender::new();
     let trigger_self = tx.clone();
     let workspace = Arc::new(workspace);
-    let handle = tokio::spawn(async move {
+    let mut stop = conductor_handle.task_stopper().subscribe();
+    let task = async move {
         loop {
             // Wait for next job
             if let Job::Shutdown = next_job_or_exit(&mut rx, &mut stop).await {
@@ -60,6 +57,6 @@ pub fn spawn_app_validation_consumer(
             };
         }
         Ok(())
-    });
-    (tx, handle)
+    };
+    (tx, task)
 }

--- a/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
@@ -1,10 +1,8 @@
 //! The workflow and queue consumer for DhtOp integration
 
 use super::*;
-use crate::conductor::manager::ManagedTaskResult;
 use crate::core::workflow::integrate_dht_ops_workflow::integrate_dht_ops_workflow;
 use holochain_types::db_cache::DhtDbQueryCache;
-use tokio::task::JoinHandle;
 use tracing::*;
 
 /// Spawn the QueueConsumer for DhtOpIntegration workflow
@@ -16,10 +14,10 @@ pub fn spawn_integrate_dht_ops_consumer(
     mut stop: sync::broadcast::Receiver<()>,
     trigger_receipt: TriggerSender,
     network: HolochainP2pDna,
-) -> (TriggerSender, JoinHandle<ManagedTaskResult>) {
+) -> (TriggerSender, impl ManagedTaskFut) {
     let (tx, mut rx) = TriggerSender::new();
     let trigger_self = tx.clone();
-    let handle = tokio::spawn(async move {
+    let handle = async move {
         loop {
             // Wait for next job
             if let Job::Shutdown = next_job_or_exit(&mut rx, &mut stop).await {
@@ -47,6 +45,6 @@ pub fn spawn_integrate_dht_ops_consumer(
             };
         }
         Ok(())
-    });
+    };
     (tx, handle)
 }

--- a/crates/holochain/src/core/queue_consumer/publish_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/publish_dht_ops_consumer.rs
@@ -34,7 +34,7 @@ pub fn spawn_publish_dht_ops_consumer(
             }
 
             if conductor_handle
-                .get_config()
+                .config()
                 .network
                 .as_ref()
                 .map(|c| c.tuning_params.disable_publish)

--- a/crates/holochain/src/core/queue_consumer/validation_receipt_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/validation_receipt_consumer.rs
@@ -1,24 +1,23 @@
 //! The workflow and queue consumer for validation receipt
 
 use super::*;
-use crate::conductor::manager::ManagedTaskResult;
+use crate::conductor::manager::ManagedTaskFut;
 use crate::core::workflow::validation_receipt_workflow::validation_receipt_workflow;
-use tokio::task::JoinHandle;
 use tracing::*;
 
 /// Spawn the QueueConsumer for validation receipt workflow
-#[instrument(skip(env, conductor_handle, stop, network))]
+#[instrument(skip(env, conductor_handle, network))]
 pub fn spawn_validation_receipt_consumer(
     dna_hash: Arc<DnaHash>,
     env: DbWrite<DbKindDht>,
     conductor_handle: ConductorHandle,
-    mut stop: sync::broadcast::Receiver<()>,
     network: HolochainP2pDna,
-) -> (TriggerSender, JoinHandle<ManagedTaskResult>) {
+) -> (TriggerSender, impl ManagedTaskFut) {
     let (tx, mut rx) = TriggerSender::new();
     let trigger_self = tx.clone();
     let keystore = conductor_handle.keystore().clone();
-    let handle = tokio::spawn(async move {
+    let handle = async move {
+        let mut stop = conductor_handle.task_stopper().subscribe();
         loop {
             // Wait for next job
             if let Job::Shutdown = next_job_or_exit(&mut rx, &mut stop).await {
@@ -47,6 +46,6 @@ pub fn spawn_validation_receipt_consumer(
             };
         }
         Ok(())
-    });
+    };
     (tx, handle)
 }

--- a/crates/holochain/tests/test_utils/mod.rs
+++ b/crates/holochain/tests/test_utils/mod.rs
@@ -281,6 +281,7 @@ pub fn create_config(port: u16, environment_path: PathBuf) -> ConductorConfig {
         keystore: KeystoreConfig::DangerTestKeystore,
         db_sync_strategy: DbSyncStrategy::default(),
         chc_namespace: None,
+        tracing_scope: "".to_string(),
     }
 }
 

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -62,6 +62,10 @@ pub struct ConductorConfig {
     /// [sqlite documentation]: https://www.sqlite.org/pragma.html#pragma_synchronous
     #[serde(default)]
     pub db_sync_strategy: DbSyncStrategy,
+
+    /// All logs coming from this conductor will get scoped by this value
+    #[serde(default)]
+    pub tracing_scope: String,
     //
     //
     // Which signals to emit
@@ -134,6 +138,7 @@ pub mod tests {
                 admin_interfaces: None,
                 db_sync_strategy: DbSyncStrategy::default(),
                 chc_namespace: None,
+                tracing_scope: "".to_string(),
             }
         );
     }
@@ -183,6 +188,8 @@ pub mod tests {
       network_type: quic_bootstrap
 
     db_sync_strategy: Fast
+
+    tracing_scope: "scope"
     "#;
         let result: ConductorConfigResult<ConductorConfig> = config_from_yaml(yaml);
         use holochain_p2p::kitsune_p2p::*;
@@ -225,6 +232,7 @@ pub mod tests {
                 network: Some(network_config),
                 db_sync_strategy: DbSyncStrategy::Fast,
                 chc_namespace: None,
+                tracing_scope: "scope".to_string()
             }
         );
     }
@@ -252,6 +260,7 @@ pub mod tests {
                 admin_interfaces: None,
                 db_sync_strategy: DbSyncStrategy::Fast,
                 chc_namespace: None,
+                tracing_scope: "".to_string()
             }
         );
     }


### PR DESCRIPTION
### Summary

Instrument all traces from all tasks that get spawned by a conductor, according to a tag in the ConductorConfig. This is so that when we have multiple Conductors running in the same process, we can tell their logs apart.

It would be nice if we could just use the `ConductorStateTag` in the state, but this needs to be unique, and this scoping tag is meant to be human readable foremost, and also as unique as the user needs, so the constraints are slightly different.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
