### PR TITLE
fix(release-automation): consider dependency state of all matched crates

### DIFF
--- a/crates/release-automation/src/lib/crate_selection/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/mod.rs
@@ -351,6 +351,10 @@ impl<'a> Crate<'a> {
                     if member
                         .dependencies_in_workspace()?
                         .iter()
+                        // FIXME: applying the filter here is incorrect, because
+                        // it persists the return value for the first call and
+                        // returns that for every subsequent call, regardless of
+                        // the filter function that's passed
                         .filter(filter_fn)
                         .map(|(dep_name, _)| dep_name)
                         .collect::<LinkedHashSet<_>>()

--- a/crates/release-automation/src/lib/crate_selection/tests/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/tests/mod.rs
@@ -15,7 +15,7 @@ fn init_logger() {
 }
 
 #[test]
-fn detect_changed_files() {
+fn detect_changed_crates() {
     let workspace_mocker = example_workspace_1().unwrap();
     workspace_mocker.add_or_replace_file(
         "README",
@@ -53,27 +53,6 @@ fn workspace_members() {
         .collect::<HashSet<_>>();
 
     assert_eq!(expected_result, result);
-}
-
-#[test]
-fn detect_changed_crates() {
-    let workspace_mocker = example_workspace_1().unwrap();
-    workspace_mocker.add_or_replace_file(
-        "README",
-        r#"# Example
-
-            Some changes
-        "#,
-    );
-    let before = workspace_mocker.head().unwrap();
-    let after = workspace_mocker.commit(None);
-
-    let workspace = ReleaseWorkspace::try_new(workspace_mocker.root()).unwrap();
-
-    assert_eq!(
-        vec![PathBuf::from(workspace.root()).join("README")],
-        changed_files(workspace.root(), &before, &after).unwrap()
-    );
 }
 
 #[test]

--- a/crates/release-automation/src/lib/crate_selection/tests/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/tests/mod.rs
@@ -70,6 +70,8 @@ fn release_selection() {
     let workspace =
         ReleaseWorkspace::try_new_with_criteria(workspace_mocker.root(), criteria).unwrap();
 
+    // TODO: verify that a crate can be selected by being an unmatched, changed crate that's a dependency of a matched, unchanged crate.
+
     let selection = workspace
         .release_selection()
         .unwrap()

--- a/crates/release-automation/src/lib/crate_selection/tests/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/tests/mod.rs
@@ -47,10 +47,12 @@ fn workspace_members() {
         .map(|crt| crt.name())
         .collect::<HashSet<_>>();
 
-    let expected_result = ["crate_a", "crate_b", "crate_c", "crate_e", "crate_f"]
-        .iter()
-        .map(std::string::ToString::to_string)
-        .collect::<HashSet<_>>();
+    let expected_result = [
+        "crate_g", "crate_a", "crate_b", "crate_c", "crate_e", "crate_f",
+    ]
+    .iter()
+    .map(std::string::ToString::to_string)
+    .collect::<HashSet<_>>();
 
     assert_eq!(expected_result, result);
 }
@@ -78,7 +80,7 @@ fn release_selection() {
         .into_iter()
         .map(|c| c.name())
         .collect::<Vec<_>>();
-    let expected_selection = vec!["crate_b", "crate_a", "crate_e"];
+    let expected_selection = vec!["crate_g", "crate_b", "crate_a", "crate_e"];
 
     assert_eq!(expected_selection, selection);
 }
@@ -161,10 +163,12 @@ fn members_sorted_ws1() {
         .map(|crt| crt.name())
         .collect::<Vec<_>>();
 
-    let expected_result = ["crate_b", "crate_a", "crate_c", "crate_e", "crate_f"]
-        .iter()
-        .map(std::string::ToString::to_string)
-        .collect::<Vec<_>>();
+    let expected_result = [
+        "crate_g", "crate_b", "crate_a", "crate_c", "crate_e", "crate_f",
+    ]
+    .iter()
+    .map(std::string::ToString::to_string)
+    .collect::<Vec<_>>();
 
     assert_eq!(expected_result, result);
 }

--- a/crates/release-automation/src/lib/release.rs
+++ b/crates/release-automation/src/lib/release.rs
@@ -170,7 +170,6 @@ fn bump_release_versions<'a>(
     };
 
     // check the workspace and determine the release selection
-    // todo: double-check that we select matching cratese that had their dependencies change
     let selection = crate::common::selection_check(&cmd_args.check_args, ws)?;
 
     if selection.is_empty() {

--- a/crates/release-automation/src/lib/tests/cli.rs
+++ b/crates/release-automation/src/lib/tests/cli.rs
@@ -531,6 +531,7 @@ fn multiple_subsequent_releases() {
             expected_crates,
             allowed_missing_dependencies,
             expect_new_release,
+            maybe_match_filter,
             pre_release_fn,
         ),
     ) in [
@@ -541,6 +542,7 @@ fn multiple_subsequent_releases() {
             // allowed missing dependencies
             Vec::<&str>::new(),
             true,
+            None,
             Box::new(|_| {}) as F,
         ),
         (
@@ -550,6 +552,7 @@ fn multiple_subsequent_releases() {
             // allowed missing dependencies
             Vec::<&str>::new(),
             false,
+            None,
             Box::new(|_| {}) as F,
         ),
         (
@@ -559,6 +562,7 @@ fn multiple_subsequent_releases() {
             // crate_b won't be part of the release so we allow it to be missing as we're not publishing
             vec!["crate_b"],
             true,
+            None,
             Box::new(|args: A| {
                 let root = args.0;
 
@@ -579,12 +583,13 @@ fn multiple_subsequent_releases() {
             }) as F,
         ),
         (
-            "change crate_b, and as crate_a depends on crate_b it'll be bumped as well",
+            "matching only crate_a, a change of its dependency crate_b leads to a bump in both",
             vec!["0.0.1", "0.1.2", "0.0.2"],
             vec!["crate_b", "crate_a", "crate_e"],
             // allowed missing dependencies
             vec![],
             true,
+            Some("crate_a"),
             Box::new(|args: A| {
                 let root = args.0;
 
@@ -610,6 +615,7 @@ fn multiple_subsequent_releases() {
             // allowed missing dependencies
             vec![],
             true,
+            None,
             Box::new(|args: A| {
                 let root = args.0;
 
@@ -651,6 +657,7 @@ fn multiple_subsequent_releases() {
             // allowed missing dependencies
             vec![],
             true,
+            None,
             Box::new(|args: A| {
                 let root = args.0;
 
@@ -676,6 +683,7 @@ fn multiple_subsequent_releases() {
             // allowed missing dependencies
             vec![],
             true,
+            None,
             Box::new(|args: A| {
                 let root = args.0;
 
@@ -717,6 +725,7 @@ fn multiple_subsequent_releases() {
             // allowed missing dependencies
             vec![],
             true,
+            None,
             Box::new(|args: A| {
                 let root = args.0;
 
@@ -755,6 +764,8 @@ fn multiple_subsequent_releases() {
                 .collect(),
         ));
 
+        let match_filter = maybe_match_filter.unwrap_or("crate_(a|b|e)");
+
         let topmost_release_title_pre = {
             let workspace = ReleaseWorkspace::try_new(workspace_mocker.root()).unwrap();
             let topmost_release_title_pre = match workspace
@@ -775,7 +786,7 @@ fn multiple_subsequent_releases() {
             let cmd = cmd.args(&[
                 &format!("--workspace-path={}", workspace.root().display()),
                 "--log-level=trace",
-                "--match-filter=crate_(a|b|e)",
+                &format!("--match-filter={match_filter}"),
                 "release",
                 &format!(
                     "--cargo-target-dir={}",

--- a/crates/release-automation/src/lib/tests/cli.rs
+++ b/crates/release-automation/src/lib/tests/cli.rs
@@ -292,6 +292,8 @@ fn bump_versions_on_selection() {
 
         - `Signature` is a 64 byte ‘secure primitive’
 
+        ## [crate\_g-0.0.2](crates/crate_g/CHANGELOG.md#0.0.2)
+
         # \[20210304.120604\]
 
         This will include the hdk-0.0.100 release.
@@ -333,6 +335,7 @@ fn bump_versions_on_selection() {
 
         the following crates are part of this release:
 
+        - crate_g-0.0.2
         - crate_b-0.0.0
         - crate_a-0.1.0
         - crate_e-0.0.1
@@ -537,8 +540,8 @@ fn multiple_subsequent_releases() {
     ) in [
         (
             "bump the first time as they're initially released",
-            vec!["0.0.0", "0.1.0", "0.0.1"],
-            vec!["crate_b", "crate_a", "crate_e"],
+            vec!["0.0.0", "0.1.0", "0.0.1", "0.0.2"],
+            vec!["crate_b", "crate_a", "crate_e", "crate_g"],
             // allowed missing dependencies
             Vec::<&str>::new(),
             true,
@@ -557,8 +560,8 @@ fn multiple_subsequent_releases() {
         ),
         (
             "only crate_a and crate_e have changed, expect these to be bumped",
-            vec!["0.0.0", "0.1.1", "0.0.2"],
-            vec!["crate_b", "crate_a", "crate_e"],
+            vec!["0.0.0", "0.1.1", "0.0.2", "0.0.2"],
+            vec!["crate_b", "crate_a", "crate_e", "crate_g"],
             // crate_b won't be part of the release so we allow it to be missing as we're not publishing
             vec!["crate_b"],
             true,
@@ -583,9 +586,9 @@ fn multiple_subsequent_releases() {
             }) as F,
         ),
         (
-            "matching only crate_a, a change of its dependency crate_b leads to a bump in both",
-            vec!["0.0.1", "0.1.2", "0.0.2"],
-            vec!["crate_b", "crate_a", "crate_e"],
+            "matching only crate_a, a change of its transitive dependency crate_g leads to bump in the dependency chain",
+            vec!["0.0.1", "0.1.2", "0.0.3"],
+            vec!["crate_b", "crate_a", "crate_g"],
             // allowed missing dependencies
             vec![],
             true,
@@ -593,7 +596,7 @@ fn multiple_subsequent_releases() {
             Box::new(|args: A| {
                 let root = args.0;
 
-                for crt in &["crate_b"] {
+                for crt in &["crate_g"] {
                     let mut readme = std::fs::OpenOptions::new()
                         .write(true)
                         .append(true)

--- a/crates/release-automation/src/lib/tests/workspace_mocker.rs
+++ b/crates/release-automation/src/lib/tests/workspace_mocker.rs
@@ -2,8 +2,8 @@ use crate::*;
 
 use anyhow::{bail, Context};
 use cargo_test_support::git::{self, Repository};
-use cargo_test_support::{Project, ProjectBuilder};
 use cargo_test_support::paths::init_root;
+use cargo_test_support::{Project, ProjectBuilder};
 use educe::Educe;
 use log::debug;
 use std::collections::HashMap;
@@ -320,12 +320,13 @@ pub fn example_workspace_1_aggregated_changelog() -> String {
 }
 
 /// A workspace to test changelogs and change detection.
-/// crate_a -> crate_b
+/// crate_a -> crate_b -> crate_g
 /// crate_b -> []
 /// crate_c -> []
 /// crate_d -> []
 /// crate_e -> []
 /// crate_f -> []
+/// crate_g -> []
 pub fn example_workspace_1<'a>() -> Fallible<WorkspaceMocker> {
     use crate::tests::workspace_mocker::{self, MockProject, WorkspaceMocker};
 
@@ -376,7 +377,9 @@ pub fn example_workspace_1<'a>() -> Fallible<WorkspaceMocker> {
         MockProject {
             name: "crate_b".to_string(),
             version: "0.0.0-alpha.1".to_string(),
-            dependencies: vec![],
+            dependencies: vec![
+                r#"crate_g = { path = "../crate_g", version = "=0.0.1" }"#.to_string(),
+            ],
             excluded: false,
             ty: workspace_mocker::MockProjectType::Lib,
             changelog: Some(indoc::formatdoc!(
@@ -453,6 +456,22 @@ pub fn example_workspace_1<'a>() -> Fallible<WorkspaceMocker> {
         MockProject {
             name: "crate_f".to_string(),
             version: "0.2.0".to_string(),
+            dependencies: vec![],
+            excluded: false,
+            ty: workspace_mocker::MockProjectType::Lib,
+            changelog: Some(indoc::formatdoc!(
+                    r#"
+                    # Changelog
+                    Hello. This crate is releasable.
+
+                    ## Unreleased
+                    "#
+                )),
+            .. Default::default()
+        },
+        MockProject {
+            name: "crate_g".to_string(),
+            version: "0.0.1".to_string(),
             dependencies: vec![],
             excluded: false,
             ty: workspace_mocker::MockProjectType::Lib,

--- a/crates/release-automation/src/lib/tests/workspace_mocker.rs
+++ b/crates/release-automation/src/lib/tests/workspace_mocker.rs
@@ -319,7 +319,13 @@ pub fn example_workspace_1_aggregated_changelog() -> String {
     ))
 }
 
-/// A workspace with four crates to test changelogs and change detection.
+/// A workspace to test changelogs and change detection.
+/// crate_a -> crate_b
+/// crate_b -> []
+/// crate_c -> []
+/// crate_d -> []
+/// crate_e -> []
+/// crate_f -> []
 pub fn example_workspace_1<'a>() -> Fallible<WorkspaceMocker> {
     use crate::tests::workspace_mocker::{self, MockProject, WorkspaceMocker};
 


### PR DESCRIPTION
### Summary
the change filter could lead to dependency changes not
including the changed dependency in the release, if the selected crate
itself didn't have any changed.

the blocked filter was removed because it adds unnecessary obfuscation.


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
