### PR TITLE
feat(release-workflow): use self-hosted runner for testing

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -10,7 +10,7 @@ status-level = "all"
 # Treat a test that takes longer than this period as slow, and print a message.
 # Given a non-zero positive integer, shutdown the tests when the number periods
 # have passed.
-slow-timeout = { period = "30s", terminate-after = 4 }
+slow-timeout = { period = "30s", terminate-after = 8 }
 
 # * "immediate-final": output failures as soon as they happen and at the end of
 #   the test run

--- a/.github/actions/extend-space/action.yml
+++ b/.github/actions/extend-space/action.yml
@@ -26,7 +26,7 @@ runs:
     # for new directories (such as /nix), a bind mount is enough for existing
     # directories (such as $HOME and /tmp), we use an overlay to preserve access
     # to the existing files, while redirecting changes to the extended space.
-    - name: Use extended space for /nix, /tmp, and $HOME
+    - name: Use extended space for /nix, /tmp, /var/tmp, and $HOME
       shell: "bash"
       run: |
         export EXTENDED_PATH=/mnt/extended
@@ -39,6 +39,14 @@ runs:
           -o lowerdir=/tmp_lower,upperdir=$EXTENDED_PATH/tmp/upper,workdir=$EXTENDED_PATH/tmp/work \
           /tmp
         sudo chown $(id -u):$(id -g) /tmp
+
+        sudo mkdir -p $EXTENDED_PATH/var/tmp/{upper,work}
+        sudo mv /var/tmp{,_lower}
+        sudo mkdir -p /var/tmp
+        sudo mount -t overlay overlay \
+          -o lowerdir=/var/tmp_lower,upperdir=$EXTENDED_PATH/var/tmp/upper,workdir=$EXTENDED_PATH/var/tmp/work \
+          /var/tmp
+        sudo chown $(id -u):$(id -g) /var/tmp
 
         sudo mkdir /nix
         sudo mount -o bind $EXTENDED_PATH/nix /nix

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Install nix
         uses: cachix/install-nix-action@v17
       - name: Setup cachix
-        uses: cachix/cachix-action@v10
+        uses: cachix/cachix-action@v11
         continue-on-error: ${{ github.event_name != 'pull_request' }}
         with:
           name: holochain-ci

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -7,6 +7,9 @@ on:
       debug:
         type: string
         required: true
+      skip_prepare_logic:
+        type: string
+        required: true
 
       HOLOCHAIN_SOURCE_BRANCH:
         type: string
@@ -70,6 +73,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Extend space
         uses: ./.github/actions/extend-space
+        if: ${{ inputs.skip_prepare_logic != 'true' }}
 
       - name: Install nix
         uses: cachix/install-nix-action@v17
@@ -91,26 +95,27 @@ jobs:
         uses: steveeJ-forks/actions-cache/restore@main
         with:
           path: |
-            /tmp/holochain_release.sh
+            /var/tmp/holochain_release.sh
             # asterisk is a workaround for https://github.com/actions/cache/issues/494
