### PR TITLE
Treat lair error as such, instead of signature failure

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Improves error messages when validation fails with an InvalidCommit error
+- Fixed bug where if signature verification fails due to the lair service being unavailable, validation could fail. Now, that failure is treated as a normal error, so validation cannot proceed. [#2604](https://github.com/holochain/holochain/pull/2604)
 
 ## 0.3.0-beta-dev.10
 

--- a/crates/holochain/src/core/ribosome.rs
+++ b/crates/holochain/src/core/ribosome.rs
@@ -361,7 +361,7 @@ impl ZomeCallInvocation {
                     &self.signature,
                     ZomeCallUnsigned::from(ZomeCall::from(self.clone())).data_to_sign()?,
                 )
-                .await
+                .await?
             {
                 ZomeCallAuthorization::Authorized
             } else {

--- a/crates/holochain/src/core/ribosome/host_fn/sign_ephemeral.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/sign_ephemeral.rs
@@ -26,11 +26,7 @@ pub fn sign_ephemeral(
 
             let sig = sodoken::BufWriteSized::new_no_lock();
             for data in input.into_inner().into_iter() {
-                sodoken::sign::detached(
-                    sig.clone(),
-                    data.to_vec(),
-                    sk.clone(),
-                ).await?;
+                sodoken::sign::detached(sig.clone(), data.to_vec(), sk.clone()).await?;
                 signatures.push((*sig.read_lock_sized()).into());
             }
 
@@ -76,52 +72,48 @@ pub mod wasm_test {
         #[derive(Serialize, Deserialize, Debug)]
         struct Two([u8; 2]);
 
-        assert!(
-            output[0]
-                .key
-                .verify_signature_raw(
-                    &output[0].signatures[0],
-                    holochain_serialized_bytes::encode(&One([1, 2]))
-                        .unwrap()
-                        .into()
-                )
-                .await
-        );
+        assert!(output[0]
+            .key
+            .verify_signature_raw(
+                &output[0].signatures[0],
+                holochain_serialized_bytes::encode(&One([1, 2]))
+                    .unwrap()
+                    .into()
+            )
+            .await
+            .unwrap());
 
-        assert!(
-            output[0]
-                .key
-                .verify_signature_raw(
-                    &output[0].signatures[1],
-                    holochain_serialized_bytes::encode(&One([3, 4]))
-                        .unwrap()
-                        .into()
-                )
-                .await
-        );
+        assert!(output[0]
+            .key
+            .verify_signature_raw(
+                &output[0].signatures[1],
+                holochain_serialized_bytes::encode(&One([3, 4]))
+                    .unwrap()
+                    .into()
+            )
+            .await
+            .unwrap());
 
-        assert!(
-            output[1]
-                .key
-                .verify_signature_raw(
-                    &output[1].signatures[0],
-                    holochain_serialized_bytes::encode(&One([1, 2]))
-                        .unwrap()
-                        .into()
-                )
-                .await
-        );
+        assert!(output[1]
+            .key
+            .verify_signature_raw(
+                &output[1].signatures[0],
+                holochain_serialized_bytes::encode(&One([1, 2]))
+                    .unwrap()
+                    .into()
+            )
+            .await
+            .unwrap());
 
-        assert!(
-            output[1]
-                .key
-                .verify_signature_raw(
-                    &output[1].signatures[1],
-                    holochain_serialized_bytes::encode(&Two([2, 3]))
-                        .unwrap()
-                        .into()
-                )
-                .await
-        );
+        assert!(output[1]
+            .key
+            .verify_signature_raw(
+                &output[1].signatures[1],
+                holochain_serialized_bytes::encode(&Two([2, 3]))
+                    .unwrap()
+                    .into()
+            )
+            .await
+            .unwrap());
     }
 }

--- a/crates/holochain/src/core/ribosome/host_fn/verify_signature.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/verify_signature.rs
@@ -1,11 +1,11 @@
 use crate::core::ribosome::CallContext;
 use crate::core::ribosome::HostFnAccess;
+use crate::core::ribosome::RibosomeError;
 use crate::core::ribosome::RibosomeT;
 use holochain_keystore::AgentPubKeyExt;
 use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::*;
 use std::sync::Arc;
-use crate::core::ribosome::RibosomeError;
 
 pub fn verify_signature(
     _ribosome: Arc<impl RibosomeT>,
@@ -16,14 +16,16 @@ pub fn verify_signature(
         HostFnAccess {
             keystore_deterministic: Permission::Allow,
             ..
-        } => Ok(tokio_helper::block_forever_on(async move {
+        } => tokio_helper::block_forever_on(async move {
             let VerifySignature {
                 key,
                 signature,
                 data,
             } = input;
-            key.verify_signature_raw(&signature, data.into()).await
-        })),
+            key.verify_signature_raw(&signature, data.into())
+                .await
+                .map_err(|e| RuntimeError::user(Box::new(e)))
+        }),
         _ => Err(wasm_error!(WasmErrorInner::Host(
             RibosomeError::HostFnPermissions(
                 call_context.zome.zome_name().clone(),

--- a/crates/holochain/src/core/sys_validate.rs
+++ b/crates/holochain/src/core/sys_validate.rs
@@ -39,7 +39,7 @@ pub const MAX_TAG_SIZE: usize = 1000;
 
 /// Verify the signature for this action
 pub async fn verify_action_signature(sig: &Signature, action: &Action) -> SysValidationResult<()> {
-    if action.author().verify_signature(sig, action).await {
+    if action.author().verify_signature(sig, action).await? {
         Ok(())
     } else {
         Err(SysValidationError::ValidationOutcome(
@@ -117,7 +117,7 @@ pub async fn check_countersigning_preflight_response_signature(
                 })?
                 .into(),
         )
-        .await;
+        .await?;
     if signature_is_valid {
         Ok(())
     } else {

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -226,7 +226,7 @@ pub(crate) async fn countersigning_success(
     // Verify signatures of actions.
     let mut i_am_an_author = false;
     for SignedAction(action, signature) in &signed_actions {
-        if !action.author().verify_signature(signature, action).await {
+        if !action.author().verify_signature(signature, action).await? {
             return Ok(());
         }
         if action.author() == &author {

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -87,7 +87,7 @@ async fn test_validation_receipt() {
             } = receipt;
             let validator = receipt.validators[0].clone();
             assert!(validator == *bobbo.agent_pubkey() || validator == *carol.agent_pubkey());
-            assert!(validator.verify_signature(&sigs[0], receipt).await);
+            assert!(validator.verify_signature(&sigs[0], receipt).await.unwrap());
         }
     }
 

--- a/crates/holochain_keystore/src/agent_pubkey_ext.rs
+++ b/crates/holochain_keystore/src/agent_pubkey_ext.rs
@@ -27,7 +27,7 @@ pub trait AgentPubKeyExt {
         &self,
         signature: &Signature,
         data: Arc<[u8]>,
-    ) -> MustBoxFuture<'static, bool>;
+    ) -> MustBoxFuture<'static, KeystoreResult<bool>>;
 
     // -- provided -- //
 
@@ -53,7 +53,11 @@ pub trait AgentPubKeyExt {
     }
 
     /// verify a signature for given data with this agent public_key is valid
-    fn verify_signature<D>(&self, signature: &Signature, data: D) -> MustBoxFuture<'static, bool>
+    fn verify_signature<D>(
+        &self,
+        signature: &Signature,
+        data: D,
+    ) -> MustBoxFuture<'static, KeystoreResult<bool>>
     where
         D: TryInto<SerializedBytes, Error = SerializedBytesError>,
     {
@@ -62,7 +66,7 @@ pub trait AgentPubKeyExt {
         let data = match data.try_into() {
             Err(e) => {
                 tracing::error!("Serialization Error: {:?}", e);
-                return async move { false }.boxed().into();
+                return async move { Err(e.into()) }.boxed().into();
             }
             Ok(data) => data,
         };
@@ -97,25 +101,17 @@ impl AgentPubKeyExt for holo_hash::AgentPubKey {
         &self,
         signature: &Signature,
         data: Arc<[u8]>,
-    ) -> MustBoxFuture<'static, bool> {
+    ) -> MustBoxFuture<'static, KeystoreResult<bool>> {
         let mut pub_key = [0; 32];
         pub_key.copy_from_slice(self.get_raw_32());
         let pub_key = <lair_keystore_api::prelude::BinDataSized<32>>::from(pub_key);
         let sig = signature.0;
 
         MustBoxFuture::new(async move {
-            match pub_key.verify_detached(sig.into(), data).await {
-                Ok(b) => b,
-                Err(e) => {
-                    tracing::error!(
-                        "Signature failed to verify: {:?}. Signature: {:?}, Pub key: {}",
-                        e,
-                        sig,
-                        pub_key
-                    );
-                    false
-                }
-            }
+            pub_key
+                .verify_detached(sig.into(), data)
+                .await
+                .map_err(KeystoreError::LairError)
         })
     }
 }

--- a/crates/holochain_keystore/src/error.rs
+++ b/crates/holochain_keystore/src/error.rs
@@ -12,6 +12,10 @@ pub enum KeystoreError {
     #[error("Invalid signature {0:?}, for {1}")]
     InvalidSignature(Signature, String),
 
+    /// Error from Lair
+    #[error(transparent)]
+    LairError(one_err::OneErr),
+
     /// Used in TryFrom implementations for some zome types.
     #[error("Secure primitive error: {0}")]
     SecurePrimitiveError(
@@ -22,6 +26,9 @@ pub enum KeystoreError {
     #[error("Other: {0}")]
     Other(String),
 }
+
+/// alias
+pub type KeystoreResult<T> = Result<T, KeystoreError>;
 
 impl std::cmp::PartialEq for KeystoreError {
     fn eq(&self, o: &Self) -> bool {

--- a/crates/holochain_types/src/record.rs
+++ b/crates/holochain_types/src/record.rs
@@ -378,7 +378,7 @@ impl SignedActionHashedExt for SignedActionHashed {
             .action()
             .author()
             .verify_signature(self.signature(), self.action())
-            .await
+            .await?
         {
             return Err(KeystoreError::InvalidSignature(
                 self.signature().clone(),


### PR DESCRIPTION
### Summary

I noticed that if signature verification fails due to inability to connect to lair, it simply returns `false` which is indistinguishable from an actually invalid signature. This value is used in sys validation to reject ops, so that seems wrong to allow a local problem to affect deterministic validation.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
