### PR TITLE
build(deps): upgrade all holochain_serialized_bytes to v0.0.52

### DIFF
--- a/crates/fixt/Cargo.toml
+++ b/crates/fixt/Cargo.toml
@@ -11,7 +11,7 @@ categories = [ "fixtures" ]
 edition = "2021"
 
 [dependencies]
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 lazy_static = "1.4"
 parking_lot = "0.10"
 paste = "1.0.12"

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -24,7 +24,7 @@ futures = "0.3"
 anyhow = "1.0"
 clap = { version = "4.0", features = [ "derive" ] }
 holochain_util = { path = "../holochain_util", features = ["backtrace"], version = "^0.2.0"}
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_types = { version = "^0.2.0", path = "../holochain_types" }
 mr_bundle = {version = "^0.2.0", path = "../mr_bundle"}
 serde = { version = "1.0", features = [ "derive" ] }

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -22,7 +22,7 @@ blake2b_simd = { version = "0.5.10", optional = true }
 derive_more = { version = "0.99", optional = true }
 fixt = { version = "^0.2.0", path = "../fixt", optional = true }
 futures = { version = "0.3", optional = true }
-holochain_serialized_bytes = { version = "=0.0.51", optional = true }
+holochain_serialized_bytes = { version = "=0.0.52", optional = true }
 kitsune_p2p_dht_arc = { version = "^0.2.0", path = "../kitsune_p2p/dht_arc" }
 must_future = { version = "0.1", optional = true }
 rand = { version = "0.8.5", optional = true }

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -30,7 +30,7 @@ holochain_conductor_api = { version = "^0.3.0-beta-dev.0", path = "../holochain_
 holochain_keystore = { version = "^0.2.0", path = "../holochain_keystore", default-features = false }
 holochain_p2p = { version = "^0.2.0", path = "../holochain_p2p" }
 holochain_sqlite = { version = "^0.2.0", path = "../holochain_sqlite" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_state = { version = "^0.2.0", path = "../holochain_state" }
 holochain_types = { version = "^0.2.0", path = "../holochain_types" }
 holochain_util = { version = "^0.2.0", path = "../holochain_util", features = [ "pw" ] }

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -20,7 +20,7 @@ hdk_derive = { version = "^0.2.0", path = "../hdk_derive" }
 holo_hash = { version = "^0.2.0", path = "../holo_hash", features = ["full"] }
 holochain_sqlite = { version = "^0.2.0", path = "../holochain_sqlite" }
 holochain_p2p = { version = "^0.2.0", path = "../holochain_p2p" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_state = { version = "^0.2.0", path = "../holochain_state" }
 holochain_types = { version = "^0.2.0", path = "../holochain_types" }
 holochain_trace = { version = "^0.2.0", path = "../holochain_trace" }

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -15,7 +15,7 @@ kitsune_p2p = { version = "^0.2.0", path = "../kitsune_p2p/kitsune_p2p" }
 holo_hash = { version = "^0.2.0", path = "../holo_hash", features = ["full"] }
 holochain_p2p = { version = "^0.2.0", path = "../holochain_p2p" }
 holochain_state = { version = "^0.2.0", path = "../holochain_state" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_types = { version = "^0.2.0", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.2.0", path = "../holochain_zome_types" }
 serde = { version = "1.0", features = [ "derive" ] }

--- a/crates/holochain_integrity_types/Cargo.toml
+++ b/crates/holochain_integrity_types/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 holo_hash = { version = "^0.2.0", path = "../holo_hash" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 paste = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11"

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 base64 = "0.13.0"
 futures = "0.3.23"
 holo_hash = { version = "^0.2.0", path = "../holo_hash", features = ["full"] }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_zome_types = { path = "../holochain_zome_types", version = "^0.2.0"}
 kitsune_p2p_types = { version = "^0.2.0", path = "../kitsune_p2p/types" }
 lair_keystore = { version = "0.2.4", default-features = false }

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3"
 ghost_actor = "0.3.0-alpha.5"
 holo_hash = { version = "^0.2.0", path = "../holo_hash" }
 holochain_keystore = { version = "^0.2.0", path = "../holochain_keystore" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_types = { version = "^0.2.0", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.2.0", path = "../holochain_zome_types" }
 kitsune_p2p = { version = "^0.2.0", path = "../kitsune_p2p/kitsune_p2p" }

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -24,7 +24,7 @@ failure = "0.1.6"
 fixt = { version = "^0.2.0", path = "../fixt" }
 futures = "0.3.1"
 holo_hash = { path = "../holo_hash", version = "^0.2.0"}
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_util = { version = "^0.2.0", path = "../holochain_util", features = ["backtrace"] }
 holochain_zome_types = { version = "^0.2.0", path = "../holochain_zome_types" }
 kitsune_p2p = { version = "^0.2.0", path = "../kitsune_p2p/kitsune_p2p" }

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -19,7 +19,7 @@ holo_hash = { version = "^0.2.0", path = "../holo_hash", features = ["full"] }
 fallible-iterator = "0.2.0"
 futures = "0.3"
 holochain_keystore = { version = "^0.2.0", path = "../holochain_keystore" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_p2p = { version = "^0.2.0", path = "../holochain_p2p" }
 holochain_types = { version = "^0.2.0", path = "../holochain_types" }
 holochain_util = { version = "^0.2.0", path = "../holochain_util" }

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -29,7 +29,7 @@ futures = "0.3"
 one_err = "0.0.8"
 holo_hash = { version = "^0.2.0", path = "../holo_hash", features = ["encoding"] }
 holochain_keystore = { version = "^0.2.0", path = "../holochain_keystore" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_sqlite = { path = "../holochain_sqlite", version = "^0.2.0"}
 holochain_zome_types = { path = "../holochain_zome_types", version = "^0.2.0", features = ["full"] }
 itertools = { version = "0.10" }

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 futures = "0.3"
 ghost_actor = "0.4.0-alpha.5"
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 nanoid = "0.3"
 net2 = "0.2"
 must_future = "0.1"

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -18,7 +18,7 @@ kitsune_p2p_block = { version = "^0.2.0", path = "../kitsune_p2p/block" }
 kitsune_p2p_bin_data = { version = "^0.2.0", path = "../kitsune_p2p/bin_data" }
 holo_hash = { version = "^0.2.0", path = "../holo_hash", features = ["encoding"] }
 holochain_integrity_types = { version = "^0.2.0", path = "../holochain_integrity_types", features = ["tracing"] }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 paste = "1.0.12"
 serde = { version = "1.0", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"

--- a/crates/kitsune_p2p/dht/Cargo.toml
+++ b/crates/kitsune_p2p/dht/Cargo.toml
@@ -33,7 +33,7 @@ tracing = "0.1.29"
 [dev-dependencies]
 kitsune_p2p_dht = { path = ".", features = ["test_utils", "sqlite"]}
 kitsune_p2p_dht_arc = { path = "../dht_arc", features = ["test_utils"]}
-holochain_serialized_bytes = "0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 maplit = "1"
 holochain_trace = { version = "^0.2.0", path = "../../holochain_trace" }
 pretty_assertions = "0.7.2"

--- a/crates/kitsune_p2p/fetch/Cargo.toml
+++ b/crates/kitsune_p2p/fetch/Cargo.toml
@@ -29,7 +29,7 @@ human-repr = { version = "1", optional = true}
 
 [dev-dependencies]
 kitsune_p2p_fetch = { path = ".", features = ["test_utils", "sqlite"]}
-holochain_serialized_bytes = "0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_trace = { version = "^0.2.0", path = "../../holochain_trace" }
 pretty_assertions = "0.7.2"
 test-case = "1.2"

--- a/crates/kitsune_p2p/timestamp/Cargo.toml
+++ b/crates/kitsune_p2p/timestamp/Cargo.toml
@@ -26,7 +26,7 @@ rusqlite = { version = "0.29", optional = true }
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 serde_yaml = "0.9"
 
 [features]


### PR DESCRIPTION
### Summary

The crate `holochain_serialized_bytes` was pinned at v0.0.51, whereas the most recent version is v0.0.52.


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
