### PR TITLE
fix(nix/modules/launcher): add wrapGAppsHook

### DIFF
--- a/containers/ubuntu-podman/Containerfile
+++ b/containers/ubuntu-podman/Containerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:22.10
+
+ARG USERNAME=user
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Create the user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    #
+    # [Optional] Add sudo support. Omit if you don't need to install software after connecting.
+    && apt-get update \
+    && apt-get install -y sudo git \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+
+# ********************************************************
+# * Anything else you want to do like clean up goes here *
+# ********************************************************
+
+# [Optional] Set the default user. Omit if you want to keep the default as root.
+USER $USERNAME
+
+WORKDIR /home/$USERNAME

--- a/containers/ubuntu-podman/run.sh
+++ b/containers/ubuntu-podman/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -xeu
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+podman build --build-arg USERNAME="$USER" --tag ubuntu-nix "${SCRIPT_DIR}"
+xhost +si:localuser:"$USER"
+podman run -it --rm \
+  --userns keep-id \
+  --security-opt label=type:container_runtime_t \
+  -v "$XAUTHORITY":"$XAUTHORITY":ro \
+  -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
+  --env XAUTHORITY \
+  --env DISPLAY \
+  --env NIX_REMOTE="daemon" \
+  --env NIX_CONFIG="experimental-features = nix-command flakes" \
+  -v /nix/store:/nix/store:ro \
+  -v /nix/var/nix/db:/nix/var/nix/db:ro \
+  -v /nix/var/nix/daemon-socket:/nix/var/nix/daemon-socket:ro \
+  -v "$(readlink "$(which nix)")":/usr/bin/nix:ro \
+  -v "${SCRIPT_DIR}"/../..:/home/"$USER"/project \
+  --workdir /home/"$USER"/project \
+  localhost/ubuntu-nix \
+  bash
+

--- a/nix/modules/launcher.nix
+++ b/nix/modules/launcher.nix
@@ -77,24 +77,14 @@
         preFixup = ''
           gappsWrapperArgs+=(
             --set WEBKIT_DISABLE_COMPOSITING_MODE 1
-            --prefix XDG_DATA_DIRS : "${pkgs.shared-mime-info}/share"
             --prefix GIO_EXTRA_MODULES : ${pkgs.glib-networking}/lib/gio/modules
           )
+
+          # without this the DevTools will just display an unparsed HTML file (see https://github.com/tauri-apps/tauri/issues/5711#issuecomment-1336409601)
+          gappsWrapperArgs+=(
+            --prefix XDG_DATA_DIRS : "${pkgs.shared-mime-info}/share"
+          )
         '';
-
-
-        # --prefix XDG_DATA_DIRS : ${pkgs.lib.concatMapStringsSep ":" (x: "${x}/share") [
-        #   # pkgs.gnome.adwaita-icon-theme
-        #   pkgs.shared-mime-info
-        # ]}
-
-        # --prefix XDG_DATA_DIRS : ${pkgs.lib.concatMapStringsSep ":" (x: "${x}/share/gsettings-schemas/${x.name}") [
-        #   pkgs.glib
-        #   pkgs.gsettings-desktop-schemas
-        #   pkgs.gtk3
-        # ]}
-
-
       });
 
     in

--- a/nix/modules/launcher.nix
+++ b/nix/modules/launcher.nix
@@ -67,16 +67,34 @@
 
         nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
           pkgs.makeBinaryWrapper
+          pkgs.shared-mime-info
+        ];
+
+        buildInputs = commonArgs.buildInputs ++ [
+          pkgs.shared-mime-info
         ];
 
         preFixup = ''
           gappsWrapperArgs+=(
             --set WEBKIT_DISABLE_COMPOSITING_MODE 1
-            --prefix XDG_DATA_DIRS : ${pkgs.lib.concatMapStringsSep ":" (x: "${x}/share") [ pkgs.gnome.adwaita-icon-theme pkgs.shared-mime-info ]}
-            --prefix XDG_DATA_DIRS : ${pkgs.lib.concatMapStringsSep ":" (x: "${x}/share/gsettings-schemas/${x.name}") [ pkgs.glib pkgs.gsettings-desktop-schemas pkgs.gtk3 ]}
+            --prefix XDG_DATA_DIRS : "${pkgs.shared-mime-info}/share"
             --prefix GIO_EXTRA_MODULES : ${pkgs.glib-networking}/lib/gio/modules
           )
         '';
