### PR TITLE
chore(default.nix): bump rust version to 1.66

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { nixpkgs ? null
 , rustVersion ? {
     track = "stable";
-    version = "1.60.0";
+    version = "1.66.0";
   }
 
 , holonixArgs ? { }


### PR DESCRIPTION
### Summary

How about this?


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
