### PR TITLE
feat(workflows/holochain-build-and-test): dedup and run all tests on x86_64-darwin

### DIFF
--- a/.github/workflows/holochain-build-and-test.yml
+++ b/.github/workflows/holochain-build-and-test.yml
@@ -27,7 +27,7 @@ jobs:
               - holonix-tests-integration
             extra_arg: ""
         platform:
-          # - system: x86_64-darwin
+          - system: x86_64-darwin
           - system: aarch64-darwin
           - system: x86_64-linux
 
@@ -44,14 +44,6 @@ jobs:
               extra_arg: "--override-input holochain ${{ inputs.repo_path }}"
             platform:
               system: x86_64-linux
-
-          # only needed as long as x86_64-darwin is excluded in the matrix
-          - cmd:
-              pkgs:
-                - holonix-tests-integration
-              extra_arg: ""
-            platform:
-              system: x86_64-darwin
 
     # runs-on: ${{ matrix.platform.runs-on }}
     runs-on: [self-hosted, multi-arch]


### PR DESCRIPTION
### Summary

with https://github.com/holochain/holochain-infra/pull/21 we now have enough bandwidth to enable more tests on *x86_64-darwin*.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] refactor the macos code into a module?
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
