### PR TITLE
[backport][develop-0.1] feat(github/workflows): run PR tests from within release.yml (#2175)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@
 
 on:
   workflow_dispatch:
-  pull_request:
 
 concurrency:
   group: build-${{ github.ref_name }}-${{ github.event_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
 
   test:
     needs: [vars, prepare]
-    if: ${{ github.event_name != 'pull_request' && needs.vars.outputs.skip_test != 'true' }}
+    if: ${{ needs.vars.outputs.skip_test != 'true' }}
     uses: ./.github/workflows/holochain-build-and-test.yml
     with:
       repo_path: ${{ needs.prepare.outputs.repo_nix_store_path }}
@@ -383,7 +383,7 @@ jobs:
   github-actions-ci-jobs-succeed:
     if: ${{ always() && github.event_name == 'pull_request' }}
     runs-on: "ubuntu-latest"
-    needs: [vars, prepare]
+    needs: [vars, test, prepare]
     steps:
       - name: Check status
         id: check-status


### PR DESCRIPTION
this lets use the 'github-actions-ci-jobs-succeed' to determine success of PR tests.

### Summary

backport of https://github.com/holochain/holochain/pull/2175



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
