### PR TITLE
rename ZomeId to ZomeIndex

### DIFF
--- a/crates/hdi/src/link.rs
+++ b/crates/hdi/src/link.rs
@@ -41,7 +41,7 @@ where
 {
     fn try_into_filter(self) -> Result<LinkTypeFilter, WasmError> {
         // Collect into a 2d vector of where `LinkType`s are collected
-        // into their common `ZomeId`s.
+        // into their common `ZomeIndex`s.
         let vec = self
             .into_iter()
             .try_fold(HashMap::new(), |mut map: HashMap<_, Vec<_>>, t| {

--- a/crates/hdi/src/op.rs
+++ b/crates/hdi/src/op.rs
@@ -589,9 +589,9 @@ where
     }
 }
 
-/// Get the app defined link type from a [`ZomeId`] and [`LinkType`].
-/// If the [`ZomeId`] is not a dependency of this zome then return a host error.
-fn in_scope_link_type<LT>(zome_id: ZomeId, link_type: LinkType) -> Result<LT, WasmError>
+/// Get the app defined link type from a [`ZomeIndex`] and [`LinkType`].
+/// If the [`ZomeIndex`] is not a dependency of this zome then return a host error.
+fn in_scope_link_type<LT>(zome_id: ZomeIndex, link_type: LinkType) -> Result<LT, WasmError>
 where
     LT: LinkTypesHelper,
     WasmError: From<<LT as LinkTypesHelper>::Error>,
@@ -602,9 +602,9 @@ where
     }
 }
 
-/// Get the app defined link type from a [`ZomeId`] and [`LinkType`].
-/// If the [`ZomeId`] is not a dependency of this zome then return a host error.
-fn activity_link_type<LT>(zome_id: ZomeId, link_type: LinkType) -> Result<Option<LT>, WasmError>
+/// Get the app defined link type from a [`ZomeIndex`] and [`LinkType`].
+/// If the [`ZomeIndex`] is not a dependency of this zome then return a host error.
+fn activity_link_type<LT>(zome_id: ZomeIndex, link_type: LinkType) -> Result<Option<LT>, WasmError>
 where
     LT: LinkTypesHelper,
     WasmError: From<<LT as LinkTypesHelper>::Error>,
@@ -617,7 +617,7 @@ where
 /// Returns a [`WasmErrorInner::Guest`] error if the zome id is a
 /// dependency but the [`EntryDefIndex`] is out of range.
 fn get_unit_entry_type<ET>(
-    zome_id: ZomeId,
+    zome_id: ZomeIndex,
     entry_def_index: EntryDefIndex,
 ) -> Result<Option<<ET as UnitEnum>::Unit>, WasmError>
 where

--- a/crates/hdi/src/test_utils.rs
+++ b/crates/hdi/src/test_utils.rs
@@ -80,13 +80,13 @@ pub fn set_zome_types(entries: &[(u8, u8)], links: &[(u8, u8)]) {
         entries: ScopedZomeTypes(
             entries
                 .into_iter()
-                .map(|(z, types)| (ZomeId(*z), (0..*types).map(|t| EntryDefIndex(t)).collect()))
+                .map(|(z, types)| (ZomeIndex(*z), (0..*types).map(|t| EntryDefIndex(t)).collect()))
                 .collect(),
         ),
         links: ScopedZomeTypes(
             links
                 .into_iter()
-                .map(|(z, types)| (ZomeId(*z), (0..*types).map(|t| LinkType(t)).collect()))
+                .map(|(z, types)| (ZomeIndex(*z), (0..*types).map(|t| LinkType(t)).collect()))
                 .collect(),
         ),
     }));

