### PR TITLE
Fix problems with disabled and reenabled cells

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fixes problem where disabling and re-enabling an app causes all of its cells to become unresponsive to any `get*` requests. [\#1744](https://github.com/holochain/holochain/pull/1744)
+
 ## 0.1.0-beta-rc.2
 
 ## 0.1.0-beta-rc.1

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -524,7 +524,8 @@ pub mod test {
         let shutdown = conductor_handle.take_shutdown_handle().unwrap();
         let app_id = "test app".to_string();
 
-        // Activate the app
+        // Enable the app
+        println!("### ENABLE ###");
         let msg = AdminRequest::EnableApp {
             installed_app_id: app_id.clone(),
         };
@@ -545,6 +546,7 @@ pub mod test {
         let initial_state: ConductorState = conductor_handle.get_state_from_handle().await.unwrap();
 
         // Now make sure we can call a zome
+        println!("### CALL ZOME ###");
         call_zome(
             conductor_handle.clone(),
             cell_id_0.clone(),
@@ -592,6 +594,7 @@ pub mod test {
         }
 
         // Now deactivate app
+        println!("### DISABLE ###");
         let msg = AdminRequest::DisableApp {
             installed_app_id: app_id.clone(),
         };
@@ -634,7 +637,8 @@ pub mod test {
             assert!(false);
         }
 
-        // Activate the app one more time
+        // Enable the app one more time
+        println!("### ENABLE ###");
         let msg = AdminRequest::EnableApp {
             installed_app_id: app_id.clone(),
         };
@@ -656,6 +660,7 @@ pub mod test {
         assert_eq!(initial_state, state);
 
         // Now make sure we can call a zome once again
+        println!("### CALL ZOME ###");
         call_zome(
             conductor_handle.clone(),
             cell_id_0.clone(),

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -517,15 +517,14 @@ pub mod test {
             .collect::<Vec<_>>();
         let cell_id_0 = cell_ids_with_proofs.first().cloned().unwrap().0;
 
-        dbg!(&cell_ids_with_proofs);
         let (_tmpdir, conductor_handle) = setup_admin_fake_cells(dnas, cell_ids_with_proofs).await;
-        dbg!(conductor_handle.get_dna_def(cell_id_0.dna_hash()).unwrap());
 
         let shutdown = conductor_handle.take_shutdown_handle().unwrap();
         let app_id = "test app".to_string();
 
         // Enable the app
         println!("### ENABLE ###");
+
         let msg = AdminRequest::EnableApp {
             installed_app_id: app_id.clone(),
         };
@@ -547,6 +546,7 @@ pub mod test {
 
         // Now make sure we can call a zome
         println!("### CALL ZOME ###");
+
         call_zome(
             conductor_handle.clone(),
             cell_id_0.clone(),
@@ -595,6 +595,7 @@ pub mod test {
 
         // Now deactivate app
         println!("### DISABLE ###");
+
         let msg = AdminRequest::DisableApp {
             installed_app_id: app_id.clone(),
         };
@@ -639,6 +640,7 @@ pub mod test {
 
         // Enable the app one more time
         println!("### ENABLE ###");
+
         let msg = AdminRequest::EnableApp {
             installed_app_id: app_id.clone(),
         };
@@ -661,6 +663,7 @@ pub mod test {
 
         // Now make sure we can call a zome once again
         println!("### CALL ZOME ###");
+
         call_zome(
             conductor_handle.clone(),
             cell_id_0.clone(),

--- a/crates/holochain/src/core/workflow/genesis_workflow.rs
+++ b/crates/holochain/src/core/workflow/genesis_workflow.rs
@@ -2,7 +2,6 @@
 //! - Dna
 //! - AgentValidationPkg
 //! - AgentId
-//!
 
 use std::sync::Arc;
 

--- a/crates/holochain_sqlite/src/sql.rs
+++ b/crates/holochain_sqlite/src/sql.rs
@@ -66,6 +66,7 @@ pub(crate) mod sql_p2p_agent_store {
     pub(crate) const INSERT: &str = include_str!("sql/p2p_agent_store/insert.sql");
     pub(crate) const SELECT_ALL: &str = include_str!("sql/p2p_agent_store/select_all.sql");
     pub(crate) const SELECT: &str = include_str!("sql/p2p_agent_store/select.sql");
+    pub(crate) const DELETE: &str = include_str!("sql/p2p_agent_store/delete.sql");
     pub(crate) const GOSSIP_QUERY: &str = include_str!("sql/p2p_agent_store/gossip_query.sql");
     pub(crate) const QUERY_NEAR_BASIS: &str =
         include_str!("sql/p2p_agent_store/query_near_basis.sql");

--- a/crates/holochain_sqlite/src/sql/p2p_agent_store/delete.sql
+++ b/crates/holochain_sqlite/src/sql/p2p_agent_store/delete.sql
@@ -1,0 +1,5 @@
+-- simple select the matching agent
+DELETE FROM
+  p2p_agent_store
+WHERE
+  agent = :agent;

--- a/crates/kitsune_p2p/direct/src/v1.rs
+++ b/crates/kitsune_p2p/direct/src/v1.rs
@@ -303,6 +303,11 @@ impl KitsuneHostDefaultError for Kd1 {
         .boxed()
         .into()
     }
+
+    fn remove_agent_info_signed(&self, _input: GetAgentInfoSignedEvt) -> KitsuneHostResult<bool> {
+        // hope for the best
+        async move { Ok(false) }.boxed().into()
+    }
 }
 
 impl FetchQueueConfig for Kd1 {

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Fixes some bad logic around leaving spaces, which can cause problems upon rejoining [\#1744](https://github.com/holochain/holochain/pull/1744)
+  - When an agent leaves a space, an `AgentInfoSigned` with an empty arc is published before leaving. Previously, this empty-arc agent info was also persisted to the database, but this is inappropriate because upon rejoining, they will start with an empty arc. Now, the persisted agent info is not updated upon leave, so that upon rejoining, the last known agent info is used.
+
 ## 0.1.0-beta-rc.0
 
 - **BREAKING CHANGE:** The gossip and publishing algorithms have undergone a significant rework, making this version incompatible with previous versions. Rather than gossiping and publishing entire Ops, only hashes are sent, which the recipient uses to maintain a queue of items which need to be fetched from various other sources on the DHT. This allows for finer-grained control over receiving Ops from multiple sources, and allows each node to manage their own incoming data flow. [\#1662](https://github.com/holochain/holochain/pull/1662)

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## \[Unreleased\]
 
 - Fixes some bad logic around leaving spaces, which can cause problems upon rejoining [\#1744](https://github.com/holochain/holochain/pull/1744)
-  - When an agent leaves a space, an `AgentInfoSigned` with an empty arc is published before leaving. Previously, this empty-arc agent info was also persisted to the database, but this is inappropriate because upon rejoining, they will start with an empty arc. Now, the persisted agent info is not updated upon leave, so that upon rejoining, the last known agent info is used.
+  - When an agent leaves a space, an `AgentInfoSigned` with an empty arc is published before leaving. Previously, this empty-arc agent info was also persisted to the database, but this is inappropriate because upon rejoining, they will start with an empty arc. Now, the agent info is removed from the database altogether upon leaving.
 
 ## 0.1.0-beta-rc.0
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -37,6 +37,14 @@ impl KitsuneHost for StandardResponsesHostApi {
         box_fut(Ok(Some(agent)))
     }
 
+    fn remove_agent_info_signed(
+        &self,
+        _input: GetAgentInfoSignedEvt,
+    ) -> crate::KitsuneHostResult<bool> {
+        // unimplemented
+        box_fut(Ok(false))
+    }
+
     fn peer_extrapolated_coverage(
         &self,
         _space: Arc<KitsuneSpace>,

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
@@ -28,6 +28,9 @@ pub trait KitsuneHost: 'static + Send + Sync {
         input: GetAgentInfoSignedEvt,
     ) -> KitsuneHostResult<Option<crate::types::agent_store::AgentInfoSigned>>;
 
+    /// Remove an agent info from storage
+    fn remove_agent_info_signed(&self, input: GetAgentInfoSignedEvt) -> KitsuneHostResult<bool>;
+
     /// Extrapolated Peer Coverage.
     fn peer_extrapolated_coverage(
         &self,

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_default_error.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_default_error.rs
@@ -24,6 +24,15 @@ pub trait KitsuneHostDefaultError: KitsuneHost + FetchQueueConfig {
         .into()))
     }
 
+    fn remove_agent_info_signed(&self, _input: GetAgentInfoSignedEvt) -> KitsuneHostResult<bool> {
+        box_fut(Err(format!(
+            "error for unimplemented KitsuneHost test behavior: method {} of {}",
+            "remove_agent_info_signed",
+            Self::NAME
+        )
+        .into()))
+    }
+
     fn peer_extrapolated_coverage(
         &self,
         _space: Arc<KitsuneSpace>,
@@ -122,6 +131,10 @@ impl<T: KitsuneHostDefaultError> KitsuneHost for T {
         input: GetAgentInfoSignedEvt,
     ) -> KitsuneHostResult<Option<crate::types::agent_store::AgentInfoSigned>> {
         KitsuneHostDefaultError::get_agent_info_signed(self, input)
+    }
+
+    fn remove_agent_info_signed(&self, input: GetAgentInfoSignedEvt) -> KitsuneHostResult<bool> {
+        KitsuneHostDefaultError::remove_agent_info_signed(self, input)
     }
 
     fn peer_extrapolated_coverage(

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
@@ -58,6 +58,10 @@ impl KitsuneHost for HostStub {
         KitsuneHostDefaultError::get_agent_info_signed(&self.err, input)
     }
 
+    fn remove_agent_info_signed(&self, input: GetAgentInfoSignedEvt) -> KitsuneHostResult<bool> {
+        KitsuneHostDefaultError::remove_agent_info_signed(&self.err, input)
+    }
+
     fn peer_extrapolated_coverage(
         &self,
         space: Arc<KitsuneSpace>,

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -1563,6 +1563,9 @@ impl Space {
 
             tracing::debug!(?agent_info_signed);
 
+            // TODO: at some point, we should not remove agents who have left, but rather
+            // there should be a flag indicating they have left. The removed agent may just
+            // get re-gossiped to another local agent in the same space, defeating the purpose.
             host.remove_agent_info_signed(GetAgentInfoSignedEvt { space, agent })
                 .await
                 .map_err(KitsuneP2pError::other)?;

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -759,7 +759,7 @@ impl KitsuneP2pHandler for Space {
         agent: Arc<KitsuneAgent>,
         initial_arc: Option<DhtArc>,
     ) -> KitsuneP2pHandlerResult<()> {
-        dbg!(&space, &agent, &initial_arc);
+        tracing::debug!(?space, ?agent, ?initial_arc, "handle_join");
         if let Some(initial_arc) = initial_arc {
             self.agent_arcs.insert(agent.clone(), initial_arc);
         }

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -759,6 +759,7 @@ impl KitsuneP2pHandler for Space {
         agent: Arc<KitsuneAgent>,
         initial_arc: Option<DhtArc>,
     ) -> KitsuneP2pHandlerResult<()> {
+        dbg!(&space, &agent, &initial_arc);
         if let Some(initial_arc) = initial_arc {
             self.agent_arcs.insert(agent.clone(), initial_arc);
         }
@@ -1559,13 +1560,6 @@ impl Space {
             .await?;
 
             tracing::debug!(?agent_info_signed);
-
-            evt_sender
-                .put_agent_info_signed(PutAgentInfoSignedEvt {
-                    space: space.clone(),
-                    peer_data: vec![agent_info_signed.clone()],
-                })
-                .await?;
 
             // Push to the network as well
             match network_type {

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic.rs
@@ -61,7 +61,7 @@ pub(crate) async fn handle_rpc_multi_as_single(
                         .write()
                         .record_latency_micros(start.elapsed().as_micros(), [&agent]);
                     tracing::warn!(?oth, "unexpected remote call result");
-                    Err("rpc_multi failed to get results".into())
+                    Err(format!("rpc_multi request failed: {:?}", oth).into())
                 }
             }
         }
@@ -70,6 +70,7 @@ pub(crate) async fn handle_rpc_multi_as_single(
 
     max_timeout
         .mix("rpc_multi", async move {
+            let mut errs = vec![];
             for _ in 0..2 {
                 let mut infos = None;
 
@@ -115,11 +116,12 @@ pub(crate) async fn handle_rpc_multi_as_single(
                         .await
                         {
                             PeerDiscoverResult::OkShortcut => {
-                                tracing::trace!("remote peer is local");
+                                tracing::warn!("remote peer is local");
                                 continue;
                             }
                             PeerDiscoverResult::Err(err) => {
-                                tracing::warn!(?err, "remote call error");
+                                tracing::warn!(?err, "peer discovery error");
+                                errs.push(err);
                                 continue;
                             }
                             PeerDiscoverResult::OkRemote { con_hnd, .. } => con_hnd,
@@ -127,11 +129,17 @@ pub(crate) async fn handle_rpc_multi_as_single(
 
                         match make_req(con_hnd, info.agent.clone()).await {
                             Ok(res) => return Ok(res),
-                            _ => continue,
+                            Err(err) => {
+                                tracing::warn!(?err, "remote call error");
+                                errs.push(err);
+                                continue;
+                            }
                         }
                     }
                 }
             }
+
+            let num_local_agents = local_joined_agents.len();
 
             // fall back to self-get
             for agent in local_joined_agents {
@@ -145,13 +153,19 @@ pub(crate) async fn handle_rpc_multi_as_single(
                     }
                     Err(err) => {
                         tracing::warn!(?err, "local call error");
+                        errs.push(err);
                         continue;
                     }
                 }
             }
 
             // finally, return an error
-            Err("rpc_multi failed to get results".into())
+            let error_msg = format!(
+                "rpc_multi failed to get results. Local agents: {}, Errors: {:?}",
+                num_local_agents, errs
+            );
+            tracing::error!("{}", error_msg);
+            Err(error_msg.into())
         })
         .await
         .map_err(|err| err.into())

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
@@ -68,6 +68,18 @@ impl KitsuneHost for SwitchboardEventHandler {
         })))
     }
 
+    fn remove_agent_info_signed(
+        &self,
+        GetAgentInfoSignedEvt { agent, space: _ }: GetAgentInfoSignedEvt,
+    ) -> crate::KitsuneHostResult<bool> {
+        box_fut(Ok(self.sb.share(|state| {
+            let node = state.nodes.get_mut(&self.node).unwrap();
+            node.local_agents
+                .retain(|_, entry| entry.info.agent == agent);
+            true
+        })))
+    }
+
     fn peer_extrapolated_coverage(
         &self,
         _space: Arc<KitsuneSpace>,


### PR DESCRIPTION
### Summary

Any app which is disabled becomes permanently unresponsive when it is re-enabled. This PR reproduces that problem and fixes it.

The problem occurred upon leaving a space. An agent info with an empty arc is published and persisted. However, this means that when rejoining, the local agent is loaded from the database with an empty arc. I found that the simplest way to fix this is to just not persist the empty arc info upon leaving, only publishing it to our peers. Then, upon rejoining, we start with the same arc we had just before leaving.

But this isn't really correct. Other agents may think this agent is online. So I think we should just remove the entry altogether, so when we rejoin, we can interpret it as such more easily. Maybe if arc resizing was robust and correct, this wouldn't be an issue, but we haven't streamlined that yet.

@neonphog feedback on approach?

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
