### PR TITLE
serde_yaml bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2051,7 +2051,7 @@ dependencies = [
  "sd-notify",
  "serde",
  "serde_json",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "serial_test",
  "shrinkwraprs",
  "sodoken",
@@ -2138,7 +2138,7 @@ dependencies = [
  "predicates 1.0.8",
  "serde",
  "serde_bytes",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "structopt",
  "tempfile",
  "thiserror",
@@ -2165,7 +2165,7 @@ dependencies = [
  "once_cell",
  "portpicker",
  "serde",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "sodoken",
  "structopt",
  "tokio",
@@ -2191,7 +2191,7 @@ dependencies = [
  "observability",
  "serde",
  "serde_derive",
- "serde_yaml 0.9.11",
+ "serde_yaml",
  "structopt",
  "thiserror",
  "tracing",
@@ -2231,7 +2231,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "serde",
  "serde_bytes",
- "serde_yaml 0.9.11",
+ "serde_yaml",
  "sodoken",
  "tempdir",
  "thiserror",
@@ -2451,7 +2451,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "shrinkwraprs",
  "strum",
  "strum_macros",
@@ -2585,7 +2585,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_bytes",
- "serde_yaml 0.9.11",
+ "serde_yaml",
  "shrinkwraprs",
  "strum",
  "subtle",
@@ -3102,7 +3102,7 @@ dependencies = [
  "holochain_serialized_bytes",
  "rusqlite",
  "serde",
- "serde_yaml 0.8.26",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -3201,7 +3201,7 @@ dependencies = [
  "rcgen",
  "serde",
  "serde_json",
- "serde_yaml 0.9.11",
+ "serde_yaml",
  "tokio",
  "toml",
  "tracing",
@@ -3321,12 +3321,6 @@ dependencies = [
  "mortal",
  "winapi",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
@@ -3662,7 +3656,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_derive",
- "serde_yaml 0.8.26",
+ "serde_yaml",
  "tempfile",
  "thiserror",
  "tokio",
@@ -5575,18 +5569,6 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
-name = "serde_yaml"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89f31df3f50926cdf2855da5fd8812295c34752cb20438dae42a67f79e021ac3"
@@ -7365,15 +7347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,7 +2585,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_bytes",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.11",
  "shrinkwraprs",
  "strum",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,7 +2191,7 @@ dependencies = [
  "observability",
  "serde",
  "serde_derive",
- "serde_yaml 0.8.26",
+ "serde_yaml 0.9.11",
  "structopt",
  "thiserror",
  "tracing",

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -26,7 +26,7 @@ holochain_types = { version = "^0.0.67", path = "../holochain_types" }
 mr_bundle = {version = "^0.0.18", path = "../mr_bundle"}
 serde = { version = "1.0", features = [ "derive" ] }
 serde_bytes = "0.11"
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 structopt = "0.3.11"
 thiserror = "1.0.22"
 tokio = { version = "1.11", features = [ "full" ] }

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -28,7 +28,7 @@ nanoid = "0.3"
 observability = "0.1.3"
 once_cell = "1.13.0"
 serde = { version = "1.0", features = [ "derive" ] }
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 sodoken = "=0.0.6"
 tokio = { version = "1.11", features = [ "full" ] }
 structopt = "0.3"

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -55,7 +55,7 @@ rpassword = "5.0.1"
 rusqlite = { version = "0.28" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 shrinkwraprs = "0.3.0"
 sodoken = "=0.0.6"
 structopt = "0.3.11"

--- a/crates/holochain/tests/test_cli/mod.rs
+++ b/crates/holochain/tests/test_cli/mod.rs
@@ -29,7 +29,7 @@ fn malformed_toml_error_is_friendly() {
         .stdout(predicate::str::is_match("[Pp]lease").unwrap());
     cmd.assert()
         .append_context("reason", "output contains the wrong reason for error")
-        .stdout(predicate::str::contains("did not find expected"));
+        .stdout(predicate::str::contains("invalid type"));
 }
 
 #[test]

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -20,7 +20,7 @@ holochain_types = { version = "^0.0.67", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.0.56", path = "../holochain_zome_types" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 structopt = "0.3"
 tracing = "0.1.26"
 thiserror = "1.0.22"

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -45,7 +45,7 @@ serde = { version = "1.0", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"
 serde_derive = "1.0"
 serde_with = "1.12.0"
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 shrinkwraprs = "0.3.0"
 strum = "0.18.0"
 strum_macros = "0.18.0"

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -19,7 +19,7 @@ holochain_serialized_bytes = "=0.0.51"
 paste = "=1.0.5"
 serde = { version = "1.0", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"
-serde_yaml = { version = "0.8", optional = true }
+serde_yaml = { version = "0.9", optional = true }
 subtle = "2"
 thiserror = "1.0.22"
 tracing = "0.1"

--- a/crates/kitsune_p2p/timestamp/Cargo.toml
+++ b/crates/kitsune_p2p/timestamp/Cargo.toml
@@ -27,7 +27,7 @@ arbitrary = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 holochain_serialized_bytes = "=0.0.51"
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 
 [features]
 default = ["chrono"]

--- a/crates/mr_bundle/Cargo.toml
+++ b/crates/mr_bundle/Cargo.toml
@@ -23,13 +23,13 @@ serde_derive = "1.0"
 thiserror = "1.0"
 
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
-serde_yaml = { version = "0.8", optional = true }
+serde_yaml = { version = "0.9", optional = true }
 
 [dev-dependencies]
 anyhow = "1.0"
 matches = "0.1"
 maplit = "1"
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 tokio = { version = "1.11", features = ["full"] }
 tempfile = "3"
 

--- a/crates/mr_bundle/src/location.rs
+++ b/crates/mr_bundle/src/location.rs
@@ -62,6 +62,7 @@ mod tests {
 
     use super::*;
     use serde::{Deserialize, Serialize};
+    use serde_yaml::value::{Tag, TaggedValue};
 
     #[derive(Serialize, Deserialize)]
     struct TunaSalad {
@@ -77,8 +78,8 @@ mod tests {
     /// The YAML produced by this test looks like:
     /// ---
     /// celery:
-    ///   - bundled: b
-    ///   - path: p
+    ///   - !bundled: b
+    ///   - !path: p
     /// url: "http://r.co"
     #[test]
     fn location_flattening() {
@@ -91,8 +92,20 @@ mod tests {
         let val = serde_yaml::to_value(&tuna).unwrap();
         println!("yaml produced:\n{}", serde_yaml::to_string(&tuna).unwrap());
 
-        assert_eq!(val["celery"][0]["bundled"], Value::from("b"));
-        assert_eq!(val["celery"][1]["path"], Value::from("p"));
+        assert_eq!(
+            val["celery"][0],
+            Value::Tagged(Box::new(TaggedValue {
+                tag: Tag::new("!bundled"),
+                value: Value::from("b")
+            }))
+        );
+        assert_eq!(
+            val["celery"][1],
+            Value::Tagged(Box::new(TaggedValue {
+                tag: Tag::new("!path"),
+                value: Value::from("p")
+            }))
+        );
         assert_eq!(val["url"], Value::from("http://r.co"));
     }
 }

--- a/crates/test_utils/wasm/wasm_workspace/zome_info/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/zome_info/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk", features = ["properties"] }
 serde = "1.0"
-serde_yaml = "0.8"
+serde_yaml = "0.9"
 hdi = { path = "../../../../hdi" }
 
 [dev-dependencies]


### PR DESCRIPTION
### Summary

serde_yaml bump to `0.9` to be compatible with lair-keystore-apis expectations

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
