### PR TITLE
feat(github/workflow/release-prepare): remove verification

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -203,12 +203,20 @@ jobs:
               --log-level=debug \
               --match-filter="^(holochain|holochain_cli|kitsune_p2p_proxy)$" \
               release \
-                --no-verify-pre \
+                --no-verify \
                 --force-tag-creation \
                 --force-branch-creation \
                 --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
                 --disallowed-version-reqs=">=0.3" \
                 --steps=CreateReleaseBranch,BumpReleaseVersions
+
+            release-automation \
+                --workspace-path=$PWD \
+                --log-level=debug \
+                release \
+                  --dry-run \
+                  --no-verify \
+                  --steps=PublishToCratesIo
 
             cargo sweep -f
             '

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -77,10 +77,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Extend space
-        uses: ./.github/actions/extend-space
-        if: ${{ inputs.skip_prepare_logic != 'true' }}
-
       - name: Install nix
         uses: cachix/install-nix-action@v19
       - name: Setup cachix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,9 +178,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Extend space
-        uses: ./.github/actions/extend-space
-        if: ${{ needs.vars.outputs.dry_run == 'false' }}
       - name: Install nix
         uses: cachix/install-nix-action@v19
       - name: Setup cachix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -281,6 +281,7 @@ jobs:
                 --workspace-path=$PWD \
                 --log-level=trace \
                 release \
+                  --no-verify \
                   --steps=PublishToCratesIo,AddOwnersToCratesIo
 
       - name: Push the tags


### PR DESCRIPTION
### Summary

since 0cdcb54b5e36259b55a0351fba8a073965e448f5 introduced the *holochain-crates-standalone* test we don't need the verification in the prepare and finalize steps anymore.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
