### PR TITLE
chore(holonix): add github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/holonix_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/holonix_bug_report.md
@@ -12,7 +12,7 @@ A description of what the bug is, which dependency it is to do with,
 how you encountered it, and the text of any error you received.
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+A description of what you expected to happen.
 
 **System information:**
  - OS: [e.g. macOS 13, Ubuntu Linux 22.04]

--- a/.github/ISSUE_TEMPLATE/holonix_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/holonix_bug_report.md
@@ -2,7 +2,7 @@
 name: Holonix bug report
 about: Create a report to help us improve the Holonix dev shell
 title: "[BUG - HOLONIX]"
-labels: ''
+labels: ["bug", "nix"]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/holonix_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/holonix_bug_report.md
@@ -19,7 +19,7 @@ A description of what you expected to happen.
  - Nix version: (`nix --version`)
 
 **Steps to reproduce**
-Detailed, specific steps which will reliably reproduce this bug.
+Steps which will reliably reproduce this bug.
 
 If you have the means to do so, it would be extremely helpful to create a minimal reproduction of the problem.
 

--- a/.github/ISSUE_TEMPLATE/holonix_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/holonix_bug_report.md
@@ -15,7 +15,7 @@ how you encountered it, and the text of any error you received.
 A clear and concise description of what you expected to happen.
 
 **System information:**
- - OS: [e.g. iOS]
+ - OS: [e.g. macOS 13, Ubuntu Linux 22.04]
  - Nix version: (`nix --version`)
 
 **Steps to reproduce**

--- a/.github/ISSUE_TEMPLATE/holonix_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/holonix_bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Holonix bug report
+about: Create a report to help us improve the Holonix dev shell
+title: "[BUG - HOLONIX]"
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is, which dependency it is to do with,
+how you encountered it, and the text of any error you received.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**System information:**
+ - OS: [e.g. iOS]
+ - Nix version: (`nix --version`)
+
+**Steps to reproduce**
+Detailed, specific steps which will reliably reproduce this bug.
+
+If you have the means to do so, it would be extremely helpful to create a minimal reproduction of the problem.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.

--- a/.github/ISSUE_TEMPLATE/holonix_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/holonix_bug_report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is, which dependency it is to do with,
+A description of what the bug is, which dependency it is to do with,
 how you encountered it, and the text of any error you received.
 
 **Expected behavior**


### PR DESCRIPTION
### Summary
Add an issue template for bugs related to Holonix.


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
