### PR TITLE
Remove excessive warnings

### DIFF
--- a/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
@@ -453,7 +453,7 @@ impl Metrics {
             };
             record_item(&mut history.initiates, round);
             if history.current_round {
-                tracing::warn!("Recorded initiate with current round already set");
+                tracing::info!("Recorded initiate with current round already set");
             }
             history.current_round = true;
         }
@@ -476,7 +476,7 @@ impl Metrics {
             };
             record_item(&mut history.accepts, round);
             if history.current_round {
-                tracing::warn!("Recorded accept with current round already set");
+                tracing::info!("Recorded accept with current round already set");
             }
             history.current_round = true;
         }

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/discover.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/discover.rs
@@ -76,7 +76,7 @@ pub(crate) fn search_and_discover_peer_connect(
                                 {
                                     tracing::error!(
                                         ?err,
-                                        "search_and_discover error putting agent info"
+                                        "search_and_discover_peer_connect: error putting agent info"
                                     );
                                 }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/wire.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/wire.rs
@@ -120,9 +120,9 @@ kitsune_p2p_types::write_codec_enum! {
             agent.1: Arc<KitsuneAgent>,
         },
 
-        /// Response to a peer get
+        /// Response to a peer get. If the agent isn't known, None will be returned.
         PeerGetResp(0x51) {
-            agent_info_signed.0: AgentInfoSigned,
+            agent_info_signed.0: Option<AgentInfoSigned>,
         },
 
         /// Query a remote node for peers holding
@@ -132,7 +132,7 @@ kitsune_p2p_types::write_codec_enum! {
             basis_loc.1: DhtLocation,
         },
 
-        /// Response to a peer query
+        /// Response to a peer query. May be empty if no matching agents are known.
         PeerQueryResp(0x53) {
             peer_list.0: Vec<AgentInfoSigned>,
         },


### PR DESCRIPTION
### Summary

Some warnings flood the logs. This should make things a little better.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
