### PR TITLE
fix(sqlite): skip build check if `git status` fails

### DIFF
--- a/crates/holochain_sqlite/build.rs
+++ b/crates/holochain_sqlite/build.rs
@@ -88,7 +88,11 @@ fn check_migrations() {
     let root = PathBuf::from(SQL_DIR);
 
     // If git is unavailable, skip this check
-    if Command::new("git").arg("status").output().is_err() {
+    if match Command::new("git").arg("status").output() {
+        Ok(output) => !output.status.success(),
+        Err(_) => true,
+    } {
+        eprintln!("git or .git not available, cannot check schema migration files.");
         return;
     }
 

--- a/crates/holochain_sqlite/build.rs
+++ b/crates/holochain_sqlite/build.rs
@@ -92,7 +92,7 @@ fn check_migrations() {
         Ok(output) => !output.status.success(),
         Err(_) => true,
     } {
-        eprintln!("git or .git not available, cannot check schema migration files.");
+        println!("cargo:warning=git or .git not available, cannot check schema migration files.");
         return;
     }
 


### PR DESCRIPTION
also regard the exit code of the command if git is available, but e.g. `.git` is not available in the source directory.

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
