### PR TITLE
Implements CloneOnly provisioning strategy (formerly called "Disabled")

### DIFF
--- a/crates/hc_bundle/schema/happ-manifest.schema.json
+++ b/crates/hc_bundle/schema/happ-manifest.schema.json
@@ -62,26 +62,7 @@
                   }
                 }
               },
-              {
-                "description": "Always create a new Cell when installing the App, and use a unique network seed to ensure a distinct DHT network",
-                "type": "object",
-                "required": [
-                  "deferred",
-                  "strategy"
-                ],
-                "properties": {
-                  "deferred": {
-                    "type": "boolean"
-                  },
-                  "strategy": {
-                    "type": "string",
-                    "enum": [
-                      "create_clone"
-                    ]
-                  }
-                }
-              },
-              {
+              /*{
                 "description": "Require that a Cell is already installed which matches the DNA version spec, and which has an Agent that's associated with this App's agent via DPKI. If no such Cell exists, *app installation fails*.",
                 "type": "object",
                 "required": [
@@ -118,9 +99,9 @@
                     ]
                   }
                 }
-              },
+              },*/
               {
-                "description": "Disallow provisioning altogether. In this case, we expect `clone_limit > 0`: otherwise, no Cells will ever be created.",
+                "description": "Install or locate the DNA, but never create a Cell for this DNA. Only allow clones to be created from the DNA specified. This case requires `clone_limit > 0`, otherwise no Cells will ever be created.",
                 "type": "object",
                 "required": [
                   "strategy"
@@ -129,7 +110,7 @@
                   "strategy": {
                     "type": "string",
                     "enum": [
-                      "disabled"
+                      "clone_only"
                     ]
                   }
                 }

--- a/crates/hc_bundle/schema/happ-manifest.schema.json
+++ b/crates/hc_bundle/schema/happ-manifest.schema.json
@@ -62,8 +62,8 @@
                   }
                 }
               },
