### PR TITLE
feat(nix): fix nextest derivation for macos

### DIFF
--- a/nix/modules/srcCleaned.nix
+++ b/nix/modules/srcCleaned.nix
@@ -2,8 +2,13 @@
   options.srcCleaned = lib.mkOption { type = lib.types.raw; };
   config.srcCleaned = inputs.nix-filter.lib {
     root = self;
-    # Works like include, but the reverse.
-    include =
-      [ "crates" "Cargo.toml" "Cargo.lock" "rustfmt.toml" "nextest.toml" ];
+    include = [
+      ".config"
+      "crates"
+      "Cargo.toml"
+      "Cargo.lock"
+      "rustfmt.toml"
+      "nextest.toml"
+    ];
   };
 }


### PR DESCRIPTION
### Summary
This fixes the nextest derivation .#holochain-tests-nextest on macos


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
