### PR TITLE
create a release from branch release-20230508.190706

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # \[Unreleased\]
 
+# 20230508.190706
+
+## [holochain\_cli-0.1.5-beta-rc.1](crates/holochain_cli/CHANGELOG.md#0.1.5-beta-rc.1)
+
+## [holochain\_cli\_sandbox-0.1.5-beta-rc.1](crates/holochain_cli_sandbox/CHANGELOG.md#0.1.5-beta-rc.1)
+
+## [holochain\_cli\_bundle-0.1.5-beta-rc.1](crates/holochain_cli_bundle/CHANGELOG.md#0.1.5-beta-rc.1)
+
+## [holochain-0.1.5-beta-rc.1](crates/holochain/CHANGELOG.md#0.1.5-beta-rc.1)
+
+- The feature `test_utils` is no longer a default feature. To consume `sweetest` from this crate please now use `default-features = false` and the feature `sweetest`.
+
+## [holochain\_test\_wasm\_common-0.1.3-beta-rc.1](crates/holochain_test_wasm_common/CHANGELOG.md#0.1.3-beta-rc.1)
+
+## [holochain\_conductor\_api-0.1.5-beta-rc.1](crates/holochain_conductor_api/CHANGELOG.md#0.1.5-beta-rc.1)
+
+## [holochain\_wasm\_test\_utils-0.1.5-beta-rc.1](crates/holochain_wasm_test_utils/CHANGELOG.md#0.1.5-beta-rc.1)
+
+## [holochain\_cascade-0.1.5-beta-rc.1](crates/holochain_cascade/CHANGELOG.md#0.1.5-beta-rc.1)
+
+## [holochain\_state-0.1.5-beta-rc.1](crates/holochain_state/CHANGELOG.md#0.1.5-beta-rc.1)
+
+## [holochain\_p2p-0.1.5-beta-rc.1](crates/holochain_p2p/CHANGELOG.md#0.1.5-beta-rc.1)
+
+## [holochain\_types-0.1.5-beta-rc.1](crates/holochain_types/CHANGELOG.md#0.1.5-beta-rc.1)
+
+## [holochain\_keystore-0.1.5-beta-rc.1](crates/holochain_keystore/CHANGELOG.md#0.1.5-beta-rc.1)
+
+## [holochain\_sqlite-0.1.5-beta-rc.1](crates/holochain_sqlite/CHANGELOG.md#0.1.5-beta-rc.1)
+
+## [kitsune\_p2p-0.1.4-beta-rc.1](crates/kitsune_p2p/CHANGELOG.md#0.1.4-beta-rc.1)
+
+## [kitsune\_p2p\_proxy-0.1.3-beta-rc.1](crates/kitsune_p2p_proxy/CHANGELOG.md#0.1.3-beta-rc.1)
+
+## [kitsune\_p2p\_transport\_quic-0.1.3-beta-rc.1](crates/kitsune_p2p_transport_quic/CHANGELOG.md#0.1.3-beta-rc.1)
+
+## [hdk-0.1.3-beta-rc.1](crates/hdk/CHANGELOG.md#0.1.3-beta-rc.1)
+
+## [holochain\_zome\_types-0.1.3-beta-rc.1](crates/holochain_zome_types/CHANGELOG.md#0.1.3-beta-rc.1)
+
+- Reverts the below change so that `name` in DnaDef does effect on the DNA hash. Holochain does not support the DNA hash changing so this change will remain in `0.2` but be removed from the `0.1` stream.
+
 # 20230424.185716
 
 ## [holochain\_cli-0.1.5-beta-rc.0](crates/holochain_cli/CHANGELOG.md#0.1.5-beta-rc.0)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.1.3-beta-rc.0"
