### PR TITLE
Rename FetchQueue to FetchPool

### DIFF
--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -805,8 +805,8 @@ mod network_impls {
         ) -> ConductorResult<Vec<NetworkInfo>> {
             futures::future::join_all(dnas.iter().map(|dna| async move {
                 let d = self.holochain_p2p.get_diagnostics(dna.clone()).await?;
-                let fetch_queue_info = d.fetch_queue.info([dna.to_kitsune()].into_iter().collect());
-                ConductorResult::Ok(NetworkInfo { fetch_queue_info })
+                let fetch_pool_info = d.fetch_pool.info([dna.to_kitsune()].into_iter().collect());
+                ConductorResult::Ok(NetworkInfo { fetch_pool_info })
             }))
             .await
             .into_iter()

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -254,7 +254,7 @@ pub mod test {
     use holochain_zome_types::test_utils::fake_agent_pubkey_2;
     use holochain_zome_types::ExternIO;
     use kitsune_p2p::agent_store::AgentInfoSigned;
-    use kitsune_p2p::dependencies::kitsune_p2p_fetch::FetchQueueInfo;
+    use kitsune_p2p::dependencies::kitsune_p2p_fetch::FetchPoolInfo;
     use kitsune_p2p::fixt::AgentInfoSignedFixturator;
     use kitsune_p2p::{KitsuneAgent, KitsuneSpace};
     use matches::assert_matches;
@@ -479,7 +479,7 @@ pub mod test {
                     assert_eq!(
                         info,
                         vec![NetworkInfo {
-                            fetch_queue_info: FetchQueueInfo::default()
+                            fetch_pool_info: FetchPoolInfo::default()
                         }]
                     )
                 }

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -3,7 +3,7 @@ use holo_hash::AgentPubKey;
 use holochain_keystore::LairResult;
 use holochain_keystore::MetaLairClient;
 use holochain_types::prelude::*;
-use kitsune_p2p::dependencies::kitsune_p2p_fetch::FetchQueueInfo;
+use kitsune_p2p::dependencies::kitsune_p2p_fetch::FetchPoolInfo;
 use std::collections::HashMap;
 
 /// Represents the available conductor functions to call over an app interface
@@ -400,7 +400,7 @@ impl From<AppInfoStatus> for AppStatus {
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, SerializedBytes)]
 pub struct NetworkInfo {
-    pub fetch_queue_info: FetchQueueInfo,
+    pub fetch_pool_info: FetchPoolInfo,
 }
 
 #[test]

--- a/crates/kitsune_p2p/direct/src/v1.rs
+++ b/crates/kitsune_p2p/direct/src/v1.rs
@@ -5,7 +5,7 @@ use crate::*;
 use futures::future::{BoxFuture, FutureExt};
 use futures::stream::StreamExt;
 use ghost_actor::GhostControlSender;
-use kitsune_p2p::dependencies::kitsune_p2p_fetch::FetchQueueConfig;
+use kitsune_p2p::dependencies::kitsune_p2p_fetch::FetchPoolConfig;
 use kitsune_p2p::test_util::hash_op_data;
 //use ghost_actor::dependencies::tracing;
 use crate::types::direct::*;
@@ -310,7 +310,7 @@ impl KitsuneHostDefaultError for Kd1 {
     }
 }
 
