### PR TITLE
feat(nix): support and recommend custom override mechanism for versions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,17 +37,15 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    versions = {
-      url = "github:holochain/holochain?dir=versions/0_1";
-    };
+    versions.url = "github:holochain/holochain?dir=versions/0_1";
 
-    holochain.follows = "versions/holochain";
+    holochain.url = "file:///dev/null";
     holochain.flake = false;
-    lair.follows = "versions/lair";
+    lair.url = "file:///dev/null";
     lair.flake = false;
-    launcher.follows = "versions/launcher";
+    launcher.url = "file:///dev/null";
     launcher.flake = false;
-    scaffolding.follows = "versions/scaffolding";
+    scaffolding.url = "file:///dev/null";
     scaffolding.flake = false;
 
     cargo-chef = {

--- a/holonix/README.md
+++ b/holonix/README.md
@@ -2,58 +2,46 @@
 
 this implementation of holonix uses the flake- and crane-based nix expressions.
 
-coarse compatibility with the previous holonix interface is provided so that
-all previously working nix expressions targetting the holonix repository still
-work.
-
 more advanced customization features are now possible via the flake's native
 input override feature.
 
-as an exmaple, here is a _flake.nix_ that references a custom branch.
+## recommended versioning specification in a consumer's flake.nix
 
-```nix=
-{
-  description = "Template for Holochain app development";
+#### use the "versions" flake as a separate input in their flake.nix and configuring the holochain flake to follow the versions flake, as in:
 
-  inputs = {
-    nixpkgs.follows = "holochain-flake/nixpkgs";
+```nix
+inputs = {
+  holochain-versions.url = "github:holochain/holochain?dir=versions/0_1";
 
-    holochain-flake = {
-      url = "github:holochain/holochain";
-      inputs.versions.url = "github:holochain/holochain/?dir=versions/0_1";
-      inputs.holochain.url = "github:holochain/holochain/holochain-0.1.3";
-    };
-  };
-
-  outputs = inputs @ { ... }:
-    inputs.holochain-flake.inputs.flake-parts.lib.mkFlake
-      {
-        inherit inputs;
-      }
-      {
-        systems = builtins.attrNames inputs.holochain-flake.devShells;
-        perSystem =
-          { config
-          , pkgs
-          , system
-          , ...
-          }: {
-            devShells.default = pkgs.mkShell {
-              inputsFrom = [ inputs.holochain-flake.devShells.${system}.holonix ];
-              packages = with pkgs; [
-                  # more packages go here
-              ];
-            };
-          };
-      };
-}
+  holochain-flake.url = "github:holochain/holochain";
+  holochain-flake.inputs.versions.follows = "holochain-versions";
+};
 ```
 
-this exmaple would translate to the following CLI invocatin
+#### override single components either via the holochain versions flake:
 
-```shell=
-nix develop \
-  github:holochain/holochain#holonix \
-  --override-input versions 'github:holochain/holochain/?dir=versions/0_1' \
-  --override-input holochain 'github:holochain/holochain/holochain-0.1.3'
+```nix
+inputs = {
+  holochain-versions.url = "github:holochain/holochain?dir=versions/0_1"; holochain-versions.inputs.holochain.url = "github:holochain/holochain/holochain-0.1.5-beta-rc.0";
+
+  holochain-flake.url = "github:holochain/holochain";
+  holochain-flake.inputs.versions.follows = "holochain-versions";
+};
 ```
+
+or via their the toplevel component input:
+
+```nix
+inputs = {
+  holochain-versions.url = "github:holochain/holochain?dir=versions/0_1";
+
+  holochain-flake.url = "github:holochain/holochain";
+  holochain-flake.inputs.versions.follows = "holochain-versions";
+
+  holochain-flake.inputs.holochain.url = "github:holochain/holochain/holochain-0.1.5-beta-rc.0";
+};
+```
+
+please see the following examples to learn more about common and more specific use cases:
+
+* [specifying custom component versions](examples/custom_versions/flake.nix)

--- a/holonix/examples/custom_versions/flake.lock
+++ b/holonix/examples/custom_versions/flake.lock
@@ -61,29 +61,17 @@
     "crate2nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1681086579,
