### PR TITLE
feat(release-prepare): force removeal of .git subdirs before caching

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -266,7 +266,7 @@ jobs:
           export RELEASE_BRANCH=$(git branch --show-current)
 
           # clean the repo before adding it to the store
-          git clean -fdx
+          git clean -ffdx
           export STORE_PATH=$(nix store add-path --name holochain_repo .)
 
           echo "tag=${TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
