### PR TITLE
p2p_agent memory cache for p2p_query_near_basis

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -214,7 +214,7 @@ jobs:
                 --force-tag-creation \
                 --force-branch-creation \
                 --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
-                --allowed-semver-increment-modes="!patch" \
+                --allowed-semver-increment-modes="!pre_patch beta-rc" \
                 --steps=CreateReleaseBranch,BumpReleaseVersions
 
             release-automation \

--- a/crates/holochain_sqlite/src/db/p2p_agent_store.rs
+++ b/crates/holochain_sqlite/src/db/p2p_agent_store.rs
@@ -183,7 +183,7 @@ fn ai_cache_query_near_basis(
         .values()
         .filter_map(|v| {
             if v.is_active() {
-                Some((basis.abs_diff(u32::from(v.storage_arc.start_loc())), v))
+                Some((v.storage_arc.dist(basis), v))
             } else {
                 None
             }

--- a/crates/holochain_sqlite/src/db/p2p_agent_store.rs
+++ b/crates/holochain_sqlite/src/db/p2p_agent_store.rs
@@ -102,6 +102,105 @@ impl AsP2pAgentStoreConExt for crate::db::PConnGuard {
     }
 }
 
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use std::collections::{hash_map, HashMap};
+
+#[allow(clippy::type_complexity)]
+static AI_CACHE: Lazy<Mutex<HashMap<String, HashMap<Arc<KitsuneAgent>, AgentInfoSigned>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+fn ai_cache_load(con: &Connection) -> DatabaseResult<HashMap<Arc<KitsuneAgent>, AgentInfoSigned>> {
+    let mut stmt = con
+        .prepare(sql_p2p_agent_store::SELECT_ALL)
+        .map_err(|e| rusqlite::Error::ToSqlConversionFailure(e.into()))?;
+    let mut out = HashMap::new();
+    for r in stmt.query_map([], |r| {
+        let r = r.get_ref(0)?;
+        let r = r.as_blob()?;
+        let signed = AgentInfoSigned::decode(r)
+            .map_err(|e| rusqlite::Error::ToSqlConversionFailure(e.into()))?;
+
+        Ok(signed)
+    })? {
+        let r = r?;
+        out.insert(r.agent.clone(), r);
+    }
+    Ok(out)
+}
+
+macro_rules! ai_cache_lock {
+    ($c:ident, $con:ident) => {
+        let mut $c = AI_CACHE.lock();
+        let $c = match $c.entry($con.path().unwrap().to_string()) {
+            hash_map::Entry::Occupied(e) => e.into_mut(),
+            hash_map::Entry::Vacant(e) => e.insert(ai_cache_load($con)?),
+        };
+    };
+}
+
+fn ai_cache_put(con: &Connection, agent_info: AgentInfoSigned) -> DatabaseResult<()> {
+    ai_cache_lock!(cache, con);
+
+    if let Some(a) = cache.get(&agent_info.agent) {
+        if a.signed_at_ms >= agent_info.signed_at_ms {
+            return Ok(());
+        }
+    }
+
+    cache.insert(agent_info.agent.clone(), agent_info);
+
+    Ok(())
+}
+
+fn ai_cache_prune(
+    con: &Connection,
+    now: u64,
+    local_agents: &[Arc<KitsuneAgent>],
+) -> DatabaseResult<()> {
+    ai_cache_lock!(cache, con);
+
+    cache.retain(|_, v| {
+        for l in local_agents {
+            if &v.agent == l {
+                return true;
+            }
+        }
+        v.expires_at_ms > now
+    });
+
+    Ok(())
+}
+
+fn ai_cache_query_near_basis(
+    con: &Connection,
+    basis: u32,
+    limit: u32,
+) -> DatabaseResult<Vec<AgentInfoSigned>> {
+    ai_cache_lock!(cache, con);
+
+    let mut out: Vec<(u32, &AgentInfoSigned)> = cache
+        .values()
+        .filter_map(|v| {
+            if v.is_active() {
+                Some((basis.abs_diff(u32::from(v.storage_arc.start_loc())), v))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if out.len() > 1 {
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+    }
+
+    Ok(out
+        .into_iter()
+        .map(|(_, v)| v.clone())
+        .take(limit as usize)
+        .collect())
+}
+
 /// Put an AgentInfoSigned record into the p2p_store
 pub async fn p2p_put(
     db: &DbWrite<DbKindP2pAgents>,
@@ -117,10 +216,16 @@ pub async fn p2p_put_all(
     signed: impl Iterator<Item = &AgentInfoSigned>,
 ) -> DatabaseResult<()> {
     let mut records = Vec::new();
+    let mut ns = Vec::new();
     for s in signed {
+        ns.push(s.clone());
         records.push(P2pRecord::from_signed(s)?);
     }
     db.async_commit(move |txn| {
+        for s in ns {
+            ai_cache_put(&*txn, s)?;
+        }
+
         for record in records {
             tx_p2p_put(txn, record)?;
         }
@@ -131,6 +236,7 @@ pub async fn p2p_put_all(
 
 /// Insert a p2p record from within a write transaction.
 pub fn p2p_put_single(txn: &mut Transaction<'_>, signed: &AgentInfoSigned) -> DatabaseResult<()> {
+    ai_cache_put(&*txn, signed.clone())?;
     let record = P2pRecord::from_signed(signed)?;
     tx_p2p_put(txn, record)
 }
@@ -175,6 +281,8 @@ pub async fn p2p_prune(
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_millis() as u64;
+
+        ai_cache_prune(&*txn, now, &local_agents)?;
 
         txn.execute(
             sql_p2p_agent_store::PRUNE,
@@ -272,6 +380,8 @@ impl AsP2pStateTxExt for Transaction<'_> {
     }
 
     fn p2p_query_near_basis(&self, basis: u32, limit: u32) -> DatabaseResult<Vec<AgentInfoSigned>> {
+        ai_cache_query_near_basis(self, basis, limit)
+        /*
         let mut stmt = self
             .prepare(sql_p2p_agent_store::QUERY_NEAR_BASIS)
             .map_err(|e| rusqlite::Error::ToSqlConversionFailure(e.into()))?;
@@ -288,6 +398,7 @@ impl AsP2pStateTxExt for Transaction<'_> {
             out.push(r?);
         }
         Ok(out)
+        */
     }
 
     fn p2p_extrapolated_coverage(&self, dht_arc_set: DhtArcSet) -> DatabaseResult<Vec<f64>> {
@@ -374,7 +485,7 @@ impl P2pRecord {
 
         let storage_center_loc = arc.start_loc().into();
 
-        let is_active = !signed.url_list.is_empty();
+        let is_active = signed.is_active();
 
         let (storage_start_loc, storage_end_loc) = arc.to_primitive_bounds_detached();
 

--- a/crates/holochain_sqlite/src/sql.rs
+++ b/crates/holochain_sqlite/src/sql.rs
@@ -65,8 +65,8 @@ pub(crate) mod sql_p2p_agent_store {
     pub(crate) const SELECT: &str = include_str!("sql/p2p_agent_store/select.sql");
     pub(crate) const DELETE: &str = include_str!("sql/p2p_agent_store/delete.sql");
     pub(crate) const GOSSIP_QUERY: &str = include_str!("sql/p2p_agent_store/gossip_query.sql");
-    pub(crate) const QUERY_NEAR_BASIS: &str =
-        include_str!("sql/p2p_agent_store/query_near_basis.sql");
+    // pub(crate) const QUERY_NEAR_BASIS: &str =
+    //     include_str!("sql/p2p_agent_store/query_near_basis.sql");
     pub(crate) const EXTRAPOLATED_COVERAGE: &str =
         include_str!("sql/p2p_agent_store/extrapolated_coverage.sql");
     pub(crate) const PRUNE: &str = include_str!("sql/p2p_agent_store/prune.sql");

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
@@ -300,6 +300,32 @@ impl DhtArcRange<DhtLocation> {
         matches!(self, Self::Bounded(_, _))
     }
 
+    /// Get the min distance to a location.
+    /// Zero if Full, u32::MAX if Empty.
+    pub fn dist(&self, tgt: u32) -> u32 {
+        match self {
+            DhtArcRange::Empty => u32::MAX,
+            DhtArcRange::Full => 0,
+            DhtArcRange::Bounded(start, end) => {
+                let start = u32::from(*start);
+                let end = u32::from(*end);
+                if start < end {
+                    if tgt >= start && tgt <= end {
+                        0
+                    } else if tgt < start {
+                        std::cmp::min(start - tgt, (u32::MAX - end) + tgt)
+                    } else {
+                        std::cmp::min(tgt - end, (u32::MAX - tgt) + start)
+                    }
+                } else if tgt <= end || tgt >= start {
+                    0
+                } else {
+                    std::cmp::min(tgt - end, start - tgt)
+                }
+            }
+        }
+    }
+
     /// Check if arcs overlap
     pub fn overlaps(&self, other: &Self) -> bool {
         let a = DhtArcSet::from(self);

--- a/crates/kitsune_p2p/types/src/agent_info.rs
+++ b/crates/kitsune_p2p/types/src/agent_info.rs
@@ -88,6 +88,13 @@ pub struct AgentInfoInner {
     pub encoded_bytes: Box<[u8]>,
 }
 
+impl AgentInfoInner {
+    /// If this agent is considered active.
+    pub fn is_active(&self) -> bool {
+        !self.url_list.is_empty()
+    }
+}
+
 impl std::fmt::Debug for AgentInfoInner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AgentInfoSigned")


### PR DESCRIPTION
- Adds a memory cache to the p2p agent store mainly to speed up the incredibly frequently called `p2p_query_near_basis` function.
- Now that we have the mem cache we should probably make most of the other p2p agent queries go through it, but that's for a later date.
- So far this has only manually been tested in situations without sharding, so it may be good enough for dweb, but perhaps not production release.