### PR TITLE
feat(nix): add crate2nix build

### DIFF
--- a/nix/modules/crate2nix.nix
+++ b/nix/modules/crate2nix.nix
@@ -1,0 +1,10 @@
+{ self, lib, inputs, ... }: {
+  perSystem = { config, self', inputs', pkgs, ... }: {
+    options.crate2nix = lib.mkOption {
+      type = lib.types.package;
+    };
+    config.crate2nix = import inputs.crate2nix {
+      inherit pkgs;
+    };
+  };
+}

--- a/nix/modules/holochain-crate2nix.nix
+++ b/nix/modules/holochain-crate2nix.nix
@@ -1,0 +1,53 @@
+{ self, lib, inputs, ...  } @ flake: {
+  perSystem = { config, self', inputs', pkgs, ... }: let
+    crate2nixTools = import "${inputs.crate2nix}/tools.nix" {
+      inherit pkgs;
+    };
+    # TODO: Tests are not running despite the overrides
+    customBuildRustCrateForPkgs = pkgs: pkgs.buildRustCrate.override {
+      defaultCrateOverrides = pkgs.defaultCrateOverrides // {
+        holochain = attrs: {
+          codegenUnits = 16;
+        };
+      };
+    };
+    generated = crate2nixTools.generatedCargoNix {
+      name = "holochain-generated-crate2nix";
+      src = flake.config.srcCleanedHolochain;
+    };
+    called = pkgs.callPackage "${generated}/default.nix" {
+      buildRustCrateForPkgs = customBuildRustCrateForPkgs;
+    };
+    holochain = called.workspaceMembers.holochain.build.override {
+      # buildTests = true;
+      # runTests = true;
+
+      # Setting the features leads to errors like:
+      #   (building openssl-sys):
+      #     thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/lib.rs:515:32
+      # features = [
+      #   "slow_tests"
+      #   "glacial_tests"
+      #   "test_utils"
+      #   "build_wasms"
+      #   "db-encryption"
+      # ];
+
+    };
+
+    # `nix flake show` is incompatible with IFD by default
+    # This works around the issue by making the name of the package
+    #   discoverable without IFD.
+    mkNoIfdPackage = name: pkg: {
+      inherit name;
+      inherit (pkg) drvPath outPath;
+      type = "derivation";
+      orig = pkg;
+    };
+  in {
+    packages = {
+      holochain-crate2nix = mkNoIfdPackage "holochain" holochain;
+      crate2nix = import inputs.crate2nix {inherit pkgs;};
+    };
+  };
+}


### PR DESCRIPTION
### Summary
This draft explores building holochain with nix via crate2nix.

I do not recommend to merge this, because of the following reasons:

### 1. It introduces an additional tool to the stack
It is unlikely that crate2nix can replace `crane` which is currently used for our rust builds, because some of our tooling, like nextest depends on cargo, and crate2nix is not compatible with cargo.

### 2. Bad documentation
For `crate2nix` there is no good documentation like [crane.dev](https://crane.dev) for crane.
Figuring things out requires reading the source code and studying templates which are far from trivial to understand.

### 3. Likelihood of maintenance overhead
Crate2nix re-implements cargo's logic itself, which leads to the following problems:
  - It is unlikely that it will ever reach feature parity with cargo
  - Increased chance of bugs, due to the high complexity
  - If cargo changes, crate2nix will likely suffer breakages.

### 4. Overriding things is flaky
Adding `runTests = true` to the override leads to an infinite recursion.

@steveeJ 

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
