### PR TITLE
DRAFT ONLY: hc database explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2557,12 +2557,19 @@ name = "holochain_cli"
 version = "0.2.0-beta-rc.1"
 dependencies = [
  "anyhow",
+ "clap 4.1.14",
  "futures",
+ "holochain",
  "holochain_cli_bundle",
  "holochain_cli_sandbox",
+ "holochain_conductor_api",
+ "holochain_keystore",
  "holochain_trace",
+ "holochain_websocket",
+ "shlex",
  "structopt",
  "tokio",
+ "walkdir",
 ]
 
 [[package]]
@@ -6374,6 +6381,12 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "shrinkwraprs"

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -3,9 +3,9 @@ name = "holochain_cli"
 version = "0.2.0-beta-rc.1"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli"
-authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
-keywords = [ "holochain", "holo" ]
-categories = [ "command-line-utilities", "development-tools::build-utils", "filesystem" ]
+authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
+keywords = ["holochain", "holo"]
+categories = ["command-line-utilities", "development-tools::build-utils", "filesystem"]
 edition = "2021"
 license = "Apache-2.0"
 description = "Provides the `hc` binary, a helpful CLI tool for working with Holochain."
@@ -25,4 +25,16 @@ holochain_cli_bundle = { path = "../hc_bundle", version = "^0.2.0-beta-rc.0"}
 holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.2.0-beta-rc.0"}
 holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
 structopt = "0.3"
