### PR TITLE
minimize tests for 'Fix bug with get dependants filtered caching its filter'

### DIFF
--- a/crates/release-automation/src/lib/crate_selection/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/mod.rs
@@ -53,6 +53,15 @@ pub struct Crate<'a> {
     dependants_in_workspace: OnceCell<Vec<&'a Crate<'a>>>,
 }
 
+#[cfg(test)]
+impl PartialEq for Crate<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.package == other.package
+            && self.dependencies_in_workspace == other.dependencies_in_workspace
+            && self.dependants_in_workspace == other.dependants_in_workspace
+    }
+}
+
 impl<'a> Crate<'a> {
     /// Instantiate a new Crate with the given CargoPackage.
     pub fn with_cargo_package(

--- a/crates/release-automation/src/lib/crate_selection/tests/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/tests/mod.rs
@@ -103,7 +103,7 @@ fn release_selection() {
 }
 
 #[test]
-fn members_dependencies() {
+fn crate_dependants_unfiltered_and_filtered() {
     let workspace_mocker = example_workspace_2().unwrap();
     let workspace = ReleaseWorkspace::try_new_with_criteria(
         workspace_mocker.root(),
@@ -114,211 +114,54 @@ fn members_dependencies() {
     )
     .unwrap();
 
-    let result = workspace
+    let crate_b = workspace
         .members()
         .unwrap()
         .iter()
-        .map(|crt| {
-            (
-                crt.name(),
-                crt.dependencies_in_workspace()
-                    .unwrap()
-                    .into_iter()
-                    .map(|(dep_name, _)| dep_name.clone())
-                    .collect::<HashSet<_>>(),
-            )
-        })
-        .collect::<Vec<_>>();
+        .find(|crt| crt.name() == "crate_b")
+        .unwrap();
 
-    let expected_result = [
-        ("crate_b".to_string(), vec![]),
-        ("crate_c".to_string(), vec!["crate_b".to_string()]),
-        (
-            "crate_a".to_string(),
-            vec!["crate_c".to_string(), "crate_b".to_string()],
-        ),
-        (
-            "crate_d".to_string(),
-            vec![
-                "crate_a".to_string(),
-                "crate_c".to_string(),
-                "crate_b".to_string(),
-            ],
-        ),
-    ]
-    .into_iter()
-    .map(|(name, deps)| (name, deps.into_iter().collect::<HashSet<_>>()))
-    .collect::<Vec<_>>();
+    // get something back
+    pretty_assertions::assert_ne!(
+        Vec::<&Crate>::new(),
+        crate_b.dependants_in_workspace_filtered(|_| true).unwrap()
+    );
 
-    pretty_assertions::assert_eq!(expected_result, result, "left is expected");
-}
+    // unfiltered equals the 'true' filter
+    pretty_assertions::assert_eq!(
+        crate_b.dependants_in_workspace().unwrap(),
+        &crate_b.dependants_in_workspace_filtered(|_| true).unwrap()
+    );
 
-#[test]
-fn members_dependants() {
-    let workspace_mocker = example_workspace_2().unwrap();
-    let workspace = ReleaseWorkspace::try_new_with_criteria(
-        workspace_mocker.root(),
-        SelectionCriteria {
-            exclude_optional_deps: true,
-            ..Default::default()
-        },
-    )
-    .unwrap();
-
-    let result = workspace
-        .members()
-        .unwrap()
-        .iter()
-        .map(|crt| {
-            (
-                crt.name(),
-                crt.dependants_in_workspace()
-                    .unwrap()
-                    .into_iter()
-                    .map(|crt| crt.name())
-                    .collect::<Vec<_>>(),
-            )
-        })
-        .collect::<Vec<_>>();
-
-    let expected_result = vec![
-        (
-            "crate_b".to_string(),
-            vec![
-                "crate_c".to_string(),
-                "crate_a".to_string(),
-                "crate_d".to_string(), // through crate_a
-            ],
-        ),
-        (
-            "crate_c".to_string(),
-            vec![
-                "crate_a".to_string(),
-                "crate_d".to_string(), // through crate_a
-            ],
-        ),
-        ("crate_a".to_string(), vec!["crate_d".to_string()]),
-        ("crate_d".to_string(), vec![]),
-    ];
-
-    pretty_assertions::assert_eq!(expected_result, result, "left is expected");
-}
-
-#[test]
-fn members_dependants_filtered() {
-    let workspace_mocker = example_workspace_2().unwrap();
-    let workspace = ReleaseWorkspace::try_new_with_criteria(
-        workspace_mocker.root(),
-        SelectionCriteria {
-            exclude_optional_deps: true,
-            ..Default::default()
-        },
-    )
-    .unwrap();
-
-    let result = workspace
-        .members()
-        .unwrap()
-        .iter()
-        .map(|crt| {
-            (
-                crt.name(),
-                crt.dependants_in_workspace_filtered(|(name, _)| !name.contains("_b"))
-                    .unwrap()
-                    .into_iter()
-                    .map(|crt| crt.name())
-                    .collect::<Vec<_>>(),
-            )
-        })
-        .collect::<Vec<_>>();
-
-    let expected_result = vec![
-        ("crate_b".to_string(), vec![]), // Filtered out
-        (
-            "crate_c".to_string(),
-            vec![
-                "crate_a".to_string(),
-                "crate_d".to_string(), // through crate_a
-            ],
-        ),
-        ("crate_a".to_string(), vec!["crate_d".to_string()]),
-        ("crate_d".to_string(), vec![]),
-    ];
-
-    pretty_assertions::assert_eq!(expected_result, result, "left is expected");
-}
-
-#[test]
-fn members_dependants_with_two_different_filters() {
-    let workspace_mocker = example_workspace_2().unwrap();
-    let workspace = ReleaseWorkspace::try_new_with_criteria(
-        workspace_mocker.root(),
-        SelectionCriteria {
-            exclude_optional_deps: true,
-            ..Default::default()
-        },
-    )
-    .unwrap();
-
-    let result = workspace
-        .members()
-        .unwrap()
-        .iter()
-        .map(|crt| {
-            (
-                crt.name(),
-                crt.dependants_in_workspace_filtered(|_| false)
-                    .unwrap()
-                    .into_iter()
-                    .map(|crt| crt.name())
-                    .collect::<Vec<_>>(),
-            )
-        })
-        .collect::<Vec<_>>();
-
-    // Everything filtered out
-    let expected_result = vec![
-        ("crate_b".to_string(), vec![]),
-        ("crate_c".to_string(), vec![]),
-        ("crate_a".to_string(), vec![]),
-        ("crate_d".to_string(), vec![]),
-    ];
-
-    pretty_assertions::assert_eq!(expected_result, result, "left is expected");
-
-    let result = workspace
-        .members()
-        .unwrap()
-        .iter()
-        .map(|crt| {
-            (
-                crt.name(),
-                crt.dependants_in_workspace_filtered(|(name, _)| !name.contains("_c"))
-                    .unwrap()
-                    .into_iter()
-                    .map(|crt| crt.name())
-                    .collect::<Vec<_>>(),
-            )
-        })
-        .collect::<Vec<_>>();
-
+    // filter changes work
+    //
     // The actual values in here aren't that important, just need to see that the filter is applied and not
-    // cached as `false` from above.
-    let expected_result = vec![
-        (
-            "crate_b".to_string(),
-            vec![
-                "crate_c".to_string(),
-                "crate_a".to_string(),
-                "crate_d".to_string(),
-            ],
-        ),
-        ("crate_c".to_string(), vec![]),
-        ("crate_a".to_string(), vec!["crate_d".to_string()]),
-        ("crate_d".to_string(), vec![]),
-    ];
+    // cached as `true` from above.
+    pretty_assertions::assert_eq!(
+        Vec::<&Crate>::new(),
+        crate_b.dependants_in_workspace_filtered(|_| false).unwrap()
+    );
 
-    pretty_assertions::assert_eq!(expected_result, result, "left is expected");
+    // dependency doesn't include itself
+    pretty_assertions::assert_eq!(
+        None,
+        crate_b
+            .dependants_in_workspace()
+            .unwrap()
+            .into_iter()
+            .find(|crt| crt.name() == "crate_b")
+    );
+
+    // for the sake of completeness exhaustively check the result
+    pretty_assertions::assert_eq!(
+        vec!["crate_c", "crate_a", "crate_d"],
+        crate_b
+            .dependants_in_workspace()
+            .unwrap()
+            .iter()
+            .map(|crt| crt.name())
+            .collect::<Vec<_>>(),
+    );
 }
 
 #[test]

--- a/crates/release-automation/src/lib/tests/workspace_mocker.rs
+++ b/crates/release-automation/src/lib/tests/workspace_mocker.rs
@@ -2,8 +2,8 @@ use crate::*;
 
 use anyhow::{bail, Context};
 use cargo_test_support::git::{self, Repository};
-use cargo_test_support::{Project, ProjectBuilder};
 use cargo_test_support::paths::init_root;
+use cargo_test_support::{Project, ProjectBuilder};
 use educe::Educe;
 use log::debug;
 use std::collections::HashMap;
@@ -557,6 +557,10 @@ pub fn example_workspace_1<'a>() -> Fallible<WorkspaceMocker> {
 }
 
 /// A workspace to test dependencies and crate sorting.
+/// crate_a -> [crate_b, crate_c]
+/// crate_b -> []
+/// crate_c -> [crate_b]
+/// crate_d -> [crate_a]
 pub fn example_workspace_2<'a>() -> Fallible<WorkspaceMocker> {
     use crate::tests::workspace_mocker::{self, MockProject, WorkspaceMocker};
 


### PR DESCRIPTION


### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
