### PR TITLE
Revert "chore(versions/0_1): bump holochain 0.1.3 -> 0.1.4 (#2236)"

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -158,16 +158,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1681507583,
-        "narHash": "sha256-lRnums2gv1oXVwo4gMF2QAnzEu8prwxg1uKjUzNwJV4=",
+        "lastModified": 1675455504,
+        "narHash": "sha256-619bpPtO0IUSzPzLNzHERuvqGblpjO65rsw3jdxoEkQ=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "ac50baed6b53e9d0552729e69e1e20312e4edc08",
+        "rev": "ed5b7bb461c2a8bfd4d2633bad604a20b8f2da03",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.1.4",
+        "ref": "holochain-0.1.3",
         "repo": "holochain",
         "type": "github"
       }
@@ -387,8 +387,8 @@
         "scaffolding": "scaffolding"
       },
       "locked": {
-        "lastModified": 1681548994,
-        "narHash": "sha256-KjknqzRdYNtg1mwKmBvrwFdDUmmwWAiv43OMFLx+dIM=",
+        "lastModified": 1677514543,
+        "narHash": "sha256-SkVzM+QIfTZ0TuA9tuvF7ML9aLTdwNqzqrK5/TuCLlI=",
         "path": "./versions/0_1",
         "type": "path"
       },

--- a/versions/0_1/flake.lock
+++ b/versions/0_1/flake.lock
@@ -3,16 +3,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1681507583,
-        "narHash": "sha256-lRnums2gv1oXVwo4gMF2QAnzEu8prwxg1uKjUzNwJV4=",
+        "lastModified": 1675455504,
+        "narHash": "sha256-619bpPtO0IUSzPzLNzHERuvqGblpjO65rsw3jdxoEkQ=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "ac50baed6b53e9d0552729e69e1e20312e4edc08",
+        "rev": "ed5b7bb461c2a8bfd4d2633bad604a20b8f2da03",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.1.4",
+        "ref": "holochain-0.1.3",
         "repo": "holochain",
         "type": "github"
       }

--- a/versions/0_1/flake.nix
+++ b/versions/0_1/flake.nix
@@ -2,7 +2,7 @@
   inputs =
     {
       holochain = {
-        url = "github:holochain/holochain/holochain-0.1.4";
+        url = "github:holochain/holochain/holochain-0.1.3";
         flake = false;
       };
 


### PR DESCRIPTION
This reverts commit 7faf341a262e85b80ef5ad1aff7393313ba7b655.

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
