### PR TITLE
docs(release): replace `nix-shell` with `nix run`

### DIFF
--- a/docs/release/release.md
+++ b/docs/release/release.md
@@ -188,11 +188,10 @@ With
 When we plan to change the versions of many or all workspace crates, there's a command that can be used to overwrite the frontmatter of multiple crates' changelogs in one go:
 
 ```console
-nix-shell --pure --argstr devShellId release --run 'release-automation --workspace-path=$PWD --log-level=debug --match-filter=".*" changelog set-frontmatter <(cat <<EOF
+nix run .#release-automation -- --workspace-path=$PWD --log-level=debug --match-filter=".*" changelog set-frontmatter <(cat <<EOF
 (...)
 EOF
 )
-'
 ```
 
 The `--match-filter` argument takes a regular expression to select to filter the crate names.
@@ -202,19 +201,17 @@ The ellipsis give the position of the new YAML code for the frontmatters.
 
 
 ```console
-nix-shell --pure --argstr devShellId release --run 'release-automation --workspace-path=$PWD --log-level=debug --match-filter=".*" changelog set-frontmatter <(cat <<EOF
+nix run .#release-automation -- --workspace-path=$PWD --log-level=debug --match-filter=".*" changelog set-frontmatter <(cat <<EOF
 default_semver_increment_mode: !pre_minor beta-rc
 EOF
 )
-'
 ```
 
 ### Example: initiate a one-time minor version bump
 
 ```console
-nix-shell --pure --argstr devShellId release --run 'release-automation --workspace-path=$PWD --log-level=debug --match-filter=".*" changelog set-frontmatter <(cat <<EOF
+nix run .#release-automation -- --workspace-path=$PWD --log-level=debug --match-filter=".*" changelog set-frontmatter <(cat <<EOF
 semver_increment_mode: !minor
 EOF
 )
-'
 ```


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
