### PR TITLE
fix(release-automation): consider dependency state of all matched crates

### DIFF
--- a/crates/release-automation/src/lib/crate_selection/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/mod.rs
@@ -351,6 +351,10 @@ impl<'a> Crate<'a> {
                     if member
                         .dependencies_in_workspace()?
                         .iter()
+                        // FIXME: applying the filter here is incorrect, because
+                        // it persists the return value for the first call and
+                        // returns that for every subsequent call, regardless of
+                        // the filter function that's passed
                         .filter(filter_fn)
                         .map(|(dep_name, _)| dep_name)
                         .collect::<LinkedHashSet<_>>()
@@ -893,9 +897,10 @@ impl<'a> ReleaseWorkspace<'a> {
                                     insert_state!(CrateStateFlags::HasPreviousRelease);
 
                                     // todo: make comparison ref configurable
-                                    if !changed_files(member.package.root(), &git_tag, "HEAD")?
-                                        .is_empty()
+                                    let changed_files = changed_files(member.package.root(), &git_tag, "HEAD")?;
+                                    if !changed_files.is_empty()
                                     {
+                                        debug!("[{}] changed files since {git_tag}: {changed_files:?}", member.name());
                                         insert_state!(CrateStateFlags::ChangedSincePreviousRelease)
                                     }
                                 } else {
@@ -907,18 +912,33 @@ impl<'a> ReleaseWorkspace<'a> {
                         }
                     }
 
+                    // semver_increment_mode checks
+                    if let Some(allowed_semver_increment_modes) = &self.criteria.allowed_semver_increment_modes {
+                        let effective_semver_increment_mode  = member
+                            .changelog()
+                            .map(|cl| cl.front_matter().ok())
+                            .flatten()
+                            .flatten()
+                            .map(|fm| fm.semver_increment_mode())
+                            .unwrap_or_default();
+
+
+                        if !allowed_semver_increment_modes.contains(&effective_semver_increment_mode) {
+                            debug!("Blocking {} due to {:?} with mode: {effective_semver_increment_mode:?}", member.name(), CrateStateFlags::AllowedSemverIncrementModeViolated);
+                            insert_state!(CrateStateFlags::AllowedSemverIncrementModeViolated);
+                        }
+                    }
+                }
+
+                {
                     // dependency state
                     // only dependencies of explicitly matched packages are considered here.
-                    //
-                    // note(steveej):
-                    // while trying to signal the inclusion of reverse dependencies it eventually occurred to me
-                    // that only considering the crates in the dependency trees that start with a selected package is preferred.
-                    // even if a reverse dependency of a matched package is changed during the release (by having its dependency version updated),
-                    // its not relevant to the release if it hasn't been requested for release excplicitly or as a dependency of one that has been, in which case it is already considered.
-                    // if get_state!(member.name()).is_matched() && !get_state!(member.name()).blocked()
+                    // this detects changes in the transitive dependency chain by two mechanisms
+                    // 1. the loop we're in iterates over the result of `ReleaseWorkspace::members`,
+                    //    which orders the members according to the workspace dependency trees from leafs to roots.
+                    //    this ensures that the states of a member's transitive dependencies have been evaluated by the time *it* is evaluated.
+                    // 2. the `member.dependencies_in_workspace()` yields transitive results.
                     if get_state!(member.name()).is_matched()
-                        && get_state!(member.name()).changed()
-                        && !get_state!(member.name()).blocked()
                     {
                         for (_, deps) in member.dependencies_in_workspace()? {
                             for dep in deps {
@@ -953,22 +973,6 @@ impl<'a> ReleaseWorkspace<'a> {
                     }
                 }
 
-                // semver_increment_mode checks
-                if let Some(allowed_semver_increment_modes) = &self.criteria.allowed_semver_increment_modes {
-                    let effective_semver_increment_mode  = member
-                        .changelog()
-                        .map(|cl| cl.front_matter().ok())
-                        .flatten()
-                        .flatten()
-                        .map(|fm| fm.semver_increment_mode())
-                        .unwrap_or_default();
-
-
-                    if !allowed_semver_increment_modes.contains(&effective_semver_increment_mode) {
-                        debug!("Blocking {} due to {:?} with mode: {effective_semver_increment_mode:?}", member.name(), CrateStateFlags::AllowedSemverIncrementModeViolated);
-                        insert_state!(CrateStateFlags::AllowedSemverIncrementModeViolated);
-                    }
-                }
             }
 
             Ok(members_states)

--- a/crates/release-automation/src/lib/crate_selection/tests/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/tests/mod.rs
@@ -15,7 +15,7 @@ fn init_logger() {
 }
 
 #[test]
-fn detect_changed_files() {
+fn detect_changed_crates() {
     let workspace_mocker = example_workspace_1().unwrap();
     workspace_mocker.add_or_replace_file(
         "README",
@@ -47,33 +47,14 @@ fn workspace_members() {
         .map(|crt| crt.name())
         .collect::<HashSet<_>>();
 
-    let expected_result = ["crate_a", "crate_b", "crate_c", "crate_e", "crate_f"]
-        .iter()
-        .map(std::string::ToString::to_string)
-        .collect::<HashSet<_>>();
+    let expected_result = [
+        "crate_g", "crate_a", "crate_b", "crate_c", "crate_e", "crate_f",
+    ]
+    .iter()
+    .map(std::string::ToString::to_string)
+    .collect::<HashSet<_>>();
 
     assert_eq!(expected_result, result);
-}
-
-#[test]
-fn detect_changed_crates() {
-    let workspace_mocker = example_workspace_1().unwrap();
-    workspace_mocker.add_or_replace_file(
-        "README",
-        r#"# Example
-
-            Some changes
-        "#,
-    );
-    let before = workspace_mocker.head().unwrap();
-    let after = workspace_mocker.commit(None);
-
-    let workspace = ReleaseWorkspace::try_new(workspace_mocker.root()).unwrap();
-
-    assert_eq!(
-        vec![PathBuf::from(workspace.root()).join("README")],
-        changed_files(workspace.root(), &before, &after).unwrap()
-    );
 }
 
 #[test]
@@ -91,13 +72,15 @@ fn release_selection() {
     let workspace =
         ReleaseWorkspace::try_new_with_criteria(workspace_mocker.root(), criteria).unwrap();
 
+    // TODO: verify that a crate can be selected by being an unmatched, changed crate that's a dependency of a matched, unchanged crate.
+
     let selection = workspace
         .release_selection()
         .unwrap()
         .into_iter()
         .map(|c| c.name())
         .collect::<Vec<_>>();
-    let expected_selection = vec!["crate_b", "crate_a", "crate_e"];
+    let expected_selection = vec!["crate_g", "crate_b", "crate_a", "crate_e"];
 
     assert_eq!(expected_selection, selection);
 }
@@ -180,10 +163,12 @@ fn members_sorted_ws1() {
         .map(|crt| crt.name())
         .collect::<Vec<_>>();
 
-    let expected_result = ["crate_b", "crate_a", "crate_c", "crate_e", "crate_f"]
-        .iter()
-        .map(std::string::ToString::to_string)
-        .collect::<Vec<_>>();
+    let expected_result = [
+        "crate_g", "crate_b", "crate_a", "crate_c", "crate_e", "crate_f",
+    ]
+    .iter()
+    .map(std::string::ToString::to_string)
+    .collect::<Vec<_>>();
 
     assert_eq!(expected_result, result);
 }

--- a/crates/release-automation/src/lib/release.rs
+++ b/crates/release-automation/src/lib/release.rs
@@ -170,7 +170,6 @@ fn bump_release_versions<'a>(
     };
 
     // check the workspace and determine the release selection
-    // todo: double-check that we select matching cratese that had their dependencies change
     let selection = crate::common::selection_check(&cmd_args.check_args, ws)?;
 
     if selection.is_empty() {

--- a/crates/release-automation/src/lib/tests/workspace_mocker.rs
+++ b/crates/release-automation/src/lib/tests/workspace_mocker.rs
@@ -2,8 +2,8 @@ use crate::*;
 
 use anyhow::{bail, Context};
 use cargo_test_support::git::{self, Repository};
-use cargo_test_support::{Project, ProjectBuilder};
 use cargo_test_support::paths::init_root;
+use cargo_test_support::{Project, ProjectBuilder};
 use educe::Educe;
 use log::debug;
 use std::collections::HashMap;
@@ -319,7 +319,14 @@ pub fn example_workspace_1_aggregated_changelog() -> String {
     ))
 }
 
-/// A workspace with four crates to test changelogs and change detection.
+/// A workspace to test changelogs and change detection.
+/// crate_a -> crate_b -> crate_g
+/// crate_b -> []
+/// crate_c -> []
+/// crate_d -> []
+/// crate_e -> []
+/// crate_f -> []
+/// crate_g -> []
 pub fn example_workspace_1<'a>() -> Fallible<WorkspaceMocker> {
     use crate::tests::workspace_mocker::{self, MockProject, WorkspaceMocker};
 
@@ -370,7 +377,9 @@ pub fn example_workspace_1<'a>() -> Fallible<WorkspaceMocker> {
         MockProject {
             name: "crate_b".to_string(),
             version: "0.0.0-alpha.1".to_string(),
-            dependencies: vec![],
+            dependencies: vec![
+                r#"crate_g = { path = "../crate_g", version = "=0.0.1" }"#.to_string(),
+            ],
             excluded: false,
             ty: workspace_mocker::MockProjectType::Lib,
             changelog: Some(indoc::formatdoc!(
@@ -447,6 +456,22 @@ pub fn example_workspace_1<'a>() -> Fallible<WorkspaceMocker> {
         MockProject {
             name: "crate_f".to_string(),
             version: "0.2.0".to_string(),
+            dependencies: vec![],
+            excluded: false,
+            ty: workspace_mocker::MockProjectType::Lib,
+            changelog: Some(indoc::formatdoc!(
+                    r#"
+                    # Changelog
+                    Hello. This crate is releasable.
+
+                    ## Unreleased
+                    "#
+                )),
+            .. Default::default()
+        },
+        MockProject {
+            name: "crate_g".to_string(),
+            version: "0.0.1".to_string(),
             dependencies: vec![],
             excluded: false,
             ty: workspace_mocker::MockProjectType::Lib,


### PR DESCRIPTION
forwardport of #2149

---

* fix(release-automation): consider dependency state of all matched crates

the change filter could lead to dependency changes not including the changed dependency in the release, if the selected crate itself didn't have any changed.

the blocked filter was removed because it adds unnecessary obfuscation.

* chore(release-automation): remove duplicate test

* test(relase-automation): cover the fixed case

* chore: add FIXME comment for a bug in the dependencies_in_workspace_filter function

* test(release-automation): extend dependency bump test to cover the transitive case

* refactor(release-automation/crate_selection): clarify transitive change detection

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
