### PR TITLE
Tx5 fix tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7031,9 +7031,7 @@ dependencies = [
 
 [[package]]
 name = "tx5"
-version = "0.0.1-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80ab97492505545ecfdd2f1c3996cbf22a815d76eb898bb39bf7dbbef5b5e4c"
+version = "0.0.1-alpha.4"
 dependencies = [
  "futures",
  "once_cell",
@@ -7051,9 +7049,7 @@ dependencies = [
 
 [[package]]
 name = "tx5-core"
-version = "0.0.1-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aeb460272a40a32f4253782b4da938166aa8fabedd5bb3a757c22215bc68a07"
+version = "0.0.1-alpha.2"
 dependencies = [
  "base64 0.13.1",
  "serde",
@@ -7063,9 +7059,7 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion"
-version = "0.0.1-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec23921731761c1fd6290071e7252439db641608b9ced5e6ef1de17721847856"
+version = "0.0.1-alpha.4"
 dependencies = [
  "parking_lot 0.12.1",
  "tokio",
@@ -7076,16 +7070,16 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-sys"
-version = "0.0.1-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba8e0d086d4f34ff00d4170bba9ba4dbd12465b4c39ceaf541626454385d16b"
+version = "0.0.1-alpha.6"
 dependencies = [
  "Inflector",
+ "base64 0.13.1",
+ "dirs 4.0.0",
  "libc",
  "libloading",
  "once_cell",
  "ouroboros",
- "tempfile",
+ "sha2 0.10.6",
  "tracing",
  "tx5-core",
  "zip",
@@ -7093,9 +7087,7 @@ dependencies = [
 
 [[package]]
 name = "tx5-signal"
-version = "0.0.1-alpha.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cf6d24449a2a7b76bbee610aaf020a61d268a40f5de5f51fc6459e2fb4a72c"
+version = "0.0.1-alpha.2"
 dependencies = [
  "futures",
  "lair_keystore_api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7032,6 +7032,8 @@ dependencies = [
 [[package]]
 name = "tx5"
 version = "0.0.1-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d4f2f63e0150607e2660faa9e7efb35cc64bffe4a8a048a65d49f73a5caf846"
 dependencies = [
  "futures",
  "once_cell",
@@ -7050,6 +7052,8 @@ dependencies = [
 [[package]]
 name = "tx5-core"
 version = "0.0.1-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8590a82f158651ddc89669e1bd01314c58827e8b7aa6a992580b5d2de630c3cf"
 dependencies = [
  "base64 0.13.1",
  "serde",
@@ -7060,6 +7064,8 @@ dependencies = [
 [[package]]
 name = "tx5-go-pion"
 version = "0.0.1-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce036496f0e92e2a77cfd7bfc4ebff280f1cc45a6b16a438630955510c90176"
 dependencies = [
  "parking_lot 0.12.1",
  "tokio",
@@ -7071,6 +7077,8 @@ dependencies = [
 [[package]]
 name = "tx5-go-pion-sys"
 version = "0.0.1-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93319a2801a89d9f7be3780a7585ec7e22ef33e434b267081bf0549fd4422c8"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -7088,6 +7096,8 @@ dependencies = [
 [[package]]
 name = "tx5-signal"
 version = "0.0.1-alpha.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206ade2798fbd3e5a90ebb02460e0a088a2d0669329abe2916777ad5d14f6a84"
 dependencies = [
  "futures",
  "lair_keystore_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,7 @@ incremental = false
 codegen-units = 16
 
 [patch.crates-io]
-# tx5 = { path = "../tx5/crates/tx5" }
-# tx5-signal = { path = "../tx5/crates/tx5-signal" }
+tx5 = { path = "../tx5/crates/tx5" }
 # isotest = { git = "https://github.com/maackle/isotest-rs.git" }
 # holochain_wasmer_guest = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "pr/bump-serde" }
 # holochain_wasmer_host = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "pr/bump-serde" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ incremental = false
 codegen-units = 16
 
 [patch.crates-io]
-tx5 = { path = "../tx5/crates/tx5" }
+# tx5 = { path = "../tx5/crates/tx5" }
 # isotest = { git = "https://github.com/maackle/isotest-rs.git" }
 # holochain_wasmer_guest = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "pr/bump-serde" }
 # holochain_wasmer_host = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "pr/bump-serde" }

--- a/crates/holochain/src/bin/holochain/main.rs
+++ b/crates/holochain/src/bin/holochain/main.rs
@@ -159,12 +159,18 @@ async fn conductor_handle_from_config_path(opt: &Opt) -> ConductorHandle {
     }
 
     // Initialize the Conductor
-    Conductor::builder()
+    match Conductor::builder()
         .config(config)
         .passphrase(passphrase)
         .build()
         .await
-        .expect("Could not initialize Conductor from configuration")
+    {
+        Err(err) => panic!(
+            "Could not initialize Conductor from configuration: {:?}",
+            err
+        ),
+        Ok(res) => res,
+    }
 }
 
 /// Load config, throw friendly error on failure

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -106,6 +106,12 @@ impl ConductorBuilder {
         let spaces = Spaces::new(&config)?;
         let tag = spaces.get_state().await?.tag().clone();
 
+        let tag_ed: Arc<str> = format!("{}_ed", tag.0).into_boxed_str().into();
+        let _ = keystore
+            .lair_client()
+            .new_seed(tag_ed.clone(), None, false)
+            .await;
+
         let network_config = config.network.clone().unwrap_or_default();
         let (cert_digest, cert, cert_priv_key) = keystore
             .get_or_create_tls_cert_by_tag(tag.0.clone())
@@ -123,12 +129,18 @@ impl ConductorBuilder {
             ribosome_store.clone(),
             network_config.tuning_params.clone(),
             strat,
-            Some(tag.0),
+            Some(tag_ed),
             Some(keystore.lair_client()),
         );
 
         let (holochain_p2p, p2p_evt) =
-            holochain_p2p::spawn_holochain_p2p(network_config, tls_config, host).await?;
+            match holochain_p2p::spawn_holochain_p2p(network_config, tls_config, host).await {
+                Ok(r) => r,
+                Err(err) => {
+                    tracing::error!(?err, "Error spawning networking");
+                    return Err(err.into());
+                }
+            };
 
         let (post_commit_sender, post_commit_receiver) =
             tokio::sync::mpsc::channel(POST_COMMIT_CHANNEL_BOUND);

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -41,7 +41,7 @@ thiserror = "1.0.22"
 tokio = { version = "1.11", features = ["full"] }
 tracing = "0.1"
 tokio-stream = "0.1"
-tx5 = { version = "0.0.1-alpha.3", optional = true }
+tx5 = { version = "0.0.1-alpha.4", optional = true }
 url2 = "0.0.6"
 fixt = { path = "../../fixt", version = "^0.1.0"}
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net.rs
@@ -482,6 +482,8 @@ impl MetaNet {
             .with_max_conn_count(tuning_params.tx5_max_conn_count)
             .with_max_conn_init(tuning_params.tx5_max_conn_init());
 
+        tracing::info!(/*?tx5_config,*/ "meta net startup tx5");
+
         if let Some(lair_client) = host.lair_client() {
             tx5_config.set_lair_client(lair_client);
         }
@@ -493,6 +495,7 @@ impl MetaNet {
         let (ep_hnd, mut ep_evt) = tx5::Ep::with_config(tx5_config).await?;
 
         let cli_url = ep_hnd.listen(tx5::Tx5Url::new(&signal_url)?).await?;
+        tracing::info!(%cli_url, "tx5 listening at url");
 
         let res_store = Arc::new(Mutex::new(HashMap::new()));
 


### PR DESCRIPTION
### Summary

The conductor "tag" directly represents a TLS key in lair, so we need to use a modified tag to represent the seed needed by tx5.