### PR TITLE
Fix flaky test `remote_signals`

### DIFF
--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -303,7 +303,9 @@ async fn remote_signals() -> anyhow::Result<()> {
             // Each handle should recv a signal
             assert_matches!(r, Ok(Signal::App{signal: a,..}) if a == signal);
         }
-    }).await.unwrap();
+    })
+    .await
+    .unwrap();
 
     Ok(())
 }

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -280,9 +280,8 @@ async fn remote_signals() -> anyhow::Result<()> {
 
     let mut rxs = Vec::new();
     for h in conductors.iter().map(|c| c) {
-        rxs.push(h.signal_broadcaster().subscribe_separately())
+        rxs.extend(h.signal_broadcaster().subscribe_separately())
     }
-    let rxs = rxs.into_iter().flatten().collect::<Vec<_>>();
 
     let signal = fixt!(ExternIo);
 
@@ -297,14 +296,14 @@ async fn remote_signals() -> anyhow::Result<()> {
         )
         .await;
 
-    tokio::time::sleep(std::time::Duration::from_millis(2000)).await;
-
-    let signal = AppSignal::new(signal);
-    for mut rx in rxs {
-        let r = rx.try_recv();
-        // Each handle should recv a signal
-        assert_matches!(r, Ok(Signal::App{signal: a,..}) if a == signal);
-    }
+    tokio::time::timeout(Duration::from_secs(60), async move {
+        let signal = AppSignal::new(signal);
+        for mut rx in rxs {
+            let r = rx.recv().await;
+            // Each handle should recv a signal
+            assert_matches!(r, Ok(Signal::App{signal: a,..}) if a == signal);
+        }
+    }).await.unwrap();
 
     Ok(())
 }


### PR DESCRIPTION
### Summary

This test was waiting 2 seconds then trying once to receive on each channel. Changed to an await with a timeout which should be more robust when the test runs slowly on a busy runner. Elapsed time for the test is slightly lower without the sleep locally.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
