### PR TITLE
Remove Kitsune `rpc_multi`

### DIFF
--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -488,7 +488,7 @@ mod tests {
             .unwrap();
 
         tracing::info!("test - check res");
-        assert_eq!(2, res.len());
+        assert_eq!(1, res.len());
 
         for r in res {
             assert!(r == test_1 || r == test_2);
@@ -576,7 +576,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(2, res.len());
+        assert_eq!(1, res.len());
 
         for r in res {
             assert_eq!(r, test_1);

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- `rpc_multi` now only actually makes a single request. This greatly simplifies the code path and eliminates a source of network bandwidth congestion, but removes the redundancy of aggregating the results of multiple peers. [\#1651](https://github.com/holochain/holochain/pull/1651)
+
 ## 0.0.50
 
 ## 0.0.49

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic.rs
@@ -1,486 +1,158 @@
 use super::*;
 use futures::future::BoxFuture;
-use kitsune_p2p_types::agent_info::AgentInfoSigned;
-use kitsune_p2p_types::reverse_semaphore::*;
-use kitsune_p2p_types::task_agg::TaskAgg;
-use kitsune_p2p_types::tx2::tx2_utils::*;
-use std::future::Future;
-use tokio::sync::Notify;
 
 pub(crate) async fn handle_rpc_multi(
     input: actor::RpcMulti,
     ro_inner: Arc<SpaceReadOnlyInner>,
     local_joined_agents: HashSet<Arc<KitsuneAgent>>,
 ) -> KitsuneP2pResult<Vec<actor::RpcMultiResponse>> {
-    let (driver, agg) = TaskAgg::new();
-
-    let out = Outer::new(input, ro_inner, local_joined_agents, agg);
-
-    driver.await;
-
-    Ok(out.finish())
+    handle_rpc_multi_as_single(input, ro_inner, local_joined_agents).await
 }
 
-struct Inner {
-    response: Vec<actor::RpcMultiResponse>,
-    remain_remote_count: u8,
-    already_tried: HashSet<Arc<KitsuneAgent>>,
-}
-
-fn check_already_tried(inner: &mut Inner, agent: &Arc<KitsuneAgent>) -> bool {
-    if inner.already_tried.contains(agent) {
-        true
-    } else {
-        inner.already_tried.insert(agent.clone());
-        false
-    }
-}
-
-fn check_local_agent(inner: &Share<Inner>, agent: &Arc<KitsuneAgent>) -> bool {
-    inner
-        .share_mut(|i, _| Ok(check_already_tried(i, agent)))
-        .expect("we never close this share")
-}
-
-fn check_remote_agent(inner: &Share<Inner>, agent: &Arc<KitsuneAgent>) -> bool {
-    inner
-        .share_mut(|i, _| {
-            if i.remain_remote_count == 0 || check_already_tried(i, agent) {
-                Ok(true)
-            } else {
-                i.remain_remote_count -= 1;
-                Ok(false)
-            }
-        })
-        .expect("we never close this share")
-}
-
-struct Outer {
-    inner: Share<Inner>,
+pub(crate) async fn handle_rpc_multi_as_single(
+    input: actor::RpcMulti,
     ro_inner: Arc<SpaceReadOnlyInner>,
-    agg: TaskAgg,
-    kill: Arc<Kill>,
-    got_data: Arc<Notify>,
-    grace_rs: ReverseSemaphore,
-    remote_request_grace_ms: u64,
-    max_timeout: KitsuneTimeout,
-    space: Arc<KitsuneSpace>,
-    basis: Arc<KitsuneBasis>,
-    payload: Vec<u8>,
-}
+    local_joined_agents: HashSet<Arc<KitsuneAgent>>,
+) -> KitsuneP2pResult<Vec<actor::RpcMultiResponse>> {
+    let RpcMulti {
+        space,
+        basis,
+        payload,
+        max_timeout,
+        ..
+    } = input;
 
-struct Kill {
-    closed: AtomicBool,
-    kill: Notify,
-}
+    let ro_inner = &ro_inner;
+    let space = &space;
+    let payload = &payload;
 
-impl Kill {
-    fn new() -> Arc<Self> {
-        Arc::new(Self {
-            closed: AtomicBool::new(false),
-            kill: Notify::new(),
-        })
-    }
-    fn kill_all(&self) {
-        self.closed
-            .store(true, std::sync::atomic::Ordering::Release);
-        self.kill.notify_waiters();
-    }
-    async fn wait(&self) {
-        if !self.closed.load(std::sync::atomic::Ordering::Acquire) {
-            self.kill.notified().await;
+    let make_req = move |con_hnd: Tx2ConHnd<crate::wire::Wire>,
+                         agent: Arc<KitsuneAgent>|
+          -> BoxFuture<'_, KitsuneP2pResult<Vec<actor::RpcMultiResponse>>> {
+        async move {
+            let msg = wire::Wire::call(space.clone(), agent.clone(), payload.clone().into());
+
+            let start = tokio::time::Instant::now();
+
+            let res = con_hnd.request(&msg, max_timeout).await;
+
+            match res {
+                Ok(wire::Wire::CallResp(c)) => {
+                    ro_inner
+                        .metrics
+                        .write()
+                        .record_reachability_event(true, [&agent]);
+                    ro_inner
+                        .metrics
+                        .write()
+                        .record_latency_micros(start.elapsed().as_micros(), [&agent]);
+                    Ok(vec![RpcMultiResponse {
+                        agent: agent.clone(),
+                        response: c.data.into(),
+                    }])
+                }
+                oth => {
+                    ro_inner
+                        .metrics
+                        .write()
+                        .record_reachability_event(false, [&agent]);
+                    ro_inner
+                        .metrics
+                        .write()
+                        .record_latency_micros(start.elapsed().as_micros(), [&agent]);
+                    tracing::warn!(?oth, "unexpected remote call result");
+                    Err("rpc_multi failed to get results".into())
+                }
+            }
         }
-    }
-}
+        .boxed()
+    };
 
-impl Outer {
-    /// construct a new container for this rpc_multi logic
-    fn new(
-        input: actor::RpcMulti,
-        ro_inner: Arc<SpaceReadOnlyInner>,
-        local_joined_agents: HashSet<Arc<KitsuneAgent>>,
-        agg: TaskAgg,
-    ) -> Self {
-        let RpcMulti {
-            space,
-            basis,
-            payload,
-            max_remote_agent_count,
-            max_timeout,
-            remote_request_grace_ms,
-        } = input;
+    max_timeout
+        .mix("rpc_multi", async move {
+            for _ in 0..2 {
+                let mut infos = None;
 
-        let grace_rs = ReverseSemaphore::new();
-        let local_start_permit = grace_rs.acquire();
-        let remote_start_permit = grace_rs.acquire();
-
-        let out = Self {
-            inner: Share::new(Inner {
-                response: Vec::new(),
-                remain_remote_count: max_remote_agent_count,
-                already_tried: HashSet::new(),
-            }),
-            ro_inner,
-            agg,
-            kill: Kill::new(),
-            got_data: Arc::new(Notify::new()),
-            grace_rs,
-            remote_request_grace_ms,
-            max_timeout,
-            space,
-            basis,
-            payload,
-        };
-
-        out.add_max_timeout_task(max_timeout);
-        out.add_data_and_grace_timeout_task();
-        out.add_local_fetch_task(local_start_permit, local_joined_agents);
-        out.add_remote_fetch_task(remote_start_permit);
-
-        out
-    }
-
-    /// consume this logic container, returning the results
-    fn finish(self) -> Vec<actor::RpcMultiResponse> {
-        let Self { inner, .. } = self;
-
-        inner
-            .share_mut(|i, _| Ok(i.response.drain(..).collect()))
-            .expect("we never close this share")
-    }
-
-    /// add a task that will be dropped if `kill` is notified.
-    fn add_task<F>(&self, f: F)
-    where
-        F: Future<Output = ()> + 'static + Send,
-    {
-        let f = f.boxed();
-        let kill = self.kill.clone();
-        self.agg.push(
-            async move {
-                // ignore the result,
-                // either we got a unit value `()` from the driver
-                // or we got a notification from the kill Notify
-                // either way, we don't want to process any more.
-                let _ = futures::future::select(f, kill.wait().boxed()).await;
-            }
-            .boxed(),
-        )
-    }
-
-    /// generate a closure that will
-    /// add a task that will be dropped if `kill` is notified.
-    ///
-    /// Unlike `add_task` this task will be executed in a proper tokio task.
-    /// this is needed for requests that might make calls on conductor
-    /// becasue conductor has some `block_in_place` calls esp around wasm
-    /// that can cause all our other pseudo-tasks managed in a single future
-    /// to be cpu starved, especially around timing concerns.
-    ///
-    /// Once the `block_in_place` calls are removed from conductor,
-    /// we can remove this specialization.
-    fn gen_add_tokio_task_fn(&self) -> Arc<dyn Fn(BoxFuture<'static, ()>) + 'static + Send + Sync> {
-        let kill = self.kill.clone();
-        Arc::new(move |f| {
-            let kill = kill.clone();
-            tokio::task::spawn(async move {
-                // ignore the result,
-                // either we got a unit value `()` from the driver
-                // or we got a notification from the kill Notify
-                // either way, we don't want to process any more.
-                let _ = futures::future::select(f, kill.wait().boxed()).await;
-            });
-        })
-    }
-
-    /// stop all processing if/when we reach our max timeout.
-    fn add_max_timeout_task(&self, max_timeout: KitsuneTimeout) {
-        let kill = self.kill.clone();
-
-        self.add_task(async move {
-            // wait the max timeout
-            tokio::time::sleep(max_timeout.time_remaining()).await;
-
-            // end all processing
-            kill.kill_all();
-
-            tracing::trace!("(rpc_multi_logic) max time elapsed");
-        });
-    }
-
-    /// once we have any data, wait for any grace period timeouts,
-    /// then allow our processing to die, and return what results we have.
-    fn add_data_and_grace_timeout_task(&self) {
-        let kill = self.kill.clone();
-        let got_data = self.got_data.clone();
-        let grace_rs = self.grace_rs.clone();
-
-        self.add_task(async move {
-            tracing::trace!("(rpc_multi_logic) grace time check start");
-
-            // wait to have any data
-            got_data.notified().await;
-            tracing::trace!("(rpc_multi_logic) grace time got data");
-
-            // wait for any pending grace permits
-            grace_rs.wait_on_zero_permits().await;
-            tracing::trace!("(rpc_multi_logic) grace time zero permits");
-
-            // end all processing
-            kill.kill_all();
-
-            tracing::trace!("(rpc_multi_logic) grace time elapsed");
-        });
-    }
-
-    /// generate a closure that will in-turn generate a grace permit
-    fn gen_grace_permit_fn(
-        &self,
-    ) -> Arc<dyn Fn() -> Share<ReverseSemaphorePermit> + 'static + Send + Sync> {
-        let remote_request_grace_ms = self.remote_request_grace_ms;
-        let agg = self.agg.clone();
-        let grace_rs = self.grace_rs.clone();
-        let kill = self.kill.clone();
-        Arc::new(move || {
-            let permit = Share::new(grace_rs.acquire());
-            let permit2 = permit.clone();
-            let kill = kill.clone();
-
-            // the permit will exist for max grace period
-            agg.push(
-                async move {
-                    let f = tokio::time::sleep(std::time::Duration::from_millis(
-                        remote_request_grace_ms,
-                    ))
-                    .boxed();
-                    // This select is safe because we don't care if the timeout
-                    // or the kill notifier get cancelled.
-                    let _ = futures::future::select(f, kill.wait().boxed()).await;
-                    permit2.close();
-                }
-                .boxed(),
-            );
-
-            // return so the permit can also be closed at the end of a call
-            permit
-        })
-    }
-
-    /// generate a closure that will in-turn report rpc_multi results (response)
-    fn gen_report_results_fn(&self) -> Arc<dyn Fn(RpcMultiResponse) + 'static + Send + Sync> {
-        let inner = self.inner.clone();
-        let got_data = self.got_data.clone();
-        Arc::new(move |resp| {
-            // store the results in our inner data structure
-            inner
-                .share_mut(move |i, _| {
-                    i.response.push(resp);
-                    Ok(())
-                })
-                .expect("we never close this share");
-
-            // notify tasks that we have received data
-            got_data.notify_waiters();
-        })
-    }
-
-    /// generate a closure that will in-turn make a local "call" to conductor
-    fn gen_local_call_fn(
-        &self,
-    ) -> Arc<dyn Fn(Arc<KitsuneAgent>, Share<ReverseSemaphorePermit>) + 'static + Send + Sync> {
-        let add_tokio_task = self.gen_add_tokio_task_fn();
-        let report_results = self.gen_report_results_fn();
-        let evt_sender = self.ro_inner.evt_sender.clone();
-
-        let space = self.space.clone();
-        let payload = self.payload.clone();
-
-        Arc::new(move |to_agent, permit| {
-            let report_results = report_results.clone();
-            let fut = evt_sender.call(space.clone(), to_agent.clone(), payload.clone());
-
-            // see add_tokio_task vs add_task
-            add_tokio_task(
-                async move {
-                    match fut.await {
-                        Ok(res) => {
-                            report_results(RpcMultiResponse {
-                                agent: to_agent,
-                                response: res,
-                            });
-                        }
-                        Err(err) => {
-                            tracing::warn!(?err, "local call error");
-                        }
-                    }
-
-                    permit.close();
-                }
-                .boxed(),
-            );
-        })
-    }
-
-    /// generate a closure that will in-turn make a remote "call" to agent
-    fn gen_remote_call_fn(
-        &self,
-    ) -> Arc<dyn Fn(AgentInfoSigned, Share<ReverseSemaphorePermit>) + 'static + Send + Sync> {
-        let add_tokio_task = self.gen_add_tokio_task_fn();
-        let report_results = self.gen_report_results_fn();
-
-        let ro_inner = self.ro_inner.clone();
-        let space = self.space.clone();
-        let payload = self.payload.clone();
-        let max_timeout = self.max_timeout;
-
-        Arc::new(move |info, permit| {
-            let report_results = report_results.clone();
-            let ro_inner = ro_inner.clone();
-            let space = space.clone();
-            let payload = payload.clone();
-
-            add_tokio_task(
-                async move {
-                    use discover::PeerDiscoverResult;
-
-                    let con_hnd =
-                        match discover::peer_connect(ro_inner.clone(), &info, max_timeout).await {
-                            PeerDiscoverResult::OkShortcut => {
-                                tracing::trace!("remote peer is local");
-                                permit.close();
-                                return;
-                            }
-                            PeerDiscoverResult::Err(err) => {
-                                tracing::warn!(?err, "remote call error");
-                                permit.close();
-                                return;
-                            }
-                            PeerDiscoverResult::OkRemote { con_hnd, .. } => con_hnd,
-                        };
-
-                    let msg = wire::Wire::call(space, info.agent.clone(), payload.into());
-
-                    let start = tokio::time::Instant::now();
-
-                    let res = con_hnd.request(&msg, max_timeout).await;
-
-                    match res {
-                        Ok(wire::Wire::CallResp(c)) => {
-                            ro_inner
-                                .metrics
-                                .write()
-                                .record_reachability_event(true, [&info.agent]);
-                            ro_inner
-                                .metrics
-                                .write()
-                                .record_latency_micros(start.elapsed().as_micros(), [&info.agent]);
-                            report_results(RpcMultiResponse {
-                                agent: info.agent.clone(),
-                                response: c.data.into(),
-                            });
-                        }
-                        oth => {
-                            ro_inner
-                                .metrics
-                                .write()
-                                .record_reachability_event(false, [&info.agent]);
-                            ro_inner
-                                .metrics
-                                .write()
-                                .record_latency_micros(start.elapsed().as_micros(), [&info.agent]);
-                            tracing::warn!(?oth, "unexpected remote call result");
-                        }
-                    }
-
-                    permit.close();
-                }
-                .boxed(),
-            );
-        })
-    }
-
-    /// fetch results from any matching local agents
-    fn add_local_fetch_task(
-        &self,
-        startup_permit: ReverseSemaphorePermit,
-        local_joined_agents: HashSet<Arc<KitsuneAgent>>,
-    ) {
-        let inner = self.inner.clone();
-        let grace_permit = self.gen_grace_permit_fn();
-        let local_call = self.gen_local_call_fn();
-
-        self.add_task(async move {
-            let _startup_permit = startup_permit;
-
-            let agent_count = local_joined_agents.len();
-            tracing::trace!(%agent_count, "(rpc_multi_logic) local get start");
-
-            for agent in local_joined_agents {
-                if check_local_agent(&inner, &agent) {
-                    continue;
-                }
-
-                // get a new permit for this call
-                let permit = grace_permit();
-
-                local_call(agent, permit);
-            }
-
-            tracing::trace!("(rpc_multi_logic) local get done");
-        });
-    }
-
-    /// fetch results from discovered remote nodes
-    fn add_remote_fetch_task(&self, startup_permit: ReverseSemaphorePermit) {
-        let inner = self.inner.clone();
-        let ro_inner = self.ro_inner.clone();
-        let basis = self.basis.clone();
-        let max_timeout = self.max_timeout;
-        let grace_permit = self.gen_grace_permit_fn();
-        let add_tokio_task = self.gen_add_tokio_task_fn();
-        let remote_call = self.gen_remote_call_fn();
-
-        // see add_tokio_task vs add_task
-        add_tokio_task(
-            async move {
-                let first_discover_permit = grace_permit();
-                drop(startup_permit);
-
-                tracing::trace!("(rpc_multi_logic) remote get searched start");
-
-                // if we still have requests to send, let's discover new nodes
-                if let Ok(infos) = discover::search_remotes_covering_basis(
+                if let Ok(i) = discover::get_cached_remotes_near_basis(
                     ro_inner.clone(),
                     basis.get_loc(),
                     max_timeout,
                 )
                 .await
                 {
-                    let searched_remote_count = infos.len();
-                    tracing::trace!(
-                        %searched_remote_count,
-                        "(rpc_multi_logic) remote get searched",
-                    );
-
-                    for info in infos {
-                        if check_remote_agent(&inner, &info.agent) {
-                            continue;
-                        }
-
-                        let permit = grace_permit();
-                        remote_call(info, permit);
+                    if !i.is_empty() {
+                        infos = Some(i);
                     }
                 }
 
-                first_discover_permit.close();
+                if infos.is_none() {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-                tracing::trace!("(rpc_multi_logic) remote get done");
+                    if let Ok(i) = discover::get_cached_remotes_near_basis(
+                        ro_inner.clone(),
+                        basis.get_loc(),
+                        max_timeout,
+                    )
+                    .await
+                    {
+                        if !i.is_empty() {
+                            infos = Some(i);
+                        }
+                    }
+                }
+
+                if let Some(mut infos) = infos {
+                    rand::seq::SliceRandom::shuffle(infos.as_mut_slice(), &mut rand::thread_rng());
+
+                    for info in infos {
+                        use discover::PeerDiscoverResult;
+
+                        let con_hnd = match discover::peer_connect(
+                            ro_inner.clone(),
+                            &info,
+                            max_timeout,
+                        )
+                        .await
+                        {
+                            PeerDiscoverResult::OkShortcut => {
+                                tracing::trace!("remote peer is local");
+                                continue;
+                            }
+                            PeerDiscoverResult::Err(err) => {
+                                tracing::warn!(?err, "remote call error");
+                                continue;
+                            }
+                            PeerDiscoverResult::OkRemote { con_hnd, .. } => con_hnd,
+                        };
+
+                        match make_req(con_hnd, info.agent.clone()).await {
+                            Ok(res) => return Ok(res),
+                            _ => continue,
+                        }
+                    }
+                }
             }
-            .boxed(),
-        );
-    }
-}
 
-#[cfg(test)]
-#[cfg(feature = "test_utils")]
-mod test;
+            // fall back to self-get
+            for agent in local_joined_agents {
+                match ro_inner
+                    .evt_sender
+                    .call(space.clone(), agent.clone(), payload.clone())
+                    .await
+                {
+                    Ok(response) => {
+                        return Ok(vec![RpcMultiResponse { agent, response }]);
+                    }
+                    Err(err) => {
+                        tracing::warn!(?err, "local call error");
+                        continue;
+                    }
+                }
+            }
+
+            // finally, return an error
+            Err("rpc_multi failed to get results".into())
+        })
+        .await
+        .map_err(|err| err.into())
+}

--- a/crates/kitsune_p2p/kitsune_p2p/src/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test.rs
@@ -138,12 +138,12 @@ mod tests {
             b"test-multi-request".to_vec(),
         );
         input.max_remote_agent_count = 2;
-        input.max_timeout = kitsune_p2p_types::KitsuneTimeout::from_millis(20);
+        input.max_timeout = kitsune_p2p_types::KitsuneTimeout::from_millis(2000);
         let res = p2p.rpc_multi(input).await.unwrap();
 
         harness.ghost_actor_shutdown().await?;
 
-        assert_eq!(3, res.len());
+        assert_eq!(1, res.len());
         for r in res {
             let data = String::from_utf8_lossy(&r.response);
             assert_eq!("echo: test-multi-request", &data);
@@ -169,7 +169,7 @@ mod tests {
             b"test-multi-request".to_vec(),
         );
         input.max_remote_agent_count = 1;
-        input.max_timeout = kitsune_p2p_types::KitsuneTimeout::from_millis(20);
+        input.max_timeout = kitsune_p2p_types::KitsuneTimeout::from_millis(2000);
         let res = p2p.rpc_multi(input).await.unwrap();
 
         assert_eq!(1, res.len());

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/actor.rs
@@ -98,6 +98,9 @@ ghost_actor::ghost_chan! {
 
         /// Make a request to multiple destination agents - awaiting/aggregating the responses.
         /// The remote sides will see these messages as "Call" events.
+        /// NOTE: We've currently disabled the "multi" part of this.
+        /// It will still pick appropriate peers by basis, but will only
+        /// make requests one at a time, returning the first success.
         fn rpc_multi(input: RpcMulti) -> Vec<RpcMultiResponse>;
 
         /// Publish data to a "neighborhood" of remote nodes surrounding the


### PR DESCRIPTION
### Summary

Don't treat this PR as a foregone conclusion.

This PR exchanges redundancy, in the sense of making get calls to multiple remotes, for clarity in a code maintenance sense, logging, and individual call results.

Greatly simplifying gets down to making a single request should be far superior from a gossip / dependency validation standpoint, as it removes a source of network bandwidth overload, and if we fail a single instant, we'll just try again at the appropriate time frame.

For me, the open question here is how this will affect zome code. Are hApps depending on the redundancy to function? How difficult is it UI-wise to tolerate get errors by trying again?

Another way to phrase this question might be: Does anybody use gets outside of validation code? If hApps mostly do gets / get_links / etc only in validation code, it will just try again later per the design and this PR should probably be merged.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
