### PR TITLE
Give up waiting if it takes too long to get a db permit

### DIFF
--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1097,7 +1097,7 @@ mod network_impls {
                 } => {
                     use holochain_sqlite::db::AsP2pAgentStoreConExt;
                     let db = { self.p2p_agents_db(&dna_hash) };
-                    let permit = db.conn_permit().await;
+                    let permit = db.conn_permit().await?;
                     let res = tokio::task::spawn_blocking(move || {
                         let mut conn = db.with_permit(permit)?;
                         conn.p2p_gossip_query_agents(since_ms, until_ms, (*arc_set).clone())

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -878,7 +878,7 @@ mod network_impls {
 
                 // query number of agents from peer db
                 let db = { self.p2p_agents_db(dna) };
-                let permit = db.conn_permit().await;
+                let permit = db.conn_permit::<DatabaseError>().await?;
                 let mut conn = db.with_permit(permit)?;
                 let current_number_of_peers = conn.p2p_count_agents()?;
 
@@ -1097,7 +1097,7 @@ mod network_impls {
                 } => {
                     use holochain_sqlite::db::AsP2pAgentStoreConExt;
                     let db = { self.p2p_agents_db(&dna_hash) };
-                    let permit = db.conn_permit().await?;
+                    let permit = db.conn_permit::<DatabaseError>().await?;
                     let res = tokio::task::spawn_blocking(move || {
                         let mut conn = db.with_permit(permit)?;
                         conn.p2p_gossip_query_agents(since_ms, until_ms, (*arc_set).clone())

--- a/crates/holochain/src/conductor/kitsune_host_impl.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl.rs
@@ -16,6 +16,7 @@ use holochain_p2p::{
     dht::{spacetime::Topology, ArqStrat},
     DnaHashExt,
 };
+use holochain_sqlite::error::DatabaseError;
 use holochain_sqlite::prelude::AsP2pStateTxExt;
 use holochain_types::{
     db::PermittedConn,
@@ -113,7 +114,7 @@ impl KitsuneHost for KitsuneHostImpl {
         async move {
             let db = self.spaces.p2p_agents_db(&DnaHash::from_kitsune(&space))?;
             use holochain_sqlite::db::AsP2pAgentStoreConExt;
-            let permit = db.conn_permit().await;
+            let permit = db.conn_permit::<DatabaseError>().await?;
             let task = tokio::task::spawn_blocking(move || {
                 let mut conn = db.with_permit(permit)?;
                 conn.p2p_extrapolated_coverage(dht_arc_set)
@@ -133,7 +134,7 @@ impl KitsuneHost for KitsuneHostImpl {
         async move {
             let db = self.spaces.p2p_metrics_db(&DnaHash::from_kitsune(&space))?;
             use holochain_sqlite::db::AsP2pMetricStoreConExt;
-            let permit = db.conn_permit().await;
+            let permit = db.conn_permit::<DatabaseError>().await?;
             let task = tokio::task::spawn_blocking(move || {
                 let mut conn = db.with_permit(permit)?;
                 conn.p2p_log_metrics(records)

--- a/crates/holochain/src/conductor/p2p_agent_store.rs
+++ b/crates/holochain/src/conductor/p2p_agent_store.rs
@@ -188,7 +188,7 @@ where
     R: Send + 'static,
     F: FnOnce(PConnGuard) -> ConductorResult<R> + Send + 'static,
 {
-    let permit = db.conn_permit().await;
+    let permit = db.conn_permit::<DatabaseError>().await?;
     let r = tokio::task::spawn_blocking(move || {
         let conn = db.with_permit(permit)?;
         f(conn)

--- a/crates/holochain/src/conductor/p2p_agent_store.rs
+++ b/crates/holochain/src/conductor/p2p_agent_store.rs
@@ -353,7 +353,7 @@ mod tests {
         p2p_put(&db, &agent_info_signed).await.unwrap();
 
         let ret = db
-            .with_permit(db.conn_permit().await)
+            .with_permit(db.conn_permit::<DatabaseError>().await.unwrap())
             .unwrap()
             .p2p_get_agent(&agent_info_signed.agent)
             .unwrap();
@@ -369,7 +369,7 @@ mod tests {
 
         // - Check no data in the store to start
         let count = db
-            .with_permit(db.conn_permit().await)
+            .with_permit(db.conn_permit::<DatabaseError>().await.unwrap())
             .unwrap()
             .p2p_list_agents()
             .unwrap()

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -47,7 +47,7 @@ serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 shrinkwraprs = "0.3.0"
 tempfile = "3.3"
 thiserror = "1.0.22"
-tokio = { version = "1.27", features = [ "macros", "rt-multi-thread", "io-util", "sync" ] }
+tokio = { version = "1.27", features = [ "macros", "rt-multi-thread", "io-util", "sync", "time" ] }
 tracing = "0.1.18"
 tracing-futures = "0.2"
 getrandom = "0.2.7"

--- a/crates/holochain_sqlite/src/db.rs
+++ b/crates/holochain_sqlite/src/db.rs
@@ -211,7 +211,7 @@ impl<Kind: DbKindT> DbRead<Kind> {
         E: From<DatabaseError> + Send + 'static,
     {
         match tokio::time::timeout(
-            std::time::Duration::from_secs(2),
+            std::time::Duration::from_secs(10),
             self.read_semaphore.clone().acquire_owned(),
         )
         .await

--- a/crates/holochain_sqlite/src/db.rs
+++ b/crates/holochain_sqlite/src/db.rs
@@ -4,6 +4,7 @@ use crate::{
     conn::{new_connection_pool, ConnectionPool, DbSyncLevel, PConn, DATABASE_HANDLES},
     prelude::*,
 };
+use anyhow::anyhow;
 use derive_more::Into;
 use futures::Future;
 use holo_hash::DnaHash;
@@ -142,13 +143,17 @@ impl<Kind: DbKindT> PermittedConn for DbWrite<Kind> {
 }
 
 impl<Kind: DbKindT> DbRead<Kind> {
+    // TODO should not be public, it is only used internally and by tests
     pub fn conn(&self) -> DatabaseResult<PConn> {
         self.connection_pooled()
     }
 
-    pub async fn conn_permit(&self) -> PConnPermit {
-        let g = self.acquire_reader_permit().await;
-        PConnPermit(g)
+    pub async fn conn_permit<E>(&self) -> Result<PConnPermit, E>
+    where
+        E: From<DatabaseError> + Send + 'static,
+    {
+        let g = self.acquire_reader_permit::<E>().await?;
+        Ok(PConnPermit(g))
     }
 
     /// Accessor for the [DbKindT] of the DbWrite
@@ -191,7 +196,7 @@ impl<Kind: DbKindT> DbRead<Kind> {
                 )
             });
         }
-        let _g = self.acquire_reader_permit().await;
+        let _g = self.acquire_reader_permit().await?;
         self.num_readers
             .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
         let mut conn = self.conn()?;
@@ -201,12 +206,23 @@ impl<Kind: DbKindT> DbRead<Kind> {
         r
     }
 
-    async fn acquire_reader_permit(&self) -> OwnedSemaphorePermit {
-        self.read_semaphore
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("We don't ever close these semaphores")
+    async fn acquire_reader_permit<E>(&self) -> Result<OwnedSemaphorePermit, E>
+    where
+        E: From<DatabaseError> + Send + 'static,
+    {
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            self.read_semaphore.clone().acquire_owned(),
+        )
+        .await
+        {
+            Ok(Ok(s)) => Ok(s),
+            Ok(Err(e)) => {
+                tracing::error!("Semaphore should not be closed but got an error while acquiring a permit, {:?}", e);
+                Err(DatabaseError::Other(e.into()).into())
+            }
+            Err(e) => Err(DatabaseError::Timeout(e).into()),
+        }
     }
 }
 

--- a/crates/holochain_sqlite/src/db/p2p_agent_store/p2p_test.rs
+++ b/crates/holochain_sqlite/src/db/p2p_agent_store/p2p_test.rs
@@ -90,7 +90,7 @@ async fn test_p2p_agent_store_extrapolated_coverage() {
         rand_insert(&db, &space, &example_agent, true).await;
     }
 
-    let permit = db.conn_permit().await;
+    let permit = db.conn_permit::<DatabaseError>().await.unwrap();
     let mut con = db.with_permit(permit).unwrap();
 
     let res = con.p2p_extrapolated_coverage(DhtArcSet::Full).unwrap();
@@ -134,7 +134,7 @@ async fn test_p2p_agent_store_gossip_query_sanity() {
         }
     }
 
-    let permit = db.conn_permit().await;
+    let permit = db.conn_permit::<DatabaseError>().await.unwrap();
     let mut con = db.with_permit(permit).unwrap();
 
     // check that we only get 20 results

--- a/crates/holochain_sqlite/src/db/p2p_metrics/p2p_metrics_test.rs
+++ b/crates/holochain_sqlite/src/db/p2p_metrics/p2p_metrics_test.rs
@@ -32,7 +32,7 @@ async fn test_p2p_metric_store_sanity() {
 
     let db = DbWrite::test(tmp_dir.path(), DbKindP2pMetrics(space.clone())).unwrap();
 
-    let permit = db.conn_permit().await;
+    let permit = db.conn_permit::<DatabaseError>().await.unwrap();
     let mut con = db.with_permit(permit).unwrap();
 
     con.p2p_log_metrics(vec![

--- a/crates/holochain_sqlite/src/error.rs
+++ b/crates/holochain_sqlite/src/error.rs
@@ -59,6 +59,9 @@ pub enum DatabaseError {
 
     #[error(transparent)]
     GetRandom(getrandom::Error),
+
+    #[error(transparent)]
+    Timeout(#[from] tokio::time::error::Elapsed),
 }
 
 impl From<TimestampError> for DatabaseError {


### PR DESCRIPTION
### Summary

Requesting permits is another operation that can block indefinitely. It makes more sense to find and fix the places that are holding permits unreasonably long than let Holochain lock up so I've make it time out

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
