### PR TITLE
feat(release-automation): simplify version bump logic

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -191,6 +191,7 @@ jobs:
           HOLOCHAIN_SOURCE_BRANCH: ${{ inputs.HOLOCHAIN_SOURCE_BRANCH }}
         run: |
           set -exu
+
           cd ${HOLOCHAIN_REPO}
 
           nix develop .#release --ignore-environment --command bash -c '
@@ -200,24 +201,14 @@ jobs:
             release-automation \
               --workspace-path=$PWD \
               --log-level=debug \
-              release \
-                --force-branch-creation \
-                --steps=CreateReleaseBranch
-
-            release-automation \
-              --workspace-path=$PWD \
-              crate apply-dev-versions --commit --no-verify
-
-            release-automation \
-              --workspace-path=$PWD \
-              --log-level=debug \
               --match-filter="^(holochain|holochain_cli|kitsune_p2p_proxy)$" \
               release \
                 --no-verify-pre \
                 --force-tag-creation \
+                --force-branch-creation \
                 --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
                 --disallowed-version-reqs=">=0.3" \
-                --steps=BumpReleaseVersions
+                --steps=CreateReleaseBranch,BumpReleaseVersions
 
             cargo sweep -f
             '

--- a/crates/release-automation/src/lib/tests/cli.rs
+++ b/crates/release-automation/src/lib/tests/cli.rs
@@ -532,6 +532,7 @@ fn multiple_subsequent_releases() {
     for (
         i,
         (
+            description,
             expected_versions,
             expected_crates,
             allowed_missing_dependencies,
@@ -540,8 +541,7 @@ fn multiple_subsequent_releases() {
         ),
     ) in [
         (
-            // bump the first time as they're initially released
-            // vec!["0.0.2-dev.0", "0.0.3-dev.0", "0.0.2-dev.0"],
+            "bump the first time as they're initially released",
             vec!["0.0.0", "0.1.0", "0.0.1"],
             vec!["crate_b", "crate_a", "crate_e"],
             // allowed missing dependencies
@@ -550,8 +550,7 @@ fn multiple_subsequent_releases() {
             Box::new(|_| {}) as F,
         ),
         (
-            // should not bump the second time without making any changes
-            // vec!["0.0.2-dev.0", "0.0.3-dev.0", "0.0.2-dev.0"],
+            "should not bump the second time without making any changes",
             vec!["0.0.0", "0.1.0", "0.0.1"],
             vec!["crate_b", "crate_a", "crate_e"],
             // allowed missing dependencies
@@ -560,7 +559,7 @@ fn multiple_subsequent_releases() {
             Box::new(|_| {}) as F,
         ),
         (
-            // only crate_a and crate_e have changed, expect these to be bumped
+            "only crate_a and crate_e have changed, expect these to be bumped",
             vec!["0.0.0", "0.1.1", "0.0.2"],
             vec!["crate_b", "crate_a", "crate_e"],
             // crate_b won't be part of the release so we allow it to be missing as we're not publishing
@@ -586,7 +585,7 @@ fn multiple_subsequent_releases() {
             }) as F,
         ),
         (
-            // change crate_b, and as crate_a depends on crate_b it'll be bumped as well
+            "change crate_b, and as crate_a depends on crate_b it'll be bumped as well",
             vec!["0.0.1", "0.1.2", "0.0.2"],
             vec!["crate_b", "crate_a", "crate_e"],
             // allowed missing dependencies
@@ -611,7 +610,7 @@ fn multiple_subsequent_releases() {
             }) as F,
         ),
         (
-            // add a pre-release for crate_b
+            "add a pre-release for crate_b",
             vec!["1.0.0-rc.0", "0.1.3", "0.0.2"],
             vec!["crate_b", "crate_a", "crate_e"],
             // allowed missing dependencies
@@ -652,7 +651,7 @@ fn multiple_subsequent_releases() {
             }) as F,
         ),
         (
-            // do another pre-release for crate_b
+            "do another pre-release for crate_b",
             vec!["1.0.0-rc.1", "0.1.4", "0.0.2"],
             vec!["crate_b", "crate_a", "crate_e"],
             // allowed missing dependencies
@@ -677,7 +676,7 @@ fn multiple_subsequent_releases() {
             }) as F,
         ),
         (
-            // do major release for crate_b
+            "do major release for crate_b",
             vec!["1.0.0", "0.1.5", "0.0.2"],
             vec!["crate_b", "crate_a", "crate_e"],
             // allowed missing dependencies
@@ -718,7 +717,7 @@ fn multiple_subsequent_releases() {
             }) as F,
         ),
         (
-            // and a default patch release for crate_b again
+            "and a default patch release for crate_b again",
             vec!["1.0.1", "0.1.6", "0.0.2"],
             vec!["crate_b", "crate_a", "crate_e"],
             // allowed missing dependencies
@@ -810,7 +809,8 @@ fn multiple_subsequent_releases() {
             assert_eq!(
                 expected_versions,
                 &get_crate_versions(expected_crates, &workspace),
-                "{}",
+                "{} ({})",
+                description,
                 i
             );
 

--- a/crates/release-automation/src/lib/tests/workspace_mocker.rs
+++ b/crates/release-automation/src/lib/tests/workspace_mocker.rs
@@ -427,7 +427,7 @@ pub fn example_workspace_1<'a>() -> Fallible<WorkspaceMocker> {
         },
         MockProject {
             name: "crate_e".to_string(),
-            version: "0.0.1".to_string(),
+            version: "0.0.1-dev.0".to_string(),
             dependencies: vec![],
             excluded: false,
             ty: workspace_mocker::MockProjectType::Lib,

--- a/nix/modules/release-automation.nix
+++ b/nix/modules/release-automation.nix
@@ -88,7 +88,7 @@
           in
           '' \
             --config-file=${nextestToml} \
-          '';
+          '' + builtins.getEnv "NEXTEST_EXTRA_ARGS";
 
         dontPatchELF = true;
         dontFixup = true;

--- a/nix/modules/release-automation.nix
+++ b/nix/modules/release-automation.nix
@@ -69,11 +69,11 @@
         buildInputs = commonArgs.buildInputs ++ [ pkgs.cacert ];
         nativeBuildInputs = commonArgs.nativeBuildInputs ++
           [
+            package
+
+            rustToolchain
             pkgs.gitFull
-            (config.writers.writePureShellScriptBin
-              "release-automation"
-              ([ pkgs.gitFull rustToolchain ] ++ commonArgs.nativeBuildInputs ++ commonArgs.buildInputs)
-              "exec ${package}/bin/release-automation $@")
+            pkgs.coreutils
           ];
 
         cargoNextestExtraArgs =


### PR DESCRIPTION
remove most special conditions for whether to increment or release a version of a crate.

the only condition under which no release is attempted is the error case, where the current and incremented version do not exceed the previous release version.

in all other cases, the current or incremented version is released.

### Summary



### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] merge #1807 
- [x] remove the apply-dev-versions step from release-prepare
- [x] dry-run: https://github.com/holochain/holochain/actions/runs/4206711049 / https://github.com/holochain/holochain/pull/1963
- [x] review and deduplicate between this and https://github.com/holochain/holochain/pull/1961
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
