### PR TITLE
Add CellId to GenesisFailed errors

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Change `GenesisFailed` error to include `CellId` so that genesis failures can be correlated with the cells that failed. [2616](https://github.com/holochain/holochain/pull/2616)
+
 ## 0.3.0-beta-dev.11
 
 - Improves error messages when validation fails with an InvalidCommit error

--- a/crates/holochain/src/conductor/error.rs
+++ b/crates/holochain/src/conductor/error.rs
@@ -79,7 +79,7 @@ pub enum ConductorError {
     InterfaceError(#[from] Box<InterfaceError>),
 
     #[error("Failed to run genesis on the following cells in the app: {errors:?}")]
-    GenesisFailed { errors: Vec<CellError> },
+    GenesisFailed { errors: Vec<(CellId, CellError)> },
 
     #[error(transparent)]
     SerializedBytesError(#[from] holochain_serialized_bytes::SerializedBytesError),


### PR DESCRIPTION
### Summary

Add CellId to GenesisFailed errors, so the errors can be correlated with cells

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
