### PR TITLE
fix: merge main into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,70 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # \[Unreleased\]
 
+# 20230322.003727
+
+## [holochain\_cli-0.2.0-beta-rc.1](crates/holochain_cli/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [holochain-0.2.0-beta-rc.1](crates/holochain/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [holochain\_websocket-0.2.0-beta-rc.1](crates/holochain_websocket/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [holochain\_test\_wasm\_common-0.2.0-beta-rc.1](crates/holochain_test_wasm_common/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [holochain\_conductor\_api-0.2.0-beta-rc.1](crates/holochain_conductor_api/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [holochain\_wasm\_test\_utils-0.2.0-beta-rc.1](crates/holochain_wasm_test_utils/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [holochain\_cascade-0.2.0-beta-rc.1](crates/holochain_cascade/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [holochain\_state-0.2.0-beta-rc.1](crates/holochain_state/CHANGELOG.md#0.2.0-beta-rc.1)
+
+- Optimize capability grant verification during zome calls. This speeds up all remote calls, under which fall calls with a cap secret from clients other than the Launcher. Previously hundreds of calls would slow down response time noticeably because of grant verification. Now thousands of calls (rather thousands of records) won’t affect grant verification by more than a millisecond. [\#2097](https://github.com/holochain/holochain/pull/2097)
+
+## [holochain\_p2p-0.2.0-beta-rc.1](crates/holochain_p2p/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [kitsune\_p2p\_bootstrap-0.1.0-beta-rc.0](crates/kitsune_p2p_bootstrap/CHANGELOG.md#0.1.0-beta-rc.0)
+
+## [holochain\_types-0.2.0-beta-rc.1](crates/holochain_types/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [holochain\_keystore-0.2.0-beta-rc.1](crates/holochain_keystore/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [holochain\_sqlite-0.2.0-beta-rc.1](crates/holochain_sqlite/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [kitsune\_p2p-0.2.0-beta-rc.1](crates/kitsune_p2p/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [kitsune\_p2p\_proxy-0.2.0-beta-rc.1](crates/kitsune_p2p_proxy/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [kitsune\_p2p\_transport\_quic-0.2.0-beta-rc.1](crates/kitsune_p2p_transport_quic/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [kitsune\_p2p\_fetch-0.2.0-beta-rc.1](crates/kitsune_p2p_fetch/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [kitsune\_p2p\_types-0.2.0-beta-rc.1](crates/kitsune_p2p_types/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [hdk-0.2.0-beta-rc.1](crates/hdk/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [holochain\_zome\_types-0.2.0-beta-rc.1](crates/holochain_zome_types/CHANGELOG.md#0.2.0-beta-rc.1)
+
+- `name` in DnaDef no longer has an effect on the DNA hash [\#2099](https://github.com/holochain/holochain/pull/2099)
+
+## [kitsune\_p2p\_dht-0.2.0-beta-rc.1](crates/kitsune_p2p_dht/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [kitsune\_p2p\_block-0.2.0-beta-rc.1](crates/kitsune_p2p_block/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [kitsune\_p2p\_bin\_data-0.2.0-beta-rc.1](crates/kitsune_p2p_bin_data/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [hdi-0.3.0-beta-rc.1](crates/hdi/CHANGELOG.md#0.3.0-beta-rc.1)
+
+## [hdk\_derive-0.2.0-beta-rc.1](crates/hdk_derive/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [holochain\_integrity\_types-0.2.0-beta-rc.1](crates/holochain_integrity_types/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [holo\_hash-0.2.0-beta-rc.1](crates/holo_hash/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [kitsune\_p2p\_dht\_arc-0.2.0-beta-rc.1](crates/kitsune_p2p_dht_arc/CHANGELOG.md#0.2.0-beta-rc.1)
+
+## [holochain\_trace-0.2.0-beta-rc.1](crates/holochain_trace/CHANGELOG.md#0.2.0-beta-rc.1)
+
 # 20230315.183209
 
 ## [holochain\_cli-0.2.0-beta-rc.0](crates/holochain_cli/CHANGELOG.md#0.2.0-beta-rc.0)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,9 +207,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0b2340f55d9661d76793b2bfc2eb0e62689bd79d067a95707ea762afd5e9dd"
 dependencies = [
  "anstyle",
- "bstr 1.4.0",
+ "bstr 1.3.0",
  "doc-comment",
- "predicates 3.0.2",
+ "predicates 3.0.1",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -279,7 +279,7 @@ dependencies = [
  "log",
  "parking",
  "polling",
- "rustix 0.37.4",
+ "rustix 0.37.3",
  "slab",
  "socket2",
  "waker-fn",
@@ -374,19 +374,19 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.4.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
+checksum = "7a40729d2133846d9ed0ea60a8b9541bccddab49cd30f0715a1da672fe9a2524"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -586,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.4.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d4260bcc2e8fc9df1eac4919a720effeb63a3f0952f5bf4944adfa18897f09"
+checksum = "5ffdb39cb703212f3c11973452c2861b972f757b021158f3516ba10f2fa8b2c1"
 dependencies = [
  "memchr",
  "once_cell",
@@ -780,24 +780,15 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.14"
+version = "4.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "906f7fe1da4185b7a282b2bc90172a496f9def1aca4545fe7526810741591e14"
-dependencies = [
- "clap_builder",
- "clap_derive 4.1.14",
- "once_cell",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351f9ad9688141ed83dfd8f5fb998a06225ef444b48ff4dc43de6d409b7fd10b"
+checksum = "3c911b090850d79fc64fe9ea01e28e465f65e821e08813ced95bced72f7a8a9b"
 dependencies = [
  "bitflags",
- "clap_lex 0.4.0",
+ "clap_derive 4.1.12",
+ "clap_lex 0.3.3",
  "is-terminal",
+ "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "terminal_size",
@@ -818,14 +809,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.14"
+version = "4.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d7dc0031c3a59a04fc2ba395c8e2dd463cba1859275f065d225f6122221b45"
+checksum = "9a932373bab67b984c790ddf2c9ca295d8e3af3b7ef92de5a5bacdccdee4b09b"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -839,9 +830,12 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0807fb6f644c83f3e4ec014fec9858c1c8b26a7db8eb5f0bde5817df9c1df7"
+checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "cloudabi"
@@ -971,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -1266,9 +1260,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.94"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
+checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1278,9 +1272,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.94"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
+checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1288,24 +1282,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.11",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.94"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
+checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.94"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
+checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2059,9 +2053,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -2118,7 +2112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0f758b0048e5f55f4d927932a32eb4ab8a850c4b9a7951b259ba6c8792d5c38"
 dependencies = [
  "futures",
- "mockall 0.11.4",
+ "mockall 0.11.3",
  "must_future",
  "paste",
  "thiserror",
@@ -2267,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "hdi"
-version = "0.3.0-beta-rc.0"
+version = "0.3.0-beta-rc.1"
 dependencies = [
  "arbitrary",
  "fixt",
@@ -2275,7 +2269,7 @@ dependencies = [
  "holo_hash",
  "holochain_integrity_types",
  "holochain_wasmer_guest",
- "mockall 0.11.4",
+ "mockall 0.11.3",
  "paste",
  "serde",
  "serde_bytes",
@@ -2287,7 +2281,7 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "fixt",
  "getrandom 0.2.8",
@@ -2296,7 +2290,7 @@ dependencies = [
  "holo_hash",
  "holochain_wasmer_guest",
  "holochain_zome_types",
- "mockall 0.11.4",
+ "mockall 0.11.3",
  "paste",
  "serde",
  "serde_bytes",
@@ -2308,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "darling 0.14.4",
  "heck 0.4.1",
@@ -2392,7 +2386,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "holo_hash"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",
@@ -2414,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2467,7 +2461,7 @@ dependencies = [
  "lazy_static",
  "maplit",
  "matches",
- "mockall 0.11.4",
+ "mockall 0.11.3",
  "mr_bundle",
  "must_future",
  "nanoid 0.3.0",
@@ -2516,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2538,7 +2532,7 @@ dependencies = [
  "isotest",
  "kitsune_p2p",
  "matches",
- "mockall 0.11.4",
+ "mockall 0.11.3",
  "pretty_assertions 0.7.2",
  "serde",
  "serde_derive",
@@ -2551,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -2614,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "derive_more",
  "directories",
@@ -2655,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "arbitrary",
  "holo_hash",
@@ -2671,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "assert_cmd 2.0.10",
  "base64 0.13.1",
@@ -2701,12 +2695,12 @@ name = "holochain_mock_hdi"
 version = "0.0.1"
 dependencies = [
  "hdi",
- "mockall 0.11.4",
+ "mockall 0.11.3",
 ]
 
 [[package]]
 name = "holochain_p2p"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2722,7 +2716,7 @@ dependencies = [
  "holochain_zome_types",
  "kitsune_p2p",
  "kitsune_p2p_types",
- "mockall 0.11.4",
+ "mockall 0.11.3",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
@@ -2785,7 +2779,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2835,7 +2829,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2865,7 +2859,7 @@ dependencies = [
  "holochain_zome_types",
  "kitsune_p2p",
  "matches",
- "mockall 0.11.4",
+ "mockall 0.11.3",
  "nanoid 0.3.0",
  "one_err",
  "parking_lot 0.10.2",
@@ -2883,7 +2877,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "hdk",
  "serde",
@@ -2891,7 +2885,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_trace"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "chrono",
  "derive_more",
@@ -2913,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2944,7 +2938,7 @@ dependencies = [
  "lazy_static",
  "maplit",
  "matches",
- "mockall 0.11.4",
+ "mockall 0.11.3",
  "mr_bundle",
  "must_future",
  "nanoid 0.3.0",
@@ -2988,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_test_utils"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "holochain_types",
  "holochain_util",
@@ -3046,7 +3040,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "criterion",
  "futures",
@@ -3074,7 +3068,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "arbitrary",
  "contrafact",
@@ -3297,9 +3291,9 @@ checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown 0.12.3",
@@ -3313,7 +3307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb7c1b80a1dfa604bb4a649a5c5aeef3d913f7c520cb42b40e534e8a61bcdfc"
 dependencies = [
  "ahash 0.8.3",
- "clap 4.1.14",
+ "clap 4.1.13",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap 5.4.0",
@@ -3373,9 +3367,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.7.2"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
@@ -3434,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "arbitrary",
  "arrayref",
@@ -3461,7 +3455,7 @@ dependencies = [
  "kitsune_p2p_types",
  "maplit",
  "mockall 0.10.2",
- "mockall 0.11.4",
+ "mockall 0.11.3",
  "must_future",
  "nanoid 0.4.0",
  "num-traits",
@@ -3486,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bin_data"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",
@@ -3499,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_block"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_timestamp",
@@ -3508,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bootstrap"
-version = "0.0.12-dev.0"
+version = "0.1.0-beta-rc.0"
 dependencies = [
  "clap 3.2.23",
  "criterion",
@@ -3530,7 +3524,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "colored 1.9.3",
  "derivative",
@@ -3559,7 +3553,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht_arc"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "derive_more",
  "gcollections",
@@ -3628,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_fetch"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "derive_more",
  "futures",
@@ -3667,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_proxy"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "base64 0.13.1",
  "blake2b_simd 0.5.11",
@@ -3705,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_transport_quic"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "blake2b_simd 1.0.1",
  "futures",
@@ -3723,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_types"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",
@@ -3738,7 +3732,7 @@ dependencies = [
  "kitsune_p2p_types",
  "lair_keystore_api",
  "lru",
- "mockall 0.11.4",
+ "mockall 0.11.3",
  "nanoid 0.3.0",
  "once_cell",
  "parking_lot 0.11.2",
@@ -4197,15 +4191,15 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.4"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
 dependencies = [
  "cfg-if 1.0.0",
  "downcast 0.11.0",
  "fragile 2.0.0",
  "lazy_static",
- "mockall_derive 0.11.4",
+ "mockall_derive 0.11.3",
  "predicates 2.1.5",
  "predicates-tree",
 ]
@@ -4224,9 +4218,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.4"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
@@ -4688,9 +4682,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.25.2+1.1.1t"
+version = "111.25.1+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320708a054ad9b3bf314688b5db87cf4d6683d64cfc835e2337924ae62bf4431"
+checksum = "1ef9a9cc6ea7d9d5e7c4a913dc4b48d0e359eddf01af1dfec96ba7064b4aba10"
 dependencies = [
  "cc",
 ]
@@ -5082,9 +5076,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.0.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c575290b64d24745b6c57a12a31465f0a66f3a4799686a6921526a33b0797965"
+checksum = "1ba7d6ead3e3966038f68caa9fc1f860185d95a793180bbcfe0d0da47b3961ed"
 dependencies = [
  "anstyle",
  "difflib",
@@ -5180,9 +5174,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
 dependencies = [
  "unicode-ident",
 ]
@@ -5693,9 +5687,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5749,9 +5743,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.16"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "0ba30cc2c0cd02af1222ed216ba659cdb2f879dfe3181852fe7c50b1d0005949"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -5978,9 +5972,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.4"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c348b5dc624ecee40108aa2922fed8bad89d7fcc2b9f8cb18f632898ac4a37f9"
+checksum = "62b24138615de35e32031d041a09032ef3487a616d901ca4db224e7d557efae2"
 dependencies = [
  "bitflags",
  "errno 0.3.0",
@@ -6181,9 +6175,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 dependencies = [
  "serde_derive",
 ]
@@ -6218,20 +6212,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.8",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "indexmap",
  "itoa",
@@ -6705,9 +6699,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.11"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
+checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6955,7 +6949,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.8",
 ]
 
 [[package]]
@@ -7053,13 +7047,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg 1.1.0",
  "bytes",
  "libc",
+ "memchr",
  "mio 0.8.6",
  "num_cpus",
  "parking_lot 0.12.1",
@@ -7072,13 +7067,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -7346,9 +7341,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "trybuild"
-version = "1.0.80"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501dbdbb99861e4ab6b60eb6a7493956a9defb644fd034bc4a5ef27c693c8a3a"
+checksum = "db3115bddce1b5f52dd4b5e0ec8298a66ce733e4cc6759247dc2d1c11508ec38"
 dependencies = [
  "basic-toml",
  "glob",
@@ -7563,7 +7558,7 @@ version = "0.0.1-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3c93ec8a0c5ea84e09c3068db716584959c925428a25972cdae200a6e60e3e6"
 dependencies = [
- "clap 4.1.14",
+ "clap 4.1.13",
  "dirs 4.0.0",
  "futures",
  "get_if_addrs",
@@ -8453,9 +8448,9 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+checksum = "deac0939bd6e4f24ab5919fbf751c97a8cfc8543bb083a305ed5c0c10bb241d1"
 dependencies = [
  "memchr",
 ]
@@ -8495,22 +8490,23 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.1"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25588073e5216b50bca71d61cb8595cdb9745e87032a58c199730def2862c934"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 1.0.109",
+ "synstructure",
 ]
 
 [[package]]

--- a/crates/diagnostic_tests/Cargo.toml
+++ b/crates/diagnostic_tests/Cargo.toml
@@ -8,7 +8,7 @@ chashmap = "2.2"
 colored = "2"
 futures = "*"
 holochain_diagnostics = { path = "../holochain_diagnostics" }
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
 tokio = { version = "1.11", features = ["full"] }
 tokio-stream = "*"
 

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
@@ -23,6 +23,6 @@ anyhow = "1.0"
 futures = "0.3"
 holochain_cli_bundle = { path = "../hc_bundle", version = "^0.2.0-beta-rc.0"}
 holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.2.0-beta-rc.0"}
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
 structopt = "0.3"
 tokio = { version = "1.11", features = [ "full" ] }

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/bin/hc-dna.rs"
 anyhow = "1.0"
 holochain_util = { path = "../holochain_util", features = ["backtrace"], version = "^0.2.0-beta-rc.0"}
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_types" }
+holochain_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_types" }
 mr_bundle = {version = "^0.2.0-beta-rc.0", path = "../mr_bundle"}
 serde = { version = "1.0", features = [ "derive" ] }
 serde_bytes = "0.11"

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -19,13 +19,13 @@ anyhow = "1.0"
 ansi_term = "0.12"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 futures = "0.3"
-holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.2.0-beta-rc.0"}
-holochain_types = { path = "../holochain_types", version = "^0.2.0-beta-rc.0"}
-holochain_websocket = { path = "../holochain_websocket", version = "^0.2.0-beta-rc.0"}
-holochain_p2p = { path = "../holochain_p2p", version = "^0.2.0-beta-rc.0"}
+holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.2.0-beta-rc.1"}
+holochain_types = { path = "../holochain_types", version = "^0.2.0-beta-rc.1"}
+holochain_websocket = { path = "../holochain_websocket", version = "^0.2.0-beta-rc.1"}
+holochain_p2p = { path = "../holochain_p2p", version = "^0.2.0-beta-rc.1"}
 holochain_util = { version = "^0.2.0-beta-rc.0", path = "../holochain_util", features = [ "pw" ] }
 nanoid = "0.3"
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
 once_cell = "1.13.0"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_yaml = "0.9"

--- a/crates/hdi/CHANGELOG.md
+++ b/crates/hdi/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.3.0-beta-rc.1
+
 ## 0.3.0-beta-rc.0
 
 ## 0.2.0

--- a/crates/hdi/Cargo.toml
+++ b/crates/hdi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdi"
-version = "0.3.0-beta-rc.0"
+version = "0.3.0-beta-rc.1"
 description = "The HDI"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain/tree/develop/crates/hdi"
@@ -19,12 +19,12 @@ test_utils = [
 ]
 
 [dependencies]
-hdk_derive = { version = "^0.2.0-beta-rc.0", path = "../hdk_derive" }
-holo_hash = { version = "^0.2.0-beta-rc.0", path = "../holo_hash" }
+hdk_derive = { version = "^0.2.0-beta-rc.1", path = "../hdk_derive" }
+holo_hash = { version = "^0.2.0-beta-rc.1", path = "../holo_hash" }
 holochain_wasmer_guest = "=0.0.83"
 # it's important that we depend on holochain_integrity_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
-holochain_integrity_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_integrity_types", default-features = false }
+holochain_integrity_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_integrity_types", default-features = false }
 paste = "1.0"
 serde = "1.0"
 serde_bytes = "0.11"

--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 - Add block/unblock agent functions to HDK [\#1828](https://github.com/holochain/holochain/pull/1828)

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "The Holochain HDK"
 license = "CAL-1.0"
 homepage = "https://github.com/holochain/holochain/tree/develop/crates/hdk"
@@ -24,13 +24,13 @@ test_utils = [
 properties = ["holochain_zome_types/properties"]
 
 [dependencies]
-hdi = { version = "=0.3.0-beta-rc.0", path = "../hdi", features = ["trace"] }
-hdk_derive = { version = "^0.2.0-beta-rc.0", path = "../hdk_derive" }
-holo_hash = { version = "^0.2.0-beta-rc.0", path = "../holo_hash" }
+hdi = { version = "=0.3.0-beta-rc.1", path = "../hdi", features = ["trace"] }
+hdk_derive = { version = "^0.2.0-beta-rc.1", path = "../hdk_derive" }
+holo_hash = { version = "^0.2.0-beta-rc.1", path = "../holo_hash" }
 holochain_wasmer_guest = "=0.0.83"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
-holochain_zome_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_zome_types", default-features = false }
+holochain_zome_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_zome_types", default-features = false }
 paste = "1.0"
 serde = "1.0"
 serde_bytes = "0.11"

--- a/crates/hdk_derive/CHANGELOG.md
+++ b/crates/hdk_derive/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/hdk_derive/Cargo.toml
+++ b/crates/hdk_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk_derive"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "derive macros for the holochain hdk"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -22,7 +22,7 @@ darling = "0.14.1"
 heck = "0.4"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdi, to reduce code bloat
-holochain_integrity_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_integrity_types", default-features = false }
+holochain_integrity_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_integrity_types", default-features = false }
 proc-macro-error = "1.0.4"
 
 [features]

--- a/crates/holo_hash/CHANGELOG.md
+++ b/crates/holo_hash/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holo_hash"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
 keywords = [ "holochain", "holo", "hash", "blake", "blake2b" ]
 categories = [ "cryptography" ]
@@ -23,7 +23,7 @@ derive_more = { version = "0.99", optional = true }
 fixt = { version = "^0.2.0-beta-rc.0", path = "../fixt", optional = true }
 futures = {version = "0.3", optional = true}
 holochain_serialized_bytes = {version = "=0.0.51", optional = true }
-kitsune_p2p_dht_arc = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/dht_arc" }
+kitsune_p2p_dht_arc = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p/dht_arc" }
 must_future = {version = "0.1", optional = true}
 rand = {version = "0.8.5", optional = true}
 rusqlite = { version = "0.28", optional = true }

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fixes bug where supplying a `network_seed` during an `InstallApp` call does not actually update the network seed for roles whose `provisioning` is set to `None` in the manifest. Now the network seed is correctly updated. [\#2102](https://github.com/holochain/holochain/pull/2102)
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 - When uninstalling an app, local data is now cleaned up where appropriate. [\#1805](https://github.com/holochain/holochain/pull/1805)

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "Holochain, a framework for distributed applications"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -24,30 +24,30 @@ futures = "0.3.1"
 getrandom = "0.2.7"
 get_if_addrs = "0.5.3"
 ghost_actor = "0.3.0-alpha.5"
-holo_hash = { version = "^0.2.0-beta-rc.0", path = "../holo_hash", features = ["full"] }
-holochain_cascade = { version = "^0.2.0-beta-rc.0", path = "../holochain_cascade" }
-holochain_conductor_api = { version = "^0.2.0-beta-rc.0", path = "../holochain_conductor_api" }
-holochain_keystore = { version = "^0.2.0-beta-rc.0", path = "../holochain_keystore", default-features = false }
-holochain_p2p = { version = "^0.2.0-beta-rc.0", path = "../holochain_p2p" }
-holochain_sqlite = { version = "^0.2.0-beta-rc.0", path = "../holochain_sqlite" }
+holo_hash = { version = "^0.2.0-beta-rc.1", path = "../holo_hash", features = ["full"] }
+holochain_cascade = { version = "^0.2.0-beta-rc.1", path = "../holochain_cascade" }
+holochain_conductor_api = { version = "^0.2.0-beta-rc.1", path = "../holochain_conductor_api" }
+holochain_keystore = { version = "^0.2.0-beta-rc.1", path = "../holochain_keystore", default-features = false }
+holochain_p2p = { version = "^0.2.0-beta-rc.1", path = "../holochain_p2p" }
+holochain_sqlite = { version = "^0.2.0-beta-rc.1", path = "../holochain_sqlite" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_state = { version = "^0.2.0-beta-rc.0", path = "../holochain_state" }
-holochain_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_types" }
+holochain_state = { version = "^0.2.0-beta-rc.1", path = "../holochain_state" }
+holochain_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_types" }
 holochain_util = { version = "^0.2.0-beta-rc.0", path = "../holochain_util", features = [ "pw" ] }
 holochain_wasmer_host = "=0.0.83"
-holochain_websocket = { version = "^0.2.0-beta-rc.0", path = "../holochain_websocket" }
-holochain_zome_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_zome_types", features = ["full"] }
+holochain_websocket = { version = "^0.2.0-beta-rc.1", path = "../holochain_websocket" }
+holochain_zome_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_zome_types", features = ["full"] }
 human-panic = "1.0.3"
-kitsune_p2p = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/kitsune_p2p", default-features = false }
-kitsune_p2p_types = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/types" }
-kitsune_p2p_block = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/block" }
+kitsune_p2p = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p/kitsune_p2p", default-features = false }
+kitsune_p2p_types = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p/types" }
+kitsune_p2p_block = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p/block" }
 lazy_static = "1.4.0"
 mockall = "0.11.3"
 mr_bundle = { version = "^0.2.0-beta-rc.0", path = "../mr_bundle" }
 must_future = "0.1.1"
 nanoid = "0.3"
 num_cpus = "1.8"
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
 once_cell = "1.4.1"
 one_err = "0.0.8"
 parking_lot = "0.10"
@@ -77,16 +77,16 @@ url = "1.7.2"
 url2 = "0.0.6"
 url_serde = "0.2.0"
 uuid = { version = "0.7", features = [ "serde", "v4" ] }
-holochain_wasm_test_utils = { version = "^0.2.0-beta-rc.0", path = "../test_utils/wasm" }
+holochain_wasm_test_utils = { version = "^0.2.0-beta-rc.1", path = "../test_utils/wasm" }
 tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
 async-recursion = "0.3"
 wasmer-middlewares = "2"
 
 # Dependencies for test_utils: keep in sync with below
-hdk = { version = "^0.2.0-beta-rc.0", path = "../hdk", optional = true }
+hdk = { version = "^0.2.0-beta-rc.1", path = "../hdk", optional = true }
 matches = {version = "0.1.8", optional = true }
-holochain_test_wasm_common = { version = "^0.2.0-beta-rc.0", path = "../test_utils/wasm_common", optional = true  }
-kitsune_p2p_bootstrap = { version = "0.0.12-dev.0", path = "../kitsune_p2p/bootstrap", optional = true }
+holochain_test_wasm_common = { version = "^0.2.0-beta-rc.1", path = "../test_utils/wasm_common", optional = true  }
+kitsune_p2p_bootstrap = { version = "^0.1.0-beta-rc.0", path = "../kitsune_p2p/bootstrap", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
 itertools = { version = "0.10", optional = false }
 tx5-go-pion-turn = { version = "0.0.1-alpha.4", optional = true }
@@ -117,15 +117,15 @@ serial_test = "0.4.0"
 test-case = "1.2.1"
 
 # Dependencies for test_utils: keep in sync with above
-hdk = { version = "^0.2.0-beta-rc.0", path = "../hdk", optional = false }
+hdk = { version = "^0.2.0-beta-rc.1", path = "../hdk", optional = false }
 matches = {version = "0.1.8", optional = false }
-holochain_test_wasm_common = { version = "^0.2.0-beta-rc.0", path = "../test_utils/wasm_common", optional = false  }
+holochain_test_wasm_common = { version = "^0.2.0-beta-rc.1", path = "../test_utils/wasm_common", optional = false  }
 kitsune_p2p_bootstrap = { path = "../kitsune_p2p/bootstrap", optional = false }
 unwrap_to = { version = "0.1.0", optional = false }
 arbitrary = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-hdk = { version = "^0.2.0-beta-rc.0", path = "../hdk"}
+hdk = { version = "^0.2.0-beta-rc.1", path = "../hdk"}
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0.51" }
 toml = "0.5.6"

--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cascade"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "Logic for cascading updates to Holochain state and network interaction"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -15,17 +15,17 @@ fallible-iterator = "0.2"
 fixt = { version = "^0.2.0-beta-rc.0", path = "../fixt" }
 futures = "0.3"
 ghost_actor = "0.3.0-alpha.5"
-hdk = { version = "^0.2.0-beta-rc.0", path = "../hdk" }
-hdk_derive = { version = "^0.2.0-beta-rc.0", path = "../hdk_derive" }
-holo_hash = { version = "^0.2.0-beta-rc.0", path = "../holo_hash", features = ["full"] }
-holochain_sqlite = { version = "^0.2.0-beta-rc.0", path = "../holochain_sqlite" }
-holochain_p2p = { version = "^0.2.0-beta-rc.0", path = "../holochain_p2p" }
+hdk = { version = "^0.2.0-beta-rc.1", path = "../hdk" }
+hdk_derive = { version = "^0.2.0-beta-rc.1", path = "../hdk_derive" }
+holo_hash = { version = "^0.2.0-beta-rc.1", path = "../holo_hash", features = ["full"] }
+holochain_sqlite = { version = "^0.2.0-beta-rc.1", path = "../holochain_sqlite" }
+holochain_p2p = { version = "^0.2.0-beta-rc.1", path = "../holochain_p2p" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_state = { version = "^0.2.0-beta-rc.0", path = "../holochain_state" }
-holochain_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_types" }
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../holochain_trace" }
-holochain_zome_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
+holochain_state = { version = "^0.2.0-beta-rc.1", path = "../holochain_state" }
+holochain_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_types" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
+holochain_zome_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_zome_types" }
+kitsune_p2p = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p/kitsune_p2p" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 tokio = { version = "1.11", features = ["full"] }

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -7,12 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 - Reject creation of duplicate clone cells. It was possible to create a clone cell with a DNA hash identical to an already existing DNA. [\#1997](https://github.com/holochain/holochain/pull/1997)
 - Adds doc comments for `StemCell`, `ProvisionedCell` and `CloneCell` structs
-- Various methods may return a `CellMissing` error if an operation is performed on a disabled cell. Now such calls will return `CellDisabled` to differentiate between a truly missing cell and one that's just disabled. [\#2092](https://github.com/holochain/holochain/pull/2092)
-- Enabling a clone cell that's already enabled or disabling a clone cell that's already disabled would previously return a `CloneCellNotFound` error. Now, in those cases, nothing happens and a successful result is returned. [\#2093](https://github.com/holochain/holochain/pull/2093)
+- Various methods may return a `CellMissing` error if an operation is performed on a disabled cell. Now such calls will return `CellDisabled` to differentiate between a truly missing cell and one that’s just disabled. [\#2092](https://github.com/holochain/holochain/pull/2092)
+- Enabling a clone cell that’s already enabled or disabling a clone cell that’s already disabled would previously return a `CloneCellNotFound` error. Now, in those cases, nothing happens and a successful result is returned. [\#2093](https://github.com/holochain/holochain/pull/2093)
 
 ## 0.1.0
 

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_conductor_api"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "Message types for Holochain admin and app interface protocols"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -11,13 +11,13 @@ edition = "2021"
 [dependencies]
 directories = "2.0.2"
 derive_more = "0.99.3"
-kitsune_p2p = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
-holo_hash = { version = "^0.2.0-beta-rc.0", path = "../holo_hash", features = ["full"] }
-holochain_p2p = { version = "^0.2.0-beta-rc.0", path = "../holochain_p2p" }
-holochain_state = { version = "^0.2.0-beta-rc.0", path = "../holochain_state" }
+kitsune_p2p = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p/kitsune_p2p" }
+holo_hash = { version = "^0.2.0-beta-rc.1", path = "../holo_hash", features = ["full"] }
+holochain_p2p = { version = "^0.2.0-beta-rc.1", path = "../holochain_p2p" }
+holochain_state = { version = "^0.2.0-beta-rc.1", path = "../holochain_state" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_zome_types" }
+holochain_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_zome_types" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_yaml = "0.9"
@@ -25,8 +25,8 @@ structopt = "0.3"
 tracing = "0.1.26"
 thiserror = "1.0.22"
 url2 = "0.0.6"
-holochain_keystore = { version = "^0.2.0-beta-rc.0", path = "../holochain_keystore" }
+holochain_keystore = { version = "^0.2.0-beta-rc.1", path = "../holochain_keystore" }
 
 [dev-dependencies]
 matches = {version = "0.1.8"}
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }

--- a/crates/holochain_integrity_types/CHANGELOG.md
+++ b/crates/holochain_integrity_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/holochain_integrity_types/Cargo.toml
+++ b/crates/holochain_integrity_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_integrity_types"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "Holochain integrity types"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -10,7 +10,7 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 
 [dependencies]
-holo_hash = { version = "^0.2.0-beta-rc.0", path = "../holo_hash" }
+holo_hash = { version = "^0.2.0-beta-rc.1", path = "../holo_hash" }
 holochain_serialized_bytes = "=0.0.51"
 paste = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_keystore"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "keystore for libsodium keypairs"
 license = "CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -19,10 +19,10 @@ no-deps = [ "lair_keystore/rusqlite-bundled" ]
 [dependencies]
 base64 = "0.13.0"
 futures = "0.3.23"
-holo_hash = { version = "^0.2.0-beta-rc.0", path = "../holo_hash", features = ["full"] }
+holo_hash = { version = "^0.2.0-beta-rc.1", path = "../holo_hash", features = ["full"] }
 holochain_serialized_bytes = "=0.0.51"
-holochain_zome_types = { path = "../holochain_zome_types", version = "^0.2.0-beta-rc.0"}
-kitsune_p2p_types = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/types" }
+holochain_zome_types = { path = "../holochain_zome_types", version = "^0.2.0-beta-rc.1"}
+kitsune_p2p_types = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p/types" }
 lair_keystore = { version = "0.2.3", default-features = false }
 must_future = "0.1.2"
 nanoid = "0.4.0"
@@ -37,7 +37,7 @@ tracing = "0.1"
 
 # This is a redundant dependency.
 # It's included only to set the proper feature flag for database encryption.
-holochain_sqlite = { version = "^0.2.0-beta-rc.0", path = "../holochain_sqlite" }
+holochain_sqlite = { version = "^0.2.0-beta-rc.1", path = "../holochain_sqlite" }
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_p2p"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "holochain specific wrapper around more generic p2p module"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -16,15 +16,15 @@ derive_more = "0.99"
 fixt = { path = "../fixt", version = "^0.2.0-beta-rc.0"}
 futures = "0.3"
 ghost_actor = "0.3.0-alpha.5"
-holo_hash = { version = "^0.2.0-beta-rc.0", path = "../holo_hash" }
-holochain_keystore = { version = "^0.2.0-beta-rc.0", path = "../holochain_keystore" }
+holo_hash = { version = "^0.2.0-beta-rc.1", path = "../holo_hash" }
+holochain_keystore = { version = "^0.2.0-beta-rc.1", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
-kitsune_p2p_types = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/types" }
+holochain_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_zome_types" }
+kitsune_p2p = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p_types = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p/types" }
 mockall = "0.11.3"
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_sqlite"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "Abstractions for persistence of Holochain state via SQLite"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -23,11 +23,11 @@ fallible-iterator = "0.2.0"
 failure = "0.1.6"
 fixt = { version = "^0.2.0-beta-rc.0", path = "../fixt" }
 futures = "0.3.1"
-holo_hash = { path = "../holo_hash", features = ["rusqlite"], version = "^0.2.0-beta-rc.0"}
+holo_hash = { path = "../holo_hash", features = ["rusqlite"], version = "^0.2.0-beta-rc.1"}
 holochain_serialized_bytes = "=0.0.51"
 holochain_util = { version = "^0.2.0-beta-rc.0", path = "../holochain_util", features = ["backtrace"] }
-holochain_zome_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
+holochain_zome_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_zome_types" }
+kitsune_p2p = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p/kitsune_p2p" }
 lazy_static = "1.4.0"
 once_cell = "1.4.1"
 must_future = "0.1.1"
@@ -65,7 +65,7 @@ rusqlite = { version = "0.28", features = [
 ] }
 
 [dev-dependencies]
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
 
 [build-dependencies]
 pretty_assertions = "0.7.2"

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
-- Optimize capability grant verification during zome calls. This speeds up all remote calls, under which fall calls with a cap secret from clients other than the Launcher. Previously hundreds of calls would slow down response time noticeably because of grant verification. Now thousands of calls (rather thousands of records) won't affect grant verification by more than a millisecond. [#2097](https://github.com/holochain/holochain/pull/2097)
+## 0.2.0-beta-rc.1
+
+- Optimize capability grant verification during zome calls. This speeds up all remote calls, under which fall calls with a cap secret from clients other than the Launcher. Previously hundreds of calls would slow down response time noticeably because of grant verification. Now thousands of calls (rather thousands of records) won’t affect grant verification by more than a millisecond. [\#2097](https://github.com/holochain/holochain/pull/2097)
 
 ## 0.2.0-beta-rc.0
 

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_state"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "TODO minimize deps"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -14,19 +14,19 @@ cfg-if = "0.1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 derive_more = "0.99.3"
 either = "1.5"
-holochain_sqlite = { version = "^0.2.0-beta-rc.0", path = "../holochain_sqlite" }
-holo_hash = { version = "^0.2.0-beta-rc.0", path = "../holo_hash", features = ["full"] }
+holochain_sqlite = { version = "^0.2.0-beta-rc.1", path = "../holochain_sqlite" }
+holo_hash = { version = "^0.2.0-beta-rc.1", path = "../holo_hash", features = ["full"] }
 fallible-iterator = "0.2.0"
 futures = "0.3"
-holochain_keystore = { version = "^0.2.0-beta-rc.0", path = "../holochain_keystore" }
+holochain_keystore = { version = "^0.2.0-beta-rc.1", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_p2p = { version = "^0.2.0-beta-rc.0", path = "../holochain_p2p" }
-holochain_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_types" }
+holochain_p2p = { version = "^0.2.0-beta-rc.1", path = "../holochain_p2p" }
+holochain_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_types" }
 holochain_util = { version = "^0.2.0-beta-rc.0", path = "../holochain_util" }
-holochain_zome_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_zome_types", features = [
+holochain_zome_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_zome_types", features = [
     "full",
 ] }
-kitsune_p2p = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p/kitsune_p2p" }
 mockall = "0.11.3"
 one_err = "0.0.8"
 parking_lot = "0.10"
@@ -56,7 +56,7 @@ fixt = { path = "../fixt" }
 hdk = { path = "../hdk" }
 holochain_wasm_test_utils = { path = "../test_utils/wasm" }
 matches = "0.1.8"
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
 pretty_assertions = "0.6.1"
 
 tempfile = "3.3"

--- a/crates/holochain_trace/CHANGELOG.md
+++ b/crates/holochain_trace/CHANGELOG.md
@@ -7,4 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0

--- a/crates/holochain_trace/Cargo.toml
+++ b/crates/holochain_trace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_trace"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 authors = ["freesig <tom.gowan@holo.host>", "Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 description = "tracing helpers"

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_types"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "Holochain common types"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -25,19 +25,19 @@ fixt = { path = "../fixt", version = "^0.2.0-beta-rc.0"}
 flate2 = "1.0.14"
 futures = "0.3"
 one_err = "0.0.8"
-holo_hash = { version = "^0.2.0-beta-rc.0", path = "../holo_hash", features = ["encoding"] }
-holochain_keystore = { version = "^0.2.0-beta-rc.0", path = "../holochain_keystore" }
+holo_hash = { version = "^0.2.0-beta-rc.1", path = "../holo_hash", features = ["encoding"] }
+holochain_keystore = { version = "^0.2.0-beta-rc.1", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_sqlite = { path = "../holochain_sqlite", version = "^0.2.0-beta-rc.0"}
-holochain_zome_types = { path = "../holochain_zome_types", version = "^0.2.0-beta-rc.0", features = ["full"] }
+holochain_sqlite = { path = "../holochain_sqlite", version = "^0.2.0-beta-rc.1"}
+holochain_zome_types = { path = "../holochain_zome_types", version = "^0.2.0-beta-rc.1", features = ["full"] }
 itertools = { version = "0.10" }
-kitsune_p2p_dht = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/dht" }
+kitsune_p2p_dht = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p/dht" }
 lazy_static = "1.4.0"
 mockall = "0.11.3"
 mr_bundle = { path = "../mr_bundle", features = ["packing"], version = "^0.2.0-beta-rc.0"}
 must_future = "0.1.1"
 nanoid = "0.3"
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
 parking_lot = "0.10"
 rand = "0.8.5"
 regex = "1.4"

--- a/crates/holochain_websocket/CHANGELOG.md
+++ b/crates/holochain_websocket/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_websocket"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "Holochain utilities for serving and connection with websockets"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -31,7 +31,7 @@ url2 = "0.0.6"
 holochain_types = { path = "../holochain_types" }
 linefeed = "0.6"
 unwrap_to = "0.1.0"
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
 criterion = "0.3.4"
 
 [[bench]]

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 - `name` in DnaDef no longer has an effect on the DNA hash [\#2099](https://github.com/holochain/holochain/pull/2099)
 
 ## 0.2.0-beta-rc.0

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_zome_types"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "Holochain zome types"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -12,11 +12,11 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kitsune_p2p_dht = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/dht" }
+kitsune_p2p_dht = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p/dht" }
 kitsune_p2p_timestamp = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/timestamp" }
-kitsune_p2p_block = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p/block" }
-holo_hash = { version = "^0.2.0-beta-rc.0", path = "../holo_hash", features = ["encoding"] }
-holochain_integrity_types = { version = "^0.2.0-beta-rc.0", path = "../holochain_integrity_types", features = ["tracing"] }
+kitsune_p2p_block = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p/block" }
+holo_hash = { version = "^0.2.0-beta-rc.1", path = "../holo_hash", features = ["encoding"] }
+holochain_integrity_types = { version = "^0.2.0-beta-rc.1", path = "../holochain_integrity_types", features = ["tracing"] }
 holochain_serialized_bytes = "=0.0.51"
 paste = "1.0.12"
 serde = { version = "1.0", features = [ "derive", "rc" ] }

--- a/crates/kitsune_p2p/bin_data/CHANGELOG.md
+++ b/crates/kitsune_p2p/bin_data/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 - Crate now exists

--- a/crates/kitsune_p2p/bin_data/Cargo.toml
+++ b/crates/kitsune_p2p/bin_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_bin_data"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "Binary data types for kitsune_p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -11,7 +11,7 @@ categories = [ "network-programming" ]
 edition = "2021"
 
 [dependencies]
-kitsune_p2p_dht_arc = { version = "^0.2.0-beta-rc.0", path = "../dht_arc" }
+kitsune_p2p_dht_arc = { version = "^0.2.0-beta-rc.1", path = "../dht_arc" }
 shrinkwraprs = "0.3.0"
 derive_more = "0.99.7"
 serde = { version = "1", features = [ "derive", "rc" ] }

--- a/crates/kitsune_p2p/block/CHANGELOG.md
+++ b/crates/kitsune_p2p/block/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 - Crate now exists

--- a/crates/kitsune_p2p/block/Cargo.toml
+++ b/crates/kitsune_p2p/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_block"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "(un)Block datatype for kitsune_p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -12,5 +12,5 @@ edition = "2021"
 
 [dependencies]
 kitsune_p2p_timestamp = { version = "^0.2.0-beta-rc.0", path = "../timestamp", features = ["now"] }
-kitsune_p2p_bin_data = { version = "^0.2.0-beta-rc.0", path = "../bin_data" }
+kitsune_p2p_bin_data = { version = "^0.2.0-beta-rc.1", path = "../bin_data" }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/kitsune_p2p/bootstrap/CHANGELOG.md
+++ b/crates/kitsune_p2p/bootstrap/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.0-beta-rc.0
+
 ## 0.0.12-dev.0
 
 ## 0.0.11

--- a/crates/kitsune_p2p/bootstrap/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_bootstrap"
-version = "0.0.12-dev.0"
+version = "0.1.0-beta-rc.0"
 description = "Bootstrap server written in rust for kitsune nodes to find each other"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -15,7 +15,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "3.1.18", features = [ "derive" ] }
 futures = "0.3.15"
-kitsune_p2p_types = { version = "^0.2.0-beta-rc.0", path = "../types" }
+kitsune_p2p_types = { version = "^0.2.0-beta-rc.1", path = "../types" }
 once_cell = "1.7.2"
 parking_lot = "0.11"
 rand = "0.8.5"

--- a/crates/kitsune_p2p/dht/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/kitsune_p2p/dht/Cargo.toml
+++ b/crates/kitsune_p2p/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_dht"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "Kitsune P2p DHT definition"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -18,7 +18,7 @@ derivative = "2.2.0"
 derive_more = "0.99"
 futures = "0.3"
 gcollections = "1.5"
-kitsune_p2p_dht_arc = { version = "^0.2.0-beta-rc.0", path = "../dht_arc"}
+kitsune_p2p_dht_arc = { version = "^0.2.0-beta-rc.1", path = "../dht_arc"}
 kitsune_p2p_timestamp = { version = "^0.2.0-beta-rc.0", path = "../timestamp", features = ["now"]}
 intervallum = "1.4"
 must_future = "0.1"
@@ -35,7 +35,7 @@ kitsune_p2p_dht = { path = ".", features = ["test_utils"]}
 kitsune_p2p_dht_arc = { path = "../dht_arc", features = ["test_utils"]}
 holochain_serialized_bytes = "0.0.51"
 maplit = "1"
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../../holochain_trace" }
 pretty_assertions = "0.7.2"
 proptest = "1"
 rand = "0.8"

--- a/crates/kitsune_p2p/dht_arc/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht_arc/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/kitsune_p2p/dht_arc/Cargo.toml
+++ b/crates/kitsune_p2p/dht_arc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_dht_arc"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "Kitsune P2p Dht Arc Utils"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -21,7 +21,7 @@ rusqlite = { version = "0.28", optional = true }
 
 [dev-dependencies]
 maplit = "1"
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../../holochain_trace" }
 pretty_assertions = "0.7.2"
 rand = "0.8.5"
 statrs = "0.15"

--- a/crates/kitsune_p2p/direct/Cargo.toml
+++ b/crates/kitsune_p2p/direct/Cargo.toml
@@ -17,12 +17,12 @@ derive_more = "0.99"
 futures = "0.3.14"
 hyper = { version = "0.14", features = ["server","http1","http2","tcp"] }
 if-addrs = "0.8"
-kitsune_p2p_bootstrap = { version = "0.0.12-dev.0", path = "../bootstrap" }
+kitsune_p2p_bootstrap = { version = "^0.1.0-beta-rc.0", path = "../bootstrap" }
 kitsune_p2p_direct_api = { version = "0.0.1", path = "../direct_api" }
-kitsune_p2p_types = { version = "^0.2.0-beta-rc.0", path = "../types" }
-kitsune_p2p = { version = "^0.2.0-beta-rc.0", path = "../kitsune_p2p", features = ["test_utils"] }
-kitsune_p2p_transport_quic = { version = "^0.2.0-beta-rc.0", path = "../transport_quic" }
-kitsune_p2p_proxy = { version = "^0.2.0-beta-rc.0", path = "../proxy" }
+kitsune_p2p_types = { version = "^0.2.0-beta-rc.1", path = "../types" }
+kitsune_p2p = { version = "^0.2.0-beta-rc.1", path = "../kitsune_p2p", features = ["test_utils"] }
+kitsune_p2p_transport_quic = { version = "^0.2.0-beta-rc.1", path = "../transport_quic" }
+kitsune_p2p_proxy = { version = "^0.2.0-beta-rc.1", path = "../proxy" }
 rand = "0.8.5"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/crates/kitsune_p2p/direct_api/Cargo.toml
+++ b/crates/kitsune_p2p/direct_api/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2021"
 [dependencies]
 arrayref = "0.3.6"
 base64 = "0.13"
-kitsune_p2p_dht_arc = { version = "^0.2.0-beta-rc.0", path = "../dht_arc" }
+kitsune_p2p_dht_arc = { version = "^0.2.0-beta-rc.1", path = "../dht_arc" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/crates/kitsune_p2p/direct_test/Cargo.toml
+++ b/crates/kitsune_p2p/direct_test/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2021"
 
 [dependencies]
 kitsune_p2p_direct = { version = "0.0.1", path = "../direct" }
-kitsune_p2p_transport_quic = { version = "^0.2.0-beta-rc.0", path = "../transport_quic" }
-kitsune_p2p_proxy = { version = "^0.2.0-beta-rc.0", path = "../proxy" }
+kitsune_p2p_transport_quic = { version = "^0.2.0-beta-rc.1", path = "../transport_quic" }
+kitsune_p2p_proxy = { version = "^0.2.0-beta-rc.1", path = "../proxy" }
 rand = "0.8.5"
 structopt = "0.3.21"
 tokio = { version = "1.11", features = ["full"] }

--- a/crates/kitsune_p2p/fetch/CHANGELOG.md
+++ b/crates/kitsune_p2p/fetch/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/kitsune_p2p/fetch/Cargo.toml
+++ b/crates/kitsune_p2p/fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_fetch"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "Kitsune P2p Fetch Queue Logic"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 derive_more = "0.99"
 futures = "0.3"
-kitsune_p2p_types = { version = "^0.2.0-beta-rc.0", path = "../types" }
+kitsune_p2p_types = { version = "^0.2.0-beta-rc.1", path = "../types" }
 kitsune_p2p_timestamp = { version = "^0.2.0-beta-rc.0", path = "../timestamp", features = ["now"]}
 must_future = "0.1"
 num-traits = "0.2.14"
@@ -30,7 +30,7 @@ human-repr = { version = "1", optional = true}
 [dev-dependencies]
 kitsune_p2p_fetch = { path = ".", features = ["test_utils"]}
 holochain_serialized_bytes = "0.0.51"
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../../holochain_trace" }
 pretty_assertions = "0.7.2"
 test-case = "1.2"
 tokio = { version = "1.11", features = [ "full", "test-util" ] }

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 - Adds feature flipper `tx5` which enables experimental integration with holochains WebRTC networking backend. This is not enabled by default. [\#1741](https://github.com/holochain/holochain/pull/1741)

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "p2p / dht communication framework"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -20,17 +20,17 @@ futures = "0.3"
 ghost_actor = "=0.3.0-alpha.5"
 governor = "0.3.2"
 itertools = "0.10"
-kitsune_p2p_fetch = { version = "^0.2.0-beta-rc.0", path = "../fetch" }
+kitsune_p2p_fetch = { version = "^0.2.0-beta-rc.1", path = "../fetch" }
 kitsune_p2p_mdns = { version = "^0.2.0-beta-rc.0", path = "../mdns" }
-kitsune_p2p_proxy = { version = "^0.2.0-beta-rc.0", path = "../proxy" }
+kitsune_p2p_proxy = { version = "^0.2.0-beta-rc.1", path = "../proxy" }
 kitsune_p2p_timestamp = { version = "^0.2.0-beta-rc.0", path = "../timestamp", features = ["now"] }
-kitsune_p2p_block = { version = "^0.2.0-beta-rc.0", path = "../block" }
-kitsune_p2p_transport_quic = { version = "^0.2.0-beta-rc.0", path = "../transport_quic", optional = true }
-kitsune_p2p_types = { version = "^0.2.0-beta-rc.0", path = "../types", default-features = false }
+kitsune_p2p_block = { version = "^0.2.0-beta-rc.1", path = "../block" }
+kitsune_p2p_transport_quic = { version = "^0.2.0-beta-rc.1", path = "../transport_quic", optional = true }
+kitsune_p2p_types = { version = "^0.2.0-beta-rc.1", path = "../types", default-features = false }
 must_future = "0.1.1"
 nanoid = "0.4"
 num-traits = "0.2"
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../../holochain_trace" }
 once_cell = "1.4.1"
 parking_lot = "0.11.1"
 rand = "0.8.5"

--- a/crates/kitsune_p2p/proxy/CHANGELOG.md
+++ b/crates/kitsune_p2p/proxy/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/kitsune_p2p/proxy/Cargo.toml
+++ b/crates/kitsune_p2p/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_proxy"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "Proxy transport module for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -15,10 +15,10 @@ base64 = "0.13"
 blake2b_simd = "0.5.10"
 derive_more = "0.99.7"
 futures = "0.3"
-kitsune_p2p_types = { version = "^0.2.0-beta-rc.0", path = "../types" }
-kitsune_p2p_transport_quic = { version = "^0.2.0-beta-rc.0", path = "../transport_quic" }
+kitsune_p2p_types = { version = "^0.2.0-beta-rc.1", path = "../types" }
+kitsune_p2p_transport_quic = { version = "^0.2.0-beta-rc.1", path = "../transport_quic" }
 nanoid = "0.3"
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../../holochain_trace" }
 parking_lot = "0.11"
 rmp-serde = "0.15"
 rustls = { version = "0.20.4", features = [ "dangerous_configuration" ] }

--- a/crates/kitsune_p2p/transport_quic/CHANGELOG.md
+++ b/crates/kitsune_p2p/transport_quic/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/kitsune_p2p/transport_quic/Cargo.toml
+++ b/crates/kitsune_p2p/transport_quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_transport_quic"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "QUIC transport module for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -14,7 +14,7 @@ edition = "2021"
 blake2b_simd = "1.0.0"
 futures = "0.3.21"
 if-addrs = "0.8"
-kitsune_p2p_types = { version = "^0.2.0-beta-rc.0", path = "../types" }
+kitsune_p2p_types = { version = "^0.2.0-beta-rc.1", path = "../types" }
 nanoid = "0.4.0"
 once_cell = "1.9.0"
 quinn = "0.8.1"

--- a/crates/kitsune_p2p/types/CHANGELOG.md
+++ b/crates/kitsune_p2p/types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_types"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 description = "types subcrate for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -16,13 +16,13 @@ base64 = "0.13"
 derive_more = "0.99.7"
 futures = "0.3"
 ghost_actor = "=0.3.0-alpha.5"
-kitsune_p2p_dht = { version = "^0.2.0-beta-rc.0", path = "../dht" }
-kitsune_p2p_dht_arc = { version = "^0.2.0-beta-rc.0", path = "../dht_arc" }
-kitsune_p2p_bin_data = { version = "^0.2.0-beta-rc.0", path = "../bin_data" }
+kitsune_p2p_dht = { version = "^0.2.0-beta-rc.1", path = "../dht" }
+kitsune_p2p_dht_arc = { version = "^0.2.0-beta-rc.1", path = "../dht_arc" }
+kitsune_p2p_bin_data = { version = "^0.2.0-beta-rc.1", path = "../bin_data" }
 lru = "0.8.1"
 mockall = { version = "0.11.3", optional = true }
 nanoid = "0.3"
-holochain_trace = { version = "^0.2.0-beta-rc.0", path = "../../holochain_trace" }
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../../holochain_trace" }
 once_cell = "1.4"
 parking_lot = "0.11"
 paste = "1.0.12"

--- a/crates/test_utils/wasm/CHANGELOG.md
+++ b/crates/test_utils/wasm/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/test_utils/wasm/Cargo.toml
+++ b/crates/test_utils/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_wasm_test_utils"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2021"
 description = "Utilities for Wasm testing for Holochain"
@@ -19,7 +19,7 @@ only_check = []
 
 
 [dependencies]
-holochain_types = { path = "../../holochain_types", version = "^0.2.0-beta-rc.0"}
+holochain_types = { path = "../../holochain_types", version = "^0.2.0-beta-rc.1"}
 strum = "0.18.0"
 strum_macros = "0.18.0"
 holochain_util = { version = "^0.2.0-beta-rc.0", path = "../../holochain_util" }

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -464,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.94"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
+checksum = "9a140f260e6f3f79013b8bfc65e7ce630c9ab4388c6a89c71e07226f49487b72"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.94"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
+checksum = "da6383f459341ea689374bf0a42979739dc421874f112ff26f829b8040b8e613"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -486,24 +486,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.11",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.94"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
+checksum = "90201c1a650e95ccff1c8c0bb5a343213bdd317c6e600a93075bca2eff54ec97"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.94"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
+checksum = "0b75aed41bb2e6367cae39e6326ef817a851db13c13e4f3263714ca3cfb8de56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -886,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -1211,9 +1211,9 @@ checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown 0.12.3",
@@ -1510,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.4"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
+checksum = "50e4a1c770583dac7ab5e2f6c139153b783a53a1bbee9729613f193e59828326"
 dependencies = [
  "cfg-if 1.0.0",
  "downcast",
@@ -1525,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.4"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
+checksum = "832663583d5fa284ca8810bf7015e46c9fff9622d3cf34bd1eea5003fec06dd0"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
@@ -1809,9 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.54"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e472a104799c74b514a57226160104aa483546de37e839ec50e3c2e41dd87534"
+checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
 dependencies = [
  "unicode-ident",
 ]
@@ -2056,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "cce168fea28d3e05f158bda4576cf0c844d5045bc2cc3620fa0292ed5bb5814c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2242,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.159"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 dependencies = [
  "serde_derive",
 ]
@@ -2269,20 +2269,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.159"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.8",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2451,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.11"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e3787bb71465627110e7d87ed4faaa36c1f61042ee67badb9e2ef173accc40"
+checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2996,7 +2996,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.11",
+ "syn 2.0.8",
 ]
 
 [[package]]

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -942,7 +942,7 @@ dependencies = [
 
 [[package]]
 name = "hdi"
-version = "0.3.0-beta-rc.0"
+version = "0.3.0-beta-rc.1"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "getrandom",
  "hdi",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "darling 0.14.4",
  "heck 0.4.1",
@@ -1035,7 +1035,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "holo_hash"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "arbitrary",
  "base64",
@@ -1054,7 +1054,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "arbitrary",
  "holo_hash",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "hdk",
  "serde",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "derive_builder",
  "fixt",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bin_data"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "base64",
  "derive_more",
@@ -1300,7 +1300,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_block"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_timestamp",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "colored",
  "derivative",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht_arc"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 dependencies = [
  "derive_more",
  "gcollections",

--- a/crates/test_utils/wasm_common/CHANGELOG.md
+++ b/crates/test_utils/wasm_common/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-rc.1
+
 ## 0.2.0-beta-rc.0
 
 ## 0.1.0

--- a/crates/test_utils/wasm_common/Cargo.toml
+++ b/crates/test_utils/wasm_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_test_wasm_common"
-version = "0.2.0-beta-rc.0"
+version = "0.2.0-beta-rc.1"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2021"
 description = "Common code for Wasm testing for Holochain"
@@ -13,5 +13,5 @@ crate-type = [ "cdylib", "rlib" ]
 path = "src/lib.rs"
 
 [dependencies]
-hdk = { path = "../../hdk", version = "^0.2.0-beta-rc.0"}
+hdk = { path = "../../hdk", version = "^0.2.0-beta-rc.1"}
 serde = "1.0"


### PR DESCRIPTION
### Summary

this merges main into develop which was skipped during the most recent release, 
due to the bug fixed in #2151.

note: we can't merge this via GitHub's squash merging feature make `--ff-only` break into _main_. hence i'll merge and push this manually once approved.

### TODO:
- [x] update Cargo.lock files
- [x] double check i merged [crates/holochain/CHANGELOG.md](https://github.com/holochain/holochain/pull/2171/files#diff-146f4dc7b1de7ae4bef22ef602d01a681b4bd271ba5d06a74a930855d841ed2c) correctly (reviewers please help with this)
    - verified that https://github.com/holochain/holochain/commit/c50ffc91db8dc80a3db2efd01411ce6be99533f1 was not part of the most recent release
- [ ] dry-run with _main_ as its target branch
    - [x] https://github.com/holochain/holochain/actions/runs/4600137446/jobs/8126500602 (without test)
    - [x] ~~https://github.com/holochain/holochain/actions/runs/4600261746~~
    - [ ] https://github.com/holochain/holochain/actions/runs/4600309730
