### PR TITLE
Improve HoloHash::from_raw_32 and use it

### DIFF
--- a/crates/holo_hash/src/fixt.rs
+++ b/crates/holo_hash/src/fixt.rs
@@ -1,6 +1,5 @@
 #![allow(missing_docs)]
 
-use crate::encode::holo_dht_location_bytes;
 use crate::hash_type;
 use crate::ActionHash;
 use crate::ActionHashB64;
@@ -49,20 +48,20 @@ fixturator!(
 );
 
 /// A type alias for a `Vec<u8>` whose fixturator is expected to only return
-/// a Vec of length 36
+/// a Vec of length 32
 pub type ThirtyTwoHashBytes = Vec<u8>;
 
-// Simply generate "bytes" which is a Vec<u8> of 36 bytes
+// Simply generate "bytes" which is a Vec<u8> of 32 bytes
 fixturator!(
     ThirtyTwoHashBytes,
-    append_location([0; 32].to_vec()),
+    [0; 32].to_vec(),
     {
         let mut u8_fixturator = U8Fixturator::new(Unpredictable);
         let mut bytes = vec![];
         for _ in 0..32 {
             bytes.push(u8_fixturator.next().unwrap());
         }
-        append_location(bytes)
+        bytes
     },
     {
         let mut index = get_fixt_index!();
@@ -73,15 +72,9 @@ fixturator!(
         }
         index += 1;
         set_fixt_index!(index);
-        append_location(bytes)
+        bytes
     }
 );
