### PR TITLE
Fix bug with get dependants filtered caching its filter (#2155)

### DIFF
--- a/crates/release-automation/src/lib/crate_selection/tests/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/tests/mod.rs
@@ -137,6 +137,68 @@ fn members_dependencies() {
 }
 
 #[test]
+fn crate_dependants_unfiltered_and_filtered() {
+    let workspace_mocker = example_workspace_2().unwrap();
+    let workspace = ReleaseWorkspace::try_new_with_criteria(
+        workspace_mocker.root(),
+        SelectionCriteria {
+            exclude_optional_deps: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let crate_b = workspace
+        .members()
+        .unwrap()
+        .iter()
+        .find(|crt| crt.name() == "crate_b")
+        .unwrap();
+
+    // get something back
+    pretty_assertions::assert_ne!(
+        Vec::<&Crate>::new(),
+        crate_b.dependants_in_workspace_filtered(|_| true).unwrap()
+    );
+
+    // unfiltered equals the 'true' filter
+    pretty_assertions::assert_eq!(
+        crate_b.dependants_in_workspace().unwrap(),
+        &crate_b.dependants_in_workspace_filtered(|_| true).unwrap()
+    );
+
+    // filter changes work
+    //
+    // The actual values in here aren't that important, just need to see that the filter is applied and not
+    // cached as `true` from above.
+    pretty_assertions::assert_eq!(
+        Vec::<&Crate>::new(),
+        crate_b.dependants_in_workspace_filtered(|_| false).unwrap()
+    );
+
+    // dependency doesn't include itself
+    pretty_assertions::assert_eq!(
+        None,
+        crate_b
+            .dependants_in_workspace()
+            .unwrap()
+            .into_iter()
+            .find(|crt| crt.name() == "crate_b")
+    );
+
+    // for the sake of completeness exhaustively check the result
+    pretty_assertions::assert_eq!(
+        vec!["crate_c", "crate_a", "crate_d"],
+        crate_b
+            .dependants_in_workspace()
+            .unwrap()
+            .iter()
+            .map(|crt| crt.name())
+            .collect::<Vec<_>>(),
+    );
+}
+
+#[test]
 fn members_sorted_ws1() {
     let workspace_mocker = example_workspace_1().unwrap();
     let workspace = ReleaseWorkspace::try_new_with_criteria(
@@ -224,7 +286,7 @@ fn crate_state_block_consistency() {
 
     let allowed_dev_dependency_blockers: BitFlags<CrateStateFlags> = (&[
         // CrateStateFlags::MissingChangelog
-        ]
+    ]
         as &[CrateStateFlags])
         .iter()
         .cloned()

--- a/crates/release-automation/src/lib/tests/workspace_mocker.rs
+++ b/crates/release-automation/src/lib/tests/workspace_mocker.rs
@@ -582,6 +582,10 @@ pub fn example_workspace_1<'a>() -> Fallible<WorkspaceMocker> {
 }
 
 /// A workspace to test dependencies and crate sorting.
+/// crate_a -> [crate_b, crate_c]
+/// crate_b -> []
+/// crate_c -> [crate_b]
+/// crate_d -> [crate_a]
 pub fn example_workspace_2<'a>() -> Fallible<WorkspaceMocker> {
     use crate::tests::workspace_mocker::{self, MockProject, WorkspaceMocker};
 


### PR DESCRIPTION
### Summary

Backport of #2155 to the develop-0.1 branch

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
