### PR TITLE
feat(ci): add nix build for individual crates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
           # we only run repo consistency checks on x86_64-linux
           - cmd:
               pkgs:
+                - holochain-crates-standalone
                 - release-automation-tests
                 - release-automation-tests-repo
                 - holochain-tests-clippy

--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -6,7 +6,7 @@
         (
           builtins.map
             (package: ''
-              echo ${package.pname} \($(${package}/bin/${package.pname} -V)\): ${package.src.rev or "na"}'')
+              echo ${package.pname} \($(${package}/bin/${package.pname} -V)\): ${package.rev or "na"}'')
             holonixPackages
         );
       hn-introspect =


### PR DESCRIPTION
### Summary
Aside from being part of the workspace, crates can be built individually. This check ensures that this is possible.
The package to build all crates individually is called `.#holochain-crates-standalone`
In CI it is only built on linux and the job takes 5:20 sec.


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
