### PR TITLE
change emit signal permissions to non determinism

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - BREAKING CHANGE - The max entry size has been lowered to 4MB (strictly 4,000,000 bytes) [\#1659](https://github.com/holochain/holochain/pull/1659)
+- BREAKING CHANGE - emit signal permissions are changed from writing workspace to non determinism [\#1661](https://github.com/holochain/holochain/pull/1661)
 
 ## 0.0.173
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - BREAKING CHANGE - The max entry size has been lowered to 4MB (strictly 4,000,000 bytes) [\#1659](https://github.com/holochain/holochain/pull/1659)
-- BREAKING CHANGE - emit signal permissions are changed from writing workspace to non determinism [\#1661](https://github.com/holochain/holochain/pull/1661)
+- BREAKING CHANGE - `emit_signal` permissions are changed so that it can be called during `post_commit`, which previously was not allowed [\#1661](https://github.com/holochain/holochain/pull/1661)
 
 ## 0.0.173
 

--- a/crates/holochain/src/core/ribosome/host_fn/emit_signal.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/emit_signal.rs
@@ -13,7 +13,7 @@ pub fn emit_signal(
     input: AppSignal,
 ) -> Result<(), RuntimeError> {
     match HostFnAccess::from(&call_context.host_context()) {
-        HostFnAccess{ write_workspace: Permission::Allow, .. } => {
+        HostFnAccess{ non_determinism: Permission::Allow, .. } => {
             let cell_id = CellId::new(
                 ribosome.dna_def().as_hash().clone(),
                 call_context.host_context.workspace().source_chain().as_ref().expect("Must have a source chain to emit signals").agent_pubkey().clone(),


### PR DESCRIPTION
### Summary

- changed signal permissions from writing workspace to non determinism

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
