### PR TITLE
feat(github/build-and-test): pass github access-token to nix

### DIFF
--- a/.github/workflows/holochain-build-and-test.yml
+++ b/.github/workflows/holochain-build-and-test.yml
@@ -57,6 +57,7 @@ jobs:
       - name: "Test command ${{ matrix.nixCommand }}"
         env:
           system: ${{ matrix.platform.system }}
+          NIX_CONFIG: "access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}"
         run: |
           set -xe
 


### PR DESCRIPTION
### Summary

without this we get rate-limit errors occasionally.



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
