### PR TITLE
feat(holonix): add crate and version info to hn-introspect

### DIFF
--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -6,12 +6,11 @@
         (
           builtins.map
             (package: ''
-              ${package.pname}: ${package.src.rev or "na"}'')
+              echo ${package.pname} \($(${package}/bin/${package.pname} -V)\): ${package.src.rev or "na"}'')
             holonixPackages
         );
-      versionsFile = pkgs.writeText "hn-introspect" versionsFileText;
       hn-introspect =
-        pkgs.writeShellScriptBin "hn-introspect" "${pkgs.coreutils}/bin/cat ${versionsFile}";
+        pkgs.writeShellScriptBin "hn-introspect" versionsFileText;
     in
     {
       packages = {


### PR DESCRIPTION
### Summary

```
$ nix run --tarball-ttl 0 github:/holochain/holochain/pr_hnintrospect_version#hn-introspect
holochain (holochain 0.1.3): ed5b7bb461c2a8bfd4d2633bad604a20b8f2da03
lair-keystore (lair_keystore 0.2.3): cbfbefefe43073904a914c8181a450209a74167b
hc-launch (holochain_cli_launch 0.0.10): b3a14c79198ef0b52f55a0e646a371fcb49f53e4
hc-scaffold (holochain_scaffolding_cli 0.1.6): 894134c7fa8d70a55d0e6eabe03865c768de5327
```


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