+
+
+        # --prefix XDG_DATA_DIRS : ${pkgs.lib.concatMapStringsSep ":" (x: "${x}/share") [
+        #   # pkgs.gnome.adwaita-icon-theme
+        #   pkgs.shared-mime-info
+        # ]}
+
+        # --prefix XDG_DATA_DIRS : ${pkgs.lib.concatMapStringsSep ":" (x: "${x}/share/gsettings-schemas/${x.name}") [
+        #   pkgs.glib
+        #   pkgs.gsettings-desktop-schemas
+        #   pkgs.gtk3
+        # ]}
+
+
       });
 
     in
@@ -87,3 +105,4 @@
       };
     };
 }
+

--- a/nix/modules/launcher.nix
+++ b/nix/modules/launcher.nix
@@ -67,11 +67,6 @@
 
         nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
           pkgs.makeBinaryWrapper
-          pkgs.shared-mime-info
-        ];
-
-        buildInputs = commonArgs.buildInputs ++ [
-          pkgs.shared-mime-info
         ];
 
         preFixup = ''

--- a/nix/modules/launcher.nix
+++ b/nix/modules/launcher.nix
@@ -77,7 +77,6 @@
         preFixup = ''
           gappsWrapperArgs+=(
             --set WEBKIT_DISABLE_COMPOSITING_MODE 1
-            --prefix GIO_EXTRA_MODULES : ${pkgs.glib-networking}/lib/gio/modules
           )
 
           # without this the DevTools will just display an unparsed HTML file (see https://github.com/tauri-apps/tauri/issues/5711#issuecomment-1336409601)

--- a/nix/modules/launcher.nix
+++ b/nix/modules/launcher.nix
@@ -72,6 +72,8 @@
         preFixup = ''
           gappsWrapperArgs+=(
             --set WEBKIT_DISABLE_COMPOSITING_MODE 1
+            --prefix XDG_DATA_DIRS : ${pkgs.lib.concatMapStringsSep ":" (x: "${x}/share") [ pkgs.gnome.adwaita-icon-theme pkgs.shared-mime-info ]}
+            --prefix XDG_DATA_DIRS : ${pkgs.lib.concatMapStringsSep ":" (x: "${x}/share/gsettings-schemas/${x.name}") [ pkgs.glib pkgs.gsettings-desktop-schemas pkgs.gtk3 ]}
             --prefix GIO_EXTRA_MODULES : ${pkgs.glib-networking}/lib/gio/modules
           )
         '';

--- a/nix/modules/launcher.nix
+++ b/nix/modules/launcher.nix
@@ -46,6 +46,10 @@
             perl
             pkg-config
           ])
+          ++ (lib.optionals pkgs.stdenv.isLinux
+            (with pkgs; [
+              wrapGAppsHook
+            ]))
           ++ lib.optionals pkgs.stdenv.isDarwin (with pkgs; [
             xcbuild
             libiconv

--- a/nix/modules/launcher.nix
+++ b/nix/modules/launcher.nix
@@ -70,10 +70,10 @@
         ];
 
         preFixup = ''
-          wrapProgram $out/bin/hc-launch \
-            --set WEBKIT_DISABLE_COMPOSITING_MODE 1 \
-            --set GIO_MODULE_DIR ${pkgs.glib-networking}/lib/gio/modules \
+          gappsWrapperArgs+=(
+            --set WEBKIT_DISABLE_COMPOSITING_MODE 1
             --prefix GIO_EXTRA_MODULES : ${pkgs.glib-networking}/lib/gio/modules
+          )
         '';
       });
 

--- a/scripts/test-hc-launch.sh
+++ b/scripts/test-hc-launch.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# TODO: build the hc-launch-test.webhapp file from source
+echo pass | nix develop .#holonix --command hc-launch --piped -n1 ./hc-launch-test.webhapp network mdns


### PR DESCRIPTION
this fixes an issue where the filechooser doesn't work

### Summary

can be tried out using `nix develop github:holochain/holochain/pr_hc-launch_fix_filechooser#holonix`


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] make proper use of [wrapGAppsHooks](https://nixos.org/manual/nixpkgs/stable/#ssec-gnome-hooks)
- [x] @matthme how can we verify the other workarounds (WEBKIT_DISABLE_COMPOSITING_MODE and GIO_MODULE_DIR) are still functionaL?
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
