### PR TITLE
Add tests for the round state map

### DIFF
--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
@@ -283,7 +283,6 @@ mod tests {
         assert!(state.is_none());
     }
 
-    // TODO behaves differently to `get_mut`
     #[test]
     fn round_state_removed_if_finished_on_get() {
         let mut u = Unstructured::new(&NOISE);

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
@@ -91,3 +91,239 @@ impl From<HashMap<NodeCert, RoundState>> for RoundStateMap {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::dht_arc::DhtArcSet;
+    use crate::gossip::sharded_gossip::state_map::RoundStateMap;
+    use crate::gossip::sharded_gossip::{RoundState, StateKey};
+    use crate::NOISE;
+    use arbitrary::{Arbitrary, Unstructured};
+    use kitsune_p2p_types::Tx2Cert;
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[test]
+    fn hold_round_state() {
+        let mut u = Unstructured::new(&NOISE);
+        let (mut state_map, key) = test_round_state_map_with_single_key(&mut u);
+        assert!(state_map.round_exists(&key));
+
+        let state = state_map.get(&key);
+        assert!(state.is_some());
+        assert_eq!(Duration::from_millis(5), state.unwrap().round_timeout);
+    }
+
+    #[test]
+    fn remove_round_state() {
+        let mut u = Unstructured::new(&NOISE);
+        let (mut state_map, key) = test_round_state_map_with_single_key(&mut u);
+        assert!(state_map.round_exists(&key));
+
+        let removed = state_map.remove(&key);
+        assert!(removed.is_some());
+
+        assert!(!state_map.round_exists(&key));
+    }
+
+    #[test]
+    fn modify_round_state() {
+        let mut u = Unstructured::new(&NOISE);
+        let (mut state_map, key) = test_round_state_map_with_single_key(&mut u);
+
+        {
+            let state = state_map.get_mut(&key).unwrap();
+            state.id = "test-change-state".to_string();
+        }
+
+        assert_eq!(
+            "test-change-state".to_string(),
+            state_map.get(&key).unwrap().id
+        );
+    }
+
+    #[test]
+    fn round_state_times_out_after_round_timeout() {
+        let mut u = Unstructured::new(&NOISE);
+        let (mut state_map, key) = test_round_state_map_with_single_key(&mut u);
+
+        {
+            let state = state_map.get_mut(&key).unwrap();
+            state.last_touch = state.last_touch - Duration::from_secs(10);
+            assert!(state.last_touch.elapsed() > state.round_timeout);
+        }
+
+        // TODO would have to check if the round exists to trigger the timeout.
+        // let exists = state_map.round_exists(&key);
+        // assert!(!exists);
+
+        let state = state_map.get(&key);
+        assert!(state.is_none());
+    }
+
+    #[test]
+    fn round_state_mut_times_out_after_round_timeout() {
+        let mut u = Unstructured::new(&NOISE);
+        let (mut state_map, key) = test_round_state_map_with_single_key(&mut u);
+
+        {
+            let state = state_map.get_mut(&key).unwrap();
+            state.last_touch = state.last_touch - Duration::from_secs(10);
+            assert!(state.last_touch.elapsed() > state.round_timeout);
+        }
+
+        // TODO Would have to check if the round exists, or list current rounds, to trigger the timeout.
+        // let exists = state_map.round_exists(&key);
+        // assert!(!exists);
+
+        let state = state_map.get_mut(&key);
+        assert!(state.is_none());
+    }
+
+    #[test]
+    fn round_state_does_not_time_out_if_fetched() {
+        let mut u = Unstructured::new(&NOISE);
+        let (mut state_map, key) = test_round_state_map_with_single_key(&mut u);
+
+        {
+            let state = state_map.get_mut(&key).unwrap();
+            state.last_touch = state.last_touch - Duration::from_secs(10);
+            // Should be marked as timed out on next `round_exists`
+            assert!(state.last_touch.elapsed() > state.round_timeout);
+        }
+
+        // Reset the last_touch
+        state_map.get(&key);
+
+        // Just reset by getting, so this will not remove
+        let exists = state_map.round_exists(&key);
+        assert!(exists);
+
+        let state = state_map.get(&key);
+        assert!(state.is_some())
+    }
+
+    #[test]
+    fn round_state_mut_does_not_time_out_if_fetched() {
+        let mut u = Unstructured::new(&NOISE);
+        let (mut state_map, key) = test_round_state_map_with_single_key(&mut u);
+
+        {
+            let state = state_map.get_mut(&key).unwrap();
+            state.last_touch = state.last_touch - Duration::from_secs(10);
+            // Should be marked as timed out on next `round_exists`
+            assert!(state.last_touch.elapsed() > state.round_timeout);
+        }
+
+        // Reset the last_touch
+        state_map.get_mut(&key);
+
+        // Just reset by getting, so this will not remove
+        let exists = state_map.round_exists(&key);
+        assert!(exists);
+
+        let state = state_map.get_mut(&key);
+        assert!(state.is_some())
+    }
+
+    #[test]
+    fn get_current_rounds_from_round_state() {
+        let mut u = Unstructured::new(&NOISE);
+        let (mut state_map, key_1) = test_round_state_map_with_single_key(&mut u);
+
+        let key_2 = insert_new_state(&mut state_map, &mut u);
+        let key_3 = insert_new_state(&mut state_map, &mut u);
+
+        assert_eq!(3, state_map.current_rounds().len());
+
+        // Mark the state for key_2 as timed out
+        {
+            let state = state_map.get_mut(&key_2).unwrap();
+            state.last_touch = state.last_touch - Duration::from_secs(10);
+            // Should be marked as timed out on next `round_exists`
+            assert!(state.last_touch.elapsed() > state.round_timeout);
+        }
+
+        let mut expected_current = HashSet::new();
+        expected_current.insert(key_1);
+        expected_current.insert(key_3);
+
+        assert_eq!(expected_current, state_map.current_rounds());
+        assert_eq!(1, state_map.take_timed_out_rounds().len());
+    }
+
+    #[test]
+    fn expired_rounds_can_only_be_fetched_from_round_state_once() {
+        let mut u = Unstructured::new(&NOISE);
+        let (mut state_map, key) = test_round_state_map_with_single_key(&mut u);
+
+        {
+            let state = state_map.get_mut(&key).unwrap();
+            state.last_touch = state.last_touch - Duration::from_secs(10);
+            // Should be marked as timed out on next `round_exists`
+            assert!(state.last_touch.elapsed() > state.round_timeout);
+        }
+
+        assert!(!state_map.round_exists(&key));
+        assert_eq!(1, state_map.take_timed_out_rounds().len());
+        assert_eq!(0, state_map.take_timed_out_rounds().len());
+    }
+
+    #[test]
+    fn round_state_removed_if_finished_on_get_mut() {
+        let mut u = Unstructured::new(&NOISE);
+        let (mut state_map, key) = test_round_state_map_with_single_key(&mut u);
+
+        {
+            let state = state_map.get_mut(&key).unwrap();
+            state.received_all_incoming_op_blooms = true;
+            state.regions_are_queued = true;
+            assert!(state.is_finished());
+        }
+
+        let state = state_map.get_mut(&key);
+        assert!(state.is_none());
+    }
+
+    // TODO behaves differently to `get_mut`
+    #[test]
+    fn round_state_removed_if_finished_on_get() {
+        let mut u = Unstructured::new(&NOISE);
+        let (mut state_map, key) = test_round_state_map_with_single_key(&mut u);
+
+        {
+            let state = state_map.get_mut(&key).unwrap();
+            state.received_all_incoming_op_blooms = true;
+            state.regions_are_queued = true;
+            assert!(state.is_finished());
+        }
+
+        let state = state_map.get(&key);
+        assert!(state.is_none());
+    }
+
+    fn test_round_state_map_with_single_key(u: &mut Unstructured) -> (RoundStateMap, StateKey) {
+        let mut state_map = RoundStateMap::default();
+        let key = insert_new_state(&mut state_map, u);
+
+        (state_map, key)
+    }
+
+    fn test_round_state() -> RoundState {
+        RoundState::new(
+            vec![],
+            Arc::new(DhtArcSet::new_empty()),
+            None,
+            Duration::from_millis(5),
+        )
+    }
+
+    fn insert_new_state(state_map: &mut RoundStateMap, u: &mut Unstructured) -> StateKey {
+        let cert = Tx2Cert::arbitrary(u).unwrap();
+        let key: StateKey = cert.into();
+        state_map.insert(key.clone(), test_round_state());
+
+        key
+    }
+}

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
@@ -96,7 +96,7 @@ impl From<HashMap<NodeCert, RoundState>> for RoundStateMap {
 mod tests {
     use crate::dht_arc::DhtArcSet;
     use crate::gossip::sharded_gossip::state_map::RoundStateMap;
-    use crate::gossip::sharded_gossip::{RoundState, StateKey};
+    use crate::gossip::sharded_gossip::{NodeCert, RoundState};
     use crate::NOISE;
     use arbitrary::{Arbitrary, Unstructured};
     use kitsune_p2p_types::Tx2Cert;
@@ -303,7 +303,7 @@ mod tests {
         assert!(state.is_none());
     }
 
-    fn test_round_state_map_with_single_key(u: &mut Unstructured) -> (RoundStateMap, StateKey) {
+    fn test_round_state_map_with_single_key(u: &mut Unstructured) -> (RoundStateMap, NodeCert) {
         let mut state_map = RoundStateMap::default();
         let key = insert_new_state(&mut state_map, u);
 
@@ -319,9 +319,9 @@ mod tests {
         )
     }
 
-    fn insert_new_state(state_map: &mut RoundStateMap, u: &mut Unstructured) -> StateKey {
+    fn insert_new_state(state_map: &mut RoundStateMap, u: &mut Unstructured) -> NodeCert {
         let cert = Tx2Cert::arbitrary(u).unwrap();
-        let key: StateKey = cert.into();
+        let key: NodeCert = cert.into();
         state_map.insert(key.clone(), test_round_state());
 
         key

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/state_map.rs
@@ -32,6 +32,7 @@ impl RoundStateMap {
     /// Get the state if it hasn't timed out.
     pub(super) fn get(&mut self, key: &NodeCert) -> Option<&RoundState> {
         self.touch(key);
+        self.check_timeout(key);
         self.map.get(key)
     }
 
@@ -149,14 +150,12 @@ mod tests {
         let (mut state_map, key) = test_round_state_map_with_single_key(&mut u);
 
         {
+            // We must use a zero timeout here, unlike the other tests which just set the last_touch in the past,
+            // because `get` also performs a touch, which would undo that change.
             let state = state_map.get_mut(&key).unwrap();
-            state.last_touch = state.last_touch - Duration::from_secs(10);
+            state.round_timeout = Duration::ZERO;
             assert!(state.last_touch.elapsed() > state.round_timeout);
         }
-
-        // TODO would have to check if the round exists to trigger the timeout.
-        // let exists = state_map.round_exists(&key);
-        // assert!(!exists);
 
         let state = state_map.get(&key);
         assert!(state.is_none());
@@ -168,14 +167,12 @@ mod tests {
         let (mut state_map, key) = test_round_state_map_with_single_key(&mut u);
 
         {
+            // We must use a zero timeout here, unlike the other tests which just set the last_touch in the past,
+            // because `get` also performs a touch, which would undo that change.
             let state = state_map.get_mut(&key).unwrap();
-            state.last_touch = state.last_touch - Duration::from_secs(10);
+            state.round_timeout = Duration::ZERO;
             assert!(state.last_touch.elapsed() > state.round_timeout);
         }
-
-        // TODO Would have to check if the round exists, or list current rounds, to trigger the timeout.
-        // let exists = state_map.round_exists(&key);
-        // assert!(!exists);
 
         let state = state_map.get_mut(&key);
         assert!(state.is_none());


### PR DESCRIPTION
### Summary

Adding tests for this because it seems like a sufficiently complex data structure to warrant some testing. It also took me a bit of time to understand how it works which seemed like a second reason.

I have left 3 tests failing:
- Two appear to break with the information provided by their documentation. `get` and `get_mut` will return timed out round state unless `current_rounds` or `round_exists` have been called first.
- The other test is about when `check_timeout` is called. The `get` and `get_mut` behave differently which is not what I'd expect as a consumer of the `RoundStateMap`.

The `check_timeout` function is slightly confusing in its own right:
- It has a side-effect if the round is finished of directly removing the state.
- It returns a value that we never consume.
- It is `pub(super)` although it's only actually consumed inside this `impl`.
This function could probably be renamed and have its signature tweaked to make its intention clearer.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
