### PR TITLE
Fix all warnings not picked up by CI

### DIFF
--- a/crates/hc_sandbox/src/cli.rs
+++ b/crates/hc_sandbox/src/cli.rs
@@ -236,6 +236,7 @@ impl LaunchInfo {
     }
 }
 
+/// Run a conductor for each path
 pub async fn run_n(
     holochain_path: &Path,
     paths: Vec<PathBuf>,
@@ -282,6 +283,7 @@ pub async fn run_n(
     Ok(())
 }
 
+/// Perform the `generate` subcommand
 pub async fn generate(
     holochain_path: &Path,
     happ: Option<PathBuf>,

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -272,6 +272,7 @@ mod tests {
 
     fn assert_type<T: HashType>(t: &str, h: HoloHash<T>) {
         assert_eq!(3_688_618_971, h.get_loc().as_u32());
+        assert_eq!(h.hash_type().hash_name(), t);
         assert_eq!(
             "[219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219]",
             format!("{:?}", h.get_raw_32()),

--- a/crates/holochain/src/core/workflow.rs
+++ b/crates/holochain/src/core/workflow.rs
@@ -36,5 +36,7 @@ pub mod validation_receipt_workflow;
 
 // MAYBE: either remove wildcards or add wildcards for all above child modules
 pub use call_zome_workflow::*;
+
+#[allow(ambiguous_glob_reexports)]
 pub use genesis_workflow::*;
 pub use initialize_zomes_workflow::*;

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -1,4 +1,3 @@
-use crate::holochain_wasmer_host::prelude::*;
 use crate::sweettest::SweetConductorBatch;
 use crate::sweettest::SweetDnaFile;
 use crate::test_utils::host_fn_caller::*;

--- a/crates/holochain/src/lib.rs
+++ b/crates/holochain/src/lib.rs
@@ -36,6 +36,7 @@ pub use tracing;
 #[cfg(test)]
 mod local_network_tests;
 
+#[allow(ambiguous_glob_reexports)]
 pub mod prelude {
     pub use holo_hash;
     pub use holochain_p2p::AgentPubKeyExt;

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -566,17 +566,6 @@ pub async fn wait_for_integration<Db: ReadAccess<DbKindDht>>(
     num_attempts: usize,
     delay: Duration,
 ) {
-    fn display_op(op: &DhtOp) -> String {
-        format!(
-            "{} {:>3}  {} ({})",
-            op.action().author(),
-            op.action().action_seq(),
-            // op.to_light().action_hash().clone(),
-            op.get_type(),
-            op.action().action_type(),
-        )
-    }
-
     for i in 0..num_attempts {
         let num_integrated = get_integrated_count(db).await;
         if num_integrated >= num_published {

--- a/crates/holochain_state/src/prelude.rs
+++ b/crates/holochain_state/src/prelude.rs
@@ -1,5 +1,6 @@
 pub use crate::mutations::*;
 pub use crate::query::prelude::*;
+#[allow(ambiguous_glob_reexports)]
 pub use crate::source_chain::*;
 pub use crate::validation_db::*;
 pub use crate::validation_receipts::*;

--- a/crates/holochain_types/src/prelude.rs
+++ b/crates/holochain_types/src/prelude.rs
@@ -2,15 +2,18 @@
 
 pub use holochain_keystore::AgentPubKeyExt;
 pub use holochain_serialized_bytes::prelude::*;
+#[allow(ambiguous_glob_reexports)]
 pub use holochain_zome_types::prelude::*;
 pub use holochain_zome_types::zome_io::Nonce256Bits;
 pub use std::convert::TryFrom;
 pub use std::convert::TryInto;
 
 pub use crate::access::*;
+#[allow(ambiguous_glob_reexports)]
 pub use crate::action::*;
 pub use crate::activity::*;
 pub use crate::app::error::*;
+#[allow(ambiguous_glob_reexports)]
 pub use crate::app::*;
 pub use crate::autonomic::*;
 pub use crate::chain::*;

--- a/crates/holochain_zome_types/src/prelude.rs
+++ b/crates/holochain_zome_types/src/prelude.rs
@@ -1,6 +1,7 @@
 //! Common types
 
 pub use crate::action::conversions::*;
+#[allow(ambiguous_glob_reexports)]
 pub use crate::action::*;
 pub use crate::agent_activity::*;
 pub use crate::block::*;
@@ -14,6 +15,7 @@ pub use crate::crdt::*;
 pub use crate::dna_def::*;
 pub use crate::entry::*;
 pub use crate::entry_def::*;
+#[allow(ambiguous_glob_reexports)]
 pub use crate::genesis::*;
 pub use crate::hash::*;
 pub use crate::info::*;
@@ -22,6 +24,7 @@ pub use crate::judged::*;
 pub use crate::link::*;
 pub use crate::metadata::*;
 pub use crate::migrate_agent::*;
+#[allow(ambiguous_glob_reexports)]
 pub use crate::op::*;
 #[cfg(feature = "properties")]
 pub use crate::properties::*;
@@ -43,9 +46,11 @@ pub use crate::x_salsa20_poly1305::key_ref::*;
 pub use crate::x_salsa20_poly1305::x25519::*;
 pub use crate::x_salsa20_poly1305::*;
 pub use crate::zome::error::*;
+#[allow(ambiguous_glob_reexports)]
 pub use crate::zome::*;
 pub use crate::zome_io::ExternIO;
 pub use crate::zome_io::*;
+#[allow(ambiguous_glob_reexports)]
 pub use crate::*;
 
 pub use holochain_integrity_types::prelude::*;


### PR DESCRIPTION
### Summary

When running `cargo check`, there are lots of warnings that CI isn't picking up. We should find out why those warnings aren't being recognized in CI, and then this PR is one way to fix those warnings.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
