### PR TITLE
[BACKPORT-0.2] Add more context to InvalidCommit errors on the source chain (#2591)

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Improves error messages when validation fails with an InvalidCommit error
+
 ## 0.2.1
 
 ## 0.2.1-beta-rc.0

--- a/crates/holochain/src/core/sys_validate.rs
+++ b/crates/holochain/src/core/sys_validate.rs
@@ -169,16 +169,16 @@ pub fn check_prev_action(action: &Action) -> SysValidationResult<()> {
         if is_dna && !has_prev {
             Ok(())
         } else {
-            Err(PrevActionError::InvalidRoot)
+            Err(PrevActionErrorKind::InvalidRoot)
         }
     } else {
         if !is_dna && has_prev {
             Ok(())
         } else {
-            Err(PrevActionError::MissingPrev)
+            Err(PrevActionErrorKind::MissingPrev)
         }
     }
-    .map_err(|e| ValidationOutcome::from(e).into())
+    .map_err(|e| ValidationOutcome::PrevActionError((e, action.clone()).into()).into())
 }
 
 /// Check that Dna actions are only added to empty source chains
@@ -191,8 +191,9 @@ pub fn check_valid_if_dna(action: &Action, dna_def: &DnaDefHashed) -> SysValidat
             } else if action.timestamp() < dna_def.modifiers.origin_time {
                 // If the Dna timestamp is ahead of the origin time, every other action
                 // will be inductively so also due to the prev_action check
-                Err(PrevActionError::InvalidRootOriginTime)
-                    .map_err(|e| ValidationOutcome::from(e).into())
+                Err(PrevActionErrorKind::InvalidRootOriginTime).map_err(|e| {
+                    ValidationOutcome::PrevActionError((e, action.clone()).into()).into()
+                })
             } else {
                 Ok(())
             }
@@ -260,11 +261,11 @@ pub fn check_agent_validation_pkg_predecessor(
     };
 
     if let Some(error) = maybe_error {
-        Err(PrevActionError::InvalidSuccessor(
+        Err(PrevActionErrorKind::InvalidSuccessor(
             error.to_string(),
             Box::new((prev_action.clone(), action.clone())),
         ))
-        .map_err(|e| ValidationOutcome::from(e).into())
+        .map_err(|e| ValidationOutcome::PrevActionError((e, action.clone()).into()).into())
     } else {
         Ok(())
     }
@@ -297,7 +298,8 @@ pub fn check_prev_author(action: &Action, prev_action: &Action) -> SysValidation
     if a1 == *a2 {
         Ok(())
     } else {
-        Err(PrevActionError::Author(a1, a2.clone())).map_err(|e| ValidationOutcome::from(e).into())
+        Err(PrevActionErrorKind::Author(a1, a2.clone()))
+            .map_err(|e| ValidationOutcome::PrevActionError((e, action.clone()).into()).into())
     }
 }
 
@@ -308,7 +310,8 @@ pub fn check_prev_timestamp(action: &Action, prev_action: &Action) -> SysValidat
     if t2 > t1 {
         Ok(())
     } else {
-        Err(PrevActionError::Timestamp(t1, t2)).map_err(|e| ValidationOutcome::from(e).into())
+        Err(PrevActionErrorKind::Timestamp(t1, t2))
+            .map_err(|e| ValidationOutcome::PrevActionError((e, action.clone()).into()).into())
     }
 }
 
@@ -319,8 +322,8 @@ pub fn check_prev_seq(action: &Action, prev_action: &Action) -> SysValidationRes
     if action_seq > 0 && prev_seq == action_seq - 1 {
         Ok(())
     } else {
-        Err(PrevActionError::InvalidSeq(action_seq, prev_seq))
-            .map_err(|e| ValidationOutcome::from(e).into())
+        Err(PrevActionErrorKind::InvalidSeq(action_seq, prev_seq))
+            .map_err(|e| ValidationOutcome::PrevActionError((e, action.clone()).into()).into())
     }
 }
 
@@ -450,7 +453,10 @@ pub fn validate_chain<'iter, A: 'iter + ChainItem>(
                     // If there's no persisted chain head, then the first action
                     // must have no parent.
                     if item.prev_hash().is_some() {
-                        return Err(ValidationOutcome::from(PrevActionError::InvalidRoot).into());
+                        return Err(ValidationOutcome::PrevActionError(
+                            (PrevActionErrorKind::InvalidRoot, item).into(),
+                        )
+                        .into());
                     }
                 }
             }
