### PR TITLE
Remove other uses of conn_permit

### DIFF
--- a/crates/holochain/src/conductor/kitsune_host_impl.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl.rs
@@ -129,8 +129,9 @@ impl KitsuneHost for KitsuneHostImpl {
     ) -> KitsuneHostResult<()> {
         async move {
             let db = self.spaces.p2p_metrics_db(&DnaHash::from_kitsune(&space))?;
-            db.write_async(move |txn| txn.p2p_log_metrics(records))
-                .await
+            Ok(db
+                .write_async(move |txn| txn.p2p_log_metrics(records))
+                .await?)
         }
         .boxed()
         .into()

--- a/crates/holochain/src/conductor/p2p_agent_store.rs
+++ b/crates/holochain/src/conductor/p2p_agent_store.rs
@@ -340,7 +340,8 @@ mod tests {
                 let agent = agent_info_signed.agent.clone();
                 move |txn| txn.p2p_get_agent(&agent)
             })
-            .await?;
+            .await
+            .unwrap();
 
         assert_eq!(ret, Some(agent_info_signed));
     }
@@ -352,7 +353,11 @@ mod tests {
         let db = t_db.to_db();
 
         // - Check no data in the store to start
-        let count = db.read_async(move |txn| txn.p2p_list_agents()).await?.len();
+        let count = db
+            .read_async(move |txn| txn.p2p_list_agents())
+            .await
+            .unwrap()
+            .len();
 
         assert_eq!(count, 0);
 

--- a/crates/holochain/src/conductor/p2p_agent_store.rs
+++ b/crates/holochain/src/conductor/p2p_agent_store.rs
@@ -182,30 +182,15 @@ pub async fn reveal_peer_info(
     }
 }
 
-async fn run_query<F, R>(db: DbRead<DbKindP2pAgents>, f: F) -> ConductorResult<R>
-where
-    R: Send + 'static,
-    F: FnOnce(PConnGuard) -> ConductorResult<R> + Send + 'static,
-{
-    let permit = db.conn_permit::<DatabaseError>().await?;
-    let r = tokio::task::spawn_blocking(move || {
-        let conn = db.with_permit(permit)?;
-        f(conn)
-    })
-    .await??;
-    Ok(r)
-}
-
 /// Get agent info for a single agent
 pub async fn get_agent_info_signed(
     environ: DbRead<DbKindP2pAgents>,
     _kitsune_space: Arc<kitsune_p2p::KitsuneSpace>,
     kitsune_agent: Arc<kitsune_p2p::KitsuneAgent>,
 ) -> ConductorResult<Option<AgentInfoSigned>> {
-    run_query(environ, move |mut conn| {
-        Ok(conn.p2p_get_agent(&kitsune_agent)?)
-    })
-    .await
+    Ok(environ
+        .read_async(move |txn| txn.p2p_get_agent(&kitsune_agent))
+        .await?)
 }
 
 /// Get all agent info for a single space
@@ -213,7 +198,7 @@ pub async fn list_all_agent_info(
     environ: DbRead<DbKindP2pAgents>,
     _kitsune_space: Arc<kitsune_p2p::KitsuneSpace>,
 ) -> ConductorResult<Vec<AgentInfoSigned>> {
-    run_query(environ, move |mut conn| Ok(conn.p2p_list_agents()?)).await
+    Ok(environ.read_async(move |txn| txn.p2p_list_agents()).await?)
 }
 
 /// Get all agent info for a single space near a basis loc
@@ -223,10 +208,9 @@ pub async fn list_all_agent_info_signed_near_basis(
     basis_loc: u32,
     limit: u32,
 ) -> ConductorResult<Vec<AgentInfoSigned>> {
-    run_query(environ, move |mut conn| {
-        Ok(conn.p2p_query_near_basis(basis_loc, limit)?)
-    })
-    .await
+    Ok(environ
+        .read_async(move |txn| txn.p2p_query_near_basis(basis_loc, limit))
+        .await?)
 }
 
 /// Get the peer density an agent is currently seeing within
