### PR TITLE
Enable and fix sandbox tests

### DIFF
--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -123,10 +123,7 @@ async fn clean_sandboxes() {
 
 /// Generates a new sandbox with a single app deployed and tries to get app info
 #[tokio::test(flavor = "multi_thread")]
-// #[ignore = "TODO: @ThetaSinner please have a look"]
 async fn generate_sandbox_and_connect() {
-    println!("started test 1");
-
     clean_sandboxes().await;
     package_fixture_if_not_packaged().await;
 
@@ -144,7 +141,7 @@ async fn generate_sandbox_and_connect() {
         .arg("tests/fixtures/my-app/")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        //.stderr(Stdio::null())
+        .stderr(Stdio::null())
         .kill_on_drop(true);
 
     let mut hc_admin = cmd.spawn().expect("Failed to spawn holochain");
@@ -162,9 +159,7 @@ async fn generate_sandbox_and_connect() {
 
 /// Generates a new sandbox with a single app deployed and tries to list DNA
 #[tokio::test(flavor = "multi_thread")]
-// #[ignore = "TODO: @ThetaSinner please have a look"]
 async fn generate_sandbox_and_call_list_dna() {
-    println!("started test 2");
     clean_sandboxes().await;
     package_fixture_if_not_packaged().await;
 
@@ -182,7 +177,7 @@ async fn generate_sandbox_and_call_list_dna() {
         .arg("tests/fixtures/my-app/")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        //.stderr(Stdio::null())
+        .stderr(Stdio::null())
         .kill_on_drop(true);
 
     let mut hc_admin = cmd.spawn().expect("Failed to spawn holochain");
@@ -199,7 +194,7 @@ async fn generate_sandbox_and_call_list_dna() {
         .arg(format!("--running={}", launch_info.admin_port))
         .arg("list-dnas")
         .stdin(Stdio::piped())
-        //.stdout(Stdio::null())
+        .stdout(Stdio::null())
         .stderr(Stdio::inherit());
     let mut hc_call = cmd.spawn().expect("Failed to spawn holochain");
 
@@ -233,10 +228,8 @@ fn get_sandbox_command() -> Command {
 async fn get_launch_info(stdout: &mut ChildStdout) -> LaunchInfo {
     let mut lines = BufReader::new(stdout).lines();
     while let Ok(Some(line)) = lines.next_line().await {
-        println!("{}", line);
         if let Some(index) = line.find("#!0") {
             let launch_info_str = &line[index + 3..].trim();
-            println!("found output line");
             return serde_json::from_str::<LaunchInfo>(launch_info_str).unwrap();
         }
     }

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -153,7 +153,8 @@ async fn generate_sandbox_and_connect() {
     child_stdin.write_all(b"test-phrase\n").await.unwrap();
     drop(child_stdin);
 
-    let launch_info = get_launch_info(hc_admin.stdout.take().unwrap()).await;
+    let mut stdout = hc_admin.stdout.take().unwrap();
+    let launch_info = get_launch_info(&mut stdout).await;
 
     // - Make a call to list app info to the port
     get_app_info(*launch_info.app_ports.first().expect("No app ports found")).await;
@@ -189,7 +190,8 @@ async fn generate_sandbox_and_call_list_dna() {
     child_stdin.write_all(b"test-phrase\n").await.unwrap();
     drop(child_stdin);
 
-    let launch_info = get_launch_info(hc_admin.stdout.take().unwrap()).await;
+    let mut stdout = hc_admin.stdout.take().unwrap();
+    let launch_info = get_launch_info(&mut stdout).await;
 
     let mut cmd = get_sandbox_command();
     cmd.env("RUST_BACKTRACE", "1")
@@ -228,7 +230,7 @@ fn get_sandbox_command() -> Command {
     }
 }
 
-async fn get_launch_info(stdout: ChildStdout) -> LaunchInfo {
+async fn get_launch_info(stdout: &mut ChildStdout) -> LaunchInfo {
     let mut lines = BufReader::new(stdout).lines();
     while let Ok(Some(line)) = lines.next_line().await {
         println!("{}", line);

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -123,8 +123,10 @@ async fn clean_sandboxes() {
 
 /// Generates a new sandbox with a single app deployed and tries to get app info
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "TODO: @ThetaSinner please have a look"]
+// #[ignore = "TODO: @ThetaSinner please have a look"]
 async fn generate_sandbox_and_connect() {
+    println!("started test 1");
+
     clean_sandboxes().await;
     package_fixture_if_not_packaged().await;
 
@@ -142,7 +144,7 @@ async fn generate_sandbox_and_connect() {
         .arg("tests/fixtures/my-app/")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        //.stderr(Stdio::null())
         .kill_on_drop(true);
 
     let mut hc_admin = cmd.spawn().expect("Failed to spawn holochain");
@@ -159,8 +161,9 @@ async fn generate_sandbox_and_connect() {
 
 /// Generates a new sandbox with a single app deployed and tries to list DNA
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "TODO: @ThetaSinner please have a look"]
+// #[ignore = "TODO: @ThetaSinner please have a look"]
 async fn generate_sandbox_and_call_list_dna() {
+    println!("started test 2");
     clean_sandboxes().await;
     package_fixture_if_not_packaged().await;
 
@@ -178,7 +181,7 @@ async fn generate_sandbox_and_call_list_dna() {
         .arg("tests/fixtures/my-app/")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        //.stderr(Stdio::null())
         .kill_on_drop(true);
 
     let mut hc_admin = cmd.spawn().expect("Failed to spawn holochain");
@@ -194,7 +197,7 @@ async fn generate_sandbox_and_call_list_dna() {
         .arg(format!("--running={}", launch_info.admin_port))
         .arg("list-dnas")
         .stdin(Stdio::piped())
-        .stdout(Stdio::null())
+        //.stdout(Stdio::null())
         .stderr(Stdio::inherit());
     let mut hc_call = cmd.spawn().expect("Failed to spawn holochain");
 
@@ -228,8 +231,10 @@ fn get_sandbox_command() -> Command {
 async fn get_launch_info(stdout: ChildStdout) -> LaunchInfo {
     let mut lines = BufReader::new(stdout).lines();
     while let Ok(Some(line)) = lines.next_line().await {
+        println!("{}", line);
         if let Some(index) = line.find("#!0") {
             let launch_info_str = &line[index + 3..].trim();
+            println!("found output line");
             return serde_json::from_str::<LaunchInfo>(launch_info_str).unwrap();
         }
     }

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -200,8 +200,6 @@ async fn generate_sandbox_and_call_list_dna() {
 
     let exit_code = hc_call.wait().await.unwrap();
     assert!(exit_code.success());
-
-    hc_admin.kill().await.unwrap();
 }
 
 fn get_hc_command() -> Command {


### PR DESCRIPTION
### Summary

I think this is the solution to the problem. Passing `stdout` to `get_launch_info` as owned was causing it to be dropped, which then caused `holochain` to die the next time it tried to write to stdout. That'd be why I was having some trouble keeping the process alive. I had thought it was to do with the child handle getting dropped too early and tried to fix that, but this makes more sense.

It's reliable locally but I want to be reasonably sure it's stable on CI so I'll leave this open and keep an eye on the build for a bit.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
