### PR TITLE
Require dev dependencies on workspace crates to use path only req

### DIFF
--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -58,7 +58,7 @@ arbitrary = "1.0"
 fixt = { path = "../fixt" }
 holochain_wasm_test_utils = { path = "../test_utils/wasm" }
 matches = "0.1.8"
-holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../holochain_trace" }
+holochain_trace = { path = "../holochain_trace" }
 pretty_assertions = "0.6.1"
 
 tempfile = "3.3"

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -31,7 +31,7 @@ url2 = "0.0.6"
 holochain_types = { path = "../holochain_types", features = ["sqlite"] }
 linefeed = "0.6"
 unwrap_to = "0.1.0"
-holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../holochain_trace" }
+holochain_trace = { path = "../holochain_trace" }
 criterion = "0.3.4"
 
 [features]


### PR DESCRIPTION
### Summary

Prevents the issue that was stopping #2608 building from happening again

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
