### PR TITLE
Add wildcard to GrantedFunctions in CapGrant.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,7 +467,7 @@ jobs:
             '
 
       - name: ${{ matrix.testCommand.name }} (build only)
-        continue-on-error: ${{ if matrix.platform.runs-on == 'macos-latest' }}
+        continue-on-error: ${{ matrix.platform.runs-on == 'macos-latest' }}
         if: ${{ matrix.testCommand.hasBuildStep == true }}
         env:
           CARGO_TEST_ARGS: "--no-run"
@@ -484,7 +484,7 @@ jobs:
         timeout-minutes: 720
 
       - name: ${{ matrix.testCommand.name }} (run)
-        continue-on-error: ${{ if matrix.platform.runs-on == 'macos-latest' }}
+        continue-on-error: ${{ matrix.platform.runs-on == 'macos-latest' }}
         uses: nick-fields/retry@v2.8.1
         env:
           HOLOCHAIN_NIXPKGS_SOURCE_BRANCH: ${{ needs.vars.outputs.holochain_nixpkgs_source_branch }}

--- a/crates/holochain/src/conductor/tests/signed_zome_call.rs
+++ b/crates/holochain/src/conductor/tests/signed_zome_call.rs
@@ -1,6 +1,9 @@
 use holochain_state::source_chain::SourceChainRead;
 use holochain_wasm_test_utils::TestWasm;
-use holochain_zome_types::{CapSecret, GrantZomeCallCapabilityPayload, RoleName, Nonce256Bits};
+use holochain_zome_types::{
+    CapSecret, GrantZomeCallCapabilityPayload, GrantedFunction, GrantedFunctions, Nonce256Bits,
+    RoleName,
+};
 use std::collections::BTreeSet;
 
 use crate::fixt::AgentPubKeyFixturator;