-              /*{
-                "description": "Require that a Cell is already installed which matches the DNA version spec, and which has an Agent that's associated with this App's agent via DPKI. If no such Cell exists, *app installation fails*.",
+              {
+                "description": "**NOT YET IMPLEMENTED**: Require that a Cell is already installed which matches the DNA version spec, and which has an Agent that's associated with this App's agent via DPKI. If no such Cell exists, *app installation fails*.",
                 "type": "object",
                 "required": [
                   "deferred",
@@ -82,7 +82,7 @@
                 }
               },
               {
-                "description": "Try `UseExisting`, and if that fails, fallback to `Create`",
+                "description": "**NOT YET IMPLEMENTED**: Try `UseExisting`, and if that fails, fallback to `Create`",
                 "type": "object",
                 "required": [
                   "deferred",
@@ -99,7 +99,7 @@
                     ]
                   }
                 }
-              },*/
+              },
               {
                 "description": "Install or locate the DNA, but never create a Cell for this DNA. Only allow clones to be created from the DNA specified. This case requires `clone_limit > 0`, otherwise no Cells will ever be created.",
                 "type": "object",

--- a/crates/hc_bundle/tests/fixtures/my-app/happ.yaml
+++ b/crates/hc_bundle/tests/fixtures/my-app/happ.yaml
@@ -17,7 +17,7 @@ roles:
       clone_limit: 0
   - name: role-2
     provisioning:
-      strategy: create
+      strategy: clone_only
       deferred: true
     dna:
       bundled: dnas/dna2/another dna.dna

--- a/crates/hc_bundle/tests/fixtures/my-app/happ.yaml
+++ b/crates/hc_bundle/tests/fixtures/my-app/happ.yaml
@@ -18,7 +18,6 @@ roles:
   - name: role-2
     provisioning:
       strategy: clone_only
-      deferred: true
     dna:
       bundled: dnas/dna2/another dna.dna
       modifiers:

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Implements the `clone_only` cell provisioning strategy, desgined for situations where no cell should be installed upon app installation but clones may be created later, via `roles[].provisioning.strategy` in the app manifest [\#2243](https://github.com/holochain/holochain/pull/2243)
+
 ## 0.2.0-beta-rc.4
 
 ## 0.2.0-beta-rc.3

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1561,7 +1561,6 @@ mod cell_impls {
 /// Methods related to clone cell management
 mod clone_cell_impls {
     use holochain_conductor_api::ClonedCell;
-    use itertools::Itertools;
 
     use super::*;
 
@@ -1588,22 +1587,6 @@ mod clone_cell_impls {
                         .to_string(),
                 ));
             }
-            let state = self.get_state().await?;
-            let app = state.get_app(&app_id)?;
-
-            app.provisioned_cells()
-                .find(|(app_role_name, _)| **app_role_name == role_name)
-                .ok_or_else(|| {
-                    let role_names = app
-                        .provisioned_cells()
-                        .map(|(role_name, _)| format!("'{}'", role_name))
-                        .join(", ");
-
-                    ConductorError::CloneCellError(format!(
-                        "no base cell found for provided role name. Available role names are: ({})",
-                        role_names
-                    ))
-                })?;
 
             // add cell to app
             let clone_cell = self

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -30,7 +30,9 @@ pub type SignalStream = Box<dyn tokio_stream::Stream<Item = Signal> + Send + Syn
 /// as easy installation of apps across multiple Conductors and Agents.
 ///
 /// This is intentionally NOT `Clone`, because the drop handle triggers a shutdown of
-/// the conductor handle, which would render all other cloned instances useless.
+/// the conductor handle, which would render all other cloned instances useless,
+/// as well as the fact that the SweetConductor has some extra state which would not
+/// be tracked by cloned instances.
 /// If you need multiple references to a SweetConductor, put it in an Arc
 #[derive(derive_more::From)]
 pub struct SweetConductor {

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -554,7 +554,7 @@ impl InstalledAppCommon {
             app_role_assignment.agent_key(),
             "A clone cell must use the same agent key as the role it is added to"
         );
-        
+
         if app_role_assignment.is_clone_limit_reached() {
             return Err(AppError::CloneLimitExceeded(
                 app_role_assignment.clone_limit,

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -548,11 +548,13 @@ impl InstalledAppCommon {
     /// Add a clone cell.
     pub fn add_clone(&mut self, role_name: &RoleName, cell_id: &CellId) -> AppResult<CloneId> {
         let app_role_assignment = self.role_mut(role_name)?;
+
         assert_eq!(
             cell_id.agent_pubkey(),
             app_role_assignment.agent_key(),
             "A clone cell must use the same agent key as the role it is added to"
         );
+        
         if app_role_assignment.is_clone_limit_reached() {
             return Err(AppError::CloneLimitExceeded(
                 app_role_assignment.clone_limit,
@@ -784,6 +786,11 @@ impl InstalledAppCommon {
     /// Return the manifest if available
     pub fn manifest(&self) -> &AppManifest {
         &self.manifest
+    }
+
+    /// Return the list of role assignments
+    pub fn role_assignments(&self) -> &HashMap<RoleName, AppRoleAssignment> {
+        &self.role_assignments
     }
 }
 

--- a/crates/holochain_types/src/app/app_bundle.rs
+++ b/crates/holochain_types/src/app/app_bundle.rs
@@ -68,7 +68,10 @@ impl AppBundle {
         let bundle = Arc::new(self);
         let tasks = roles.into_iter().map(|(role_name, role)| async {
             let bundle = bundle.clone();
-            Ok((role_name, bundle.resolve_cell(dna_store, role).await?))
+            Ok((
+                role_name.clone(),
+                bundle.resolve_cell(dna_store, role_name, role).await?,
+            ))
         });
         let resolution = futures::future::join_all(tasks)
             .await
@@ -95,14 +98,21 @@ impl AppBundle {
                                 let role = AppRoleAssignment::new(cell_id, true, clone_limit);
                                 resolution.role_assignments.push((role_name, role));
                             }
-                            CellProvisioningOp::Noop(cell_id, clone_limit) => {
+                            CellProvisioningOp::ProvisionOnly(dna, clone_limit) => {
+                                let agent = resolution.agent.clone();
+                                let dna_hash = dna.dna_hash().clone();
+                                let cell_id = CellId::new(dna_hash, agent);
+
+                                // TODO: could sequentialize this to remove the clone
+                                let proof = membrane_proofs.get(&role_name).cloned();
+                                resolution.dnas_to_register.push((dna, proof));
                                 resolution.role_assignments.push((
                                     role_name,
                                     AppRoleAssignment::new(cell_id, false, clone_limit),
                                 ));
                             }
-                            other @ CellProvisioningOp::HashMismatch(_, _)
-                            | other @ CellProvisioningOp::Conflict(_) => {
+                            other @ (CellProvisioningOp::HashMismatch(_, _)
+                            | CellProvisioningOp::Conflict(_)) => {
                                 tracing::error!(
                                     "Encountered unexpected CellProvisioningOp: {:?}",
                                     other
@@ -124,6 +134,7 @@ impl AppBundle {
     async fn resolve_cell(
         &self,
         dna_store: &impl DnaStore,
+        role_name: RoleName,
         role: AppRoleManifestValidated,
     ) -> AppBundleResult<CellProvisioningOp> {
         Ok(match role {
@@ -134,14 +145,16 @@ impl AppBundle {
                 modifiers,
                 deferred: _,
             } => {
-                self.resolve_cell_create(
-                    dna_store,
-                    &location,
-                    installed_hash.as_ref(),
-                    clone_limit,
-                    modifiers,
-                )
-                .await?
+                let dna = self
+                    .resolve_dna(
+                        role_name,
+                        dna_store,
+                        &location,
+                        installed_hash.as_ref(),
+                        modifiers,
+                    )
+                    .await?;
+                CellProvisioningOp::CreateFromDnaFile(dna, clone_limit)
             }
 
             AppRoleManifestValidated::UseExisting {
@@ -158,14 +171,16 @@ impl AppBundle {
             } => match self.resolve_cell_existing(&installed_hash, clone_limit) {
                 op @ CellProvisioningOp::Existing(_, _) => op,
                 CellProvisioningOp::HashMismatch(_, _) => {
-                    self.resolve_cell_create(
-                        dna_store,
-                        &location,
-                        Some(&installed_hash),
-                        clone_limit,
-                        modifiers,
-                    )
-                    .await?
+                    let dna = self
+                        .resolve_dna(
+                            role_name,
+                            dna_store,
+                            &location,
+                            Some(&installed_hash),
+                            modifiers,
+                        )
+                        .await?;
+                    CellProvisioningOp::CreateFromDnaFile(dna, clone_limit)
                 }
                 CellProvisioningOp::Conflict(_) => {
                     unimplemented!("conflicts are not handled, or even possible yet")
@@ -173,28 +188,38 @@ impl AppBundle {
                 CellProvisioningOp::CreateFromDnaFile(_, _) => {
                     unreachable!("resolve_cell_existing will never return a Create op")
                 }
-                CellProvisioningOp::Noop(_, _) => {
-                    unreachable!("resolve_cell_existing will never return a Noop")
+                CellProvisioningOp::ProvisionOnly(_, _) => {
+                    unreachable!("resolve_cell_existing will never return a ProvisionOnly")
                 }
             },
             AppRoleManifestValidated::CloneOnly {
-                installed_hash: _,
-                clone_limit: _,
+                clone_limit,
+                location,
+                modifiers,
+                installed_hash,
             } => {
-                unimplemented!("`disabled` provisioning strategy is currently unimplemented")
-                // CellProvisioningOp::Noop(clone_limit)
+                let dna = self
+                    .resolve_dna(
+                        role_name,
+                        dna_store,
+                        &location,
+                        Some(&installed_hash),
+                        modifiers,
+                    )
+                    .await?;
+                CellProvisioningOp::ProvisionOnly(dna, clone_limit)
             }
         })
     }
 
-    async fn resolve_cell_create(
+    async fn resolve_dna(
         &self,
+        role_name: RoleName,
         dna_store: &impl DnaStore,
         location: &mr_bundle::Location,
         installed_hash: Option<&DnaHashB64>,
-        clone_limit: u32,
         modifiers: DnaModifiersOpt,
-    ) -> AppBundleResult<CellProvisioningOp> {
+    ) -> AppBundleResult<DnaFile> {
         let dna_file = if let Some(hash) = installed_hash {
             let (dna_file, original_hash) =
                 if let Some(mut dna_file) = dna_store.get_dna(&hash.clone().into()) {
@@ -204,18 +229,18 @@ impl AppBundle {
                 } else {
                     self.resolve_location(location, modifiers).await?
                 };
-            let expected_hash = hash.clone().into();
+            let expected_hash: DnaHash = hash.clone().into();
             if expected_hash != original_hash {
-                return Ok(CellProvisioningOp::HashMismatch(
-                    expected_hash,
-                    original_hash,
+                return Err(AppBundleError::CellResolutionFailure(
+                    role_name,
+                    format!("Hash mismatch: {} {}", expected_hash, original_hash),
                 ));
             }
             dna_file
         } else {
             self.resolve_location(location, modifiers).await?.0
         };
-        Ok(CellProvisioningOp::CreateFromDnaFile(dna_file, clone_limit))
+        Ok(dna_file)
     }
 
     fn resolve_cell_existing(
@@ -289,9 +314,9 @@ pub enum CellProvisioningOp {
     CreateFromDnaFile(DnaFile, u32),
     /// Use an existing Cell
     Existing(CellId, u32),
-    /// No provisioning needed, but there might be a clone_limit, and so we need
-    /// to know which DNA and Agent to use for making clones
-    Noop(CellId, u32),
+    /// No creation needed, but there might be a clone_limit, and so we need
+    /// to know which DNA to use for making clones
+    ProvisionOnly(DnaFile, u32),
     /// The specified installed_hash does not match the actual hash of the DNA selected for provisioning. Expected: {0}, Actual: {1}
     HashMismatch(DnaHash, DnaHash),
     /// Ambiguous result, needs manual resolution; can't provision (should this be an Err?)

--- a/crates/holochain_types/src/app/app_bundle.rs
+++ b/crates/holochain_types/src/app/app_bundle.rs
@@ -177,7 +177,7 @@ impl AppBundle {
                     unreachable!("resolve_cell_existing will never return a Noop")
                 }
             },
-            AppRoleManifestValidated::Disabled {
+            AppRoleManifestValidated::CloneOnly {
                 installed_hash: _,
                 clone_limit: _,
             } => {

--- a/crates/holochain_types/src/app/app_bundle.rs
+++ b/crates/holochain_types/src/app/app_bundle.rs
@@ -144,9 +144,6 @@ impl AppBundle {
                 .await?
             }
 
-            AppRoleManifestValidated::CreateClone { .. } => {
-                unimplemented!("`create_clone` provisioning strategy is currently unimplemented")
-            }
             AppRoleManifestValidated::UseExisting {
                 installed_hash,
                 clone_limit,

--- a/crates/holochain_types/src/app/app_bundle/error.rs
+++ b/crates/holochain_types/src/app/app_bundle/error.rs
@@ -6,8 +6,8 @@ use crate::prelude::{AppManifestError, DnaError, RoleName};
 /// Errors occurring while installing an AppBundle
 #[derive(thiserror::Error, Debug)]
 pub enum AppBundleError {
-    #[error("Could not resolve the app role '{0}'")]
-    CellResolutionFailure(RoleName),
+    #[error("Could not resolve the app role '{0}'. Detail: {1}")]
+    CellResolutionFailure(RoleName, String),
 
     #[error(transparent)]
     AppManifestError(#[from] AppManifestError),

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
@@ -214,10 +214,12 @@ impl AppManifestV1 {
                         }
                         CellProvisioning::CloneOnly => AppRoleManifestValidated::CloneOnly {
                             clone_limit,
+                            location: Self::require(location, "roles.dna.(path|url)")?,
                             installed_hash: Self::require(
                                 installed_hash,
                                 "roles.dna.installed_hash",
                             )?,
+                            modifiers,
                         },
                     };
                     AppManifestResult::Ok((name, validated))

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
@@ -120,13 +120,20 @@ pub type DnaLocation = mr_bundle::Location;
 pub enum CellProvisioning {
     /// Always create a new Cell when installing this App
     Create { deferred: bool },
-    /// Require that a Cell is already installed which matches the DNA installed_hash
-    /// spec, and which has an Agent that's associated with this App's agent
-    /// via DPKI. If no such Cell exists, *app installation fails*.
-    UseExisting { deferred: bool },
-    /// Try `UseExisting`, and if that fails, fallback to `Create`
-    CreateIfNotExists { deferred: bool },
-    /// Install or located the DNA, but never create a Cell for this DNA.
+
+    /*
+        TODO: implement
+
+        /// Require that a Cell is already installed which matches the DNA installed_hash
+        /// spec, and which has an Agent that's associated with this App's agent
+        /// via DPKI. If no such Cell exists, *app installation fails*.
+        UseExisting { deferred: bool },
+
+        /// Try `UseExisting`, and if that fails, fallback to `Create`
+        CreateIfNotExists { deferred: bool },
+
+    */
+    /// Install or locate the DNA, but never create a Cell for this DNA.
     /// Only allow clones to be created from the DNA specified.
     /// This case requires `clone_limit > 0`, otherwise no Cells will ever be created.
     CloneOnly,

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
@@ -126,9 +126,10 @@ pub enum CellProvisioning {
     UseExisting { deferred: bool },
     /// Try `UseExisting`, and if that fails, fallback to `Create`
     CreateIfNotExists { deferred: bool },
-    /// Disallow provisioning altogether. In this case, we expect
-    /// `clone_limit > 0`: otherwise, no Cells will ever be created.
-    Disabled,
+    /// Install or located the DNA, but never create a Cell for this DNA.
+    /// Only allow clones to be created from the DNA specified.
+    /// This case requires `clone_limit > 0`, otherwise no Cells will ever be created.
+    CloneOnly,
 }
 
 impl Default for CellProvisioning {
@@ -211,7 +212,7 @@ impl AppManifestV1 {
                                 modifiers,
                             }
                         }
-                        CellProvisioning::Disabled => AppRoleManifestValidated::Disabled {
+                        CellProvisioning::CloneOnly => AppRoleManifestValidated::CloneOnly {
                             clone_limit,
                             installed_hash: Self::require(
                                 installed_hash,

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
@@ -155,12 +155,11 @@ impl AppManifestV1 {
     // we know we need it, since this way is substantially simpler.
     pub fn set_network_seed(&mut self, network_seed: NetworkSeed) {
         for mut role in self.roles.iter_mut() {
-            if !matches!(
-                role.provisioning.clone().unwrap_or_default(),
-                CellProvisioning::UseExisting { .. }
-            ) {
-                // Only update the network seed for roles for which it makes sense to do so
-                role.dna.modifiers.network_seed = Some(network_seed.clone());
+            // Only update the network seed for roles for which it makes sense to do so
+            match role.provisioning.clone().unwrap_or_default() {
+                CellProvisioning::Create { .. } | CellProvisioning::CloneOnly => {
+                    role.dna.modifiers.network_seed = Some(network_seed.clone());
+                }
             }
         }
     }
@@ -197,28 +196,28 @@ impl AppManifestV1 {
                             modifiers,
                             installed_hash,
                         },
-                        CellProvisioning::UseExisting { deferred } => {
-                            AppRoleManifestValidated::UseExisting {
-                                deferred,
-                                clone_limit,
-                                installed_hash: Self::require(
-                                    installed_hash,
-                                    "roles.dna.installed_hash",
-                                )?,
-                            }
-                        }
-                        CellProvisioning::CreateIfNotExists { deferred } => {
-                            AppRoleManifestValidated::CreateIfNotExists {
-                                deferred,
-                                clone_limit,
-                                location: Self::require(location, "roles.dna.(path|url)")?,
-                                installed_hash: Self::require(
-                                    installed_hash,
-                                    "roles.dna.installed_hash",
-                                )?,
-                                modifiers,
-                            }
-                        }
+                        // CellProvisioning::UseExisting { deferred } => {
+                        //     AppRoleManifestValidated::UseExisting {
+                        //         deferred,
+                        //         clone_limit,
+                        //         installed_hash: Self::require(
+                        //             installed_hash,
+                        //             "roles.dna.installed_hash",
+                        //         )?,
+                        //     }
+                        // }
+                        // CellProvisioning::CreateIfNotExists { deferred } => {
+                        //     AppRoleManifestValidated::CreateIfNotExists {
+                        //         deferred,
+                        //         clone_limit,
+                        //         location: Self::require(location, "roles.dna.(path|url)")?,
+                        //         installed_hash: Self::require(
+                        //             installed_hash,
+                        //             "roles.dna.installed_hash",
+                        //         )?,
+                        //         modifiers,
+                        //     }
+                        // }
                         CellProvisioning::CloneOnly => AppRoleManifestValidated::CloneOnly {
                             clone_limit,
                             location: Self::require(location, "roles.dna.(path|url)")?,
@@ -354,14 +353,14 @@ roles:
         manifest.roles = vec![
             AppRoleManifest::arbitrary(&mut u).unwrap(),
             AppRoleManifest::arbitrary(&mut u).unwrap(),
-            AppRoleManifest::arbitrary(&mut u).unwrap(),
-            AppRoleManifest::arbitrary(&mut u).unwrap(),
+            // AppRoleManifest::arbitrary(&mut u).unwrap(),
+            // AppRoleManifest::arbitrary(&mut u).unwrap(),
         ];
         manifest.roles[0].provisioning = Some(CellProvisioning::Create { deferred: false });
         manifest.roles[1].provisioning = Some(CellProvisioning::Create { deferred: false });
-        manifest.roles[2].provisioning = Some(CellProvisioning::UseExisting { deferred: false });
-        manifest.roles[3].provisioning =
-            Some(CellProvisioning::CreateIfNotExists { deferred: false });
+        // manifest.roles[2].provisioning = Some(CellProvisioning::UseExisting { deferred: false });
+        // manifest.roles[3].provisioning =
+        //     Some(CellProvisioning::CreateIfNotExists { deferred: false });
 
         let network_seed = NetworkSeed::from("blabla");
         manifest.set_network_seed(network_seed.clone());
@@ -375,15 +374,15 @@ roles:
             manifest.roles[1].dna.modifiers.network_seed.as_ref(),
             Some(&network_seed)
         );
-        assert_eq!(
-            manifest.roles[3].dna.modifiers.network_seed.as_ref(),
-            Some(&network_seed)
-        );
+        // assert_eq!(
+        //     manifest.roles[3].dna.modifiers.network_seed.as_ref(),
+        //     Some(&network_seed)
+        // );
 
-        // - The others do not.
-        assert_ne!(
-            manifest.roles[2].dna.modifiers.network_seed.as_ref(),
-            Some(&network_seed)
-        );
+        // // - The others do not.
+        // assert_ne!(
+        //     manifest.roles[2].dna.modifiers.network_seed.as_ref(),
+        //     Some(&network_seed)
+        // );
     }
 }

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_validated.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_validated.rs
@@ -33,7 +33,7 @@ impl AppManifestValidated {
         roles: HashMap<RoleName, AppRoleManifestValidated>,
     ) -> AppManifestResult<Self> {
         for (role_name, role) in roles.iter() {
-            if let AppRoleManifestValidated::Disabled { clone_limit, .. } = role {
+            if let AppRoleManifestValidated::CloneOnly { clone_limit, .. } = role {
                 if *clone_limit == 0 {
                     return Err(AppManifestError::InvalidStrategyDisabled(
                         role_name.to_owned(),
@@ -73,9 +73,10 @@ pub enum AppRoleManifestValidated {
         modifiers: DnaModifiersOpt,
         installed_hash: DnaHashB64,
     },
-    /// Disallow provisioning altogether. In this case, we expect
-    /// `clone_limit > 0`: otherwise, no cells will ever be created.
-    Disabled {
+    /// Install or located the DNA, but never create a Cell for this DNA.
+    /// Only allow clones to be created from the DNA specified.
+    /// This case requires `clone_limit > 0`, otherwise no Cells will ever be created.
+    CloneOnly {
         installed_hash: DnaHashB64,
         clone_limit: u32,
     },

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_validated.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_validated.rs
@@ -57,15 +57,6 @@ pub enum AppRoleManifestValidated {
         modifiers: DnaModifiersOpt,
         installed_hash: Option<DnaHashB64>,
     },
-    /// Always create a new Cell when installing the App,
-    /// and use a unique network seed to ensure a distinct DHT network
-    CreateClone {
-        clone_limit: u32,
-        deferred: bool,
-        location: DnaLocation,
-        modifiers: DnaModifiersOpt,
-        installed_hash: Option<DnaHashB64>,
-    },
     /// Require that a Cell is already installed with a specified DNA hash,
     /// and which has an Agent that's associated with this App's agent
     /// via DPKI. If no such Cell exists, *app installation fails*.

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_validated.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_validated.rs
@@ -73,7 +73,7 @@ pub enum AppRoleManifestValidated {
         modifiers: DnaModifiersOpt,
         installed_hash: DnaHashB64,
     },
-    /// Install or located the DNA, but never create a Cell for this DNA.
+    /// Install or locate the DNA, but never create a Cell for this DNA.
     /// Only allow clones to be created from the DNA specified.
     /// This case requires `clone_limit > 0`, otherwise no Cells will ever be created.
     CloneOnly {

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_validated.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_validated.rs
@@ -35,7 +35,7 @@ impl AppManifestValidated {
         for (role_name, role) in roles.iter() {
             if let AppRoleManifestValidated::CloneOnly { clone_limit, .. } = role {
                 if *clone_limit == 0 {
-                    return Err(AppManifestError::InvalidStrategyDisabled(
+                    return Err(AppManifestError::InvalidStrategyCloneOnly(
                         role_name.to_owned(),
                     ));
                 }
@@ -77,7 +77,9 @@ pub enum AppRoleManifestValidated {
     /// Only allow clones to be created from the DNA specified.
     /// This case requires `clone_limit > 0`, otherwise no Cells will ever be created.
     CloneOnly {
-        installed_hash: DnaHashB64,
         clone_limit: u32,
+        location: DnaLocation,
+        modifiers: DnaModifiersOpt,
+        installed_hash: DnaHashB64,
     },
 }

--- a/crates/holochain_types/src/app/app_manifest/error.rs
+++ b/crates/holochain_types/src/app/app_manifest/error.rs
@@ -4,13 +4,13 @@ use thiserror::Error;
 use crate::prelude::RoleName;
 
 #[allow(missing_docs)]
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub enum AppManifestError {
     #[error("Missing required field in app manifest: {0}")]
     MissingField(String),
 
-    #[error("Invalid manifest for app role '{0}': Using strategy 'disabled' with clone_limit == 0 is pointless")]
-    InvalidStrategyDisabled(RoleName),
+    #[error("Invalid manifest for app role '{0}': Using strategy 'clone-only' with clone_limit == 0 is pointless")]
+    InvalidStrategyCloneOnly(RoleName),
 
     #[error(transparent)]
     SerializationError(#[from] SerializedBytesError),


### PR DESCRIPTION
### Summary

Can specify `clone-only` provisioning strategy for situations where no cell should be installed upon installation but clones may be created later.

Closes #1738

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
