### PR TITLE
refactor(admin-api)!: rename authorize key call

### DIFF
--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -336,12 +336,12 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     .await?;
                 Ok(AdminResponse::RecordsGrafted)
             }
-            AuthorizeZomeCallSigningKey(payload) => {
+            GrantZomeCallCap(payload) => {
                 self.conductor_handle
                     .clone()
                     .authorize_zome_call_signing_key(*payload)
                     .await?;
-                Ok(AdminResponse::ZomeCallSigningKeyAuthorized)
+                Ok(AdminResponse::ZomeCallCapGranted)
             }
             RestoreCloneCell(payload) => {
                 let restored_cell = self

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -336,12 +336,12 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     .await?;
                 Ok(AdminResponse::RecordsGrafted)
             }
-            GrantZomeCallCap(payload) => {
+            GrantZomeCallCapability(payload) => {
                 self.conductor_handle
                     .clone()
-                    .authorize_zome_call_signing_key(*payload)
+                    .grant_zome_call_capability(*payload)
                     .await?;
-                Ok(AdminResponse::ZomeCallCapGranted)
+                Ok(AdminResponse::ZomeCallCapabilityGranted)
             }
             RestoreCloneCell(payload) => {
                 let restored_cell = self

--- a/crates/holochain/src/conductor/api/error.rs
+++ b/crates/holochain/src/conductor/api/error.rs
@@ -20,10 +20,6 @@ pub enum ConductorApiError {
     #[error("The Dna for this Cell is not installed in the conductor! DnaHash: {0}")]
     DnaMissing(DnaHash),
 
-    /// Attempted to authorize a zome call signing key for another agent's cell.
-    #[error("Attempted to authorize a zome call signing for another agent's cell.\nCellId: {0:?}\nAgentPubKey: {1:?}")]
-    IllegalZomeCallSigningKeyAuthorization(CellId, AgentPubKey),
-
     /// Cell was referenced, but is missing from the conductor.
     #[error(
         "A Cell attempted to use an CellConductorApi it was not given.\nAPI CellId: {api_cell_id:?}\nInvocation CellId: {call_cell_id:?}"

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1787,9 +1787,9 @@ mod misc_impls {
         /// Authorize a zome call signing key for a cell
         pub async fn authorize_zome_call_signing_key(
             &self,
-            payload: AuthorizeZomeCallSigningKeyPayload,
+            payload: GrantZomeCallCapPayload,
         ) -> ConductorApiResult<()> {
-            let AuthorizeZomeCallSigningKeyPayload {
+            let GrantZomeCallCapPayload {
                 provenance,
                 cell_id,
                 cap_grant,

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1779,8 +1779,6 @@ mod scheduler_impls {
 mod misc_impls {
     use holochain_zome_types::builder;
 
-    use crate::conductor::api::error::ConductorApiError;
-
     use super::*;
 
     impl Conductor {
@@ -1789,25 +1787,14 @@ mod misc_impls {
             &self,
             payload: GrantZomeCallCapPayload,
         ) -> ConductorApiResult<()> {
-            let GrantZomeCallCapPayload {
-                provenance,
-                cell_id,
-                cap_grant,
-            } = payload;
-
-            if provenance != *cell_id.agent_pubkey() {
-                return Err(ConductorApiError::IllegalZomeCallSigningKeyAuthorization(
-                    cell_id.clone(),
-                    provenance.clone(),
-                ));
-            }
+            let GrantZomeCallCapPayload { cell_id, cap_grant } = payload;
 
             let source_chain = SourceChain::new(
                 self.get_authored_db(cell_id.dna_hash())?,
                 self.get_dht_db(cell_id.dna_hash())?,
                 self.get_dht_db_cache(cell_id.dna_hash())?,
                 self.keystore.clone(),
-                provenance.clone(),
+                cell_id.agent_pubkey().clone(),
             )
             .await?;
 

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1782,12 +1782,12 @@ mod misc_impls {
     use super::*;
 
     impl Conductor {
-        /// Authorize a zome call signing key for a cell
-        pub async fn authorize_zome_call_signing_key(
+        /// Grant a zome call capability for a cell
+        pub async fn grant_zome_call_capability(
             &self,
-            payload: GrantZomeCallCapPayload,
+            payload: GrantZomeCallCapabilityPayload,
         ) -> ConductorApiResult<()> {
-            let GrantZomeCallCapPayload { cell_id, cap_grant } = payload;
+            let GrantZomeCallCapabilityPayload { cell_id, cap_grant } = payload;
 
             let source_chain = SourceChain::new(
                 self.get_authored_db(cell_id.dna_hash())?,

--- a/crates/holochain/src/conductor/tests/authorize_signing_key.rs
+++ b/crates/holochain/src/conductor/tests/authorize_signing_key.rs
@@ -1,10 +1,8 @@
 use holochain_state::source_chain::SourceChainRead;
 use holochain_wasm_test_utils::TestWasm;
 use holochain_zome_types::{AppRoleId, CapSecret, GrantZomeCallCapPayload};
-use matches::assert_matches;
 use std::collections::BTreeSet;
 
-use crate::conductor::api::error::ConductorApiError;
 use crate::fixt::AgentPubKeyFixturator;
 use crate::sweettest::{SweetAgents, SweetConductor, SweetDnaFile};
 use ::fixt::fixt;
@@ -54,25 +52,9 @@ async fn authorize_signing_key() {
         },
     };
 
-    // request authorization of signing key for another agent's cell should fail
-    let another_agent_key = fixt!(AgentPubKey);
-    let authorization_result = conductor
-        .authorize_zome_call_signing_key(GrantZomeCallCapPayload {
-            provenance: another_agent_key.clone(),
-            cell_id: cell_id.clone(),
-            cap_grant: cap_grant.clone(),
-        })
-        .await;
-    assert!(authorization_result.is_err());
-    assert_matches!(
-        authorization_result,
-        Err(ConductorApiError::IllegalZomeCallSigningKeyAuthorization(c_id, key)) if c_id == *cell_id && key == another_agent_key
-    );
-
     // request authorization of signing key for agent's own cell should succeed
     conductor
         .authorize_zome_call_signing_key(GrantZomeCallCapPayload {
-            provenance: agent_pub_key.clone(),
             cell_id: cell_id.clone(),
             cap_grant: cap_grant.clone(),
         })

--- a/crates/holochain/src/conductor/tests/authorize_signing_key.rs
+++ b/crates/holochain/src/conductor/tests/authorize_signing_key.rs
@@ -1,6 +1,6 @@
 use holochain_state::source_chain::SourceChainRead;
 use holochain_wasm_test_utils::TestWasm;
-use holochain_zome_types::{AppRoleId, AuthorizeZomeCallSigningKeyPayload, CapSecret};
+use holochain_zome_types::{AppRoleId, CapSecret, GrantZomeCallCapPayload};
 use matches::assert_matches;
 use std::collections::BTreeSet;
 
@@ -57,7 +57,7 @@ async fn authorize_signing_key() {
     // request authorization of signing key for another agent's cell should fail
     let another_agent_key = fixt!(AgentPubKey);
     let authorization_result = conductor
-        .authorize_zome_call_signing_key(AuthorizeZomeCallSigningKeyPayload {
+        .authorize_zome_call_signing_key(GrantZomeCallCapPayload {
             provenance: another_agent_key.clone(),
             cell_id: cell_id.clone(),
             cap_grant: cap_grant.clone(),
@@ -71,7 +71,7 @@ async fn authorize_signing_key() {
 
     // request authorization of signing key for agent's own cell should succeed
     conductor
-        .authorize_zome_call_signing_key(AuthorizeZomeCallSigningKeyPayload {
+        .authorize_zome_call_signing_key(GrantZomeCallCapPayload {
             provenance: agent_pub_key.clone(),
             cell_id: cell_id.clone(),
             cap_grant: cap_grant.clone(),

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -348,12 +348,12 @@ pub enum AdminRequest {
         records: Vec<Record>,
     },
 
-    /// Request authorization of a public key for signing zome calls.
+    /// Request cap grant for making zome calls.
     ///
     /// # Returns
     ///
-    /// [`AdminResponse::ZomeCallSigningKeyAuthorized`]
-    AuthorizeZomeCallSigningKey(Box<AuthorizeZomeCallSigningKeyPayload>),
+    /// [`AdminResponse::ZomeCallCapGranted`]
+    GrantZomeCallCap(Box<GrantZomeCallCapPayload>),
 
     /// Restore a clone cell that was previously archived.
     ///
@@ -523,8 +523,8 @@ pub enum AdminResponse {
     /// The successful response to an [`AdminRequest::GraftRecords`].
     RecordsGrafted,
 
-    /// The successful response to an [`AdminRequest::AuthorizeZomeCallSigningKey`].
-    ZomeCallSigningKeyAuthorized,
+    /// The successful response to an [`AdminRequest::GrantZomeCallCap`].
+    ZomeCallCapGranted,
 
     // The successful response to an [`AdminRequest::RestoreCloneCell`].
     CloneCellRestored(InstalledCell),

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -348,12 +348,12 @@ pub enum AdminRequest {
         records: Vec<Record>,
     },
 
-    /// Request cap grant for making zome calls.
+    /// Request capability grant for making zome calls.
     ///
     /// # Returns
     ///
-    /// [`AdminResponse::ZomeCallCapGranted`]
-    GrantZomeCallCap(Box<GrantZomeCallCapPayload>),
+    /// [`AdminResponse::ZomeCallCapabilityGranted`]
+    GrantZomeCallCapability(Box<GrantZomeCallCapabilityPayload>),
 
     /// Restore a clone cell that was previously archived.
     ///
@@ -523,8 +523,8 @@ pub enum AdminResponse {
     /// The successful response to an [`AdminRequest::GraftRecords`].
     RecordsGrafted,
 
-    /// The successful response to an [`AdminRequest::GrantZomeCallCap`].
-    ZomeCallCapGranted,
+    /// The successful response to an [`AdminRequest::GrantZomeCallCapability`].
+    ZomeCallCapabilityGranted,
 
     // The successful response to an [`AdminRequest::RestoreCloneCell`].
     CloneCellRestored(InstalledCell),

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -3,6 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## \[Unreleased\]
+**BREAKING CHANGE**: Rename `AuthorizeZomeCallSigningKey` to `GrantZomeCallCapability` & remove parameter `provenance`. [\#1647](https://github.com/holochain/holochain/pull/1647)
 
 ## 0.0.53
 

--- a/crates/holochain_zome_types/src/capability.rs
+++ b/crates/holochain_zome_types/src/capability.rs
@@ -34,7 +34,7 @@ use crate::CellId;
 
 /// Parameters for granting a zome call capability.
 #[derive(Debug, Deserialize, Serialize)]
-pub struct GrantZomeCallCapPayload {
+pub struct GrantZomeCallCapabilityPayload {
     /// Cell for which to authorize the capability.
     pub cell_id: CellId,
     /// Specifies the capability, consisting of zomes and functions to allow

--- a/crates/holochain_zome_types/src/capability.rs
+++ b/crates/holochain_zome_types/src/capability.rs
@@ -27,7 +27,6 @@
 mod grant;
 pub use grant::*;
 
-use holo_hash::AgentPubKey;
 pub use holochain_integrity_types::capability::*;
 use serde::{Deserialize, Serialize};
 
@@ -36,8 +35,6 @@ use crate::CellId;
 /// Parameters for granting a zome call capability.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct GrantZomeCallCapPayload {
-    /// Agent that is requesting authorization of a signing key.
-    pub provenance: AgentPubKey,
     /// Cell for which to authorize the capability.
     pub cell_id: CellId,
     /// Specifies the capability, consisting of zomes and functions to allow

--- a/crates/holochain_zome_types/src/capability.rs
+++ b/crates/holochain_zome_types/src/capability.rs
@@ -33,14 +33,14 @@ use serde::{Deserialize, Serialize};
 
 use crate::CellId;
 
-/// Parameters for authorizing a zome call signing key.
+/// Parameters for granting a zome call capability.
 #[derive(Debug, Deserialize, Serialize)]
-pub struct AuthorizeZomeCallSigningKeyPayload {
+pub struct GrantZomeCallCapPayload {
     /// Agent that is requesting authorization of a signing key.
     pub provenance: AgentPubKey,
-    /// Cell for which to authorize the signing key.
+    /// Cell for which to authorize the capability.
     pub cell_id: CellId,
-    /// Specifies zomes and functions to allow signing for as well as key
-    /// and secret.
+    /// Specifies the capability, consisting of zomes and functions to allow
+    /// signing for as well as access level, secret and assignees.
     pub cap_grant: ZomeCallCapGrant,
 }


### PR DESCRIPTION
### Summary
- rename `AuthorizeZomeCallSigningKey` to `GrantZomeCallCapability`
- remove parameter `provenance`


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
