### PR TITLE
feat(nix/devShells/coreDev): remove holochain binaries

### DIFF
--- a/nix/modules/holochain-crate2nix.nix
+++ b/nix/modules/holochain-crate2nix.nix
@@ -35,6 +35,10 @@
       packages = {
         build-holochain-build-crates-standalone =
           mkNoIfdPackage "holochain" cargoNix.allWorkspaceMembers;
+
+        # exposed just for manual debugging
+        holochain-crate2nix =
+          mkNoIfdPackage "holochain" cargoNix.workspaceMembers.holochain.build;
       };
     };
 }

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -128,7 +128,7 @@
           '';
         });
 
-      build-holochain-tests-unit = craneLib.cargoNextest holochainTestsNextestArgs;
+      build-holochain-tests-unit = lib.makeOverridable craneLib.cargoNextest holochainTestsNextestArgs;
 
       build-holochain-tests-static-fmt = craneLib.cargoFmt (commonArgs // {
         src = flake.config.srcCleanedHolochain;


### PR DESCRIPTION
filter out the holochain binary crates from the shell because it's at best unnecessary in local development. it's currently a nativeBuildInput because one of the unit tests requires `holochain` and `hc-sandbox` in PATH.

---

feat(nix/packages): add holochain-crate2nix for manual testing

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
