### PR TITLE
feat(release): temporarily disable release schedule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: release holochain
 
 on:
-  schedule:
-    - cron: "0 0 * * 3" # at 0 AM on wednesday
+  # schedule:
+  #   - cron: "0 0 * * 3" # at 0 AM on wednesday
   workflow_dispatch:
     inputs:
       # holochain_url:


### PR DESCRIPTION
we're going to skip this week's automated release in favor of manual coordination and execution for the the transition to 0.1.0.

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
