### PR TITLE
Enable hackable DNA hashes to workaround breaking changes during testing

### DIFF
--- a/crates/hc_bundle/tests/test_cli.rs
+++ b/crates/hc_bundle/tests/test_cli.rs
@@ -223,6 +223,7 @@ async fn test_multi_integrity() {
                 .into(),
             ),
         ],
+        hacked_hash: None,
     };
     assert_eq!(
         dna.dna_def().integrity_zomes[0]

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -181,6 +181,9 @@ no-deps = [ "holochain_keystore/no-deps", "holochain_sqlite/no-deps" ]
 # Extremely verbose wasm memory read/write logging
 wasmer_debug_memory = ["holochain_wasmer_host/debug_memory"]
 
+# Enable hackable DNA hashes, for testing
+hackable-dna-hashes = ["holochain_zome_types/hackable-dna-hashes"]
+
 # Enable chain head coordination
 chc = [
   "bytes",

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -614,6 +614,7 @@ pub mod test {
                     .map(TestZomes::from)
                     .map(|z| z.coordinator.into_inner())
                     .collect(),
+                hacked_hash: None,
             },
             zomes.into_iter().flat_map(|t| Vec::<DnaWasm>::from(t)),
         )

--- a/crates/holochain/src/core/sys_validate/tests.rs
+++ b/crates/holochain/src/core/sys_validate/tests.rs
@@ -337,6 +337,7 @@ async fn check_app_entry_type_test() {
             coordinator_zomes: vec![TestZomes::from(TestWasm::EntryDefs)
                 .coordinator
                 .into_inner()],
+            hacked_hash: None,
         },
         [integrity, coordinator],
     )

--- a/crates/holochain/src/core/workflow/call_zome_workflow/validation_test.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow/validation_test.rs
@@ -31,6 +31,7 @@ async fn direct_validation_test() {
             },
             integrity_zomes: vec![TestZomes::from(TestWasm::Update).integrity.into_inner()],
             coordinator_zomes: vec![TestZomes::from(TestWasm::Update).coordinator.into_inner()],
+            hacked_hash: None,
         },
         [integrity, coordinator],
     )

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -475,6 +475,7 @@ async fn setup(
                 .map(TestZomes::from)
                 .map(|z| z.coordinator.into_inner())
                 .collect(),
+            hacked_hash: None,
         },
         zomes.into_iter().map(Into::into),
     )

--- a/crates/holochain/src/test_utils/conductor_setup.rs
+++ b/crates/holochain/src/test_utils/conductor_setup.rs
@@ -182,26 +182,26 @@ impl ConductorTestData {
         network: Option<KitsuneP2pConfig>,
     ) -> Self {
         let dna_file = DnaFile::new(
-            DnaDef {
-                name: "conductor_test".to_string(),
-                modifiers: DnaModifiers {
+            DnaDef::new(
+                "conductor_test".to_string(),
+                DnaModifiers {
                     network_seed: "ba1d046d-ce29-4778-914b-47e6010d2faf".to_string(),
                     properties: SerializedBytes::try_from(()).unwrap(),
                     origin_time: Timestamp::HOLOCHAIN_EPOCH,
                 },
-                integrity_zomes: zomes
+                zomes
                     .clone()
                     .into_iter()
                     .map(TestZomes::from)
                     .map(|z| z.integrity.into_inner())
                     .collect(),
-                coordinator_zomes: zomes
+                zomes
                     .clone()
                     .into_iter()
                     .map(TestZomes::from)
                     .map(|z| z.coordinator.into_inner())
                     .collect(),
-            },
+            ),
             zomes.into_iter().flat_map(Vec::<DnaWasm>::from),
         )
         .await;

--- a/crates/holochain/tests/network_tests/mod.rs
+++ b/crates/holochain/tests/network_tests/mod.rs
@@ -173,7 +173,7 @@ async fn get_from_another_agent() {
             properties: SerializedBytes::try_from(()).unwrap(),
             zomes: vec![TestWasm::Create.into()].into(),
         },
-        vec![TestWasm::Create.into()],
+        vec![TestWasm::Create.into()],        
     )
     .await
     .unwrap();
@@ -307,7 +307,8 @@ async fn get_links_from_another_agent() {
             properties: SerializedBytes::try_from(()).unwrap(),
             zomes: vec![TestWasm::Create.into()].into(),
         },
-        vec![TestWasm::Create.into()],
+        vec![TestWasm::Create.into()],        
+
     )
     .await
     .unwrap();

