### PR TITLE
fix(nix/modules/holochain): use cleaned source for wasm tests

### DIFF
--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -170,8 +170,8 @@
         cargoExtraArgs =
           "--lib --all-features";
 
-        cargoToml = "${self}/crates/test_utils/wasm/wasm_workspace/Cargo.toml";
-        cargoLock = "${self}/crates/test_utils/wasm/wasm_workspace/Cargo.lock";
+        cargoToml = "${flake.config.srcCleanedHolochain}/crates/test_utils/wasm/wasm_workspace/Cargo.toml";
+        cargoLock = "${flake.config.srcCleanedHolochain}/crates/test_utils/wasm/wasm_workspace/Cargo.lock";
 
         postUnpack = ''
           cd $sourceRoot/crates/test_utils/wasm/wasm_workspace


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
