### PR TITLE
Add initial otel metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,8 +3039,6 @@ dependencies = [
  "holochain_serialized_bytes",
  "inferno",
  "once_cell",
- "opentelemetry",
- "opentelemetry-stdout",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -3052,6 +3050,8 @@ dependencies = [
  "tracing-futures",
  "tracing-serde",
  "tracing-subscriber",
+ "ts_opentelemetry",
+ "ts_opentelemetry_stdout",
 ]
 
 [[package]]
@@ -4893,64 +4893,6 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "opentelemetry"
-version = "0.19.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust.git#00641fb01de4411bbac77f161f5d7b2baec69f00"
-dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk",
-]
-
-[[package]]
-name = "opentelemetry-stdout"
-version = "0.1.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust.git#00641fb01de4411bbac77f161f5d7b2baec69f00"
-dependencies = [
- "async-trait",
- "opentelemetry_api",
- "opentelemetry_sdk",
- "ordered-float",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.19.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust.git#00641fb01de4411bbac77f161f5d7b2baec69f00"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.19.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust.git#00641fb01de4411bbac77f161f5d7b2baec69f00"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry_api",
- "ordered-float",
- "percent-encoding 2.2.0",
- "rand 0.8.5",
- "regex",
- "thiserror",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -7650,6 +7592,68 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "termcolor",
+]
+
+[[package]]
+name = "ts_opentelemetry"
+version = "0.20.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "988161c8c59ad38eda33f242441100bd96a4310c09d043cdf0a830f9401ff32c"
+dependencies = [
+ "ts_opentelemetry_api",
+ "ts_opentelemetry_sdk",
+]
+
+[[package]]
+name = "ts_opentelemetry_api"
+version = "0.20.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d186495330f646b5881aeb3b83bac75b8a462d7ef32fda06a2a68f3869d5ba82"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "indexmap",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "ts_opentelemetry_sdk"
+version = "0.20.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b26b9d08e0eeba804aa5d3b1a720bc47ae831a034869569030e25a5bcd006f46"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "ordered-float",
+ "percent-encoding 2.2.0",
+ "rand 0.8.5",
+ "regex",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "ts_opentelemetry_api",
+]
+
+[[package]]
+name = "ts_opentelemetry_stdout"
+version = "0.1.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2229fc8f126fcba3b4329b224bd5f724ceadd6df47c6ea9086c44d0e3c46c29"
+dependencies = [
+ "async-trait",
+ "ordered-float",
+ "serde",
+ "serde_json",
+ "ts_opentelemetry_api",
+ "ts_opentelemetry_sdk",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3039,6 +3039,8 @@ dependencies = [
  "holochain_serialized_bytes",
  "inferno",
  "once_cell",
+ "opentelemetry",
+ "opentelemetry-stdout",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -3092,7 +3094,7 @@ dependencies = [
  "nanoid 0.3.0",
  "one_err",
  "parking_lot 0.10.2",
- "pretty_assertions 0.6.1",
+ "pretty_assertions 0.7.2",
  "rand 0.8.5",
  "regex",
  "rusqlite",
@@ -3716,6 +3718,7 @@ dependencies = [
  "criterion",
  "fixt",
  "futures",
+ "holochain_trace",
  "kitsune_p2p",
  "kitsune_p2p_types",
  "once_cell",
@@ -3810,6 +3813,7 @@ dependencies = [
  "err-derive",
  "futures-core",
  "futures-util",
+ "holochain_trace",
  "libmdns",
  "mdns",
  "tokio",
@@ -4892,10 +4896,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.19.0"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust.git#00641fb01de4411bbac77f161f5d7b2baec69f00"
+dependencies = [
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.1.0"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust.git#00641fb01de4411bbac77f161f5d7b2baec69f00"
+dependencies = [
+ "async-trait",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+ "ordered-float",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.19.0"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust.git#00641fb01de4411bbac77f161f5d7b2baec69f00"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "indexmap",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.19.0"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust.git#00641fb01de4411bbac77f161f5d7b2baec69f00"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry_api",
+ "ordered-float",
+ "percent-encoding 2.2.0",
+ "rand 0.8.5",
+ "regex",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc2dbde8f8a79f2102cc474ceb0ad68e3b80b85289ea62389b60e66777e4213"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "os_info"
@@ -7933,6 +8004,12 @@ dependencies = [
  "serde",
  "url 1.7.2",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "utf-8"

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Adds optional metrics to Holochain to help diagnose behaviour and errors. The conductor must be built with the `"otel"` feature to opt in to metrics.
+  Metrics are not shipped off the machine where they are being captured, they are simply dumped to stdout on an interval.
+
 ## 0.3.0-beta-dev.4
 
 ## 0.3.0-beta-dev.3

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -235,3 +235,7 @@ sweetest = [
   "test_utils",
   "sqlite",
 ]
+
+otel = [
+  "kitsune_p2p/otel"  
+]

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -237,5 +237,11 @@ sweetest = [
 ]
 
 otel = [
-  "kitsune_p2p/otel"  
+  "holochain_trace/otel",
+  "kitsune_p2p/otel",
+  "holochain_p2p/otel",
+  "holochain_state/otel",
+  "kitsune_p2p_bootstrap/otel",
+  "holochain_cascade/otel",
+  "holochain_conductor_api/otel",
 ]

--- a/crates/holochain/src/bin/holochain/main.rs
+++ b/crates/holochain/src/bin/holochain/main.rs
@@ -86,6 +86,9 @@ async fn async_main() {
         std::env::set_var("CUSTOM_FILTER", t);
     }
 
+    #[cfg(feature = "otel")]
+    holochain_trace::metric::init_metrics();
+
     holochain_trace::init_fmt(opt.structured.clone()).expect("Failed to start contextual logging");
     debug!("holochain_trace initialized");
 

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -3008,8 +3008,15 @@ async fn p2p_event_task(
     const NUM_PARALLEL_EVTS: usize = 100;
     let num_tasks = Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let max_time = Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+    #[cfg(feature = "otel")]
+    let task_run = holochain_trace::metric::TaskRunMetric::new("dispatch_p2p_event");
+
     p2p_evt
         .for_each_concurrent(NUM_PARALLEL_EVTS, |evt| {
+            #[cfg(feature = "otel")]
+            task_run.record_start();
+
             let handle = handle.clone();
             let num_tasks = num_tasks.clone();
             let max_time = max_time.clone();

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -63,10 +63,14 @@ pub fn spawn_admin_interface_tasks<A: InterfaceApi>(
         handle.close_on(stop.map(|_| true)).map(Ok)
     });
 
-    tm.add_conductor_task_ignored(&format!("admin interface, port {}", port), |_stop| {
+    tm.add_conductor_task_ignored(&format!("admin interface, port {}", port), move |_stop| {
         async move {
             let mut active_connections = Vec::new();
             futures::pin_mut!(listener);
+
+            #[cfg(feature = "otel")]
+            let conn_metric = holochain_trace::metric::WebsocketConnectionsMetric::new(port);
+
             // establish a new connection to a client
             while let Some(connection) = listener.next().await {
                 active_connections.retain_mut(|handle: &mut JoinHandle<()>| !handle.is_finished());
@@ -84,6 +88,9 @@ pub fn spawn_admin_interface_tasks<A: InterfaceApi>(
                             api.clone(),
                             rx_from_iface,
                         )));
+
+                        #[cfg(feature = "otel")]
+                        conn_metric.record_current(active_connections.len() as u64);
                     }
                     Err(err) => {
                         warn!("Admin socket connection failed: {}", err);

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -63,3 +63,10 @@ sqlite = [
     "holochain_zome_types/sqlite",
     "kitsune_p2p/sqlite",
 ]
+
+otel = [
+    "holochain_trace/otel",
+    "holochain_p2p/otel",
+    "kitsune_p2p/otel",
+    "holochain_state/otel",
+]

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -51,3 +51,9 @@ sqlite = [
     "holochain_keystore/sqlite",
 ]
 
+otel = [
+    "holochain_trace/otel",
+    "holochain_p2p/otel",
+    "kitsune_p2p/otel",
+    "holochain_state/otel",
+]

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -52,3 +52,8 @@ sqlite = [
   "kitsune_p2p/sqlite",
   "kitsune_p2p_types/sqlite",
 ]
+
+otel = [
+  "holochain_trace/otel",
+  "kitsune_p2p/otel",
+]

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -91,3 +91,7 @@ sqlite = [
     "holochain_zome_types/sqlite",
     "kitsune_p2p/sqlite",
 ]
+
+otel = [
+    "holochain_trace/otel"
+]

--- a/crates/holochain_trace/Cargo.toml
+++ b/crates/holochain_trace/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 # default = ["opentelemetry-on"]
 # Allows across thread and process tracing
 # opentelemetry-on = ["opentelemetry", "tracing-opentelemetry", "holochain_serialized_bytes", "serde", "serde_bytes"]
-otel = ["dep:opentelemetry", "dep:opentelemetry-stdout"]
+otel = ["dep:opentelemetry", "dep:opentelemetry_stdout"]
 channels = ["tokio", "shrinkwraprs"]
 
 [dependencies]
@@ -27,8 +27,9 @@ tracing-core = "0.1.30"
 tracing-serde = "0.1.3"
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter", "time", "json" ] }
 
-opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", features = ["metrics", "rt-tokio"], optional = true }
-opentelemetry-stdout = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", features = ["metrics"], optional = true }
+# Publish of the upcoming version of opentelemetry, they are slow to publish changes. Switch to 0.20.x when it is released
+opentelemetry = { version = "0.20.0-beta.1", features = ["metrics", "rt-tokio"], package = "ts_opentelemetry", optional = true }
+opentelemetry_stdout = { version = "0.1.0-beta.1", features = ["metrics"], package = "ts_opentelemetry_stdout", optional = true }
 # tracing-opentelemetry = { version = "0.8.0", optional = true }
 holochain_serialized_bytes = {version = "0.0", optional = true }
 serde = { version = "1", optional = true }

--- a/crates/holochain_trace/Cargo.toml
+++ b/crates/holochain_trace/Cargo.toml
@@ -13,6 +13,7 @@ default = []
 # default = ["opentelemetry-on"]
 # Allows across thread and process tracing
 # opentelemetry-on = ["opentelemetry", "tracing-opentelemetry", "holochain_serialized_bytes", "serde", "serde_bytes"]
+otel = ["dep:opentelemetry", "dep:opentelemetry-stdout"]
 channels = ["tokio", "shrinkwraprs"]
 
 [dependencies]
@@ -26,7 +27,8 @@ tracing-core = "0.1.30"
 tracing-serde = "0.1.3"
 tracing-subscriber = { version = "0.3.16", features = [ "env-filter", "time", "json" ] }
 
-# opentelemetry = { version = "0.8", default-features = false, features = ["trace", "serialize"], optional = true }
+opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", features = ["metrics", "rt-tokio"], optional = true }
+opentelemetry-stdout = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", features = ["metrics"], optional = true }
 # tracing-opentelemetry = { version = "0.8.0", optional = true }
 holochain_serialized_bytes = {version = "0.0", optional = true }
 serde = { version = "1", optional = true }

--- a/crates/holochain_trace/src/lib.rs
+++ b/crates/holochain_trace/src/lib.rs
@@ -93,6 +93,8 @@ mod fmt;
 pub mod metrics;
 mod writer;
 // mod open;
+#[cfg(feature = "otel")]
+pub mod metric;
 
 // #[cfg(all(feature = "opentelemetry-on", feature = "channels"))]
 // pub use open::channel;

--- a/crates/holochain_trace/src/metric/init.rs
+++ b/crates/holochain_trace/src/metric/init.rs
@@ -1,0 +1,14 @@
+use opentelemetry::global;
+use opentelemetry::sdk::metrics::{MeterProvider, PeriodicReader};
+use opentelemetry::sdk::runtime;
+use std::time::Duration;
+
+/// Initialise metrics reporting
+pub fn init_metrics() {
+    let exporter = opentelemetry_stdout::MetricsExporter::default();
+    let reader = PeriodicReader::builder(exporter, runtime::Tokio)
+        .with_interval(Duration::from_secs(15))
+        .build();
+    let provider = MeterProvider::builder().with_reader(reader).build();
+    global::set_meter_provider(provider);
+}

--- a/crates/holochain_trace/src/metric/mod.rs
+++ b/crates/holochain_trace/src/metric/mod.rs
@@ -2,6 +2,8 @@
 
 mod init;
 mod task_run;
+mod websocket_connections;
 
 pub use init::init_metrics;
 pub use task_run::TaskRunMetric;
+pub use websocket_connections::WebsocketConnectionsMetric;

--- a/crates/holochain_trace/src/metric/mod.rs
+++ b/crates/holochain_trace/src/metric/mod.rs
@@ -1,4 +1,4 @@
-//! Wrappers for working with OTEL metrics
+//! Wrappers for working with OpenTelemetry metrics
 
 mod init;
 mod task_run;

--- a/crates/holochain_trace/src/metric/mod.rs
+++ b/crates/holochain_trace/src/metric/mod.rs
@@ -1,0 +1,7 @@
+//! Wrappers for working with OTEL metrics
+
+mod init;
+mod task_run;
+
+pub use init::init_metrics;
+pub use task_run::TaskRunMetric;

--- a/crates/holochain_trace/src/metric/task_run.rs
+++ b/crates/holochain_trace/src/metric/task_run.rs
@@ -1,0 +1,29 @@
+use opentelemetry::{global, metrics::Counter, Context, Key, KeyValue, Value};
+
+/// Record run cycles for a Tokio task.
+pub struct TaskRunMetric {
+    attributes: Vec<KeyValue>,
+    counter: Counter<u64>,
+}
+
+impl TaskRunMetric {
+    /// Create a new metric handle with a unique name for the current task.
+    pub fn new(task_name: &'static str) -> Self {
+        let meter = global::meter("holochain.task");
+        let counter = meter.u64_counter("run_count").init();
+
+        TaskRunMetric {
+            attributes: vec![KeyValue {
+                key: Key::from_static_str("task_name"),
+                value: Value::String(task_name.into()),
+            }],
+            counter,
+        }
+    }
+
+    /// Record a task cycle starting.
+    pub fn record_start(&self) {
+        let ctx = Context::current();
+        self.counter.add(&ctx, 1, &self.attributes);
+    }
+}

--- a/crates/holochain_trace/src/metric/websocket_connections.rs
+++ b/crates/holochain_trace/src/metric/websocket_connections.rs
@@ -1,0 +1,28 @@
+use opentelemetry::{global, metrics::ObservableGauge, Context, Key, KeyValue, Value};
+
+/// Record the number of open connections on a websocket server
+pub struct WebsocketConnectionsMetric {
+    attributes: Vec<KeyValue>,
+    gauge: ObservableGauge<u64>,
+}
+
+impl WebsocketConnectionsMetric {
+    /// Create a new metric handle with the port the websocket is listening on.
+    pub fn new(listen_port: u16) -> Self {
+        let meter = global::meter("holochain.ws.connections");
+        let counter = meter.u64_observable_gauge("conn_count").init();
+
+        WebsocketConnectionsMetric {
+            attributes: vec![KeyValue {
+                key: Key::from_static_str("listen_port"),
+                value: Value::I64(listen_port as i64),
+            }],
+            gauge: counter,
+        }
+    }
+
+    /// Record the current connection count.
+    pub fn record_current(&self, connection_count: u64) {
+        self.gauge.observe(connection_count, &self.attributes);
+    }
+}

--- a/crates/kitsune_p2p/bootstrap/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap/Cargo.toml
@@ -25,6 +25,7 @@ serde_bytes = "0.11"
 serde_json = { version = "1", features = [ "preserve_order" ] }
 tokio = { version = "1", features = ["full"] }
 warp = "0.3"
+holochain_trace = { version = "^0.3.0-beta-dev.0", path = "../../holochain_trace", optional = true }
 
 [dev-dependencies]
 kitsune_p2p = { path = "../kitsune_p2p", features = ["sqlite"] }
@@ -50,4 +51,8 @@ sqlite-encrypted = [
 ]
 sqlite = [
     "kitsune_p2p_types/sqlite",
+]
+
+otel = [
+    "holochain_trace/otel"
 ]

--- a/crates/kitsune_p2p/bootstrap/src/lib.rs
+++ b/crates/kitsune_p2p/bootstrap/src/lib.rs
@@ -48,10 +48,17 @@ pub async fn run_with_prune_freq(
     let store = Store::new(proxy_list);
 
     {
+        #[cfg(feature = "otel")]
+        let task_run_metric = holochain_trace::metric::TaskRunMetric::new("bootstrap_prune");
+
         let store = store.clone();
         tokio::task::spawn(async move {
             loop {
                 tokio::time::sleep(prune_frequency).await;
+
+                #[cfg(feature = "otel")]
+                task_run_metric.record_start();
+
                 store.prune();
             }
         });

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -106,5 +106,7 @@ sqlite = [
 ]
 
 otel = [
-  "holochain_trace/otel"  
+  "holochain_trace/otel",
+  "kitsune_p2p_mdns/otel",
+  "kitsune_p2p_bootstrap/otel",
 ]

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -104,3 +104,7 @@ sqlite = [
   "kitsune_p2p_transport_quic/sqlite",
   "kitsune_p2p_types/sqlite",
 ]
+
+otel = [
+  "holochain_trace/otel"  
+]

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -199,11 +199,12 @@ impl ShardedGossip {
             },
             bandwidth,
         });
+
+        #[cfg(feature = "otel")]
+        let task_run = holochain_trace::metric::TaskRunMetric::new("gossip");
+
         metric_task({
             let this = this.clone();
-
-            #[cfg(feature = "otel")]
-            let task_run = holochain_trace::metric::TaskRunMetric::new("gossip");
 
             async move {
                 let mut stats = Stats::reset();

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -202,6 +202,9 @@ impl ShardedGossip {
         metric_task({
             let this = this.clone();
 
+            #[cfg(feature = "otel")]
+            let task_run = holochain_trace::metric::TaskRunMetric::new("gossip");
+
             async move {
                 let mut stats = Stats::reset();
                 while !this
@@ -210,6 +213,10 @@ impl ShardedGossip {
                     .load(std::sync::atomic::Ordering::Relaxed)
                 {
                     tokio::time::sleep(GOSSIP_LOOP_INTERVAL).await;
+
+                    #[cfg(feature = "otel")]
+                    task_run.record_start();
+
                     this.run_one_iteration().await;
                     this.stats(&mut stats);
                 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -240,7 +240,13 @@ impl KitsuneP2pActor {
             let i_s = internal_sender.clone();
             let host = host.clone();
             tokio::task::spawn(async move {
+                #[cfg(feature = "otel")]
+                let task_run_metric = holochain_trace::metric::TaskRunMetric::new("fetch_items");
+
                 loop {
+                    #[cfg(feature = "otel")]
+                    task_run_metric.record_start();
+
                     let list = fetch_pool.get_items_to_fetch();
 
                     for (key, space, source, context) in list {
@@ -274,6 +280,9 @@ impl KitsuneP2pActor {
             let tuning_params = config.tuning_params.clone();
             let fetch_pool = fetch_pool.clone();
             async move {
+                #[cfg(feature = "otel")]
+                let task_run_metric = holochain_trace::metric::TaskRunMetric::new("meta_net_event");
+
                 let fetch_response_queue = &fetch_response_queue;
                 let fetch_pool = &fetch_pool;
                 ep_evt
@@ -281,6 +290,9 @@ impl KitsuneP2pActor {
                         let evt_sender = evt_sender.clone();
                         let host = host.clone();
                         let i_s = i_s.clone();
+
+                        #[cfg(feature = "otel")]
+                        task_run_metric.record_start();
 
                         async move {
                             let evt_sender = &evt_sender;

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -287,12 +287,12 @@ impl KitsuneP2pActor {
                 let fetch_pool = &fetch_pool;
                 ep_evt
                     .for_each_concurrent(tuning_params.concurrent_limit_per_thread, move |event| {
+                        #[cfg(feature = "otel")]
+                        task_run_metric.record_start();
+
                         let evt_sender = evt_sender.clone();
                         let host = host.clone();
                         let i_s = i_s.clone();
-
-                        #[cfg(feature = "otel")]
-                        task_run_metric.record_start();
 
                         async move {
                             let evt_sender = &evt_sender;

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net.rs
@@ -508,8 +508,15 @@ impl MetaNet {
         let ep_hnd = ep.handle().clone();
 
         tokio::task::spawn(async move {
+            #[cfg(feature = "otel")]
+            let task_run_metric =
+                holochain_trace::metric::TaskRunMetric::new("meta_net_tx2_ep_event");
+
             let tuning_params = &tuning_params;
             while let Some(evt) = ep.next().await {
+                #[cfg(feature = "otel")]
+                task_run_metric.record_start();
+
                 match evt {
                     Tx2EpEvent::OutgoingConnection(Tx2EpConnection { con, url }) => {
                         if evt_send
@@ -681,7 +688,14 @@ impl MetaNet {
         let res_store2 = res_store.clone();
         let tuning_params2 = tuning_params.clone();
         tokio::task::spawn(async move {
+            #[cfg(feature = "otel")]
+            let task_run_metric =
+                holochain_trace::metric::TaskRunMetric::new("meta_net_tx5_ep_event");
+
             while let Some(evt) = ep_evt.recv().await {
+                #[cfg(feature = "otel")]
+                task_run_metric.record_start();
+
                 let evt = match evt {
                     Ok(evt) => evt,
                     Err(err) => {

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -801,9 +801,16 @@ impl KitsuneP2pHandler for Space {
                 if !self.mdns_listened_spaces.contains(&space_b64) {
                     self.mdns_listened_spaces.insert(space_b64.clone());
                     tokio::task::spawn(async move {
+                        #[cfg(feature = "otel")]
+                        let task_run_metric =
+                            holochain_trace::metric::TaskRunMetric::new("mdns_bootstrap");
+
                         let stream = mdns_listen(space_b64);
                         tokio::pin!(stream);
                         while let Some(maybe_response) = stream.next().await {
+                            #[cfg(feature = "otel")]
+                            task_run_metric.record_start();
+
                             match maybe_response {
                                 Ok(response) => {
                                     tracing::trace!(msg = "Peer found via MDNS", ?response);
@@ -1355,11 +1362,17 @@ impl Space {
             let metrics = metrics.clone();
             let host = host_api.clone();
             tokio::task::spawn(async move {
+                #[cfg(feature = "otel")]
+                let task_run_metric = holochain_trace::metric::TaskRunMetric::new("host_metrics");
+
                 loop {
                     tokio::time::sleep(std::time::Duration::from_millis(
                         HISTORICAL_METRIC_RECORD_FREQ_MS,
                     ))
                     .await;
+
+                    #[cfg(feature = "otel")]
+                    task_run_metric.record_start();
 
                     let records = metrics.read().dump_historical();
 
@@ -1432,11 +1445,18 @@ impl Space {
         let agent_info_update_interval_ms =
             config.tuning_params.gossip_agent_info_update_interval_ms as u64;
         tokio::task::spawn(async move {
+            #[cfg(feature = "otel")]
+            let task_run_metric = holochain_trace::metric::TaskRunMetric::new("agent_info_update");
+
             loop {
                 tokio::time::sleep(std::time::Duration::from_millis(
                     agent_info_update_interval_ms,
                 ))
                 .await;
+
+                #[cfg(feature = "otel")]
+                task_run_metric.record_start();
+
                 if let Err(e) = i_s_c.update_agent_info().await {
                     tracing::error!(failed_to_update_agent_info_for_space = ?e);
                 }
@@ -1453,12 +1473,18 @@ impl Space {
                 .bootstrap_check_delay_backoff_multiplier;
             let space_c = space.clone();
             tokio::task::spawn(async move {
+                #[cfg(feature = "otel")]
+                let task_run_metric = holochain_trace::metric::TaskRunMetric::new("quic_bootstrap");
+
                 const START_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
                 const MAX_DELAY: std::time::Duration = std::time::Duration::from_secs(60 * 60);
 
                 let mut delay_len = START_DELAY;
 
                 loop {
+                    #[cfg(feature = "otel")]
+                    task_run_metric.record_start();
+
                     use ghost_actor::GhostControlSender;
                     if !i_s_c.ghost_actor_is_active() {
                         break;

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/metric_exchange.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/metric_exchange.rs
@@ -167,10 +167,17 @@ impl MetricExchangeSync {
         {
             let mx = out.clone();
             tokio::task::spawn(async move {
+                #[cfg(feature = "otel")]
+                let task_run_metric =
+                    holochain_trace::metric::TaskRunMetric::new("metric_exchange_sync");
+
                 let mut last_extrap_cov = ShouldTrigger::new(EXTRAP_COV_CHECK_FREQ);
 
                 loop {
                     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+                    #[cfg(feature = "otel")]
+                    task_run_metric.record_start();
 
                     if last_extrap_cov.should_trigger() {
                         let arc_set = mx.read().arc_set.clone();

--- a/crates/kitsune_p2p/mdns/Cargo.toml
+++ b/crates/kitsune_p2p/mdns/Cargo.toml
@@ -28,7 +28,8 @@ base64 = "0.13"
 err-derive = "0.2.1"
 tokio = { version = "1.27", features = [ "full" ] }
 tokio-stream = { version = "0.1" }
-holochain_trace = { version = "^0.3.0-beta-dev.0", path = "../../holochain_trace", optional = true }
+holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../../holochain_trace", optional = true }
+
 [features]
 otel = [
     "holochain_trace/otel",

--- a/crates/kitsune_p2p/mdns/Cargo.toml
+++ b/crates/kitsune_p2p/mdns/Cargo.toml
@@ -28,3 +28,8 @@ base64 = "0.13"
 err-derive = "0.2.1"
 tokio = { version = "1.27", features = [ "full" ] }
 tokio-stream = { version = "0.1" }
+holochain_trace = { version = "^0.3.0-beta-dev.0", path = "../../holochain_trace", optional = true }
+[features]
+otel = [
+    "holochain_trace/otel",
+]

--- a/crates/kitsune_p2p/mdns/src/lib.rs
+++ b/crates/kitsune_p2p/mdns/src/lib.rs
@@ -62,6 +62,9 @@ pub fn mdns_create_broadcast_thread(
     //);
     // Create thread
     let _handle = tokio::task::spawn(async move {
+        #[cfg(feature = "otel")]
+        let task_run_metric = holochain_trace::metric::TaskRunMetric::new("mdns_broadcast");
+
         // Split buffer to fix TXT max size
         let mut substrs = Vec::new();
         while b64.len() > MAX_TXT_SIZE {
@@ -78,6 +81,10 @@ pub fn mdns_create_broadcast_thread(
         // Loop forever unless termination command received
         loop {
             tokio::time::sleep(::std::time::Duration::from_secs(BROADCAST_INTERVAL_SEC)).await;
+
+            #[cfg(feature = "otel")]
+            task_run_metric.record_start();
+
             if !can_run_clone.load(Ordering::Relaxed) {
                 //println!("Terminating.");
                 break;


### PR DESCRIPTION
### Summary

I don't want to add too many metrics before validating the core changes here.

I've covered 
- Most of the task-loops in the conductor, using counts
- The number of open connections to each admin port, as a gauge

What I've not touched yet
- Queue depth for actor messaging queues
- Invocation counts for integration points (e.g. calls from remote conductors, calls between the conductor and kitsune)
- Many other things that might be useful

A sample JSON output (apparently not a supported format to upload in a description)
[test.txt](https://github.com/holochain/holochain/files/11749462/test.txt)

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