--- a/crates/hdk/src/hash_path/path.rs
+++ b/crates/hdk/src/hash_path/path.rs
@@ -311,7 +311,7 @@ impl Path {
 }
 
 impl TypedPath {
-    /// Create a new [`TypedPath`] by attaching a [`ZomeId`] and [`LinkType`] to a [`Path`].
+    /// Create a new [`TypedPath`] by attaching a [`ZomeIndex`] and [`LinkType`] to a [`Path`].
     pub fn new(link_type: impl Into<ScopedLinkType>, path: Path) -> Self {
         Self {
             link_type: link_type.into(),

--- a/crates/hdk/src/hash_path/path/test.rs
+++ b/crates/hdk/src/hash_path/path/test.rs
@@ -4,7 +4,7 @@ use crate::hash_path::path::root_hash;
 use crate::prelude::*;
 
 const LINK_TYPE: ScopedLinkType = ScopedLinkType {
-    zome_id: ZomeId(0),
+    zome_id: ZomeIndex(0),
     zome_type: LinkType(0),
 };
 
@@ -25,7 +25,7 @@ fn root_ensures() {
         .with(eq(CreateLinkInput {
             base_address: root_hash().unwrap(),
             target_address: Path::from("foo").path_entry_hash().unwrap().into(),
-            zome_id: ZomeId(0),
+            zome_id: ZomeIndex(0),
             link_type: LinkType(0),
             tag: Path::from("foo").make_tag().unwrap(),
             chain_top_ordering: Default::default(),
@@ -88,7 +88,7 @@ fn parent_path_committed() {
         .with(eq(CreateLinkInput {
             base_address: Path::from("foo").path_entry_hash().unwrap().into(),
             target_address: Path::from("foo.bar").path_entry_hash().unwrap().into(),
-            zome_id: ZomeId(0),
+            zome_id: ZomeIndex(0),
             link_type: LinkType(0),
             tag: Path::from("bar").make_tag().unwrap(),
             chain_top_ordering: Default::default(),
@@ -99,7 +99,7 @@ fn parent_path_committed() {
         .with(eq(CreateLinkInput {
             base_address: root_hash().unwrap(),
             target_address: Path::from("foo").path_entry_hash().unwrap().into(),
-            zome_id: ZomeId(0),
+            zome_id: ZomeIndex(0),
             link_type: LinkType(0),
             tag: Path::from("foo").make_tag().unwrap(),
             chain_top_ordering: Default::default(),
@@ -127,7 +127,7 @@ fn parent_path_committed() {
         .with(eq(CreateLinkInput {
             base_address: Path::from("foo.bar").path_entry_hash().unwrap().into(),
             target_address: Path::from("foo.bar.baz").path_entry_hash().unwrap().into(),
-            zome_id: ZomeId(0),
+            zome_id: ZomeIndex(0),
             link_type: LinkType(0),
             tag: Path::from("baz").make_tag().unwrap(),
             chain_top_ordering: Default::default(),
@@ -138,7 +138,7 @@ fn parent_path_committed() {
         .with(eq(CreateLinkInput {
             base_address: Path::from("foo").path_entry_hash().unwrap().into(),
             target_address: Path::from("foo.bar").path_entry_hash().unwrap().into(),
-            zome_id: ZomeId(0),
+            zome_id: ZomeIndex(0),
             link_type: LinkType(0),
             tag: Path::from("bar").make_tag().unwrap(),
             chain_top_ordering: Default::default(),
@@ -149,7 +149,7 @@ fn parent_path_committed() {
         .with(eq(CreateLinkInput {
             base_address: root_hash().unwrap(),
             target_address: Path::from("foo").path_entry_hash().unwrap().into(),
-            zome_id: ZomeId(0),
+            zome_id: ZomeIndex(0),
             link_type: LinkType(0),
             tag: Path::from("foo").make_tag().unwrap(),
             chain_top_ordering: Default::default(),

--- a/crates/hdk/tests/integration.rs
+++ b/crates/hdk/tests/integration.rs
@@ -144,7 +144,7 @@ fn combine_integrity_zomes() {
 
 #[test]
 fn link_types_create_link() {
-    set_zome_types_and_compare(&[], &[(3, 3)], CreateLink(ZomeId(3), LinkType(0)));
+    set_zome_types_and_compare(&[], &[(3, 3)], CreateLink(ZomeIndex(3), LinkType(0)));
     create_link(
         base(),
         base(),
@@ -173,14 +173,14 @@ fn link_zomes_create_link() {
     set_zome_types_and_compare(
         &[],
         &[(32, 3), (15, 3)],
-        CreateLink(ZomeId(32), LinkType(2)),
+        CreateLink(ZomeIndex(32), LinkType(2)),
     );
     create_link(base(), base(), LinkZomes::A(integrity_a::LinkTypes::C), ()).unwrap();
 
     set_zome_types_and_compare(
         &[],
         &[(32, 3), (15, 6)],
-        CreateLink(ZomeId(15), LinkType(2)),
+        CreateLink(ZomeIndex(15), LinkType(2)),
     );
     create_link(base(), base(), LinkZomes::B(integrity_b::LinkTypes::C), ()).unwrap();
 
@@ -417,7 +417,7 @@ fn link_zomes_from_action() {
 
 enum Compare {
     GetLinks(LinkTypeFilter),
-    CreateLink(ZomeId, LinkType),
+    CreateLink(ZomeIndex, LinkType),
     Nothing,
 }
 
@@ -426,7 +426,7 @@ fn make_filter(r: &[(u8, std::ops::RangeInclusive<u8>)]) -> LinkTypeFilter {
         r.iter()
             .map(|(z, r)| {
                 (
-                    ZomeId(*z),
+                    ZomeIndex(*z),
                     r.clone().map(|t| LinkType(t)).collect::<Vec<_>>(),
                 )
             })
@@ -451,13 +451,13 @@ fn set_zome_types_and_compare(entries: &[(u8, u8)], links: &[(u8, u8)], compare:
             entries: ScopedZomeTypes(
                 entries
                     .iter()
-                    .map(|(z, types)| (ZomeId(*z), (0..*types).map(|t| EntryDefIndex(t)).collect()))
+                    .map(|(z, types)| (ZomeIndex(*z), (0..*types).map(|t| EntryDefIndex(t)).collect()))
                     .collect(),
             ),
             links: ScopedZomeTypes(
                 links
                     .iter()
-                    .map(|(z, types)| (ZomeId(*z), (0..*types).map(|t| LinkType(t)).collect()))
+                    .map(|(z, types)| (ZomeIndex(*z), (0..*types).map(|t| LinkType(t)).collect()))
                     .collect(),
             ),
         };

--- a/crates/hdk_derive/src/entry_defs_name_registration.rs
+++ b/crates/hdk_derive/src/entry_defs_name_registration.rs
@@ -83,7 +83,7 @@ pub fn build(attrs: TokenStream, input: TokenStream) -> TokenStream {
                 match zome_info()?.zome_types.entries.get(value) {
                     Some(t) => Ok(t),
                     _ => Err(wasm_error!(WasmErrorInner::Guest(format!(
-                        "{:?} does not map to any ZomeId and EntryDefIndex that is in scope for this zome.",
+                        "{:?} does not map to any ZomeIndex and EntryDefIndex that is in scope for this zome.",
                         value
                     )))),
                 }
@@ -232,7 +232,7 @@ pub fn build(attrs: TokenStream, input: TokenStream) -> TokenStream {
                 entry: &Entry,
             ) -> std::result::Result<Option<Self>, Self::Error>
             where
-                Z: Into<ZomeId>,
+                Z: Into<ZomeIndex>,
                 I: Into<EntryDefIndex>
             {
                 let s = ScopedEntryDefIndex{ zome_id: zome_id.into(), zome_type: entry_def_index.into() };
@@ -244,7 +244,7 @@ pub fn build(attrs: TokenStream, input: TokenStream) -> TokenStream {
                     None => if entries.dependencies().any(|z| z == s.zome_id) {
                         Err(wasm_error!(WasmErrorInner::Guest(format!(
                             "Entry type: {:?} is out of range for this zome. \
-                            This happens when an Action is created with a ZomeId for a dependency \
+                            This happens when an Action is created with a ZomeIndex for a dependency \
                             of this zome and an EntryDefIndex that is out of range of all the \
                             app defined entry types.",
                             s

--- a/crates/hdk_derive/src/entry_zomes.rs
+++ b/crates/hdk_derive/src/entry_zomes.rs
@@ -107,7 +107,7 @@ pub fn build(_attrs: TokenStream, input: TokenStream) -> TokenStream {
                 match zome_info()?.zome_types.entries.get(value) {
                     Some(t) => Ok(t),
                     _ => Err(wasm_error!(WasmErrorInner::Guest(format!(
-                        "{:?} does not map to any ZomeId and EntryDefIndex that is in scope for this zome.",
+                        "{:?} does not map to any ZomeIndex and EntryDefIndex that is in scope for this zome.",
                         value
                     )))),
                 }
@@ -152,7 +152,7 @@ pub fn build(_attrs: TokenStream, input: TokenStream) -> TokenStream {
                 entry: &Entry,
             ) -> Result<Option<Self>, Self::Error>
             where
-                Z: Into<ZomeId>,
+                Z: Into<ZomeIndex>,
                 I: Into<EntryDefIndex>
             {
                 let scoped_type = ScopedEntryDefIndex {

--- a/crates/hdk_derive/src/link_types.rs
+++ b/crates/hdk_derive/src/link_types.rs
@@ -68,7 +68,7 @@ pub fn build(attrs: TokenStream, input: TokenStream) -> TokenStream {
                 match zome_info()?.zome_types.links.get(value) {
                     Some(t) => Ok(t),
                     _ => Err(wasm_error!(WasmErrorInner::Guest(format!(
-                        "{:?} does not map to any ZomeId and LinkType that is in scope for this zome.",
+                        "{:?} does not map to any ZomeIndex and LinkType that is in scope for this zome.",
                         value
                     )))),
                 }
@@ -135,7 +135,7 @@ pub fn build(attrs: TokenStream, input: TokenStream) -> TokenStream {
 
             fn from_type<Z, I>(zome_id: Z, link_type: I) -> Result<Option<Self>, Self::Error>
             where
-                Z: Into<ZomeId>,
+                Z: Into<ZomeIndex>,
                 I: Into<LinkType>
             {
                 let link_type = ScopedLinkType {

--- a/crates/hdk_derive/src/link_zomes.rs
+++ b/crates/hdk_derive/src/link_zomes.rs
@@ -43,7 +43,7 @@ pub fn build(_attrs: TokenStream, input: TokenStream) -> TokenStream {
                 match zome_info()?.zome_types.links.get(value) {
                     Some(t) => Ok(t),
                     _ => Err(wasm_error!(WasmErrorInner::Guest(format!(
-                        "{:?} does not map to any ZomeId and LinkType that is in scope for this zome.",
+                        "{:?} does not map to any ZomeIndex and LinkType that is in scope for this zome.",
                         value
                     )))),
                 }
@@ -115,7 +115,7 @@ pub fn build(_attrs: TokenStream, input: TokenStream) -> TokenStream {
 
             fn from_type<Z, I>(zome_id: Z, link_type: I) -> Result<Option<Self>, Self::Error>
             where
-                Z: Into<ZomeId>,
+                Z: Into<ZomeIndex>,
                 I: Into<LinkType>
             {
                 let link_type = ScopedLinkType {

--- a/crates/holochain/src/conductor/entry_def_store.rs
+++ b/crates/holochain/src/conductor/entry_def_store.rs
@@ -63,7 +63,7 @@ pub(crate) async fn get_entry_defs(
         .iter()
         .cloned()
         .enumerate()
-        .map(|(i, (zome_name, zome))| (zome_name, (ZomeId(i as u8), zome)))
+        .map(|(i, (zome_name, zome))| (zome_name, (ZomeIndex(i as u8), zome)))
         .collect::<HashMap<_, _>>();
 
     let result = tokio::task::spawn_blocking(move || {

--- a/crates/holochain/src/core/ribosome.rs
+++ b/crates/holochain/src/core/ribosome.rs
@@ -493,18 +493,18 @@ pub trait RibosomeT: Sized + std::fmt::Debug + Send + Sync {
         }
     }
 
-    fn zome_name_to_id(&self, zome_name: &ZomeName) -> RibosomeResult<ZomeId> {
+    fn zome_name_to_id(&self, zome_name: &ZomeName) -> RibosomeResult<ZomeIndex> {
         match self
             .dna_def()
             .all_zomes()
             .position(|(name, _)| name == zome_name)
         {
-            Some(index) => Ok(holochain_zome_types::action::ZomeId::from(index as u8)),
+            Some(index) => Ok(holochain_zome_types::action::ZomeIndex::from(index as u8)),
             None => Err(RibosomeError::ZomeNotExists(zome_name.to_owned())),
         }
     }
 
-    fn get_integrity_zome(&self, zome_id: &ZomeId) -> Option<IntegrityZome>;
+    fn get_integrity_zome(&self, zome_id: &ZomeIndex) -> Option<IntegrityZome>;
 
     fn call_iterator<I: Invocation + 'static>(
         &self,

--- a/crates/holochain/src/core/ribosome/host_fn/zome_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/zome_info.rs
@@ -49,7 +49,7 @@ pub mod test {
 
         let zome_info: ZomeInfo = conductor.call(&alice, "zome_info", ()).await;
         assert_eq!(zome_info.name, "entry_defs".into());
-        assert_eq!(zome_info.id, ZomeId::new(1));
+        assert_eq!(zome_info.id, ZomeIndex::new(1));
         assert_eq!(
             zome_info.entry_defs,
             vec![
@@ -84,8 +84,8 @@ pub mod test {
                 FunctionName::new("zome_info"),
             ],
         );
-        let entries = vec![(ZomeId(0), vec![EntryDefIndex(0), EntryDefIndex(1)])];
-        let links = vec![(ZomeId(0), vec![])];
+        let entries = vec![(ZomeIndex(0), vec![EntryDefIndex(0), EntryDefIndex(1)])];
+        let links = vec![(ZomeIndex(0), vec![])];
         assert_eq!(
             zome_info.zome_types,
             ScopedZomeTypesSet {

--- a/crates/holochain/src/core/ribosome/real_ribosome.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome.rs
@@ -105,7 +105,7 @@ pub struct RealRibosome {
     pub zome_types: Arc<GlobalZomeTypes>,
 
     /// Dependencies for every zome.
-    pub zome_dependencies: Arc<HashMap<ZomeName, Vec<ZomeId>>>,
+    pub zome_dependencies: Arc<HashMap<ZomeName, Vec<ZomeIndex>>>,
 }
 
 struct HostFnBuilder {
@@ -280,13 +280,13 @@ impl RealRibosome {
 
         let zome_types = Arc::new(map?);
 
-        // Create a map of integrity zome names to ZomeIds.
+        // Create a map of integrity zome names to ZomeIndexs.
         let integrity_zomes: HashMap<_, _> = ribosome
             .dna_def()
             .integrity_zomes
             .iter()
             .enumerate()
-            .map(|(i, (n, _))| Some((n.clone(), ZomeId(i.try_into().ok()?))))
+            .map(|(i, (n, _))| Some((n.clone(), ZomeIndex(i.try_into().ok()?))))
             .collect::<Option<_>>()
             .ok_or(ZomeTypesError::ZomeIndexOverflow)?;
 
@@ -299,18 +299,18 @@ impl RealRibosome {
 
                 if integrity_zomes.len() == 1 {
                     // If there's only one integrity zome we add it to this zome and are done.
-                    dependencies.push(ZomeId(0));
+                    dependencies.push(ZomeIndex(0));
                 } else {
                     // Integrity zomes need to have themselves as a dependency.
                     if ribosome.dna_def().is_integrity_zome(zome_name) {
-                        // Get the ZomeId for this zome.
+                        // Get the ZomeIndex for this zome.
                         let id = integrity_zomes.get(zome_name).copied().ok_or_else(|| {
                             ZomeTypesError::MissingDependenciesForZome(zome_name.clone())
                         })?;
                         dependencies.push(id);
                     }
                     for name in def.dependencies() {
-                        // Get the ZomeId for this dependency.
+                        // Get the ZomeIndex for this dependency.
                         let id = integrity_zomes.get(name).copied().ok_or_else(|| {
                             ZomeTypesError::MissingDependenciesForZome(zome_name.clone())
                         })?;
@@ -600,7 +600,7 @@ impl RealRibosome {
         imports
     }
 
-    pub fn get_zome_dependencies(&self, zome_name: &ZomeName) -> RibosomeResult<&[ZomeId]> {
+    pub fn get_zome_dependencies(&self, zome_name: &ZomeName) -> RibosomeResult<&[ZomeIndex]> {
         Ok(self
             .zome_dependencies
             .get(zome_name)
@@ -942,7 +942,7 @@ impl RibosomeT for RealRibosome {
         &self.dna_file
     }
 
-    fn get_integrity_zome(&self, zome_id: &ZomeId) -> Option<IntegrityZome> {
+    fn get_integrity_zome(&self, zome_id: &ZomeIndex) -> Option<IntegrityZome> {
         self.dna_file
             .dna_def()
             .integrity_zomes

--- a/crates/holochain/src/core/sys_validate.rs
+++ b/crates/holochain/src/core/sys_validate.rs
@@ -270,7 +270,7 @@ pub fn check_entry_type(entry_type: &EntryType, entry: &Entry) -> SysValidationR
 }
 
 /// Check the AppEntryType is valid for the zome.
-/// Check the EntryDefId and ZomeId are in range.
+/// Check the EntryDefId and ZomeIndex are in range.
 pub async fn check_app_entry_type(
     dna_hash: &DnaHash,
     entry_type: &AppEntryType,
@@ -285,7 +285,7 @@ pub async fn check_app_entry_type(
     // Check if the zome is found
     let zome = ribosome
         .get_integrity_zome(&entry_type.zome_id())
-        .ok_or_else(|| ValidationOutcome::ZomeId(entry_type.clone()))?
+        .ok_or_else(|| ValidationOutcome::ZomeIndex(entry_type.clone()))?
         .into_inner()
         .1;
 

--- a/crates/holochain/src/core/sys_validate/error.rs
+++ b/crates/holochain/src/core/sys_validate/error.rs
@@ -133,8 +133,8 @@ pub enum ValidationOutcome {
     UpdateTypeMismatch(EntryType, EntryType),
     #[error("Signature {0:?} failed to verify for Action {1:?}")]
     VerifySignature(Signature, Action),
-    #[error("The app entry type {0:?} zome id was out of range")]
-    ZomeId(AppEntryType),
+    #[error("The app entry type {0:?} zome index was out of range")]
+    ZomeIndex(AppEntryType),
 }
 
 impl ValidationOutcome {

--- a/crates/holochain/src/core/sys_validate/tests.rs
+++ b/crates/holochain/src/core/sys_validate/tests.rs
@@ -357,7 +357,7 @@ async fn check_app_entry_type_test() {
     );
 
     // # Dna but no entry def in buffer
-    // ## ZomeId out of range
+    // ## ZomeIndex out of range
     conductor_handle.register_dna(dna_file).await.unwrap();
 
     // ## EntryId is out of range
@@ -373,7 +373,7 @@ async fn check_app_entry_type_test() {
     assert_matches!(
         check_app_entry_type(&dna_hash, &aet, &conductor_handle).await,
         Err(SysValidationError::ValidationOutcome(
-            ValidationOutcome::ZomeId(_)
+            ValidationOutcome::ZomeIndex(_)
         ))
     );
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow/error.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/error.rs
@@ -28,8 +28,8 @@ pub enum AppValidationError {
     RibosomeError(#[from] RibosomeError),
     #[error(transparent)]
     SourceChainError(#[from] SourceChainError),
-    #[error("The app entry type {0:?} zome id was out of range")]
-    ZomeId(ZomeId),
+    #[error("The app entry type {0:?} zome index was out of range")]
+    ZomeIndex(ZomeIndex),
 }
 
 pub type AppValidationResult<T> = Result<T, AppValidationError>;

--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
@@ -7,7 +7,7 @@ use holo_hash::{ActionHash, AgentPubKey};
 use holochain_types::{dht_op::DhtOpType, inline_zome::InlineZomeSet};
 use holochain_zome_types::{
     op::*, Action, ActionType, AppEntryType, BoxApi, ChainTopOrdering, CreateInput, Entry,
-    EntryDef, EntryDefIndex, EntryVisibility, TryInto, ZomeId,
+    EntryDef, EntryDefIndex, EntryVisibility, TryInto, ZomeIndex,
 };
 
 use crate::{
@@ -28,7 +28,7 @@ struct Event {
     action: ActionLocation,
     op_type: DhtOpType,
     called_zome: &'static str,
-    with_zome_id: Option<ZomeId>,
+    with_zome_id: Option<ZomeIndex>,
     with_entry_def_index: Option<EntryDefIndex>,
 }
 
@@ -405,7 +405,7 @@ async fn app_validation_ops() {
 
     event.op_type = DhtOpType::StoreEntry;
     event.called_zome = ZOME_A_0;
-    event.with_zome_id = Some(ZomeId(0));
+    event.with_zome_id = Some(ZomeIndex(0));
     event.with_entry_def_index = Some(0.into());
     expected.0.insert(event.clone());
 

--- a/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
+++ b/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
@@ -231,7 +231,6 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn commit_during_init() {
-        // SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create, TestWasm::InitFail])
         let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
         let mut conductor = SweetConductor::from_standard_config().await;
         let keystore = conductor.keystore();

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -297,7 +297,7 @@ fn handle_failed(error: ValidationOutcome) -> Outcome {
         ValidationOutcome::PreflightResponseSignature(_) => Rejected,
         ValidationOutcome::UpdateTypeMismatch(_, _) => Rejected,
         ValidationOutcome::VerifySignature(_, _) => Rejected,
-        ValidationOutcome::ZomeId(_) => Rejected,
+        ValidationOutcome::ZomeIndex(_) => Rejected,
         ValidationOutcome::CounterSigningError(_) => Rejected,
     }
 }

--- a/crates/holochain/src/test_utils/host_fn_caller.rs
+++ b/crates/holochain/src/test_utils/host_fn_caller.rs
@@ -225,7 +225,7 @@ impl HostFnCaller {
         let zome_types = self
             .ribosome
             .zome_types()
-            .in_scope_subset(&[ZomeId(zome_id as u8)]);
+            .in_scope_subset(&[ZomeIndex(zome_id as u8)]);
         zome_types
             .entries
             .get(ZomeTypesKey {
@@ -250,7 +250,7 @@ impl HostFnCaller {
         let zome_types = self
             .ribosome
             .zome_types()
-            .in_scope_subset(&[ZomeId(zome_id as u8)]);
+            .in_scope_subset(&[ZomeIndex(zome_id as u8)]);
         zome_types
             .links
             .get(ZomeTypesKey {
@@ -337,7 +337,7 @@ impl HostFnCaller {
         &self,
         base: AnyLinkableHash,
         target: AnyLinkableHash,
-        zome_id: impl Into<ZomeId>,
+        zome_id: impl Into<ZomeIndex>,
         link_type: impl Into<LinkType>,
         link_tag: LinkTag,
     ) -> ActionHash {

--- a/crates/holochain/tests/agent_scaling/mod.rs
+++ b/crates/holochain/tests/agent_scaling/mod.rs
@@ -19,7 +19,7 @@ fn links_zome() -> InlineIntegrityZome {
             let hash = api.create_link(CreateLinkInput::new(
                 base_target.0,
                 base_target.1,
-                ZomeId(0),
+                ZomeIndex(0),
                 LinkType::new(0),
                 ().into(),
                 ChainTopOrdering::default(),

--- a/crates/holochain_integrity_types/src/action.rs
+++ b/crates/holochain_integrity_types/src/action.rs
@@ -376,9 +376,9 @@ impl_hashable_content_for_ref!(Delete);
     SerializedBytes,
 )]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-pub struct ZomeId(pub u8);
+pub struct ZomeIndex(pub u8);
 
-impl ZomeId {
+impl ZomeIndex {
     pub fn new(u: u8) -> Self {
         Self(u)
     }
@@ -445,7 +445,7 @@ pub struct CreateLink<W = RateWeight> {
 
     pub base_address: AnyLinkableHash,
     pub target_address: AnyLinkableHash,
-    pub zome_id: ZomeId,
+    pub zome_id: ZomeIndex,
     pub link_type: LinkType,
     pub tag: LinkTag,
 
@@ -634,14 +634,14 @@ pub struct AppEntryType {
     /// entry type.
     pub id: EntryDefIndex,
     /// The id of the zome that defines this entry type.
-    pub zome_id: ZomeId,
+    pub zome_id: ZomeIndex,
     // @todo don't do this, use entry defs instead
     /// The visibility of this app entry.
     pub visibility: EntryVisibility,
 }
 
 impl AppEntryType {
-    pub fn new(id: EntryDefIndex, zome_id: ZomeId, visibility: EntryVisibility) -> Self {
+    pub fn new(id: EntryDefIndex, zome_id: ZomeIndex, visibility: EntryVisibility) -> Self {
         Self {
             id,
             zome_id,
@@ -652,7 +652,7 @@ impl AppEntryType {
     pub fn id(&self) -> EntryDefIndex {
         self.id
     }
-    pub fn zome_id(&self) -> ZomeId {
+    pub fn zome_id(&self) -> ZomeIndex {
         self.zome_id
     }
     pub fn visibility(&self) -> &EntryVisibility {
@@ -666,14 +666,14 @@ impl From<EntryDefIndex> for u8 {
     }
 }
 
-impl ZomeId {
+impl ZomeIndex {
     /// Use as an index into a slice
     pub fn index(&self) -> usize {
         self.0 as usize
     }
 }
 
-impl std::ops::Deref for ZomeId {
+impl std::ops::Deref for ZomeIndex {
     type Target = u8;
 
     fn deref(&self) -> &Self::Target {
@@ -681,7 +681,7 @@ impl std::ops::Deref for ZomeId {
     }
 }
 
-impl Borrow<u8> for ZomeId {
+impl Borrow<u8> for ZomeIndex {
     fn borrow(&self) -> &u8 {
         &self.0
     }

--- a/crates/holochain_integrity_types/src/action/builder.rs
+++ b/crates/holochain_integrity_types/src/action/builder.rs
@@ -8,7 +8,7 @@ use crate::ActionWeighed;
 use crate::EntryRateWeight;
 use crate::MembraneProof;
 use crate::RateWeight;
-use crate::ZomeId;
+use crate::ZomeIndex;
 use action::Dna;
 use holo_hash::ActionHash;
 use holo_hash::AgentPubKey;
@@ -235,7 +235,7 @@ builder_variant!(InitZomesComplete {});
 builder_variant!(CreateLink<RateWeight> {
     base_address: AnyLinkableHash,
     target_address: AnyLinkableHash,
-    zome_id: ZomeId,
+    zome_id: ZomeIndex,
     link_type: LinkType,
     tag: LinkTag,
 });

--- a/crates/holochain_integrity_types/src/action/conversions.rs
+++ b/crates/holochain_integrity_types/src/action/conversions.rs
@@ -1,18 +1,18 @@
 use super::*;
 
-impl From<u8> for ZomeId {
+impl From<u8> for ZomeIndex {
     fn from(a: u8) -> Self {
         Self(a)
     }
 }
 
-impl From<ZomeId> for u8 {
-    fn from(a: ZomeId) -> Self {
+impl From<ZomeIndex> for u8 {
+    fn from(a: ZomeIndex) -> Self {
         a.0
     }
 }
 
-impl std::fmt::Display for ZomeId {
+impl std::fmt::Display for ZomeIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }

--- a/crates/holochain_integrity_types/src/entry.rs
+++ b/crates/holochain_integrity_types/src/entry.rs
@@ -10,7 +10,7 @@ use crate::capability::CapGrant;
 use crate::capability::ZomeCallCapGrant;
 use crate::countersigning::CounterSigningSessionData;
 use crate::EntryDefIndex;
-use crate::ZomeId;
+use crate::ZomeIndex;
 use holo_hash::hash_type;
 use holo_hash::ActionHash;
 use holo_hash::AgentPubKey;
@@ -46,7 +46,7 @@ pub type EntryHashed = holo_hash::HoloHashed<Entry>;
 pub trait EntryTypesHelper: Sized {
     /// The error associated with this conversion.
     type Error;
-    /// Check if the [`ZomeId`] and [`EntryDefIndex`] matches one of the
+    /// Check if the [`ZomeIndex`] and [`EntryDefIndex`] matches one of the
     /// `ZomeEntryTypesKey::from(Self::variant)` and if
     /// it does deserialize the [`Entry`] into that type.
     fn deserialize_from_type<Z, I>(
@@ -55,7 +55,7 @@ pub trait EntryTypesHelper: Sized {
         entry: &Entry,
     ) -> Result<Option<Self>, Self::Error>
     where
-        Z: Into<ZomeId>,
+        Z: Into<ZomeIndex>,
         I: Into<EntryDefIndex>;
 }
 
@@ -68,7 +68,7 @@ impl EntryTypesHelper for () {
         _entry: &Entry,
     ) -> Result<Option<Self>, Self::Error>
     where
-        Z: Into<ZomeId>,
+        Z: Into<ZomeIndex>,
         I: Into<EntryDefIndex>,
     {
         Ok(Some(()))

--- a/crates/holochain_integrity_types/src/info.rs
+++ b/crates/holochain_integrity_types/src/info.rs
@@ -1,5 +1,5 @@
 //! Information about the current zome and dna.
-use crate::action::ZomeId;
+use crate::action::ZomeIndex;
 use crate::zome::ZomeName;
 use crate::EntryDefIndex;
 use crate::EntryDefs;
@@ -17,7 +17,7 @@ mod test;
 pub struct ZomeInfo {
     pub name: ZomeName,
     /// The position of this zome in the `dna.json`
-    pub id: ZomeId,
+    pub id: ZomeIndex,
     pub properties: SerializedBytes,
     pub entry_defs: EntryDefs,
     // @todo make this include function signatures when they exist.
@@ -30,7 +30,7 @@ impl ZomeInfo {
     /// Create a new ZomeInfo.
     pub fn new(
         name: ZomeName,
-        id: ZomeId,
+        id: ZomeIndex,
         properties: SerializedBytes,
         entry_defs: EntryDefs,
         extern_fns: Vec<FunctionName>,
@@ -56,7 +56,7 @@ pub struct DnaInfo {
     pub hash: DnaHash,
     /// The properties of this DNA.
     pub properties: SerializedBytes,
-    // In ZomeId order as to match corresponding `ZomeInfo` for each.
+    // In ZomeIndex order as to match corresponding `ZomeInfo` for each.
     /// The zomes in this DNA.
     pub zome_names: Vec<ZomeName>,
 }
@@ -72,7 +72,7 @@ pub struct ScopedZomeTypesSet {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 /// zome types that are in scope for the calling zome.
-pub struct ScopedZomeTypes<T>(pub Vec<(ZomeId, Vec<T>)>);
+pub struct ScopedZomeTypes<T>(pub Vec<(ZomeIndex, Vec<T>)>);
 
 impl<T> Default for ScopedZomeTypes<T> {
     fn default() -> Self {
@@ -86,7 +86,7 @@ pub struct ZomeTypesKey<T>
 where
     T: U8Index + Copy,
 {
-    /// The index into the [`ZomeId`] vec.
+    /// The index into the [`ZomeIndex`] vec.
     pub zome_index: ZomeDependencyIndex,
     /// The index into the types vec.
     pub type_index: T,
@@ -98,14 +98,14 @@ pub type ZomeEntryTypesKey = ZomeTypesKey<EntryDefIndex>;
 pub type ZomeLinkTypesKey = ZomeTypesKey<LinkType>;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-/// The index into the [`ZomeId`] vec.
+/// The index into the [`ZomeIndex`] vec.
 pub struct ZomeDependencyIndex(pub u8);
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// A type with the zome that it is defined in.
 pub struct ScopedZomeType<T> {
     /// The zome that defines this type.
-    pub zome_id: ZomeId,
+    pub zome_id: ZomeIndex,
     /// The type that is defined.
     pub zome_type: T,
 }
@@ -173,8 +173,8 @@ where
             })
     }
 
-    /// Get all the [`ZomeId`] dependencies for the calling zome.
-    pub fn dependencies(&self) -> impl Iterator<Item = ZomeId> + '_ {
+    /// Get all the [`ZomeIndex`] dependencies for the calling zome.
+    pub fn dependencies(&self) -> impl Iterator<Item = ZomeIndex> + '_ {
         self.0.iter().map(|(zome_id, _)| *zome_id)
     }
 }

--- a/crates/holochain_integrity_types/src/link.rs
+++ b/crates/holochain_integrity_types/src/link.rs
@@ -1,4 +1,4 @@
-use crate::ZomeId;
+use crate::ZomeIndex;
 use holochain_serialized_bytes::prelude::*;
 
 #[derive(
@@ -62,14 +62,14 @@ impl LinkTag {
 /// Filter on a set of [`LinkType`]s.
 pub enum LinkTypeFilter {
     /// Return links that match any of these types.
-    Types(Vec<(ZomeId, Vec<LinkType>)>),
+    Types(Vec<(ZomeIndex, Vec<LinkType>)>),
     /// Return links that match any types defined
     /// in any of this zomes dependencies.
-    Dependencies(Vec<ZomeId>),
+    Dependencies(Vec<ZomeIndex>),
 }
 
 /// A helper trait for finding the app defined link type
-/// from a [`ZomeId`] and [`LinkType`].
+/// from a [`ZomeIndex`] and [`LinkType`].
 ///
 /// If the zome id is a dependency of the calling zome and
 /// the link type is out of range (greater than the number of defined
@@ -81,12 +81,12 @@ pub enum LinkTypeFilter {
 pub trait LinkTypesHelper: Sized {
     /// The error associated with this conversion.
     type Error;
-    /// Check if the [`ZomeId`] and [`LinkType`] matches one of the
+    /// Check if the [`ZomeIndex`] and [`LinkType`] matches one of the
     /// `ZomeLinkTypeKey::from(Self::variant)` and if
     /// it does return that type.
     fn from_type<Z, I>(zome_id: Z, link_type: I) -> Result<Option<Self>, Self::Error>
     where
-        Z: Into<ZomeId>,
+        Z: Into<ZomeIndex>,
         I: Into<LinkType>;
 }
 
@@ -95,7 +95,7 @@ impl LinkTypesHelper for () {
 
     fn from_type<Z, I>(_zome_id: Z, _link_type: I) -> Result<Option<Self>, Self::Error>
     where
-        Z: Into<ZomeId>,
+        Z: Into<ZomeIndex>,
         I: Into<LinkType>,
     {
         Ok(Some(()))
@@ -103,11 +103,11 @@ impl LinkTypesHelper for () {
 }
 
 impl LinkTypeFilter {
-    pub fn zome_for<E>(link_type: impl TryInto<ZomeId, Error = E>) -> Result<Self, E> {
+    pub fn zome_for<E>(link_type: impl TryInto<ZomeIndex, Error = E>) -> Result<Self, E> {
         link_type.try_into().map(LinkTypeFilter::single_dep)
     }
 
-    pub fn contains(&self, zome_id: &ZomeId, link_type: &LinkType) -> bool {
+    pub fn contains(&self, zome_id: &ZomeIndex, link_type: &LinkType) -> bool {
         match self {
             LinkTypeFilter::Types(types) => types
                 .iter()
@@ -116,11 +116,11 @@ impl LinkTypeFilter {
         }
     }
 
-    pub fn single_type(zome_id: ZomeId, link_type: LinkType) -> Self {
+    pub fn single_type(zome_id: ZomeIndex, link_type: LinkType) -> Self {
         Self::Types(vec![(zome_id, vec![link_type])])
     }
 
-    pub fn single_dep(zome_id: ZomeId) -> Self {
+    pub fn single_dep(zome_id: ZomeIndex) -> Self {
         Self::Dependencies(vec![zome_id])
     }
 }
@@ -157,14 +157,14 @@ impl From<u8> for LinkType {
     }
 }
 
-impl From<(ZomeId, LinkType)> for LinkType {
-    fn from((_, l): (ZomeId, LinkType)) -> Self {
+impl From<(ZomeIndex, LinkType)> for LinkType {
+    fn from((_, l): (ZomeIndex, LinkType)) -> Self {
         l
     }
 }
 
-impl From<(ZomeId, LinkType)> for ZomeId {
-    fn from((z, _): (ZomeId, LinkType)) -> Self {
+impl From<(ZomeIndex, LinkType)> for ZomeIndex {
+    fn from((z, _): (ZomeIndex, LinkType)) -> Self {
         z
     }
 }

--- a/crates/holochain_state/src/query/link.rs
+++ b/crates/holochain_state/src/query/link.rs
@@ -42,7 +42,7 @@ impl LinksQuery {
         s
     }
 
-    pub fn base(base: AnyLinkableHash, dependencies: Vec<ZomeId>) -> Self {
+    pub fn base(base: AnyLinkableHash, dependencies: Vec<ZomeIndex>) -> Self {
         Self::new(base, LinkTypeFilter::Dependencies(dependencies), None)
     }
 
@@ -139,7 +139,7 @@ impl GetLinksQuery {
         }
     }
 
-    pub fn base(base: AnyLinkableHash, dependencies: Vec<ZomeId>) -> Self {
+    pub fn base(base: AnyLinkableHash, dependencies: Vec<ZomeIndex>) -> Self {
         Self {
             query: LinksQuery::base(base, dependencies),
         }

--- a/crates/holochain_state/src/query/test_data.rs
+++ b/crates/holochain_state/src/query/test_data.rs
@@ -128,7 +128,7 @@ impl LinkTestData {
             create_link_hash: later_create_link_hash.clone(),
         };
 
-        let base_query = GetLinksQuery::base(base_hash.clone().into(), vec![ZomeId(0)]);
+        let base_query = GetLinksQuery::base(base_hash.clone().into(), vec![ZomeIndex(0)]);
         let tag_query = GetLinksQuery::new(
             base_hash.clone().into(),
             LinkTypeFilter::single_dep(0.into()),

--- a/crates/holochain_state/src/query/tests/links_test.rs
+++ b/crates/holochain_state/src/query/tests/links_test.rs
@@ -11,7 +11,7 @@ struct TestData {
     link_add: CreateLink,
     link_remove: DeleteLink,
     base_hash: EntryHash,
-    zome_id: ZomeId,
+    zome_id: ZomeIndex,
     link_type: LinkType,
     tag: LinkTag,
     expected_link: Link,
@@ -32,7 +32,7 @@ fn fixtures(env: DbWrite<DbKindDht>, n: usize) -> Vec<TestData> {
         let target_address = target_hash_fixt.next().unwrap();
 
         let tag = LinkTag::new(tag_fix.next().unwrap());
-        let zome_id = ZomeId(i as u8);
+        let zome_id = ZomeIndex(i as u8);
         let link_type = LinkType(i as u8);
 
         let link_add = KnownCreateLink {

--- a/crates/holochain_types/src/link.rs
+++ b/crates/holochain_types/src/link.rs
@@ -71,7 +71,7 @@ pub struct WireCreateLink {
     pub prev_action: ActionHash,
 
     pub target_address: AnyLinkableHash,
-    pub zome_id: ZomeId,
+    pub zome_id: ZomeIndex,
     pub link_type: LinkType,
     pub tag: Option<LinkTag>,
     pub signature: Signature,

--- a/crates/holochain_types/src/sql.rs
+++ b/crates/holochain_types/src/sql.rs
@@ -80,8 +80,8 @@ impl<'a> From<&'a LinkTag> for SqlOutput<'a> {
     }
 }
 
-impl<'a, 'b> From<&'b ZomeId> for SqlOutput<'a> {
-    fn from(d: &'b ZomeId) -> Self {
+impl<'a, 'b> From<&'b ZomeIndex> for SqlOutput<'a> {
+    fn from(d: &'b ZomeIndex) -> Self {
         Self(d.0.into())
     }
 }

--- a/crates/holochain_types/src/sql/test.rs
+++ b/crates/holochain_types/src/sql/test.rs
@@ -1,14 +1,14 @@
 use super::ToSqlStatement;
 use holochain_zome_types::LinkType;
 use holochain_zome_types::LinkTypeFilter;
-use holochain_zome_types::ZomeId;
+use holochain_zome_types::ZomeIndex;
 use test_case::test_case;
 
 fn make_multi(types: &[(u8, &[u8])]) -> LinkTypeFilter {
     LinkTypeFilter::Types(
         types
             .iter()
-            .map(|(z, t)| (ZomeId(*z), t.iter().map(|t| LinkType(*t)).collect()))
+            .map(|(z, t)| (ZomeIndex(*z), t.iter().map(|t| LinkType(*t)).collect()))
             .collect(),
     )
 }
@@ -18,8 +18,8 @@ fn make_multi(types: &[(u8, &[u8])]) -> LinkTypeFilter {
 #[test_case(make_multi(&[(0, &[0]), (1, &[0, 1])]) => " AND ( ( zome_id = 0 AND ( link_type = 0 ) ) OR ( zome_id = 1 AND ( link_type = 0 OR link_type = 1 ) ) ) ".to_string())]
 #[test_case(make_multi(&[(0, &[0, 2, 5])]) => " AND ( ( zome_id = 0 AND ( link_type = 0 OR link_type = 2 OR link_type = 5 ) ) ) ".to_string())]
 #[test_case(LinkTypeFilter::Dependencies(vec![]) => "".to_string())]
-#[test_case(LinkTypeFilter::Dependencies(vec![ZomeId(0)]) => " AND ( zome_id = 0 ) ".to_string())]
-#[test_case(LinkTypeFilter::Dependencies(vec![ZomeId(0), ZomeId(3)]) => " AND ( zome_id = 0 OR zome_id = 3 ) ".to_string())]
+#[test_case(LinkTypeFilter::Dependencies(vec![ZomeIndex(0)]) => " AND ( zome_id = 0 ) ".to_string())]
+#[test_case(LinkTypeFilter::Dependencies(vec![ZomeIndex(0), ZomeIndex(3)]) => " AND ( zome_id = 0 OR zome_id = 3 ) ".to_string())]
 fn link_type_filter_to_sql(filter: LinkTypeFilter) -> String {
     filter.to_sql_statement()
 }
@@ -39,13 +39,13 @@ fn link_type_filter_to_sql(filter: LinkTypeFilter) -> String {
 #[test_case(make_multi(&[(0, &[0, 2, 5])]), 0, 6 => false)]
 #[test_case(make_multi(&[(0, &[0, 2, 5])]), 1, 5 => false)]
 #[test_case(LinkTypeFilter::Dependencies(vec![]), 0, 0 => false)]
-#[test_case(LinkTypeFilter::Dependencies(vec![ZomeId(0)]), 0, 0 => true)]
-#[test_case(LinkTypeFilter::Dependencies(vec![ZomeId(0)]), 0, 1 => true)]
-#[test_case(LinkTypeFilter::Dependencies(vec![ZomeId(0)]), 1, 0 => false)]
-#[test_case(LinkTypeFilter::Dependencies(vec![ZomeId(0), ZomeId(3)]), 0, 0 => true)]
-#[test_case(LinkTypeFilter::Dependencies(vec![ZomeId(0), ZomeId(3)]), 3, 0 => true)]
-#[test_case(LinkTypeFilter::Dependencies(vec![ZomeId(0), ZomeId(3)]), 2, 0 => false)]
-#[test_case(LinkTypeFilter::Dependencies(vec![ZomeId(0), ZomeId(3)]), 4, 0 => false)]
+#[test_case(LinkTypeFilter::Dependencies(vec![ZomeIndex(0)]), 0, 0 => true)]
+#[test_case(LinkTypeFilter::Dependencies(vec![ZomeIndex(0)]), 0, 1 => true)]
+#[test_case(LinkTypeFilter::Dependencies(vec![ZomeIndex(0)]), 1, 0 => false)]
+#[test_case(LinkTypeFilter::Dependencies(vec![ZomeIndex(0), ZomeIndex(3)]), 0, 0 => true)]
+#[test_case(LinkTypeFilter::Dependencies(vec![ZomeIndex(0), ZomeIndex(3)]), 3, 0 => true)]
+#[test_case(LinkTypeFilter::Dependencies(vec![ZomeIndex(0), ZomeIndex(3)]), 2, 0 => false)]
+#[test_case(LinkTypeFilter::Dependencies(vec![ZomeIndex(0), ZomeIndex(3)]), 4, 0 => false)]
 fn link_type_filter_contains(filter: LinkTypeFilter, z: u8, l: u8) -> bool {
-    filter.contains(&ZomeId(z), &LinkType(l))
+    filter.contains(&ZomeIndex(z), &LinkType(l))
 }

--- a/crates/holochain_types/src/zome_types.rs
+++ b/crates/holochain_types/src/zome_types.rs
@@ -6,7 +6,7 @@ use holochain_zome_types::EntryDefIndex;
 use holochain_zome_types::LinkType;
 use holochain_zome_types::ScopedZomeTypes;
 use holochain_zome_types::ScopedZomeTypesSet;
-use holochain_zome_types::ZomeId;
+use holochain_zome_types::ZomeIndex;
 
 #[allow(missing_docs)]
 mod error;
@@ -18,8 +18,8 @@ pub type NumZomeTypes = u8;
 /// Zome types at the global scope for a DNA.
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct GlobalZomeTypes {
-    entries: HashMap<ZomeId, NumZomeTypes>,
-    links: HashMap<ZomeId, NumZomeTypes>,
+    entries: HashMap<ZomeIndex, NumZomeTypes>,
+    links: HashMap<ZomeIndex, NumZomeTypes>,
 }
 
 impl GlobalZomeTypes {
@@ -43,7 +43,7 @@ impl GlobalZomeTypes {
         let r = ordered_iterator.into_iter().enumerate().try_fold(
             Self::default(),
             |mut zome_types, (zome_id, (num_entry_types, num_link_types))| {
-                let zome_id: ZomeId = u8::try_from(zome_id)
+                let zome_id: ZomeIndex = u8::try_from(zome_id)
                     .map_err(|_| ZomeTypesError::ZomeIndexOverflow)?
                     .into();
                 zome_types.entries.insert(zome_id, num_entry_types.0);
@@ -55,7 +55,7 @@ impl GlobalZomeTypes {
     }
 
     /// Create a new zome types map within the scope of the given integrity zomes.
-    pub fn in_scope_subset(&self, zomes: &[ZomeId]) -> ScopedZomeTypesSet {
+    pub fn in_scope_subset(&self, zomes: &[ZomeIndex]) -> ScopedZomeTypesSet {
         let entries = zomes
             .iter()
             .filter_map(|zome_id| self.entries.get_key_value(zome_id).map(|(z, l)| (*z, *l)));
@@ -68,7 +68,7 @@ impl GlobalZomeTypes {
     }
 }
 
-fn new_scope<T>(iter: impl Iterator<Item = (ZomeId, NumZomeTypes)>) -> ScopedZomeTypes<T>
+fn new_scope<T>(iter: impl Iterator<Item = (ZomeIndex, NumZomeTypes)>) -> ScopedZomeTypes<T>
 where
     T: From<u8>,
 {

--- a/crates/holochain_types/src/zome_types/error.rs
+++ b/crates/holochain_types/src/zome_types/error.rs
@@ -1,4 +1,4 @@
-use holochain_zome_types::ZomeId;
+use holochain_zome_types::ZomeIndex;
 use holochain_zome_types::ZomeName;
 use thiserror::Error;
 
@@ -13,7 +13,7 @@ pub enum ZomeTypesError {
     #[error("Missing dependencies for zome {0}")]
     MissingDependenciesForZome(ZomeName),
     #[error("Missing type scope for zome id {0}")]
-    MissingZomeType(ZomeId),
+    MissingZomeType(ZomeIndex),
 }
 
 pub type ZomeTypesResult<T> = Result<T, ZomeTypesError>;

--- a/crates/holochain_types/src/zome_types/test.rs
+++ b/crates/holochain_types/src/zome_types/test.rs
@@ -2,19 +2,19 @@ use super::*;
 use test_case::test_case;
 
 fn make_set(entries: &[(u8, u8)], links: &[(u8, u8)]) -> GlobalZomeTypes {
-    let entries = entries.into_iter().map(|(z, l)| (ZomeId(*z), *l)).collect();
-    let links = links.into_iter().map(|(z, l)| (ZomeId(*z), *l)).collect();
+    let entries = entries.into_iter().map(|(z, l)| (ZomeIndex(*z), *l)).collect();
+    let links = links.into_iter().map(|(z, l)| (ZomeIndex(*z), *l)).collect();
     GlobalZomeTypes { entries, links }
 }
 
 fn make_scope(entries: &[(u8, u8)], links: &[(u8, u8)]) -> ScopedZomeTypesSet {
     let entries = entries
         .into_iter()
-        .map(|(z, l)| (ZomeId(*z), (0..*l).map(|t| t.into()).collect()))
+        .map(|(z, l)| (ZomeIndex(*z), (0..*l).map(|t| t.into()).collect()))
         .collect();
     let links = links
         .into_iter()
-        .map(|(z, l)| (ZomeId(*z), (0..*l).map(|t| t.into()).collect()))
+        .map(|(z, l)| (ZomeIndex(*z), (0..*l).map(|t| t.into()).collect()))
         .collect();
     ScopedZomeTypesSet {
         entries: ScopedZomeTypes(entries),
@@ -65,15 +65,15 @@ fn construction_is_deterministic() {
 
     let mut expect = GlobalZomeTypes::default();
 
-    expect.entries.insert(ZomeId(0), 3);
-    expect.entries.insert(ZomeId(1), 0);
-    expect.entries.insert(ZomeId(2), 5);
-    expect.entries.insert(ZomeId(3), 12);
+    expect.entries.insert(ZomeIndex(0), 3);
+    expect.entries.insert(ZomeIndex(1), 0);
+    expect.entries.insert(ZomeIndex(2), 5);
+    expect.entries.insert(ZomeIndex(3), 12);
 
-    expect.links.insert(ZomeId(0), 2);
-    expect.links.insert(ZomeId(1), 0);
-    expect.links.insert(ZomeId(2), 1);
-    expect.links.insert(ZomeId(3), 0);
+    expect.links.insert(ZomeIndex(0), 2);
+    expect.links.insert(ZomeIndex(1), 0);
+    expect.links.insert(ZomeIndex(2), 1);
+    expect.links.insert(ZomeIndex(3), 0);
 
     assert_eq!(
         GlobalZomeTypes::from_ordered_iterator(zome_types).unwrap(),
@@ -91,6 +91,6 @@ fn construction_is_deterministic() {
 #[test_case(make_set(&[(0, 20), (1, 10), (2, 15)], &[(0, 5), (1, 10), (2, 3)]), &[2, 1] => make_scope(&[(2, 15), (1, 10)], &[(2, 3), (1, 10)]))]
 #[test_case(make_set(&[(0, 20), (1, 10), (2, 15)], &[(0, 5), (1, 10), (2, 3)]), &[0, 2] => make_scope(&[(0, 20), (2, 15)], &[(0, 5), (2, 3)]))]
 fn test_in_scope_subset(set: GlobalZomeTypes, zomes: &[u8]) -> ScopedZomeTypesSet {
-    let zomes = zomes.iter().map(|z| ZomeId(*z)).collect::<Vec<_>>();
+    let zomes = zomes.iter().map(|z| ZomeIndex(*z)).collect::<Vec<_>>();
     set.in_scope_subset(&zomes[..])
 }

--- a/crates/holochain_zome_types/src/entry.rs
+++ b/crates/holochain_zome_types/src/entry.rs
@@ -9,7 +9,7 @@ use crate::action::ChainTopOrdering;
 use holochain_integrity_types::EntryDefIndex;
 use holochain_integrity_types::EntryVisibility;
 use holochain_integrity_types::ScopedEntryDefIndex;
-use holochain_integrity_types::ZomeId;
+use holochain_integrity_types::ZomeIndex;
 use holochain_serialized_bytes::prelude::*;
 
 mod app_entry_bytes;
@@ -42,7 +42,7 @@ pub enum EntryDefLocation {
 /// The location of an app entry definition.
 pub struct AppEntryDefLocation {
     /// The zome that defines this entry type.
-    pub zome_id: ZomeId,
+    pub zome_id: ZomeIndex,
     /// The entry type within the zome.
     pub entry_def_index: EntryDefIndex,
 }
@@ -216,7 +216,7 @@ impl From<holo_hash::ActionHash> for DeleteInput {
 
 impl EntryDefLocation {
     /// Create an [`EntryDefLocation::App`].
-    pub fn app(zome_id: impl Into<ZomeId>, entry_def_index: impl Into<EntryDefIndex>) -> Self {
+    pub fn app(zome_id: impl Into<ZomeIndex>, entry_def_index: impl Into<EntryDefIndex>) -> Self {
         Self::App(AppEntryDefLocation {
             zome_id: zome_id.into(),
             entry_def_index: entry_def_index.into(),

--- a/crates/holochain_zome_types/src/fixt.rs
+++ b/crates/holochain_zome_types/src/fixt.rs
@@ -94,7 +94,7 @@ fixturator!(
 
 fixturator!(
     CreateLink;
-    constructor fn from_builder(ActionBuilderCommon, AnyLinkableHash, AnyLinkableHash, ZomeId, LinkType, LinkTag);
+    constructor fn from_builder(ActionBuilderCommon, AnyLinkableHash, AnyLinkableHash, ZomeIndex, LinkType, LinkTag);
 );
 
 fixturator!(
@@ -109,7 +109,7 @@ pub struct KnownCreateLink {
     pub base_address: AnyLinkableHash,
     pub target_address: AnyLinkableHash,
     pub tag: LinkTag,
-    pub zome_id: ZomeId,
+    pub zome_id: ZomeIndex,
     pub link_type: LinkType,
 }
 
@@ -176,7 +176,7 @@ fixturator!(
 );
 
 fixturator!(
-    ZomeId;
+    ZomeIndex;
     from u8;
 );
 
@@ -187,7 +187,7 @@ fixturator!(
 
 fixturator!(
     ZomeInfo;
-    constructor fn new(ZomeName, ZomeId, SerializedBytes, EntryDefs, FunctionNameVec, ScopedZomeTypesSet);
+    constructor fn new(ZomeName, ZomeIndex, SerializedBytes, EntryDefs, FunctionNameVec, ScopedZomeTypesSet);
 );
 
 fixturator!(

--- a/crates/holochain_zome_types/src/link.rs
+++ b/crates/holochain_zome_types/src/link.rs
@@ -1,7 +1,7 @@
 use crate::record::SignedActionHashed;
 use crate::ChainTopOrdering;
 use holo_hash::ActionHash;
-use holochain_integrity_types::ZomeId;
+use holochain_integrity_types::ZomeIndex;
 use holochain_serialized_bytes::prelude::*;
 
 pub use holochain_integrity_types::link::*;
@@ -23,8 +23,8 @@ pub struct Link {
     pub target: holo_hash::AnyLinkableHash,
     /// When the link was added
     pub timestamp: crate::Timestamp,
-    /// The [`ZomeId`] for where this link is defined.
-    pub zome_id: ZomeId,
+    /// The [`ZomeIndex`] for where this link is defined.
+    pub zome_id: ZomeIndex,
     /// The [`LinkType`] for this link.
     pub link_type: LinkType,
     /// A tag used to find this link
@@ -38,7 +38,7 @@ pub struct Link {
 pub struct CreateLinkInput {
     pub base_address: holo_hash::AnyLinkableHash,
     pub target_address: holo_hash::AnyLinkableHash,
-    pub zome_id: ZomeId,
+    pub zome_id: ZomeIndex,
     pub link_type: LinkType,
     pub tag: LinkTag,
     pub chain_top_ordering: ChainTopOrdering,
@@ -48,7 +48,7 @@ impl CreateLinkInput {
     pub fn new(
         base_address: holo_hash::AnyLinkableHash,
         target_address: holo_hash::AnyLinkableHash,
-        zome_id: ZomeId,
+        zome_id: ZomeIndex,
         link_type: LinkType,
         tag: LinkTag,
         chain_top_ordering: ChainTopOrdering,


### PR DESCRIPTION
### Summary

1. Rename ZomeId to ZomeIndex (consistent with EntryDefIndex with is also a u8)

2. Rename AppEntryType.id to AppEntryType.entry_index (already requested this some time ago)

3. Rename AppEntryType to AppEntryDef (types suffixed with Type should be enums and not structs)

4. Rename AppEntryDefName to AppEntryName (its obvious we are not going to name each entry instance)

5. Rename AppRoleId to RoleName

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
