### PR TITLE
Fix connection limiting in the admin websocket

### DIFF
--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -18,10 +18,9 @@ use holochain_websocket::WebsocketReceiver;
 use holochain_websocket::WebsocketSender;
 use std::convert::TryFrom;
 
-use std::sync::atomic::AtomicIsize;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
 use tracing::*;
 use url2::url2;
@@ -30,7 +29,8 @@ use url2::url2;
 /// Number of signals in buffer before applying
 /// back pressure.
 pub(crate) const SIGNAL_BUFFER_SIZE: usize = 50;
-const MAX_CONNECTIONS: isize = 400;
+/// The maximum number of connections allowed to the admin interface
+pub const MAX_CONNECTIONS: usize = 400;
 
 /// Create a WebsocketListener to be used in interfaces
 pub async fn spawn_websocket_listener(
@@ -65,22 +65,25 @@ pub fn spawn_admin_interface_tasks<A: InterfaceApi>(
 
     tm.add_conductor_task_ignored(&format!("admin interface, port {}", port), |_stop| {
         async move {
-            let num_connections = Arc::new(AtomicIsize::new(0));
+            let mut active_connections = Vec::new();
             futures::pin_mut!(listener);
             // establish a new connection to a client
             while let Some(connection) = listener.next().await {
+                active_connections.retain_mut(|handle: &mut JoinHandle<()>| !handle.is_finished());
+
                 match connection {
                     Ok((_, rx_from_iface)) => {
-                        if num_connections.fetch_add(1, Ordering::Relaxed) > MAX_CONNECTIONS {
+                        if active_connections.len() >= MAX_CONNECTIONS {
+                            warn!("Connection limit reached, dropping newly opened connection. num_connections={}", active_connections.len());
                             // Max connections so drop this connection
                             // which will close it.
                             continue;
                         };
-                        tokio::task::spawn(recv_incoming_admin_msgs(
+                        debug!("Accepting new connection with number of existing connections {}", active_connections.len());
+                        active_connections.push(tokio::task::spawn(recv_incoming_admin_msgs(
                             api.clone(),
                             rx_from_iface,
-                            num_connections.clone(),
-                        ));
+                        )));
                     }
                     Err(err) => {
                         warn!("Admin socket connection failed: {}", err);
@@ -146,7 +149,6 @@ pub async fn spawn_app_interface_task<A: InterfaceApi>(
 async fn recv_incoming_admin_msgs<A: InterfaceApi>(
     api: A,
     rx_from_iface: WebsocketReceiver,
-    num_connections: Arc<AtomicIsize>,
 ) {
     use futures::stream::StreamExt;
 
@@ -160,7 +162,6 @@ async fn recv_incoming_admin_msgs<A: InterfaceApi>(
             }
         })
         .await;
-    num_connections.fetch_sub(1, Ordering::SeqCst);
 }
 
 /// Polls for messages coming in from the external client while simultaneously

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -146,10 +146,7 @@ pub async fn spawn_app_interface_task<A: InterfaceApi>(
 
 /// Polls for messages coming in from the external client.
 /// Used by Admin interface.
-async fn recv_incoming_admin_msgs<A: InterfaceApi>(
-    api: A,
-    rx_from_iface: WebsocketReceiver,
-) {
+async fn recv_incoming_admin_msgs<A: InterfaceApi>(api: A, rx_from_iface: WebsocketReceiver) {
     use futures::stream::StreamExt;
 
     rx_from_iface

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -2,6 +2,7 @@ use ::fixt::prelude::*;
 use anyhow::Result;
 use futures::future;
 use hdk::prelude::RemoteSignal;
+use holochain::conductor::interface::websocket::MAX_CONNECTIONS;
 use holochain::sweettest::SweetConductor;
 use holochain::sweettest::SweetConductorBatch;
 use holochain::sweettest::SweetDnaFile;
@@ -28,7 +29,6 @@ use tempfile::TempDir;
 use tokio_stream::StreamExt;
 use tracing::*;
 use url2::prelude::*;
-use holochain::conductor::interface::websocket::MAX_CONNECTIONS;
 
 use crate::test_utils::*;
 
@@ -68,7 +68,7 @@ test: "example"
 how_many: 42
     "#,
         )
-            .unwrap(),
+        .unwrap(),
     );
 
     // Install Dna
@@ -84,7 +84,7 @@ how_many: 42
         "role_name".into(),
         10000,
     )
-        .await;
+    .await;
 
     // List Dnas
     let request = AdminRequest::ListDnas;
@@ -143,7 +143,7 @@ async fn call_zome() {
         "".into(),
         10000,
     )
-        .await;
+    .await;
     let cell_id = CellId::new(dna_hash.clone(), agent_key.clone());
 
     // List Dnas
@@ -177,7 +177,7 @@ async fn call_zome() {
         fn_name.clone(),
         signing_key,
     )
-        .await;
+    .await;
 
     // Attach App Interface
     let app_port = attach_app_interface(&mut admin_tx, None).await;
@@ -195,7 +195,7 @@ async fn call_zome() {
         fn_name.clone(),
         &(),
     )
-        .await;
+    .await;
 
     // Ensure that the other client does not receive any messages, i.e. that
     // responses are not broadcast to all connected clients, only the one
@@ -241,7 +241,7 @@ async fn call_zome() {
         fn_name.clone(),
         &(),
     )
-        .await;
+    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -306,8 +306,8 @@ async fn remote_signals() -> anyhow::Result<()> {
             assert_matches!(r, Ok(Signal::App{signal: a,..}) if a == signal);
         }
     })
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     Ok(())
 }
@@ -352,7 +352,7 @@ async fn emit_signals() {
         "".into(),
         10000,
     )
-        .await;
+    .await;
     let cell_id = CellId::new(dna_hash.clone(), agent_key.clone());
 
     // Activate cells
@@ -378,7 +378,7 @@ async fn emit_signals() {
         fn_name.clone(),
         signing_key,
     )
-        .await;
+    .await;
 
     // Attach App Interface
     let app_port = attach_app_interface(&mut admin_tx, None).await;
@@ -398,7 +398,7 @@ async fn emit_signals() {
         fn_name,
         &(),
     )
-        .await;
+    .await;
 
     let (sig1, msg1) = Box::pin(app_rx_1.timeout(Duration::from_secs(1)))
         .next()
@@ -472,7 +472,7 @@ async fn list_app_interfaces_succeeds() -> Result<()> {
             ..Default::default()
         }),
     )
-        .await?;
+    .await?;
 
     let request = AdminRequest::ListAppInterfaces;
 
@@ -511,7 +511,7 @@ async fn conductor_admin_interface_ends_with_shutdown_inner() -> Result<()> {
             ..Default::default()
         }),
     )
-        .await?;
+    .await?;
 
     info!("client connect");
 
@@ -572,16 +572,22 @@ async fn connection_limit_is_respected() {
     // The first `MAX_CONNECTIONS` connections should succeed
     for _ in 0..MAX_CONNECTIONS {
         let (mut sender, _) = connect(url.clone(), cfg.clone()).await.unwrap();
-        let _: AdminResponse = sender.request(AdminRequest::ListDnas).await.expect("Admin request should succeed because there are enough available connections");
+        let _: AdminResponse = sender
+            .request(AdminRequest::ListDnas)
+            .await
+            .expect("Admin request should succeed because there are enough available connections");
         handles.push(sender);
     }
 
     // Try lots of failed connections to make sure the limit is respected
-    for _ in 0..2*MAX_CONNECTIONS {
+    for _ in 0..2 * MAX_CONNECTIONS {
         let (mut sender, _) = connect(url.clone(), cfg.clone()).await.unwrap();
 
         // Getting a sender back isn't enough to know that the connection succeeded because the other side takes a moment to shutdown, try sending to be sure
-        sender.request::<AdminRequest, AdminResponse>(AdminRequest::ListDnas).await.expect_err("Should be no available connection slots");
+        sender
+            .request::<AdminRequest, AdminResponse>(AdminRequest::ListDnas)
+            .await
+            .expect_err("Should be no available connection slots");
     }
 
     // Disconnect all the clients
@@ -590,7 +596,10 @@ async fn connection_limit_is_respected() {
     // Should now be possible to connect new clients
     for _ in 0..MAX_CONNECTIONS {
         let (mut sender, _) = connect(url.clone(), cfg.clone()).await.unwrap();
-        let _: AdminResponse = sender.request(AdminRequest::ListDnas).await.expect("Admin request should succeed because there are enough available connections");
+        let _: AdminResponse = sender
+            .request(AdminRequest::ListDnas)
+            .await
+            .expect("Admin request should succeed because there are enough available connections");
         handles.push(sender);
     }
 
@@ -649,7 +658,7 @@ async fn concurrent_install_dna() {
                 name.clone(),
                 REQ_TIMEOUT_MS,
             )
-                .await;
+            .await;
 
             //println!(
             //    "[{}] installed dna with hash {} and name {}",
@@ -657,7 +666,7 @@ async fn concurrent_install_dna() {
             //);
         })
     }))
-        .buffer_unordered(NUM_CONCURRENT_INSTALLS.into());
+    .buffer_unordered(NUM_CONCURRENT_INSTALLS.into());
 
     let install_tasks = futures::StreamExt::collect::<Vec<_>>(install_tasks_stream);
 
@@ -743,7 +752,7 @@ async fn full_state_dump_cursor_works() {
         cell_id,
         Some(full_state.integration_dump.dht_ops_cursor - 1),
     )
-        .await;
+    .await;
 
     let integrated_ops_count = full_state.integration_dump.integrated.len();
     let validation_limbo_ops_count = full_state.integration_dump.validation_limbo.len();


### PR DESCRIPTION
### Summary

I'm going to put comments onto the code rather than a description here. The quick summary is that the number of connections we thought we had open wasn't necessarily the number we actually had open. Similarly the test we thought we had to check this scenario was checking less than it needed to.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