@@ -42,16 +45,16 @@ async fn signed_zome_call() {
 
     // set up functions to grant access to
     let mut functions = BTreeSet::new();
-    let granted_function = ("create_entry".into(), "get_entry".into());
+    let granted_function: GrantedFunction = ("create_entry".into(), "get_entry".into());
     functions.insert(granted_function.clone());
-
+    let granted_functions = GrantedFunctions::Listed(functions);
     // set up assignees which is only the agent key
     let mut assignees = BTreeSet::new();
     assignees.insert(cap_access_public_key.clone());
 
     let cap_grant = ZomeCallCapGrant {
         tag: "signing_key".into(),
-        functions,
+        functions: granted_functions,
         access: CapAccess::Assigned {
             secret: cap_access_secret,
             assignees,
@@ -104,7 +107,7 @@ async fn signed_zome_call() {
             ZomeCall::try_from_unsigned_zome_call(
                 &conductor.keystore(),
                 ZomeCallUnsigned {
-                    provenance: cap_access_public_key.clone(),
+                    provenance: cap_access_public_key.clone(), // N.B.: using agent key would bypass capgrant lookup
                     cell_id: cell_id.clone(),
                     zome_name: zome.coordinator_zome_name(),
                     fn_name: "get_entry".into(),
@@ -132,7 +135,122 @@ async fn signed_zome_call() {
             ZomeCall::try_from_unsigned_zome_call(
                 &conductor.keystore(),
                 ZomeCallUnsigned {
-                    provenance: cap_access_public_key.clone(),
+                    provenance: cap_access_public_key.clone(), // N.B.: using agent key would bypass capgrant lookup
+                    cell_id: cell_id.clone(),
+                    zome_name: zome.coordinator_zome_name(),
+                    fn_name: "get_entry".into(),
+                    cap_secret: Some(cap_access_secret),
+                    payload: ExternIO::encode(()).unwrap(),
+                    nonce,
+                    expires_at,
+                },
+            )
+            .await
+            .unwrap(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    assert_matches!(response, holochain_zome_types::ZomeCallResponse::Ok(_));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg(feature = "test_utils")]
+async fn signed_zome_call_wildcard() {
+    use holochain_conductor_api::ZomeCall;
+    use holochain_state::nonce::fresh_nonce;
+    use holochain_zome_types::{
+        CapAccess, ExternIO, Timestamp, ZomeCallCapGrant, ZomeCallUnsigned,
+    };
+    use matches::assert_matches;
+
+    let zome = TestWasm::Create;
+    let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![zome]).await;
+    let role_name: RoleName = "dna".to_string();
+    let mut conductor = SweetConductor::from_standard_config().await;
+    let agent_pub_key = SweetAgents::one(conductor.keystore()).await;
+    let app = conductor
+        .setup_app_for_agent(
+            "app",
+            agent_pub_key.clone(),
+            [&(role_name.clone(), dna.clone())],
+        )
+        .await
+        .unwrap();
+    let cell_id = app.cells()[0].cell_id();
+
+    // generate a cap access public key
+    let cap_access_public_key = fixt!(AgentPubKey, fixt::Predictable, 1);
+
+    // compute a cap access secret
+    let mut buf = arbitrary::Unstructured::new(&[]);
+    let cap_access_secret = CapSecret::arbitrary(&mut buf).unwrap();
+
+    // set up functions to grant access to
+    let granted_functions = GrantedFunctions::All;
+
+    // set up assignees which is only the agent key
+    let mut assignees = BTreeSet::new();
+    assignees.insert(cap_access_public_key.clone());
+
+    let cap_grant = ZomeCallCapGrant {
+        tag: "signing_key".into(),
+        functions: granted_functions,
+        access: CapAccess::Assigned {
+            secret: cap_access_secret,
+            assignees,
+        },
+    };
+
+    // request authorization of signing key for agent's own cell should succeed
+    conductor
+        .grant_zome_call_capability(GrantZomeCallCapabilityPayload {
+            cell_id: cell_id.clone(),
+            cap_grant: cap_grant.clone(),
+        })
+        .await
+        .unwrap();
+
+    // create a source chain read to query for the cap grant
+    let authored_db = conductor.get_authored_db(cell_id.dna_hash()).unwrap();
+    let dht_db = conductor.get_dht_db(cell_id.dna_hash()).unwrap();
+    let dht_db_cache = conductor.get_dht_db_cache(cell_id.dna_hash()).unwrap();
+
+    let source_chain_read = SourceChainRead::new(
+        authored_db.into(),
+        dht_db.into(),
+        dht_db_cache,
+        conductor.keystore(),
+        agent_pub_key.clone(),
+    )
+    .await
+    .unwrap();
+
+    let called_function: GrantedFunction = ("create_entry".into(), "get_entry".into());
+
+    let actual_cap_grant = source_chain_read
+        .valid_cap_grant(
+            called_function.clone(),
+            cap_access_public_key.clone(),
+            Some(cap_access_secret.clone()),
+        )
+        .await
+        .unwrap();
+    assert!(actual_cap_grant.is_some());
+    assert!(actual_cap_grant.unwrap().is_valid(
+        &called_function,
+        &cap_access_public_key,
+        Some(&cap_access_secret)
+    ));
+
+    // a zome call with the cap secret of the authorized signing key should succeed
+    let (nonce, expires_at) = fresh_nonce(Timestamp::now()).unwrap();
+    let response = conductor
+        .call_zome(
+            ZomeCall::try_from_unsigned_zome_call(
+                &conductor.keystore(),
+                ZomeCallUnsigned {
+                    provenance: cap_access_public_key.clone(), // N.B.: using agent key would bypass capgrant lookup
                     cell_id: cell_id.clone(),
                     zome_name: zome.coordinator_zome_name(),
                     fn_name: "get_entry".into(),

--- a/crates/holochain/src/core/ribosome/host_fn/remote_signal.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/remote_signal.rs
@@ -133,8 +133,9 @@ mod tests {
                 api.emit_signal(AppSignal::new(signal)).map_err(Into::into)
             })
             .function("init", move |api, ()| {
-                let mut functions: GrantedFunctions = BTreeSet::new();
-                functions.insert((api.zome_info(()).unwrap().name, "recv_remote_signal".into()));
+                let mut fns = BTreeSet::new();
+                fns.insert((api.zome_info(()).unwrap().name, "recv_remote_signal".into()));
+                let functions = GrantedFunctions::Listed(fns);
                 let cap_grant_entry = CapGrantEntry {
                     tag: "".into(),
                     // empty access converts to unrestricted

--- a/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
+++ b/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
@@ -294,7 +294,9 @@ pub mod tests {
                 Entry::CapGrant(CapGrantEntry {
                     tag: "".into(),
                     access: ().into(),
-                    functions: vec![("no-init".into(), "xxx".into())].into_iter().collect(),
+                    functions: GrantedFunctions::Listed(
+                        vec![("no-init".into(), "xxx".into())].into_iter().collect(),
+                    ),
                 }),
                 ChainTopOrdering::default(),
             ))?;

--- a/crates/holochain/tests/test_utils/mod.rs
+++ b/crates/holochain/tests/test_utils/mod.rs
@@ -89,8 +89,9 @@ pub async fn grant_zome_call_capability(
     fn_name: FunctionName,
     signing_key: AgentPubKey,
 ) -> CapSecret {
-    let mut functions = BTreeSet::new();
-    functions.insert((zome_name, fn_name));
+    let mut fns = BTreeSet::new();
+    fns.insert((zome_name, fn_name));
+    let functions = GrantedFunctions::Listed(fns);
 
     let mut assignees = BTreeSet::new();
     assignees.insert(signing_key.clone());

--- a/crates/holochain_integrity_types/CHANGELOG.md
+++ b/crates/holochain_integrity_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- **BREAKING CHANGE**: Updated capability grant structure `GrantedFunctions` to be an enum with `All` for allowing all zomes all functions to be called, along with `Listed` to specify a zome and function as before. [\#1732](https://github.com/holochain/holochain/pull/1732)
+
 ## 0.1.0-beta-rc.0
 
 ## 0.0.25

--- a/crates/holochain_integrity_types/src/capability/grant.rs
+++ b/crates/holochain_integrity_types/src/capability/grant.rs
@@ -177,7 +177,8 @@ impl From<(CapSecret, AgentPubKey)> for CapAccess {
 pub type GrantedFunction = (ZomeName, FunctionName);
 /// A collection of zome/function pairs
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Arbitrary)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum GrantedFunctions {
     /// grant all zomes all functions
     All,

--- a/crates/holochain_integrity_types/src/capability/grant.rs
+++ b/crates/holochain_integrity_types/src/capability/grant.rs
@@ -1,7 +1,6 @@
 use super::CapSecret;
 use crate::zome::FunctionName;
 use crate::zome::ZomeName;
-use arbitrary::Arbitrary;
 use holo_hash::*;
 use serde::Deserialize;
 use serde::Serialize;

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -1587,8 +1587,9 @@ pub mod tests {
         // @todo curry
         let _curry = CurryPayloadsFixturator::new(Empty).next().unwrap();
         let function: GrantedFunction = ("foo".into(), "bar".into());
-        let mut functions: GrantedFunctions = BTreeSet::new();
-        functions.insert(function.clone());
+        let mut fns = BTreeSet::new();
+        fns.insert(function.clone());
+        let functions = GrantedFunctions::Listed(fns);
         let grant = ZomeCallCapGrant::new("tag".into(), access.clone(), functions.clone());
         let mut agents = AgentPubKeyFixturator::new(Predictable);
         let alice = agents.next().unwrap();

--- a/crates/holochain_zome_types/src/fixt.rs
+++ b/crates/holochain_zome_types/src/fixt.rs
@@ -305,11 +305,11 @@ fixturator!(
                 let mut rng = rng();
                 let number_of_zomes = rng.gen_range(0..5);
 
-                let mut granted_functions: GrantedFunctions = BTreeSet::new();
+                let mut fns = BTreeSet::new();
                 for _ in 0..number_of_zomes {
-                    granted_functions.insert(GrantedFunctionFixturator::new(Empty).next().unwrap());
+                    fns.insert(GrantedFunctionFixturator::new(Empty).next().unwrap());
                 }
-                granted_functions
+                GrantedFunctions::Listed(fns)
             }, // CurryPayloadsFixturator::new(Empty).next().unwrap(),
         )
     };
@@ -321,15 +321,15 @@ fixturator!(
                 let mut rng = rand::thread_rng();
                 let number_of_zomes = rng.gen_range(0..5);
 
-                let mut granted_functions: GrantedFunctions = BTreeSet::new();
+                let mut fns = BTreeSet::new();
                 for _ in 0..number_of_zomes {
-                    granted_functions.insert(
-                        GrantedFunctionFixturator::new(Unpredictable)
-                            .next()
-                            .unwrap(),
+                    fns.insert(
+                    GrantedFunctionFixturator::new(Unpredictable)
+                        .next()
+                        .unwrap(),
                     );
                 }
-                granted_functions
+                GrantedFunctions::Listed(fns)
             },
             // CurryPayloadsFixturator::new(Unpredictable).next().unwrap(),
         )
@@ -343,14 +343,16 @@ fixturator!(
                 .next()
                 .unwrap(),
             {
-                let mut granted_functions: GrantedFunctions = BTreeSet::new();
-                for _ in 0..get_fixt_index!() % 3 {
-                    granted_functions
-                        .insert(GrantedFunctionFixturator::new(Predictable).next().unwrap());
+                if get_fixt_index!() %2 == 0{
+                    let mut fns = BTreeSet::new();
+                    for _ in 0..get_fixt_index!() % 3 {
+                        fns.insert(GrantedFunctionFixturator::new(Predictable).next().unwrap());
+                    }
+                    GrantedFunctions::Listed(fns)
+                } else {
+                    GrantedFunctions::All
                 }
-                granted_functions
-            },
-            // CurryPayloadsFixturator::new(Predictable).next().unwrap(),
+            }
         )
     };
 );

--- a/crates/test_utils/wasm/wasm_workspace/capability/src/coordinator.rs
+++ b/crates/test_utils/wasm/wasm_workspace/capability/src/coordinator.rs
@@ -6,9 +6,10 @@ pub struct CapFor(CapSecret, AgentPubKey);
 #[hdk_extern]
 fn init(_: ()) -> ExternResult<InitCallbackResult> {
     // grant unrestricted access to accept_cap_claim so other agents can send us claims
-    let mut functions: GrantedFunctions = BTreeSet::new();
-    functions.insert((zome_info()?.name, "accept_cap_claim".into()));
-    functions.insert((zome_info()?.name, "another_cap_claim".into()));
+    let mut fns = BTreeSet::new();
+    fns.insert((zome_info()?.name, "accept_cap_claim".into()));
+    fns.insert((zome_info()?.name, "another_cap_claim".into()));
+    let functions = GrantedFunctions::Listed(fns);
     create_cap_grant(CapGrantEntry {
         tag: "".into(),
         // empty access converts to unrestricted
@@ -25,9 +26,10 @@ pub fn cap_secret(_: ()) -> ExternResult<CapSecret> {
 }
 
 fn cap_grant_entry(secret: CapSecret) -> ExternResult<CapGrantEntry> {
-    let mut functions: GrantedFunctions = BTreeSet::new();
+    let mut fns = BTreeSet::new();
     let this_zome = zome_info()?.name;
-    functions.insert((this_zome, "needs_cap_claim".into()));
+    fns.insert((this_zome, "needs_cap_claim".into()));
+    let functions = GrantedFunctions::Listed(fns);
     Ok(CapGrantEntry {
         tag: "".into(),
         access: secret.into(),
@@ -92,9 +94,10 @@ fn send_assigned_cap_claim(agent: AgentPubKey) -> ExternResult<()> {
     let secret = CapSecret::try_from_random()?;
 
     // grant the secret as assigned (can only be used by the intended agent)
-    let mut functions: GrantedFunctions = BTreeSet::new();
+    let mut fns = BTreeSet::new();
     let this_zome = zome_info()?.name;
-    functions.insert((this_zome.clone(), "needs_cap_claim".into()));
+    fns.insert((this_zome.clone(), "needs_cap_claim".into()));
+    let functions = GrantedFunctions::Listed(fns);
     create_cap_grant(CapGrantEntry {
         access: (secret, agent.clone()).into(),
         functions,

--- a/crates/test_utils/wasm/wasm_workspace/coordinator_zome/src/lib.rs
+++ b/crates/test_utils/wasm/wasm_workspace/coordinator_zome/src/lib.rs
@@ -89,8 +89,9 @@ fn get_activity(
 #[hdk_extern]
 fn init(_: ()) -> ExternResult<InitCallbackResult> {
     // grant unrestricted access to accept_cap_claim so other agents can send us claims
-    let mut functions: GrantedFunctions = BTreeSet::new();
-    functions.insert((zome_info()?.name, "create_entry".into()));
+    let mut fns = BTreeSet::new();
+    fns.insert((zome_info()?.name, "create_entry".into()));
+    let functions = GrantedFunctions::Listed(fns);
     create_cap_grant(CapGrantEntry {
         tag: "".into(),
         // empty access converts to unrestricted

--- a/crates/test_utils/wasm/wasm_workspace/create_entry/src/coordinator.rs
+++ b/crates/test_utils/wasm/wasm_workspace/create_entry/src/coordinator.rs
@@ -95,8 +95,9 @@ fn get_activity(
 #[hdk_extern]
 fn init(_: ()) -> ExternResult<InitCallbackResult> {
     // grant unrestricted access to accept_cap_claim so other agents can send us claims
-    let mut functions: GrantedFunctions = BTreeSet::new();
-    functions.insert((zome_info()?.name, "create_entry".into()));
+    let mut fns = BTreeSet::new();
+    fns.insert((zome_info()?.name, "create_entry".into()));
+    let functions = GrantedFunctions::Listed(fns);
     create_cap_grant(CapGrantEntry {
         tag: "".into(),
         // empty access converts to unrestricted

--- a/crates/test_utils/wasm/wasm_workspace/emit_signal/src/lib.rs
+++ b/crates/test_utils/wasm/wasm_workspace/emit_signal/src/lib.rs
@@ -18,8 +18,9 @@ fn recv_remote_signal(signal: ExternIO) -> ExternResult<()> {
 
 #[hdk_extern]
 fn init(_: ()) -> ExternResult<InitCallbackResult> {
-    let mut functions: GrantedFunctions = BTreeSet::new();
-    functions.insert((zome_info()?.name, "recv_remote_signal".into()));
+    let mut fns = BTreeSet::new();
+    fns.insert((zome_info()?.name, "recv_remote_signal".into()));
+    let functions = GrantedFunctions::Listed(fns);
     create_cap_grant(CapGrantEntry {
         tag: "".into(),
         // empty access converts to unrestricted

--- a/crates/test_utils/wasm/wasm_workspace/foo/src/lib.rs
+++ b/crates/test_utils/wasm/wasm_workspace/foo/src/lib.rs
@@ -3,9 +3,10 @@ use hdk::prelude::*;
 #[hdk_extern]
 fn init(_: ()) -> ExternResult<InitCallbackResult> {
     // grant unrestricted access to accept_cap_claim so other agents can send us claims
-    let mut functions: GrantedFunctions = BTreeSet::new();
-    functions.insert((zome_info()?.name, "foo".into()));
-    // functions.insert((zome_info()?.name, "needs_cap_claim".into()));
+    let mut fns = BTreeSet::new();
+    fns.insert((zome_info()?.name, "foo".into()));
+    // fns.insert((zome_info()?.name, "needs_cap_claim".into()));
+    let functions = GrantedFunctions::Listed(fns);
     create_cap_grant(CapGrantEntry {
         tag: "".into(),
         // empty access converts to unrestricted

--- a/crates/test_utils/wasm/wasm_workspace/post_commit_volley/src/coordinator.rs
+++ b/crates/test_utils/wasm/wasm_workspace/post_commit_volley/src/coordinator.rs
@@ -3,8 +3,9 @@ use hdk::prelude::*;
 
 #[hdk_extern]
 fn set_access(_: ()) -> ExternResult<()> {
-    let mut functions: GrantedFunctions = BTreeSet::new();
-    functions.insert((zome_info()?.name, "ping".into()));
+    let mut fns = BTreeSet::new();
+    fns.insert((zome_info()?.name, "ping".into()));
+    let functions = GrantedFunctions::Listed(fns);
     create_cap_grant(CapGrantEntry {
         tag: "".into(),
         // empty access converts to unrestricted

--- a/crates/test_utils/wasm/wasm_workspace/whoami/src/lib.rs
+++ b/crates/test_utils/wasm/wasm_workspace/whoami/src/lib.rs
@@ -14,8 +14,9 @@ impl From<Zomes> for ZomeName {
 
 #[hdk_extern]
 fn set_access(_: ()) -> ExternResult<()> {
-    let mut functions: GrantedFunctions = BTreeSet::new();
-    functions.insert((zome_info()?.name, "whoami".into()));
+    let mut fns = BTreeSet::new();
+    fns.insert((zome_info()?.name, "whoami".into()));
+    let functions = GrantedFunctions::Listed(fns);
     create_cap_grant(CapGrantEntry {
         tag: "".into(),
         // empty access converts to unrestricted

--- a/crates/test_utils/wasm/wasm_workspace/zome_info/src/coordinator.rs
+++ b/crates/test_utils/wasm/wasm_workspace/zome_info/src/coordinator.rs
@@ -4,9 +4,11 @@ use serde_yaml::Value;
 
 #[hdk_extern]
 fn set_access(_: ()) -> ExternResult<()> {
-    let mut functions: GrantedFunctions = BTreeSet::new();
-    functions.insert((hdk::prelude::zome_info()?.name, "call_info".into()));
-    functions.insert((hdk::prelude::zome_info()?.name, "remote_call_info".into()));
+    let mut fns = BTreeSet::new();
+    fns.insert((hdk::prelude::zome_info()?.name, "call_info".into()));
+    fns.insert((hdk::prelude::zome_info()?.name, "remote_call_info".into()));
+    let functions = GrantedFunctions::Listed(fns);
+
     create_cap_grant(CapGrantEntry {
         tag: "".into(),
         // empty access converts to unrestricted


### PR DESCRIPTION
### Summary

Updates capability grant structure `GrantedFunctions` to be an enum with `All` for allowing all zomes all functions to be called, along with `Listed` to specify a zome and function as before.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
