### PR TITLE
refactor(conductor-api)!: rename cloning calls

### DIFF
--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -343,13 +343,13 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     .await?;
                 Ok(AdminResponse::ZomeCallCapabilityGranted)
             }
-            RestoreCloneCell(payload) => {
-                let restored_cell = self
+            EnableCloneCell(payload) => {
+                let enabled_cell = self
                     .conductor_handle
                     .clone()
-                    .restore_archived_clone_cell(&*payload)
+                    .enable_clone_cell(&*payload)
                     .await?;
-                Ok(AdminResponse::CloneCellRestored(restored_cell))
+                Ok(AdminResponse::CloneCellEnabled(enabled_cell))
             }
             DeleteArchivedCloneCells(payload) => {
                 self.conductor_handle

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -343,14 +343,6 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     .await?;
                 Ok(AdminResponse::ZomeCallCapabilityGranted)
             }
-            EnableCloneCell(payload) => {
-                let enabled_cell = self
-                    .conductor_handle
-                    .clone()
-                    .enable_clone_cell(&*payload)
-                    .await?;
-                Ok(AdminResponse::CloneCellEnabled(enabled_cell))
-            }
             DeleteArchivedCloneCells(payload) => {
                 self.conductor_handle
                     .clone()

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -343,12 +343,12 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     .await?;
                 Ok(AdminResponse::ZomeCallCapabilityGranted)
             }
-            DeleteArchivedCloneCells(payload) => {
+            DeleteCloneCell(payload) => {
                 self.conductor_handle
                     .clone()
-                    .delete_archived_clone_cells(&*payload)
+                    .delete_clone_cell(&*payload)
                     .await?;
-                Ok(AdminResponse::ArchivedCloneCellsDeleted)
+                Ok(AdminResponse::CloneCellDeleted)
             }
 
             // deprecated aliases

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -109,12 +109,12 @@ impl AppInterfaceApi for RealAppInterfaceApi {
                     .await?;
                 Ok(AppResponse::CloneCellCreated(installed_clone_cell))
             }
-            AppRequest::ArchiveCloneCell(payload) => {
+            AppRequest::DisableCloneCell(payload) => {
                 self.conductor_handle
                     .clone()
-                    .archive_clone_cell(&*payload)
+                    .disable_clone_cell(&*payload)
                     .await?;
-                Ok(AppResponse::CloneCellArchived)
+                Ok(AppResponse::CloneCellDisabled)
             }
             AppRequest::GossipInfo(payload) => {
                 let info = self.conductor_handle.gossip_info(&payload.dnas).await?;

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -116,6 +116,14 @@ impl AppInterfaceApi for RealAppInterfaceApi {
                     .await?;
                 Ok(AppResponse::CloneCellDisabled)
             }
+            AppRequest::EnableCloneCell(payload) => {
+                let enabled_cell = self
+                    .conductor_handle
+                    .clone()
+                    .enable_clone_cell(&*payload)
+                    .await?;
+                Ok(AppResponse::CloneCellEnabled(enabled_cell))
+            }
             AppRequest::GossipInfo(payload) => {
                 let info = self.conductor_handle.gossip_info(&payload.dnas).await?;
                 Ok(AppResponse::GossipInfo(info))

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1319,12 +1319,12 @@ mod clone_cell_impls {
         }
 
         /// Archive a clone cell for future deletion from the app.
-        pub(crate) async fn archive_clone_cell(
+        pub(crate) async fn disable_clone_cell(
             &self,
-            ArchiveCloneCellPayload {
+            DisableCloneCellPayload {
                 app_id,
                 clone_cell_id,
-            }: &ArchiveCloneCellPayload,
+            }: &DisableCloneCellPayload,
         ) -> ConductorResult<()> {
             let (_, removed_cell_id) = self
                 .update_state_prime({
@@ -1334,7 +1334,7 @@ mod clone_cell_impls {
                         let app = state.get_app_mut(&app_id)?;
                         let clone_id = app.get_clone_id(&clone_cell_id)?;
                         let cell_id = app.get_clone_cell_id(&clone_cell_id)?;
-                        app.archive_clone_cell(&clone_id)?;
+                        app.disable_clone_cell(&clone_id)?;
                         Ok((state, cell_id))
                     }
                 })
@@ -1346,10 +1346,10 @@ mod clone_cell_impls {
         /// Restore an archived clone cell for an app.
         pub(crate) async fn restore_clone_cell(
             &self,
-            ArchiveCloneCellPayload {
+            DisableCloneCellPayload {
                 app_id,
                 clone_cell_id,
-            }: &ArchiveCloneCellPayload,
+            }: &DisableCloneCellPayload,
         ) -> ConductorResult<InstalledCell> {
             let (_, restored_cell) = self
                 .update_state_prime({
@@ -1388,7 +1388,7 @@ mod clone_cell_impls {
         /// Restore an archived clone cell
         pub async fn restore_archived_clone_cell(
             self: Arc<Self>,
-            payload: &ArchiveCloneCellPayload,
+            payload: &DisableCloneCellPayload,
         ) -> ConductorResult<InstalledCell> {
             let restored_cell = self.restore_clone_cell(payload).await?;
             self.create_and_add_initialized_cells_for_running_apps(Some(&payload.app_id))

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1318,7 +1318,7 @@ mod clone_cell_impls {
             Ok(installed_clone_cell)
         }
 
-        /// Archive a clone cell for future deletion from the app.
+        /// Disable a clone cell.
         pub(crate) async fn disable_clone_cell(
             &self,
             DisableCloneCellPayload {

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1343,7 +1343,7 @@ mod clone_cell_impls {
             Ok(())
         }
 
-        /// Enable a disabled clone cell
+        /// Enable a disabled clone cell.
         pub async fn enable_clone_cell(
             self: Arc<Self>,
             payload: &EnableCloneCellPayload,
@@ -1366,17 +1366,21 @@ mod clone_cell_impls {
             Ok(enabled_cell)
         }
 
-        /// Remove a clone cell from an app.
-        pub(crate) async fn delete_archived_clone_cells(
+        /// Delete a clone cell.
+        pub(crate) async fn delete_clone_cell(
             &self,
-            DeleteArchivedCloneCellsPayload { app_id, role_name }: &DeleteArchivedCloneCellsPayload,
+            DeleteCloneCellPayload {
+                app_id,
+                clone_cell_id,
+            }: &DeleteCloneCellPayload,
         ) -> ConductorResult<()> {
             self.update_state_prime({
                 let app_id = app_id.clone();
-                let role_name = role_name.clone();
+                let clone_cell_id = clone_cell_id.clone();
                 move |mut state| {
                     let app = state.get_app_mut(&app_id)?;
-                    app.delete_archived_clone_cells_for_role(&role_name)?;
+                    let clone_id = app.get_disabled_clone_id(&clone_cell_id)?;
+                    app.delete_clone_cell(&clone_id)?;
                     Ok((state, ()))
                 }
             })

--- a/crates/holochain/src/conductor/tests/cell_cloning.rs
+++ b/crates/holochain/src/conductor/tests/cell_cloning.rs
@@ -224,7 +224,7 @@ async fn clone_cell_deletion() {
     // restore the archived clone cell by clone id
     let restored_cell = conductor
         .raw_handle()
-        .restore_archived_clone_cell(&DisableCloneCellPayload {
+        .enable_clone_cell(&DisableCloneCellPayload {
             app_id: app_id.into(),
             clone_cell_id: CloneCellId::CloneId(
                 CloneId::try_from(installed_clone_cell.clone().into_role_name()).unwrap(),
@@ -265,7 +265,7 @@ async fn clone_cell_deletion() {
     // restore clone cell by cell id
     let restored_cell = conductor
         .raw_handle()
-        .restore_archived_clone_cell(&DisableCloneCellPayload {
+        .enable_clone_cell(&DisableCloneCellPayload {
             app_id: app_id.into(),
             clone_cell_id: CloneCellId::CellId(installed_clone_cell.as_id().clone()),
         })
@@ -297,7 +297,7 @@ async fn clone_cell_deletion() {
     // assert the deleted cell cannot be restored
     let restore_result = conductor
         .raw_handle()
-        .restore_archived_clone_cell(&DisableCloneCellPayload {
+        .enable_clone_cell(&DisableCloneCellPayload {
             app_id: app_id.into(),
             clone_cell_id: CloneCellId::CloneId(
                 CloneId::try_from(installed_clone_cell.clone().into_role_name()).unwrap(),

--- a/crates/holochain/src/conductor/tests/cell_cloning.rs
+++ b/crates/holochain/src/conductor/tests/cell_cloning.rs
@@ -2,7 +2,7 @@ use crate::sweettest::*;
 use holo_hash::ActionHash;
 use holochain_types::{
     app::CreateCloneCellPayload,
-    prelude::{ArchiveCloneCellPayload, CloneCellId, DeleteArchivedCloneCellsPayload},
+    prelude::{DisableCloneCellPayload, CloneCellId, DeleteArchivedCloneCellsPayload},
 };
 use holochain_wasm_test_utils::TestWasm;
 use holochain_zome_types::{CloneId, DnaModifiersOpt, RoleName};
@@ -194,7 +194,7 @@ async fn clone_cell_deletion() {
     // archive clone cell
     conductor
         .raw_handle()
-        .archive_clone_cell(&ArchiveCloneCellPayload {
+        .disable_clone_cell(&DisableCloneCellPayload {
             app_id: app_id.to_string(),
             clone_cell_id: CloneCellId::CloneId(
                 CloneId::try_from(installed_clone_cell.clone().into_role_name()).unwrap(),
@@ -224,7 +224,7 @@ async fn clone_cell_deletion() {
     // restore the archived clone cell by clone id
     let restored_cell = conductor
         .raw_handle()
-        .restore_archived_clone_cell(&ArchiveCloneCellPayload {
+        .restore_archived_clone_cell(&DisableCloneCellPayload {
             app_id: app_id.into(),
             clone_cell_id: CloneCellId::CloneId(
                 CloneId::try_from(installed_clone_cell.clone().into_role_name()).unwrap(),
@@ -253,7 +253,7 @@ async fn clone_cell_deletion() {
     // archive clone cell again
     conductor
         .raw_handle()
-        .archive_clone_cell(&ArchiveCloneCellPayload {
+        .disable_clone_cell(&DisableCloneCellPayload {
             app_id: app_id.to_string(),
             clone_cell_id: CloneCellId::CloneId(
                 CloneId::try_from(installed_clone_cell.clone().into_role_name()).unwrap(),
@@ -265,7 +265,7 @@ async fn clone_cell_deletion() {
     // restore clone cell by cell id
     let restored_cell = conductor
         .raw_handle()
-        .restore_archived_clone_cell(&ArchiveCloneCellPayload {
+        .restore_archived_clone_cell(&DisableCloneCellPayload {
             app_id: app_id.into(),
             clone_cell_id: CloneCellId::CellId(installed_clone_cell.as_id().clone()),
         })
@@ -278,7 +278,7 @@ async fn clone_cell_deletion() {
     // archive and delete clone cell
     conductor
         .raw_handle()
-        .archive_clone_cell(&ArchiveCloneCellPayload {
+        .disable_clone_cell(&DisableCloneCellPayload {
             app_id: app_id.to_string(),
             clone_cell_id: CloneCellId::CloneId(
                 CloneId::try_from(installed_clone_cell.clone().into_role_name()).unwrap(),
@@ -297,7 +297,7 @@ async fn clone_cell_deletion() {
     // assert the deleted cell cannot be restored
     let restore_result = conductor
         .raw_handle()
-        .restore_archived_clone_cell(&ArchiveCloneCellPayload {
+        .restore_archived_clone_cell(&DisableCloneCellPayload {
             app_id: app_id.into(),
             clone_cell_id: CloneCellId::CloneId(
                 CloneId::try_from(installed_clone_cell.clone().into_role_name()).unwrap(),

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- **BREAKING CHANGE**: Rename ArchiveCloneCell to DisableCloneCell.
+- **BREAKING CHANGE**: Rename RestoreArchivedCloneCell to EnableCloneCell.
+- **BREAKING CHANGE**: Move EnableCloneCell to App API.
+- **BREAKING CHANGE**: Refactor DeleteCloneCell to delete a single disabled clone cell. [\#1704](https://github.com/holochain/holochain/pull/1704)
+
 ## 0.0.72
 
 ## 0.0.71

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -355,13 +355,6 @@ pub enum AdminRequest {
     /// [`AdminResponse::ZomeCallCapabilityGranted`]
     GrantZomeCallCapability(Box<GrantZomeCallCapabilityPayload>),
 
-    /// Enable a clone cell that was previously disabled.
-    ///
-    /// # Returns
-    ///
-    /// [`AdminResponse::CloneCellEnabled`]
-    EnableCloneCell(Box<EnableCloneCellPayload>),
-
     /// Delete all clone cells that were previously archived.
     ///
     /// # Returns
@@ -525,9 +518,6 @@ pub enum AdminResponse {
 
     /// The successful response to an [`AdminRequest::GrantZomeCallCapability`].
     ZomeCallCapabilityGranted,
-
-    // The successful response to an [`AdminRequest::EnableCloneCell`].
-    CloneCellEnabled(InstalledCell),
 
     /// The successful response to an [`AdminRequest::DeleteArchivedCloneCells`].
     ArchivedCloneCellsDeleted,

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -355,12 +355,12 @@ pub enum AdminRequest {
     /// [`AdminResponse::ZomeCallCapabilityGranted`]
     GrantZomeCallCapability(Box<GrantZomeCallCapabilityPayload>),
 
-    /// Restore a clone cell that was previously archived.
+    /// Enable a clone cell that was previously disabled.
     ///
     /// # Returns
     ///
-    /// [`AdminResponse::CloneCellRestored`]
-    RestoreCloneCell(Box<RestoreCloneCellPayload>),
+    /// [`AdminResponse::CloneCellEnabled`]
+    EnableCloneCell(Box<EnableCloneCellPayload>),
 
     /// Delete all clone cells that were previously archived.
     ///
@@ -526,8 +526,8 @@ pub enum AdminResponse {
     /// The successful response to an [`AdminRequest::GrantZomeCallCapability`].
     ZomeCallCapabilityGranted,
 
-    // The successful response to an [`AdminRequest::RestoreCloneCell`].
-    CloneCellRestored(InstalledCell),
+    // The successful response to an [`AdminRequest::EnableCloneCell`].
+    CloneCellEnabled(InstalledCell),
 
     /// The successful response to an [`AdminRequest::DeleteArchivedCloneCells`].
     ArchivedCloneCellsDeleted,

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -355,12 +355,12 @@ pub enum AdminRequest {
     /// [`AdminResponse::ZomeCallCapabilityGranted`]
     GrantZomeCallCapability(Box<GrantZomeCallCapabilityPayload>),
 
-    /// Delete all clone cells that were previously archived.
+    /// Delete a clone cell that was previously disabled.
     ///
     /// # Returns
     ///
-    /// [`AdminResponse::ArchivedCloneCellsDeleted`]
-    DeleteArchivedCloneCells(Box<DeleteArchivedCloneCellsPayload>),
+    /// [`AdminResponse::CloneCellDeleted`]
+    DeleteCloneCell(Box<DeleteCloneCellPayload>),
 }
 
 /// Represents the possible responses to an [`AdminRequest`]
@@ -519,8 +519,8 @@ pub enum AdminResponse {
     /// The successful response to an [`AdminRequest::GrantZomeCallCapability`].
     ZomeCallCapabilityGranted,
 
-    /// The successful response to an [`AdminRequest::DeleteArchivedCloneCells`].
-    ArchivedCloneCellsDeleted,
+    /// The successful response to an [`AdminRequest::DeleteCloneCell`].
+    CloneCellDeleted,
 }
 
 /// Error type that goes over the websocket wire.

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -60,6 +60,13 @@ pub enum AppRequest {
     /// and has been disabled.
     DisableCloneCell(Box<DisableCloneCellPayload>),
 
+    /// Enable a clone cell that was previously disabled.
+    ///
+    /// # Returns
+    ///
+    /// [`AppResponse::CloneCellEnabled`]
+    EnableCloneCell(Box<EnableCloneCellPayload>),
+
     /// Info about gossip
     GossipInfo(Box<GossipInfoRequestPayload>),
 
@@ -111,6 +118,11 @@ pub enum AppResponse {
     ///
     /// An existing clone cell has been disabled.
     CloneCellDisabled,
+
+    /// The successful response to an [`AppRequest::EnableCloneCell`].
+    ///
+    /// A previously disabled clone cell has been enabled.
+    CloneCellEnabled(InstalledCell),
 
     /// GossipInfo is returned
     GossipInfo(Vec<DnaGossipInfo>),

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -48,17 +48,17 @@ pub enum AppRequest {
     /// [`AppResponse::CloneCellCreated`]
     CreateCloneCell(Box<CreateCloneCellPayload>),
 
-    /// Archive a clone cell.
+    /// Disable a clone cell.
     ///
-    /// Providing a [`CloneId`] or [`CellId`], archive an existing clone cell.
-    /// When the clone cell exists, it is archived and can not be called any
+    /// Providing a [`CloneId`] or [`CellId`], disable an existing clone cell.
+    /// When the clone cell exists, it is disabled and can not be called any
     /// longer. If it doesn't exist, the call is a no-op.
     ///
     /// # Returns
     ///
-    /// [`AppResponse::CloneCellArchived`] if the clone cell existed
-    /// and was archived.
-    ArchiveCloneCell(Box<ArchiveCloneCellPayload>),
+    /// [`AppResponse::CloneCellDisabled`] if the clone cell existed
+    /// and has been disabled.
+    DisableCloneCell(Box<DisableCloneCellPayload>),
 
     /// Info about gossip
     GossipInfo(Box<GossipInfoRequestPayload>),
@@ -107,8 +107,10 @@ pub enum AppResponse {
     /// cell's [`CloneId`] and [`CellId`].
     CloneCellCreated(InstalledCell),
 
-    /// An existing clone cell has been archived.
-    CloneCellArchived,
+    /// The successful response to an [`AppRequest::DisableCloneCell`].
+    ///
+    /// An existing clone cell has been disabled.
+    CloneCellDisabled,
 
     /// GossipInfo is returned
     GossipInfo(Vec<DnaGossipInfo>),


### PR DESCRIPTION
### Summary

- rename ArchiveCloneCell to DisableCloneCell
- rename RestoreArchivedCloneCell to EnableCloneCell
- move EnableCloneCell to App API
- refactor DeleteCloneCell to delete a single clone cell


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
