### PR TITLE
Fix a bug where DNA modifiers set in a happ manifest are not respected

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -82,7 +82,7 @@ jobs:
         continue-on-error: ${{ github.event_name != 'pull_request' }}
         with:
           name: holochain-ci
-          signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
+          # signingKey: "${{ secrets.CACHIX_SIGNING_KEY }}"
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           installCommand: |
             nix-env -if https://github.com/cachix/cachix/tarball/${CACHIX_REV:?} \

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Fixed a bug where DNA modifiers specified in a hApp manifest would not be respected when specifying a `network_seed` in a `InstallAppBundlePayload`. [\#1642](https://github.com/holochain/holochain/pull/1642)
+
 ## 0.0.63
 
 ## 0.0.62

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
@@ -196,8 +196,7 @@ impl AppManifestV1 {
     pub fn set_network_seed(&mut self, network_seed: NetworkSeed) {
         for mut role in self.roles.iter_mut() {
             if matches!(role.provisioning, Some(CellProvisioning::Create { .. })) {
-                role.dna.modifiers =
-                    DnaModifiersOpt::none().with_network_seed(network_seed.clone());
+                role.dna.modifiers.network_seed = Some(network_seed.clone());
             }
         }
     }

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
@@ -305,7 +305,8 @@ pub mod tests {
     pub async fn app_manifest_fixture<I: IntoIterator<Item = DnaDef>>(
         location: Option<mr_bundle::Location>,
         dnas: I,
-    ) -> (AppManifest, Vec<DnaHashB64>) {
+        modifiers: DnaModifiersOpt<YamlProperties>,
+    ) -> (AppManifestV1, Vec<DnaHashB64>) {
         let hashes = join_all(
             dnas.into_iter()
                 .map(|dna| async move { DnaHash::with_data_sync(&dna).into() }),
@@ -313,11 +314,6 @@ pub mod tests {
         .await;
 
         let version = DnaVersionSpec::from(hashes.clone()).into();
-        let modifiers = DnaModifiersOpt {
-            properties: Some(app_manifest_properties_fixture()),
-            network_seed: Some("network_seed".into()),
-            origin_time: None,
-        };
 
         let roles = vec![AppRoleManifest {
             id: "role_id".into(),
@@ -329,19 +325,25 @@ pub mod tests {
             },
             provisioning: Some(CellProvisioning::Create { deferred: false }),
         }];
-        let manifest = AppManifest::V1(AppManifestV1 {
+        let manifest = AppManifestV1 {
             name: "Test app".to_string(),
             description: Some("Serialization roundtrip test".to_string()),
             roles,
-        });
+        };
         (manifest, hashes)
     }
 
     #[tokio::test]
     async fn manifest_v1_roundtrip() {
         let location = Some(mr_bundle::Location::Path(PathBuf::from("/tmp/test.dna")));
+        let modifiers = DnaModifiersOpt {
+            properties: Some(app_manifest_properties_fixture()),
+            network_seed: Some("network_seed".into()),
+            origin_time: None,
+        };
         let (manifest, dna_hashes) =
-            app_manifest_fixture(location, vec![fixt!(DnaDef), fixt!(DnaDef)]).await;
+            app_manifest_fixture(location, vec![fixt!(DnaDef), fixt!(DnaDef)], modifiers).await;
+        let manifest = AppManifest::from(manifest);
         let manifest_yaml = serde_yaml::to_string(&manifest).unwrap();
         let manifest_roundtrip = serde_yaml::from_str(&manifest_yaml).unwrap();
 

--- a/crates/holochain_zome_types/src/dna_def.rs
+++ b/crates/holochain_zome_types/src/dna_def.rs
@@ -342,3 +342,39 @@ impl HashableContent for DnaDef {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use holochain_serialized_bytes::prelude::*;
+
+    #[test]
+    fn test_update_modifiers() {
+        #[derive(Debug, Clone, Serialize, Deserialize, SerializedBytes)]
+        struct Props(u32);
+
+        let props = SerializedBytes::try_from(Props(42)).unwrap();
+
+        let now = Timestamp::now();
+        let mods = DnaModifiers {
+            network_seed: "seed".into(),
+            properties: ().try_into().unwrap(),
+            origin_time: Timestamp::HOLOCHAIN_EPOCH,
+        };
+
+        let opt = DnaModifiersOpt {
+            network_seed: None,
+            properties: Some(props.clone()),
+            origin_time: Some(now),
+        };
+
+        let expected = DnaModifiers {
+            network_seed: "seed".into(),
+            properties: props.clone(),
+            origin_time: now,
+        };
+
+        assert_eq!(mods.update(opt), expected);
+    }
+}


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
