### PR TITLE
fix(release-automation): disallow wildcard dev-dependencies and fixup the repo

### DIFF
--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -96,7 +96,7 @@ sd-notify = "0.3.0"
 
 
 [dev-dependencies]
-holochain = { path = ".", features = ["test_utils"] }
+holochain = { path = ".", features = ["test_utils"], version = "0.1.0" }
 
 anyhow = "1.0.26"
 assert_cmd = "1.0.1"
@@ -104,7 +104,7 @@ contrafact = "0.1.0-dev.1"
 criterion = { version = "0.3", features = [ "async_tokio" ] }
 ed25519-dalek = "1"
 isotest = "0"
-kitsune_p2p_bootstrap = { path = "../kitsune_p2p/bootstrap" }
+kitsune_p2p_bootstrap = { path = "../kitsune_p2p/bootstrap", version = "0.0.12-dev.0" }
 maplit = "1"
 pretty_assertions = "0.6.1"
 rand_dalek = {package = "rand", version = "0.7"}

--- a/crates/release-automation/Cargo.lock
+++ b/crates/release-automation/Cargo.lock
@@ -2125,7 +2125,7 @@ dependencies = [
  "enumflags2",
  "env_logger 0.8.4",
  "fancy-regex",
- "git2 0.15.0",
+ "git2 0.16.1",
  "indoc",
  "itertools",
  "linked-hash-map",

--- a/crates/release-automation/src/lib/crate_selection/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/mod.rs
@@ -489,6 +489,7 @@ impl CrateState {
             | MissingDescription
             | MissingLicense
             | HasWildcardDependency
+            | HasWildcardDevDependency
             | ManifestKeywordExceeds20Chars
             | ManifestKeywordContainsInvalidChar
             | ManifestKeywordsMoreThan5

--- a/crates/release-automation/src/lib/tests/cli.rs
+++ b/crates/release-automation/src/lib/tests/cli.rs
@@ -943,6 +943,7 @@ fn release_dry_run_fails_on_unallowed_conditions() {
             "--log-level=debug",
             "release",
             "--dry-run",
+            "--no-verify",
             "--steps=BumpReleaseVersions",
         ]);
 


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
