### PR TITLE
Make run_n and generate functions of hc_sandbox public

### DIFF
--- a/crates/hc_sandbox/src/cli.rs
+++ b/crates/hc_sandbox/src/cli.rs
@@ -189,7 +189,7 @@ impl HcSandbox {
     }
 }
 
-async fn run_n(
+pub async fn run_n(
     holochain_path: &Path,
     paths: Vec<PathBuf>,
     app_ports: Vec<u16>,
@@ -218,7 +218,7 @@ async fn run_n(
     Ok(())
 }
 
-async fn generate(
+pub async fn generate(
     holochain_path: &Path,
     happ: Option<PathBuf>,
     create: Create,


### PR DESCRIPTION
### Summary
I use the `generate` and `run_n` functions in `holochain_cli_launch` to start sandbox conductors. Instead of having to copy over those functions I would like to import them if there is nothing speaking against making them public.


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
