### PR TITLE
Remove preflight warning for empty remote agent list

### DIFF
--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -235,8 +235,9 @@ impl Spaces {
 
         // If node_agents_in_spaces is not yet initialized, we can't know anything about
         // which cells are blocked, so avoid the race condition by returning false
+        // TODO: actually fix the preflight, because this could be a loophole for someone
+        //       to evade a block in some circumstances
         if cell_ids.is_empty() {
-            tracing::warn!(?target_id, "is_blocked(): No agents were found for the target. This indicates that preflight agent exchange may not be working properly.");
             return Ok(false);
         }
 


### PR DESCRIPTION
### Summary



### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
