### PR TITLE
chore(versions/0_2): use holochain-0.2.1-beta-rc.0

### DIFF
--- a/versions/0_2/flake.lock
+++ b/versions/0_2/flake.lock
@@ -3,16 +3,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1684139928,
-        "narHash": "sha256-uno5MTiBwf9RiEiX6iKzJsB+3srJFKwV/1ReXzaZVVw=",
+        "lastModified": 1689700874,
+        "narHash": "sha256-mmWMY2vxzQqUsUCOcxy7/dJJWvDrFRHED6do1YQuQtM=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "a91b262e87653f5f2e3a50c06eaac2bb81fb88d3",
+        "rev": "265a80c3b7993447412e9e6a63291e55ad08f403",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.2.1-beta-dev.0",
+        "ref": "holochain-0.2.1-beta-rc.0",
         "repo": "holochain",
         "type": "github"
       }

--- a/versions/0_2/flake.nix
+++ b/versions/0_2/flake.nix
@@ -2,7 +2,7 @@
   inputs =
     {
       holochain = {
-        url = "github:holochain/holochain/holochain-0.2.1-beta-dev.0";
+        url = "github:holochain/holochain/holochain-0.2.1-beta-rc.0";
         flake = false;
       };
 


### PR DESCRIPTION
### Summary

confirmed working

```
$ nix develop github:holochain/holochain --override-input versions 'github:holochain/holochain/pr_version_0_2_update?dir=versions/0_2' --command holochain --version
warning: not writing modified lock file of flake 'github:holochain/holochain':
• Updated input 'versions':
    'path:./versions/0_1?lastModified=1686618210&narHash=sha256-lXY9ob0WAekcoEgWcFL3cJiPkwoKlsR2OMqG0S3vXzA=' (2023-06-13)
  → 'github:holochain/holochain/4d0a60884e228f47989a9133be3a34abe233a7ec?dir=versions%2f0_2' (2023-07-18)
• Updated input 'versions/holochain':
    'github:holochain/holochain/db5b8b27da3bf296958c3bf54ac3950dc60a39c8' (2023-06-08)
  → 'github:holochain/holochain/265a80c3b7993447412e9e6a63291e55ad08f403' (2023-07-18)
• Updated input 'versions/launcher':
    'github:holochain/launcher/1ad188a43900c139e52df10a21e3722f41dfb967' (2023-02-24)
  → 'github:holochain/launcher/75ecdd0aa191ed830cc209a984a6030e656042ff' (2023-05-15)
• Updated input 'versions/scaffolding':
    'github:holochain/scaffolding/861397c975542306be6d8529e5c6bdb21c7ba6a6' (2023-06-13)
  → 'github:holochain/scaffolding/1ca1092ad5d147bd23a75444874830cc033aa9cf' (2023-05-12)
Holochain development shell spawned. Type exit to leave.
holochain 0.2.1-beta-rc.0
```


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
