### PR TITLE
Skip build check if git is unavailable (#1844)

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -240,7 +240,7 @@ jobs:
                 --no-verify-pre \
                 --force-tag-creation \
                 --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
-                --disallowed-version-reqs=">=0.2" \
+                --disallowed-version-reqs=">=0.3" \
                 --steps=BumpReleaseVersions
 
             cargo sweep -f

--- a/crates/holochain_sqlite/build.rs
+++ b/crates/holochain_sqlite/build.rs
@@ -78,9 +78,20 @@ fn check_fmt(path: &std::path::Path) {
     }
 }
 
+/// Ensure that schema migration files have no changes since `GIT_BASE_REF` (origin/develop).
+/// Pure additions are excluded, which allows new files to be created, but once they are merged
+/// as a PR, then no changes can be made.
+/// This is a loose check and obviously can be easily circumvented, but it hopefully helps remind us
+/// that we must never change migration files.
 fn check_migrations() {
     use std::process::Command;
     let root = PathBuf::from(SQL_DIR);
+
+    // If git is unavailable, skip this check
+    if Command::new("git").arg("status").output().is_err() {
+        return;
+    }
+
     for dir in [
         root.join("cell/schema"),
         root.join("conductor/schema"),


### PR DESCRIPTION
backport of https://github.com/holochain/holochain/pull/1844

---


* Skip build check if git is unavailable

* Update crates/holochain_sqlite/build.rs

Co-authored-by: Stefan Junker <1181362+steveeJ@users.noreply.github.com>

---------

Co-authored-by: Stefan Junker <1181362+steveeJ@users.noreply.github.com>

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
