### PR TITLE
Tightening up OpType/FlatOp logic

### DIFF
--- a/crates/hdi/src/flat_op/flat_op_record.rs
+++ b/crates/hdi/src/flat_op/flat_op_record.rs
@@ -1,11 +1,11 @@
+use holochain_integrity_types::{EntryType, RecordEntry};
+use holochain_wasmer_guest::WasmError;
+
 use super::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Data specific to the [`Op::StoreRecord`] operation.
-pub enum OpRecord<ET, LT>
-where
-    ET: UnitEnum,
-{
+pub enum OpRecord<ET: UnitEnum, LT> {
     /// This operation stores the [`Record`] for an
     /// app defined entry type.
     CreateEntry {
@@ -183,4 +183,14 @@ where
         /// The [`InitZomesComplete`] action
         action: InitZomesComplete,
     },
+}
+
+impl<ET: UnitEnum, LT> OpRecord<ET, LT> {
+    pub fn new(
+        entry_type: &EntryType,
+        entry_hash: &EntryHash,
+        entry: &RecordEntry,
+    ) -> Result<Self, WasmError> {
+        todo!()
+    }
 }

--- a/crates/hdi/src/hdi.rs
+++ b/crates/hdi/src/hdi.rs
@@ -57,57 +57,57 @@ pub trait HdiT: Send + Sync {
 pub struct ErrHdi;
 
 impl ErrHdi {
-    fn err<T>() -> ExternResult<T> {
-        Err(wasm_error!(WasmErrorInner::Guest(
-            HDI_NOT_REGISTERED.to_string()
-        )))
+    fn err<T>(name: &str) -> ExternResult<T> {
+        Err(wasm_error!(WasmErrorInner::Guest(format!(
+            "error calling '{name}': {HDI_NOT_REGISTERED}"
+        ))))
     }
 }
 
 /// Every call is an error for the ErrHdi.
 impl HdiT for ErrHdi {
     fn verify_signature(&self, _: VerifySignature) -> ExternResult<bool> {
-        Self::err()
+        Self::err("verify_signature")
     }
     fn hash(&self, _: HashInput) -> ExternResult<HashOutput> {
-        Self::err()
+        Self::err("hash")
     }
     fn must_get_entry(&self, _: MustGetEntryInput) -> ExternResult<EntryHashed> {
-        Self::err()
+        Self::err("must_get_entry")
     }
     fn must_get_action(&self, _: MustGetActionInput) -> ExternResult<SignedActionHashed> {
-        Self::err()
+        Self::err("must_get_action")
     }
     fn must_get_valid_record(&self, _: MustGetValidRecordInput) -> ExternResult<Record> {
-        Self::err()
+        Self::err("must_get_valid_record")
     }
     fn must_get_agent_activity(
         &self,
         _: MustGetAgentActivityInput,
     ) -> ExternResult<Vec<RegisterAgentActivity>> {
-        Self::err()
+        Self::err("must_get_agent_activity")
     }
     fn dna_info(&self, _: ()) -> ExternResult<DnaInfo> {
-        Self::err()
+        Self::err("dna_info")
     }
     fn zome_info(&self, _: ()) -> ExternResult<ZomeInfo> {
-        Self::err()
+        Self::err("zome_info")
     }
     // Trace
     fn trace(&self, _: TraceMsg) -> ExternResult<()> {
-        Self::err()
+        Self::err("trace")
     }
     fn x_salsa20_poly1305_decrypt(
         &self,
         _: XSalsa20Poly1305Decrypt,
     ) -> ExternResult<Option<XSalsa20Poly1305Data>> {
-        Self::err()
+        Self::err("x_salsa20_poly1305_decrypt")
     }
     fn x_25519_x_salsa20_poly1305_decrypt(
         &self,
         _: X25519XSalsa20Poly1305Decrypt,
     ) -> ExternResult<Option<XSalsa20Poly1305Data>> {
-        Self::err()
+        Self::err("x_25519_x_salsa20_poly1305_decrypt")
     }
 }
 

--- a/crates/hdi/src/op.rs
+++ b/crates/hdi/src/op.rs
@@ -599,7 +599,7 @@ where
     WasmError: From<<ET as EntryTypesHelper>::Error>,
 {
     match entry {
-        RecordEntryRef::Present(entry) => match entry_type {
+        RecordEntryRef::Present(entry) => match dbg!(entry_type) {
             EntryType::App(AppEntryDef {
                 zome_index,
                 entry_index: entry_def_index,
@@ -629,10 +629,18 @@ where
                 }
                 Ok(InScopeEntry::Agent(entry_hash.clone().into()))
             }
-            _ => Err(wasm_error!(WasmErrorInner::Guest(
-                "Entry type is a capability and should be private but there is an entry present"
+            EntryType::App(AppEntryDef {
+                visibility: EntryVisibility::Private,
+                ..
+            })
+            | EntryType::CapGrant
+            | EntryType::CapClaim => {
+                dbg!("the spot");
+                Err(wasm_error!(WasmErrorInner::Guest(
+                "EntryType is CapGrant or CapClaim, but there is an entry present where there shouldn't be."
                     .to_string()
-            ))),
+            )))
+            }
         },
         RecordEntryRef::Hidden => match entry_type {
             EntryType::App(AppEntryDef {

--- a/crates/hdi/src/op.rs
+++ b/crates/hdi/src/op.rs
@@ -151,8 +151,32 @@ impl OpHelper for Op {
                             entry_hash,
                             ..
                         } = action;
-                        map_entry(entry_type, entry_hash, (&record.entry).into())?
-                            .into_op_record(action)?
+                        match entry_type {
+                            EntryType::AgentPubKey => OpRecord::CreateAgent {
+                                agent: entry_hash.clone().into(),
+                                action: action.clone(),
+                            },
+                            EntryType::App(entry_def) => {
+                                match map_entry(entry_def, record.entry.as_option())? {
+                                    UnitEnumEither::Enum(app_entry) => OpRecord::CreateEntry {
+                                        app_entry,
+                                        action: action.clone(),
+                                    },
+                                    UnitEnumEither::Unit(app_entry_type) => {
+                                        OpRecord::CreatePrivateEntry {
+                                            app_entry_type,
+                                            action: action.clone(),
+                                        }
+                                    }
+                                }
+                            }
+                            EntryType::CapClaim => OpRecord::CreateCapClaim {
+                                action: action.clone(),
+                            },
+                            EntryType::CapGrant => OpRecord::CreateCapGrant {
+                                action: action.clone(),
+                            },
+                        }
                     }
                     Action::Update(action) => {
                         let Update {
@@ -162,31 +186,37 @@ impl OpHelper for Op {
                             original_entry_address: original_entry_hash,
                             ..
                         } = action;
-                        match map_entry::<ET>(entry_type, entry_hash, (&record.entry).into())? {
-                            InScopeEntry::App(entry_type) => OpRecord::UpdateEntry {
-                                original_action_hash: original_action_hash.clone(),
-                                original_entry_hash: original_entry_hash.clone(),
-                                app_entry: entry_type,
-                                action: action.clone(),
-                            },
-                            InScopeEntry::PrivateApp(entry_type) => OpRecord::UpdatePrivateEntry {
-                                original_action_hash: original_action_hash.clone(),
-                                original_entry_hash: original_entry_hash.clone(),
-                                app_entry_type: entry_type,
-                                action: action.clone(),
-                            },
-                            InScopeEntry::Agent(new_key) => OpRecord::UpdateAgent {
+                        match entry_type {
+                            EntryType::AgentPubKey => OpRecord::UpdateAgent {
                                 original_key: original_entry_hash.clone().into(),
                                 original_action_hash: original_action_hash.clone(),
-                                new_key,
+                                new_key: entry_hash.clone().into(),
                                 action: action.clone(),
                             },
-                            InScopeEntry::CapClaim => OpRecord::UpdateCapClaim {
+                            EntryType::App(entry_def) => {
+                                match map_entry(entry_def, record.entry.as_option())? {
+                                    UnitEnumEither::Enum(app_entry) => OpRecord::UpdateEntry {
+                                        original_action_hash: original_action_hash.clone(),
+                                        original_entry_hash: original_entry_hash.clone(),
+                                        app_entry,
+                                        action: action.clone(),
+                                    },
+                                    UnitEnumEither::Unit(app_entry_type) => {
+                                        OpRecord::UpdatePrivateEntry {
+                                            original_action_hash: original_action_hash.clone(),
+                                            original_entry_hash: original_entry_hash.clone(),
+                                            app_entry_type,
+                                            action: action.clone(),
+                                        }
+                                    }
+                                }
+                            }
+                            EntryType::CapClaim => OpRecord::UpdateCapClaim {
                                 original_action_hash: original_action_hash.clone(),
                                 original_entry_hash: original_entry_hash.clone(),
                                 action: action.clone(),
                             },
-                            InScopeEntry::CapGrant => OpRecord::UpdateCapGrant {
+                            EntryType::CapGrant => OpRecord::UpdateCapGrant {
                                 original_action_hash: original_action_hash.clone(),
                                 original_entry_hash: original_entry_hash.clone(),
                                 action: action.clone(),
@@ -221,28 +251,24 @@ impl OpHelper for Op {
                             entry_hash,
                             ..
                         } = action;
-                        match map_entry::<ET>(
-                            entry_type,
-                            entry_hash,
-                            RecordEntryRef::Present(entry),
-                        )? {
-                            InScopeEntry::App(entry_type) => OpEntry::UpdateEntry {
-                                original_action_hash: original_action_hash.clone(),
-                                original_entry_hash: original_entry_hash.clone(),
-                                app_entry: entry_type,
-                                action: action.clone(),
-                            },
-                            InScopeEntry::Agent(agent_key) => OpEntry::UpdateAgent {
+                        match entry_type {
+                            EntryType::AgentPubKey => OpEntry::UpdateAgent {
                                 original_key: original_entry_hash.clone().into(),
                                 original_action_hash: original_action_hash.clone(),
-                                new_key: agent_key,
+                                new_key: entry_hash.clone().into(),
                                 action: action.clone(),
                             },
-                            _ => {
-                                return Err(wasm_error!(WasmErrorInner::Guest(
-                                    "StoreEntry should not exist for private entries Id"
-                                        .to_string()
-                                )))
+                            EntryType::App(_) => {
+                                let app_entry = map_full_entry(entry_type, entry)?;
+                                OpEntry::UpdateEntry {
+                                    original_action_hash: original_action_hash.clone(),
+                                    original_entry_hash: original_entry_hash.clone(),
+                                    app_entry,
+                                    action: action.clone(),
+                                }
+                            }
+                            EntryType::CapClaim | EntryType::CapGrant => {
+                                todo!("make OpEntry variants for caps, which are indeed valid for StoreEntry!")
                             }
                         }
                     }
@@ -262,67 +288,59 @@ impl OpHelper for Op {
                     entry_hash,
                     ..
                 } = &update.hashed.content;
-                if original_action.entry_type() != entry_type
-                    && ((new_entry.is_some() && original_entry.is_some())
-                        || (new_entry.is_none() && original_entry.is_none()))
-                {
+                if original_action.entry_type() != entry_type {
                     return Err(wasm_error!(WasmErrorInner::Guest(format!(
                         "New entry type {:?} doesn't match original entry type {:?}",
                         entry_type,
                         original_action.entry_type()
                     ))));
                 }
-                let new_entry = new_entry
-                    .as_ref()
-                    .map_or(RecordEntryRef::Hidden, RecordEntryRef::Present);
-                let original_entry = original_entry
-                    .as_ref()
-                    .map_or(RecordEntryRef::Hidden, RecordEntryRef::Present);
-                let r = match map_entry::<ET>(original_action.entry_type(), entry_hash, new_entry)?
-                {
-                    InScopeEntry::Agent(new_key) => Some(OpUpdate::Agent {
+                let update = match entry_type {
+                    EntryType::AgentPubKey => OpUpdate::Agent {
                         original_key: original_entry_hash.clone().into(),
                         original_action_hash: original_action_hash.clone(),
-                        new_key,
+                        new_key: entry_hash.clone().into(),
                         action: update.hashed.content.clone(),
-                    }),
-                    InScopeEntry::App(new_entry_type) => {
-                        match map_entry::<ET>(entry_type, entry_hash, original_entry)? {
-                            InScopeEntry::App(original_entry_type) => Some(OpUpdate::Entry {
-                                original_action: original_action.clone(),
-                                app_entry: new_entry_type,
-                                original_app_entry: original_entry_type,
-                                action: update.hashed.content.clone(),
-                            }),
-                            _ => None,
-                        }
-                    }
-                    InScopeEntry::PrivateApp(new_entry_type) => {
-                        match map_entry::<ET>(entry_type, entry_hash, original_entry)? {
-                            InScopeEntry::PrivateApp(original_entry_type) => {
-                                Some(OpUpdate::PrivateEntry {
-                                    original_action_hash: original_action_hash.clone(),
-                                    app_entry_type: new_entry_type,
-                                    original_app_entry_type: original_entry_type,
+                    },
+                    EntryType::App(entry_def) => {
+                        let old = map_entry::<ET>(entry_def, original_entry.as_ref())?;
+                        let new = map_entry::<ET>(entry_def, new_entry.as_ref())?;
+                        match (old, new) {
+                            (UnitEnumEither::Enum(old), UnitEnumEither::Enum(new)) => {
+                                OpUpdate::Entry {
+                                    original_action: original_action.clone(),
+                                    app_entry: new,
+                                    original_app_entry: old,
                                     action: update.hashed.content.clone(),
-                                })
+                                }
                             }
-                            _ => None,
+                            (UnitEnumEither::Unit(old), UnitEnumEither::Unit(new)) => {
+                                OpUpdate::PrivateEntry {
+                                    original_action_hash: original_action_hash.clone(),
+                                    app_entry_type: new,
+                                    original_app_entry_type: old,
+                                    action: update.hashed.content.clone(),
+                                }
+                            }
+                            (old, new) => {
+                                return Err(wasm_error!(WasmErrorInner::Guest(format!(
+                                    "Attempting to update a private entry to a public entry, or vice versa. old: {:?} new: {:?}",
+                                    original_action.entry_type(),
+                                    entry_type,
+                                ))))
+                            }
                         }
                     }
-                    InScopeEntry::CapClaim => Some(OpUpdate::CapClaim {
+                    EntryType::CapClaim => OpUpdate::CapClaim {
                         original_action_hash: original_action_hash.clone(),
                         action: update.hashed.content.clone(),
-                    }),
-                    InScopeEntry::CapGrant => Some(OpUpdate::CapGrant {
+                    },
+                    EntryType::CapGrant => OpUpdate::CapGrant {
                         original_action_hash: original_action_hash.clone(),
                         action: update.hashed.content.clone(),
-                    }),
+                    },
                 };
-                match r {
-                    Some(r) => Ok(FlatOp::RegisterUpdate(r)),
-                    None => unreachable!("As entry types are already checked to match"),
-                }
+                Ok(FlatOp::RegisterUpdate(update))
             }
             Op::RegisterAgentActivity(RegisterAgentActivity { action, .. }) => {
                 let r = match &action.hashed.content {
@@ -521,13 +539,7 @@ impl OpHelper for Op {
                     deletes_entry_address: original_entry_hash,
                     ..
                 } = &delete.hashed.content;
-                let r = match map_entry::<ET>(
-                    original_action.entry_type(),
-                    original_entry_hash,
-                    orig_entry
-                        .as_ref()
-                        .map_or(RecordEntryRef::Hidden, RecordEntryRef::Present),
-                )? {
+                let r = match map_entry::<ET>(original_action.entry_type(), orig_entry.as_ref())? {
                     InScopeEntry::Agent(_) => OpDelete::Agent {
                         original_action: original_action.clone(),
                         original_key: original_entry_hash.clone().into(),
@@ -588,92 +600,61 @@ where
 /// [`InScopeEntry`]. This will return a guest error
 /// and invalidate the op if the zome id is this zome but
 /// entry type is not in scope.
-fn map_entry<ET>(
-    entry_type: &EntryType,
-    entry_hash: &EntryHash,
-    entry: RecordEntryRef,
-) -> Result<InScopeEntry<ET>, WasmError>
+fn map_full_entry<ET>(entry_type: &EntryType, entry: &Entry) -> Result<ET, WasmError>
 where
     ET: EntryTypesHelper + UnitEnum,
     <ET as UnitEnum>::Unit: Into<ZomeEntryTypesKey>,
     WasmError: From<<ET as EntryTypesHelper>::Error>,
 {
-    match entry {
-        RecordEntryRef::Present(entry) => match dbg!(entry_type) {
-            EntryType::App(AppEntryDef {
-                zome_index,
-                entry_index: entry_def_index,
-                visibility: EntryVisibility::Public,
-                ..
-            }) => {
-                if !matches!(entry, Entry::App(_)) {
-                    return Err(wasm_error!(WasmErrorInner::Guest(
-                        "Entry type is App but Entry is not App".to_string()
-                    )));
-                }
-                let entry_type = <ET as EntryTypesHelper>::deserialize_from_type(
-                    *zome_index,
-                    *entry_def_index,
-                    entry,
-                )?;
-                match entry_type {
-                    Some(entry_type) => Ok(InScopeEntry::App(entry_type)),
-                    None => Err(deny_other_zome()),
-                }
-            }
-            EntryType::AgentPubKey => {
-                if !matches!(entry, Entry::Agent(_)) {
-                    return Err(wasm_error!(WasmErrorInner::Guest(
-                        "Entry type is AgentPubKey but Entry is not AgentPubKey".to_string()
-                    )));
-                }
-                Ok(InScopeEntry::Agent(entry_hash.clone().into()))
-            }
-            EntryType::App(AppEntryDef {
-                visibility: EntryVisibility::Private,
-                ..
-            })
-            | EntryType::CapGrant
-            | EntryType::CapClaim => {
-                dbg!("the spot");
-                Err(wasm_error!(WasmErrorInner::Guest(
-                "EntryType is CapGrant or CapClaim, but there is an entry present where there shouldn't be."
-                    .to_string()
-            )))
-            }
-        },
-        RecordEntryRef::Hidden => match entry_type {
-            EntryType::App(AppEntryDef {
-                zome_index,
-                entry_index: entry_def_index,
-                visibility: EntryVisibility::Private,
-            }) => match get_unit_entry_type::<ET>(*zome_index, *entry_def_index)? {
-                Some(unit) => Ok(InScopeEntry::PrivateApp(unit)),
+    todo!()
+}
+
+/// Maps an entry type and entry to an
+/// [`InScopeEntry`]. This will return a guest error
+/// and invalidate the op if the zome id is this zome but
+/// entry type is not in scope.
+fn map_entry<ET>(
+    entry_def: &AppEntryDef,
+    entry: Option<&Entry>,
+) -> Result<UnitEnumEither<ET>, WasmError>
+where
+    ET: EntryTypesHelper + UnitEnum,
+    <ET as UnitEnum>::Unit: Into<ZomeEntryTypesKey>,
+    WasmError: From<<ET as EntryTypesHelper>::Error>,
+{
+    let AppEntryDef {
+        zome_index,
+        entry_index: entry_def_index,
+        visibility,
+        ..
+    } = entry_def;
+    match (entry, visibility) {
+        (Some(entry), EntryVisibility::Public) => {
+            let entry_type = <ET as EntryTypesHelper>::deserialize_from_type(
+                *zome_index,
+                *entry_def_index,
+                entry,
+            )?;
+            match entry_type {
+                Some(entry_type) => Ok(UnitEnumEither::Enum(entry_type)),
                 None => Err(deny_other_zome()),
-            },
-            EntryType::App(AppEntryDef {
-                visibility: EntryVisibility::Public,
-                ..
-            }) => Err(wasm_error!(WasmErrorInner::Guest(
-                "Entry type is public but entry is hidden".to_string()
-            ))),
-            EntryType::CapClaim => Ok(InScopeEntry::CapClaim),
-            EntryType::CapGrant => Ok(InScopeEntry::CapGrant),
-            EntryType::AgentPubKey => Err(wasm_error!(WasmErrorInner::Guest(
-                "Entry type AgentPubKey is missing entry.".to_string()
-            ))),
-        },
-        RecordEntryRef::NotApplicable => Err(wasm_error!(WasmErrorInner::Guest(
-            "Has Entry type but entry is marked not applicable".to_string()
+            }
+        }
+
+        (None, EntryVisibility::Public) => Err(wasm_error!(WasmErrorInner::Host(
+            "Entry visibility is public but no entry is available".to_string()
         ))),
-        RecordEntryRef::NotStored => match entry_type {
-            EntryType::CapClaim | EntryType::CapGrant => Err(wasm_error!(WasmErrorInner::Guest(
-                "Capability tokens are never publicly stored.".to_string()
-            ))),
-            _ => Err(wasm_error!(WasmErrorInner::Host(
-                "Has Entry type but the entry is not currently stored.".to_string()
-            ))),
-        },
+
+        (Some(_), EntryVisibility::Private) => Err(wasm_error!(WasmErrorInner::Host(
+            "Entry visibility is private but an entry was provided!".to_string()
+        ))),
+
+        (None, EntryVisibility::Private) => {
+            match get_unit_entry_type::<ET>(*zome_index, *entry_def_index)? {
+                Some(unit) => Ok(UnitEnumEither::Unit(unit)),
+                None => Err(deny_other_zome()),
+            }
+        }
     }
 }
 

--- a/crates/hdi/src/test_utils.rs
+++ b/crates/hdi/src/test_utils.rs
@@ -79,19 +79,14 @@ pub fn set_zome_types(entries: &[(u8, u8)], links: &[(u8, u8)]) {
     set_hdi(TestHdi(ScopedZomeTypesSet {
         entries: ScopedZomeTypes(
             entries
-                .into_iter()
-                .map(|(z, types)| {
-                    (
-                        ZomeIndex(*z),
-                        (0..*types).map(|t| EntryDefIndex(t)).collect(),
-                    )
-                })
+                .iter()
+                .map(|(z, types)| (ZomeIndex(*z), (0..*types).map(EntryDefIndex).collect()))
                 .collect(),
         ),
         links: ScopedZomeTypes(
             links
-                .into_iter()
-                .map(|(z, types)| (ZomeIndex(*z), (0..*types).map(|t| LinkType(t)).collect()))
+                .iter()
+                .map(|(z, types)| (ZomeIndex(*z), (0..*types).map(LinkType).collect()))
                 .collect(),
         ),
     }));

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -17,6 +17,7 @@ encoding = ["holo_hash/encoding"]
 fixturators = ["holochain_zome_types/fixturators", "holo_hash/fixturators"]
 test_utils = [
     "fixturators",
+    "hdi/test_utils",
     "holochain_zome_types/test_utils",
     "holo_hash/test_utils",
 ]

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -153,7 +153,7 @@ tx5 = [ "kitsune_p2p/tx5" ]
 # This feature should be turned off for production builds.
 test_utils = [
   "ghost_actor/test_utils",
-  "hdk",
+  "hdk/test_utils",
   "holochain_sqlite/test_utils",
   "holochain_state/test_utils",
   "holochain_types/test_utils",

--- a/crates/holochain/src/core/ribosome/host_fn/trace.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/trace.rs
@@ -84,6 +84,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "Doesn't work concurrently"]
     async fn wasm_trace_test() {
+        use holochain_types::prelude::Level::*;
         CAPTURE.store(true, std::sync::atomic::Ordering::SeqCst);
         observability::test_run().ok();
         let RibosomeTestFixture {
@@ -93,29 +94,44 @@ pub mod wasm_test {
         let _: () = conductor.call(&alice, "debug", ()).await;
         let r: Vec<_> = CAPTURED.lock().unwrap().clone();
         let expect = vec![
+            // two traces from the two validations of genesis entries
+            TraceMsg {
+                msg:
+                    "integrity_test_wasm_debug:debug/src/integrity.rs:5 tracing in validation works"
+                        .to_string(),
+                level: INFO,
+            },
+            TraceMsg {
+                msg:
+                    "integrity_test_wasm_debug:debug/src/integrity.rs:5 tracing in validation works"
+                        .to_string(),
+                level: INFO,
+            },
+            // followed by the zome call traces
             TraceMsg {
                 msg: "test_wasm_debug:debug/src/lib.rs:5 tracing works!".to_string(),
-                level: holochain_types::prelude::Level::TRACE,
+                level: TRACE,
             },
             TraceMsg {
                 msg: "test_wasm_debug:debug/src/lib.rs:6 debug works".to_string(),
-                level: holochain_types::prelude::Level::DEBUG,
+                level: DEBUG,
             },
             TraceMsg {
                 msg: "test_wasm_debug:debug/src/lib.rs:7 info works".to_string(),
-                level: holochain_types::prelude::Level::INFO,
+                level: INFO,
             },
             TraceMsg {
                 msg: "test_wasm_debug:debug/src/lib.rs:8 warn works".to_string(),
-                level: holochain_types::prelude::Level::WARN,
+                level: WARN,
             },
             TraceMsg {
                 msg: "test_wasm_debug:debug/src/lib.rs:9 error works".to_string(),
-                level: holochain_types::prelude::Level::ERROR,
+                level: ERROR,
             },
             TraceMsg {
-                msg: "test_wasm_debug:debug/src/lib.rs:10 foo = \"fields\"; bar = \"work\"; too".to_string(),
-                level: holochain_types::prelude::Level::DEBUG,
+                msg: "test_wasm_debug:debug/src/lib.rs:10 foo = \"fields\"; bar = \"work\"; too"
+                    .to_string(),
+                level: DEBUG,
             },
         ];
         assert_eq!(r, expect);

--- a/crates/holochain_integrity_types/src/entry.rs
+++ b/crates/holochain_integrity_types/src/entry.rs
@@ -133,10 +133,7 @@ impl Entry {
     }
 
     /// Create an Entry::App from SerializedBytes
-    pub fn app_fancy<
-        E: Into<EntryError>,
-        SB: TryInto<SerializedBytes, Error = SerializedBytesError>,
-    >(
+    pub fn app_fancy<SB: TryInto<SerializedBytes, Error = SerializedBytesError>>(
         sb: SB,
     ) -> Result<Self, EntryError> {
         Ok(Entry::App(AppEntryBytes::try_from(sb.try_into()?)?))

--- a/crates/holochain_integrity_types/src/lib.rs
+++ b/crates/holochain_integrity_types/src/lib.rs
@@ -263,3 +263,11 @@ impl UnitEnum for () {
         Box::new([].into_iter())
     }
 }
+
+/// A full UnitEnum, or just the unit type of that UnitEnum
+pub enum UnitEnumEither<E: UnitEnum> {
+    /// The full enum
+    Enum(E),
+    /// Just the unit enum
+    Unit(E::Unit),
+}

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -2565,6 +2565,7 @@ dependencies = [
 name = "test_wasm_debug"
 version = "0.0.1"
 dependencies = [
+ "hdi",
  "hdk",
  "serde",
  "tracing",

--- a/crates/test_utils/wasm/wasm_workspace/debug/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/debug/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 serde = "1.0"
 tracing = "0.1"
 tracing-core = "0.1"
+hdi = { path = "../../../../hdi", features = ["trace"] }
 hdk = { path = "../../../../hdk" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/debug/src/integrity.rs
+++ b/crates/test_utils/wasm/wasm_workspace/debug/src/integrity.rs
@@ -1,0 +1,7 @@
+use hdi::prelude::*;
+
+#[hdk_extern]
+fn validate(_op: Op) -> ExternResult<ValidateCallbackResult> {
+    tracing::info!("tracing in validation works");
+    Ok(ValidateCallbackResult::Valid)
+}


### PR DESCRIPTION
### Summary

We have decided that StoreEntry validators should always get the full entry, even if it's private. This of course means that StoreEntry authorities will not get other agents' private CRUD or capability-related ops, unless they are the author.

StoreRecord and AgentActivity validators should never have the entry data in their op if it is private, even the author (for the sake of determinism).

We need to ensure that gossip and publishing follows these rules too.

The current codebase has discrepancies in all of these areas, so this will get the implementation in line with current design.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
