### PR TITLE
Add websocket test for heavy use

### DIFF
--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -34,6 +34,9 @@ unwrap_to = "0.1.0"
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../holochain_trace" }
 criterion = "0.3.4"
 
+[features]
+slow_tests = []
+
 [[bench]]
 name = "bench"
 harness = false

--- a/crates/holochain_websocket/tests/integration.rs
+++ b/crates/holochain_websocket/tests/integration.rs
@@ -2,12 +2,12 @@ use std::sync::Arc;
 
 use futures::StreamExt;
 use holochain_serialized_bytes::prelude::*;
-use holochain_websocket::connect;
 use holochain_websocket::ListenerHandle;
 use holochain_websocket::ListenerItem;
 use holochain_websocket::WebsocketConfig;
 use holochain_websocket::WebsocketError;
 use holochain_websocket::WebsocketListener;
+use holochain_websocket::{connect, Pair};
 use stream_cancel::Tripwire;
 use tracing::Instrument;
 use url2::url2;
@@ -77,6 +77,34 @@ fn server_recv(
         {
             let msg: TestString = msg.try_into().unwrap();
             tracing::debug!(server_recv_msg = ?msg);
+        }
+    })
+}
+
+/// Runs a listener and accepts multiple incoming connections. A task is spawned for each connection
+/// that will listen until the client disconnects.
+fn server_recv_multi(
+    mut listener: impl futures::stream::Stream<Item = ListenerItem> + Unpin + Send + 'static,
+) -> tokio::task::JoinHandle<()> {
+    tokio::task::spawn(async move {
+        loop {
+            let (_, mut receiver) = listener
+                .next()
+                .instrument(tracing::debug_span!("next_server_connection"))
+                .await
+                .unwrap()
+                .unwrap() as Pair;
+
+            let _ = tokio::task::spawn(async move {
+                while let Some((msg, _)) = receiver
+                    .next()
+                    .instrument(tracing::debug_span!("server_recv_msg"))
+                    .await
+                {
+                    let msg: TestString = msg.try_into().unwrap();
+                    tracing::debug!(server_recv_msg = ?msg);
+                }
+            });
         }
     })
 }
@@ -451,4 +479,54 @@ async fn cancel_response() {
     rh.close();
     c_jh.await.unwrap();
     s_jh.await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg(feature = "slow_tests")]
+async fn can_handle_many_connections_and_disconnects() {
+    holochain_trace::test_run().ok();
+    let (handle, listener) = server().await;
+    let s_jh = server_recv_multi(listener);
+    let binding = handle.local_addr().clone();
+
+    let b2 = binding.clone();
+    tokio::spawn(async move {
+        let mut senders = Vec::new();
+        for i in 0..100_000 {
+            if i % 5_000 == 0 {
+                senders.clear();
+            }
+
+            let (mut sender, _) = connect(b2.clone(), Arc::new(WebsocketConfig::default()))
+                .instrument(tracing::debug_span!("client"))
+                .await
+                .unwrap();
+
+            sender
+                .signal(TestString("Hey from client".to_owned()))
+                .instrument(tracing::debug_span!("client_sending_message"))
+                .await
+                .unwrap();
+
+            senders.push(sender);
+        }
+
+        senders.clear();
+    })
+    .await
+    .unwrap();
+
+    // Check that the listener is still up and healthy after the many connections/disconnects above
+    let (mut sender, _) = connect(binding.clone(), Arc::new(WebsocketConfig::default()))
+        .instrument(tracing::debug_span!("client"))
+        .await
+        .unwrap();
+
+    sender
+        .signal(TestString("Ho from client".to_owned()))
+        .instrument(tracing::debug_span!("client_sending_message"))
+        .await
+        .unwrap();
+
+    s_jh.abort();
 }

--- a/crates/holochain_websocket/tests/integration.rs
+++ b/crates/holochain_websocket/tests/integration.rs
@@ -493,9 +493,14 @@ async fn can_handle_many_connections_and_disconnects() {
 
     let b2 = binding.clone();
     tokio::spawn(async move {
+        // Hold opened senders to avoid immediately dropping them. Otherwise we're not really testing lots of open
+        // connections at once.
         let mut senders = Vec::new();
         for i in 0..100_000 {
             if i % 800 == 0 {
+                // Rather than attempting to exhaust resources by opening 100,000 connections at once, drop/close
+                // connections at intervals. If we are able to keep opening connections up to 100,000 then it's likely
+                // that connection closing is working correctly on both the client and server
                 senders.clear();
             }
 

--- a/crates/holochain_websocket/tests/integration.rs
+++ b/crates/holochain_websocket/tests/integration.rs
@@ -484,6 +484,7 @@ async fn cancel_response() {
 
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "slow_tests")]
+#[ignore = "takes at least 45s, please run me occasionally"]
 async fn can_handle_many_connections_and_disconnects() {
     holochain_trace::test_run().ok();
     let (handle, listener) = server().await;
@@ -493,7 +494,7 @@ async fn can_handle_many_connections_and_disconnects() {
     let b2 = binding.clone();
     tokio::spawn(async move {
         let mut senders = Vec::new();
-        for i in 0..10_000 {
+        for i in 0..100_000 {
             if i % 800 == 0 {
                 senders.clear();
             }

--- a/crates/holochain_websocket/tests/integration.rs
+++ b/crates/holochain_websocket/tests/integration.rs
@@ -83,6 +83,7 @@ fn server_recv(
 
 /// Runs a listener and accepts multiple incoming connections. A task is spawned for each connection
 /// that will listen until the client disconnects.
+#[cfg(feature = "slow_tests")]
 fn server_recv_multi(
     mut listener: impl futures::stream::Stream<Item = ListenerItem> + Unpin + Send + 'static,
 ) -> tokio::task::JoinHandle<()> {
@@ -492,8 +493,8 @@ async fn can_handle_many_connections_and_disconnects() {
     let b2 = binding.clone();
     tokio::spawn(async move {
         let mut senders = Vec::new();
-        for i in 0..100_000 {
-            if i % 5_000 == 0 {
+        for i in 0..10_000 {
+            if i % 800 == 0 {
                 senders.clear();
             }
 


### PR DESCRIPTION
### Summary

I have another branch that I can use to flood Holochain and prevent further connections https://github.com/holochain/holochain-client-rust/compare/add-spam-example-for-holochain?expand=1. This test proves the problem isn't in the websocket code, or that this test isn't written right to demonstrate the problem. Chances are then that the problem is in the use of this crate in the conductor which at least helps narrow things down. Opening a PR for now to keep track of this branch but not ready to merge!

See the original issue https://github.com/holochain/holochain/issues/1666

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