-        "narHash": "sha256-MEcdG7EXkFsmrTo1/X5tq7UDFY6enHdl65k0wbTCuD0=",
+        "lastModified": 1675642992,
+        "narHash": "sha256-uDBDZuiq7qyg82Udp82/r4zg5HKfIzBQqgl2U9THiQM=",
         "owner": "kolloch",
         "repo": "crate2nix",
-        "rev": "1b042dab3928aaa37421a83d4e1023e7a79527e2",
+        "rev": "45fc83132c8c91c77a1cd61fe0c945411d1edba8",
         "type": "github"
       },
       "original": {
         "owner": "kolloch",
         "repo": "crate2nix",
         "type": "github"
-      }
-    },
-    "dummy": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-d6xi4mKdjkX2JFicDIv5niSzpyI0m/Hnm8GGAIU04kY=",
-        "type": "file",
-        "url": "file:/dev/null"
-      },
-      "original": {
-        "type": "file",
-        "url": "file:/dev/null"
       }
     },
     "flake-compat": {
@@ -186,7 +174,6 @@
         "cargo-rdme": "cargo-rdme",
         "crane": "crane",
         "crate2nix": "crate2nix",
-        "dummy": "dummy",
         "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts",
         "holochain": "holochain",
@@ -198,44 +185,20 @@
         "rust-overlay": "rust-overlay_2",
         "scaffolding": "scaffolding",
         "versions": [
-          "holochain-versions"
+          "versions"
         ]
       },
       "locked": {
-        "lastModified": 1683277593,
-        "narHash": "sha256-qZ1nSs5ubFXxf3W4z+iDyX6CsTosC2QnG/SF9J+Z5v4=",
+        "lastModified": 1683444768,
+        "narHash": "sha256-9e0+YSafThk4qSh9tO2VsoeLfw4/rXIih9rqVeayrDI=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "6dd903765384ff38c3c7f35e1a1a95f9e7a57280",
+        "rev": "cf29f234341470d2421bbc1cc4ba6b7457a98ce0",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "experiment_deprecate_component_inputs",
-        "repo": "holochain",
-        "type": "github"
-      }
-    },
-    "holochain-versions": {
-      "inputs": {
-        "holochain": "holochain_2",
-        "lair": "lair_2",
-        "launcher": "launcher_2",
-        "scaffolding": "scaffolding_2"
-      },
-      "locked": {
-        "dir": "versions/0_1",
-        "lastModified": 1683303040,
-        "narHash": "sha256-80M442urktOVwg4EIUDHQY6vtjdM70eEnAgT4PQYPBI=",
-        "owner": "holochain",
-        "repo": "holochain",
-        "rev": "5abbdfd5e7e1d5bb1cd01bf37db53ef083404278",
-        "type": "github"
-      },
-      "original": {
-        "dir": "versions/0_1",
-        "owner": "holochain",
-        "ref": "experiment_deprecate_component_inputs",
+        "ref": "develop",
         "repo": "holochain",
         "type": "github"
       }
@@ -252,7 +215,7 @@
       },
       "original": {
         "owner": "holochain",
-        "ref": "main-0.1",
+        "ref": "holochain-0.1.4",
         "repo": "holochain",
         "type": "github"
       }
@@ -272,16 +235,16 @@
     "lair_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1682356264,
-        "narHash": "sha256-5ZYJ1gyyL3hLR8hCjcN5yremg8cSV6w1iKCOrpJvCmc=",
+        "lastModified": 1670953460,
+        "narHash": "sha256-cqOr7iWzsNeomYQiiFggzG5Dr4X0ysnTkjtA8iwDLAQ=",
         "owner": "holochain",
         "repo": "lair",
-        "rev": "43be404da0fd9d57bf4429c44def405bd6490f61",
+        "rev": "cbfbefefe43073904a914c8181a450209a74167b",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "lair_keystore-v0.2.4",
+        "ref": "lair_keystore-v0.2.3",
         "repo": "lair",
         "type": "github"
       }
