### PR TITLE
Update lockfiles on schedule

### DIFF
--- a/.github/workflows/update-dispatch.yml
+++ b/.github/workflows/update-dispatch.yml
@@ -42,7 +42,7 @@ jobs:
           - source: "nixpkgs"
             cmd: "nix flake lock --update-input nixpkgs"
           - source: "crates-io"
-            cmd: "nix run .#scripts-cargo-update"
+            cmd: "nix develop .#coreDev --command scripts-cargo-update"
 
     runs-on: "ubuntu-latest"
     steps:

--- a/.github/workflows/update-dispatch.yml
+++ b/.github/workflows/update-dispatch.yml
@@ -41,6 +41,8 @@ jobs:
             cmd: "nix flake lock --update-input rust-overlay"
           - source: "nixpkgs"
             cmd: "nix flake lock --update-input nixpkgs"
+          - source: "crates-io"
+            cmd: "nix run .#scripts-cargo-update"
 
     runs-on: "ubuntu-latest"
     steps:

--- a/cargo-update.sh
+++ b/cargo-update.sh
@@ -1,3 +1,0 @@
-cargo update --manifest-path Cargo.toml
-cargo update --manifest-path crates/release-automation/Cargo.toml
-cargo update --manifest-path crates/test_utils/wasm/wasm_workspace/Cargo.toml 

--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -130,6 +130,16 @@
                 cargo generate-lockfile --offline --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml
               '')
 
+              (pkgs.writeShellScriptBin "scripts-cargo-update" ''
+                 set -xeou pipefail
+
+                 # Update the Holochain project Cargo.lock
+                 cargo update --manifest-path Cargo.toml
+                 # Update the release-automation crate's Cargo.lock
+                 cargo update --manifest-path crates/release-automation/Cargo.toml
+                 # Update the WASM workspace Cargo.lock
+                 cargo update --manifest-path crates/test_utils/wasm/wasm_workspace/Cargo.toml
+               '')
             ]
 
             # generate one script for each of the "holochain-tests-" prefixed derivations by reusing their checkPhase

--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -131,7 +131,7 @@
               '')
 
               (pkgs.writeShellScriptBin "scripts-cargo-update" ''
-                 set -xeou pipefail
+                 set -xeu -o pipefail
 
                  # Update the Holochain project Cargo.lock
                  cargo update --manifest-path Cargo.toml

--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -64,6 +64,17 @@
 
         git commit -m "chore(flakes): update $VERSIONS_DIR"
       '';
+
+      scripts-cargo-update = pkgs.writeShellScriptBin ''
+        set -xeou pipefail
+
+        # Update the Holochain project Cargo.lock
+        cargo update --manifest-path Cargo.toml
+        # Update the release-automation crate's Cargo.lock
+        cargo update --manifest-path crates/release-automation/Cargo.toml
+        # Update the WASM workspace Cargo.lock
+        cargo update --manifest-path crates/test_utils/wasm/wasm_workspace/Cargo.toml
+      '';
     };
   };
 }

--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -65,7 +65,7 @@
         git commit -m "chore(flakes): update $VERSIONS_DIR"
       '';
 
-      scripts-cargo-update = pkgs.writeShellScriptBin ''
+      scripts-cargo-update = pkgs.writeShellScriptBin "scripts-cargo-update" ''
         set -xeou pipefail
 
         # Update the Holochain project Cargo.lock

--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -64,17 +64,6 @@
 
         git commit -m "chore(flakes): update $VERSIONS_DIR"
       '';
-
-      scripts-cargo-update = pkgs.writeShellScriptBin "scripts-cargo-update" ''
-        set -xeou pipefail
-
-        # Update the Holochain project Cargo.lock
-        cargo update --manifest-path Cargo.toml
-        # Update the release-automation crate's Cargo.lock
-        cargo update --manifest-path crates/release-automation/Cargo.toml
-        # Update the WASM workspace Cargo.lock
-        cargo update --manifest-path crates/test_utils/wasm/wasm_workspace/Cargo.toml
-      '';
     };
   };
 }


### PR DESCRIPTION
### Summary

We should rely on our Cargo.toml version specs as a source of truth because that's what consumers of Holochain libs/bins rely on when they build from crates.io. By updating regularly (every 6 hours) we will discover more often that there are problems, and hopefully less often find this after a release has been cut.

There is nothing to stop the build breaking after we release so this is about the best we can do by keeping up-to-date within our repository as we work.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
