### PR TITLE
Allow use of loopback

### DIFF
--- a/crates/holochain/src/sweettest/sweet_conductor_config_rendezvous.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor_config_rendezvous.rs
@@ -53,9 +53,6 @@ impl SweetLocalRendezvous {
         let mut addr = None;
 
         for iface in get_if_addrs::get_if_addrs().expect("failed to get_if_addrs") {
-            if iface.is_loopback() {
-                continue;
-            }
             if iface.ip().is_ipv6() {
                 continue;
             }
@@ -63,7 +60,7 @@ impl SweetLocalRendezvous {
             break;
         }
 
-        let addr = addr.expect("failed to get_if_addrs");
+        let addr = addr.expect("no matching network interfaces found");
 
         let (bs_driver, bs_addr, bs_shutdown) = kitsune_p2p_bootstrap::run((addr, 0), Vec::new())
             .await


### PR DESCRIPTION
### Summary

This seems to not be necessary and puts extra networking requirements on CI where loopback is always available but we're having to make other network interfaces available.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
