### PR TITLE
Add sizes to fetch queue

### DIFF
--- a/crates/holochain/src/conductor/kitsune_host_impl.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl.rs
@@ -19,7 +19,8 @@ use holochain_types::{
     share::RwShare,
 };
 use kitsune_p2p::{
-    agent_store::AgentInfoSigned, event::GetAgentInfoSignedEvt, KitsuneHost, KitsuneHostResult,
+    agent_store::AgentInfoSigned, dependencies::kitsune_p2p_fetch::OpHashSized,
+    event::GetAgentInfoSignedEvt, KitsuneHost, KitsuneHostResult,
 };
 use kitsune_p2p_types::{config::KitsuneP2pTuningParams, KOpData, KOpHash};
 
@@ -144,7 +145,7 @@ impl KitsuneHost for KitsuneHostImpl {
         &self,
         space: Arc<kitsune_p2p::KitsuneSpace>,
         region: holochain_p2p::dht::region::RegionCoords,
-    ) -> KitsuneHostResult<Vec<KOpHash>> {
+    ) -> KitsuneHostResult<Vec<OpHashSized>> {
         let dna_hash = DnaHash::from_kitsune(&space);
         async move {
             let db = self.spaces.dht_db(&dna_hash)?;

--- a/crates/holochain/src/conductor/kitsune_host_impl/query_region_op_hashes.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl/query_region_op_hashes.rs
@@ -26,7 +26,10 @@ pub(super) async fn query_region_op_hashes(
                     },
                     |row| {
                         let hash: DhtOpHash = row.get("hash")?;
-                        Ok(OpHashSized::new(hash.to_kitsune(), todo!("get size")))
+                        let action_size: usize = row.get("action_size")?;
+                        let entry_size: usize = row.get("entry_size")?;
+                        let op_size = (action_size + entry_size).into();
+                        Ok(OpHashSized::new(hash.to_kitsune(), Some(op_size)))
                     },
                 )?
                 .collect::<Result<Vec<_>, _>>()

--- a/crates/holochain/src/conductor/kitsune_host_impl/query_region_op_hashes.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl/query_region_op_hashes.rs
@@ -1,7 +1,7 @@
 use holo_hash::DhtOpHash;
 use holochain_p2p::{dht::prelude::*, DhtOpHashExt};
 use holochain_sqlite::prelude::*;
-use kitsune_p2p_types::KOpHash;
+use kitsune_p2p::dependencies::kitsune_p2p_fetch::OpHashSized;
 use rusqlite::named_params;
 
 use crate::conductor::error::ConductorResult;
@@ -9,7 +9,7 @@ use crate::conductor::error::ConductorResult;
 pub(super) async fn query_region_op_hashes(
     db: DbWrite<DbKindDht>,
     bounds: RegionBounds,
-) -> ConductorResult<Vec<KOpHash>> {
+) -> ConductorResult<Vec<OpHashSized>> {
     Ok(db
         .async_reader(move |txn| {
             let sql = holochain_sqlite::sql::sql_cell::FETCH_REGION_OP_HASHES;
@@ -26,7 +26,7 @@ pub(super) async fn query_region_op_hashes(
                     },
                     |row| {
                         let hash: DhtOpHash = row.get("hash")?;
-                        Ok(hash.to_kitsune())
+                        Ok(OpHashSized::new(hash.to_kitsune(), todo!("get size")))
                     },
                 )?
                 .collect::<Result<Vec<_>, _>>()

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -516,73 +516,49 @@ impl Spaces {
         dna_hash: &DnaHash,
         op_hashes: Vec<holo_hash::DhtOpHash>,
     ) -> ConductorResult<Vec<(holo_hash::DhtOpHash, holochain_types::dht_op::DhtOp)>> {
-        const OPS_IN_MEMORY_BOUND_BYTES: usize = 3_000_000; // 3MB
-                                                            // FIXME: Test this query.
         let db = self.dht_db(dna_hash)?;
         let results = db
             .async_reader(move |txn| {
                 let mut out = Vec::with_capacity(op_hashes.len());
-                let mut total_bytes = 0;
                 for hash in op_hashes {
-                    // FIXME: cache this query (make prepared statement)
-                    let r = txn.query_row_and_then(
+                    let mut stmt = txn.prepare_cached(
                         "
-                            SELECT DhtOp.hash, DhtOp.type AS dht_type,
-                            Action.blob AS action_blob, Entry.blob AS entry_blob,
-                            LENGTH(Action.blob) as action_size, LENGTH(Entry.blob) as entry_size
-                            FROM DHtOp
-                            JOIN Action ON DhtOp.action_hash = Action.hash
-                            LEFT JOIN Entry ON Action.entry_hash = Entry.hash
-                            WHERE
-                            DhtOp.hash = ?
-                            AND
-                            DhtOp.when_integrated IS NOT NULL
-                        ",
-                        [hash],
-                        |row| {
-                            let action_bytes: Option<usize> = row.get("action_size")?;
-                            let entry_bytes: Option<usize> = row.get("entry_size")?;
-                            let bytes = action_bytes.unwrap_or(0) + entry_bytes.unwrap_or(0);
-                            let action = from_blob::<SignedAction>(row.get("action_blob")?)?;
-                            let op_type: DhtOpType = row.get("dht_type")?;
-                            let hash: DhtOpHash = row.get("hash")?;
-                            // Check the entry isn't private before gossiping it.
-                            let mut entry: Option<Entry> = None;
-                            if action
-                                .0
-                                .entry_type()
-                                .filter(|et| *et.visibility() == EntryVisibility::Public)
-                                .is_some()
-                            {
-                                let e: Option<Vec<u8>> = row.get("entry_blob")?;
-                                entry = match e {
-                                    Some(entry) => Some(from_blob::<Entry>(entry)?),
-                                    None => None,
-                                };
-                            }
-                            let op = DhtOp::from_type(op_type, action, entry)?;
-                            StateQueryResult::Ok(((hash, op), bytes))
-                        },
-                    );
-                    match r {
-                        Ok((r, bytes)) => {
-                            out.push(r);
-                            total_bytes += bytes;
-                            // pair(maackle, freesig): be sure to add this limit in the region fetch case too
-                            // david.b: No! actually, we don't even want to
-                            // do this here!
-                            if total_bytes > OPS_IN_MEMORY_BOUND_BYTES {
-                                // david.b: disabling this. We're tracking
-                                //          memory bounds in the fetch handler
-                                //          so we don't want to limit it in
-                                //          two places!
-                                //break;
-                            }
+                    SELECT DhtOp.hash, DhtOp.type AS dht_type,
+                    Action.blob AS action_blob, Entry.blob AS entry_blob,
+                    FROM DHtOp
+                    JOIN Action ON DhtOp.action_hash = Action.hash
+                    LEFT JOIN Entry ON Action.entry_hash = Entry.hash
+                    WHERE
+                    DhtOp.hash = ?
+                    AND
+                    DhtOp.when_integrated IS NOT NULL
+                ",
+                    )?;
+                    let mut rows = stmt.query([hash])?;
+                    if let Some(row) = rows.next()? {
+                        let action = from_blob::<SignedAction>(row.get("action_blob")?)?;
+                        let op_type: DhtOpType = row.get("dht_type")?;
+                        let hash: DhtOpHash = row.get("hash")?;
+                        // Check the entry isn't private before gossiping it.
+                        let mut entry: Option<Entry> = None;
+                        if action
+                            .0
+                            .entry_type()
+                            .filter(|et| *et.visibility() == EntryVisibility::Public)
+                            .is_some()
+                        {
+                            let e: Option<Vec<u8>> = row.get("entry_blob")?;
+                            entry = match e {
+                                Some(entry) => Some(from_blob::<Entry>(entry)?),
+                                None => None,
+                            };
                         }
-                        Err(holochain_state::query::StateQueryError::Sql(
+                        let op = DhtOp::from_type(op_type, action, entry)?;
+                        out.push((hash, op))
+                    } else {
+                        return Err(holochain_state::query::StateQueryError::Sql(
                             rusqlite::Error::QueryReturnedNoRows,
-                        )) => (),
-                        Err(e) => return Err(e),
+                        ));
                     }
                 }
                 StateQueryResult::Ok(out)

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -18,7 +18,7 @@ use holochain::{
 use holochain_p2p::*;
 use holochain_sqlite::db::*;
 use kitsune_p2p::agent_store::AgentInfoSigned;
-use kitsune_p2p::gossip::sharded_gossip::test_utils::{check_ops_boom, create_agent_bloom};
+use kitsune_p2p::gossip::sharded_gossip::test_utils::{check_ops_bloom, create_agent_bloom};
 use kitsune_p2p::KitsuneP2pConfig;
 use kitsune_p2p_types::config::RECENT_THRESHOLD_DEFAULT;
 
@@ -624,7 +624,8 @@ async fn mock_network_sharded_gossip() {
                                             )
                                         });
 
-                                        let missing_hashes = check_ops_boom(hashes, missing_hashes);
+                                        let missing_hashes =
+                                            check_ops_bloom(hashes, missing_hashes);
                                         let missing_hashes = match &last_intervals {
                                             Some(intervals) => missing_hashes
                                                 .into_iter()
@@ -689,7 +690,10 @@ async fn mock_network_sharded_gossip() {
                                             module,
                                             gossip: GossipProtocol::Sharded(
                                                 ShardedGossipWire::missing_op_hashes(
-                                                    missing_hashes,
+                                                    missing_hashes
+                                                        .into_iter()
+                                                        .map(|h| kitsune_p2p::dependencies::kitsune_p2p_fetch::OpHashSized::new(h, None))
+                                                        .collect(),
                                                     MissingOpsStatus::AllComplete as u8,
                                                 ),
                                             ),
@@ -1150,7 +1154,8 @@ async fn mock_network_sharding() {
                                             )
                                         });
 
-                                        let missing_hashes = check_ops_boom(hashes, missing_hashes);
+                                        let missing_hashes =
+                                            check_ops_bloom(hashes, missing_hashes);
                                         let missing_hashes = match &last_intervals {
                                             Some(intervals) => missing_hashes
                                                 .into_iter()
@@ -1169,7 +1174,10 @@ async fn mock_network_sharding() {
                                             module,
                                             gossip: GossipProtocol::Sharded(
                                                 ShardedGossipWire::missing_op_hashes(
-                                                    missing_hashes,
+                                                    missing_hashes
+                                                        .into_iter()
+                                                        .map(|h| kitsune_p2p::dependencies::kitsune_p2p_fetch::OpHashSized::new(h, None))
+                                                        .collect(),
                                                     2,
                                                 ),
                                             ),

--- a/crates/holochain_sqlite/src/sql/cell/fetch_region_op_hashes.sql
+++ b/crates/holochain_sqlite/src/sql/cell/fetch_region_op_hashes.sql
@@ -1,5 +1,6 @@
 SELECT
   DhtOp.hash,
+  -- TODO: get size
 FROM
   DhtOp
 WHERE

--- a/crates/holochain_sqlite/src/sql/cell/fetch_region_op_hashes.sql
+++ b/crates/holochain_sqlite/src/sql/cell/fetch_region_op_hashes.sql
@@ -1,8 +1,16 @@
 SELECT
   DhtOp.hash,
-  -- TODO: get size
+  LENGTH(Action.blob) AS action_size,
+  -- We need to only account for entry data in the size count when the op contains the entry itself.
+  -- Other ops refer to actions that refer to entries, but we don't want to include that in the size.
+  CASE
+    WHEN DhtOp.type IN ('StoreEntry', 'StoreRecord') THEN LENGTH(Entry.blob)
+    ELSE 0
+  END AS entry_size
 FROM
   DhtOp
+  JOIN Action ON DhtOp.action_hash = Action.hash
+  LEFT JOIN Entry ON Action.entry_hash = Entry.hash
 WHERE
   (
     (

--- a/crates/kitsune_p2p/fetch/src/rough_sized.rs
+++ b/crates/kitsune_p2p/fetch/src/rough_sized.rs
@@ -1,0 +1,108 @@
+use std::hash::Hash;
+
+use kitsune_p2p_types::KOpHash;
+
+/// The granularity once we're > i16::MAX
+const GRAN: usize = 4096;
+
+// const G: f64 = 1690.0; // x / (ln_phi 128000000)
+// const LOW: f64 = 15.0 * G;
+// const THRESH: u16 = 30000;
+
+/// Roughly track an approximate integer value.
+#[derive(Clone, Copy, Default, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
+pub struct RoughInt(i16);
+
+impl std::fmt::Debug for RoughInt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.get())
+    }
+}
+
+impl RoughInt {
+    /// Get the full value from the rough int
+    pub fn get(&self) -> usize {
+        if self.0 > 0 {
+            // positive is exact value
+            self.0 as usize
+        } else {
+            // negative is in chunks of size GRAN
+            (-self.0) as usize * GRAN
+        }
+    }
+
+    /// Set the rough int from the full value
+    pub fn set(&mut self, v: usize) -> Self {
+        if v <= i16::MAX as usize {
+            // if we're under i16::MAX, we can store the exact value
+            self.0 = v as i16
+        } else {
+            // otherwise, divide by GRAN and store as negative
+            self.0 = -(std::cmp::min(i16::MAX as usize, v / GRAN) as i16);
+        }
+        *self
+    }
+}
+
+impl From<usize> for RoughInt {
+    fn from(v: usize) -> Self {
+        Self::default().set(v)
+    }
+}
+
+/// An op hash combined with an approximate size of the op
+pub type OpHashSized = RoughSized<KOpHash>;
+
+/// Some data which has a RoughInt assigned for its size
+#[derive(
+    Clone,
+    Debug,
+    serde::Deserialize,
+    serde::Serialize,
+    derive_more::From,
+    derive_more::Into,
+    derive_more::Constructor,
+    derive_more::Deref,
+)]
+pub struct RoughSized<T> {
+    /// The data to be sized
+    #[deref]
+    data: T,
+    /// The approximate size of the hash
+    size: Option<RoughInt>,
+}
+
+impl<T> RoughSized<T> {
+    /// Break into constituent parts
+    pub fn into_inner(self) -> (T, Option<RoughInt>) {
+        (self.data, self.size)
+    }
+}
+
+impl<T: Clone> RoughSized<T> {
+    /// Accessor
+    pub fn data(&self) -> T {
+        self.data.clone()
+    }
+
+    /// Accessor
+    pub fn size(&self) -> RoughInt {
+        self.size.unwrap_or_default()
+    }
+}
+
+impl<T: Hash> Hash for RoughSized<T> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // size is omitted from the hash
+        self.data.hash(state);
+    }
+}
+
+impl<T: PartialEq> PartialEq for RoughSized<T> {
+    fn eq(&self, other: &Self) -> bool {
+        // size is omitted from the equality
+        self.data == other.data
+    }
+}
+
+impl<T: Eq> Eq for RoughSized<T> {}

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -11,7 +11,7 @@ use ghost_actor::dependencies::tracing;
 use governor::clock::DefaultClock;
 use governor::state::{InMemoryState, NotKeyed};
 use governor::RateLimiter;
-use kitsune_p2p_fetch::{FetchQueue, FetchQueueConfig, FetchSource};
+use kitsune_p2p_fetch::{FetchQueue, FetchQueueConfig, FetchSource, OpHashSized};
 use kitsune_p2p_timestamp::Timestamp;
 use kitsune_p2p_types::codec::Codec;
 use kitsune_p2p_types::config::*;
@@ -1194,7 +1194,7 @@ kitsune_p2p_types::write_codec_enum! {
         /// Any ops that were missing from the remote bloom.
         MissingOpHashes(0x60) {
             /// The missing op hashes
-            ops.0: Vec<KOpHash>,
+            ops.0: Vec<OpHashSized>,
             /// Ops that are missing from a bloom that you have sent.
             /// These will be chunked into a maximum size of about 16MB.
             /// If the amount of missing ops is larger then the

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/test_utils.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/test_utils.rs
@@ -52,7 +52,7 @@ pub fn create_op_bloom(ops: Vec<Arc<KitsuneOpHash>>) -> PoolBuf {
 }
 
 /// Check an ops bloom for testing.
-pub fn check_ops_boom<'a>(
+pub fn check_ops_bloom<'a>(
     ops: impl Iterator<Item = (kitsune_p2p_timestamp::Timestamp, &'a Arc<KitsuneOpHash>)>,
     bloom: EncodedTimedBloomFilter,
 ) -> Vec<&'a Arc<KitsuneOpHash>> {

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -110,7 +110,7 @@ impl KitsuneHost for StandardResponsesHostApi {
         &self,
         _space: Arc<KitsuneSpace>,
         _region: dht::region::RegionCoords,
-    ) -> crate::KitsuneHostResult<Vec<KOpHash>> {
+    ) -> crate::KitsuneHostResult<Vec<OpHashSized>> {
         todo!()
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
@@ -1,4 +1,4 @@
-use kitsune_p2p_fetch::FetchQueueConfig;
+use kitsune_p2p_fetch::{FetchQueueConfig, OpHashSized};
 use must_future::MustBoxFuture;
 use std::sync::Arc;
 
@@ -57,7 +57,7 @@ pub trait KitsuneHost: 'static + Send + Sync {
         &self,
         space: Arc<KitsuneSpace>,
         region: RegionCoords,
-    ) -> KitsuneHostResult<Vec<KOpHash>>;
+    ) -> KitsuneHostResult<Vec<OpHashSized>>;
 
     /// Record a set of metric records.
     fn record_metrics(

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_default_error.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_default_error.rs
@@ -101,7 +101,7 @@ pub trait KitsuneHostDefaultError: KitsuneHost + FetchQueueConfig {
         &self,
         _space: Arc<KitsuneSpace>,
         _region: RegionCoords,
-    ) -> KitsuneHostResult<Vec<KOpHash>> {
+    ) -> KitsuneHostResult<Vec<OpHashSized>> {
         box_fut(Err(format!(
             "error for unimplemented KitsuneHost test behavior: method {} of {}",
             "query_op_hashes_by_region",
@@ -168,7 +168,7 @@ impl<T: KitsuneHostDefaultError> KitsuneHost for T {
         &self,
         space: Arc<KitsuneSpace>,
         region: RegionCoords,
-    ) -> KitsuneHostResult<Vec<KOpHash>> {
+    ) -> KitsuneHostResult<Vec<OpHashSized>> {
         KitsuneHostDefaultError::query_op_hashes_by_region(self, space, region)
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -501,13 +501,13 @@ impl KitsuneP2pActor {
 
                                             for key in key_list {
                                                 match key {
-                                                    FetchKey::Region { region_coords } => {
+                                                    FetchKey::Region(region_coords) => {
                                                         regions.push((
                                                             region_coords,
                                                             region_coords.to_bounds(&topo),
                                                         ));
                                                     }
-                                                    FetchKey::Op { op_hash } => {
+                                                    FetchKey::Op(op_hash) => {
                                                         hashes.push(op_hash);
                                                     }
                                                 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::types::event::{KitsuneP2pEvent, KitsuneP2pEventHandler, KitsuneP2pEventHandlerResult};
 use crate::{event::*, KitsuneHost};
 use futures::FutureExt;
-use kitsune_p2p_fetch::FetchQueueConfig;
+use kitsune_p2p_fetch::{FetchQueueConfig, OpHashSized};
 use kitsune_p2p_timestamp::Timestamp;
 use kitsune_p2p_types::bin_types::*;
 use kitsune_p2p_types::combinators::second;
@@ -182,7 +182,7 @@ impl KitsuneHost for SwitchboardEventHandler {
         &self,
         _space: Arc<KitsuneSpace>,
         _region: RegionCoords,
-    ) -> crate::KitsuneHostResult<Vec<kitsune_p2p_types::KOpHash>> {
+    ) -> crate::KitsuneHostResult<Vec<OpHashSized>> {
         todo!()
     }
 }


### PR DESCRIPTION
### Summary

Adds sizes to op hashes sent via historical gossip.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
