### PR TITLE
Fetch queue shares its sources across items

### DIFF
--- a/crates/kitsune_p2p/fetch/src/queue/queue_reader.rs
+++ b/crates/kitsune_p2p/fetch/src/queue/queue_reader.rs
@@ -48,11 +48,12 @@ mod tests {
     #[test]
     fn queue_info() {
         let cfg = Config(1, 1);
+        let mut ss = TestSources::new(cfg.clone());
         let q = {
             let mut queue = [
-                (key_op(1), item(&cfg, sources(0..=2), ctx(1))),
-                (key_op(2), item(&cfg, sources(1..=3), ctx(1))),
-                (key_op(3), item(&cfg, sources(2..=4), ctx(1))),
+                (key_op(1), ss.item(0..=2, ctx(1))),
+                (key_op(2), ss.item(1..=3, ctx(1))),
+                (key_op(3), ss.item(2..=4, ctx(1))),
             ];
 
             queue[0].1.size = Some(100.into());
@@ -61,7 +62,10 @@ mod tests {
             let queue = queue.into_iter().collect();
             FetchQueueReader(FetchQueue {
                 config: Arc::new(cfg),
-                state: ShareOpen::new(State { queue }),
+                state: ShareOpen::new(State {
+                    queue,
+                    sources: ss.into_hashmap(),
+                }),
             })
         };
         let info = q.info([space(0)].into_iter().collect());

--- a/crates/kitsune_p2p/types/src/tx2/tx2_utils/share.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_utils/share.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use crate::*;
 
 /// Synchronized droppable share-lock around internal state date.
@@ -85,6 +87,13 @@ impl<T: 'static + Send> Share<T> {
     }
 }
 
+impl<T: 'static + Send + Debug> Debug for Share<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.share_ref(|s| Ok(f.debug_tuple("Share").field(s).finish()))
+            .unwrap()
+    }
+}
+
 /// A version of Share which can never be closed, and thus every
 /// share is infallible (no Err possible).
 #[derive(PartialEq, Eq, Hash)]
@@ -120,5 +129,11 @@ impl<T: 'static + Send> ShareOpen<T> {
         self.0
             .share_mut(|s, _| Ok(f(s)))
             .expect("ShareOpen state is never dropped")
+    }
+}
+
+impl<T: 'static + Send + Debug> Debug for ShareOpen<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.share_ref(|s| f.debug_tuple("ShareOpen").field(s).finish())
     }
 }


### PR DESCRIPTION
### Summary

Previously, we tracked each source for each item separately. Now a single source's last requested time is shared across all items, so we can more effectively track metrics about that source.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