--- a/crates/holochain/tests/ser_regression/mod.rs
+++ b/crates/holochain/tests/ser_regression/mod.rs
@@ -54,6 +54,7 @@ async fn ser_regression_test() {
             coordinator_zomes: vec![TestZomes::from(TestWasm::SerRegression)
                 .coordinator
                 .into_inner()],
+            hacked_hash: None,
         },
         <Vec<DnaWasm>>::from(TestWasm::SerRegression),
     )

--- a/crates/holochain/tests/speed_tests/mod.rs
+++ b/crates/holochain/tests/speed_tests/mod.rs
@@ -130,6 +130,7 @@ async fn speed_test(n: Option<usize>) -> Arc<TempDir> {
             },
             integrity_zomes: vec![TestZomes::from(TestWasm::Anchor).integrity.into_inner()],
             coordinator_zomes: vec![TestZomes::from(TestWasm::Anchor).coordinator.into_inner()],
+            hacked_hash: None,
         },
         vec![TestWasm::Anchor.into()],
     )

--- a/crates/holochain_types/src/dna/dna_bundle.rs
+++ b/crates/holochain_types/src/dna/dna_bundle.rs
@@ -127,6 +127,7 @@ impl DnaBundle {
                     },
                     integrity_zomes,
                     coordinator_zomes,
+                    hacked_hash: None,
                 };
 
                 let original_hash = DnaHash::with_data_sync(&dna_def);

--- a/crates/holochain_types/src/test_utils.rs
+++ b/crates/holochain_types/src/test_utils.rs
@@ -49,6 +49,7 @@ pub fn fake_dna_zomes_named(
         },
         integrity_zomes: Vec::new(),
         coordinator_zomes: Vec::new(),
+        hacked_hash: None,
     };
     tokio_helper::block_forever_on(async move {
         let mut wasm_code = Vec::new();

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -65,6 +65,8 @@ full = ["default", "rusqlite", "num_enum", "kitsune_p2p_timestamp/full", "proper
 
 fixturators = ["fixt", "rand", "strum", "holo_hash/fixturators", "holochain_integrity_types/test_utils"]
 
+hackable-dna-hashes = ["full-dna-def"]
+
 properties = ["serde_yaml"]
 
 test_utils = [

--- a/crates/holochain_zome_types/src/dna_def.rs
+++ b/crates/holochain_zome_types/src/dna_def.rs
@@ -161,7 +161,6 @@ pub struct DnaDef {
     /// Make this DNA register itself with a different hash than what its content implies.
     /// Obviously only for testing!
     #[serde(default)]
-    #[cfg(feature = "hackable-dna-hashes")]
     #[cfg_attr(feature = "full-dna-def", builder(default))]
     pub hacked_hash: Option<DnaHashB64>,
 }
@@ -193,6 +192,21 @@ impl DnaDef {
 }
 
 impl DnaDef {
+    /// Constructor
+    pub fn new(
+        name: String,
+        modifiers: DnaModifiers,
+        integrity_zomes: IntegrityZomes,
+        coordinator_zomes: CoordinatorZomes,
+    ) -> Self {
+        Self {
+            name,
+            modifiers,
+            integrity_zomes,
+            coordinator_zomes,
+            hacked_hash: None,
+        }
+    }
     /// Get all zomes including the integrity and coordinator zomes.
     pub fn all_zomes(&self) -> impl Iterator<Item = (&ZomeName, &zome::ZomeDef)> {
         self.integrity_zomes

--- a/crates/holochain_zome_types/src/fixt.rs
+++ b/crates/holochain_zome_types/src/fixt.rs
@@ -747,6 +747,7 @@ fixturator!(
         coordinator_zomes: CoordinatorZomesFixturator::new_indexed(Empty, get_fixt_index!())
             .next()
             .unwrap(),
+        hacked_hash: None,
     };
 
     curve Unpredictable DnaDef {
@@ -768,6 +769,7 @@ fixturator!(
         coordinator_zomes: CoordinatorZomesFixturator::new_indexed(Empty, get_fixt_index!())
             .next()
             .unwrap(),
+        hacked_hash: None,
     };
 
     curve Predictable DnaDef {
@@ -789,6 +791,7 @@ fixturator!(
         coordinator_zomes: CoordinatorZomesFixturator::new_indexed(Empty, get_fixt_index!())
             .next()
             .unwrap(),
+        hacked_hash: None,
     };
 );
 


### PR DESCRIPTION
### Summary

This is the PR that we need, not one we deserve.

At least I need it, so I can connect to an existing network with the latest conductor version, which is inaccessible to me because the serialization format is different between the old conductor and the new one, which changes the DNA hash even though the behavior is identical.

As a followup, we should make DNA serialization + hashing more robust, but this is what I need right now.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
