### PR TITLE
Include the name of a crate if it has a versioning issue

### DIFF
--- a/crates/release-automation/src/lib/release.rs
+++ b/crates/release-automation/src/lib/release.rs
@@ -228,7 +228,7 @@ fn bump_release_versions<'a>(
                     crt.set_version(cmd_args.dry_run, &incremented_version)?;
                     incremented_version.clone()
                 } else {
-                    bail!("neither current version '{}' nor incremented version '{}' exceed previously released version '{}'", &current_version, &incremented_version, previous_release_version);
+                    bail!("[{}] neither current version '{}' nor incremented version '{}' exceed previously released version '{}'", crt.name(), &current_version, &incremented_version, previous_release_version);
                 }
             }
 


### PR DESCRIPTION
### Summary

Just a minor thing I noticed while working on #2580 that this wasn't printing the current crate if the check failed

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
