### PR TITLE
Fix crash when restarting conductor with cloned cell

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fixes bug that causes crash when starting a conductor with a clone cell installed
+
 ## 0.0.167
 
 - Adds `SweetConductorConfig`, which adds a few builder methods for constructing variations of the standard ConductorConfig

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -773,6 +773,7 @@ impl Conductor {
         role_id: AppRoleId,
         dna_modifiers: DnaModifiersOpt,
         name: Option<String>,
+        handle: ConductorHandle,
     ) -> ConductorResult<InstalledCell> {
         let ribosome_store = &self.ribosome_store;
         // retrieve base cell DNA hash from conductor
@@ -808,6 +809,7 @@ impl Conductor {
             }
             Ok::<_, DnaError>(dna_file)
         })?;
+
         let clone_dna_hash = clone_dna.dna_hash().to_owned();
         // add clone cell to app and instantiate resulting clone cell
         let (_, installed_clone_cell) = self
@@ -821,9 +823,10 @@ impl Conductor {
                 Ok((state, installed_clone_cell))
             })
             .await?;
+
         // register clone cell dna in ribosome store
-        let clone_ribosome = RealRibosome::new(clone_dna)?;
-        self.add_ribosome_to_store(clone_ribosome);
+        handle.register_dna(clone_dna).await?;
+
         Ok(installed_clone_cell)
     }
 

--- a/crates/holochain/src/conductor/handle.rs
+++ b/crates/holochain/src/conductor/handle.rs
@@ -965,6 +965,7 @@ impl ConductorHandleT for ConductorHandleImpl {
                 role_id.clone(),
                 modifiers.serialized()?,
                 name,
+                self.clone(),
             )
             .await?;
 

--- a/crates/holochain/src/conductor/tests/cell_cloning.rs
+++ b/crates/holochain/src/conductor/tests/cell_cloning.rs
@@ -316,3 +316,34 @@ async fn clone_cell_deletion() {
         .await;
     assert!(restore_result.is_err());
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn conductor_can_startup_with_cloned_cell() {
+    let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create])
+        .await
+        .unwrap();
+    let role_id: AppRoleId = "dna_1".to_string();
+    let mut conductor = SweetConductor::from_standard_config().await;
+    let alice = SweetAgents::one(conductor.keystore()).await;
+    let app = conductor
+        .setup_app_for_agent("app", alice.clone(), [&(role_id.clone(), dna)])
+        .await
+        .unwrap();
+
+    let installed_clone_cell = conductor
+        .clone()
+        .create_clone_cell(CreateCloneCellPayload {
+            app_id: app.installed_app_id().clone(),
+            role_id: role_id.clone(),
+            modifiers: DnaModifiersOpt::none().with_network_seed("seed_1".to_string()),
+            membrane_proof: None,
+            name: None,
+        })
+        .await
+        .unwrap();
+
+    conductor.shutdown().await;
+    conductor.startup().await;
+
+    // Simply test that the conductor can startup with a cloned cell present.
+}

--- a/crates/holochain/src/conductor/tests/cell_cloning.rs
+++ b/crates/holochain/src/conductor/tests/cell_cloning.rs
@@ -330,7 +330,7 @@ async fn conductor_can_startup_with_cloned_cell() {
         .await
         .unwrap();
 
-    let installed_clone_cell = conductor
+    let _ = conductor
         .clone()
         .create_clone_cell(CreateCloneCellPayload {
             app_id: app.installed_app_id().clone(),


### PR DESCRIPTION
### Summary

The funky `ConductorHandle`-passing nonsense will be cleaned up in #1618 (and when merging this into that branch, we have to make sure this change is not clobbered!

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
