### PR TITLE
backport: fix cap grant lookup query

### DIFF
--- a/crates/holochain_sqlite/src/sql/conductor/select_valid_cap_grant_for_cap_secret.sql
+++ b/crates/holochain_sqlite/src/sql/conductor/select_valid_cap_grant_for_cap_secret.sql
@@ -2,17 +2,20 @@ SELECT
   Entry.blob
 FROM
   Entry
+  INNER JOIN Action ON Action.author = ?2
+  AND Action.entry_hash = Entry.hash
 WHERE
   Entry.cap_secret = ?1
   AND (
+    -- cap grant must not have been updated or deleted
     SELECT
-      COUNT(Action.hash)
+      COUNT(UpdateActions.hash)
     FROM
-      Action
+      Action AS UpdateActions
     WHERE
-      Action.author = ?2
+      UpdateActions.author = ?2
       AND (
-        Action.original_entry_hash = Entry.hash
-        OR Action.deletes_entry_hash = Entry.hash
+        UpdateActions.original_entry_hash = Entry.hash
+        OR UpdateActions.deletes_entry_hash = Entry.hash
       )
   ) = 0

--- a/crates/holochain_sqlite/src/sql/conductor/select_valid_unrestricted_cap_grant.sql
+++ b/crates/holochain_sqlite/src/sql/conductor/select_valid_unrestricted_cap_grant.sql
@@ -1,18 +1,21 @@
 SELECT
-  blob
+  Entry.blob
 FROM
   Entry
+  INNER JOIN Action ON Action.author = ?2
+  AND Action.entry_hash = Entry.hash
 WHERE
   access_type = ?1
   AND (
+    -- cap grant must not have been updated or deleted
     SELECT
-      COUNT(Action.hash)
+      COUNT(UpdateActions.hash)
     FROM
-      Action
+      Action as UpdateActions
     WHERE
-      Action.author = ?2
+      UpdateActions.author = ?2
       AND (
-        Action.original_entry_hash = Entry.hash
-        OR Action.deletes_entry_hash = Entry.hash
+        UpdateActions.original_entry_hash = Entry.hash
+        OR UpdateActions.deletes_entry_hash = Entry.hash
       )
   ) = 0;

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -6,8 +6,7 @@ default_semver_increment_mode: !pre_patch beta-rc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## \[Unreleased\]
-
-## 0.2.1
+- fix: in a scenario where two agents create a cell from the same DNA in the same conductor, cap grant lookup for zome calls succeeded erroneously for any calling agent. The cap grant author was not taken into consideration for the lookup, only the cap secret or the unrestricted cap entry. Fixed by filtering the lookup by cap grant author.
 
 ## 0.2.1-beta-rc.0
 

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## \[Unreleased\]
 - fix: in a scenario where two agents create a cell from the same DNA in the same conductor, cap grant lookup for zome calls succeeded erroneously for any calling agent. The cap grant author was not taken into consideration for the lookup, only the cap secret or the unrestricted cap entry. Fixed by filtering the lookup by cap grant author.
 
+## 0.2.1
+
 ## 0.2.1-beta-rc.0
 
 ## 0.2.1-beta-dev.0


### PR DESCRIPTION
### Summary
Backport fix of cap grant lookup query to develop-0.2


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
