### PR TITLE
Make installed_hash optional in CloneOnly strategy

### DIFF
--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -270,7 +270,7 @@ pub fn bytes_to_hex(bytes: &[u8], caps: bool) -> String {
 mod tests {
     use crate::*;
 
-    fn assert_type<T: HashType>(t: &str, h: HoloHash<T>) {
+    fn assert_type<T: HashType>(_: &str, h: HoloHash<T>) {
         assert_eq!(3_688_618_971, h.get_loc().as_u32());
         assert_eq!(
             "[219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219, 219]",

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- In the CloneOnly provisioning strategy, `installed_hash` is no longer required (it's now optional). [#2600](https://github.com/holochain/holochain/pull/2600)
+
 ## 0.3.0-beta-dev.9
 
 ## 0.3.0-beta-dev.8

--- a/crates/holochain_types/src/app/app_bundle.rs
+++ b/crates/holochain_types/src/app/app_bundle.rs
@@ -203,7 +203,7 @@ impl AppBundle {
                         role_name,
                         dna_store,
                         &location,
-                        Some(&installed_hash),
+                        installed_hash.as_ref(),
                         modifiers,
                     )
                     .await?;

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
@@ -221,10 +221,7 @@ impl AppManifestV1 {
                         CellProvisioning::CloneOnly => AppRoleManifestValidated::CloneOnly {
                             clone_limit,
                             location: Self::require(location, "roles.dna.(path|url)")?,
-                            installed_hash: Self::require(
-                                installed_hash,
-                                "roles.dna.installed_hash",
-                            )?,
+                            installed_hash,
                             modifiers,
                         },
                     };

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_validated.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_validated.rs
@@ -80,6 +80,6 @@ pub enum AppRoleManifestValidated {
         clone_limit: u32,
         location: DnaLocation,
         modifiers: DnaModifiersOpt,
-        installed_hash: DnaHashB64,
+        installed_hash: Option<DnaHashB64>,
     },
 }


### PR DESCRIPTION
### Summary

It was an oversight to have it required

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
