### PR TITLE
Filter release tags to current branch

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -59,9 +59,9 @@ on:
       latest_holochain_release_tag:
         description: "which holochain tag, if one, will be released"
         value: ${{ jobs.prepare.outputs.latest_holochain_release_tag }}
-      latest_holochain_version:
+      latest_holochain_release_version:
         description: "which holochain version, if one, will be released"
-        value: ${{ jobs.prepare.outputs.latest_holochain_version }}
+        value: ${{ jobs.prepare.outputs.latest_holochain_release_version }}
       release_branch:
         description: "the branch that contains the changes made during this action"
         value: ${{ jobs.prepare.outputs.release_branch }}
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       latest_holochain_release_tag: ${{ steps.write-env-and-tag.outputs.latest_holochain_release_tag }}
-      latest_holochain_version: ${{ steps.write-env-and-tag.outputs.latest_holochain_version }}
+      latest_holochain_release_version: ${{ steps.write-env-and-tag.outputs.latest_holochain_release_version }}
       release_branch: ${{ steps.write-env-and-tag.outputs.release_branch }}
       repo_nix_store_path: ${{ steps.write-env-and-tag.outputs.repo_nix_store_path }}
       releasable_crates: ${{ steps.bump-versions.outputs.releasable_crates }}
@@ -264,14 +264,14 @@ jobs:
           git tag --sort=-taggerdate --merged "${RELEASE_BRANCH}" | grep holochain-
 
           export LATEST_HOLOCHAIN_RELEASE_TAG=$(git tag --sort=-taggerdate --merged "${RELEASE_BRANCH}" | grep holochain- | head -n1)
-          export LATEST_HOLOCHAIN_VERSION=${LATEST_HOLOCHAIN_RELEASE_TAG/holochain-/}
+          export LATEST_HOLOCHAIN_RELEASE_VERSION=${LATEST_HOLOCHAIN_RELEASE_TAG/holochain-/}
 
           # clean the repo before adding it to the store
           git clean -ffdx
           export STORE_PATH=$(nix store add-path --name holochain_repo .)
 
           echo "latest_holochain_release_tag=${LATEST_HOLOCHAIN_RELEASE_TAG}" >> $GITHUB_OUTPUT
-          echo "latest_holochain_version=${LATEST_HOLOCHAIN_VERSION}" >> $GITHUB_OUTPUT
+          echo "latest_holochain_release_version=${LATEST_HOLOCHAIN_RELEASE_VERSION}" >> $GITHUB_OUTPUT
           echo "release_branch=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
           echo "repo_nix_store_path=${STORE_PATH}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -56,9 +56,9 @@ on:
         required: true
 
     outputs:
-      latest_holochain_tag:
+      latest_holochain_release_tag:
         description: "which holochain tag, if one, will be released"
-        value: ${{ jobs.prepare.outputs.latest_holochain_tag }}
+        value: ${{ jobs.prepare.outputs.latest_holochain_release_tag }}
       latest_holochain_version:
         description: "which holochain version, if one, will be released"
         value: ${{ jobs.prepare.outputs.latest_holochain_version }}
@@ -79,7 +79,7 @@ jobs:
       CACHIX_REV: ${{ inputs.CACHIX_REV }}
     runs-on: ubuntu-latest
     outputs:
-      latest_holochain_tag: ${{ steps.write-env-and-tag.outputs.latest_holochain_tag }}
+      latest_holochain_release_tag: ${{ steps.write-env-and-tag.outputs.latest_holochain_release_tag }}
       latest_holochain_version: ${{ steps.write-env-and-tag.outputs.latest_holochain_version }}
       release_branch: ${{ steps.write-env-and-tag.outputs.release_branch }}
       repo_nix_store_path: ${{ steps.write-env-and-tag.outputs.repo_nix_store_path }}
@@ -263,14 +263,14 @@ jobs:
 
           git tag --sort=-taggerdate --merged "${RELEASE_BRANCH}" | grep holochain-
 
-          export LATEST_HOLOCHAIN_TAG=$(git tag --sort=-taggerdate --merged "${RELEASE_BRANCH}" | grep holochain- | head -n1)
-          export LATEST_HOLOCHAIN_VERSION=${LATEST_HOLOCHAIN_TAG/holochain-/}
+          export LATEST_HOLOCHAIN_RELEASE_TAG=$(git tag --sort=-taggerdate --merged "${RELEASE_BRANCH}" | grep holochain- | head -n1)
+          export LATEST_HOLOCHAIN_VERSION=${LATEST_HOLOCHAIN_RELEASE_TAG/holochain-/}
 
           # clean the repo before adding it to the store
           git clean -ffdx
           export STORE_PATH=$(nix store add-path --name holochain_repo .)
 
