### PR TITLE
Fix reference to missing Quic enum variant

### DIFF
--- a/crates/holochain/src/sweettest/sweet_conductor_config.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor_config.rs
@@ -67,14 +67,14 @@ impl SweetConductorConfig {
         let mut network = KitsuneP2pConfig::default();
         network.bootstrap_service = Some(url2::url2!("rendezvous:"));
 
-        #[cfg(not(feature = "tx5"))]
+        /*#[cfg(not(feature = "tx5"))]
         {
             network.transport_pool = vec![kitsune_p2p::TransportConfig::Quic {
                 bind_to: None,
                 override_host: None,
                 override_port: None,
             }];
-        }
+        }*/
 
         #[cfg(feature = "tx5")]
         {


### PR DESCRIPTION
### Summary

Raised on https://github.com/holochain/holochain/issues/2229. Disabling the tx5 feature causes a reference to the `Quic` enum variant of `TransportConfig` to be introduced to sweetest which doesn't build at `Quic` is commented out. Commenting this out too to avoid compilation failures when using `default-features = false`.

This does mean ending up with no transport_pool configured which is worse in a way because it will probably be harder to work out why.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
