### PR TITLE
feat(holonix): add the hn-introspect command

### DIFF
--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -55,11 +55,13 @@
       });
 
       # derivation with the main crates
-      holochain = craneLib.buildPackage (commonArgs // {
+      holochain = (craneLib.buildPackage (commonArgs // {
         cargoArtifacts = holochainDepsRelease;
         src = flake.config.srcCleanedHolochain;
         doCheck = false;
-      });
+      })) // {
+        src.rev = inputs.holochain.rev;
+      };
 
       holochainNextestDeps = craneLib.buildDepsOnly (commonArgs // rec {
         pname = "holochain-nextest";


### PR DESCRIPTION
### Summary

```
$ nix run --tarball-ttl 0 github:/holochain/holochain/pr_hnintrospect#hn-introspect
holochain: ed5b7bb461c2a8bfd4d2633bad604a20b8f2da03
lair-keystore: cbfbefefe43073904a914c8181a450209a74167b
hc-launch: 5e8b28b1f0c90d3bac27f1ccc0bd133b46a430eb
hc-scaffold: 894134c7fa8d70a55d0e6eabe03865c768de5327          

$ nix develop github:/holochain/holochain/pr_hnintrospect#holonix --command hn-introspect
holochain: ed5b7bb461c2a8bfd4d2633bad604a20b8f2da03
lair-keystore: cbfbefefe43073904a914c8181a450209a74167b
hc-launch: 5e8b28b1f0c90d3bac27f1ccc0bd133b46a430eb
hc-scaffold: 894134c7fa8d70a55d0e6eabe03865c768de5327

$ nix-shell https://github.com/holochain/holochain/tarball/pr_hnintrospect --run "hn-introspect"
cargoVendorDir not set, will not attempt to remove any references
cargoVendorDir not set, will not automatically configure vendored sources
cargoArtifacts not set, will not reuse any cargo artifacts
holochain: ed5b7bb461c2a8bfd4d2633bad604a20b8f2da03
lair-keystore: cbfbefefe43073904a914c8181a450209a74167b
hc-launch: 5e8b28b1f0c90d3bac27f1ccc0bd133b46a430eb
hc-scaffold: 894134c7fa8d70a55d0e6eabe03865c768de5327            
```


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