@@ -239,7 +223,7 @@ pub async fn query_peer_density(
     dht_arc: DhtArc,
 ) -> ConductorResult<PeerView> {
     let now = now();
-    let arcs = run_query(env, move |mut conn| Ok(conn.p2p_list_agents()?)).await?;
+    let arcs = env.read_async(move |conn| conn.p2p_list_agents()).await?;
     let arcs: Vec<_> = arcs
         .into_iter()
         .filter_map(|v| {
@@ -352,10 +336,11 @@ mod tests {
         p2p_put(&db, &agent_info_signed).await.unwrap();
 
         let ret = db
-            .with_permit(db.conn_permit::<DatabaseError>().await.unwrap())
-            .unwrap()
-            .p2p_get_agent(&agent_info_signed.agent)
-            .unwrap();
+            .read_async({
+                let agent = agent_info_signed.agent.clone();
+                move |txn| txn.p2p_get_agent(&agent)
+            })
+            .await?;
 
         assert_eq!(ret, Some(agent_info_signed));
     }
@@ -367,12 +352,7 @@ mod tests {
         let db = t_db.to_db();
 
         // - Check no data in the store to start
-        let count = db
-            .with_permit(db.conn_permit::<DatabaseError>().await.unwrap())
-            .unwrap()
-            .p2p_list_agents()
-            .unwrap()
-            .len();
+        let count = db.read_async(move |txn| txn.p2p_list_agents()).await?.len();
 
         assert_eq!(count, 0);
 

--- a/crates/holochain_sqlite/src/db/p2p_metrics/p2p_metrics_test.rs
+++ b/crates/holochain_sqlite/src/db/p2p_metrics/p2p_metrics_test.rs
@@ -32,35 +32,35 @@ async fn test_p2p_metric_store_sanity() {
 
     let db = DbWrite::test(tmp_dir.path(), DbKindP2pMetrics(space.clone())).unwrap();
 
-    let permit = db.conn_permit::<DatabaseError>().await.unwrap();
-    let mut con = db.with_permit(permit).unwrap();
-
-    con.p2p_log_metrics(vec![
-        // -- reachability quotient -- //
-        MetricRecord {
-            kind: MetricRecordKind::ReachabilityQuotient,
-            agent: Some(rand_agent()),
-            recorded_at_utc: Timestamp::MIN,
-            expires_at_utc: Timestamp::MAX,
-            data: serde_json::json!(42.42),
-        },
-        // -- latency micros -- //
-        MetricRecord {
-            kind: MetricRecordKind::LatencyMicros,
-            agent: Some(rand_agent()),
-            recorded_at_utc: Timestamp::MIN,
-            expires_at_utc: Timestamp::MAX,
-            data: serde_json::json!(42.42),
-        },
-        // -- agg extrap cov -- //
-        MetricRecord {
-            kind: MetricRecordKind::AggExtrapCov,
-            agent: None,
-            recorded_at_utc: Timestamp::MIN,
-            expires_at_utc: Timestamp::MAX,
-            data: serde_json::json!(42.42),
-        },
-    ])
+    db.read_async(move |txn| {
+        txn.p2p_log_metrics(vec![
+            // -- reachability quotient -- //
+            MetricRecord {
+                kind: MetricRecordKind::ReachabilityQuotient,
+                agent: Some(rand_agent()),
+                recorded_at_utc: Timestamp::MIN,
+                expires_at_utc: Timestamp::MAX,
+                data: serde_json::json!(42.42),
+            },
+            // -- latency micros -- //
+            MetricRecord {
+                kind: MetricRecordKind::LatencyMicros,
+                agent: Some(rand_agent()),
+                recorded_at_utc: Timestamp::MIN,
+                expires_at_utc: Timestamp::MAX,
+                data: serde_json::json!(42.42),
+            },
+            // -- agg extrap cov -- //
+            MetricRecord {
+                kind: MetricRecordKind::AggExtrapCov,
+                agent: None,
+                recorded_at_utc: Timestamp::MIN,
+                expires_at_utc: Timestamp::MAX,
+                data: serde_json::json!(42.42),
+            },
+        ])
+    })
+    .await
     .unwrap();
 
     // clean up temp dir


### PR DESCRIPTION
### Summary

The other uses of `conn_permit` ignoring tests inside the sqlite crate and cascade (different PR).

With this change and the cascade change PR this can now be removed.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