-impl FetchQueueConfig for Kd1 {
+impl FetchPoolConfig for Kd1 {
     fn merge_fetch_contexts(&self, _a: u32, _b: u32) -> u32 {
         unimplemented!()
     }

--- a/crates/kitsune_p2p/fetch/src/lib.rs
+++ b/crates/kitsune_p2p/fetch/src/lib.rs
@@ -7,12 +7,12 @@
 use kitsune_p2p_types::{dht::region::RegionCoords, KAgent, KOpHash, KSpace};
 
 mod error;
-mod queue;
+mod pool;
 mod respond;
 mod rough_sized;
 
 pub use error::*;
-pub use queue::*;
+pub use pool::*;
 pub use respond::*;
 pub use rough_sized::*;
 
@@ -31,7 +31,7 @@ pub enum FetchKey {
 
 /// A fetch "unit" that can be de-duplicated.
 #[derive(Debug, Clone, PartialEq)]
-pub struct FetchQueuePush {
+pub struct FetchPoolPush {
     /// Description of what to fetch.
     pub key: FetchKey,
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
@@ -1,4 +1,4 @@
-use kitsune_p2p_fetch::{FetchKey, FetchQueuePush, OpHashSized};
+use kitsune_p2p_fetch::{FetchKey, FetchPoolPush, OpHashSized};
 use kitsune_p2p_types::{combinators::second, dht::region::Region};
 
 use super::*;
@@ -299,7 +299,7 @@ impl ShardedGossipLocal {
     ) -> KitsuneResult<()> {
         for op_hash in ops {
             let (hash, size) = op_hash.into_inner();
-            let request = FetchQueuePush {
+            let request = FetchPoolPush {
                 key: FetchKey::Op(hash),
                 author: None,
                 context: None,
@@ -307,7 +307,7 @@ impl ShardedGossipLocal {
                 source: source.clone(),
                 size,
             };
-            self.fetch_queue.push(request);
+            self.fetch_pool.push(request);
         }
         Ok(())
     }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests.rs
@@ -23,7 +23,7 @@ impl ShardedGossipLocal {
         let mut u = arbitrary::Unstructured::new(&NOISE);
         let space = KitsuneSpace::arbitrary(&mut u).unwrap();
         let space = Arc::new(space);
-        let fetch_queue = FetchQueue::new_bitwise_or();
+        let fetch_pool = FetchPool::new_bitwise_or();
 
         Self {
             gossip_type,
@@ -33,7 +33,7 @@ impl ShardedGossipLocal {
             host_api: host,
             inner: Share::new(inner),
             closing: std::sync::atomic::AtomicBool::new(false),
-            fetch_queue,
+            fetch_pool,
         }
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -1,7 +1,7 @@
 use crate::test_util::hash_op_data;
 pub use crate::test_util::spawn_handler;
 use crate::{HostStub, KitsuneHost};
-use kitsune_p2p_fetch::FetchQueueConfig;
+use kitsune_p2p_fetch::FetchPoolConfig;
 use kitsune_p2p_types::box_fut;
 use kitsune_p2p_types::dht::prelude::{ArqBoundsSet, RegionCoordSetLtcs, RegionData};
 use kitsune_p2p_types::dht::spacetime::{TelescopingTimes, Topology};
@@ -17,7 +17,7 @@ pub struct StandardResponsesHostApi {
     with_data: bool,
 }
 
-impl FetchQueueConfig for StandardResponsesHostApi {
+impl FetchPoolConfig for StandardResponsesHostApi {
     fn merge_fetch_contexts(&self, _a: u32, _b: u32) -> u32 {
         unimplemented!()
     }

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_default_error.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_default_error.rs
@@ -1,4 +1,4 @@
-use kitsune_p2p_fetch::FetchQueueConfig;
+use kitsune_p2p_fetch::FetchPoolConfig;
 use kitsune_p2p_types::box_fut;
 use kitsune_p2p_types::dht::region_set::RegionSetLtcs;
 
@@ -8,7 +8,7 @@ use super::*;
 /// Allows only specifying the methods you care about, and letting all the rest
 /// throw errors if called
 #[allow(missing_docs)]
-pub trait KitsuneHostDefaultError: KitsuneHost + FetchQueueConfig {
+pub trait KitsuneHostDefaultError: KitsuneHost + FetchPoolConfig {
     /// Name to be printed out on unimplemented error
     const NAME: &'static str;
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
@@ -20,7 +20,7 @@ impl KitsuneHostDefaultError for HostStubErr {
     const NAME: &'static str = "HostStub";
 }
 
-impl FetchQueueConfig for HostStubErr {
+impl FetchPoolConfig for HostStubErr {
     fn merge_fetch_contexts(&self, _a: u32, _b: u32) -> u32 {
         unimplemented!()
     }
@@ -125,7 +125,7 @@ impl KitsuneHost for HostStub {
     }
 }
 
-impl FetchQueueConfig for HostStub {
+impl FetchPoolConfig for HostStub {
     fn merge_fetch_contexts(&self, _a: u32, _b: u32) -> u32 {
         unimplemented!()
     }

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::metrics::*;
 use crate::types::gossip::GossipModule;
 use ghost_actor::dependencies::tracing;
-use kitsune_p2p_fetch::FetchQueue;
+use kitsune_p2p_fetch::FetchPool;
 use kitsune_p2p_mdns::*;
 use kitsune_p2p_types::agent_info::AgentInfoSigned;
 use kitsune_p2p_types::codec::{rmp_decode, rmp_encode};
@@ -109,7 +109,7 @@ pub(crate) async fn spawn_space(
     config: Arc<KitsuneP2pConfig>,
     bandwidth_throttles: BandwidthThrottles,
     parallel_notify_permit: Arc<tokio::sync::Semaphore>,
-    fetch_queue: FetchQueue,
+    fetch_pool: FetchPool,
 ) -> KitsuneP2pResult<(
     ghost_actor::GhostSender<KitsuneP2p>,
     ghost_actor::GhostSender<SpaceInternal>,
@@ -138,7 +138,7 @@ pub(crate) async fn spawn_space(
         config,
         bandwidth_throttles,
         parallel_notify_permit,
-        fetch_queue,
+        fetch_pool,
     )));
 
     Ok((sender, i_s, evt_recv))
@@ -474,7 +474,7 @@ impl SpaceInternalHandler for Space {
                     continue;
                 } else {
                     // Add this hash to our fetch queue.
-                    ro_inner.fetch_queue.push(FetchQueuePush {
+                    ro_inner.fetch_pool.push(FetchPoolPush {
                         key: FetchKey::Op(op_hash.data()),
                         space: space.clone(),
                         source: FetchSource::Agent(source.clone()),
@@ -1219,7 +1219,7 @@ impl KitsuneP2pHandler for Space {
     ) -> KitsuneP2pHandlerResult<KitsuneDiagnostics> {
         let diagnostics = KitsuneDiagnostics {
             metrics: self.ro_inner.metrics.clone(),
-            fetch_queue: self.ro_inner.fetch_queue.clone().into(),
+            fetch_pool: self.ro_inner.fetch_pool.clone().into(),
         };
         Ok(async move { Ok(diagnostics) }.boxed().into())
     }
@@ -1248,7 +1248,7 @@ pub(crate) struct SpaceReadOnlyInner {
     pub(crate) metric_exchange: MetricExchangeSync,
     pub(crate) publish_pending_delegates: parking_lot::Mutex<HashMap<KOpHash, PendingDelegate>>,
     #[allow(dead_code)]
-    pub(crate) fetch_queue: FetchQueue,
+    pub(crate) fetch_pool: FetchPool,
 }
 
 impl SpaceReadOnlyInner {
@@ -1326,7 +1326,7 @@ impl Space {
         config: Arc<KitsuneP2pConfig>,
         bandwidth_throttles: BandwidthThrottles,
         parallel_notify_permit: Arc<tokio::sync::Semaphore>,
-        fetch_queue: FetchQueue,
+        fetch_pool: FetchPool,
     ) -> Self {
         let metrics = MetricsSync::default();
 
@@ -1395,7 +1395,7 @@ impl Space {
                         evt_sender.clone(),
                         host_api.clone(),
                         metrics.clone(),
-                        fetch_queue.clone(),
+                        fetch_pool.clone(),
                     ),
                 )
             })
@@ -1495,7 +1495,7 @@ impl Space {
             metrics,
             metric_exchange,
             publish_pending_delegates: parking_lot::Mutex::new(HashMap::new()),
-            fetch_queue,
+            fetch_pool,
         });
 
         Self {

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/harness_agent.rs
@@ -31,7 +31,7 @@ impl HarnessHost {
     }
 }
 
-impl FetchQueueConfig for HarnessHost {
+impl FetchPoolConfig for HarnessHost {
     fn merge_fetch_contexts(&self, _a: u32, _b: u32) -> u32 {
         unimplemented!()
     }
@@ -96,7 +96,7 @@ pub(crate) async fn spawn_test_agent(
     Ok((agent, p2p, control))
 }
 
-use kitsune_p2p_fetch::FetchQueueConfig;
+use kitsune_p2p_fetch::FetchPoolConfig;
 use kitsune_p2p_timestamp::Timestamp;
 use kitsune_p2p_types::box_fut;
 use kitsune_p2p_types::dependencies::lair_keystore_api::dependencies::sodoken;

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::types::event::{KitsuneP2pEvent, KitsuneP2pEventHandler, KitsuneP2pEventHandlerResult};
 use crate::{event::*, KitsuneHost};
 use futures::FutureExt;
-use kitsune_p2p_fetch::{FetchQueueConfig, OpHashSized};
+use kitsune_p2p_fetch::{FetchPoolConfig, OpHashSized};
 use kitsune_p2p_timestamp::Timestamp;
 use kitsune_p2p_types::bin_types::*;
 use kitsune_p2p_types::combinators::second;
@@ -47,7 +47,7 @@ impl SwitchboardEventHandler {
 impl ghost_actor::GhostHandler<KitsuneP2pEvent> for SwitchboardEventHandler {}
 impl ghost_actor::GhostControlHandler for SwitchboardEventHandler {}
 
-impl FetchQueueConfig for SwitchboardEventHandler {
+impl FetchPoolConfig for SwitchboardEventHandler {
     fn merge_fetch_contexts(&self, _a: u32, _b: u32) -> u32 {
         unimplemented!()
     }

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_state.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_state.rs
@@ -141,7 +141,7 @@ impl Switchboard {
             self.gossip_type,
             bandwidth,
             Default::default(),
-            kitsune_p2p_fetch::FetchQueue::new_bitwise_or(),
+            kitsune_p2p_fetch::FetchPool::new_bitwise_or(),
         );
         let gossip_module = GossipModule(gossip.clone());
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/gossip.rs
@@ -1,7 +1,7 @@
 use crate::metrics::*;
 use crate::types::*;
 use crate::HostApi;
-use kitsune_p2p_fetch::FetchQueue;
+use kitsune_p2p_fetch::FetchPool;
 use kitsune_p2p_types::config::*;
 use kitsune_p2p_types::tx2::tx2_api::*;
 use kitsune_p2p_types::tx2::tx2_utils::TxUrl;
@@ -79,7 +79,7 @@ pub trait AsGossipModuleFactory: 'static + Send + Sync {
         evt_sender: futures::channel::mpsc::Sender<event::KitsuneP2pEvent>,
         host: HostApi,
         metrics: MetricsSync,
-        fetch_queue: FetchQueue,
+        fetch_pool: FetchPool,
     ) -> GossipModule;
 }
 
@@ -95,7 +95,7 @@ impl GossipModuleFactory {
         evt_sender: futures::channel::mpsc::Sender<event::KitsuneP2pEvent>,
         host: HostApi,
         metrics: MetricsSync,
-        fetch_queue: FetchQueue,
+        fetch_pool: FetchPool,
     ) -> GossipModule {
         self.0.spawn_gossip_task(
             tuning_params,
@@ -104,7 +104,7 @@ impl GossipModuleFactory {
             evt_sender,
             host,
             metrics,
-            fetch_queue,
+            fetch_pool,
         )
     }
 }


### PR DESCRIPTION
### Summary

Because it's not a queue. It's a pool.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
