### PR TITLE
accept comma-delimited argument for `hc sandbox g -d`

### DIFF
--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Fix bug in `hc sandbox generate`, where a comma-separated argument passed to the `--directories` option was treated as a single directory name. [\#2080](https://github.com/holochain/holochain/pull/2080)
+
 ## 0.1.0
 
 ## 0.1.0-beta-rc.0

--- a/crates/hc_sandbox/src/cmds.rs
+++ b/crates/hc_sandbox/src/cmds.rs
@@ -24,7 +24,7 @@ pub struct Create {
     /// This directory must already exist.
     #[structopt(long)]
     pub root: Option<PathBuf>,
-    #[structopt(short, long)]
+    #[structopt(short, long, value_delimiter = ",")]
     /// Specify the directory name for each sandbox that is created.
     /// By default, new sandbox directories get a random name
     /// like "kAOXQlilEtJKlTM_W403b".

--- a/crates/hc_sandbox/src/cmds.rs
+++ b/crates/hc_sandbox/src/cmds.rs
@@ -30,7 +30,7 @@ pub struct Create {
     /// like "kAOXQlilEtJKlTM_W403b".
     /// Use this option to override those names with something explicit.
     ///
-    /// For example `hc gen -r path/to/my/chains -n 3 -d=first,second,third`
+    /// For example `hc s generate path/to/my/chains -r -n 3 -d=first,second,third`
     /// will create three sandboxes with directories named "first", "second", and "third".
     pub directories: Vec<PathBuf>,
 }


### PR DESCRIPTION
### Summary

While testing and writing about `hc`, I discovered that the `--directories` argument doesn't actually accept a comma-delimited list; it'll use the whole list as the first directory name and then autogenerate the rest of them.

I built and tested it manually, and it works. But I'd love to learn how to write an automated test for this sort of thing, cuz I might be dipping into `hc`'s codebase a few more times by the time I finish this adventure.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
