### PR TITLE
feat(github/workflows/release): evaluate 'make_latest' and 'prerelease'

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -56,12 +56,12 @@ on:
         required: true
 
     outputs:
-      tag:
+      latest_holochain_tag:
         description: "which holochain tag, if one, will be released"
-        value: ${{ jobs.prepare.outputs.tag }}
-      version:
+        value: ${{ jobs.prepare.outputs.latest_holochain_tag }}
+      latest_holochain_version:
         description: "which holochain version, if one, will be released"
-        value: ${{ jobs.prepare.outputs.version }}
+        value: ${{ jobs.prepare.outputs.latest_holochain_version }}
       release_branch:
         description: "the branch that contains the changes made during this action"
         value: ${{ jobs.prepare.outputs.release_branch }}
@@ -84,6 +84,8 @@ jobs:
       release_branch: ${{ steps.write-env-and-tag.outputs.release_branch }}
       repo_nix_store_path: ${{ steps.write-env-and-tag.outputs.repo_nix_store_path }}
       releasable_crates: ${{ steps.bump-versions.outputs.releasable_crates }}
+      latest_holochain_tag: ${{ steps.bump-versions.outputs.latest_holochain_tag }}
+      latest_holochain_version: ${{ steps.bump-versions.outputs.latest_holochain_version }}
 
     steps:
       - name: Checkout repository
@@ -261,16 +263,16 @@ jobs:
 
           git tag --sort=-taggerdate | grep holochain-
 
-          export TAG=$(git tag --sort=-taggerdate | grep holochain- | head -n1)
-          export VERSION=${TAG/holochain-/}
+          export LATEST_HOLOCHAIN_TAG=$(git tag --sort=-taggerdate | grep holochain- | head -n1)
+          export LATEST_HOLOCHAIN_VERSION=${LATEST_HOLOCHAIN_TAG/holochain-/}
           export RELEASE_BRANCH=$(git branch --show-current)
 
           # clean the repo before adding it to the store
           git clean -ffdx
           export STORE_PATH=$(nix store add-path --name holochain_repo .)
 
-          echo "tag=${TAG}" >> $GITHUB_OUTPUT
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "latest_holochain_tag=${LATEST_HOLOCHAIN_TAG}" >> $GITHUB_OUTPUT
+          echo "latest_holochain_version=${LATEST_HOLOCHAIN_VERSION}" >> $GITHUB_OUTPUT
           echo "release_branch=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
           echo "repo_nix_store_path=${STORE_PATH}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -79,13 +79,11 @@ jobs:
       CACHIX_REV: ${{ inputs.CACHIX_REV }}
     runs-on: ubuntu-latest
     outputs:
-      tag: ${{ steps.write-env-and-tag.outputs.tag }}
-      version: ${{ steps.write-env-and-tag.outputs.version }}
+      latest_holochain_tag: ${{ steps.write-env-and-tag.outputs.latest_holochain_tag }}
+      latest_holochain_version: ${{ steps.write-env-and-tag.outputs.latest_holochain_version }}
       release_branch: ${{ steps.write-env-and-tag.outputs.release_branch }}
       repo_nix_store_path: ${{ steps.write-env-and-tag.outputs.repo_nix_store_path }}
       releasable_crates: ${{ steps.bump-versions.outputs.releasable_crates }}
