### PR TITLE
Add a developer setup guide to the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,10 @@ We are committed to foster a vibrant thriving community, including growing a cul
 
 Please make use of these resources to support your contributions, or simply to contribute your voice.
 
+## Getting started with developing Holochain
+
+To get a development environment and tools set up for developing holochain, you can work through [this guide](https://github.com/holochain/holochain/blob/develop/docs/developer-setup.md).
+
 ## Git Hygiene
 This section describes our practices and guidelines for using git and making changes to the repo.
 

--- a/docs/core_testing.md
+++ b/docs/core_testing.md
@@ -58,6 +58,20 @@ script-holochain-tests-all
 
 Or use `script-holochain-tests-unit-all` if you don't want to run the static checks (cargo doc, cargo fmt and cargo clippy, but all of these this will be RUN on CI.
 
+### Filtering tests
+
+To run the tests for a specific package you can pass a filter to `nextest`
+
+```shell
+env NEXTEST_EXTRA_ARGS="-E 'package(hdk)'" nix build --impure --override-input holochain . .#build-holochain-tests-unit
+```
+
+Or you can select a test by name
+
+```shell
+env NEXTEST_EXTRA_ARGS="-E 'test(paths_exists)'" nix build --impure --override-input holochain . .#build-holochain-tests-unit
+```
+
 ### Using `cargo test` manually
 
 - To run only one test from your crate, run this command:
@@ -70,6 +84,8 @@ cargo test [NAME_OF_THE_TEST_FUNCTION] --lib  --features 'slow_tests build_wasms
 If the test is located in a crate other than `holochain`, `cd` into its folder instead.
 
 ## Adding a test
+
+The documentation for the Holochain test harness is [here](https://docs.rs/holochain/latest/holochain/sweettest/index.html). Or you can run `cargo doc -p holochain --open` to view the documentation from your current branch. 
 
 The simplest way to add a new test is to locate a similar test, copy and paste it, and modify the necessary instructions to test what you want. Don't forget to change its name. Note that these tests are for testing holochain core, and not the wasms themselves. To unit test a wasm, the test should be added to the wasm.
 

--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -1,0 +1,41 @@
+## Setting up a Holochain development environment
+
+### Pre-requisites
+
+You will need one of the following
+
+- *recommended* - Having `nix` installed following these [instructions](https://nixos.org/download.html).
+- *alternative* - Having Rust installed via [rustup](https://www.rust-lang.org/tools/install) and configured to use the stable toolchain.
+
+### Build holochain
+
+If using Nix, start by opening a developer shell using `nix develop .#coreDev` at the root of the repository. This will take
+some time you run it.
+
+Now you can build the project with `cargo build`.
+
+This is a good check that your environment is ready to use. If you have problems here you can [get in touch](https://github.com/holochain/holochain/blob/develop/CONTRIBUTING.md#coordination) or open an issue.
+
+### Run the tests
+
+There is a [testing guide](https://github.com/holochain/holochain/blob/develop/docs/core_testing.md) which will get you started running
+the tests the same way the CI does.
+
+### Build CLI tools
+
+Other documentation will assume you have access to CLI tools provided by this repository, so it's a good idea to build these now.
+You should rebuild these as needed when making changes or pulling changed code from your upstream branch, e.g. `develop`.
+
+```shell
+cargo install --path crates/holochain --locked
+cargo install --path crates/hc --locked
+cargo install --path crates/hc_sandbox --locked
+cargo install --path crates/hc_signal_srv --locked
+```
+
+### Verifying changes and reproducing issues
+
+If you are able to create a sweettest test case that reproduces an issue then that is a great way to make sure the issue stays fixed.
+
+Otherwise, you can test your changes or try to reproduce an issue manually using the `hc sandbox`. This tool is used to launch a `holochain` instance (conductor) that
+has been built locally. You can find the documentation for this tool [here](https://github.com/holochain/holochain/blob/develop/crates/hc_sandbox/README.md).

--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -23,7 +23,7 @@ the tests the same way the CI does.
 
 ### Verifying changes and reproducing issues
 
-If you are able to create a [sweettest](https://github.com/holochain/holochain/tree/develop/crates/holochain/src/sweettest) test case that reproduces an issue then that is a great way to make sure the issue stays fixed.
+If you are able to create a [sweettest](https://github.com/holochain/holochain/tree/develop/crates/holochain/src/sweettest) test case that reproduces an issue, then that is a great way to make sure the issue stays fixed.
 There are many tests written with this harness, so take a look at what's already there as a guide for writing new tests.
 
 Otherwise, you can test your changes or try to reproduce an issue manually using the `hc sandbox`. This tool is used to launch a `holochain` instance (conductor) that

--- a/docs/developer_setup.md
+++ b/docs/developer_setup.md
@@ -21,9 +21,18 @@ This is a good check that your environment is ready to use. If you have problems
 There is a [testing guide](https://github.com/holochain/holochain/blob/develop/docs/core_testing.md) which will get you started running
 the tests the same way the CI does.
 
-### Build CLI tools
+### Verifying changes and reproducing issues
 
-Other documentation will assume you have access to CLI tools provided by this repository, so it's a good idea to build these now.
+If you are able to create a [sweettest](https://github.com/holochain/holochain/tree/develop/crates/holochain/src/sweettest) test case that reproduces an issue then that is a great way to make sure the issue stays fixed.
+There are many tests written with this harness, so take a look at what's already there as a guide for writing new tests.
+
+Otherwise, you can test your changes or try to reproduce an issue manually using the `hc sandbox`. This tool is used to launch a `holochain` instance (conductor) that
+has been built locally. You can find the documentation for this tool [here](https://github.com/holochain/holochain/blob/develop/crates/hc_sandbox/README.md).
+You'll want to read the next section for instructions to build all the tools you might want to use with the sandbox.
+
+### Build CLI tools for manual testing
+
+If you need to interact with a running conductor or start one for testing then there are CLI tools provided for that.
 You should rebuild these as needed when making changes or pulling changed code from your upstream branch, e.g. `develop`.
 
 ```shell
@@ -32,10 +41,3 @@ cargo install --path crates/hc --locked
 cargo install --path crates/hc_sandbox --locked
 cargo install --path crates/hc_signal_srv --locked
 ```
-
-### Verifying changes and reproducing issues
-
-If you are able to create a sweettest test case that reproduces an issue then that is a great way to make sure the issue stays fixed.
-
-Otherwise, you can test your changes or try to reproduce an issue manually using the `hc sandbox`. This tool is used to launch a `holochain` instance (conductor) that
-has been built locally. You can find the documentation for this tool [here](https://github.com/holochain/holochain/blob/develop/crates/hc_sandbox/README.md).


### PR DESCRIPTION
### Summary

This attempts to close #9 and while also adding information I would have found useful on day 1 working on holochain. There are tools and documentation but it takes a bit of time to find what's important for getting started. The idea of this change is really just to make documentation that already exists more discoverable for new developers.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