-          echo "latest_holochain_tag=${LATEST_HOLOCHAIN_TAG}" >> $GITHUB_OUTPUT
+          echo "latest_holochain_release_tag=${LATEST_HOLOCHAIN_RELEASE_TAG}" >> $GITHUB_OUTPUT
           echo "latest_holochain_version=${LATEST_HOLOCHAIN_VERSION}" >> $GITHUB_OUTPUT
           echo "release_branch=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
           echo "repo_nix_store_path=${STORE_PATH}" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -263,7 +263,6 @@ jobs:
 
           git tag --sort=-taggerdate --merged "${RELEASE_BRANCH}" | grep holochain-
 
-          export RELEASE_BRANCH=$(git branch --show-current)
           export LATEST_HOLOCHAIN_TAG=$(git tag --sort=-taggerdate --merged "${RELEASE_BRANCH}" | grep holochain- | head -n1)
           export LATEST_HOLOCHAIN_VERSION=${LATEST_HOLOCHAIN_TAG/holochain-/}
 

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -259,7 +259,9 @@ jobs:
 
           cd "${HOLOCHAIN_REPO}"
 
-          git tag --sort=-taggerdate --merged $(git branch --show-current) | grep holochain-
+          export RELEASE_BRANCH=$(git branch --show-current)
+
+          git tag --sort=-taggerdate --merged "${RELEASE_BRANCH}" | grep holochain-
 
           export RELEASE_BRANCH=$(git branch --show-current)
           export LATEST_HOLOCHAIN_TAG=$(git tag --sort=-taggerdate --merged "${RELEASE_BRANCH}" | grep holochain- | head -n1)

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -259,11 +259,11 @@ jobs:
 
           cd "${HOLOCHAIN_REPO}"
 
-          git tag --sort=-taggerdate | grep holochain-
+          git tag --sort=-taggerdate --merged $(git branch --show-current) | grep holochain-
 
-          export LATEST_HOLOCHAIN_TAG=$(git tag --sort=-taggerdate | grep holochain- | head -n1)
-          export LATEST_HOLOCHAIN_VERSION=${LATEST_HOLOCHAIN_TAG/holochain-/}
           export RELEASE_BRANCH=$(git branch --show-current)
+          export LATEST_HOLOCHAIN_TAG=$(git tag --sort=-taggerdate --merged $RELEASE_BRANCH | grep holochain- | head -n1)
+          export LATEST_HOLOCHAIN_VERSION=${LATEST_HOLOCHAIN_TAG/holochain-/}
 
           # clean the repo before adding it to the store
           git clean -ffdx

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -262,7 +262,7 @@ jobs:
           git tag --sort=-taggerdate --merged $(git branch --show-current) | grep holochain-
 
           export RELEASE_BRANCH=$(git branch --show-current)
-          export LATEST_HOLOCHAIN_TAG=$(git tag --sort=-taggerdate --merged $RELEASE_BRANCH | grep holochain- | head -n1)
+          export LATEST_HOLOCHAIN_TAG=$(git tag --sort=-taggerdate --merged "${RELEASE_BRANCH}" | grep holochain- | head -n1)
           export LATEST_HOLOCHAIN_VERSION=${LATEST_HOLOCHAIN_TAG/holochain-/}
 
           # clean the repo before adding it to the store

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,7 +369,7 @@ jobs:
           HOLOCHAIN_TARGET_BRANCH: ${{ needs.vars.outputs.holochain_target_branch }}
           RELEASE_BRANCH: ${{ needs.prepare.outputs.release_branch }}
           LATEST_HOLOCHAIN_RELEASE_TAG: ${{ needs.prepare.outputs.latest_holochain_release_tag }}
-          LATEST_HOLOCHAIN_VERSION: ${{ needs.prepare.outputs.latest_holochain_version }}
+          LATEST_HOLOCHAIN_RELEASE_VERSION: ${{ needs.prepare.outputs.latest_holochain_release_version }}
           DRY_RUN: "${{ needs.vars.outputs.dry_run }}"
         run: |
           set -eux
@@ -410,7 +410,7 @@ jobs:
         continue-on-error: true
         env:
           STATUS: ${{ steps.check-status.outcome }}
-          VERSION: ${{ needs.prepare.outputs.latest_holochain_version }}
+          VERSION: ${{ needs.prepare.outputs.latest_holochain_release_version }}
           TAG: ${{ needs.prepare.outputs.latest_holochain_release_tag }}
           WORKFLOW_RUN_URL: "https://github.com/holochain/holochain/actions/runs/${{ github.run_id }}"
           HRA_MATTERMOST_TOKEN: ${{ secrets.HRA_MATTERMOST_TOKEN }}
@@ -483,7 +483,7 @@ jobs:
         continue-on-error: true
         env:
           STATUS: ${{ steps.check-status.outcome }}
