### PR TITLE
 feat(github/workflows): factor out CI tests and call them in a release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: holochain build and test
+name: build and test
 on:
   workflow_dispatch:
   pull_request:
@@ -8,95 +8,5 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  "test":
-    strategy:
-      fail-fast: false
-      matrix:
-        cmd:
-          # ensure functionality on multiple platforms
-          - pkgs:
-              - holochain-tests-wasm
-              - holochain-tests-nextest
-              - holochain-tests-nextest-tx5
-              - holonix-tests-integration
-            extra_arg: '--override-input holochain "."'
-          # ensures to keep the cache populated for the most recent stable version on multiple platforms
-          - pkgs:
-              - holonix-tests-integration
-            extra_arg: ""
-        platform:
-          # - system: x86_64-darwin
-          - system: aarch64-darwin
-          - system: x86_64-linux
-
-        include:
-          # we only run repo consistency checks on x86_64-linux
-          - cmd:
-              pkgs:
-                - holochain-crates-standalone
-                - release-automation-tests
-                - release-automation-tests-repo
-                - holochain-tests-clippy
-                - holochain-tests-fmt
-                - holochain-tests-doc
-              extra_arg: '--override-input holochain "."'
-            platform:
-              system: x86_64-linux
-
-          # only needed as long as x86_64-darwin is excluded in the matrix
-          - cmd:
-              pkgs:
-                - holonix-tests-integration
-              extra_arg: ""
-            platform:
-              system: x86_64-darwin
-
-    # runs-on: ${{ matrix.platform.runs-on }}
-    runs-on: [self-hosted, multi-arch]
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          lfs: false
-
-      # - name: Install nix
-      #   uses: cachix/install-nix-action@v19
-      #   if: ${{ ! contains(matrix.platform.runs-on, 'self-hosted') }}
-      #   with:
-      #     extra_nix_config: |
-      #       experimental-features = flakes nix-command
-      # - name: Setup cachix
-      #   uses: cachix/cachix-action@v12
-      #   if: ${{ ! contains(matrix.platform.runs-on, 'self-hosted') }}
-      #   with:
-      #     name: holochain-ci
-      #     authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      #     pushFilter: "tmp-.*-"
-      # - name: Restart nix-daemon
-      #   if: ${{ matrix.platform.runs-on == 'ubuntu-latest' }}
-      #   run: |
-      #     sudo bash -c 'echo extra-experimental-features = ca-derivations impure-derivations >> /etc/nix/nix.conf'
-      #     sudo systemctl stop nix-daemon
-
-      - name: Print matrix
-        env:
-          MATRIX: ${{ toJSON(matrix) }}
-        run: echo ${MATRIX}
-
-      - name: "Test comand ${{ matrix.nixCommand }}"
-        env:
-          system: ${{ matrix.platform.system }}
-        run: |
-          set -xe
-
-          # first build all derivations. this could be enough for test derivations.
-          nix build -L --show-trace \
-            ${{ matrix.cmd.extra_arg }} \
-            --override-input versions ./versions/0_1 \
-            .#packages.${system}.${{ join(matrix.cmd.pkgs, ' .#packages.${system}.')}}
-
-          # if there's something to run we generate separate commands
-          # if [[ ${{ matrix.cmd.verb }} == "run" ]]; then
-          #   export basecmd="nix run -L --show-trace .#packages.${system}."
-          #   ${basecmd}${{ join(matrix.cmd.pkgs, '; ${basecmd}') }}
-          # fi
+  holochain-build-and-test:
+    uses: ./.github/workflows/holochain-build-and-test.yml

--- a/.github/workflows/holochain-build-and-test.yml
+++ b/.github/workflows/holochain-build-and-test.yml
@@ -61,25 +61,6 @@ jobs:
         with:
           lfs: false
 
-      # - name: Install nix
-      #   uses: cachix/install-nix-action@v19
-      #   if: ${{ ! contains(matrix.platform.runs-on, 'self-hosted') }}
-      #   with:
-      #     extra_nix_config: |
-      #       experimental-features = flakes nix-command
-      # - name: Setup cachix
-      #   uses: cachix/cachix-action@v12
-      #   if: ${{ ! contains(matrix.platform.runs-on, 'self-hosted') }}
-      #   with:
-      #     name: holochain-ci
-      #     authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      #     pushFilter: "tmp-.*-"
-      # - name: Restart nix-daemon
-      #   if: ${{ matrix.platform.runs-on == 'ubuntu-latest' }}
-      #   run: |
-      #     sudo bash -c 'echo extra-experimental-features = ca-derivations impure-derivations >> /etc/nix/nix.conf'
-      #     sudo systemctl stop nix-daemon
-
       - name: Print matrix
         env:
           MATRIX: ${{ toJSON(matrix) }}
@@ -102,6 +83,7 @@ jobs:
             --override-input versions ./versions/0_1 \
             .#packages.${system}.${{ join(matrix.cmd.pkgs, ' .#packages.${system}.')}}
 
