### PR TITLE
feat(nix/modules/devShells/coreDev): generate test scripts from test derivations

### DIFF
--- a/.github/workflows/holochain-build-and-test.yml
+++ b/.github/workflows/holochain-build-and-test.yml
@@ -17,14 +17,12 @@ jobs:
         cmd:
           # ensure functionality on multiple platforms
           - pkgs:
-              - holochain-tests-wasm
-              - holochain-tests-nextest
-              - holochain-tests-nextest-tx5
-              - holonix-tests-integration
+              - build-holochain-tests-unit-all
+              - build-holonix-tests-integration
             extra_arg: "--override-input holochain ${{ inputs.repo_path }}"
           # ensures to keep the cache populated for the most recent stable version on multiple platforms
           - pkgs:
-              - holonix-tests-integration
+              - build-holonix-tests-integration
             extra_arg: ""
         platform:
           - system: x86_64-darwin
@@ -35,12 +33,10 @@ jobs:
           # we only run repo consistency checks on x86_64-linux
           - cmd:
               pkgs:
-                - holochain-crates-standalone
-                - release-automation-tests
-                - release-automation-tests-repo
-                - holochain-tests-clippy
-                - holochain-tests-fmt
-                - holochain-tests-doc
+                - build-holochain-build-crates-standalone
+                - build-release-automation-tests
+                - build-release-automation-tests-repo
+                - build-holochain-tests-static-all
               extra_arg: "--override-input holochain ${{ inputs.repo_path }}"
             platform:
               system: x86_64-linux

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ We gladly welcome pull requests that help us identify and fix bugs!
 
 The end goal of addressing any bug is to have a test written in our codebase to reproduce the bug, and of course to implement the fix for the bug. A PR with at least a minimal reproduction demonstrating the bug is extremely helpful, even if the fix has not been discovered.
 