-          VERSION: ${{ needs.prepare.outputs.latest_holochain_version }}
+          VERSION: ${{ needs.prepare.outputs.latest_holochain_release_version }}
           TAG: ${{ needs.prepare.outputs.latest_holochain_release_tag }}
           WORKFLOW_RUN_URL: "https://github.com/holochain/holochain/actions/runs/${{ github.run_id }}"
           HRA_MATTERMOST_TOKEN: ${{ secrets.HRA_MATTERMOST_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -368,7 +368,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOLOCHAIN_TARGET_BRANCH: ${{ needs.vars.outputs.holochain_target_branch }}
           RELEASE_BRANCH: ${{ needs.prepare.outputs.release_branch }}
-          LATEST_HOLOCHAIN_TAG: ${{ needs.prepare.outputs.latest_holochain_tag }}
+          LATEST_HOLOCHAIN_RELEASE_TAG: ${{ needs.prepare.outputs.latest_holochain_release_tag }}
           LATEST_HOLOCHAIN_VERSION: ${{ needs.prepare.outputs.latest_holochain_version }}
           DRY_RUN: "${{ needs.vars.outputs.dry_run }}"
         run: |
@@ -411,7 +411,7 @@ jobs:
         env:
           STATUS: ${{ steps.check-status.outcome }}
           VERSION: ${{ needs.prepare.outputs.latest_holochain_version }}
-          TAG: ${{ needs.prepare.outputs.latest_holochain_tag }}
+          TAG: ${{ needs.prepare.outputs.latest_holochain_release_tag }}
           WORKFLOW_RUN_URL: "https://github.com/holochain/holochain/actions/runs/${{ github.run_id }}"
           HRA_MATTERMOST_TOKEN: ${{ secrets.HRA_MATTERMOST_TOKEN }}
 
@@ -484,7 +484,7 @@ jobs:
         env:
           STATUS: ${{ steps.check-status.outcome }}
           VERSION: ${{ needs.prepare.outputs.latest_holochain_version }}
-          TAG: ${{ needs.prepare.outputs.latest_holochain_tag }}
+          TAG: ${{ needs.prepare.outputs.latest_holochain_release_tag }}
           WORKFLOW_RUN_URL: "https://github.com/holochain/holochain/actions/runs/${{ github.run_id }}"
           HRA_MATTERMOST_TOKEN: ${{ secrets.HRA_MATTERMOST_TOKEN }}
           DRY_RUN: "${{ needs.vars.outputs.dry_run }}"

--- a/scripts/ci-gh-release.sh
+++ b/scripts/ci-gh-release.sh
@@ -2,11 +2,11 @@
 set -eux
 
 # a positive condition means the current holochain version has already been released, hence this release doesn't contain holochain
-if gh release view "${LATEST_HOLOCHAIN_TAG}"; then
+if gh release view "${LATEST_HOLOCHAIN_RELEASE_TAG}"; then
   export RELEASE_TAG=${RELEASE_BRANCH}
   export IS_HOLOCHAIN_RELEASE="false"
 else
-  export RELEASE_TAG=${LATEST_HOLOCHAIN_TAG}
+  export RELEASE_TAG=${LATEST_HOLOCHAIN_RELEASE_TAG}
   export IS_HOLOCHAIN_RELEASE="true"
 fi
 

--- a/scripts/ci-gh-release.sh
+++ b/scripts/ci-gh-release.sh
@@ -19,7 +19,7 @@ else
 fi
 
 # simply check for the delimeter between the version number and a pre-release suffix
-if [[ "${LATEST_HOLOCHAIN_VERSION}" == *"-"* ]]; then
+if [[ "${LATEST_HOLOCHAIN_RELEASE_VERSION}" == *"-"* ]]; then
   export IS_PRE_RELEASE="true"
 else
   export IS_PRE_RELEASE="false"
@@ -32,7 +32,7 @@ cmd=(
    -H "Accept: application/vnd.github+json"
    -f tag_name="${RELEASE_TAG}"
    -f target_commitish="${HOLOCHAIN_TARGET_BRANCH}"
-   -f name="holochain ${LATEST_HOLOCHAIN_VERSION} (${RELEASE_BRANCH#*-})"
+   -f name="holochain ${LATEST_HOLOCHAIN_RELEASE_VERSION} (${RELEASE_BRANCH#*-})"
    -f body="***Please read [this release's top-level CHANGELOG](https://github.com/holochain/holochain/blob/${HOLOCHAIN_TARGET_BRANCH}/CHANGELOG.md#$(sed -E 's/(release-|\.)//g' <<<"${RELEASE_BRANCH}")) to see the full list of crates that were released together.***" \
    -F draft=false
    -F generate_release_notes=false


### PR DESCRIPTION
### Summary

This should help reduce confusion when there are tag problems and also makes it clear what tags make sense on the current release branch. `--merged` is basically a 'reachable' filter from the given input, so running locally on the `develop-0.1` branch I see

```
$ git tag --sort=-taggerdate --merged develop-0.1 | grep holochain-
holochain-0.1.5-beta-rc.0
holochain-0.1.4
holochain-0.1.3
holochain-0.1.2
holochain-0.1.1
holochain-0.1.0
holochain-0.1.0-beta-rc.4
holochain-0.1.0-beta-rc.3
holochain-0.1.0-beta-rc.2
holochain-0.1.0-beta-rc.1
holochain-0.1.0-beta-rc.0
```

Rather than the full set of tags

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
