### PR TITLE
fix(storage-info)!: rename all variants to snake case

### DIFF
--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- `StorageBlob` is an enum that serialized to camel case named variants. Renames all variants to snake case now.
+
 ## 0.2.0-beta-rc.4
 
 ## 0.2.0-beta-rc.3

--- a/crates/holochain_conductor_api/src/storage_info.rs
+++ b/crates/holochain_conductor_api/src/storage_info.rs
@@ -14,6 +14,7 @@ pub struct DnaStorageInfo {
 
 /// The type of storage blob
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, SerializedBytes)]
+#[serde(rename_all = "snake_case")]
 pub enum StorageBlob {
     /// Storage blob used by hApps to store data
     Dna(DnaStorageInfo),


### PR DESCRIPTION
### Summary
`StorageBlob` is an enum that serializes to camel case named variants. This PR renames all variants to snake case.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