-
-fn append_location(mut base: Vec<u8>) -> Vec<u8> {
-    let mut loc_bytes = holo_dht_location_bytes(&base);
-    base.append(&mut loc_bytes);
-    base
-}
 
 fixturator!(
     with_vec 0 5;

--- a/crates/holo_hash/src/fixt.rs
+++ b/crates/holo_hash/src/fixt.rs
@@ -50,11 +50,11 @@ fixturator!(
 
 /// A type alias for a `Vec<u8>` whose fixturator is expected to only return
 /// a Vec of length 36
-pub type ThirtySixHashBytes = Vec<u8>;
+pub type ThirtyTwoHashBytes = Vec<u8>;
 
 // Simply generate "bytes" which is a Vec<u8> of 36 bytes
 fixturator!(
-    ThirtySixHashBytes,
+    ThirtyTwoHashBytes,
     append_location([0; 32].to_vec()),
     {
         let mut u8_fixturator = U8Fixturator::new(Unpredictable);
@@ -86,8 +86,8 @@ fn append_location(mut base: Vec<u8>) -> Vec<u8> {
 fixturator!(
     with_vec 0 5;
     AgentPubKey;
-    curve Empty AgentPubKey::from_raw_36(ThirtySixHashBytesFixturator::new_indexed(Empty, get_fixt_index!()).next().unwrap());
-    curve Unpredictable AgentPubKey::from_raw_36(ThirtySixHashBytesFixturator::new_indexed(Unpredictable, get_fixt_index!()).next().unwrap());
+    curve Empty AgentPubKey::from_raw_32(ThirtyTwoHashBytesFixturator::new_indexed(Empty, get_fixt_index!()).next().unwrap());
+    curve Unpredictable AgentPubKey::from_raw_32(ThirtyTwoHashBytesFixturator::new_indexed(Unpredictable, get_fixt_index!()).next().unwrap());
     curve Predictable {
         // these agent keys match what the mock keystore spits out for the first two agents
         // don't mess with this unless you also update the keystore!!!
@@ -108,7 +108,7 @@ fixturator!(
 
 fixturator!(
     EntryHash;
-    constructor fn from_raw_36(ThirtySixHashBytes);
+    constructor fn from_raw_32(ThirtyTwoHashBytes);
 );
 fixturator!(
     EntryHashB64;
@@ -117,7 +117,7 @@ fixturator!(
 
 fixturator!(
     DnaHash;
-    constructor fn from_raw_36(ThirtySixHashBytes);
+    constructor fn from_raw_32(ThirtyTwoHashBytes);
 );
 fixturator!(
     DnaHashB64;
@@ -126,7 +126,7 @@ fixturator!(
 
 fixturator!(
     DhtOpHash;
-    constructor fn from_raw_36(ThirtySixHashBytes);
+    constructor fn from_raw_32(ThirtyTwoHashBytes);
 );
 fixturator!(
     DhtOpHashB64;
@@ -136,7 +136,7 @@ fixturator!(
 fixturator!(
     with_vec 0 5;
     ActionHash;
-    constructor fn from_raw_36(ThirtySixHashBytes);
+    constructor fn from_raw_32(ThirtyTwoHashBytes);
 );
 fixturator!(
     ActionHashB64;
@@ -145,7 +145,7 @@ fixturator!(
 
 fixturator!(
     NetIdHash;
-    constructor fn from_raw_36(ThirtySixHashBytes);
+    constructor fn from_raw_32(ThirtyTwoHashBytes);
 );
 fixturator!(
     NetIdHashB64;
@@ -154,7 +154,7 @@ fixturator!(
 
 fixturator!(
     WasmHash;
-    constructor fn from_raw_36(ThirtySixHashBytes);
+    constructor fn from_raw_32(ThirtyTwoHashBytes);
 );
 fixturator!(
     WasmHashB64;
@@ -163,7 +163,7 @@ fixturator!(
 
 fixturator!(
     AnyDhtHash;
-    constructor fn from_raw_36_and_type(ThirtySixHashBytes, HashTypeAnyDht);
+    constructor fn from_raw_36_and_type(ThirtyTwoHashBytes, HashTypeAnyDht);
 );
 fixturator!(
     AnyDhtHashB64;
@@ -172,7 +172,7 @@ fixturator!(
 
 fixturator!(
     AnyLinkableHash;
-    constructor fn from_raw_36_and_type(ThirtySixHashBytes, HashTypeAnyLinkable);
+    constructor fn from_raw_36_and_type(ThirtyTwoHashBytes, HashTypeAnyLinkable);
 );
 fixturator!(
     AnyLinkableHashB64;

--- a/crates/holo_hash/src/fixt.rs
+++ b/crates/holo_hash/src/fixt.rs
@@ -156,7 +156,7 @@ fixturator!(
 
 fixturator!(
     AnyDhtHash;
-    constructor fn from_raw_36_and_type(ThirtyTwoHashBytes, HashTypeAnyDht);
+    constructor fn from_raw_32_and_type(ThirtyTwoHashBytes, HashTypeAnyDht);
 );
 fixturator!(
     AnyDhtHashB64;
@@ -165,7 +165,7 @@ fixturator!(
 
 fixturator!(
     AnyLinkableHash;
-    constructor fn from_raw_36_and_type(ThirtyTwoHashBytes, HashTypeAnyLinkable);
+    constructor fn from_raw_32_and_type(ThirtyTwoHashBytes, HashTypeAnyLinkable);
 );
 fixturator!(
     AnyLinkableHashB64;

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -175,9 +175,10 @@ impl<T: HashType> HoloHash<T> {
     /// The 3 prefix bytes will be added based on the provided HashType,
     /// and the 4 location bytes will be computed.
     pub fn from_raw_32_and_type(mut hash: Vec<u8>, hash_type: T) -> Self {
-        assert_length!(HOLO_HASH_UNTYPED_LEN, &hash);
+        assert_length!(HOLO_HASH_CORE_LEN, &hash);
         hash.append(&mut encode::holo_dht_location_bytes(&hash));
         assert_length!(HOLO_HASH_UNTYPED_LEN, &hash);
+
         HoloHash::from_raw_36_and_type(hash, hash_type)
     }
 }

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -174,16 +174,10 @@ impl<T: HashType> HoloHash<T> {
     /// Construct a HoloHash from a 32-byte hash.
     /// The 3 prefix bytes will be added based on the provided HashType,
     /// and the 4 location bytes will be computed.
-    ///
-    /// For convenience, 36 bytes can also be passed in, in which case
-    /// the location bytes will used as provided, not computed.
     pub fn from_raw_32_and_type(mut hash: Vec<u8>, hash_type: T) -> Self {
-        if hash.len() == HOLO_HASH_CORE_LEN {
-            hash.append(&mut encode::holo_dht_location_bytes(&hash));
-        }
-
         assert_length!(HOLO_HASH_UNTYPED_LEN, &hash);
-
+        hash.append(&mut encode::holo_dht_location_bytes(&hash));
+        assert_length!(HOLO_HASH_UNTYPED_LEN, &hash);
         HoloHash::from_raw_36_and_type(hash, hash_type)
     }
 }

--- a/crates/holochain_zome_types/src/test_utils.rs
+++ b/crates/holochain_zome_types/src/test_utils.rs
@@ -10,7 +10,7 @@ use holo_hash::*;
 use holochain_serialized_bytes::prelude::*;
 
 fn fake_holo_hash<T: holo_hash::HashType>(name: u8, hash_type: T) -> HoloHash<T> {
-    HoloHash::from_raw_36_and_type([name; HOLO_HASH_UNTYPED_LEN].to_vec(), hash_type)
+    HoloHash::from_raw_32_and_type([name; 32].to_vec(), hash_type)
 }
 
 /// A fixture DnaHash for unit testing.


### PR DESCRIPTION
### Summary

`HoloHash:;from_raw_32` is the only way to create a fake hash that includes a valid checksum (final 4 bytes). I had a test in another branch that was failing because a test hash was being used in a context where the checksum was being checked. So, this just makes sure that that function always computes a proper checksum, and I use it where it matters.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
