### PR TITLE
Disable flaky tests on macos test runners

### DIFF
--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -29,7 +29,7 @@ use std::convert::TryInto;
 use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(darwin, ignore = "flaky on darwin test runners")]
+#[cfg_attr(target_os = "macos", ignore = "flaky on darwin test runners")]
 async fn app_validation_workflow_test() {
     observability::test_run().ok();
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -29,6 +29,7 @@ use std::convert::TryInto;
 use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(darwin, ignore = "flaky on darwin test runners")]
 async fn app_validation_workflow_test() {
     observability::test_run().ok();
 

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -32,6 +32,7 @@ use tracing::debug_span;
 #[test_case(2)]
 #[test_case(4)]
 #[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(darwin, ignore = "flaky on darwin test runners")]
 async fn conductors_call_remote(num_conductors: usize) {
     observability::test_run().ok();
     let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -32,7 +32,7 @@ use tracing::debug_span;
 #[test_case(2)]
 #[test_case(4)]
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(darwin, ignore = "flaky on darwin test runners")]
+#[cfg_attr(target_os = "macos", ignore = "flaky on darwin test runners")]
 async fn conductors_call_remote(num_conductors: usize) {
     observability::test_run().ok();
     let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;

--- a/crates/holochain/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/multi_conductor/mod.rs
@@ -70,7 +70,7 @@ async fn test_publish() -> anyhow::Result<()> {
 
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(darwin, ignore = "flaky on darwin test runners")]
+#[cfg_attr(target_os = "macos", ignore = "flaky on darwin test runners")]
 async fn multi_conductor() -> anyhow::Result<()> {
     use holochain::test_utils::inline_zomes::simple_create_read_zome;
 
@@ -121,7 +121,7 @@ async fn multi_conductor() -> anyhow::Result<()> {
 
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(darwin, ignore = "flaky on darwin test runners")]
+#[cfg_attr(target_os = "macos", ignore = "flaky on darwin test runners")]
 async fn sharded_consistency() {
     use std::sync::Arc;
 

--- a/crates/holochain/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/multi_conductor/mod.rs
@@ -70,6 +70,7 @@ async fn test_publish() -> anyhow::Result<()> {
 
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(darwin, ignore = "flaky on darwin test runners")]
 async fn multi_conductor() -> anyhow::Result<()> {
     use holochain::test_utils::inline_zomes::simple_create_read_zome;
 
@@ -120,6 +121,7 @@ async fn multi_conductor() -> anyhow::Result<()> {
 
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(darwin, ignore = "flaky on darwin test runners")]
 async fn sharded_consistency() {
     use std::sync::Arc;
 

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -98,6 +98,7 @@ async fn fullsync_sharded_gossip() -> anyhow::Result<()> {
 
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(darwin, ignore = "flaky on darwin test runners")]
 async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
     // let _g = observability::test_run().ok();
 
@@ -172,6 +173,7 @@ async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
 /// and when it restarts, gossip resumes.
 #[cfg(feature = "slow_tests")]
 #[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(darwin, ignore = "flaky on darwin test runners")]
 async fn test_gossip_shutdown() {
     observability::test_run().ok();
     let mut conductors = SweetConductorBatch::from_config(2, make_config(true, true, None)).await;

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -98,7 +98,7 @@ async fn fullsync_sharded_gossip() -> anyhow::Result<()> {
 
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(darwin, ignore = "flaky on darwin test runners")]
+#[cfg_attr(target_os = "macos", ignore = "flaky on darwin test runners")]
 async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
     // let _g = observability::test_run().ok();
 
@@ -173,7 +173,7 @@ async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
 /// and when it restarts, gossip resumes.
 #[cfg(feature = "slow_tests")]
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(darwin, ignore = "flaky on darwin test runners")]
+#[cfg_attr(target_os = "macos", ignore = "flaky on darwin test runners")]
 async fn test_gossip_shutdown() {
     observability::test_run().ok();
     let mut conductors = SweetConductorBatch::from_config(2, make_config(true, true, None)).await;

--- a/crates/kitsune_p2p/direct_test/src/consistency_stress.rs
+++ b/crates/kitsune_p2p/direct_test/src/consistency_stress.rs
@@ -810,6 +810,7 @@ mod tests {
     use super::*;
 
     #[tokio::test(flavor = "multi_thread")]
+    #[cfg_attr(darwin, ignore = "flaky on darwin test runners")]
     async fn consistency_test() {
         let mut tuning_params =
             kitsune_p2p_types::config::tuning_params_struct::KitsuneP2pTuningParams::default();

--- a/crates/kitsune_p2p/direct_test/src/consistency_stress.rs
+++ b/crates/kitsune_p2p/direct_test/src/consistency_stress.rs
@@ -810,7 +810,7 @@ mod tests {
     use super::*;
 
     #[tokio::test(flavor = "multi_thread")]
-    #[cfg_attr(darwin, ignore = "flaky on darwin test runners")]
+    #[cfg_attr(target_os = "macos", ignore = "flaky on darwin test runners")]
     async fn consistency_test() {
         let mut tuning_params =
             kitsune_p2p_types::config::tuning_params_struct::KitsuneP2pTuningParams::default();

--- a/crates/kitsune_p2p/transport_quic/src/tx2.rs
+++ b/crates/kitsune_p2p/transport_quic/src/tx2.rs
@@ -470,6 +470,7 @@ mod tests {
     use super::*;
 
     #[tokio::test(flavor = "multi_thread")]
+    #[cfg_attr(target_os = "macos", ignore = "flaky on darwin test runners")]
     async fn test_quic_tx2() {
         kitsune_p2p_types::dependencies::observability::test_run().ok();
 


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
