### PR TITLE
fix(hn-introspect): revert to using `.src.rev`

### DIFF
--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -6,7 +6,7 @@
         (
           builtins.map
             (package: ''
-              echo ${package.pname} \($(${package}/bin/${package.pname} -V)\): ${package.rev or "na"}'')
+              echo ${package.pname} \($(${package}/bin/${package.pname} -V)\): ${package.src.rev or "na"}'')
             holonixPackages
         );
       hn-introspect =

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -60,7 +60,7 @@
         cargoArtifacts = holochainDepsRelease;
         src = flake.config.srcCleanedHolochain;
         doCheck = false;
-        passthru.rev = inputs.holochain.rev;
+        passthru.src.rev = inputs.holochain.rev;
       });
 
       # Tests if all workspace crates can be built via their own Cargo.toml,


### PR DESCRIPTION
### Summary

addresses https://github.com/holochain/holochain/pull/1981#issuecomment-1438670258 which was introduced by 0cdcb54b5e36259b55a0351fba8a073965e448f5.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
