### PR TITLE
Always include all local agents when doing an rpc multi call -- complex version

### DIFF
--- a/crates/holochain/src/conductor/kitsune_host_impl/query_get_local_authors.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl/query_get_local_authors.rs
@@ -1,0 +1,32 @@
+use holo_hash::{AgentPubKey, AnyDhtHash};
+use holochain_p2p::DhtOpHashExt;
+use holochain_sqlite::prelude::*;
+use rusqlite::named_params;
+
+use crate::conductor::error::ConductorResult;
+
+/// Find if a local agent has authored the given basis hash
+pub async fn query_get_local_authors(
+    db: DbRead<DbKindAuthored>,
+    basis: AnyDhtHash,
+) -> ConductorResult<Vec<AgentPubKey>> {
+    Ok(db
+        .async_reader(move |txn| {
+            let sql = holochain_sqlite::sql::sql_cell::GET_LOCAL_AUTHORS;
+            let mut stmt = txn.prepare_cached(sql).map_err(DatabaseError::from)?;
+            let authors = stmt
+                .query_map(
+                    named_params! {
+                        ":basis": basis,
+                    },
+                    |row| {
+                        let author: AgentPubKey = row.get("author")?;
+                        Ok(author)
+                    },
+                )?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(DatabaseError::from);
+            authors
+        })
+        .await?)
+}

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -191,6 +191,36 @@ async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
 /// Test that conductors with arcs clamped to zero do not gossip.
 #[cfg(feature = "slow_tests")]
 #[tokio::test(flavor = "multi_thread")]
+async fn test_zero_arc_get_links() {
+    holochain_trace::test_run().ok();
+
+    // Standard config with arc clamped to zero
+    let mut tuning = make_tuning(true, true, true, None);
+    tuning.gossip_arc_clamping = "empty".into();
+    let config = SweetConductorConfig::standard().tune(Arc::new(tuning));
+
+    let mut conductor0 = SweetConductor::from_config(config).await;
+    let mut conductor1 = SweetConductor::from_standard_config().await;
+
+    let tw = holochain_wasm_test_utils::TestWasm::Link;
+    let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![tw]).await;
+    let app0 = conductor0.setup_app("app", [&dna_file]).await.unwrap();
+    let app1 = conductor1.setup_app("app", [&dna_file]).await.unwrap();
+    let (cell0,) = app0.into_tuple();
+    // let (cell1,) = app1.into_tuple();
+
+    // conductors.exchange_peer_info().await;
+
+    let zome0 = cell0.zome(tw);
+    let _hash0: ActionHash = conductor0.call(&zome0, "create_link", ()).await;
+
+    let links: Vec<Link> = conductor0.call(&zome0, "get_links", ()).await;
+    assert_eq!(links.len(), 1);
+}
+
+/// Test that conductors with arcs clamped to zero do not gossip.
+#[cfg(feature = "slow_tests")]
+#[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn test_zero_arc_no_gossip_2way() {
     holochain_trace::test_run().ok();

