### PR TITLE
fix(nix/launcher): reintroduce glib buildInput

### DIFF
--- a/nix/modules/launcher.nix
+++ b/nix/modules/launcher.nix
@@ -20,6 +20,9 @@
 
         buildInputs = (with pkgs; [
           openssl
+
+          # this is required for glib-networking
+          glib
         ])
         ++ (lib.optionals pkgs.stdenv.isLinux
           (with pkgs; [


### PR DESCRIPTION
it's required for glib-networking

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
