### PR TITLE
ci(actions/update): pass github's access-token to nix to increase rat…

### DIFF
--- a/.github/actions/update/action.yml
+++ b/.github/actions/update/action.yml
@@ -27,13 +27,15 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v2.4.0
+      uses: actions/checkout@v3
       with:
         ref: ${{ inputs.branch }}
     - name: Install nix
       uses: cachix/install-nix-action@v18
       with:
         install_url: https://releases.nixos.org/nix/nix-2.12.0/install
+        extra_nix_config: |
+          access-tokens = github.com=${{ inputs.GITHUB_TOKEN }}
     - name: Setup cachix
       uses: cachix/cachix-action@v12
       with:


### PR DESCRIPTION
…e-limit

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
