### PR TITLE
Traits for admin and app interface methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,6 +2172,7 @@ dependencies = [
 name = "holochain_conductor_api"
 version = "0.0.64"
 dependencies = [
+ "async-trait",
  "derive_more",
  "directories",
  "holo_hash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2015,6 +2015,7 @@ dependencies = [
  "holochain_wasm_test_utils",
  "holochain_wasmer_host",
  "holochain_websocket",
+ "holochain_websocket_client",
  "holochain_zome_types",
  "hostname",
  "human-panic",
@@ -2562,6 +2563,16 @@ dependencies = [
  "tracing-futures",
  "tungstenite 0.12.0",
  "unwrap_to",
+ "url2",
+]
+
+[[package]]
+name = "holochain_websocket_client"
+version = "0.0.1"
+dependencies = [
+ "async-trait",
+ "holochain_conductor_api",
+ "holochain_websocket",
  "url2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "crates/holochain_state",
   "crates/holochain_sqlite",
   "crates/holochain_websocket",
+  "crates/holochain_websocket_client",
   "crates/holochain_util",
 
   "crates/hc",

--- a/crates/hc_sandbox/src/ports.rs
+++ b/crates/hc_sandbox/src/ports.rs
@@ -45,10 +45,10 @@ pub async fn get_admin_ports(paths: Vec<PathBuf>) -> anyhow::Result<Vec<u16>> {
 
 pub(crate) async fn get_admin_api(port: u16) -> WebsocketResult<WebsocketSender> {
     tracing::debug!(port);
-    websocket_client_by_port(port).await.map(|p| p.0)
+    local_websocket_client(port).await.map(|p| p.0)
 }
 
-async fn websocket_client_by_port(
+async fn local_websocket_client(
     port: u16,
 ) -> WebsocketResult<(WebsocketSender, WebsocketReceiver)> {
     ws::connect(

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -17,9 +17,7 @@ use url2::url2;
 
 const WEBSOCKET_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3);
 
-async fn websocket_client_by_port(
-    port: u16,
-) -> anyhow::Result<(WebsocketSender, WebsocketReceiver)> {
+async fn local_websocket_client(port: u16) -> anyhow::Result<(WebsocketSender, WebsocketReceiver)> {
     Ok(ws::connect(
         url2!("ws://127.0.0.1:{}", port),
         Arc::new(WebsocketConfig::default()),
@@ -29,7 +27,7 @@ async fn websocket_client_by_port(
 
 async fn call_app_interface(port: u16) {
     tracing::debug!(calling_app_interface = ?port);
-    let (mut app_tx, _) = websocket_client_by_port(port)
+    let (app_tx, _) = local_websocket_client(port)
         .await
         .expect(&format!("Failed to get port {}", port));
     let request = AppRequest::AppInfo {

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -34,6 +34,7 @@ holochain_state = { version = "0.0.64", path = "../holochain_state" }
 holochain_types = { version = "0.0.61", path = "../holochain_types" }
 holochain_wasmer_host = "=0.0.80"
 holochain_websocket = { version = "0.0.39", path = "../holochain_websocket" }
+holochain_websocket_client = { version = "0.0.1", path = "../holochain_websocket_client" }
 holochain_zome_types = { version = "0.0.51", path = "../holochain_zome_types", features = ["full"] }
 human-panic = "1.0.3"
 kitsune_p2p = { version = "0.0.49", path = "../kitsune_p2p/kitsune_p2p" }

--- a/crates/holochain/benches/websocket.rs
+++ b/crates/holochain/benches/websocket.rs
@@ -10,6 +10,7 @@ use holochain_types::prelude::fake_dna_zomes_named;
 use holochain_types::prelude::write_fake_dna_file;
 use holochain_util::tokio_helper;
 use holochain_wasm_test_utils::TestWasm;
+use holochain_websocket::local_websocket_client;
 use std::time::Duration;
 use tempfile::TempDir;
 
@@ -49,7 +50,7 @@ pub fn websocket_concurrent_install(c: &mut Criterion) {
                         let config_path = write_config(path, &config);
                         let holochain = start_holochain(config_path.clone()).await;
 
-                        let (client, _) = websocket_client_by_port(admin_port).await.unwrap();
+                        let (client, _) = local_websocket_client(admin_port).await.unwrap();
 
                         let zomes = vec![(TestWasm::Foo.into(), TestWasm::Foo.into())];
 

--- a/crates/holochain/examples/websocket_install_dna.rs
+++ b/crates/holochain/examples/websocket_install_dna.rs
@@ -6,6 +6,7 @@ use holochain_wasm_test_utils::TestWasm;
 #[path = "../tests/test_utils/mod.rs"]
 mod test_utils;
 
+use holochain_websocket::local_websocket_client;
 use test_utils::*;
 
 #[tokio::main]
@@ -21,7 +22,7 @@ pub async fn main() {
     let admin_port = 9211;
 
     let zomes = vec![(TestWasm::Foo.into(), TestWasm::Foo.into())];
-    let (client, _) = websocket_client_by_port(admin_port).await.unwrap();
+    let (client, _) = local_websocket_client(admin_port).await.unwrap();
 
     let install_tasks_stream = futures::stream::iter((0..NUM_DNA).into_iter().map(|i| {
         let mut client = client.clone();

--- a/crates/holochain/src/conductor/api/api_external.rs
+++ b/crates/holochain/src/conductor/api/api_external.rs
@@ -1,11 +1,9 @@
 use crate::conductor::interface::error::InterfaceResult;
-use holochain_serialized_bytes::prelude::*;
 
 mod admin_interface;
 mod app_interface;
 pub use admin_interface::*;
 pub use app_interface::*;
-
 /// A trait that unifies both the admin and app interfaces
 #[async_trait::async_trait]
 pub trait InterfaceApi: 'static + Send + Sync + Clone {
@@ -18,44 +16,4 @@ pub trait InterfaceApi: 'static + Send + Sync + Clone {
         &self,
         request: Result<Self::ApiRequest, SerializedBytesError>,
     ) -> InterfaceResult<Self::ApiResponse>;
-}
-
-#[macro_export]
-macro_rules! impl_handler {
-    ($enum: ident . $res: ident (Box) <= $fut: expr) => {
-        match $fut.await.map_err(|e| ExternalApiWireError::internal(e))? {
-            $enum::$res(v) => Ok(*v),
-            $enum::Error(err) => Err(err),
-            r => Err(ExternalApiWireError::internal(format!(
-                "Invalid return value, expected a {}::{} but got: {:?}",
-                stringify!($enum),
-                stringify!($res),
-                r
-            ))),
-        }
-    };
-    ($enum: ident . $res: ident (_) <= $fut: expr) => {
-        match $fut.await.map_err(|e| ExternalApiWireError::internal(e))? {
-            $enum::$res(v) => Ok(v),
-            $enum::Error(err) => Err(err),
-            r => Err(ExternalApiWireError::internal(format!(
-                "Invalid return value, expected a {}::{} but got: {:?}",
-                stringify!($enum),
-                stringify!($res),
-                r
-            ))),
-        }
-    };
-    ($enum: ident . $res: ident <= $fut: expr) => {
-        match $fut.await.map_err(|e| ExternalApiWireError::internal(e))? {
-            $enum::$res => Ok(()),
-            $enum::Error(err) => Err(err),
-            r => Err(ExternalApiWireError::internal(format!(
-                "Invalid return value, expected a {}::{} but got: {:?}",
-                stringify!($enum),
-                stringify!($res),
-                r
-            ))),
-        }
-    };
 }

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -9,9 +9,8 @@ use crate::conductor::error::ConductorError;
 use crate::conductor::interface::error::InterfaceError;
 use crate::conductor::interface::error::InterfaceResult;
 use crate::conductor::ConductorHandle;
-use holochain_serialized_bytes::prelude::*;
+
 use holochain_types::dna::DnaBundle;
-use holochain_types::prelude::*;
 use mr_bundle::Bundle;
 
 use holochain_zome_types::cell::CellId;
@@ -650,57 +649,5 @@ mod test {
         tokio::time::timeout(std::time::Duration::from_secs(1), shutdown)
             .await
             .ok();
-    }
-}
-
-#[async_trait::async_trait]
-impl AdminInterface for RealAdminInterfaceApi {
-    async fn update_coordinators(&self, payload: UpdateCoordinatorsPayload) -> Res<()> {
-        crate::impl_handler!(
-            AdminResponse.CoordinatorsUpdated
-                <= self.handle_request(Ok(AdminRequest::UpdateCoordinators(Box::new(payload))))
-        )
-    }
-
-    async fn install_app(&self, payload: InstallAppPayload) -> Res<InstalledAppInfo> {
-        crate::impl_handler!(
-            AdminResponse.AppInstalled(_)
-                <= self.handle_request(Ok(AdminRequest::InstallApp(Box::new(payload))))
-        )
-    }
-
-    async fn install_app_bundle(&self, payload: InstallAppBundlePayload) -> Res<InstalledAppInfo> {
-        crate::impl_handler!(
-            AdminResponse.AppBundleInstalled(_)
-                <= self.handle_request(Ok(AdminRequest::InstallAppBundle(Box::new(payload))))
-        )
-    }
-
-    async fn uninstall_app(&self, installed_app_id: InstalledAppId) -> Res<()> {
-        crate::impl_handler!(
-            AdminResponse.AppUninstalled
-                <= self.handle_request(Ok(AdminRequest::UninstallApp { installed_app_id }))
-        )
-    }
-
-    async fn enable_app(&self, installed_app_id: InstalledAppId) -> Res<AppEnabledResponse> {
-        crate::impl_handler!(
-            AdminResponse.AppEnabled(_)
-                <= self.handle_request(Ok(AdminRequest::EnableApp { installed_app_id }))
-        )
-    }
-
-    async fn disable_app(&self, installed_app_id: InstalledAppId) -> Res<()> {
-        crate::impl_handler!(
-            AdminResponse.AppDisabled
-                <= self.handle_request(Ok(AdminRequest::DisableApp { installed_app_id }))
-        )
-    }
-
-    async fn start_app(&self, installed_app_id: InstalledAppId) -> Res<bool> {
-        crate::impl_handler!(
-            AdminResponse.AppStarted(_)
-                <= self.handle_request(Ok(AdminRequest::StartApp { installed_app_id }))
-        )
     }
 }

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -652,3 +652,55 @@ mod test {
             .ok();
     }
 }
+
+#[async_trait::async_trait]
+impl AdminInterface for RealAdminInterfaceApi {
+    async fn update_coordinators(&self, payload: UpdateCoordinatorsPayload) -> Res<()> {
+        crate::impl_handler!(
+            AdminResponse.CoordinatorsUpdated
+                <= self.handle_request(Ok(AdminRequest::UpdateCoordinators(Box::new(payload))))
+        )
+    }
+
+    async fn install_app(&self, payload: InstallAppPayload) -> Res<InstalledAppInfo> {
+        crate::impl_handler!(
+            AdminResponse.AppInstalled(_)
+                <= self.handle_request(Ok(AdminRequest::InstallApp(Box::new(payload))))
+        )
+    }
+
+    async fn install_app_bundle(&self, payload: InstallAppBundlePayload) -> Res<InstalledAppInfo> {
+        crate::impl_handler!(
+            AdminResponse.AppBundleInstalled(_)
+                <= self.handle_request(Ok(AdminRequest::InstallAppBundle(Box::new(payload))))
+        )
+    }
+
+    async fn uninstall_app(&self, installed_app_id: InstalledAppId) -> Res<()> {
+        crate::impl_handler!(
+            AdminResponse.AppUninstalled
+                <= self.handle_request(Ok(AdminRequest::UninstallApp { installed_app_id }))
+        )
+    }
+
+    async fn enable_app(&self, installed_app_id: InstalledAppId) -> Res<AppEnabledResponse> {
+        crate::impl_handler!(
+            AdminResponse.AppEnabled(_)
+                <= self.handle_request(Ok(AdminRequest::EnableApp { installed_app_id }))
+        )
+    }
+
+    async fn disable_app(&self, installed_app_id: InstalledAppId) -> Res<()> {
+        crate::impl_handler!(
+            AdminResponse.AppDisabled
+                <= self.handle_request(Ok(AdminRequest::DisableApp { installed_app_id }))
+        )
+    }
+
+    async fn start_app(&self, installed_app_id: InstalledAppId) -> Res<bool> {
+        crate::impl_handler!(
+            AdminResponse.AppStarted(_)
+                <= self.handle_request(Ok(AdminRequest::StartApp { installed_app_id }))
+        )
+    }
+}

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -257,10 +257,10 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     .map(|(cell_id, error)| (cell_id, error.to_string()))
                     .collect();
 
-                Ok(AdminResponse::AppEnabled {
+                Ok(AdminResponse::AppEnabled(AppEnabledResponse {
                     app: app_info,
                     errors,
-                })
+                }))
             }
             DisableApp { installed_app_id } => {
                 // Disable app
@@ -620,7 +620,7 @@ mod test {
             })
             .await;
         assert_matches!(res,
-            AdminResponse::AppEnabled {app, ..} if app == expected_enabled_app_info
+            AdminResponse::AppEnabled(AppEnabledResponse {app, ..}) if app == expected_enabled_app_info
         );
 
         let res = admin_api

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -6,10 +6,6 @@ use crate::conductor::interface::error::InterfaceError;
 use crate::conductor::interface::error::InterfaceResult;
 use crate::conductor::ConductorHandle;
 
-use holochain_serialized_bytes::prelude::*;
-
-use holochain_types::prelude::*;
-
 pub use holochain_conductor_api::*;
 
 /// The interface that a Conductor exposes to the outside world.
@@ -140,36 +136,5 @@ impl InterfaceApi for RealAppInterfaceApi {
             Ok(request) => Ok(AppInterfaceApi::handle_app_request(self, request).await),
             Err(e) => Ok(AppResponse::Error(SerializationError::from(e).into())),
         }
-    }
-}
-
-#[async_trait::async_trait]
-impl AppInterface for RealAppInterfaceApi {
-    async fn app_info(&self, installed_app_id: InstalledAppId) -> Res<Option<InstalledAppInfo>> {
-        crate::impl_handler!(
-            AppResponse.AppInfo(_)
-                <= self.handle_request(Ok(AppRequest::AppInfo { installed_app_id }))
-        )
-    }
-
-    async fn zome_call(&self, call: ZomeCall) -> Res<ZomeCallResponse> {
-        crate::impl_handler!(
-            AppResponse.ZomeCall(Box)
-                <= self.handle_request(Ok(AppRequest::ZomeCall(Box::new(call))))
-        )
-    }
-
-    async fn create_clone_cell(&self, payload: CreateCloneCellPayload) -> Res<InstalledCell> {
-        crate::impl_handler!(
-            AppResponse.CloneCellCreated(_)
-                <= self.handle_request(Ok(AppRequest::CreateCloneCell(Box::new(payload))))
-        )
-    }
-
-    async fn archive_clone_cell(&self, payload: ArchiveCloneCellPayload) -> Res<()> {
-        crate::impl_handler!(
-            AppResponse.CloneCellArchived
-                <= self.handle_request(Ok(AppRequest::ArchiveCloneCell(Box::new(payload))))
-        )
     }
 }

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -142,3 +142,34 @@ impl InterfaceApi for RealAppInterfaceApi {
         }
     }
 }
+
+#[async_trait::async_trait]
+impl AppInterface for RealAppInterfaceApi {
+    async fn app_info(&self, installed_app_id: InstalledAppId) -> Res<Option<InstalledAppInfo>> {
+        crate::impl_handler!(
+            AppResponse.AppInfo(_)
+                <= self.handle_request(Ok(AppRequest::AppInfo { installed_app_id }))
+        )
+    }
+
+    async fn zome_call(&self, call: ZomeCall) -> Res<ZomeCallResponse> {
+        crate::impl_handler!(
+            AppResponse.ZomeCall(Box)
+                <= self.handle_request(Ok(AppRequest::ZomeCall(Box::new(call))))
+        )
+    }
+
+    async fn create_clone_cell(&self, payload: CreateCloneCellPayload) -> Res<InstalledCell> {
+        crate::impl_handler!(
+            AppResponse.CloneCellCreated(_)
+                <= self.handle_request(Ok(AppRequest::CreateCloneCell(Box::new(payload))))
+        )
+    }
+
+    async fn archive_clone_cell(&self, payload: ArchiveCloneCellPayload) -> Res<()> {
+        crate::impl_handler!(
+            AppResponse.CloneCellArchived
+                <= self.handle_request(Ok(AppRequest::ArchiveCloneCell(Box::new(payload))))
+        )
+    }
+}

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -18,6 +18,7 @@ use holochain_state::prelude::test_keystore;
 use holochain_types::inline_zome::InlineZomeSet;
 use holochain_types::test_utils::fake_cell_id;
 use holochain_wasm_test_utils::TestWasm;
+use holochain_websocket::local_websocket_client;
 use holochain_websocket::WebsocketSender;
 use holochain_zome_types::op::Op;
 use maplit::hashset;
@@ -401,8 +402,8 @@ async fn test_signing_error_during_genesis_doesnt_bork_interfaces() {
         .add_app_interface(either::Either::Left(0))
         .await
         .unwrap();
-    let (mut app_client, _) = websocket_client_by_port(app_port).await.unwrap();
-    let (mut admin_client, _) = conductor.admin_ws_client().await;
+    let (mut app_client, _) = local_websocket_client(app_port).await.unwrap();
+    let (admin_client, _) = conductor.admin_ws_client().await;
 
     // Now use the bad keystore to cause a signing error on the next zome call
     keystore_control.use_mock();

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -180,7 +180,7 @@ fn spawn_recv_incoming_msgs_and_outgoing_signals<A: InterfaceApi>(
     });
 
     tokio::task::spawn(rx_from_cell.for_each_concurrent(4096, move |signal| {
-        let mut tx_to_iface = tx_to_iface.clone();
+        let tx_to_iface = tx_to_iface.clone();
         async move {
             trace!(msg = "Sending signal!", ?signal);
             if let Err(err) = async move {
@@ -236,10 +236,7 @@ pub mod test {
     use ::fixt::prelude::*;
     use futures::future::FutureExt;
     use holochain_p2p::{AgentPubKeyExt, DnaHashExt};
-    use holochain_serialized_bytes::prelude::*;
-    use holochain_sqlite::prelude::*;
     use holochain_state::prelude::test_db_dir;
-    use holochain_types::prelude::*;
     use holochain_types::test_utils::fake_agent_pubkey_1;
     use holochain_types::test_utils::fake_dna_hash;
     use holochain_types::test_utils::fake_dna_zomes;

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -17,7 +17,6 @@ use holochain_state::prelude::test_db_dir;
 use holochain_types::prelude::*;
 use holochain_websocket::*;
 use std::path::Path;
-use std::sync::Arc;
 use tempfile::TempDir;
 
 /// A stream of signals.
@@ -383,7 +382,7 @@ impl SweetConductor {
         let port = self
             .get_arbitrary_admin_websocket_port()
             .expect("No admin port open on conductor");
-        websocket_client_by_port(port).await.unwrap()
+        local_websocket_client(port).await.unwrap()
     }
 
     /// Shutdown this conductor.
@@ -463,17 +462,6 @@ impl SweetConductor {
                 .await;
         }
     }
-}
-
-/// Get a websocket client on localhost at the specified port
-pub async fn websocket_client_by_port(
-    port: u16,
-) -> WebsocketResult<(WebsocketSender, WebsocketReceiver)> {
-    holochain_websocket::connect(
-        url2::url2!("ws://127.0.0.1:{}", port),
-        Arc::new(WebsocketConfig::default()),
-    )
-    .await
 }
 
 impl Drop for SweetConductor {

--- a/crates/holochain/tests/new_lair/mod.rs
+++ b/crates/holochain/tests/new_lair/mod.rs
@@ -3,6 +3,7 @@ use holochain_conductor_api::config::conductor::ConductorConfig;
 use holochain_conductor_api::config::conductor::KeystoreConfig;
 use holochain_conductor_api::AdminInterfaceConfig;
 use holochain_conductor_api::InterfaceDriver;
+use holochain_websocket::local_websocket_client;
 use kitsune_p2p_types::dependencies::lair_keystore_api;
 use lair_keystore_api::dependencies::*;
 use lair_keystore_api::ipc_keystore::*;
@@ -82,7 +83,7 @@ async fn test_new_lair_conductor_integration() {
         panic!("failed to start holochain: {:?}", status);
     }
 
-    let (mut client, _) = websocket_client_by_port(ADMIN_PORT).await.unwrap();
+    let (mut client, _) = local_websocket_client(ADMIN_PORT).await.unwrap();
 
     let agent_key = generate_agent_pubkey(&mut client, 15000).await;
     println!("GENERATED AGENT KEY: {}", agent_key);

--- a/crates/holochain/tests/speed_tests/mod.rs
+++ b/crates/holochain/tests/speed_tests/mod.rs
@@ -26,10 +26,10 @@ use holochain::conductor::api::AppResponse;
 use holochain::conductor::api::ZomeCall;
 use holochain::test_utils::setup_app;
 use holochain_wasm_test_utils::TestZomes;
+use holochain_websocket::local_websocket_client;
 use tempfile::TempDir;
 
 use super::test_utils::*;
-use holochain::sweettest::*;
 use holochain_test_wasm_common::AnchorInput;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
@@ -175,7 +175,7 @@ async fn speed_test(n: Option<usize>) -> Arc<TempDir> {
     .await;
 
     // Setup websocket handle and app interface
-    let (mut client, _) = websocket_client(&handle).await.unwrap();
+    let (client, _) = websocket_client(&handle).await.unwrap();
     let request = AdminRequest::AttachAppInterface { port: None };
     let response = client.request(request);
     let response = response.await.unwrap();
@@ -183,7 +183,7 @@ async fn speed_test(n: Option<usize>) -> Arc<TempDir> {
         AdminResponse::AppInterfaceAttached { port } => port,
         _ => panic!("Attach app interface failed: {:?}", response),
     };
-    let (mut app_interface, _) = websocket_client_by_port(app_port).await.unwrap();
+    let (mut app_interface, _) = local_websocket_client(app_port).await.unwrap();
 
     // /////////////
     // END CONDUCTOR

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -55,7 +55,9 @@ async fn call_admin() {
     let (_holochain, port) = start_holochain(config_path.clone()).await;
     let port = port.await.unwrap();
 
-    let (mut client, _) = websocket_client_by_port(port).await.unwrap();
+    let (mut client, _) = holochain_websocket::local_websocket_client(port)
+        .await
+        .unwrap();
 
     let original_dna_hash = dna.dna_hash().clone();
 
@@ -121,8 +123,12 @@ async fn call_zome() {
     let (holochain, admin_port) = start_holochain(config_path.clone()).await;
     let admin_port = admin_port.await.unwrap();
 
-    let (mut client, _) = websocket_client_by_port(admin_port).await.unwrap();
-    let (_, receiver2) = websocket_client_by_port(admin_port).await.unwrap();
+    let (mut client, _) = holochain_websocket::local_websocket_client(admin_port)
+        .await
+        .unwrap();
+    let (_, receiver2) = holochain_websocket::local_websocket_client(admin_port)
+        .await
+        .unwrap();
 
     let uuid = uuid::Uuid::new_v4();
     let dna = fake_dna_zomes(
@@ -186,7 +192,7 @@ async fn call_zome() {
     let (_holochain, admin_port) = start_holochain(config_path).await;
     let admin_port = admin_port.await.unwrap();
 
-    let (mut client, _) = websocket_client_by_port(admin_port).await.unwrap();
+    let (client, _) = local_websocket_client(admin_port).await.unwrap();
 
     tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
 
@@ -278,7 +284,7 @@ async fn emit_signals() {
     let (_holochain, admin_port) = start_holochain(config_path.clone()).await;
     let admin_port = admin_port.await.unwrap();
 
-    let (mut admin_tx, _) = websocket_client_by_port(admin_port).await.unwrap();
+    let (mut admin_tx, _) = local_websocket_client(admin_port).await.unwrap();
 
     let uuid = uuid::Uuid::new_v4();
     let dna = fake_dna_zomes(
@@ -316,8 +322,8 @@ async fn emit_signals() {
     ///////////////////////////////////////////////////////
     // Emit signals (the real test!)
 
-    let (mut app_tx_1, app_rx_1) = websocket_client_by_port(app_port).await.unwrap();
-    let (_, app_rx_2) = websocket_client_by_port(app_port).await.unwrap();
+    let (mut app_tx_1, app_rx_1) = local_websocket_client(app_port).await.unwrap();
+    let (_, app_rx_2) = local_websocket_client(app_port).await.unwrap();
 
     call_zome_fn(
         &mut app_tx_1,
@@ -358,7 +364,7 @@ async fn conductor_admin_interface_runs_from_config() -> Result<()> {
     let environment_path = tmp_dir.path().to_path_buf();
     let config = create_config(0, environment_path);
     let conductor_handle = Conductor::builder().config(config).build().await?;
-    let (mut client, _) = websocket_client(&conductor_handle).await?;
+    let (client, _) = websocket_client(&conductor_handle).await?;
 
     let dna = fake_dna_zomes(
         "".into(),
@@ -389,7 +395,7 @@ async fn list_app_interfaces_succeeds() -> Result<()> {
     let conductor_handle = Conductor::builder().config(config).build().await?;
     let port = admin_port(&conductor_handle).await;
     info!("building conductor");
-    let (mut client, mut _rx): (WebsocketSender, WebsocketReceiver) = holochain_websocket::connect(
+    let (client, mut _rx): (WebsocketSender, WebsocketReceiver) = holochain_websocket::connect(
         url2!("ws://127.0.0.1:{}", port),
         Arc::new(WebsocketConfig {
             default_request_timeout_s: 1,
@@ -428,7 +434,7 @@ async fn conductor_admin_interface_ends_with_shutdown_inner() -> Result<()> {
     let conductor_handle = Conductor::builder().config(config).build().await?;
     let port = admin_port(&conductor_handle).await;
     info!("building conductor");
-    let (mut client, mut rx): (WebsocketSender, WebsocketReceiver) = holochain_websocket::connect(
+    let (client, mut rx): (WebsocketSender, WebsocketReceiver) = holochain_websocket::connect(
         url2!("ws://127.0.0.1:{}", port),
         Arc::new(WebsocketConfig {
             default_request_timeout_s: 1,
@@ -526,7 +532,7 @@ async fn concurrent_install_dna() {
     let (_holochain, admin_port) = start_holochain(config_path.clone()).await;
     let admin_port = admin_port.await.unwrap();
 
-    let (client, _) = websocket_client_by_port(admin_port).await.unwrap();
+    let (client, _) = local_websocket_client(admin_port).await.unwrap();
 
     let before = std::time::Instant::now();
 

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- **BREAKING CHANGE:** Admin api method EnableApp has a slightly different serialized output 
+
 ## 0.0.64
 
 ## 0.0.63

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -9,6 +9,7 @@ authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
 edition = "2021"
 
 [dependencies]
+async-trait = "0.1"
 directories = "2.0.2"
 derive_more = "0.99.3"
 kitsune_p2p = { version = "0.0.49", path = "../kitsune_p2p/kitsune_p2p" }

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -448,16 +448,10 @@ pub enum AdminResponse {
     /// It means the app was enabled successfully. If it was possible to
     /// put the app in a running state, it will be running, otherwise it will
     /// be paused.
-    AppEnabled {
-        app: InstalledAppInfo,
-        errors: Vec<(CellId, String)>,
-    },
+    AppEnabled(AppEnabledResponse),
 
     #[deprecated = "alias for AppEnabled"]
-    AppActivated {
-        app: InstalledAppInfo,
-        errors: Vec<(CellId, String)>,
-    },
+    AppActivated(AppEnabledResponse),
 
     /// The successful response to an [`AdminRequest::DisableApp`].
     ///
@@ -511,6 +505,13 @@ pub enum AdminResponse {
 
     /// The successful response to an [`AdminRequest::DeleteArchivedCloneCells`].
     ArchivedCloneCellsDeleted,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, SerializedBytes)]
+#[cfg_attr(test, derive(Clone))]
+pub struct AppEnabledResponse {
+    pub app: InstalledAppInfo,
+    pub errors: Vec<(CellId, String)>,
 }
 
 /// Error type that goes over the websocket wire.

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -4,6 +4,55 @@ use crate::{signal_subscription::SignalSubscription, ExternalApiWireError};
 use holo_hash::AgentPubKey;
 use holochain_types::prelude::*;
 
+mod app_impl {
+
+    use holochain_types::prelude::{
+        ArchiveCloneCellPayload, CreateCloneCellPayload, InstalledAppId, InstalledCell,
+    };
+    use holochain_zome_types::ZomeCallResponse;
+
+    use crate::{ExternalApiWireError, ZomeCall};
+
+    pub type Res<T> = Result<T, ExternalApiWireError>;
+
+    pub trait AppInterface {
+        fn app_info(installed_app_id: InstalledAppId) -> Res<Option<InstalledAppId>>;
+
+        fn zome_call(call: ZomeCall) -> Res<ZomeCallResponse>;
+
+        fn create_clone_cell(payload: CreateCloneCellPayload) -> Res<InstalledCell>;
+
+        fn archive_clone_cell(payload: ArchiveCloneCellPayload) -> Res<()>;
+    }
+}
+
+mod admin_impl {
+
+    use holochain_types::prelude::{
+        InstallAppBundlePayload, InstallAppPayload, InstalledAppId, UpdateCoordinatorsPayload,
+    };
+
+    use crate::{AppEnabledResponse, ExternalApiWireError, InstalledAppInfo};
+
+    pub type Res<T> = Result<T, ExternalApiWireError>;
+
+    pub trait AdminInterface {
+        fn update_coordinators(payload: UpdateCoordinatorsPayload) -> Res<()>;
+
+        fn install_app(payload: InstallAppPayload) -> Res<InstalledAppInfo>;
+
+        fn install_app_bundle(payload: InstallAppBundlePayload) -> Res<InstalledAppInfo>;
+
+        fn uninstall_app(id: InstalledAppId) -> Res<()>;
+
+        fn enable_app(id: InstalledAppId) -> Res<AppEnabledResponse>;
+
+        fn disable_app(id: InstalledAppId) -> Res<()>;
+
+        fn start_app(id: InstalledAppId) -> Res<bool>;
+    }
+}
+
 /// Represents the available conductor functions to call over an app interface
 /// and will result in a corresponding [`AppResponse`] message being sent back over the
 /// interface connection.

--- a/crates/holochain_conductor_api/src/lib.rs
+++ b/crates/holochain_conductor_api/src/lib.rs
@@ -8,3 +8,5 @@ pub use admin_interface::*;
 pub use app_interface::*;
 pub use config::*;
 pub use state_dump::*;
+
+pub use holochain_types::prelude::*;

--- a/crates/holochain_websocket/benches/bench.rs
+++ b/crates/holochain_websocket/benches/bench.rs
@@ -88,7 +88,7 @@ async fn setup() -> (ListenerHandle, Url2, JoinHandle<()>) {
     let jh = tokio::task::spawn(async move {
         let mut jhs = Vec::new();
         // Handle new connections
-        while let Some(Ok((mut send, mut recv))) = listener.next().await {
+        while let Some(Ok((send, mut recv))) = listener.next().await {
             let jh = tokio::task::spawn(async move {
                 // Receive a message and echo it back
                 while let Some((msg, resp)) = recv.next().await {

--- a/crates/holochain_websocket/examples/docs.rs
+++ b/crates/holochain_websocket/examples/docs.rs
@@ -8,7 +8,7 @@ struct TestMessage(pub String);
 
 #[tokio::main]
 async fn main() {
-    let (mut send, _) = connect(
+    let (send, _) = connect(
         url2!("ws://127.0.0.1:12345"),
         std::sync::Arc::new(WebsocketConfig::default()),
     )

--- a/crates/holochain_websocket/examples/echo.rs
+++ b/crates/holochain_websocket/examples/echo.rs
@@ -40,7 +40,7 @@ async fn main() {
     });
 
     // Connect the client to the server
-    let (mut send, _recv) = connect(binding, std::sync::Arc::new(WebsocketConfig::default()))
+    let (send, _recv) = connect(binding, std::sync::Arc::new(WebsocketConfig::default()))
         .await
         .unwrap();
 

--- a/crates/holochain_websocket/examples/echo_client.rs
+++ b/crates/holochain_websocket/examples/echo_client.rs
@@ -12,7 +12,7 @@ struct ResponseMessage(pub String);
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
-    let (mut send_socket, mut recv_socket) = connect(
+    let (send_socket, mut recv_socket) = connect(
         url2!("ws://127.0.0.1:12345"),
         std::sync::Arc::new(WebsocketConfig::default()),
     )

--- a/crates/holochain_websocket/examples/echo_server.rs
+++ b/crates/holochain_websocket/examples/echo_server.rs
@@ -25,7 +25,7 @@ async fn main() {
     let (send_b, _) = tokio::sync::broadcast::channel(10);
 
     tokio::task::spawn(async move {
-        while let Some(Ok((mut send_socket, mut recv_socket))) = listener_stream.next().await {
+        while let Some(Ok((send_socket, mut recv_socket))) = listener_stream.next().await {
             let loc_send_b = send_b.clone();
             let mut loc_recv_b = send_b.subscribe();
 

--- a/crates/holochain_websocket/src/lib.rs
+++ b/crates/holochain_websocket/src/lib.rs
@@ -135,6 +135,17 @@ pub async fn connect(
     Websocket::create_ends(config, socket, valve)
 }
 
+/// Get a websocket client on localhost at the specified port, with default settings
+pub async fn local_websocket_client(
+    port: u16,
+) -> WebsocketResult<(WebsocketSender, WebsocketReceiver)> {
+    connect(
+        url2::url2!("ws://127.0.0.1:{}", port),
+        Arc::new(WebsocketConfig::default()),
+    )
+    .await
+}
+
 #[derive(Debug, serde::Serialize, serde::Deserialize, SerializedBytes)]
 #[serde(tag = "type")]
 /// The messages actually sent over the wire by this library.

--- a/crates/holochain_websocket/src/websocket.rs
+++ b/crates/holochain_websocket/src/websocket.rs
@@ -795,7 +795,7 @@ mod tests {
                 .instrument(tracing::debug_span!("next_server_connection"))
                 .await;
         });
-        let (mut sender, _) = connect(binding.clone(), Arc::new(WebsocketConfig::default()))
+        let (sender, _) = connect(binding.clone(), Arc::new(WebsocketConfig::default()))
             .instrument(tracing::debug_span!("client"))
             .await
             .unwrap();

--- a/crates/holochain_websocket/src/websocket_sender.rs
+++ b/crates/holochain_websocket/src/websocket_sender.rs
@@ -117,7 +117,7 @@ impl WebsocketSender {
     #[tracing::instrument(skip(self))]
     /// Make a request to for the other side to respond to.
     pub async fn request_timeout<I, O>(
-        &mut self,
+        &self,
         msg: I,
         timeout: std::time::Duration,
     ) -> WebsocketResult<O>
@@ -140,7 +140,7 @@ impl WebsocketSender {
     /// Note:
     /// There is no timeouts in this code. You either need to wrap
     /// this future in a timeout or use [`WebsocketSender::request_timeout`].
-    pub async fn request<I, O>(&mut self, msg: I) -> WebsocketResult<O>
+    pub async fn request<I, O>(&self, msg: I) -> WebsocketResult<O>
     where
         I: std::fmt::Debug,
         O: std::fmt::Debug,
@@ -185,7 +185,7 @@ impl WebsocketSender {
     /// Send a message to the other side that doesn't require a response.
     /// There is no guarantee this message will arrive. If you need confirmation
     /// of receipt use [`WebsocketSender::request`].
-    pub async fn signal<I, E>(&mut self, msg: I) -> WebsocketResult<()>
+    pub async fn signal<I, E>(&self, msg: I) -> WebsocketResult<()>
     where
         I: std::fmt::Debug,
         WebsocketError: From<E>,
@@ -204,7 +204,7 @@ impl WebsocketSender {
     }
 
     #[cfg(test)]
-    pub(crate) async fn debug(&mut self) -> WebsocketResult<(Vec<u64>, u64)> {
+    pub(crate) async fn debug(&self) -> WebsocketResult<(Vec<u64>, u64)> {
         let (tx_resp, rx_resp) = tokio::sync::oneshot::channel();
         let msg = OutgoingMessage::Debug(tx_resp);
         self.tx_to_websocket

--- a/crates/holochain_websocket/tests/integration.rs
+++ b/crates/holochain_websocket/tests/integration.rs
@@ -31,7 +31,7 @@ fn server_wait(
     mut listener: impl futures::stream::Stream<Item = ListenerItem> + Unpin + Send + 'static,
 ) -> tokio::task::JoinHandle<()> {
     tokio::task::spawn(async move {
-        let (mut sender, mut receiver) = listener
+        let (sender, mut receiver) = listener
             .next()
             .instrument(tracing::debug_span!("next_server_connection"))
             .await
@@ -86,7 +86,7 @@ fn server_signal(
     n: usize,
 ) -> tokio::task::JoinHandle<()> {
     tokio::task::spawn(async move {
-        let (mut sender, _) = listener
+        let (sender, _) = listener
             .next()
             .instrument(tracing::debug_span!("next_server_connection"))
             .await
@@ -126,7 +126,7 @@ async fn can_send_signal() {
     observability::test_run().ok();
     let (handle, mut listener) = server().await;
     let jh = tokio::task::spawn(async move {
-        let (mut sender, mut receiver) = listener
+        let (sender, mut receiver) = listener
             .next()
             .instrument(tracing::debug_span!("next_server_connection"))
             .await
@@ -153,7 +153,7 @@ async fn can_send_signal() {
 
     // - Connect client
     let binding = handle.local_addr().clone();
-    let (mut sender, mut receiver) = connect(binding, Arc::new(WebsocketConfig::default()))
+    let (sender, mut receiver) = connect(binding, Arc::new(WebsocketConfig::default()))
         .instrument(tracing::debug_span!("client"))
         .await
         .unwrap();
@@ -184,7 +184,7 @@ async fn can_send_request() {
     observability::test_run().ok();
     let (handle, mut listener) = server().await;
     let jh = tokio::task::spawn(async move {
-        let (mut sender, mut receiver) = listener
+        let (sender, mut receiver) = listener
             .next()
             .instrument(tracing::debug_span!("next_server_connection"))
             .await
@@ -218,7 +218,7 @@ async fn can_send_request() {
 
     // - Connect client
     let binding = handle.local_addr().clone();
-    let (mut sender, mut receiver) = connect(binding, Arc::new(WebsocketConfig::default()))
+    let (sender, mut receiver) = connect(binding, Arc::new(WebsocketConfig::default()))
         .instrument(tracing::debug_span!("client"))
         .await
         .unwrap();
@@ -394,7 +394,7 @@ async fn drop_receiver() {
     let (handle, listener) = server().await;
     let s_jh = server_recv(listener);
     let binding = handle.local_addr().clone();
-    let (mut sender, _) = connect(binding, Arc::new(WebsocketConfig::default()))
+    let (sender, _) = connect(binding, Arc::new(WebsocketConfig::default()))
         .instrument(tracing::debug_span!("client"))
         .await
         .unwrap();
@@ -417,7 +417,7 @@ async fn cancel_response() {
     observability::test_run().ok();
     let (handle, mut listener) = server().await;
     let s_jh = tokio::task::spawn(async move {
-        let (mut sender, _receiver) = listener
+        let (sender, _receiver) = listener
             .next()
             .instrument(tracing::debug_span!(
                 "next_server_connection:cancel_response"

--- a/crates/holochain_websocket_client/Cargo.toml
+++ b/crates/holochain_websocket_client/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "holochain_websocket_client"
+version = "0.0.1"
+description = "Client for connecting to Holochain websocket servers"
+license-file = "LICENSE_CAL-1.0"
+homepage = "https://github.com/holochain/holochain"
+documentation = "https://docs.rs/holochain_websocket_client"
+authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
+edition = "2021"
+
+[dependencies]
+async-trait = "0.1"
+holochain_conductor_api = { version = "0.0.64", path = "../holochain_conductor_api" }
+holochain_websocket = { version = "0.0.39", path = "../holochain_websocket" }
+url2 = "0.0.6"

--- a/crates/holochain_websocket_client/src/lib.rs
+++ b/crates/holochain_websocket_client/src/lib.rs
@@ -1,0 +1,144 @@
+use holochain_conductor_api::*;
+use holochain_websocket::*;
+
+pub struct InterfaceClient {
+    ws: WebsocketSender,
+    timeout: std::time::Duration,
+}
+
+macro_rules! impl_handler {
+    ($self: ident , $in: expr => $enum: ident , $res: ident (Box(_))) => {
+        match $self
+            .ws
+            .request_timeout($in, $self.timeout)
+            .await
+            .map_err(|e| ExternalApiWireError::internal(e))?
+        {
+            $enum::$res(v) => Ok(*v),
+            $enum::Error(err) => Err(err),
+            r => Err(ExternalApiWireError::internal(format!(
+                "Invalid return value, expected a {}::{} but got: {:?}",
+                stringify!($enum),
+                stringify!($res),
+                r
+            ))),
+        }
+    };
+    ($self: ident , $in: expr => $enum: ident , $res: ident (_)) => {
+        match $self
+            .ws
+            .request_timeout($in, $self.timeout)
+            .await
+            .map_err(|e| ExternalApiWireError::internal(e))?
+        {
+            $enum::$res(v) => Ok(v),
+            $enum::Error(err) => Err(err),
+            r => Err(ExternalApiWireError::internal(format!(
+                "Invalid return value, expected a {}::{} but got: {:?}",
+                stringify!($enum),
+                stringify!($res),
+                r
+            ))),
+        }
+    };
+    ($self: ident , $in: expr => $enum: ident , $res: ident) => {
+        match $self
+            .ws
+            .request_timeout($in, $self.timeout)
+            .await
+            .map_err(|e| ExternalApiWireError::internal(e))?
+        {
+            $enum::$res => Ok(()),
+            $enum::Error(err) => Err(err),
+            r => Err(ExternalApiWireError::internal(format!(
+                "Invalid return value, expected a {}::{} but got: {:?}",
+                stringify!($enum),
+                stringify!($res),
+                r
+            ))),
+        }
+    };
+}
+
+#[async_trait::async_trait]
+impl AppInterface for InterfaceClient {
+    async fn app_info(&self, installed_app_id: InstalledAppId) -> Res<Option<InstalledAppInfo>> {
+        impl_handler!(
+            self, AppRequest::AppInfo { installed_app_id } => AppResponse, AppInfo(_)
+
+        )
+    }
+
+    async fn zome_call(&self, call: ZomeCall) -> Res<ZomeCallResponse> {
+        impl_handler!(
+            self, AppRequest::ZomeCall(Box::new(call)) => AppResponse, ZomeCall(Box(_))
+        )
+        .map(ZomeCallResponse::Ok)
+    }
+
+    async fn create_clone_cell(&self, payload: CreateCloneCellPayload) -> Res<InstalledCell> {
+        impl_handler!(
+            self, AppRequest::CreateCloneCell(Box::new(payload)) => AppResponse, CloneCellCreated(_)
+
+        )
+    }
+
+    async fn archive_clone_cell(&self, payload: ArchiveCloneCellPayload) -> Res<()> {
+        impl_handler!(
+            self, AppRequest::ArchiveCloneCell(Box::new(payload)) => AppResponse, CloneCellArchived
+
+        )
+    }
+}
+
+#[async_trait::async_trait]
+impl AdminInterface for InterfaceClient {
+    async fn update_coordinators(&self, payload: UpdateCoordinatorsPayload) -> Res<()> {
+        impl_handler!(
+            self, AdminRequest::UpdateCoordinators(Box::new(payload)) => AdminResponse, CoordinatorsUpdated
+
+        )
+    }
+
+    async fn install_app(&self, payload: InstallAppPayload) -> Res<InstalledAppInfo> {
+        impl_handler!(
+            self, AdminRequest::InstallApp(Box::new(payload)) => AdminResponse, AppInstalled(_)
+
+        )
+    }
+
+    async fn install_app_bundle(&self, payload: InstallAppBundlePayload) -> Res<InstalledAppInfo> {
+        impl_handler!(
+            self, AdminRequest::InstallAppBundle(Box::new(payload)) => AdminResponse, AppBundleInstalled(_)
+
+        )
+    }
+
+    async fn uninstall_app(&self, installed_app_id: InstalledAppId) -> Res<()> {
+        impl_handler!(
+            self, AdminRequest::UninstallApp { installed_app_id } => AdminResponse, AppUninstalled
+
+        )
+    }
+
+    async fn enable_app(&self, installed_app_id: InstalledAppId) -> Res<AppEnabledResponse> {
+        impl_handler!(
+            self, AdminRequest::EnableApp { installed_app_id } => AdminResponse, AppEnabled(_)
+
+        )
+    }
+
+    async fn disable_app(&self, installed_app_id: InstalledAppId) -> Res<()> {
+        impl_handler!(
+            self, AdminRequest::DisableApp { installed_app_id } => AdminResponse, AppDisabled
+
+        )
+    }
+
+    async fn start_app(&self, installed_app_id: InstalledAppId) -> Res<bool> {
+        impl_handler!(
+            self, AdminRequest::StartApp { installed_app_id } => AdminResponse, AppStarted(_)
+
+        )
+    }
+}


### PR DESCRIPTION
### Summary

Needed to adapt Sweettest to be able to work with both the local Conductor via ConductorHandle, or a remote one via WebsocketSender. The `AppInterface` and `AdminInterface` traits ensure the same interface is maintained between both.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
