### PR TITLE
refactor(conductor-api)!: remove deprecated api calls

### DIFF
--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -359,12 +359,6 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                 Ok(AdminResponse::ArchivedCloneCellsDeleted)
             }
             #[allow(deprecated)]
-            ActivateApp { installed_app_id } => {
-                tracing::warn!("Admin method ActivateApp is deprecated: use EnableApp instead (functionality is identical).");
-                self.handle_admin_request_inner(EnableApp { installed_app_id })
-                    .await
-            }
-            #[allow(deprecated)]
             DeactivateApp { installed_app_id } => {
                 tracing::warn!("Admin method DeactivateApp is deprecated: use DisableApp instead (functionality is identical).");
                 self.handle_admin_request_inner(DisableApp { installed_app_id })

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -358,13 +358,6 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     .await?;
                 Ok(AdminResponse::ArchivedCloneCellsDeleted)
             }
-
-            // deprecated aliases
-            #[allow(deprecated)]
-            ListActiveApps => {
-                tracing::warn!("Admin method ListActiveApps is deprecated: use ListApps instead.");
-                self.handle_admin_request_inner(ListEnabledApps).await
-            }
             #[allow(deprecated)]
             ActivateApp { installed_app_id } => {
                 tracing::warn!("Admin method ActivateApp is deprecated: use EnableApp instead (functionality is identical).");

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -230,14 +230,6 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     .list_cell_ids(Some(CellStatus::Joined));
                 Ok(AdminResponse::CellIdsListed(cell_ids))
             }
-            ListEnabledApps => {
-                tracing::warn!(
-                    "AdminRequest::ListEnabledApps is deprecated, use AdminRequest::ListApps (TODO: update conductor-api)"
-                );
-
-                let app_ids = self.conductor_handle.list_running_apps().await?;
-                Ok(AdminResponse::EnabledAppsListed(app_ids))
-            }
             ListApps { status_filter } => {
                 let apps = self.conductor_handle.list_apps(status_filter).await?;
                 Ok(AdminResponse::AppsListed(apps))

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -358,12 +358,6 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     .await?;
                 Ok(AdminResponse::ArchivedCloneCellsDeleted)
             }
-            #[allow(deprecated)]
-            DeactivateApp { installed_app_id } => {
-                tracing::warn!("Admin method DeactivateApp is deprecated: use DisableApp instead (functionality is identical).");
-                self.handle_admin_request_inner(DisableApp { installed_app_id })
-                    .await
-            }
         }
     }
 }

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -63,22 +63,6 @@ impl AppInterfaceApi for RealAppInterfaceApi {
                     .get_app_info(&installed_app_id)
                     .await?,
             )),
-            #[allow(deprecated)]
-            AppRequest::ZomeCallInvocation(call) => {
-                tracing::warn!(
-                    "AppRequest::ZomeCallInvocation is deprecated, use AppRequest::ZomeCall (TODO: update conductor-api)"
-                );
-                self.handle_app_request_inner(AppRequest::ZomeCall(call))
-                    .await
-                    .map(|r| {
-                        match r {
-                            // if successful, re-wrap in the deprecated response type
-                            AppResponse::ZomeCall(zc) => AppResponse::ZomeCallInvocation(zc),
-                            // else (probably an error), return as-is
-                            other => other,
-                        }
-                    })
-            }
             AppRequest::ZomeCall(call) => {
                 match self.conductor_handle.call_zome(*call.clone()).await? {
                     Ok(ZomeCallResponse::Ok(output)) => Ok(AppResponse::ZomeCall(Box::new(output))),

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -161,9 +161,6 @@ pub enum AdminRequest {
         installed_app_id: InstalledAppId,
     },
 
-    #[deprecated = "alias for EnableApp"]
-    ActivateApp { installed_app_id: InstalledAppId },
-
     /// Changes the specified app from an enabled to a disabled state in the conductor.
     ///
     /// When an app is disabled, zome calls can no longer be made, and the app will not be

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -174,9 +174,6 @@ pub enum AdminRequest {
         installed_app_id: InstalledAppId,
     },
 
-    #[deprecated = "alias for DisableApp"]
-    DeactivateApp { installed_app_id: InstalledAppId },
-
     StartApp {
         /// The app ID to (re)start
         installed_app_id: InstalledAppId,

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -135,9 +135,6 @@ pub enum AdminRequest {
     /// [`AdminResponse::ActiveAppsListed`]
     ListEnabledApps,
 
-    #[deprecated = "alias for ListEnabledApps"]
-    ListActiveApps,
-
     /// List the apps and their information that are installed in the conductor.
     ///
     /// If `status_filter` is `Some(_)`, it will return only the apps with the specified status.

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 use holo_hash::*;
 use holochain_types::prelude::*;
 use holochain_zome_types::cell::CellId;
@@ -127,13 +125,6 @@ pub enum AdminRequest {
     ///
     /// [`AdminResponse::CellIdsListed`]
     ListCellIds,
-
-    /// List the IDs of all enabled apps in the conductor.
-    ///
-    /// # Returns
-    ///
-    /// [`AdminResponse::ActiveAppsListed`]
-    ListEnabledApps,
 
     /// List the apps and their information that are installed in the conductor.
     ///
@@ -425,14 +416,6 @@ pub enum AdminResponse {
     /// Contains a list of all the cell IDs in the conductor.
     CellIdsListed(Vec<CellId>),
 
-    /// The successful response to an [`AdminRequest::ListEnabledApps`].
-    ///
-    /// Contains a list of all the active app IDs in the conductor.
-    EnabledAppsListed(Vec<InstalledAppId>),
-
-    #[deprecated = "alias for EnabledAppsListed"]
-    ActiveAppsListed(Vec<InstalledAppId>),
-
     /// The successful response to an [`AdminRequest::ListApps`].
     ///
     /// Contains a list of the `InstalledAppInfo` of the installed apps in the conductor.
@@ -461,12 +444,6 @@ pub enum AdminResponse {
         errors: Vec<(CellId, String)>,
     },
 
-    #[deprecated = "alias for AppEnabled"]
-    AppActivated {
-        app: InstalledAppInfo,
-        errors: Vec<(CellId, String)>,
-    },
-
     /// The successful response to an [`AdminRequest::DisableApp`].
     ///
     /// It means the app was disabled successfully.
@@ -479,8 +456,6 @@ pub enum AdminResponse {
     /// failed to start.
     /// TODO: add reason why app couldn't start
     AppStarted(bool),
-    #[deprecated = "alias for AppDisabled"]
-    AppDeactivated,
 
     /// The successful response to an [`AdminRequest::DumpState`].
     ///

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 use crate::{signal_subscription::SignalSubscription, ExternalApiWireError};
 use holo_hash::AgentPubKey;
 use holochain_types::prelude::*;
@@ -63,9 +61,6 @@ pub enum AppRequest {
     /// Info about gossip
     GossipInfo(Box<GossipInfoRequestPayload>),
 
-    #[deprecated = "use ZomeCall"]
-    ZomeCallInvocation(Box<ZomeCall>),
-
     /// Is currently unimplemented and will return
     /// an [`AppResponse::Unimplemented`].
     Crypto(Box<CryptoRequest>),
@@ -112,9 +107,6 @@ pub enum AppResponse {
 
     /// GossipInfo is returned
     GossipInfo(Vec<DnaGossipInfo>),
-
-    #[deprecated = "use ZomeCall"]
-    ZomeCallInvocation(Box<ExternIO>),
 }
 
 /// The data provided over an app interface in order to make a zome call


### PR DESCRIPTION
### Summary
- remove deprecated Admin API calls
- remove deprecated App API calls


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
