### PR TITLE
New GossipInfo interface method for historical gossip progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2911,6 +2911,7 @@ dependencies = [
  "maplit",
  "mockall 0.10.2",
  "must_future",
+ "nanoid 0.4.0",
  "num-traits",
  "observability",
  "once_cell",

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - BREAKING CHANGE - Update wasmer crate dependency [\#1620](https://github.com/holochain/holochain/pull/1620)
+- Adds GossipInfo app interface method, which returns data about historical gossip progress which can be used to implement a progress bar in app UIs. [\#1649](https://github.com/holochain/holochain/pull/1649)
 
 ## 0.0.171
 

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -116,6 +116,10 @@ impl AppInterfaceApi for RealAppInterfaceApi {
                     .await?;
                 Ok(AppResponse::CloneCellArchived)
             }
+            AppRequest::GossipInfo(payload) => {
+                let info = self.conductor_handle.gossip_info(&payload.dnas).await?;
+                Ok(AppResponse::GossipInfo(info))
+            }
             AppRequest::SignalSubscription(_) => Ok(AppResponse::Unimplemented(request)),
             AppRequest::Crypto(_) => Ok(AppResponse::Unimplemented(request)),
         }

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -744,6 +744,9 @@ mod dna_impls {
 
 /// Network-related methods
 mod network_impls {
+    use holochain_conductor_api::DnaGossipInfo;
+    use holochain_p2p::HolochainP2pSender;
+
     use super::*;
 
     impl Conductor {
@@ -793,6 +796,27 @@ mod network_impls {
             }
 
             Ok(())
+        }
+
+        pub(crate) async fn gossip_info(
+            &self,
+            dnas: &[DnaHash],
+        ) -> ConductorResult<Vec<DnaGossipInfo>> {
+            futures::future::join_all(dnas.iter().map(|dna| async move {
+                let m = self
+                    .holochain_p2p()
+                    .get_diagnostics(dna.clone())
+                    .await?
+                    .metrics;
+                let total_historical_gossip_throughput =
+                    m.read().total_current_historical_throughput().into();
+                ConductorResult::Ok(DnaGossipInfo {
+                    total_historical_gossip_throughput,
+                })
+            }))
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
         }
 
         #[instrument(skip(self))]

--- a/crates/holochain/src/conductor/kitsune_host_impl/query_region_set.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl/query_region_set.rs
@@ -53,11 +53,9 @@ pub async fn query_region_set(
         .async_reader(move |txn| {
             let sql = holochain_sqlite::sql::sql_cell::FETCH_OP_REGION;
             let mut stmt = txn.prepare_cached(sql).map_err(DatabaseError::from)?;
-            DatabaseResult::Ok(
-                coords.into_region_set(|(_, coords)| {
-                    query_region_data(&mut stmt, &topology, coords)
-                })?,
-            )
+            let regions = coords
+                .into_region_set(|(_, coords)| query_region_data(&mut stmt, &topology, coords))?;
+            DatabaseResult::Ok(regions)
         })
         .await?;
 
@@ -80,7 +78,9 @@ pub(super) fn query_region_data(
             ":timestamp_max": t1,
         },
         |row| {
-            let size: f64 = row.get("total_size")?;
+            let total_action_size: f64 = row.get("total_action_size")?;
+            let total_entry_size: f64 = row.get("total_entry_size")?;
+            let size = total_action_size + total_entry_size;
             Ok(RegionData {
                 hash: RegionHash::from_vec(row.get("xor_hash")?)
                     .expect("region hash must be 32 bytes"),
@@ -90,4 +90,84 @@ pub(super) fn query_region_data(
         },
     )
     .map_err(DatabaseError::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use holochain_serialized_bytes::UnsafeBytes;
+    use holochain_state::prelude::StateMutationResult;
+    use holochain_state::{prelude::insert_op, test_utils::test_dht_db};
+    use holochain_types::fixt::*;
+    use holochain_types::prelude::{DhtOp, DhtOpHashed, NewEntryAction};
+    use holochain_zome_types::{AppEntryBytes, Entry};
+
+    /// Ensure that the size reported by RegionData is "close enough" to the actual size of
+    /// ops that get transferred over the wire.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn query_region_set_diff_size() {
+        let db = test_dht_db();
+        let topo = Topology::standard(Timestamp::now(), Duration::ZERO);
+        let strat = ArqStrat::default();
+        let arcset = Arc::new(DhtArcSet::Full);
+
+        let regions_empty = query_region_set(db.to_db(), topo.clone(), &strat, arcset.clone())
+            .await
+            .unwrap();
+        {
+            let sum: RegionData = regions_empty.regions().map(|r| r.data).sum();
+            assert_eq!(sum.count, 0);
+            assert_eq!(sum.size, 0);
+        }
+
+        let mk_op = |i: u8| {
+            let entry = Box::new(Entry::App(AppEntryBytes(
+                UnsafeBytes::from(vec![i % 10; 10_000_000])
+                    .try_into()
+                    .unwrap(),
+            )));
+            let sig = fixt::fixt!(Signature);
+            let mut create = fixt::fixt!(Create);
+            create.timestamp = Timestamp::now();
+            let action = NewEntryAction::Create(create);
+            DhtOpHashed::from_content_sync(DhtOp::StoreEntry(sig, action, entry))
+        };
+        let num = 100;
+
+        let ops: Vec<_> = (0..num).map(mk_op).collect();
+        let wire_bytes: usize = ops
+            .clone()
+            .into_iter()
+            .map(|op| {
+                holochain_p2p::WireDhtOpData {
+                    op_data: op.into_content(),
+                }
+                .encode()
+                .unwrap()
+                .len()
+            })
+            .sum();
+
+        db.test_commit(|txn| {
+            for op in ops.iter() {
+                insert_op(txn, op).unwrap()
+            }
+            StateMutationResult::Ok(())
+        })
+        .unwrap();
+
+        let regions = query_region_set(db.to_db(), topo, &strat, arcset)
+            .await
+            .unwrap();
+
+        let diff = regions.diff(regions_empty).unwrap();
+        {
+            let sum: RegionData = diff.into_iter().map(|r| r.data).sum();
+            assert_eq!(sum.count, num as u32);
+            // 32 bytes is "close enough"
+            assert!(wire_bytes as u32 - sum.size < 32 * num as u32);
+        }
+    }
 }

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -431,7 +431,9 @@ impl Spaces {
                         ":timestamp_max": t1,
                     },
                     |row| {
-                        let size: f64 = row.get("total_size")?;
+                        let total_action_size: f64 = row.get("total_action_size")?;
+                        let total_entry_size: f64 = row.get("total_entry_size")?;
+                        let size = total_action_size + total_entry_size;
                         Ok(RegionData {
                             hash: RegionHash::from_vec(row.get("xor_hash")?)
                                 .expect("region hash must be 32 bytes"),
@@ -476,34 +478,33 @@ impl Spaces {
             .dht_db(dna_hash)?
             .async_reader(move |txn| {
                 let mut stmt = txn.prepare_cached(sql).map_err(StateQueryError::from)?;
-                StateQueryResult::Ok(
-                    regions
-                        .into_iter()
-                        .map(|bounds| {
-                            let (x0, x1) = bounds.x;
-                            let (t0, t1) = bounds.t;
-                            stmt.query_and_then(
-                                named_params! {
-                                    ":storage_start_loc": x0,
-                                    ":storage_end_loc": x1,
-                                    ":timestamp_min": t0,
-                                    ":timestamp_max": t1,
-                                },
-                                |row| {
-                                    let hash: DhtOpHash =
-                                        row.get("hash").map_err(StateQueryError::from)?;
-                                    Ok(map_sql_dht_op_common(row)?.map(|op| (hash, op)))
-                                },
-                            )
-                            .map_err(StateQueryError::from)?
-                            .collect::<Result<Vec<Option<_>>, StateQueryError>>()
-                        })
-                        .collect::<Result<Vec<Vec<Option<_>>>, _>>()?
-                        .into_iter()
-                        .flatten()
-                        .flatten()
-                        .collect(),
-                )
+                let results = regions
+                    .into_iter()
+                    .map(|bounds| {
+                        let (x0, x1) = bounds.x;
+                        let (t0, t1) = bounds.t;
+                        stmt.query_and_then(
+                            named_params! {
+                                ":storage_start_loc": x0,
+                                ":storage_end_loc": x1,
+                                ":timestamp_min": t0,
+                                ":timestamp_max": t1,
+                            },
+                            |row| {
+                                let hash: DhtOpHash =
+                                    row.get("hash").map_err(StateQueryError::from)?;
+                                Ok(map_sql_dht_op_common(row)?.map(|op| (hash, op)))
+                            },
+                        )
+                        .map_err(StateQueryError::from)?
+                        .collect::<Result<Vec<Option<_>>, StateQueryError>>()
+                    })
+                    .collect::<Result<Vec<Vec<Option<_>>>, _>>()?
+                    .into_iter()
+                    .flatten()
+                    .flatten()
+                    .collect();
+                StateQueryResult::Ok(results)
             })
             .await?)
     }

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -82,7 +82,7 @@ pub async fn app_validation_workflow(
 async fn app_validation_workflow_inner(
     dna_hash: Arc<DnaHash>,
     workspace: Arc<AppValidationWorkspace>,
-    conductor_handle: ConductorHandle,
+    conductor: ConductorHandle,
     network: &HolochainP2pDna,
     dht_query_cache: DhtDbQueryCache,
 ) -> WorkflowResult<WorkComplete> {
@@ -99,7 +99,7 @@ async fn app_validation_workflow_inner(
         let workspace = workspace.clone();
         move |so| {
             let network = network.clone();
-            let conductor_handle = conductor_handle.clone();
+            let conductor = conductor.clone();
             let workspace = workspace.clone();
             let dna_hash = dna_hash.clone();
             async move {
@@ -122,8 +122,7 @@ async fn app_validation_workflow_inner(
                 let mut cascade = workspace.full_cascade(network.clone());
                 let r = match dhtop_to_op(op, &mut cascade).await {
                     Ok(op) => {
-                        validate_op_outer(dna_hash, &op, &conductor_handle, &(*workspace), &network)
-                            .await
+                        validate_op_outer(dna_hash, &op, &conductor, &(*workspace), &network).await
                     }
                     Err(e) => Err(e),
                 };

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -139,6 +139,7 @@ impl SweetConductor {
         Conductor::builder()
             .config(config.clone())
             .with_keystore(keystore)
+            .no_print_setup()
             .test(db_dir, extra_dnas)
             .await
             .unwrap()
@@ -155,8 +156,9 @@ impl SweetConductor {
     }
 
     /// Make the temp db dir persistent
-    pub fn persist(&mut self) {
+    pub fn persist(&mut self) -> &Path {
         self.db_dir.persist();
+        &self.db_dir
     }
 
     /// Access the MetaLairClient for this conductor

--- a/crates/holochain/src/test_utils/inline_zomes.rs
+++ b/crates/holochain/src/test_utils/inline_zomes.rs
@@ -114,8 +114,8 @@ pub fn simple_crud_zome() -> InlineZomeSet {
             ))?;
             Ok(hash)
         })
-        .function("create_bytes", move |api, bs: Vec<u8>| {
-            let entry = Entry::app(UnsafeBytes::try_from(bs).unwrap().into()).unwrap();
+        .function("create_bytes", move |api, bs: Bytes| {
+            let entry = Entry::app(UnsafeBytes::try_from(bs.to_vec()).unwrap().into()).unwrap();
             let hash = api.create(CreateInput::new(
                 InlineZomeSet::get_entry_location(&api, EntryDefIndex(2)),
                 EntryVisibility::Public,

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -228,12 +228,15 @@ pub struct DnaGossipInfo {
 pub struct HistoricalGossipThroughput {
     /// Total number of bytes expected to be sent for region data (historical only)
     pub expected_op_bytes: InOut,
+
     /// Total number of ops expected to be sent for region data (historical only)
     pub expected_op_count: InOut,
-    /// Total number of ops sent
-    pub op_count: InOut,
+
     /// Total number of bytes sent for op data
     pub op_bytes: InOut,
+
+    /// Total number of ops sent
+    pub op_count: InOut,
 }
 
 impl From<RoundThroughput> for HistoricalGossipThroughput {

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -3,6 +3,7 @@
 use crate::{signal_subscription::SignalSubscription, ExternalApiWireError};
 use holo_hash::AgentPubKey;
 use holochain_types::prelude::*;
+use kitsune_p2p::gossip::sharded_gossip::{InOut, RoundThroughput};
 
 /// Represents the available conductor functions to call over an app interface
 /// and will result in a corresponding [`AppResponse`] message being sent back over the
@@ -27,9 +28,7 @@ pub enum AppRequest {
         /// The app ID for which to get information
         installed_app_id: InstalledAppId,
     },
-    /// Is currently unimplemented and will return
-    /// an [`AppResponse::Unimplemented`].
-    Crypto(Box<CryptoRequest>),
+
     /// Call a zome function. See [`ZomeCall`]
     /// to understand the data that must be provided.
     ///
@@ -61,8 +60,15 @@ pub enum AppRequest {
     /// and was archived.
     ArchiveCloneCell(Box<ArchiveCloneCellPayload>),
 
+    /// Info about gossip
+    GossipInfo(Box<GossipInfoRequestPayload>),
+
     #[deprecated = "use ZomeCall"]
     ZomeCallInvocation(Box<ZomeCall>),
+
+    /// Is currently unimplemented and will return
+    /// an [`AppResponse::Unimplemented`].
+    Crypto(Box<CryptoRequest>),
 
     /// Is currently unimplemented and will return
     /// an [`AppResponse::Unimplemented`].
@@ -103,6 +109,9 @@ pub enum AppResponse {
 
     /// An existing clone cell has been archived.
     CloneCellArchived,
+
+    /// GossipInfo is returned
+    GossipInfo(Vec<DnaGossipInfo>),
 
     #[deprecated = "use ZomeCall"]
     ZomeCallInvocation(Box<ExternIO>),
@@ -203,6 +212,37 @@ impl From<InstalledAppInfoStatus> for AppStatus {
             InstalledAppInfoStatus::Running => AppStatus::Running,
             InstalledAppInfoStatus::Disabled { reason } => AppStatus::Disabled(reason),
             InstalledAppInfoStatus::Paused { reason } => AppStatus::Paused(reason),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, SerializedBytes)]
+pub struct DnaGossipInfo {
+    pub total_historical_gossip_throughput: HistoricalGossipThroughput,
+}
+
+/// Throughput info specific to historical rounds
+#[derive(
+    Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize, SerializedBytes,
+)]
+pub struct HistoricalGossipThroughput {
+    /// Total number of bytes expected to be sent for region data (historical only)
+    pub expected_op_bytes: InOut,
+    /// Total number of ops expected to be sent for region data (historical only)
+    pub expected_op_count: InOut,
+    /// Total number of ops sent
+    pub op_count: InOut,
+    /// Total number of bytes sent for op data
+    pub op_bytes: InOut,
+}
+
+impl From<RoundThroughput> for HistoricalGossipThroughput {
+    fn from(r: RoundThroughput) -> Self {
+        Self {
+            expected_op_bytes: r.expected_op_bytes,
+            expected_op_count: r.expected_op_count,
+            op_count: r.op_count,
+            op_bytes: r.op_bytes,
         }
     }
 }

--- a/crates/holochain_p2p/src/types/wire.rs
+++ b/crates/holochain_p2p/src/types/wire.rs
@@ -36,6 +36,8 @@ pub enum WireMessage {
     Publish {
         request_validation_receipt: bool,
         countersigning_session: bool,
+        // For backward compat with holochain < 0.0.164
+        #[serde(alias = "dht_hash")]
         basis_hash: holo_hash::OpBasis,
         ops: Vec<holochain_types::dht_op::DhtOp>,
     },

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -63,6 +63,13 @@ pub struct RegisterDnaPayload {
     pub source: DnaSource,
 }
 
+/// The instructions on how to request GossipInfo
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct GossipInfoRequestPayload {
+    /// Get gossip info for these DNAs
+    pub dnas: Vec<DnaHash>,
+}
+
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// The instructions on how to update coordinators for a dna file.
 pub struct UpdateCoordinatorsPayload {

--- a/crates/holochain_types/src/dht_op.rs
+++ b/crates/holochain_types/src/dht_op.rs
@@ -262,44 +262,44 @@ impl DhtOp {
     ) -> DhtOpLight {
         let basis = self.dht_basis();
         match self {
-            DhtOp::StoreRecord(_, h, _) => {
-                let e = h.entry_data().map(|(e, _)| e.clone());
-                let h = ActionHash::with_data_sync(h);
+            DhtOp::StoreRecord(_, a, _) => {
+                let e = a.entry_data().map(|(e, _)| e.clone());
+                let h = ActionHash::with_data_sync(a);
                 DhtOpLight::StoreRecord(h, e, basis)
             }
-            DhtOp::StoreEntry(_, h, _) => {
-                let e = h.entry().clone();
-                let h = ActionHash::with_data_sync(&Action::from(h.clone()));
+            DhtOp::StoreEntry(_, a, _) => {
+                let e = a.entry().clone();
+                let h = ActionHash::with_data_sync(&Action::from(a.clone()));
                 DhtOpLight::StoreEntry(h, e, basis)
             }
-            DhtOp::RegisterAgentActivity(_, h) => {
-                let h = ActionHash::with_data_sync(h);
+            DhtOp::RegisterAgentActivity(_, a) => {
+                let h = ActionHash::with_data_sync(a);
                 DhtOpLight::RegisterAgentActivity(h, basis)
             }
-            DhtOp::RegisterUpdatedContent(_, h, _) => {
-                let e = h.entry_hash.clone();
-                let h = ActionHash::with_data_sync(&Action::from(h.clone()));
+            DhtOp::RegisterUpdatedContent(_, a, _) => {
+                let e = a.entry_hash.clone();
+                let h = ActionHash::with_data_sync(&Action::from(a.clone()));
                 DhtOpLight::RegisterUpdatedContent(h, e, basis)
             }
-            DhtOp::RegisterUpdatedRecord(_, h, _) => {
-                let e = h.entry_hash.clone();
-                let h = ActionHash::with_data_sync(&Action::from(h.clone()));
+            DhtOp::RegisterUpdatedRecord(_, a, _) => {
+                let e = a.entry_hash.clone();
+                let h = ActionHash::with_data_sync(&Action::from(a.clone()));
                 DhtOpLight::RegisterUpdatedRecord(h, e, basis)
             }
-            DhtOp::RegisterDeletedBy(_, h) => {
-                let h = ActionHash::with_data_sync(&Action::from(h.clone()));
+            DhtOp::RegisterDeletedBy(_, a) => {
+                let h = ActionHash::with_data_sync(&Action::from(a.clone()));
                 DhtOpLight::RegisterDeletedBy(h, basis)
             }
-            DhtOp::RegisterDeletedEntryAction(_, h) => {
-                let h = ActionHash::with_data_sync(&Action::from(h.clone()));
+            DhtOp::RegisterDeletedEntryAction(_, a) => {
+                let h = ActionHash::with_data_sync(&Action::from(a.clone()));
                 DhtOpLight::RegisterDeletedEntryAction(h, basis)
             }
-            DhtOp::RegisterAddLink(_, h) => {
-                let h = ActionHash::with_data_sync(&Action::from(h.clone()));
+            DhtOp::RegisterAddLink(_, a) => {
+                let h = ActionHash::with_data_sync(&Action::from(a.clone()));
                 DhtOpLight::RegisterAddLink(h, basis)
             }
-            DhtOp::RegisterRemoveLink(_, h) => {
-                let h = ActionHash::with_data_sync(&Action::from(h.clone()));
+            DhtOp::RegisterRemoveLink(_, a) => {
+                let h = ActionHash::with_data_sync(&Action::from(a.clone()));
                 DhtOpLight::RegisterRemoveLink(h, basis)
             }
         }

--- a/crates/kitsune_p2p/dht/src/region.rs
+++ b/crates/kitsune_p2p/dht/src/region.rs
@@ -29,7 +29,7 @@ use std::ops::{AddAssign, Sub};
 pub const REGION_MASS: u32 = std::mem::size_of::<Region<RegionData>>() as u32;
 
 /// The coordinates defining the Region, along with the calculated [`RegionData`]
-#[derive(Debug, Clone, derive_more::Constructor)]
+#[derive(Debug, Clone, PartialEq, Eq, derive_more::Constructor)]
 pub struct Region<D: RegionDataConstraints = RegionData> {
     /// The coords
     pub coords: RegionCoords,

--- a/crates/kitsune_p2p/dht/src/region/region_data.rs
+++ b/crates/kitsune_p2p/dht/src/region/region_data.rs
@@ -70,7 +70,7 @@ impl From<OpHash> for RegionHash {
 pub struct RegionData {
     /// The XOR of hashes of all Ops in this Region
     pub hash: RegionHash,
-    /// The total size of Op data contains in this Region
+    /// The total size of Op data contained in this Region
     pub size: u32,
     /// The number of Ops in this Region.
     pub count: u32,
@@ -82,7 +82,7 @@ impl RegionDataConstraints for RegionData {
     }
 
     fn size(&self) -> u32 {
-        self.count
+        self.size
     }
 }
 

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -25,6 +25,7 @@ kitsune_p2p_timestamp = { version = "0.0.14", path = "../timestamp", features = 
 kitsune_p2p_transport_quic = { version = "^0.0.37", path = "../transport_quic" }
 kitsune_p2p_types = { version = "^0.0.37", path = "../types" }
 must_future = "0.1.1"
+nanoid = "0.4"
 num-traits = "0.2"
 observability = "0.1.3"
 once_cell = "1.4.1"

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -276,7 +276,7 @@ impl ShardedGossip {
                     i.metrics.write().update_current_round(
                         &cert,
                         self.gossip.gossip_type.into(),
-                        &state,
+                        state,
                     );
                     // println!("throughput OUT {:?}", state.throughput);
                 }
@@ -942,7 +942,7 @@ impl ShardedGossipLocal {
                     i.metrics.write().update_current_round(
                         &peer_cert,
                         self.gossip_type.into(),
-                        &state,
+                        state,
                     );
                     // println!("throughput IN {:?}", state.throughput);
                 }
@@ -1023,9 +1023,6 @@ impl ShardedGossipLocal {
                 }
             }
             ShardedGossipWire::MissingOps(MissingOps { ops, finished }) => {
-                // for op in &ops {
-                //     println!("OP RECEIVED: {} B, data: {:?}", op.0.len(), op.0);
-                // }
                 let mut gossip = Vec::with_capacity(0);
                 let finished = MissingOpsStatus::try_from(finished)?;
 
@@ -1177,16 +1174,6 @@ impl RoundState {
 
         let ops_finished = ops_in >= expected_in && ops_out >= expected_out;
 
-        // tracing::debug!(
-        //     "FINISHED? {} {} {} {} {} {} {}",
-        //     self.num_expected_op_blooms == 0,
-        //     !self.has_pending_historical_op_data,
-        //     self.received_all_incoming_op_blooms,
-        //     self.regions_are_queued,
-        //     self.bloom_batch_cursor.is_none(),
-        //     self.ops_batch_queue.is_empty(),
-        //     ops_finished
-        // );
         self.num_expected_op_blooms == 0
             && !self.has_pending_historical_op_data
             && self.received_all_incoming_op_blooms

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -748,7 +748,9 @@ impl Sum for RoundThroughput {
 }
 
 /// Incoming and outgoing throughput
-#[derive(Debug, Clone, Default, PartialEq, Eq, derive_more::Add)]
+#[derive(
+    Debug, Clone, Default, PartialEq, Eq, derive_more::Add, serde::Serialize, serde::Deserialize,
+)]
 pub struct InOut {
     /// Incoming throughput
     pub incoming: u32,

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -257,7 +257,7 @@ impl ShardedGossip {
                             state.throughput.op_bloom_bytes.outgoing +=
                                 missing_hashes.size() as u32;
                         }
-                        ShardedGossipWire::OpRegions(OpRegions { region_set: _, .. }) => {}
+                        ShardedGossipWire::OpRegions(OpRegions { region_set: _, .. }) => (),
                         ShardedGossipWire::MissingOps(MissingOps { ops, .. }) => {
                             state.throughput.op_count.outgoing += ops.len() as u32;
                             state.throughput.op_bytes.outgoing +=
@@ -278,7 +278,6 @@ impl ShardedGossip {
                         self.gossip.gossip_type.into(),
                         state,
                     );
-                    // println!("throughput OUT {:?}", state.throughput);
                 }
                 Ok(())
             })

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -1163,24 +1163,12 @@ impl RoundState {
     /// - This node has no queued missing ops to send to the remote node.
     /// - If running historical gossip, the number of ops sent/received matches expectations
     fn is_finished(&self) -> bool {
-        let InOut {
-            incoming: expected_in,
-            outgoing: expected_out,
-        } = self.throughput.expected_op_count;
-        let InOut {
-            incoming: ops_in,
-            outgoing: ops_out,
-        } = self.throughput.op_count;
-
-        let ops_finished = ops_in >= expected_in && ops_out >= expected_out;
-
         self.num_expected_op_blooms == 0
             && !self.has_pending_historical_op_data
             && self.received_all_incoming_op_blooms
             && self.regions_are_queued
             && self.bloom_batch_cursor.is_none()
             && self.ops_batch_queue.is_empty()
-            && ops_finished
     }
 }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -14,7 +14,7 @@ use governor::RateLimiter;
 use kitsune_p2p_timestamp::Timestamp;
 use kitsune_p2p_types::codec::Codec;
 use kitsune_p2p_types::config::*;
-use kitsune_p2p_types::dht::region::RegionData;
+use kitsune_p2p_types::dht::region::{Region, RegionData};
 use kitsune_p2p_types::dht::region_set::RegionSetLtcs;
 use kitsune_p2p_types::dht_arc::{DhtArcRange, DhtArcSet};
 use kitsune_p2p_types::metrics::*;
@@ -23,6 +23,7 @@ use kitsune_p2p_types::tx2::tx2_utils::*;
 use kitsune_p2p_types::*;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::{TryFrom, TryInto};
+use std::iter::Sum;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -44,7 +45,7 @@ pub use bandwidth::BandwidthThrottles;
 /// on every iteration. We should add a longer interval for refreshing this
 /// list (perhaps once per second), and use a cached value for other iterations,
 /// so as not to do hundreds of DB queries per second.
-const GOSSIP_LOOP_INTERVAL_MS: Duration = Duration::from_millis(10);
+const GOSSIP_LOOP_INTERVAL: Duration = Duration::from_millis(10);
 
 #[cfg(any(test, feature = "test_utils"))]
 #[allow(missing_docs)]
@@ -209,7 +210,7 @@ impl ShardedGossip {
                     .closing
                     .load(std::sync::atomic::Ordering::Relaxed)
                 {
-                    tokio::time::sleep(GOSSIP_LOOP_INTERVAL_MS).await;
+                    tokio::time::sleep(GOSSIP_LOOP_INTERVAL).await;
                     this.run_one_iteration().await;
                     this.stats(&mut stats);
                 }
@@ -256,10 +257,7 @@ impl ShardedGossip {
                             state.throughput.op_bloom_bytes.outgoing +=
                                 missing_hashes.size() as u32;
                         }
-                        ShardedGossipWire::OpRegions(OpRegions { region_set, .. }) => {
-                            state.throughput.region_bytes.outgoing +=
-                                region_set.regions().map(|r| r.data.size).sum::<u32>();
-                        }
+                        ShardedGossipWire::OpRegions(OpRegions { region_set: _, .. }) => {}
                         ShardedGossipWire::MissingOps(MissingOps { ops, .. }) => {
                             state.throughput.op_count.outgoing += ops.len() as u32;
                             state.throughput.op_bytes.outgoing +=
@@ -275,6 +273,12 @@ impl ShardedGossip {
                         ShardedGossipWire::NoAgents(_) => {}
                         ShardedGossipWire::AlreadyInProgress(_) => {}
                     }
+                    i.metrics.write().update_current_round(
+                        &cert,
+                        self.gossip.gossip_type.into(),
+                        &state,
+                    );
+                    // println!("throughput OUT {:?}", state.throughput);
                 }
                 Ok(())
             })
@@ -317,7 +321,7 @@ impl ShardedGossip {
 
         if let Some(msg) = outgoing.as_ref() {
             tracing::debug!(
-                "OUTGOING GOSSIP [{}]  => {:16} ({:10}) : {:?} -> {:?} [{}]",
+                "OUTGOING GOSSIP [{}]  => {:17} ({:10}) : {:?} -> {:?} [{}]",
                 gossip_type_char,
                 msg.2
                     .variant_type()
@@ -331,7 +335,6 @@ impl ShardedGossip {
                     .share_mut(|s, _| Ok(s.round_map.current_rounds().len()))
                     .unwrap(),
             );
-            tracing::debug!("url + message: {:?} {:#?}", &msg.1, &msg.2);
         }
 
         if let Some((con, remote_url, msg, bytes)) = incoming {
@@ -344,7 +347,7 @@ impl ShardedGossip {
             let outgoing = match self.gossip.process_incoming(con.peer_cert(), msg).await {
                 Ok(r) => {
                     tracing::debug!(
-                        "INCOMING GOSSIP [{}] <=  {:16} ({:10}) : {:?} -> {:?} [{}]",
+                        "INCOMING GOSSIP [{}] <=  {:17} ({:10}) : {:?} -> {:?} [{}]",
                         gossip_type_char,
                         variant_type,
                         len,
@@ -473,6 +476,9 @@ type Outgoing = (Tx2Cert, HowToConnect, ShardedGossipWire);
 
 type StateKey = Tx2Cert;
 
+/// A peer (from the perspective of any other node) is uniquely identified by its Cert
+pub type NodeId = Tx2Cert;
+
 /// Info associated with an outgoing gossip target
 #[derive(Debug)]
 pub(crate) struct ShardedGossipTarget {
@@ -524,25 +530,18 @@ impl ShardedGossipLocalState {
             vec![]
         };
         let r = self.round_map.remove(state_key);
+        let mut metrics = self.metrics.write();
         if let Some(r) = &r {
             if error {
-                self.metrics.write().record_error(
-                    &r.remote_agent_list,
-                    Some(r.into()),
-                    gossip_type.into(),
-                );
+                metrics.record_error(&r.remote_agent_list, gossip_type.into());
             } else {
-                self.metrics.write().record_success(
-                    &r.remote_agent_list,
-                    Some(r.into()),
-                    gossip_type.into(),
-                );
+                metrics.record_success(&r.remote_agent_list, gossip_type.into());
             }
         } else if init_tgt && error {
-            self.metrics
-                .write()
-                .record_error(&remote_agent_list, None, gossip_type.into());
+            metrics.record_error(&remote_agent_list, gossip_type.into());
         }
+
+        metrics.complete_current_round(state_key, error);
         r
     }
 
@@ -559,12 +558,18 @@ impl ShardedGossipLocalState {
                     if no_current_round_exist && when_initiated.elapsed() > ROUND_TIMEOUT =>
                 {
                     tracing::error!("Tgt expired {:?}", cert);
-                    self.metrics
-                        .write()
-                        .record_error(remote_agent_list, None, gossip_type.into());
+                    {
+                        let mut metrics = self.metrics.write();
+                        metrics.complete_current_round(&cert, true);
+                        metrics.record_error(remote_agent_list, gossip_type.into());
+                    }
                     self.initiate_tgt = None;
                 }
                 None if no_current_round_exist => {
+                    {
+                        let mut metrics = self.metrics.write();
+                        metrics.complete_current_round(&cert, true);
+                    }
                     self.initiate_tgt = None;
                 }
                 _ => (),
@@ -653,12 +658,14 @@ impl ShardedGossipState {
 #[derive(Debug, Clone)]
 pub struct RoundState {
     /// The remote agents hosted by the remote node, used for metrics tracking
-    remote_agent_list: Vec<AgentInfoSigned>,
+    pub(crate) remote_agent_list: Vec<AgentInfoSigned>,
     /// The common ground with our gossip partner for the purposes of this round
     common_arc_set: Arc<DhtArcSet>,
     /// We've received the last op bloom filter from our partner
     /// (the one with `finished` == true)
     received_all_incoming_op_blooms: bool,
+    /// If historic gossip, we calculated and queued our region diff (will be true for Recent)
+    regions_are_queued: bool,
     /// Number of ops blooms we have sent for this round, which is also the
     /// number of MissingOps sets we expect in response
     num_expected_op_blooms: u16,
@@ -678,11 +685,16 @@ pub struct RoundState {
     /// The RegionSet we will send to our gossip partner during Historical
     /// gossip (will be None for Recent).
     region_set_sent: Option<Arc<RegionSetLtcs>>,
-    /// When this round began
-    pub(crate) start_time: Instant,
-    /// Stats about ops, regions, and bytes sent and received
+    /// Stats about ops, regions, bloom filter, and bytes sent and received,
     pub(crate) throughput: RoundThroughput,
+    /// Region diffs, if doing Historical gossip
+    pub(crate) region_diffs: RegionDiffs,
+    /// Unique string ID for this round
+    pub(crate) id: String,
 }
+
+/// Our region diff and their region diff
+pub type RegionDiffs = Option<(Vec<Region>, Vec<Region>)>;
 
 impl RoundState {
     /// Constructor
@@ -697,37 +709,47 @@ impl RoundState {
             common_arc_set,
             received_all_incoming_op_blooms: false,
             has_pending_historical_op_data: false,
+            regions_are_queued: false,
             bloom_batch_cursor: None,
             num_expected_op_blooms: 0,
             ops_batch_queue: OpsBatchQueue::new(),
-            start_time: Instant::now(),
+            id: nanoid::nanoid!(),
             last_touch: Instant::now(),
             round_timeout,
             region_set_sent,
             throughput: Default::default(),
+            region_diffs: Default::default(),
         }
     }
 }
 
 /// Stats about ops, regions, and blooms sent and received
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, derive_more::Add)]
 pub struct RoundThroughput {
     /// Number of ops blooms we have sent for this round, which is also the
     /// number of MissingOps sets we expect in response
-    pub op_bloom_count: ThroughputItem,
+    pub op_bloom_count: InOut,
     /// Total number of bytes sent for bloom filters
-    pub op_bloom_bytes: ThroughputItem,
-    /// Total number of bytes sent for region data (historical only)
-    pub region_bytes: ThroughputItem,
+    pub op_bloom_bytes: InOut,
+    /// Total number of bytes expected to be sent for region data (historical only)
+    pub expected_op_bytes: InOut,
+    /// Total number of ops expected to be sent for region data (historical only)
+    pub expected_op_count: InOut,
     /// Total number of ops sent
-    pub op_count: ThroughputItem,
+    pub op_count: InOut,
     /// Total number of bytes sent for op data
-    pub op_bytes: ThroughputItem,
+    pub op_bytes: InOut,
+}
+
+impl Sum for RoundThroughput {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.fold(Self::default(), |a, r| a + r)
+    }
 }
 
 /// Incoming and outgoing throughput
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct ThroughputItem {
+#[derive(Debug, Clone, Default, PartialEq, Eq, derive_more::Add)]
+pub struct InOut {
     /// Incoming throughput
     pub incoming: u32,
     /// Outgoing throughput
@@ -798,17 +820,9 @@ impl ShardedGossipLocal {
             {
                 let initiate_tgt = i.initiate_tgt.take().unwrap();
                 if error {
-                    i.metrics.write().record_error(
-                        &initiate_tgt.remote_agent_list,
-                        None,
-                        self.gossip_type.into(),
-                    );
-                } else {
-                    i.metrics.write().record_success(
-                        &initiate_tgt.remote_agent_list,
-                        None,
-                        self.gossip_type.into(),
-                    );
+                    i.metrics
+                        .write()
+                        .record_error(&initiate_tgt.remote_agent_list, self.gossip_type.into());
                 }
             }
             Ok(())
@@ -852,7 +866,7 @@ impl ShardedGossipLocal {
 
     fn decrement_op_blooms(&self, state_id: &StateKey) -> KitsuneResult<Option<RoundState>> {
         self.inner.share_mut(|i, _| {
-            let update_state = |state: &mut RoundState| {
+            let remove_state = |state: &mut RoundState| {
                 let num_op_blooms = state.num_expected_op_blooms.saturating_sub(1);
                 state.num_expected_op_blooms = num_op_blooms;
                 // NOTE: there is only ever one "batch" of OpRegions
@@ -861,7 +875,7 @@ impl ShardedGossipLocal {
             };
             if i.round_map
                 .get_mut(state_id)
-                .map(update_state)
+                .map(remove_state)
                 .unwrap_or(true)
             {
                 Ok(i.remove_state(state_id, self.gossip_type, false))
@@ -873,23 +887,23 @@ impl ShardedGossipLocal {
 
     async fn process_incoming(
         &self,
-        cert: Tx2Cert,
+        peer_cert: Tx2Cert,
         msg: ShardedGossipWire,
     ) -> KitsuneResult<Vec<ShardedGossipWire>> {
         let s = match self.gossip_type {
             GossipType::Recent => {
-                let s = tracing::trace_span!("process_incoming_recent", ?cert, agents = ?self.show_local_agents(), ?msg);
+                let s = tracing::trace_span!("process_incoming_recent", ?peer_cert, agents = ?self.show_local_agents(), ?msg);
                 s.in_scope(|| self.log_state());
                 s
             }
             GossipType::Historical => match &msg {
                 ShardedGossipWire::MissingOps(MissingOps { ops, finished }) => {
-                    let s = tracing::trace_span!("process_incoming_historical", ?cert, agents = ?self.show_local_agents(), msg = %"MissingOps", num_ops = %ops.len(), ?finished);
+                    let s = tracing::trace_span!("process_incoming_historical", ?peer_cert, agents = ?self.show_local_agents(), msg = %"MissingOps", num_ops = %ops.len(), ?finished);
                     s.in_scope(|| self.log_state());
                     s
                 }
                 _ => {
-                    let s = tracing::trace_span!("process_incoming_historical", ?cert, agents = ?self.show_local_agents(), ?msg);
+                    let s = tracing::trace_span!("process_incoming_historical", ?peer_cert, agents = ?self.show_local_agents(), ?msg);
                     s.in_scope(|| self.log_state());
                     s
                 }
@@ -899,17 +913,14 @@ impl ShardedGossipLocal {
         // Record size metrics
         self.inner
             .share_mut(|i, _| {
-                if let Some(state) = i.round_map.get_mut(&cert) {
+                if let Some(state) = i.round_map.get_mut(&peer_cert) {
                     match &msg {
                         ShardedGossipWire::OpBloom(OpBloom { missing_hashes, .. }) => {
                             state.throughput.op_bloom_count.incoming += 1;
                             state.throughput.op_bloom_bytes.incoming +=
                                 missing_hashes.size() as u32;
                         }
-                        ShardedGossipWire::OpRegions(OpRegions { region_set, .. }) => {
-                            state.throughput.region_bytes.incoming +=
-                                region_set.regions().map(|r| r.data.size).sum::<u32>();
-                        }
+                        ShardedGossipWire::OpRegions(OpRegions { region_set: _, .. }) => {}
                         ShardedGossipWire::MissingOps(MissingOps { ops, .. }) => {
                             state.throughput.op_count.incoming += ops.len() as u32;
                             state.throughput.op_bytes.incoming +=
@@ -925,6 +936,13 @@ impl ShardedGossipLocal {
                         ShardedGossipWire::NoAgents(_) => {}
                         ShardedGossipWire::AlreadyInProgress(_) => {}
                     }
+
+                    i.metrics.write().update_current_round(
+                        &peer_cert,
+                        self.gossip_type.into(),
+                        &state,
+                    );
+                    // println!("throughput IN {:?}", state.throughput);
                 }
                 Ok(())
             })
@@ -937,15 +955,18 @@ impl ShardedGossipLocal {
                 id,
                 agent_list,
             }) => {
-                self.incoming_initiate(cert, intervals, id, agent_list)
+                self.incoming_initiate(peer_cert, intervals, id, agent_list)
                     .await?
             }
             ShardedGossipWire::Accept(Accept {
                 intervals,
                 agent_list,
-            }) => self.incoming_accept(cert, intervals, agent_list).await?,
+            }) => {
+                self.incoming_accept(peer_cert, intervals, agent_list)
+                    .await?
+            }
             ShardedGossipWire::Agents(Agents { filter }) => {
-                if let Some(state) = self.get_state(&cert)? {
+                if let Some(state) = self.get_state(&peer_cert)? {
                     let filter = decode_bloom_filter(&filter);
                     self.incoming_agents(state, filter).await?
                 } else {
@@ -953,7 +974,7 @@ impl ShardedGossipLocal {
                 }
             }
             ShardedGossipWire::MissingAgents(MissingAgents { agents }) => {
-                if self.get_state(&cert)?.is_some() {
+                if self.get_state(&peer_cert)?.is_some() {
                     self.incoming_missing_agents(agents.as_slice()).await?;
                 }
                 Vec::with_capacity(0)
@@ -963,9 +984,9 @@ impl ShardedGossipLocal {
                 finished,
             }) => {
                 let state = if finished {
-                    self.incoming_op_blooms_finished(&cert)?
+                    self.incoming_op_blooms_finished(&peer_cert)?
                 } else {
-                    self.get_state(&cert)?
+                    self.get_state(&peer_cert)?
                 };
                 match state {
                     Some(state) => match missing_hashes {
@@ -992,31 +1013,35 @@ impl ShardedGossipLocal {
                 }
             }
             ShardedGossipWire::OpRegions(OpRegions { region_set }) => {
-                if let Some(state) = self.incoming_op_blooms_finished(&cert)? {
-                    self.queue_incoming_regions(state, region_set).await?
+                if let Some(state) = self.incoming_op_blooms_finished(&peer_cert)? {
+                    self.queue_incoming_regions(&peer_cert, state, region_set)
+                        .await?
                 } else {
                     vec![]
                 }
             }
             ShardedGossipWire::MissingOps(MissingOps { ops, finished }) => {
+                // for op in &ops {
+                //     println!("OP RECEIVED: {} B, data: {:?}", op.0.len(), op.0);
+                // }
                 let mut gossip = Vec::with_capacity(0);
                 let finished = MissingOpsStatus::try_from(finished)?;
 
                 let state = match finished {
                     // This is a single chunk of ops. No need to reply.
-                    MissingOpsStatus::ChunkComplete => self.get_state(&cert)?,
+                    MissingOpsStatus::ChunkComplete => self.get_state(&peer_cert)?,
                     // This is the last chunk in the batch. Reply with [`OpBatchReceived`]
                     // to get the next batch of missing ops.
                     MissingOpsStatus::BatchComplete => {
                         gossip = vec![ShardedGossipWire::op_batch_received()];
-                        self.get_state(&cert)?
+                        self.get_state(&peer_cert)?
                     }
                     // All the batches of missing ops for the bloom this node sent
                     // to the remote node have been sent back to this node.
                     MissingOpsStatus::AllComplete => {
                         // This node can decrement the number of outstanding ops bloom replies
                         // it is waiting for.
-                        let mut state = self.decrement_op_blooms(&cert)?;
+                        let mut state = self.decrement_op_blooms(&peer_cert)?;
 
                         // If there are more blooms to send because this node had to batch the blooms
                         // and all the outstanding blooms have been received then this node will send
@@ -1029,7 +1054,7 @@ impl ShardedGossipLocal {
                             // Generate the next ops blooms batch.
                             *state = self.next_bloom_batch(state.clone(), &mut gossip).await?;
                             // Update the state.
-                            self.update_state_if_active(cert.clone(), state.clone())?;
+                            self.update_state_if_active(peer_cert.clone(), state.clone())?;
                         }
                         state
                     }
@@ -1045,35 +1070,35 @@ impl ShardedGossipLocal {
                 }
                 gossip
             }
-            ShardedGossipWire::OpBatchReceived(_) => match self.get_state(&cert)? {
+            ShardedGossipWire::OpBatchReceived(_) => match self.get_state(&peer_cert)? {
                 Some(state) => {
                     // The last ops batch has been received by the
                     // remote node so now send the next batch.
                     let r = self.next_missing_ops_batch(state.clone()).await?;
                     if state.is_finished() {
-                        self.remove_state(&cert, false)?;
+                        self.remove_state(&peer_cert, false)?;
                     }
                     r
                 }
                 None => Vec::with_capacity(0),
             },
             ShardedGossipWire::NoAgents(_) => {
-                tracing::warn!("No agents to gossip with on the node {:?}", cert);
-                self.remove_state(&cert, true)?;
+                tracing::warn!("No agents to gossip with on the node {:?}", peer_cert);
+                self.remove_state(&peer_cert, true)?;
                 Vec::with_capacity(0)
             }
             ShardedGossipWire::AlreadyInProgress(_) => {
-                self.remove_target(&cert, false)?;
+                self.remove_target(&peer_cert, false)?;
                 Vec::with_capacity(0)
             }
             ShardedGossipWire::Busy(_) => {
-                tracing::warn!("The node {:?} is busy", cert);
-                self.remove_target(&cert, true)?;
+                tracing::warn!("The node {:?} is busy", peer_cert);
+                self.remove_target(&peer_cert, true)?;
                 Vec::with_capacity(0)
             }
             ShardedGossipWire::Error(Error { message }) => {
-                tracing::warn!("gossiping with: {:?} and got error: {}", cert, message);
-                self.remove_state(&cert, true)?;
+                tracing::warn!("gossiping with: {:?} and got error: {}", peer_cert, message);
+                self.remove_state(&peer_cert, true)?;
                 Vec::with_capacity(0)
             }
         };
@@ -1101,11 +1126,9 @@ impl ShardedGossipLocal {
             .share_mut(|i, _| {
                 for (cert, ref r) in i.round_map.take_timed_out_rounds() {
                     tracing::warn!("The node {:?} has timed out their gossip round", cert);
-                    i.metrics.write().record_error(
-                        &r.remote_agent_list,
-                        Some(r.into()),
-                        self.gossip_type.into(),
-                    );
+                    let mut metrics = i.metrics.write();
+                    metrics.record_error(&r.remote_agent_list, self.gossip_type.into());
+                    metrics.complete_current_round(&cert, true);
                 }
                 Ok(())
             })
@@ -1139,12 +1162,36 @@ impl RoundState {
     /// - This node has received all the ops blooms from the remote node.
     /// - This node has no saved ops bloom batch cursor.
     /// - This node has no queued missing ops to send to the remote node.
+    /// - If running historical gossip, the number of ops sent/received matches expectations
     fn is_finished(&self) -> bool {
+        let InOut {
+            incoming: expected_in,
+            outgoing: expected_out,
+        } = self.throughput.expected_op_count;
+        let InOut {
+            incoming: ops_in,
+            outgoing: ops_out,
+        } = self.throughput.op_count;
+
+        let ops_finished = ops_in >= expected_in && ops_out >= expected_out;
+
+        // tracing::debug!(
+        //     "FINISHED? {} {} {} {} {} {} {}",
+        //     self.num_expected_op_blooms == 0,
+        //     !self.has_pending_historical_op_data,
+        //     self.received_all_incoming_op_blooms,
+        //     self.regions_are_queued,
+        //     self.bloom_batch_cursor.is_none(),
+        //     self.ops_batch_queue.is_empty(),
+        //     ops_finished
+        // );
         self.num_expected_op_blooms == 0
             && !self.has_pending_historical_op_data
             && self.received_all_incoming_op_blooms
+            && self.regions_are_queued
             && self.bloom_batch_cursor.is_none()
             && self.ops_batch_queue.is_empty()
+            && ops_finished
     }
 }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/accept.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/accept.rs
@@ -70,11 +70,12 @@ impl ShardedGossipLocal {
             // TODO: What happen if we are in the middle of a new outgoing and
             // a stale accept comes in for the same peer cert?
             // Maybe we need to check timestamps on messages or have unique round ids?
+
+            let mut metrics = inner.metrics.write();
+            metrics.update_current_round(&peer_cert, self.gossip_type.into(), &state);
+            metrics.record_initiate(&remote_agent_list, self.gossip_type.into());
+
             inner.round_map.insert(peer_cert.clone(), state);
-            inner
-                .metrics
-                .write()
-                .record_initiate(&remote_agent_list, self.gossip_type.into());
             Ok(())
         })?;
         Ok(gossip)

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/next_target.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/next_target.rs
@@ -266,22 +266,18 @@ mod tests {
         metrics
             .write()
             .record_initiate(&last.agent_info_list, GossipModuleType::ShardedRecent);
-        metrics.write().record_success(
-            &last.agent_info_list,
-            None,
-            GossipModuleType::ShardedRecent,
-        );
+        metrics
+            .write()
+            .record_success(&last.agent_info_list, GossipModuleType::ShardedRecent);
 
         // - Record successful initiate rounds for the rest of the nodes at later times.
         for node in remote_nodes.iter() {
             metrics
                 .write()
                 .record_initiate(&node.agent_info_list, GossipModuleType::ShardedRecent);
-            metrics.write().record_success(
-                &node.agent_info_list,
-                None,
-                GossipModuleType::ShardedRecent,
-            );
+            metrics
+                .write()
+                .record_success(&node.agent_info_list, GossipModuleType::ShardedRecent);
         }
 
         // - Push the last node back into the remote nodes.
@@ -313,11 +309,9 @@ mod tests {
             metrics
                 .write()
                 .record_initiate(&node.agent_info_list, GossipModuleType::ShardedRecent);
-            metrics.write().record_success(
-                &node.agent_info_list,
-                None,
-                GossipModuleType::ShardedRecent,
-            );
+            metrics
+                .write()
+                .record_success(&node.agent_info_list, GossipModuleType::ShardedRecent);
         }
 
         // - Push the last node back into the remote nodes.
@@ -347,11 +341,9 @@ mod tests {
             metrics
                 .write()
                 .record_initiate(&node.agent_info_list, GossipModuleType::ShardedRecent);
-            metrics.write().record_success(
-                &node.agent_info_list,
-                None,
-                GossipModuleType::ShardedRecent,
-            );
+            metrics
+                .write()
+                .record_success(&node.agent_info_list, GossipModuleType::ShardedRecent);
         }
 
         // - Push the last two nodes back into the remote nodes.
@@ -392,7 +384,7 @@ mod tests {
         for node in remote_nodes.iter() {
             metrics
                 .write()
-                .record_remote_round(&node.agent_info_list, GossipModuleType::ShardedRecent);
+                .record_accept(&node.agent_info_list, GossipModuleType::ShardedRecent);
         }
 
         let r = next_remote_node(remote_nodes.clone(), &metrics, tuning_params_no_delay());
@@ -404,11 +396,9 @@ mod tests {
         metrics
             .write()
             .record_initiate(&last.agent_info_list, GossipModuleType::ShardedRecent);
-        metrics.write().record_success(
-            &last.agent_info_list,
-            None,
-            GossipModuleType::ShardedRecent,
-        );
+        metrics
+            .write()
+            .record_success(&last.agent_info_list, GossipModuleType::ShardedRecent);
         remote_nodes.push(last);
 
         let r = next_remote_node(remote_nodes.clone(), &metrics, tuning_params_no_delay());
@@ -431,11 +421,9 @@ mod tests {
             metrics
                 .write()
                 .record_initiate(&node.agent_info_list, GossipModuleType::ShardedRecent);
-            metrics.write().record_success(
-                &node.agent_info_list,
-                None,
-                GossipModuleType::ShardedRecent,
-            );
+            metrics
+                .write()
+                .record_success(&node.agent_info_list, GossipModuleType::ShardedRecent);
         }
 
         let r = next_remote_node(
@@ -476,11 +464,9 @@ mod tests {
             metrics
                 .write()
                 .record_initiate(&node.agent_info_list, GossipModuleType::ShardedRecent);
-            metrics.write().record_error(
-                &node.agent_info_list,
-                None,
-                GossipModuleType::ShardedRecent,
-            );
+            metrics
+                .write()
+                .record_error(&node.agent_info_list, GossipModuleType::ShardedRecent);
         }
 
         let r = next_remote_node(
@@ -536,22 +522,18 @@ mod tests {
         metrics
             .write()
             .record_initiate(&last.agent_info_list, GossipModuleType::ShardedRecent);
-        metrics.write().record_success(
-            &last.agent_info_list,
-            None,
-            GossipModuleType::ShardedRecent,
-        );
+        metrics
+            .write()
+            .record_success(&last.agent_info_list, GossipModuleType::ShardedRecent);
 
         // - Record successful initiate rounds for the rest of the nodes.
         for node in remote_nodes.iter() {
             metrics
                 .write()
                 .record_initiate(&node.agent_info_list, GossipModuleType::ShardedRecent);
-            metrics.write().record_success(
-                &node.agent_info_list,
-                None,
-                GossipModuleType::ShardedRecent,
-            );
+            metrics
+                .write()
+                .record_success(&node.agent_info_list, GossipModuleType::ShardedRecent);
         }
 
         // - Push the last node back on the list.
@@ -586,11 +568,9 @@ mod tests {
         metrics
             .write()
             .record_initiate(&last.agent_info_list, GossipModuleType::ShardedRecent);
-        metrics.write().record_success(
-            &last.agent_info_list,
-            None,
-            GossipModuleType::ShardedRecent,
-        );
+        metrics
+            .write()
+            .record_success(&last.agent_info_list, GossipModuleType::ShardedRecent);
 
         let r = next_remote_node(
             remote_nodes.clone(),
@@ -607,11 +587,9 @@ mod tests {
         metrics
             .write()
             .record_initiate(&first.agent_info_list, GossipModuleType::ShardedRecent);
-        metrics.write().record_success(
-            &first.agent_info_list,
-            None,
-            GossipModuleType::ShardedRecent,
-        );
+        metrics
+            .write()
+            .record_success(&first.agent_info_list, GossipModuleType::ShardedRecent);
 
         let r = next_remote_node(
             remote_nodes.clone(),
@@ -659,11 +637,9 @@ mod tests {
         metrics
             .write()
             .record_initiate(&node.agent_info_list, GossipModuleType::ShardedRecent);
-        metrics.write().record_success(
-            &node.agent_info_list,
-            None,
-            GossipModuleType::ShardedRecent,
-        );
+        metrics
+            .write()
+            .record_success(&node.agent_info_list, GossipModuleType::ShardedRecent);
 
         let r = next_remote_node(
             remote_nodes.clone(),
@@ -680,11 +656,9 @@ mod tests {
         metrics
             .write()
             .record_initiate(&node.agent_info_list, GossipModuleType::ShardedRecent);
-        metrics.write().record_success(
-            &node.agent_info_list,
-            None,
-            GossipModuleType::ShardedRecent,
-        );
+        metrics
+            .write()
+            .record_success(&node.agent_info_list, GossipModuleType::ShardedRecent);
 
         let r = next_remote_node(
             remote_nodes.clone(),
@@ -714,11 +688,9 @@ mod tests {
         metrics
             .write()
             .record_initiate(&node.agent_info_list, GossipModuleType::ShardedRecent);
-        metrics.write().record_success(
-            &node.agent_info_list,
-            None,
-            GossipModuleType::ShardedRecent,
-        );
+        metrics
+            .write()
+            .record_success(&node.agent_info_list, GossipModuleType::ShardedRecent);
 
         // - Forth force initiate overlaps with third so it resets.
         metrics.write().record_force_initiate();
@@ -738,11 +710,9 @@ mod tests {
         metrics
             .write()
             .record_initiate(&node.agent_info_list, GossipModuleType::ShardedRecent);
-        metrics.write().record_success(
-            &node.agent_info_list,
-            None,
-            GossipModuleType::ShardedRecent,
-        );
+        metrics
+            .write()
+            .record_success(&node.agent_info_list, GossipModuleType::ShardedRecent);
 
         let r = next_remote_node(
             remote_nodes.clone(),
@@ -759,11 +729,9 @@ mod tests {
         metrics
             .write()
             .record_initiate(&node.agent_info_list, GossipModuleType::ShardedRecent);
-        metrics.write().record_success(
-            &node.agent_info_list,
-            None,
-            GossipModuleType::ShardedRecent,
-        );
+        metrics
+            .write()
+            .record_success(&node.agent_info_list, GossipModuleType::ShardedRecent);
 
         let r = next_remote_node(
             remote_nodes.clone(),

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
@@ -127,7 +127,7 @@ impl ShardedGossipLocal {
                     i.metrics.write().update_current_round(
                         peer_cert,
                         GossipModuleType::ShardedHistorical,
-                        &round,
+                        round,
                     );
                 } else {
                     tracing::warn!(

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
@@ -99,13 +99,44 @@ impl ShardedGossipLocal {
 
     pub(super) async fn queue_incoming_regions(
         &self,
+        peer_cert: &Tx2Cert,
         state: RoundState,
         region_set: RegionSetLtcs,
     ) -> KitsuneResult<Vec<ShardedGossipWire>> {
         if let Some(sent) = state.region_set_sent.as_ref().map(|r| (**r).clone()) {
             // because of the order of arguments, the diff regions will contain the data
             // from *our* side, not our partner's.
-            let diff_regions = sent.diff(region_set.clone()).map_err(KitsuneError::other)?;
+            let our_region_diff = sent
+                .clone()
+                .diff(region_set.clone())
+                .map_err(KitsuneError::other)?;
+            let their_region_diff = region_set.clone().diff(sent).map_err(KitsuneError::other)?;
+
+            self.inner.share_mut(|i, _| {
+                if let Some(round) = i.round_map.get_mut(peer_cert) {
+                    round.throughput.expected_op_bytes.outgoing +=
+                        our_region_diff.iter().map(|r| r.data.size).sum::<u32>();
+                    round.throughput.expected_op_count.outgoing +=
+                        our_region_diff.iter().map(|r| r.data.count).sum::<u32>();
+                    round.throughput.expected_op_bytes.incoming +=
+                        their_region_diff.iter().map(|r| r.data.size).sum::<u32>();
+                    round.throughput.expected_op_count.incoming +=
+                        their_region_diff.iter().map(|r| r.data.count).sum::<u32>();
+                    round.region_diffs = Some((our_region_diff.clone(), their_region_diff));
+                    round.regions_are_queued = true;
+                    i.metrics.write().update_current_round(
+                        peer_cert,
+                        GossipModuleType::ShardedHistorical,
+                        &round,
+                    );
+                } else {
+                    tracing::warn!(
+                        "attempting to queue_incoming_regions for round with no cert: {:?}",
+                        peer_cert
+                    );
+                }
+                Ok(())
+            })?;
 
             // This is a good place to see all the region data go by.
             // Note, this is a LOT of output!
@@ -120,7 +151,7 @@ impl ShardedGossipLocal {
                 .query_size_limited_regions(
                     self.space.clone(),
                     self.tuning_params.gossip_max_batch_size,
-                    diff_regions,
+                    our_region_diff,
                 )
                 .await
                 .map_err(KitsuneError::other)?;

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
@@ -11,13 +11,20 @@ impl RoundStateMap {
     /// Check if round has timed out and remove it if it has.
     pub(super) fn check_timeout(&mut self, key: &StateKey) -> bool {
         let mut timed_out = false;
+        let mut finished = false;
         if let Some(state) = self.map.get(key) {
             if state.last_touch.elapsed() > state.round_timeout {
                 if let Some(v) = self.map.remove(key) {
                     self.timed_out.push((key.clone(), v));
                 }
                 timed_out = true;
+            } else if state.is_finished() {
+                finished = true;
             }
+        }
+        // MD: I added this just to be safe. It made a difference.
+        if finished {
+            self.map.remove(key);
         }
         timed_out
     }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/test_two_nodes.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/test_two_nodes.rs
@@ -140,18 +140,19 @@ async fn partial_missing_doesnt_finish() {
         ShardedGossipLocalState {
             round_map: maplit::hashmap! {
                 cert.clone() => RoundState {
-                    remote_agent_list:vec![],
-                    common_arc_set:Arc::new(DhtArcSet::Full),
-                    num_expected_op_blooms:1,
-                    received_all_incoming_op_blooms:true,
-                    has_pending_historical_op_data:false,
-                    start_time:Instant::now(),
-                    last_touch:Instant::now(),
-                    round_timeout:std::time::Duration::MAX,
-                    bloom_batch_cursor:None,
-                    ops_batch_queue:OpsBatchQueue::new(),
-                    region_set_sent:None,
-                    throughput: Default::default()
+                    remote_agent_list: vec![],
+                    common_arc_set: Arc::new(DhtArcSet::Full),
+                    num_expected_op_blooms: 1,
+                    received_all_incoming_op_blooms: true,
+                    has_pending_historical_op_data: false,
+                    regions_are_queued: true,
+                    id: nanoid::nanoid!(),
+                    last_touch: Instant::now(),
+                    round_timeout: std::time::Duration::MAX,
+                    bloom_batch_cursor: None,
+                    ops_batch_queue: OpsBatchQueue::new(),
+                    region_set_sent: None,
+                    throughput: Default::default(), region_diffs: Default::default(),
                 }
             }
             .into(),
@@ -197,13 +198,14 @@ async fn missing_ops_finishes() {
                     num_expected_op_blooms: 1,
                     received_all_incoming_op_blooms: true,
                     has_pending_historical_op_data: false,
-                    start_time: Instant::now(),
+                    regions_are_queued: true,
+                    id: nanoid::nanoid!(),
                     last_touch: Instant::now(),
                     round_timeout: std::time::Duration::MAX,
                     bloom_batch_cursor: None,
                     ops_batch_queue: OpsBatchQueue::new(),
                     region_set_sent: None,
-                    throughput: Default::default()
+                    throughput: Default::default(), region_diffs: Default::default(),
                 }
             }
             .into(),
@@ -250,13 +252,14 @@ async fn missing_ops_doesnt_finish_awaiting_bloom_responses() {
                     num_expected_op_blooms: 1,
                     received_all_incoming_op_blooms: false,
                     has_pending_historical_op_data: false,
-                    start_time: Instant::now(),
+                    regions_are_queued: true,
+                    id: nanoid::nanoid!(),
                     last_touch: Instant::now(),
                     round_timeout: std::time::Duration::MAX,
                     bloom_batch_cursor: None,
                     ops_batch_queue: OpsBatchQueue::new(),
                     region_set_sent: None,
-                    throughput: Default::default()
+                    throughput: Default::default(), region_diffs: Default::default(),
                 }
             }
             .into(),
@@ -303,13 +306,14 @@ async fn bloom_response_finishes() {
                     num_expected_op_blooms: 0,
                     received_all_incoming_op_blooms: false,
                     has_pending_historical_op_data: false,
-                    start_time: Instant::now(),
+                    regions_are_queued: true,
+                    id: nanoid::nanoid!(),
                     last_touch: Instant::now(),
                     round_timeout: std::time::Duration::MAX,
                     bloom_batch_cursor: None,
                     ops_batch_queue: OpsBatchQueue::new(),
                     region_set_sent: None,
-                    throughput: Default::default()
+                    throughput: Default::default(), region_diffs: Default::default(),
                 }
             }
             .into(),
@@ -356,13 +360,14 @@ async fn bloom_response_doesnt_finish_outstanding_incoming() {
                     num_expected_op_blooms: 1,
                     received_all_incoming_op_blooms: false,
                     has_pending_historical_op_data: false,
-                    start_time: Instant::now(),
+                    regions_are_queued: true,
+                    id: nanoid::nanoid!(),
                     last_touch: Instant::now(),
                     round_timeout: std::time::Duration::MAX,
                     bloom_batch_cursor: None,
                     ops_batch_queue: OpsBatchQueue::new(),
                     region_set_sent: None,
-                    throughput: Default::default()
+                    throughput: Default::default(), region_diffs: Default::default(),
                 }
             }
             .into(),
@@ -412,13 +417,14 @@ async fn no_data_still_finishes() {
                     num_expected_op_blooms: 0,
                     received_all_incoming_op_blooms: false,
                     has_pending_historical_op_data: false,
-                    start_time: Instant::now(),
+                    regions_are_queued: true,
+                    id: nanoid::nanoid!(),
                     last_touch: Instant::now(),
                     round_timeout: std::time::Duration::MAX,
                     bloom_batch_cursor: None,
                     ops_batch_queue: OpsBatchQueue::new(),
                     region_set_sent: None,
-                    throughput: Default::default()
+                    throughput: Default::default(), region_diffs: Default::default(),
                 }
             }
             .into(),
@@ -439,13 +445,14 @@ async fn no_data_still_finishes() {
                     num_expected_op_blooms: 1,
                     received_all_incoming_op_blooms: true,
                     has_pending_historical_op_data: false,
-                    start_time: Instant::now(),
+                    regions_are_queued: true,
+                    id: nanoid::nanoid!(),
                     last_touch: Instant::now(),
                     round_timeout: std::time::Duration::MAX,
                     bloom_batch_cursor: None,
                     ops_batch_queue: OpsBatchQueue::new(),
                     region_set_sent: None,
-                    throughput: Default::default()
+                    throughput: Default::default(), region_diffs: Default::default(),
                 }
             }
             .into(),

--- a/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
@@ -7,6 +7,8 @@ use std::time::Duration;
 
 use tokio::time::Instant;
 
+use crate::gossip::sharded_gossip::NodeId;
+use crate::gossip::sharded_gossip::RegionDiffs;
 use crate::gossip::sharded_gossip::RoundState;
 use crate::gossip::sharded_gossip::RoundThroughput;
 use crate::types::event::*;
@@ -105,8 +107,9 @@ const MAX_TRIGGERS: u8 = 2;
 const MAX_HISTORY: usize = 10;
 
 #[derive(Debug, Clone, Default)]
-/// Information about a remote node.
-pub struct NodeInfo {
+/// The history of gossip with an agent on a remote node.
+/// We record metrics per agent,
+pub struct PeerAgentHistory {
     /// Sucessful and unsuccessful messages from the remote
     /// can be combined to estimate a "reachability quotient"
     /// between 1 (or 0 if empty) and 100. Errors are weighted
@@ -115,16 +118,29 @@ pub struct NodeInfo {
     /// Running average for latency microseconds for any direct
     /// request/response calls to remote agent.
     pub latency_micros: RunAvg,
+    /// Times we recorded successful initiates to this node (they accepted).
+    pub initiates: VecDeque<RoundMetric>,
+    /// Times we recorded initates from this node (we accepted).
+    pub accepts: VecDeque<RoundMetric>,
+    /// Times we recorded complete rounds for this node.
+    pub successes: VecDeque<RoundMetric>,
     /// Times we recorded errors for this node.
     pub errors: VecDeque<RoundMetric>,
-    /// Times we recorded initiates to this node.
-    pub initiates: VecDeque<Instant>,
-    /// Times we recorded remote rounds from this node.
-    pub remote_rounds: VecDeque<Instant>,
-    /// Times we recorded complete rounds for this node.
-    pub complete_rounds: VecDeque<RoundMetric>,
     /// Is this node currently in an active round?
-    pub current_round: Option<RoundMetric>,
+    pub current_round: bool,
+}
+
+/// Detailed info about the history of gossip with this node
+#[derive(Debug, Clone, Default)]
+pub struct PeerNodeHistory {
+    /// The most recent list of remote agents reported by this node
+    pub remote_agents: Vec<Arc<KitsuneAgent>>,
+
+    /// Detailed info about the ongoing round with this node
+    pub current_round: Option<CurrentRound>,
+
+    /// Detailed info about rounds completed with this node
+    pub completed_rounds: VecDeque<CompletedRound>,
 }
 
 /// Info about a completed gossip round
@@ -134,31 +150,89 @@ pub struct RoundMetric {
     pub instant: Instant,
     /// The type of gossip module
     pub gossip_type: GossipModuleType,
-    /// If the round completed, include info about that
-    pub round: Option<CompleteRound>,
 }
 
-/// Minimal metrics about a completed round
+/// Metrics about a completed gossip round
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CompleteRound {
+pub struct CompletedRound {
+    /// Unique string id
+    pub id: String,
+    /// The type of gossip module
+    pub gossip_type: GossipModuleType,
     /// The start time of the round
     pub start_time: Instant,
+    /// The end time of the round
+    pub end_time: Instant,
     /// Throughput stats
     pub throughput: RoundThroughput,
+    /// This round ended in an error
+    pub error: bool,
+    /// If historical, the region diffs
+    pub region_diffs: RegionDiffs,
+}
+
+impl CompletedRound {
+    /// Total duration of this round, from start to end
+    pub fn duration(&self) -> Duration {
+        self.end_time.duration_since(self.start_time)
+    }
+}
+
+/// Metrics about an ongoing gossip round
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CurrentRound {
+    /// Unique string id
+    pub id: String,
+    /// The type of gossip module
+    pub gossip_type: GossipModuleType,
+    /// Last time this was updated
+    pub last_touch: Instant,
+    /// The start time of the round
+    pub start_time: Instant,
+    /// Total information sent/received so far
+    pub throughput: RoundThroughput,
+    /// If historical, the region diffs
+    pub region_diffs: RegionDiffs,
+}
+
+impl CurrentRound {
+    /// Constructor
+    pub fn new(id: String, gossip_type: GossipModuleType, start_time: Instant) -> Self {
+        Self {
+            id,
+            gossip_type,
+            start_time,
+            last_touch: Instant::now(),
+            throughput: Default::default(),
+            region_diffs: Default::default(),
+        }
+    }
+
+    /// Update status based on an existing round
+    pub fn update(&mut self, round_state: &RoundState) {
+        self.last_touch = Instant::now();
+        self.throughput = round_state.throughput.clone();
+        self.region_diffs = round_state.region_diffs.clone();
+    }
+
+    /// Convert to a CompletedRound
+    pub fn completed(self, error: bool) -> CompletedRound {
+        CompletedRound {
+            id: self.id,
+            gossip_type: self.gossip_type,
+            start_time: self.start_time,
+            end_time: Instant::now(),
+            throughput: self.throughput,
+            error,
+            region_diffs: self.region_diffs,
+        }
+    }
 }
 
 impl RoundMetric {
     /// Time elapsed since this round was recorded
     pub fn elapsed(&self) -> Duration {
         self.instant.elapsed()
-    }
-
-    /// Total duration of this round, from start to end
-    pub fn duration(&self) -> Duration {
-        match &self.round {
-            Some(round) => self.instant - round.start_time,
-            None => Duration::from_nanos(0),
-        }
     }
 }
 
@@ -174,12 +248,31 @@ impl Ord for RoundMetric {
     }
 }
 
-impl From<&RoundState> for CompleteRound {
-    fn from(r: &RoundState) -> Self {
-        Self {
-            start_time: r.start_time,
-            throughput: r.throughput.clone(),
+impl PartialOrd for CompletedRound {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CompletedRound {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match self.start_time.cmp(&other.start_time) {
+            core::cmp::Ordering::Equal => {}
+            ord => return ord,
         }
+        self.end_time.cmp(&other.end_time)
+    }
+}
+
+impl PartialOrd for CurrentRound {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CurrentRound {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.start_time.cmp(&other.start_time)
     }
 }
 
@@ -187,8 +280,11 @@ impl From<&RoundState> for CompleteRound {
 /// Metrics tracking for remote nodes to help
 /// choose which remote node to initiate the next round with.
 pub struct Metrics {
-    /// Map of remote agents.
-    nodes: HashMap<Arc<KitsuneAgent>, NodeInfo>,
+    /// Map of remote agents and gossip history with each.
+    agent_history: HashMap<Arc<KitsuneAgent>, PeerAgentHistory>,
+
+    /// Map of remote nodes and gossip history with each
+    node_history: HashMap<NodeId, PeerNodeHistory>,
 
     /// Aggregate Extrapolated Dht Coverage
     agg_extrap_cov: RunAvg,
@@ -247,7 +343,7 @@ impl Metrics {
 
         let mut out = Vec::new();
 
-        for (agent, node) in self.nodes.iter() {
+        for (agent, node) in self.agent_history.iter() {
             out.push(MetricRecord {
                 kind: MetricRecordKind::ReachabilityQuotient,
                 agent: Some(agent.clone()),
@@ -279,7 +375,7 @@ impl Metrics {
     /// Dump json encoded metrics
     pub fn dump(&self) -> serde_json::Value {
         let agents: serde_json::Value = self
-            .nodes
+            .agent_history
             .iter()
             .map(|(a, i)| {
                 (
@@ -297,6 +393,19 @@ impl Metrics {
             "aggExtrapCov": *self.agg_extrap_cov,
             "agents": agents,
         })
+    }
+
+    /// Get the sum of throughputs for all current rounds
+    pub fn current_throughputs(&self) -> impl Iterator<Item = RoundThroughput> + '_ {
+        self.node_history
+            .values()
+            .flat_map(|r| &r.current_round)
+            .map(|r| r.throughput.clone())
+    }
+
+    /// Get the sum of throughputs for all current rounds
+    pub fn total_current_throughput(&self) -> RoundThroughput {
+        self.current_throughputs().sum()
     }
 
     /// Record an individual extrapolated coverage event
@@ -320,7 +429,7 @@ impl Metrics {
     {
         for agent_info in remote_agent_list {
             let info = self
-                .nodes
+                .agent_history
                 .entry(agent_info.into().agent().clone())
                 .or_default();
             if success {
@@ -340,11 +449,11 @@ impl Metrics {
         V: AsPrimitive<f32>,
     {
         for agent_info in remote_agent_list {
-            let info = self
-                .nodes
+            let history = self
+                .agent_history
                 .entry(agent_info.into().agent().clone())
                 .or_default();
-            info.latency_micros.push(micros);
+            history.latency_micros.push(micros);
         }
     }
 
@@ -355,68 +464,66 @@ impl Metrics {
         I: IntoIterator<Item = T>,
     {
         for agent_info in remote_agent_list {
-            let info = self
-                .nodes
+            let history = self
+                .agent_history
                 .entry(agent_info.into().agent().clone())
                 .or_default();
-            record_item(&mut info.initiates, Instant::now());
-            info.current_round = Some(RoundMetric {
+            let round = RoundMetric {
                 instant: Instant::now(),
-                round: None,
                 gossip_type,
-            });
+            };
+            record_item(&mut history.initiates, round);
+            if history.current_round {
+                tracing::warn!("Recorded initiate with current round already set");
+            }
+            history.current_round = true;
         }
     }
 
-    /// Record a remote gossip round has started.
-    pub fn record_remote_round<'a, T, I>(
-        &mut self,
-        remote_agent_list: I,
-        gossip_type: GossipModuleType,
-    ) where
+    /// Record a gossip round has been initiated by a peer.
+    pub fn record_accept<'a, T, I>(&mut self, remote_agent_list: I, gossip_type: GossipModuleType)
+    where
         T: Into<AgentLike<'a>>,
         I: IntoIterator<Item = T>,
     {
         for agent_info in remote_agent_list {
-            let info = self
-                .nodes
+            let history = self
+                .agent_history
                 .entry(agent_info.into().agent().clone())
                 .or_default();
-            record_item(&mut info.remote_rounds, Instant::now());
-            info.current_round = Some(RoundMetric {
+            let round = RoundMetric {
                 instant: Instant::now(),
-                round: None,
                 gossip_type,
-            });
+            };
+            record_item(&mut history.accepts, round);
+            if history.current_round {
+                tracing::warn!("Recorded accept with current round already set");
+            }
+            history.current_round = true;
         }
     }
 
     /// Record a gossip round has completed successfully.
-    pub fn record_success<'a, T, I>(
-        &mut self,
-        remote_agent_list: I,
-        complete_round: Option<CompleteRound>,
-        gossip_type: GossipModuleType,
-    ) where
+    pub fn record_success<'a, T, I>(&mut self, remote_agent_list: I, gossip_type: GossipModuleType)
+    where
         T: Into<AgentLike<'a>>,
         I: IntoIterator<Item = T>,
     {
         let mut should_dec_force_initiates = false;
 
         for agent_info in remote_agent_list {
-            let info = self
-                .nodes
+            let history = self
+                .agent_history
                 .entry(agent_info.into().agent().clone())
                 .or_default();
-            info.reachability_quotient.push(100);
+            history.reachability_quotient.push(100);
             let round = RoundMetric {
                 instant: Instant::now(),
-                round: complete_round.clone(),
                 gossip_type,
             };
-            record_item(&mut info.complete_rounds, round);
-            info.current_round = None;
-            if info.is_initiate_round() {
+            record_item(&mut history.successes, round);
+            history.current_round = false;
+            if history.is_initiate_round() {
                 should_dec_force_initiates = true;
             }
         }
@@ -432,33 +539,82 @@ impl Metrics {
     }
 
     /// Record a gossip round has finished with an error.
-    pub fn record_error<'a, T, I>(
-        &mut self,
-        remote_agent_list: I,
-        complete_round: Option<CompleteRound>,
-        gossip_type: GossipModuleType,
-    ) where
+    pub fn record_error<'a, T, I>(&mut self, remote_agent_list: I, gossip_type: GossipModuleType)
+    where
         T: Into<AgentLike<'a>>,
         I: IntoIterator<Item = T>,
     {
         for agent_info in remote_agent_list {
-            let info = self
-                .nodes
+            let history = self
+                .agent_history
                 .entry(agent_info.into().agent().clone())
                 .or_default();
-            info.reachability_quotient.push_n(1, 5);
+            history.reachability_quotient.push_n(1, 5);
             let round = RoundMetric {
                 instant: Instant::now(),
-                round: complete_round.clone(),
                 gossip_type,
             };
-            record_item(&mut info.errors, round);
-            info.current_round = None;
+            record_item(&mut history.errors, round);
+            history.current_round = false;
         }
         tracing::debug!(
             "recorded error in metrics. force_initiates={}",
             self.force_initiates
         );
+    }
+
+    /// Update node-level info about a current round, or create one if it doesn't exist
+    pub fn update_current_round(
+        &mut self,
+        peer: &NodeId,
+        gossip_type: GossipModuleType,
+        round_state: &RoundState,
+    ) {
+        let remote_agents = round_state
+            .remote_agent_list
+            .clone()
+            .into_iter()
+            .map(|a| a.agent())
+            .collect();
+        let history = self.node_history.entry(peer.clone()).or_default();
+        history.remote_agents = remote_agents;
+        if let Some(r) = &mut history.current_round {
+            r.update(round_state);
+        } else {
+            history.current_round = Some(CurrentRound::new(
+                round_state.id.clone(),
+                gossip_type,
+                Instant::now(),
+            ));
+        }
+
+        // print progress
+        {
+            let tps = self.current_throughputs().count();
+            let tot = self.total_current_throughput();
+            let n = tot.op_bytes.incoming;
+            let d = tot.expected_op_bytes.incoming;
+            if d > 0 {
+                let r = n as f64 / d as f64 * 100.0;
+                tracing::debug!(
+                    "PROGRESS [{:?}] {} / {} ({:>3.1}%) : {}",
+                    peer,
+                    n,
+                    d,
+                    r,
+                    tps,
+                );
+            }
+        }
+    }
+
+    /// Remove the current round info once it's complete, and put it into the history list
+    pub fn complete_current_round(&mut self, node: &NodeId, error: bool) {
+        let history = self.node_history.entry(node.clone()).or_default();
+        let r = history.current_round.take();
+        if let Some(r) = r {
+            history.completed_rounds.push_back(r.completed(error))
+        }
     }
 
     /// Record that we should force initiate the next few rounds.
@@ -474,8 +630,8 @@ impl Metrics {
     {
         remote_agent_list
             .into_iter()
-            .filter_map(|agent_info| self.nodes.get(agent_info.into().agent()))
-            .filter_map(|info| info.complete_rounds.back())
+            .filter_map(|agent_info| self.agent_history.get(agent_info.into().agent()))
+            .filter_map(|info| info.successes.back())
             .min_by_key(|r| r.instant)
     }
 
@@ -487,8 +643,8 @@ impl Metrics {
     {
         remote_agent_list
             .into_iter()
-            .filter_map(|agent_info| self.nodes.get(agent_info.into().agent()))
-            .any(|info| info.current_round.is_some())
+            .filter_map(|agent_info| self.agent_history.get(agent_info.into().agent()))
+            .any(|info| info.current_round)
     }
 
     /// What was the last outcome for this node's gossip round?
@@ -500,11 +656,11 @@ impl Metrics {
         #[allow(clippy::map_flatten)]
         remote_agent_list
             .into_iter()
-            .filter_map(|agent_info| self.nodes.get(agent_info.into().agent()))
+            .filter_map(|agent_info| self.agent_history.get(agent_info.into().agent()))
             .map(|info| {
                 [
                     info.errors.back().map(|x| RoundOutcome::Error(x.clone())),
-                    info.complete_rounds
+                    info.successes
                         .back()
                         .map(|x| RoundOutcome::Success(x.clone())),
                 ]
@@ -528,7 +684,7 @@ impl Metrics {
     {
         let (sum, cnt) = remote_agent_list
             .into_iter()
-            .filter_map(|agent_info| self.nodes.get(agent_info.into().agent()))
+            .filter_map(|agent_info| self.agent_history.get(agent_info.into().agent()))
             .map(|info| *info.reachability_quotient)
             .fold((0.0, 0.0), |acc, x| (acc.0 + x, acc.1 + 1.0));
         if cnt <= 0.0 {
@@ -547,7 +703,7 @@ impl Metrics {
     {
         let (sum, cnt) = remote_agent_list
             .into_iter()
-            .filter_map(|agent_info| self.nodes.get(agent_info.into().agent()))
+            .filter_map(|agent_info| self.agent_history.get(agent_info.into().agent()))
             .map(|info| *info.latency_micros)
             .fold((0.0, 0.0), |acc, x| (acc.0 + x, acc.1 + 1.0));
         if cnt <= 0.0 {
@@ -558,15 +714,20 @@ impl Metrics {
     }
 
     /// Getter
-    pub fn node_info(&self) -> &HashMap<Arc<KitsuneAgent>, NodeInfo> {
-        &self.nodes
+    pub fn peer_agent_histories(&self) -> &HashMap<Arc<KitsuneAgent>, PeerAgentHistory> {
+        &self.agent_history
+    }
+
+    /// Getter
+    pub fn peer_node_histories(&self) -> &HashMap<NodeId, PeerNodeHistory> {
+        &self.node_history
     }
 }
 
-impl NodeInfo {
+impl PeerAgentHistory {
     /// Was the last round for this node initiated by us?
     fn is_initiate_round(&self) -> bool {
-        match (self.remote_rounds.back(), self.initiates.back()) {
+        match (self.accepts.back(), self.initiates.back()) {
             (None, None) | (Some(_), None) => false,
             (None, Some(_)) => true,
             (Some(remote), Some(initiate)) => initiate > remote,
@@ -593,24 +754,24 @@ impl std::fmt::Display for Metrics {
         let mut average_completion_frequency = std::time::Duration::default();
         let mut complete_rounds = 0;
         let mut min_complete_rounds = usize::MAX;
-        for (key, info) in &self.nodes {
+        for (key, info) in &self.agent_history {
             let completion_frequency: std::time::Duration =
-                info.complete_rounds.iter().map(|i| i.elapsed()).sum();
+                info.successes.iter().map(|i| i.elapsed()).sum();
             let completion_frequency = completion_frequency
-                .checked_div(info.complete_rounds.len() as u32)
+                .checked_div(info.successes.len() as u32)
                 .unwrap_or_default();
             let last_completion = info
-                .complete_rounds
+                .successes
                 .back()
                 .map(|i| i.elapsed())
                 .unwrap_or_default();
             average_last_completion += last_completion;
             max_last_completion = max_last_completion.max(last_completion);
             average_completion_frequency += completion_frequency;
-            if !info.complete_rounds.is_empty() {
+            if !info.successes.is_empty() {
                 complete_rounds += 1;
             }
-            min_complete_rounds = min_complete_rounds.min(info.complete_rounds.len());
+            min_complete_rounds = min_complete_rounds.min(info.successes.len());
             if trace {
                 write!(f, "\n\t{:?}:", key)?;
                 write!(
@@ -631,16 +792,13 @@ impl std::fmt::Display for Metrics {
                 write!(
                     f,
                     "\n\t\tRemote Rounds: {}, Last: {:?}",
-                    info.remote_rounds.len(),
-                    info.remote_rounds
-                        .back()
-                        .map(|i| i.elapsed())
-                        .unwrap_or_default()
+                    info.accepts.len(),
+                    info.accepts.back().map(|i| i.elapsed()).unwrap_or_default()
                 )?;
                 write!(
                     f,
                     "\n\t\tComplete Rounds: {}, Last: {:?}, Average completion Frequency: {:?}",
-                    info.complete_rounds.len(),
+                    info.successes.len(),
                     last_completion,
                     completion_frequency
                 )?;
@@ -651,14 +809,14 @@ impl std::fmt::Display for Metrics {
             f,
             "\n\tNumber of remote nodes complete {} out of {}. Min per node: {}.",
             complete_rounds,
-            self.nodes.len(),
+            self.agent_history.len(),
             min_complete_rounds
         )?;
         write!(
             f,
             "\n\tAverage time since last completion: {:?}",
             average_last_completion
-                .checked_div(self.nodes.len() as u32)
+                .checked_div(self.agent_history.len() as u32)
                 .unwrap_or_default()
         )?;
         write!(
@@ -670,7 +828,7 @@ impl std::fmt::Display for Metrics {
             f,
             "\n\tAverage completion frequency: {:?}",
             average_completion_frequency
-                .checked_div(self.nodes.len() as u32)
+                .checked_div(self.agent_history.len() as u32)
                 .unwrap_or_default()
         )?;
         write!(f, "\n\tForce Initiate: {}", self.force_initiates)?;

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
@@ -210,7 +210,7 @@ pub struct MetricRecord {
     pub kind: MetricRecordKind,
 
     /// agent associated with this metric (if applicable)
-    pub agent: Option<Arc<super::KitsuneAgent>>,
+    pub agent: Option<KAgent>,
 
     /// timestamp this metric was recorded at
     pub recorded_at_utc: Timestamp,

--- a/crates/kitsune_p2p/types/src/agent_info.rs
+++ b/crates/kitsune_p2p/types/src/agent_info.rs
@@ -259,6 +259,11 @@ impl AgentInfoSigned {
     pub fn to_agent_arc(&self) -> AgentArc {
         (self.agent.clone(), self.storage_arc)
     }
+
+    /// Accessor
+    pub fn agent(&self) -> Arc<KitsuneAgent> {
+        self.agent.clone()
+    }
 }
 
 #[cfg(test)]

--- a/crates/kitsune_p2p/types/src/config.rs
+++ b/crates/kitsune_p2p/types/src/config.rs
@@ -218,7 +218,9 @@ pub mod tuning_params_struct {
         danger_tls_keylog: String = "no_keylog".to_string(),
 
         /// Set the cutoff time when gossip switches over from recent
-        /// to historical gossip. This is dangerous, because gossip may not be
+        /// to historical gossip.
+        ///
+        /// This is dangerous to change, because gossip may not be
         /// possible with nodes using a different setting for this threshold.
         /// Do not change this except in testing environments.
         /// [Default: 15 minutes]


### PR DESCRIPTION
### Summary

Adds new GossipInfo method, which contains info that can be used to display current progress of historical gossip, both incoming and outgoing, per DNA.

Help me name these things better.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
