### PR TITLE
fix(CI): disable cachix in more places for self-hosted

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
             experimental-features = flakes nix-command
       - name: Setup cachix
         uses: cachix/cachix-action@v12
-        continue-on-error: ${{ matrix.platform.runs-on == 'multi-arch' }}
+        if: ${{ matrix.platform.runs-on != 'multi-arch' }}
         with:
           name: holochain-ci
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -406,7 +406,7 @@ jobs:
         uses: cachix/install-nix-action@v17
       - name: Setup cachix
         uses: cachix/cachix-action@v11
-        if: ${{ matrix.platform.runs-on != 'self-hosted' }} && ${{ contains(matrix.platform.largeCacheStorage.nix, 'cachix') && contains(matrix.testCommand.largeCacheStorage, 'nix') }}
+        if: ${{ (! contains(matrix.platform.runs-on, 'self-hosted')) && contains(matrix.platform.largeCacheStorage.nix, 'cachix') && contains(matrix.testCommand.largeCacheStorage, 'nix') }}
         with:
           name: holochain-ci
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
@@ -555,6 +555,7 @@ jobs:
         uses: cachix/install-nix-action@v17
       - name: Setup cachix
         uses: cachix/cachix-action@v11
+        if: ${{ ! contains(matrix.platform.runs-on, 'self-hosted') }}
         with:
           name: holochain-ci
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
