### PR TITLE
update.sh: fix git add

### DIFF
--- a/holonix/nix/update.sh
+++ b/holonix/nix/update.sh
@@ -15,7 +15,7 @@ fi
 
 nix/regen_versions.sh
 
-cat << EOF | git commit VERSIONS.md nix/sources.* -F -
+cat << EOF | git commit VERSIONS.md $(realpath nix/sources.*) -F -
 update nix sources
 
 see VERSIONS.md for the exact changes


### PR DESCRIPTION
### Summary
This should finally fix the update operation


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
