### PR TITLE
macOS: Use non-static OpenSSL on x86_64-darwin

### DIFF
--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -10,7 +10,10 @@
 
       craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
 
-      opensslStatic = pkgs.pkgsStatic.openssl;
+      opensslStatic = if system == "x86_64-darwin"
+                      then pkgs.openssl # pkgsStatic is considered a cross build
+                                        # and this is not yet supported
+                      else pkgs.pkgsStatic.openssl;
 
       commonArgs = {
         RUST_SODIUM_LIB_DIR = "${pkgs.libsodium}/lib";


### PR DESCRIPTION
Nixpkgs' `pkgsStatic` was recently fixed to actually do mostly static builds. However, this relies on cross-compiling infrastructure in Nixpkgs and that is not yet supported on x86_64-darwin.

As a temporary patch we branch on the platform to determine whether to actually use the static package.

### Summary

This should unblock the Darwin side of #2510.

@steveej 

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
