### PR TITLE
feat(CI): ensure crate versions are bumped

### DIFF
--- a/.github/workflows/ensure-versions-bumped.yml
+++ b/.github/workflows/ensure-versions-bumped.yml
@@ -1,0 +1,27 @@
+name: Ensure versions bumped
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  ensure-versions-bumped:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v19
+        with:
+          extra_nix_config: |
+            experimental-features = flakes nix-command
+
+      - name: Setup cachix
+        uses: cachix/cachix-action@v12
+        with:
+          name: holochain-ci
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
+      - name: Ensure crate versions are bumped
+        run: |
+          nix run .#ensure-versions-bumped

--- a/nix/modules/ensure-versions-bumped.nix
+++ b/nix/modules/ensure-versions-bumped.nix
@@ -1,0 +1,34 @@
+{ self, lib, inputs, ... }: {
+  perSystem = { config, self', inputs', pkgs, ... }: let
+    loadToml = file: builtins.fromTOML (builtins.readFile file);
+    cargoToml = loadToml (self + /Cargo.toml);
+    members = cargoToml.workspace.members;
+
+    # script for a given member to fail if version is not bumped
+    checkMember = member: let
+      oldPath = lib.cleanSource (inputs.holochain + "/${member}");
+      newPath = lib.cleanSource (self + "/${member}");
+      oldVersion = (loadToml "${oldPath}/Cargo.toml").package.version;
+      newVersion = (loadToml "${newPath}/Cargo.toml").package.version;
+    in ''
+      if [ "${oldPath}" != "${newPath}" ] && [ "${oldVersion}" == "${newVersion}" ]; then
+        echo "ERROR: Crate ${member} has changed since the last release. Please bump its version."
+        failed=true
+      fi
+    '';
+
+    # script for all members to fail if at least one version bump is missing
+    script = ''
+      failed=false
+      ${lib.concatStringsSep "\n" (map checkMember members)}
+      if [ "$failed" == "true" ]; then
+        exit 1
+      fi
+    '';
+    program = config.writers.writePureShellScript [pkgs.coreutils] script;
+
+  in {
+    apps.ensure-versions-bumped.type = "app";
+    apps.ensure-versions-bumped.program = toString program;
+  };
+}


### PR DESCRIPTION
### Summary
This adds a CI job which ensures that the versions of all crates are bumped if changes have been made since the last holochain release.

This should allow us to remove the version bumping operations from the release workflow. 

### Motivation
- Move closer to the ideal CI scenario where the state of the repo represents exactly what is released.
- Reduce time required for release workflow
- Simplify complexity of release workflow

@steveeJ 

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
