### PR TITLE
Get as authority with GetOptions::Latest

### DIFF
--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Updated the meaning of `GetOptions` to produce slightly different behaviors for all cascade queries [\#2119](https://github.com/holochain/holochain/pull/2119)
+    - `GetOptions::Latest` always causes the query to go to the network for the latest data
+    - `GetOptions::Content` will only go to the network if you are not an authority and no data could be found
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -777,7 +777,7 @@ where
         };
 
         // Check if we have the data now after the network call.
-        Ok(self.cascading(query).await?)
+        self.cascading(query).await
     }
 
     /// Perform a concurrent `get` on multiple hashes simultaneously, returning

--- a/crates/holochain_cascade/tests/get_entry.rs
+++ b/crates/holochain_cascade/tests/get_entry.rs
@@ -298,9 +298,9 @@ async fn entry_authority() {
     fill_db(&vault.to_db(), td_record.any_store_record_op.clone());
 
     // Network
-    // - Not expecting any calls to the network.
     let mut mock = MockHolochainP2pDnaT::new();
     mock.expect_authority_for_hash().returning(|_| Ok(true));
+    mock.expect_get().returning(|_, _| Ok(vec![]));
     let mock = MockNetwork::new(mock);
 
     // Cascade

--- a/crates/holochain_state/src/query.rs
+++ b/crates/holochain_state/src/query.rs
@@ -81,7 +81,7 @@ impl<T> Maps<T> {
     }
 }
 
-/// Differentiates between reasons for data not being found
+/// Contains either the extant data, or a contextual reason why it doesn't exist.
 pub enum Resolved<T> {
     /// The value is definitely available
     Exists(T),

--- a/crates/holochain_state/src/query/live_record/test.rs
+++ b/crates/holochain_state/src/query/live_record/test.rs
@@ -30,6 +30,7 @@ async fn can_handle_update_in_scratch() {
     let r = query
         .run(Txn::from(&txn))
         .unwrap()
+        .into_option()
         .expect("Record not found");
     assert_eq!(*r.entry().as_option().unwrap(), td.entry);
     assert_eq!(*r.action(), *td.update_action.action());
@@ -44,6 +45,7 @@ async fn can_handle_update_in_scratch() {
     let r = query
         .run(scratch.clone())
         .unwrap()
+        .into_option()
         .expect("Record not found");
     assert_eq!(*r.entry().as_option().unwrap(), td.entry);
     assert_eq!(*r.action(), *td.update_action.action());

--- a/crates/holochain_zome_types/src/entry.rs
+++ b/crates/holochain_zome_types/src/entry.rs
@@ -96,13 +96,15 @@ impl Default for GetOptions {
 /// the caller is concerned about.
 /// This helps the subconscious avoid unnecessary network calls.
 pub enum GetStrategy {
-    /// Will try to get the latest metadata but fallback
-    /// to the cache if none is found.
-    /// Does not go to the network if you are an authority for the data.
+    /// Will try to get the latest metadata but fallback to the cache if not found.
+    /// Will always go to the network, even if you are an authority for the data.
     Latest,
-    /// Will try to get the content locally but go
-    /// to the network if it is not found.
-    /// Does not go to the network if you are an authority for the data.
+    /// Will try to definitively get the content locally and fallback to the network
+    /// if you're not an authority. Does *not* go to the network if you are an authority
+    /// for the data.
+    ///
+    /// NOTE: if the content has been tombstoned (deleted), it will not be returned.
+    ///       This needs to be fixed. TODO.
     Content,
 }
 


### PR DESCRIPTION
### Summary

#### TL;DR, read the changelog:

- Updated the meaning of `GetOptions` to produce slightly different behaviors for all cascade queries [\#2119](https://github.com/holochain/holochain/pull/2119)
    - `GetOptions::Latest` always causes the query to go to the network for the latest data
    - `GetOptions::Content` will only go to the network if you are not an authority and no data could be found

#### More detail:

There is currently no way to do a `get` which will go out to the network for data you are an authority for. This is problematic in the unsharded case when you are an authority for everything, and you are syncing a large amount of data.

Also, the current `GetOptions` are advertised a bit falsely. `Content` claims to only get "the content", but it uses the same query under the hood as the `Latest` strategy, so it respects tombstones. It seems that the real distinction is that `Content` allows a non-authority to avoid a network call if they have some data which satisfies the query. It could have been named as such.

Since the get options are really about potentially avoiding a network call, I tweaked the definitions, and updated the code accordingly, so that `Latest` will always go to the network to get the latest data, and `Content` will be less comprehensive, only falling back to the network if you are not an authority and you have no cached data at all. (Though the concept of "content" doesn't make much sense anyway for metadata-centric calls like `get_entry_details`)

As a followup, we could do some work on the cascade to make these options make more sense, and in particular we should rename the options so that they make sense in all contexts.

This should be a drop-in improvement for DevHub, since it uses the `Latest` strategy for its gets.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
