### PR TITLE
Make holochain build without test utils and sweetest easier to consume

### DIFF
--- a/.config/test-args.nix
+++ b/.config/test-args.nix
@@ -1,1 +1,1 @@
-"--workspace --no-default-features --features slow_tests,glacial_tests,tx2,tx5,sweetest,build_wasms,sqlite-encrypted --lib --tests --bins"
+"--workspace --no-default-features --features slow_tests,glacial_tests,sweetest,build_wasms,sqlite-encrypted --lib --tests --bins"

--- a/.config/test-args.nix
+++ b/.config/test-args.nix
@@ -1,1 +1,1 @@
-"--workspace --features slow_tests,glacial_tests,test_utils,build_wasms,sqlite-encrypted --lib --tests --bins"
+"--workspace --no-default-features --features slow_tests,glacial_tests,tx2,tx5,sweetest,build_wasms,sqlite-encrypted --lib --tests --bins"

--- a/.config/test-args.nix
+++ b/.config/test-args.nix
@@ -1,1 +1,1 @@
-"--workspace --no-default-features --features slow_tests,glacial_tests,sweetest,build_wasms,sqlite-encrypted --lib --tests --bins"
+"--workspace --features slow_tests,glacial_tests,sweetest,build_wasms,sqlite-encrypted --lib --tests --bins"

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- The feature `test_utils` is no longer a default feature. To consume `sweetest` from this crate please now use `default-features = false` and the feature `sweetest`.
+
 ## 0.2.0
 
 ## 0.2.0-beta-rc.7

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -149,7 +149,7 @@ name = "holochain"
 path = "src/bin/holochain/main.rs"
 
 [features]
-default = ["slow_tests", "glacial_tests", "test_utils", "sqlite", "tx2", "tx5"]
+default = ["slow_tests", "glacial_tests", "sqlite", "tx2", "tx5"]
 
 tx2 = [ "kitsune_p2p/tx2" ]
 tx5 = [ "kitsune_p2p/tx5", "tx5-go-pion-turn", "tx5-signal-srv" ]
@@ -233,3 +233,8 @@ chc = [
 
 # Transitional feature flag for code that is only ready when DPKI integration lands.
 dpki = []
+
+sweetest = [
+  "test_utils",
+  "sqlite",
+]

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -451,7 +451,7 @@ mod interface_impls {
                 state.app_interfaces.insert(interface_id, config);
                 Ok(state)
             })
-                .await?;
+            .await?;
             tracing::debug!("App interface added at port: {}", port);
             Ok(port)
         }
@@ -558,8 +558,8 @@ mod dna_impls {
         pub(crate) async fn load_wasms_into_dna_files(
             &self,
         ) -> ConductorResult<(
-            impl IntoIterator<Item=(DnaHash, RealRibosome)>,
-            impl IntoIterator<Item=(EntryDefBufferKey, EntryDef)>,
+            impl IntoIterator<Item = (DnaHash, RealRibosome)>,
+            impl IntoIterator<Item = (EntryDefBufferKey, EntryDef)>,
         )> {
             let db = &self.spaces.wasm_db;
 
@@ -687,7 +687,7 @@ mod dna_impls {
         pub(crate) async fn put_wasm_code(
             &self,
             dna: DnaDefHashed,
-            code: impl Iterator<Item=wasm::DnaWasm>,
+            code: impl Iterator<Item = wasm::DnaWasm>,
             zome_defs: Vec<(EntryDefBufferKey, EntryDef)>,
         ) -> ConductorResult<Vec<(EntryDefBufferKey, EntryDef)>> {
             // TODO: PERF: This loop might be slow
@@ -796,7 +796,7 @@ mod network_impls {
                 Timestamp::now(),
                 expires,
             )
-                .await?)
+            .await?)
         }
 
         /// Block some target.
@@ -912,7 +912,8 @@ mod network_impls {
                     })
                     .await?;
 
