### PR TITLE
Flamegraph in memory

### DIFF
--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -15,6 +15,7 @@ use holochain::{
 };
 use holochain_p2p::*;
 use holochain_sqlite::db::*;
+use holochain_trace::{init_fmt, test_run_timed_flame};
 use kitsune_p2p::agent_store::AgentInfoSigned;
 use kitsune_p2p::gossip::sharded_gossip::test_utils::{check_ops_bloom, create_agent_bloom};
 use kitsune_p2p::KitsuneP2pConfig;
@@ -63,6 +64,8 @@ fn make_config(
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn fullsync_sharded_gossip_low_data() -> anyhow::Result<()> {
+    let f = test_run_timed_flame().unwrap();
+
     let _g = holochain_trace::test_run().ok();
     const NUM_CONDUCTORS: usize = 2;
 

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -15,7 +15,6 @@ use holochain::{
 };
 use holochain_p2p::*;
 use holochain_sqlite::db::*;
-use holochain_trace::{init_fmt, test_run_timed_flame};
 use kitsune_p2p::agent_store::AgentInfoSigned;
 use kitsune_p2p::gossip::sharded_gossip::test_utils::{check_ops_bloom, create_agent_bloom};
 use kitsune_p2p::KitsuneP2pConfig;
@@ -64,8 +63,6 @@ fn make_config(
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn fullsync_sharded_gossip_low_data() -> anyhow::Result<()> {
-    let f = test_run_timed_flame().unwrap();
-
     let _g = holochain_trace::test_run().ok();
     const NUM_CONDUCTORS: usize = 2;
 

--- a/crates/holochain/tests/speed_tests/mod.rs
+++ b/crates/holochain/tests/speed_tests/mod.rs
@@ -67,7 +67,7 @@ async fn speed_test_timed_json() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_timed_flame() {
-    let _g = holochain_trace::test_run_timed_flame(None).unwrap();
+    let _g = holochain_trace::test_run_timed_flame().unwrap();
     speed_test(None).await;
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 }
@@ -75,7 +75,7 @@ async fn speed_test_timed_flame() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "speed tests are ignored by default; unignore to run"]
 async fn speed_test_timed_ice() {
-    let _g = holochain_trace::test_run_timed_ice(None).unwrap();
+    let _g = holochain_trace::test_run_timed_ice().unwrap();
     speed_test(None).await;
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 }

--- a/crates/holochain_trace/src/flames.rs
+++ b/crates/holochain_trace/src/flames.rs
@@ -33,6 +33,22 @@ impl Visit for EventFieldFlameVisitor {
     }
 }
 
+pub(crate) struct FlameTimedConsole {
+    path: PathBuf,
+}
+
+impl FlameTimedConsole {
+    pub(crate) fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+}
+
+impl Drop for FlameTimedConsole {
+    fn drop(&mut self) {
+        save_flamegraph(self.path.clone());
+    }
+}
+
 pub(crate) struct FlameTimed(InMemoryWriter);
 
 impl FlameTimed {
@@ -75,6 +91,30 @@ pub(crate) fn toml_path() -> Option<PathBuf> {
         None
     })?;
     Some(PathBuf::from(path))
+}
+
+fn save_flamegraph(path: PathBuf) -> Option<()> {
+    println!("path {:?}", path);
+    let now = chrono::Local::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+    let inf = std::fs::File::open(path.join("flames.folded"))
+        .ok()
+        .or_else(|| {
+            eprintln!("failed to create flames dir");
+            None
+        })?;
+    let reader = std::io::BufReader::new(inf);
+
+    let out = std::fs::File::create(path.join(format!("tracing_flame_{}.svg", now)))
+        .ok()
+        .or_else(|| {
+            eprintln!("failed to create flames inferno");
+            None
+        })?;
+    let writer = std::io::BufWriter::new(out);
+
+    let mut opts = inferno::flamegraph::Options::default();
+    inferno::flamegraph::from_reader(&mut opts, reader, writer).unwrap();
+    Some(())
 }
 
 fn parse_time(samples: &mut usize, value: &dyn std::fmt::Debug) {

--- a/crates/holochain_trace/src/flames.rs
+++ b/crates/holochain_trace/src/flames.rs
@@ -1,9 +1,9 @@
 use tracing_core::field::Field;
 use tracing_subscriber::field::Visit;
 
+use crate::writer::InMemoryWriter;
 use chrono::SecondsFormat;
 use std::path::PathBuf;
-use crate::writer::InMemoryWriter;
 
 pub(crate) struct EventFieldFlameVisitor {
     pub samples: usize,
@@ -45,12 +45,16 @@ impl FlameTimed {
         println!("data size {}", self.0.buf().unwrap().len());
         let reader = std::io::BufReader::new(&mut self.0);
 
-        let out = std::fs::File::create(toml_path().unwrap_or(PathBuf::from(".")).join(format!("tracing_flame_{}.svg", now)))
-            .ok()
-            .or_else(|| {
-                eprintln!("failed to create flames inferno");
-                None
-            })?;
+        let out = std::fs::File::create(
+            toml_path()
+                .unwrap_or(PathBuf::from("."))
+                .join(format!("tracing_flame_{}.svg", now)),
+        )
+        .ok()
+        .or_else(|| {
+            eprintln!("failed to create flames inferno");
+            None
+        })?;
         let writer = std::io::BufWriter::new(out);
 
         let mut opts = inferno::flamegraph::Options::default();

--- a/crates/holochain_trace/src/flames.rs
+++ b/crates/holochain_trace/src/flames.rs
@@ -47,7 +47,7 @@ impl FlameTimed {
 
         let out = std::fs::File::create(
             toml_path()
-                .unwrap_or(PathBuf::from("."))
+                .unwrap_or_else(|| PathBuf::from("."))
                 .join(format!("tracing_flame_{}.svg", now)),
         )
         .ok()

--- a/crates/holochain_trace/src/lib.rs
+++ b/crates/holochain_trace/src/lib.rs
@@ -100,10 +100,10 @@ mod writer;
 // pub use open::should_run;
 // pub use open::{Config, Context, MsgWrap, OpenSpanExt};
 
+use crate::flames::{toml_path, FlameTimedConsole};
 use crate::writer::InMemoryWriter;
 pub use tracing;
 use tracing_subscriber::fmt::MakeWriter;
-use crate::flames::{FlameTimedConsole, toml_path};
 
 #[derive(Debug, Clone, Display)]
 /// Sets the kind of structured logging output you want
@@ -210,7 +210,9 @@ pub fn test_run_timed_flame() -> Result<Option<Box<impl Drop>>, errors::TracingE
 /// `2>| inferno-flamegraph > flamegraph_test_ice_(date +'%d-%m-%y-%X').svg`
 /// And run with `cargo test --quiet`
 #[deprecated]
-pub fn test_run_timed_flame_console(path: Option<&str>) -> Result<Option<impl Drop>, errors::TracingError> {
+pub fn test_run_timed_flame_console(
+    path: Option<&str>,
+) -> Result<Option<impl Drop>, errors::TracingError> {
     if std::env::var_os("RUST_LOG").is_none() {
         return Ok(None);
     }
@@ -238,7 +240,6 @@ pub fn test_run_timed_ice() -> Result<Option<Box<impl Drop>>, errors::TracingErr
     Ok(Some(Box::new(FlameTimed::new(writer_handle))))
 }
 
-
 /// Generate a flamegraph from timed spans "idle time".
 /// Takes a path where you are piping the output into.
 /// If the path is provided a flamegraph will automatically be generated.
@@ -247,7 +248,9 @@ pub fn test_run_timed_ice() -> Result<Option<Box<impl Drop>>, errors::TracingErr
 /// `2>| inferno-flamegraph -c blue > flamegraph_test_ice_(date +'%d-%m-%y-%X').svg`
 /// And run with `cargo test --quiet`
 #[deprecated]
-pub fn test_run_timed_ice_console(path: Option<&str>) -> Result<Option<impl Drop>, errors::TracingError> {
+pub fn test_run_timed_ice_console(
+    path: Option<&str>,
+) -> Result<Option<impl Drop>, errors::TracingError> {
     if std::env::var_os("RUST_LOG").is_none() {
         return Ok(None);
     }
@@ -267,8 +270,8 @@ pub fn init_fmt(output: Output) -> Result<(), errors::TracingError> {
 }
 
 fn init_fmt_with_opts<W>(output: Output, writer: W) -> Result<(), errors::TracingError>
-    where
-        W: for<'writer> MakeWriter<'writer> + Send + Sync + 'static,
+where
+    W: for<'writer> MakeWriter<'writer> + Send + Sync + 'static,
 {
     let mut filter = match std::env::var("RUST_LOG") {
         Ok(_) => EnvFilter::from_default_env(),
@@ -361,8 +364,8 @@ fn init_fmt_with_opts<W>(output: Output, writer: W) -> Result<(), errors::Tracin
 }
 
 fn finish<S>(subscriber: S) -> Result<(), errors::TracingError>
-    where
-        S: Subscriber + Send + Sync + for<'span> LookupSpan<'span>,
+where
+    S: Subscriber + Send + Sync + for<'span> LookupSpan<'span>,
 {
     let mut result = Ok(());
     INIT.call_once(|| {

--- a/crates/holochain_trace/src/lib.rs
+++ b/crates/holochain_trace/src/lib.rs
@@ -83,10 +83,12 @@ use tracing_subscriber::{
 
 use derive_more::Display;
 use std::{str::FromStr, sync::Once};
+use std::sync::{Arc, Mutex};
 
-use flames::{toml_path, FlameTimed};
+use flames::FlameTimed;
 use fmt::*;
 
+mod writer;
 mod flames;
 mod fmt;
 pub mod metrics;
@@ -99,6 +101,8 @@ pub mod metrics;
 // pub use open::{Config, Context, MsgWrap, OpenSpanExt};
 
 pub use tracing;
+use tracing_subscriber::fmt::MakeWriter;
+use crate::writer::InMemoryWriter;
 
 #[derive(Debug, Clone, Display)]
 /// Sets the kind of structured logging output you want
@@ -146,13 +150,14 @@ impl FromStr for Output {
     }
 }
 
-/// Run logging in a unit test
-/// RUST_LOG or CUSTOM_FILTER must be set or
-/// this is a no-op
+/// Run logging in a unit test.
+///
+/// RUST_LOG must be set or this is a no-op.
 pub fn test_run() -> Result<(), errors::TracingError> {
     if std::env::var_os("RUST_LOG").is_none() {
         return Ok(());
     }
+
     init_fmt(Output::Log)
 }
 
@@ -181,49 +186,39 @@ pub fn test_run_timed_json() -> Result<(), errors::TracingError> {
     init_fmt(Output::JsonTimed)
 }
 
-/// Generate a flamegraph from timed spans "busy time".
-/// Takes a path where you are piping the output into.
-/// If the path is provided a flamegraph will automatically be generated.
-/// TODO: Get auto inferno to work
-/// for now use (fish, or the bash equiv):
-/// `2>| inferno-flamegraph > flamegraph_test_ice_(date +'%d-%m-%y-%X').svg`
-/// And run with `cargo test --quiet`
-pub fn test_run_timed_flame(path: Option<&str>) -> Result<Option<impl Drop>, errors::TracingError> {
+/// Generate a flamegraph from timed spans of "busy time".
+pub fn test_run_timed_flame() -> Result<Option<Box<impl Drop>>, errors::TracingError> {
     if std::env::var_os("RUST_LOG").is_none() {
         return Ok(None);
     }
-    init_fmt(Output::FlameTimed)?;
-    Ok(path.and_then(|p| {
-        toml_path().map(|mut t| {
-            t.push(p);
-            FlameTimed::new(t)
-        })
-    }))
+
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let writer_handle = InMemoryWriter::new(buffer.clone());
+
+    init_fmt_with_opts(Output::FlameTimed, move || InMemoryWriter::new(buffer.clone()))?;
+    Ok(Some(Box::new(FlameTimed::new(writer_handle))))
 }
 
-/// Generate a flamegraph from timed spans "idle time".
-/// Takes a path where you are piping the output into.
-/// If the path is provided a flamegraph will automatically be generated.
-/// TODO: Get auto inferno to work
-/// for now use (fish, or the bash equiv):
-/// `2>| inferno-flamegraph -c blue > flamegraph_test_ice_(date +'%d-%m-%y-%X').svg`
-/// And run with `cargo test --quiet`
-pub fn test_run_timed_ice(path: Option<&str>) -> Result<Option<impl Drop>, errors::TracingError> {
+/// Generate a flamegraph from timed spans of "idle time".
+pub fn test_run_timed_ice() -> Result<Option<Box<impl Drop>>, errors::TracingError> {
     if std::env::var_os("RUST_LOG").is_none() {
         return Ok(None);
     }
-    init_fmt(Output::IceTimed)?;
-    Ok(path.and_then(|p| {
-        toml_path().map(|mut t| {
-            t.push(p);
-            FlameTimed::new(t)
-        })
-    }))
+
+    let buffer = Arc::new(Mutex::new(Vec::new()));
+    let writer_handle = InMemoryWriter::new(buffer.clone());
+
+    init_fmt_with_opts(Output::IceTimed, move || InMemoryWriter::new(buffer.clone()))?;
+    Ok(Some(Box::new(FlameTimed::new(writer_handle))))
 }
 
 /// This checks RUST_LOG for a filter but doesn't complain if there is none or it doesn't parse.
 /// It then checks for CUSTOM_FILTER which if set will output an error if it doesn't parse.
 pub fn init_fmt(output: Output) -> Result<(), errors::TracingError> {
+    init_fmt_with_opts(output, std::io::stderr)
+}
+
+fn init_fmt_with_opts<W>(output: Output, writer: W) -> Result<(), errors::TracingError> where W: for<'writer> MakeWriter<'writer> + Send + Sync + 'static {
     let mut filter = match std::env::var("RUST_LOG") {
         Ok(_) => EnvFilter::from_default_env(),
         Err(_) => EnvFilter::from_default_env().add_directive("[wasm_debug]=debug".parse()?),
@@ -238,7 +233,8 @@ pub fn init_fmt(output: Output) -> Result<(), errors::TracingError> {
     }
 
     let subscriber = FmtSubscriber::builder()
-        .with_writer(std::io::stderr)
+        .with_test_writer()
+        .with_writer(writer)
         .with_file(true)
         .with_line_number(true)
         .with_target(true);

--- a/crates/holochain_trace/src/writer.rs
+++ b/crates/holochain_trace/src/writer.rs
@@ -1,0 +1,32 @@
+use std::io;
+use std::sync::{Arc, Mutex, MutexGuard};
+
+pub(crate) struct InMemoryWriter {
+    buf: Arc<Mutex<Vec<u8>>>,
+}
+
+impl InMemoryWriter {
+    pub(crate) fn new(buf: Arc<Mutex<Vec<u8>>>) -> Self {
+        Self { buf }
+    }
+
+    pub(crate) fn buf(&self) -> io::Result<MutexGuard<'_, Vec<u8>>> {
+        self.buf.try_lock().map_err(|_| io::Error::from(io::ErrorKind::Other))
+    }
+}
+
+impl io::Write for InMemoryWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf()?.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.buf()?.flush()
+    }
+}
+
+impl io::Read for InMemoryWriter {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.buf()?.as_slice().read(buf)
+    }
+}


### PR DESCRIPTION
### Summary

This means flamegraphs can be generated from test code without the need to install CLI tools or wrestle with the details of redirecting streams in different shells. Simply replace `test_run` with one of `test_run_timed_flame` or `test_run_timed_ice` and have a good chunk of RAM available 😄 The RAM usage is quite significant either way, you get a lot of data out of the system in tests.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