-To write a minimal reproduction of a problem discovered "in the wild", we recommend you to write a sample zome, DNA, or hApp which demonstrates the problem, and open a PR with your failing test. We have a library called [`sweettest`](https://docs.rs/holochain/latest/holochain/sweettest/index.html) which is well-suited to the task of testing the behavior of Holochain applications. 
+To write a minimal reproduction of a problem discovered "in the wild", we recommend you to write a sample zome, DNA, or hApp which demonstrates the problem, and open a PR with your failing test. We have a library called [`sweettest`](https://docs.rs/holochain/latest/holochain/sweettest/index.html) which is well-suited to the task of testing the behavior of Holochain applications.
 
 When writing your reproduction PR, you can recreate the problematic part of your app in one of two ways: "inline zomes", or "test wasms".
 
@@ -105,10 +105,10 @@ We use rust-fmt to enforce code style so that we don't spend time arguing about 
 Run the formatter with:
 
 ``` shell
-nix-shell --run hc-rust-fmt
+nix develop .#coreDev --command cargo fmt
 ```
 
-or, if you have a version of `cargo` locally installed which matches the version used in the nix-shell:
+or, if you have a version of `cargo` locally installed which matches the version used in the `nix develop` environment:
 
 ```shell
 cargo fmt

--- a/docs/core_testing.md
+++ b/docs/core_testing.md
@@ -17,9 +17,35 @@ Either of these:
 
 ## Running tests
 
-First of all, from the root folder, run `nix develop .#coreDev`.
+
+### Using the same Nix derivations as CI
+
+CI runs all Holochain tests via the `nix build` command by referencing the various packages.
+As of 2023-03-02, we have the following test derivations:
+
+- build-holochain-tests-all
+- build-holochain-tests-static-all
+- build-holochain-tests-static-clippy
+- build-holochain-tests-static-doc
+- build-holochain-tests-static-fmt
+- build-holochain-tests-unit
+- build-holochain-tests-unit-all
+- build-holochain-tests-unit-tx5
+- build-holochain-tests-unit-wasm
+
+The ones ending in *-all* are meta packages, combining all tests in the same category.
+
+The following command builds the meta-package that incorporates all Holochain tests, and passes the current directory as the source that's to be tested:
+
+```
+nix build -L \
+  --override-input holochain . \
+  .#build-holochain-tests-all
+```
 
 ### Using test preconfigured impure test scripts
+
+First of all, from the root folder, run `nix develop .#coreDev`.
 
 The _coreDev_ developer shell provides impure test scripts that are automatically generated from the Nix derivations that we use for testing on CI.
 They are prefixed with *script-* and you should be able to autocomplete them by typing _script-<TAB>_.

--- a/docs/core_testing.md
+++ b/docs/core_testing.md
@@ -10,20 +10,29 @@ These tests will be run every time you post a new pull request in CircleCI.
 
 ## Requirements
 
-- Having `nix-shell` installed ([instructions](https://nixos.org/download.html)).
-- Having rust and `cargo` installed and in the stable toolchain
+Either of these:
+
+- *(recommended)* Having `nix` installed ([instructions](https://nixos.org/download.html)).
+- *(alternative)* Having rust and `cargo` installed and in the stable toolchain
 
 ## Running tests
 
-First of all, from the root folder, run `nix-shell`.
+First of all, from the root folder, run `nix develop .#coreDev`.
 
-- To run all tests in from all the crates, run this from the root folder:
+### Using test preconfigured impure test scripts
+
+The _coreDev_ developer shell provides impure test scripts that are automatically generated from the Nix derivations that we use for testing on CI.
+They are prefixed with *script-* and you should be able to autocomplete them by typing _script-<TAB>_.
+
+For example To run all tests in from all the crates, run this from the root folder:
 
 ```bash
-hc-merge-test
+script-holochain-tests-all
 ```
 
-You can also use `hc-test` if you don't want to run cargo fmt and cargo clippy, but both of this will be RUN on CircleCI.
+Or use `script-holochain-tests-unit-all` if you don't want to run the static checks (cargo doc, cargo fmt and cargo clippy, but all of these this will be RUN on CI.
+
+### Using `cargo test` manually
 
 - To run only one test from your crate, run this command:
 

--- a/nix/modules/crate2nix.nix
+++ b/nix/modules/crate2nix.nix
@@ -1,5 +1,5 @@
 { self, lib, inputs, ... }: {
   perSystem = { config, self', inputs', pkgs, ... }: {
-    packages.crate2nix = pkgs.callPackage inputs.crate2nix;
+    packages.crate2nix = pkgs.callPackage inputs.crate2nix { };
   };
 }

--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -41,11 +41,49 @@
             holochainTestDrvs =
               (
                 lib.attrsets.filterAttrs
-                  (name: _package:
-                    (builtins.match "^holochain-tests.*" name) != null
+                  (name: package:
+                    # (package.checkPhase or null) != null &&
+                    (builtins.match "^build-holochain-tests.*" name) != null
                   )
                   self'.packages
               );
+
+            mkTestScript = name: package:
+              pkgs.writeShellScriptBin (builtins.replaceStrings [ "build-" ] [ "script-" ] name)
+                (
+                  ''
+                    set -xue
+                  ''
+                  # remove the craneLib internals that are part of the checkPhase and
+                  # some characters that would prevent the passing of args
+                  + (
+                    let
+                      cleanCmd = cmd:
+                        (builtins.replaceStrings
+                          [ "cargo --version" "cargoWithProfile" "runHook preCheck" "runHook postCheck" "runHook preBuild" "runHook postBuild" "\n" "\\" "  " ]
+                          [ "" "cargo" "" "" "" "" "" "" " " ]
+                          cmd);
+
+                      checkPhaseClean = cleanCmd (package.checkPhase or "");
+                      buildPhaseClean = cleanCmd (package.buildPhase or "");
+                      checkOrBuildPhase =
+                        if checkPhaseClean != "" then checkPhaseClean
+                        else buildPhaseClean;
+                    in
+                    if checkOrBuildPhase != "" then
+                      ''${checkOrBuildPhase} ''${@}''
+                    else if (package.passthru.dependencies or null) != null then
+                    # recursive call to generate one script call per dependency
+                      builtins.concatStringsSep "\n" (builtins.map (pkg: "${mkTestScript pkg.name pkg}/bin/${pkg.name}") package.passthru.dependencies)
+                    else
+                      throw ''${name} has neither of these
+                              - checkPhase: (${checkPhaseClean})
+                              - buildPhase: (${buildPhaseClean})
+                              - passthru.dependencies
+                            ''
+                  )
+                );
+
           in
           pkgs.mkShell {
             inputsFrom = [ self'.devShells.rustDev ] ++ (builtins.attrValues holochainTestDrvs);
@@ -53,7 +91,7 @@
             packages = with pkgs; [
               cargo-nextest
 
-              (pkgs.writeShellScriptBin "scripts-cargo-regen-lockfiles" ''
+              (pkgs.writeShellScriptBin "script-cargo-regen-lockfiles" ''
                 cargo fetch --locked
                 cargo generate-lockfile --offline --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml
                 cargo generate-lockfile --offline
@@ -63,24 +101,8 @@
             ]
 
             # generate one script for each of the "holochain-tests-" prefixed derivations by reusing their checkPhase
-            ++ (builtins.attrValues (builtins.mapAttrs
-              (name: package:
-                pkgs.writeShellScriptBin "scripts-${name}"
-                  (
-                    ''
-                      set -xue
-                    ''
-                    # remove the craneLib internals that are part of the checkPhase and
-                    # some characters that would prevent the passing of args
-                    + (builtins.replaceStrings
-                      [ "cargoWithProfile" "runHook preCheck" "runHook postCheck" "\n" "\\" "  " ]
-                      [ "cargo" "" "" "" "" " " ]
-                      package.checkPhase)
-                    + "$@"
-                  )
-              )
-              holochainTestDrvs)
-            );
+            ++ builtins.attrValues (builtins.mapAttrs mkTestScript holochainTestDrvs)
+            ;
 
             shellHook = ''
               export PS1='\n\[\033[1;34m\][coreDev:\w]\$\[\033[0m\] '
@@ -96,23 +118,26 @@
             '';
           };
 
-        rustDev = pkgs.mkShell
-          {
-            inputsFrom = [
-              self'.packages.holochain
-            ];
+        rustDev =
+          pkgs.mkShell
+            {
+              inputsFrom = [
+                self'.packages.holochain
+              ];
 
-            shellHook = ''
-              export CARGO_HOME="$PWD/.cargo"
-              export CARGO_INSTALL_ROOT="$PWD/.cargo"
-              export CARGO_TARGET_DIR="$PWD/target"
-              export CARGO_CACHE_RUSTC_INFO=1
-              export PATH="$CARGO_INSTALL_ROOT/bin:$PATH"
-              export NIX_PATH="nixpkgs=${pkgs.path}"
-            '' + (lib.strings.optionalString pkgs.stdenv.isDarwin ''
-              export DYLD_FALLBACK_LIBRARY_PATH="$(rustc --print sysroot)/lib"
-            '');
-          };
+              shellHook = ''
+                export CARGO_HOME="$PWD/.cargo"
+                export CARGO_INSTALL_ROOT="$PWD/.cargo"
+                export CARGO_TARGET_DIR="$PWD/target"
+                export CARGO_CACHE_RUSTC_INFO=1
+                export PATH="$CARGO_INSTALL_ROOT/bin:$PATH"
+                export NIX_PATH="nixpkgs=${pkgs.path}"
+              '' + (lib.strings.optionalString pkgs.stdenv.isDarwin ''
+                export DYLD_FALLBACK_LIBRARY_PATH="$(rustc --print sysroot)/lib"
+              '');
+            };
       };
     };
 }
+
+

--- a/nix/modules/holochain-crate2nix.nix
+++ b/nix/modules/holochain-crate2nix.nix
@@ -31,7 +31,7 @@
     in
     {
       packages = {
-        holochain-crates-standalone =
+        build-holochain-build-crates-standalone =
           mkNoIfdPackage "holochain" cargoNix.allWorkspaceMembers;
       };
     };

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -64,7 +64,7 @@
       });
 
       holochainNextestDeps = craneLib.buildDepsOnly (commonArgs // {
-        pname = "holochain-nextest";
+        pname = "holochain-tests-nextest";
         CARGO_PROFILE = "fast-test";
         nativeBuildInputs = [ pkgs.cargo-nextest ];
         buildPhase = ''
@@ -100,6 +100,8 @@
           __noChroot = pkgs.stdenv.isLinux;
           cargoArtifacts = holochainNextestDeps;
 
+          pname = "holochain-tests-nextest";
+
           preCheck = ''
             export DYLD_FALLBACK_LIBRARY_PATH=$(rustc --print sysroot)/lib
           '';
@@ -125,7 +127,7 @@
       holochain-tests-nextest = craneLib.cargoNextest holochainTestsNextestArgs;
       holochain-tests-nextest-tx5 = craneLib.cargoNextest
         (holochainTestsNextestArgs // {
-          pname = "holochain-nextest-tx5";
+          pname = "holochain-tests-nextest-tx5";
           cargoExtraArgs = holochainTestsNextestArgs.cargoExtraArgs + '' \
             --features tx5 \
           '';

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -124,8 +124,8 @@
           '';
         });
 
-      holochain-tests-nextest = craneLib.cargoNextest holochainTestsNextestArgs;
-      holochain-tests-nextest-tx5 = craneLib.cargoNextest
+      build-holochain-tests-unit = craneLib.cargoNextest holochainTestsNextestArgs;
+      build-holochain-tests-unit-tx5 = craneLib.cargoNextest
         (holochainTestsNextestArgs // {
           pname = "holochain-tests-nextest-tx5";
           cargoExtraArgs = holochainTestsNextestArgs.cargoExtraArgs + '' \
@@ -137,7 +137,7 @@
           ];
         });
 
-      holochain-tests-fmt = craneLib.cargoFmt (commonArgs // {
+      build-holochain-tests-static-fmt = craneLib.cargoFmt (commonArgs // {
         src = flake.config.srcCleanedHolochain;
         cargoArtifacts = null;
         doCheck = false;
@@ -146,7 +146,7 @@
         dontFixup = true;
       });
 
-      holochain-tests-clippy = craneLib.cargoClippy (commonArgs // {
+      build-holochain-tests-static-clippy = craneLib.cargoClippy (commonArgs // {
         pname = "holochain-tests-clippy";
         src = flake.config.srcCleanedHolochain;
         cargoArtifacts = holochainDeps;
@@ -180,7 +180,7 @@
         cargoArtifacts = null;
       });
 
-      holochain-tests-wasm = craneLib.cargoTest (holochainWasmArgs // {
+      build-holochain-tests-unit-wasm = craneLib.cargoTest (holochainWasmArgs // {
         cargoArtifacts = holochainDepsWasm;
 
         dontPatchELF = true;
@@ -192,23 +192,50 @@
         '';
       });
 
-      holochain-tests-doc = craneLib.cargoDoc (commonArgs // {
+      build-holochain-tests-static-doc = craneLib.cargoDoc (commonArgs // {
         pname = "holochain-tests-docs";
         cargoArtifacts = holochainDeps;
       });
 
+
+
+      # meta packages to build multiple test packages at once
+      build-holochain-tests-unit-all = config.lib.mkMetaPkg "holochain-tests-unit-all" [
+        build-holochain-tests-unit
+        build-holochain-tests-unit-tx5
+        build-holochain-tests-unit-wasm
+      ];
+
+      build-holochain-tests-static-all = config.lib.mkMetaPkg "holochain-tests-static-all" [
+        build-holochain-tests-static-doc
+        build-holochain-tests-static-fmt
+        build-holochain-tests-static-clippy
+      ];
+
+      build-holochain-tests-all = config.lib.mkMetaPkg "build-holochain-tests-all" [
+        build-holochain-tests-unit-all
+        build-holochain-tests-static-all
+      ];
+
     in
     {
-      packages = {
-        inherit
-          holochain
-          holochain-tests-nextest
-          holochain-tests-nextest-tx5
-          holochain-tests-doc
-          holochain-tests-wasm
-          holochain-tests-fmt
-          holochain-tests-clippy
-          ;
-      };
+      packages =
+        {
+          inherit
+            holochain
+
+            build-holochain-tests-unit
+            build-holochain-tests-unit-tx5
+            build-holochain-tests-unit-wasm
+            build-holochain-tests-unit-all
+
+            build-holochain-tests-static-doc
+            build-holochain-tests-static-fmt
+            build-holochain-tests-static-clippy
+            build-holochain-tests-static-all
+
+            build-holochain-tests-all
+            ;
+        };
     };
 }

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -163,16 +163,15 @@
 
       holochainWasmArgs = (commonArgs // {
         pname = "holochain-tests-wasm";
-        cargoExtraArgs =
-          "--lib --all-features";
 
-        cargoToml = "${flake.config.srcCleanedHolochain}/crates/test_utils/wasm/wasm_workspace/Cargo.toml";
-        cargoLock = "${flake.config.srcCleanedHolochain}/crates/test_utils/wasm/wasm_workspace/Cargo.lock";
-
-        postUnpack = ''
-          cd $sourceRoot/crates/test_utils/wasm/wasm_workspace
-          sourceRoot="."
+        postConfigure = ''
+          export CARGO_TARGET_DIR=''${CARGO_TARGET_DIR:-$PWD/target}
         '';
+
+        cargoExtraArgs =
+          "--lib --all-features --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml";
+
+        cargoLock = "${flake.config.srcCleanedHolochain}/crates/test_utils/wasm/wasm_workspace/Cargo.lock";
       });
 
       holochainDepsWasm = craneLib.buildDepsOnly (holochainWasmArgs // {

--- a/nix/modules/holonix-integration-test.nix
+++ b/nix/modules/holonix-integration-test.nix
@@ -23,7 +23,7 @@
           '';
     in
     {
-      packages.holonix-tests-integration = self'.devShells.holonix.overrideAttrs (old: {
+      packages.build-holonix-tests-integration = self'.devShells.holonix.overrideAttrs (old: {
         buildPhase = ''
           ${testScript}
           touch $out

--- a/nix/modules/lib.nix
+++ b/nix/modules/lib.nix
@@ -1,0 +1,19 @@
+{ self, lib, ... }: {
+  perSystem = { config, self', inputs', pkgs, ... }: {
+    options.lib = lib.mkOption { type = lib.types.raw; };
+    config.lib.mkMetaPkg = name: dependencies: pkgs.stdenv.mkDerivation {
+      inherit name;
+      dontUnpack = true;
+      installPhase = ''
+        mkdir $out
+      '' + builtins.concatStringsSep "\n" (builtins.map (pkg: "${pkgs.coreutils}/bin/ln -sf ${pkg} $out/${pkg.name or pkg.pname}")
+        dependencies
+      );
+
+      passthru = { inherit dependencies; };
+    };
+
+
+  };
+  flake = { };
+}

--- a/nix/modules/release-automation.nix
+++ b/nix/modules/release-automation.nix
@@ -105,7 +105,7 @@
       packages = {
         release-automation = package;
 
-        release-automation-tests = tests;
+        build-release-automation-tests = tests;
 
         # check the state of the repository
         # TODO: to get the actual .git repo we could be something like this:
@@ -121,7 +121,7 @@
         # nix flake lock --update-input repo-git --override-input repo-git "path:$tmpdir"
         # rm -rf $tmpgit
         # ```
-        release-automation-tests-repo = pkgs.runCommand
+        build-release-automation-tests-repo = pkgs.runCommand
           "release-automation-tests-repo"
           {
             __noChroot = pkgs.stdenv.isLinux;


### PR DESCRIPTION
### Summary
these scripts allow running the test commands in an impure working
directory, so that the target directory can be reused across runs.

this is a compromise to enable quick iterations on the codebase.

FYI @DavHau 


### TODO:
- [x] propse and get consensus on a naming scheme for test packages and scripts
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
