### PR TITLE
Test demonstrating possible regression in cap grant implementation

### DIFF
--- a/crates/holochain/tests/cap_tokens/mod.rs
+++ b/crates/holochain/tests/cap_tokens/mod.rs
@@ -16,7 +16,6 @@ async fn alice_cant_remote_call_bobs_private_function() {
     use holochain::conductor::api::error::ConductorApiResult;
 
     holochain_trace::test_run().ok();
-    const NUM_AGENTS: usize = 30;
 
     let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::CapTokens]).await;
 
@@ -32,23 +31,45 @@ async fn alice_cant_remote_call_bobs_private_function() {
     let alice = cells[0].clone();
     let bob = cells[1].clone();
 
-    let alice_secret: CapSecret = conductor.call(&alice.zome(TestWasm::CapTokens), "create_cap_grant_for_private_function", ()).await;
-
     #[derive(Serialize, Deserialize, Debug, SerializedBytes)]
     pub struct RemoteCallPrivateInput {
         pub to_cell: CellId,
-        pub cap_secret: CapSecret,
+        pub maybe_cap_secret: Option<CapSecret>,
     }    
+
+    // Making a remote call to bobs cell without a secret should fail
+    let remote_call_to_bob: RemoteCallPrivateInput = RemoteCallPrivateInput {
+        to_cell: bob.cell_id().to_owned(),
+        maybe_cap_secret: None
+    };
+
+    let attempted_call_no_secret: ConductorApiResult<String> = conductor.call_fallible(&alice.zome(TestWasm::CapTokens), "remote_call_private_function", remote_call_to_bob ).await;
+
+    match attempted_call_no_secret {
+        Ok(_) => {
+            panic!("calling bobs cell remotely with no secret should fail")
+        },
+        Err(err) => match err {
+            // This is the result we expect
+            holochain::conductor::api::error::ConductorApiError::Other(_boxed_call_error) => {
+                // specifically boxed_call_error should be `CallError("Unauthorized call to private_function".to_string())` but 
+                // I wasn't sure how to assert that
+            },
+            _ => panic!("Unexpected err {}", err),
+        },
+    };
+
+    let alice_secret: CapSecret = conductor.call(&alice.zome(TestWasm::CapTokens), "create_cap_grant_for_private_function", ()).await;
 
     // Making a remote call to bobs cell using a secret alice created should fail
     let remote_call_to_bob: RemoteCallPrivateInput = RemoteCallPrivateInput {
         to_cell: bob.cell_id().to_owned(),
-        cap_secret: alice_secret
+        maybe_cap_secret: Some(alice_secret)
     };
 
-    let attempted_call: ConductorApiResult<String> = conductor.call_fallible(&alice.zome(TestWasm::CapTokens), "remote_call_private_function", remote_call_to_bob ).await;
+    let attempted_call_wrong_secret: ConductorApiResult<String> = conductor.call_fallible(&alice.zome(TestWasm::CapTokens), "remote_call_private_function", remote_call_to_bob ).await;
 
-    match attempted_call {
+    match attempted_call_wrong_secret {
         Ok(_) => {
             panic!("calling bobs cell remotely using alices secret should fail")
         },

--- a/crates/holochain/tests/cap_tokens/mod.rs
+++ b/crates/holochain/tests/cap_tokens/mod.rs
@@ -1,0 +1,65 @@
+#![cfg(feature = "test_utils")]
+
+use holochain::sweettest::SweetAgents;
+use holochain::sweettest::SweetConductor;
+use holochain::sweettest::SweetDnaFile;
+use holochain_serialized_bytes::prelude::*;
+use holochain_types::prelude::*;
+use holochain_wasm_test_utils::TestWasm;
+
+/// A single link with a Path for the base and target is committed by one
+/// agent, and after a delay, all agents can get the link
+#[tokio::test(flavor = "multi_thread")]
+
+#[cfg(feature = "slow_tests")]
+async fn alice_cant_remote_call_bobs_private_function() {
+    use holochain::conductor::api::error::ConductorApiResult;
+
+    holochain_trace::test_run().ok();
+    const NUM_AGENTS: usize = 30;
+
+    let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::CapTokens]).await;
+
+    // Create a Conductor
+    let mut conductor = SweetConductor::from_standard_config().await;
+
+    let agents = SweetAgents::get(conductor.keystore(), 2).await;
+    let apps = conductor
+        .setup_app_for_agents("app", &agents, &[dna_file])
+        .await
+        .unwrap();
+    let cells = apps.cells_flattened();
+    let alice = cells[0].clone();
+    let bob = cells[1].clone();
+
+    let alice_secret: CapSecret = conductor.call(&alice.zome(TestWasm::CapTokens), "create_cap_grant_for_private_function", ()).await;
+
+    #[derive(Serialize, Deserialize, Debug, SerializedBytes)]
+    pub struct RemoteCallPrivateInput {
+        pub to_cell: CellId,
+        pub cap_secret: CapSecret,
+    }    
+
+    // Making a remote call to bobs cell using a secret alice created should fail
+    let remote_call_to_bob: RemoteCallPrivateInput = RemoteCallPrivateInput {
+        to_cell: bob.cell_id().to_owned(),
+        cap_secret: alice_secret
+    };
+
+    let attempted_call: ConductorApiResult<String> = conductor.call_fallible(&alice.zome(TestWasm::CapTokens), "remote_call_private_function", remote_call_to_bob ).await;
+
+    match attempted_call {
+        Ok(_) => {
+            panic!("calling bobs cell remotely using alices secret should fail")
+        },
+        Err(err) => match err {
+            // This is the result we expect
+            holochain::conductor::api::error::ConductorApiError::Other(_boxed_call_error) => {
+                // specifically boxed_call_error should be `CallError("Unauthorized call to private_function".to_string())` but 
+                // I wasn't sure how to assert that
+            },
+            _ => panic!("Unexpected err {}", err),
+        },
+    };
+}
+

--- a/crates/holochain/tests/integration.rs
+++ b/crates/holochain/tests/integration.rs
@@ -1,5 +1,6 @@
 mod agent_scaling;
 mod authored_test;
+mod cap_tokens;
 mod dht_arc;
 mod inline_zome_spec;
 mod integrity_zome;

--- a/crates/test_utils/wasm/src/lib.rs
+++ b/crates/test_utils/wasm/src/lib.rs
@@ -23,6 +23,7 @@ pub enum TestWasm {
     Anchor,
     Bench,
     Capability,
+    CapTokens,
     CounterSigning,
     Create,
     Crd,
@@ -119,6 +120,7 @@ impl From<TestWasm> for ZomeName {
             TestWasm::Anchor => "anchor",
             TestWasm::Bench => "bench",
             TestWasm::Capability => "capability",
+            TestWasm::CapTokens => "cap_tokens",
             TestWasm::CounterSigning => "countersigning",
             TestWasm::Create => "create_entry",
             TestWasm::Crd => "crd",
@@ -180,6 +182,7 @@ impl From<TestWasm> for PathBuf {
             TestWasm::Anchor => "wasm32-unknown-unknown/release/test_wasm_anchor.wasm",
             TestWasm::Bench => "wasm32-unknown-unknown/release/test_wasm_bench.wasm",
             TestWasm::Capability => "wasm32-unknown-unknown/release/test_wasm_capability.wasm",
+            TestWasm::CapTokens => "wasm32-unknown-unknown/release/test_wasm_cap_tokens.wasm",
             TestWasm::CounterSigning => {
                 "wasm32-unknown-unknown/release/test_wasm_countersigning.wasm"
             }

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -2628,6 +2628,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_wasm_cap_tokens"
+version = "0.0.1"
+dependencies = [
+ "hdi",
+ "hdk",
+ "holochain_test_wasm_common",
+ "serde",
+]
+
+[[package]]
 name = "test_wasm_capability"
 version = "0.0.1"
 dependencies = [

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "anchor",
     "bench",
     "capability",
+    "cap_tokens",
     "coordinator_zome",
     "coordinator_zome_update",
     "countersigning",

--- a/crates/test_utils/wasm/wasm_workspace/cap_tokens/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/cap_tokens/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "test_wasm_cap_tokens"
+version = "0.0.1"
+authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
+edition = "2021"
+
+[lib]
+name = "test_wasm_cap_tokens"
+crate-type = ["cdylib", "rlib"]
+
+[[example]]
+name = "integrity_test_wasm_cap_tokens"
+path = "src/integrity.rs"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+serde = "1.0"
+hdk = { path = "../../../../hdk", optional = true }
+holochain_test_wasm_common = { path = "../../../wasm_common" }
+hdi = { path = "../../../../hdi" }
+
+[features]
+default = ["hdk"]
+integrity = []

--- a/crates/test_utils/wasm/wasm_workspace/cap_tokens/src/coordinator.rs
+++ b/crates/test_utils/wasm/wasm_workspace/cap_tokens/src/coordinator.rs
@@ -1,27 +1,5 @@
 use hdk::prelude::*;
 
-pub fn set_cap_tokens() -> ExternResult<()> {
-    let mut functions = BTreeSet::new();
-    functions.insert((zome_info()?.name, "get_cap_grant".into()));
-    functions.insert((
-        zome_info()?.name,
-        "create_cap_grant_for_private_function".into(),
-    ));
-    create_cap_grant(CapGrantEntry {
-        tag: "".into(),
-        access: ().into(),
-        functions: GrantedFunctions::Listed(functions),
-    })?;
-    Ok(())
-}
-
-#[hdk_extern]
-fn init(_: ()) -> ExternResult<InitCallbackResult> {
-    // set_cap_tokens()?;
-
-    Ok(InitCallbackResult::Pass)
-}
-
 #[hdk_extern]
 fn create_cap_grant_for_private_function(_: ()) -> ExternResult<CapSecret> {
     let cap_secret = generate_cap_secret()?;
@@ -29,6 +7,7 @@ fn create_cap_grant_for_private_function(_: ()) -> ExternResult<CapSecret> {
     let mut functions = BTreeSet::new();
     functions.insert((zome_info()?.name, "private_function".into()));
 
+    // If you comment out this call, the test behaves as expected.
     create_cap_grant(CapGrantEntry {
         tag: "".into(),
         access: cap_secret.into(),
@@ -46,22 +25,23 @@ fn private_function(_: ()) -> ExternResult<String> {
 #[derive(Serialize, Deserialize, Debug, SerializedBytes)]
 pub struct RemoteCallPrivateInput {
     pub to_cell: CellId,
-    pub cap_secret: CapSecret,
+    pub maybe_cap_secret: Option<CapSecret>,
 }
 
 #[hdk_extern]
 fn remote_call_private_function(input: RemoteCallPrivateInput) -> ExternResult<String> {
     let zome_name = zome_info()?.name;
+
     let RemoteCallPrivateInput {
         to_cell,
-        cap_secret,
+        maybe_cap_secret,
     } = input;
 
     match hdk::p2p::call_remote(
         to_cell.agent_pubkey().clone(),
         zome_name,
         FunctionName::new("private_function".to_owned()),
-        Some(cap_secret),
+        maybe_cap_secret,
         Some(()),
     )? {
         ZomeCallResponse::Ok(response) => match response.decode() {

--- a/crates/test_utils/wasm/wasm_workspace/cap_tokens/src/coordinator.rs
+++ b/crates/test_utils/wasm/wasm_workspace/cap_tokens/src/coordinator.rs
@@ -1,0 +1,81 @@
+use hdk::prelude::*;
+
+pub fn set_cap_tokens() -> ExternResult<()> {
+    let mut functions = BTreeSet::new();
+    functions.insert((zome_info()?.name, "get_cap_grant".into()));
+    functions.insert((
+        zome_info()?.name,
+        "create_cap_grant_for_private_function".into(),
+    ));
+    create_cap_grant(CapGrantEntry {
+        tag: "".into(),
+        access: ().into(),
+        functions: GrantedFunctions::Listed(functions),
+    })?;
+    Ok(())
+}
+
+#[hdk_extern]
+fn init(_: ()) -> ExternResult<InitCallbackResult> {
+    // set_cap_tokens()?;
+
+    Ok(InitCallbackResult::Pass)
+}
+
+#[hdk_extern]
+fn create_cap_grant_for_private_function(_: ()) -> ExternResult<CapSecret> {
+    let cap_secret = generate_cap_secret()?;
+
+    let mut functions = BTreeSet::new();
+    functions.insert((zome_info()?.name, "private_function".into()));
+
+    create_cap_grant(CapGrantEntry {
+        tag: "".into(),
+        access: cap_secret.into(),
+        functions: GrantedFunctions::Listed(functions),
+    })?;
+
+    Ok(cap_secret)
+}
+
+#[hdk_extern]
+fn private_function(_: ()) -> ExternResult<String> {
+    Ok("this is the result of the private function".to_string())
+}
+
+#[derive(Serialize, Deserialize, Debug, SerializedBytes)]
+pub struct RemoteCallPrivateInput {
+    pub to_cell: CellId,
+    pub cap_secret: CapSecret,
+}
+
+#[hdk_extern]
+fn remote_call_private_function(input: RemoteCallPrivateInput) -> ExternResult<String> {
+    let zome_name = zome_info()?.name;
+    let RemoteCallPrivateInput {
+        to_cell,
+        cap_secret,
+    } = input;
+
+    match hdk::p2p::call_remote(
+        to_cell.agent_pubkey().clone(),
+        zome_name,
+        FunctionName::new("private_function".to_owned()),
+        Some(cap_secret),
+        Some(()),
+    )? {
+        ZomeCallResponse::Ok(response) => match response.decode() {
+            Ok(r) => Ok(r),
+            Err(e) => Err(wasm_error!(WasmErrorInner::Guest(e.to_string()))),
+        },
+        ZomeCallResponse::Unauthorized(..) => Err(wasm_error!(WasmErrorInner::CallError(
+            "Unauthorized call to private_function".to_string()
+        ))),
+        ZomeCallResponse::NetworkError(_) => Err(wasm_error!(WasmErrorInner::CallError(
+            "Network error while calling private_function".to_string()
+        ))),
+        ZomeCallResponse::CountersigningSession(_) => Err(wasm_error!(WasmErrorInner::CallError(
+            "Unexpected CountersigningSession while calling private_function".to_string()
+        ))),
+    }
+}

--- a/crates/test_utils/wasm/wasm_workspace/cap_tokens/src/integrity.rs
+++ b/crates/test_utils/wasm/wasm_workspace/cap_tokens/src/integrity.rs
@@ -1,0 +1,1 @@
+use hdi::prelude::*;

--- a/crates/test_utils/wasm/wasm_workspace/cap_tokens/src/lib.rs
+++ b/crates/test_utils/wasm/wasm_workspace/cap_tokens/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod integrity;
+
+#[cfg(not(feature = "integrity"))]
+pub mod coordinator;
+
+#[cfg(not(feature = "integrity"))]
+pub use coordinator::*;


### PR DESCRIPTION
### Summary

We've seen what looks like a regression in handling cap tokens. We have a test for this same basic flow in envoy-chaperone that used to behave as expected, but now fails as of holochain 0.2.0. This PR contains a test that demonstrates this.

The gist is: Alice creates a cap grant for her private function, and using the cap token, she is able to remote call Bobs private function, despite not having a cap grant to do so.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
