### PR TITLE
Tracing Fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "getrandom 0.2.8",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.2.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e90af4de65aa7b293ef2d09daff88501eb254f58edde2e1ac02c82d873eadad"
+checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -292,7 +304,7 @@ dependencies = [
  "log",
  "memchr",
  "once_cell",
- "pin-project-lite",
+ "pin-project-lite 0.2.9",
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
@@ -474,7 +486,7 @@ checksum = "3c2f0dc9a68c6317d884f97cc36cf5a3d20ba14ce404227df55e1af708ab04bc"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.2",
- "constant_time_eq 0.2.4",
+ "constant_time_eq 0.2.5",
 ]
 
 [[package]]
@@ -488,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -595,6 +607,12 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
@@ -607,9 +625,9 @@ checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "camino"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6031a462f977dd38968b6f23378356512feeace69cef817e1a4475108093cec3"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
  "serde",
 ]
@@ -631,7 +649,7 @@ checksum = "08a1ec454bc3eead8719cb56e15dbbfecdbc14e4b3a3ae4936cc6e31f5fc0d07"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.16",
+ "semver 1.0.17",
  "serde",
  "serde_json",
  "thiserror",
@@ -679,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -710,19 +728,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive 3.1.18",
+ "clap_derive 3.2.18",
  "clap_lex 0.2.4",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.15.2",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
@@ -743,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
@@ -860,9 +878,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ad85c1f65dc7b37604eb0e89748faf0b9653065f2a8ef69f96a687ec1e9279"
+checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 
 [[package]]
 name = "contrafact"
@@ -1014,7 +1032,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
- "tokio",
+ "tokio 1.26.0",
  "walkdir",
 ]
 
@@ -1274,12 +1292,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core 0.14.3",
- "darling_macro 0.14.3",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
 ]
 
 [[package]]
@@ -1312,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1348,11 +1366,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core 0.14.3",
+ "darling_core 0.14.4",
  "quote",
  "syn",
 ]
@@ -1393,9 +1411,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.2.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8beee4701e2e229e8098bbdecdca12449bc3e322f137d269182fa1291e20bd00"
+checksum = "f3cdeb9ec472d588e539a818b2dee436825730da08ad0017c4b1a17676bdc8b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1449,8 +1467,8 @@ dependencies = [
  "crossterm 0.26.1",
  "futures",
  "holochain_diagnostics",
- "observability",
- "tokio",
+ "holochain_trace",
+ "tokio 1.26.0",
  "tokio-stream",
  "tui",
 ]
@@ -1488,7 +1506,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "crypto-common",
 ]
 
@@ -1640,7 +1658,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03e7b551eba279bf0fa88b83a46330168c1560a52a94f5126f892f0b364ab3e0"
 dependencies = [
- "darling 0.14.3",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn",
@@ -1648,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
  "log",
 ]
@@ -1855,9 +1873,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1870,9 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1880,15 +1898,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1897,9 +1915,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-lite"
@@ -1912,15 +1930,15 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite",
+ "pin-project-lite 0.2.9",
  "waker-fn",
 ]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1929,15 +1947,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-timer"
@@ -1947,9 +1965,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1958,7 +1976,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.2.9",
  "pin-utils",
  "slab",
 ]