@@ -332,11 +295,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682566018,
-        "narHash": "sha256-HPzPRFiy2o/7k7mtnwfM1E6NVZHiFbPdmYCMoIpkHO4=",
+        "lastModified": 1683286087,
+        "narHash": "sha256-xseOd7W7xwF5GOF2RW8qhjmVGrKoBz+caBlreaNzoeI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8e3b64db39f2aaa14b35ee5376bd6a2e707cadc2",
+        "rev": "3e313808bd2e0a0669430787fb22e43b2f4bf8bf",
         "type": "github"
       },
       "original": {
@@ -386,11 +349,11 @@
           "flake-parts"
         ],
         "holochain-flake": "holochain-flake",
-        "holochain-versions": "holochain-versions",
         "nixpkgs": [
           "holochain-flake",
           "nixpkgs"
-        ]
+        ],
+        "versions": "versions"
       }
     },
     "rust-overlay": {
@@ -429,11 +392,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1682648393,
-        "narHash": "sha256-VH0/4PXTPHVc3E6NxuB51w2eW1/Yn8NGq+HkB8kA0cU=",
+        "lastModified": 1683426137,
+        "narHash": "sha256-iqLjaJDMppvK1ae1eL55b2r7EX+rbUuEnssFOe9eOm8=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2c22a41baadfac75a4af5303fc3ef8d4145b795b",
+        "rev": "546a8209ce0965475495dd422e4ab3c6de7a268c",
         "type": "github"
       },
       "original": {
@@ -483,6 +446,29 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "versions": {
+      "inputs": {
+        "holochain": "holochain_2",
+        "lair": "lair_2",
+        "launcher": "launcher_2",
+        "scaffolding": "scaffolding_2"
+      },
+      "locked": {
+        "dir": "versions/0_1",
+        "lastModified": 1683440412,
+        "narHash": "sha256-PFn0VRHOmjI3Y4XIfFFylTaX1GyUN1J2FBEJCmmxIvs=",
+        "owner": "holochain",
+        "repo": "holochain",
+        "rev": "7b4601be260f62e1012659b6c63384a18bb09a97",
+        "type": "github"
+      },
+      "original": {
+        "dir": "versions/0_1",
+        "owner": "holochain",
+        "repo": "holochain",
         "type": "github"
       }
     }

--- a/holonix/examples/custom_versions/flake.lock
+++ b/holonix/examples/custom_versions/flake.lock
@@ -39,6 +39,7 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": [
+          "holochain-flake",
           "nixpkgs"
         ],
         "rust-overlay": "rust-overlay"
@@ -60,17 +61,29 @@
     "crate2nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1675642992,
-        "narHash": "sha256-uDBDZuiq7qyg82Udp82/r4zg5HKfIzBQqgl2U9THiQM=",
+        "lastModified": 1681086579,
+        "narHash": "sha256-MEcdG7EXkFsmrTo1/X5tq7UDFY6enHdl65k0wbTCuD0=",
         "owner": "kolloch",
         "repo": "crate2nix",
-        "rev": "45fc83132c8c91c77a1cd61fe0c945411d1edba8",
+        "rev": "1b042dab3928aaa37421a83d4e1023e7a79527e2",
         "type": "github"
       },
       "original": {
         "owner": "kolloch",
         "repo": "crate2nix",
         "type": "github"
+      }
+    },
+    "dummy": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-d6xi4mKdjkX2JFicDIv5niSzpyI0m/Hnm8GGAIU04kY=",
+        "type": "file",
+        "url": "file:/dev/null"
+      },
+      "original": {
+        "type": "file",
+        "url": "file:/dev/null"
       }
     },
     "flake-compat": {
@@ -167,19 +180,79 @@
         "url": "file:///dev/null"
       }
     },
