### PR TITLE
chore(workflows/release-prepare): allow 0.3.0-beta-dev.N version bumps

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -214,7 +214,7 @@ jobs:
                 --force-tag-creation \
                 --force-branch-creation \
                 --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
-                --allowed-semver-increment-modes="minor" \
+                --allowed-semver-increment-modes="!pre_minor beta-dev" \
                 --steps=CreateReleaseBranch,BumpReleaseVersions
 
             release-automation \

--- a/nix/modules/release-automation.nix
+++ b/nix/modules/release-automation.nix
@@ -160,7 +160,7 @@
               --force-tag-creation \
               --force-branch-creation \
               --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
-              --disallowed-version-reqs=">=0.3" \
+              --disallowed-version-reqs=">=0.4" \
               --steps=CreateReleaseBranch,BumpReleaseVersions
 
           release-automation \


### PR DESCRIPTION
### Summary



### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
