### PR TITLE
Bump zome call error level

### DIFF
--- a/crates/holochain/src/core/ribosome/real_ribosome.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome.rs
@@ -684,7 +684,7 @@ impl RealRibosome {
             let (can_cache, result) = match result {
                 Err(runtime_error) => {
                     // This will bubble up and be logged later but capture zome/function that was called while the context is available
-                    tracing::info!(?runtime_error, ?zome, ?to_call);
+                    tracing::error!(?runtime_error, ?zome, ?to_call);
                     match runtime_error.downcast::<WasmError>() {
                         Ok(wasm_error) => {
                             (!wasm_error.error.maybe_corrupt(), Err(wasm_error.into()))


### PR DESCRIPTION
### Summary

This is a tweak to #2493 which was supposed to provide more information when zome calls fail but we aren't running Holochain with INFO logs in the places that the errors I'm looking at are happening. Increasing the log level for now and if it turns out to be noisy it can be moved down again.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
