### PR TITLE
fix(github/workflows/holonix-integration): use multi-arch runner

### DIFF
--- a/.github/workflows/holonix-integration.yml
+++ b/.github/workflows/holonix-integration.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         platform:
           - arch: macos-aarch64
-            runs-on: [macOS, self-hosted, arm64]
+            runs-on: multi-arch
           - arch: macos-x86_64
-            runs-on: macos-latest
+            runs-on: multi-arch
           - arch: linux-x86_64
             runs-on: ubuntu-latest
     runs-on: ${{ matrix.platform.runs-on }}

--- a/.github/workflows/holonix-integration.yml
+++ b/.github/workflows/holonix-integration.yml
@@ -24,13 +24,14 @@ jobs:
     runs-on: ${{ matrix.platform.runs-on }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.0
+        uses: actions/checkout@v3
       - name: Install nix
         uses: cachix/install-nix-action@v18
         with:
           install_url: https://releases.nixos.org/nix/nix-2.12.0/install
       - name: Setup cachix
         uses: cachix/cachix-action@v12
+        if: ${{ matrix.platform.runs-on != 'multi-arch' }}
         with:
           name: holochain-ci
           signingKey: ${{ secrets.CACHIX_SIGNING_KEY }}


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