-    "holochain_2": {
-      "flake": false,
+    "holochain-flake": {
+      "inputs": {
+        "cargo-chef": "cargo-chef",
+        "cargo-rdme": "cargo-rdme",
+        "crane": "crane",
+        "crate2nix": "crate2nix",
+        "dummy": "dummy",
+        "flake-compat": "flake-compat_2",
+        "flake-parts": "flake-parts",
+        "holochain": "holochain",
+        "lair": "lair",
+        "launcher": "launcher",
+        "nix-filter": "nix-filter",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
+        "rust-overlay": "rust-overlay_2",
+        "scaffolding": "scaffolding",
+        "versions": [
+          "holochain-versions"
+        ]
+      },
       "locked": {
-        "lastModified": 1681507583,
-        "narHash": "sha256-lRnums2gv1oXVwo4gMF2QAnzEu8prwxg1uKjUzNwJV4=",
+        "lastModified": 1683277593,
+        "narHash": "sha256-qZ1nSs5ubFXxf3W4z+iDyX6CsTosC2QnG/SF9J+Z5v4=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "ac50baed6b53e9d0552729e69e1e20312e4edc08",
+        "rev": "6dd903765384ff38c3c7f35e1a1a95f9e7a57280",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.1.4",
+        "ref": "experiment_deprecate_component_inputs",
+        "repo": "holochain",
+        "type": "github"
+      }
+    },
+    "holochain-versions": {
+      "inputs": {
+        "holochain": "holochain_2",
+        "lair": "lair_2",
+        "launcher": "launcher_2",
+        "scaffolding": "scaffolding_2"
+      },
+      "locked": {
+        "dir": "versions/0_1",
+        "lastModified": 1683303040,
+        "narHash": "sha256-80M442urktOVwg4EIUDHQY6vtjdM70eEnAgT4PQYPBI=",
+        "owner": "holochain",
+        "repo": "holochain",
+        "rev": "5abbdfd5e7e1d5bb1cd01bf37db53ef083404278",
+        "type": "github"
+      },
+      "original": {
+        "dir": "versions/0_1",
+        "owner": "holochain",
+        "ref": "experiment_deprecate_component_inputs",
+        "repo": "holochain",
+        "type": "github"
+      }
+    },
+    "holochain_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1682362638,
+        "narHash": "sha256-pL+3zQo6/4ctj/hEI0vihAPpBRiZ+9n7Vxl0fDRZc3g=",
+        "owner": "holochain",
+        "repo": "holochain",
+        "rev": "9242f34515dfaeaf722629f9550d064b7f248121",
+        "type": "github"
+      },
+      "original": {
+        "owner": "holochain",
+        "ref": "main-0.1",
         "repo": "holochain",
         "type": "github"
       }
@@ -199,16 +272,16 @@
     "lair_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1670953460,
-        "narHash": "sha256-cqOr7iWzsNeomYQiiFggzG5Dr4X0ysnTkjtA8iwDLAQ=",
+        "lastModified": 1682356264,
+        "narHash": "sha256-5ZYJ1gyyL3hLR8hCjcN5yremg8cSV6w1iKCOrpJvCmc=",
         "owner": "holochain",
         "repo": "lair",
-        "rev": "cbfbefefe43073904a914c8181a450209a74167b",
+        "rev": "43be404da0fd9d57bf4429c44def405bd6490f61",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "lair_keystore-v0.2.3",
+        "ref": "lair_keystore-v0.2.4",
         "repo": "lair",
         "type": "github"
       }
