### PR TITLE
feat(app-api): return agent_pub_key in AppInfo

### DIFF
--- a/crates/holochain/src/conductor/tests/app_info.rs
+++ b/crates/holochain/src/conductor/tests/app_info.rs
@@ -73,6 +73,9 @@ async fn app_info_returns_all_cells_with_info() {
 
     let app_info = conductor.get_app_info(&app_id).await.unwrap().unwrap();
 
+    // agent pub key matches
+    assert_eq!(app_info.agent_pub_key, agent_pub_key);
+
     // app info has cell info for two role names
     assert_eq!(app_info.cell_info.len(), 2);
 

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **BREAKING CHANGE**: `EnableCloneCell` returns `ClonedCell` instead of `InstalledCell`.
 - **BREAKING CHANGE**: `Cell` is split up into `ProvisionedCell` and `ClonedCell`.
 - **BREAKING CHANGE**: `CellInfo` variants are renamed to snake case during serde.
+- Return additional field `agent_pub_key` in `AppInfo`.
 
 ## 0.1.0-beta-rc.3
 

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -282,6 +282,8 @@ pub struct AppInfo {
     pub cell_info: HashMap<RoleName, Vec<CellInfo>>,
     /// The app's current status, in an API-friendly format
     pub status: AppInfoStatus,
+    /// The app's agent pub key.
+    pub agent_pub_key: AgentPubKey,
 }
 
 impl AppInfo {
@@ -291,6 +293,7 @@ impl AppInfo {
     ) -> Self {
         let installed_app_id = app.id().clone();
         let status = app.status().clone().into();
+        let agent_pub_key = app._agent_key().to_owned();
 
         let mut cell_info: HashMap<RoleName, Vec<CellInfo>> = HashMap::new();
         app.roles().iter().for_each(|(role_name, role_assignment)| {
@@ -361,6 +364,7 @@ impl AppInfo {
             installed_app_id,
             cell_info,
             status,
+            agent_pub_key,
         }
     }
 }

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -293,7 +293,7 @@ impl AppInfo {
     ) -> Self {
         let installed_app_id = app.id().clone();
         let status = app.status().clone().into();
-        let agent_pub_key = app._agent_key().to_owned();
+        let agent_pub_key = app.agent_key().to_owned();
 
         let mut cell_info: HashMap<RoleName, Vec<CellInfo>> = HashMap::new();
         app.roles().iter().for_each(|(role_name, role_assignment)| {

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -403,7 +403,7 @@ pub struct InstalledAppCommon {
     /// The agent key used to install this app. Currently this is meaningless,
     /// but I'm leaving it here as a placeholder in case we ever want it to
     /// have formal significance.
-    _agent_key: AgentPubKey,
+    agent_key: AgentPubKey,
     /// Assignments of DNA roles to cells and their clones, as specified in the AppManifest
     role_assignments: HashMap<RoleName, AppRoleAssignment>,
 }
@@ -412,7 +412,7 @@ impl InstalledAppCommon {
     /// Constructor
     pub fn new<S: ToString, I: IntoIterator<Item = (RoleName, AppRoleAssignment)>>(
         installed_app_id: S,
-        _agent_key: AgentPubKey,
+        agent_key: AgentPubKey,
         role_assignments: I,
     ) -> AppResult<Self> {
         let role_assignments: HashMap<_, _> = role_assignments.into_iter().collect();
@@ -425,7 +425,7 @@ impl InstalledAppCommon {
         }
         Ok(InstalledAppCommon {
             installed_app_id: installed_app_id.to_string(),
-            _agent_key,
+            agent_key,
             role_assignments,
         })
     }
@@ -681,8 +681,8 @@ impl InstalledAppCommon {
     }
 
     /// Accessor
-    pub fn _agent_key(&self) -> &AgentPubKey {
-        &self._agent_key
+    pub fn agent_key(&self) -> &AgentPubKey {
+        &self.agent_key
     }
 
     /// Constructor for apps not using a manifest.
@@ -742,7 +742,7 @@ impl InstalledAppCommon {
             .collect();
         Ok(Self {
             installed_app_id,
-            _agent_key,
+            agent_key: _agent_key,
             role_assignments: roles,
         })
     }


### PR DESCRIPTION
### Summary
- Return additional field `agent_pub_key` in `AppInfo`.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
