### PR TITLE
convert panic into a tracing log

### DIFF
--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net.rs
@@ -684,8 +684,10 @@ impl MetaNet {
             while let Some(evt) = ep_evt.recv().await {
                 let evt = match evt {
                     Ok(evt) => evt,
-                    // TODO - FIXME - handle errors / reconnect?
-                    Err(err) => panic!("{:?}", err),
+                    Err(err) => {
+                        tracing::debug!(?err, "tx5 err event");
+                        continue;
+                    }
                 };
 
                 match evt {


### PR DESCRIPTION
Fixes networking panic:

https://github.com/holochain/holochain/blob/07d9be37a68e4d6a0d12d005de4bfd479d733442/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net.rs#L688

```
[2023-04-24T23:21:00.187407+02:00] INFO - [HOLOCHAIN 0.2.0-beta-rc.6] FATAL PANIC PanicInfo {
[2023-04-24T23:21:00.187649+02:00] INFO - [HOLOCHAIN 0.2.0-beta-rc.6] payload: Any { .. },
[2023-04-24T23:21:00.187850+02:00] INFO - [HOLOCHAIN 0.2.0-beta-rc.6] message: Some(
[2023-04-24T23:21:00.187894+02:00] INFO - [HOLOCHAIN 0.2.0-beta-rc.6] Custom { kind: Other, error: Ban },
[2023-04-24T23:21:00.187920+02:00] INFO - [HOLOCHAIN 0.2.0-beta-rc.6] ),
[2023-04-24T23:21:00.188074+02:00] INFO - [HOLOCHAIN 0.2.0-beta-rc.6] location: Location {
[2023-04-24T23:21:00.188141+02:00] INFO - [HOLOCHAIN 0.2.0-beta-rc.6] file: "/Users/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/kitsune_p2p-0.2.0-beta-rc.5/src/spawn/actor/meta_net.rs",
[2023-04-24T23:21:00.188185+02:00] INFO - [HOLOCHAIN 0.2.0-beta-rc.6] line: 688,
[2023-04-24T23:21:00.188266+02:00] INFO - [HOLOCHAIN 0.2.0-beta-rc.6] col: 33,
[2023-04-24T23:21:00.188319+02:00] INFO - [HOLOCHAIN 0.2.0-beta-rc.6] },
[2023-04-24T23:21:00.188356+02:00] INFO - [HOLOCHAIN 0.2.0-beta-rc.6] can_unwind: true,
[2023-04-24T23:21:00.188387+02:00] INFO - [HOLOCHAIN 0.2.0-beta-rc.6] }
```