### PR TITLE
Fix bug with get dependants filtered caching its filter

### DIFF
--- a/crates/release-automation/src/lib/crate_selection/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/mod.rs
@@ -328,47 +328,38 @@ impl<'a> Crate<'a> {
     }
 
     /// Returns a reference to all workspace crates that depend on this crate.
-    // todo: write a unit test for this
     pub fn dependants_in_workspace(&'a self) -> Fallible<&'a Vec<&'a Crate<'a>>> {
-        self.dependants_in_workspace_filtered(|_| true)
+        self.dependants_in_workspace
+            .get_or_try_init(|| -> Fallible<_> { self.dependants_in_workspace_filtered(|_| true) })
     }
 
     /// Returns a reference to all workspace crates that depend on this crate.
     /// Features filtering by applying a filter function to the dependant's dependencies.
-    // todo: write a unit test for this
     pub fn dependants_in_workspace_filtered<F>(
         &'a self,
         filter_fn: F,
-    ) -> Fallible<&'a Vec<&'a Crate<'a>>>
+    ) -> Fallible<Vec<&'a Crate<'a>>>
     where
         F: Fn(&(&String, &Vec<Dependency>)) -> bool,
         F: Copy,
     {
-        self.dependants_in_workspace.get_or_try_init(|| {
-            let members_dependants = self.workspace.members()?.iter().try_fold(
-                LinkedHashMap::<String, &'a Crate<'a>>::new(),
-                |mut acc, member| -> Fallible<_> {
-                    if member
-                        .dependencies_in_workspace()?
-                        .iter()
-                        // FIXME: applying the filter here is incorrect, because
-                        // it persists the return value for the first call and
-                        // returns that for every subsequent call, regardless of
-                        // the filter function that's passed
-                        .filter(filter_fn)
-                        .map(|(dep_name, _)| dep_name)
-                        .collect::<LinkedHashSet<_>>()
-                        .contains(&self.name())
-                    {
-                        acc.insert(member.name(), *member);
-                    };
+        let members_dependants = self.workspace.members()?.iter().try_fold(
+            LinkedHashMap::<String, &'a Crate<'a>>::new(),
+            |mut acc, member| -> Fallible<_> {
+                if member
+                    .dependencies_in_workspace()?
+                    .iter()
+                    .filter(filter_fn)
+                    .any(|(dep_name, _)| dep_name == &self.name())
+                {
+                    acc.insert(member.name(), *member);
+                };
 
-                    Ok(acc)
-                },
-            )?;
+                Ok(acc)
+            },
+        )?;
 
-            Ok(members_dependants.values().cloned().collect())
-        })
+        Ok(members_dependants.values().cloned().collect())
     }
 
     pub fn root(&self) -> &Path {

--- a/crates/release-automation/src/lib/crate_selection/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/mod.rs
@@ -53,6 +53,15 @@ pub struct Crate<'a> {
     dependants_in_workspace: OnceCell<Vec<&'a Crate<'a>>>,
 }
 
