### PR TITLE
fix(nix/modules/launcher): only use selected apple_sdk frameworks

### DIFF
--- a/nix/modules/launcher.nix
+++ b/nix/modules/launcher.nix
@@ -30,8 +30,15 @@
               gdk-pixbuf
               gtk3
             ]))
-          ++ lib.optionals pkgs.stdenv.isDarwin (builtins.attrValues (builtins.removeAttrs pkgs.darwin.apple_sdk.frameworks [ "QuickTime" ]))
-        ;
+          ++ (lib.optionals pkgs.stdenv.isDarwin (with pkgs.darwin.apple_sdk.frameworks; [
+            AppKit
+            CoreFoundation
+            CoreServices
+            Security
+            IOKit
+            WebKit
+          ]));
+
 
         nativeBuildInputs =
           (with pkgs;


### PR DESCRIPTION
this is to prevent a too long argument list for `ld`

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
