### PR TITLE
quantum_time modifier

### DIFF
--- a/crates/hc_bundle/tests/test_cli.rs
+++ b/crates/hc_bundle/tests/test_cli.rs
@@ -5,6 +5,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
     str::FromStr,
+    time::Duration,
 };
 
 fn read_app(path: &Path) -> anyhow::Result<AppBundle> {
@@ -186,6 +187,7 @@ async fn test_multi_integrity() {
             network_seed: "00000000-0000-0000-0000-000000000000".into(),
             properties: ().try_into().unwrap(),
             origin_time,
+            quantum_time: Duration::from_secs(5 * 60),
         },
         integrity_zomes: vec![
             (

--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -443,6 +443,7 @@ pub async fn register_dna(cmd: &mut CmdRunner, args: RegisterDna) -> anyhow::Res
             properties,
             network_seed,
             origin_time,
+            quantum_time: None,
         },
         source,
     };

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - BREAKING CHANGE - Update wasmer crate dependency [\#1620](https://github.com/holochain/holochain/pull/1620)
 - Adds GossipInfo app interface method, which returns data about historical gossip progress which can be used to implement a progress bar in app UIs. [\#1649](https://github.com/holochain/holochain/pull/1649)
+- BREAKING CHANGE - Add `quantum_time` as a DNA modifier. The default is set to 5 minutes, which is what it was previously hardcoded to. DNA manifests do not need to be updated, but this will change the DNA hash of all existing DNAs.
 
 ## 0.0.171
 

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -652,6 +652,7 @@ pub mod test {
                     network_seed: network_seed.to_string(),
                     properties: SerializedBytes::try_from(()).unwrap(),
                     origin_time: Timestamp::HOLOCHAIN_EPOCH,
+                    quantum_time: holochain_p2p::dht::spacetime::STANDARD_QUANTUM_TIME,
                 },
                 integrity_zomes: zomes
                     .clone()

--- a/crates/holochain/src/conductor/space/tests.rs
+++ b/crates/holochain/src/conductor/space/tests.rs
@@ -8,6 +8,7 @@ use holochain_conductor_api::conductor::ConductorConfig;
 use holochain_p2p::dht::hash::RegionHash;
 use holochain_p2p::dht::prelude::Dimension;
 use holochain_p2p::dht::region::RegionData;
+use holochain_p2p::dht::spacetime::STANDARD_QUANTUM_TIME;
 use holochain_p2p::dht_arc::DhtArcSet;
 use holochain_types::dht_op::facts::valid_dht_op;
 use holochain_types::dht_op::{DhtOp, DhtOpHashed};
@@ -52,6 +53,7 @@ async fn test_region_queries() {
 
     // - The origin time is five time quanta ago
     dna_def.modifiers.origin_time = five_quanta_ago.clone();
+    dna_def.modifiers.quantum_time = STANDARD_QUANTUM_TIME;
 
     // Cutoff duration is 2 quanta, meaning historic gossip goes up to 1 quantum ago
     let cutoff = Duration::from_micros(q_us * 2);

--- a/crates/holochain/src/core/sys_validate/tests.rs
+++ b/crates/holochain/src/core/sys_validate/tests.rs
@@ -332,6 +332,7 @@ async fn check_app_entry_type_test() {
                 network_seed: "ba1d046d-ce29-4778-914b-47e6010d2faf".to_string(),
                 properties: SerializedBytes::try_from(()).unwrap(),
                 origin_time: Timestamp::HOLOCHAIN_EPOCH,
+                quantum_time: holochain_p2p::dht::spacetime::STANDARD_QUANTUM_TIME,
             },
             integrity_zomes: vec![TestZomes::from(TestWasm::EntryDefs).integrity.into_inner()],
             coordinator_zomes: vec![TestZomes::from(TestWasm::EntryDefs)

--- a/crates/holochain/src/core/workflow/call_zome_workflow/validation_test.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow/validation_test.rs
@@ -28,6 +28,7 @@ async fn direct_validation_test() {
                 network_seed: "ba1d046d-ce29-4778-914b-47e6010d2faf".to_string(),
                 properties: SerializedBytes::try_from(()).unwrap(),
                 origin_time: Timestamp::HOLOCHAIN_EPOCH,
+                quantum_time: holochain_p2p::dht::spacetime::STANDARD_QUANTUM_TIME,
             },
             integrity_zomes: vec![TestZomes::from(TestWasm::Update).integrity.into_inner()],
             coordinator_zomes: vec![TestZomes::from(TestWasm::Update).coordinator.into_inner()],

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -15,6 +15,7 @@ use hdk::prelude::CellId;
 use holo_hash::ActionHash;
 use holo_hash::AgentPubKey;
 use holochain_keystore::AgentPubKeyExt;
+use holochain_p2p::dht::spacetime::STANDARD_QUANTUM_TIME;
 use holochain_serialized_bytes::SerializedBytes;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
@@ -462,6 +463,7 @@ async fn setup(
                 network_seed,
                 properties: SerializedBytes::try_from(()).unwrap(),
                 origin_time: Timestamp::HOLOCHAIN_EPOCH,
+                quantum_time: STANDARD_QUANTUM_TIME,
             },
             integrity_zomes: zomes
                 .clone()

--- a/crates/holochain/src/sweettest/sweet_dna.rs
+++ b/crates/holochain/src/sweettest/sweet_dna.rs
@@ -1,3 +1,4 @@
+use holochain_p2p::dht::spacetime::STANDARD_QUANTUM_TIME;
 use holochain_types::inline_zome::InlineZomeSet;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasmPair;
@@ -62,6 +63,7 @@ impl SweetDnaFile {
                 network_seed,
                 properties: properties.clone(),
                 origin_time: Timestamp::HOLOCHAIN_EPOCH,
+                quantum_time: STANDARD_QUANTUM_TIME,
             })
             .integrity_zomes(iz)
             .coordinator_zomes(cz)

--- a/crates/holochain/src/test_utils/conductor_setup.rs
+++ b/crates/holochain/src/test_utils/conductor_setup.rs
@@ -188,6 +188,7 @@ impl ConductorTestData {
                     network_seed: "ba1d046d-ce29-4778-914b-47e6010d2faf".to_string(),
                     properties: SerializedBytes::try_from(()).unwrap(),
                     origin_time: Timestamp::HOLOCHAIN_EPOCH,
+                    quantum_time: holochain_p2p::dht::spacetime::STANDARD_QUANTUM_TIME,
                 },
                 integrity_zomes: zomes
                     .clone()

--- a/crates/holochain/tests/ser_regression/mod.rs
+++ b/crates/holochain/tests/ser_regression/mod.rs
@@ -47,6 +47,7 @@ async fn ser_regression_test() {
                 network_seed: "ba1d046d-ce29-4778-914b-47e6010d2faf".to_string(),
                 properties: SerializedBytes::try_from(()).unwrap(),
                 origin_time: Timestamp::HOLOCHAIN_EPOCH,
+                quantum_time: holochain_p2p::dht::spacetime::STANDARD_QUANTUM_TIME,
             },
             integrity_zomes: vec![TestZomes::from(TestWasm::SerRegression)
                 .integrity

--- a/crates/holochain/tests/speed_tests/mod.rs
+++ b/crates/holochain/tests/speed_tests/mod.rs
@@ -127,6 +127,7 @@ async fn speed_test(n: Option<usize>) -> Arc<TempDir> {
                 network_seed: "ba1d046d-ce29-4778-914b-47e6010d2faf".to_string(),
                 properties: SerializedBytes::try_from(()).unwrap(),
                 origin_time: Timestamp::HOLOCHAIN_EPOCH,
+                quantum_time: holochain_p2p::dht::spacetime::STANDARD_QUANTUM_TIME,
             },
             integrity_zomes: vec![TestZomes::from(TestWasm::Anchor).integrity.into_inner()],
             coordinator_zomes: vec![TestZomes::from(TestWasm::Anchor).coordinator.into_inner()],

--- a/crates/holochain_types/src/app/app_bundle/tests.rs
+++ b/crates/holochain_types/src/app/app_bundle/tests.rs
@@ -45,6 +45,7 @@ async fn provisioning_1_create() {
         properties: Some(app_manifest_properties_fixture()),
         network_seed: Some("network_seed".into()),
         origin_time: None,
+        quantum_time: None,
     };
     let (bundle, dna) = app_bundle_fixture(modifiers).await;
 

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
@@ -340,6 +340,7 @@ pub mod tests {
             properties: Some(app_manifest_properties_fixture()),
             network_seed: Some("network_seed".into()),
             origin_time: None,
+            quantum_time: None,
         };
         let (manifest, dna_hashes) =
             app_manifest_fixture(location, vec![fixt!(DnaDef), fixt!(DnaDef)], modifiers).await;

--- a/crates/holochain_types/src/dna/dna_bundle.rs
+++ b/crates/holochain_types/src/dna/dna_bundle.rs
@@ -124,6 +124,7 @@ impl DnaBundle {
                             manifest.integrity.properties.clone().unwrap_or_default(),
                         )?,
                         origin_time: manifest.integrity.origin_time.into(),
+                        quantum_time: kitsune_p2p_dht::spacetime::STANDARD_QUANTUM_TIME,
                     },
                     integrity_zomes,
                     coordinator_zomes,

--- a/crates/holochain_types/src/test_utils.rs
+++ b/crates/holochain_types/src/test_utils.rs
@@ -46,6 +46,7 @@ pub fn fake_dna_zomes_named(
                 .unwrap(),
             network_seed: network_seed.to_string(),
             origin_time: Timestamp::HOLOCHAIN_EPOCH,
+            quantum_time: kitsune_p2p_dht::spacetime::STANDARD_QUANTUM_TIME,
         },
         integrity_zomes: Vec::new(),
         coordinator_zomes: Vec::new(),

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -63,7 +63,7 @@ full-dna-def = ["derive_builder", "kitsune_p2p_dht", "nanoid", "shrinkwraprs"]
 
 full = ["default", "rusqlite", "num_enum", "kitsune_p2p_timestamp/full", "properties"]
 
-fixturators = ["fixt", "rand", "strum", "holo_hash/fixturators", "holochain_integrity_types/test_utils"]
+fixturators = ["fixt", "rand", "strum", "holo_hash/fixturators", "holochain_integrity_types/test_utils", "full-dna-def"]
 
 properties = ["serde_yaml"]
 

--- a/crates/holochain_zome_types/src/dna_def.rs
+++ b/crates/holochain_zome_types/src/dna_def.rs
@@ -50,7 +50,7 @@ pub struct DnaModifiers {
     /// The smallest unit of time used for gossip time windows.
     /// You probably don't need to change this.
     #[cfg_attr(feature = "full-dna-def", builder(default = "standard_quantum_time()"))]
-    #[serde(default = "standard_quantum_time")]
+    #[cfg_attr(feature = "full-dna-def", serde(default = "standard_quantum_time"))]
     pub quantum_time: Duration,
 }
 

--- a/crates/holochain_zome_types/src/dna_def.rs
+++ b/crates/holochain_zome_types/src/dna_def.rs
@@ -54,6 +54,7 @@ pub struct DnaModifiers {
     pub quantum_time: Duration,
 }
 
+#[cfg(feature = "full-dna-def")]
 const fn standard_quantum_time() -> Duration {
     kitsune_p2p_dht::spacetime::STANDARD_QUANTUM_TIME
 }

--- a/crates/holochain_zome_types/src/dna_def.rs
+++ b/crates/holochain_zome_types/src/dna_def.rs
@@ -1,5 +1,7 @@
 //! Defines DnaDef struct
 
+use std::time::Duration;
+
 use super::zome;
 use crate::prelude::*;
 
@@ -7,6 +9,9 @@ use crate::prelude::*;
 use crate::zome::error::ZomeError;
 #[cfg(feature = "full-dna-def")]
 use holo_hash::*;
+
+#[cfg(feature = "full-dna-def")]
+use kitsune_p2p_dht::spacetime::Dimension;
 
 /// Ordered list of integrity zomes in this DNA.
 pub type IntegrityZomes = Vec<(ZomeName, zome::IntegrityZomeDef)>;
@@ -41,6 +46,16 @@ pub struct DnaModifiers {
     /// All Action timestamps must come after this time.
     #[cfg_attr(feature = "full-dna-def", builder(default = "Timestamp::now()"))]
     pub origin_time: Timestamp,
+
+    /// The smallest unit of time used for gossip time windows.
+    /// You probably don't need to change this.
+    #[cfg_attr(feature = "full-dna-def", builder(default = "standard_quantum_time()"))]
+    #[serde(default = "standard_quantum_time")]
+    pub quantum_time: Duration,
+}
+
+const fn standard_quantum_time() -> Duration {
+    kitsune_p2p_dht::spacetime::STANDARD_QUANTUM_TIME
 }
 
 impl DnaModifiers {
@@ -50,6 +65,7 @@ impl DnaModifiers {
         self.network_seed = modifiers.network_seed.unwrap_or(self.network_seed);
         self.properties = modifiers.properties.unwrap_or(self.properties);
         self.origin_time = modifiers.origin_time.unwrap_or(self.origin_time);
+        self.quantum_time = modifiers.quantum_time.unwrap_or(self.quantum_time);
         self
     }
 }
@@ -64,6 +80,8 @@ pub struct DnaModifiersOpt<P = SerializedBytes> {
     pub properties: Option<P>,
     /// see [`DnaModifiers`]
     pub origin_time: Option<Timestamp>,
+    /// see [`DnaModifiers`]
+    pub quantum_time: Option<Duration>,
 }
 
 impl<P: TryInto<SerializedBytes, Error = E>, E: Into<SerializedBytesError>> Default
@@ -81,6 +99,7 @@ impl<P: TryInto<SerializedBytes, Error = E>, E: Into<SerializedBytesError>> DnaM
             network_seed: None,
             properties: None,
             origin_time: None,
+            quantum_time: None,
         }
     }
 
@@ -90,6 +109,7 @@ impl<P: TryInto<SerializedBytes, Error = E>, E: Into<SerializedBytesError>> DnaM
             network_seed,
             properties,
             origin_time,
+            quantum_time,
         } = self;
         let properties = if let Some(p) = properties {
             Some(p.try_into()?)
@@ -100,6 +120,7 @@ impl<P: TryInto<SerializedBytes, Error = E>, E: Into<SerializedBytesError>> DnaM
             network_seed,
             properties,
             origin_time,
+            quantum_time,
         })
     }
 
