### PR TITLE
build.yml: enable for x86_64-darwin

### DIFF
--- a/.config/nextest-args.nix
+++ b/.config/nextest-args.nix
@@ -1,0 +1,1 @@
+"--workspace --features slow_tests,glacial_tests,test_utils,build_wasms,db-encryption --lib --tests --cargo-profile fast-test"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,3 +18,5 @@ failure-output = "immediate-final"
 
 # Do not cancel the test run on the first failure.
 fail-fast = false
+
+test-threads = 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: build holochain
 on:
   workflow_dispatch:
-  pull_request:
 
 jobs:
   holochain-binaries:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: build holochain
 on:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   holochain-binaries:
@@ -10,11 +11,11 @@ jobs:
         nixCommand:
           - "nix build .#holochain --no-link"
         platform:
-          - arch: macos-x86_64
-            runs-on: [macos-latest]
-          - arch: macos-arm64
+          - system: x86_64-darwin
             runs-on: [self-hosted, macOS, ARM64]
-          - arch: linux-x86_64
+          - system: aarch64-darwin
+            runs-on: [self-hosted, macOS, ARM64]
+          - system: x86_64-linux
             runs-on: [ubuntu-latest]
         cachixName:
           - holochain-ci
@@ -41,4 +42,4 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - name: "Test comand ${{ matrix.nixCommand }}"
-        run: "${{ matrix.nixCommand }} -L --show-trace"
+        run: "${{ matrix.nixCommand }} -L --show-trace --system ${{ matrix.platform.system }}"

--- a/flake.nix
+++ b/flake.nix
@@ -20,11 +20,11 @@
     };
   };
 
-  outputs = inputs@{ flake-parts, ... }:
+  outputs = inputs@{ self, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = ["aarch64-darwin" "x86_64-linux" "x86_64-darwin"];
       # auto import all nix code from `./modules`
-      imports = map (m: "${./nix/modules}/${m}")
+      imports = map (m: "${./.}/nix/modules/${m}")
         (builtins.attrNames (builtins.readDir ./nix/modules));
       perSystem = { config, self', inputs', ... }: {
         # Per-system attributes can be defined here. The self' and inputs'

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -68,23 +68,24 @@
       RUST_SODIUM_LIB_DIR = "${pkgs.libsodium}/lib";
       RUST_SODIUM_SHARED = "1";
       pname = "holochain-tests";
-      cargoExtraArgs = ''
-        --features slow_tests,glacial_tests,test_utils,build_wasms,db-encryption --lib --tests
-      '';
+      CARGO_PROFILE = "fast-test";
+      # cargoExtraArgs = ''
+      #   --features slow_tests,glacial_tests,test_utils,build_wasms,db-encryption --lib --tests
+      # '';
     });
 
     disabledTests = [
-      "conductor::cell::gossip_test::gossip_test"
-      "conductor::interface::websocket::test::enable_disable_enable_app"
-      "conductor::interface::websocket::test::websocket_call_zome_function"
-      "core::ribosome::host_fn::accept_countersigning_preflight_request::wasm_test::enzymatic_session_fail"
-      "core::ribosome::host_fn::remote_signal::tests::remote_signal_test"
-      "core::workflow::app_validation_workflow::tests::app_validation_workflow_test"
-      "core::workflow::app_validation_workflow::validation_tests::app_validation_ops"
-      "core::workflow::sys_validation_workflow::tests::sys_validation_workflow_test"
-      "local_network_tests::conductors_call_remote::_2"
-      "local_network_tests::conductors_call_remote::_4"
-      "conductor::interface::websocket::test::enable_disable_enable_apped"
+      # "conductor::cell::gossip_test::gossip_test"
+      # "conductor::interface::websocket::test::enable_disable_enable_app"
+      # "conductor::interface::websocket::test::websocket_call_zome_function"
+      # "core::ribosome::host_fn::accept_countersigning_preflight_request::wasm_test::enzymatic_session_fail"
+      # "core::ribosome::host_fn::remote_signal::tests::remote_signal_test"
+      # "core::workflow::app_validation_workflow::tests::app_validation_workflow_test"
+      # "core::workflow::app_validation_workflow::validation_tests::app_validation_ops"
+      # "core::workflow::sys_validation_workflow::tests::sys_validation_workflow_test"
+      # "local_network_tests::conductors_call_remote::_2"
+      # "local_network_tests::conductors_call_remote::_4"
+      # "conductor::interface::websocket::test::enable_disable_enable_apped"
     ];
 
     disabledTestsArgs =
@@ -92,17 +93,21 @@
 
 
     holochain-tests-nextest = craneLib.cargoNextest (commonArgs // {
-      cargoArtifacts = holochainDeps;
+      __noChroot = true;
+      cargoArtifacts = holochainTestDeps;
       preCheck = ''
-        rm /build/source/target/debug/.fingerprint/holochain_wasm_test_utils-*/invoked.timestamp
-        rm /build/source/target/debug/.fingerprint/holochain_test_wasm_common-*/invoked.timestamp
+        pwd
+        # rm /build/source/target/debug/.fingerprint/holochain_wasm_test_utils-*/invoked.timestamp
+        # rm /build/source/target/debug/.fingerprint/holochain_test_wasm_common-*/invoked.timestamp
       '';
       # cargoExtraArgs = "--features slow_tests,glacial_tests,test_utils,build_wasms,db-encryption";
       # CARGO_PROFILE = "release";
       cargoExtraArgs = ''
-        --test-threads 2 --workspace --features slow_tests,glacial_tests,test_utils,build_wasms,db-encryption --lib --tests \
+        --test-threads 2 --workspace --features slow_tests,glacial_tests,test_utils,build_wasms,db-encryption --lib --tests --cargo-profile fast-test \
         ${lib.concatStringsSep " " disabledTestsArgs}
       '';
+
+      dontPatchELF = true;
 
       # cargoNextestExtraArgs = lib.concatStringsSep " " disabledTestsArgs;
     });

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -103,11 +103,12 @@
       # cargoExtraArgs = "--features slow_tests,glacial_tests,test_utils,build_wasms,db-encryption";
       # CARGO_PROFILE = "release";
       cargoExtraArgs = ''
-        --test-threads 2 --workspace --features slow_tests,glacial_tests,test_utils,build_wasms,db-encryption --lib --tests --cargo-profile fast-test \
+        ${import ../../.config/nextest-args.nix} \
         ${lib.concatStringsSep " " disabledTestsArgs}
       '';
 
       dontPatchELF = true;
+      dontFixup = true;
 
       # cargoNextestExtraArgs = lib.concatStringsSep " " disabledTestsArgs;
     });

--- a/nix/pkgs/core.nix
+++ b/nix/pkgs/core.nix
@@ -34,7 +34,7 @@ rec {
 
     # run all the cargo tests
     cargo build --features 'build' -p holochain_wasm_test_utils
-    cargo nextest ''${CARGO_NEXTEST_ARGS:-run --test-threads=2} --workspace --features slow_tests,glacial_tests,test_utils,build_wasms,db-encryption --lib --tests --cargo-profile fast-test ''${1-}
+    cargo nextest ''${CARGO_NEXTEST_ARGS:-run} ${import ../../.config/nextest-args.nix} ''${1-}
   '';
 
   hcWasmTests = writeShellScriptBin "hc-test-wasm" ''


### PR DESCRIPTION
### Summary
Reuse the existing aarch64-darwin runners to execute build for x86_64-darwin


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
