### PR TITLE
Adjust gossip timeouts and chunk sizing to mitigate upload errors

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- BREAKING CHANGE - The max entry size has been lowered to 4MB (strictly 4,000,000 bytes) [\#1659](https://github.com/holochain/holochain/pull/1659)
+
 ## 0.0.173
 
 ## 0.0.172

--- a/crates/holochain/src/core/sys_validate.rs
+++ b/crates/holochain/src/core/sys_validate.rs
@@ -28,8 +28,11 @@ mod error;
 mod tests;
 
 /// 16mb limit on Entries due to websocket limits.
+/// 4mb limit to constrain bandwidth usage on uploading.
+/// (Assuming a baseline 5mbps upload for now... update this
+/// as consumer internet connections trend toward more upload)
 /// Consider splitting large entries up.
-pub const MAX_ENTRY_SIZE: usize = 16_000_000;
+pub const MAX_ENTRY_SIZE: usize = 4_000_000;
 
 /// 1kb limit on LinkTags.
 /// Tags are used as keys to the database to allow

--- a/crates/holochain/tests/integrity_zome/mod.rs
+++ b/crates/holochain/tests/integrity_zome/mod.rs
@@ -297,7 +297,7 @@ async fn test_wasm_memory() {
     #[derive(Debug, Serialize)]
     struct Post(String);
 
-    let data = String::from_utf8(vec![0u8; 10_000_000]).unwrap();
+    let data = String::from_utf8(vec![0u8; 3_000_000]).unwrap();
 
     let mut cum = 0;
     for i in 0..100 {

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -238,7 +238,7 @@ async fn three_way_gossip(config: ConductorConfig) {
         .map(|c| c.zome(SweetInlineZomes::COORDINATOR))
         .collect();
 
-    let size = 15_000_000;
+    let size = 3_000_000;
     let num = 2;
 
     let mut hashes = vec![];

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- The soft maximum gossip batch size has been lowered to 1MB (entries larger than this will just be in a batch alone), and the default timeouts have been increased from 30 seconds to 60 seconds. This is NOT a breaking change, though the usfullness is negated unless the majority of peers are running with the same settings.
+
 ## 0.0.51
 
 - `rpc_multi` now only actually makes a single request. This greatly simplifies the code path and eliminates a source of network bandwidth congestion, but removes the redundancy of aggregating the results of multiple peers. [\#1651](https://github.com/holochain/holochain/pull/1651)

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
-- The soft maximum gossip batch size has been lowered to 1MB (entries larger than this will just be in a batch alone), and the default timeouts have been increased from 30 seconds to 60 seconds. This is NOT a breaking change, though the usfullness is negated unless the majority of peers are running with the same settings.  [\#1659](https://github.com/holochain/holochain/pull/1659)
+- The soft maximum gossip batch size has been lowered to 1MB (entries larger than this will just be in a batch alone), and the default timeouts have been increased from 30 seconds to 60 seconds. This is NOT a breaking change, though the usefulness is negated unless the majority of peers are running with the same settings.  [\#1659](https://github.com/holochain/holochain/pull/1659)
 
 ## 0.0.51
 

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -4,7 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
-- The soft maximum gossip batch size has been lowered to 1MB (entries larger than this will just be in a batch alone), and the default timeouts have been increased from 30 seconds to 60 seconds. This is NOT a breaking change, though the usfullness is negated unless the majority of peers are running with the same settings.
+- The soft maximum gossip batch size has been lowered to 1MB (entries larger than this will just be in a batch alone), and the default timeouts have been increased from 30 seconds to 60 seconds. This is NOT a breaking change, though the usfullness is negated unless the majority of peers are running with the same settings.  [\#1659](https://github.com/holochain/holochain/pull/1659)
 
 ## 0.0.51
 

--- a/crates/kitsune_p2p/proxy/src/bin/kitsune-p2p-tx2-proxy.rs
+++ b/crates/kitsune_p2p/proxy/src/bin/kitsune-p2p-tx2-proxy.rs
@@ -117,7 +117,7 @@ async fn inner() -> KitsuneResult<()> {
     let f = tx2_proxy(f, conf)?;
 
     let ep = f
-        .bind(opt.bind_to.into(), KitsuneTimeout::from_millis(30 * 1000))
+        .bind(opt.bind_to.into(), KitsuneTimeout::from_millis(60 * 1000))
         .await?;
     println!("{}", ep.handle().local_addr()?);
 
@@ -140,7 +140,7 @@ async fn inner() -> KitsuneResult<()> {
                 let debug = serde_json::to_string_pretty(&debug).unwrap();
                 data.clear();
                 data.extend_from_slice(debug.as_bytes());
-                let t = KitsuneTimeout::from_millis(30 * 1000);
+                let t = KitsuneTimeout::from_millis(60 * 1000);
                 let msg_id = if msg_id.is_notify() {
                     0.into()
                 } else {

--- a/crates/kitsune_p2p/proxy/src/bin/proxy-tx2-cli.rs
+++ b/crates/kitsune_p2p/proxy/src/bin/proxy-tx2-cli.rs
@@ -36,7 +36,7 @@ async fn inner() -> KitsuneResult<()> {
     let f = tx2_pool_promote(f, Default::default());
     let f = tx2_proxy(f, Default::default())?;
 
-    let t = KitsuneTimeout::from_millis(30 * 1000);
+    let t = KitsuneTimeout::from_millis(60 * 1000);
 
     let mut ep = f.bind("kitsune-quic://0.0.0.0:0".into(), t).await?;
 

--- a/crates/kitsune_p2p/types/src/config.rs
+++ b/crates/kitsune_p2p/types/src/config.rs
@@ -138,7 +138,7 @@ pub mod tuning_params_struct {
 
         /// The max number of bytes of op data to send in a single message.
         /// Payloads larger than this are split into multiple batches.
-        gossip_max_batch_size: u32 = 16_000_000,
+        gossip_max_batch_size: u32 = 1_000_000,
 
         /// Should gossip dynamically resize storage arcs?
         gossip_dynamic_arcs: bool = true,
@@ -152,8 +152,8 @@ pub mod tuning_params_struct {
         /// what you are doing.
         gossip_single_storage_arc_per_space: bool = false,
 
-        /// Default timeout for rpc single. [Default: 30s]
-        default_rpc_single_timeout_ms: u32 = 1000 * 30,
+        /// Default timeout for rpc single. [Default: 60s]
+        default_rpc_single_timeout_ms: u32 = 1000 * 60,
 
         /// Default agent count for rpc multi. [Default: 3]
         default_rpc_multi_remote_agent_count: u8 = 3,
@@ -186,8 +186,8 @@ pub mod tuning_params_struct {
         concurrent_limit_per_thread: usize = 4096,
 
         /// tx2 quic max_idle_timeout
-        /// [Default: 30 seconds]
-        tx2_quic_max_idle_timeout_ms: u32 = 1000 * 30,
+        /// [Default: 60 seconds]
+        tx2_quic_max_idle_timeout_ms: u32 = 1000 * 60,
 
         /// tx2 pool max connection count
         /// [Default: 4096]
@@ -199,8 +199,8 @@ pub mod tuning_params_struct {
 
         /// tx2 timeout used for passive background operations
         /// like reads / responds.
-        /// [Default: 30 seconds]
-        tx2_implicit_timeout_ms: u32 = 1000 * 30,
+        /// [Default: 60 seconds]
+        tx2_implicit_timeout_ms: u32 = 1000 * 60,
 
         /// tx2 initial connect retry delay
         /// (note, this delay is currenty exponentially backed off--

--- a/crates/kitsune_p2p/types/src/config.rs
+++ b/crates/kitsune_p2p/types/src/config.rs
@@ -137,7 +137,11 @@ pub mod tuning_params_struct {
         gossip_redundancy_target: f64 = 100.0,
 
         /// The max number of bytes of op data to send in a single message.
-        /// Payloads larger than this are split into multiple batches.
+        /// Payloads larger than this are split into multiple batches
+        /// when possible  -- currently, a single Op exceeding this size
+        /// will not be further split up, and there are other cases where
+        /// densely populated DHT regions may contain more than this
+        /// limit when transferred.
         gossip_max_batch_size: u32 = 1_000_000,
 
         /// Should gossip dynamically resize storage arcs?


### PR DESCRIPTION
### Summary

- It is difficult to get a quantitative picture of how this compares, given the strong effects of live networking happenstance
- This almost certainly is not the main fix for the devhub issues
- This does seem to reduce the log warnings / errors, though many remain
- Doesn't seem to damage the speed at which a devhub client can get a full sync

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
