### PR TITLE
fix(github/release*): merge release into target branch before pushing

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -102,7 +102,7 @@ jobs:
       # - name: Set NIX_PATH (FIXME)
       #   run: echo NIX_PATH=nixpkgs=$(./scripts/nix_path.sh) >> $GITHUB_ENV
 
-      - name: Merge ${{ inputs.HOLOCHAIN_SOURCE_BRANCH }} into ${{ inputs.HOLOCHAIN_TARGET_BRANCH }}
+      - name: Merge source branch (${{ inputs.HOLOCHAIN_SOURCE_BRANCH }}) into target branch (${{ inputs.HOLOCHAIN_TARGET_BRANCH }})
         env:
           HRA_GITHUB_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
           HOLOCHAIN_REPO: ${{ inputs.HOLOCHAIN_REPO }}
@@ -143,13 +143,13 @@ jobs:
             git branch -D ${obsolete_branches}
           fi
 
-          # Merge source branch into the release branch
+          # Merge source branch into the target branch
           if ! (git branch --list --all | grep origin/${HOLOCHAIN_TARGET_BRANCH}); then
             git checkout -B ${HOLOCHAIN_TARGET_BRANCH}
           else
             git checkout --force -B ${HOLOCHAIN_TARGET_BRANCH} origin/${HOLOCHAIN_TARGET_BRANCH}
-            git merge --ff-only "${HOLOCHAIN_SOURCE_BRANCH}"
           fi
+          git merge --ff-only "${HOLOCHAIN_SOURCE_BRANCH}"
 
       - name: Restore holochain cargo related state and build files
         if: ${{ inputs.skip_prepare_logic != 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,17 +252,23 @@ jobs:
           # use our custom token for more permissions, e.g. "workflow" which is needed to push workflow files
           git config --local "http.https://github.com/.extraheader" "AUTHORIZATION: basic $(echo -n pat:${HRA_GITHUB_TOKEN} | base64)"
 
-      - name: Push the target branch
-        if: ${{ needs.vars.outputs.dry_run == 'false' }}
+      - name: Merge release branch (${{ needs.prepare.outputs.release_branch }}) into target branch (${{ needs.vars.outputs.holochain_target_branch }}) and push it
         env:
+          RELEASE_BRANCH: ${{ needs.prepare.outputs.release_branch }}
           HOLOCHAIN_TARGET_BRANCH: ${{ needs.vars.outputs.holochain_target_branch }}
+          DRY_RUN: "${{ needs.vars.outputs.dry_run }}"
         run: |
           set -xeu
           cd "${HOLOCHAIN_REPO}"
 
           git status
 
-          git push origin ${HOLOCHAIN_TARGET_BRANCH}
+          git checkout ${HOLOCHAIN_TARGET_BRANCH}
+          git merge --ff-only ${RELEASE_BRANCH}
+
+          if [[ "${DRY_RUN}" == "false" ]]; then
+            git push origin ${HOLOCHAIN_TARGET_BRANCH}
+          fi
 
       - name: Push the release branch
         id: push-release-branch


### PR DESCRIPTION
### Summary

in recent releases, the target branch was not updated properly.
this fixes that, specifically the merging and pushing of the target (e.g. main) and release (e.g. release-20230405..) branches.

### TODO:
- [x] dry release run
    - [x] https://github.com/holochain/holochain/actions/runs/4554267522
    - [ ] https://github.com/holochain/holochain/actions/runs/4597682734
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
