### PR TITLE
Lockable regions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2965,6 +2965,7 @@ dependencies = [
  "gcollections",
  "holochain_serialized_bytes",
  "intervallum",
+ "itertools 0.10.3",
  "kitsune_p2p_dht",
  "kitsune_p2p_dht_arc",
  "kitsune_p2p_timestamp",

--- a/crates/holochain/src/conductor/kitsune_host_impl/query_region_set.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl/query_region_set.rs
@@ -1,6 +1,9 @@
-use std::sync::{
-    atomic::{AtomicI64, Ordering},
-    Arc,
+use std::{
+    collections::HashSet,
+    sync::{
+        atomic::{AtomicI64, Ordering},
+        Arc,
+    },
 };
 
 use holochain_p2p::{dht::prelude::*, dht_arc::DhtArcSet};
@@ -18,6 +21,7 @@ pub async fn query_region_set(
     topology: Topology,
     strat: &ArqStrat,
     dht_arc_set: Arc<DhtArcSet>,
+    locked_regions: HashSet<RegionCoords>,
 ) -> ConductorResult<RegionSetLtcs> {
     let (arq_set, rounded) = ArqBoundsSet::from_dht_arc_set_rounded(&topology, strat, &dht_arc_set);
     if rounded {
@@ -53,8 +57,9 @@ pub async fn query_region_set(
         .async_reader(move |txn| {
             let sql = holochain_sqlite::sql::sql_cell::FETCH_OP_REGION;
             let mut stmt = txn.prepare_cached(sql).map_err(DatabaseError::from)?;
-            let regions = coords
-                .into_region_set(|(_, coords)| query_region_data(&mut stmt, &topology, coords))?;
+            let regions = coords.into_region_set(locked_regions, |(_, coords)| {
+                query_region_data(&mut stmt, &topology, coords)
+            })?;
             DatabaseResult::Ok(regions)
         })
         .await?;
@@ -113,11 +118,20 @@ mod tests {
         let strat = ArqStrat::default();
         let arcset = Arc::new(DhtArcSet::Full);
 
-        let regions_empty = query_region_set(db.to_db(), topo.clone(), &strat, arcset.clone())
-            .await
-            .unwrap();
+        let regions_empty = query_region_set(
+            db.to_db(),
+            topo.clone(),
+            &strat,
+            arcset.clone(),
+            Default::default(),
+        )
+        .await
+        .unwrap();
         {
-            let sum: RegionData = regions_empty.regions().map(|r| r.data).sum();
+            let sum: RegionData = regions_empty
+                .regions()
+                .map(|r| r.data.into_option().unwrap())
+                .sum();
             assert_eq!(sum.count, 0);
             assert_eq!(sum.size, 0);
         }
@@ -158,13 +172,16 @@ mod tests {
         })
         .unwrap();
 
-        let regions = query_region_set(db.to_db(), topo, &strat, arcset)
+        let regions = query_region_set(db.to_db(), topo, &strat, arcset, Default::default())
             .await
             .unwrap();
 
         let diff = regions.diff(regions_empty).unwrap().ours;
         {
-            let sum: RegionData = diff.into_iter().map(|r| r.data).sum();
+            let sum: RegionData = diff
+                .into_iter()
+                .map(|r| r.data.into_option().unwrap())
+                .sum();
             assert_eq!(sum.count, num as u32);
             // 32 bytes is "close enough"
             assert!(wire_bytes as u32 - sum.size < 32 * num as u32);

--- a/crates/holochain/src/conductor/kitsune_host_impl/query_region_set.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl/query_region_set.rs
@@ -162,7 +162,7 @@ mod tests {
             .await
             .unwrap();
 
-        let diff = regions.diff(regions_empty).unwrap();
+        let diff = regions.diff(regions_empty).unwrap().ours;
         {
             let sum: RegionData = diff.into_iter().map(|r| r.data).sum();
             assert_eq!(sum.count, num as u32);

--- a/crates/holochain/src/conductor/kitsune_host_impl/query_size_limited_regions.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl/query_size_limited_regions.rs
@@ -31,7 +31,7 @@ pub async fn query_size_limited_regions(
                 // partition the set into regions which need to be split, and those which don't
                 let (smalls, bigs): (Vec<_>, Vec<_>) = unchecked
                     .iter()
-                    .partition(|(r, quantum)| *quantum || r.data.size <= size_limit);
+                    .partition(|(r, quantum)| *quantum || r.data.size() <= size_limit);
                 // add the unsplittables to the final set to be returned
                 checked.extend(smalls.into_iter().map(first_ref).cloned());
 
@@ -47,7 +47,7 @@ pub async fn query_size_limited_regions(
                     })
                     .map(|(c, q)| {
                         let data = query_region_data(&mut stmt, &topology, c)?;
-                        DatabaseResult::Ok((Region::new(c, data), q))
+                        DatabaseResult::Ok((Region::new(c, RegionCell::Data(data)), q))
                     })
                     .collect::<Result<Vec<(Region, bool)>, _>>()?;
             }

--- a/crates/holochain/src/conductor/kitsune_host_impl/query_size_limited_regions.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl/query_size_limited_regions.rs
@@ -27,10 +27,13 @@ pub async fn query_size_limited_regions(
             let mut unchecked: Vec<(Region, bool)> =
                 regions.into_iter().map(|r| (r, false)).collect();
             let mut checked: Vec<Region> = vec![];
+
             while !unchecked.is_empty() {
                 // partition the set into regions which need to be split, and those which don't
                 let (smalls, bigs): (Vec<_>, Vec<_>) = unchecked
                     .iter()
+                    // If the region is locked, the size is considered 0, so a locked region
+                    // will not be a candidate for quandrisection
                     .partition(|(r, quantum)| *quantum || r.data.size() <= size_limit);
                 // add the unsplittables to the final set to be returned
                 checked.extend(smalls.into_iter().map(first_ref).cloned());

--- a/crates/holochain/src/conductor/space/tests.rs
+++ b/crates/holochain/src/conductor/space/tests.rs
@@ -75,10 +75,18 @@ async fn test_region_queries() {
 
     // - Check that we have no ops to begin with
     let region_set = spaces
-        .handle_fetch_op_regions(dna_def.as_hash(), topo.clone(), DhtArcSet::Full)
+        .handle_fetch_op_regions(
+            dna_def.as_hash(),
+            topo.clone(),
+            DhtArcSet::Full,
+            Default::default(),
+        )
         .await
         .unwrap();
-    let region_sum: RegionData = region_set.regions().map(|r| r.data).sum();
+    let region_sum: RegionData = region_set
+        .regions()
+        .map(|r| r.data.into_option().unwrap())
+        .sum();
     assert_eq!(region_sum.count as usize, 0);
 
     for _ in 0..NUM_OPS {
@@ -103,12 +111,20 @@ async fn test_region_queries() {
         fill_db(&db, op2);
     }
     let region_set = spaces
-        .handle_fetch_op_regions(dna_def.as_hash(), topo.clone(), DhtArcSet::Full)
+        .handle_fetch_op_regions(
+            dna_def.as_hash(),
+            topo.clone(),
+            DhtArcSet::Full,
+            Default::default(),
+        )
         .await
         .unwrap();
 
     // - Check that the aggregate of all region data matches expectations
-    let region_sum: RegionData = region_set.regions().map(|r| r.data).sum();
+    let region_sum: RegionData = region_set
+        .regions()
+        .map(|r| r.data.into_option().unwrap())
+        .sum();
     let hash_sum = ops
         .iter()
         .map(|op| RegionHash::from_vec(op.as_hash().get_raw_39().to_vec()).unwrap())

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -726,6 +726,7 @@ async fn mock_network_sharded_gossip() {
                                     ShardedGossipWire::NoAgents(_) => (),
                                     ShardedGossipWire::AlreadyInProgress(_) => (),
                                     ShardedGossipWire::Busy(_) => (),
+                                    ShardedGossipWire::ChottoMatte(_) => (),
                                     ShardedGossipWire::Error(_) => (),
                                     ShardedGossipWire::OpBatchReceived(_) => (),
                                 }
@@ -1229,6 +1230,7 @@ async fn mock_network_sharding() {
                                     ShardedGossipWire::NoAgents(_) => (),
                                     ShardedGossipWire::AlreadyInProgress(_) => (),
                                     ShardedGossipWire::Busy(_) => (),
+                                    ShardedGossipWire::ChottoMatte(_) => (),
                                     ShardedGossipWire::Error(_) => (),
                                     ShardedGossipWire::OpBatchReceived(_) => (),
                                 }

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -726,7 +726,6 @@ async fn mock_network_sharded_gossip() {
                                     ShardedGossipWire::NoAgents(_) => (),
                                     ShardedGossipWire::AlreadyInProgress(_) => (),
                                     ShardedGossipWire::Busy(_) => (),
-                                    ShardedGossipWire::ChottoMatte(_) => (),
                                     ShardedGossipWire::Error(_) => (),
                                     ShardedGossipWire::OpBatchReceived(_) => (),
                                 }
@@ -1230,7 +1229,6 @@ async fn mock_network_sharding() {
                                     ShardedGossipWire::NoAgents(_) => (),
                                     ShardedGossipWire::AlreadyInProgress(_) => (),
                                     ShardedGossipWire::Busy(_) => (),
-                                    ShardedGossipWire::ChottoMatte(_) => (),
                                     ShardedGossipWire::Error(_) => (),
                                     ShardedGossipWire::OpBatchReceived(_) => (),
                                 }

--- a/crates/kitsune_p2p/dht/Cargo.toml
+++ b/crates/kitsune_p2p/dht/Cargo.toml
@@ -21,6 +21,7 @@ gcollections = "1.5"
 kitsune_p2p_dht_arc = { version = "0.0.16", path = "../dht_arc"}
 kitsune_p2p_timestamp = { version = "0.0.14", path = "../timestamp", features = ["now"]}
 intervallum = "1.4"
+itertools = "0.10"
 must_future = "0.1"
 num-traits = "0.2.14"
 once_cell = "1.8"

--- a/crates/kitsune_p2p/dht/src/persistence.rs
+++ b/crates/kitsune_p2p/dht/src/persistence.rs
@@ -57,7 +57,7 @@ pub trait AccessOpStore<O: OpRegion<D>, D: RegionDataConstraints = RegionData>: 
     fn region_set(&self, arq_set: ArqBoundsSet, now: TimeQuantum) -> RegionSet<D> {
         let coords = RegionCoordSetLtcs::new(TelescopingTimes::new(now), arq_set);
         coords
-            .into_region_set_infallible(|(_, coords)| self.query_region_data(&coords))
+            .into_region_set_infallible_unlocked(|(_, coords)| self.query_region_data(&coords))
             .into()
     }
 }

--- a/crates/kitsune_p2p/dht/src/region.rs
+++ b/crates/kitsune_p2p/dht/src/region.rs
@@ -15,9 +15,11 @@
 //! Regions represents the union of those two Regions. The sum of hashes is defined
 //! as the XOR of hashes, which allows this compatibility.
 
+mod region_cell;
 mod region_coords;
 mod region_data;
 
+pub use region_cell::*;
 pub use region_coords::*;
 pub use region_data::*;
 
@@ -34,7 +36,7 @@ pub struct Region<D = RegionData> {
     /// The coords
     pub coords: RegionCoords,
     /// The data
-    pub data: D,
+    pub data: RegionCell<D>,
 }
 
 impl<D: RegionDataConstraints> Region<D> {}

--- a/crates/kitsune_p2p/dht/src/region.rs
+++ b/crates/kitsune_p2p/dht/src/region.rs
@@ -30,7 +30,7 @@ pub const REGION_MASS: u32 = std::mem::size_of::<Region<RegionData>>() as u32;
 
 /// The coordinates defining the Region, along with the calculated [`RegionData`]
 #[derive(Debug, Clone, PartialEq, Eq, derive_more::Constructor)]
-pub struct Region<D: RegionDataConstraints = RegionData> {
+pub struct Region<D = RegionData> {
     /// The coords
     pub coords: RegionCoords,
     /// The data

--- a/crates/kitsune_p2p/dht/src/region/region_cell.rs
+++ b/crates/kitsune_p2p/dht/src/region/region_cell.rs
@@ -34,6 +34,11 @@ impl<D: RegionDataConstraints> RegionCell<D> {
         }
     }
 
+    /// This region is locked
+    pub fn is_locked(&self) -> bool {
+        *self == Self::Locked
+    }
+
     /// Get the op count for this region, or zero if locked
     pub fn count(&self) -> u32 {
         match self {

--- a/crates/kitsune_p2p/dht/src/region/region_cell.rs
+++ b/crates/kitsune_p2p/dht/src/region/region_cell.rs
@@ -1,0 +1,93 @@
+use std::{
+    iter::Sum,
+    ops::{Add, AddAssign},
+};
+
+use num_traits::Zero;
+
+use super::{RegionData, RegionDataConstraints};
+
+#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "test_utils", derive(Clone))]
+/// Different states of region. If Locked, there is no need to include the data.
+pub enum RegionCell<D = RegionData> {
+    /// The data is present
+    Data(D),
+    /// The data is omitted because this region is locked.
+    Locked,
+}
+
+impl<D: RegionDataConstraints> RegionCell<D> {
+    /// Return data if not locked, else None
+    pub fn as_option(&self) -> Option<&D> {
+        match self {
+            Self::Data(d) => Some(d),
+            Self::Locked => None,
+        }
+    }
+
+    /// Return data if not locked, else None
+    pub fn into_option(self) -> Option<D> {
+        match self {
+            Self::Data(d) => Some(d),
+            Self::Locked => None,
+        }
+    }
+
+    /// Get the op count for this region, or zero if locked
+    pub fn count(&self) -> u32 {
+        match self {
+            Self::Data(d) => d.count(),
+            _ => 0,
+        }
+    }
+
+    /// Get the size of ops in this region, or zero if locked
+    pub fn size(&self) -> u32 {
+        match self {
+            Self::Data(d) => d.size(),
+            _ => 0,
+        }
+    }
+}
+
+impl<D: AddAssign + Zero> Zero for RegionCell<D> {
+    fn zero() -> Self {
+        Self::Data(Zero::zero())
+    }
+
+    fn is_zero(&self) -> bool {
+        match self {
+            Self::Data(d) => d.is_zero(),
+            // TODO: should we consider locked data as zero?
+            _ => false,
+        }
+    }
+}
+
+impl<D: AddAssign> AddAssign for RegionCell<D> {
+    fn add_assign(&mut self, other: Self) {
+        match (self, other) {
+            (Self::Data(ref mut a), Self::Data(b)) => {
+                *a += b;
+            }
+            // Locked regions "infect" the whole sum
+            (s, _) => *s = Self::Locked,
+        }
+    }
+}
+
+impl<D: AddAssign> Add for RegionCell<D> {
+    type Output = Self;
+
+    fn add(mut self, other: Self) -> Self::Output {
+        self += other;
+        self
+    }
+}
+
+impl<D: Zero + AddAssign> Sum for RegionCell<D> {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.reduce(|a, b| a + b).unwrap_or_else(Zero::zero)
+    }
+}

--- a/crates/kitsune_p2p/dht/src/region_set.rs
+++ b/crates/kitsune_p2p/dht/src/region_set.rs
@@ -62,7 +62,7 @@ impl<D: RegionDataConstraints> RegionSet<D> {
 
     /// Find a set of Regions which represents the intersection of the two
     /// input RegionSets.
-    pub fn diff(self, other: Self) -> GossipResult<Vec<Region<D>>> {
+    pub fn diff(self, other: Self) -> GossipResult<RegionDiffs<D>> {
         match (self, other) {
             (Self::Ltcs(left), Self::Ltcs(right)) => left.diff(right),
         }
@@ -261,7 +261,7 @@ mod tests {
         let rset_b = RegionSetLtcs::from_store(&store2, coords_b);
         assert_ne!(rset_a.data(), rset_b.data());
 
-        let diff = rset_a.clone().diff(rset_b.clone()).unwrap();
+        let diff = rset_a.clone().diff(rset_b.clone()).unwrap().ours;
         dbg!(&diff, &extra_ops);
         assert_eq!(diff.len(), 2);
 
@@ -323,7 +323,7 @@ mod tests {
         let rset_b = RegionSetLtcs::from_store(&store2, coords_b);
         assert_ne!(rset_a.data(), rset_b.data());
 
-        let diff = rset_a.clone().diff(rset_b.clone()).unwrap();
+        let diff = rset_a.clone().diff(rset_b.clone()).unwrap().ours;
         dbg!(&diff, &extra_ops);
         assert_eq!(diff.len(), 2);
 

--- a/crates/kitsune_p2p/dht/src/region_set/ltcs.rs
+++ b/crates/kitsune_p2p/dht/src/region_set/ltcs.rs
@@ -1,16 +1,18 @@
 use std::collections::HashSet;
 
-use once_cell::sync::OnceCell;
-
 use crate::{
     arq::*,
     error::{GossipError, GossipResult},
     op::OpRegion,
+    region::RegionCell,
     spacetime::*,
 };
 use derivative::Derivative;
 
 use super::{Region, RegionCoords, RegionData, RegionDataConstraints};
+
+/// The nested set of data for a RegionSet
+pub type RegionDataGrid<D> = Vec<Vec<Vec<RegionCell<D>>>>;
 
 /// A compact representation of a set of [`RegionCoords`].
 /// The [`TelescopingTimes`] generates all relevant [`TimeSegment`]s, and the
@@ -58,7 +60,11 @@ impl RegionCoordSetLtcs {
     }
 
     /// Generate data for each coord in the set, creating the corresponding [`RegionSetLtcs`].
-    pub fn into_region_set<D, F, E>(self, mut f: F) -> Result<RegionSetLtcs<D>, E>
+    pub fn into_region_set<D, F, E>(
+        self,
+        locked_regions: HashSet<RegionCoords>,
+        mut f: F,
+    ) -> Result<RegionSetLtcs<D>, E>
     where
         D: RegionDataConstraints,
         F: FnMut(((usize, usize, usize), RegionCoords)) -> Result<D, E>,
@@ -67,27 +73,36 @@ impl RegionCoordSetLtcs {
             .region_coords_nested()
             .map(|arqdata| {
                 arqdata
-                    .map(|column| column.map(&mut f).collect::<Result<Vec<D>, E>>())
-                    .collect::<Result<Vec<Vec<D>>, E>>()
+                    .map(|column| {
+                        column
+                            .map(|t| {
+                                Ok(if locked_regions.contains(&t.1) {
+                                    RegionCell::Locked
+                                } else {
+                                    RegionCell::Data(f(t)?)
+                                })
+                            })
+                            .collect::<Result<Vec<RegionCell<D>>, E>>()
+                    })
+                    .collect::<Result<Vec<Vec<_>>, E>>()
             })
-            .collect::<Result<Vec<Vec<Vec<D>>>, E>>()?;
-        let set = RegionSetLtcs {
-            coords: self,
-            data,
-            _region_coords: OnceCell::new(),
-        };
+            .collect::<Result<Vec<Vec<Vec<_>>>, E>>()?;
+        let set = RegionSetLtcs { coords: self, data };
         Ok(set)
     }
 
     /// Generate data for each coord in the set, creating the corresponding [`RegionSetLtcs`],
     /// using a mapping function which cannot fail.
-    pub fn into_region_set_infallible<D, F>(self, mut f: F) -> RegionSetLtcs<D>
+    #[cfg(feature = "test_utils")]
+    pub fn into_region_set_infallible_unlocked<D, F>(self, mut f: F) -> RegionSetLtcs<D>
     where
         D: RegionDataConstraints,
         F: FnMut(((usize, usize, usize), RegionCoords)) -> D,
     {
-        self.into_region_set(|c| Result::<D, std::convert::Infallible>::Ok(f(c)))
-            .unwrap()
+        self.into_region_set(Default::default(), |c| {
+            Result::<D, std::convert::Infallible>::Ok(f(c))
+        })
+        .unwrap()
     }
 
     /// An empty set of coords
@@ -114,23 +129,17 @@ impl RegionCoordSetLtcs {
 /// The coordinates for the regions are specified by a few values.
 /// The data to match the coordinates are specified in a 2D vector which must
 /// correspond to the generated coordinates.
-#[derive(serde::Serialize, serde::Deserialize, Derivative)]
-#[derivative(PartialEq, Eq)]
+#[derive(PartialEq, Eq, serde::Serialize, serde::Deserialize, Derivative)]
 #[cfg_attr(feature = "test_utils", derive(Clone))]
 pub struct RegionSetLtcs<D: RegionDataConstraints = RegionData> {
     /// The generator for the coordinates
     pub coords: RegionCoordSetLtcs,
 
-    /// the actual coordinates as generated
-    #[derivative(PartialEq = "ignore")]
-    #[serde(skip)]
-    pub(crate) _region_coords: OnceCell<Vec<RegionCoords>>,
-
     /// The outermost vec corresponds to arqs in the ArqSet;
     /// The middle vecs correspond to the spatial segments per arq;
     /// the innermost vecs are the time segments per arq.
     #[serde(bound(deserialize = "D: serde::de::DeserializeOwned"))]
-    data: Vec<Vec<Vec<D>>>,
+    data: RegionDataGrid<D>,
 }
 
 impl<D: RegionDataConstraints> std::fmt::Debug for RegionSetLtcs<D> {
@@ -150,7 +159,6 @@ impl<D: RegionDataConstraints> RegionSetLtcs<D> {
         Self {
             coords: RegionCoordSetLtcs::empty(),
             data: vec![],
-            _region_coords: OnceCell::new(),
         }
     }
 
@@ -175,7 +183,8 @@ impl<D: RegionDataConstraints> RegionSetLtcs<D> {
         self.coords
             .region_coords_flat()
             .map(|((ia, ix, it), coords)| {
-                Region::new(coords, self.data[ia][ix as usize][it as usize].clone())
+                let data = self.data[ia][ix as usize][it as usize].clone();
+                Region::new(coords, data)
             })
     }
 
@@ -220,7 +229,7 @@ impl<D: RegionDataConstraints> RegionSetLtcs<D> {
     /// sparse scenarios.
     pub fn nonzero_regions(
         &self,
-    ) -> impl '_ + Iterator<Item = ((usize, usize, usize), RegionCoords, D)> {
+    ) -> impl '_ + Iterator<Item = ((usize, usize, usize), RegionCoords, RegionCell<D>)> {
         self.coords
             .region_coords_flat()
             .filter_map(|((a, x, y), c)| {
@@ -229,13 +238,13 @@ impl<D: RegionDataConstraints> RegionSetLtcs<D> {
                     .get(a)
                     .and_then(|d| d.get(x))
                     .and_then(|d| d.get(y));
-                d.filter(|d| d.count() > 0)
+                d.filter(|d| d.as_option().map(|d| d.count() > 0).unwrap_or(false))
                     .map(|d| ((a, x, y), c, d.clone()))
             })
     }
 
     /// Accessor
-    pub fn data(&self) -> &[Vec<Vec<D>>] {
+    pub fn data(&self) -> &[Vec<Vec<RegionCell<D>>>] {
         self.data.as_ref()
     }
 }
@@ -256,36 +265,31 @@ pub struct RegionDiffs<D> {
 impl<D: RegionDataConstraints> RegionDiffs<D> {
     /// Pick regions from both sets up until the max_size is reached, skipping locked regions,
     /// and discard all others
-    pub fn round_limited(self, max_size: u32, locked: HashSet<RegionCoords>) -> Self {
+    pub fn round_limited(self, max_size: u32) -> Self {
         Self {
-            ours: Self::round_limited_1(self.ours, max_size, &locked),
-            theirs: Self::round_limited_1(self.theirs, max_size, &locked),
+            ours: Self::round_limited_1(self.ours, max_size),
+            theirs: Self::round_limited_1(self.theirs, max_size),
         }
     }
 
-    fn round_limited_1(
-        regions: Vec<Region<D>>,
-        max_size: u32,
-        locked: &HashSet<RegionCoords>,
-    ) -> Vec<Region<D>> {
+    fn round_limited_1(regions: Vec<Region<D>>, max_size: u32) -> Vec<Region<D>> {
         use itertools::FoldWhile::{Continue, Done};
         use itertools::Itertools;
 
         let (limited, _) = regions
             .into_iter()
             .enumerate()
-            .fold_while((vec![], 0), |(mut v, total), (i, r)| {
-                let size = r.data.size();
-                if i == 0 || total + size <= max_size {
-                    if locked.contains(&r.coords) {
-                        Continue((v, total))
-                    } else {
-                        v.push(r);
+            .fold_while((vec![], 0), |(mut v, total), (i, r)| match &r.data {
+                RegionCell::Data(data) => {
+                    let size = data.size();
+                    if i == 0 || total + size <= max_size {
+                        v.push(r.clone());
                         Continue((v, total + size))
+                    } else {
+                        Done((v, total))
                     }
-                } else {
-                    Done((v, total))
                 }
+                RegionCell::Locked => Continue((v, total)),
             })
             .into_inner();
         limited
@@ -309,12 +313,14 @@ impl<D: RegionDataConstraints> RegionSetLtcs<D> {
         store: &S,
         coords: RegionCoordSetLtcs,
     ) -> Self {
-        coords.into_region_set_infallible(|(_, coords)| store.query_region_data(&coords))
+        coords.into_region_set_infallible_unlocked(|(_, coords)| store.query_region_data(&coords))
     }
 }
 
 #[cfg(test)]
 mod tests {
+
+    use std::convert::Infallible;
 
     use num_traits::Zero;
 
@@ -329,35 +335,70 @@ mod tests {
         );
         assert_eq!(coords.count(), num_coords as usize);
 
-        let a = coords.clone().into_region_set_infallible(|_| RegionData {
-            count: 1,
-            size: 100,
-            hash: Zero::zero(),
-        });
-        let b = coords.clone().into_region_set_infallible(|_| RegionData {
-            count: 1,
-            size: 200,
-            hash: Zero::zero(),
-        });
-        let diffs = a.diff(b).unwrap();
+        let locked: HashSet<_> = coords
+            .region_coords_flat()
+            .map(|(_, c)| c)
+            .take(12)
+            .collect();
+
+        let diffs = {
+            let a = coords
+                .clone()
+                .into_region_set_infallible_unlocked(|_| RegionData {
+                    count: 1,
+                    size: 100,
+                    hash: Zero::zero(),
+                });
+            let b = coords
+                .clone()
+                .into_region_set_infallible_unlocked(|_| RegionData {
+                    count: 1,
+                    size: 200,
+                    hash: Zero::zero(),
+                });
+            a.diff(b).unwrap()
+        };
+
+        let diffs_locked = {
+            let al = coords
+                .clone()
+                .into_region_set(locked.clone(), |_| {
+                    Result::<_, Infallible>::Ok(RegionData {
+                        count: 1,
+                        size: 100,
+                        hash: Zero::zero(),
+                    })
+                })
+                .unwrap();
+            let bl = coords
+                .clone()
+                .into_region_set(locked.clone(), |_| {
+                    Result::<_, Infallible>::Ok(RegionData {
+                        count: 1,
+                        size: 200,
+                        hash: Zero::zero(),
+                    })
+                })
+                .unwrap();
+
+            al.diff(bl).unwrap()
+        };
 
         {
-            let diffs_1k = diffs.clone().round_limited(1000, HashSet::new());
+            let diffs_1k = diffs.clone().round_limited(1000);
             assert_eq!(diffs_1k.ours.len(), 10);
             assert_eq!(diffs_1k.theirs.len(), 5);
-            assert_eq!(diffs_1k.ours.iter().map(|r| r.data.size).sum::<u32>(), 1000);
             assert_eq!(
-                diffs_1k.theirs.iter().map(|r| r.data.size).sum::<u32>(),
+                diffs_1k.ours.iter().map(|r| r.data.size()).sum::<u32>(),
+                1000
+            );
+            assert_eq!(
+                diffs_1k.theirs.iter().map(|r| r.data.size()).sum::<u32>(),
                 1000
             );
         }
         {
-            let locked = coords
-                .region_coords_flat()
-                .map(|(_, c)| c)
-                .take(12)
-                .collect();
-            let diffs_1k_locked = diffs.clone().round_limited(1000, locked);
+            let diffs_1k_locked = diffs_locked.clone().round_limited(1000);
             assert_eq!(diffs_1k_locked.ours.len(), 8);
             assert_eq!(diffs_1k_locked.theirs.len(), 5);
             // - we're constrained by the lack of unlocked regions
@@ -365,7 +406,7 @@ mod tests {
                 diffs_1k_locked
                     .ours
                     .iter()
-                    .map(|r| r.data.size)
+                    .map(|r| r.data.size())
                     .sum::<u32>(),
                 800
             );
@@ -374,18 +415,21 @@ mod tests {
                 diffs_1k_locked
                     .theirs
                     .iter()
-                    .map(|r| r.data.size)
+                    .map(|r| r.data.size())
                     .sum::<u32>(),
                 1000
             );
         }
         {
-            let diffs_5k = diffs.round_limited(5000, HashSet::new());
+            let diffs_5k = diffs.round_limited(5000);
             assert_eq!(diffs_5k.ours.len(), 20);
             assert_eq!(diffs_5k.theirs.len(), 20);
-            assert_eq!(diffs_5k.ours.iter().map(|r| r.data.size).sum::<u32>(), 2000);
             assert_eq!(
-                diffs_5k.theirs.iter().map(|r| r.data.size).sum::<u32>(),
+                diffs_5k.ours.iter().map(|r| r.data.size()).sum::<u32>(),
+                2000
+            );
+            assert_eq!(
+                diffs_5k.theirs.iter().map(|r| r.data.size()).sum::<u32>(),
                 4000
             );
         }

--- a/crates/kitsune_p2p/dht/src/region_set/ltcs.rs
+++ b/crates/kitsune_p2p/dht/src/region_set/ltcs.rs
@@ -250,7 +250,7 @@ impl<D: RegionDataConstraints> RegionSetLtcs<D> {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 /// The diff of two region sets, from the perspective of both parties
 ///
 /// Both sets of regions will have the same coordinates: what's different is the data
@@ -387,9 +387,14 @@ mod tests {
 
             al.diff(bl).unwrap()
         };
-
+        {
+            let (diffs_10k, lim) = diffs.clone().round_limited(10000);
+            assert!(!lim);
+            assert_eq!(diffs, diffs_10k);
+        }
         {
             let (diffs_1k, lim) = diffs.clone().round_limited(1000);
+            assert!(lim);
             assert_eq!(diffs_1k.ours.len(), 10);
             assert_eq!(diffs_1k.theirs.len(), 5);
             assert_eq!(
@@ -403,6 +408,7 @@ mod tests {
         }
         {
             let (diffs_1k_locked, lim) = diffs_locked.clone().round_limited(1000);
+            assert!(lim);
             assert_eq!(diffs_1k_locked.ours.len(), 8);
             assert_eq!(diffs_1k_locked.theirs.len(), 5);
             // - we're constrained by the lack of unlocked regions
@@ -426,6 +432,7 @@ mod tests {
         }
         {
             let (diffs_5k, lim) = diffs.round_limited(5000);
+            assert!(lim);
             assert_eq!(diffs_5k.ours.len(), 20);
             assert_eq!(diffs_5k.theirs.len(), 20);
             assert_eq!(

--- a/crates/kitsune_p2p/dht/src/region_set/ltcs.rs
+++ b/crates/kitsune_p2p/dht/src/region_set/ltcs.rs
@@ -219,7 +219,8 @@ impl<D: RegionDataConstraints> RegionSetLtcs<D> {
             .regions()
             .into_iter()
             .zip(other.regions().into_iter())
-            .filter_map(|(a, b)| (a.data != b.data).then(|| (a, b)))
+            // Any regions which are declared locked, or which match perfectly, are excluded
+            .filter(|(a, b)| !(a.data.is_locked() || b.data.is_locked() || a.data == b.data))
             .unzip();
 
         Ok(RegionDiffs { ours, theirs })

--- a/crates/kitsune_p2p/dht/src/test_utils/gossip_direct.rs
+++ b/crates/kitsune_p2p/dht/src/test_utils/gossip_direct.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::{GossipError, GossipResult},
     persistence::HostAccessTest,
-    prelude::ArqBoundsSet,
+    prelude::{ArqBoundsSet, RegionDiffs},
     region::REGION_MASS,
     spacetime::{Quantum, TimeQuantum},
 };
@@ -75,15 +75,14 @@ pub fn gossip_direct<Peer: HostAccessTest>(
         // ROUND IV: Calculate diffs and send missing ops
 
         // - calculate diffs
-        let diff_left = regions_left.clone().diff(regions_right.clone())?;
-        let diff_right = regions_right.diff(regions_left)?;
+        let RegionDiffs { ours, theirs } = regions_left.clone().diff(regions_right.clone())?;
 
         // - fetch ops
-        let ops_left: Vec<_> = diff_left
+        let ops_left: Vec<_> = ours
             .iter()
             .flat_map(|r| left.query_op_data(&r.coords))
             .collect();
-        let ops_right: Vec<_> = diff_right
+        let ops_right: Vec<_> = theirs
             .iter()
             .flat_map(|r| right.query_op_data(&r.coords))
             .collect();

--- a/crates/kitsune_p2p/dht/src/test_utils/gossip_direct.rs
+++ b/crates/kitsune_p2p/dht/src/test_utils/gossip_direct.rs
@@ -75,7 +75,7 @@ pub fn gossip_direct<Peer: HostAccessTest>(
         // ROUND IV: Calculate diffs and send missing ops
 
         // - calculate diffs
-        let RegionDiffs { ours, theirs } = regions_left.clone().diff(regions_right.clone())?;
+        let RegionDiffs { ours, theirs } = regions_left.diff(regions_right)?;
 
         // - fetch ops
         let ops_left: Vec<_> = ours

--- a/crates/kitsune_p2p/dht/src/test_utils/op_store.rs
+++ b/crates/kitsune_p2p/dht/src/test_utils/op_store.rs
@@ -56,9 +56,12 @@ impl<D: RegionDataConstraints, O: OpRegion<D>> AccessOpStore<O, D> for OpStore<O
         &self,
         coords: crate::prelude::RegionCoordSetLtcs,
     ) -> must_future::MustBoxFuture<Result<crate::prelude::RegionSetLtcs<D>, ()>> {
-        async move { coords.into_region_set(|(_, coords)| Ok(self.query_region_data(&coords))) }
-            .boxed()
-            .into()
+        async move {
+            Ok(coords
+                .into_region_set_infallible_unlocked(|(_, coords)| self.query_region_data(&coords)))
+        }
+        .boxed()
+        .into()
     }
 
     fn integrate_ops<Ops: Clone + Iterator<Item = Arc<O>>>(&mut self, ops: Ops) {

--- a/crates/kitsune_p2p/dht/src/test_utils/test_node.rs
+++ b/crates/kitsune_p2p/dht/src/test_utils/test_node.rs
@@ -39,10 +39,10 @@ impl TestNode {
     }
 
     /// Get the RegionSet for this node, suitable for gossiping
-    pub fn region_set(&self, arq_set: ArqBoundsSet, now: TimeQuantum) -> RegionSet {
+    pub fn region_set_no_lock(&self, arq_set: ArqBoundsSet, now: TimeQuantum) -> RegionSet {
         let coords = RegionCoordSetLtcs::new(TelescopingTimes::new(now), arq_set);
         coords
-            .into_region_set_infallible(|(_, coords)| self.query_region_data(&coords))
+            .into_region_set_infallible_unlocked(|(_, coords)| self.query_region_data(&coords))
             .into()
     }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -887,7 +887,7 @@ impl ShardedGossipLocal {
         &self,
         state_id: &StateKey,
     ) -> KitsuneResult<Option<RoundState>> {
-        let r = self.inner.share_mut(|i, _| {
+        self.inner.share_mut(|i, _| {
             let finished = i
                 .round_map
                 .get_mut(state_id)
@@ -901,8 +901,7 @@ impl ShardedGossipLocal {
             } else {
                 Ok(i.round_map.get(state_id).cloned())
             }
-        });
-        r
+        })
     }
 
     fn decrement_op_blooms(&self, state_id: &StateKey) -> KitsuneResult<Option<RoundState>> {

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -1028,6 +1028,9 @@ impl ShardedGossipLocal {
                     // This is the last chunk in the batch. Reply with [`OpBatchReceived`]
                     // to get the next batch of missing ops.
                     MissingOpsStatus::BatchComplete => {
+                        // TODO: if this is historical gossip and an entire region is complete,
+                        // we can unlock that region for this round. But currently we have no way to associate
+                        // the ops received with the region that they were for.
                         gossip = vec![ShardedGossipWire::op_batch_received()];
                         self.get_state(&peer_cert)?
                     }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -547,8 +547,14 @@ impl ShardedGossipLocalState {
             metrics.record_completion(&r.remote_agent_list, gossip_type.into(), outcome);
             metrics.complete_current_round(state_key, outcome);
         } else if init_tgt {
-            metrics.record_completion(&remote_agent_list, gossip_type.into(), RoundOutcome::Error);
-            metrics.complete_current_round(state_key, RoundOutcome::Error);
+            let outcome = if error {
+                RoundOutcome::Error
+            } else {
+                // TODO: could this cause an endless loop of retries?
+                RoundOutcome::SuccessPartial
+            };
+            metrics.record_completion(&remote_agent_list, gossip_type.into(), outcome);
+            metrics.complete_current_round(state_key, outcome);
         }
 
         r

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -614,32 +614,6 @@ impl ShardedGossipLocalState {
             ?self.initiate_tgt,
         )
     }
-
-    /// Are there any historical rounds which have begun but have not yet calculated
-    /// the region diff and hence the locked regions?
-    ///
-    /// This check is useful because we want to turn away new historic gossip requests
-    /// while this negotiation is happening, so that we don't have a race condition
-    /// for region locking.
-    ///
-    /// Note that there can still be a race due to the delay between initiate and accept:
-    /// if a node initiates with someone, and then accepts a new round with someone else,
-    /// both rounds will run concurrently.
-    pub fn negotiating_region_diff(&self, _peer_cert: &Tx2Cert) -> bool {
-        if let Some((tgt, accepted)) = self.initiate_tgt.as_ref() {
-            self.round_map
-                .map
-                .iter()
-                // if we have an initiate target that hasn't been accepted,
-                // then that round will always have regions_are_queued == false.
-                // If we don't filter that out, then deadlocks become possible wrt
-                // to initate/accept handshake, e.g. when a cycle forms.
-                .filter(|(cert, _)| *accepted || **cert != tgt.cert)
-                .any(|(_, r)| !r.regions_are_queued)
-        } else {
-            self.round_map.map.values().any(|r| !r.regions_are_queued)
-        }
-    }
 }
 
 /// The incoming and outgoing queues for [`ShardedGossip`]

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -14,7 +14,7 @@ use governor::RateLimiter;
 use kitsune_p2p_timestamp::Timestamp;
 use kitsune_p2p_types::codec::Codec;
 use kitsune_p2p_types::config::*;
-use kitsune_p2p_types::dht::region::{Region, RegionData};
+use kitsune_p2p_types::dht::region::{RegionCoords, RegionData};
 use kitsune_p2p_types::dht::region_set::RegionSetLtcs;
 use kitsune_p2p_types::dht_arc::{DhtArcRange, DhtArcSet};
 use kitsune_p2p_types::metrics::*;
@@ -686,14 +686,11 @@ pub struct RoundState {
     region_set_sent: Option<Arc<RegionSetLtcs>>,
     /// Stats about ops, regions, bloom filter, and bytes sent and received,
     pub(crate) throughput: RoundThroughput,
-    /// Region diffs, if doing Historical gossip
-    pub(crate) region_diffs: RegionDiffs,
+    /// If doing Historical gossip, the set of regions I am expecting data for this round.
+    pub(crate) locked_regions: HashSet<RegionCoords>,
     /// Unique string ID for this round
     pub(crate) id: String,
 }
-
-/// Our region diff and their region diff
-pub type RegionDiffs = Option<(Vec<Region>, Vec<Region>)>;
 
 impl RoundState {
     /// Constructor
@@ -717,7 +714,7 @@ impl RoundState {
             round_timeout,
             region_set_sent,
             throughput: Default::default(),
-            region_diffs: Default::default(),
+            locked_regions: Default::default(),
         }
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/accept.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/accept.rs
@@ -15,9 +15,12 @@ impl ShardedGossipLocal {
                 let accept_is_from_target = i
                     .initiate_tgt
                     .as_ref()
-                    .map(|tgt| tgt.cert == peer_cert)
+                    .map(|(tgt, _)| tgt.cert == peer_cert)
                     .unwrap_or(false);
-                let when_initiated = i.initiate_tgt.as_ref().and_then(|i| i.when_initiated);
+                let when_initiated = i
+                    .initiate_tgt
+                    .as_ref()
+                    .and_then(|(tgt, _)| tgt.when_initiated);
                 Ok((
                     i.local_agents.clone(),
                     when_initiated,
@@ -76,6 +79,10 @@ impl ShardedGossipLocal {
             metrics.record_initiate(&remote_agent_list, self.gossip_type.into());
 
             inner.round_map.insert(peer_cert.clone(), state);
+            if let Some(tgt) = inner.initiate_tgt.as_mut() {
+                // record that the target has accepted
+                tgt.1 = true;
+            }
             Ok(())
         })?;
         Ok(gossip)

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/accept.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/accept.rs
@@ -54,14 +54,11 @@ impl ShardedGossipLocal {
         // leading to massive redundancy when multiple nodes try to gossip with us
         // in quick succession
         if self.gossip_type == GossipType::Historical
-            && self.inner.share_mut(|i, _| {
-                let yes = i.negotiating_region_diff(&peer_cert);
-                if yes {
-                    i.remove_state(&peer_cert, self.gossip_type, false);
-                }
-                Ok(yes)
-            })?
+            && self
+                .inner
+                .share_ref(|i| Ok(i.negotiating_region_diff(&peer_cert)))?
         {
+            self.remove_state(&peer_cert, false)?;
             return Ok(vec![ShardedGossipWire::chotto_matte()]);
         }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/accept.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/accept.rs
@@ -49,19 +49,6 @@ impl ShardedGossipLocal {
             return Ok(vec![ShardedGossipWire::no_agents()]);
         }
 
-        // We don't want to accept a new accept if any of our rounds are negotiating
-        // a region diff, so we don't have a race condition over the locking of regions,
-        // leading to massive redundancy when multiple nodes try to gossip with us
-        // in quick succession
-        if self.gossip_type == GossipType::Historical
-            && self
-                .inner
-                .share_ref(|i| Ok(i.negotiating_region_diff(&peer_cert)))?
-        {
-            self.remove_state(&peer_cert, false)?;
-            return Ok(vec![ShardedGossipWire::chotto_matte()]);
-        }
-
         // Get the local intervals.
         let local_agent_arcs: Vec<_> =
             store::local_agent_arcs(&self.evt_sender, &self.space, &local_agents)

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
@@ -121,10 +121,9 @@ impl ShardedGossipLocal {
         // leading to massive redundancy when multiple nodes try to initiate with us
         // in quick successions
         if self.gossip_type == GossipType::Historical
-            && self.inner.share_mut(|i, _| {
-                let yes = i.negotiating_region_diff(&peer_cert);
-                Ok(yes)
-            })?
+            && self
+                .inner
+                .share_ref(|i| Ok(i.negotiating_region_diff(&peer_cert)))?
         {
             self.remove_target(&peer_cert, false)?;
             return Ok(vec![ShardedGossipWire::chotto_matte()]);

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
@@ -116,19 +116,6 @@ impl ShardedGossipLocal {
             }
         }
 
-        // We don't want to accept a new initiate if any of our rounds are negotiating
-        // a region diff, so we don't have a race condition over the locking of regions,
-        // leading to massive redundancy when multiple nodes try to initiate with us
-        // in quick successions
-        if self.gossip_type == GossipType::Historical
-            && self
-                .inner
-                .share_ref(|i| Ok(i.negotiating_region_diff(&peer_cert)))?
-        {
-            self.remove_target(&peer_cert, false)?;
-            return Ok(vec![ShardedGossipWire::chotto_matte()]);
-        }
-
         // If we don't have a local agent then there's nothing to do.
         if local_agents.is_empty() {
             // No local agents so there's no one to initiate gossip from.

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
@@ -61,7 +61,6 @@ impl ShardedGossipLocal {
             };
 
             self.inner.share_mut(|inner, _| {
-                dbg!();
                 inner.initiate_tgt = Some((tgt, false));
                 Ok(())
             })?;
@@ -87,13 +86,8 @@ impl ShardedGossipLocal {
                 let same_as_target = i
                     .initiate_tgt
                     .as_ref()
-                    .map(|(tgt, _)| {
-                        dbg!(tgt.cert.as_nick());
-                        dbg!(peer_cert.as_nick());
-                        dbg!(tgt.cert == peer_cert)
-                    })
+                    .map(|(tgt, _)| tgt.cert == peer_cert)
                     .unwrap_or(false);
-                dbg!(&self.local_cert.as_nick());
                 Ok((i.local_agents.clone(), same_as_target, already_in_progress))
             })?;
 
@@ -116,7 +110,6 @@ impl ShardedGossipLocal {
                 return Ok(Vec::with_capacity(0));
             } else {
                 self.inner.share_mut(|i, _| {
-                    dbg!();
                     i.initiate_tgt = None;
                     Ok(())
                 })?;
@@ -189,7 +182,6 @@ impl ShardedGossipLocal {
             inner.round_map.insert(peer_cert.clone(), state);
 
             // If this is the target then we should clear the when initiated timeout.
-            dbg!();
             if let Some((tgt, _)) = inner.initiate_tgt.as_mut() {
                 if tgt.cert == peer_cert {
                     tgt.when_initiated = None;

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
@@ -109,7 +109,7 @@ impl ShardedGossipLocal {
         // leading to massive redundancy when multiple nodes try to initiate with us
         // in quick successions
         if self.gossip_type == GossipType::Historical
-            && self.inner.share_ref(|i| Ok(i.negotiating_region_diff()))?
+            && self.inner.share_ref(|i| Ok(i.negotiating_region_diff(&peer_cert)))?
         {
             tracing::warn!("chotto matte kudasai! {:?}", peer_cert);
             return Ok(vec![ShardedGossipWire::chotto_matte()]);
@@ -181,7 +181,6 @@ impl ShardedGossipLocal {
                 metrics.record_accept(&remote_agent_list, self.gossip_type.into());
             }
 
-            dbg!("round added", state.regions_are_queued);
             inner.round_map.insert(peer_cert.clone(), state);
 
             // If this is the target then we should clear the when initiated timeout.
@@ -244,7 +243,6 @@ impl ShardedGossipLocal {
             // we consider recent gossip to have "sent its region"
             // for purposes of determining the round is complete
             state.regions_are_queued = true;
-            dbg!("regions_are_queued = true");
 
             self.next_bloom_batch(state, gossip).await
         } else {
@@ -253,7 +251,6 @@ impl ShardedGossipLocal {
             // be considered "finished" until all op data is received.
             state.has_pending_historical_op_data = true;
             state.regions_are_queued = false;
-            dbg!("regions_are_queued = false");
             Ok(state)
         }
     }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
@@ -109,9 +109,10 @@ impl ShardedGossipLocal {
         // leading to massive redundancy when multiple nodes try to initiate with us
         // in quick successions
         if self.gossip_type == GossipType::Historical
-            && self.inner.share_ref(|i| Ok(i.negotiating_region_diff(&peer_cert)))?
+            && self
+                .inner
+                .share_ref(|i| Ok(i.negotiating_region_diff(&peer_cert)))?
         {
-            tracing::warn!("chotto matte kudasai! {:?}", peer_cert);
             return Ok(vec![ShardedGossipWire::chotto_matte()]);
         }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
@@ -109,9 +109,11 @@ impl ShardedGossipLocal {
         // leading to massive redundancy when multiple nodes try to initiate with us
         // in quick successions
         if self.gossip_type == GossipType::Historical
-            && self
-                .inner
-                .share_ref(|i| Ok(i.negotiating_region_diff(&peer_cert)))?
+            && self.inner.share_mut(|i, _| {
+                let yes = i.negotiating_region_diff(&peer_cert);
+                i.remove_state(&peer_cert, self.gossip_type, false);
+                Ok(yes)
+            })?
         {
             return Ok(vec![ShardedGossipWire::chotto_matte()]);
         }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
@@ -203,10 +203,12 @@ impl ShardedGossipLocal {
         let common_arc_set = Arc::new(arc_set.intersection(&remote_arc_set));
 
         let region_set = if let GossipType::Historical = self.gossip_type {
+            let locked_regions = self.inner.share_ref(|s| Ok(s.round_map.locked_regions()))?;
             let region_set = store::query_region_set(
                 self.host_api.clone(),
                 self.space.clone(),
                 common_arc_set.clone(),
+                locked_regions,
             )
             .await?;
             gossip.push(ShardedGossipWire::op_regions(region_set.clone()));

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
@@ -204,6 +204,7 @@ impl ShardedGossipLocal {
 
         let region_set = if let GossipType::Historical = self.gossip_type {
             let locked_regions = self.inner.share_ref(|s| Ok(s.round_map.locked_regions()))?;
+            tracing::info!("num locked regions: {}", locked_regions.len());
             let region_set = store::query_region_set(
                 self.host_api.clone(),
                 self.space.clone(),

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/next_target.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/next_target.rs
@@ -82,8 +82,6 @@ impl ShardedGossipLocal {
                 })
                 .next();
 
-            // dbg!(&info);
-
             // If we found a remote address add this agent to the node
             // or create the node if it doesn't exist.
             if let Some((info, cert, url)) = info {
@@ -124,8 +122,6 @@ fn next_remote_node(
 ) -> Option<Node> {
     use rand::prelude::*;
     let mut rng = thread_rng();
-
-    // dbg!(&remote_nodes, metrics);
 
     // Sort the nodes by longest time since we last successfully gossiped with them.
     // Randomly break ties between nodes we haven't successfully gossiped with.
@@ -189,7 +185,7 @@ fn next_remote_node(
                         >= tuning_params.gossip_peer_on_error_next_gossip_delay_ms
                 }
                 Some((_, RoundOutcome::SuccessPartial)) => true,
-                _ => true,
+                _ => dbg!(true),
             }
         })
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
@@ -137,6 +137,7 @@ impl ShardedGossipLocal {
                         .sum::<u32>();
                     round.locked_regions = theirs.into_iter().map(|r| r.coords).collect();
                     round.regions_are_queued = true;
+                    dbg!("regions_are_queued = true");
                     tracing::info!("Locked regions are recorded with peer {:?}", peer_cert);
                     i.metrics.write().update_current_round(
                         peer_cert,

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
@@ -137,7 +137,6 @@ impl ShardedGossipLocal {
                         .sum::<u32>();
                     round.locked_regions = theirs.into_iter().map(|r| r.coords).collect();
                     round.regions_are_queued = true;
-                    dbg!("regions_are_queued = true");
                     tracing::info!("Locked regions are recorded with peer {:?}", peer_cert);
                     i.metrics.write().update_current_round(
                         peer_cert,

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
@@ -137,6 +137,7 @@ impl ShardedGossipLocal {
                         .sum::<u32>();
                     round.locked_regions = theirs.into_iter().map(|r| r.coords).collect();
                     round.regions_are_queued = true;
+                    tracing::info!("Locked regions are recorded with peer {:?}", peer_cert);
                     i.metrics.write().update_current_round(
                         peer_cert,
                         GossipModuleType::ShardedHistorical,

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
@@ -107,7 +107,7 @@ impl ShardedGossipLocal {
         region_set: RegionSetLtcs,
     ) -> KitsuneResult<Vec<ShardedGossipWire>> {
         if let Some(sent) = state.region_set_sent.as_ref().map(|r| (**r).clone()) {
-            let RegionDiffs { ours, theirs } = sent
+            let (RegionDiffs { ours, theirs }, limited) = sent
                 .clone()
                 .diff(region_set.clone())
                 .map_err(KitsuneError::other)?
@@ -137,6 +137,7 @@ impl ShardedGossipLocal {
                         .sum::<u32>();
                     round.locked_regions = theirs.into_iter().map(|r| r.coords).collect();
                     round.regions_are_queued = true;
+                    round.size_limited = limited;
                     tracing::info!("Locked regions are recorded with peer {:?}", peer_cert);
                     i.metrics.write().update_current_round(
                         peer_cert,

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
@@ -2,8 +2,8 @@ use super::*;
 
 /// Map of gossip round state that checks for timed out rounds on gets.
 #[derive(Default, Debug)]
-pub(super) struct RoundStateMap {
-    map: HashMap<StateKey, RoundState>,
+pub(crate) struct RoundStateMap {
+    pub(crate) map: HashMap<StateKey, RoundState>,
     timed_out: Vec<(StateKey, RoundState)>,
 }
 
@@ -81,16 +81,6 @@ impl RoundStateMap {
             .values()
             .flat_map(|r| r.locked_regions.clone())
             .collect()
-    }
-
-    /// Are there any historical rounds which have begun but have not yet calculated
-    /// the region diff and hence the locked regions?
-    ///
-    /// This check is useful because we want to turn away new historic gossip requests
-    /// while this negotiation is happening, so that we don't have a race condition
-    /// for region locking
-    pub fn negotiating_region_diff(&self) -> bool {
-        self.map.values().any(|r| !r.regions_are_queued)
     }
 
     /// Touch a round to reset its timeout.

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
@@ -75,6 +75,14 @@ impl RoundStateMap {
         std::mem::take(&mut self.timed_out)
     }
 
+    /// Get the set of all locked regions for all rounds
+    pub fn locked_regions(&self) -> HashSet<RegionCoords> {
+        self.map
+            .values()
+            .flat_map(|r| r.locked_regions.clone())
+            .collect()
+    }
+
     /// Touch a round to reset its timeout.
     fn touch(&mut self, key: &StateKey) {
         if let Some(state) = self.map.get_mut(key) {

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
@@ -83,6 +83,16 @@ impl RoundStateMap {
             .collect()
     }
 
+    /// Are there any historical rounds which have begun but have not yet calculated
+    /// the region diff and hence the locked regions?
+    ///
+    /// This check is useful because we want to turn away new historic gossip requests
+    /// while this negotiation is happening, so that we don't have a race condition
+    /// for region locking
+    pub fn negotiating_region_diff(&self) -> bool {
+        self.map.values().any(|r| !r.regions_are_queued)
+    }
+
     /// Touch a round to reset its timeout.
     fn touch(&mut self, key: &StateKey) {
         if let Some(state) = self.map.get_mut(key) {

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/store.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/store.rs
@@ -10,6 +10,7 @@ use crate::event::{
 use crate::types::event::KitsuneP2pEventSender;
 use crate::HostApi;
 use kitsune_p2p_timestamp::Timestamp;
+use kitsune_p2p_types::dht::region::RegionCoords;
 use kitsune_p2p_types::dht::region_set::RegionSetLtcs;
 use kitsune_p2p_types::{
     agent_info::AgentInfoSigned,
@@ -264,9 +265,10 @@ pub(super) async fn query_region_set<'a>(
     host_api: HostApi,
     space: Arc<KitsuneSpace>,
     common_arc_set: Arc<DhtArcSet>,
+    locked_regions: HashSet<RegionCoords>,
 ) -> KitsuneResult<RegionSetLtcs> {
     host_api
-        .query_region_set(space, common_arc_set)
+        .query_region_set(space, common_arc_set, locked_regions)
         .await
         .map_err(KitsuneError::other)
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests.rs
@@ -23,6 +23,7 @@ impl ShardedGossipLocal {
         let mut u = arbitrary::Unstructured::new(&NOISE);
         let space = KitsuneSpace::arbitrary(&mut u).unwrap();
         let space = Arc::new(space);
+        let local_cert = Tx2Cert::arbitrary(&mut u).unwrap();
         Self {
             gossip_type,
             tuning_params: Default::default(),
@@ -31,6 +32,7 @@ impl ShardedGossipLocal {
             host_api: host,
             inner: Share::new(inner),
             closing: std::sync::atomic::AtomicBool::new(false),
+            local_cert,
         }
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -53,6 +53,7 @@ impl KitsuneHost for StandardResponsesHostApi {
         &self,
         space: Arc<KitsuneSpace>,
         dht_arc_set: Arc<DhtArcSet>,
+        _locked_regions: HashSet<RegionCoords>,
     ) -> crate::KitsuneHostResult<RegionSetLtcs> {
         async move {
             let arqs = ArqBoundsSet::from_dht_arc_set(
@@ -71,9 +72,9 @@ impl KitsuneHost for StandardResponsesHostApi {
                     size: 1,
                     count: 1,
                 };
-                coords.into_region_set_infallible(|_| data.clone())
+                coords.into_region_set_infallible_unlocked(|_| data.clone())
             } else {
-                coords.into_region_set_infallible(|_| RegionData::zero())
+                coords.into_region_set_infallible_unlocked(|_| RegionData::zero())
             };
             Ok(region_set)
         }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/ops.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/ops.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use kitsune_p2p_types::dht::{
     prelude::Segment,
-    region::{Region, RegionCoords, RegionData},
+    region::{Region, RegionCell, RegionCoords, RegionData},
 };
 
 use crate::gossip::sharded_gossip::ops::get_region_queue_batch;
@@ -13,11 +13,11 @@ fn fake_region(count: u32, size: u32) -> Region {
             space: Segment::new(0, 0),
             time: Segment::new(0, 0),
         },
-        data: RegionData {
+        data: RegionCell::Data(RegionData {
             hash: [0; 32].into(),
             count,
             size,
-        },
+        }),
     }
 }
 
@@ -26,7 +26,7 @@ fn test_region_queue() {
     fn run(queue: &mut VecDeque<Region>, batch_size: u32) -> Vec<u32> {
         get_region_queue_batch(queue, batch_size)
             .into_iter()
-            .map(|r| r.data.size)
+            .map(|r| r.data.size())
             .collect()
     }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/test_two_nodes.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/test_two_nodes.rs
@@ -639,6 +639,7 @@ async fn initiate_times_out() {
         .unwrap();
 }
 
+#[cfg(TODO)]
 #[tokio::test(flavor = "multi_thread")]
 /// Checks that incoming initates are not accepted as long as there is either:
 /// - a pending initiate that hasn't been accepted, using historical gossip, or

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/test_two_nodes.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/test_two_nodes.rs
@@ -20,6 +20,7 @@ fn new_round(num_expected_op_blooms: u16, received_all_incoming_op_blooms: bool)
         region_set_sent: None,
         throughput: Default::default(),
         locked_regions: Default::default(),
+        size_limited: false,
     }
 }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/test_two_nodes.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/test_two_nodes.rs
@@ -703,7 +703,7 @@ async fn region_diff_race_condition_is_handled() {
     // - Alice initiates with bob
     let (bob_cert, _, alice_initiate) = alice.try_initiate().await.unwrap().unwrap();
     assert_eq!(bob_cert, bob_node.cert);
-    assert!(is_negotiating(&alice));
+    assert!(!is_negotiating(&alice));
     assert!(!is_negotiating(&bob));
 
     let bob_outgoing = bob

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/test_two_nodes.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/test_two_nodes.rs
@@ -152,7 +152,7 @@ async fn partial_missing_doesnt_finish() {
                     bloom_batch_cursor: None,
                     ops_batch_queue: OpsBatchQueue::new(),
                     region_set_sent: None,
-                    throughput: Default::default(), region_diffs: Default::default(),
+                    throughput: Default::default(), locked_regions: Default::default(),
                 }
             }
             .into(),
@@ -205,7 +205,7 @@ async fn missing_ops_finishes() {
                     bloom_batch_cursor: None,
                     ops_batch_queue: OpsBatchQueue::new(),
                     region_set_sent: None,
-                    throughput: Default::default(), region_diffs: Default::default(),
+                    throughput: Default::default(), locked_regions: Default::default(),
                 }
             }
             .into(),
@@ -259,7 +259,7 @@ async fn missing_ops_doesnt_finish_awaiting_bloom_responses() {
                     bloom_batch_cursor: None,
                     ops_batch_queue: OpsBatchQueue::new(),
                     region_set_sent: None,
-                    throughput: Default::default(), region_diffs: Default::default(),
+                    throughput: Default::default(), locked_regions: Default::default(),
                 }
             }
             .into(),
@@ -313,7 +313,7 @@ async fn bloom_response_finishes() {
                     bloom_batch_cursor: None,
                     ops_batch_queue: OpsBatchQueue::new(),
                     region_set_sent: None,
-                    throughput: Default::default(), region_diffs: Default::default(),
+                    throughput: Default::default(), locked_regions: Default::default(),
                 }
             }
             .into(),
@@ -367,7 +367,7 @@ async fn bloom_response_doesnt_finish_outstanding_incoming() {
                     bloom_batch_cursor: None,
                     ops_batch_queue: OpsBatchQueue::new(),
                     region_set_sent: None,
-                    throughput: Default::default(), region_diffs: Default::default(),
+                    throughput: Default::default(), locked_regions: Default::default(),
                 }
             }
             .into(),
@@ -424,7 +424,7 @@ async fn no_data_still_finishes() {
                     bloom_batch_cursor: None,
                     ops_batch_queue: OpsBatchQueue::new(),
                     region_set_sent: None,
-                    throughput: Default::default(), region_diffs: Default::default(),
+                    throughput: Default::default(), locked_regions: Default::default(),
                 }
             }
             .into(),
@@ -452,7 +452,7 @@ async fn no_data_still_finishes() {
                     bloom_batch_cursor: None,
                     ops_batch_queue: OpsBatchQueue::new(),
                     region_set_sent: None,
-                    throughput: Default::default(), region_diffs: Default::default(),
+                    throughput: Default::default(), locked_regions: Default::default(),
                 }
             }
             .into(),

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
@@ -1,9 +1,13 @@
 use must_future::MustBoxFuture;
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use kitsune_p2p_types::{
     bin_types::KitsuneSpace,
-    dht::{region::Region, region_set::RegionSetLtcs, spacetime::Topology},
+    dht::{
+        region::{Region, RegionCoords},
+        region_set::RegionSetLtcs,
+        spacetime::Topology,
+    },
     dht_arc::DhtArcSet,
 };
 
@@ -34,6 +38,7 @@ pub trait KitsuneHost: 'static + Send + Sync {
         &self,
         space: Arc<KitsuneSpace>,
         dht_arc_set: Arc<DhtArcSet>,
+        locked_regions: HashSet<RegionCoords>,
     ) -> KitsuneHostResult<RegionSetLtcs>;
 
     /// Given an input list of regions, return a list of equal or greater length

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_default_error.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_default_error.rs
@@ -126,6 +126,7 @@ impl<T: KitsuneHostDefaultError> KitsuneHost for T {
         &self,
         space: Arc<KitsuneSpace>,
         dht_arc_set: Arc<DhtArcSet>,
+        _locked_regions: HashSet<RegionCoords>,
     ) -> KitsuneHostResult<RegionSetLtcs> {
         KitsuneHostDefaultError::query_region_set(self, space, dht_arc_set)
     }

--- a/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
@@ -1,14 +1,15 @@
 //! metrics tracked by kitsune_p2p spaces
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
 
+use kitsune_p2p_types::dht::region::RegionCoords;
 use tokio::time::Instant;
 
 use crate::gossip::sharded_gossip::NodeId;
-use crate::gossip::sharded_gossip::RegionDiffs;
 use crate::gossip::sharded_gossip::RoundState;
 use crate::gossip::sharded_gossip::RoundThroughput;
 use crate::types::event::*;
@@ -168,7 +169,7 @@ pub struct CompletedRound {
     /// This round ended in an error
     pub error: bool,
     /// If historical, the region diffs
-    pub region_diffs: RegionDiffs,
+    pub locked_regions: HashSet<RegionCoords>,
 }
 
 impl CompletedRound {
@@ -192,7 +193,7 @@ pub struct CurrentRound {
     /// Total information sent/received so far
     pub throughput: RoundThroughput,
     /// If historical, the region diffs
-    pub region_diffs: RegionDiffs,
+    pub locked_regions: HashSet<RegionCoords>,
 }
 
 impl CurrentRound {
@@ -204,7 +205,7 @@ impl CurrentRound {
             start_time,
             last_touch: Instant::now(),
             throughput: Default::default(),
-            region_diffs: Default::default(),
+            locked_regions: Default::default(),
         }
     }
 
@@ -212,7 +213,7 @@ impl CurrentRound {
     pub fn update(&mut self, round_state: &RoundState) {
         self.last_touch = Instant::now();
         self.throughput = round_state.throughput.clone();
-        self.region_diffs = round_state.region_diffs.clone();
+        self.locked_regions = round_state.locked_regions.clone();
     }
 
     /// Convert to a CompletedRound
@@ -224,7 +225,7 @@ impl CurrentRound {
             end_time: Instant::now(),
             throughput: self.throughput,
             error,
-            region_diffs: self.region_diffs,
+            locked_regions: self.locked_regions,
         }
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
@@ -636,6 +636,25 @@ impl Metrics {
             .min_by_key(|r| r.instant)
     }
 
+    /// Get the last successful round time.
+    pub fn last_partial_success<'a, T, I>(&self, remote_agent_list: I) -> Option<&RoundMetric>
+    where
+        T: Into<AgentLike<'a>>,
+        I: IntoIterator<Item = T>,
+    {
+        remote_agent_list
+            .into_iter()
+            .filter_map(|agent_info| self.agent_history.get(agent_info.into().agent()))
+            .filter_map(|info| {
+                info.completions
+                    .iter()
+                    .rev()
+                    .find(|(outcome, _)| *outcome == RoundOutcome::SuccessPartial)
+            })
+            .map(|(_, r)| r)
+            .min_by_key(|r| r.instant)
+    }
+
     /// Is this node currently in an active round?
     pub fn is_current_round<'a, T, I>(&self, remote_agent_list: I) -> bool
     where

--- a/crates/kitsune_p2p/types/src/config.rs
+++ b/crates/kitsune_p2p/types/src/config.rs
@@ -138,7 +138,13 @@ pub mod tuning_params_struct {
 
         /// The max number of bytes of op data to send in a single message.
         /// Payloads larger than this are split into multiple batches.
+        /// [Default: 16MB]
         gossip_max_batch_size: u32 = 16_000_000,
+
+        /// The max number of bytes that will be sent in a single gossip round for
+        /// transmitting op data. Only applies to historical gossip, currently.
+        /// [Default: 64MiB]
+        gossip_max_round_op_bytes: u32 = 67_108_864,
 
         /// Should gossip dynamically resize storage arcs?
         gossip_dynamic_arcs: bool = true,

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -1099,6 +1099,7 @@ dependencies = [
  "futures",
  "gcollections",
  "intervallum",
+ "itertools 0.10.3",
  "kitsune_p2p_dht_arc",
  "kitsune_p2p_timestamp",
  "must_future",


### PR DESCRIPTION
### Summary

We can massively increase parallelism and reduce redundancy in historical gossip by:

- limiting total op data sent per round, and
- marking regions currently being gossiped as "locked", which will be ignored in future concurrent rounds

The next step is to make gossip metrics aware of the distinction between rounds which end in total completion, vs rounds which ended because the size limit was reached, or there were no more unlocked regions to gossip about, so that rounds that end due to a limitation still allow immediate reconnection.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
