### PR TITLE
[duplicate] macOS: Use non-static OpenSSL on x86_64-darwin

### DIFF
--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -10,7 +10,10 @@
 
       craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
 
-      opensslStatic = pkgs.pkgsStatic.openssl;
+      opensslStatic = if system == "x86_64-darwin"
+                      then pkgs.openssl # pkgsStatic is considered a cross build
+                                        # and this is not yet supported
+                      else pkgs.pkgsStatic.openssl;
 
       commonArgs = {
         RUST_SODIUM_LIB_DIR = "${pkgs.libsodium}/lib";


### PR DESCRIPTION
### Summary

duplicated #2625 for CI.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
