### PR TITLE
Always include all local agents when doing an rpc multi call -- simple version

### DIFF
--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -191,6 +191,36 @@ async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
 /// Test that conductors with arcs clamped to zero do not gossip.
 #[cfg(feature = "slow_tests")]
 #[tokio::test(flavor = "multi_thread")]
+async fn test_zero_arc_get_links() {
+    holochain_trace::test_run().ok();
+
+    // Standard config with arc clamped to zero
+    let mut tuning = make_tuning(true, true, true, None);
+    tuning.gossip_arc_clamping = "empty".into();
+    let config = SweetConductorConfig::standard().tune(Arc::new(tuning));
+
+    let mut conductor0 = SweetConductor::from_config(config).await;
+    let mut conductor1 = SweetConductor::from_standard_config().await;
+
+    let tw = holochain_wasm_test_utils::TestWasm::Link;
+    let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![tw]).await;
+    let app0 = conductor0.setup_app("app", [&dna_file]).await.unwrap();
+    let app1 = conductor1.setup_app("app", [&dna_file]).await.unwrap();
+    let (cell0,) = app0.into_tuple();
+    // let (cell1,) = app1.into_tuple();
+
+    // conductors.exchange_peer_info().await;
+
+    let zome0 = cell0.zome(tw);
+    let _hash0: ActionHash = conductor0.call(&zome0, "create_link", ()).await;
+
+    let links: Vec<Link> = conductor0.call(&zome0, "get_links", ()).await;
+    assert_eq!(links.len(), 1);
+}
+
+/// Test that conductors with arcs clamped to zero do not gossip.
+#[cfg(feature = "slow_tests")]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn test_zero_arc_no_gossip_2way() {
     holochain_trace::test_run().ok();

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Fixes bug where authored data cannot be retrieved locally if the storage arc is not covering that data [\#2425](https://github.com/holochain/holochain/pull/2425)
+
 ## 0.3.0-beta-dev.0
 
 - Bump tx5 to include https://github.com/holochain/tx5/pull/31 which should fix the network loop halting on certain error types, like Ban on data send. [\#2315](https://github.com/holochain/holochain/pull/2315)

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -932,21 +932,9 @@ impl KitsuneP2pHandler for Space {
         input: actor::RpcMulti,
     ) -> KitsuneP2pHandlerResult<Vec<actor::RpcMultiResponse>> {
         let location = input.basis.get_loc();
-        let local_agents_holding_basis = self
-            .local_joined_agents
-            .keys()
-            .filter(|agent_key| {
-                self.agent_arcs
-                    .get(*agent_key)
-                    .map_or(false, |arc| arc.contains(location))
-            })
-            .cloned()
-            .collect();
-        let fut = rpc_multi_logic::handle_rpc_multi(
-            input,
-            self.ro_inner.clone(),
-            local_agents_holding_basis,
-        );
+        let local_joined_agents = self.local_joined_agents.keys().cloned().collect();
+        let fut =
+            rpc_multi_logic::handle_rpc_multi(input, self.ro_inner.clone(), local_joined_agents);
         Ok(async move { fut.await }.boxed().into())
     }
 


### PR DESCRIPTION
### Summary

There was a bug where authored data could not be retrieved locally if your storage arc didn't cover it. This fixes that.

Closes #2422

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
