### PR TITLE
chore: re-enable the weekly release schedule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@
 name: release holochain
 
 on:
-  # schedule:
-  #   - cron: "0 0 * * 3" # at 0 AM on wednesday
+  schedule:
+    - cron: "0 0 * * 3" # at 0 AM on wednesday
   workflow_dispatch:
     inputs:
       # holochain_url:


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
