### PR TITLE
[BACKPORT 0.2] Prevent zome calls when the network is not initialised (#2280)

### DIFF
--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -172,6 +172,7 @@ pub enum CellStatus {
 pub type CellStatusFilter = CellStatus;
 
 /// A [`Cell`] tracked by a Conductor, along with its [`CellStatus`]
+#[derive(Debug, Clone)]
 struct CellItem {
     cell: Arc<Cell>,
     status: CellStatus,
@@ -1150,7 +1151,7 @@ mod network_impls {
                 | ValidationReceiptReceived { .. } => {
                     let cell_id =
                         CellId::new(event.dna_hash().clone(), event.target_agents().clone());
-                    let cell = self.cell_by_id(&cell_id).await?;
+                    let cell = self.cell_by_id(&cell_id, true).await?;
                     cell.handle_holochain_p2p_event(event).await?;
                 }
                 Publish {
@@ -1223,7 +1224,7 @@ mod network_impls {
 
         /// Invoke a zome function on a Cell
         pub async fn call_zome(&self, call: ZomeCall) -> ConductorApiResult<ZomeCallResult> {
-            let cell = self.cell_by_id(&call.cell_id).await?;
+            let cell = self.cell_by_id(&call.cell_id, true).await?;
             Ok(cell.call_zome(call, None).await?)
         }
 
@@ -1233,7 +1234,7 @@ mod network_impls {
             workspace_lock: SourceChainWorkspace,
         ) -> ConductorApiResult<ZomeCallResult> {
             debug!(cell_id = ?call.cell_id);
-            let cell = self.cell_by_id(&call.cell_id).await?;
+            let cell = self.cell_by_id(&call.cell_id, true).await?;
             Ok(cell.call_zome(call, Some(workspace_lock)).await?)
         }
 
@@ -1509,13 +1510,18 @@ mod cell_impls {
     use super::*;
 
     impl Conductor {
-        pub(crate) async fn cell_by_id(&self, cell_id: &CellId) -> ConductorResult<Arc<Cell>> {
+        pub(crate) async fn cell_by_id(
+            &self,
+            cell_id: &CellId,
+            require_network_ready: bool,
+        ) -> ConductorResult<Arc<Cell>> {
             // Can only get a cell from the running_cells list
-            if let Some(cell) = self
-                .running_cells
-                .share_ref(|c| c.get(cell_id).map(|i| i.cell.clone()))
-            {
-                Ok(cell)
+            if let Some(cell) = self.running_cells.share_ref(|c| c.get(cell_id).cloned()) {
+                if require_network_ready && cell.status != CellStatus::Joined {
+                    Err(ConductorError::CellNetworkNotReady(cell.status))
+                } else {
+                    Ok(cell.cell)
+                }
             } else {
                 // If not in running_cells list, check if the cell id is registered at all,
                 // to give a different error message for disabled vs missing.
@@ -2076,7 +2082,7 @@ mod scheduler_impls {
             let cell_arcs = {
                 let mut cell_arcs = vec![];
                 for cell_id in self.live_cell_ids() {
-                    if let Ok(cell_arc) = self.cell_by_id(&cell_id).await {
+                    if let Ok(cell_arc) = self.cell_by_id(&cell_id, false).await {
                         cell_arcs.push(cell_arc);
                     }
                 }
@@ -2130,7 +2136,7 @@ mod misc_impls {
                 )
                 .await?;
 
-            let cell = self.cell_by_id(&cell_id).await?;
+            let cell = self.cell_by_id(&cell_id, false).await?;
             source_chain.flush(cell.holochain_p2p_dna()).await?;
 
             Ok(())
@@ -2138,7 +2144,7 @@ mod misc_impls {
 
         /// Create a JSON dump of the cell's state
         pub async fn dump_cell_state(&self, cell_id: &CellId) -> ConductorApiResult<String> {
-            let cell = self.cell_by_id(cell_id).await?;
+            let cell = self.cell_by_id(cell_id, false).await?;
             let authored_db = cell.authored_db();
             let dht_db = cell.dht_db();
             let space = cell_id.dna_hash();
@@ -2786,7 +2792,7 @@ mod test_utils_impls {
             &self,
             cell_id: &CellId,
         ) -> ConductorApiResult<DbWrite<DbKindCache>> {
-            let cell = self.cell_by_id(cell_id).await?;
+            let cell = self.cell_by_id(cell_id, false).await?;
             Ok(cell.cache().clone())
         }
 
@@ -2806,7 +2812,7 @@ mod test_utils_impls {
             &self,
             cell_id: &CellId,
         ) -> ConductorApiResult<QueueTriggers> {
-            let cell = self.cell_by_id(cell_id).await?;
+            let cell = self.cell_by_id(cell_id, false).await?;
             Ok(cell.triggers().clone())
         }
     }

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -5,7 +5,6 @@ use crate::conductor::kitsune_host_impl::KitsuneHostImpl;
 use crate::conductor::manager::OutcomeReceiver;
 use crate::conductor::ribosome_store::RibosomeStore;
 use crate::conductor::ConductorHandle;
-use holochain_types::prelude::test_keystore;
 
 /// A configurable Builder for Conductor and sometimes ConductorHandle
 #[derive(Default)]
@@ -299,7 +298,9 @@ impl ConductorBuilder {
         env_path: &std::path::Path,
         extra_dnas: &[DnaFile],
     ) -> ConductorResult<ConductorHandle> {
-        let keystore = self.keystore.unwrap_or_else(test_keystore);
+        let keystore = self
+            .keystore
+            .unwrap_or_else(holochain_types::prelude::test_keystore);
         self.config.environment_path = env_path.to_path_buf().into();
 
         let spaces = Spaces::new(&self.config)?;

--- a/crates/holochain/src/conductor/error.rs
+++ b/crates/holochain/src/conductor/error.rs
@@ -1,6 +1,7 @@
 use super::interface::error::InterfaceError;
 use super::{entry_def_store::error::EntryDefStoreError, state::AppInterfaceId};
 use crate::conductor::cell::error::CellError;
+use crate::conductor::conductor::CellStatus;
 use crate::core::workflow::error::WorkflowError;
 use holochain_conductor_api::conductor::ConductorConfigError;
 use holochain_sqlite::error::DatabaseError;
@@ -30,6 +31,9 @@ pub enum ConductorError {
 
     #[error("Cell is not initialized.")]
     CellNotInitialized,
+
+    #[error("Cell network is not ready. Status: {0:?}")]
+    CellNetworkNotReady(CellStatus),
 
     #[error("Cell was referenced, but is currently disabled. CellId: {0:?}")]
     CellDisabled(CellId),

--- a/crates/holochain/src/core/ribosome/guest_callback/init.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/init.rs
@@ -226,13 +226,24 @@ mod test {
 #[cfg(feature = "slow_tests")]
 mod slow_tests {
     use super::InitResult;
+    use crate::conductor::api::error::ConductorApiResult;
+    use crate::conductor::conductor::CellStatus;
     use crate::core::ribosome::RibosomeT;
     use crate::fixt::curve::Zomes;
     use crate::fixt::InitHostAccessFixturator;
     use crate::fixt::InitInvocationFixturator;
     use crate::fixt::RealRibosomeFixturator;
+    use crate::sweettest::SweetConductor;
+    use crate::sweettest::SweetDnaFile;
+    use crate::sweettest::SweetZome;
+    use crate::test_utils::host_fn_caller::Post;
     use ::fixt::prelude::*;
+    use holo_hash::ActionHash;
+    use holochain_types::app::{CloneCellId, DisableCloneCellPayload};
+    use holochain_types::prelude::CreateCloneCellPayload;
     use holochain_wasm_test_utils::TestWasm;
+    use holochain_zome_types::prelude::*;
+    use std::time::Duration;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_init_unimplemented() {
@@ -290,6 +301,90 @@ mod slow_tests {
         assert_eq!(
             result,
             InitResult::Fail(TestWasm::InitFail.into(), "because i said so".into()),
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn conductor_will_not_accept_zome_calls_before_the_network_is_initialised() {
+        let (dna_file, _, _) = SweetDnaFile::from_test_wasms(
+            random_network_seed(),
+            vec![TestWasm::Create],
+            SerializedBytes::default(),
+        )
+        .await;
+
+        let mut conductor = SweetConductor::from_standard_config().await;
+
+        let app = conductor.setup_app("app", [&dna_file]).await.unwrap();
+
+        let cloned = conductor
+            .create_clone_cell(CreateCloneCellPayload {
+                app_id: app.installed_app_id().clone(),
+                role_name: dna_file.dna_hash().to_string().clone(),
+                modifiers: DnaModifiersOpt::none().with_network_seed("anything else".to_string()),
+                membrane_proof: None,
+                name: Some("cloned".to_string()),
+            })
+            .await
+            .unwrap();
+
+        let enable_or_disable_payload = DisableCloneCellPayload {
+            app_id: app.installed_app_id().clone(),
+            clone_cell_id: CloneCellId::CloneId(cloned.clone_id.clone()),
+        };
+        conductor
+            .disable_clone_cell(&enable_or_disable_payload)
+            .await
+            .unwrap();
+
+        let zome: SweetZome = SweetZome::new(
+            cloned.cell_id.clone(),
+            TestWasm::Create.coordinator_zome_name(),
+        );
+
+        // Run the cell enable in parallel. If we wait for it then we shouldn't see the error we're looking for
+        let conductor_handle = conductor.raw_handle().clone();
+        let payload = enable_or_disable_payload.clone();
+        tokio::spawn(async move {
+            conductor_handle.enable_clone_cell(&payload).await.unwrap();
+        });
+
+        let mut had_successful_zome_call = false;
+        for _ in 0..30 {
+            let create_post_result: ConductorApiResult<ActionHash> = conductor
+                .call_fallible(
+                    &zome,
+                    "create_post",
+                    Post(format!("clone message").to_string()),
+                )
+                .await;
+
+            match create_post_result {
+                Err(crate::conductor::api::error::ConductorApiError::ConductorError(
+                    crate::conductor::error::ConductorError::CellNetworkNotReady(
+                        CellStatus::Joining,
+                    )
+                    | crate::conductor::error::ConductorError::CellDisabled(_),
+                )) => {
+                    // Expected errors, but CellNetworkNotReady won't always be seen depending on system performance
+                }
+                Ok(_) => {
+                    had_successful_zome_call = true;
+
+                    // Stop trying after the first successful zome call
+                    break;
+                }
+                Err(e) => {
+                    panic!("Other types of error are not expected {:?}", e);
+                }
+            }
+
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        assert!(
+            had_successful_zome_call,
+            "Should have seen a clone cell join the network and allow calls"
         );
     }
 }


### PR DESCRIPTION
### Summary

Back-port the network initialisation checks to the develop-0.2 branch

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