+#[cfg(test)]
+impl PartialEq for Crate<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.package == other.package
+            && self.dependencies_in_workspace == other.dependencies_in_workspace
+            && self.dependants_in_workspace == other.dependants_in_workspace
+    }
+}
+
 impl<'a> Crate<'a> {
     /// Instantiate a new Crate with the given CargoPackage.
     pub fn with_cargo_package(

--- a/crates/release-automation/src/lib/crate_selection/tests/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/tests/mod.rs
@@ -86,7 +86,7 @@ fn release_selection() {
 }
 
 #[test]
-fn members_dependencies() {
+fn crate_dependants_unfiltered_and_filtered() {
     let workspace_mocker = example_workspace_2().unwrap();
     let workspace = ReleaseWorkspace::try_new_with_criteria(
         workspace_mocker.root(),
@@ -97,211 +97,54 @@ fn members_dependencies() {
     )
     .unwrap();
 
-    let result = workspace
+    let crate_b = workspace
         .members()
         .unwrap()
         .iter()
-        .map(|crt| {
-            (
-                crt.name(),
-                crt.dependencies_in_workspace()
-                    .unwrap()
-                    .into_iter()
-                    .map(|(dep_name, _)| dep_name.clone())
-                    .collect::<HashSet<_>>(),
-            )
-        })
-        .collect::<Vec<_>>();
+        .find(|crt| crt.name() == "crate_b")
+        .unwrap();
 
-    let expected_result = [
-        ("crate_b".to_string(), vec![]),
-        ("crate_c".to_string(), vec!["crate_b".to_string()]),
-        (
-            "crate_a".to_string(),
-            vec!["crate_c".to_string(), "crate_b".to_string()],
-        ),
-        (
-            "crate_d".to_string(),
-            vec![
-                "crate_a".to_string(),
-                "crate_c".to_string(),
-                "crate_b".to_string(),
-            ],
-        ),
-    ]
-    .into_iter()
-    .map(|(name, deps)| (name, deps.into_iter().collect::<HashSet<_>>()))
-    .collect::<Vec<_>>();
+    // get something back
+    pretty_assertions::assert_ne!(
+        Vec::<&Crate>::new(),
+        crate_b.dependants_in_workspace_filtered(|_| true).unwrap()
+    );
 
-    pretty_assertions::assert_eq!(expected_result, result, "left is expected");
-}
+    // unfiltered equals the 'true' filter
+    pretty_assertions::assert_eq!(
+        crate_b.dependants_in_workspace().unwrap(),
+        &crate_b.dependants_in_workspace_filtered(|_| true).unwrap()
+    );
 
-#[test]
-fn members_dependants() {
-    let workspace_mocker = example_workspace_2().unwrap();
-    let workspace = ReleaseWorkspace::try_new_with_criteria(
-        workspace_mocker.root(),
-        SelectionCriteria {
-            exclude_optional_deps: true,
-            ..Default::default()
-        },
-    )
-    .unwrap();
-
-    let result = workspace
-        .members()
-        .unwrap()
-        .iter()
-        .map(|crt| {
-            (
-                crt.name(),
-                crt.dependants_in_workspace()
-                    .unwrap()
-                    .into_iter()
-                    .map(|crt| crt.name())
-                    .collect::<Vec<_>>(),
-            )
-        })
-        .collect::<Vec<_>>();
-
-    let expected_result = vec![
-        (
-            "crate_b".to_string(),
-            vec![
-                "crate_c".to_string(),
-                "crate_a".to_string(),
-                "crate_d".to_string(), // through crate_a
-            ],
-        ),
-        (
-            "crate_c".to_string(),
-            vec![
-                "crate_a".to_string(),
-                "crate_d".to_string(), // through crate_a
-            ],
-        ),
-        ("crate_a".to_string(), vec!["crate_d".to_string()]),
-        ("crate_d".to_string(), vec![]),
-    ];
-
-    pretty_assertions::assert_eq!(expected_result, result, "left is expected");
-}
-
-#[test]
-fn members_dependants_filtered() {
-    let workspace_mocker = example_workspace_2().unwrap();
-    let workspace = ReleaseWorkspace::try_new_with_criteria(
-        workspace_mocker.root(),
-        SelectionCriteria {
-            exclude_optional_deps: true,
-            ..Default::default()
-        },
-    )
-    .unwrap();
-
-    let result = workspace
-        .members()
-        .unwrap()
-        .iter()
-        .map(|crt| {
-            (
-                crt.name(),
-                crt.dependants_in_workspace_filtered(|(name, _)| !name.contains("_b"))
-                    .unwrap()
-                    .into_iter()
-                    .map(|crt| crt.name())
-                    .collect::<Vec<_>>(),
-            )
-        })
-        .collect::<Vec<_>>();
-
-    let expected_result = vec![
-        ("crate_b".to_string(), vec![]), // Filtered out
-        (
-            "crate_c".to_string(),
-            vec![
-                "crate_a".to_string(),
-                "crate_d".to_string(), // through crate_a
-            ],
-        ),
-        ("crate_a".to_string(), vec!["crate_d".to_string()]),
-        ("crate_d".to_string(), vec![]),
-    ];
-
-    pretty_assertions::assert_eq!(expected_result, result, "left is expected");
-}
-
-#[test]
-fn members_dependants_with_two_different_filters() {
-    let workspace_mocker = example_workspace_2().unwrap();
-    let workspace = ReleaseWorkspace::try_new_with_criteria(
-        workspace_mocker.root(),
-        SelectionCriteria {
-            exclude_optional_deps: true,
-            ..Default::default()
-        },
-    )
-    .unwrap();
-
-    let result = workspace
-        .members()
-        .unwrap()
-        .iter()
-        .map(|crt| {
-            (
-                crt.name(),
-                crt.dependants_in_workspace_filtered(|_| false)
-                    .unwrap()
-                    .into_iter()
-                    .map(|crt| crt.name())
-                    .collect::<Vec<_>>(),
-            )
-        })
-        .collect::<Vec<_>>();
-
-    // Everything filtered out
-    let expected_result = vec![
-        ("crate_b".to_string(), vec![]),
-        ("crate_c".to_string(), vec![]),
-        ("crate_a".to_string(), vec![]),
-        ("crate_d".to_string(), vec![]),
-    ];
-
-    pretty_assertions::assert_eq!(expected_result, result, "left is expected");
-
-    let result = workspace
-        .members()
-        .unwrap()
-        .iter()
-        .map(|crt| {
-            (
-                crt.name(),
-                crt.dependants_in_workspace_filtered(|(name, _)| !name.contains("_c"))
-                    .unwrap()
-                    .into_iter()
-                    .map(|crt| crt.name())
-                    .collect::<Vec<_>>(),
-            )
-        })
-        .collect::<Vec<_>>();
-
+    // filter changes work
+    //
     // The actual values in here aren't that important, just need to see that the filter is applied and not
-    // cached as `false` from above.
-    let expected_result = vec![
-        (
-            "crate_b".to_string(),
-            vec![
-                "crate_c".to_string(),
-                "crate_a".to_string(),
-                "crate_d".to_string(),
-            ],
-        ),
-        ("crate_c".to_string(), vec![]),
-        ("crate_a".to_string(), vec!["crate_d".to_string()]),
-        ("crate_d".to_string(), vec![]),
-    ];
+    // cached as `true` from above.
+    pretty_assertions::assert_eq!(
+        Vec::<&Crate>::new(),
+        crate_b.dependants_in_workspace_filtered(|_| false).unwrap()
+    );
 
-    pretty_assertions::assert_eq!(expected_result, result, "left is expected");
+    // dependency doesn't include itself
+    pretty_assertions::assert_eq!(
+        None,
+        crate_b
+            .dependants_in_workspace()
+            .unwrap()
+            .into_iter()
+            .find(|crt| crt.name() == "crate_b")
+    );
+
+    // for the sake of completeness exhaustively check the result
+    pretty_assertions::assert_eq!(
+        vec!["crate_c", "crate_a", "crate_d"],
+        crate_b
+            .dependants_in_workspace()
+            .unwrap()
+            .iter()
+            .map(|crt| crt.name())
+            .collect::<Vec<_>>(),
+    );
 }
 
 #[test]

--- a/crates/release-automation/src/lib/tests/workspace_mocker.rs
+++ b/crates/release-automation/src/lib/tests/workspace_mocker.rs
@@ -582,6 +582,10 @@ pub fn example_workspace_1<'a>() -> Fallible<WorkspaceMocker> {
 }
 
 /// A workspace to test dependencies and crate sorting.
+/// crate_a -> [crate_b, crate_c]
+/// crate_b -> []
+/// crate_c -> [crate_b]
+/// crate_d -> [crate_a]
 pub fn example_workspace_2<'a>() -> Fallible<WorkspaceMocker> {
     use crate::tests::workspace_mocker::{self, MockProject, WorkspaceMocker};
 


### PR DESCRIPTION
### Summary

Fixes a bug where the `filter_fn` used by `dependants_in_workspace_filtered` is cached by the `OnceCell` that it uses to avoid repeating work.

The caching has been moved up a level into `dependants_in_workspace` which always give back an unfiltered result. The filter will always recompute if called.

Discovered during https://github.com/holochain/holochain/pull/2149/files#diff-f0903ab3d30b02d95cbe6b4e77ee4d38e5b404f2346045990c357dc6a6f15f9fR354

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
- [ ] backport to develop-0.1