-                let cache_db = self.get_or_create_cache_db(dna)
+                let cache_db = self
+                    .get_or_create_cache_db(dna)
                     .map_err(|err| ConductorError::Other(Box::new(err)))?;
                 let cache_bytes_received = cache_db
                     .async_reader(move |txn| {
@@ -950,9 +951,9 @@ mod network_impls {
                     completed_rounds_since_last_time_queried,
                 })
             }))
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>, _>>()
         }
 
         pub(crate) async fn storage_info(&self) -> ConductorResult<StorageInfo> {
@@ -977,9 +978,9 @@ mod network_impls {
                 futures::future::join_all(all_dna.iter().map(|(dna_hash, used_by)| async {
                     self.storage_info_for_dna(dna_hash, used_by).await
                 }))
-                    .await
-                    .into_iter()
-                    .collect::<Result<Vec<StorageBlob>, ConductorError>>()?;
+                .await
+                .into_iter()
+                .collect::<Result<Vec<StorageBlob>, ConductorError>>()?;
 
             Ok(StorageInfo {
                 blobs: app_data_blobs,
@@ -1083,7 +1084,7 @@ mod network_impls {
                         let mut conn = db.with_permit(permit)?;
                         conn.p2p_gossip_query_agents(since_ms, until_ms, (*arc_set).clone())
                     })
-                        .await;
+                    .await;
                     let res = res
                         .map_err(holochain_p2p::HolochainP2pError::other)
                         .and_then(|r| r.map_err(holochain_p2p::HolochainP2pError::other));
@@ -1103,8 +1104,8 @@ mod network_impls {
                         basis_loc,
                         limit,
                     )
-                        .await
-                        .map_err(holochain_p2p::HolochainP2pError::other);
+                    .await
+                    .map_err(holochain_p2p::HolochainP2pError::other);
                     respond.respond(Ok(async move { res }.boxed().into()));
                 }
                 QueryPeerDensity {
@@ -1173,8 +1174,8 @@ mod network_impls {
                             .map_err(holochain_p2p::HolochainP2pError::other);
                         respond.respond(Ok(async move { res }.boxed().into()));
                     }
-                        .instrument(debug_span!("handle_publish"))
-                        .await;
+                    .instrument(debug_span!("handle_publish"))
+                    .await;
                 }
                 FetchOpData {
                     respond,
@@ -1190,8 +1191,8 @@ mod network_impls {
                             .map_err(holochain_p2p::HolochainP2pError::other);
                         respond.respond(Ok(async move { res }.boxed().into()));
                     }
-                        .instrument(debug_span!("handle_fetch_op_data"))
-                        .await;
+                    .instrument(debug_span!("handle_fetch_op_data"))
+                    .await;
                 }
 
                 HolochainP2pEvent::QueryOpHashes {
@@ -1246,11 +1247,11 @@ mod network_impls {
             fn_name: F,
             payload: I,
         ) -> ConductorApiResult<O>
-            where
-                FunctionName: From<F>,
-                ZomeName: From<Z>,
-                I: Serialize + std::fmt::Debug,
-                O: serde::de::DeserializeOwned + std::fmt::Debug,
+        where
+            FunctionName: From<F>,
+            ZomeName: From<Z>,
+            I: Serialize + std::fmt::Debug,
+            O: serde::de::DeserializeOwned + std::fmt::Debug,
         {
             let payload = ExternIO::encode(payload).expect("Couldn't serialize payload");
             let now = Timestamp::now();
@@ -1295,7 +1296,7 @@ mod app_impls {
                     .map(|(c, p)| (c.as_id().clone(), p.clone()))
                     .collect(),
             )
-                .await?;
+            .await?;
 
             let cell_data = cell_data.into_iter().map(|(c, _)| c);
             let app = InstalledAppCommon::new_legacy(installed_app_id, cell_data)?;
@@ -1692,7 +1693,7 @@ mod clone_cell_impls {
                     Ok((state, ()))
                 }
             })
-                .await?;
+            .await?;
             self.remove_dangling_cells().await?;
             Ok(())
         }
@@ -1935,7 +1936,7 @@ mod app_status_impls {
             let (_, delta) = self
                 .update_state_prime(move |mut state| {
                     #[allow(deprecated)]
-                        let apps = state.installed_apps_mut().iter_mut().filter(|(id, _)| {
+                    let apps = state.installed_apps_mut().iter_mut().filter(|(id, _)| {
                         app_ids
                             .as_ref()
                             .map(|ids| ids.contains(&**id))
@@ -2007,8 +2008,8 @@ mod state_impls {
 
         /// Update the internal state with a pure function mapping old state to new
         pub(crate) async fn update_state<F: Send>(&self, f: F) -> ConductorResult<ConductorState>
-            where
-                F: FnOnce(ConductorState) -> ConductorResult<ConductorState> + 'static,
+        where
+            F: FnOnce(ConductorState) -> ConductorResult<ConductorState> + 'static,
         {
             self.spaces.update_state(f).await
         }
@@ -2020,9 +2021,9 @@ mod state_impls {
             &self,
             f: F,
         ) -> ConductorResult<(ConductorState, O)>
-            where
-                F: FnOnce(ConductorState) -> ConductorResult<(ConductorState, O)> + Send + 'static,
-                O: Send + 'static,
+        where
+            F: FnOnce(ConductorState) -> ConductorResult<(ConductorState, O)> + Send + 'static,
+            O: Send + 'static,
         {
             self.check_running()?;
             self.spaces.update_state_prime(f).await
@@ -2107,11 +2108,12 @@ mod misc_impls {
             let source_chain = SourceChain::new(
                 self.get_or_create_authored_db(cell_id.dna_hash())?,
                 self.get_or_create_dht_db(cell_id.dna_hash())?,
-                self.get_or_create_space(cell_id.dna_hash())?.dht_query_cache,
+                self.get_or_create_space(cell_id.dna_hash())?
+                    .dht_query_cache,
                 self.keystore.clone(),
                 cell_id.agent_pubkey().clone(),
             )
-                .await?;
+            .await?;
 
             let cap_grant_entry = Entry::CapGrant(cap_grant);
             let entry_hash = EntryHash::with_data_sync(&cap_grant_entry);
@@ -2148,7 +2150,7 @@ mod misc_impls {
                 authored_db.clone().into(),
                 cell_id.agent_pubkey().clone(),
             )
-                .await?;
+            .await?;
 
             let out = JsonDump {
                 peer_dump,
@@ -2239,7 +2241,7 @@ mod misc_impls {
             graft_records_onto_source_chain::graft_records_onto_source_chain(
                 self, cell_id, validate, records,
             )
-                .await
+            .await
         }
 
         /// Update coordinator zomes on an existing dna.
@@ -2268,7 +2270,7 @@ mod misc_impls {
                 wasms.into_iter(),
                 Vec::with_capacity(0),
             )
-                .await?;
+            .await?;
 
             // Update RibosomeStore.
             self.ribosome_store()
@@ -2502,11 +2504,11 @@ impl Conductor {
                         .boxed(),
                     // TODO: also delete stale Wasms
                 ]
-                    .into_iter(),
+                .into_iter(),
             )
-                .await
-                .into_iter()
-                .collect::<Result<Vec<usize>, _>>()?;
+            .await
+            .into_iter()
+            .collect::<Result<Vec<usize>, _>>()?;
         }
 
         Ok(())
@@ -2538,15 +2540,15 @@ impl Conductor {
             }
             None =>
             // Collect all CellIds across all apps, deduped
-                {
-                    state
-                        .installed_apps()
-                        .iter()
-                        .filter(|(_, app)| app.status().is_running())
-                        .flat_map(|(_id, app)| app.all_enabled_cells().collect::<Vec<&CellId>>())
-                        .cloned()
-                        .collect()
-                }
+            {
+                state
+                    .installed_apps()
+                    .iter()
+                    .filter(|(_, app)| app.status().is_running())
+                    .flat_map(|(_id, app)| app.all_enabled_cells().collect::<Vec<&CellId>>())
+                    .cloned()
+                    .collect()
+            }
         };
 
         // calculate the existing cells so we can filter those out, only creating
@@ -2845,11 +2847,11 @@ pub(crate) async fn genesis_cells(
                     proof,
                     chc,
                 )
-                    .await
-            })
-                .map_err(CellError::from)
-                .and_then(|result| async move { result.map(|_| cell_id) })
                 .await
+            })
+            .map_err(CellError::from)
+            .and_then(|result| async move { result.map(|_| cell_id) })
+            .await
         }
     });
     let (success, errors): (Vec<_>, Vec<_>) = futures::future::join_all(cells_tasks)

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -5,6 +5,7 @@ use crate::conductor::kitsune_host_impl::KitsuneHostImpl;
 use crate::conductor::manager::OutcomeReceiver;
 use crate::conductor::ribosome_store::RibosomeStore;
 use crate::conductor::ConductorHandle;
+use holochain_types::prelude::test_keystore;
 
 /// A configurable Builder for Conductor and sometimes ConductorHandle
 #[derive(Default)]

--- a/crates/holochain/src/conductor/p2p_agent_store.rs
+++ b/crates/holochain/src/conductor/p2p_agent_store.rs
@@ -14,7 +14,6 @@ use holochain_sqlite::prelude::*;
 use holochain_state::prelude::StateMutationResult;
 use holochain_state::prelude::StateQueryResult;
 use holochain_zome_types::CellId;
-use std::collections::HashSet;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -142,7 +141,7 @@ pub async fn exchange_peer_info(envs: Vec<DbWrite<DbKindP2pAgents>>) {
 #[cfg(any(test, feature = "test_utils"))]
 pub async fn exchange_peer_info_sparse(
     envs: Vec<DbWrite<DbKindP2pAgents>>,
-    connectivity: Vec<HashSet<usize>>,
+    connectivity: Vec<std::collections::HashSet<usize>>,
 ) {
     assert_eq!(envs.len(), connectivity.len());
     for (i, a) in envs.iter().enumerate() {

--- a/crates/holochain_diagnostics/Cargo.toml
+++ b/crates/holochain_diagnostics/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 anyhow = "*"
 arbitrary = { version = "1.0" }
-holochain = { path = "../holochain", features = ["sqlite"] }
+holochain = { path = "../holochain", features = ["sweetest"] }
 human-repr = "1"
 rand = "0.8"
 tracing = "0.1"


### PR DESCRIPTION
### Summary

See #2229, #2222 and #588 which are all related in a way to consuming the `holochain` crate to get sweetest. The intention is to make this easier.

- In CI we will run with the `sweetest` feature which we then know works for running sweetest tests (at least in one environment)
- Everywhere else we should not depend on `test_utils` to build holochain. The feature is documented like that but I see anywhere that `no-default-features` is being used when building production holochain. I expect the code we don't want is gone anyway for the most part but without these changes `holochain` didn't actually build without the feature so we must have been shipping at least some test code.

This does mean that you now have to specify a feature to run the tests on the `holochain` crate. This isn't a problem if you're using a Nix command to run all the tests but it is for individual tests. Not sure what to do for the best here but somewhere we need to build without `test_utils` to make sure that always compiles.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
