### PR TITLE
Set default semver increment mode

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -214,7 +214,7 @@ jobs:
                 --force-tag-creation \
                 --force-branch-creation \
                 --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
-                --allowed-semver-increment-modes="patch beta-rc" \
+                --allowed-semver-increment-modes="patch,beta-rc" \
                 --steps=CreateReleaseBranch,BumpReleaseVersions
 
             release-automation \

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -214,7 +214,7 @@ jobs:
                 --force-tag-creation \
                 --force-branch-creation \
                 --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
-                --allowed-semver-increment-modes="patch,beta-rc" \
+                --allowed-semver-increment-modes="patch,!pre_minor beta-rc" \
                 --steps=CreateReleaseBranch,BumpReleaseVersions
 
             release-automation \

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -214,7 +214,7 @@ jobs:
                 --force-tag-creation \
                 --force-branch-creation \
                 --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
-                --allowed-semver-increment-modes="patch,!pre_minor beta-rc" \
+                --allowed-semver-increment-modes="patch,!pre_patch beta-rc" \
                 --steps=CreateReleaseBranch,BumpReleaseVersions
 
             release-automation \

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -214,7 +214,7 @@ jobs:
                 --force-tag-creation \
                 --force-branch-creation \
                 --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
-                --allowed-semver-increment-modes="patch,!pre_patch beta-rc" \
+                --allowed-semver-increment-modes="!pre_patch beta-rc" \
                 --steps=CreateReleaseBranch,BumpReleaseVersions
 
             release-automation \

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -214,7 +214,7 @@ jobs:
                 --force-tag-creation \
                 --force-branch-creation \
                 --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
-                --allowed-semver-increment-modes="patch" \
+                --allowed-semver-increment-modes="patch beta-rc" \
                 --steps=CreateReleaseBranch,BumpReleaseVersions
 
             release-automation \

--- a/crates/fixt/CHANGELOG.md
+++ b/crates/fixt/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/fixt/test/CHANGELOG.md
+++ b/crates/fixt/test/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/hdi/CHANGELOG.md
+++ b/crates/hdi/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/hdk_derive/CHANGELOG.md
+++ b/crates/hdk_derive/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/holo_hash/CHANGELOG.md
+++ b/crates/holo_hash/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/holochain_integrity_types/CHANGELOG.md
+++ b/crates/holochain_integrity_types/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -1,10 +1,13 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## \[Unreleased\]
 
-- Adds deserialization backward compatibility to `InstalledAppCommon`, for databases which contain apps installed prior to `0.1.4`. Without this fix, older database values can't be deserialized into more current conductors. [\#2253](https://github.com/holochain/holochain/pull/2253)
+- Adds deserialization backward compatibility to `InstalledAppCommon`, for databases which contain apps installed prior to `0.1.4`. Without this fix, older database values can’t be deserialized into more current conductors. [\#2253](https://github.com/holochain/holochain/pull/2253)
 
 ## 0.1.4
 

--- a/crates/holochain_util/CHANGELOG.md
+++ b/crates/holochain_util/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/holochain_websocket/CHANGELOG.md
+++ b/crates/holochain_websocket/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/kitsune_p2p/bootstrap/CHANGELOG.md
+++ b/crates/kitsune_p2p/bootstrap/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/kitsune_p2p/dht/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/kitsune_p2p/dht_arc/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht_arc/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/kitsune_p2p/fetch/CHANGELOG.md
+++ b/crates/kitsune_p2p/fetch/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/kitsune_p2p/mdns/CHANGELOG.md
+++ b/crates/kitsune_p2p/mdns/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/kitsune_p2p/proxy/CHANGELOG.md
+++ b/crates/kitsune_p2p/proxy/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/kitsune_p2p/timestamp/CHANGELOG.md
+++ b/crates/kitsune_p2p/timestamp/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/kitsune_p2p/transport_quic/CHANGELOG.md
+++ b/crates/kitsune_p2p/transport_quic/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/kitsune_p2p/types/CHANGELOG.md
+++ b/crates/kitsune_p2p/types/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/mock_hdi/CHANGELOG.md
+++ b/crates/mock_hdi/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/mr_bundle/CHANGELOG.md
+++ b/crates/mr_bundle/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/test_utils/wasm/CHANGELOG.md
+++ b/crates/test_utils/wasm/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/crates/test_utils/wasm_common/CHANGELOG.md
+++ b/crates/test_utils/wasm_common/CHANGELOG.md
@@ -1,3 +1,6 @@
+---
+default_semver_increment_mode: !pre_patch beta-rc
+---
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).


### PR DESCRIPTION
### Summary

Set the default semver increment mode to pre-release. For example, we want to release `0.1.5-beta.rc.1` before releasing `0.1.5` so that we can check the release before committing to it.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
