### PR TITLE
Fix bad link size in test

### DIFF
--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -216,7 +216,7 @@ async fn bob_links_in_a_legit_way(
     let target = Post("Potassium is radioactive".into());
     let base_entry_hash = Entry::try_from(base.clone()).unwrap().to_hash();
     let target_entry_hash = Entry::try_from(target.clone()).unwrap().to_hash();
-    let link_tag = fixt!(LinkTag);
+    let link_tag = LinkTag::from(vec![0; 256]);
     let call_data = HostFnCaller::create(bob_cell_id, handle, dna_file).await;
     let zome_index = call_data
         .get_entry_type(TestWasm::Create, POST_INDEX)


### PR DESCRIPTION
### Summary

I don't know how this got into develop and passed most of the time. We were using a random link tag which wasn't guaranteed to be under the allowable limit, which caused an invalid action sometimes when a valid action was expected. Also, there was some logic which causes an invalid action to be committed (the old validation rules allowed it, but the stricter ones don't), and there was a race condition around getting blocked before the test ended, which caused a flaky failure. I removed the part of the test which triggers the block.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
