### PR TITLE
fix(devShells/coreDev): remove holochain-crate2nix because it fails on macos

### DIFF
--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -100,7 +100,6 @@
                               !lib.lists.any (unwantedPackage: nativeBuildInput == unwantedPackage)
                                 [
                                   self'.packages.holochain
-                                  self'.packages.holochain-crate2nix
                                 ]
                             )
                             (testDrvAttrs.nativeBuildInputs or [ ])


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
