### PR TITLE
fix(holonix-tests-integration): remove recursion

### DIFF
--- a/nix/modules/holonix-integration-test.nix
+++ b/nix/modules/holonix-integration-test.nix
@@ -16,37 +16,12 @@
 
     in
     {
-      packages =
-        {
-          holonix-tests-integration = pkgs.runCommand
-            "holonix-tests-integration"
-            {
-              __noChroot = pkgs.stdenv.isLinux;
-
-              requiredSystemFeatures = [ "recursive-nix" ];
-
-              nativeBuildInputs = [
-                pkgs.nix
-              ];
-              buildInputs = [
-                pkgs.cacert
-              ];
-            } ''
-
-            export HOME=$PWD/.writeable_home
-            mkdir -p $HOME
-
-            set -x
-
-            nix develop ${self}#holonix \
-              --override-input versions/holochain ${self} \
-              --extra-experimental-features "flakes nix-command" \
-              --command ${testScript}
-
-            echo this line causes ${self'.devShells.holonix} to be pre-built | tee $out
-
-            set +x
+      packages.holonix-tests-integration =
+        self'.devShells.holonix.overrideAttrs (old: {
+          buildPhase = ''
+            ${testScript}
+            touch $out
           '';
-        };
-    };
+        });
+      };
 }


### PR DESCRIPTION
Nix develop imitates a nix build environment outside the sandbox. This is only useful if we are not inside the sandbox. Inside the nix sandbox we can just use the shell derivation as is.

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
