### PR TITLE
Support multiple action or entry types in query filters

### DIFF
--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -799,7 +799,7 @@ where
                         ORDER BY Action.seq
                         ", named_param_seq("entry_type", query.entry_type.as_ref().map_or(0, |t| t.len())), named_param_seq("action_type", query.action_type.as_ref().map_or(0, |t| t.len()))).as_str(),
                     );
-                    sql.push_str(if query.order_descending { " DESC" } else { " ASC" });
+                    sql.push_str(if query.order_descending {" DESC"} else {" ASC"});
                     let mut stmt = txn.prepare(&sql)?;
 
                     let mut args: Vec<(String, Box<dyn rusqlite::ToSql>)> = Vec::with_capacity(6 + query.entry_type.as_ref().map_or(0, |t| t.len()) + query.action_type.as_ref().map_or(0, |t| t.len()));

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -73,8 +73,8 @@ use holo_hash::EntryHash;
 use holochain_serialized_bytes::prelude::*;
 
 pub use error::*;
-use holochain_zome_types::EntryType;
 use holochain_sqlite::rusqlite;
+use holochain_zome_types::EntryType;
 
 mod error;
 
@@ -209,7 +209,7 @@ impl SourceChain {
                 Some(entry),
                 chain_top_ordering,
             )
-                .await
+            .await
         } else {
             // The caller MUST guard against this case.
             unreachable!("Put countersigned called with the wrong entry type");
@@ -220,7 +220,7 @@ impl SourceChain {
     /// for an action type which has no weight data.
     /// If needing to `put` an action with weight data, use
     /// [`SourceChain::put_weighed`] instead.
-    pub async fn put<U: ActionUnweighed<Weight=()>, B: ActionBuilder<U>>(
+    pub async fn put<U: ActionUnweighed<Weight = ()>, B: ActionBuilder<U>>(
         &self,
         action_builder: B,
         maybe_entry: Option<Entry>,
@@ -232,7 +232,7 @@ impl SourceChain {
 
     /// Put a new record at the end of the source chain, using a ActionBuilder
     /// and the specified weight for rate limiting.
-    pub async fn put_weighed<W, U: ActionUnweighed<Weight=W>, B: ActionBuilder<U>>(
+    pub async fn put_weighed<W, U: ActionUnweighed<Weight = W>, B: ActionBuilder<U>>(
         &self,
         action_builder: B,
         maybe_entry: Option<Entry>,
@@ -268,11 +268,11 @@ impl SourceChain {
             maybe_entry,
             chain_top_ordering,
         )
-            .await
+        .await
     }
 
     #[cfg(feature = "test_utils")]
-    pub async fn put_weightless<W: Default, U: ActionUnweighed<Weight=W>, B: ActionBuilder<U>>(
+    pub async fn put_weightless<W: Default, U: ActionUnweighed<Weight = W>, B: ActionBuilder<U>>(
         &self,
         action_builder: B,
         maybe_entry: Option<Entry>,
@@ -284,7 +284,7 @@ impl SourceChain {
             chain_top_ordering,
             Default::default(),
         )
-            .await
+        .await
     }
 
     #[async_recursion]
@@ -418,7 +418,7 @@ impl SourceChain {
                         keystore.clone(),
                         (*self.author).clone(),
                     )
-                        .await?;
+                    .await?;
                     let rebased_actions =
                         rebase_actions_on(&keystore, actions, new_head_info).await?;
                     child_chain.scratch.apply(move |scratch| {
@@ -447,7 +447,7 @@ impl SourceChain {
                     &self.dht_db,
                     &self.dht_db_cache,
                 )
-                    .await?;
+                .await?;
                 SourceChainResult::Ok(actions)
             }
             result => result,
@@ -456,9 +456,9 @@ impl SourceChain {
 }
 
 impl<AuthorDb, DhtDb> SourceChain<AuthorDb, DhtDb>
-    where
-        AuthorDb: ReadAccess<DbKindAuthored>,
-        DhtDb: ReadAccess<DbKindDht>,
+where
+    AuthorDb: ReadAccess<DbKindAuthored>,
+    DhtDb: ReadAccess<DbKindDht>,
 {
     pub async fn new(
         vault: AuthorDb,
@@ -671,7 +671,7 @@ impl<AuthorDb, DhtDb> SourceChain<AuthorDb, DhtDb>
                             params![cap_secret_blob, agent_pubkey],
                             query_row_fn,
                         )
-                            .optional()?
+                        .optional()?
                     } else {
                         // unrestricted cap grant must exist
                         // that has not been updated or deleted
@@ -680,7 +680,7 @@ impl<AuthorDb, DhtDb> SourceChain<AuthorDb, DhtDb>
                             params![CapAccess::Unrestricted.as_sql(), agent_pubkey],
                             query_row_fn,
                         )
-                            .optional()?
+                        .optional()?
                     };
 
                     Ok(maybe_entry)
@@ -723,9 +723,9 @@ impl<AuthorDb, DhtDb> SourceChain<AuthorDb, DhtDb>
     pub async fn query(&self, query: QueryFilter) -> SourceChainResult<Vec<Record>> {
         if query.sequence_range != ChainQueryFilterRange::Unbounded
             && (query.action_type.is_some()
-            || query.entry_type.is_some()
-            || query.entry_hashes.is_some()
-            || query.include_entries)
+                || query.entry_type.is_some()
+                || query.entry_hashes.is_some()
+                || query.include_entries)
         {
             return Err(SourceChainError::UnsupportedQuery(query));
         }
@@ -1093,8 +1093,8 @@ pub async fn genesis(
         chc.add_entries(vec![EntryHashed::from_content_sync(Entry::Agent(
             agent_pubkey,
         ))])
-            .await
-            .map_err(SourceChainError::other)?;
+        .await
+        .map_err(SourceChainError::other)?;
         match chc
             .add_actions(vec![
                 dna_action.clone(),
@@ -1389,8 +1389,8 @@ pub mod tests {
             None,
             None,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
         let chain_1 = SourceChain::new(
             db.clone().into(),
             dht_db.to_db(),
@@ -1398,7 +1398,7 @@ pub mod tests {
             keystore.clone(),
             alice.clone(),
         )
-            .await?;
+        .await?;
         let chain_2 = SourceChain::new(
             db.clone().into(),
             dht_db.to_db(),
@@ -1406,7 +1406,7 @@ pub mod tests {
             keystore.clone(),
             alice.clone(),
         )
-            .await?;
+        .await?;
         let chain_3 = SourceChain::new(
             db.clone().into(),
             dht_db.to_db(),
@@ -1414,7 +1414,7 @@ pub mod tests {
             keystore.clone(),
             alice.clone(),
         )
-            .await?;
+        .await?;
 
         let action_builder = builder::CloseChain {
             new_dna_hash: fixt!(DnaHash),
@@ -1483,8 +1483,8 @@ pub mod tests {
             None,
             None,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         let chain_1 = SourceChain::new(
             db.clone().into(),
@@ -1493,7 +1493,7 @@ pub mod tests {
             keystore.clone(),
             alice.clone(),
         )
-            .await?;
+        .await?;
         let chain_2 = SourceChain::new(
             db.clone().into(),
             dht_db.to_db(),
@@ -1501,7 +1501,7 @@ pub mod tests {
             keystore.clone(),
             alice.clone(),
         )
-            .await?;
+        .await?;
         let chain_3 = SourceChain::new(
             db.clone().into(),
             dht_db.to_db(),
@@ -1509,7 +1509,7 @@ pub mod tests {
             keystore.clone(),
             alice.clone(),
         )
-            .await?;
+        .await?;
 
         let entry_1 = Entry::App(fixt!(AppEntryBytes));
         let eh1 = EntryHash::with_data_sync(&entry_1);
@@ -1632,8 +1632,8 @@ pub mod tests {
             None,
             None,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         let chain = SourceChain::new(
             db.clone(),
@@ -1642,7 +1642,7 @@ pub mod tests {
             keystore.clone(),
             alice.clone(),
         )
-            .await?;
+        .await?;
         // alice as chain author always has a valid cap grant; provided secrets
         // are ignored
         assert_eq!(
@@ -1722,7 +1722,7 @@ pub mod tests {
                 keystore.clone(),
                 alice.clone(),
             )
-                .await?;
+            .await?;
             let (entry, entry_hash) =
                 EntryHashed::from_content_sync(Entry::CapGrant(updated_grant.clone())).into_inner();
             let action_builder = builder::Update {
@@ -1795,7 +1795,7 @@ pub mod tests {
                 keystore.clone(),
                 alice.clone(),
             )
-                .await?;
+            .await?;
             let action_builder = builder::Delete {
                 deletes_address: updated_action_hash,
                 deletes_entry_address: updated_entry_hash,
@@ -1849,7 +1849,7 @@ pub mod tests {
                 keystore.clone(),
                 alice.clone(),
             )
-                .await?;
+            .await?;
             let (entry, entry_hash) =
                 EntryHashed::from_content_sync(Entry::CapGrant(unrestricted_grant.clone()))
                     .into_inner();
@@ -1889,7 +1889,7 @@ pub mod tests {
                 keystore.clone(),
                 alice.clone(),
             )
-                .await?;
+            .await?;
             let action_builder = builder::Delete {
                 deletes_address: original_action_address,
                 deletes_entry_address: original_entry_address,
@@ -1981,8 +1981,8 @@ pub mod tests {
             None,
             None,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         let source_chain = SourceChain::new(
             vault.clone().into(),
@@ -1991,8 +1991,8 @@ pub mod tests {
             keystore.clone(),
             (*author).clone(),
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
         let entry = Entry::App(fixt!(AppEntryBytes));
         let create = builder::Create {
             entry_type: EntryType::App(fixt!(AppEntryDef)),
@@ -2040,8 +2040,8 @@ pub mod tests {
             keystore.clone(),
             (*author).clone(),
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
         let res = source_chain.query(QueryFilter::new()).await.unwrap();
         assert_eq!(res.len(), 5);
         assert_eq!(*res[3].action_address(), h1);
@@ -2068,8 +2068,8 @@ pub mod tests {
             None,
             None,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         let json = dump_state(vault.clone().into(), author.clone()).await?;
         let json = serde_json::to_string_pretty(&json)?;
@@ -2110,8 +2110,8 @@ pub mod tests {
             None,
             None,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         genesis(
             vault.clone().into(),
@@ -2123,8 +2123,8 @@ pub mod tests {
             None,
             None,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         // test_db.dump_tmp();
 
@@ -2212,9 +2212,9 @@ pub mod tests {
                 };
                 if sequence_range != ChainQueryFilterRange::Unbounded
                     && (action_type.is_some()
-                    || entry_type.is_some()
-                    || entry_hashes.is_some()
-                    || include_entries)
+                        || entry_type.is_some()
+                        || entry_hashes.is_some()
+                        || include_entries)
                 {
                     assert!(matches!(
                         chain.query(query.clone()).await,
@@ -2254,8 +2254,8 @@ pub mod tests {
             None,
             None,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         let chain = SourceChain::new(vault, dht_db.to_db(), dht_db_cache, keystore, alice.clone())
             .await
@@ -2295,8 +2295,8 @@ pub mod tests {
             None,
             None,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         let chain = SourceChain::new(vault, dht_db.to_db(), dht_db_cache, keystore, alice.clone())
             .await

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -740,7 +740,7 @@ where
                 SELECT DISTINCT
                 Action.hash AS action_hash, Action.blob AS action_blob
             "
-                        .to_string();
+                    .to_string();
                     if query.include_entries {
                         sql.push_str(
                             "

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -802,6 +802,8 @@ where
                     sql.push_str(if query.order_descending {" DESC"} else {" ASC"});
                     let mut stmt = txn.prepare(&sql)?;
 
+                    // This type is similar to what `named_params!` from rusqlite creates, escept for the use of boxing to allow references to be passed to the query.
+                    // The reserved capacity here should account for the number of parameters inserted below, including the variable inputs like entry_types and actions_types.
                     let mut args: Vec<(String, Box<dyn rusqlite::ToSql>)> = Vec::with_capacity(6 + query.entry_type.as_ref().map_or(0, |t| t.len()) + query.action_type.as_ref().map_or(0, |t| t.len()));
                     args.push((":author".to_string(), Box::new(author)));
 

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Changes the `ChainQueryFilter` to support filtering on multiple entry types and actions types in the same query. The query builder interface 
+  hasn't changed but if your code was calling `entry_type` or `action_type` more than once it will now create a logical OR rather than replacing the
+  action or entry type to filter on.
+
 ## 0.2.0
 
 ## 0.2.0-beta-rc.6

--- a/crates/holochain_zome_types/src/query.rs
+++ b/crates/holochain_zome_types/src/query.rs
@@ -312,7 +312,12 @@ impl ChainQueryFilter {
                     && self
                         .entry_type
                         .as_ref()
-                        .map(|entry_types| action.entry_type().map(|entry_type| entry_types.contains(entry_type)).unwrap_or(false))
+                        .map(|entry_types| {
+                            action
+                                .entry_type()
+                                .map(|entry_type| entry_types.contains(entry_type))
+                                .unwrap_or(false)
+                        })
                         .unwrap_or(true)
                     && self
                         .entry_hashes

--- a/crates/holochain_zome_types/src/query.rs
+++ b/crates/holochain_zome_types/src/query.rs
@@ -607,6 +607,7 @@ mod tests {
     fn filter_by_multiple_action_types() {
         let actions = fixtures();
 
+        // Filter for create and update actions
         assert_eq!(
             map_query(
                 &ChainQueryFilter::new()
@@ -616,12 +617,22 @@ mod tests {
             ),
             [true, true, false, true, true, true, false].to_vec()
         );
+
+        // Filter for create actions only
+        assert_eq!(
+            map_query(
+                &ChainQueryFilter::new().action_type(actions[0].action_type()),
+                &actions
+            ),
+            [true, false, false, true, true, false, false].to_vec()
+        );
     }
 
     #[test]
     fn filter_by_multiple_entry_types() {
         let actions = fixtures();
 
+        // Filter for app entries and agent public keys
         assert_eq!(
             map_query(
                 &ChainQueryFilter::new()
@@ -630,6 +641,15 @@ mod tests {
                 &actions
             ),
             [true, true, false, true, true, true, false].to_vec()
+        );
+
+        // Filter for app entries only
+        assert_eq!(
+            map_query(
+                &ChainQueryFilter::new().entry_type(actions[0].entry_type().unwrap().clone()),
+                &actions
+            ),
+            [true, false, false, false, true, true, false].to_vec()
         );
     }
 }


### PR DESCRIPTION
### Summary

Adressing #387 by allowing multiple action types or entry types to be queried for

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
