### PR TITLE
feat(release-automation): add changelog cmd for frontmatter batch setting

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -229,10 +229,10 @@ jobs:
             release-automation \
               --workspace-path=$PWD \
               --log-level=debug \
+              --match-filter="^(holochain|holochain_cli|kitsune_p2p_proxy)$" \
               release \
                 --no-verify-pre \
                 --force-tag-creation \
-                --match-filter="^(holochain|holochain_cli|kitsune_p2p_proxy)$" \
                 --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
                 --disallowed-version-reqs=">=0.2" \
                 --steps=BumpReleaseVersions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -511,7 +511,7 @@ jobs:
           limit-access-to-users: steveeJ,jost-s,freesig,neonphog,thedavidmeister,maackle
 
   finalize:
-    if: ${{ github.event_name != 'pull_request' && needs.prepare.outputs.releasable_crates == 'true' }}
+    if: ${{ always() && needs.prepare.result == 'success' && (needs.test.result == 'success' || needs.test.result == 'skipped') && github.event_name != 'pull_request' && needs.prepare.outputs.releasable_crates == 'true' }}
     needs: [vars, prepare, test]
     env:
       HOLOCHAIN_REPO: ${{ needs.vars.outputs.HOLOCHAIN_REPO }}

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -161,7 +161,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 #### Example
 
 ``` yaml
----
 passphrase_service:
   type: danger_insecure_from_config
   passphrase: "foobar"

--- a/crates/release-automation/README.md
+++ b/crates/release-automation/README.md
@@ -141,10 +141,10 @@ Automated steps still require running the tool manually ;-).
     nix-shell --run '
       hc-ra \
         --workspace-path=$PWD \
+        --match-filter="^(holochain|holochain_cli|kitsune_p2p_proxy)$" \
         --log-level=info \
         release \
           --dry-run \
-          --match-filter="^(holochain|holochain_cli|kitsune_p2p_proxy)$" \
           --disallowed-version-reqs=">=0.1" \
           --steps=BumpReleaseVersions
       '

--- a/crates/release-automation/src/lib/check.rs
+++ b/crates/release-automation/src/lib/check.rs
@@ -6,7 +6,7 @@ use super::*;
 pub(crate) fn cmd(args: &cli::Args, cmd_args: &cli::CheckArgs) -> CommandResult {
     let ws = crate_selection::ReleaseWorkspace::try_new_with_criteria(
         args.workspace_path.clone(),
-        cmd_args.to_selection_criteria(),
+        cmd_args.to_selection_criteria(&args),
     )?;
 
     let release_candidates = common::selection_check(cmd_args, &ws)?;

--- a/crates/release-automation/src/lib/common.rs
+++ b/crates/release-automation/src/lib/common.rs
@@ -242,6 +242,7 @@ mod test {
     #[test_case(Minor, "0.0.1", "0.1.0")]
     #[test_case(Minor, "0.0.1-dev.0", "0.1.0")]
     #[test_case(Minor, "0.1.1-dev.0", "0.2.0")]
+    #[test_case(Minor, "0.1.0-beta-rc.1", "0.1.0")]
     //
     // Patch
     //
@@ -275,6 +276,8 @@ mod test {
     #[test_case(PreMinor("rc".to_string()), "0.1.0-rc", "0.1.0-rc.0")]
     // TODO: check with someone else if this seems counter-intuitive
     #[test_case(PreMinor("rc".to_string()), "0.1.0-rc.0", "0.1.0-rc.1")]
+    #[test_case(PreMinor("beta-rc".to_string()), "0.0.170", "0.1.0-beta-rc.0")]
+    #[test_case(PreMinor("beta-rc".to_string()), "0.1.0-beta-rc.0", "0.1.0-beta-rc.1")]
     //
     // PrePatch
     //

--- a/crates/release-automation/src/lib/crate_selection/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/mod.rs
@@ -391,6 +391,7 @@ pub(crate) struct ReleaseWorkspace<'a> {
     cargo_workspace: OnceCell<CargoWorkspace<'a>>,
     members_unsorted: OnceCell<Vec<Crate<'a>>>,
     members_sorted: OnceCell<Vec<&'a Crate<'a>>>,
+    members_matched: OnceCell<Vec<&'a Crate<'a>>>,
     members_states: OnceCell<MemberStates>,
     #[debug(skip)]
     git_repo: git2::Repository,
@@ -732,6 +733,7 @@ impl<'a> ReleaseWorkspace<'a> {
             cargo_workspace: Default::default(),
             members_unsorted: Default::default(),
             members_sorted: Default::default(),
+            members_matched: Default::default(),
             members_states: Default::default(),
         };
 
@@ -1018,6 +1020,33 @@ impl<'a> ReleaseWorkspace<'a> {
             }
 
             Ok(members)
+        })
+    }
+
+    /// Return all member crates matched by `SelectionCriteria::match_filter`
+    pub(crate) fn members_matched(&'a self) -> Fallible<&'a Vec<&'a Crate<'a>>> {
+        self.members_matched.get_or_try_init(|| {
+            let states = self.members_states()?;
+
+            self.members().map(|members| {
+                members
+                    .into_iter()
+                    .filter(|crt| {
+                        states
+                            .get(&crt.name())
+                            .cloned()
+                            .unwrap_or_else(|| {
+                                warn!(
+                                    "cannot get CrateState for {}, using default state",
+                                    crt.name()
+                                );
+                                CrateState::default()
+                            })
+                            .contains(CrateStateFlags::Matched)
+                    })
+                    .map(|crt| *crt)
+                    .collect::<Vec<_>>()
+            })
         })
     }
 

--- a/crates/release-automation/src/lib/release.rs
+++ b/crates/release-automation/src/lib/release.rs
@@ -68,7 +68,7 @@ pub(crate) fn cmd(args: &crate::cli::Args, cmd_args: &crate::cli::ReleaseArgs) -
         // read the workspace after every step in case it was mutated
         let ws = ReleaseWorkspace::try_new_with_criteria(
             args.workspace_path.clone(),
-            cmd_args.check_args.to_selection_criteria(),
+            cmd_args.check_args.to_selection_criteria(args),
         )?;
 
         macro_rules! _skip_on_empty_selection {

--- a/crates/release-automation/src/lib/tests/cli.rs
+++ b/crates/release-automation/src/lib/tests/cli.rs
@@ -65,6 +65,7 @@ fn release_createreleasebranch_fails_on_dirty_repo() {
         .failure();
 }
 
+#[macro_export]
 macro_rules! assert_cmd_success {
     ($cmd:expr) => {{
         let output = $cmd.output().unwrap();
@@ -746,12 +747,12 @@ fn multiple_subsequent_releases() {
             let cmd = cmd.args(&[
                 &format!("--workspace-path={}", workspace.root().display()),
                 "--log-level=trace",
+                "--match-filter=crate_(a|b|e)",
                 "release",
                 &format!(
                     "--cargo-target-dir={}",
                     workspace.root().join("target").display()
                 ),
-                "--match-filter=crate_(a|b|e)",
                 "--allowed-matched-blockers=UnreleasableViaChangelogFrontmatter",
                 "--steps=CreateReleaseBranch,BumpReleaseVersions",
                 &format!(
@@ -909,9 +910,9 @@ fn release_dry_run_fails_on_unallowed_conditions() {
         let mut cmd = assert_cmd::Command::cargo_bin("release-automation").unwrap();
         let cmd = cmd.args(&[
             &format!("--workspace-path={}", workspace.root().display()),
+            &format!("--match-filter={}", member),
             "--log-level=debug",
             "release",
-            &format!("--match-filter={}", member),
             "--dry-run",
             "--steps=BumpReleaseVersions",
         ]);

--- a/nix/pkgs/core.nix
+++ b/nix/pkgs/core.nix
@@ -75,12 +75,12 @@ rec {
         ${releaseAutomation} \
             --workspace-path=''${TEST_WORKSPACE:?} \
             --log-level=${logLevel} \
+            --match-filter="^(holochain|holochain_cli|kitsune_p2p_proxy)$" \
           release \
             --no-verify-pre \
             --force-branch-creation \
             --disallowed-version-reqs=">=0.1" \
             --allowed-matched-blockers=UnreleasableViaChangelogFrontmatter \
-            --match-filter="^(holochain|holochain_cli|kitsune_p2p_proxy)$" \
             --steps=CreateReleaseBranch,BumpReleaseVersions
       '';
     in


### PR DESCRIPTION
### Summary
this reduces manual effort for adjusting all of the crate changelog's
frontmatters to a common value.

note that `--match-filter=<regex>` can be used to limit the crates that
will be affected.



### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