@@ -118,6 +139,12 @@ impl<P: TryInto<SerializedBytes, Error = E>, E: Into<SerializedBytesError>> DnaM
     /// Return a modified form with the `origin_time` field set
     pub fn with_origin_time(mut self, origin_time: Timestamp) -> Self {
         self.origin_time = Some(origin_time);
+        self
+    }
+
+    /// Return a modified form with the `quantum_time` field set
+    pub fn with_quantum_time(mut self, quantum_time: Duration) -> Self {
+        self.quantum_time = Some(quantum_time);
         self
     }
 
@@ -292,7 +319,12 @@ impl DnaDef {
 
     /// Get the topology to use for kitsune gossip
     pub fn topology(&self, cutoff: std::time::Duration) -> kitsune_p2p_dht::spacetime::Topology {
-        kitsune_p2p_dht::spacetime::Topology::standard(self.modifiers.origin_time, cutoff)
+        kitsune_p2p_dht::spacetime::Topology {
+            space: Dimension::standard_space(),
+            time: Dimension::time(self.modifiers.quantum_time),
+            time_origin: self.modifiers.origin_time,
+            time_cutoff: cutoff,
+        }
     }
 }
 
@@ -306,11 +338,12 @@ pub fn random_network_seed() -> String {
 impl DnaDefBuilder {
     /// Provide a random network seed
     pub fn random_network_seed(&mut self) -> &mut Self {
-        self.modifiers = Some(DnaModifiers {
-            network_seed: random_network_seed(),
-            properties: SerializedBytes::try_from(()).unwrap(),
-            origin_time: Timestamp::now(),
-        });
+        self.modifiers = Some(
+            DnaModifiersBuilder::default()
+                .network_seed(random_network_seed())
+                .build()
+                .unwrap(),
+        );
         self
     }
 }
@@ -348,6 +381,7 @@ mod tests {
 
     use super::*;
     use holochain_serialized_bytes::prelude::*;
+    use kitsune_p2p_dht::spacetime::STANDARD_QUANTUM_TIME;
 
     #[test]
     fn test_update_modifiers() {
@@ -361,18 +395,21 @@ mod tests {
             network_seed: "seed".into(),
             properties: ().try_into().unwrap(),
             origin_time: Timestamp::HOLOCHAIN_EPOCH,
+            quantum_time: STANDARD_QUANTUM_TIME,
         };
 
         let opt = DnaModifiersOpt {
             network_seed: None,
             properties: Some(props.clone()),
             origin_time: Some(now),
+            quantum_time: Some(Duration::from_secs(60)),
         };
 
         let expected = DnaModifiers {
             network_seed: "seed".into(),
             properties: props.clone(),
             origin_time: now,
+            quantum_time: Duration::from_secs(60),
         };
 
         assert_eq!(mods.update(opt), expected);

--- a/crates/holochain_zome_types/src/fixt.rs
+++ b/crates/holochain_zome_types/src/fixt.rs
@@ -740,6 +740,7 @@ fixturator!(
                 .next()
                 .unwrap(),
             origin_time: Timestamp::HOLOCHAIN_EPOCH,
+            quantum_time: kitsune_p2p_dht::spacetime::STANDARD_QUANTUM_TIME,
         },
         integrity_zomes: IntegrityZomesFixturator::new_indexed(Empty, get_fixt_index!())
             .next()
@@ -761,6 +762,7 @@ fixturator!(
                 .next()
                 .unwrap(),
             origin_time: Timestamp::HOLOCHAIN_EPOCH,
+            quantum_time: kitsune_p2p_dht::spacetime::STANDARD_QUANTUM_TIME,
         },
         integrity_zomes: IntegrityZomesFixturator::new_indexed(Unpredictable, get_fixt_index!())
             .next()
@@ -782,6 +784,7 @@ fixturator!(
                 .next()
                 .unwrap(),
             origin_time: Timestamp::HOLOCHAIN_EPOCH,
+            quantum_time: kitsune_p2p_dht::spacetime::STANDARD_QUANTUM_TIME,
         },
         integrity_zomes: IntegrityZomesFixturator::new_indexed(Predictable, get_fixt_index!())
             .next()

--- a/crates/kitsune_p2p/dht/src/spacetime/topology.rs
+++ b/crates/kitsune_p2p/dht/src/spacetime/topology.rs
@@ -231,3 +231,13 @@ impl GossipParams {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_quantum_time() {
+        assert_eq!(Dimension::standard_time(), Dimension::time(STANDARD_QUANTUM_TIME));
+    }
+}

--- a/crates/kitsune_p2p/dht/src/spacetime/topology.rs
+++ b/crates/kitsune_p2p/dht/src/spacetime/topology.rs
@@ -238,6 +238,9 @@ mod tests {
 
     #[test]
     fn custom_quantum_time() {
-        assert_eq!(Dimension::standard_time(), Dimension::time(STANDARD_QUANTUM_TIME));
+        assert_eq!(
+            Dimension::standard_time(),
+            Dimension::time(STANDARD_QUANTUM_TIME)
+        );
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip.rs
@@ -1,4 +1,24 @@
-//! Various gossip strategies for kitsune
+//! Various gossip strategies for Kitsune.
+//!
+//! Gossip is one of the main methods for nodes to exchange data in a Kitsune network.
+//! During a gossip round, there are two things gossiped about:
+//! info about other Agents in the network, and Ops, which are opaque chunks of data
+//! used by the user of Kitsune.
+//!
+//! There are two types of gossip, Recent and Historical.
+//!
+//! Recent gossip is covers the last N minutes (currently N =  5) of Op activity. It uses bloom filters
+//! to convey which ops are held and to discover which ops need to be transmitted during this round.
+//! It is "pessimistic" in that we *a priori* expect our gossip partner to have different ops than we do.
+//! Recent gossip is also solely responsible for gossiping info about other Agents, which it does using
+//! the same method of employing bloom filters.
+//!
+//! Historical gossip is for everything else, namely for Ops which were created more than N minutes ago.
+//! It is "optimistic" in that it expects ops to be mostly the same between nodes. Rather than bloom
+//! filters, it uses a novel method of splitting the possible hash space into a number of regions with
+//! deterministic hashes associated with each based on the contents, which are sent to the gossip partner.
+//! For regions which mismatch, the ops in those regions will be exchanged between partners. For regions
+//! which match, no data will be transferred.
 
 pub mod sharded_gossip;
 

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -47,6 +47,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +75,26 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "autocfg"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
+dependencies = [
+ "autocfg 1.1.0",
+]
 
 [[package]]
 name = "autocfg"
@@ -201,6 +230,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,7 +264,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9847f90f32a50b0dcbd68bc23ff242798b13080b97b0569f6ed96a45ce4cf2cd"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "cfg-if 1.0.0",
  "libc",
  "scopeguard",
@@ -326,7 +366,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "cfg-if 1.0.0",
  "crossbeam-utils",
  "memoffset",
@@ -342,6 +382,16 @@ checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if 1.0.0",
  "once_cell",
+]
+
+[[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core 0.10.2",
+ "darling_macro 0.10.2",
 ]
 
 [[package]]
@@ -362,6 +412,20 @@ checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
 dependencies = [
  "darling_core 0.14.1",
  "darling_macro 0.14.1",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.9.3",
+ "syn",
 ]
 
 [[package]]
@@ -387,7 +451,18 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core 0.10.2",
+ "quote",
  "syn",
 ]
 
@@ -414,11 +489,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9a577516173adb681466d517d39bd468293bc2c2a16439375ef0f35bba45f3d"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
+dependencies = [
+ "darling 0.10.2",
+ "derive_builder_core",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
+dependencies = [
+ "darling 0.10.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -519,8 +630,8 @@ dependencies = [
  "lazy_static",
  "parking_lot 0.10.2",
  "paste",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.3",
  "serde",
  "strum",
  "strum_macros",
@@ -546,6 +657,12 @@ name = "fragile"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -773,7 +890,7 @@ dependencies = [
  "holochain_serialized_bytes",
  "kitsune_p2p_dht_arc",
  "must_future",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_bytes",
  "thiserror",
@@ -866,17 +983,21 @@ dependencies = [
 name = "holochain_zome_types"
 version = "0.0.54"
 dependencies = [
+ "derive_builder",
  "fixt",
  "holo_hash",
  "holochain_integrity_types",
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
+ "kitsune_p2p_dht",
  "kitsune_p2p_timestamp",
+ "nanoid",
  "paste",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_bytes",
  "serde_yaml",
+ "shrinkwraprs",
  "strum",
  "subtle",
  "thiserror",
@@ -908,7 +1029,7 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "hashbrown 0.12.3",
  "serde",
 ]
@@ -937,6 +1058,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
@@ -957,6 +1087,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kitsune_p2p_dht"
+version = "0.0.9"
+dependencies = [
+ "colored",
+ "derivative",
+ "derive_more",
+ "futures",
+ "gcollections",
+ "intervallum",
+ "kitsune_p2p_dht_arc",
+ "kitsune_p2p_timestamp",
+ "must_future",
+ "num-traits",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "statrs",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
@@ -1009,6 +1161,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1029,7 +1187,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "scopeguard",
 ]
 
@@ -1073,6 +1231,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+dependencies = [
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,7 +1260,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -1149,10 +1316,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "462fffe4002f4f2e1f6a9dcf12cc1a6fc0e15989014efc02a941d3e0f5dc2120"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_distr",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "nanoid"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6226bc4e142124cb44e309a37a04cd9bb10e740d8642855441d3b14808f635e"
+dependencies = [
+ "rand 0.6.5",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "num-complex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-integer"
@@ -1160,7 +1374,18 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg 1.1.0",
+ "num-integer",
  "num-traits",
 ]
 
@@ -1170,7 +1395,8 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
+ "libm",
 ]
 
 [[package]]
@@ -1289,7 +1515,7 @@ checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
  "float-cmp",
- "itertools",
+ "itertools 0.10.3",
  "normalize-line-endings",
  "predicates-core",
  "regex",
@@ -1375,13 +1601,42 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
+dependencies = [
+ "autocfg 0.1.8",
+ "libc",
+ "rand_chacha 0.1.1",
+ "rand_core 0.4.2",
+ "rand_hc",
+ "rand_isaac",
+ "rand_jitter",
+ "rand_os",
+ "rand_pcg",
+ "rand_xorshift",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1391,8 +1646,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -1404,12 +1674,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_isaac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_jitter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
+dependencies = [
+ "libc",
+ "rand_core 0.4.2",
+ "winapi",
+]
+
+[[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
+dependencies = [
+ "autocfg 0.1.8",
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+dependencies = [
+ "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "rayon"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -1425,6 +1773,15 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1661,12 +2018,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "shrinkwraprs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63e6744142336dfb606fe2b068afa2e1cca1ee6a5d8377277a92945d81fa331"
+dependencies = [
+ "bitflags",
+ "itertools 0.8.2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "simba"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e82063457853d00243beda9952e910b82593e4b07ae9f721b9278a99a0d3d5c"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
- "autocfg",
+ "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -1680,6 +2062,25 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "statrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05bdbb8e4e78216a85785a85d3ec3183144f98d0097b9281802c019bb07a6f05"
+dependencies = [
+ "approx",
+ "lazy_static",
+ "nalgebra",
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "strsim"
@@ -2033,7 +2434,7 @@ version = "0.0.1"
 dependencies = [
  "fixt",
  "hdk",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -2245,6 +2646,12 @@ name = "trilean"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683ba5022fe6dbd7133cad150478ccf51bdb6d861515181e5fc6b4323d4fa424"
+
+[[package]]
+name = "typenum"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-ident"


### PR DESCRIPTION
### Summary

Adds quantum_time to the set of DNA modifiers.

Not strictly necessary, but I found it useful for testing quantized gossip in real world situations, to be able to have data fit into different time chunks at a more rapid pace. 

This uses the default value of 5 minutes. It is a breaking change in that this will change everyone's DNA hash, but it does not require any modification to the DNA itself.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
