### PR TITLE
create a new hc command to run a holochain webrtc signal server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4785,9 +4785,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.51"
+version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ea2d98598bf9ada7ea6ee8a30fb74f9156b63bbe495d64ec2b87c269d2dda3"
+checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
@@ -4826,9 +4826,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.86"
+version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992bac49bdbab4423199c654a5515bd2a6c6a23bf03f2dd3bdb7e5ae6259bc69"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -107,42 +107,51 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342258dd14006105c2b75ab1bd7543a03bdf0cfc94383303ac212a04939dff6f"
+checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
 dependencies = [
  "anstyle",
  "anstyle-parse",
+ "anstyle-query",
  "anstyle-wincon",
- "concolor-override",
- "concolor-query",
+ "colorchoice",
  "is-terminal",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "0.3.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ea9e81bd02e310c216d080f6223c179012256e5151c41db88d12c88a1684d2"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d1bb534e9efed14f3e5f44e7dd1a4f709384023a4165199a4241e18dff0116"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
-name = "anstyle-wincon"
-version = "0.2.0"
+name = "anstyle-query"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3127af6145b149f3287bb9a0d10ad9c5692dba8c53ad48285e5bec4063834fa"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
 dependencies = [
  "anstyle",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -203,14 +212,14 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.10"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0b2340f55d9661d76793b2bfc2eb0e62689bd79d067a95707ea762afd5e9dd"
+checksum = "86d6b683edf8d1119fe420a94f8a7e389239666aa72e65495d91c00462510151"
 dependencies = [
  "anstyle",
  "bstr 1.4.0",
  "doc-comment",
- "predicates 3.0.2",
+ "predicates 3.0.3",
  "predicates-core",
  "predicates-tree",
  "wait-timeout",
@@ -387,7 +396,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -510,6 +519,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -600,9 +615,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "bytecheck"
@@ -755,7 +770,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
@@ -769,7 +784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive 3.2.18",
  "clap_lex 0.2.4",
  "indexmap",
@@ -781,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.1"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046ae530c528f252094e4a77886ee1374437744b2bff1497aa898bbddbbb29b3"
+checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
 dependencies = [
  "clap_builder",
  "clap_derive 4.2.0",
@@ -792,13 +807,13 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.1"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223163f58c9a40c3b0a43e1c4b50a9ce09f007ea2cb1ec258a687945b4b7929f"
+checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex 0.4.1",
  "strsim 0.10.0",
  "terminal_size",
@@ -826,7 +841,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -850,7 +865,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -862,6 +877,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
@@ -883,21 +904,6 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "concolor-override"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a855d4a1978dc52fb0536a04d384c2c0c1aa273597f08b77c8c4d3b2eec6037f"
-
-[[package]]
-name = "concolor-query"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d11d52c3d7ca2e6d0040212be9e4dbbcd78b6447f535b6b561f449427944cf"
-dependencies = [
- "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -972,9 +978,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -1145,7 +1151,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c36c10130df424b2f3552fcc2ddcd9b28a27b1e54b358b45874f88d1ca6888c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi 0.7.0",
  "lazy_static",
  "libc",
@@ -1161,7 +1167,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi 0.9.0",
  "libc",
  "mio 0.8.6",
@@ -1177,7 +1183,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crossterm_winapi 0.9.0",
  "libc",
  "mio 0.8.6",
@@ -1289,7 +1295,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1306,7 +1312,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1556,7 +1562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "551a778172a450d7fc12e629ca3b0428d00f6afa9a43da1b630d54604e97371c"
 dependencies = [
  "cfg-if 0.1.10",
- "dirs-sys",
+ "dirs-sys 0.3.7",
 ]
 
 [[package]]
@@ -1576,7 +1582,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dece029acd3353e3a58ac2e3eb3c8d6c35827a892edc6cc4138ef9c33df46ecd"
+dependencies = [
+ "dirs-sys 0.4.0",
 ]
 
 [[package]]
@@ -1588,6 +1603,17 @@ dependencies = [
  "libc",
  "redox_users 0.4.3",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04414300db88f70d74c5ff54e50f9e1d1737d9a5b90f53fcf2e95ca2a9ab554b"
+dependencies = [
+ "libc",
+ "redox_users 0.4.3",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1620,9 +1646,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dunce"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "ed25519"
@@ -2013,7 +2039,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2214,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",
@@ -2278,7 +2304,7 @@ dependencies = [
 name = "hc_demo_cli"
 version = "0.2.0-beta-rc.0"
 dependencies = [
- "clap 4.2.1",
+ "clap 4.2.4",
  "flate2",
  "hdi",
  "hdk",
@@ -2307,7 +2333,7 @@ dependencies = [
  "rmpv",
  "serde",
  "serde_bytes",
- "sodoken",
+ "sodoken 0.0.7",
 ]
 
 [[package]]
@@ -2372,7 +2398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -2534,7 +2560,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "shrinkwraprs",
- "sodoken",
+ "sodoken 0.0.7",
  "structopt",
  "strum 0.18.0",
  "subtle-encoding",
@@ -2653,13 +2679,24 @@ dependencies = [
  "portpicker",
  "serde",
  "serde_yaml",
- "sodoken",
+ "sodoken 0.0.7",
  "structopt",
  "tokio",
  "tracing",
  "url2",
  "walkdir",
  "which",
+]
+
+[[package]]
+name = "holochain_cli_signal_srv"
+version = "0.2.0-beta-rc.1"
+dependencies = [
+ "holochain_trace",
+ "structopt",
+ "tokio",
+ "tracing",
+ "tx5-signal-srv",
 ]
 
 [[package]]
@@ -2723,7 +2760,7 @@ dependencies = [
 name = "holochain_keystore"
 version = "0.2.0-beta-rc.5"
 dependencies = [
- "assert_cmd 2.0.10",
+ "assert_cmd 2.0.11",
  "base64 0.13.1",
  "futures",
  "holo_hash",
@@ -2738,7 +2775,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_yaml",
- "sodoken",
+ "sodoken 0.0.7",
  "tempdir",
  "thiserror",
  "tokio",
@@ -2999,7 +3036,7 @@ dependencies = [
  "nanoid 0.3.0",
  "one_err",
  "parking_lot 0.10.2",
- "pretty_assertions 0.6.1",
+ "pretty_assertions 0.7.2",
  "rand 0.8.5",
  "regex",
  "rusqlite",
@@ -3031,7 +3068,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rpassword 7.2.0",
- "sodoken",
+ "sodoken 0.0.7",
  "tokio",
 ]
 
@@ -3211,9 +3248,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "human-panic"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6557b29bbdc9d6c7a5cdbe2962e78eaf48115e8d55b0b62282956981c1f605"
+checksum = "c16465f6227e18e5a64eba488245d7b2974d4db0c4404ca5a69b550defa18d0a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3227,15 +3264,15 @@ dependencies = [
 
 [[package]]
 name = "human-repr"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fb489e3108b684bba475a4cb9804260365870e2f60058265e3d0a3b309bdb1"
+checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3340,6 +3377,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfc4a06638d2fd0dda83b01126fefd38ef9f04f54d2fc717a938df68b83a68d"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "if_chain"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3363,7 +3410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb7c1b80a1dfa604bb4a649a5c5aeef3d913f7c520cb42b40e534e8a61bcdfc"
 dependencies = [
  "ahash 0.8.3",
- "clap 4.2.1",
+ "clap 4.2.4",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap 5.4.0",
@@ -3510,7 +3557,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.0",
  "bytecount",
- "clap 4.2.1",
+ "clap 4.2.4",
  "fancy-regex",
  "fraction",
  "getrandom 0.2.9",
@@ -3872,9 +3919,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libflate"
@@ -3924,7 +3971,7 @@ dependencies = [
  "if-addrs 0.7.0",
  "log",
  "multimap",
- "nix",
+ "nix 0.23.2",
  "rand 0.8.5",
  "socket2",
  "thiserror",
@@ -3989,9 +4036,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
 
 [[package]]
 name = "lock_api"
@@ -4090,9 +4137,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+checksum = "bb99c395ae250e1bf9133673f03ca9f97b7e71b705436bf8f089453445d1e9fe"
 dependencies = [
  "rawpointer",
 ]
@@ -4285,13 +4332,13 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mortal"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3b281c45a2dbb0609b854de9df94694fb77eab2fa2933c07d07001dcb29377"
+checksum = "2c624fa1b7aab6bd2aff6e9b18565cc0363b6d45cbcd7465c9ed5e3740ebf097"
 dependencies = [
- "bitflags",
+ "bitflags 2.1.0",
  "libc",
- "nix",
+ "nix 0.26.2",
  "smallstr",
  "terminfo",
  "unicode-normalization",
@@ -4439,11 +4486,23 @@ version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cc",
  "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if 1.0.0",
+ "libc",
+ "static_assertions",
 ]
 
 [[package]]
@@ -4462,16 +4521,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c349f68f25f596b9f44cf0e7c69752a5c633b0550c3ff849518bfba0233774a"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "nom"
-version = "5.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
-dependencies = [
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -4507,9 +4556,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi 0.3.9",
 ]
@@ -4701,11 +4750,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.50"
+version = "0.10.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
+checksum = "97ea2d98598bf9ada7ea6ee8a30fb74f9156b63bbe495d64ec2b87c269d2dda3"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -4722,7 +4771,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -4733,18 +4782,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.25.2+1.1.1t"
+version = "111.25.3+1.1.1t"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320708a054ad9b3bf314688b5db87cf4d6683d64cfc835e2337924ae62bf4431"
+checksum = "924757a6a226bf60da5f7dd0311a34d2b52283dd82ddeb103208ddc66362f80c"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.85"
+version = "0.9.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
+checksum = "992bac49bdbab4423199c654a5515bd2a6c6a23bf03f2dd3bdb7e5ae6259bc69"
 dependencies = [
  "cc",
  "libc",
@@ -5068,12 +5117,12 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be1c66a6add46bff50935c313dae30a5030cf8385c5206e8a95e9e9def974aa"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg 1.1.0",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "concurrent-queue",
  "libc",
@@ -5126,9 +5175,9 @@ dependencies = [
 
 [[package]]
 name = "predicates"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c575290b64d24745b6c57a12a31465f0a66f3a4799686a6921526a33b0797965"
+checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
 dependencies = [
  "anstyle",
  "difflib",
@@ -5253,7 +5302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
 dependencies = [
  "bit-set",
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "num-traits",
@@ -5261,7 +5310,7 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift 0.3.0",
- "regex-syntax",
+ "regex-syntax 0.6.29",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -5699,7 +5748,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -5708,7 +5757,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -5746,13 +5795,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.1",
 ]
 
 [[package]]
@@ -5761,7 +5810,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "regex-syntax",
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -5771,12 +5820,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
+
+[[package]]
 name = "region"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "mach",
  "winapi 0.3.9",
@@ -5974,7 +6029,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -5996,9 +6051,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -6017,11 +6072,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -6168,7 +6223,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -6257,7 +6312,7 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -6424,7 +6479,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e63e6744142336dfb606fe2b068afa2e1cca1ee6a5d8377277a92945d81fa331"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "itertools 0.8.2",
  "proc-macro2",
  "quote",
@@ -6564,6 +6619,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sodoken"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104adab71dd6d150443c67890f336e27b9bcb20b4c9ff0c5123c54b16198c6fd"
+dependencies = [
+ "libc",
+ "libsodium-sys-stable",
+ "num_cpus",
+ "once_cell",
+ "one_err",
+ "parking_lot 0.12.1",
+ "tokio",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6596,6 +6666,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "statrs"
@@ -6744,9 +6820,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.14"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6774,7 +6850,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
  "libc",
- "ntapi 0.4.0",
+ "ntapi 0.4.1",
  "once_cell",
  "rayon",
  "winapi 0.3.9",
@@ -6853,13 +6929,13 @@ dependencies = [
 
 [[package]]
 name = "terminfo"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da31aef70da0f6352dbcb462683eb4dd2bfad01cf3fc96cf204547b9a839a585"
+checksum = "666cd3a6681775d22b200409aad3b089c5b99fb11ecdd8a204d9d62f8148498f"
 dependencies = [
  "dirs 4.0.0",
  "fnv",
- "nom 5.1.2",
+ "nom 7.1.3",
  "phf",
  "phf_codegen",
 ]
@@ -6994,7 +7070,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -7117,7 +7193,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -7403,7 +7479,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccdd26cbd674007e649a272da4475fb666d3aa0ad0531da7136db6fab0e5bad1"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cassowary",
  "crossterm 0.25.0",
  "unicode-segmentation",
@@ -7486,9 +7562,21 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tx5-core",
+ "tx5-core 0.0.1-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tx5-go-pion",
  "tx5-signal",
+ "url 2.3.1",
+]
+
+[[package]]
+name = "tx5-core"
+version = "0.0.1-alpha.4"
+dependencies = [
+ "base64 0.13.1",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
  "url 2.3.1",
 ]
 
@@ -7535,7 +7623,7 @@ dependencies = [
  "ouroboros",
  "sha2 0.10.6",
  "tracing",
- "tx5-core",
+ "tx5-core 0.0.1-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip",
 ]
 
@@ -7553,7 +7641,7 @@ dependencies = [
  "sha2 0.10.6",
  "tokio",
  "tracing",
- "tx5-core",
+ "tx5-core 0.0.1-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "zip",
 ]
 
@@ -7581,28 +7669,26 @@ dependencies = [
  "tokio-rustls",
  "tokio-tungstenite 0.17.2",
  "tracing",
- "tx5-core",
+ "tx5-core 0.0.1-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 2.3.1",
 ]
 
 [[package]]
 name = "tx5-signal-srv"
 version = "0.0.1-alpha.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c93ec8a0c5ea84e09c3068db716584959c925428a25972cdae200a6e60e3e6"
 dependencies = [
- "clap 4.2.1",
- "dirs 4.0.0",
+ "clap 4.2.4",
+ "dirs 5.0.0",
  "futures",
- "get_if_addrs",
+ "if-addrs 0.10.1",
  "once_cell",
  "prometheus",
  "rand 0.8.5",
- "sodoken",
+ "sodoken 0.0.8",
  "tokio",
  "tracing",
  "tracing-subscriber",
- "tx5-core",
+ "tx5-core 0.0.1-alpha.4",
  "warp",
 ]
 
@@ -8280,9 +8366,9 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
-version = "55.0.0"
+version = "56.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4984d3e1406571f4930ba5cf79bd70f75f41d0e87e17506e0bd19b0e5d085f05"
+checksum = "6b54185c051d7bbe23757d50fe575880a2426a2f06d2e9f6a10fd9a4a42920c0"
 dependencies = [
  "leb128",
  "memchr",
@@ -8292,9 +8378,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2b53f4da14db05d32e70e9c617abdf6620c575bd5dd972b7400037b4df2091"
+checksum = "56681922808216ab86d96bb750f70d500b5a7800e41564290fd46bb773581299"
 dependencies = [
  "wast",
 ]
@@ -8644,7 +8730,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
+checksum = "6342bd4f5a1205d7f41e94a41a901f5647c938cdfa96036338e8533c9d6c2450"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -291,7 +291,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "socket2",
+ "socket2 0.4.9",
  "waker-fn",
 ]
 
@@ -520,9 +520,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
+checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
 
 [[package]]
 name = "blake2b_simd"
@@ -2292,6 +2292,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash 0.8.3",
+]
+
+[[package]]
 name = "hashlink"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2323,9 +2332,9 @@ dependencies = [
 
 [[package]]
 name = "hc_seed_bundle"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bfd1584a885bb064bd877e78a43465261c5bd369c001e7095ab5b00cb57b3c5"
+checksum = "63bba5629a49d90007bb81a27a9ba8f9c597a82246d44e73126130617f11c52b"
 dependencies = [
  "futures",
  "one_err",
@@ -2333,7 +2342,7 @@ dependencies = [
  "rmpv",
  "serde",
  "serde_bytes",
- "sodoken 0.0.7",
+ "sodoken",
 ]
 
 [[package]]
@@ -2560,7 +2569,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "shrinkwraprs",
- "sodoken 0.0.7",
+ "sodoken",
  "structopt",
  "strum 0.18.0",
  "subtle-encoding",
@@ -2628,6 +2637,7 @@ dependencies = [
  "futures",
  "holochain_cli_bundle",
  "holochain_cli_sandbox",
+ "holochain_cli_signal_srv",
  "holochain_trace",
  "structopt",
  "tokio",
@@ -2679,7 +2689,7 @@ dependencies = [
  "portpicker",
  "serde",
  "serde_yaml",
- "sodoken 0.0.7",
+ "sodoken",
  "structopt",
  "tokio",
  "tracing",
@@ -2775,7 +2785,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_yaml",
- "sodoken 0.0.7",
+ "sodoken",
  "tempdir",
  "thiserror",
  "tokio",
@@ -2902,7 +2912,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "pretty_assertions 0.7.2",
  "r2d2",
- "r2d2_sqlite",
+ "r2d2_sqlite_neonphog",
  "rand 0.8.5",
  "rmp-serde 0.15.5",
  "rusqlite",
@@ -3068,7 +3078,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rpassword 7.2.0",
- "sodoken 0.0.7",
+ "sodoken",
  "tokio",
 ]
 
@@ -3285,7 +3295,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -3833,7 +3843,7 @@ dependencies = [
  "kitsune_p2p_dht_arc",
  "kitsune_p2p_types",
  "lair_keystore_api",
- "lru",
+ "lru 0.8.1",
  "mockall 0.11.4",
  "nanoid 0.3.0",
  "once_cell",
@@ -3845,7 +3855,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "shrinkwraprs",
- "sysinfo",
+ "sysinfo 0.27.8",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3866,9 +3876,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaa5e8f029253e54888ad85db4d3843904f5814c6c5d14985257f5263dd8e97b"
+checksum = "d453c328fa04779277f6f4b8e4a71f2bd20e0f0566cb837e6f800bc58777e4a8"
 dependencies = [
  "lair_keystore_api",
  "pretty_assertions 1.3.0",
@@ -3876,20 +3886,20 @@ dependencies = [
  "rusqlite",
  "sqlformat 0.2.1",
  "structopt",
- "sysinfo",
+ "sysinfo 0.28.4",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00cbc9276859e19728b03e65ab8f25903f8e9a70dd3d5e63b19ced26e25dd479"
+checksum = "b379baacc103ee1939976fb8f32e6b8ae887a245fbde78bf1ef95e95b3035216"
 dependencies = [
  "base64 0.13.1",
  "dunce",
  "hc_seed_bundle",
- "lru",
+ "lru 0.10.0",
  "nanoid 0.4.0",
  "once_cell",
  "parking_lot 0.12.1",
@@ -3899,6 +3909,7 @@ dependencies = [
  "serde_yaml",
  "tokio",
  "toml 0.5.11",
+ "toml 0.7.3",
  "tracing",
  "url 2.3.1",
  "winapi 0.3.9",
@@ -3954,6 +3965,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3973,7 +3994,7 @@ dependencies = [
  "multimap",
  "nix 0.23.2",
  "rand 0.8.5",
- "socket2",
+ "socket2 0.4.9",
  "thiserror",
  "tokio",
  "winapi 0.3.9",
@@ -3998,9 +4019,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.25.2"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
 dependencies = [
  "cc",
  "openssl-sys",
@@ -4036,9 +4057,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
+checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
 
 [[package]]
 name = "lock_api"
@@ -4097,6 +4118,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 dependencies = [
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "lru"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03f1160296536f10c833a82dca22267d5486734230d47bf00bf435885814ba1e"
+dependencies = [
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -4336,7 +4366,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c624fa1b7aab6bd2aff6e9b18565cc0363b6d45cbcd7465c9ed5e3740ebf097"
 dependencies = [
- "bitflags 2.1.0",
+ "bitflags 2.2.1",
  "libc",
  "nix 0.26.2",
  "smallstr",
@@ -5421,7 +5451,7 @@ dependencies = [
  "futures-util",
  "libc",
  "quinn-proto",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tracing",
 ]
@@ -5447,10 +5477,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "r2d2_sqlite"
-version = "0.21.0"
+name = "r2d2_sqlite_neonphog"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f5d0337e99cd5cacd91ffc326c6cc9d8078def459df560c4f9bf9ba4a51034"
+checksum = "4d1e95b387a49ce52c5e4994fbe18af7b6cd52510f74c9a243b12abfc207f49c"
 dependencies = [
  "r2d2",
  "rusqlite",
@@ -6025,11 +6055,11 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
+checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.2.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -6072,9 +6102,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.13"
+version = "0.37.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
+checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -6604,25 +6634,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "sodoken"
-version = "0.0.7"
+name = "socket2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c6c18e49cbf5a8b8bae94ce992b4ae019fdcb5872a318348e97de3d1f671776"
+checksum = "6d283f86695ae989d1e18440a943880967156325ba025f05049946bff47bcc2b"
 dependencies = [
  "libc",
- "libsodium-sys-stable",
- "num_cpus",
- "once_cell",
- "one_err",
- "parking_lot 0.12.1",
- "tokio",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "sodoken"
-version = "0.0.8"
+version = "0.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104adab71dd6d150443c67890f336e27b9bcb20b4c9ff0c5123c54b16198c6fd"
+checksum = "4ebd7d30290221181652f7a08112f5e7871e3deffde718dfa621025aa0e9c290"
 dependencies = [
  "libc",
  "libsodium-sys-stable",
@@ -6846,6 +6871,21 @@ name = "sysinfo"
 version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a902e9050fca0a5d6877550b769abd2bd1ce8c04634b941dbe2809735e1a1e33"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi 0.4.1",
+ "once_cell",
+ "rayon",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.28.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c2f3ca6693feb29a89724516f016488e9aafc7f37264f898593ee4b942f31b"
 dependencies = [
  "cfg-if 1.0.0",
  "core-foundation-sys",
@@ -7180,7 +7220,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.4.9",
  "tokio-macros",
  "windows-sys 0.45.0",
 ]
@@ -7246,9 +7286,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
+checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
 dependencies = [
  "futures-util",
  "log",
@@ -7256,20 +7296,8 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.17.3",
- "webpki 0.22.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
  "tungstenite 0.18.0",
+ "webpki 0.22.0",
 ]
 
 [[package]]
@@ -7374,13 +7402,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -7426,9 +7454,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -7508,27 +7536,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
-dependencies = [
- "base64 0.13.1",
- "byteorder",
- "bytes",
- "http",
- "httparse",
- "log",
- "rand 0.8.5",
- "rustls",
- "sha-1 0.10.1",
- "thiserror",
- "url 2.3.1",
- "utf-8",
- "webpki 0.22.0",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
@@ -7540,17 +7547,19 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls",
  "sha1",
  "thiserror",
  "url 2.3.1",
  "utf-8",
+ "webpki 0.22.0",
 ]
 
 [[package]]
 name = "tx5"
-version = "0.0.1-alpha.11"
+version = "0.0.1-alpha.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c73f036c327aa5ded5d7795be94b43ffc4fec34a70b6859127c166ae4ea9286d"
+checksum = "d092c04f27e61d8d14ca32cb04d5f855c01f32cc03b7405d81f74201917bbfac"
 dependencies = [
  "bytes",
  "futures",
@@ -7562,7 +7571,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "tx5-core 0.0.1-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tx5-core",
  "tx5-go-pion",
  "tx5-signal",
  "url 2.3.1",
@@ -7570,21 +7579,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-core"
-version = "0.0.1-alpha.4"
-dependencies = [
- "base64 0.13.1",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "url 2.3.1",
-]
-
-[[package]]
-name = "tx5-core"
-version = "0.0.1-alpha.4"
+version = "0.0.1-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115dcaf6103f82161164ec106df7f9b78f89093c66b5847540d81052e4081a3d"
+checksum = "ceeeff809f86347164035661f475c0a9bbf4040c4a6755183d0b84c8c6491d25"
 dependencies = [
  "base64 0.13.1",
  "once_cell",
@@ -7596,9 +7593,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion"
-version = "0.0.1-alpha.7"
+version = "0.0.1-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40a2a06014d8c061ece18eb9a695395262b2986b6da3ad8fc3b0104d472820"
+checksum = "a3f4cf8c2763b07e1eac6a60030c0456685142ac85741a761949a7ea275e8591"
 dependencies = [
  "parking_lot 0.12.1",
  "tokio",
@@ -7609,47 +7606,47 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-sys"
-version = "0.0.1-alpha.9"
+version = "0.0.1-alpha.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92a9d445cc2ec59c1b68d78d7673eb17e0fd114bdfb3ecf81187492d697acee"
+checksum = "8967286bdd9d20c56b2f32d8f48db754cf7b6e7eca2de4cf880a45dcca70091d"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
- "dirs 4.0.0",
+ "dirs 5.0.0",
  "dunce",
  "libc",
- "libloading",
+ "libloading 0.8.0",
  "once_cell",
  "ouroboros",
  "sha2 0.10.6",
  "tracing",
- "tx5-core 0.0.1-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tx5-core",
  "zip",
 ]
 
 [[package]]
 name = "tx5-go-pion-turn"
-version = "0.0.1-alpha.4"
+version = "0.0.1-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6517d958b39b693a1a26ded427bfdbd5bd40ae377c5daa91f2a93ed4536717e"
+checksum = "71db717f9fe2e83925a4489f0a3f542546a8797e225f23afd125799214c44a8f"
 dependencies = [
  "base64 0.13.1",
- "dirs 4.0.0",
+ "dirs 5.0.0",
  "dunce",
- "get_if_addrs",
+ "if-addrs 0.10.1",
  "once_cell",
  "sha2 0.10.6",
  "tokio",
  "tracing",
- "tx5-core 0.0.1-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tx5-core",
  "zip",
 ]
 
 [[package]]
 name = "tx5-signal"
-version = "0.0.1-alpha.5"
+version = "0.0.1-alpha.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864e07dcea8bbefff8074ca920e8dcc3bb414f9b71f8f06e0e227010b89af75f"
+checksum = "3cb3165fabcb68fd23d5b7c3a2dce189d6af30c6ace9e1357fe55a22a937971b"
 dependencies = [
  "futures",
  "lair_keystore_api",
@@ -7657,25 +7654,27 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rand-utf8",
- "rcgen 0.9.3",
+ "rcgen 0.10.0",
  "ring",
  "rustls",
  "rustls-native-certs",
  "rustls-pemfile 1.0.2",
  "serde_json",
  "sha2 0.10.6",
- "socket2",
+ "socket2 0.5.2",
  "tokio",
  "tokio-rustls",
- "tokio-tungstenite 0.17.2",
+ "tokio-tungstenite 0.18.0",
  "tracing",
- "tx5-core 0.0.1-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tx5-core",
  "url 2.3.1",
 ]
 
 [[package]]
 name = "tx5-signal-srv"
-version = "0.0.1-alpha.5"
+version = "0.0.1-alpha.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9671d940802c9ff79974d96c2add464f8bf4e4d02e340d3d3a0ddb739fae6bfb"
 dependencies = [
  "clap 4.2.4",
  "dirs 5.0.0",
@@ -7684,11 +7683,11 @@ dependencies = [
  "once_cell",
  "prometheus",
  "rand 0.8.5",
- "sodoken 0.0.8",
+ "sodoken",
  "tokio",
  "tracing",
  "tracing-subscriber",
- "tx5-core 0.0.1-alpha.4",
+ "tx5-core",
  "warp",
 ]
 
@@ -8238,7 +8237,7 @@ dependencies = [
  "enum-iterator",
  "enumset",
  "leb128",
- "libloading",
+ "libloading 0.7.4",
  "loupe",
  "object 0.28.4",
  "rkyv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
   "crates/hc",
   "crates/hc_bundle",
   "crates/hc_sandbox",
+  "crates/hc_signal_srv",
   "crates/hc_demo_cli",
 
   "crates/kitsune_p2p/bootstrap",
@@ -67,6 +68,7 @@ codegen-units = 16
 # tx5 = { path = "../tx5/crates/tx5" }
 # tx5-go-pion-turn = { path = "../tx5/crates/tx5-go-pion-turn" }
 # tx5-signal = { path = "../tx5/crates/tx5-signal" }
+tx5-signal-srv = { path = "../tx5/crates/tx5-signal-srv" }
 # tx5 = { git = "https://github.com/holochain/tx5.git", rev = "da4cc7ea3cbb53b12e15ab0932a0ad14fdd41659" }
 # tx5-go-pion-turn = { git = "https://github.com/holochain/tx5.git", rev = "da4cc7ea3cbb53b12e15ab0932a0ad14fdd41659" }
 # isotest = { git = "https://github.com/maackle/isotest-rs.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ codegen-units = 16
 # tx5 = { path = "../tx5/crates/tx5" }
 # tx5-go-pion-turn = { path = "../tx5/crates/tx5-go-pion-turn" }
 # tx5-signal = { path = "../tx5/crates/tx5-signal" }
-tx5-signal-srv = { path = "../tx5/crates/tx5-signal-srv" }
+# tx5-signal-srv = { path = "../tx5/crates/tx5-signal-srv" }
 # tx5 = { git = "https://github.com/holochain/tx5.git", rev = "da4cc7ea3cbb53b12e15ab0932a0ad14fdd41659" }
 # tx5-go-pion-turn = { git = "https://github.com/holochain/tx5.git", rev = "da4cc7ea3cbb53b12e15ab0932a0ad14fdd41659" }
 # isotest = { git = "https://github.com/maackle/isotest-rs.git" }

--- a/crates/diagnostic_tests/Cargo.toml
+++ b/crates/diagnostic_tests/Cargo.toml
@@ -9,7 +9,7 @@ colored = "2"
 futures = "*"
 holochain_diagnostics = { path = "../holochain_diagnostics" }
 holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
-tokio = { version = "1.11", features = ["full"] }
+tokio = { version = "1.27", features = ["full"] }
 tokio-stream = "*"
 
 crossterm = "*"

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Adds a new `hc signal-srv` command to run a local holochain webrtc signal server that can be passed into a command like `cargo run -- sandbox generate network webrtc ws://127.0.0.1:xxx`. [\#2265](https://github.com/holochain/holochain/pull/2265)
+
 ## 0.2.0-beta-rc.6
 
 ## 0.2.0-beta-rc.5

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Adds a new `hc signal-srv` command to run a local holochain webrtc signal server that can be passed into a command like `cargo run -- sandbox generate network webrtc ws://127.0.0.1:xxx`. [\#2265](https://github.com/holochain/holochain/pull/2265)
+- Adds a new `hc signal-srv` command to run a local holochain webrtc signal server that can be passed into a command like `hc sandbox generate network webrtc ws://127.0.0.1:xxx`. [\#2265](https://github.com/holochain/holochain/pull/2265)
 
 ## 0.2.0-beta-rc.6
 

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -23,6 +23,7 @@ anyhow = "1.0"
 futures = "0.3"
 holochain_cli_bundle = { path = "../hc_bundle", version = "^0.2.0-beta-rc.5"}
 holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.2.0-beta-rc.5"}
+holochain_cli_signal_srv = { path = "../hc_signal_srv", version = "^0.2.0-beta-rc.1" }
 holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
 structopt = "0.3"
-tokio = { version = "1.11", features = ["full"] }
+tokio = { version = "1.27", features = ["full"] }

--- a/crates/hc/src/lib.rs
+++ b/crates/hc/src/lib.rs
@@ -113,6 +113,7 @@ use std::process::Command;
 // Useful to have this public when using this as a library.
 pub use holochain_cli_bundle as hc_bundle;
 use holochain_cli_sandbox as hc_sandbox;
+use holochain_cli_signal_srv as hc_signal_srv;
 use structopt::{lazy_static::lazy_static, StructOpt};
 
 mod external_subcommands;
@@ -165,6 +166,8 @@ pub enum Opt {
     WebApp(hc_bundle::HcWebAppBundle),
     /// Work with sandboxed environments for testing and development
     Sandbox(hc_sandbox::HcSandbox),
+    /// Run a signal server
+    SignalSrv(hc_signal_srv::HcSignalSrv),
     /// Allow redirect of external subcommands (like hc-scaffold and hc-launch)
     #[structopt(external_subcommand)]
     External(Vec<String>),
@@ -178,6 +181,7 @@ impl Opt {
             Self::App(cmd) => cmd.run().await?,
             Self::WebApp(cmd) => cmd.run().await?,
             Self::Sandbox(cmd) => cmd.run().await?,
+            Self::SignalSrv(cmd) => cmd.run().await,
             Self::External(args) => {
                 let command_suffix = args.first().expect("Missing subcommand name");
                 Command::new(format!("hc-{}", command_suffix))

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -29,7 +29,7 @@ serde_bytes = "0.11"
 serde_yaml = "0.9"
 structopt = "0.3.11"
 thiserror = "1.0.22"
-tokio = { version = "1.11", features = [ "full" ] }
+tokio = { version = "1.27", features = [ "full" ] }
 
 [dev-dependencies]
 assert_cmd = "1.0"

--- a/crates/hc_demo_cli/Cargo.toml
+++ b/crates/hc_demo_cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-clap = { version = "4.1.11", features = [ "derive", "wrap_help" ], optional = true }
+clap = { version = "4.2.2", features = [ "derive", "wrap_help" ], optional = true }
 flate2 = { version = "1.0.25", optional = true }
 hdi = { path = "../hdi", version = "^0.3.0-beta-rc.4", optional = true }
 hdk = { path = "../hdk", version = "^0.2.0-beta-rc.5", optional = true }

--- a/crates/hc_demo_cli/Cargo.toml
+++ b/crates/hc_demo_cli/Cargo.toml
@@ -17,7 +17,7 @@ holochain_keystore = { path = "../holochain_keystore", version = "^0.2.0-beta-rc
 rand = { version = "0.8.5", optional = true }
 rand-utf8 = { version = "0.0.1", optional = true }
 serde = { version = "1", optional = true }
-tokio = { version = "1.26.0", features = [ "full" ], optional = true }
+tokio = { version = "1.27", features = [ "full" ], optional = true }
 tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.16", optional = true }
 

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -29,8 +29,8 @@ holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
 once_cell = "1.13.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
-sodoken = "=0.0.7"
-tokio = { version = "1.11", features = ["full"] }
+sodoken = "=0.0.9"
+tokio = { version = "1.27", features = ["full"] }
 structopt = "0.3"
 tracing = "0.1"
 url2 = "0.0.6"

--- a/crates/hc_signal_srv/CHANGELOG.md
+++ b/crates/hc_signal_srv/CHANGELOG.md
@@ -1,0 +1,9 @@
+---
+default_semver_increment_mode: !pre_minor beta-rc
+---
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## \[Unreleased\]
+

--- a/crates/hc_signal_srv/Cargo.toml
+++ b/crates/hc_signal_srv/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/bin/hc-signal-srv.rs"
 
 [dependencies]
 holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
-tokio = { version = "1.11", features = ["full"] }
+tokio = { version = "1.27", features = ["full"] }
 tracing = "0.1"
-tx5-signal-srv = "0.0.1-alpha.5"
+tx5-signal-srv = "0.0.1-alpha.7"
 structopt = "0.3"

--- a/crates/hc_signal_srv/Cargo.toml
+++ b/crates/hc_signal_srv/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "holochain_cli_signal_srv"
+version = "0.2.0-beta-rc.1"
+homepage = "https://github.com/holochain/holochain"
+documentation = "https://docs.rs/holochain_cli_signal_srv"
+authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
+keywords = ["holochain", "holo"]
+categories = ["command-line-utilities", "development-tools::build-utils", "filesystem"]
+edition = "2021"
+license = "Apache-2.0"
+description = "Run a holochain webrtc signal server."
+
+[[bin]]
+name = "hc-signal-srv"
+path = "src/bin/hc-signal-srv.rs"
+
+[dependencies]
+holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
+tokio = { version = "1.11", features = ["full"] }
+tracing = "0.1"
+tx5-signal-srv = "0.0.1-alpha.5"
+structopt = "0.3"

--- a/crates/hc_signal_srv/Cargo.toml
+++ b/crates/hc_signal_srv/Cargo.toml
@@ -18,5 +18,5 @@ path = "src/bin/hc-signal-srv.rs"
 holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
 tokio = { version = "1.27", features = ["full"] }
 tracing = "0.1"
-tx5-signal-srv = "0.0.1-alpha.7"
+tx5-signal-srv = "=0.0.1-alpha.7"
 structopt = "0.3"

--- a/crates/hc_signal_srv/README.md
+++ b/crates/hc_signal_srv/README.md
@@ -1,0 +1,3 @@
+# hc_signal_srv
+
+Run a holochain webrtc signal server. Run `hc signal-srv --help` for details.

--- a/crates/hc_signal_srv/src/bin/hc-signal-srv.rs
+++ b/crates/hc_signal_srv/src/bin/hc-signal-srv.rs
@@ -1,0 +1,11 @@
+use structopt::StructOpt;
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    if std::env::var_os("RUST_LOG").is_some() {
+        holochain_trace::init_fmt(holochain_trace::Output::Log).ok();
+    }
+    let ops = holochain_cli_signal_srv::HcSignalSrv::from_args();
+
+    ops.run().await
+}

--- a/crates/hc_signal_srv/src/lib.rs
+++ b/crates/hc_signal_srv/src/lib.rs
@@ -1,0 +1,70 @@
+use structopt::StructOpt;
+use tokio::io::AsyncWriteExt;
+use tx5_signal_srv::Result;
+
+#[derive(Debug, StructOpt)]
+/// Helper for running a holochain webrtc signal server.
+pub struct HcSignalSrv {
+    /// The port to use for the signal server. You probably want
+    /// to leave this as 0 (zero) to be assigned an available port.
+    #[structopt(short, long, default_value = "0")]
+    port: u16,
+
+    /// A Comma separated list of interfaces on which to run the signal server.
+    #[structopt(short, long, default_value = "127.0.0.1")]
+    interfaces: String,
+
+    /// If set, write the bound address list to a new file, separated by
+    /// newlines. If the file exists, an error will be returned.
+    #[structopt(long)]
+    address_list_file_path: Option<std::path::PathBuf>,
+}
+
+impl HcSignalSrv {
+    pub async fn run(self) {
+        if let Err(err) = self.run_err().await {
+            eprintln!("We were not able to start the signal server.");
+            eprintln!("{err:#?}");
+        }
+    }
+
+    pub async fn run_err(self) -> Result<()> {
+        let mut config = tx5_signal_srv::Config::default();
+        config.interfaces = self.interfaces;
+        config.port = self.port;
+        config.demo = false;
+        tracing::info!(?config);
+
+        let (driver, addr_list, err_list) = tx5_signal_srv::exec_tx5_signal_srv(config)?;
+
+        for err in err_list {
+            tracing::error!(?err);
+        }
+
+        if let Some(path) = &self.address_list_file_path {
+            let mut file = tokio::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(path)
+                .await?;
+
+            for addr in &addr_list {
+                file.write_all(format!("ws://{addr}\n").as_bytes()).await?;
+            }
+
+            file.flush().await?;
+            file.shutdown().await?;
+            drop(file);
+        }
+
+        for addr in addr_list {
+            println!("# HC SIGNAL SRV - ADDR: ws://{addr}");
+        }
+
+        println!("# HC SIGNAL SRV - RUNNING");
+
+        driver.await;
+
+        Ok(())
+    }
+}

--- a/crates/hc_signal_srv/src/lib.rs
+++ b/crates/hc_signal_srv/src/lib.rs
@@ -38,7 +38,7 @@ impl HcSignalSrv {
         let (driver, addr_list, err_list) = tx5_signal_srv::exec_tx5_signal_srv(config)?;
 
         for err in err_list {
-            tracing::error!(?err);
+            println!("# HC SIGNAL SRV - ERROR: {err:?}");
         }
 
         if let Some(path) = &self.address_list_file_path {

--- a/crates/hc_signal_srv/src/lib.rs
+++ b/crates/hc_signal_srv/src/lib.rs
@@ -10,7 +10,7 @@ pub struct HcSignalSrv {
     #[structopt(short, long, default_value = "0")]
     port: u16,
 
-    /// A Comma separated list of interfaces on which to run the signal server.
+    /// A comma separated list of interfaces on which to run the signal server.
     #[structopt(short, long, default_value = "127.0.0.1")]
     interfaces: String,
 

--- a/crates/hc_signal_srv/src/lib.rs
+++ b/crates/hc_signal_srv/src/lib.rs
@@ -23,7 +23,7 @@ pub struct HcSignalSrv {
 impl HcSignalSrv {
     pub async fn run(self) {
         if let Err(err) = self.run_err().await {
-            eprintln!("We were not able to start the signal server.");
+            eprintln!("Unable to start the signal server.");
             eprintln!("{err:#?}");
         }
     }

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -26,7 +26,7 @@ holochain_serialized_bytes = { version = "=0.0.51", optional = true }
 kitsune_p2p_dht_arc = { version = "^0.2.0-beta-rc.2", path = "../kitsune_p2p/dht_arc" }
 must_future = { version = "0.1", optional = true }
 rand = { version = "0.8.5", optional = true }
-rusqlite = { version = "0.28", optional = true }
+rusqlite = { version = "0.29", optional = true }
 serde = { version = "1", optional = true }
 serde_bytes = { version = "0.11", optional = true }
 tracing = { version = "0.1", optional = true }

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -89,8 +89,8 @@ holochain_test_wasm_common = { version = "^0.2.0-beta-rc.5", path = "../test_uti
 kitsune_p2p_bootstrap = { version = "^0.1.0-beta-rc.3", path = "../kitsune_p2p/bootstrap", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
 itertools = { version = "0.10", optional = false }
-tx5-go-pion-turn = { version = "0.0.1-alpha.5", optional = true }
-tx5-signal-srv = { version = "0.0.1-alpha.7", optional = true }
+tx5-go-pion-turn = { version = "=0.0.1-alpha.5", optional = true }
+tx5-signal-srv = { version = "=0.0.1-alpha.7", optional = true }
 
 # chc deps
 bytes = { version = "1", optional = true }

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -55,18 +55,18 @@ predicates = "1.0.4"
 rand = "0.8.5"
 rand-utf8 = "0.0.1"
 rpassword = "5.0.1"
-rusqlite = { version = "0.28" }
+rusqlite = { version = "0.29" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 serde_yaml = "0.9"
 shrinkwraprs = "0.3.0"
-sodoken = "=0.0.7"
+sodoken = "=0.0.9"
 structopt = "0.3.11"
 strum = "0.18.0"
 subtle-encoding = "0.5"
 tempfile = "3.3"
 thiserror = "1.0.22"
-tokio = { version = "1.11", features = [ "full"] }
+tokio = { version = "1.27", features = [ "full"] }
 tokio-stream = { version = "0.1", features = [ "sync", "net" ] }
 task-motel = "0.1.0-rc.1"
 toml = "0.5.6"
@@ -89,8 +89,8 @@ holochain_test_wasm_common = { version = "^0.2.0-beta-rc.5", path = "../test_uti
 kitsune_p2p_bootstrap = { version = "^0.1.0-beta-rc.3", path = "../kitsune_p2p/bootstrap", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
 itertools = { version = "0.10", optional = false }
-tx5-go-pion-turn = { version = "0.0.1-alpha.4", optional = true }
-tx5-signal-srv = { version = "0.0.1-alpha.5", optional = true }
+tx5-go-pion-turn = { version = "0.0.1-alpha.5", optional = true }
+tx5-signal-srv = { version = "0.0.1-alpha.7", optional = true }
 
 # chc deps
 bytes = { version = "1", optional = true }

--- a/crates/holochain/src/sweettest/sweet_conductor_config_rendezvous.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor_config_rendezvous.rs
@@ -98,8 +98,9 @@ impl SweetLocalRendezvous {
                 serde_json::to_string_pretty(&sig_conf.ice_servers).unwrap()
             );
 
-            let (sig_addr, sig_driver) = tx5_signal_srv::exec_tx5_signal_srv(sig_conf).unwrap();
-            let sig_port = sig_addr.port();
+            let (sig_driver, sig_addr_list, _sig_err_list) =
+                tx5_signal_srv::exec_tx5_signal_srv(sig_conf).unwrap();
+            let sig_port = sig_addr_list.get(0).unwrap().port();
             let sig_addr: std::net::SocketAddr = (addr, sig_port).into();
             let sig_shutdown = tokio::task::spawn(sig_driver);
             let sig_addr = format!("ws://{sig_addr}");

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -28,7 +28,7 @@ holochain_zome_types = { version = "^0.2.0-beta-rc.5", path = "../holochain_zome
 kitsune_p2p = { version = "^0.2.0-beta-rc.5", path = "../kitsune_p2p/kitsune_p2p" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
-tokio = { version = "1.11", features = ["full"] }
+tokio = { version = "1.27", features = ["full"] }
 thiserror = "1.0"
 tracing = "0.1"
 tracing-futures = "0.2"

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -17,16 +17,16 @@ holo_hash = { version = "^0.2.0-beta-rc.4", path = "../holo_hash", features = ["
 holochain_serialized_bytes = "=0.0.51"
 holochain_zome_types = { path = "../holochain_zome_types", version = "^0.2.0-beta-rc.5"}
 kitsune_p2p_types = { version = "^0.2.0-beta-rc.4", path = "../kitsune_p2p/types" }
-lair_keystore = { version = "0.2.3", default-features = false }
+lair_keystore = { version = "0.2.4", default-features = false }
 must_future = "0.1.2"
 nanoid = "0.4.0"
 one_err = "0.0.8"
 parking_lot = "0.11"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_bytes = "0.11"
-sodoken = "=0.0.7"
+sodoken = "=0.0.9"
 thiserror = "1.0.22"
-tokio = { version = "1.11", features = [ "full" ] }
+tokio = { version = "1.27", features = [ "full" ] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 thiserror = "1.0.22"
-tokio = { version = "1.11", features = [ "full" ] }
+tokio = { version = "1.27", features = [ "full" ] }
 tokio-stream = "0.1"
 holochain_util = { version = "^0.2.0-beta-rc.0", path = "../holochain_util" }
 

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -38,7 +38,7 @@ page_size = "0.4.2"
 parking_lot = "0.10"
 rand = "0.8.5"
 r2d2 = "0.8"
-r2d2_sqlite = "0.21"
+r2d2_sqlite = { version = "0.1", package = "r2d2_sqlite_neonphog" }
 rmp-serde = "0.15"
 scheduled-thread-pool = "0.2"
 serde = "1.0"
@@ -47,12 +47,12 @@ serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 shrinkwraprs = "0.3.0"
 tempfile = "3.3"
 thiserror = "1.0.22"
-tokio = { version = "1.11", features = [ "macros", "rt-multi-thread", "io-util", "sync" ] }
+tokio = { version = "1.27", features = [ "macros", "rt-multi-thread", "io-util", "sync" ] }
 tracing = "0.1.18"
 tracing-futures = "0.2"
 getrandom = "0.2.7"
 
-rusqlite = { version = "0.28", features = [
+rusqlite = { version = "0.29", features = [
   "blob",        # better integration with blob types (Read, Write, etc)
   "backup",
   "trace",

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -34,7 +34,7 @@ shrinkwraprs = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.51", features = ["preserve_order"] }
 thiserror = "1.0.22"
-tokio = { version = "1.11", features = ["full"] }
+tokio = { version = "1.27", features = ["full"] }
 tracing = "0.1.26"
 tracing-futures = "0.2.5"
 cron = "0.9"

--- a/crates/holochain_trace/Cargo.toml
+++ b/crates/holochain_trace/Cargo.toml
@@ -31,10 +31,10 @@ tracing-subscriber = { version = "0.3.16", features = [ "env-filter", "time", "j
 holochain_serialized_bytes = {version = "0.0", optional = true }
 serde = { version = "1", optional = true }
 serde_bytes = { version = "0.11", optional = true }
-tokio = { version = "1.26", features = [ "sync" ], optional = true }
+tokio = { version = "1.27", features = [ "sync" ], optional = true }
 shrinkwraprs = { version = "0.3.0", optional = true }
 once_cell = "1.5"
 
 [dev-dependencies]
-tokio = { version = "1.26", features = [ "full" ] }
+tokio = { version = "1.27", features = [ "full" ] }
 tracing-futures = "0.2.5"

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -41,7 +41,7 @@ holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../holochain_trace" }
 parking_lot = "0.10"
 rand = "0.8.5"
 regex = "1.4"
-rusqlite = { version = "0.28" }
+rusqlite = { version = "0.29" }
 serde = { version = "1.0", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"
 serde_derive = "1.0"
@@ -52,7 +52,7 @@ strum = "0.18.0"
 strum_macros = "0.18.0"
 tempfile = "3"
 thiserror = "1.0.22"
-tokio = { version = "1.11", features = [ "rt" ] }
+tokio = { version = "1.27", features = [ "rt" ] }
 holochain_util = { version = "^0.2.0-beta-rc.0", path = "../holochain_util", features = ["backtrace"] }
 tracing = "0.1.26"
 derive_builder = "0.9.0"

--- a/crates/holochain_util/Cargo.toml
+++ b/crates/holochain_util/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/holochain_util"
 
 [dependencies]
 once_cell = "1.13.0"
-tokio = { version = "1.11", features = [ "full" ], optional = true }
+tokio = { version = "1.27", features = [ "full" ], optional = true }
 num_cpus = "1.8"
 futures = "0.3"
 backtrace = { version = "0.3", optional = true }
@@ -18,7 +18,7 @@ cfg-if = "0.1"
 derive_more = "0.99"
 dunce = "1.0"
 rpassword = { version = "7.0.0", optional = true }
-sodoken = { version = "0.0.7", optional = true }
+sodoken = { version = "0.0.9", optional = true }
 
 [features]
 default = [ "tokio" ]

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", features = [ "derive" ] }
 serde_bytes = "0.11"
 stream-cancel = "0.8.0"
 thiserror = "1.0.22"
-tokio = { version = "1", features = [ "full" ] }
+tokio = { version = "1.27", features = [ "full" ] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tokio-tungstenite = { version = "0.13", features = [ "tls" ] }
 tracing = "0.1"

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -34,7 +34,7 @@ strum = { version = "0.18.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 
 # sqlite dependencies
-rusqlite = { version = "0.28", optional = true }
+rusqlite = { version = "0.29", optional = true }
 num_enum = { version = "0.5", optional = true }
 
 # full-dna-def dependencies

--- a/crates/kitsune_p2p/dht_arc/Cargo.toml
+++ b/crates/kitsune_p2p/dht_arc/Cargo.toml
@@ -17,7 +17,7 @@ intervallum = "1.4.0"
 num-traits = "0.2"
 serde = {version = "1.0", features = ["derive"]}
 
-rusqlite = { version = "0.28", optional = true }
+rusqlite = { version = "0.29", optional = true }
 
 [dev-dependencies]
 maplit = "1"

--- a/crates/kitsune_p2p/fetch/Cargo.toml
+++ b/crates/kitsune_p2p/fetch/Cargo.toml
@@ -21,7 +21,7 @@ num-traits = "0.2.14"
 serde = { version = "1.0", features = [ "derive" ] }
 serde_bytes = "0.11"
 thiserror = "1.0"
-tokio = { version = "1.11", features = [ "full" ] }
+tokio = { version = "1.27", features = [ "full" ] }
 tracing = "0.1.29"
 linked-hash-map = "0.5.6"
 
@@ -33,7 +33,7 @@ holochain_serialized_bytes = "0.0.51"
 holochain_trace = { version = "^0.2.0-beta-rc.1", path = "../../holochain_trace" }
 pretty_assertions = "0.7.2"
 test-case = "1.2"
-tokio = { version = "1.11", features = [ "full", "test-util" ] }
+tokio = { version = "1.27", features = [ "full", "test-util" ] }
 
 [features]
 test_utils = ["human-repr"]

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -43,7 +43,7 @@ thiserror = "1.0.22"
 tokio = { version = "1.27", features = ["full"] }
 tracing = "0.1"
 tokio-stream = "0.1"
-tx5 = { version = "0.0.1-alpha.13", optional = true }
+tx5 = { version = "=0.0.1-alpha.13", optional = true }
 url2 = "0.0.6"
 fixt = { path = "../../fixt", version = "^0.2.0-beta-rc.0"}
 

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -40,10 +40,10 @@ serde_bytes = "0.11"
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 shrinkwraprs = "0.3.0"
 thiserror = "1.0.22"
-tokio = { version = "1.11", features = ["full"] }
+tokio = { version = "1.27", features = ["full"] }
 tracing = "0.1"
 tokio-stream = "0.1"
-tx5 = { version = "0.0.1-alpha.11", optional = true }
+tx5 = { version = "0.0.1-alpha.13", optional = true }
 url2 = "0.0.6"
 fixt = { path = "../../fixt", version = "^0.2.0-beta-rc.0"}
 

--- a/crates/kitsune_p2p/mdns/Cargo.toml
+++ b/crates/kitsune_p2p/mdns/Cargo.toml
@@ -26,5 +26,5 @@ futures-core = "0.3.1"
 async-stream = "0.2.0"
 base64 = "0.13"
 err-derive = "0.2.1"
-tokio = { version = "1.11", features = [ "full" ] }
+tokio = { version = "1.27", features = [ "full" ] }
 tokio-stream = { version = "0.1" }

--- a/crates/kitsune_p2p/proxy/Cargo.toml
+++ b/crates/kitsune_p2p/proxy/Cargo.toml
@@ -25,7 +25,7 @@ rustls = { version = "0.20.4", features = [ "dangerous_configuration" ] }
 serde = { version = "1", features = [ "derive" ] }
 serde_bytes = "0.11"
 structopt = "0.3"
-tokio = { version = "1.11", features = [ "full" ] }
+tokio = { version = "1.27", features = [ "full" ] }
 tracing-subscriber = "0.3.16"
 webpki = "0.21.2"
 

--- a/crates/kitsune_p2p/timestamp/Cargo.toml
+++ b/crates/kitsune_p2p/timestamp/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"], optional = true }
 
 # Dependencies only needed for full.
-rusqlite = { version = "0.28", optional = true }
+rusqlite = { version = "0.29", optional = true }
 
 # Dependencies only needed for testing by downstream crates.
 arbitrary = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/kitsune_p2p/transport_quic/Cargo.toml
+++ b/crates/kitsune_p2p/transport_quic/Cargo.toml
@@ -21,7 +21,7 @@ quinn = "0.8.1"
 rcgen = "0.9.2"
 rustls = { version = "0.20.4", features = [ "dangerous_configuration" ] }
 serde = { version = "1.0", features = [ "derive" ] }
-tokio = { version = "1.17.0", features = [ "full" ] }
+tokio = { version = "1.27", features = [ "full" ] }
 webpki = "0.22.0"
 
 [features]

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -11,7 +11,7 @@ categories = [ "network-programming" ]
 edition = "2021"
 
 [dependencies]
-lair_keystore_api = "=0.2.3"
+lair_keystore_api = "=0.2.4"
 base64 = "0.13"
 derive_more = "0.99.7"
 futures = "0.3"
@@ -35,7 +35,7 @@ serde_json = { version = "1", features = [ "preserve_order" ] }
 shrinkwraprs = "0.3.0"
 sysinfo = "0.27"
 thiserror = "1.0.22"
-tokio = { version = "1.11", features = [ "full" ] }
+tokio = { version = "1.27", features = [ "full" ] }
 tokio-stream = { version = "0.1", features = [ "sync", "net" ] }
 url = "2"
 url2 = "0.0.6"

--- a/crates/mr_bundle/Cargo.toml
+++ b/crates/mr_bundle/Cargo.toml
@@ -30,7 +30,7 @@ anyhow = "1.0"
 matches = "0.1"
 maplit = "1"
 serde_yaml = "0.9"
-tokio = { version = "1.11", features = ["full"] }
+tokio = { version = "1.27", features = ["full"] }
 tempfile = "3"
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -1397,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
+checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
 
 [[package]]
 name = "lock_api"
@@ -2173,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.13"
+version = "0.37.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
+checksum = "d9b864d3c18a5785a05953adeed93e2dca37ed30f18e69bba9f30079d51f363f"
 dependencies = [
  "bitflags",
  "errno",
@@ -3049,13 +3049,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "bytecheck"
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
 dependencies = [
  "libc",
 ]
@@ -486,7 +486,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -503,7 +503,7 @@ checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -839,7 +839,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1366,9 +1366,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libloading"
@@ -1397,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
 
 [[package]]
 name = "lock_api"
@@ -1461,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+checksum = "bb99c395ae250e1bf9133673f03ca9f97b7e71b705436bf8f089453445d1e9fe"
 dependencies = [
  "rawpointer",
 ]
@@ -2067,9 +2067,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2078,9 +2078,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "region"
@@ -2152,9 +2152,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a36c42d1873f9a77c53bde094f9664d9891bc604a45b4798fd2c389ed12e5b"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustc-hash"
@@ -2173,9 +2173,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
 dependencies = [
  "bitflags",
  "errno",
@@ -2286,7 +2286,7 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2462,9 +2462,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.14"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3007,7 +3007,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -3457,9 +3457,9 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
-version = "55.0.0"
+version = "56.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4984d3e1406571f4930ba5cf79bd70f75f41d0e87e17506e0bd19b0e5d085f05"
+checksum = "6b54185c051d7bbe23757d50fe575880a2426a2f06d2e9f6a10fd9a4a42920c0"
 dependencies = [
  "leb128",
  "memchr",
@@ -3469,9 +3469,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af2b53f4da14db05d32e70e9c617abdf6620c575bd5dd972b7400037b4df2091"
+checksum = "56681922808216ab86d96bb750f70d500b5a7800e41564290fd46bb773581299"
 dependencies = [
  "wast",
 ]


### PR DESCRIPTION
### Summary

Adds a new `hc signal-srv` command to run a local holochain webrtc signal server that can be passed into a command like `hc sandbox generate network webrtc ws://127.0.0.1:xxx`.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
