### PR TITLE
Disable network_stats test on macos

### DIFF
--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -652,6 +652,7 @@ async fn concurrent_install_dna() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(target_os = "macos", ignore)]
 async fn network_stats() {
     holochain_trace::test_run().ok();
 


### PR DESCRIPTION
### Summary

Flaky and blocked the release here https://github.com/holochain/holochain/actions/runs/4998017851/jobs/8953065537

It is being looked at as part of https://github.com/holochain/holochain/pull/2361

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