@@ -259,11 +332,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683286087,
-        "narHash": "sha256-xseOd7W7xwF5GOF2RW8qhjmVGrKoBz+caBlreaNzoeI=",
+        "lastModified": 1682566018,
+        "narHash": "sha256-HPzPRFiy2o/7k7mtnwfM1E6NVZHiFbPdmYCMoIpkHO4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e313808bd2e0a0669430787fb22e43b2f4bf8bf",
+        "rev": "8e3b64db39f2aaa14b35ee5376bd6a2e707cadc2",
         "type": "github"
       },
       "original": {
@@ -308,30 +381,27 @@
     },
     "root": {
       "inputs": {
-        "cargo-chef": "cargo-chef",
-        "cargo-rdme": "cargo-rdme",
-        "crane": "crane",
-        "crate2nix": "crate2nix",
-        "flake-compat": "flake-compat_2",
-        "flake-parts": "flake-parts",
-        "holochain": "holochain",
-        "lair": "lair",
-        "launcher": "launcher",
-        "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs",
-        "pre-commit-hooks-nix": "pre-commit-hooks-nix",
-        "rust-overlay": "rust-overlay_2",
-        "scaffolding": "scaffolding",
-        "versions": "versions"
+        "flake-parts": [
+          "holochain-flake",
+          "flake-parts"
+        ],
+        "holochain-flake": "holochain-flake",
+        "holochain-versions": "holochain-versions",
+        "nixpkgs": [
+          "holochain-flake",
+          "nixpkgs"
+        ]
       }
     },
     "rust-overlay": {
       "inputs": {
         "flake-utils": [
+          "holochain-flake",
           "crane",
           "flake-utils"
         ],
         "nixpkgs": [
+          "holochain-flake",
           "crane",
           "nixpkgs"
         ]
@@ -354,15 +424,16 @@
       "inputs": {
         "flake-utils": "flake-utils_2",
         "nixpkgs": [
+          "holochain-flake",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1683426137,
-        "narHash": "sha256-iqLjaJDMppvK1ae1eL55b2r7EX+rbUuEnssFOe9eOm8=",
+        "lastModified": 1682648393,
+        "narHash": "sha256-VH0/4PXTPHVc3E6NxuB51w2eW1/Yn8NGq+HkB8kA0cU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "546a8209ce0965475495dd422e4ab3c6de7a268c",
+        "rev": "2c22a41baadfac75a4af5303fc3ef8d4145b795b",
         "type": "github"
       },
       "original": {
@@ -412,29 +483,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "versions": {
-      "inputs": {
-        "holochain": "holochain_2",
-        "lair": "lair_2",
-        "launcher": "launcher_2",
-        "scaffolding": "scaffolding_2"
-      },
-      "locked": {
-        "dir": "versions/0_1",
-        "lastModified": 1683438962,
-        "narHash": "sha256-YE3OLW1h4S/L3bWADEw166IKxYK+869s2jDy8htaQvY=",
-        "owner": "holochain",
-        "repo": "holochain",
-        "rev": "50090ef32c15bceb0a0996d9161970fb089fbec1",
-        "type": "github"
-      },
-      "original": {
-        "dir": "versions/0_1",
-        "owner": "holochain",
-        "repo": "holochain",
         "type": "github"
       }
     }

--- a/holonix/examples/custom_versions/flake.nix
+++ b/holonix/examples/custom_versions/flake.nix
@@ -34,7 +34,8 @@
 
             devShells.default = pkgs.mkShell {
               inputsFrom = [ inputs'.holochain-flake.devShells.holonix ];
-              packages = with pkgs; [
+              packages = [
+                pkgs.nodejs-18_x
                 # more packages go here
               ];
             };

--- a/holonix/examples/custom_versions/flake.nix
+++ b/holonix/examples/custom_versions/flake.nix
@@ -1,0 +1,43 @@
+{
+  description = "Template for Holochain app development that uses a specific versions set";
+
+  # this example is equivalent to the following CLI invocation:
+  #
+  # nix develop \
+  #   github:holochain/holochain#holonix \
+  #   --override-input versions 'github:holochain/holochain/?dir=versions/0_1' \
+  #   --override-input versions/holochain 'github:holochain/holochain/holochain-0.1.5-beta-rc.0'
+
+  inputs = {
+    versions.url = "github:holochain/holochain?dir=versions/0_1";
+    versions.inputs.holochain.url = "github:holochain/holochain/holochain-0.1.5-beta-rc.0";
+
+    holochain-flake.url = "github:holochain/holochain";
+    holochain-flake.inputs.versions.follows = "versions";
+
+    nixpkgs.follows = "holochain-flake/nixpkgs";
+    flake-parts.follows = "holochain-flake/flake-parts";
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; }
+      {
+        systems = builtins.attrNames inputs.holochain-flake.devShells;
+
+        perSystem =
+          { inputs'
+          , config
+          , pkgs
+          , system
+          , ...
+          }: {
+
+            devShells.default = pkgs.mkShell {
+              inputsFrom = [ inputs'.holochain-flake.devShells.holonix ];
+              packages = with pkgs; [
+                # more packages go here
+              ];
+            };
+          };
+      };
+}

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -60,7 +60,7 @@
         cargoArtifacts = holochainDepsRelease;
         src = flake.config.srcCleanedHolochain;
         doCheck = false;
-        passthru.src.rev = inputs.holochain.rev;
+        passthru.src.rev = flake.config.reconciledInputs.holochain.rev;
       });
 
       holochainNextestDeps = craneLib.buildDepsOnly (commonArgs // {

--- a/nix/modules/lair.nix
+++ b/nix/modules/lair.nix
@@ -13,7 +13,7 @@
       commonArgs = {
 
         pname = "lair-keystore";
-        src = inputs.lair;
+        src = flake.config.reconciledInputs.lair;
 
         CARGO_PROFILE = "release";
 

--- a/nix/modules/launcher.nix
+++ b/nix/modules/launcher.nix
@@ -13,7 +13,7 @@
       commonArgs = {
 
         pname = "hc-launch";
-        src = inputs.launcher;
+        src = flake.config.reconciledInputs.launcher;
 
         CARGO_PROFILE = "release";
 

--- a/nix/modules/reconciledInputs.nix
+++ b/nix/modules/reconciledInputs.nix
@@ -1,0 +1,17 @@
+{ self, lib, inputs, ... }:
+
+{
+  options.reconciledInputs = lib.mkOption { type = lib.types.raw; };
+  config.reconciledInputs = lib.genAttrs (builtins.attrNames inputs.versions.inputs)
+    (name:
+      let
+        input =
+          if builtins.pathExists (inputs."${name}" + "/Cargo.toml")
+          then inputs."${name}"
+          else
+            inputs.versions.inputs."${name}";
+        rev = input.rev or self.rev;
+      in
+      (input // { inherit rev; })
+    );
+}

--- a/nix/modules/scaffolding.nix
+++ b/nix/modules/scaffolding.nix
@@ -13,7 +13,7 @@
       commonArgs = {
 
         pname = "hc-scaffold";
-        src = inputs.scaffolding;
+        src = flake.config.reconciledInputs.scaffolding;
 
         CARGO_PROFILE = "release";
 
@@ -22,7 +22,8 @@
         buildInputs =
           (with pkgs; [
             # TODO: remove sqlite package once https://github.com/holochain/holochain/pull/2248 is released
-            openssl sqlite
+            openssl
+            sqlite
           ])
           ++ (lib.optionals pkgs.stdenv.isDarwin
             (with pkgs.darwin.apple_sdk_11_0.frameworks; [

--- a/nix/modules/srcCleaned.nix
+++ b/nix/modules/srcCleaned.nix
@@ -1,4 +1,4 @@
-{ self, lib, inputs, ... }:
+{ self, lib, inputs, config, ... }:
 
 let
   includeCommon =
@@ -15,7 +15,7 @@ in
   options.srcCleanedHolochain = lib.mkOption { type = lib.types.raw; };
   config.srcCleanedHolochain = inputs.nix-filter.lib {
     include = includeCommon;
-    root = inputs.holochain;
+    root = config.reconciledInputs.holochain;
   };
 
   options.srcCleanedReleaseAutomationRepo = lib.mkOption { type = lib.types.raw; };
@@ -34,5 +34,4 @@ in
     ];
     root = self;
   };
-
 }

--- a/nix/modules/srcCleaned.nix
+++ b/nix/modules/srcCleaned.nix
@@ -1,4 +1,4 @@
-{ self, lib, inputs, config, ... }:
+{ self, lib, inputs, config, ... }@flake:
 
 let
   includeCommon =
@@ -15,7 +15,7 @@ in
   options.srcCleanedHolochain = lib.mkOption { type = lib.types.raw; };
   config.srcCleanedHolochain = inputs.nix-filter.lib {
     include = includeCommon;
-    root = config.reconciledInputs.holochain;
+    root = flake.config.reconciledInputs.holochain;
   };
 
   options.srcCleanedReleaseAutomationRepo = lib.mkOption { type = lib.types.raw; };


### PR DESCRIPTION
**not** using a distinct input for the versions flake has been observed
to be ineffective at locking the component versions via the versions flake.
therefore it is highly recommended to end-users to refactor their
flake.nix files to use a distinct input for the versions flake as shown
in the examples.