+version = "0.1.3-beta-rc.1"
 dependencies = [
  "fixt",
  "getrandom 0.2.8",
@@ -2203,7 +2203,7 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2301,7 +2301,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2336,7 +2336,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 dependencies = [
  "anyhow",
  "futures",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_bundle"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 dependencies = [
  "anyhow",
  "assert_cmd 1.0.8",
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_sandbox"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -2399,7 +2399,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 dependencies = [
  "derive_more",
  "directories",
@@ -2440,7 +2440,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 dependencies = [
  "assert_cmd 2.0.8",
  "base64 0.13.1",
@@ -2475,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_p2p"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2554,7 +2554,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2604,7 +2604,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.1.3-beta-rc.0"
+version = "0.1.3-beta-rc.1"
 dependencies = [
  "hdk",
  "serde",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_test_utils"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 dependencies = [
  "holochain_types",
  "holochain_util",
@@ -2821,7 +2821,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.1.3-beta-rc.0"
+version = "0.1.3-beta-rc.1"
 dependencies = [
  "arbitrary",
  "contrafact",
@@ -3185,7 +3185,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p"
-version = "0.1.4-beta-rc.0"
+version = "0.1.4-beta-rc.1"
 dependencies = [
  "arbitrary",
  "arrayref",
@@ -3392,7 +3392,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_proxy"
-version = "0.1.3-beta-rc.0"
+version = "0.1.3-beta-rc.1"
 dependencies = [
  "base64 0.13.1",
  "blake2b_simd 0.5.11",
@@ -3430,7 +3430,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_transport_quic"
-version = "0.1.3-beta-rc.0"
+version = "0.1.3-beta-rc.1"
 dependencies = [
  "blake2b_simd 1.0.1",
  "futures",

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.1.5-beta-rc.1
+
 ## 0.1.5-beta-rc.0
 
 ## 0.1.4

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
@@ -21,8 +21,8 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0"
 futures = "0.3"
-holochain_cli_bundle = { path = "../hc_bundle", version = "^0.1.5-beta-rc.0"}
-holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.1.5-beta-rc.0"}
+holochain_cli_bundle = { path = "../hc_bundle", version = "^0.1.5-beta-rc.1"}
+holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.1.5-beta-rc.1"}
 observability = "0.1.3"
 structopt = "0.3"
 tokio = { version = "1.11", features = [ "full" ] }

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-beta-rc.1
+
 ## 0.1.5-beta-rc.0
 
 ## 0.1.4

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_bundle"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 description = "DNA and hApp bundling functionality for the `hc` Holochain CLI utility"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -22,7 +22,7 @@ path = "src/bin/hc-dna.rs"
 anyhow = "1.0"
 holochain_util = { path = "../holochain_util", features = ["backtrace"], version = "^0.1.1-beta-rc.0"}
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "^0.1.5-beta-rc.0", path = "../holochain_types" }
+holochain_types = { version = "^0.1.5-beta-rc.1", path = "../holochain_types" }
 mr_bundle = {version = "^0.1.1-beta-rc.0", path = "../mr_bundle"}
 serde = { version = "1.0", features = [ "derive" ] }
 serde_bytes = "0.11"

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-beta-rc.1
+
 ## 0.1.5-beta-rc.0
 
 ## 0.1.4

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_sandbox"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli_sandbox"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
@@ -19,10 +19,10 @@ anyhow = "1.0"
 ansi_term = "0.12"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 futures = "0.3"
-holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.1.5-beta-rc.0", features = ["sqlite"] }
-holochain_types = { path = "../holochain_types", version = "^0.1.5-beta-rc.0", features = ["sqlite"] }
+holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.1.5-beta-rc.1", features = ["sqlite"] }
+holochain_types = { path = "../holochain_types", version = "^0.1.5-beta-rc.1", features = ["sqlite"] }
 holochain_websocket = { path = "../holochain_websocket", version = "^0.1.1-beta-rc.0"}
-holochain_p2p = { path = "../holochain_p2p", version = "^0.1.5-beta-rc.0", features = ["sqlite"] }
+holochain_p2p = { path = "../holochain_p2p", version = "^0.1.5-beta-rc.1", features = ["sqlite"] }
 holochain_util = { version = "^0.1.1-beta-rc.0", path = "../holochain_util", features = [ "pw" ] }
 nanoid = "0.3"
 observability = "0.1.3"

--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.1.3-beta-rc.1
+
 ## 0.1.3-beta-rc.0
 
 ## 0.1.2

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk"
-version = "0.1.3-beta-rc.0"
+version = "0.1.3-beta-rc.1"
 description = "The Holochain HDK"
 license = "CAL-1.0"
 homepage = "https://github.com/holochain/holochain/tree/develop/crates/hdk"
@@ -30,7 +30,7 @@ holo_hash = { version = "^0.1.3-beta-rc.0", path = "../holo_hash" }
 holochain_wasmer_guest = "=0.0.83"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
-holochain_zome_types = { version = "^0.1.3-beta-rc.0", path = "../holochain_zome_types", default-features = false }
+holochain_zome_types = { version = "^0.1.3-beta-rc.1", path = "../holochain_zome_types", default-features = false }
 paste = "=1.0.5"
 serde = "1.0"
 serde_bytes = "0.11"

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.1.5-beta-rc.1
+
 - The feature `test_utils` is no longer a default feature. To consume `sweetest` from this crate please now use `default-features = false` and the feature `sweetest`.
 
 ## 0.1.5-beta-rc.0

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 description = "Holochain, a framework for distributed applications"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -24,20 +24,20 @@ futures = "0.3.1"
 getrandom = "0.2.7"
 ghost_actor = "0.3.0-alpha.4"
 holo_hash = { version = "^0.1.3-beta-rc.0", path = "../holo_hash", features = ["full"] }
-holochain_cascade = { version = "^0.1.5-beta-rc.0", path = "../holochain_cascade" }
-holochain_conductor_api = { version = "^0.1.5-beta-rc.0", path = "../holochain_conductor_api" }
-holochain_keystore = { version = "^0.1.5-beta-rc.0", path = "../holochain_keystore", default-features = false }
-holochain_p2p = { version = "^0.1.5-beta-rc.0", path = "../holochain_p2p" }
-holochain_sqlite = { version = "^0.1.5-beta-rc.0", path = "../holochain_sqlite" }
+holochain_cascade = { version = "^0.1.5-beta-rc.1", path = "../holochain_cascade" }
+holochain_conductor_api = { version = "^0.1.5-beta-rc.1", path = "../holochain_conductor_api" }
+holochain_keystore = { version = "^0.1.5-beta-rc.1", path = "../holochain_keystore", default-features = false }
+holochain_p2p = { version = "^0.1.5-beta-rc.1", path = "../holochain_p2p" }
+holochain_sqlite = { version = "^0.1.5-beta-rc.1", path = "../holochain_sqlite" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_state = { version = "^0.1.5-beta-rc.0", path = "../holochain_state" }
-holochain_types = { version = "^0.1.5-beta-rc.0", path = "../holochain_types" }
+holochain_state = { version = "^0.1.5-beta-rc.1", path = "../holochain_state" }
+holochain_types = { version = "^0.1.5-beta-rc.1", path = "../holochain_types" }
 holochain_util = { version = "^0.1.1-beta-rc.0", path = "../holochain_util", features = [ "pw" ] }
 holochain_wasmer_host = "=0.0.83"
 holochain_websocket = { version = "^0.1.1-beta-rc.0", path = "../holochain_websocket" }
-holochain_zome_types = { version = "^0.1.3-beta-rc.0", path = "../holochain_zome_types", features = ["full"] }
+holochain_zome_types = { version = "^0.1.3-beta-rc.1", path = "../holochain_zome_types", features = ["full"] }
 human-panic = "1.0.3"
-kitsune_p2p = { version = "^0.1.4-beta-rc.0", path = "../kitsune_p2p/kitsune_p2p", default-features = false }
+kitsune_p2p = { version = "^0.1.4-beta-rc.1", path = "../kitsune_p2p/kitsune_p2p", default-features = false }
 kitsune_p2p_types = { version = "^0.1.3-beta-rc.0", path = "../kitsune_p2p/types" }
 lazy_static = "1.4.0"
 mockall = "0.10.2"
@@ -75,15 +75,15 @@ url = "1.7.2"
 url2 = "0.0.6"
 url_serde = "0.2.0"
 uuid = { version = "0.7", features = [ "serde", "v4" ] }
-holochain_wasm_test_utils = { version = "^0.1.5-beta-rc.0", path = "../test_utils/wasm" }
+holochain_wasm_test_utils = { version = "^0.1.5-beta-rc.1", path = "../test_utils/wasm" }
 tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
 async-recursion = "0.3"
 wasmer-middlewares = "2"
 
 # Dependencies for test_utils: keep in sync with below
-hdk = { version = "^0.1.3-beta-rc.0", path = "../hdk", optional = true }
+hdk = { version = "^0.1.3-beta-rc.1", path = "../hdk", optional = true }
 matches = {version = "0.1.8", optional = true }
-holochain_test_wasm_common = { version = "^0.1.3-beta-rc.0", path = "../test_utils/wasm_common", optional = true  }
+holochain_test_wasm_common = { version = "^0.1.3-beta-rc.1", path = "../test_utils/wasm_common", optional = true  }
 unwrap_to = { version = "0.1.0", optional = true }
 itertools = { version = "0.10", optional = false }
 
@@ -113,14 +113,14 @@ serial_test = "0.4.0"
 test-case = "1.2.1"
 
 # Dependencies for test_utils: keep in sync with above
-hdk = { version = "^0.1.3-beta-rc.0", path = "../hdk", optional = false }
+hdk = { version = "^0.1.3-beta-rc.1", path = "../hdk", optional = false }
 matches = {version = "0.1.8", optional = false }
-holochain_test_wasm_common = { version = "^0.1.3-beta-rc.0", path = "../test_utils/wasm_common", optional = false  }
+holochain_test_wasm_common = { version = "^0.1.3-beta-rc.1", path = "../test_utils/wasm_common", optional = false  }
 unwrap_to = { version = "0.1.0", optional = false }
 arbitrary = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-hdk = { version = "^0.1.3-beta-rc.0", path = "../hdk"}
+hdk = { version = "^0.1.3-beta-rc.1", path = "../hdk"}
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0.51" }
 toml = "0.5.6"

--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-beta-rc.1
+
 ## 0.1.5-beta-rc.0
 
 ## 0.1.4

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cascade"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 description = "Logic for cascading updates to Holochain state and network interaction"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -15,17 +15,17 @@ fallible-iterator = "0.2"
 fixt = { version = "^0.1.2-beta-rc.0", path = "../fixt" }
 futures = "0.3"
 ghost_actor = "=0.3.0-alpha.4"
-hdk = { version = "^0.1.3-beta-rc.0", path = "../hdk" }
+hdk = { version = "^0.1.3-beta-rc.1", path = "../hdk" }
 hdk_derive = { version = "^0.1.3-beta-rc.0", path = "../hdk_derive" }
 holo_hash = { version = "^0.1.3-beta-rc.0", path = "../holo_hash", features = ["full"] }
-holochain_sqlite = { version = "^0.1.5-beta-rc.0", path = "../holochain_sqlite" }
-holochain_p2p = { version = "^0.1.5-beta-rc.0", path = "../holochain_p2p" }
+holochain_sqlite = { version = "^0.1.5-beta-rc.1", path = "../holochain_sqlite" }
+holochain_p2p = { version = "^0.1.5-beta-rc.1", path = "../holochain_p2p" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_state = { version = "^0.1.5-beta-rc.0", path = "../holochain_state" }
-holochain_types = { version = "^0.1.5-beta-rc.0", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.1.3-beta-rc.0", path = "../holochain_zome_types" }
+holochain_state = { version = "^0.1.5-beta-rc.1", path = "../holochain_state" }
+holochain_types = { version = "^0.1.5-beta-rc.1", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.1.3-beta-rc.1", path = "../holochain_zome_types" }
 observability = "0.1.3"
-kitsune_p2p = { version = "^0.1.4-beta-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "^0.1.4-beta-rc.1", path = "../kitsune_p2p/kitsune_p2p" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 tokio = { version = "1.11", features = ["full"] }

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-beta-rc.1
+
 ## 0.1.5-beta-rc.0
 
 ## 0.1.4

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_conductor_api"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 description = "Message types for Holochain admin and app interface protocols"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -11,13 +11,13 @@ edition = "2021"
 [dependencies]
 directories = "2.0.2"
 derive_more = "0.99.3"
-kitsune_p2p = { version = "^0.1.4-beta-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "^0.1.4-beta-rc.1", path = "../kitsune_p2p/kitsune_p2p" }
 holo_hash = { version = "^0.1.3-beta-rc.0", path = "../holo_hash", features = ["full"] }
-holochain_p2p = { version = "^0.1.5-beta-rc.0", path = "../holochain_p2p" }
-holochain_state = { version = "^0.1.5-beta-rc.0", path = "../holochain_state" }
+holochain_p2p = { version = "^0.1.5-beta-rc.1", path = "../holochain_p2p" }
+holochain_state = { version = "^0.1.5-beta-rc.1", path = "../holochain_state" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "^0.1.5-beta-rc.0", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.1.3-beta-rc.0", path = "../holochain_zome_types" }
+holochain_types = { version = "^0.1.5-beta-rc.1", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.1.3-beta-rc.1", path = "../holochain_zome_types" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_yaml = "0.9"
@@ -25,7 +25,7 @@ structopt = "0.3"
 tracing = "0.1.26"
 thiserror = "1.0.22"
 url2 = "0.0.6"
-holochain_keystore = { version = "^0.1.5-beta-rc.0", path = "../holochain_keystore" }
+holochain_keystore = { version = "^0.1.5-beta-rc.1", path = "../holochain_keystore" }
 
 [dev-dependencies]
 matches = {version = "0.1.8"}

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-beta-rc.1
+
 ## 0.1.5-beta-rc.0
 
 ## 0.1.4

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_keystore"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 description = "keystore for libsodium keypairs"
 license = "CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -15,7 +15,7 @@ base64 = "0.13.0"
 futures = "0.3.23"
 holo_hash = { version = "^0.1.3-beta-rc.0", path = "../holo_hash", features = ["full"] }
 holochain_serialized_bytes = "=0.0.51"
-holochain_zome_types = { path = "../holochain_zome_types", version = "^0.1.3-beta-rc.0"}
+holochain_zome_types = { path = "../holochain_zome_types", version = "^0.1.3-beta-rc.1"}
 kitsune_p2p_types = { version = "^0.1.3-beta-rc.0", path = "../kitsune_p2p/types" }
 lair_keystore = { version = "0.2.3", default-features = false }
 must_future = "0.1.2"
@@ -31,7 +31,7 @@ tracing = "0.1"
 
 # This is a redundant dependency.
 # It's included only to set the proper feature flag for database encryption.
-holochain_sqlite = { version = "^0.1.5-beta-rc.0", path = "../holochain_sqlite" }
+holochain_sqlite = { version = "^0.1.5-beta-rc.1", path = "../holochain_sqlite" }
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-beta-rc.1
+
 ## 0.1.5-beta-rc.0
 
 ## 0.1.4

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_p2p"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 description = "holochain specific wrapper around more generic p2p module"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -17,11 +17,11 @@ fixt = { path = "../fixt", version = "^0.1.2-beta-rc.0"}
 futures = "0.3"
 ghost_actor = "=0.3.0-alpha.4"
 holo_hash = { version = "^0.1.3-beta-rc.0", path = "../holo_hash" }
-holochain_keystore = { version = "^0.1.5-beta-rc.0", path = "../holochain_keystore" }
+holochain_keystore = { version = "^0.1.5-beta-rc.1", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "^0.1.5-beta-rc.0", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.1.3-beta-rc.0", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "^0.1.4-beta-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
+holochain_types = { version = "^0.1.5-beta-rc.1", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.1.3-beta-rc.1", path = "../holochain_zome_types" }
+kitsune_p2p = { version = "^0.1.4-beta-rc.1", path = "../kitsune_p2p/kitsune_p2p" }
 kitsune_p2p_types = { version = "^0.1.3-beta-rc.0", path = "../kitsune_p2p/types" }
 mockall = "0.10.2"
 observability = "0.1.3"

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-beta-rc.1
+
 ## 0.1.5-beta-rc.0
 
 ## 0.1.4

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_sqlite"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 description = "Abstractions for persistence of Holochain state via SQLite"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -26,8 +26,8 @@ futures = "0.3.1"
 holo_hash = { path = "../holo_hash", version = "^0.1.3-beta-rc.0"}
 holochain_serialized_bytes = "=0.0.51"
 holochain_util = { version = "^0.1.1-beta-rc.0", path = "../holochain_util", features = ["backtrace"] }
-holochain_zome_types = { version = "^0.1.3-beta-rc.0", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "^0.1.4-beta-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
+holochain_zome_types = { version = "^0.1.3-beta-rc.1", path = "../holochain_zome_types" }
+kitsune_p2p = { version = "^0.1.4-beta-rc.1", path = "../kitsune_p2p/kitsune_p2p" }
 lazy_static = "1.4.0"
 once_cell = "1.4.1"
 must_future = "0.1.1"

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-beta-rc.1
+
 ## 0.1.5-beta-rc.0
 
 ## 0.1.4

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_state"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 description = "TODO minimize deps"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -14,19 +14,19 @@ cfg-if = "0.1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 derive_more = "0.99.3"
 either = "1.5"
-holochain_sqlite = { version = "^0.1.5-beta-rc.0", path = "../holochain_sqlite" }
+holochain_sqlite = { version = "^0.1.5-beta-rc.1", path = "../holochain_sqlite" }
 holo_hash = { version = "^0.1.3-beta-rc.0", path = "../holo_hash", features = ["full"] }
 fallible-iterator = "0.2.0"
 futures = "0.3"
-holochain_keystore = { version = "^0.1.5-beta-rc.0", path = "../holochain_keystore" }
+holochain_keystore = { version = "^0.1.5-beta-rc.1", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_p2p = { version = "^0.1.5-beta-rc.0", path = "../holochain_p2p" }
-holochain_types = { version = "^0.1.5-beta-rc.0", path = "../holochain_types" }
+holochain_p2p = { version = "^0.1.5-beta-rc.1", path = "../holochain_p2p" }
+holochain_types = { version = "^0.1.5-beta-rc.1", path = "../holochain_types" }
 holochain_util = { version = "^0.1.1-beta-rc.0", path = "../holochain_util" }
-holochain_zome_types = { version = "^0.1.3-beta-rc.0", path = "../holochain_zome_types", features = [
+holochain_zome_types = { version = "^0.1.3-beta-rc.1", path = "../holochain_zome_types", features = [
     "full",
 ] }
-kitsune_p2p = { version = "^0.1.4-beta-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "^0.1.4-beta-rc.1", path = "../kitsune_p2p/kitsune_p2p" }
 mockall = "0.10.2"
 one_err = "0.0.8"
 parking_lot = "0.10"

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-beta-rc.1
+
 ## 0.1.5-beta-rc.0
 
 - Adds deserialization backward compatibility to `InstalledAppCommon`, for databases which contain apps installed prior to `0.1.4`. Without this fix, older database values can’t be deserialized into more current conductors. [\#2253](https://github.com/holochain/holochain/pull/2253)

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_types"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 description = "Holochain common types"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -26,10 +26,10 @@ flate2 = "1.0.14"
 futures = "0.3"
 one_err = "0.0.8"
 holo_hash = { version = "^0.1.3-beta-rc.0", path = "../holo_hash", features = ["encoding"] }
-holochain_keystore = { version = "^0.1.5-beta-rc.0", path = "../holochain_keystore" }
+holochain_keystore = { version = "^0.1.5-beta-rc.1", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_sqlite = { path = "../holochain_sqlite", version = "^0.1.5-beta-rc.0"}
-holochain_zome_types = { path = "../holochain_zome_types", version = "^0.1.3-beta-rc.0", features = ["full"] }
+holochain_sqlite = { path = "../holochain_sqlite", version = "^0.1.5-beta-rc.1"}
+holochain_zome_types = { path = "../holochain_zome_types", version = "^0.1.3-beta-rc.1", features = ["full"] }
 itertools = { version = "0.10" }
 kitsune_p2p_dht = { version = "^0.1.1-beta-rc.0", path = "../kitsune_p2p/dht" }
 lazy_static = "1.4.0"

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -7,8 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
-- Reverts the below change so that `name` in DnaDef does effect on the DNA hash. Holochain does not support the DNA hash changing
-  so this change will remain in `0.2` but be removed from the `0.1` stream.
+## 0.1.3-beta-rc.1
+
+- Reverts the below change so that `name` in DnaDef does effect on the DNA hash. Holochain does not support the DNA hash changing so this change will remain in `0.2` but be removed from the `0.1` stream.
 
 ## 0.1.3-beta-rc.0
 

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_zome_types"
-version = "0.1.3-beta-rc.0"
+version = "0.1.3-beta-rc.1"
 description = "Holochain zome types"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/direct/Cargo.toml
+++ b/crates/kitsune_p2p/direct/Cargo.toml
@@ -20,9 +20,9 @@ if-addrs = "0.6"
 kitsune_p2p_bootstrap = { version = "0.0.12-dev.0", path = "../bootstrap" }
 kitsune_p2p_direct_api = { version = "0.0.1", path = "../direct_api" }
 kitsune_p2p_types = { version = "^0.1.3-beta-rc.0", path = "../types" }
-kitsune_p2p = { version = "^0.1.4-beta-rc.0", path = "../kitsune_p2p", features = ["test_utils"] }
-kitsune_p2p_transport_quic = { version = "^0.1.3-beta-rc.0", path = "../transport_quic" }
-kitsune_p2p_proxy = { version = "^0.1.3-beta-rc.0", path = "../proxy" }
+kitsune_p2p = { version = "^0.1.4-beta-rc.1", path = "../kitsune_p2p", features = ["test_utils"] }
+kitsune_p2p_transport_quic = { version = "^0.1.3-beta-rc.1", path = "../transport_quic" }
+kitsune_p2p_proxy = { version = "^0.1.3-beta-rc.1", path = "../proxy" }
 rand = "0.8.5"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/crates/kitsune_p2p/direct_test/Cargo.toml
+++ b/crates/kitsune_p2p/direct_test/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2021"
 
 [dependencies]
 kitsune_p2p_direct = { version = "0.0.1", path = "../direct" }
-kitsune_p2p_transport_quic = { version = "^0.1.3-beta-rc.0", path = "../transport_quic" }
-kitsune_p2p_proxy = { version = "^0.1.3-beta-rc.0", path = "../proxy" }
+kitsune_p2p_transport_quic = { version = "^0.1.3-beta-rc.1", path = "../transport_quic" }
+kitsune_p2p_proxy = { version = "^0.1.3-beta-rc.1", path = "../proxy" }
 rand = "0.8.5"
 structopt = "0.3.21"
 tokio = { version = "1.11", features = ["full"] }

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.4-beta-rc.1
+
 ## 0.1.4-beta-rc.0
 
 ## 0.1.3

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p"
-version = "0.1.4-beta-rc.0"
+version = "0.1.4-beta-rc.1"
 description = "p2p / dht communication framework"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -21,9 +21,9 @@ governor = "0.3.2"
 itertools = "0.10"
 kitsune_p2p_fetch = { version = "^0.1.3-beta-rc.0", path = "../fetch" }
 kitsune_p2p_mdns = { version = "^0.1.1-beta-rc.0", path = "../mdns" }
-kitsune_p2p_proxy = { version = "^0.1.3-beta-rc.0", path = "../proxy" }
+kitsune_p2p_proxy = { version = "^0.1.3-beta-rc.1", path = "../proxy" }
 kitsune_p2p_timestamp = { version = "^0.1.1-beta-rc.0", path = "../timestamp", features = ["now"] }
-kitsune_p2p_transport_quic = { version = "^0.1.3-beta-rc.0", path = "../transport_quic", optional = true }
+kitsune_p2p_transport_quic = { version = "^0.1.3-beta-rc.1", path = "../transport_quic", optional = true }
 kitsune_p2p_types = { version = "^0.1.3-beta-rc.0", path = "../types", default-features = false }
 must_future = "0.1.1"
 nanoid = "0.4"

--- a/crates/kitsune_p2p/proxy/CHANGELOG.md
+++ b/crates/kitsune_p2p/proxy/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.3-beta-rc.1
+
 ## 0.1.3-beta-rc.0
 
 ## 0.1.2

--- a/crates/kitsune_p2p/proxy/Cargo.toml
+++ b/crates/kitsune_p2p/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_proxy"
-version = "0.1.3-beta-rc.0"
+version = "0.1.3-beta-rc.1"
 description = "Proxy transport module for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -16,7 +16,7 @@ blake2b_simd = "0.5.10"
 derive_more = "0.99.7"
 futures = "0.3"
 kitsune_p2p_types = { version = "^0.1.3-beta-rc.0", path = "../types" }
-kitsune_p2p_transport_quic = { version = "^0.1.3-beta-rc.0", path = "../transport_quic" }
+kitsune_p2p_transport_quic = { version = "^0.1.3-beta-rc.1", path = "../transport_quic" }
 nanoid = "0.3"
 observability = "0.1.3"
 parking_lot = "0.11"

--- a/crates/kitsune_p2p/transport_quic/CHANGELOG.md
+++ b/crates/kitsune_p2p/transport_quic/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.3-beta-rc.1
+
 ## 0.1.3-beta-rc.0
 
 ## 0.1.2

--- a/crates/kitsune_p2p/transport_quic/Cargo.toml
+++ b/crates/kitsune_p2p/transport_quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_transport_quic"
-version = "0.1.3-beta-rc.0"
+version = "0.1.3-beta-rc.1"
 description = "QUIC transport module for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/test_utils/wasm/CHANGELOG.md
+++ b/crates/test_utils/wasm/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-beta-rc.1
+
 ## 0.1.5-beta-rc.0
 
 ## 0.1.4

--- a/crates/test_utils/wasm/Cargo.toml
+++ b/crates/test_utils/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_wasm_test_utils"
-version = "0.1.5-beta-rc.0"
+version = "0.1.5-beta-rc.1"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2021"
 description = "Utilities for Wasm testing for Holochain"
@@ -19,7 +19,7 @@ only_check = []
 
 
 [dependencies]
-holochain_types = { path = "../../holochain_types", version = "^0.1.5-beta-rc.0"}
+holochain_types = { path = "../../holochain_types", version = "^0.1.5-beta-rc.1"}
 strum = "0.18.0"
 strum_macros = "0.18.0"
 holochain_util = { version = "^0.1.1-beta-rc.0", path = "../../holochain_util" }

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -957,7 +957,7 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.1.3-beta-rc.0"
+version = "0.1.3-beta-rc.1"
 dependencies = [
  "getrandom",
  "hdi",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.1.3-beta-rc.0"
+version = "0.1.3-beta-rc.1"
 dependencies = [
  "hdk",
  "serde",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.1.3-beta-rc.0"
+version = "0.1.3-beta-rc.1"
 dependencies = [
  "derive_builder",
  "fixt",

--- a/crates/test_utils/wasm_common/CHANGELOG.md
+++ b/crates/test_utils/wasm_common/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.3-beta-rc.1
+
 ## 0.1.3-beta-rc.0
 
 ## 0.1.2

--- a/crates/test_utils/wasm_common/Cargo.toml
+++ b/crates/test_utils/wasm_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_test_wasm_common"
-version = "0.1.3-beta-rc.0"
+version = "0.1.3-beta-rc.1"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2021"
 description = "Common code for Wasm testing for Holochain"
@@ -13,5 +13,5 @@ crate-type = [ "cdylib", "rlib" ]
 path = "src/lib.rs"
 
 [dependencies]
-hdk = { path = "../../hdk", version = "^0.1.3-beta-rc.0"}
+hdk = { path = "../../hdk", version = "^0.1.3-beta-rc.1"}
 serde = "1.0"


### PR DESCRIPTION
the following crates are part of this release:

- holochain_zome_types-0.1.3-beta-rc.1
- hdk-0.1.3-beta-rc.1
- kitsune_p2p_transport_quic-0.1.3-beta-rc.1
- kitsune_p2p_proxy-0.1.3-beta-rc.1
- kitsune_p2p-0.1.4-beta-rc.1
- holochain_sqlite-0.1.5-beta-rc.1
- holochain_keystore-0.1.5-beta-rc.1
- holochain_types-0.1.5-beta-rc.1
- holochain_p2p-0.1.5-beta-rc.1
- holochain_state-0.1.5-beta-rc.1
- holochain_cascade-0.1.5-beta-rc.1
- holochain_wasm_test_utils-0.1.5-beta-rc.1
- holochain_conductor_api-0.1.5-beta-rc.1
- holochain_test_wasm_common-0.1.3-beta-rc.1
- holochain-0.1.5-beta-rc.1
- holochain_cli_bundle-0.1.5-beta-rc.1
- holochain_cli_sandbox-0.1.5-beta-rc.1
- holochain_cli-0.1.5-beta-rc.1

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
