### PR TITLE
Path TryInto String

### DIFF
--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -6,6 +6,7 @@ default_semver_increment_mode: !pre_minor beta-dev
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Add String<TryInto> for Path for easy conversion of Path to string representation
 
 ## 0.3.0-beta-dev.5
 

--- a/crates/hdk/src/hash_path/path.rs
+++ b/crates/hdk/src/hash_path/path.rs
@@ -261,11 +261,12 @@ impl From<String> for Path {
 impl TryInto<String> for Path {
     type Error = SerializedBytesError;
     fn try_into(self) -> Result<String, Self::Error> {
-        let s = self.as_ref()
-            .into_iter()
-            .map(|c| String::try_from(c))
+        let s = self
+            .as_ref()
+            .iter()
+            .map(String::try_from)
             .collect::<Result<Vec<String>, Self::Error>>()?;
-        
+
         Ok(s.join(DELIMITER))
     }
 }
@@ -599,8 +600,5 @@ fn hash_path_path() {
     }
 
     let path_to_string: String = Path::from("foo.a.b.c.abcdef.bar").try_into().unwrap();
-    assert_eq!(
-        String::from("foo.a.b.c.abcdef.bar"),
-        path_to_string,
-    );
+    assert_eq!(String::from("foo.a.b.c.abcdef.bar"), path_to_string,);
 }

--- a/crates/hdk/src/hash_path/path.rs
+++ b/crates/hdk/src/hash_path/path.rs
@@ -599,6 +599,7 @@ fn hash_path_path() {
         assert_eq!(Path::from(input), Path::from(output),);
     }
 
-    let path_to_string: String = Path::from("foo.a.b.c.abcdef.bar").try_into().unwrap();
-    assert_eq!(String::from("foo.a.b.c.abcdef.bar"), path_to_string,);
+    let path = "foo.a.b.c.abcdef.bar";
+    let path_to_string: String = Path::from(path).try_into().unwrap();
+    assert_eq!(path.to_string(), path_to_string,);
 }

--- a/crates/hdk/src/hash_path/path.rs
+++ b/crates/hdk/src/hash_path/path.rs
@@ -258,6 +258,18 @@ impl From<String> for Path {
     }
 }
 
+impl TryInto<String> for Path {
+    type Error = SerializedBytesError;
+    fn try_into(self) -> Result<String, Self::Error> {
+        let s = self.as_ref()
+            .into_iter()
+            .map(|c| String::try_from(c))
+            .collect::<Result<Vec<String>, Self::Error>>()?;
+        
+        Ok(s.join(DELIMITER))
+    }
+}
+
 impl Path {
     /// Attach a [`LinkType`] to this path
     /// so its type is known for [`create_link`] and [`get_links`].
@@ -457,6 +469,13 @@ impl From<TypedPath> for Path {
     }
 }
 
+impl TryInto<String> for TypedPath {
+    type Error = SerializedBytesError;
+    fn try_into(self) -> Result<String, Self::Error> {
+        self.path.try_into()
+    }
+}
+
 #[test]
 #[cfg(test)]
 fn hash_path_delimiter() {
@@ -578,4 +597,10 @@ fn hash_path_path() {
     ] {
         assert_eq!(Path::from(input), Path::from(output),);
     }
+
+    let path_to_string: String = Path::from("foo.a.b.c.abcdef.bar").try_into().unwrap();
+    assert_eq!(
+        String::from("foo.a.b.c.abcdef.bar"),
+        path_to_string,
+    );
 }


### PR DESCRIPTION
### Summary
Adds TryInto<String> for path for easy conversion of paths to a string representation


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
