### PR TITLE
Exposed zomes manifests from `DnaManifest`

### DIFF
--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Exposed the integrity manifest getter from `DnaManifest`.
+- Exposed the coordinator manifest getter from `DnaManifest`.
+
 ## 0.0.61
 
 - Added `WebAppManifestCurrentBuilder` and exposed it.

--- a/crates/holochain_types/src/dna/dna_manifest.rs
+++ b/crates/holochain_types/src/dna/dna_manifest.rs
@@ -84,6 +84,20 @@ impl DnaManifest {
             DnaManifest::V1(manifest) => manifest.name.clone(),
         }
     }
+
+    /// Getter for the integrity manifest
+    pub fn integrity_manifest(&self) -> IntegrityManifest {
+        match self {
+            DnaManifest::V1(manifest) => manifest.integrity.clone(),
+        }
+    }
+
+    /// Getter for the coordinator manifest
+    pub fn coordinator_manifest(&self) -> CoordinatorManifest {
+        match self {
+            DnaManifest::V1(manifest) => manifest.coordinator.clone(),
+        }
+    }
 }
 
 impl TryFrom<DnaManifest> for ValidatedDnaManifest {


### PR DESCRIPTION
### Summary

- Exposed integrity manifest from `DnaManifest`.
- Exposed coordinator manifest from `DnaManifest`.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