+          # TODO: remove this once we've implemented all tests and know that we don't need it
           # if there's something to run we generate separate commands
           # if [[ ${{ matrix.cmd.verb }} == "run" ]]; then
           #   export basecmd="nix run -L --show-trace .#packages.${system}."

--- a/.github/workflows/holochain-build-and-test.yml
+++ b/.github/workflows/holochain-build-and-test.yml
@@ -1,0 +1,109 @@
+name: "holochain build and test"
+
+on:
+  workflow_call:
+    inputs:
+      repo_path:
+        description: "a path to the holochain repository"
+        required: false
+        type: string
+        default: "."
+
+jobs:
+  "test":
+    strategy:
+      fail-fast: false
+      matrix:
+        cmd:
+          # ensure functionality on multiple platforms
+          - pkgs:
+              - holochain-tests-wasm
+              - holochain-tests-nextest
+              - holochain-tests-nextest-tx5
+              - holonix-tests-integration
+            extra_arg: "--override-input holochain ${{ inputs.repo_path }}"
+          # ensures to keep the cache populated for the most recent stable version on multiple platforms
+          - pkgs:
+              - holonix-tests-integration
+            extra_arg: ""
+        platform:
+          # - system: x86_64-darwin
+          - system: aarch64-darwin
+          - system: x86_64-linux
+
+        include:
+          # we only run repo consistency checks on x86_64-linux
+          - cmd:
+              pkgs:
+                - holochain-crates-standalone
+                - release-automation-tests
+                - release-automation-tests-repo
+                - holochain-tests-clippy
+                - holochain-tests-fmt
+                - holochain-tests-doc
+              extra_arg: "--override-input holochain ${{ inputs.repo_path }}"
+            platform:
+              system: x86_64-linux
+
+          # only needed as long as x86_64-darwin is excluded in the matrix
+          - cmd:
+              pkgs:
+                - holonix-tests-integration
+              extra_arg: ""
+            platform:
+              system: x86_64-darwin
+
+    # runs-on: ${{ matrix.platform.runs-on }}
+    runs-on: [self-hosted, multi-arch]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          lfs: false
+
+      # - name: Install nix
+      #   uses: cachix/install-nix-action@v19
+      #   if: ${{ ! contains(matrix.platform.runs-on, 'self-hosted') }}
+      #   with:
+      #     extra_nix_config: |
+      #       experimental-features = flakes nix-command
+      # - name: Setup cachix
+      #   uses: cachix/cachix-action@v12
+      #   if: ${{ ! contains(matrix.platform.runs-on, 'self-hosted') }}
+      #   with:
+      #     name: holochain-ci
+      #     authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      #     pushFilter: "tmp-.*-"
+      # - name: Restart nix-daemon
+      #   if: ${{ matrix.platform.runs-on == 'ubuntu-latest' }}
+      #   run: |
+      #     sudo bash -c 'echo extra-experimental-features = ca-derivations impure-derivations >> /etc/nix/nix.conf'
+      #     sudo systemctl stop nix-daemon
+
+      - name: Print matrix
+        env:
+          MATRIX: ${{ toJSON(matrix) }}
+        run: echo ${MATRIX}
+
+      - name: "Test comand ${{ matrix.nixCommand }}"
+        env:
+          system: ${{ matrix.platform.system }}
+        run: |
+          set -xe
+
+          # if a nix store path was passed, ensure it exists locally
+          if [[ ${{ inputs.repo_path }} == "/nix/"* ]]; then
+            nix-store --realise ${{inputs.repo_path }}
+          fi
+
+          # first build all derivations. this could be enough for test derivations.
+          nix build -L --show-trace \
+            ${{ matrix.cmd.extra_arg }} \
+            --override-input versions ./versions/0_1 \
+            .#packages.${system}.${{ join(matrix.cmd.pkgs, ' .#packages.${system}.')}}
+
+          # if there's something to run we generate separate commands
+          # if [[ ${{ matrix.cmd.verb }} == "run" ]]; then
+          #   export basecmd="nix run -L --show-trace .#packages.${system}."
+          #   ${basecmd}${{ join(matrix.cmd.pkgs, '; ${basecmd}') }}
+          # fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,11 +165,9 @@ jobs:
   test:
     needs: [vars, prepare]
     if: ${{ github.event_name != 'pull_request' && needs.vars.outputs.skip_test != 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo currently unimplemented
-          exit 1
+    uses: ./.github/workflows/holochain-build-and-test.yml
+    with:
+      repo_path: ${{ needs.prepare.outputs.repo_nix_store_path }}
 
   finalize:
     if: ${{ always() && needs.prepare.result == 'success' && (needs.test.result == 'success' || needs.test.result == 'skipped') && github.event_name != 'pull_request' && (needs.prepare.outputs.releasable_crates == 'true' || needs.vars.outputs.skip_prepare_logic == 'true') }}


### PR DESCRIPTION
### Summary



### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] merge https://github.com/holochain/holochain/pull/1984
- [x] double-check that the repository passed is actually used for testing. i expect there to be rebuilds but the result seems to be already cached. cc @DavHau 
- [x] ~~tell git a file has been moved and created anew~~
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
