### PR TITLE
Fixes for macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ test_cert
 .my-shell.nix
 .DS_Store
 .cov
+
+.direnv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3296,7 +3296,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "shrinkwraprs",
- "sysinfo 0.15.9",
+ "sysinfo",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3327,7 +3327,7 @@ dependencies = [
  "rusqlite",
  "sqlformat 0.2.0",
  "structopt",
- "sysinfo 0.27.2",
+ "sysinfo",
  "tracing-subscriber 0.3.16",
 ]
 
@@ -6156,23 +6156,6 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.15.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de94457a09609f33fec5e7fceaf907488967c6c7c75d64da6a7ce6ffdb8b5abd"
-dependencies = [
- "cc",
- "cfg-if 1.0.0",
- "core-foundation-sys",
- "doc-comment",
- "libc",
- "ntapi 0.3.7",
- "once_cell",
- "rayon",
- "winapi",
 ]
 
 [[package]]

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"
 serde_json = { version = "1", features = [ "preserve_order" ] }
 shrinkwraprs = "0.3.0"
-sysinfo = "0.15.9"
+sysinfo = "0.27"
 thiserror = "1.0.22"
 tokio = { version = "1.11", features = [ "full" ] }
 tokio-stream = { version = "0.1", features = [ "sync", "net" ] }

--- a/crates/kitsune_p2p/types/src/metrics.rs
+++ b/crates/kitsune_p2p/types/src/metrics.rs
@@ -225,9 +225,9 @@ pub fn init_sys_info_poll() {
 
             loop {
                 system.refresh_process(pid);
-                system.get_networks_mut().refresh();
+                system.networks_mut().refresh();
 
-                let proc = system.get_process(pid).unwrap();
+                let proc = system.process(pid).unwrap();
 
                 let mem = proc.memory();
                 USED_MEM_KB.store(mem, Ordering::Relaxed);
@@ -237,9 +237,9 @@ pub fn init_sys_info_poll() {
 
                 let mut tx = 0;
                 let mut rx = 0;
-                for (_n, network) in system.get_networks().iter() {
-                    tx += network.get_transmitted();
-                    rx += network.get_received();
+                for (_n, network) in system.networks().iter() {
+                    tx += network.transmitted();
+                    rx += network.received();
                 }
                 tx_avg.push(tx);
                 rx_avg.push(rx);

--- a/default.nix
+++ b/default.nix
@@ -67,8 +67,14 @@ let
       };
     })
 
-  ];
+  ]
+  ++ [(
+    self: super: {
+      inherit crate2nix;
+    }
+  )];
 
+  crate2nix = (import (nixpkgs.path or holonix.pkgs.path) {}).crate2nix;
   nixpkgs' = import (nixpkgs.path or holonix.pkgs.path) { inherit overlays; };
   inherit (nixpkgs') callPackage;
 

--- a/default.nix
+++ b/default.nix
@@ -51,8 +51,6 @@ let
 
       inherit (self.rustPlatform.rust) rustc cargo;
 
-      crate2nix = import sources.crate2nix.outPath { };
-
       cargo-nextest = self.rustPlatform.buildRustPackage {
         name = "cargo-nextest";
 

--- a/nix/pkgs/core.nix
+++ b/nix/pkgs/core.nix
@@ -3,7 +3,6 @@
 , lib
 , writeShellScriptBin
 , crate2nix
-
 , holonix
 , holonixPath
 , hcToplevelDir

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -59,9 +59,6 @@ rec {
       nixpkgs-fmt
       cargo-sweep
     ])
-    ++ (lib.optionals stdenv.isLinux [
-      crate2nix
-    ])
     ++ (lib.optionals stdenv.isDarwin
       (with holonix.pkgs.darwin; [
         Security

--- a/nix/shells.nix
+++ b/nix/shells.nix
@@ -51,15 +51,24 @@ rec {
     nativeBuildInputs = builtins.attrValues (pkgs.core)
       ++ [
       cargo-nextest
-      crate2nix
     ]
-      ++ (with holonix.pkgs;[
+    ++ (with holonix.pkgs;[
       sqlcipher
       gdb
       gh
       nixpkgs-fmt
       cargo-sweep
-    ]);
+    ])
+    ++ (lib.optionals stdenv.isLinux [
+      crate2nix
+    ])
+    ++ (lib.optionals stdenv.isDarwin
+      (with holonix.pkgs.darwin; [
+        Security
+        IOKit
+        apple_sdk_11_0.frameworks.CoreFoundation
+      ])
+    );
   };
 
   release = coreDev.overrideAttrs (attrs: {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "78cb2455a9a8b6f5d32005dc6ca8efa0a18063c8",
-        "sha256": "1hm9nlypq2cwyhcvq5spm180nn6mp7wl1yfw57ils72v65wr9kcr",
+        "rev": "86c4772d45688fb0f5850ce2c4893aa1bfbe3f0f",
+        "sha256": "03hnshx59q9n3djlhhpppzjkb16df5kqyxfbrxppb1kv7ykbfnf8",
         "type": "tarball",
-        "url": "https://github.com/holochain/holonix/archive/78cb2455a9a8b6f5d32005dc6ca8efa0a18063c8.tar.gz",
+        "url": "https://github.com/holochain/holonix/archive/86c4772d45688fb0f5850ce2c4893aa1bfbe3f0f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nextest": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "5d54ea8e262202861bad3cbe3df41edf77e162ed",
-        "sha256": "0q8f9iap0s0cmx4hyqdbgg09v5gfz3lmzvq59w7bvvbp2xl84ycd",
+        "rev": "2fdd7fcd55ceecc6f837ec98a78bb827a83ea2e3",
+        "sha256": "063cc2ryswxyx6ci7dafjg2iy66ip7lp5vi02njwzayn0lpcpp75",
         "type": "tarball",
-        "url": "https://github.com/holochain/holonix/archive/5d54ea8e262202861bad3cbe3df41edf77e162ed.tar.gz",
+        "url": "https://github.com/holochain/holonix/archive/2fdd7fcd55ceecc6f837ec98a78bb827a83ea2e3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nextest": {

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "2fdd7fcd55ceecc6f837ec98a78bb827a83ea2e3",
-        "sha256": "063cc2ryswxyx6ci7dafjg2iy66ip7lp5vi02njwzayn0lpcpp75",
+        "rev": "78cb2455a9a8b6f5d32005dc6ca8efa0a18063c8",
+        "sha256": "1hm9nlypq2cwyhcvq5spm180nn6mp7wl1yfw57ils72v65wr9kcr",
         "type": "tarball",
-        "url": "https://github.com/holochain/holonix/archive/2fdd7fcd55ceecc6f837ec98a78bb827a83ea2e3.tar.gz",
+        "url": "https://github.com/holochain/holonix/archive/78cb2455a9a8b6f5d32005dc6ca8efa0a18063c8.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nextest": {


### PR DESCRIPTION
### Summary
- update sysinfo dependency of kitsune_p2p/types
- patch kitsune_p2p/types to work with updated sysinfo
- update holonix input to new version containing fixes for macos

Chore:
- add direnv to .gitignore


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