-tokio = { version = "1.11", features = [ "full" ] }
+tokio = { version = "1.11", features = ["full"] }
+clap = { version = "4", optional = true }
+shlex = { version = "1.1.0", optional = true }
+holochain_conductor_api = { version = "^0.2.0-beta-rc.0", path = "../holochain_conductor_api", optional = true }
+holochain = { version = "^0.2.0-beta-rc.0", path = "../holochain", optional = true }
+walkdir = { version = "2.3.3", optional = true }
+holochain_websocket = { version = "^0.2.0-beta-rc.0", path = "../holochain_websocket", optional = true }
+holochain_keystore = { version = "^0.2.0-beta-rc.0", path = "../holochain_keystore", optional = true }
+
+[features]
+default = []
+
+db_explorer = ["dep:clap", "dep:shlex", "dep:holochain_conductor_api", "dep:holochain", "dep:walkdir", "dep:holochain_websocket", "dep:holochain_keystore"]

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -38,3 +38,6 @@ holochain_keystore = { version = "^0.2.0-beta-rc.0", path = "../holochain_keysto
 default = []
 
 db_explorer = ["dep:clap", "dep:shlex", "dep:holochain_conductor_api", "dep:holochain", "dep:walkdir", "dep:holochain_websocket", "dep:holochain_keystore"]
+
+db-encryption = [ "holochain_keystore?/db-encryption", "holochain?/db-encryption" ]
+

--- a/crates/hc/src/db_explorer.rs
+++ b/crates/hc/src/db_explorer.rs
@@ -1,0 +1,344 @@
+use crate::db_explorer::state::ExplorerState;
+use anyhow::anyhow;
+use clap::{Arg, Command, Parser, Subcommand, ValueEnum};
+use holochain::core::DnaHash;
+use holochain_conductor_api::conductor::ConductorConfig;
+use shlex;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+// configure /var/folders/8g/tvqzjrfj4d529fg72xp0g50h0000gp/T/bvxlPkFxdk2TU9VU2-qu7/conductor-config.yaml --admin-port 56152
+
+#[derive(Parser)]
+#[command(multicall = true)]
+struct DbExplorerCli {
+    #[command(subcommand)]
+    command: DbExplorerCommand,
+}
+
+#[derive(Subcommand)]
+enum DbExplorerCommand {
+    /// Configure the conductor to use by providing its config file
+    Configure {
+        /// The root directory for the conductor
+        #[arg(value_name = "DIR")]
+        dir: PathBuf,
+
+        /// Override the admin port found in the conductor config (e.g. when it is 0)
+        #[arg(long, value_name = "PORT")]
+        admin_port: Option<u16>,
+    },
+
+    /// List currently installed DNA hashes
+    ListDna,
+
+    /// List agents for a DNA
+    ListAgents { dna_hash: String },
+
+    /// Select a DNA (by hash) and database type to use
+    Use {
+        #[arg(value_enum)]
+        kind: DbKind,
+        hash: String,
+    },
+
+    /// Dump a source chain
+    Dump { agent_public_key: String },
+
+    /// Exit the explorer
+    Quit,
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+enum DbKind {
+    Authored,
+    Dnt,
+}
+
+pub async fn run_db_explorer() -> anyhow::Result<()> {
+    let mut state = ExplorerState::new();
+
+    loop {
+        let line = readline()?;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+
+        match respond(line, &mut state).await {
+            Ok(quit) => {
+                if quit {
+                    break;
+                }
+            }
+            Err(err) => {
+                write!(std::io::stdout(), "{err}")?;
+                std::io::stdout().flush()?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn respond(line: &str, state: &mut ExplorerState) -> anyhow::Result<bool> {
+    let args = shlex::split(line).ok_or(anyhow!("Invalid quoting"))?;
+    match DbExplorerCli::try_parse_from(args)?.command {
+        DbExplorerCommand::Configure { dir, admin_port } => {
+            write!(std::io::stdout(), "Attempting to load {:?}\n", dir)?;
+            state.reconfigure(PathBuf::from(dir), admin_port).await;
+            println!("Done");
+            std::io::stdout().flush()?;
+        }
+        DbExplorerCommand::ListDna => {
+            state.list_dnas().await;
+        }
+        DbExplorerCommand::ListAgents { dna_hash } => {
+            state.list_agents(dna_hash).await;
+        }
+        DbExplorerCommand::Use { kind, hash } => {
+            let dna_hash = DnaHash::try_from(hash.as_str()).unwrap();
+            state.use_db(kind, dna_hash).await;
+        }
+        DbExplorerCommand::Dump { agent_public_key } => {
+            state.dump(agent_public_key).await;
+        }
+        DbExplorerCommand::Quit => {
+            write!(std::io::stdout(), "Exiting ...")?;
+            std::io::stdout().flush()?;
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn readline() -> anyhow::Result<String> {
+    write!(std::io::stdout(), "$ ")?;
+    std::io::stdout().flush()?;
+    let mut buffer = String::new();
+    std::io::stdin().read_line(&mut buffer)?;
+    Ok(buffer)
+}
+
+mod state {
+    use crate::db_explorer::DbKind;
+    use holochain::conductor::space::Spaces;
+    use holochain::core::DnaHash;
+    use holochain::prelude::kitsune_p2p::dependencies::url2::url2;
+    use holochain::prelude::{AgentPubKey, ChainQueryFilter, DbKindT};
+    use holochain::test_utils::itertools::Itertools;
+    use holochain_conductor_api::conductor::{ConductorConfig, KeystoreConfig};
+    use holochain_conductor_api::{AdminRequest, AdminResponse};
+    use holochain_websocket::{
+        WebsocketConfig, WebsocketError, WebsocketReceiver, WebsocketResult, WebsocketSender,
+    };
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use walkdir::WalkDir;
+    use holochain::prelude::kitsune_p2p::dependencies::kitsune_p2p_types::dependencies::lair_keystore_api::dependencies::sodoken;
+    use holochain_keystore::lair_keystore::{spawn_lair_keystore, spawn_lair_keystore_in_proc};
+    use holochain_keystore::MetaLairClient;
+
+    pub struct ExplorerState {
+        work_dir: Option<PathBuf>,
+        conductor_config: Option<ConductorConfig>,
+        spaces: Option<Spaces>,
+        admin_ws: Option<WebsocketSender>,
+        current_db_kind: Option<DbKind>,
+        current_dna_hash: Option<DnaHash>,
+    }
+
+    impl ExplorerState {
+        pub fn new() -> Self {
+            Self {
+                work_dir: None,
+                conductor_config: None,
+                spaces: None,
+                admin_ws: None,
+                current_db_kind: None,
+                current_dna_hash: None,
+            }
+        }
+
+        pub async fn reconfigure(&mut self, work_dir: PathBuf, admin_port: Option<u16>) {
+            self.work_dir = Some(work_dir);
+            self.conductor_config = self.try_load_conductor_config();
+
+            self.refresh(admin_port).await;
+        }
+
+        pub async fn refresh(&mut self, admin_port: Option<u16>) {
+            if let Some(cfg) = &self.conductor_config {
+                self.spaces = Some(Spaces::new(cfg).unwrap());
+
+                println!("Connecting to the conductor's admin interface");
+                self.admin_ws = Some(
+                    self.connect_admin_ws(admin_port.unwrap_or_else(|| {
+                        cfg.admin_interfaces
+                            .as_ref()
+                            .map(|v| v.first().cloned())
+                            .flatten()
+                            .expect("No admin interface specified in conductor config")
+                            .driver
+                            .port()
+                    }))
+                    .await
+                    .unwrap()
+                    .0,
+                );
+            } else {
+                eprintln!("No config, please run `configure` first");
+            }
+        }
+
+        pub async fn list_dnas(&mut self) {
+            let dnas = if let Some(ws) = &mut self.admin_ws {
+                match ws.request(AdminRequest::ListDnas).await.unwrap() {
+                    AdminResponse::DnasListed(dnas) => dnas,
+                    _ => {
+                        eprintln!("Unexpected response while listing DNAs");
+                        return;
+                    }
+                }
+            } else {
+                eprintln!("No config, please run `configure` first");
+                return;
+            };
+
+            if dnas.is_empty() {
+                println!("No DNAs found")
+            } else {
+                println!("{:?}", dnas);
+            }
+        }
+
+        pub async fn list_agents(&mut self, dna_hash: String) {
+            let cell_ids = if let Some(ws) = &mut self.admin_ws {
+                match ws.request(AdminRequest::ListCellIds).await.unwrap() {
+                    AdminResponse::CellIdsListed(cell_ids) => cell_ids,
+                    _ => {
+                        eprintln!("Unexpected response while listing agents");
+                        return;
+                    }
+                }
+            } else {
+                eprintln!("No config, please run `configure` first");
+                return;
+            };
+
+            if cell_ids.is_empty() {
+                println!("No agents found")
+            } else {
+                let dna_hash = DnaHash::try_from(dna_hash).unwrap();
+
+                println!(
+                    "{:?}",
+                    cell_ids
+                        .iter()
+                        .filter(|c| c.dna_hash() == &dna_hash)
+                        .map(|c| c.agent_pubkey().to_string())
+                        .collect_vec()
+                );
+            }
+        }
+
+        pub async fn use_db(&mut self, kind: DbKind, dna_hash: DnaHash) {
+            self.current_db_kind = Some(kind);
+            self.current_dna_hash = Some(dna_hash);
+        }
+
+        pub async fn dump(&mut self, agent_public_key: String) {
+            let agent_public_key = AgentPubKey::try_from(agent_public_key.as_str()).unwrap();
+
+            let lair_client = match &self.conductor_config.as_ref().unwrap().keystore {
+                KeystoreConfig::LairServer { connection_url } => {
+                    let passphrase = sodoken::BufRead::from(&b"1234"[..]);
+                    spawn_lair_keystore(connection_url.clone(), passphrase)
+                        .await
+                        .unwrap()
+                }
+                _ => {
+                    unimplemented!("only know how to use a lair server")
+                }
+            };
+
+            let space = self
+                .spaces
+                .as_ref()
+                .unwrap()
+                .get_or_create_space(self.current_dna_hash.as_ref().unwrap())
+                .unwrap();
+
+            let chain = space
+                .source_chain(lair_client, agent_public_key)
+                .await
+                .unwrap();
+
+            let all = chain.query(ChainQueryFilter::new()).await.unwrap();
+
+            println!("all {:?}", all);
+        }
+
+        fn try_load_conductor_config(&self) -> Option<ConductorConfig> {
+            if let Some(work_dir) = &self.work_dir {
+                let files: Vec<_> = WalkDir::new(work_dir)
+                    .max_depth(1)
+                    .into_iter()
+                    .filter_map(|e| e.ok())
+                    .filter(|d| d.file_type().is_file())
+                    .filter(|f| f.file_name().to_string_lossy().eq("conductor-config.yaml"))
+                    .map(|f| f.into_path())
+                    .collect();
+
+                if files.len() == 1 {
+                    ConductorConfig::load_yaml(files.first().unwrap()).ok()
+                } else {
+                    if files.len() > 1 {
+                        eprintln!("Multiple possible conductor configs, specify a specific file rather than a directory");
+                    } else {
+                        eprintln!(
+                            "No `conductor-config.yaml` found, please specify a specific file"
+                        );
+                    }
+                    None
+                }
+            } else {
+                None
+            }
+        }
+
+        async fn connect_admin_ws(
+            &self,
+            port: u16,
+        ) -> WebsocketResult<(WebsocketSender, WebsocketReceiver)> {
+            if port == 0 {
+                eprintln!("Cannot connect to port 0, please override the admin port with `configure <path> --admin-port <PORT>`");
+                return Err(WebsocketError::Shutdown);
+            }
+
+            println!("Connecting to admin port {}", port);
+            holochain_websocket::connect(
+                url2!("ws://127.0.0.1:{}", port),
+                Arc::new(WebsocketConfig::default()),
+            )
+            .await
+        }
+
+        // fn get_current_db(&self) -> Option<Box<>> {
+        //     if let (Some(kind), Some(dna_hash)) = (&self.current_db_kind, &self.current_dna_hash) {
+        //         let x: Box<dyn DbKindT> = if let Some(spaces) = &self.spaces {
+        //             match kind {
+        //                 DbKind::Authored => Box::new(spaces.authored_db(&dna_hash).unwrap()),
+        //                 DbKind::Dnt => Box::new(spaces.dht_db(&dna_hash).unwrap()),
+        //             }
+        //         } else {
+        //             eprintln!("No config, please run `configure` first");
+        //             return;
+        //         };
+        //
+        //         self.current_db = Some(x);
+        //     }
+        // }
+    }
+}

--- a/crates/hc/src/lib.rs
+++ b/crates/hc/src/lib.rs
@@ -115,6 +115,8 @@ pub use holochain_cli_bundle as hc_bundle;
 use holochain_cli_sandbox as hc_sandbox;
 use structopt::{lazy_static::lazy_static, StructOpt};
 
+#[cfg(feature = "db_explorer")]
+mod db_explorer;
 mod external_subcommands;
 
 lazy_static! {
@@ -163,6 +165,9 @@ pub enum Opt {
     App(hc_bundle::HcAppBundle),
     /// Work with Web-hApp bundles
     WebApp(hc_bundle::HcWebAppBundle),
+    /// Explore holochain data interactively
+    #[cfg(feature = "db_explorer")]
+    DbExplore,
     /// Work with sandboxed environments for testing and development
     Sandbox(hc_sandbox::HcSandbox),
     /// Allow redirect of external subcommands (like hc-scaffold and hc-launch)
@@ -178,6 +183,8 @@ impl Opt {
             Self::App(cmd) => cmd.run().await?,
             Self::WebApp(cmd) => cmd.run().await?,
             Self::Sandbox(cmd) => cmd.run().await?,
+            #[cfg(feature = "db_explorer")]
+            Self::DbExplore => db_explorer::run_db_explorer().await?,
             Self::External(args) => {
                 let command_suffix = args.first().expect("Missing subcommand name");
                 Command::new(format!("hc-{}", command_suffix))


### PR DESCRIPTION
### Summary

For now this is a very rough draft PR. It adds a basic ability to connect to a database and look at its contents.

The question is, would this be useful to persue? Is it something people would use?

Please don't put too much attention on looking at the code beyond a high-level 'is it using the right access points into the code base' etc. It's very rough at the moment!

##### Current problems

Connecting to a database you don't own is risky. For example, connecting this to the Launcher's conductor upgrades those databases and the Launcher can no longer start. That's definitely not good but unfortunately the entrypoint I'm using doesn't let me scope down to a read-only connection. This really ought to be read-only.

It takes a fair few new packages for `hc` to achieve this. Including this tool by default would increase the size of the binary. I haven't looked yet at how much but I think that's something we would want to consider before going down this route.

##### How to use

Set up with

```shell
cargo install --path . --features db-encryption
cargo install --path . --features db_explorer,db-encryption
```

Run a sandbox, install an app and then

```text
> hc db-explore
$ configure /var/folders/8g/tvqzjrfj4d529fg72xp0g50h0000gp/T/mAekeeCnavso3W12m6O8K/conductor-config.yaml --admin-port 63481
Attempting to load "/var/folders/8g/tvqzjrfj4d529fg72xp0g50h0000gp/T/mAekeeCnavso3W12m6O8K/conductor-config.yaml"
Connecting to the conductor's admin interface
Connecting to admin port 63481
Done
$ list-dna
[DnaHash(uhC0kKKpj6ha7_kvx3tZJNsHf_SraLzhWHbdC1fNJmjFcuEt9TBaJ)]
$ use authored uhC0kKKpj6ha7_kvx3tZJNsHf_SraLzhWHbdC1fNJmjFcuEt9TBaJ
$ list-agents uhC0kKKpj6ha7_kvx3tZJNsHf_SraLzhWHbdC1fNJmjFcuEt9TBaJ
["uhCAkE64n582bdmQJXZn3CYZ45bdRPyhoFE32W9ZdT9Xao_A7Qw-Q", "uhCAkojuH9IuAoeIW5Au3pXUArJgAxJ8LJJhdjiVVHl9OO3i_DZt-"]
$ dump uhCAkE64n582bdmQJXZn3CYZ45bdRPyhoFE32W9ZdT9Xao_A7Qw-Q
all [Record { signed_action: SignedHashed { hashed: HoloHashed { content: Dna(Dna { author: AgentPubKey(uhCAkE64n582bdmQJXZn3CYZ45bdRPyhoFE32W9ZdT9Xao_A7Qw-Q), timestamp: Timestamp(2023-04-05T10:15:20.562229Z), hash: DnaHash(uhC0kKKpj6ha7_kvx3tZJNsHf_SraLzhWHbdC1fNJmjFcuEt9TBaJ) }), hash: ActionHash(uhCkk9-EXIfzEq8G5MWY3n62xN1lUnWUQhfHCU9n_6V4qjOMzowLF) }, signature: [95, 158, 188, 144, 25, 112, 244, 138, 27, 139, 100, 185, 68, 183, 24, 115, 237, 54, 228, 35, 196, 126, 21, 165, 159, 21, 2, 145, 41, 207, 107, 239, 55, 61, 39, 43, 165, 7, 194, 171, 61, 66, 73, 184, 143, 197, 50, 40, 0, 178, 195, 19, 121, 47, 194, 95, 109, 218, 69, 135, 73, 255, 144, 3] }, entry: NotApplicable }, Record { signed_action: SignedHashed { hashed: HoloHashed { content: AgentValidationPkg(AgentValidationPkg { author: AgentPubKey(uhCAkE64n582bdmQJXZn3CYZ45bdRPyhoFE32W9ZdT9Xao_A7Qw-Q), timestamp: Timestamp(2023-04-05T10:15:20.564669Z), action_seq: 1, prev_action: ActionHash(uhCkk9-EXIfzEq8G5MWY3n62xN1lUnWUQhfHCU9n_6V4qjOMzowLF), membrane_proof: None }), hash: ActionHash(uhCkk_NNxYZJ7hdehqxoRZFCiXTnM5KlWlWOYRQpS1qSbumJLU6u0) }, signature: [11, 203, 59, 191, 4, 93, 127, 238, 233, 63, 154, 186, 210, 221, 191, 72, 4, 212, 80, 208, 158, 136, 143, 43, 26, 254, 78, 226, 178, 151, 235, 8, 10, 223, 78, 182, 39, 178, 120, 23, 91, 174, 27, 206, 12, 40, 248, 63, 171, 54, 110, 157, 238, 210, 253, 173, 245, 27, 3, 138, 169, 133, 174, 4] }, entry: NotApplicable }, Record { signed_action: SignedHashed { hashed: HoloHashed { content: Create(Create { author: AgentPubKey(uhCAkE64n582bdmQJXZn3CYZ45bdRPyhoFE32W9ZdT9Xao_A7Qw-Q), timestamp: Timestamp(2023-04-05T10:15:20.564739Z), action_seq: 2, prev_action: ActionHash(uhCkk_NNxYZJ7hdehqxoRZFCiXTnM5KlWlWOYRQpS1qSbumJLU6u0), entry_type: AgentPubKey, entry_hash: EntryHash(uhCEkE64n582bdmQJXZn3CYZ45bdRPyhoFE32W9ZdT9Xao_A7Qw-Q), weight: EntryRateWeight { bucket_id: 255, units: 0, rate_bytes: 0 } }), hash: ActionHash(uhCkkW-wE-N5HG9tm-zXYeaC0DM7r8JQE9US9he8HLrku_plrw6-p) }, signature: [222, 156, 109, 166, 142, 25, 50, 239, 98, 193, 199, 32, 203, 212, 38, 192, 250, 62, 142, 18, 139, 94, 34, 107, 166, 0, 134, 205, 218, 121, 41, 160, 12, 203, 233, 212, 136, 47, 118, 190, 44, 203, 195, 197, 146, 126, 229, 173, 237, 19, 138, 74, 247, 103, 156, 116, 93, 62, 223, 209, 56, 143, 87, 1] }, entry: NotStored }]
$ dump uhCAkojuH9IuAoeIW5Au3pXUArJgAxJ8LJJhdjiVVHl9OO3i_DZt-
all [Record { signed_action: SignedHashed { hashed: HoloHashed { content: Dna(Dna { author: AgentPubKey(uhCAkojuH9IuAoeIW5Au3pXUArJgAxJ8LJJhdjiVVHl9OO3i_DZt-), timestamp: Timestamp(2023-04-05T10:05:04.729566Z), hash: DnaHash(uhC0kKKpj6ha7_kvx3tZJNsHf_SraLzhWHbdC1fNJmjFcuEt9TBaJ) }), hash: ActionHash(uhCkkqjNw4_DvHFuwS1gi1Rt__fCJ7cBZgSqTT2QWlUUmrsQBL71h) }, signature: [53, 101, 178, 92, 209, 132, 37, 100, 54, 149, 71, 105, 96, 171, 255, 83, 98, 146, 4, 179, 163, 44, 161, 112, 202, 26, 216, 81, 57, 158, 56, 213, 2, 55, 60, 163, 165, 191, 161, 85, 156, 52, 61, 244, 63, 20, 193, 115, 31, 197, 222, 61, 136, 237, 109, 181, 44, 33, 247, 17, 10, 248, 110, 15] }, entry: NotApplicable }, Record { signed_action: SignedHashed { hashed: HoloHashed { content: AgentValidationPkg(AgentValidationPkg { author: AgentPubKey(uhCAkojuH9IuAoeIW5Au3pXUArJgAxJ8LJJhdjiVVHl9OO3i_DZt-), timestamp: Timestamp(2023-04-05T10:05:04.731515Z), action_seq: 1, prev_action: ActionHash(uhCkkqjNw4_DvHFuwS1gi1Rt__fCJ7cBZgSqTT2QWlUUmrsQBL71h), membrane_proof: None }), hash: ActionHash(uhCkkqiAtFavSyb_Hha54AhAgY5JPx4solktnhkt9fAu5SGe9XQ_d) }, signature: [64, 20, 191, 159, 50, 202, 252, 21, 251, 137, 118, 181, 53, 105, 13, 96, 146, 121, 115, 112, 20, 248, 242, 240, 216, 36, 9, 111, 177, 89, 222, 8, 6, 195, 17, 92, 64, 17, 35, 240, 210, 190, 188, 102, 232, 155, 146, 146, 212, 105, 174, 250, 29, 10, 6, 151, 140, 184, 26, 38, 159, 98, 36, 2] }, entry: NotApplicable }, Record { signed_action: SignedHashed { hashed: HoloHashed { content: Create(Create { author: AgentPubKey(uhCAkojuH9IuAoeIW5Au3pXUArJgAxJ8LJJhdjiVVHl9OO3i_DZt-), timestamp: Timestamp(2023-04-05T10:05:04.731599Z), action_seq: 2, prev_action: ActionHash(uhCkkqiAtFavSyb_Hha54AhAgY5JPx4solktnhkt9fAu5SGe9XQ_d), entry_type: AgentPubKey, entry_hash: EntryHash(uhCEkojuH9IuAoeIW5Au3pXUArJgAxJ8LJJhdjiVVHl9OO3i_DZt-), weight: EntryRateWeight { bucket_id: 255, units: 0, rate_bytes: 0 } }), hash: ActionHash(uhCkkohFwIelCle0NKr5kX1jLvecjmqD2xn2ChA8Fdx7inMI9cgz3) }, signature: [73, 194, 134, 232, 91, 226, 244, 87, 184, 172, 169, 92, 18, 166, 154, 192, 183, 61, 189, 38, 148, 0, 165, 249, 108, 127, 201, 100, 176, 2, 28, 20, 138, 126, 178, 70, 147, 169, 1, 19, 190, 102, 71, 173, 4, 4, 14, 6, 157, 27, 155, 189, 141, 164, 140, 119, 123, 103, 68, 104, 82, 18, 37, 14] }, entry: NotStored }]
```

Check that the database is encrypted and you wouldn't be able to read it otherwise

```text
> sqlite3 /var/folders/8g/tvqzjrfj4d529fg72xp0g50h0000gp/T/mAekeeCnavso3W12m6O8K/authored/authored-uhC0kKKpj6ha7_kvx3tZJNsHf_SraLzhWHbdC1fNJmjFcuEt9TBaJ.sqlite3
SQLite version 3.41.2 2023-03-22 11:56:21
Enter ".help" for usage hints.
sqlite> SELECT name FROM sqlite_schema WHERE type='table' ORDER BY name;
Parse error: file is not a database (26)
sqlite>
```

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
