### PR TITLE
 feat(holonix): change the PS1 do indicate the shell 

### DIFF
--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -24,6 +24,7 @@
           packages = holonixPackages ++ [ hn-introspect ];
           shellHook = ''
             echo Holochain development shell spawned. Type 'exit' to leave.
+            export PS1='\n\[\033[1;34m\][holonix:\w]\$\[\033[0m\] '
           '';
         };
 


### PR DESCRIPTION
### Summary

i learned that `nix develop` does not alter PS1 in any way, so it's now obvious that a nix environment is loaded.

my main hesitation here is that this might not work well on macos or exotic shells. but if we agree on this being an acceptable risk i'm happy to merge it. 


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