@@ -475,17 +481,21 @@ fn check_prev_action_chain<A: ChainItem>(
 ) -> Result<(), PrevActionError> {
     // The root cannot appear later in the chain
     if action.prev_hash().is_none() {
-        Err(PrevActionError::MissingPrev)
+        Err((PrevActionErrorKind::MissingPrev, action).into())
     } else if action.prev_hash().map_or(true, |p| p != prev_action_hash) {
         // Check the prev hash matches.
-        Err(PrevActionError::HashMismatch(action.seq()))
+        Err((PrevActionErrorKind::HashMismatch(action.seq()), action).into())
     } else if action
         .seq()
         .checked_sub(1)
         .map_or(true, |s| prev_action_seq != s)
     {
         // Check the prev seq is one less.
-        Err(PrevActionError::InvalidSeq(action.seq(), prev_action_seq))
+        Err((
+            PrevActionErrorKind::InvalidSeq(action.seq(), prev_action_seq),
+            action,
+        )
+            .into())
     } else {
         Ok(())
     }

--- a/crates/holochain/src/core/sys_validate/tests.rs
+++ b/crates/holochain/src/core/sys_validate/tests.rs
@@ -296,10 +296,11 @@ async fn check_previous_action() {
         .unwrap_err()
         .into_outcome();
 
-        let expected = Some(ValidationOutcome::PrevActionError(
-            PrevActionError::InvalidRoot,
-        ));
-        assert_eq!(actual, expected);
+        let actual = match actual {
+            Some(ValidationOutcome::PrevActionError(pae)) => pae.source,
+            v => panic!("Expected PrevActionError, got {:?}", v),
+        };
+        assert_eq!(actual, PrevActionErrorKind::InvalidRoot);
     }
 
     // Dna is always ok because of the type system
@@ -360,7 +361,10 @@ async fn check_valid_if_dna_test() {
     assert_matches!(
         check_valid_if_dna(&action.clone().into(), &workspace.dna_def_hashed()),
         Err(SysValidationError::ValidationOutcome(
-            ValidationOutcome::PrevActionError(PrevActionError::InvalidRootOriginTime)
+            ValidationOutcome::PrevActionError(PrevActionError {
+                source: PrevActionErrorKind::InvalidRootOriginTime,
+                ..
+            })
         ))
     );
 
@@ -419,9 +423,10 @@ async fn check_previous_timestamp() {
 
     assert_matches!(
         r,
-        Some(ValidationOutcome::PrevActionError(
-            PrevActionError::Timestamp(_, _)
-        ))
+        Some(ValidationOutcome::PrevActionError(PrevActionError {
+            source: PrevActionErrorKind::Timestamp(_, _),
+            ..
+        }))
     );
 }
 
@@ -445,38 +450,41 @@ async fn check_previous_seq() {
     );
 
     *deps[0].as_action_mut().action_seq_mut().unwrap() = 2;
-    assert_eq!(
+    assert_matches!(
         sys_validate_record(&record, &MockCascade::with_records(deps.clone()))
             .await
             .unwrap_err()
             .into_outcome(),
-        Some(ValidationOutcome::PrevActionError(
-            PrevActionError::InvalidSeq(2, 2)
-        )),
+        Some(ValidationOutcome::PrevActionError(PrevActionError {
+            source: PrevActionErrorKind::InvalidSeq(2, 2),
+            ..
+        }))
     );
 
     *deps[0].as_action_mut().action_seq_mut().unwrap() = 3;
-    assert_eq!(
+    assert_matches!(
         sys_validate_record(&record, &MockCascade::with_records(deps.clone()))
             .await
             .unwrap_err()
             .into_outcome(),
-        Some(ValidationOutcome::PrevActionError(
-            PrevActionError::InvalidSeq(2, 3)
-        )),
+        Some(ValidationOutcome::PrevActionError(PrevActionError {
+            source: PrevActionErrorKind::InvalidSeq(2, 3),
+            ..
+        }))
     );
 
     *record.as_action_mut().action_seq_mut().unwrap() = 0;
     let record = rebuild_record(record, &keystore).await;
     *deps[0].as_action_mut().action_seq_mut().unwrap() = 0;
-    assert_eq!(
+    assert_matches!(
         sys_validate_record(&record, &MockCascade::with_records(deps.clone()))
             .await
             .unwrap_err()
             .into_outcome(),
-        Some(ValidationOutcome::PrevActionError(
-            PrevActionError::InvalidRoot
-        )),
+        Some(ValidationOutcome::PrevActionError(PrevActionError {
+            source: PrevActionErrorKind::InvalidRoot,
+            ..
+        }))
     );
 }
 
@@ -722,9 +730,10 @@ fn valid_chain_test() {
         let err = validate_chain(fork.iter(), &None).expect_err("Forked chain");
         assert_matches!(
             err,
-            SysValidationError::ValidationOutcome(ValidationOutcome::PrevActionError(
-                PrevActionError::HashMismatch(_)
-            ))
+            SysValidationError::ValidationOutcome(ValidationOutcome::PrevActionError(PrevActionError {
+                source: PrevActionErrorKind::HashMismatch(_),
+                ..
+            }))
         );
 
         // Test a chain with the wrong seq.
@@ -733,8 +742,11 @@ fn valid_chain_test() {
         let err = validate_chain(wrong_seq.iter(), &None).expect_err("Wrong seq");
         assert_matches!(
             err,
-            SysValidationError::ValidationOutcome(ValidationOutcome::PrevActionError(
-                PrevActionError::InvalidSeq(_, _)
+            SysValidationError::ValidationOutcome(ValidationOutcome::PrevActionError(PrevActionError {
+                source: PrevActionErrorKind::InvalidSeq(_, _),
+                ..
+            }
+
             ))
         );
 
@@ -747,8 +759,11 @@ fn valid_chain_test() {
         let err = validate_chain(wrong_root.iter(), &None).expect_err("Wrong root");
         assert_matches!(
             err,
-            SysValidationError::ValidationOutcome(ValidationOutcome::PrevActionError(
-                PrevActionError::InvalidRoot
+            SysValidationError::ValidationOutcome(ValidationOutcome::PrevActionError(PrevActionError {
+                source: PrevActionErrorKind::InvalidRoot,
+                ..
+            }
+
             ))
         );
 
@@ -758,8 +773,11 @@ fn valid_chain_test() {
         let err = validate_chain(dna_not_at_root.iter(), &None).expect_err("Dna not at root");
         assert_matches!(
             err,
-            SysValidationError::ValidationOutcome(ValidationOutcome::PrevActionError(
-                PrevActionError::MissingPrev
+            SysValidationError::ValidationOutcome(ValidationOutcome::PrevActionError(PrevActionError {
+                source: PrevActionErrorKind::MissingPrev,
+                ..
+            }
+
             ))
         );
 
@@ -768,8 +786,11 @@ fn valid_chain_test() {
         let err = validate_chain(actions.iter(), &Some((hash, 0))).expect_err("Dna not at root");
         assert_matches!(
             err,
-            SysValidationError::ValidationOutcome(ValidationOutcome::PrevActionError(
-                PrevActionError::MissingPrev
+            SysValidationError::ValidationOutcome(ValidationOutcome::PrevActionError(PrevActionError {
+                source: PrevActionErrorKind::MissingPrev,
+                ..
+            }
+
             ))
         );
 
@@ -785,8 +806,11 @@ fn valid_chain_test() {
         .expect_err("Wrong seq");
         assert_matches!(
             err,
-            SysValidationError::ValidationOutcome(ValidationOutcome::PrevActionError(
-                PrevActionError::InvalidSeq(_, _)
+            SysValidationError::ValidationOutcome(ValidationOutcome::PrevActionError(PrevActionError {
+                source: PrevActionErrorKind::InvalidSeq(_, _),
+                ..
+            }
+
             ))
         );
 
@@ -802,8 +826,11 @@ fn valid_chain_test() {
         let err = validate_chain(correct_seq.iter(), &Some((hash, 0))).expect_err("Hash is wrong");
         assert_matches!(
             err,
-            SysValidationError::ValidationOutcome(ValidationOutcome::PrevActionError(
-                PrevActionError::HashMismatch(_)
+            SysValidationError::ValidationOutcome(ValidationOutcome::PrevActionError(PrevActionError {
+                source: PrevActionErrorKind::HashMismatch(_),
+                ..
+            }
+
             ))
         );
     });

--- a/crates/holochain/src/core/workflow/call_zome_workflow.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow.rs
@@ -296,7 +296,11 @@ fn map_outcome(
         // from the network where unmet dependencies would need to be
         // rescheduled to attempt later due to partitions etc.
         app_validation_workflow::Outcome::AwaitingDeps(hashes) => {
-            return Err(SourceChainError::InvalidCommit(format!("{:?}", hashes)).into());
+            return Err(SourceChainError::InvalidCommit(format!(
+                "Awaiting deps {:?} but this is not allowed when committing entries to the source chain",
+                hashes
+            ))
+            .into());
         }
     }
     Ok(())

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -265,10 +265,10 @@ fn handle_failed(error: &ValidationOutcome) -> Outcome {
         ValidationOutcome::NotCreateLink(_) => Rejected,
         ValidationOutcome::NotNewEntry(_) => Rejected,
         ValidationOutcome::NotHoldingDep(dep) => AwaitingOpDep(dep.clone()),
-        ValidationOutcome::PrevActionError(PrevActionError::MissingMeta(dep)) => {
-            AwaitingOpDep(dep.clone().into())
-        }
-        ValidationOutcome::PrevActionError(_) => Rejected,
+        ValidationOutcome::PrevActionError(PrevActionError { source: inner, .. }) => match inner {
+            PrevActionErrorKind::MissingMeta(dep) => AwaitingOpDep(dep.clone().into()),
+            _ => Rejected,
+        },
         ValidationOutcome::PrivateEntryLeaked => Rejected,
         ValidationOutcome::PreflightResponseSignature(_) => Rejected,
         ValidationOutcome::UpdateTypeMismatch(_, _) => Rejected,

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -1,4 +1,3 @@
-use crate::holochain_wasmer_host::prelude::*;
 use crate::sweettest::SweetConductorBatch;
 use crate::sweettest::SweetDnaFile;
 use crate::test_utils::host_fn_caller::*;

--- a/crates/holochain_integrity_types/src/action.rs
+++ b/crates/holochain_integrity_types/src/action.rs
@@ -1,4 +1,5 @@
 use std::borrow::Borrow;
+use std::fmt::{Display, Formatter};
 
 use crate::entry_def::EntryVisibility;
 use crate::link::LinkTag;
@@ -47,6 +48,45 @@ pub enum Action {
     Create(Create),
     Update(Update),
     Delete(Delete),
+}
+
+/// A summary display for communicating the content of an action
+impl Display for Action {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Action::Dna(dna) =>
+                write!(f, "dna={:?}", dna),
+
+            Action::AgentValidationPkg(avp) =>
+                write!(
+                    f,
+                    "agent_validation_pkg=[author={}, timestamp={}]",
+                    avp.author, avp.timestamp
+                ),
+
+            Action::InitZomesComplete(izc) =>
+                write!(
+                    f,
+                    "init_zomes_complete=[author={}, timestamp={}]",
+                    izc.author, izc.timestamp
+                ),
+            Action::CreateLink(link) => write!(f, "create_link=[author={}, timestamp={}, base_address={}, target_address={}, zome_index={}, link_type={:?}]", link.author, link.timestamp, link.base_address, link.target_address, link.zome_index, link.link_type),
+            Action::DeleteLink(link) => write!(f, "delete_link=[author={}, timestamp={}]", link.author, link.timestamp),
+            Action::OpenChain(oc) => write!(
+                f,
+                "open_chain=[author={}, timestamp={}]",
+                oc.author, oc.timestamp
+            ),
+            Action::CloseChain(cc) => write!(
+                f,
+                "close_chain=[author={}, timestamp={}]",
+                cc.author, cc.timestamp
+            ),
+            Action::Create(create) => write!(f, "create=[author={}, timestamp={}, entry_type={:?}, entry_hash={}]", create.author, create.timestamp, create.entry_type, create.entry_hash),
+            Action::Update(update) => write!(f, "create=[author={}, timestamp={}, original_action_address={}, original_entry_address={}, entry_type={:?}, entry_hash={}]", update.author, update.timestamp, update.original_action_address, update.original_entry_address, update.entry_type, update.entry_hash),
+            Action::Delete(delete) => write!(f, "create=[author={}, timestamp={}, deletes_address={}, deletes_entry_address={}]", delete.author, delete.timestamp, delete.deletes_address, delete.deletes_entry_address),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, PartialEq, Eq, Hash)]

--- a/crates/holochain_types/src/chain.rs
+++ b/crates/holochain_types/src/chain.rs
@@ -58,6 +58,9 @@ pub trait ChainItem: Clone + PartialEq + Eq + std::fmt::Debug + Send + Sync {
 
     /// The hash of the previous item
     fn prev_hash(&self) -> Option<&Self::Hash>;
+
+    /// A display representation of the item
+    fn to_display(&self) -> String;
 }
 
 /// Alias for getting the associated hash type of a ChainItem
@@ -77,6 +80,10 @@ impl ChainItem for ActionHashed {
     fn prev_hash(&self) -> Option<&Self::Hash> {
         self.prev_action()
     }
+
+    fn to_display(&self) -> String {
+        format!("{}", self.content)
+    }
 }
 
 impl ChainItem for SignedActionHashed {
@@ -92,6 +99,10 @@ impl ChainItem for SignedActionHashed {
 
     fn prev_hash(&self) -> Option<&Self::Hash> {
         self.hashed.prev_hash()
+    }
+
+    fn to_display(&self) -> String {
+        format!("{}", self.hashed.content)
     }
 }
 

--- a/crates/holochain_types/src/test_utils/chain.rs
+++ b/crates/holochain_types/src/test_utils/chain.rs
@@ -105,6 +105,10 @@ impl ChainItem for TestChainItem {
     fn prev_hash(&self) -> Option<&Self::Hash> {
         self.prev.as_ref()
     }
+
+    fn to_display(&self) -> String {
+        String::from("test chain item")
+    }
 }
 
 impl AsRef<Self> for TestChainItem {


### PR DESCRIPTION
### Summary

Backport of #2591

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
