### PR TITLE
whoops, fix mistaken bootstrap net assumption

### DIFF
--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net.rs
@@ -367,8 +367,11 @@ impl MetaNet {
                     };
                     conf.proxy_from_bootstrap_cb = Arc::new(|bootstrap_url| {
                         Box::pin(async move {
-                            match crate::spawn::actor::bootstrap::proxy_list(bootstrap_url.into())
-                                .await
+                            match crate::spawn::actor::bootstrap::proxy_list(
+                                bootstrap_url.into(),
+                                crate::spawn::actor::bootstrap::BootstrapNet::Tx2,
+                            )
+                            .await
                             {
                                 Ok(mut proxy_list) => {
                                     if proxy_list.is_empty() {


### PR DESCRIPTION
I mistakenly set the `tx5` net flag when the `tx5` feature was enabled. But the feature just allows WebRTC to be used, so we need to only pass that flag to the bootstrap server when the config is actually using WebRTC.