### PR TITLE
Take `name` out of DnaDefHash

### DIFF
--- a/crates/holochain/src/conductor/tests/app_info.rs
+++ b/crates/holochain/src/conductor/tests/app_info.rs
@@ -33,30 +33,28 @@ async fn app_info_returns_all_cells_with_info() {
         .unwrap();
 
     // create 1 clone cell for role 1 = clone cell 1
-    let clone_name_1 = "clone_1".to_string();
     let clone_cell_1 = conductor
         .clone()
         .create_clone_cell(CreateCloneCellPayload {
             app_id: app_id.clone(),
             role_name: role_name_1.clone(),
-            modifiers: DnaModifiersOpt::none().with_network_seed("seed".to_string()),
+            modifiers: DnaModifiersOpt::none().with_network_seed("seed numero uno".to_string()),
             membrane_proof: None,
-            name: Some(clone_name_1.clone()),
+            name: None,
         })
         .await
         .unwrap();
     assert_eq!(clone_cell_1.original_dna_hash, dna_1.dna_hash().clone());
 
     // create 1 clone cell for role 2 = clone cell 2
-    let clone_name_2 = "clone_2".to_string();
     let clone_cell_2 = conductor
         .clone()
         .create_clone_cell(CreateCloneCellPayload {
             app_id: app_id.clone(),
             role_name: role_name_2.clone(),
-            modifiers: DnaModifiersOpt::none().with_network_seed("seed".to_string()),
+            modifiers: DnaModifiersOpt::none().with_network_seed("seed numero dos".to_string()),
             membrane_proof: None,
-            name: Some(clone_name_2.clone()),
+            name: None,
         })
         .await
         .unwrap();

--- a/crates/holochain/src/sweettest/sweet_app.rs
+++ b/crates/holochain/src/sweettest/sweet_app.rs
@@ -65,7 +65,12 @@ impl SweetApp {
 
 /// A collection of installed apps
 #[derive(
-    Clone, derive_more::From, derive_more::Into, derive_more::AsRef, derive_more::IntoIterator,
+    Clone,
+    derive_more::From,
+    derive_more::Into,
+    derive_more::AsRef,
+    derive_more::IntoIterator,
+    derive_more::Index,
 )]
 pub struct SweetAppBatch(pub(super) Vec<SweetApp>);
 

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- A change to `name` in a DnaDef no longer has an effect on the DNA hash [\#2099](https://github.com/holochain/holochain/pull/2099)
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
-- A change to `name` in a DnaDef no longer has an effect on the DNA hash [\#2099](https://github.com/holochain/holochain/pull/2099)
+- `name` in DnaDef no longer has an effect on the DNA hash [\#2099](https://github.com/holochain/holochain/pull/2099)
 
 ## 0.2.0-beta-rc.0
 

--- a/crates/holochain_zome_types/src/dna_def.rs
+++ b/crates/holochain_zome_types/src/dna_def.rs
@@ -189,7 +189,6 @@ pub struct DnaDef {
 #[derive(Serialize, Debug, PartialEq, Eq)]
 /// A reference to for creating the hash for [`DnaDef`].
 struct DnaDefHash<'a> {
-    name: &'a String,
     modifiers: &'a DnaModifiers,
     integrity_zomes: &'a IntegrityZomes,
 }
@@ -362,7 +361,6 @@ impl HashableContent for DnaDef {
 
     fn hashable_content(&self) -> HashableContentBytes {
         let hash = DnaDefHash {
-            name: &self.name,
             modifiers: &self.modifiers,
             integrity_zomes: &self.integrity_zomes,
         };


### PR DESCRIPTION
Fixes #2038

### Summary

Oops! Despite having talked about it extensively and affirming that the name doesn't affect the DNA hash, sure enough, it did. This fixes that.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
