### PR TITLE
refactor(admin-api)!: remove call StartApp

### DIFF
--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -218,15 +218,6 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     .await?;
                 Ok(AdminResponse::AppDisabled)
             }
-            StartApp { installed_app_id } => {
-                // TODO: check to see if app was actually started
-                let app = self
-                    .conductor_handle
-                    .clone()
-                    .start_app(installed_app_id)
-                    .await?;
-                Ok(AdminResponse::AppStarted(app.status().is_running()))
-            }
             AttachAppInterface { port } => {
                 let port = port.unwrap_or(0);
                 let port = self

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **BREAKING CHANGE**: `CreateCloneCell` returns `ClonedCell` instead of `InstalledCell`.
 - **BREAKING CHANGE**: `EnableCloneCell` returns `ClonedCell` instead of `InstalledCell`.
+- **BREAKING CHANGE**: Remove unused call `AdminRequest::StartApp`.
 - **BREAKING CHANGE**: `Cell` is split up into `ProvisionedCell` and `ClonedCell`.
 - **BREAKING CHANGE**: `CellInfo` variants are renamed to snake case during serde.
 

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -147,11 +147,6 @@ pub enum AdminRequest {
         installed_app_id: InstalledAppId,
     },
 
-    StartApp {
-        /// The app ID to (re)start
-        installed_app_id: InstalledAppId,
-    },
-
     /// Open up a new websocket for processing [`AppRequest`]s.
     ///
     /// Any active app will be callable via the attached app interface.
@@ -416,14 +411,6 @@ pub enum AdminResponse {
     ///
     /// It means the app was disabled successfully.
     AppDisabled,
-
-    /// The successful response to an [`AdminRequest::StartApp`].
-    ///
-    /// The boolean determines whether or not the app was actually started.
-    /// If `false`, it was because the app was in a disabled state, or the app
-    /// failed to start.
-    /// TODO: add reason why app couldn't start
-    AppStarted(bool),
 
     /// The successful response to an [`AdminRequest::DumpState`].
     ///


### PR DESCRIPTION
### Summary
- Removed unused call `AdminRequest::StartApp`.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
