### PR TITLE
build(nix): add dev shells to flake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # \[Unreleased\]
 
+- Added dev shells to Nix flake:
+  1. `default` for happ developers; usage `nix develop github:holochain/holochain` from any folder
+  2. `coreDev` for holochain developers; usage `nix develop .#coreDev` from within repo's root folder
+
 # 20230126.223635
 
 - First beta release

--- a/flake.nix
+++ b/flake.nix
@@ -12,12 +12,12 @@
     # filter out all .nix files to not affect the input hash
     # when these are changes
     nix-filter.url = "github:numtide/nix-filter";
-    # provide downward compatibility for non-flake users
+    # provide downward compatibility for nix-shell/derivation users
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
     };
-    # input for rust, rustup and cargo
+    # rustup, rust and cargo
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -25,8 +25,8 @@
   };
 
   # refer to flake-parts docs https://flake.parts/
-  outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
-    # all possible arguments for a module: https://flake.parts/module-arguments.html#top-level-module-arguments
+  outputs = inputs @ { self, nixpkgs, flake-parts, ... }:
+    # all possible parameters for a module: https://flake.parts/module-arguments.html#top-level-module-arguments
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "aarch64-darwin" "x86_64-linux" "x86_64-darwin" ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -24,24 +24,14 @@
     };
   };
 
-  outputs = inputs@{ self, flake-parts, ... }:
+  # refer to flake-parts docs https://flake.parts/
+  outputs = inputs@{ self, nixpkgs, flake-parts, ... }:
+    # all possible arguments for a module: https://flake.parts/module-arguments.html#top-level-module-arguments
     flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = ["aarch64-darwin" "x86_64-linux" "x86_64-darwin"];
+      systems = [ "aarch64-darwin" "x86_64-linux" "x86_64-darwin" ];
       # auto import all nix code from `./modules`, treat each one as
       # a flake and merge them
       imports = map (m: "${./.}/nix/modules/${m}")
         (builtins.attrNames (builtins.readDir ./nix/modules));
-      perSystem = { config, self', inputs', ... }: {
-        # Per-system attributes can be defined here. The self' and inputs'
-        # module parameters provide easy access to attributes of the same
-        # system.
-
-      };
-      flake = {
-        # The usual flake attributes can be defined here, including system-
-        # agnostic ones like nixosModule and system-enumerating ones, although
-        # those are more easily expressed in perSystem.
-
-      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -2,28 +2,33 @@
   description = "The new, performant, and simplified version of Holochain on Rust (sometimes called Holochain RSM for Refactored State Model) ";
 
   inputs = {
+    # nix packages pointing to the github repo
     nixpkgs.url = "nixpkgs/nixos-unstable";
+    # lib to build nix packages from rust crates
     crane = {
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    # filter out all .nix files to not affect the input hash
+    # when these are changes
     nix-filter.url = "github:numtide/nix-filter";
+    # provide downward compatibility for non-flake users
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
     };
+    # input for rust, rustup and cargo
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-      };
+      inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
   outputs = inputs@{ self, flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {
       systems = ["aarch64-darwin" "x86_64-linux" "x86_64-darwin"];
-      # auto import all nix code from `./modules`
+      # auto import all nix code from `./modules`, treat each one as
+      # a flake and merge them
       imports = map (m: "${./.}/nix/modules/${m}")
         (builtins.attrNames (builtins.readDir ./nix/modules));
       perSystem = { config, self', inputs', ... }: {

--- a/nix/modules/dev-shells.nix
+++ b/nix/modules/dev-shells.nix
@@ -1,0 +1,8 @@
+{ self, lib, ... } @ flake: {
+  # all possible arguments for perSystem: https://flake.parts/module-arguments.html#persystem-module-parameters
+  perSystem = { config, self', inputs', pkgs, ... }: {
+    devShells.default = pkgs.mkShell {
+      packages = [ self'.packages.holochain ];
+    };
+  };
+}

--- a/nix/modules/dev-shells.nix
+++ b/nix/modules/dev-shells.nix
@@ -1,8 +1,13 @@
 { self, lib, ... } @ flake: {
-  # all possible arguments for perSystem: https://flake.parts/module-arguments.html#persystem-module-parameters
+  # all possible parameters for perSystem: https://flake.parts/module-arguments.html#persystem-module-parameters
   perSystem = { config, self', inputs', pkgs, ... }: {
     devShells.default = pkgs.mkShell {
-      packages = [ self'.packages.holochain ];
+      packages = [ config.rust.rustHolochain self'.packages.holochain ];
     };
+
+    devShells.coreDev =
+      pkgs.mkShell {
+        packages = [ config.rust.rustHolochain ];
+      };
   };
 }


### PR DESCRIPTION
### Summary
- add two dev shells to flake:
1. `default` for happ developers; usage `nix develop github:holochain/holochain`
2. `coreDev` for holochain developers; usage `nix develop .#coreDev` from within repo's root folder


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