@@ -2046,14 +2064,13 @@ dependencies = [
 
 [[package]]
 name = "ghost_actor"
-version = "0.3.0-alpha.4"
+version = "0.3.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecc8c54b8ebb1e0347a75a2c1e54268c737313da693f99c0964643011e5406d"
+checksum = "b0f758b0048e5f55f4d927932a32eb4ab8a850c4b9a7951b259ba6c8792d5c38"
 dependencies = [
  "futures",
- "mockall 0.10.2",
+ "mockall 0.11.3",
  "must_future",
- "observability",
  "paste",
  "thiserror",
  "tracing",
@@ -2128,7 +2145,7 @@ version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -2136,7 +2153,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 1.26.0",
  "tokio-util",
  "tracing",
 ]
@@ -2209,7 +2226,7 @@ dependencies = [
  "holo_hash",
  "holochain_integrity_types",
  "holochain_wasmer_guest",
- "mockall 0.10.2",
+ "mockall 0.11.3",
  "paste",
  "serde",
  "serde_bytes",
@@ -2244,7 +2261,7 @@ dependencies = [
 name = "hdk_derive"
 version = "0.1.0"
 dependencies = [
- "darling 0.14.3",
+ "darling 0.14.4",
  "heck 0.4.1",
  "holochain_integrity_types",
  "paste",
@@ -2262,7 +2279,7 @@ checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
  "bitflags",
- "bytes",
+ "bytes 1.4.0",
  "headers-core",
  "http",
  "httpdate",
@@ -2357,7 +2374,7 @@ dependencies = [
  "async-trait",
  "base64 0.13.1",
  "byteorder",
- "bytes",
+ "bytes 1.4.0",
  "cfg-if 0.1.10",
  "chrono",
  "contrafact",
@@ -2371,7 +2388,7 @@ dependencies = [
  "futures",
  "get_if_addrs",
  "getrandom 0.2.8",
- "ghost_actor 0.3.0-alpha.4",
+ "ghost_actor 0.3.0-alpha.5",
  "hdk",
  "holo_hash",
  "holochain",
@@ -2383,6 +2400,7 @@ dependencies = [
  "holochain_sqlite",
  "holochain_state",
  "holochain_test_wasm_common",
+ "holochain_trace",
  "holochain_types",
  "holochain_util",
  "holochain_wasm_test_utils",
@@ -2400,12 +2418,11 @@ dependencies = [
  "lazy_static",
  "maplit",
  "matches",
- "mockall 0.10.2",
+ "mockall 0.11.3",
  "mr_bundle",
  "must_future",
  "nanoid 0.3.0",
  "num_cpus",
- "observability",
  "once_cell",
  "one_err",
  "parking_lot 0.10.2",
@@ -2432,12 +2449,12 @@ dependencies = [
  "test-case 1.2.3",
  "thiserror",
  "tiny-keccak",
- "tokio",
+ "tokio 1.26.0",
  "tokio-stream",
  "toml 0.5.11",
  "tracing",
  "tracing-futures",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber",
  "tx5-go-pion-turn",
  "tx5-signal-srv",
  "unwrap_to",
@@ -2458,7 +2475,7 @@ dependencies = [
  "fallible-iterator",
  "fixt",
  "futures",
- "ghost_actor 0.3.0-alpha.4",
+ "ghost_actor 0.3.0-alpha.5",
  "hdk",
  "hdk_derive",
  "holo_hash",
@@ -2466,19 +2483,19 @@ dependencies = [
  "holochain_serialized_bytes 0.0.51",
  "holochain_sqlite",
  "holochain_state",
+ "holochain_trace",
  "holochain_types",
  "holochain_zome_types",
  "isotest",
  "kitsune_p2p",
  "matches",
- "mockall 0.10.2",
- "observability",
+ "mockall 0.11.3",
  "pretty_assertions 0.7.2",
  "serde",
  "serde_derive",
  "test-case 2.2.2",
  "thiserror",
- "tokio",
+ "tokio 1.26.0",
  "tracing",
  "tracing-futures",
 ]
@@ -2491,9 +2508,9 @@ dependencies = [
  "futures",
  "holochain_cli_bundle",
  "holochain_cli_sandbox",
- "observability",
+ "holochain_trace",
  "structopt",
- "tokio",
+ "tokio 1.26.0",
 ]
 
 [[package]]
@@ -2514,7 +2531,7 @@ dependencies = [
  "structopt",
  "tempfile",
  "thiserror",
- "tokio",
+ "tokio 1.26.0",
 ]
 
 [[package]]
@@ -2528,19 +2545,19 @@ dependencies = [
  "futures",
  "holochain_conductor_api",
  "holochain_p2p",
+ "holochain_trace",
  "holochain_types",
  "holochain_util",
  "holochain_websocket",
  "matches",
  "nanoid 0.3.0",
- "observability",
  "once_cell",
  "portpicker",
  "serde",
  "serde_yaml",
  "sodoken",
  "structopt",
- "tokio",
+ "tokio 1.26.0",
  "tracing",
  "url2",
  "walkdir",
@@ -2557,11 +2574,11 @@ dependencies = [
  "holochain_p2p",
  "holochain_serialized_bytes 0.0.51",
  "holochain_state",
+ "holochain_trace",
  "holochain_types",
  "holochain_zome_types",
  "kitsune_p2p",
  "matches",
- "observability",
  "serde",
  "serde_derive",
  "serde_yaml",
@@ -2583,7 +2600,7 @@ dependencies = [
  "rand 0.8.5",
  "tracing",
  "tracing-appender",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
  "tui",
 ]
 
@@ -2626,7 +2643,7 @@ dependencies = [
  "sodoken",
  "tempdir",
  "thiserror",
- "tokio",
+ "tokio 1.26.0",
  "tracing",
 ]
 
@@ -2646,23 +2663,23 @@ dependencies = [
  "derive_more",
  "fixt",
  "futures",
- "ghost_actor 0.3.0-alpha.4",
+ "ghost_actor 0.3.0-alpha.5",
  "holo_hash",
  "holochain_keystore",
  "holochain_serialized_bytes 0.0.51",
+ "holochain_trace",
  "holochain_types",
  "holochain_util",
  "holochain_zome_types",
  "kitsune_p2p",
  "kitsune_p2p_types",
- "mockall 0.10.2",
- "observability",
+ "mockall 0.11.3",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
  "serde_json",
  "thiserror",
- "tokio",
+ "tokio 1.26.0",
  "tokio-stream",
 ]
 
@@ -2736,6 +2753,7 @@ dependencies = [
  "getrandom 0.2.8",
  "holo_hash",
  "holochain_serialized_bytes 0.0.51",
+ "holochain_trace",
  "holochain_util",
  "holochain_zome_types",
  "kitsune_p2p",
@@ -2744,7 +2762,6 @@ dependencies = [
  "nanoid 0.3.0",
  "num-traits",
  "num_cpus",
- "observability",
  "once_cell",
  "page_size",
  "parking_lot 0.10.2",
@@ -2762,7 +2779,7 @@ dependencies = [
  "sqlformat 0.1.8",
  "tempfile",
  "thiserror",
- "tokio",
+ "tokio 1.26.0",
  "tracing",
  "tracing-futures",
 ]
@@ -2792,15 +2809,15 @@ dependencies = [
  "holochain_p2p",
  "holochain_serialized_bytes 0.0.51",
  "holochain_sqlite",
+ "holochain_trace",
  "holochain_types",
  "holochain_util",
  "holochain_wasm_test_utils",
  "holochain_zome_types",
  "kitsune_p2p",
  "matches",
- "mockall 0.10.2",
+ "mockall 0.11.3",
  "nanoid 0.3.0",
- "observability",
  "one_err",
  "parking_lot 0.10.2",
  "pretty_assertions 0.6.1",
@@ -2810,7 +2827,7 @@ dependencies = [
  "shrinkwraprs",
  "tempfile",
  "thiserror",
- "tokio",
+ "tokio 1.26.0",
  "tracing",
  "tracing-futures",
 ]
@@ -2821,6 +2838,29 @@ version = "0.1.0"
 dependencies = [
  "hdk",
  "serde",
+]
+
+[[package]]
+name = "holochain_trace"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "derive_more",
+ "holochain_serialized_bytes 0.0.52",
+ "inferno",
+ "once_cell",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "shrinkwraprs",
+ "thiserror",
+ "tokio 0.2.25",
+ "tokio 1.26.0",
+ "tracing",
+ "tracing-core",
+ "tracing-futures",
+ "tracing-serde",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2846,6 +2886,7 @@ dependencies = [
  "holochain_keystore",
  "holochain_serialized_bytes 0.0.51",
  "holochain_sqlite",
+ "holochain_trace",
  "holochain_types",
  "holochain_util",
  "holochain_zome_types",
@@ -2855,11 +2896,10 @@ dependencies = [
  "lazy_static",
  "maplit",
  "matches",
- "mockall 0.10.2",
+ "mockall 0.11.3",
  "mr_bundle",
  "must_future",
  "nanoid 0.3.0",
- "observability",
  "one_err",
  "parking_lot 0.10.2",
  "pretty_assertions 0.7.2",
@@ -2878,7 +2918,7 @@ dependencies = [
  "tempfile",
  "test-case 2.2.2",
  "thiserror",
- "tokio",
+ "tokio 1.26.0",
  "tracing",
 ]
 
@@ -2895,7 +2935,7 @@ dependencies = [
  "once_cell",
  "rpassword 7.2.0",
  "sodoken",
- "tokio",
+ "tokio 1.26.0",
 ]
 
 [[package]]
@@ -2964,17 +3004,17 @@ dependencies = [
  "futures",
  "ghost_actor 0.4.0-alpha.5",
  "holochain_serialized_bytes 0.0.51",
+ "holochain_trace",
  "holochain_types",
  "linefeed",
  "must_future",
  "nanoid 0.3.0",
  "net2",
- "observability",
  "serde",
  "serde_bytes",
  "stream-cancel",
  "thiserror",
- "tokio",
+ "tokio 1.26.0",
  "tokio-stream",
  "tokio-tungstenite 0.13.0",
  "tracing",
@@ -3043,7 +3083,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "fnv",
  "itoa",
 ]
@@ -3054,9 +3094,9 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "http",
- "pin-project-lite",
+ "pin-project-lite 0.2.9",
 ]
 
 [[package]]
@@ -3083,7 +3123,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "termcolor",
- "toml 0.7.2",
+ "toml 0.7.3",
  "uuid 1.3.0",
 ]
 
@@ -3095,11 +3135,11 @@ checksum = "d0fb489e3108b684bba475a4cb9804260365870e2f60058265e3d0a3b309bdb1"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -3109,9 +3149,9 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project-lite",
+ "pin-project-lite 0.2.9",
  "socket2",
- "tokio",
+ "tokio 1.26.0",
  "tower-service",
  "tracing",
  "want",
@@ -3123,10 +3163,10 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "hyper",
  "native-tls",
- "tokio",
+ "tokio 1.26.0",
  "tokio-native-tls",
 ]
 
@@ -3220,23 +3260,22 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.10.12"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3886428c6400486522cf44b8626e7b94ad794c14390290f2a274dcf728a58f"
+checksum = "2fb7c1b80a1dfa604bb4a649a5c5aeef3d913f7c520cb42b40e534e8a61bcdfc"
 dependencies = [
- "ahash 0.7.6",
- "atty",
- "clap 3.1.18",
+ "ahash 0.8.3",
+ "clap 4.1.8",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap 5.4.0",
  "env_logger",
  "indexmap",
+ "is-terminal",
  "itoa",
- "lazy_static",
  "log",
  "num-format",
- "num_cpus",
+ "once_cell",
  "quick-xml",
  "rgb",
  "str_stack",
@@ -3248,7 +3287,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f97967975f448f1a7ddb12b0bc41069d09ed6a1c161a92687e057325db35d413"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
 ]
 
 [[package]]
@@ -3353,13 +3392,14 @@ dependencies = [
  "base64 0.13.1",
  "blake2b_simd 0.5.11",
  "bloomfilter",
- "bytes",
+ "bytes 1.4.0",
  "contrafact",
  "derive_more",
  "fixt",
  "futures",
- "ghost_actor 0.3.0-alpha.4",
+ "ghost_actor 0.3.0-alpha.5",
  "governor",
+ "holochain_trace",
  "itertools 0.10.5",
  "kitsune_p2p",
  "kitsune_p2p_block",
@@ -3372,10 +3412,10 @@ dependencies = [
  "kitsune_p2p_types",
  "maplit",
  "mockall 0.10.2",
+ "mockall 0.11.3",
  "must_future",
  "nanoid 0.4.0",
  "num-traits",
- "observability",
  "once_cell",
  "parking_lot 0.11.2",
  "pretty_assertions 0.7.2",
@@ -3387,10 +3427,10 @@ dependencies = [
  "shrinkwraprs",
  "test-case 1.2.3",
  "thiserror",
- "tokio",
+ "tokio 1.26.0",
  "tokio-stream",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber",
  "tx5",
  "url2",
 ]
@@ -3421,7 +3461,7 @@ dependencies = [
 name = "kitsune_p2p_bootstrap"
 version = "0.0.12-dev.0"
 dependencies = [
- "clap 3.1.18",
+ "clap 3.2.23",
  "criterion",
  "fixt",
  "futures",
@@ -3435,7 +3475,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "tokio",
+ "tokio 1.26.0",
  "warp",
 ]
 
@@ -3449,6 +3489,7 @@ dependencies = [
  "futures",
  "gcollections",
  "holochain_serialized_bytes 0.0.51",
+ "holochain_trace",
  "intervallum",
  "kitsune_p2p_dht",
  "kitsune_p2p_dht_arc",
@@ -3456,7 +3497,6 @@ dependencies = [
  "maplit",
  "must_future",
  "num-traits",
- "observability",
  "once_cell",
  "pretty_assertions 0.7.2",
  "proptest",
@@ -3474,10 +3514,10 @@ version = "0.1.0"
 dependencies = [
  "derive_more",
  "gcollections",
+ "holochain_trace",
  "intervallum",
  "maplit",
  "num-traits",
- "observability",
  "pretty_assertions 0.7.2",
  "rand 0.8.5",
  "rusqlite",
@@ -3507,7 +3547,7 @@ dependencies = [
  "serde_json",
  "sodoken",
  "structopt",
- "tokio",
+ "tokio 1.26.0",
  "tokio-tungstenite 0.14.0",
  "tungstenite 0.13.0",
  "url2",
@@ -3533,8 +3573,8 @@ dependencies = [
  "kitsune_p2p_transport_quic",
  "rand 0.8.5",
  "structopt",
- "tokio",
- "tracing-subscriber 0.2.25",
+ "tokio 1.26.0",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3544,6 +3584,7 @@ dependencies = [
  "derive_more",
  "futures",
  "holochain_serialized_bytes 0.0.51",
+ "holochain_trace",
  "human-repr",
  "kitsune_p2p_fetch",
  "kitsune_p2p_timestamp",
@@ -3551,13 +3592,12 @@ dependencies = [
  "linked-hash-map",
  "must_future",
  "num-traits",
- "observability",
  "pretty_assertions 0.7.2",
  "serde",
  "serde_bytes",
  "test-case 1.2.3",
  "thiserror",
- "tokio",
+ "tokio 1.26.0",
  "tracing",
 ]
 
@@ -3572,7 +3612,7 @@ dependencies = [
  "futures-util",
  "libmdns",
  "mdns",
- "tokio",
+ "tokio 1.26.0",
  "tokio-stream",
 ]
 
@@ -3586,18 +3626,18 @@ dependencies = [
  "crossterm 0.19.0",
  "derive_more",
  "futures",
+ "holochain_trace",
  "kitsune_p2p_transport_quic",
  "kitsune_p2p_types",
  "nanoid 0.3.0",
- "observability",
  "parking_lot 0.11.2",
  "rmp-serde 0.15.5",
  "rustls",
  "serde",
  "serde_bytes",
  "structopt",
- "tokio",
- "tracing-subscriber 0.2.25",
+ "tokio 1.26.0",
+ "tracing-subscriber",
  "webpki 0.21.4",
 ]
 
@@ -3628,7 +3668,7 @@ dependencies = [
  "rcgen 0.9.3",
  "rustls",
  "serde",
- "tokio",
+ "tokio 1.26.0",
  "webpki 0.22.0",
 ]
 
@@ -3641,16 +3681,16 @@ dependencies = [
  "criterion",
  "derive_more",
  "futures",
- "ghost_actor 0.3.0-alpha.4",
+ "ghost_actor 0.3.0-alpha.5",
+ "holochain_trace",
  "kitsune_p2p_bin_data",
  "kitsune_p2p_dht",
  "kitsune_p2p_dht_arc",
  "kitsune_p2p_types",
  "lair_keystore_api",
  "lru",
- "mockall 0.10.2",
+ "mockall 0.11.3",
  "nanoid 0.3.0",
- "observability",
  "once_cell",
  "parking_lot 0.11.2",
  "paste",
@@ -3662,9 +3702,9 @@ dependencies = [
  "shrinkwraprs",
  "sysinfo",
  "thiserror",
- "tokio",
+ "tokio 1.26.0",
  "tokio-stream",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber",
  "url 2.3.1",
  "url2",
  "webpki 0.22.0",
@@ -3692,7 +3732,7 @@ dependencies = [
  "sqlformat 0.2.1",
  "structopt",
  "sysinfo",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3712,7 +3752,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "tokio",
+ "tokio 1.26.0",
  "toml 0.5.11",
  "tracing",
  "url 2.3.1",
@@ -3734,9 +3774,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libflate"
@@ -3790,7 +3830,7 @@ dependencies = [
  "rand 0.8.5",
  "socket2",
  "thiserror",
- "tokio",
+ "tokio 1.26.0",
  "winapi 0.3.9",
 ]
 
@@ -3934,15 +3974,6 @@ name = "match_cfg"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
-
-[[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata",
-]
 
 [[package]]
 name = "matchers"
@@ -4176,7 +4207,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "bytes",
+ "bytes 1.4.0",
  "derive_more",
  "either",
  "flate2",
@@ -4192,7 +4223,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "thiserror",
- "tokio",
+ "tokio 1.26.0",
 ]
 
 [[package]]
@@ -4539,29 +4570,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "observability"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ee3ae3ce7a7b9f875526d3f956c106f991114f1c61a0e10553918256efc8fc"
-dependencies = [
- "chrono",
- "derive_more",
- "holochain_serialized_bytes 0.0.52",
- "inferno",
- "once_cell",
- "opentelemetry",
- "serde",
- "serde_bytes",
- "serde_json",
- "thiserror",
- "tracing",
- "tracing-core",
- "tracing-opentelemetry",
- "tracing-serde",
- "tracing-subscriber 0.2.25",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4644,21 +4652,6 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "opentelemetry"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf68b6b34b5d869342732c0dc05f74b7bdb4f17f2302d16d799231a6106441"
-dependencies = [
- "bincode",
- "futures",
- "lazy_static",
- "percent-encoding 2.2.0",
- "pin-project 0.4.30",
- "rand 0.7.3",
- "serde",
 ]
 
 [[package]]
@@ -4835,9 +4828,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.5"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pem"
@@ -4910,31 +4903,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
-dependencies = [
- "pin-project-internal 0.4.30",
-]
-
-[[package]]
-name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
- "pin-project-internal 1.0.12",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -4947,6 +4920,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "257b64915a082f7811703966789728173279bdebb956b143dbcd23f6f970a777"
 
 [[package]]
 name = "pin-project-lite"
@@ -4996,16 +4975,18 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.5.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22122d5ec4f9fe1b3916419b76be1e80bcb93f618d071d2edf841b137b2a2bd6"
+checksum = "7e1f879b2998099c2d69ab9605d145d5b661195627eccc680002c4918a7fb6fa"
 dependencies = [
  "autocfg 1.1.0",
+ "bitflags",
  "cfg-if 1.0.0",
+ "concurrent-queue",
  "libc",
  "log",
- "wepoll-ffi",
- "windows-sys 0.42.0",
+ "pin-project-lite 0.2.9",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -5138,9 +5119,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -5231,9 +5212,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.22.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8533f14c8382aaad0d592c812ac3b826162128b65662331e1127b45c3d18536b"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
 dependencies = [
  "memchr",
 ]
@@ -5244,7 +5225,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b435e71d9bfa0d8889927231970c51fb89c58fa63bffcab117c9c7a41e5ef8f"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "futures-channel",
  "futures-util",
  "fxhash",
@@ -5252,7 +5233,7 @@ dependencies = [
  "quinn-udp",
  "rustls",
  "thiserror",
- "tokio",
+ "tokio 1.26.0",
  "tracing",
  "webpki 0.22.0",
 ]
@@ -5263,7 +5244,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fce546b9688f767a57530652488420d419a8b1f44a478b451c3d1ab6d992a55"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "fxhash",
  "rand 0.8.5",
  "ring",
@@ -5287,15 +5268,15 @@ dependencies = [
  "libc",
  "quinn-proto",
  "socket2",
- "tokio",
+ "tokio 1.26.0",
  "tracing",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -5712,7 +5693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
  "base64 0.21.0",
- "bytes",
+ "bytes 1.4.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -5728,11 +5709,11 @@ dependencies = [
  "native-tls",
  "once_cell",
  "percent-encoding 2.2.0",
- "pin-project-lite",
+ "pin-project-lite 0.2.9",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 1.26.0",
  "tokio-native-tls",
  "tower-service",
  "url 2.3.1",
@@ -5917,7 +5898,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.16",
+ "semver 1.0.17",
 ]
 
 [[package]]
@@ -6026,9 +6007,9 @@ dependencies = [
 
 [[package]]
 name = "scheduled-thread-pool"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977a7519bff143a44f842fd07e80ad1329295bd71686457f18e496736f4bf9bf"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
  "parking_lot 0.12.1",
 ]
@@ -6107,9 +6088,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
 ]
@@ -6125,9 +6106,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
 dependencies = [
  "serde_derive",
 ]
@@ -6162,9 +6143,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6471,7 +6452,7 @@ dependencies = [
  "once_cell",
  "one_err",
  "parking_lot 0.12.1",
- "tokio",
+ "tokio 1.26.0",
 ]
 
 [[package]]
@@ -6534,8 +6515,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b0a9eb2715209fb8cc0d942fcdff45674bfc9f0090a0d897e85a22955ad159b"
 dependencies = [
  "futures-core",
- "pin-project 1.0.12",
- "tokio",
+ "pin-project",
+ "tokio 1.26.0",
 ]
 
 [[package]]
@@ -6699,7 +6680,7 @@ checksum = "767559c8f4ccd87d0191b0ca6bf4480a06bb7e8d98de2169e48d6b6ed18af1a6"
 dependencies = [
  "futures",
  "parking_lot 0.12.1",
- "tokio",
+ "tokio 1.26.0",
  "tracing",
 ]
 
@@ -6830,7 +6811,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "856bbca0314c328004691b9c0639fb198ca764d1ce0e20d4dd8b78f2697c2a6f"
 dependencies = [
- "darling 0.14.3",
+ "darling 0.14.4",
  "if_chain",
  "lazy_static",
  "proc-macro2",
@@ -6867,9 +6848,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -6986,18 +6967,29 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
+dependencies = [
+ "bytes 0.5.6",
+ "fnv",
+ "pin-project-lite 0.1.12",
+]
+
+[[package]]
+name = "tokio"
 version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg 1.1.0",
- "bytes",
+ "bytes 1.4.0",
  "libc",
  "memchr",
  "mio 0.8.6",
  "num_cpus",
  "parking_lot 0.12.1",
- "pin-project-lite",
+ "pin-project-lite 0.2.9",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
@@ -7022,7 +7014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio",
+ "tokio 1.26.0",
 ]
 
 [[package]]
@@ -7032,7 +7024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
 dependencies = [
  "rustls",
- "tokio",
+ "tokio 1.26.0",
  "webpki 0.22.0",
 ]
 
@@ -7043,8 +7035,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
+ "pin-project-lite 0.2.9",
+ "tokio 1.26.0",
  "tokio-util",
 ]
 
@@ -7057,8 +7049,8 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
- "pin-project 1.0.12",
- "tokio",
+ "pin-project",
+ "tokio 1.26.0",
  "tokio-native-tls",
  "tungstenite 0.12.0",
 ]
@@ -7071,8 +7063,8 @@ checksum = "1e96bb520beab540ab664bd5a9cfeaa1fcd846fa68c830b42e2c8963071251d2"
 dependencies = [
  "futures-util",
  "log",
- "pin-project 1.0.12",
- "tokio",
+ "pin-project",
+ "tokio 1.26.0",
  "tungstenite 0.13.0",
 ]
 
@@ -7086,7 +7078,7 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
- "tokio",
+ "tokio 1.26.0",
  "tokio-rustls",
  "tungstenite 0.17.3",
  "webpki 0.22.0",
@@ -7098,11 +7090,11 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "futures-core",
  "futures-sink",
- "pin-project-lite",
- "tokio",
+ "pin-project-lite 0.2.9",
+ "tokio 1.26.0",
  "tracing",
 ]
 
@@ -7117,9 +7109,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -7138,9 +7130,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.4"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+checksum = "08de71aa0d6e348f070457f85af8bd566e2bc452156a423ddf22861b3a953fae"
 dependencies = [
  "indexmap",
  "serde",
@@ -7176,7 +7168,7 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.2.9",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -7189,7 +7181,7 @@ checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
  "time 0.3.20",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -7219,7 +7211,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.12",
+ "pin-project",
  "tracing",
 ]
 
@@ -7235,20 +7227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-opentelemetry"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aba1fbd3e3152340cfa12087759543277affcce4a40a659bdb5ec21f725d3d6"
-dependencies = [
- "opentelemetry",
- "rand 0.7.3",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber 0.2.25",
-]
-
-[[package]]
 name = "tracing-serde"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7260,42 +7238,24 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
- "ansi_term 0.12.1",
- "chrono",
- "lazy_static",
- "matchers 0.0.1",
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
  "regex",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec 1.10.0",
  "thread_local",
+ "time 0.3.20",
  "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
-dependencies = [
- "matchers 0.1.0",
- "nu-ansi-term",
- "once_cell",
- "regex",
- "sharded-slab",
- "smallvec 1.10.0",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
 ]
 
 [[package]]
@@ -7346,7 +7306,7 @@ checksum = "8ada8297e8d70872fa9a551d93250a9f407beb9f37ef86494eb20012a2ff7c24"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
- "bytes",
+ "bytes 1.4.0",
  "http",
  "httparse",
  "input_buffer",
@@ -7366,7 +7326,7 @@ checksum = "5fe8dada8c1a3aeca77d6b51a4f1314e0f4b8e438b7b1b71e3ddaca8080e4093"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
- "bytes",
+ "bytes 1.4.0",
  "http",
  "httparse",
  "input_buffer",
@@ -7387,7 +7347,7 @@ checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
- "bytes",
+ "bytes 1.4.0",
  "http",
  "httparse",
  "log",
@@ -7415,14 +7375,14 @@ version = "0.0.1-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6319295029945803b08f571540ada077ac0f8d0482697feabf61655d2c7913ad"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "futures",
  "once_cell",
  "parking_lot 0.12.1",
  "prometheus",
  "rand 0.8.5",
  "rand-utf8",
- "tokio",
+ "tokio 1.26.0",
  "tracing",
  "tx5-core",
  "tx5-go-pion",
@@ -7451,7 +7411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff1b8ffc2d4f5ed903c1f4de9aa2f36dfe99b8b51998c226a6da999b4d4aec5"
 dependencies = [
  "parking_lot 0.12.1",
- "tokio",
+ "tokio 1.26.0",
  "tracing",
  "tx5-go-pion-sys",
  "url 2.3.1",
@@ -7489,7 +7449,7 @@ dependencies = [
  "get_if_addrs",
  "once_cell",
  "sha2 0.10.6",
- "tokio",
+ "tokio 1.26.0",
  "tracing",
  "tx5-core",
  "zip",
@@ -7511,7 +7471,7 @@ dependencies = [
  "rustls-pemfile 1.0.2",
  "sha2 0.10.6",
  "socket2",
- "tokio",
+ "tokio 1.26.0",
  "tokio-rustls",
  "tokio-tungstenite 0.17.2",
  "tracing",
@@ -7533,9 +7493,9 @@ dependencies = [
  "prometheus",
  "rand 0.8.5",
  "sodoken",
- "tokio",
+ "tokio 1.26.0",
  "tracing",
- "tracing-subscriber 0.3.16",
+ "tracing-subscriber",
  "tx5-core",
  "warp",
 ]
@@ -7569,9 +7529,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
 
 [[package]]
 name = "unicode-ident"
@@ -7800,7 +7760,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7b8be92646fc3d18b06147664ebc5f48d222686cb11a8755e561a735aacc6d"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "futures-channel",
  "futures-util",
  "headers",
@@ -7811,13 +7771,13 @@ dependencies = [
  "mime_guess",
  "multipart",
  "percent-encoding 2.2.0",
- "pin-project 1.0.12",
+ "pin-project",
  "rustls-pemfile 0.2.1",
  "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 1.26.0",
  "tokio-stream",
  "tokio-tungstenite 0.17.2",
  "tokio-util",
@@ -8228,15 +8188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wepoll-ffi"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "which"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8304,12 +8255,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -8323,24 +8274,24 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -8350,9 +8301,9 @@ checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8362,9 +8313,9 @@ checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8374,9 +8325,9 @@ checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8386,15 +8337,15 @@ checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8404,9 +8355,9 @@ checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "crates/holochain_sqlite",
   "crates/holochain_state",
   "crates/holochain_sqlite",
+  "crates/holochain_trace",
   "crates/holochain_websocket",
   "crates/holochain_util",
 
@@ -74,9 +75,7 @@ codegen-units = 16
 # holochain_wasmer_common = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "pr/bump-serde" }
 # holochain_serialized_bytes = { git = "https://github.com/holochain/holochain-serialization.git", branch = "develop" }
 # holochain_serialized_bytes_derive = { git = "https://github.com/holochain/holochain-serialization.git", branch = "develop" }
-# observability = { git = "https://github.com/freesig/observability.git", branch = "main" }
-# ghost_actor = { path = "../ghost_actor/crates/ghost_actor" }
-# ghost_actor = { git = "https://github.com/holochain/ghost_actor.git", branch = "add_observability" }
+#ghost_actor = { path = "../ghost_actor/crates/ghost_actor" }
 #lair_keystore_api = { path = "../lair/crates/lair_keystore_api" }
 #lair_keystore = { path = "../lair/crates/lair_keystore" }
 #lair_keystore_api_0_0 = { path = "../lair_0_0/crates/lair_keystore_api", package = "lair_keystore_api" }
@@ -84,5 +83,4 @@ codegen-units = 16
 #lair_keystore_api = { git = "https://github.com/holochain/lair.git", branch = "secretbox" }
 #lair_keystore_api_0_0 = { git = "https://github.com/holochain/lair.git", branch = "release-0.0.x-bump-sodoken", package = "lair_keystore_api" }
 #lair_keystore_client_0_0 = { git = "https://github.com/holochain/lair.git", branch = "release-0.0.x-bump-sodoken", package = "lair_keystore_client" }
-# observability = { path = "../../rust/observability" }
 # r2d2_sqlite = { path = "../r2d2-sqlite" }

--- a/crates/diagnostic_tests/Cargo.toml
+++ b/crates/diagnostic_tests/Cargo.toml
@@ -8,7 +8,7 @@ chashmap = "2.2"
 colored = "2"
 futures = "*"
 holochain_diagnostics = { path = "../holochain_diagnostics" }
-observability = "0.1"
+holochain_trace = { version = "^0.1.0", path = "../holochain_trace" }
 tokio = { version = "1.11", features = ["full"] }
 tokio-stream = "*"
 

--- a/crates/diagnostic_tests/examples/commit_loop.rs
+++ b/crates/diagnostic_tests/examples/commit_loop.rs
@@ -17,7 +17,7 @@ use holochain_diagnostics::*;
 
 #[tokio::main]
 async fn main() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let start = Instant::now();
 
     // let config = config_no_networking();

--- a/crates/diagnostic_tests/examples/link_storm.rs
+++ b/crates/diagnostic_tests/examples/link_storm.rs
@@ -70,7 +70,7 @@ fn config() -> ConductorConfig {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // observability::test_run().ok();
+    // holochain_trace::test_run().ok();
 
     let show_ui = std::env::var("NOUI").is_err();
 

--- a/crates/fixt/Cargo.toml
+++ b/crates/fixt/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 holochain_serialized_bytes = "=0.0.51"
 lazy_static = "1.4"
 parking_lot = "0.10"
-paste = "=1.0.5"
+paste = "1.0.12"
 rand = "0.8.5"
 rand_core = "0.6"
 serde = { version = "1.0", features = [ "derive" ] }

--- a/crates/fixt/test/Cargo.toml
+++ b/crates/fixt/test/Cargo.toml
@@ -12,4 +12,4 @@ edition = "2021"
 
 [dependencies]
 fixt = { path = ".." ,version = "^0.1.0"}
-paste = "1.0.5"
+paste = "1.0.12"

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -23,6 +23,6 @@ anyhow = "1.0"
 futures = "0.3"
 holochain_cli_bundle = { path = "../hc_bundle", version = "^0.1.0"}
 holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.1.0"}
-observability = "0.1.3"
+holochain_trace = { version = "^0.1.0", path = "../holochain_trace" }
 structopt = "0.3"
 tokio = { version = "1.11", features = [ "full" ] }

--- a/crates/hc/src/bin/hc.rs
+++ b/crates/hc/src/bin/hc.rs
@@ -4,7 +4,7 @@ use structopt::StructOpt;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     if std::env::var_os("RUST_LOG").is_some() {
-        observability::init_fmt(observability::Output::Log).ok();
+        holochain_trace::init_fmt(holochain_trace::Output::Log).ok();
     }
     let opt = hc::Opt::from_args();
     opt.run().await

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -25,7 +25,7 @@ holochain_websocket = { path = "../holochain_websocket", version = "^0.1.0"}
 holochain_p2p = { path = "../holochain_p2p", version = "^0.1.0"}
 holochain_util = { version = "^0.1.0", path = "../holochain_util", features = [ "pw" ] }
 nanoid = "0.3"
-observability = "0.1.3"
+holochain_trace = { version = "^0.1.0", path = "../holochain_trace" }
 once_cell = "1.13.0"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_yaml = "0.9"

--- a/crates/hc_sandbox/src/bin/hc-sandbox.rs
+++ b/crates/hc_sandbox/src/bin/hc-sandbox.rs
@@ -3,7 +3,7 @@ use structopt::StructOpt;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     if std::env::var_os("RUST_LOG").is_some() {
-        observability::init_fmt(observability::Output::Log).ok();
+        holochain_trace::init_fmt(holochain_trace::Output::Log).ok();
     }
     let ops = holochain_cli_sandbox::HcSandbox::from_args();
 

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -53,7 +53,7 @@ async fn check_timeout<T>(response: impl Future<Output = Result<T, ws::Websocket
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "Figure out how to get holochain bin in CI"]
 async fn run_holochain() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let port: u16 = pick_unused_port().expect("No ports free");
     let cmd = std::process::Command::cargo_bin("hc").unwrap();
     let mut cmd = Command::from(cmd);
@@ -70,7 +70,7 @@ async fn run_holochain() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "Figure out how to get holochain bin in CI"]
 async fn run_multiple_on_same_port() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let port: u16 = pick_unused_port().expect("No ports free");
     let app_port: u16 = pick_unused_port().expect("No ports free");
     let cmd = std::process::Command::cargo_bin("hc").unwrap();

--- a/crates/hdi/Cargo.toml
+++ b/crates/hdi/Cargo.toml
@@ -25,13 +25,13 @@ holochain_wasmer_guest = "=0.0.83"
 # it's important that we depend on holochain_integrity_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
 holochain_integrity_types = { version = "^0.1.0", path = "../holochain_integrity_types", default-features = false }
-paste = "=1.0.5"
+paste = "1.0"
 serde = "1.0"
 serde_bytes = "0.11"
 # thiserror = "1.0.22"
 tracing = { version = "0.1", optional = true }
 tracing-core = { version = "0.1", optional = true }
-mockall = { version = "0.10.2", optional = true }
+mockall = { version = "0.11.3", optional = true }
 
 
 [dev-dependencies]

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -31,13 +31,13 @@ holochain_wasmer_guest = "=0.0.83"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
 holochain_zome_types = { version = "^0.1.0", path = "../holochain_zome_types", default-features = false }
-paste = "=1.0.5"
+paste = "1.0"
 serde = "1.0"
 serde_bytes = "0.11"
 thiserror = "1.0.22"
 tracing = "0.1"
 tracing-core = "0.1"
-mockall = { version = "0.11.0", optional = true }
+mockall = { version = "0.11.3", optional = true }
 
 # When building for the WASM target, we need to configure getrandom
 # to use the host system for the source of crypto-secure randomness.

--- a/crates/hdk_derive/Cargo.toml
+++ b/crates/hdk_derive/Cargo.toml
@@ -17,7 +17,7 @@ proc-macro = true
 syn = { version = "1", features = ["full", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
-paste = "=1.0.5"
+paste = "1.0"
 darling = "0.14.1"
 heck = "0.4"
 # it's important that we depend on holochain_zome_types with no default

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -23,7 +23,7 @@ fixt = { version = "^0.1.0", path = "../fixt" }
 futures = "0.3.1"
 getrandom = "0.2.7"
 get_if_addrs = "0.5.3"
-ghost_actor = "0.3.0-alpha.4"
+ghost_actor = "0.3.0-alpha.5"
 holo_hash = { version = "^0.1.0", path = "../holo_hash", features = ["full"] }
 holochain_cascade = { version = "^0.1.0", path = "../holochain_cascade" }
 holochain_conductor_api = { version = "^0.1.0", path = "../holochain_conductor_api" }
@@ -42,12 +42,12 @@ kitsune_p2p = { version = "^0.1.0", path = "../kitsune_p2p/kitsune_p2p", default
 kitsune_p2p_types = { version = "^0.1.0", path = "../kitsune_p2p/types" }
 kitsune_p2p_block = { version = "^0.1.0", path = "../kitsune_p2p/block" }
 lazy_static = "1.4.0"
-mockall = "0.10.2"
+mockall = "0.11.3"
 mr_bundle = { version = "^0.1.0", path = "../mr_bundle" }
 must_future = "0.1.1"
 nanoid = "0.3"
 num_cpus = "1.8"
-observability = "0.1.3"
+holochain_trace = { version = "^0.1.0", path = "../holochain_trace" }
 once_cell = "1.4.1"
 one_err = "0.0.8"
 parking_lot = "0.10"
@@ -70,9 +70,9 @@ tokio = { version = "1.11", features = [ "full"] }
 tokio-stream = { version = "0.1", features = [ "sync", "net" ] }
 task-motel = "0.1.0-rc.1"
 toml = "0.5.6"
-tracing = "0.1.26"
+tracing = "0.1.37"
 tracing-futures = "0.2.5"
-tracing-subscriber = "0.2.19"
+tracing-subscriber = "0.3.16"
 url = "1.7.2"
 url2 = "0.0.6"
 url_serde = "0.2.0"

--- a/crates/holochain/benches/consistency.rs
+++ b/crates/holochain/benches/consistency.rs
@@ -21,7 +21,7 @@ criterion_group!(benches, consistency);
 criterion_main!(benches);
 
 fn consistency(bench: &mut Criterion) {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let mut group = bench.benchmark_group("consistency");
     group.sample_size(
         std::env::var_os("BENCH_SAMPLE_SIZE")

--- a/crates/holochain/benches/websocket.rs
+++ b/crates/holochain/benches/websocket.rs
@@ -21,7 +21,7 @@ use tracing::debug;
 
 // @todo fix after fixing new InstallApp tests
 // pub fn websocket_concurrent_install(c: &mut Criterion) {
-//     observability::test_run().ok();
+//     holochain_trace::test_run().ok();
 
 //     static REQ_TIMEOUT_MS: u64 = 15000;
 //     static NUM_DNA_CONCURRENCY: &[(u16, usize)] = &[(1, 1), (8, 4), (64, 10)];

--- a/crates/holochain/examples/websocket_install_dna.rs
+++ b/crates/holochain/examples/websocket_install_dna.rs
@@ -15,7 +15,7 @@ pub async fn main() {
     //     static NUM_CONCURRENT_INSTALLS: usize = 2;
     //     static REQ_TIMEOUT_MS: u64 = 30000;
 
-    //     observability::test_run().ok();
+    //     holochain_trace::test_run().ok();
     //     // NOTE: This is a full integration test that
     //     // actually runs the holochain binary
 

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -315,16 +315,16 @@ mod test {
     use crate::conductor::Conductor;
     use anyhow::Result;
     use holochain_state::prelude::*;
+    use holochain_trace;
     use holochain_types::test_utils::fake_dna_zomes;
     use holochain_types::test_utils::write_fake_dna_file;
     use holochain_wasm_test_utils::TestWasm;
     use matches::assert_matches;
-    use observability;
     use uuid::Uuid;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn register_list_dna_app() -> Result<()> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let env_dir = test_db_dir();
         let handle = Conductor::builder().test(env_dir.path(), &[]).await?;
 
@@ -451,7 +451,7 @@ mod test {
     // @todo fix test by using new InstallApp call
     // #[tokio::test(flavor = "multi_thread")]
     // async fn install_list_dna_app() {
-    // observability::test_run().ok();
+    // holochain_trace::test_run().ok();
     // let db_dir = test_db_dir();
     // let handle = Conductor::builder().test(db_dir.path(), &[]).await.unwrap();
     // let shutdown = handle.take_shutdown_handle().unwrap();

--- a/crates/holochain/src/conductor/cell/gossip_test.rs
+++ b/crates/holochain/src/conductor/cell/gossip_test.rs
@@ -11,7 +11,7 @@ use kitsune_p2p::KitsuneP2pConfig;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn gossip_test() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let config = SweetConductorConfig::standard().no_publish();
     let mut conductors = SweetConductorBatch::from_config(2, config).await;
 
@@ -40,7 +40,7 @@ async fn gossip_test() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn signature_smoke_test() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let mut network_config = KitsuneP2pConfig::default();
     network_config.transport_pool = vec![kitsune_p2p::TransportConfig::Mem {}];
     // Hit an actual bootstrap service so it can blow up and return an error if we get our end of
@@ -54,7 +54,7 @@ async fn signature_smoke_test() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn agent_info_test() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let config = SweetConductorConfig::standard().no_publish();
     let mut conductors = SweetConductorBatch::from_config(2, config).await;
 

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -157,7 +157,7 @@ async fn can_set_fake_state() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_list_running_apps_for_dependent_cell_id() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let mk_dna = |name: &'static str| async move {
         let zome = InlineIntegrityZome::new_unique(Vec::new(), 0);
@@ -246,7 +246,7 @@ async fn common_genesis_test_app(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_uninstall_app() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let (dna, _, _) = mk_dna(simple_crud_zome()).await;
     let mut conductor = SweetConductor::from_standard_config().await;
 
@@ -336,7 +336,7 @@ async fn test_uninstall_app() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_reconciliation_idempotency() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let zome = InlineIntegrityZome::new_unique(Vec::new(), 0);
     let mut conductor = SweetConductor::from_standard_config().await;
     common_genesis_test_app(&mut conductor, ("custom", zome))
@@ -360,7 +360,7 @@ async fn test_reconciliation_idempotency() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_signing_error_during_genesis() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let bad_keystore = spawn_crude_mock_keystore(|| "test error".into()).await;
 
     let db_dir = test_db_dir();
@@ -443,7 +443,7 @@ async fn test_signing_error_during_genesis() {
 // @todo fix test by using new InstallApp call
 // #[tokio::test(flavor = "multi_thread")]
 // async fn test_signing_error_during_genesis_doesnt_bork_interfaces() {
-//     observability::test_run().ok();
+//     holochain_trace::test_run().ok();
 //     let (keystore, keystore_control) = spawn_real_or_mock_keystore(|_| Err("test error".into()))
 //         .await
 //         .unwrap();
@@ -538,7 +538,7 @@ pub(crate) fn simple_create_entry_zome() -> InlineIntegrityZome {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_enable_disable_enable_app() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let zome = simple_create_entry_zome();
     let mut conductor = SweetConductor::from_standard_config().await;
     let app = common_genesis_test_app(&mut conductor, ("zome", zome))
@@ -622,7 +622,7 @@ async fn test_enable_disable_enable_app() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_enable_disable_enable_clone_cell() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let zome = simple_create_entry_zome();
     let mut conductor = SweetConductor::from_standard_config().await;
     let app = common_genesis_test_app(&mut conductor, ("zome", zome))
@@ -724,7 +724,7 @@ fn unwrap_cell_info_clone(cell_info: CellInfo) -> holochain_conductor_api::Clone
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_installation_fails_if_genesis_self_check_is_invalid() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let bad_zome = InlineZomeSet::new_unique_single("integrity", "custom", Vec::new(), 0).function(
         "integrity",
         "genesis_self_check",
@@ -751,7 +751,7 @@ async fn test_installation_fails_if_genesis_self_check_is_invalid() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_bad_entry_validation_after_genesis_returns_zome_call_error() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let unit_entry_def = EntryDef::from_id("unit");
     let bad_zome =
         InlineZomeSet::new_unique_single("integrity", "custom", vec![unit_entry_def.clone()], 0)
@@ -810,7 +810,7 @@ async fn test_bad_entry_validation_after_genesis_returns_zome_call_error() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "need to figure out how to write this test, i.e. to make genesis panic"]
 async fn test_apps_disable_on_panic_after_genesis() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let unit_entry_def = EntryDef::from_id("unit");
     let bad_zome =
         InlineZomeSet::new_unique_single("integrity", "custom", vec![unit_entry_def.clone()], 0)
@@ -861,7 +861,7 @@ async fn test_apps_disable_on_panic_after_genesis() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_app_status_states() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let zome = simple_create_entry_zome();
     let mut conductor = SweetConductor::from_standard_config().await;
     common_genesis_test_app(&mut conductor, ("zome", zome))
@@ -934,7 +934,7 @@ async fn test_app_status_states_multi_app() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_cell_and_app_status_reconciliation() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     use AppStatusFx::*;
     use AppStatusKind::*;
     use CellStatus::*;
@@ -1009,7 +1009,7 @@ async fn test_cell_and_app_status_reconciliation() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_app_status_filters() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let zome = InlineIntegrityZome::new_unique(Vec::new(), 0);
     let dnas = [mk_dna(("dna", zome)).await.0];
 
@@ -1077,7 +1077,7 @@ async fn test_app_status_filters() {
 /// concurrent initial zome function calls
 #[tokio::test(flavor = "multi_thread")]
 async fn test_init_concurrency() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let num_inits = Arc::new(AtomicU32::new(0));
     let num_calls = Arc::new(AtomicU32::new(0));
     let num_inits_clone = num_inits.clone();

--- a/crates/holochain/src/conductor/entry_def_store.rs
+++ b/crates/holochain/src/conductor/entry_def_store.rs
@@ -117,7 +117,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_store_entry_defs() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         // all the stuff needed to have a WasmBuf
         let db_dir = test_db_dir();

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -244,6 +244,7 @@ pub mod test {
     use holochain_serialized_bytes::prelude::*;
     use holochain_sqlite::prelude::*;
     use holochain_state::prelude::test_db_dir;
+    use holochain_trace;
     use holochain_types::prelude::*;
     use holochain_types::test_utils::fake_agent_pubkey_1;
     use holochain_types::test_utils::fake_dna_zomes;
@@ -258,7 +259,6 @@ pub mod test {
     use kitsune_p2p::fixt::AgentInfoSignedFixturator;
     use kitsune_p2p::{KitsuneAgent, KitsuneSpace};
     use matches::assert_matches;
-    use observability;
     use pretty_assertions::assert_eq;
     use std::collections::{HashMap, HashSet};
     use std::convert::TryInto;
@@ -381,7 +381,7 @@ pub mod test {
     #[ignore]
     #[allow(unreachable_code, unused_variables)]
     async fn invalid_request() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let (_tmpdir, conductor_handle) = setup_admin().await;
         let admin_api = RealAdminInterfaceApi::new(conductor_handle.clone());
         let dna_payload = InstallAppDnaPayload::hash_only(fake_dna_hash(1), "".to_string());
@@ -410,7 +410,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn websocket_call_zome_function() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let uuid = Uuid::new_v4();
         let dna = fake_dna_zomes(
             &uuid.to_string(),
@@ -449,7 +449,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn gossip_info_request() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let uuid = Uuid::new_v4();
         let dna = fake_dna_zomes(
             &uuid.to_string(),
@@ -498,7 +498,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn enable_disable_enable_app() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let agent_key = fake_agent_pubkey_1();
         let mut dnas = Vec::new();
         for _i in 0..2 as u32 {
@@ -684,7 +684,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn attach_app_interface() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let (_tmpdir, conductor_handle) = setup_admin().await;
         let admin_api = RealAdminInterfaceApi::new(conductor_handle.clone());
         let msg = AdminRequest::AttachAppInterface { port: None };
@@ -702,7 +702,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn dump_state() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let uuid = Uuid::new_v4();
         let dna = fake_dna_zomes(
             &uuid.to_string(),
@@ -768,7 +768,7 @@ pub mod test {
     /// across the admin websocket.
     #[tokio::test(flavor = "multi_thread")]
     async fn add_agent_info_via_admin() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let test_db_dir = test_db_dir();
         let agents = vec![fake_agent_pubkey_1(), fake_agent_pubkey_2()];
         let dnas = vec![

--- a/crates/holochain/src/conductor/manager/mod.rs
+++ b/crates/holochain/src/conductor/manager/mod.rs
@@ -420,11 +420,11 @@ mod test {
     use super::*;
     use crate::conductor::{error::ConductorError, Conductor};
     use holochain_state::test_utils::test_db_dir;
-    use observability;
+    use holochain_trace;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn unrecoverable_error() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let db_dir = test_db_dir();
         let handle = Conductor::builder().test(db_dir.path(), &[]).await.unwrap();
         let tm = handle.task_manager();
@@ -453,7 +453,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "panics in tokio break other tests, this test is here to confirm behavior but cannot be run on ci"]
     async fn unrecoverable_panic() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let db_dir = test_db_dir();
         let handle = Conductor::builder().test(db_dir.path(), &[]).await.unwrap();
         let tm = handle.task_manager();

--- a/crates/holochain/src/conductor/p2p_agent_store.rs
+++ b/crates/holochain/src/conductor/p2p_agent_store.rs
@@ -346,7 +346,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_store_agent_info_signed() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let test_db = test_p2p_agents_db();
         let db = test_db.to_db();
@@ -366,7 +366,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn add_agent_info_to_db() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let t_db = test_p2p_agents_db();
         let db = t_db.to_db();
 

--- a/crates/holochain/src/conductor/space/tests.rs
+++ b/crates/holochain/src/conductor/space/tests.rs
@@ -30,7 +30,7 @@ use super::Spaces;
 async fn test_region_queries() {
     const NUM_OPS: usize = 100;
 
-    // let _g = observability::test_run().ok();
+    // let _g = holochain_trace::test_run().ok();
 
     let mut u = Unstructured::new(&NOISE);
     let temp_dir = tempfile::TempDir::new().unwrap();

--- a/crates/holochain/src/core/ribosome.rs
+++ b/crates/holochain/src/core/ribosome.rs
@@ -698,7 +698,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn verify_zome_call_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/guest_callback/entry_defs.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/entry_defs.rs
@@ -207,7 +207,7 @@ mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_entry_defs_index_lookup() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::EntryDefs).await;

--- a/crates/holochain/src/core/ribosome/guest_callback/post_commit.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/post_commit.rs
@@ -229,7 +229,7 @@ mod slow_tests {
     #[ignore = "flakey. Sometimes fails the second last assert with 3 instead of 5"]
     #[cfg(feature = "test_utils")]
     async fn post_commit_test_volley() -> anyhow::Result<()> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/guest_callback/validate.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validate.rs
@@ -308,7 +308,7 @@ mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn pass_validate_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Validate).await;

--- a/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
@@ -158,7 +158,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "slow_tests")]
     async fn unlock_timeout_session() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -368,7 +368,7 @@ pub mod wasm_test {
     async fn unlock_invalid_session() {
         use holochain_state::nonce::fresh_nonce;
 
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -489,7 +489,7 @@ pub mod wasm_test {
     async fn lock_chain() {
         use holochain_state::nonce::fresh_nonce;
 
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -795,7 +795,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "slow_tests")]
     async fn enzymatic_session_success() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -934,7 +934,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "slow_tests")]
     async fn enzymatic_session_fail() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let (dna_file, _, _) =
             SweetDnaFile::unique_from_test_wasms(vec![TestWasm::CounterSigning]).await;

--- a/crates/holochain/src/core/ribosome/host_fn/agent_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/agent_info.rs
@@ -60,7 +60,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn agent_info_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
@@ -41,7 +41,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn zome_call_verify_block() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, alice_pubkey, bob, bob_pubkey, ..
         } = RibosomeTestFixture::new(TestWasm::Capability).await;

--- a/crates/holochain/src/core/ribosome/host_fn/call.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call.rs
@@ -231,7 +231,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn call_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let test_wasm = TestWasm::WhoAmI;
         let (dna_file_1, _, _) = SweetDnaFile::unique_from_test_wasms(vec![test_wasm]).await;
 
@@ -281,7 +281,7 @@ pub mod wasm_test {
     /// when they are both writing (moving the source chain forward)
     #[tokio::test(flavor = "multi_thread")]
     async fn call_the_same_cell() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let zomes = vec![TestWasm::WhoAmI, TestWasm::Create];
         let mut conductor_test = ConductorTestData::two_agents(zomes, false).await;
@@ -326,7 +326,7 @@ pub mod wasm_test {
     //        not be supported.
     #[tokio::test(flavor = "multi_thread")]
     async fn bridge_call() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
 
@@ -370,7 +370,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     /// we can call a fn on a remote
     async fn call_remote_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/call_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call_info.rs
@@ -98,7 +98,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn call_info_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::ZomeInfo).await;
@@ -109,7 +109,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn call_info_provenance_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/capability_grants.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/capability_grants.rs
@@ -26,7 +26,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_capability_secret_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Capability).await;
@@ -36,7 +36,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_transferable_cap_grant() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Capability).await;
@@ -61,7 +61,7 @@ pub mod wasm_test {
     // MAYBE: [ B-03669 ] can move this to an integration test (may need to switch to using a RibosomeStore)
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_authorized_call() -> anyhow::Result<()> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/create.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/create.rs
@@ -117,7 +117,7 @@ pub mod wasm_test {
     use holochain_types::prelude::*;
     use holochain_wasm_test_utils::TestWasm;
     use holochain_wasm_test_utils::TestWasmPair;
-    use observability;
+    use holochain_trace;
     use std::sync::Arc;
 
     #[tokio::test(flavor = "multi_thread")]
@@ -168,7 +168,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_create_entry_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Create).await;
@@ -201,7 +201,7 @@ pub mod wasm_test {
     async fn multiple_create_entry_limit_test() {
         const N: u32 = 50;
 
-        observability::test_run().unwrap();
+        holochain_trace::test_run().unwrap();
         let mut conductor = SweetConductor::from_standard_config().await;
         let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::MultipleCalls]).await;
 
@@ -227,7 +227,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_serialize_bytes_hash() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         #[derive(Default, SerializedBytes, Serialize, Deserialize, Debug)]
         #[repr(transparent)]
         #[serde(transparent)]

--- a/crates/holochain/src/core/ribosome/host_fn/delete.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/delete.rs
@@ -113,7 +113,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_delete_entry_test<'a>() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Crd).await;

--- a/crates/holochain/src/core/ribosome/host_fn/delete_link.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/delete_link.rs
@@ -115,7 +115,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_delete_link_add_remove() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Link).await;

--- a/crates/holochain/src/core/ribosome/host_fn/dna_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/dna_info.rs
@@ -79,7 +79,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn dna_info_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         // let RibosomeTestFixture {
         //     conductor, alice, ..
         // } = RibosomeTestFixture::new(TestWasm::ZomeInfo).await;

--- a/crates/holochain/src/core/ribosome/host_fn/get_details.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_details.rs
@@ -66,7 +66,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_get_details_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Crud).await;

--- a/crates/holochain/src/core/ribosome/host_fn/get_link_details.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_link_details.rs
@@ -76,7 +76,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_entry_hash_path_children_details() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::HashPath).await;

--- a/crates/holochain/src/core/ribosome/host_fn/get_links.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_links.rs
@@ -91,7 +91,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_entry_hash_path_children() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::HashPath).await;
@@ -130,7 +130,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn hash_path_anchor_list_anchors() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Anchor).await;
@@ -215,7 +215,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn baseless_get_links() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Link).await;
@@ -232,7 +232,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn external_get_links() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Link).await;
@@ -247,7 +247,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn multi_get_links() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Link).await;
@@ -275,7 +275,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn dup_path_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Link).await;

--- a/crates/holochain/src/core/ribosome/host_fn/hash.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/hash.rs
@@ -173,7 +173,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     /// we can get an entry hash out of the fn via. a wasm call
     async fn ribosome_hash_entry_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::HashEntry).await;

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_agent_activity.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_agent_activity.rs
@@ -114,7 +114,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_must_get_agent_activity() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_entry.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_entry.rs
@@ -109,7 +109,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_must_get_entry_test<'a>() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/query.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/query.rs
@@ -51,7 +51,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn query_smoke_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Query).await;

--- a/crates/holochain/src/core/ribosome/host_fn/random_bytes.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/random_bytes.rs
@@ -74,7 +74,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     /// we can get some random data out of the fn via. a wasm call
     async fn ribosome_random_bytes_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::RandomBytes).await;
@@ -87,7 +87,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     /// we can get some random data out of the fn via. a wasm call
     async fn ribosome_rand_random_bytes_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::RandomBytes).await;

--- a/crates/holochain/src/core/ribosome/host_fn/remote_signal.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/remote_signal.rs
@@ -157,7 +157,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "test_utils")]
     async fn remote_signal_test() -> anyhow::Result<()> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         const NUM_CONDUCTORS: usize = 5;
 
         let num_signals = Arc::new(AtomicUsize::new(0));

--- a/crates/holochain/src/core/ribosome/host_fn/schedule.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/schedule.rs
@@ -57,7 +57,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "test_utils")]
     async fn schedule_test_low_level() -> anyhow::Result<()> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             alice_pubkey,
             alice_host_fn_caller,
@@ -197,7 +197,7 @@ pub mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "test_utils")]
     async fn schedule_test_wasm() -> anyhow::Result<()> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/sign.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/sign.rs
@@ -45,7 +45,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_sign_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/sign_ephemeral.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/sign_ephemeral.rs
@@ -64,7 +64,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_sign_ephemeral_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Sign).await;

--- a/crates/holochain/src/core/ribosome/host_fn/sys_time.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/sys_time.rs
@@ -37,7 +37,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn invoke_import_sys_time_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::SysTime).await;

--- a/crates/holochain/src/core/ribosome/host_fn/trace.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/trace.rs
@@ -86,7 +86,7 @@ pub mod wasm_test {
     async fn wasm_trace_test() {
         use holochain_types::prelude::Level::*;
         CAPTURE.store(true, std::sync::atomic::Ordering::SeqCst);
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Debug).await;

--- a/crates/holochain/src/core/ribosome/host_fn/verify_signature.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/verify_signature.rs
@@ -45,7 +45,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_verify_signature_raw_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -169,7 +169,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_verify_signature_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/x_25519_x_salsa20_poly1305_encrypt.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/x_25519_x_salsa20_poly1305_encrypt.rs
@@ -63,7 +63,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn invoke_import_x_25519_x_salsa20_poly1305_encrypt_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::XSalsa20Poly1305).await;

--- a/crates/holochain/src/core/ribosome/host_fn/x_salsa20_poly1305_encrypt.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/x_salsa20_poly1305_encrypt.rs
@@ -59,7 +59,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "test_utils")]
     async fn xsalsa20_poly1305_shared_secret_round_trip() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         // we need two conductors and two x25519 pub keys to do a round trip
 

--- a/crates/holochain/src/core/ribosome/host_fn/zome_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/zome_info.rs
@@ -42,7 +42,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn zome_info_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::EntryDefs).await;

--- a/crates/holochain/src/core/ribosome/real_ribosome.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome.rs
@@ -975,7 +975,7 @@ pub mod wasm_test {
     /// Basic checks that we can call externs internally and externally the way we want using the
     /// hdk macros rather than low level rust extern syntax.
     async fn ribosome_extern_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let (dna_file, _, _) =
             SweetDnaFile::unique_from_test_wasms(vec![TestWasm::HdkExtern]).await;
@@ -1035,7 +1035,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn wasm_tooling_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Crud]).await;
         let ribosome = super::RealRibosome::new(dna_file).unwrap();
@@ -1097,7 +1097,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn the_incredible_halt_test() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::TheIncredibleHalt).await;

--- a/crates/holochain/src/core/sys_validate/tests.rs
+++ b/crates/holochain/src/core/sys_validate/tests.rs
@@ -16,12 +16,12 @@ use holochain_state::prelude::test_authored_db;
 use holochain_state::prelude::test_cache_db;
 use holochain_state::prelude::test_dht_db;
 use holochain_state::test_utils::test_db_dir;
+use holochain_trace;
 use holochain_types::db_cache::DhtDbQueryCache;
 use holochain_types::test_utils::chain::{TestChainHash, TestChainItem};
 use holochain_wasm_test_utils::*;
 use holochain_zome_types::Action;
 use matches::assert_matches;
-use observability;
 use std::convert::TryFrom;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -324,7 +324,7 @@ async fn check_link_tag_size_test() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn check_app_entry_def_test() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let TestWasmPair::<DnaWasm> {
         integrity,
         coordinator,

--- a/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
@@ -35,7 +35,7 @@ const DELAY_PER_ATTEMPT: std::time::Duration = std::time::Duration::from_millis(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_agent_activity_test() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let zomes = vec![TestWasm::Create];
     let mut conductor_test = ConductorTestData::two_agents(zomes, false).await;
@@ -316,7 +316,7 @@ async fn get_agent_activity_test() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_agent_activity_host_fn_test() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let zomes = vec![TestWasm::Create];
     let mut conductor_test = ConductorTestData::two_agents(zomes, false).await;

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -30,7 +30,7 @@ use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn app_validation_workflow_test() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![
         TestWasm::Validate,
@@ -69,7 +69,7 @@ async fn app_validation_workflow_test() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_private_entries_are_passed_to_validation_only_when_authored_with_full_entry() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     #[hdk_entry_helper]
     pub struct Post(String);

--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
@@ -173,7 +173,7 @@ impl Expected {
 /// Test that all ops are created and the correct zomes
 /// are called for each op.
 async fn app_validation_ops() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let entry_def_a = EntryDef::from_id("a");
     let entry_def_b = EntryDef::from_id("b");
     let call_back_a = |_zome_name: &'static str| {

--- a/crates/holochain/src/core/workflow/call_zome_workflow/validation_test.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow/validation_test.rs
@@ -15,7 +15,7 @@ use std::convert::TryFrom;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn direct_validation_test() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let TestWasmPair::<DnaWasm> {
         integrity,

--- a/crates/holochain/src/core/workflow/genesis_workflow.rs
+++ b/crates/holochain/src/core/workflow/genesis_workflow.rs
@@ -169,15 +169,15 @@ pub mod tests {
     use crate::core::ribosome::MockRibosomeT;
     use holochain_state::prelude::test_dht_db;
     use holochain_state::{prelude::test_authored_db, source_chain::SourceChain};
+    use holochain_trace;
     use holochain_types::test_utils::fake_agent_pubkey_1;
     use holochain_types::test_utils::fake_dna_file;
     use holochain_zome_types::Action;
     use matches::assert_matches;
-    use observability;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn genesis_initializes_source_chain() {
-        observability::test_run().unwrap();
+        holochain_trace::test_run().unwrap();
         let test_db = test_authored_db();
         let dht_db = test_dht_db();
         let dht_db_cache = DhtDbQueryCache::new(dht_db.to_db().into());

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow/test.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow/test.rs
@@ -6,7 +6,7 @@ use holochain_keystore::AgentPubKeyExt;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn incoming_ops_to_limbo() {
-    observability::test_run().unwrap();
+    holochain_trace::test_run().unwrap();
     let space = TestSpace::new(fixt!(DnaHash));
     let env = space.space.dht_db.clone();
     let keystore = holochain_state::test_utils::test_keystore();

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/query_tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/query_tests.rs
@@ -95,7 +95,7 @@ impl Scenario {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn integrate_query() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let db = test_dht_db();
     let expected = test_data(&db.to_db().into());
     let (qt, _rx) = TriggerSender::new();

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
@@ -10,10 +10,10 @@ use ::fixt::prelude::*;
 use holochain_sqlite::db::WriteManager;
 use holochain_state::query::link::GetLinksQuery;
 use holochain_state::workspace::WorkspaceError;
+use holochain_trace;
 use holochain_zome_types::ActionHashed;
 use holochain_zome_types::Entry;
 use holochain_zome_types::ValidationStatus;
-use observability;
 
 #[derive(Clone)]
 struct TestData {
@@ -517,7 +517,7 @@ fn register_delete_link_missing_base(a: TestData) -> (Vec<Db>, Vec<Db>, &'static
 // This runs the above tests
 #[tokio::test(flavor = "multi_thread")]
 async fn test_ops_state() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let test_db = test_dht_db();
     let env = test_db.to_db();
 

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -131,9 +131,9 @@ mod tests {
     use holochain_p2p::actor::HolochainP2pSender;
     use holochain_p2p::HolochainP2pDna;
     use holochain_p2p::HolochainP2pRef;
+    use holochain_trace;
     use holochain_types::db_cache::DhtDbQueryCache;
     use holochain_types::prelude::*;
-    use observability;
     use rusqlite::Transaction;
     use std::collections::HashMap;
     use std::convert::TryInto;
@@ -271,7 +271,7 @@ mod tests {
     #[ignore = "(david.b) tests should be re-written using mock network"]
     fn test_sent_to_r_nodes(num_agents: u32, num_hash: u32) {
         tokio_helper::block_forever_on(async {
-            observability::test_run().ok();
+            holochain_trace::test_run().ok();
 
             // Create test db
             let test_db = test_authored_db();
@@ -325,7 +325,7 @@ mod tests {
     #[test_case(100, 100)]
     fn test_no_republish(num_agents: u32, num_hash: u32) {
         tokio_helper::block_forever_on(async {
-            observability::test_run().ok();
+            holochain_trace::test_run().ok();
 
             // Create test db
             let test_db = test_authored_db();
@@ -378,7 +378,7 @@ mod tests {
     fn test_private_entries(num_agents: u32) {
         tokio_helper::block_forever_on(
             async {
-                observability::test_run().ok();
+                holochain_trace::test_run().ok();
 
                 // Create test db
                 let test_db = test_authored_db();

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
@@ -167,7 +167,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn publish_query() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let db = test_authored_db();
         let expected = test_data(&db.to_db().into());
         let r = get_ops_to_publish(expected.agent.clone(), &db.to_db().into())

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
@@ -10,7 +10,7 @@ use crate::test_utils::inline_zomes::simple_create_read_zome;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "TODO: complete when chain validation returns actual error"]
 async fn sys_validation_agent_activity_test() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let mut conductors = SweetConductorBatch::from_standard_config(2).await;
 

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn sys_validation_workflow_test() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
 

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validation_query.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validation_query.rs
@@ -135,7 +135,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn sys_validation_query() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let db = test_dht_db();
         let expected = test_data(&db.to_db().into());
         let r = get_ops_to_validate(&db.to_db().into(), true).await.unwrap();
@@ -222,7 +222,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     /// Make sure both workflows can't pull in the same ops.
     async fn workflows_are_exclusive() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let mut u = Unstructured::new(&NOISE);
 
         let db = test_dht_db();

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -16,7 +16,7 @@ use rusqlite::Transaction;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "flaky"]
 async fn test_validation_receipt() {
-    let _g = observability::test_run().ok();
+    let _g = holochain_trace::test_run().ok();
     const NUM_CONDUCTORS: usize = 3;
 
     let mut conductors = SweetConductorBatch::from_standard_config(NUM_CONDUCTORS).await;
@@ -111,7 +111,7 @@ macro_rules! wait_until {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_block_invalid_receipt() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let unit_entry_def = EntryDef::from_id("unit");
     let integrity_name = "integrity";
     let coordinator_name = "coordinator";
@@ -227,7 +227,7 @@ async fn test_block_invalid_receipt() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_not_block_self_receipt() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let unit_entry_def = EntryDef::from_id("unit");
     let zomes = InlineZomeSet::new_single(

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -33,7 +33,7 @@ use tracing::debug_span;
 #[test_case(4)]
 #[tokio::test(flavor = "multi_thread")]
 async fn conductors_call_remote(num_conductors: usize) {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
     let mut conductors = SweetConductorBatch::from_standard_config(num_conductors).await;
     let apps = conductors.setup_app("app", &[dna]).await.unwrap();
@@ -252,7 +252,7 @@ async fn conductors_gossip_inner(
     network: KitsuneP2pConfig,
     share_peers: bool,
 ) {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let network_seed = nanoid::nanoid!().to_string();
 
     let zomes = vec![TestWasm::Create];

--- a/crates/holochain/tests/agent_scaling/mod.rs
+++ b/crates/holochain/tests/agent_scaling/mod.rs
@@ -43,7 +43,7 @@ fn links_zome() -> InlineIntegrityZome {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "slow_tests")]
 async fn many_agents_can_reach_consistency_agent_links() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     const NUM_AGENTS: usize = 20;
 
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(("links", links_zome())).await;
@@ -92,7 +92,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "slow_tests")]
 async fn many_agents_can_reach_consistency_normal_links() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     const NUM_AGENTS: usize = 30;
 
     let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Link]).await;
@@ -129,7 +129,7 @@ async fn many_agents_can_reach_consistency_normal_links() {
 // This could become a bench.
 #[ignore = "Slow test for CI that is only useful for timing"]
 async fn stuck_conductor_wasm_calls() -> anyhow::Result<()> {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     // Bundle the single zome into a DnaFile
     let (dna_file, _, _) =
         SweetDnaFile::unique_from_test_wasms(vec![TestWasm::MultipleCalls]).await;

--- a/crates/holochain/tests/authored_test/mod.rs
+++ b/crates/holochain/tests/authored_test/mod.rs
@@ -21,7 +21,7 @@ use rusqlite::named_params;
 /// - Bob commits the entry and it is now in their authored store
 #[tokio::test(flavor = "multi_thread")]
 async fn authored_test() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     // Check if the correct number of ops are integrated
     // every 100 ms for a maximum of 10 seconds but early exit
     // if they are there.

--- a/crates/holochain/tests/inline_zome_spec/mod.rs
+++ b/crates/holochain/tests/inline_zome_spec/mod.rs
@@ -78,7 +78,7 @@ async fn inline_zome_2_agents_1_dna() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "test_utils")]
 async fn inline_zome_3_agents_2_dnas() -> anyhow::Result<()> {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let mut conductor = SweetConductor::from_standard_config().await;
 
     let (dna_foo, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
@@ -169,7 +169,7 @@ async fn inline_zome_3_agents_2_dnas() -> anyhow::Result<()> {
 // I can't remember what this test was for? Should we just delete?
 #[ignore = "Needs to be completed when HolochainP2pEvents is accessible"]
 async fn invalid_cell() -> anyhow::Result<()> {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let mut conductor = SweetConductor::from_standard_config().await;
 
     let (dna_foo, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
@@ -199,7 +199,7 @@ async fn invalid_cell() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "test_utils")]
 async fn get_deleted() -> anyhow::Result<()> {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     // Bundle the single zome into a DnaFile
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
 
@@ -271,7 +271,7 @@ async fn get_deleted() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "test_utils")]
 async fn signal_subscription() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     const N: usize = 10;
 
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
@@ -376,7 +376,7 @@ async fn simple_validation() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_call_real_zomes_too() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let mut conductor = SweetConductor::from_standard_config().await;
     let agent = SweetAgents::one(conductor.keystore()).await;

--- a/crates/holochain/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/multi_conductor/mod.rs
@@ -24,7 +24,7 @@ async fn test_publish() -> anyhow::Result<()> {
     use holochain::test_utils::{consistency_10s, inline_zomes::simple_create_read_zome};
     use kitsune_p2p::KitsuneP2pConfig;
 
-    let _g = observability::test_run().ok();
+    let _g = holochain_trace::test_run().ok();
     const NUM_CONDUCTORS: usize = 3;
 
     let mut tuning =
@@ -74,7 +74,7 @@ async fn test_publish() -> anyhow::Result<()> {
 async fn multi_conductor() -> anyhow::Result<()> {
     use holochain::test_utils::inline_zomes::simple_create_read_zome;
 
-    let _g = observability::test_run().ok();
+    let _g = holochain_trace::test_run().ok();
     const NUM_CONDUCTORS: usize = 3;
 
     let config = SweetConductorConfig::standard();
@@ -131,7 +131,7 @@ async fn sharded_consistency() {
     };
     use kitsune_p2p::KitsuneP2pConfig;
 
-    let _g = observability::test_run().ok();
+    let _g = holochain_trace::test_run().ok();
     const NUM_CONDUCTORS: usize = 3;
     const NUM_CELLS: usize = 5;
 
@@ -195,7 +195,7 @@ async fn private_entries_dont_leak() {
     use holochain::test_utils::consistency_10s;
     use holochain_types::inline_zome::InlineZomeSet;
 
-    let _g = observability::test_run().ok();
+    let _g = holochain_trace::test_run().ok();
     let mut entry_def = EntryDef::from_id("entrydef");
     entry_def.visibility = EntryVisibility::Private;
 

--- a/crates/holochain/tests/network_tests/mod.rs
+++ b/crates/holochain/tests/network_tests/mod.rs
@@ -34,11 +34,11 @@ use holochain_state::record_buf::RecordBuf;
 use holochain_types::prelude::*;
 use holochain_types::prelude::*;
 
+use holochain_trace;
 use holochain_wasm_test_utils::TestWasm;
 use holochain_zome_types::ActionHashed;
 use holochain_zome_types::Entry;
 use maplit::btreeset;
-use observability;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::convert::TryInto;
@@ -55,7 +55,7 @@ use holochain::test_utils::host_fn_caller::*;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "flaky"]
 async fn get_updates_cache() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     // Database setup
     let test_db = test_cell_db();
     let db = test_db.db();
@@ -99,7 +99,7 @@ async fn get_updates_cache() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "flaky!"]
 async fn get_meta_updates_meta_cache() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     // Database setup
     let test_db = test_cell_db();
     let db = test_db.db();
@@ -165,7 +165,7 @@ let mut reader = g.reader().unwrap();
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "flaky"]
 async fn get_from_another_agent() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let dna_file = DnaFile::new(
         DnaDef {
             name: "dht_get_test".to_string(),
@@ -297,7 +297,7 @@ async fn get_from_another_agent() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "flaky for some reason"]
 async fn get_links_from_another_agent() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let dna_file = DnaFile::new(
         DnaDef {
             name: "dht_get_test".to_string(),

--- a/crates/holochain/tests/ser_regression/mod.rs
+++ b/crates/holochain/tests/ser_regression/mod.rs
@@ -23,7 +23,7 @@ pub struct ChannelName(String);
 
 #[tokio::test(flavor = "multi_thread")]
 async fn ser_entry_hash_test() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let eh = fixt!(EntryHash);
     let extern_io: ExternIO = ExternIO::encode(eh).unwrap();
     tracing::debug!(?extern_io);
@@ -36,7 +36,7 @@ async fn ser_entry_hash_test() {
 #[tokio::test(flavor = "multi_thread")]
 /// we can call a fn on a remote
 async fn ser_regression_test() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     // ////////////
     // START DNA
     // ////////////

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -49,7 +49,7 @@ fn make_config(
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
 async fn fullsync_sharded_gossip_low_data() -> anyhow::Result<()> {
-    let _g = observability::test_run().ok();
+    let _g = holochain_trace::test_run().ok();
     const NUM_CONDUCTORS: usize = 2;
 
     let mut conductors =
@@ -92,7 +92,7 @@ async fn fullsync_sharded_gossip_low_data() -> anyhow::Result<()> {
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
 async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
-    // let _g = observability::test_run().ok();
+    // let _g = holochain_trace::test_run().ok();
 
     const NUM_CONDUCTORS: usize = 3;
     const NUM_OPS: usize = 100;
@@ -166,7 +166,7 @@ async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
 #[cfg(feature = "slow_tests")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_gossip_shutdown() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let mut conductors = SweetConductorBatch::from_config(2, make_config(true, true, None)).await;
 
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
@@ -201,7 +201,7 @@ async fn test_gossip_shutdown() {
 #[cfg(feature = "slow_tests")]
 #[tokio::test(flavor = "multi_thread")]
 async fn three_way_gossip_recent() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let config = make_config(true, false, None);
     three_way_gossip(config).await;
 }
@@ -209,7 +209,7 @@ async fn three_way_gossip_recent() {
 #[cfg(feature = "slow_tests")]
 #[tokio::test(flavor = "multi_thread")]
 async fn three_way_gossip_historical() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let config = make_config(false, true, Some(0));
     three_way_gossip(config).await;
 }
@@ -316,7 +316,7 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
 async fn fullsync_sharded_local_gossip() -> anyhow::Result<()> {
     use holochain::{sweettest::SweetConductor, test_utils::inline_zomes::simple_create_read_zome};
 
-    let _g = observability::test_run().ok();
+    let _g = holochain_trace::test_run().ok();
 
     let mut conductor = SweetConductor::from_config(make_config(true, true, None)).await;
 
@@ -398,7 +398,7 @@ async fn mock_network_sharded_gossip() {
     // Check if we should for new data to be generated even if it already exists.
     let force_new_data = std::env::var_os("FORCE_NEW_DATA").is_some();
 
-    let _g = observability::test_run().ok();
+    let _g = holochain_trace::test_run().ok();
 
     // Generate or use cached test data.
     let (data, mut conn) = generate_test_data(num_agents, min_ops, false, force_new_data).await;
@@ -940,7 +940,7 @@ async fn mock_network_sharding() {
     // Check if we should for new data to be generated even if it already exists.
     let force_new_data = std::env::var_os("FORCE_NEW_DATA").is_some();
 
-    let _g = observability::test_run().ok();
+    let _g = holochain_trace::test_run().ok();
 
     // Generate or use cached test data.
     let (data, mut conn) = generate_test_data(num_agents, min_ops, false, force_new_data).await;

--- a/crates/holochain/tests/speed_tests/mod.rs
+++ b/crates/holochain/tests/speed_tests/mod.rs
@@ -32,12 +32,12 @@ use tempfile::TempDir;
 use super::test_utils::*;
 use holochain::sweettest::*;
 use holochain_test_wasm_common::AnchorInput;
+use holochain_trace;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
 use holochain_websocket::WebsocketResult;
 use holochain_websocket::WebsocketSender;
 use matches::assert_matches;
-use observability;
 use test_case::test_case;
 use tracing::instrument;
 
@@ -53,21 +53,21 @@ async fn speed_test_prep() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_timed() {
-    let _g = observability::test_run_timed().unwrap();
+    let _g = holochain_trace::test_run_timed().unwrap();
     speed_test(None).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_timed_json() {
-    let _g = observability::test_run_timed_json().unwrap();
+    let _g = holochain_trace::test_run_timed_json().unwrap();
     speed_test(None).await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_timed_flame() {
-    let _g = observability::test_run_timed_flame(None).unwrap();
+    let _g = holochain_trace::test_run_timed_flame(None).unwrap();
     speed_test(None).await;
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 }
@@ -75,7 +75,7 @@ async fn speed_test_timed_flame() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_timed_ice() {
-    let _g = observability::test_run_timed_ice(None).unwrap();
+    let _g = holochain_trace::test_run_timed_ice(None).unwrap();
     speed_test(None).await;
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 }
@@ -83,7 +83,7 @@ async fn speed_test_timed_ice() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_normal() {
-    observability::test_run().unwrap();
+    holochain_trace::test_run().unwrap();
     speed_test(None).await;
 }
 
@@ -92,7 +92,7 @@ async fn speed_test_normal() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_persisted() {
-    observability::test_run().unwrap();
+    holochain_trace::test_run().unwrap();
     let envs = speed_test(None).await;
     let path = envs.path();
     println!("Run the following to see info about the test that just ran,");
@@ -109,7 +109,7 @@ async fn speed_test_persisted() {
 #[test_case(2000)]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 fn speed_test_all(n: usize) {
-    observability::test_run().unwrap();
+    holochain_trace::test_run().unwrap();
     tokio_helper::block_forever_on(speed_test(Some(n)));
 }
 

--- a/crates/holochain/tests/test_utils/mod.rs
+++ b/crates/holochain/tests/test_utils/mod.rs
@@ -341,11 +341,8 @@ pub fn create_config(port: u16, environment_path: PathBuf) -> ConductorConfig {
             driver: InterfaceDriver::Websocket { port },
         }]),
         environment_path: environment_path.into(),
-        network: None,
-        dpki: None,
         keystore: KeystoreConfig::DangerTestKeystore,
-        db_sync_strategy: DbSyncStrategy::default(),
-        chc_namespace: None,
+        ..Default::default()
     }
 }
 

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -14,6 +14,7 @@ use holochain::{
     },
     fixt::*,
 };
+use holochain_trace;
 use holochain_types::{
     prelude::*,
     test_utils::{fake_dna_zomes, write_fake_dna_file},
@@ -21,7 +22,6 @@ use holochain_types::{
 use holochain_wasm_test_utils::TestWasm;
 use holochain_websocket::*;
 use matches::assert_matches;
-use observability;
 use std::sync::Arc;
 use std::time::Duration;
 use tempfile::TempDir;
@@ -34,7 +34,7 @@ use crate::test_utils::*;
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "glacial_tests")]
 async fn call_admin() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     // NOTE: This is a full integration test that
     // actually runs the holochain binary
 
@@ -104,7 +104,7 @@ how_many: 42
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "glacial_tests")]
 async fn call_zome() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     // NOTE: This is a full integration test that
     // actually runs the holochain binary
 
@@ -246,7 +246,7 @@ async fn call_zome() {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "slow_tests")]
 async fn remote_signals() -> anyhow::Result<()> {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     const NUM_CONDUCTORS: usize = 2;
 
     let mut conductors = SweetConductorBatch::from_standard_config(NUM_CONDUCTORS).await;
@@ -312,7 +312,7 @@ async fn remote_signals() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "slow_tests")]
 async fn emit_signals() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     // NOTE: This is a full integration test that
     // actually runs the holochain binary
 
@@ -426,7 +426,7 @@ async fn emit_signals() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn conductor_admin_interface_runs_from_config() -> Result<()> {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let tmp_dir = TempDir::new().unwrap();
     let environment_path = tmp_dir.path().to_path_buf();
     let config = create_config(0, environment_path);
@@ -453,7 +453,7 @@ async fn conductor_admin_interface_runs_from_config() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn list_app_interfaces_succeeds() -> Result<()> {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     info!("creating config");
     let tmp_dir = TempDir::new().unwrap();
@@ -492,7 +492,7 @@ async fn conductor_admin_interface_ends_with_shutdown() -> Result<()> {
 }
 
 async fn conductor_admin_interface_ends_with_shutdown_inner() -> Result<()> {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     info!("creating config");
     let tmp_dir = TempDir::new().unwrap();
@@ -551,7 +551,7 @@ async fn conductor_admin_interface_ends_with_shutdown_inner() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn too_many_open() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     info!("creating config");
     let tmp_dir = TempDir::new().unwrap();
@@ -584,7 +584,7 @@ async fn concurrent_install_dna() {
     static NUM_CONCURRENT_INSTALLS: u8 = 10;
     static REQ_TIMEOUT_MS: u64 = 15000;
 
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     // NOTE: This is a full integration test that
     // actually runs the holochain binary
 
@@ -651,7 +651,7 @@ async fn concurrent_install_dna() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn full_state_dump_cursor_works() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let mut conductor = SweetConductor::from_standard_config().await;
 

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -23,8 +23,8 @@ holochain_p2p = { version = "^0.1.0", path = "../holochain_p2p" }
 holochain_serialized_bytes = "=0.0.51"
 holochain_state = { version = "^0.1.0", path = "../holochain_state" }
 holochain_types = { version = "^0.1.0", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.1.0", path = "../holochain_zome_types" }
 holochain_trace = { version = "^0.1.0", path = "../holochain_trace" }
+holochain_zome_types = { version = "^0.1.0", path = "../holochain_zome_types" }
 kitsune_p2p = { version = "^0.1.0", path = "../kitsune_p2p/kitsune_p2p" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -14,7 +14,7 @@ either = "1.5"
 fallible-iterator = "0.2"
 fixt = { version = "^0.1.0", path = "../fixt" }
 futures = "0.3"
-ghost_actor = "0.3.0-alpha.4"
+ghost_actor = "0.3.0-alpha.5"
 hdk = { version = "^0.1.0", path = "../hdk" }
 hdk_derive = { version = "^0.1.0", path = "../hdk_derive" }
 holo_hash = { version = "^0.1.0", path = "../holo_hash", features = ["full"] }
@@ -24,7 +24,7 @@ holochain_serialized_bytes = "=0.0.51"
 holochain_state = { version = "^0.1.0", path = "../holochain_state" }
 holochain_types = { version = "^0.1.0", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.1.0", path = "../holochain_zome_types" }
-observability = "0.1.3"
+holochain_trace = { version = "^0.1.0", path = "../holochain_trace" }
 kitsune_p2p = { version = "^0.1.0", path = "../kitsune_p2p/kitsune_p2p" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
@@ -34,7 +34,7 @@ tracing = "0.1"
 tracing-futures = "0.2"
 
 async-trait = { version = "0.1", optional = true }
-mockall = { version = "0.10.2", optional = true }
+mockall = { version = "0.11.3", optional = true }
 
 [dev-dependencies]
 isotest = "0"

--- a/crates/holochain_cascade/src/authority/get_agent_activity_query/deterministic.rs
+++ b/crates/holochain_cascade/src/authority/get_agent_activity_query/deterministic.rs
@@ -144,7 +144,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn agent_activity_query() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let test_db = test_dht_db();
         let db = test_db.to_db();
         let entry_type_1 = fixt!(EntryType);

--- a/crates/holochain_cascade/src/authority/test.rs
+++ b/crates/holochain_cascade/src/authority/test.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::authority::handle_get_agent_activity;
 use crate::test_utils::*;
-use ghost_actor::dependencies::holochain_trace;
 use holochain_p2p::actor;
 use holochain_p2p::event::GetRequest;
 use holochain_state::prelude::test_dht_db;

--- a/crates/holochain_cascade/src/authority/test.rs
+++ b/crates/holochain_cascade/src/authority/test.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::authority::handle_get_agent_activity;
 use crate::test_utils::*;
-use ghost_actor::dependencies::observability;
+use ghost_actor::dependencies::holochain_trace;
 use holochain_p2p::actor;
 use holochain_p2p::event::GetRequest;
 use holochain_state::prelude::test_dht_db;
@@ -17,7 +17,7 @@ fn options() -> holochain_p2p::event::GetOptions {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_entry() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let db = test_dht_db();
 
     let td = EntryTestData::create();
@@ -65,7 +65,7 @@ async fn get_entry() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_record() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let db = test_dht_db();
 
     let td = RecordTestData::create();
@@ -131,7 +131,7 @@ async fn get_record() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn retrieve_record() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let db = test_dht_db();
 
     let td = RecordTestData::create();
@@ -155,7 +155,7 @@ async fn retrieve_record() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_links() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let db = test_dht_db();
 
     let td = EntryTestData::create();
@@ -191,7 +191,7 @@ async fn get_links() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_agent_activity() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let db = test_dht_db();
 
     let td = ActivityTestData::valid_chain_scenario();

--- a/crates/holochain_cascade/tests/get_activity.rs
+++ b/crates/holochain_cascade/tests/get_activity.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use ghost_actor::dependencies::holochain_trace;
 use holo_hash::AgentPubKey;
 use holo_hash::DnaHash;
 use holochain_cascade::test_utils::*;

--- a/crates/holochain_cascade/tests/get_activity.rs
+++ b/crates/holochain_cascade/tests/get_activity.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use ghost_actor::dependencies::observability;
+use ghost_actor::dependencies::holochain_trace;
 use holo_hash::AgentPubKey;
 use holo_hash::DnaHash;
 use holochain_cascade::test_utils::*;
@@ -21,7 +21,7 @@ use test_case::test_case;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_activity() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     // Environments
     let cache = test_cache_db();

--- a/crates/holochain_cascade/tests/get_entry.rs
+++ b/crates/holochain_cascade/tests/get_entry.rs
@@ -1,4 +1,4 @@
-use ghost_actor::dependencies::observability;
+use ghost_actor::dependencies::holochain_trace;
 use holo_hash::HasHash;
 use holochain_cascade::test_utils::*;
 use holochain_cascade::Cascade;
@@ -225,7 +225,7 @@ async fn assert_can_retrieve<N: HolochainP2pDnaT + Clone + Send + 'static>(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn entry_not_authority_or_authoring() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     // Environments
     let cache = test_cache_db();
@@ -248,7 +248,7 @@ async fn entry_not_authority_or_authoring() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn entry_authoring() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     // Environments
     let cache = test_cache_db();
@@ -286,7 +286,7 @@ async fn entry_authoring() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn entry_authority() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     // Environments
     let cache = test_cache_db();
@@ -314,7 +314,7 @@ async fn entry_authority() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn content_not_authority_or_authoring() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     // Environments
     let cache = test_cache_db();
@@ -342,7 +342,7 @@ async fn content_not_authority_or_authoring() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn content_authoring() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     // Environments
     let cache = test_cache_db();
@@ -380,7 +380,7 @@ async fn content_authoring() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn content_authority() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     // Environments
     let cache = test_cache_db();
@@ -406,7 +406,7 @@ async fn content_authority() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn rejected_ops() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     // Environments
     let cache = test_cache_db();
@@ -428,7 +428,7 @@ async fn rejected_ops() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn check_can_handle_rejected_ops_in_cache() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     // Environments
     let cache = test_cache_db();
@@ -472,7 +472,7 @@ async fn check_all_queries_still_work_with_scratch() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pending_data_isnt_returned() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     // Environments
     let cache = test_cache_db();

--- a/crates/holochain_cascade/tests/get_entry.rs
+++ b/crates/holochain_cascade/tests/get_entry.rs
@@ -1,4 +1,3 @@
-use ghost_actor::dependencies::holochain_trace;
 use holo_hash::HasHash;
 use holochain_cascade::test_utils::*;
 use holochain_cascade::Cascade;

--- a/crates/holochain_cascade/tests/get_links.rs
+++ b/crates/holochain_cascade/tests/get_links.rs
@@ -1,4 +1,3 @@
-use ghost_actor::dependencies::holochain_trace;
 use holochain_cascade::test_utils::*;
 use holochain_cascade::Cascade;
 use holochain_p2p::MockHolochainP2pDnaT;

--- a/crates/holochain_cascade/tests/get_links.rs
+++ b/crates/holochain_cascade/tests/get_links.rs
@@ -1,4 +1,4 @@
-use ghost_actor::dependencies::observability;
+use ghost_actor::dependencies::holochain_trace;
 use holochain_cascade::test_utils::*;
 use holochain_cascade::Cascade;
 use holochain_p2p::MockHolochainP2pDnaT;
@@ -12,7 +12,7 @@ use holochain_zome_types::ChainTopOrdering;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn links_not_authority() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     // Environments
     let cache = test_cache_db();
@@ -68,7 +68,7 @@ async fn links_not_authority() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn links_authority() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     // Environments
     let cache = test_cache_db();
@@ -109,7 +109,7 @@ async fn links_authority() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn links_authoring() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     // Environments
     let cache = test_cache_db();

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -29,4 +29,4 @@ holochain_keystore = { version = "^0.1.0", path = "../holochain_keystore" }
 
 [dev-dependencies]
 matches = {version = "0.1.8"}
-observability = "0.1.3"
+holochain_trace = { version = "^0.1.0", path = "../holochain_trace" }

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -28,6 +28,10 @@ use std::path::Path;
 /// All the config information for the conductor
 #[derive(Clone, Deserialize, Serialize, Default, Debug, PartialEq)]
 pub struct ConductorConfig {
+    /// Override the environment specified tracing config.
+    #[serde(default)]
+    pub tracing_override: Option<String>,
+
     /// The path to the database for this conductor;
     /// if omitted, chooses a default path.
     pub environment_path: DatabaseRootPath,
@@ -140,7 +144,7 @@ pub mod tests {
 
     #[test]
     fn test_config_complete_config() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let yaml = r#"---
     environment_path: /path/to/env

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -131,6 +131,7 @@ pub mod tests {
         assert_eq!(
             result,
             ConductorConfig {
+                tracing_override: None,
                 environment_path: PathBuf::from("/path/to/env").into(),
                 network: None,
                 dpki: None,
@@ -217,6 +218,7 @@ pub mod tests {
         assert_eq!(
             result.unwrap(),
             ConductorConfig {
+                tracing_override: None,
                 environment_path: PathBuf::from("/path/to/env").into(),
                 dpki: Some(DpkiConfig {
                     instance_id: "some_id".into(),
@@ -247,6 +249,7 @@ pub mod tests {
         assert_eq!(
             result.unwrap(),
             ConductorConfig {
+                tracing_override: None,
                 environment_path: PathBuf::from("/path/to/env").into(),
                 network: None,
                 dpki: None,

--- a/crates/holochain_diagnostics/Cargo.toml
+++ b/crates/holochain_diagnostics/Cargo.toml
@@ -17,7 +17,7 @@ human-repr = "1"
 rand = "0.8"
 tracing = "0.1"
 tracing-appender = "0.2"
-tracing-subscriber = "0.3"
+tracing-subscriber = "0.3.16"
 
 crossterm = "*"
 tui = "*"

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1"
 derive_more = "0.99"
 fixt = { path = "../fixt", version = "^0.1.0"}
 futures = "0.3"
-ghost_actor = "0.3.0-alpha.4"
+ghost_actor = "0.3.0-alpha.5"
 holo_hash = { version = "^0.1.0", path = "../holo_hash" }
 holochain_keystore = { version = "^0.1.0", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
@@ -23,8 +23,8 @@ holochain_types = { version = "^0.1.0", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.1.0", path = "../holochain_zome_types" }
 kitsune_p2p = { version = "^0.1.0", path = "../kitsune_p2p/kitsune_p2p" }
 kitsune_p2p_types = { version = "^0.1.0", path = "../kitsune_p2p/types" }
-mockall = "0.10.2"
-observability = "0.1.3"
+mockall = "0.11.3"
+holochain_trace = { version = "^0.1.0", path = "../holochain_trace" }
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -241,7 +241,7 @@ mod tests {
         holo_hash::AgentPubKey,
         holo_hash::AgentPubKey,
     ) {
-        observability::test_run().unwrap();
+        holochain_trace::test_run().unwrap();
         (
             newhash!(DnaHash, 's'),
             fixt!(AgentPubKey, Predictable, 0),
@@ -480,7 +480,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_get_workflow() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let (dna, a1, a2, _a3) = test_setup();
 

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -65,7 +65,7 @@ rusqlite = { version = "0.28", features = [
 ] }
 
 [dev-dependencies]
-observability = { version = "0.1.3" }
+holochain_trace = { version = "^0.1.0", path = "../holochain_trace" }
 
 [build-dependencies]
 pretty_assertions = "0.7.2"

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -27,7 +27,7 @@ holochain_zome_types = { version = "^0.1.0", path = "../holochain_zome_types", f
     "full",
 ] }
 kitsune_p2p = { version = "^0.1.0", path = "../kitsune_p2p/kitsune_p2p" }
-mockall = "0.10.2"
+mockall = "0.11.3"
 one_err = "0.0.8"
 parking_lot = "0.10"
 shrinkwraprs = "0.3.0"
@@ -56,7 +56,7 @@ fixt = { path = "../fixt" }
 hdk = { path = "../hdk" }
 holochain_wasm_test_utils = { path = "../test_utils/wasm" }
 matches = "0.1.8"
-observability = "0.1.3"
+holochain_trace = { version = "^0.1.0", path = "../holochain_trace" }
 pretty_assertions = "0.6.1"
 
 tempfile = "3.3"

--- a/crates/holochain_state/src/query/chain_head.rs
+++ b/crates/holochain_state/src/query/chain_head.rs
@@ -104,7 +104,7 @@ mod tests {
 
     #[test]
     fn test_chain_head_query() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let mut conn = Connection::open_in_memory().unwrap();
         SCHEMA_CELL.initialize(&mut conn, None).unwrap();
 

--- a/crates/holochain_state/src/query/live_entry/test.rs
+++ b/crates/holochain_state/src/query/live_entry/test.rs
@@ -10,7 +10,7 @@ use super::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_handle_update_in_scratch() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let mut scratch = Scratch::new();
     let mut conn = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn, None).unwrap();

--- a/crates/holochain_state/src/query/live_record/test.rs
+++ b/crates/holochain_state/src/query/live_record/test.rs
@@ -10,7 +10,7 @@ use super::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_handle_update_in_scratch() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let mut scratch = Scratch::new();
     let mut conn = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn, None).unwrap();

--- a/crates/holochain_state/src/query/tests.rs
+++ b/crates/holochain_state/src/query/tests.rs
@@ -30,7 +30,7 @@ mod sys_meta;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_links() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let mut scratch = Scratch::new();
     let mut conn = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn, None).unwrap();
@@ -111,7 +111,7 @@ async fn get_links() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_entry() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let mut scratch = Scratch::new();
     let mut conn = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn, None).unwrap();
@@ -177,7 +177,7 @@ async fn get_entry() {
 /// Test that `insert_op` also inserts an action and potentially an entry
 #[tokio::test(flavor = "multi_thread")]
 async fn insert_op_equivalence() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let mut conn1 = Connection::open_in_memory().unwrap();
     let mut conn2 = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn1, None).unwrap();

--- a/crates/holochain_state/src/query/tests/chain_sequence.rs
+++ b/crates/holochain_state/src/query/tests/chain_sequence.rs
@@ -1,12 +1,12 @@
 use crate::{source_chain::SourceChainResult, test_utils::test_cell_db};
 use holo_hash::ActionHash;
 use holochain_sqlite::prelude::*;
+use holochain_trace;
 use matches::assert_matches;
-use observability;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn chain_sequence_scratch_awareness() -> DatabaseResult<()> {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let test_db = test_cell_db();
     let arc = test_db.env();
     {

--- a/crates/holochain_state/src/query/tests/chain_test.rs
+++ b/crates/holochain_state/src/query/tests/chain_test.rs
@@ -9,7 +9,7 @@ use holochain_zome_types::test_utils::fake_agent_pubkey_1;
 use ChainStatus::*;
 
 fn setup() -> (TestEnv, MetadataBuf, Create, Create, AgentPubKey) {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let test_db = test_cell_db();
     let meta_buf = MetadataBuf::vault(test_db.env().into()).unwrap();
     let agent_pubkey = fake_agent_pubkey_1();

--- a/crates/holochain_state/src/query/tests/details.rs
+++ b/crates/holochain_state/src/query/tests/details.rs
@@ -9,7 +9,7 @@ use super::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn entry_scratch_same_as_sql() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let mut scratch = Scratch::new();
     let mut conn = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn, None).unwrap();
@@ -43,7 +43,7 @@ async fn entry_scratch_same_as_sql() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn record_scratch_same_as_sql() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let mut scratch = Scratch::new();
     let mut conn = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn, None).unwrap();

--- a/crates/holochain_state/src/query/tests/links_test.rs
+++ b/crates/holochain_state/src/query/tests/links_test.rs
@@ -2,9 +2,9 @@ use super::*;
 use crate::here;
 use crate::prelude::mutations_helpers::insert_valid_integrated_op;
 use crate::prelude::*;
+use holochain_trace;
 use holochain_types::db::DbWrite;
 use holochain_types::record::SignedActionHashedExt;
-use observability;
 
 #[derive(Clone)]
 struct TestData {
@@ -531,7 +531,7 @@ async fn multiple_links() {
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn duplicate_links() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let test_db = test_dht_db();
     let arc = test_db.to_db();
 
@@ -593,7 +593,7 @@ async fn duplicate_links() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn links_on_same_base() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let test_db = test_dht_db();
     let arc = test_db.to_db();
 
@@ -683,7 +683,7 @@ async fn links_on_same_base() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn links_on_same_tag() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let test_db = test_dht_db();
     let arc = test_db.to_db();
 
@@ -754,7 +754,7 @@ async fn links_on_same_tag() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn links_on_same_type() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let test_db = test_dht_db();
     let arc = test_db.to_db();
 
@@ -811,7 +811,7 @@ async fn links_on_same_type() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn link_type_ranges() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let test_db = test_dht_db();
     let arc = test_db.to_db();
 

--- a/crates/holochain_state/src/query/tests/store.rs
+++ b/crates/holochain_state/src/query/tests/store.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn exists() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let mut scratch = Scratch::new();
     let mut conn = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn, None).unwrap();

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -1864,7 +1864,7 @@ pub mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn source_chain_buffer_iter_back() -> SourceChainResult<()> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let test_db = test_authored_db();
         let dht_db = test_dht_db();
         let dht_db_cache = DhtDbQueryCache::new(dht_db.to_db().into());

--- a/crates/holochain_state/src/validation_receipts.rs
+++ b/crates/holochain_state/src/validation_receipts.rs
@@ -177,7 +177,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_validation_receipts_db_populate_and_list() -> StateMutationResult<()> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let test_db = crate::test_utils::test_authored_db();
         let env = test_db.to_db();

--- a/crates/holochain_state/src/wasm.rs
+++ b/crates/holochain_state/src/wasm.rs
@@ -59,7 +59,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn wasm_store_round_trip() -> DatabaseResult<()> {
         use holochain_sqlite::prelude::*;
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         // all the stuff needed to have a WasmBuf
         let db = crate::test_utils::test_wasm_db();

--- a/crates/holochain_state/tests/corrupt_db/mod.rs
+++ b/crates/holochain_state/tests/corrupt_db/mod.rs
@@ -18,7 +18,7 @@ use tempfile::TempDir;
 /// Checks a corrupt cache will be wiped on load.
 async fn corrupt_cache_creates_new_db() {
     let mut u = arbitrary::Unstructured::new(&holochain_zome_types::NOISE);
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let kind = DbKindCache(Arc::new(DnaHash::arbitrary(&mut u).unwrap()));
 
@@ -39,7 +39,7 @@ async fn corrupt_cache_creates_new_db() {
 #[tokio::test(flavor = "multi_thread")]
 async fn corrupt_source_chain_panics() {
     let mut u = arbitrary::Unstructured::new(&holochain_zome_types::NOISE);
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let kind = DbKindAuthored(Arc::new(DnaHash::arbitrary(&mut u).unwrap()));
 

--- a/crates/holochain_trace/CHANGELOG.md
+++ b/crates/holochain_trace/CHANGELOG.md
@@ -1,0 +1,8 @@
+---
+default_semver_increment_mode: !pre_minor alpha
+---
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## \[Unreleased\]

--- a/crates/holochain_trace/CHANGELOG.md
+++ b/crates/holochain_trace/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_minor alpha
+default_semver_increment_mode: !pre_minor beta-rc
 ---
 # Changelog
 

--- a/crates/holochain_trace/Cargo.toml
+++ b/crates/holochain_trace/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "holochain_trace"
+version = "0.1.0"
+authors = ["freesig <tom.gowan@holo.host>", "Holochain Core Dev Team <devcore@holochain.org>"]
+edition = "2021"
+description = "tracing helpers"
+license = "MIT"
+documentation = "https://docs.rs/holochain_trace"
+repository = "https://github.com/holochain/holochain"
+
+[features]
+default = []
+# default = ["opentelemetry-on"]
+# Allows across thread and process tracing
+# opentelemetry-on = ["opentelemetry", "tracing-opentelemetry", "holochain_serialized_bytes", "serde", "serde_bytes"]
+channels = ["tokio", "shrinkwraprs"]
+
+[dependencies]
+chrono = "0.4.24"
+derive_more = "0.99.17"
+inferno = "0.11.15"
+serde_json = { version = "1.0.94", features = [ "preserve_order" ] }
+thiserror = "1.0.39"
+tracing = "0.1.37"
+tracing-core = "0.1.30"
+tracing-serde = "0.1.3"
+tracing-subscriber = { version = "0.3.16", features = [ "env-filter", "time", "json" ] }
+
+# opentelemetry = { version = "0.8", default-features = false, features = ["trace", "serialize"], optional = true }
+# tracing-opentelemetry = { version = "0.8.0", optional = true }
+holochain_serialized_bytes = {version = "0.0", optional = true }
+serde = { version = "1", optional = true }
+serde_bytes = { version = "0.11", optional = true }
+tokio = { version = "0.2", features = [ "sync" ], optional = true }
+shrinkwraprs = { version = "0.3.0", optional = true }
+once_cell = "1.5"
+
+[dev-dependencies]
+tokio = { version = "1.26", features = [ "full" ] }
+tracing-futures = "0.2.5"

--- a/crates/holochain_trace/LICENSE-MIT
+++ b/crates/holochain_trace/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Tom Gowan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/holochain_trace/README.md
+++ b/crates/holochain_trace/README.md
@@ -1,0 +1,75 @@
+# holochain_trace
+
+## Structured Contextual Logging (or tracing)
+### Why
+[Watch](https://www.youtube.com/watch?v=JjItsfqFIdo) or [Read](https://tokio.rs/blog/2019-08-tracing/)
+
+### Intention of this crate
+This crate is designed ot be a place to experiment with ideas around
+tracing and structured logging. This crate will probably never stabilize.
+Instead it is my hope to feed any good ideas back into the underlying
+dependencies.
+
+### Usage
+There are a couple of ways to use structured logging.
+#### Console and filter
+If you want to try and filter in on an issue it might be easiest to simply log to the console and filter on what you want.
+Here's an example command:
+```bash
+RUST_LOG='core[a{something="foo"}]=debug' my_bin
+```
+Or a more simple version using the default `Log`:
+```bash
+RUST_LOG=trace my_bin
+```
+##### Types of tracing
+There are many types of tracing exposed by this crate.
+The [Output] type is designed to be used with something like [structopt](https://docs.rs/structopt/0.3.20/structopt/)
+so you can easily set which type you want with a command line arg.
+You could also use an environment variable.
+The [Output] variant is passing into the [init_fmt] function on start up.
+##### Filtering
+```bash
+RUST_LOG='core[a{something="foo"}]=debug'
+```
+Here we are saying show me all the events that are:
+- In the `core` module
+- Inside a span called `a`
+- The span `a` has to have a field called `something` that is equal to `foo`
+- They are at least debug level.
+
+Most of these options are optional.
+They can be combined like:
+```bash
+RUST_LOG='[{}]=error,[{something}]=debug'
+```
+> The above means show me errors from anywhere but also any event or span with the field something that's at least debug.
+
+[See here](https://docs.rs/tracing-subscriber/0.2.2/tracing_subscriber/filter/struct.EnvFilter.html) for more info.
+
+##### Json
+Sometimes there's too much data and it's better to capture it to interact with using another tool later.
+For this we can output everything as Json using the flag `--structured Json`.
+Then you can pipe the output from stdout to you're file of choice.
+Here's some sample output:
+```json
+{"time":"2020-03-03T08:07:05.910Z","name":"event crates/sim2h/src/sim2h_im_state.rs:695","level":"INFO","target":"sim2h::sim2h_im_state","module_path":"sim2h::sim2h_im_state","file":"crates/sim2h/src/sim2h_im_stat
+e.rs","line":695,"fields":{"space_hashes":"[]"},"spans":[{"id":[1099511627778],"name":"check_gossip","level":"INFO","target":"sim2h::sim2h_im_state","module_path":"sim2h::sim2h_im_state","file":"crates/sim2h/src/s
+im2h_im_state.rs","line":690}]}
+```
+Every log will include the above information expect for the spans which will only show up if there are parent spans in the context of the event.
+
+You can combine filter with Json as well.
+
+###### Tools
+Some useful tools for formatting and using the json data.
+- [json2csv](https://www.npmjs.com/package/json2csv)
+- [jq](https://stedolan.github.io/jq/)
+- [tad](https://www.tadviewer.com/)
+
+A sample workflow:
+```bash
+RUST_LOG='core[{}]=debug' my_bin --structured Json > log.json
+cat out.json | jq '. | {time: .time, name: .name, message: .fields.message, file: .file, line: .line, fields: .fields, spans: .spans}' | json2csv -o log.csv
+tad log.csv
+```

--- a/crates/holochain_trace/examples/channel_wrap.rs
+++ b/crates/holochain_trace/examples/channel_wrap.rs
@@ -1,0 +1,88 @@
+fn main() {}
+/*
+use std::error::Error;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    #[cfg(feature = "channels")]
+    wrap_it::run().await?;
+    Ok(())
+}
+
+#[cfg(feature = "channels")]
+mod wrap_it {
+    use super::*;
+
+    use holochain_trace::{channel::mpsc, span_context};
+    use tracing::*;
+
+    #[derive(Debug)]
+    struct Foo;
+
+    struct MyChannel {
+        rx: mpsc::Receiver<Foo>,
+        tx: mpsc::Sender<Foo>,
+    }
+
+    impl MyChannel {
+        fn new(tx: mpsc::Sender<Foo>, rx: mpsc::Receiver<Foo>) -> Self {
+            Self { rx, tx }
+        }
+    }
+
+    pub async fn run() -> Result<(), Box<dyn Error>> {
+        holochain_trace::test_run_open().ok();
+        let (tx1, rx2) = mpsc::channel(10);
+        let (tx2, rx1) = mpsc::channel(10);
+        let c1 = MyChannel::new(tx1.clone(), rx1);
+        let c2 = MyChannel::new(tx2, rx2);
+        let (tx4, rx4) = mpsc::channel(10);
+        let (_, dead) = mpsc::channel(1);
+        let c3 = MyChannel::new(tx1, rx4);
+        let c4 = MyChannel::new(tx4, dead);
+        let mut jh = Vec::new();
+        jh.push(tokio::task::spawn(async { a(c1).await.unwrap() }));
+        jh.push(tokio::task::spawn(async { b(c2, c4).await.unwrap() }));
+        jh.push(tokio::task::spawn(async { c(c3).await.unwrap() }));
+
+        for h in jh {
+            h.await?;
+        }
+        Ok(())
+    }
+
+    #[instrument(skip(channel))]
+    async fn a(mut channel: MyChannel) -> Result<(), Box<dyn Error>> {
+        for _ in 0..10 {
+            span_context!(Span::current());
+            channel.tx.send(Foo).await?;
+            if let Some(_) = channel.rx.recv().await {}
+        }
+        tokio::time::delay_for(std::time::Duration::from_millis(500)).await;
+        Ok(())
+    }
+
+    #[instrument(skip(channel, to_c))]
+    async fn b(mut channel: MyChannel, mut to_c: MyChannel) -> Result<(), Box<dyn Error>> {
+        for _ in 0..10 {
+            span_context!(Span::current());
+            if let Some(_) = channel.rx.recv().await {}
+            channel.tx.send(Foo).await?;
+            to_c.tx.send(Foo).await?;
+        }
+        tokio::time::delay_for(std::time::Duration::from_millis(500)).await;
+        Ok(())
+    }
+
+    #[instrument(skip(from_b_to_a))]
+    async fn c(mut from_b_to_a: MyChannel) -> Result<(), Box<dyn Error>> {
+        for _ in 0..10 {
+            span_context!(Span::current());
+            if let Some(_) = from_b_to_a.rx.recv().await {}
+            from_b_to_a.tx.send(Foo).await?;
+        }
+        tokio::time::delay_for(std::time::Duration::from_millis(500)).await;
+        Ok(())
+    }
+}
+*/

--- a/crates/holochain_trace/examples/channels.rs
+++ b/crates/holochain_trace/examples/channels.rs
@@ -1,0 +1,86 @@
+fn main() {}
+/*
+use std::error::Error;
+
+use holochain_trace::{span_context, MsgWrap};
+use tokio::sync::mpsc;
+use tracing::*;
+
+#[derive(Debug)]
+struct Foo;
+
+struct MyChannel {
+    rx: mpsc::Receiver<MsgWrap<Foo>>,
+    tx: mpsc::Sender<MsgWrap<Foo>>,
+}
+
+impl MyChannel {
+    fn new(tx: mpsc::Sender<MsgWrap<Foo>>, rx: mpsc::Receiver<MsgWrap<Foo>>) -> Self {
+        Self { rx, tx }
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    holochain_trace::test_run_open().ok();
+    span_context!();
+    span_context!(current, Level::DEBUG);
+    let (tx1, rx2) = mpsc::channel(10);
+    let (tx2, rx1) = mpsc::channel(10);
+    let c1 = MyChannel::new(tx1.clone(), rx1);
+    let c2 = MyChannel::new(tx2, rx2);
+    let (tx4, rx4) = mpsc::channel(10);
+    let (_, dead) = mpsc::channel(1);
+    let c3 = MyChannel::new(tx1, rx4);
+    let c4 = MyChannel::new(tx4, dead);
+    let mut jh = Vec::new();
+    jh.push(tokio::task::spawn(async { a(c1).await.unwrap() }));
+    jh.push(tokio::task::spawn(async { b(c2, c4).await.unwrap() }));
+    jh.push(tokio::task::spawn(async { c(c3).await.unwrap() }));
+
+    for h in jh {
+        h.await?;
+    }
+    Ok(())
+}
+
+#[instrument(skip(channel))]
+async fn a(mut channel: MyChannel) -> Result<(), Box<dyn Error>> {
+    for _ in 0..10 {
+        span_context!(Span::current());
+        channel.tx.send(Foo.into()).await?;
+        if let Some(r) = channel.rx.recv().await {
+            r.inner();
+        }
+    }
+    tokio::time::delay_for(std::time::Duration::from_millis(500)).await;
+    Ok(())
+}
+
+#[instrument(skip(channel, to_c))]
+async fn b(mut channel: MyChannel, mut to_c: MyChannel) -> Result<(), Box<dyn Error>> {
+    for _ in 0..10 {
+        span_context!(Span::current());
+        if let Some(r) = channel.rx.recv().await {
+            r.inner();
+        }
+        channel.tx.send(Foo.into()).await?;
+        to_c.tx.send(Foo.into()).await?;
+    }
+    tokio::time::delay_for(std::time::Duration::from_millis(500)).await;
+    Ok(())
+}
+
+#[instrument(skip(from_b_to_a))]
+async fn c(mut from_b_to_a: MyChannel) -> Result<(), Box<dyn Error>> {
+    for _ in 0..10 {
+        span_context!(Span::current());
+        if let Some(r) = from_b_to_a.rx.recv().await {
+            r.inner();
+        }
+        from_b_to_a.tx.send(Foo.into()).await?;
+    }
+    tokio::time::delay_for(std::time::Duration::from_millis(500)).await;
+    Ok(())
+}
+*/

--- a/crates/holochain_trace/examples/metrics.rs
+++ b/crates/holochain_trace/examples/metrics.rs
@@ -1,0 +1,30 @@
+use holochain_trace::metrics;
+use std::error::Error;
+use tracing::*;
+
+metrics!(MyMetric, CounterA, CounterB);
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    holochain_trace::test_run().ok();
+    holochain_trace::metrics::init();
+    let span = debug_span!("span a");
+    let _g = span.enter();
+
+    MyMetric::count(MyMetric::CounterA, 30);
+    MyMetric::count(MyMetric::CounterA, 40);
+    MyMetric::count(MyMetric::CounterB, 40);
+    MyMetric::count(MyMetric::CounterB, 40u64);
+
+    MyMetric::count_filter(MyMetric::CounterA, 10, "my_filter");
+    MyMetric::count_filter(MyMetric::CounterA, 10, "my_other_filter");
+
+    MyMetric::print();
+    let mut td = std::env::temp_dir();
+    td.push("metrics_csv");
+    std::fs::create_dir(&td).ok();
+    td.push("metrics.csv");
+    MyMetric::save_csv(&td);
+
+    Ok(())
+}

--- a/crates/holochain_trace/examples/socket_client.rs
+++ b/crates/holochain_trace/examples/socket_client.rs
@@ -1,0 +1,57 @@
+fn main() {}
+/*
+use holochain_trace::{span_context, OpenSpanExt};
+use std::{env, error::Error, net::SocketAddr};
+use tokio::net::UdpSocket;
+use tracing::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    holochain_trace::test_run_open().ok();
+    let remote_addr: SocketAddr = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "127.0.0.1:8080".into())
+        .parse()?;
+    let local_addr: SocketAddr = if remote_addr.is_ipv4() {
+        "0.0.0.0:0"
+    } else {
+        "[::]:0"
+    }
+    .parse()?;
+
+    let mut socket = UdpSocket::bind(local_addr).await?;
+    const MAX_DATAGRAM_SIZE: usize = 65_507;
+    socket.connect(&remote_addr).await?;
+    {
+        let span = debug_span!("client send");
+        let _g = span.enter();
+        span_context!(span, Level::DEBUG);
+        let data = span.get_context_bytes();
+
+        socket.send(data.as_ref()).await?;
+    }
+    {
+        let mut data = vec![0u8; MAX_DATAGRAM_SIZE];
+        let len = socket.recv(&mut data).await?;
+        let data = data[..len].to_vec();
+        let span = debug_span!("client recv");
+        let _g = span.enter();
+        span.set_from_bytes(data);
+        span_context!(span, Level::DEBUG);
+
+        let data = span.get_context_bytes();
+
+        socket.send(data.as_ref()).await?;
+    }
+    {
+        let mut data = vec![0u8; MAX_DATAGRAM_SIZE];
+        let len = socket.recv(&mut data).await?;
+        let data = data[..len].to_vec();
+        let span = debug_span!("client recv 2");
+        let _g = span.enter();
+        span.set_from_bytes(data);
+        span_context!(span, Level::DEBUG);
+    }
+    Ok(())
+}
+*/

--- a/crates/holochain_trace/examples/socket_server.rs
+++ b/crates/holochain_trace/examples/socket_server.rs
@@ -1,0 +1,51 @@
+fn main() {}
+/*
+use holochain_trace::{span_context, OpenSpanExt};
+use std::{env, error::Error};
+use tokio::net::UdpSocket;
+use tracing::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    holochain_trace::test_run_open().ok();
+    let addr = env::args()
+        .nth(1)
+        .unwrap_or_else(|| "127.0.0.1:8080".to_string());
+
+    let mut socket = UdpSocket::bind(&addr).await?;
+    println!("Listening on: {}", socket.local_addr()?);
+
+    {
+        let mut buf = vec![0; 1024];
+        let (size, peer) = socket.recv_from(&mut buf).await?;
+
+        let data = buf[..size].to_vec();
+        let span = debug_span!("server recv");
+        span.set_from_bytes(data);
+        let _g = span.enter();
+        span_context!(span, Level::DEBUG);
+        let span = debug_span!("inner 1");
+        let _g = span.enter();
+        span_context!(span, Level::DEBUG);
+        let span = debug_span!("inner 2");
+        let _g = span.enter();
+        span_context!(span, Level::DEBUG);
+        let data = span.get_context_bytes();
+        let _amt = socket.send_to(&data[..], &peer).await?;
+    }
+
+    {
+        let mut buf = vec![0; 1024];
+        let (size, peer) = socket.recv_from(&mut buf).await?;
+
+        let data = buf[..size].to_vec();
+        let span = debug_span!("server recv 2");
+        span.set_from_bytes(data);
+        let _g = span.enter();
+        span_context!(span, Level::DEBUG);
+        let data = span.get_context_bytes();
+        let _amt = socket.send_to(&data[..], &peer).await?;
+    }
+    Ok(())
+}
+*/

--- a/crates/holochain_trace/src/flames.rs
+++ b/crates/holochain_trace/src/flames.rs
@@ -1,0 +1,102 @@
+use tracing_core::field::Field;
+use tracing_subscriber::field::Visit;
+
+use chrono::SecondsFormat;
+use std::path::PathBuf;
+
+pub(crate) struct EventFieldFlameVisitor {
+    pub samples: usize,
+    name: &'static str,
+}
+
+impl EventFieldFlameVisitor {
+    pub(crate) fn flame() -> Self {
+        EventFieldFlameVisitor {
+            samples: 0,
+            name: "time.busy",
+        }
+    }
+    pub(crate) fn ice() -> Self {
+        EventFieldFlameVisitor {
+            samples: 0,
+            name: "time.idle",
+        }
+    }
+}
+
+impl Visit for EventFieldFlameVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == self.name {
+            parse_time(&mut self.samples, value);
+        }
+    }
+}
+
+pub(crate) struct FlameTimed {
+    path: PathBuf,
+}
+
+impl FlameTimed {
+    pub(crate) fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl Drop for FlameTimed {
+    fn drop(&mut self) {
+        save_flamegraph(self.path.clone());
+    }
+}
+
+pub(crate) fn toml_path() -> Option<PathBuf> {
+    let path = std::env::var_os("CARGO_MANIFEST_DIR").or_else(|| {
+        println!("failed to get cargo manifest dir for flames");
+        None
+    })?;
+    Some(PathBuf::from(path))
+}
+
+fn save_flamegraph(path: PathBuf) -> Option<()> {
+    println!("path {:?}", path);
+    let now = chrono::Local::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+    let inf = std::fs::File::open(path.join("flames.folded"))
+        .ok()
+        .or_else(|| {
+            eprintln!("failed to create flames dir");
+            None
+        })?;
+    let reader = std::io::BufReader::new(inf);
+
+    let out = std::fs::File::create(path.join(format!("tracing_flame_{}.svg", now)))
+        .ok()
+        .or_else(|| {
+            eprintln!("failed to create flames inferno");
+            None
+        })?;
+    let writer = std::io::BufWriter::new(out);
+
+    let mut opts = inferno::flamegraph::Options::default();
+    inferno::flamegraph::from_reader(&mut opts, reader, writer).unwrap();
+    Some(())
+}
+
+fn parse_time(samples: &mut usize, value: &dyn std::fmt::Debug) {
+    let v = format!("{:?}", value);
+    if v.ends_with("ns") {
+        if let Ok(v) = v.trim_end_matches("ns").parse::<f64>() {
+            *samples = v as usize;
+        }
+    } else if v.ends_with("µs") {
+        if let Ok(v) = v.trim_end_matches("µs").parse::<f64>() {
+            *samples = (v * 1000.0) as usize;
+        }
+    } else if v.ends_with("ms") {
+        if let Ok(v) = v.trim_end_matches("ms").parse::<f64>() {
+            *samples = (v * 1000000.0) as usize;
+        }
+    } else if v.ends_with('s') {
+        if let Ok(v) = v.trim_end_matches('s').parse::<f64>() {
+            *samples = (v * 1000000000.0) as usize;
+        }
+    }
+}

--- a/crates/holochain_trace/src/fmt.rs
+++ b/crates/holochain_trace/src/fmt.rs
@@ -1,0 +1,167 @@
+use super::flames::*;
+use tracing::{Event, Metadata, Subscriber};
+use tracing_core::field::Field;
+use tracing_serde::AsSerde;
+use tracing_subscriber::{
+    field::Visit,
+    fmt::{format::Writer, FmtContext, FormatFields},
+    registry::LookupSpan,
+};
+
+use serde_json::json;
+use std::fmt::Write;
+
+struct EventFieldVisitor {
+    json: serde_json::Map<String, serde_json::Value>,
+}
+
+impl EventFieldVisitor {
+    fn new() -> Self {
+        let json = serde_json::Map::new();
+        EventFieldVisitor { json }
+    }
+}
+
+impl Visit for EventFieldVisitor {
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.json
+            .insert(field.name().into(), json!(format!("{:?}", value)));
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.json.insert(field.name().into(), json!(value));
+    }
+}
+
+/// Formatting the events for json
+pub(crate) struct FormatEvent;
+
+impl<S, N> tracing_subscriber::fmt::FormatEvent<S, N> for FormatEvent
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> std::fmt::Result {
+        let now = chrono::offset::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+        let mut parents = vec![];
+        ctx.visit_spans::<(), _>(|span| {
+            let meta = span.metadata();
+            let name = meta.name();
+            let file = meta.file();
+            let line = meta.line();
+            let module_path = meta.module_path();
+            let level = meta.level();
+            let target = meta.target();
+            let id = span.id();
+            let json = json!({"id": id.as_serde(), "name": name, "level": level.as_serde(), "target": target, "module_path": module_path, "file": file, "line": line});
+            parents.push(json);
+            Ok(())
+        })
+        .ok();
+        let meta = event.metadata();
+        let name = meta.name();
+        let file = meta.file();
+        let line = meta.line();
+        let module_path = meta.module_path();
+        let level = meta.level();
+        let target = meta.target();
+        let mut values = EventFieldVisitor::new();
+        event.record(&mut values);
+        let json = json!({"time": now, "name": name, "level": level.as_serde(), "target": target, "module_path": module_path, "file": file, "line": line, "fields": values.json, "spans": parents});
+        writeln!(writer, "{}", json)
+    }
+}
+
+/// Formatting the events for flame graphs
+pub(crate) struct FormatEventFlame;
+
+impl<S, N> tracing_subscriber::fmt::FormatEvent<S, N> for FormatEventFlame
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> std::fmt::Result {
+        let mut values = EventFieldFlameVisitor::flame();
+        event.record(&mut values);
+        let mut stack = String::new();
+        if values.samples > 0 {
+            visit_parents(&mut stack, ctx);
+            let event_data = event_data(event.metadata());
+            writeln!(writer, "all; {} {} {}", stack, event_data, values.samples)
+        } else {
+            write!(writer, "")
+        }
+    }
+}
+
+/// Formatting the events for json
+pub(crate) struct FormatEventIce;
+
+impl<S, N> tracing_subscriber::fmt::FormatEvent<S, N> for FormatEventIce
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> std::fmt::Result {
+        let mut values = EventFieldFlameVisitor::ice();
+        event.record(&mut values);
+        let mut stack = String::new();
+        if values.samples > 0 {
+            visit_parents(&mut stack, ctx);
+            let event_data = event_data(event.metadata());
+            writeln!(writer, "all; {} {} {}", stack, event_data, values.samples)
+        } else {
+            write!(writer, "")
+        }
+    }
+}
+
+fn event_data(meta: &Metadata) -> String {
+    let mut event_data = String::new();
+    if let Some(module) = meta.module_path() {
+        write!(event_data, "{}:", module).ok();
+    }
+    if let Some(line) = meta.line() {
+        write!(event_data, "{}", line).ok();
+    }
+    write!(event_data, ":{}", meta.name()).ok();
+    event_data
+}
+
+fn visit_parents<S, N>(stack: &mut String, ctx: &FmtContext<'_, S, N>)
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    ctx.visit_spans::<(), _>(|span| {
+        let meta = span.metadata();
+        let name = meta.name();
+        let module = meta.module_path();
+        let line = meta.line();
+        if let Some(module) = module {
+            write!(stack, "{}:", module).ok();
+        }
+        if let Some(line) = line {
+            write!(stack, "{}", line).ok();
+        }
+        write!(stack, ":{}", name).ok();
+        *stack += "; ";
+        Ok(())
+    })
+    .ok();
+}

--- a/crates/holochain_trace/src/lib.rs
+++ b/crates/holochain_trace/src/lib.rs
@@ -1,0 +1,342 @@
+#![warn(missing_docs)]
+//! # Structured Contextual Logging (or tracing)
+//! ## Why
+//! [Watch](https://www.youtube.com/watch?v=JjItsfqFIdo) or [Read](https://tokio.rs/blog/2019-08-tracing/)
+//!
+//! ## Intention of this crate
+//! This crate is designed ot be a place to experiment with ideas around
+//! tracing and structured logging. This crate will probably never stabilize.
+//! Instead it is my hope to feed any good ideas back into the underlying
+//! dependencies.
+//!
+//! ## Usage
+//! There are a couple of ways to use structured logging.
+//! ### Console and filter
+//! If you want to try and filter in on an issue it might be easiest to simply log to the console and filter on what you want.
+//! Here's an example command:
+//! ```bash
+//! RUST_LOG='core[a{something="foo"}]=debug' my_bin
+//! ```
+//! Or a more simple version using the default `Log`:
+//! ```bash
+//! RUST_LOG=trace my_bin
+//! ```
+//! #### Types of tracing
+//! There are many types of tracing exposed by this crate.
+//! The [Output] type is designed to be used with something like [structopt](https://docs.rs/structopt/0.3.20/structopt/)
+//! so you can easily set which type you want with a command line arg.
+//! You could also use an environment variable.
+//! The [Output] variant is passing into the [init_fmt] function on start up.
+//! #### Filtering
+//! ```bash
+//! RUST_LOG='core[a{something="foo"}]=debug'
+//! ```
+//! Here we are saying show me all the events that are:
+//! - In the `core` module
+//! - Inside a span called `a`
+//! - The span `a` has to have a field called `something` that is equal to `foo`
+//! - They are at least debug level.
+//!
+//! Most of these options are optional.
+//! They can be combined like:
+//! ```bash
+//! RUST_LOG='[{}]=error,[{something}]=debug'
+//! ```
+//! > The above means show me errors from anywhere but also any event or span with the field something that's at least debug.
+//!
+//! [See here](https://docs.rs/tracing-subscriber/0.2.2/tracing_subscriber/filter/struct.EnvFilter.html) for more info.
+//!
+//! #### Json
+//! Sometimes there's too much data and it's better to capture it to interact with using another tool later.
+//! For this we can output everything as Json using the flag `--structured Json`.
+//! Then you can pipe the output from stdout to you're file of choice.
+//! Here's some sample output:
+//! ```json
+//! {"time":"2020-03-03T08:07:05.910Z","name":"event crates/sim2h/src/sim2h_im_state.rs:695","level":"INFO","target":"sim2h::sim2h_im_state","module_path":"sim2h::sim2h_im_state","file":"crates/sim2h/src/sim2h_im_stat
+//! e.rs","line":695,"fields":{"space_hashes":"[]"},"spans":[{"id":[1099511627778],"name":"check_gossip","level":"INFO","target":"sim2h::sim2h_im_state","module_path":"sim2h::sim2h_im_state","file":"crates/sim2h/src/s
+//! im2h_im_state.rs","line":690}]}
+//! ```
+//! Every log will include the above information expect for the spans which will only show up if there are parent spans in the context of the event.
+//!
+//! You can combine filter with Json as well.
+//!
+//! ##### Tools
+//! Some useful tools for formatting and using the json data.
+//! - [json2csv](https://www.npmjs.com/package/json2csv)
+//! - [jq](https://stedolan.github.io/jq/)
+//! - [tad](https://www.tadviewer.com/)
+//!
+//! A sample workflow:
+//! ```bash
+//! RUST_LOG='core[{}]=debug' my_bin --structured Json > log.json
+//! cat out.json | jq '. | {time: .time, name: .name, message: .fields.message, file: .file, line: .line, fields: .fields, spans: .spans}' | json2csv -o log.csv
+//! tad log.csv
+//! ```
+
+use tracing::Subscriber;
+use tracing_subscriber::{
+    filter::EnvFilter,
+    fmt::{format::FmtSpan, time::UtcTime},
+    registry::LookupSpan,
+    FmtSubscriber,
+};
+
+use std::{str::FromStr, sync::Once};
+
+use flames::{toml_path, FlameTimed};
+use fmt::*;
+
+mod flames;
+mod fmt;
+pub mod metrics;
+// mod open;
+
+// #[cfg(all(feature = "opentelemetry-on", feature = "channels"))]
+// pub use open::channel;
+// #[cfg(feature = "opentelemetry-on")]
+// pub use open::should_run;
+// pub use open::{Config, Context, MsgWrap, OpenSpanExt};
+
+pub use tracing;
+
+#[derive(Debug, Clone)]
+/// Sets the kind of structured logging output you want
+pub enum Output {
+    /// More compact version of above
+    Compact,
+    /// Outputs everything as json
+    Json,
+    /// Json with timed spans
+    JsonTimed,
+    /// Regular logging (default)
+    Log,
+    /// Regular logging plus timed spans
+    LogTimed,
+    /// Creates a flamegraph from timed spans
+    FlameTimed,
+    /// Creates a flamegraph from timed spans using idle time
+    IceTimed,
+    // /// Opentelemetry tracing
+    // OpenTel,
+    /// No logging to console
+    None,
+}
+
+/// ParseError is a String
+pub type ParseError = String;
+
+static INIT: Once = Once::new();
+
+impl FromStr for Output {
+    type Err = ParseError;
+    fn from_str(day: &str) -> Result<Self, Self::Err> {
+        match day {
+            "Json" => Ok(Output::Json),
+            "JsonTimed" => Ok(Output::JsonTimed),
+            "IceTimed" => Ok(Output::IceTimed),
+            "Log" => Ok(Output::Log),
+            "LogTimed" => Ok(Output::LogTimed),
+            "FlameTimed" => Ok(Output::FlameTimed),
+            "Compact" => Ok(Output::Compact),
+            // "OpenTel" => Ok(Output::OpenTel),
+            "None" => Ok(Output::None),
+            _ => Err("Could not parse log output type".into()),
+        }
+    }
+}
+
+/// Run logging in a unit test
+/// RUST_LOG or CUSTOM_FILTER must be set or
+/// this is a no-op
+pub fn test_run() -> Result<(), errors::TracingError> {
+    if std::env::var_os("RUST_LOG").is_none() {
+        return Ok(());
+    }
+    init_fmt(Output::Log)
+}
+
+// /// Run tracing in a test that uses open telemetry to
+// /// send span contexts across process and thread boundaries.
+// pub fn test_run_open() -> Result<(), errors::TracingError> {
+//     if std::env::var_os("RUST_LOG").is_none() {
+//         return Ok(());
+//     }
+//     init_fmt(Output::OpenTel)
+// }
+
+/// Same as test_run but with timed spans
+pub fn test_run_timed() -> Result<(), errors::TracingError> {
+    if std::env::var_os("RUST_LOG").is_none() {
+        return Ok(());
+    }
+    init_fmt(Output::LogTimed)
+}
+
+/// Same as test_run_timed but saves as json
+pub fn test_run_timed_json() -> Result<(), errors::TracingError> {
+    if std::env::var_os("RUST_LOG").is_none() {
+        return Ok(());
+    }
+    init_fmt(Output::JsonTimed)
+}
+
+/// Generate a flamegraph from timed spans "busy time".
+/// Takes a path where you are piping the output into.
+/// If the path is provided a flamegraph will automatically be generated.
+/// TODO: Get auto inferno to work
+/// for now use (fish, or the bash equiv):
+/// `2>| inferno-flamegraph > flamegraph_test_ice_(date +'%d-%m-%y-%X').svg`
+/// And run with `cargo test --quiet`
+pub fn test_run_timed_flame(path: Option<&str>) -> Result<Option<impl Drop>, errors::TracingError> {
+    if std::env::var_os("RUST_LOG").is_none() {
+        return Ok(None);
+    }
+    init_fmt(Output::FlameTimed)?;
+    Ok(path.and_then(|p| {
+        toml_path().map(|mut t| {
+            t.push(p);
+            FlameTimed::new(t)
+        })
+    }))
+}
+
+/// Generate a flamegraph from timed spans "idle time".
+/// Takes a path where you are piping the output into.
+/// If the path is provided a flamegraph will automatically be generated.
+/// TODO: Get auto inferno to work
+/// for now use (fish, or the bash equiv):
+/// `2>| inferno-flamegraph -c blue > flamegraph_test_ice_(date +'%d-%m-%y-%X').svg`
+/// And run with `cargo test --quiet`
+pub fn test_run_timed_ice(path: Option<&str>) -> Result<Option<impl Drop>, errors::TracingError> {
+    if std::env::var_os("RUST_LOG").is_none() {
+        return Ok(None);
+    }
+    init_fmt(Output::IceTimed)?;
+    Ok(path.and_then(|p| {
+        toml_path().map(|mut t| {
+            t.push(p);
+            FlameTimed::new(t)
+        })
+    }))
+}
+
+/// This checks RUST_LOG for a filter but doesn't complain if there is none or it doesn't parse.
+/// It then checks for CUSTOM_FILTER which if set will output an error if it doesn't parse.
+pub fn init_fmt(output: Output) -> Result<(), errors::TracingError> {
+    let mut filter = match std::env::var("RUST_LOG") {
+        Ok(_) => EnvFilter::from_default_env(),
+        Err(_) => EnvFilter::from_default_env().add_directive("[wasm_debug]=debug".parse()?),
+    };
+    if std::env::var("CUSTOM_FILTER").is_ok() {
+        EnvFilter::try_from_env("CUSTOM_FILTER")
+            .map_err(|e| eprintln!("Failed to parse CUSTOM_FILTER {:?}", e))
+            .map(|f| {
+                filter = f;
+            })
+            .ok();
+    }
+
+    let subscriber = FmtSubscriber::builder()
+        .with_writer(std::io::stderr)
+        .with_file(true)
+        .with_line_number(true)
+        .with_target(true);
+
+    match output {
+        Output::Json => {
+            let subscriber = subscriber
+                .with_env_filter(filter)
+                .with_timer(UtcTime::rfc_3339())
+                .json()
+                .event_format(FormatEvent);
+            finish(subscriber.finish())
+        }
+        Output::JsonTimed => {
+            let subscriber = subscriber
+                .with_span_events(FmtSpan::CLOSE)
+                .with_env_filter(filter)
+                .with_timer(UtcTime::rfc_3339())
+                .json()
+                .event_format(FormatEvent);
+            finish(subscriber.finish())
+        }
+        Output::Log => finish(subscriber.with_env_filter(filter).finish()),
+        Output::LogTimed => {
+            let subscriber = subscriber.with_span_events(FmtSpan::CLOSE);
+            finish(subscriber.with_env_filter(filter).finish())
+        }
+        Output::FlameTimed => {
+            let subscriber = subscriber
+                .with_span_events(FmtSpan::CLOSE)
+                .with_env_filter(filter)
+                .with_timer(UtcTime::rfc_3339())
+                .event_format(FormatEventFlame);
+            finish(subscriber.finish())
+        }
+        Output::IceTimed => {
+            let subscriber = subscriber
+                .with_span_events(FmtSpan::CLOSE)
+                .with_env_filter(filter)
+                .with_timer(UtcTime::rfc_3339())
+                .event_format(FormatEventIce);
+            finish(subscriber.finish())
+        }
+        Output::Compact => {
+            let subscriber = subscriber.compact();
+            finish(subscriber.with_env_filter(filter).finish())
+        }
+        // Output::OpenTel => {
+        //     #[cfg(feature = "opentelemetry-on")]
+        //     {
+        //         use open::OPEN_ON;
+        //         use opentelemetry::api::Provider;
+        //         OPEN_ON.store(true, std::sync::atomic::Ordering::SeqCst);
+        //         use tracing_subscriber::prelude::*;
+        //         open::init();
+        //         let tracer = opentelemetry::sdk::Provider::default().get_tracer("component_name");
+        //         let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+        //         finish(
+        //             subscriber
+        //                 .with_env_filter(filter)
+        //                 .finish()
+        //                 .with(telemetry)
+        //                 .with(open::OpenLayer),
+        //         )
+        //     }
+        //     #[cfg(not(feature = "opentelemetry-on"))]
+        //     {
+        //         Ok(())
+        //     }
+        // }
+        Output::None => Ok(()),
+    }
+}
+
+fn finish<S>(subscriber: S) -> Result<(), errors::TracingError>
+where
+    S: Subscriber + Send + Sync + for<'span> LookupSpan<'span>,
+{
+    let mut result = Ok(());
+    INIT.call_once(|| {
+        result = tracing::subscriber::set_global_default(subscriber).map_err(Into::into);
+    });
+    result
+}
+
+pub mod errors {
+    //! Error in the tracing/logging framework
+
+    use thiserror::Error;
+
+    /// Error in the tracing/logging framework
+    #[allow(missing_docs)] // should be self-explanatory
+    #[derive(Error, Debug)]
+    pub enum TracingError {
+        #[error(transparent)]
+        SetGlobal(#[from] tracing::subscriber::SetGlobalDefaultError),
+        #[error("Failed to setup tracing flame")]
+        TracingFlame,
+        #[error(transparent)]
+        BadDirective(#[from] tracing_subscriber::filter::ParseError),
+    }
+}

--- a/crates/holochain_trace/src/metrics.rs
+++ b/crates/holochain_trace/src/metrics.rs
@@ -1,0 +1,192 @@
+//! # Metrics
+//! WIP metrics helper for counting values
+//! and sending tracing events.
+//! This is designed to be fast so everything
+//! is on the stack.
+//! This means you need to keep the metric sets small (<100 metrics per set).
+//! If you need more then make a new set.
+use std::sync::atomic::AtomicBool;
+#[allow(missing_docs)]
+#[doc(hidden)]
+static METRICS_ON: AtomicBool = AtomicBool::new(false);
+
+/// Enable all metrics for your program
+pub fn init() {
+    METRICS_ON.store(true, std::sync::atomic::Ordering::SeqCst);
+}
+
+/// Is metrics currently enabled?
+/// Call init() to enable.
+pub fn is_enabled() -> bool {
+    METRICS_ON.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Create a metrics set.
+/// Takes the name of the metric set followed by
+/// a list of metric names.
+#[macro_export]
+macro_rules! metrics {
+    ($name:ident, $($metric:ident),+) => {
+        #[allow(missing_docs)]
+        #[derive(Debug, Copy, Clone)]
+        pub enum $name {
+            $($metric),+
+        }
+
+        mod metrics_inner {
+            pub(crate) const NUM: usize = 0usize $(+ $crate::__replace_expr!($metric 1usize))+;
+            pub(crate) static METRICS: [std::sync::atomic::AtomicU64; NUM] = [$($crate::__replace_expr!($metric std::sync::atomic::AtomicU64::new(0))),+];
+            pub(crate) const NAMES: [&'static str; NUM] = [$(stringify!($metric)),+];
+        }
+
+        impl $name {
+            /// Add to this counter and emit tracing event
+            pub fn count<N, E>(metric: Self, n: N)
+            where
+                E: std::fmt::Debug,
+                std::num::TryFromIntError: From<E>,
+                N: std::convert::TryInto<u64, Error = E>,
+            {
+                $crate::metrics::__inner::count(&metrics_inner::METRICS[..], &metrics_inner::NAMES[..], metric as usize, n, "none")
+            }
+            /// Add to this counter and emit tracing event
+            /// with a field that can be used as a filter.
+            /// You can filter for this `[metric_count{filter=my_filter}]`.
+            /// Or to get all without filters `[metric_count{filter=none}]`.
+            pub fn count_filter<N, E>(metric: Self, n: N, filter: &str)
+            where
+                E: std::fmt::Debug,
+                std::num::TryFromIntError: From<E>,
+                N: std::convert::TryInto<u64, Error = E>,
+            {
+                $crate::metrics::__inner::count(&metrics_inner::METRICS[..], &metrics_inner::NAMES[..], metric as usize, n, filter)
+            }
+            /// Add to this counter without emit tracing event
+            pub fn count_silent<N, E>(metric: Self, n: N) -> u64
+            where
+                E: std::fmt::Debug,
+                std::num::TryFromIntError: From<E>,
+                N: std::convert::TryInto<u64, Error = E>,
+            {
+                $crate::metrics::__inner::count_silent(&metrics_inner::METRICS[..], metric as usize, n)
+            }
+            /// Get the current value of this metric
+            pub fn get(metric: Self) -> u64 {
+                $crate::metrics::__inner::get(&metrics_inner::METRICS[..], metric as usize)
+            }
+            /// Get an iterator over all metrics
+            pub fn iter() -> impl Iterator<Item = (Self, u64)> {
+                $crate::metrics::__inner::iter(&metrics_inner::METRICS[..], &metrics_inner::NAMES[..])
+                    .map(|(n, i)|(n.into(), i))
+            }
+            /// Emit tracing events for every metric
+            pub fn print() {
+                $crate::metrics::__inner::print(&metrics_inner::METRICS[..], &metrics_inner::NAMES[..])
+            }
+            /// Save all metrics to csv
+            pub fn save_csv(path: &std::path::Path) {
+                $crate::metrics::__inner::save_csv(&metrics_inner::METRICS[..], &metrics_inner::NAMES[..], path)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(s: &str) -> Self {
+                use $name::*;
+                match s {
+                    $(stringify!($metric) => $metric),+,
+                    _ => unreachable!("Tried to use a metric name that doesn't exist"),
+                }
+            }
+        }
+
+    };
+}
+#[macro_export]
+#[allow(missing_docs)]
+#[doc(hidden)]
+macro_rules! __replace_expr {
+    ($_t:tt $sub:expr) => {
+        $sub
+    };
+}
+
+#[allow(missing_docs)]
+#[doc(hidden)]
+pub mod __inner {
+    use super::METRICS_ON;
+    use std::sync::atomic::AtomicU64;
+    pub fn count_silent<N, E>(metrics: &[AtomicU64], metric: usize, n: N) -> u64
+    where
+        E: std::fmt::Debug,
+        std::num::TryFromIntError: From<E>,
+        N: std::convert::TryInto<u64, Error = E>,
+    {
+        if METRICS_ON.load(std::sync::atomic::Ordering::Relaxed) {
+            let n = n.try_into().expect("Failed to convert metric to u64");
+            let mut last = metrics[metric].fetch_add(n, std::sync::atomic::Ordering::Relaxed);
+            last += n;
+            last
+        } else {
+            0
+        }
+    }
+    pub fn count<N, E>(metrics: &[AtomicU64], names: &[&str], metric: usize, n: N, filter: &str)
+    where
+        E: std::fmt::Debug,
+        std::num::TryFromIntError: From<E>,
+        N: std::convert::TryInto<u64, Error = E>,
+    {
+        if METRICS_ON.load(std::sync::atomic::Ordering::Relaxed) {
+            let n = n.try_into().expect("Failed to convert metric to u64");
+            let r = count_silent::<_, std::convert::Infallible>(metrics, metric, n);
+            let name = names[metric];
+            let span = tracing::trace_span!("metric_count", %filter, %name);
+            span.in_scope(|| {
+                tracing::trace!(metric = %name, count = r, change = n);
+            });
+        }
+    }
+    pub fn get(metrics: &[AtomicU64], metric: usize) -> u64 {
+        if METRICS_ON.load(std::sync::atomic::Ordering::Relaxed) {
+            metrics[metric].load(std::sync::atomic::Ordering::Relaxed)
+        } else {
+            0
+        }
+    }
+    pub fn iter(
+        metrics: &'static [AtomicU64],
+        names: &'static [&'static str],
+    ) -> impl Iterator<Item = (&'static str, u64)> {
+        metrics
+            .iter()
+            .zip(names.iter())
+            .map(|(i, &name)| (name, i.load(std::sync::atomic::Ordering::Relaxed)))
+    }
+    pub fn print(metrics: &[AtomicU64], names: &[&str]) {
+        if METRICS_ON.load(std::sync::atomic::Ordering::Relaxed) {
+            let span = tracing::trace_span!("print_metrics");
+            for (i, count) in metrics.iter().enumerate() {
+                let metric = names[i];
+                let count = count.load(std::sync::atomic::Ordering::Relaxed);
+                span.in_scope(|| {
+                    tracing::trace!(%metric, count);
+                });
+            }
+        }
+    }
+    pub fn save_csv(metrics: &[AtomicU64], names: &[&str], path: &std::path::Path) {
+        if METRICS_ON.load(std::sync::atomic::Ordering::Relaxed) {
+            use std::fmt::Write;
+            let mut keys = String::new();
+            let mut values = String::new();
+            for (count, metric) in metrics.iter().zip(names.iter()) {
+                let count = count.load(std::sync::atomic::Ordering::Relaxed);
+                write!(keys, "{},", metric).expect("Failed to write metrics");
+                write!(values, "{},", count).expect("Failed to write metrics");
+            }
+            std::fs::write(path, format!("{}\n{}\n", keys, values))
+                .expect("Failed to write metrics to csv");
+            tracing::info!(metrics = "Saved csv to", ?path);
+        }
+    }
+}

--- a/crates/holochain_trace/src/open.rs
+++ b/crates/holochain_trace/src/open.rs
@@ -1,0 +1,554 @@
+#[cfg(not(feature = "opentelemetry-on"))]
+pub use off::*;
+#[cfg(feature = "opentelemetry-on")]
+pub use on::*;
+
+pub use context_wrap::MsgWrap;
+
+#[allow(missing_docs)]
+#[cfg(feature = "channels")]
+pub mod channel;
+mod context_wrap;
+
+#[cfg(not(feature = "opentelemetry-on"))]
+#[allow(missing_docs)]
+mod off;
+
+/// Opentelemetry span extension trait.
+/// This trait provides helper methods to the
+/// [tracing::Span] for crossing thread and
+/// process boundaries.
+pub trait OpenSpanExt {
+    /// Get the context of this span.
+    fn get_context(&self) -> Context;
+    /// Get the context of the current span.
+    fn get_current_context() -> Context;
+    /// Get the context as message pack bytes for
+    /// sending over process boundaries.
+    fn get_context_bytes(&self) -> Vec<u8> {
+        #[cfg(feature = "opentelemetry-on")]
+        {
+            use holochain_serialized_bytes::prelude::*;
+            let wc: WireContext = (&self.get_context().0).into();
+            // This shouldn't fail because there should always be a context
+            // to serialize even if it's empty.
+            let sb: SerializedBytes = wc.try_into().expect("Failed to serialize tracing wire");
+            let ub: UnsafeBytes = sb.into();
+            ub.into()
+        }
+        #[cfg(not(feature = "opentelemetry-on"))]
+        {
+            Vec::with_capacity(0)
+        }
+    }
+    /// Get the current span as message pack bytes.
+    fn get_current_bytes() -> Vec<u8>;
+    /// Set the context of this span.
+    fn set_context(&self, context: Context);
+    /// Set the context of the current span.
+    fn set_current_context(context: Context);
+    #[allow(unused_variables)]
+    /// Set the context of this span from bytes over the network.
+    fn set_from_bytes(&self, bytes: Vec<u8>) {
+        #[cfg(feature = "opentelemetry-on")]
+        {
+            use holochain_serialized_bytes::prelude::*;
+            use opentelemetry::api;
+            let sb: SerializedBytes = UnsafeBytes::from(bytes).into();
+            let context = match WireContext::try_from(sb) {
+                Ok(w) => api::Context::from(w).into(),
+                Err(e) => {
+                    tracing::error!(
+                        msg = "Failed to deserialize tracing wire context into context"
+                    );
+                    Context::new()
+                }
+            };
+            self.set_context(context);
+        }
+    }
+    /// Set the current span context from message pack bytes.
+    fn set_current_bytes(bytes: Vec<u8>);
+    /// Display this spans context as a String.
+    fn display_context(&self) -> String;
+}
+
+#[cfg(feature = "opentelemetry-on")]
+#[warn(missing_docs)]
+mod on {
+    use once_cell::sync::OnceCell;
+
+    use super::*;
+    use holochain_serialized_bytes::prelude::*;
+    use opentelemetry::api::{self, KeyValue, Link, SpanContext, TraceContextExt, Value};
+    use std::sync::atomic::Ordering;
+    use std::{collections::HashMap, ffi::OsString, sync::atomic::AtomicBool};
+    use tracing::{span::Attributes, Subscriber};
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+    use tracing_subscriber::{registry::LookupSpan, Layer};
+
+    pub(crate) static OPEN_ON: AtomicBool = AtomicBool::new(false);
+    static CONFIG: OnceCell<Config> = OnceCell::new();
+    static PROCESS_NAME: OnceCell<String> = OnceCell::new();
+
+    /// The context holds the current state of a span.
+    /// This can be used to transfer contexts across boundaries.
+    /// A boundary crossing will show up as a follower for a span.
+    #[derive(Debug, Clone, derive_more::From, derive_more::Into)]
+    pub struct Context(pub(super) api::Context);
+
+    /// Configuration for open telemetry tracing.
+    /// These can all be configured by setting the
+    /// `OPEN_TEL='process:true,file:false'`.
+    /// They all have default settings.
+    #[derive(Debug, Clone)]
+    pub struct Config {
+        /// Propagate the name of the process running
+        /// on the sender side of the boundary crossing
+        /// in the context and output when calling `spawn_context!()`.
+        /// [Default: false]
+        pub process: bool,
+        /// Propagate the name of the file and line
+        /// number of the sender side of the boundary crossing
+        /// in the context and output when calling `spawn_context!()`.
+        /// [Default: false]
+        pub file: bool,
+        /// Propagate the name of the span name
+        /// of the sender side of the boundary crossing
+        /// in the context and output when calling `spawn_context!()`.
+        /// [Default: true]
+        pub span_name: bool,
+        /// Require there to be a span enabled for the sending side of
+        /// the boundary crossing. [Default: true]
+        pub require_span: bool,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, SerializedBytes)]
+    pub struct WireContext {
+        span_context: WireSpanContext,
+        links: Option<WireLinks>,
+    }
+
+    #[derive(
+        Debug, Clone, Serialize, Deserialize, SerializedBytes, derive_more::From, derive_more::Into,
+    )]
+    pub struct WireLinks(pub Vec<WireLink>);
+
+    /// Needed because SB doesn't do u128
+    #[derive(Debug, Clone, Serialize, Deserialize, SerializedBytes)]
+    pub struct WireLink {
+        span_context: WireSpanContext,
+        attributes: Vec<api::KeyValue>,
+    }
+
+    /// Needed because SB doesn't do u128
+    #[derive(Debug, Clone, Serialize, Deserialize, SerializedBytes)]
+    pub struct WireSpanContext {
+        trace_id: String,
+        span_id: api::SpanId,
+        trace_flags: u8,
+        is_remote: bool,
+    }
+
+    impl Context {
+        /// Create a new blank context.
+        /// You usually won't do this and
+        /// instead get the context from a span.
+        pub fn new() -> Self {
+            Context(api::Context::new())
+        }
+    }
+
+    impl Default for Context {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl OpenSpanExt for tracing::Span {
+        fn get_current_context() -> Context {
+            let span = tracing::Span::current();
+            span.get_context()
+        }
+
+        fn get_context(&self) -> Context {
+            if should_not_run(self) {
+                return Context::new();
+            }
+            let context = self.context();
+            let span = context.span().span_context();
+            let context = context.with_remote_span_context(span);
+            get_followers(self, context).into()
+        }
+
+        fn get_current_bytes() -> Vec<u8> {
+            let span = tracing::Span::current();
+            span.get_context_bytes()
+        }
+
+        fn set_context(&self, context: Context) {
+            if should_not_run(self) {
+                return;
+            }
+
+            self.set_parent(&context.0);
+            set_followers(self, &context.0);
+        }
+
+        fn set_current_context(context: Context) {
+            let span = tracing::Span::current();
+            span.set_context(context);
+        }
+
+        fn set_current_bytes(bytes: Vec<u8>) {
+            let span = tracing::Span::current();
+            span.set_from_bytes(bytes)
+        }
+
+        fn display_context(&self) -> String {
+            if should_not_run(self) {
+                return String::with_capacity(0);
+            }
+            let context = self.get_context();
+            format!("{}", context)
+        }
+    }
+
+    /// Emit a tracing event with the context of a span.
+    /// ### Usage
+    /// - `span_context!()` will emit a trace event with the current span.
+    /// - `span_context!(current, Level::DEBUG)` will emit a debug event with the current span.
+    /// - Pass a span in and emit a trace event:
+    /// ```no_run
+    /// # #[macro_use] extern crate holochain_trace;
+    /// let span = tracing::debug_span!("my_pan");
+    /// span_context!(span)
+    /// ```
+    /// - Pass a span in and emit a warn event:
+    /// ```no_run
+    /// # #[macro_use] extern crate holochain_trace;
+    /// let span = tracing::debug_span!("my_pan");
+    /// span_context!(span, tracing::Level::WARN)
+    /// ```
+    #[macro_export]
+    macro_rules! span_context {
+    (current, $lvl:expr) => {
+        $crate::span_context!($crate::tracing::Span::current(), $lvl);
+    };
+    ($span:expr, $lvl:expr) => {{
+        if $crate::tracing::level_enabled!($lvl) {
+            if $crate::should_run(&$span) {
+                let context = $crate::OpenSpanExt::get_context(&$span);
+                $crate::tracing::event!(parent: &$span, $lvl, span_context = %context);
+            }
+        }
+
+    }};
+    ($span:expr) => {
+        $crate::span_context!($span, $crate::tracing::Level::TRACE);
+    };
+    () => {
+        $crate::span_context!($crate::tracing::Span::current(), $crate::tracing::Level::TRACE);
+    };
+}
+
+    #[doc(hidden)]
+    pub fn should_run(span: &tracing::Span) -> bool {
+        !should_not_run(span)
+    }
+
+    fn should_not_run(span: &tracing::Span) -> bool {
+        !OPEN_ON.load(Ordering::Relaxed) || (span.is_disabled() && Config::require_span())
+    }
+
+    impl std::fmt::Display for Context {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            let context = &self.0;
+            write!(
+                f,
+                "trace_id: {}",
+                context.span().span_context().trace_id().to_u128()
+            )?;
+            if let Some((_, links)) = context.get::<Vec<Link>>().and_then(|l| l.split_last()) {
+                for link in links {
+                    write!(f, " ->")?;
+                    for kv in link.attributes() {
+                        if let Value::String(v) = &kv.value {
+                            write!(f, " {}: {};", kv.key.as_str(), v)?;
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+
+    pub(crate) fn init() {
+        CONFIG.get_or_init(|| Config::from(std::env::var_os("OPEN_TEL")));
+        PROCESS_NAME.get_or_init(|| {
+            std::env::current_exe()
+                .ok()
+                .and_then(|p| p.file_name().map(|s| s.to_string_lossy().into_owned()))
+                .unwrap_or_else(|| "not_found".to_string())
+        });
+    }
+
+    fn get_followers(span: &tracing::Span, context: api::Context) -> api::Context {
+        let mut links = None;
+        span.with_subscriber(|(id, dispatch)| {
+            if let Some(registry) = dispatch.downcast_ref::<tracing_subscriber::Registry>() {
+                if let Some(span_ref) = registry.span(id) {
+                    let extensions = span_ref.extensions();
+                    if let Some(sb) = extensions.get::<api::SpanBuilder>() {
+                        links = sb.links.clone();
+                    }
+                }
+            }
+        });
+
+        let links = links
+            .map(|mut l| {
+                if let Some(link) = create_link(span, &context) {
+                    l.push(link);
+                }
+                l
+            })
+            .or_else(|| create_link(span, &context).map(|l| vec![l]));
+
+        match links {
+            Some(links) => context.with_value(links),
+            None => context,
+        }
+    }
+
+    fn set_followers(span: &tracing::Span, context: &api::Context) {
+        let new_links = context.get::<Vec<Link>>().cloned().unwrap_or_default();
+        if !new_links.is_empty() {
+            span.with_subscriber(|(id, dispatch)| {
+                if let Some(registry) = dispatch.downcast_ref::<tracing_subscriber::Registry>() {
+                    if let Some(span_ref) = registry.span(id) {
+                        let mut extensions = span_ref.extensions_mut();
+                        if let Some(sb) = extensions.get_mut::<api::SpanBuilder>() {
+                            let mut new_links = new_links
+                                .into_iter()
+                                .rev()
+                                .take_while(|link| {
+                                    Some(link.span_context().span_id()) != sb.span_id
+                                })
+                                .collect::<Vec<_>>();
+                            new_links.reverse();
+                            sb.links = Some(new_links);
+                        }
+                    }
+                }
+            });
+        }
+    }
+
+    fn create_link(span: &tracing::Span, context: &api::Context) -> Option<Link> {
+        if let Some(meta) = span.metadata() {
+            let mut kvs = Vec::with_capacity(2);
+            if Config::span_name() {
+                kvs.push(KeyValue::new("span", meta.name()));
+            }
+            if Config::file() {
+                if let (Some(file), Some(line)) = (meta.file(), meta.line()) {
+                    kvs.push(KeyValue::new("file", format!("{}:{}", file, line)));
+                }
+            }
+            if Config::process() {
+                kvs.push(KeyValue::new(
+                    "process",
+                    PROCESS_NAME
+                        .get()
+                        .cloned()
+                        .unwrap_or_else(|| "not_found".to_string()),
+                ))
+            }
+            let span_context = context.span().span_context();
+            return Some(Link::new(span_context, kvs));
+        }
+        None
+    }
+
+    impl Config {
+        fn require_span() -> bool {
+            CONFIG
+                .get()
+                .map(|c| c.require_span)
+                .unwrap_or_else(|| Config::default().require_span)
+        }
+        fn span_name() -> bool {
+            CONFIG
+                .get()
+                .map(|c| c.span_name)
+                .unwrap_or_else(|| Config::default().span_name)
+        }
+        fn file() -> bool {
+            CONFIG
+                .get()
+                .map(|c| c.file)
+                .unwrap_or_else(|| Config::default().file)
+        }
+        fn process() -> bool {
+            CONFIG
+                .get()
+                .map(|c| c.process)
+                .unwrap_or_else(|| Config::default().process)
+        }
+    }
+
+    pub struct OpenLayer;
+
+    impl<S> Layer<S> for OpenLayer
+    where
+        S: Subscriber + for<'span> LookupSpan<'span>,
+    {
+        fn new_span(
+            &self,
+            attrs: &Attributes<'_>,
+            id: &tracing::span::Id,
+            ctx: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            let span = ctx.span(id).expect("Span should not be missing");
+            let mut extensions = span.extensions_mut();
+            if let Some(parent) = attrs.parent() {
+                let parent = ctx.span(parent).expect("Span should not be missing");
+                let parent_extensions = parent.extensions();
+                if let Some((p, s)) = parent_extensions
+                    .get::<api::SpanBuilder>()
+                    .and_then(|p| extensions.get_mut::<api::SpanBuilder>().map(|s| (p, s)))
+                {
+                    s.links = p.links.clone()
+                }
+            } else if attrs.is_contextual() {
+                if let Some(parent) = ctx.lookup_current() {
+                    let parent_extensions = parent.extensions();
+                    if let Some((p, s)) = parent_extensions
+                        .get::<api::SpanBuilder>()
+                        .and_then(|p| extensions.get_mut::<api::SpanBuilder>().map(|s| (p, s)))
+                    {
+                        s.links = p.links.clone()
+                    }
+                }
+            }
+        }
+    }
+
+    impl From<&api::Context> for WireContext {
+        fn from(c: &api::Context) -> Self {
+            let span_context = c.span().span_context().into();
+            let links = c
+                .get::<Vec<Link>>()
+                .cloned()
+                .map(|links| WireLinks(links.into_iter().map(WireLink::from).collect()));
+            WireContext {
+                span_context,
+                links,
+            }
+        }
+    }
+
+    impl From<WireContext> for api::Context {
+        fn from(wc: WireContext) -> Self {
+            let mut c = api::Context::new().with_remote_span_context(wc.span_context.into());
+            if let Some(links) = wc.links {
+                let links: Vec<Link> = links.0.into_iter().map(Link::from).collect();
+                c = c.with_value(links);
+            }
+            c
+        }
+    }
+
+    impl From<Link> for WireLink {
+        fn from(l: Link) -> Self {
+            WireLink {
+                span_context: l.span_context().clone().into(),
+                attributes: l.attributes().clone(),
+            }
+        }
+    }
+
+    impl From<WireLink> for Link {
+        fn from(wl: WireLink) -> Self {
+            Link::new(wl.span_context.into(), wl.attributes)
+        }
+    }
+
+    impl From<SpanContext> for WireSpanContext {
+        fn from(sc: SpanContext) -> Self {
+            WireSpanContext {
+                trace_id: sc.trace_id().to_u128().to_string(),
+                span_id: sc.span_id(),
+                trace_flags: sc.trace_flags(),
+                is_remote: sc.is_remote(),
+            }
+        }
+    }
+
+    impl From<WireSpanContext> for SpanContext {
+        fn from(wsc: WireSpanContext) -> Self {
+            SpanContext::new(
+                api::TraceId::from_u128(
+                    wsc.trace_id
+                        .parse::<u128>()
+                        .expect("Failed to parse trace id"),
+                ),
+                wsc.span_id,
+                wsc.trace_flags,
+                wsc.is_remote,
+            )
+        }
+    }
+
+    impl Default for Config {
+        fn default() -> Self {
+            Self {
+                process: false,
+                file: false,
+                span_name: true,
+                require_span: true,
+            }
+        }
+    }
+
+    impl From<Option<OsString>> for Config {
+        fn from(var: Option<OsString>) -> Self {
+            let var = match var.and_then(|v| v.into_string().ok()) {
+                Some(var) => var,
+                None => return Self::default(),
+            };
+            let options = var.split(',').filter_map(|kv|{
+                let kv = kv.split(':').map(|i|i.trim()).collect::<Vec<_>>();
+                if kv.len() == 2 {
+                    Some((kv[0], kv[1]))
+                } else {
+                    eprintln!("Failed to parse config from OPEN_TEL.\nFormat is `OPEN_TEL='key: value, key: value'`");
+                    None
+                }
+            })
+            .collect::<HashMap<&str, &str>>();
+            let mut config = Config::default();
+            if let Some(file) = options.get("file").and_then(|v| v.parse::<bool>().ok()) {
+                config.file = file;
+            }
+            if let Some(process) = options.get("process").and_then(|v| v.parse::<bool>().ok()) {
+                config.process = process;
+            }
+            if let Some(span_name) = options
+                .get("span_name")
+                .and_then(|v| v.parse::<bool>().ok())
+            {
+                config.span_name = span_name;
+            }
+            if let Some(require_span) = options
+                .get("require_span")
+                .and_then(|v| v.parse::<bool>().ok())
+            {
+                config.require_span = require_span;
+            }
+
+            config
+        }
+    }
+}

--- a/crates/holochain_trace/src/open/channel.rs
+++ b/crates/holochain_trace/src/open/channel.rs
@@ -1,0 +1,81 @@
+use crate::MsgWrap;
+use derive_more::{From, Into};
+use shrinkwraprs::Shrinkwrap;
+
+pub mod mpsc {
+    use super::*;
+
+    #[derive(From, Into, Shrinkwrap)]
+    #[shrinkwrap(mutable)]
+    pub struct Sender<T>(pub tokio::sync::mpsc::Sender<MsgWrap<T>>);
+    #[derive(From, Into, Shrinkwrap)]
+    #[shrinkwrap(mutable)]
+    pub struct Receiver<T>(pub tokio::sync::mpsc::Receiver<MsgWrap<T>>);
+
+    pub fn channel<T>(buffer: usize) -> (Sender<T>, Receiver<T>) {
+        let (tx, rx) = tokio::sync::mpsc::channel(buffer);
+        (tx.into(), rx.into())
+    }
+
+    impl<T> Clone for Sender<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
+    impl<T> Sender<T> {
+        pub async fn send(
+            &mut self,
+            value: T,
+        ) -> Result<(), tokio::sync::mpsc::error::SendError<T>> {
+            self.0
+                .send(value.into())
+                .await
+                .map_err(|e| tokio::sync::mpsc::error::SendError(e.0.without_context()))
+        }
+    }
+
+    impl<T> Receiver<T> {
+        pub async fn recv(&mut self) -> Option<T> {
+            self.0.recv().await.map(|t| t.inner())
+        }
+    }
+}
+
+pub mod oneshot {
+    use super::*;
+
+    #[derive(From, Into, Shrinkwrap)]
+    #[shrinkwrap(mutable)]
+    pub struct Sender<T>(pub tokio::sync::oneshot::Sender<MsgWrap<T>>);
+    #[derive(From, Into, Shrinkwrap)]
+    #[shrinkwrap(mutable)]
+    pub struct Receiver<T>(pub tokio::sync::oneshot::Receiver<MsgWrap<T>>);
+
+    pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        (tx.into(), rx.into())
+    }
+
+    impl<T> Sender<T> {
+        pub fn send(self, value: T) -> Result<(), T> {
+            self.0.send(value.into()).map_err(|e| e.without_context())
+        }
+    }
+
+    impl<T> std::future::Future for Receiver<T> {
+        type Output = Result<T, tokio::sync::oneshot::error::RecvError>;
+
+        fn poll(
+            mut self: std::pin::Pin<&mut Self>,
+            cx: &mut std::task::Context<'_>,
+        ) -> std::task::Poll<Self::Output> {
+            use std::task::Poll;
+            let p = std::pin::Pin::new(&mut self.0);
+            match tokio::sync::oneshot::Receiver::poll(p, cx) {
+                Poll::Ready(r) => Poll::Ready(r.map(MsgWrap::inner)),
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+}

--- a/crates/holochain_trace/src/open/context_wrap.rs
+++ b/crates/holochain_trace/src/open/context_wrap.rs
@@ -1,0 +1,74 @@
+use super::*;
+
+/// Wrap a channel message in a span context.
+/// The context is automatically propagated to
+/// the current span by calling `msg_wrap.inner()`.
+/// The context is automatically propagated from
+/// the current span by calling `t.into()`.
+/// If you wish to avoid either of these propagations
+/// you can use `msg_wrap.without_context()` and
+/// `MsgWrap::from_no_context(t)` respectively.
+pub struct MsgWrap<T> {
+    t: T,
+    context: Option<Context>,
+}
+
+impl<T> MsgWrap<T> {
+    /// Create a T wrapped in a Context.
+    /// If you just need the current context use
+    /// `t.into()`.
+    pub fn new(t: T, context: Context) -> Self {
+        Self {
+            t,
+            context: Some(context),
+        }
+    }
+    /// Get the inner type and propagate the context to
+    /// the current span.
+    pub fn inner(self) -> T {
+        if let Some(context) = self.context {
+            tracing::Span::set_current_context(context);
+        }
+        self.t
+    }
+    /// Get the inner type without propagating the context.
+    pub fn without_context(self) -> T {
+        self.t
+    }
+
+    /// Create a wrapped T with no Context.
+    pub fn from_no_context(t: T) -> Self {
+        Self { t, context: None }
+    }
+
+    /// Unwrap the wrapped T into a T and Context.
+    /// If you just need to propagate the context to
+    /// the current span use `msg_wrap.inner()`
+    pub fn into_parts(self) -> (T, Context) {
+        (self.t, self.context.unwrap_or_default())
+    }
+}
+
+impl<T> From<T> for MsgWrap<T> {
+    /// Create a wrapped T with the context from
+    /// the current span.
+    fn from(t: T) -> Self {
+        let span = tracing::Span::current();
+        let context = if span.is_disabled() {
+            None
+        } else {
+            Some(span.get_context())
+        };
+
+        Self { t, context }
+    }
+}
+
+impl<T> std::fmt::Debug for MsgWrap<T>
+where
+    T: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{:?}", self.t))
+    }
+}

--- a/crates/holochain_trace/src/open/off.rs
+++ b/crates/holochain_trace/src/open/off.rs
@@ -1,0 +1,47 @@
+use super::*;
+#[derive(Debug, Clone, Default)]
+pub struct Context;
+
+#[derive(Debug, Clone)]
+pub struct WireContext {
+    span_context: WireSpanContext,
+    links: Option<WireLinks>,
+}
+
+#[derive(Debug, Clone, derive_more::From, derive_more::Into)]
+pub struct WireLinks(pub Vec<WireLink>);
+
+#[derive(Debug, Clone)]
+pub struct WireLink;
+
+#[derive(Debug, Clone)]
+pub struct WireSpanContext;
+
+impl OpenSpanExt for tracing::Span {
+    fn get_current_context() -> Context {
+        Context
+    }
+    fn get_context(&self) -> Context {
+        Context
+    }
+
+    fn get_current_bytes() -> Vec<u8> {
+        Vec::with_capacity(0)
+    }
+
+    fn set_context(&self, _: Context) {}
+
+    fn set_current_context(_: Context) {}
+    fn set_current_bytes(_bytes: Vec<u8>) {}
+
+    fn display_context(&self) -> String {
+        String::with_capacity(0)
+    }
+}
+
+impl std::fmt::Display for Context {
+    fn fmt(&self, _: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Ok(())
+    }
+}
+pub struct Config;

--- a/crates/holochain_trace/tests/open_telemetry.rs
+++ b/crates/holochain_trace/tests/open_telemetry.rs
@@ -1,0 +1,83 @@
+/*
+use holochain_trace::{span_context, Context, OpenSpanExt};
+use tokio::sync::mpsc;
+use tracing::*;
+
+#[tokio::test(threaded_scheduler)]
+async fn same_thread_test() {
+    holochain_trace::test_run_open().ok();
+    let span = debug_span!("span a");
+    let context = span.get_context();
+    let _g = span.enter();
+
+    span_context!(span, Level::DEBUG);
+    debug!(msg = "in span a");
+
+    let span = debug_span!("span b");
+    let _g = span.enter();
+    debug!("in span b");
+    span_context!(span, Level::DEBUG);
+
+    let span = debug_span!("span c");
+    span.set_context(context);
+    span_context!(span, Level::DEBUG);
+    let _g = span.enter();
+    debug!("in span c");
+}
+
+#[tokio::test(threaded_scheduler)]
+async fn cross_thread_test() {
+    holochain_trace::test_run_open().ok();
+    let (mut tx1, rx1) = mpsc::channel(100);
+    let (tx2, mut rx2) = mpsc::channel(100);
+    tokio::task::spawn(across_thread(rx1, tx2));
+    {
+        let span = debug_span!("from original thread");
+        let context = span.get_context();
+        let _g = span.enter();
+        span_context!(span, Level::DEBUG);
+        tx1.send(context).await.unwrap();
+    }
+    {
+        let context = rx2.recv().await.unwrap();
+
+        let span = debug_span!("original thread");
+        span.set_context(context);
+        span_context!(span, Level::DEBUG);
+        let _g = span.enter();
+        let span = debug_span!("inner");
+        let _g = span.enter();
+        span_context!(span, Level::DEBUG);
+    }
+    {
+        let context = rx2.recv().await.unwrap();
+
+        let span = debug_span!("original thread");
+        span.set_context(context);
+        span_context!(span, Level::DEBUG);
+        let _g = span.enter();
+    }
+}
+
+async fn across_thread(mut rx: mpsc::Receiver<Context>, mut tx: mpsc::Sender<Context>) {
+    {
+        let context = rx.recv().await.unwrap();
+        let span = debug_span!("across thread");
+        span.set_context(context);
+        span_context!(span, Level::DEBUG);
+        let _g = span.enter();
+        let span = debug_span!("inner");
+        let _g = span.enter();
+        span_context!(span, Level::DEBUG);
+        tx.send(span.get_context()).await.unwrap();
+    }
+    tokio::time::delay_for(std::time::Duration::from_millis(100)).await;
+    {
+        let span = debug_span!("from another thread");
+        let context = span.get_context();
+        let _g = span.enter();
+        span_context!(span, Level::DEBUG);
+        tx.send(context).await.unwrap();
+    }
+}
+*/

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -33,11 +33,11 @@ holochain_zome_types = { path = "../holochain_zome_types", version = "^0.1.0", f
 itertools = { version = "0.10" }
 kitsune_p2p_dht = { version = "^0.1.0", path = "../kitsune_p2p/dht" }
 lazy_static = "1.4.0"
-mockall = "0.10.2"
+mockall = "0.11.3"
 mr_bundle = { path = "../mr_bundle", features = ["packing"], version = "^0.1.0"}
 must_future = "0.1.1"
 nanoid = "0.3"
-observability = "0.1.3"
+holochain_trace = { version = "^0.1.0", path = "../holochain_trace" }
 parking_lot = "0.10"
 rand = "0.8.5"
 regex = "1.4"

--- a/crates/holochain_types/src/app/app_bundle/tests.rs
+++ b/crates/holochain_types/src/app/app_bundle/tests.rs
@@ -39,7 +39,7 @@ async fn app_bundle_fixture(modifiers: DnaModifiersOpt<YamlProperties>) -> (AppB
 /// Test that an app with a single Created cell can be provisioned
 #[tokio::test]
 async fn provisioning_1_create() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let agent = fixt!(AgentPubKey);
     let modifiers = DnaModifiersOpt {
         properties: Some(app_manifest_properties_fixture()),

--- a/crates/holochain_types/src/dht_op/tests.rs
+++ b/crates/holochain_types/src/dht_op/tests.rs
@@ -14,9 +14,9 @@ use crate::prelude::*;
 use ::fixt::prelude::*;
 use holo_hash::fixt::ActionHashFixturator;
 use holo_hash::*;
+use holochain_trace;
 use holochain_zome_types::ActionHashed;
 use holochain_zome_types::Entry;
-use observability;
 use tracing::*;
 
 use super::OpBasis;
@@ -212,7 +212,7 @@ impl RecordTest {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_all_ops() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let mut builder = RecordTest::new();
     let (record, expected) = builder.entry_create();
     let result = produce_ops_from_record(&record).unwrap();

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -31,7 +31,7 @@ url2 = "0.0.6"
 holochain_types = { path = "../holochain_types" }
 linefeed = "0.6"
 unwrap_to = "0.1.0"
-observability = "0.1.3"
+holochain_trace = { version = "^0.1.0", path = "../holochain_trace" }
 criterion = "0.3.4"
 
 [[bench]]

--- a/crates/holochain_websocket/benches/bench.rs
+++ b/crates/holochain_websocket/benches/bench.rs
@@ -21,7 +21,7 @@ criterion_main!(benches);
 struct TestMessage(pub String);
 
 fn simple_bench(bench: &mut Criterion) {
-    let _g = observability::test_run().ok();
+    let _g = holochain_trace::test_run().ok();
 
     let runtime = rt();
 

--- a/crates/holochain_websocket/examples/echo_server.rs
+++ b/crates/holochain_websocket/examples/echo_server.rs
@@ -12,7 +12,7 @@ struct ResponseMessage(pub String);
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
-    observability::test_run().unwrap();
+    holochain_trace::test_run().unwrap();
 
     let (listener_handle, mut listener_stream) = WebsocketListener::bind_with_handle(
         url2!("ws://127.0.0.1:12345"),

--- a/crates/holochain_websocket/src/websocket.rs
+++ b/crates/holochain_websocket/src/websocket.rs
@@ -774,7 +774,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_register_response() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let (handle, mut listener) = WebsocketListener::bind_with_handle(
             url2!("ws://127.0.0.1:0"),
             Arc::new(WebsocketConfig::default()),

--- a/crates/holochain_websocket/tests/integration.rs
+++ b/crates/holochain_websocket/tests/integration.rs
@@ -105,7 +105,7 @@ fn server_signal(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_connect() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let (handle, mut listener) = server().await;
     tokio::task::spawn(async move {
         let _ = listener
@@ -123,7 +123,7 @@ async fn can_connect() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_send_signal() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let (handle, mut listener) = server().await;
     let jh = tokio::task::spawn(async move {
         let (mut sender, mut receiver) = listener
@@ -181,7 +181,7 @@ async fn can_send_signal() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_send_request() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let (handle, mut listener) = server().await;
     let jh = tokio::task::spawn(async move {
         let (mut sender, mut receiver) = listener
@@ -250,7 +250,7 @@ async fn can_send_request() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn shutdown_listener() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let (handle, mut listener) = server().await;
     std::mem::drop(handle);
     assert!(listener.next().await.is_none());
@@ -293,7 +293,7 @@ async fn shutdown_listener() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn shutdown_receiver() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let (handle, listener) = server().await;
     let s_jh = server_wait(listener);
     let binding = handle.local_addr().clone();
@@ -317,7 +317,7 @@ async fn shutdown_receiver() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn listener_shuts_down_server() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let (handle, listener) = server().await;
     let s_jh = server_wait(listener);
     let binding = handle.local_addr().clone();
@@ -341,7 +341,7 @@ async fn listener_shuts_down_server() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn client_shutdown() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let (handle, listener) = server().await;
     let s_jh = server_wait(listener);
     let binding = handle.local_addr().clone();
@@ -366,7 +366,7 @@ async fn client_shutdown() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn drop_sender() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let (handle, listener) = server().await;
     let s_jh = server_signal(listener, 10);
     let binding = handle.local_addr().clone();
@@ -390,7 +390,7 @@ async fn drop_sender() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn drop_receiver() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let (handle, listener) = server().await;
     let s_jh = server_recv(listener);
     let binding = handle.local_addr().clone();
@@ -414,7 +414,7 @@ async fn drop_receiver() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn cancel_response() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let (handle, mut listener) = server().await;
     let s_jh = tokio::task::spawn(async move {
         let (mut sender, _receiver) = listener

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -18,7 +18,7 @@ kitsune_p2p_block = { version = "^0.1.0", path = "../kitsune_p2p/block" }
 holo_hash = { version = "^0.1.0", path = "../holo_hash", features = ["encoding"] }
 holochain_integrity_types = { version = "^0.1.0", path = "../holochain_integrity_types", features = ["tracing"] }
 holochain_serialized_bytes = "=0.0.51"
-paste = "=1.0.5"
+paste = "1.0.12"
 serde = { version = "1.0", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"
 serde_yaml = { version = "0.9", optional = true }

--- a/crates/kitsune_p2p/bootstrap/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = "3.1.18"
+clap = { version = "3.1.18", features = [ "derive" ] }
 futures = "0.3.15"
 kitsune_p2p_types = { version = "^0.1.0", path = "../types" }
 once_cell = "1.7.2"

--- a/crates/kitsune_p2p/dht/Cargo.toml
+++ b/crates/kitsune_p2p/dht/Cargo.toml
@@ -35,7 +35,7 @@ kitsune_p2p_dht = { path = ".", features = ["test_utils"]}
 kitsune_p2p_dht_arc = { path = "../dht_arc", features = ["test_utils"]}
 holochain_serialized_bytes = "0.0.51"
 maplit = "1"
-observability = "0.1"
+holochain_trace = { version = "^0.1.0", path = "../../holochain_trace" }
 pretty_assertions = "0.7.2"
 proptest = "1"
 rand = "0.8"

--- a/crates/kitsune_p2p/dht/src/arq/arq_set.rs
+++ b/crates/kitsune_p2p/dht/src/arq/arq_set.rs
@@ -214,7 +214,7 @@ mod tests {
 
     #[test]
     fn intersect_arqs() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let topo = Topology::unit_zero();
         let a = Arq::new(27, 536870912u32.into(), 11.into());
         let b = Arq::new(27, 805306368u32.into(), 11.into());
@@ -230,7 +230,7 @@ mod tests {
 
     #[test]
     fn intersect_arqs_multi() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let topo = Topology::unit_zero();
 
         let pow = 26;

--- a/crates/kitsune_p2p/dht/tests/arc_resizing.rs
+++ b/crates/kitsune_p2p/dht/tests/arc_resizing.rs
@@ -158,7 +158,7 @@ fn test_grow_by_multiple_chunks() {
 ///
 /// (not a very good test, probably)
 fn test_degenerate_asymmetrical_coverage() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let topo = Topology::unit_zero();
     let other = ArqBounds::from_interval(&topo, 4, DhtArcRange::from_bounds(0x0u32, 0x80))
         .unwrap()

--- a/crates/kitsune_p2p/dht/tests/arc_stability.rs
+++ b/crates/kitsune_p2p/dht/tests/arc_stability.rs
@@ -42,7 +42,7 @@ fn pass_redundancy(stats: &Stats, redundancy_target: f64) {
 #[test]
 fn stability_test_case_near_ideal() {
     std::env::set_var("RUST_LOG", "debug");
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let topo = Topology::standard_zero();
     let detail = false;
@@ -64,7 +64,7 @@ fn stability_test_case_near_ideal() {
 #[test]
 fn stability_test_case_messy() {
     std::env::set_var("RUST_LOG", "debug");
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let topo = Topology::standard_zero();
     let detail = true;
@@ -89,7 +89,7 @@ proptest::proptest! {
     #[ignore = "takes a very long time. run sparingly."]
     fn stability_test(num_peers in 100u32..300, min_coverage in 50.0f64..100.0, j in 0.0..1.0) {
         std::env::set_var("RUST_LOG", "debug");
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let topo = Topology::unit_zero();
         let detail = false;

--- a/crates/kitsune_p2p/dht/tests/gossip.rs
+++ b/crates/kitsune_p2p/dht/tests/gossip.rs
@@ -156,7 +156,7 @@ fn test_mismatched_powers() {
 /// of the nodes after enough gossip rounds
 #[test]
 fn gossip_scenario_full_sync() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let topo = Topology::standard_zero();
     let gopa = GossipParams::new(1.into(), 0);
 

--- a/crates/kitsune_p2p/dht/tests/legacy_arc_stability.rs
+++ b/crates/kitsune_p2p/dht/tests/legacy_arc_stability.rs
@@ -39,7 +39,7 @@ fn pass_redundancy(stats: &Stats, redundancy_target: f64) -> bool {
 #[ignore = "Not suitable for ci"]
 fn single_agent_convergence_debug() {
     std::env::set_var("RUST_LOG", "debug");
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let n = 1000;
     let redundancy = 100;
@@ -112,7 +112,7 @@ pub fn run_report(
 #[cfg(feature = "slow_tests")]
 fn parameterized_battery() {
     std::env::set_var("RUST_LOG", "info");
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     use std::collections::HashSet;
 
     let n = 100;
@@ -176,7 +176,7 @@ fn parameterized_battery() {
 #[ignore = "Not suitable for ci"]
 fn parameterized_stability_test() {
     std::env::set_var("RUST_LOG", "debug");
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let mut rng = seeded_rng(None);
 
@@ -212,7 +212,7 @@ fn parameterized_stability_test() {
 #[test]
 #[ignore = "Not suitable for ci"]
 fn test_peer_view_beta() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let mut rng = seeded_rng(None);
 

--- a/crates/kitsune_p2p/dht_arc/Cargo.toml
+++ b/crates/kitsune_p2p/dht_arc/Cargo.toml
@@ -21,7 +21,7 @@ rusqlite = { version = "0.28", optional = true }
 
 [dev-dependencies]
 maplit = "1"
-observability = "0.1"
+holochain_trace = { version = "^0.1.0", path = "../../holochain_trace" }
 pretty_assertions = "0.7.2"
 rand = "0.8.5"
 statrs = "0.15"

--- a/crates/kitsune_p2p/direct/src/lib.rs
+++ b/crates/kitsune_p2p/direct/src/lib.rs
@@ -29,7 +29,9 @@ pub mod dependencies {
     pub use futures;
     pub use kitsune_p2p;
     pub use kitsune_p2p_types;
-    pub use kitsune_p2p_types::dependencies::{ghost_actor::dependencies::tracing, observability};
+    pub use kitsune_p2p_types::dependencies::{
+        ghost_actor::dependencies::tracing, holochain_trace,
+    };
     pub use serde_json;
 }
 

--- a/crates/kitsune_p2p/direct_test/Cargo.toml
+++ b/crates/kitsune_p2p/direct_test/Cargo.toml
@@ -17,4 +17,4 @@ kitsune_p2p_proxy = { version = "^0.1.0", path = "../proxy" }
 rand = "0.8.5"
 structopt = "0.3.21"
 tokio = { version = "1.11", features = ["full"] }
-tracing-subscriber = "0.2.19"
+tracing-subscriber = "0.3.16"

--- a/crates/kitsune_p2p/direct_test/src/consistency_stress.rs
+++ b/crates/kitsune_p2p/direct_test/src/consistency_stress.rs
@@ -210,12 +210,11 @@ pub fn run(
     impl futures::stream::Stream<Item = Progress>,
     impl FnOnce() -> BoxFuture<'static, ()>,
 ) {
-    use tracing_subscriber::{filter::EnvFilter, fmt::time::ChronoUtc, FmtSubscriber};
+    use tracing_subscriber::{filter::EnvFilter, fmt::time::UtcTime, FmtSubscriber};
     tracing::subscriber::set_global_default(
         FmtSubscriber::builder()
             .with_writer(std::io::stderr)
-            // like rfc3339 but slightly more terse
-            .with_timer(ChronoUtc::with_format("%Y-%m-%dT%H:%M:%S.%3fZ".to_string()))
+            .with_timer(UtcTime::rfc_3339())
             .with_env_filter(EnvFilter::from_default_env())
             .pretty()
             .finish(),

--- a/crates/kitsune_p2p/direct_test/src/direct_test_local_periodic.rs
+++ b/crates/kitsune_p2p/direct_test/src/direct_test_local_periodic.rs
@@ -10,7 +10,7 @@ use kitsune_p2p_types::tx2::tx2_utils::*;
 
 /// init tracing
 pub fn init_tracing() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 }
 
 /// kdirect version harness specifier

--- a/crates/kitsune_p2p/fetch/Cargo.toml
+++ b/crates/kitsune_p2p/fetch/Cargo.toml
@@ -30,7 +30,7 @@ human-repr = { version = "1", optional = true}
 [dev-dependencies]
 kitsune_p2p_fetch = { path = ".", features = ["test_utils"]}
 holochain_serialized_bytes = "0.0.51"
-observability = "0.1"
+holochain_trace = { version = "^0.1.0", path = "../../holochain_trace" }
 pretty_assertions = "0.7.2"
 test-case = "1.2"
 tokio = { version = "1.11", features = [ "full", "test-util" ] }

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -17,7 +17,7 @@ bloomfilter = { version = "1.0.5", features = ["serde"] }
 bytes = "1.4.0"
 derive_more = "0.99.11"
 futures = "0.3"
-ghost_actor = "=0.3.0-alpha.4"
+ghost_actor = "=0.3.0-alpha.5"
 governor = "0.3.2"
 itertools = "0.10"
 kitsune_p2p_fetch = { version = "^0.1.0", path = "../fetch" }
@@ -30,7 +30,7 @@ kitsune_p2p_types = { version = "^0.1.0", path = "../types", default-features = 
 must_future = "0.1.1"
 nanoid = "0.4"
 num-traits = "0.2"
-observability = "0.1.3"
+holochain_trace = { version = "^0.1.0", path = "../../holochain_trace" }
 once_cell = "1.4.1"
 parking_lot = "0.11.1"
 rand = "0.8.5"
@@ -52,7 +52,7 @@ arbitrary = { version = "1.0", features = ["derive"] }
 
 blake2b_simd = { version = "0.5.10", optional = true }
 maplit = { version = "1", optional = true }
-mockall = { version = "0.10.2", optional = true }
+mockall = { version = "0.11.3", optional = true }
 
 [dev-dependencies]
 # include self with test_utils feature, to allow integration tests to run properly
@@ -67,7 +67,7 @@ mockall = "0.10.2"
 pretty_assertions = "0.7"
 test-case = "1.0.0"
 tokio = { version = "1.11", features = ["full", "test-util"] }
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3.16"
 
 [features]
 default = [ "tx2", "tx5" ]

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/bandwidth.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/bandwidth.rs
@@ -249,7 +249,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_limiter() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let clock = governor::clock::FakeRelativeClock::default();
         // max * 2 * 8 = 0.1 * 1_000_000 * burst_ratio => burst_ratio = max * 2 * 8 / 0.1 / 1_000_000
         let burst_ratio = MAX_SEND_BUF_BYTES as f64 * 2.0 * 8.0 / 1_000_000.0 / 0.1;

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
@@ -77,7 +77,7 @@ async fn build_ep_hnd(config: Arc<KitsuneP2pConfig>, m: MockBindAdapt) -> Tx2EpH
 
 #[tokio::test]
 async fn test_rpc_multi_logic_mocked() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     // allow fake timing during test
     tokio::time::pause();

--- a/crates/kitsune_p2p/kitsune_p2p/src/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test.rs
@@ -10,8 +10,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_transport_coms() {
-        observability::test_run().ok();
-        observability::metrics::init();
+        holochain_trace::test_run().ok();
+        holochain_trace::metrics::init();
         let (harness, _evt) = spawn_test_harness_mem().await.unwrap();
 
         let space = harness.add_space().await.unwrap();
@@ -44,7 +44,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_peer_info_store() -> Result<(), KitsuneP2pError> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let (harness, evt) = spawn_test_harness_mem().await?;
         let mut recv = evt.receive();
@@ -74,7 +74,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_transport_binding() -> Result<(), KitsuneP2pError> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let (harness, _evt) = spawn_test_harness_quic().await?;
 
@@ -103,7 +103,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_request_workflow() -> Result<(), KitsuneP2pError> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let (harness, _evt) = spawn_test_harness_quic().await?;
         let space = harness.add_space().await?;
@@ -123,7 +123,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_multi_request_workflow() -> Result<(), KitsuneP2pError> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let (harness, _evt) = spawn_test_harness_quic().await?;
 
@@ -161,7 +161,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_single_agent_multi_request_workflow() -> Result<(), KitsuneP2pError> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let (harness, _evt) = spawn_test_harness_quic().await?;
 
@@ -192,7 +192,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_gossip_workflow() -> Result<(), KitsuneP2pError> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let (harness, _evt) = spawn_test_harness_quic().await?;
 
@@ -232,7 +232,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_peer_data_workflow() -> Result<(), KitsuneP2pError> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let (harness, _evt) = spawn_test_harness_quic().await?;
 
@@ -265,7 +265,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_gossip_transport() -> Result<(), KitsuneP2pError> {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let (harness, _evt) = spawn_test_harness_mem().await?;
 
         harness.add_space().await?;
@@ -334,7 +334,7 @@ mod tests {
     // @freesig Can anyone think of a better way to do this?
     #[ignore = "Need a better way then waiting 6 minutes to test this"]
     async fn test_publish_agent_info() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let (harness, _evt) = spawn_test_harness_mem().await.unwrap();
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/tests.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/tests.rs
@@ -16,7 +16,7 @@ use pretty_assertions::assert_eq;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "(david.b) ignore until we write a switchboard fetch-queue impl"]
 async fn fullsync_3way_recent() {
-    // observability::test_run().ok();
+    // holochain_trace::test_run().ok();
     let topo = Topology::standard_epoch_full();
     let sb = Switchboard::new(topo.clone(), GossipType::Recent);
 
@@ -64,7 +64,7 @@ async fn fullsync_3way_recent() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "(david.b) ignore until we write a switchboard fetch-queue impl"]
 async fn sharded_3way_recent() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let topo = Topology::standard_epoch_full();
     let sb = Switchboard::new(topo.clone(), GossipType::Recent);
 
@@ -110,7 +110,7 @@ async fn sharded_3way_recent() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn transitive_peer_gossip() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     let topo = Topology::standard_epoch_full();
     let sb = Switchboard::new(topo.clone(), GossipType::Recent);
 
@@ -179,7 +179,7 @@ async fn transitive_peer_gossip() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "(david.b) ignore until we write a switchboard fetch-queue impl"]
 async fn sharded_4way_recent() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let topo = Topology::standard_epoch_full();
     let sb = Switchboard::new(topo.clone(), GossipType::Recent);
@@ -266,7 +266,7 @@ async fn sharded_4way_recent() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "(david.b) ignore until we write a switchboard fetch-queue impl"]
 async fn sharded_4way_historical() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     let now = Timestamp::now().as_micros();
     // 1 year ago

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/metrics.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/metrics.rs
@@ -1,6 +1,6 @@
 use ghost_actor::dependencies::tracing;
 
-observability::metrics!(
+holochain_trace::metrics!(
     KitsuneMetrics,
     Failure,
     Call,
@@ -17,7 +17,7 @@ observability::metrics!(
 /// Print all metrics as tracing events
 #[tracing::instrument]
 pub fn print_all_metrics() {
-    if observability::metrics::is_enabled() {
+    if holochain_trace::metrics::is_enabled() {
         use std::fmt::Write;
         use KitsuneMetrics::*;
         let mut out = String::new();
@@ -58,7 +58,7 @@ pub fn print_all_metrics() {
 pub fn init() {
     if let Some(km) = std::env::var_os("KITSUNE_METRICS") {
         if km == "ON" {
-            observability::metrics::init();
+            holochain_trace::metrics::init();
         }
     }
 }

--- a/crates/kitsune_p2p/proxy/Cargo.toml
+++ b/crates/kitsune_p2p/proxy/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3"
 kitsune_p2p_types = { version = "^0.1.0", path = "../types" }
 kitsune_p2p_transport_quic = { version = "^0.1.0", path = "../transport_quic" }
 nanoid = "0.3"
-observability = "0.1.3"
+holochain_trace = { version = "^0.1.0", path = "../../holochain_trace" }
 parking_lot = "0.11"
 rmp-serde = "0.15"
 rustls = { version = "0.20.4", features = [ "dangerous_configuration" ] }
@@ -26,7 +26,7 @@ serde = { version = "1", features = [ "derive" ] }
 serde_bytes = "0.11"
 structopt = "0.3"
 tokio = { version = "1.11", features = [ "full" ] }
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3.16"
 webpki = "0.21.2"
 
 [dev-dependencies]

--- a/crates/kitsune_p2p/proxy/src/bin/kitsune-p2p-tx2-proxy.rs
+++ b/crates/kitsune_p2p/proxy/src/bin/kitsune-p2p-tx2-proxy.rs
@@ -30,7 +30,7 @@ pub struct Opt {
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     kitsune_p2p_types::metrics::init_sys_info_poll();
 
     if let Err(e) = inner().await {

--- a/crates/kitsune_p2p/proxy/src/bin/proxy-tx2-cli.rs
+++ b/crates/kitsune_p2p/proxy/src/bin/proxy-tx2-cli.rs
@@ -19,7 +19,7 @@ pub struct Opt {
 
 #[tokio::main]
 async fn main() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
 
     if let Err(e) = inner().await {
         eprintln!("{:?}", e);

--- a/crates/kitsune_p2p/proxy/src/tx2.rs
+++ b/crates/kitsune_p2p/proxy/src/tx2.rs
@@ -1080,7 +1080,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_tx2_route_err() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         let t = KitsuneTimeout::from_millis(5000);
         let mut all_tasks = Vec::new();
 
@@ -1113,7 +1113,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_tx2_proxy() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
 
         let t = KitsuneTimeout::from_millis(5000);
 

--- a/crates/kitsune_p2p/proxy/tests/tx2_con_up_down/mod.rs
+++ b/crates/kitsune_p2p/proxy/tests/tx2_con_up_down/mod.rs
@@ -53,7 +53,7 @@ async fn gen_node() -> Tx2EpHnd<Wire> {
                         panic!("unexpected: {:?}", data);
                     }
                 }
-                evt => observability::tracing::trace!("unhandled: {:?}", evt),
+                evt => holochain_trace::tracing::trace!("unhandled: {:?}", evt),
             }
         })
         .await;

--- a/crates/kitsune_p2p/transport_quic/src/tx2.rs
+++ b/crates/kitsune_p2p/transport_quic/src/tx2.rs
@@ -471,7 +471,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_quic_tx2() {
-        kitsune_p2p_types::dependencies::observability::test_run().ok();
+        kitsune_p2p_types::dependencies::holochain_trace::test_run().ok();
 
         let t = KitsuneTimeout::from_millis(5000);
 

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -15,17 +15,17 @@ lair_keystore_api = "=0.2.3"
 base64 = "0.13"
 derive_more = "0.99.7"
 futures = "0.3"
-ghost_actor = "=0.3.0-alpha.4"
+ghost_actor = "=0.3.0-alpha.5"
 kitsune_p2p_dht = { version = "^0.1.0", path = "../dht" }
 kitsune_p2p_dht_arc = { version = "^0.1.0", path = "../dht_arc" }
 kitsune_p2p_bin_data = { version = "^0.1.0", path = "../bin_data" }
 lru = "0.8.1"
-mockall = { version = "0.10.2", optional = true }
+mockall = { version = "0.11.3", optional = true }
 nanoid = "0.3"
-observability = "0.1.3"
+holochain_trace = { version = "^0.1.0", path = "../../holochain_trace" }
 once_cell = "1.4"
 parking_lot = "0.11"
-paste = "1.0.5"
+paste = "1.0.12"
 rmp-serde = "0.15"
 rustls = { version = "0.20.4", features = [ "dangerous_configuration" ] }
 serde = { version = "1", features = [ "derive", "rc" ] }
@@ -46,7 +46,7 @@ arbitrary = { version = "1.0", features = ["derive"], optional = true}
 [dev-dependencies]
 kitsune_p2p_types = {path = ".", features = ["test_utils"]}
 criterion = "0.3.4"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.3.16"
 
 [[bench]]
 name = "api_thru"

--- a/crates/kitsune_p2p/types/src/lib.rs
+++ b/crates/kitsune_p2p/types/src/lib.rs
@@ -5,8 +5,8 @@
 pub mod dependencies {
     pub use ::futures;
     pub use ::ghost_actor;
+    pub use ::holochain_trace;
     pub use ::lair_keystore_api;
-    pub use ::observability;
     pub use ::paste;
     pub use ::rustls;
     pub use ::serde;

--- a/crates/kitsune_p2p/types/src/metrics.rs
+++ b/crates/kitsune_p2p/types/src/metrics.rs
@@ -323,7 +323,7 @@ async fn test_metric_task() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_sys_info() {
-    observability::test_run().ok();
+    holochain_trace::test_run().ok();
     init_sys_info_poll();
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
     let sys_info = get_sys_info();

--- a/crates/kitsune_p2p/types/src/tx2/tx2_api.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_api.rs
@@ -907,7 +907,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_tx2_api() {
-        observability::test_run().ok();
+        holochain_trace::test_run().ok();
         tracing::trace!("bob");
 
         let t = KitsuneTimeout::from_millis(5000);

--- a/crates/mock_hdi/Cargo.toml
+++ b/crates/mock_hdi/Cargo.toml
@@ -9,4 +9,4 @@ documentation = "https://docs.rs/holochain_mock_hdi"
 
 [dependencies]
 hdi = { path = "../hdi" }
-mockall = { version = "0.11.0" }
+mockall = { version = "0.11.3" }

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.2.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e90af4de65aa7b293ef2d09daff88501eb254f58edde2e1ac02c82d873eadad"
+checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -209,9 +209,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "camino"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6031a462f977dd38968b6f23378356512feeace69cef817e1a4475108093cec3"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
 dependencies = [
  "serde",
 ]
@@ -233,7 +233,7 @@ checksum = "08a1ec454bc3eead8719cb56e15dbbfecdbc14e4b3a3ae4936cc6e31f5fc0d07"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.16",
+ "semver 1.0.17",
  "serde",
  "serde_json",
  "thiserror",
@@ -259,9 +259,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
  "num-integer",
@@ -518,12 +518,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0808e1bd8671fb44a113a14e13497557533369847788fa2ae912b6ebfce9fa8"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core 0.14.3",
- "darling_macro 0.14.3",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
 ]
 
 [[package]]
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001d80444f28e193f30c2f293455da62dcf9a6b29918a4253152ae2b1de592cb"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
@@ -567,11 +567,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b36230598a2d5de7ec1c6f51f72d8a99a9208daff41de2084d06e3fd3ea56685"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core 0.14.3",
+ "darling_core 0.14.4",
  "quote",
  "syn",
 ]
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.2.3"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8beee4701e2e229e8098bbdecdca12449bc3e322f137d269182fa1291e20bd00"
+checksum = "f3cdeb9ec472d588e539a818b2dee436825730da08ad0017c4b1a17676bdc8b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -699,7 +699,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03e7b551eba279bf0fa88b83a46330168c1560a52a94f5126f892f0b364ab3e0"
 dependencies = [
- "darling 0.14.3",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn",
@@ -785,9 +785,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -800,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -810,15 +810,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
+checksum = "1997dd9df74cdac935c76252744c1ed5794fac083242ea4fe77ef3ed60ba0f83"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -827,15 +827,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -844,21 +844,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -978,7 +978,7 @@ dependencies = [
 name = "hdk_derive"
 version = "0.1.0"
 dependencies = [
- "darling 0.14.3",
+ "darling 0.14.4",
  "heck 0.4.1",
  "holochain_integrity_types",
  "paste",
@@ -1357,9 +1357,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
 name = "libloading"
@@ -1714,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.5"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pest"
@@ -1802,9 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -1831,9 +1831,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2150,7 +2150,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.16",
+ "semver 1.0.17",
 ]
 
 [[package]]
@@ -2217,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
 ]
@@ -2235,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
 dependencies = [
  "serde_derive",
 ]
@@ -2262,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "d7e29c4601e36bcec74a223228dce795f4cd3616341a4af93520ca1a837c087d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2507,7 +2507,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "856bbca0314c328004691b9c0639fb198ca764d1ce0e20d4dd8b78f2697c2a6f"
 dependencies = [
- "darling 0.14.3",
+ "darling 0.14.4",
  "if_chain",
  "lazy_static",
  "proc-macro2",
@@ -3510,12 +3510,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -3529,24 +3529,24 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.1",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3556,9 +3556,9 @@ checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3568,9 +3568,9 @@ checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3580,9 +3580,9 @@ checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3592,15 +3592,15 @@ checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3610,6 +3610,6 @@ checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"


### PR DESCRIPTION
- adds a `tracing_override` conductor config so i can specify a real RUST_LOG string through launcher which right now only allows single word filters.
- adds filenames and line numbers to tracing output so i can find where errors are generated from
- forks "observability" crate into "holochain_tracing" in the monorepo so we can manage dependencies and make updates (observability is owned by tom)
- updates dependencies of new holochain_tracing crate -- but not opentelemetry for now, because it was a difficult upgrade and we don't really use it.