-      latest_holochain_tag: ${{ steps.bump-versions.outputs.latest_holochain_tag }}
-      latest_holochain_version: ${{ steps.bump-versions.outputs.latest_holochain_version }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -361,8 +361,9 @@ jobs:
           HOLOCHAIN_TARGET_BRANCH: ${{ needs.vars.outputs.holochain_target_branch }}
           RELEASE_BRANCH: ${{ needs.prepare.outputs.release_branch }}
           LATEST_HOLOCHAIN_TAG: ${{ needs.prepare.outputs.latest_holochain_tag }}
+          LATEST_HOLOCHAIN_VERSION: ${{ needs.prepare.outputs.latest_holochain_version }}
         run: |
-          set -eu
+          set -eux
           cd "${HOLOCHAIN_REPO}"
 
           # a positive condition means the current holochain version has already been released, hence this release doesn't contain holochain
@@ -374,6 +375,21 @@ jobs:
             export IS_HOLOCHAIN_RELEASE="true"
           fi
 
+          # this configuers a single, hardcoded branch to publish "latest" release's
+          # this makes the release stand out on the right side in the github repository landing page
+          if [[ "${HOLOCHAIN_TARGET_BRANCH" == "main-0.1" && "${IS_HOLOCHAIN_RELEASE}" == "true" ]]; then
+            export IS_LATEST="true"
+          else
+            export IS_LATEST="false"
+          fi
+
+          # simply check for the delimeter between the version number and a pre-release suffix
+          if [[ "${LATEST_HOLOCHAIN_VERSION}" == *"-"*]]; then
+            export IS_PRE_RELEASE="true"
+          else
+            export IS_PRE_RELEASE="false"
+          fi
+
           gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
@@ -383,9 +399,9 @@ jobs:
             -f name="holochain ${VERSION} (${RELEASE_BRANCH#*-})" \
             -f body="***Please read [this release's top-level CHANGELOG](https://github.com/holochain/holochain/blob/${HOLOCHAIN_TARGET_BRANCH}/CHANGELOG.md#$(sed -E 's/(release-|\.)//g' <<<"${RELEASE_BRANCH}")) to see the full list of crates that were released together.***" \
             -F draft=false \
-            -F prerelease=false \
             -F generate_release_notes=false \
-            -f make_latest="${IS_HOLOCHAIN_RELEASE}"
+            -F prerelease=${IS_PRE_RELEASE} \
+            -f make_latest="${IS_LATEST}"
 
       - name: Setup SSH session
         uses: steveeJ-forks/action-upterm@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,17 +360,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOLOCHAIN_TARGET_BRANCH: ${{ needs.vars.outputs.holochain_target_branch }}
           RELEASE_BRANCH: ${{ needs.prepare.outputs.release_branch }}
-          TAG: ${{ needs.prepare.outputs.tag }}
+          LATEST_HOLOCHAIN_TAG: ${{ needs.prepare.outputs.latest_holochain_tag }}
         run: |
           set -eu
           cd "${HOLOCHAIN_REPO}"
 
           # a positive condition means the current holochain version has already been released, hence this release doesn't contain holochain
-          if gh release view ${TAG}; then
+          if gh release view ${LATEST_HOLOCHAIN_TAG}; then
             export RELEASE_TAG=${RELEASE_BRANCH}
             export IS_HOLOCHAIN_RELEASE="false"
           else
-            export RELEASE_TAG=${TAG}
+            export RELEASE_TAG=${LATEST_HOLOCHAIN_TAG}
             export IS_HOLOCHAIN_RELEASE="true"
           fi
 
@@ -421,8 +421,8 @@ jobs:
         continue-on-error: true
         env:
           STATUS: ${{ steps.check-status.outcome }}
-          VERSION: ${{ needs.prepare.outputs.version }}
-          TAG: ${{ needs.prepare.outputs.tag }}
+          VERSION: ${{ needs.prepare.outputs.latest_holochain_version }}
+          TAG: ${{ needs.prepare.outputs.latest_holochain_tag }}
           WORKFLOW_RUN_URL: "https://github.com/holochain/holochain/actions/runs/${{ github.run_id }}"
           HRA_MATTERMOST_TOKEN: ${{ secrets.HRA_MATTERMOST_TOKEN }}
 
@@ -494,8 +494,8 @@ jobs:
         continue-on-error: true
         env:
           STATUS: ${{ steps.check-status.outcome }}
-          VERSION: ${{ needs.prepare.outputs.version }}
-          TAG: ${{ needs.prepare.outputs.tag }}
+          VERSION: ${{ needs.prepare.outputs.latest_holochain_version }}
+          TAG: ${{ needs.prepare.outputs.latest_holochain_tag }}
           WORKFLOW_RUN_URL: "https://github.com/holochain/holochain/actions/runs/${{ github.run_id }}"
           HRA_MATTERMOST_TOKEN: ${{ secrets.HRA_MATTERMOST_TOKEN }}
           DRY_RUN: "${{ needs.vars.outputs.dry_run }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,8 +354,8 @@ jobs:
           pull_request_number="$(tail -n1 gh-pr-create.log | grep -oE '[0-9]+$')"
           echo "pull-request-number=${pull_request_number}" >> $GITHUB_OUTPUT
 
-      - name: Create a github release
-        if: ${{ needs.vars.outputs.dry_run == 'false' }}
+      - name: Eval variables for the github release
+        id: eval-vars-gh-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOLOCHAIN_TARGET_BRANCH: ${{ needs.vars.outputs.holochain_target_branch }}
@@ -364,7 +364,6 @@ jobs:
           LATEST_HOLOCHAIN_VERSION: ${{ needs.prepare.outputs.latest_holochain_version }}
         run: |
           set -eux
-          cd "${HOLOCHAIN_REPO}"
 
           # a positive condition means the current holochain version has already been released, hence this release doesn't contain holochain
           if gh release view ${LATEST_HOLOCHAIN_TAG}; then
@@ -389,6 +388,23 @@ jobs:
           else
             export IS_PRE_RELEASE="false"
           fi
+
+          echo "release_tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
+          echo "is_latest=${IS_LATEST}" >> $GITHUB_OUTPUT
+          echo "is_pre_release=${IS_PRE_RELEASE}" >> $GITHUB_OUTPUT
+
+      - name: Create a github release
+        if: ${{ needs.vars.outputs.dry_run == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOLOCHAIN_TARGET_BRANCH: ${{ needs.vars.outputs.holochain_target_branch }}
+          RELEASE_BRANCH: ${{ needs.prepare.outputs.release_branch }}
+          RELEASE_TAG: ${{ steps.eval-vars-gh-release.outputs.release_tag }}
+          IS_LATEST: ${{ steps.eval-vars-gh-release.is_latest }}
+          IS_PRE_RELEASE: ${{ steps.eval-vars-gh-release.is_pre_release }}
+        run: |
+          set -eux
+          cd "${HOLOCHAIN_REPO}"
 
           gh api \
             --method POST \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,14 +376,14 @@ jobs:
 
           # this configuers a single, hardcoded branch to publish "latest" release's
           # this makes the release stand out on the right side in the github repository landing page
-          if [[ "${HOLOCHAIN_TARGET_BRANCH" == "main-0.1" && "${IS_HOLOCHAIN_RELEASE}" == "true" ]]; then
+          if [[ "${HOLOCHAIN_TARGET_BRANCH}" == "main-0.1" && "${IS_HOLOCHAIN_RELEASE}" == "true" ]]; then
             export IS_LATEST="true"
           else
             export IS_LATEST="false"
           fi
 
           # simply check for the delimeter between the version number and a pre-release suffix
-          if [[ "${LATEST_HOLOCHAIN_VERSION}" == *"-"*]]; then
+          if [[ "${LATEST_HOLOCHAIN_VERSION}" == *"-"* ]]; then
             export IS_PRE_RELEASE="true"
           else
             export IS_PRE_RELEASE="false"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,70 +354,18 @@ jobs:
           pull_request_number="$(tail -n1 gh-pr-create.log | grep -oE '[0-9]+$')"
           echo "pull-request-number=${pull_request_number}" >> $GITHUB_OUTPUT
 
-      - name: Eval variables for the github release
-        id: eval-vars-gh-release
+      - name: Create a github release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOLOCHAIN_TARGET_BRANCH: ${{ needs.vars.outputs.holochain_target_branch }}
           RELEASE_BRANCH: ${{ needs.prepare.outputs.release_branch }}
           LATEST_HOLOCHAIN_TAG: ${{ needs.prepare.outputs.latest_holochain_tag }}
           LATEST_HOLOCHAIN_VERSION: ${{ needs.prepare.outputs.latest_holochain_version }}
+          DRY_RUN: "${{ needs.vars.outputs.dry_run }}"
         run: |
           set -eux
-
-          # a positive condition means the current holochain version has already been released, hence this release doesn't contain holochain
-          if gh release view ${LATEST_HOLOCHAIN_TAG}; then
-            export RELEASE_TAG=${RELEASE_BRANCH}
-            export IS_HOLOCHAIN_RELEASE="false"
-          else
-            export RELEASE_TAG=${LATEST_HOLOCHAIN_TAG}
-            export IS_HOLOCHAIN_RELEASE="true"
-          fi
-
-          # this configuers a single, hardcoded branch to publish "latest" release's
-          # this makes the release stand out on the right side in the github repository landing page
-          if [[ "${HOLOCHAIN_TARGET_BRANCH}" == "main-0.1" && "${IS_HOLOCHAIN_RELEASE}" == "true" ]]; then
-            export IS_LATEST="true"
-          else
-            export IS_LATEST="false"
-          fi
-
-          # simply check for the delimeter between the version number and a pre-release suffix
-          if [[ "${LATEST_HOLOCHAIN_VERSION}" == *"-"* ]]; then
-            export IS_PRE_RELEASE="true"
-          else
-            export IS_PRE_RELEASE="false"
-          fi
-
-          echo "release_tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
-          echo "is_latest=${IS_LATEST}" >> $GITHUB_OUTPUT
-          echo "is_pre_release=${IS_PRE_RELEASE}" >> $GITHUB_OUTPUT
-
-      - name: Create a github release
-        if: ${{ needs.vars.outputs.dry_run == 'false' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOLOCHAIN_TARGET_BRANCH: ${{ needs.vars.outputs.holochain_target_branch }}
-          RELEASE_BRANCH: ${{ needs.prepare.outputs.release_branch }}
-          RELEASE_TAG: ${{ steps.eval-vars-gh-release.outputs.release_tag }}
-          IS_LATEST: ${{ steps.eval-vars-gh-release.is_latest }}
-          IS_PRE_RELEASE: ${{ steps.eval-vars-gh-release.is_pre_release }}
-        run: |
-          set -eux
-          cd "${HOLOCHAIN_REPO}"
-
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            /repos/holochain/holochain/releases \
-            -f tag_name="${RELEASE_TAG}" \
-            -f target_commitish="${HOLOCHAIN_TARGET_BRANCH}" \
-            -f name="holochain ${VERSION} (${RELEASE_BRANCH#*-})" \
-            -f body="***Please read [this release's top-level CHANGELOG](https://github.com/holochain/holochain/blob/${HOLOCHAIN_TARGET_BRANCH}/CHANGELOG.md#$(sed -E 's/(release-|\.)//g' <<<"${RELEASE_BRANCH}")) to see the full list of crates that were released together.***" \
-            -F draft=false \
-            -F generate_release_notes=false \
-            -F prerelease=${IS_PRE_RELEASE} \
-            -f make_latest="${IS_LATEST}"
+          cd "${GITHUB_WORKSPACE}"
+          ./scripts/ci-gh-release.sh
 
       - name: Setup SSH session
         uses: steveeJ-forks/action-upterm@main

--- a/scripts/ci-gh-release.sh
+++ b/scripts/ci-gh-release.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -eux
+
+# a positive condition means the current holochain version has already been released, hence this release doesn't contain holochain
+if gh release view "${LATEST_HOLOCHAIN_TAG}"; then
+  export RELEASE_TAG=${RELEASE_BRANCH}
+  export IS_HOLOCHAIN_RELEASE="false"
+else
+  export RELEASE_TAG=${LATEST_HOLOCHAIN_TAG}
+  export IS_HOLOCHAIN_RELEASE="true"
+fi
+
+# this configuers a single, hardcoded branch to publish "latest" release's
+# this makes the release stand out on the right side in the github repository landing page
+if [[ "${HOLOCHAIN_TARGET_BRANCH}" == "main-0.1" && "${IS_HOLOCHAIN_RELEASE}" == "true" ]]; then
+  export IS_LATEST="true"
+else
+  export IS_LATEST="false"
+fi
+
+# simply check for the delimeter between the version number and a pre-release suffix
+if [[ "${LATEST_HOLOCHAIN_VERSION}" == *"-"* ]]; then
+  export IS_PRE_RELEASE="true"
+else
+  export IS_PRE_RELEASE="false"
+fi
+
+cmd=$(cat <<EOF
+gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    /repos/holochain/holochain/releases \
+    -f tag_name="${RELEASE_TAG}" \
+    -f target_commitish="${HOLOCHAIN_TARGET_BRANCH}" \
+    -f name="holochain ${LATEST_HOLOCHAIN_VERSION} (${RELEASE_BRANCH#*-})" \
+    -f body="***Please read [this release's top-level CHANGELOG](https://github.com/holochain/holochain/blob/${HOLOCHAIN_TARGET_BRANCH}/CHANGELOG.md#$(sed -E 's/(release-|\.)//g' <<<"${RELEASE_BRANCH}")) to see the full list of crates that were released together.***" \
+    -F draft=false \
+    -F generate_release_notes=false \
+    -F prerelease=${IS_PRE_RELEASE} \
+    -f make_latest="${IS_LATEST}"
+EOF
+)
+
+if [[ "${DRY_RUN:-true}" == "false" ]]; then
+    $cmd
+else
+    echo "$cmd"
+fi


### PR DESCRIPTION
### Summary
we treat only one branch as the source for the latest release.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] #2076 
- [x] verify with a dry-run
    1. https://github.com/holochain/holochain/actions/runs/4417056636 :x: 
    2. https://github.com/holochain/holochain/actions/runs/4418299290 :heavy_check_mark: 
- [x] fix missing version field in mattermost message
    - https://github.com/holochain/holochain/actions/runs/4425942439
- [x] verify gh release parameters are as expected
    - https://github.com/holochain/holochain/actions/runs/4427881445
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