--- a/crates/holochain_sqlite/src/sql.rs
+++ b/crates/holochain_sqlite/src/sql.rs
@@ -27,6 +27,8 @@ pub mod sql_cell {
 
     pub const FETCH_PUBLISHABLE_OP: &str = include_str!("sql/cell/fetch_publishable_op.sql");
 
+    pub const GET_LOCAL_AUTHORS: &str = include_str!("sql/cell/get_local_authors.sql");
+
     pub const SUM_OF_RECEIVED_BYTES_SINCE_TIMESTAMP: &str =
         include_str!("sql/cell/sum_of_received_bytes_since_timestamp.sql");
 

--- a/crates/holochain_sqlite/src/sql/cell/get_local_authors.sql
+++ b/crates/holochain_sqlite/src/sql/cell/get_local_authors.sql
@@ -1,0 +1,7 @@
+SELECT
+  Action.author AS author
+FROM
+  DhtOp
+  JOIN Action ON DhtOp.action_hash = Action.hash
+WHERE
+  DhtOp.basis = :basis

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -112,6 +112,14 @@ impl KitsuneHost for StandardResponsesHostApi {
         .into()
     }
 
+    fn get_local_authors(
+        &self,
+        _space: Arc<KitsuneSpace>,
+        _basis: Arc<KitsuneBasis>,
+    ) -> crate::KitsuneHostResult<Vec<KAgent>> {
+        todo!()
+    }
+
     fn record_metrics(
         &self,
         _space: Arc<KitsuneSpace>,

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api.rs
@@ -4,7 +4,7 @@ use must_future::MustBoxFuture;
 use std::sync::Arc;
 
 use kitsune_p2p_types::{
-    bin_types::KitsuneSpace,
+    bin_types::{KitsuneBasis, KitsuneSpace},
     dependencies::lair_keystore_api,
     dht::{
         region::{Region, RegionCoords},
@@ -12,7 +12,7 @@ use kitsune_p2p_types::{
         spacetime::Topology,
     },
     dht_arc::DhtArcSet,
-    KOpData, KOpHash,
+    KAgent, KOpData, KOpHash,
 };
 
 use crate::event::{GetAgentInfoSignedEvt, MetricRecord};
@@ -83,6 +83,14 @@ pub trait KitsuneHost: 'static + Send + Sync {
         space: Arc<KitsuneSpace>,
         records: Vec<MetricRecord>,
     ) -> KitsuneHostResult<()>;
+
+    /// Ask the host if this basis hash was authored by a local agent,
+    /// and if so, by whom.
+    fn get_local_authors(
+        &self,
+        space: Arc<KitsuneSpace>,
+        basis: Arc<KitsuneBasis>,
+    ) -> KitsuneHostResult<Vec<KAgent>>;
 
     /// Get the quantum Topology associated with this Space.
     fn get_topology(&self, space: Arc<KitsuneSpace>) -> KitsuneHostResult<Topology>;

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_default_error.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_default_error.rs
@@ -113,6 +113,19 @@ pub trait KitsuneHostDefaultError: KitsuneHost + FetchPoolConfig {
         .into()))
     }
 
+    fn get_local_authors(
+        &self,
+        _space: Arc<KitsuneSpace>,
+        _basis: Arc<KitsuneBasis>,
+    ) -> KitsuneHostResult<Vec<KAgent>> {
+        box_fut(Err(format!(
+            "error for unimplemented KitsuneHost test behavior: method {} of {}",
+            "get_local_authors",
+            Self::NAME
+        )
+        .into()))
+    }
+
     fn get_topology(&self, _space: Arc<KitsuneSpace>) -> KitsuneHostResult<Topology> {
         box_fut(Err(format!(
             "error for unimplemented KitsuneHost test behavior: method {} of {}",
@@ -210,6 +223,13 @@ impl<T: KitsuneHostDefaultError> KitsuneHost for T {
         KitsuneHostDefaultError::query_region_set(self, space, dht_arc_set)
     }
 
+    fn get_local_authors(
+        &self,
+        space: Arc<KitsuneSpace>,
+        basis: Arc<KitsuneBasis>,
+    ) -> KitsuneHostResult<Vec<KAgent>> {
+        KitsuneHostDefaultError::get_local_authors(self, space, basis)
+    }
     fn get_topology(&self, space: Arc<KitsuneSpace>) -> KitsuneHostResult<Topology> {
         KitsuneHostDefaultError::get_topology(self, space)
     }

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
@@ -112,6 +112,14 @@ impl KitsuneHost for HostStub {
         KitsuneHostDefaultError::query_region_set(&self.err, space, dht_arc_set)
     }
 
+    fn get_local_authors(
+        &self,
+        space: Arc<KitsuneSpace>,
+        basis: Arc<KitsuneBasis>,
+    ) -> KitsuneHostResult<Vec<KAgent>> {
+        KitsuneHostDefaultError::get_local_authors(&self.err, space, basis)
+    }
+
     fn get_topology(&self, space: Arc<KitsuneSpace>) -> KitsuneHostResult<Topology> {
         KitsuneHostDefaultError::get_topology(&self.err, space)
     }

--- a/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test_util/switchboard/switchboard_evt_handler.rs
@@ -195,6 +195,14 @@ impl KitsuneHost for SwitchboardEventHandler {
         .into()
     }
 
+    fn get_local_authors(
+        &self,
+        _space: Arc<KitsuneSpace>,
+        _basis: Arc<KitsuneBasis>,
+    ) -> crate::KitsuneHostResult<Vec<kitsune_p2p_types::KAgent>> {
+        box_fut(Ok(vec![]))
+    }
+
     fn get_topology(
         &self,
         _space: Arc<KitsuneSpace>,


### PR DESCRIPTION
### Summary

Alternative to #2425. It still needs more work, but it does a bunch of extra work to ensure that local agents are only queried for rpc multi requests if the local agent authored the data or if the arc covers it. It's not much benefit for a whole lot more complexity.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