-            /tmp/holochain_repo/*
-            !/tmp/holochain_repo/.cargo/
-            !/tmp/holochain_repo/target/
+            /var/tmp/holochain_repo/*
+            !/var/tmp/holochain_repo/.cargo/
+            !/var/tmp/holochain_repo/target/
           key: holochain-repo-finalize-release-
           restore-keys: |
             holochain-repo-
           required: false
 
       - name: Restore holochain cargo related state and build files
+        if: ${{ inputs.skip_prepare_logic != 'true' }}
         uses: steveeJ-forks/actions-cache/restore@main
         id: restore-build-files
         with:
           path: |
-            /tmp/holochain_repo/.cargo/bin/
-            /tmp/holochain_repo/.cargo/registry/index/
-            /tmp/holochain_repo/.cargo/registry/cache/
-            /tmp/holochain_repo/.cargo/git/db/
-            /tmp/holochain_repo/target/
+            /var/tmp/holochain_repo/.cargo/bin/
+            /var/tmp/holochain_repo/.cargo/registry/index/
+            /var/tmp/holochain_repo/.cargo/registry/cache/
+            /var/tmp/holochain_repo/.cargo/git/db/
+            /var/tmp/holochain_repo/target/
           key: ${{ runner.os }}-prepare-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-prepare
@@ -126,7 +131,7 @@ jobs:
           HOLONIX_URL: "https://github.com/holochain/holonix.git"
         run: |
           cat <<EOF > "${HOLOCHAIN_RELEASE_SH}"
-          PATH="~/.cargo/bin:$PATH"
+          export PATH="~/.cargo/bin:\$PATH"
 
           export HOLOCHAIN_URL=${HOLOCHAIN_URL:?}
           export HOLOCHAIN_NIXPKGS_URL=${HOLOCHAIN_NIXPKGS_URL:?}
@@ -177,6 +182,7 @@ jobs:
           fi
 
       - name: Detect missing release headings
+        if: ${{ inputs.skip_prepare_logic != 'true' }}
         run: |
           set -ex
           source "${HOLOCHAIN_RELEASE_SH}"
@@ -192,6 +198,7 @@ jobs:
             '
 
       - name: Generate crate READMEs from doc comments
+        if: ${{ inputs.skip_prepare_logic != 'true' }}
         run: |
           source "${HOLOCHAIN_RELEASE_SH}"
           cd "${HOLOCHAIN_REPO}"
@@ -199,6 +206,7 @@ jobs:
 
       - name: Bump the crate versions for the release
         id: bump-versions
+        if: ${{ inputs.skip_prepare_logic != 'true' }}
         run: |
           set -ex
           source "${HOLOCHAIN_RELEASE_SH}"
@@ -271,27 +279,27 @@ jobs:
         uses: steveeJ-forks/actions-cache/save@main
         with:
           path: |
-            /tmp/holochain_release.sh
+            /var/tmp/holochain_release.sh
             # asterisk is a workaround for https://github.com/actions/cache/issues/494
-            /tmp/holochain_repo/*
-            !/tmp/holochain_repo/.cargo/
-            !/tmp/holochain_repo/target/
+            /var/tmp/holochain_repo/*
+            !/var/tmp/holochain_repo/.cargo/
+            !/var/tmp/holochain_repo/target/
           key: holochain-repo-${{ github.run_id }}-${{ github.run_number }}
 
       - name: Cache cargo related build files
         uses: steveeJ-forks/actions-cache/save@main
-        if: success() || ${{ steps.restore-build-files.outputs.cache-hit != 'false' }}
+        if: ${{ inputs.skip_prepare_logic != 'true' }}
         with:
           path: |
-            /tmp/holochain_repo/.cargo/bin/
-            /tmp/holochain_repo/.cargo/registry/index/
-            /tmp/holochain_repo/.cargo/registry/cache/
-            /tmp/holochain_repo/.cargo/git/db/
-            /tmp/holochain_repo/target/
+            /var/tmp/holochain_repo/.cargo/bin/
+            /var/tmp/holochain_repo/.cargo/registry/index/
+            /var/tmp/holochain_repo/.cargo/registry/cache/
+            /var/tmp/holochain_repo/.cargo/git/db/
+            /var/tmp/holochain_repo/target/
           key: ${{ runner.os }}-prepare-${{ github.run_id }}-${{ github.run_number }}
 
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+      - name: Setup SSH session
+        uses: steveeJ-forks/action-upterm@main
         if: ${{ failure() && inputs.debug == 'true' }}
         env:
           HRA_GITHUB_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -607,7 +607,10 @@ jobs:
         id: check-status
         env:
           RESULTS: "${{ toJSON(needs.*.result) }}"
-        run: "[[ $(jq -n 'env.RESULTS | fromjson | unique == [\"success\"]') == \"true\" ]]\n"
+          DRY_RUN: "${{ needs.vars.outputs.dry_run }}"
+        run: |
+          [[ $(jq -n 'env.RESULTS | fromjson | unique == ["success"]') == 'true' ]] || \
+          [[ ${DRY_RUN} == 'true' && $(jq -n 'env.RESULTS | fromjson | unique | sort == ["skipped", "success"]') == 'true' ]]
 
       - name: Post mattermost message
         if: always()
@@ -677,7 +680,10 @@ jobs:
         id: check-status
         env:
           RESULTS: "${{ toJSON(needs.*.result) }}"
-        run: "[[ $(jq -n 'env.RESULTS | fromjson | unique == [\"success\"]') == \"true\" ]]\n"
+          DRY_RUN: "${{ needs.vars.outputs.dry_run }}"
+        run: |
+          [[ $(jq -n 'env.RESULTS | fromjson | unique == ["success"]') == 'true' ]] || \
+          [[ ${DRY_RUN} == 'true' && $(jq -n 'env.RESULTS | fromjson | unique | sort == ["skipped", "success"]') == 'true' ]]
 
       - name: Post mattermost message
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,9 +313,11 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           installCommand: |
-            nix-env -if https://github.com/cachix/cachix/tarball/${CACHIX_REV} \
-              --substituters 'https://cache.nixos.org https://cachix.cachix.org' \
-              --trusted-public-keys 'cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY='
+            if ! type -f cachix; then
+              nix-env -if https://github.com/cachix/cachix/tarball/${CACHIX_REV} \
+                --substituters 'https://cache.nixos.org https://cachix.cachix.org' \
+                --trusted-public-keys 'cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY='
+            fi
           pushFilter: "(rust-overlay|bqfq4db6nwycmkdrql9igsbrayqsw3g2)"
           # skipPush: ${{ matrix.platform == 'macos-latest' }}
       - name: Set NIX_PATH (FIXME)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
 
           echo "::set-output name=HOLOCHAIN_REPO::/tmp/holochain_repo"
           echo "::set-output name=HOLOCHAIN_RELEASE_SH::/tmp/holochain_release.sh"
-          echo "::set-output name=CACHIX_REV::v0.8.1"
+          echo "::set-output name=CACHIX_REV::v1.0.1"
   prepare:
     needs: [vars]
     uses: ./.github/workflows/release-prepare.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ on:
         default: "true"
         type: string
       debug:
-        description: "start an ssh session via upterm on failure"
+        description: "start an ssh session on failure"
         required: false
         default: "true"
         type: string
@@ -50,6 +50,11 @@ on:
         required: false
         default: "false"
         type: string
+      skip_prepare_logic:
+        description: "skip the version bump step"
+        type: string
+        default: "false"
+        required: true
       force_cancel_in_progress:
         description: "force cancelling a running action"
         required: false
@@ -79,6 +84,7 @@ jobs:
       dry_run: ${{ steps.eval.outputs.dry_run }}
       debug: ${{ steps.eval.outputs.debug }}
       skip_test: ${{ steps.eval.outputs.skip_test }}
+      skip_prepare_logic: ${{ steps.eval.outputs.skip_prepare_logic }}
     steps:
       - name: evaluate variables
         id: eval
@@ -92,6 +98,7 @@ jobs:
           input_dry_run: ${{ github.event.inputs.dry_run}}
           input_debug: ${{ github.event.inputs.debug }}
           input_skip_test: ${{ github.event.inputs.skip_test }}
+          input_skip_prepare_logic: ${{ github.event.inputs.skip_prepare_logic }}
         run: |
           set -x
 
@@ -143,8 +150,14 @@ jobs:
             echo "::set-output name=skip_test::false"
           fi
 
-          echo "::set-output name=HOLOCHAIN_REPO::/tmp/holochain_repo"
-          echo "::set-output name=HOLOCHAIN_RELEASE_SH::/tmp/holochain_release.sh"
+          if [[ ${input_skip_prepare_logic} != "" ]]; then
+            echo "::set-output name=skip_prepare_logic::${input_skip_prepare_logic}"
+          else
+            echo "::set-output name=skip_prepare_logic::false"
+          fi
+
+          echo "::set-output name=HOLOCHAIN_REPO::/var/tmp/holochain_repo"
+          echo "::set-output name=HOLOCHAIN_RELEASE_SH::/var/tmp/holochain_release.sh"
           echo "::set-output name=CACHIX_REV::v1.0.1"
   prepare:
     needs: [vars]
@@ -152,6 +165,7 @@ jobs:
     with:
       dry_run: ${{ needs.vars.outputs.dry_run }}
       debug: ${{ needs.vars.outputs.debug }}
+      skip_prepare_logic: ${{ needs.vars.outputs.skip_prepare_logic }}
       HOLOCHAIN_SOURCE_BRANCH: ${{ needs.vars.outputs.holochain_source_branch }}
       HOLOCHAIN_REPO: ${{ needs.vars.outputs.HOLOCHAIN_REPO }}
       HOLOCHAIN_RELEASE_SH: ${{ needs.vars.outputs.HOLOCHAIN_RELEASE_SH }}
@@ -162,8 +176,8 @@ jobs:
       HRA_GITHUB_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN}}
 
   test:
-    if: ${{ github.event_name != 'pull_request' }}
     needs: [vars, prepare]
+    if: ${{ needs.vars.outputs.skip_test != 'true' }}
     env:
       HOLOCHAIN_REPO: ${{ needs.vars.outputs.HOLOCHAIN_REPO }}
       HOLOCHAIN_RELEASE_SH: ${{ needs.vars.outputs.HOLOCHAIN_RELEASE_SH }}
@@ -172,64 +186,93 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - ubuntu-latest
-          - macos-latest
+          - arch: linux-x86_64
+            runs-on: [self-hosted, release]
+            largeCacheStorage:
+              generic:
+                - local
+              nix:
+                - cachix
+          - arch: macos-x86_64
+            runs-on: [macos-latest]
+            largeCacheStorage:
+              nix:
+                - cachix
+          - arch: linux-x86_64
+            runs-on: [ubuntu-latest]
+            largeCacheStorage:
+              generic:
+                - github
+              nix:
+                - cachix
         testCommand:
-          - name: cargo-test-standard
-            restoresCargoCache: true
-            savesCargoCache: true
-            ignoreErrorOnNonUbuntu: true
+          - name: cargo-test
+            largeCacheStorage:
+              - generic
+              - nix
             maxBuildSpace: true
-            timeout_minutes: 30
-            max_attempts:
-              ubuntu-latest: 2
-              macos-latest: 2
+            hasBuildStep: true
+            timeout_minutes: 60
+            max_attempts: 2
             run: |
               nix-shell \
                 --pure \
                 --keep CARGO_NEXTEST_ARGS \
                 --keep CARGO_TEST_ARGS \
-                --keep CARGO_BUILD_JOBS \
-                --fallback --argstr flavor "coreDev" --run hc-test-standard-nextest
+                --fallback --argstr flavor "coreDev" --run '
+                  set -e
+                  hc-test-standard-nextest
+                  hc-static-checks
+                  hc-test-wasm
+                '
 
-          - name: cargo-test-static
-            restoresCargoCache: true
-            savesCargoCache: true
-            ignoreErrorOnNonUbuntu: false
-            timeout_minutes: 5
-            max_attempts:
-              ubuntu-latest: 1
-              macos-latest: 1
-            run: |
-              nix-shell \
-                --pure \
-                --keep CARGO_TEST_ARGS \
-                --keep CARGO_BUILD_JOBS \
-                --fallback --argstr flavor "coreDev" --run hc-static-checks
+          # - name: cargo-test-standard
+          #   largeCacheStorage:
+          #     - generic
+          #     - nix
+          #   maxBuildSpace: true
+          #   hasBuildStep: true
+          #   timeout_minutes: 30
+          #   max_attempts: 2
+          #   run: |
+          #     nix-shell \
+          #       --pure \
+          #       --keep CARGO_NEXTEST_ARGS \
+          #       --keep CARGO_TEST_ARGS \
+          #       --fallback --argstr flavor "coreDev" --run hc-test-standard-nextest
 
-          - name: cargo-test-wasm
-            restoresCargoCache: true
-            savesCargoCache: true
-            ignoreErrorOnNonUbuntu: false
-            timeout_minutes: 5
-            max_attempts:
-              ubuntu-latest: 6
-              macos-latest: 1
-            run: |
-              nix-shell \
-                --pure \
-                --keep CARGO_TEST_ARGS \
-                --keep CARGO_BUILD_JOBS \
-                --fallback --argstr flavor "coreDev" --run hc-test-wasm
+          # - name: cargo-test-static
+          #   largeCacheStorage:
+          #     - generic
+          #     - nix
+          #   hasBuildStep: true
+          #   timeout_minutes: 5
+          #   max_attempts: 1
+          #   run: |
+          #     nix-shell \
+          #       --pure \
+          #       --keep CARGO_TEST_ARGS \
+          #       --fallback --argstr flavor "coreDev" --run hc-static-checks
+
+          # - name: cargo-test-wasm
+          #   largeCacheStorage:
+          #     - generic
+          #     - nix
+          #   hasBuildStep: true
+          #   timeout_minutes: 5
+          #   max_attempts: 6
+          #   run: |
+          #     nix-shell \
+          #       --pure \
+          #       --keep CARGO_TEST_ARGS \
+          #       --fallback --argstr flavor "coreDev" --run hc-test-wasm
 
           - name: nix-test
-            restoresCargoCache: false
-            savesCargoCache: false
-            ignoreErrorOnNonUbuntu: false
+            largeCacheStorage:
+              - nix
+            hasBuildStep: false
             timeout_minutes: 90
-            max_attempts:
-              ubuntu-latest: 1
-              macos-latest: 1
+            max_attempts: 1
             run: |
               set -x
 
@@ -271,7 +314,7 @@ jobs:
               git clone "${HOLONIX_URL}" "${HOLONIX_REPO}" -b ${HOLONIX_SOURCE_BRANCH} --depth=1
               cd "${HOLONIX_REPO}"
 
-              nix-shell
+              nix-shell \
                 --pure \
                 --keep HOLOCHAIN_NIXPKGS_REPO \
                 --run '
@@ -288,88 +331,122 @@ jobs:
                   hn-test
                 '
         exclude:
+          # dont run tests on pull request
           - event_name: pull_request
-            platform: macos-latest
-          - event_name: pull_request
+
+          # exclude all cargo test jobs on macos
+          - platform:
+              arch: macos-x86_64
+            testCommand:
+              name: cargo-test
+
+          # exclude all cargo test jobs on github's ubuntu-latest
+          - platform:
+              runs-on: [ubuntu-latest]
+            testCommand:
+              name: cargo-test
+
+          # we only run the cargo tests on the self-hosted runners
+          - platform:
+              runs-on: [self-hosted, release]
             testCommand:
               name: nix-test
+
+          # TODO: reenable these if or when we split the cargo tests up again
+          # - platform:
+          #     arch: macos-x86_64
+          #   testCommand:
+          #     name: cargo-test-standard
+          # - platform:
+          #     arch: macos-x86_64
+          #   testCommand:
+          #     name: cargo-test-wasm
+          # - platform:
+          #     arch: macos-x86_64
+          #   testCommand:
+          #     name: cargo-test-static
         event_name:
           - ${{ github.event_name }}
-    runs-on: ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform.runs-on }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Extend space
         uses: ./.github/actions/extend-space
-        if: ${{ matrix.platform == 'ubuntu-latest' && matrix.testCommand.maxBuildSpace == true && needs.vars.outputs.skip_test != 'true' }}
+        if: ${{ contains(matrix.platform.runs-on, 'ubuntu-latest') && matrix.testCommand.maxBuildSpace == true }}
 
       - name: Install nix
         uses: cachix/install-nix-action@v17
       - name: Setup cachix
-        uses: cachix/cachix-action@v10
-        continue-on-error: ${{ github.event_name != 'pull_request' }}
+        uses: cachix/cachix-action@v11
+        if: ${{ contains(matrix.platform.largeCacheStorage.nix, 'cachix') && contains(matrix.testCommand.largeCacheStorage, 'nix') }}
         with:
           name: holochain-ci
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           installCommand: |
-            if ! type -f cachix; then
-              nix-env -if https://github.com/cachix/cachix/tarball/${CACHIX_REV} \
-                --substituters 'https://cache.nixos.org https://cachix.cachix.org' \
-                --trusted-public-keys 'cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY='
-            fi
+            nix-env -if https://github.com/cachix/cachix/tarball/${CACHIX_REV} \
+              --substituters 'https://cache.nixos.org https://cachix.cachix.org' \
+              --trusted-public-keys 'cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY='
           pushFilter: "(rust-overlay|bqfq4db6nwycmkdrql9igsbrayqsw3g2)"
-          # skipPush: ${{ matrix.platform == 'macos-latest' }}
       - name: Set NIX_PATH (FIXME)
         run: echo NIX_PATH=nixpkgs=$(./scripts/nix_path.sh) >> $GITHUB_ENV
 
       - name: Restore the holochain release repository
-        uses: steveeJ-forks/actions-cache/restore@main
+        uses: steveeJ-forks/actions-cache/restore@retry
         with:
           path: |
-            /tmp/holochain_release.sh
+            /var/tmp/holochain_release.sh
             # asterisk is a workaround for https://github.com/actions/cache/issues/494
-            /tmp/holochain_repo/*
-            !/tmp/holochain_repo/.cargo/
-            !/tmp/holochain_repo/target/
+            /var/tmp/holochain_repo/*
+            !/var/tmp/holochain_repo/.cargo/
+            !/var/tmp/holochain_repo/target/
           key: holochain-repo-${{ github.run_id }}-${{ github.run_number }}
           required: true
 
       - name: Restore cargo related state and build files
         uses: steveeJ-forks/actions-cache/restore@main
-        if: ${{ matrix.testCommand.restoresCargoCache == true && needs.vars.outputs.skip_test != 'true' }}
+        if: ${{ contains(matrix.platform.largeCacheStorage.generic, 'github') && contains(matrix.testCommand.largeCacheStorage, 'generic') }}
         with:
           path: |
-            /tmp/holochain_repo/.cargo/bin/
-            /tmp/holochain_repo/.cargo/registry/index/
-            /tmp/holochain_repo/.cargo/registry/cache/
-            /tmp/holochain_repo/.cargo/git/db/
-            /tmp/holochain_repo/target/
+            /var/tmp/holochain_repo/.cargo/bin/
+            /var/tmp/holochain_repo/.cargo/registry/index/
+            /var/tmp/holochain_repo/.cargo/registry/cache/
+            /var/tmp/holochain_repo/.cargo/git/db/
+            /var/tmp/holochain_repo/target/
           key: ${{ runner.os }}-test-${{ matrix.testCommand.name }}-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-test-${{ matrix.testCommand.name }}
             ${{ runner.os }}-prepare-${{ github.run_id }}-${{ github.run_number }}
             ${{ runner.os }}-prepare-${{ github.run_id }}
             ${{ runner.os }}-prepare
-          required: ${{ matrix.platform == 'ubuntu-latest' }}
+          required: false
 
-      - name: Set cache timestamp
-        if: ${{ matrix.testCommand.savesCargoCache == true }}
+      - name: Garbage-collection pre-run procedure
+        if: ${{ contains(matrix.testCommand.largeCacheStorage, 'generic') }}
+        env:
+          MATRIX: ${{ toJSON(matrix) }}
         run: |
-          set -e
+          set -ex
+          cat "${HOLOCHAIN_RELEASE_SH}"
           source "${HOLOCHAIN_RELEASE_SH}"
           cd "${HOLOCHAIN_REPO}"
 
+          # TODO: handle this when we go back to parallel test runs
+          echo ${MATRIX}
+
           nix-shell --pure --run '
+              cargo sweep -i
               cargo sweep -s
             '
 
       - name: ${{ matrix.testCommand.name }} (build only)
-        if: ${{ matrix.testCommand.restoresCargoCache == true && needs.vars.outputs.skip_test != 'true' }}
+        if: ${{ matrix.testCommand.hasBuildStep == true }}
         env:
           CARGO_TEST_ARGS: "--no-run"
-          CARGO_NEXTEST_ARGS: "list --build-jobs=2"
-          CARGO_BUILD_JOBS: "2"
+          CARGO_NEXTEST_ARGS: "list" # --build-jobs=2"
+          # CARGO_BUILD_JOBS: "2"
         run: |
           set -e
           source "${HOLOCHAIN_RELEASE_SH}"
@@ -378,32 +455,35 @@ jobs:
           nix-shell --pure --run "cargo fetch --locked"
 
           ${{ matrix.testCommand.run }}
-        continue-on-error: ${{ matrix.platform != 'ubuntu-latest' && matrix.testCommand.ignoreErrorOnNonUbuntu == true }}
         timeout-minutes: 720
 
       - name: ${{ matrix.testCommand.name }} (run)
-        if: ${{ needs.vars.outputs.skip_test != 'true' }}
-        uses: nick-fields/retry@v2
+        uses: nick-fields/retry@v2.8.1
         env:
           HOLOCHAIN_NIXPKGS_SOURCE_BRANCH: ${{ needs.vars.outputs.holochain_nixpkgs_source_branch }}
           HOLONIX_SOURCE_BRANCH: ${{ needs.vars.outputs.holonix_source_branch }}
         with:
           timeout_minutes: ${{ matrix.testCommand.timeout_minutes }}
-          max_attempts: ${{ matrix.testCommand.max_attempts[matrix.platform] }}
+          max_attempts: ${{ matrix.testCommand.max_attempts }}
           command: |
             set -e
             source "${HOLOCHAIN_RELEASE_SH}"
             cd "${HOLOCHAIN_REPO}"
 
             ${{ matrix.testCommand.run }}
-        continue-on-error: ${{ matrix.platform != 'ubuntu-latest' && matrix.testCommand.ignoreErrorOnNonUbuntu == true }}
 
-      - name: Garbage-collect cache
-        if: ${{ always() && matrix.testCommand.savesCargoCache == true && needs.vars.outputs.skip_test != 'true' }}
+      - name: Garbage-collection post-run procedure
+        if: ${{ always() && contains(matrix.testCommand.largeCacheStorage, 'generic') }}
+        env:
+          MATRIX: ${{ toJSON(matrix) }}
         run: |
           set -e
           source "${HOLOCHAIN_RELEASE_SH}"
           cd "${HOLOCHAIN_REPO}"
+
+          # TODO: handle this
+          echo ${MATRIX}
+
           nix-shell \
             --pure \
             --run '
@@ -412,18 +492,18 @@ jobs:
 
       - name: Cache cargo related build files
         uses: steveeJ-forks/actions-cache/save@main
-        if: ${{ always() && matrix.testCommand.savesCargoCache == true && needs.vars.outputs.skip_test != 'true' }}
+        if: ${{ always() && contains(matrix.platform.largeCacheStorage.generic, 'github') && contains(matrix.testCommand.largeCacheStorage, 'generic') }}
         with:
           path: |
-            /tmp/holochain_repo/.cargo/bin/
-            /tmp/holochain_repo/.cargo/registry/index/
-            /tmp/holochain_repo/.cargo/registry/cache/
-            /tmp/holochain_repo/.cargo/git/db/
-            /tmp/holochain_repo/target/
+            /var/tmp/holochain_repo/.cargo/bin/
+            /var/tmp/holochain_repo/.cargo/registry/index/
+            /var/tmp/holochain_repo/.cargo/registry/cache/
+            /var/tmp/holochain_repo/.cargo/git/db/
+            /var/tmp/holochain_repo/target/
           key: ${{ runner.os }}-test-${{ matrix.testCommand.name }}-${{ github.run_id }}-${{ github.run_number }}
 
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+      - name: Setup SSH session
+        uses: steveeJ-forks/action-upterm@main
         if: ${{ failure() && needs.vars.outputs.debug == 'true' }}
         with:
           ## limits ssh access and adds the ssh public key for the user which triggered the workflow
@@ -447,7 +527,7 @@ jobs:
       - name: Install nix
         uses: cachix/install-nix-action@v17
       - name: Setup cachix
-        uses: cachix/cachix-action@v10
+        uses: cachix/cachix-action@v11
         with:
           name: holochain-ci
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
@@ -461,11 +541,11 @@ jobs:
         uses: steveeJ-forks/actions-cache/restore@main
         with:
           path: |
-            /tmp/holochain_release.sh
+            /var/tmp/holochain_release.sh
             # asterisk is a workaround for https://github.com/actions/cache/issues/494
-            /tmp/holochain_repo/*
-            !/tmp/holochain_repo/.cargo/
-            !/tmp/holochain_repo/target/
+            /var/tmp/holochain_repo/*
+            !/var/tmp/holochain_repo/.cargo/
+            !/var/tmp/holochain_repo/target/
           key: holochain-repo-${{ github.run_id }}-${{ github.run_number }}
           required: true
 
@@ -479,11 +559,11 @@ jobs:
         uses: steveeJ-forks/actions-cache/restore@main
         with:
           path: |
-            /tmp/holochain_repo/.cargo/bin/
-            /tmp/holochain_repo/.cargo/registry/index/
-            /tmp/holochain_repo/.cargo/registry/cache/
-            /tmp/holochain_repo/.cargo/git/db/
-            /tmp/holochain_repo/target/
+            /var/tmp/holochain_repo/.cargo/bin/
+            /var/tmp/holochain_repo/.cargo/registry/index/
+            /var/tmp/holochain_repo/.cargo/registry/cache/
+            /var/tmp/holochain_repo/.cargo/git/db/
+            /var/tmp/holochain_repo/target/
           key: ${{ runner.os }}-prepare-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-test-
@@ -585,8 +665,8 @@ jobs:
             --title "holochain ${VERSION:?}" \
             --notes "***Please read [this release's top-level CHANGELOG](https://github.com/holochain/holochain/blob/main/CHANGELOG.md#$(sed -E 's/(release-|\.)//g' <<<"${RELEASE_BRANCH:?}")) to see the full list of crates that were released together.***"
 
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+      - name: Setup SSH session
+        uses: steveeJ-forks/action-upterm@main
         if: ${{ failure() && needs.vars.outputs.debug == 'true' }}
         env:
           GITHUB_ACTION_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,10 +186,11 @@ jobs:
               macos-latest: 2
             run: |
               nix-shell \
+                --pure \
                 --keep CARGO_NEXTEST_ARGS \
                 --keep CARGO_TEST_ARGS \
                 --keep CARGO_BUILD_JOBS \
-                --fallback --pure --argstr flavor "coreDev" --run hc-test-standard-nextest
+                --fallback --argstr flavor "coreDev" --run hc-test-standard-nextest
 
           - name: cargo-test-static
             restoresCargoCache: true
@@ -201,9 +202,10 @@ jobs:
               macos-latest: 1
             run: |
               nix-shell \
+                --pure \
                 --keep CARGO_TEST_ARGS \
                 --keep CARGO_BUILD_JOBS \
-                --fallback --pure --argstr flavor "coreDev" --run hc-static-checks
+                --fallback --argstr flavor "coreDev" --run hc-static-checks
 
           - name: cargo-test-wasm
             restoresCargoCache: true
@@ -215,9 +217,10 @@ jobs:
               macos-latest: 1
             run: |
               nix-shell \
+                --pure \
                 --keep CARGO_TEST_ARGS \
                 --keep CARGO_BUILD_JOBS \
-                --fallback --pure --argstr flavor "coreDev" --run hc-test-wasm
+                --fallback --argstr flavor "coreDev" --run hc-test-wasm
 
           - name: nix-test
             restoresCargoCache: false
@@ -258,18 +261,29 @@ jobs:
               # regenerate the nix sources
               git config --global user.email "devcore@holochain.org"
               git config --global user.name "Holochain Core Dev Team"
-              nix-shell --arg flavors '["release"]' --pure --run "hnixpkgs-update-single ${VERSION_COMPAT}"
+              nix-shell \
+                --pure \
+                --keep VERSION_COMPAT \
+                --arg flavors '["release"]' \
+                --run 'hnixpkgs-update-single ${VERSION_COMPAT}'
               nix-build . -A packages.holochain.holochainAllBinariesWithDeps.${VERSION_COMPAT} --no-link
 
               git clone "${HOLONIX_URL}" "${HOLONIX_REPO}" -b ${HOLONIX_SOURCE_BRANCH} --depth=1
               cd "${HOLONIX_REPO}"
 
-              nix-shell --run '
+              nix-shell
+                --pure \
+                --keep HOLOCHAIN_NIXPKGS_REPO \
+                --run '
                   niv drop holochain-nixpkgs
                   niv add local --path ${HOLOCHAIN_NIXPKGS_REPO} --name holochain-nixpkgs
                 '
 
-              nix-shell --argstr holochainVersionId "${VERSION_COMPAT}" --arg include '{ test = true; }' --run '
+              nix-shell \
+                --pure \
+                --argstr holochainVersionId "${VERSION_COMPAT}" \
+                --arg include '{ test = true; }' \
+                --run '
                   holochain --version
                   hn-test
                 '
@@ -359,7 +373,7 @@ jobs:
           source "${HOLOCHAIN_RELEASE_SH}"
           cd "${HOLOCHAIN_REPO}"
 
-          nix-shell --run "cargo fetch --locked"
+          nix-shell --pure --run "cargo fetch --locked"
 
           ${{ matrix.testCommand.run }}
         continue-on-error: ${{ matrix.platform != 'ubuntu-latest' && matrix.testCommand.ignoreErrorOnNonUbuntu == true }}
@@ -388,7 +402,9 @@ jobs:
           set -e
           source "${HOLOCHAIN_RELEASE_SH}"
           cd "${HOLOCHAIN_REPO}"
-          nix-shell --pure --run '
+          nix-shell \
+            --pure \
+            --run '
               cargo sweep -f
             '
 
@@ -533,12 +549,15 @@ jobs:
           source ${HOLOCHAIN_RELEASE_SH}
           cd "${HOLOCHAIN_REPO}"
 
-          nix-shell --argstr flavor release --keep CARGO_REGISTRY_TOKEN --pure --run '
-            release-automation \
-              --workspace-path=$PWD \
-              --log-level=trace \
-              release \
-                --steps=PublishToCratesIo,AddOwnersToCratesIo
+          nix-shell \
+            --pure \
+            --keep CARGO_REGISTRY_TOKEN \
+            --argstr flavor release  --run '
+              release-automation \
+                --workspace-path=$PWD \
+                --log-level=trace \
+                release \
+                  --steps=PublishToCratesIo,AddOwnersToCratesIo
             '
 
       - name: Push the tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,7 +247,7 @@ jobs:
               if grep --quiet ${VERSION_COMPAT} packages/holochain/versions/update_config.toml; then
                 export VERSION_COMPAT="${VERSION_COMPAT}-ci"
                 export TAG="${TAG}-ci"
-                git -C "${HOLOCHAIN_REPO}" tag "${TAG}"
+                git -C "${HOLOCHAIN_REPO}" tag --force "${TAG}"
               fi
 
               # TODO: use a util from the holochain-nixpkgs repo to make this change as this can get out of sync

--- a/.github/workflows/ssh_session.yml
+++ b/.github/workflows/ssh_session.yml
@@ -15,6 +15,11 @@ jobs:
     steps:
       - name: Install nix
         uses: cachix/install-nix-action@v16
+      - name: Check if cachix is installed
+        id: cachix_exists
+        run: |
+          cachix --version
+        continue-on-error: false
       - name: Setup cachix
         uses: cachix/cachix-action@v10
         with:
@@ -22,9 +27,11 @@ jobs:
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           installCommand: |
-            nix-env -if https://github.com/cachix/cachix/tarball/master \
-              --substituters 'https://cache.nixos.org https://cachix.cachix.org' \
-              --trusted-public-keys 'cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY='
+            if [[ ${{ steps.cachix_exists.outcome}} != "success" ]]; then
+              nix-env -if https://github.com/cachix/cachix/tarball/master \
+                --substituters 'https://cache.nixos.org https://cachix.cachix.org' \
+                --trusted-public-keys 'cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY='
+            fi
       - name: Fetch cargo related state and build files
         uses: steveeJ-forks/actions-cache/restore@main
         with:

--- a/.github/workflows/ssh_session.yml
+++ b/.github/workflows/ssh_session.yml
@@ -25,7 +25,6 @@ jobs:
             nix-env -if https://github.com/cachix/cachix/tarball/master \
               --substituters 'https://cache.nixos.org https://cachix.cachix.org' \
               --trusted-public-keys 'cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY='
-
       - name: Fetch cargo related state and build files
         uses: steveeJ-forks/actions-cache/restore@main
         with:

--- a/.github/workflows/ssh_session.yml
+++ b/.github/workflows/ssh_session.yml
@@ -3,44 +3,78 @@ name: SSH session
 on:
   workflow_dispatch:
     inputs:
-      platform:
-        description: "target platform"
+      runs-on:
+        description: "value passed to 'runs-on'"
         required: false
-        default: "macos-latest"
+        default: "ubuntu-latest"
+        type: string
+      extend-space:
+        description: "extend the runner's space"
+        required: false
+        default: "false"
         type: string
 
 jobs:
   ssh-session:
-    runs-on: ${{ github.event.inputs.platform }}
+    runs-on: ${{ github.event.inputs.runs-on }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Extend space
+        uses: ./.github/actions/extend-space
+        if: ${{ github.event.inputs.runs-on == 'ubuntu-latest'  && github.event.inputs.extend-space == 'true' }}
+
       - name: Install nix
         uses: cachix/install-nix-action@v16
-      - name: Check if cachix is installed
-        id: cachix_exists
-        run: |
-          cachix --version
-        continue-on-error: false
+
+      # - name: Use cachix
+      #   id: cachix_use
+      #   continue-on-error: true
+      #   env:
+      #     CACHIX_AUTH_TOKEN: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      #     CACHIX_SIGNING_KEY: "${{ secrets.CACHIX_SIGNING_KEY }}"
+      #   run: |
+      #     cachix use holochain-ci
+
       - name: Setup cachix
-        uses: cachix/cachix-action@v10
+        uses: cachix/cachix-action@v11
+        if: ${{ steps.cachix_use.outcome != 'success'  }}
         with:
           name: holochain-ci
           signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           installCommand: |
-            if [[ ${{ steps.cachix_exists.outcome}} != "success" ]]; then
-              nix-env -if https://github.com/cachix/cachix/tarball/master \
-                --substituters 'https://cache.nixos.org https://cachix.cachix.org' \
-                --trusted-public-keys 'cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY='
-            fi
-      - name: Fetch cargo related state and build files
-        uses: steveeJ-forks/actions-cache/restore@main
+            nix-env -if https://github.com/cachix/cachix/tarball/master \
+              --substituters 'https://cache.nixos.org https://cachix.cachix.org' \
+              --trusted-public-keys 'cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY='
+
+      - name: Create /var/tmp
+        run: |
+          mkdir -p /var/tmp
+
+      - name: Restore the holochain release repository
+        uses: steveeJ-forks/actions-cache/restore@retry
         with:
           path: |
-            /tmp/holochain_repo/.cargo/bin/
-            /tmp/holochain_repo/.cargo/registry/index/
-            /tmp/holochain_repo/.cargo/registry/cache/
-            /tmp/holochain_repo/.cargo/git/db/
-            /tmp/holochain_repo/target/
+            /var/tmp/holochain_release.sh
+            # asterisk is a workaround for https://github.com/actions/cache/issues/494
+            /var/tmp/holochain_repo/*
+            !/var/tmp/holochain_repo/.cargo/
+            !/var/tmp/holochain_repo/target/
+          key: holochain-repo-
+          required: false
+
+      - name: Fetch cargo related state and build files
+        uses: steveeJ-forks/actions-cache/restore@main
+        if: ${{ github.event.inputs.runs-on == 'ubuntu-latest' }}
+        with:
+          path: |
+            /var/tmp/holochain_repo/.cargo/bin/
+            /var/tmp/holochain_repo/.cargo/registry/index/
+            /var/tmp/holochain_repo/.cargo/registry/cache/
+            /var/tmp/holochain_repo/.cargo/git/db/
+            /var/tmp/holochain_repo/target/
           key: ${{ runner.os }}-test-${{ matrix.testCommand.name }}-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-test-cargo-test-slow
@@ -48,23 +82,22 @@ jobs:
             ${{ runner.os }}-prepare
           required: false
 
-      - name: Checkout repository
-        uses: actions/checkout@v2.4.0
-      - name: Move cargo related state and build files
-        run: |
-          if [[ -e /tmp/holochain_repo/.cargo ]]; then
-            mv -f /tmp/holochain_repo/.cargo ./
-          fi
-          if [[ -e /tmp/holochain_repo/target ]]; then
-            mv -f /tmp/holochain_repo/target/ ./
-          fi
-      - name: Set NIX_PATH (FIXME)
-        run: echo NIX_PATH=nixpkgs=$(./scripts/nix_path.sh) >> $GITHUB_ENV
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
+      # - name: Set NIX_PATH (FIXME)
+      #   run: echo NIX_PATH=nixpkgs=$(./scripts/nix_path.sh) >> $GITHUB_ENV
+
+      - name: debug
         env:
-          HRA_GITHUB_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN}}
-          HRA_MATTERMOST_TOKEN: ${{ secrets.HRA_MATTERMOST_TOKEN }}
+          HOLOCHAIN_RELEASE_SH: "/var/tmp/holochain_release.sh"
+        run: |
+          set -x
+          env
+          nix-shell --version
+          nix --version
+          pwd
+
+      - name: Setup SSH session
+        uses: steveeJ-forks/action-upterm@main
+        if: ${{ always() }}
         with:
           ## limits ssh access and adds the ssh public key for the user which triggered the workflow
           limit-access-to-actor: true

--- a/crates/holochain/tests/test_utils/mod.rs
+++ b/crates/holochain/tests/test_utils/mod.rs
@@ -304,6 +304,8 @@ async fn check_timeout_named<T>(
     response: impl Future<Output = Result<T, WebsocketError>>,
     timeout_millis: u64,
 ) -> T {
+    // FIXME(stefan): remove this multiplier once it's faster on self-hosted CI
+    let timeout_millis = timeout_millis * 4;
     match tokio::time::timeout(std::time::Duration::from_millis(timeout_millis), response).await {
         Ok(response) => response.unwrap(),
         Err(e) => {


### PR DESCRIPTION
### Summary

* refactor matrix setup for platforms and testcommands to distinguish
  the 3 setups and the difference in appropriate caching and test
  commands
* use the self-hosted runner for the linux cargo tests
* use /var/tmp instead of /tmp, becasue on the self-hosted runner /tmp
  is a tmpfs, which can't fit our target directory

* change ssh_session for debugging
* add skip_prepare_logic parameter
* fix path issues on macos

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
