### PR TITLE
Handling of extensions

### DIFF
--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added handling of `hc` extensions. This allows for existing executables in the system whose names match `hc-<COMMAND>` to be executed with `hc <COMMAND>`.
+
 ## 0.0.69
 
 ## 0.0.68

--- a/crates/hc/src/external_subcommands.rs
+++ b/crates/hc/src/external_subcommands.rs
@@ -1,0 +1,63 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use crate::builtin_commands;
+
+/// List all runnable commands
+pub fn list_external_subcommands() -> Vec<String> {
+    let prefix = "hc-";
+    let suffix = env::consts::EXE_SUFFIX;
+    let mut commands = Vec::new();
+
+    let builtin_cmds = builtin_commands();
+
+    for dir in search_directories() {
+        let entries = match fs::read_dir(dir) {
+            Ok(entries) => entries,
+            _ => continue,
+        };
+        for entry in entries.filter_map(|e| e.ok()) {
+            let path = entry.path();
+            let filename = match path.file_name().and_then(|s| s.to_str()) {
+                Some(filename) => filename,
+                _ => continue,
+            };
+            if !filename.starts_with(prefix) || !filename.ends_with(suffix) {
+                continue;
+            }
+            let end = filename.len() - suffix.len();
+            let subcommand = filename[prefix.len()..end].to_string();
+            if is_executable(entry.path())
+                && !builtin_cmds.contains(&filename.to_string())
+                && !commands.contains(&subcommand)
+            {
+                commands.push(subcommand);
+            }
+        }
+    }
+
+    commands
+}
+#[cfg(unix)]
+fn is_executable<P: AsRef<Path>>(path: P) -> bool {
+    use std::os::unix::prelude::*;
+    fs::metadata(path)
+        .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+#[cfg(windows)]
+fn is_executable<P: AsRef<Path>>(path: P) -> bool {
+    path.as_ref().is_file()
+}
+
+fn search_directories() -> Vec<PathBuf> {
+    let path_dirs = if let Some(val) = env::var_os("PATH") {
+        env::split_paths(&val).collect()
+    } else {
+        vec![]
+    };
+
+    path_dirs
+}

--- a/crates/hc/src/lib.rs
+++ b/crates/hc/src/lib.rs
@@ -108,19 +108,54 @@
 //! ```
 //! and the examples.
 
+use std::process::Command;
+
 // Useful to have this public when using this as a library.
 pub use holochain_cli_bundle as hc_bundle;
 use holochain_cli_sandbox as hc_sandbox;
-use structopt::StructOpt;
+use structopt::{lazy_static::lazy_static, StructOpt};
 
-/// Holochain CLI
-///
-/// Work with DNA, hApp and web-hApp bundle files, set up sandbox environments for testing
-/// and development purposes, make direct admin calls to running conductors,
-/// and more.
+mod external_subcommands;
+
+lazy_static! {
+    static ref HELP: &'static str = {
+        let extensions = external_subcommands::list_external_subcommands()
+            .into_iter()
+            .map(|s| format!("    hc {}\t  Run \"hc {} help\" to see its help", s, s))
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        let extensions_str = match extensions.len() {
+            0 => format!(""),
+            _ => format!(
+                r#"
+CLI EXTENSIONS:
+{extensions}"#
+            ),
+        };
+
+        let s = format!(
+            r#"Holochain CLI
+
+Work with DNA, hApp and web-hApp bundle files, set up sandbox environments for testing and development purposes, make direct admin calls to running conductors, and more.
+{extensions_str}"#
+        );
+        Box::leak(s.into_boxed_str())
+    };
+}
+
+fn builtin_commands() -> Vec<String> {
+    ["hc-web-app", "hc-dna", "hc-app", "hc-sandbox"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Describes all the possible CLI arguments for `hc`, including external subcommands like `hc-scaffold`
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, StructOpt)]
 #[structopt(setting = structopt::clap::AppSettings::InferSubcommands)]
+#[structopt(long_about = *HELP)]
 pub enum Opt {
     /// Work with DNA bundles
     Dna(hc_bundle::HcDnaBundle),
@@ -130,6 +165,9 @@ pub enum Opt {
     WebApp(hc_bundle::HcWebAppBundle),
     /// Work with sandboxed environments for testing and development
     Sandbox(hc_sandbox::HcSandbox),
+    /// Allow redirect of external subcommands (like hc-scaffold and hc-launch)
+    #[structopt(external_subcommand)]
+    External(Vec<String>),
 }
 
 impl Opt {
@@ -140,6 +178,13 @@ impl Opt {
             Self::App(cmd) => cmd.run().await?,
             Self::WebApp(cmd) => cmd.run().await?,
             Self::Sandbox(cmd) => cmd.run().await?,
+            Self::External(args) => {
+                let command_suffix = args.first().expect("Missing subcommand name");
+                Command::new(format!("hc-{}", command_suffix))
+                    .args(&args[1..])
+                    .status()
+                    .expect("Failed to run external subcommand");
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
### Summary

Adds handling of extensions, necessary for the upcoming `hc-scaffold` and `hc-launch` to be nicely integrated in nix.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
