### PR TITLE
[backport][develop-0.1] fix(github/workflows/release): increase chances of successful pushing of source branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,6 +328,9 @@ jobs:
           HOLOCHAIN_SOURCE_BRANCH: ${{ needs.vars.outputs.holochain_source_branch }}
         run: |
           set -xeu
+          cd "${HOLOCHAIN_REPO}"
+          git status
+          git pull origin ${HOLOCHAIN_SOURCE_BRANCH}
           git push origin ${HOLOCHAIN_SOURCE_BRANCH}
 
       - name: Create a pull-request towards the source branch


### PR DESCRIPTION
### Summary
backport of https://github.com/holochain/holochain/pull/2187


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
