### PR TITLE
Error earlier when databases do not become consistent

### DIFF
--- a/crates/holochain/src/conductor/tests/network_info.rs
+++ b/crates/holochain/src/conductor/tests/network_info.rs
@@ -54,7 +54,7 @@ async fn network_info() {
 
     wait_for_integration(
         &conductors[1].get_dht_db(dna.dna_hash()).unwrap(),
-        100,
+        28,
         100,
         std::time::Duration::from_millis(100),
     )

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -703,6 +703,8 @@ pub async fn wait_for_integration<Db: ReadAccess<DbKindDht>>(
         }
         tokio::time::sleep(delay).await;
     }
+
+    panic!("Database not integrated after {} attempts", num_attempts);
 }
 
 /// Same as wait for integration but can print other states at the same time
@@ -781,6 +783,11 @@ pub async fn wait_for_integration_with_others<Db: ReadAccess<DbKindDht>>(
         }
         tokio::time::sleep(delay).await;
     }
+
+    panic!(
+        "Integration with others not complete after {} attempts",
+        num_attempts
+    );
 }
 
 #[tracing::instrument(skip(envs))]


### PR DESCRIPTION
### Summary

Tests like `three_way_gossip_historical` complain about not being able to get records by hash and with some other test failures it's less clear what went wrong. I'm proposing this minor tweak to error if waiting for consistency fails, rather than relying on each test to report a problem.

Unfortunately I haven't figured out yet why the databases aren't synced, whether that's a problem with the test code or whether something that's being tested is failing. Either way, this error puts us closer to the source of the problem.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
