### PR TITLE
[DOCS][TINY]  update comment for hc_sandbox cli opts

### DIFF
--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -6,6 +6,7 @@ default_semver_increment_mode: !pre_minor beta-dev
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## \[Unreleased\]
+- updated comment in src/cli.rs to clarify use of --force-admin-ports
 
 ## 0.2.0
 

--- a/crates/hc_sandbox/src/cli.rs
+++ b/crates/hc_sandbox/src/cli.rs
@@ -23,7 +23,7 @@ pub struct HcSandbox {
     #[structopt(long)]
     piped: bool,
     /// Force the admin port that hc uses to talk to holochain to a specific value.
-    /// For example `hc -f=9000,9001 run`
+    /// For example `hc sandbox -f=9000,9001 run`
     /// This must be set on each run or the port will change if it's in use.
     #[structopt(short, long, value_delimiter = ",")]
     force_admin_ports: Vec<u16>,


### PR DESCRIPTION
### Summary

following documentation in a comment gave me an error, fixing for clarification.

this comes from a broader goal of wanting to be able to cleanly and separately run pieces of the holochain experience, which i find to be not very well documented.  i've figured out now i can specify the admin port with `hc sandbox -f=9001 run 0`, but that requires having already generated the sandbox.  i'd love a method to do this, but with the `hc launch` command directly from a `.happ` file, like how the generated `npm start` command works.  I'd try and make this change myself, but can't figure out where the source code for  `hc-launch` is.  if anyone could point me in the right direction, i'd be grateful :) 

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
