### PR TITLE
[0.2] Upgrade to lair keystore 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,15 +59,15 @@ dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.10",
  "once_cell",
- "serde",
+ "serde 1.0.183",
  "version_check",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -168,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "approx"
@@ -243,7 +243,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
 dependencies = [
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -267,7 +267,7 @@ dependencies = [
  "async-lock",
  "async-task",
  "concurrent-queue",
- "fastrand",
+ "fastrand 1.9.0",
  "futures-lite",
  "slab",
 ]
@@ -309,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
 dependencies = [
  "event-listener",
 ]
@@ -330,7 +330,7 @@ dependencies = [
  "event-listener",
  "futures-lite",
  "rustix 0.37.23",
- "signal-hook 0.3.16",
+ "signal-hook 0.3.17",
  "windows-sys 0.48.0",
 ]
 
@@ -341,7 +341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -390,7 +390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -402,13 +402,13 @@ checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
-version = "0.1.71"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -451,7 +451,7 @@ checksum = "b99d887f4066f8a1b4a713a8121fab07ff543863ac86177ebdee6b5cb18acf12"
 dependencies = [
  "cfg-if 1.0.0",
  "derive_more",
- "serde",
+ "serde 1.0.183",
  "shrinkwraprs",
 ]
 
@@ -488,7 +488,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -503,7 +503,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -521,7 +521,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -532,9 +532,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bitvec"
@@ -598,7 +598,7 @@ dependencies = [
  "async-lock",
  "async-task",
  "atomic-waker",
- "fastrand",
+ "fastrand 1.9.0",
  "futures-lite",
  "log",
 ]
@@ -632,8 +632,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "regex-automata 0.3.3",
- "serde",
+ "regex-automata 0.3.6",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -660,7 +660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -700,7 +700,7 @@ version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -709,7 +709,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -721,7 +721,7 @@ dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.18",
- "serde",
+ "serde 1.0.183",
  "serde_json",
  "thiserror",
 ]
@@ -740,11 +740,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -779,7 +780,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "serde",
+ "serde 1.0.183",
  "time 0.1.45",
  "wasm-bindgen",
  "winapi 0.3.9",
@@ -819,9 +820,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.15"
+version = "4.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f644d0dac522c8b05ddc39aaaccc5b136d5dc4ff216610c5641e3be5becf56c"
+checksum = "b417ae4361bca3f5de378294fc7472d3c4ed86a5ef9f49e93ae722f432aae8d2"
 dependencies = [
  "clap_builder",
  "clap_derive 4.3.12",
@@ -830,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.15"
+version = "4.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af410122b9778e024f9e0fb35682cc09cc3f85cad5e8d3ba8f47a9702df6e73d"
+checksum = "9c90dc0f0e42c64bff177ca9d7be6fcc9ddb0f26a6e062174a61c84dd6c644d4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -851,7 +852,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -863,8 +864,8 @@ checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -909,11 +910,11 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+checksum = "5a5f741c91823341bebf717d4c71bda820630ce065443b58bd1b7451af008355"
 dependencies = [
- "atty",
+ "is-terminal",
  "lazy_static",
  "winapi 0.3.9",
 ]
@@ -1106,9 +1107,9 @@ dependencies = [
  "plotters",
  "rayon",
  "regex",
- "serde",
+ "serde 1.0.183",
  "serde_cbor",
- "serde_derive",
+ "serde_derive 1.0.183",
  "serde_json",
  "tinytemplate",
  "tokio",
@@ -1206,23 +1207,23 @@ dependencies = [
  "libc",
  "mio 0.8.8",
  "parking_lot 0.12.1",
- "signal-hook 0.3.16",
+ "signal-hook 0.3.17",
  "signal-hook-mio",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "crossterm"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "crossterm_winapi 0.9.1",
  "libc",
  "mio 0.8.8",
  "parking_lot 0.12.1",
- "signal-hook 0.3.16",
+ "signal-hook 0.3.17",
  "signal-hook-mio",
  "winapi 0.3.9",
 ]
@@ -1270,7 +1271,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -1288,7 +1289,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1307,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.101"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5032837c1384de3708043de9d4e97bb91290faca6c16529a28aa340592a78166"
+checksum = "666a3ec767f4bbaf0dcfcc3b4ea048b90520b254fdf88813e763f4c762636c14"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1319,34 +1320,34 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.101"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51368b3d0dbf356e10fcbfd455a038503a105ee556f7ee79b6bb8c53a7247456"
+checksum = "162bec16c4cc28b19e26db0197b60ba5480fdb9a4cbf0f4c6c104a937741b78e"
 dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "scratch",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.101"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d9062157072e4aafc8e56ceaf8325ce850c5ae37578c852a0d4de2cecdded13"
+checksum = "d6e8c238aadc4b9f2c00269d04c87abb23f96dd240803872536eed1a304bb40e"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.101"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf01e8a540f5a4e0f284595834f81cf88572f244b768f051724537afa99a2545"
+checksum = "59d9ffb4193dd22180b8d5747b1e095c3d9c9c665ce39b0483a488948f437e06"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1398,7 +1399,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "strsim 0.9.3",
  "syn 1.0.109",
 ]
@@ -1412,7 +1413,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -1426,7 +1427,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -1440,8 +1441,8 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1451,7 +1452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1462,7 +1463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1473,7 +1474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core 0.14.4",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1484,8 +1485,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1524,7 +1525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1535,8 +1536,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1548,7 +1549,7 @@ dependencies = [
  "darling 0.10.2",
  "derive_builder_core",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1560,7 +1561,7 @@ checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling 0.10.2",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1572,7 +1573,7 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -1583,7 +1584,7 @@ version = "0.1.0"
 dependencies = [
  "chashmap",
  "colored 2.0.4",
- "crossterm 0.26.1",
+ "crossterm 0.27.0",
  "futures",
  "holochain_diagnostics",
  "holochain_trace",
@@ -1737,16 +1738,16 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
- "serde",
+ "serde 1.0.183",
  "sha2 0.9.9",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "encoding_rs"
@@ -1773,7 +1774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1794,8 +1795,8 @@ checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
  "darling 0.20.3",
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1821,7 +1822,7 @@ checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "rustversion",
  "syn 1.0.109",
  "synstructure",
@@ -1829,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1850,13 +1851,13 @@ dependencies = [
 
 [[package]]
 name = "escargot"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5584ba17d7ab26a8a7284f13e5bd196294dd2f2d79773cff29b9e9edef601a6"
+checksum = "768064bd3a0e2bedcba91dc87ace90beea91acc41b6a01a3ca8e9aa8827461bf"
 dependencies = [
  "log",
  "once_cell",
- "serde",
+ "serde 1.0.183",
  "serde_json",
 ]
 
@@ -1883,7 +1884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
  "synstructure",
 ]
@@ -1920,14 +1921,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.21"
+name = "fastrand"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "filetime"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "windows-sys 0.48.0",
 ]
 
@@ -1935,13 +1942,13 @@ dependencies = [
 name = "fixt"
 version = "0.2.1"
 dependencies = [
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "lazy_static",
  "parking_lot 0.10.2",
  "paste",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "serde",
+ "serde 1.0.183",
  "strum 0.18.0",
  "strum_macros 0.18.0",
 ]
@@ -1956,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2094,7 +2101,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
- "fastrand",
+ "fastrand 1.9.0",
  "futures-core",
  "futures-io",
  "memchr",
@@ -2110,8 +2117,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2396,7 +2403,7 @@ dependencies = [
 name = "hc_demo_cli"
 version = "0.2.0-beta-rc.0"
 dependencies = [
- "clap 4.3.15",
+ "clap 4.3.22",
  "flate2",
  "hdi",
  "hdk",
@@ -2405,7 +2412,7 @@ dependencies = [
  "holochain_types",
  "rand 0.8.5",
  "rand-utf8",
- "serde",
+ "serde 1.0.183",
  "tempfile",
  "tokio",
  "tracing",
@@ -2421,9 +2428,9 @@ checksum = "ded13e388a81713db6919cd750e6113acf2fe5afbaedf8aff79780ec4fc47425"
 dependencies = [
  "futures",
  "one_err",
- "rmp-serde 1.1.1",
+ "rmp-serde 1.1.2",
  "rmpv",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "sodoken",
 ]
@@ -2440,7 +2447,7 @@ dependencies = [
  "holochain_wasmer_guest",
  "mockall",
  "paste",
- "serde",
+ "serde 0.9.15",
  "serde_bytes",
  "subtle-encoding",
  "test-case 2.2.2",
@@ -2461,7 +2468,7 @@ dependencies = [
  "holochain_zome_types",
  "mockall",
  "paste",
- "serde",
+ "serde 0.9.15",
  "serde_bytes",
  "thiserror",
  "tracing",
@@ -2479,7 +2486,7 @@ dependencies = [
  "paste",
  "proc-macro-error",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -2554,13 +2561,13 @@ dependencies = [
  "derive_more",
  "fixt",
  "futures",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_wasmer_common",
  "kitsune_p2p_dht_arc",
  "must_future",
  "rand 0.8.5",
  "rusqlite",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "serde_json",
  "thiserror",
@@ -2601,7 +2608,7 @@ dependencies = [
  "holochain_conductor_api",
  "holochain_keystore",
  "holochain_p2p",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_sqlite",
  "holochain_state",
  "holochain_test_wasm_common",
@@ -2642,7 +2649,8 @@ dependencies = [
  "rpassword 5.0.1",
  "rusqlite",
  "sd-notify",
- "serde",
+ "serde 0.9.15",
+ "serde 1.0.183",
  "serde_json",
  "serde_yaml",
  "serial_test",
@@ -2687,7 +2695,7 @@ dependencies = [
  "hdk_derive",
  "holo_hash",
  "holochain_p2p",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_sqlite",
  "holochain_state",
  "holochain_trace",
@@ -2698,8 +2706,8 @@ dependencies = [
  "matches",
  "mockall",
  "pretty_assertions 0.7.2",
- "serde",
- "serde_derive",
+ "serde 1.0.183",
+ "serde_derive 1.0.183",
  "test-case 2.2.2",
  "thiserror",
  "tokio",
@@ -2712,7 +2720,7 @@ name = "holochain_cli"
 version = "0.2.1"
 dependencies = [
  "anyhow",
- "clap 4.3.15",
+ "clap 4.3.22",
  "futures",
  "holochain_cli_bundle",
  "holochain_cli_run_local_services",
@@ -2728,9 +2736,9 @@ version = "0.2.1"
 dependencies = [
  "anyhow",
  "assert_cmd 1.0.8",
- "clap 4.3.15",
+ "clap 4.3.22",
  "futures",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_types",
  "holochain_util",
  "holochain_wasmer_host",
@@ -2738,7 +2746,7 @@ dependencies = [
  "matches",
  "mr_bundle",
  "predicates 1.0.8",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "serde_json",
  "serde_yaml",
@@ -2753,7 +2761,7 @@ dependencies = [
 name = "holochain_cli_run_local_services"
 version = "0.2.1"
 dependencies = [
- "clap 4.3.15",
+ "clap 4.3.22",
  "futures",
  "holochain_trace",
  "if-addrs 0.10.1",
@@ -2771,7 +2779,7 @@ dependencies = [
  "anyhow",
  "assert_cmd 1.0.8",
  "chrono",
- "clap 4.3.15",
+ "clap 4.3.22",
  "escargot",
  "futures",
  "holochain_conductor_api",
@@ -2783,7 +2791,7 @@ dependencies = [
  "matches",
  "nanoid 0.3.0",
  "once_cell",
- "serde",
+ "serde 1.0.183",
  "serde_json",
  "serde_yaml",
  "sodoken",
@@ -2803,15 +2811,15 @@ dependencies = [
  "holo_hash",
  "holochain_keystore",
  "holochain_p2p",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_state",
  "holochain_trace",
  "holochain_types",
  "holochain_zome_types",
  "kitsune_p2p",
  "matches",
- "serde",
- "serde_derive",
+ "serde 1.0.183",
+ "serde_derive 1.0.183",
  "serde_yaml",
  "structopt",
  "thiserror",
@@ -2825,7 +2833,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "arbitrary",
- "crossterm 0.26.1",
+ "crossterm 0.27.0",
  "holochain",
  "human-repr",
  "rand 0.8.5",
@@ -2843,11 +2851,11 @@ dependencies = [
  "derive_builder",
  "holo_hash",
  "holochain_integrity_types",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "kitsune_p2p_dht",
  "kitsune_p2p_timestamp",
  "paste",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "serde_json",
  "subtle",
@@ -2863,7 +2871,7 @@ dependencies = [
  "base64 0.13.1",
  "futures",
  "holo_hash",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_zome_types",
  "kitsune_p2p_types",
  "lair_keystore",
@@ -2871,7 +2879,7 @@ dependencies = [
  "nanoid 0.4.0",
  "one_err",
  "parking_lot 0.11.2",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "serde_yaml",
  "sodoken",
@@ -2900,7 +2908,7 @@ dependencies = [
  "ghost_actor 0.3.0-alpha.6",
  "holo_hash",
  "holochain_keystore",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_trace",
  "holochain_types",
  "holochain_util",
@@ -2909,7 +2917,7 @@ dependencies = [
  "kitsune_p2p_types",
  "mockall",
  "rand 0.8.5",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "serde_json",
  "thiserror",
@@ -2924,9 +2932,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9805b3e01e7b5c144782a0823db4dc895fec18a9ccd45a492ce7c7bf157a9e38"
 dependencies = [
  "arbitrary",
- "holochain_serialized_bytes_derive",
+ "holochain_serialized_bytes_derive 0.0.51",
  "rmp-serde 0.15.5",
- "serde",
+ "serde 1.0.183",
+ "serde-transcode",
+ "serde_bytes",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "holochain_serialized_bytes"
+version = "0.0.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac6151d65c9a6f26f1b1068046a98900214030924377a2142f60c279b091f51"
+dependencies = [
+ "holochain_serialized_bytes_derive 0.0.52",
+ "rmp-serde 0.15.5",
+ "serde 1.0.183",
  "serde-transcode",
  "serde_bytes",
  "serde_json",
@@ -2939,7 +2962,17 @@ version = "0.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1077232d0c427d64feb9e138fa22800e447eafb1810682d6c13beb95333cb32c"
 dependencies = [
- "quote",
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "holochain_serialized_bytes_derive"
+version = "0.0.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cec0d0c2317fcb87772d0a8b5b5e88c7276aef93bf3496931e89cb9231c129"
+dependencies = [
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -2961,7 +2994,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.10",
  "holo_hash",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_sqlite",
  "holochain_trace",
  "holochain_util",
@@ -2983,8 +3016,8 @@ dependencies = [
  "rmp-serde 0.15.5",
  "rusqlite",
  "scheduled-thread-pool",
- "serde",
- "serde_derive",
+ "serde 1.0.183",
+ "serde_derive 1.0.183",
  "serde_json",
  "shrinkwraprs",
  "sqlformat 0.1.8",
@@ -3018,7 +3051,7 @@ dependencies = [
  "holo_hash",
  "holochain_keystore",
  "holochain_p2p",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_sqlite",
  "holochain_trace",
  "holochain_types",
@@ -3033,7 +3066,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "pretty_assertions 0.6.1",
  "rand 0.8.5",
- "serde",
+ "serde 1.0.183",
  "serde_json",
  "shrinkwraprs",
  "tempfile",
@@ -3048,7 +3081,7 @@ name = "holochain_test_wasm_common"
 version = "0.2.1"
 dependencies = [
  "hdk",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -3057,10 +3090,10 @@ version = "0.2.1"
 dependencies = [
  "chrono",
  "derive_more",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.52",
  "inferno",
  "once_cell",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "serde_json",
  "shrinkwraprs",
@@ -3095,7 +3128,7 @@ dependencies = [
  "getrandom 0.2.10",
  "holo_hash",
  "holochain_keystore",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_sqlite",
  "holochain_trace",
  "holochain_types",
@@ -3118,9 +3151,9 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "rusqlite",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
- "serde_derive",
+ "serde_derive 1.0.183",
  "serde_json",
  "serde_with",
  "serde_yaml",
@@ -3169,8 +3202,8 @@ version = "0.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "223daec7ca62d4e36841a99d8799b29cc616f5976ad0e2975e6ca6810de8f14f"
 dependencies = [
- "holochain_serialized_bytes",
- "serde",
+ "holochain_serialized_bytes 0.0.51",
+ "serde 1.0.183",
  "serde_bytes",
  "test-fuzz",
  "thiserror",
@@ -3184,11 +3217,11 @@ version = "0.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b2026e44595cb16108464973622577936605582aa22932933a5130ad32ce42"
 dependencies = [
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_wasmer_common",
  "parking_lot 0.12.1",
  "paste",
- "serde",
+ "serde 1.0.183",
  "tracing",
 ]
 
@@ -3199,12 +3232,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65912ef579fa53ca4ad7713f13379fae53a0d79ef2d91b87670201044eae0d5e"
 dependencies = [
  "bimap",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_wasmer_common",
  "once_cell",
  "parking_lot 0.12.1",
  "rand 0.8.5",
- "serde",
+ "serde 1.0.183",
  "tracing",
  "wasmer",
 ]
@@ -3216,14 +3249,14 @@ dependencies = [
  "criterion",
  "futures",
  "ghost_actor 0.4.0-alpha.5",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_trace",
  "holochain_types",
  "linefeed",
  "must_future",
  "nanoid 0.3.0",
  "net2",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "stream-cancel",
  "thiserror",
@@ -3247,7 +3280,7 @@ dependencies = [
  "fixt",
  "holo_hash",
  "holochain_integrity_types",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_wasmer_common",
  "kitsune_p2p_bin_data",
  "kitsune_p2p_block",
@@ -3261,7 +3294,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "rusqlite",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "serde_yaml",
  "shrinkwraprs",
@@ -3322,9 +3355,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "human-panic"
@@ -3336,8 +3369,8 @@ dependencies = [
  "anstyle",
  "backtrace",
  "os_info",
- "serde",
- "serde_derive",
+ "serde 1.0.183",
+ "serde_derive 1.0.183",
  "toml 0.7.6",
  "uuid 1.4.1",
 ]
@@ -3479,7 +3512,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown 0.12.3",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -3505,7 +3538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fb7c1b80a1dfa604bb4a649a5c5aeef3d913f7c520cb42b40e534e8a61bcdfc"
 dependencies = [
  "ahash 0.8.3",
- "clap 4.3.15",
+ "clap 4.3.22",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap 5.5.0",
@@ -3585,7 +3618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.4",
+ "rustix 0.38.8",
  "windows-sys 0.48.0",
 ]
 
@@ -3660,7 +3693,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.2",
  "bytecount",
- "clap 4.3.15",
+ "clap 4.3.22",
  "fancy-regex",
  "fraction",
  "getrandom 0.2.10",
@@ -3673,7 +3706,7 @@ dependencies = [
  "percent-encoding 2.3.0",
  "regex",
  "reqwest",
- "serde",
+ "serde 1.0.183",
  "serde_json",
  "time 0.3.23",
  "url 2.4.0",
@@ -3717,7 +3750,7 @@ dependencies = [
  "pretty_assertions 0.7.2",
  "rand 0.8.5",
  "reqwest",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "serde_json",
  "shrinkwraprs",
@@ -3739,7 +3772,7 @@ dependencies = [
  "base64 0.13.1",
  "derive_more",
  "kitsune_p2p_dht_arc",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "shrinkwraprs",
 ]
@@ -3750,7 +3783,7 @@ version = "0.2.1"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_timestamp",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
 ]
 
@@ -3769,7 +3802,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "rmp-serde 0.15.5",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "serde_json",
  "tokio",
@@ -3780,12 +3813,12 @@ dependencies = [
 name = "kitsune_p2p_dht"
 version = "0.2.1"
 dependencies = [
- "colored 1.9.3",
+ "colored 1.9.4",
  "derivative",
  "derive_more",
  "futures",
  "gcollections",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_trace",
  "intervallum",
  "kitsune_p2p_dht",
@@ -3798,7 +3831,7 @@ dependencies = [
  "pretty_assertions 0.7.2",
  "proptest",
  "rand 0.8.5",
- "serde",
+ "serde 1.0.183",
  "statrs",
  "test-case 1.2.3",
  "thiserror",
@@ -3818,7 +3851,7 @@ dependencies = [
  "pretty_assertions 0.7.2",
  "rand 0.8.5",
  "rusqlite",
- "serde",
+ "serde 1.0.183",
  "statrs",
  "tracing",
 ]
@@ -3830,7 +3863,7 @@ dependencies = [
  "arbitrary",
  "derive_more",
  "futures",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_trace",
  "human-repr",
  "kitsune_p2p_fetch",
@@ -3841,7 +3874,7 @@ dependencies = [
  "num-traits",
  "pretty_assertions 0.7.2",
  "rand 0.8.5",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "test-case 1.2.3",
  "thiserror",
@@ -3881,7 +3914,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "rmp-serde 0.15.5",
  "rustls 0.20.8",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "structopt",
  "tokio",
@@ -3896,9 +3929,9 @@ dependencies = [
  "arbitrary",
  "chrono",
  "derive_more",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "rusqlite",
- "serde",
+ "serde 1.0.183",
  "serde_yaml",
 ]
 
@@ -3915,7 +3948,7 @@ dependencies = [
  "quinn",
  "rcgen 0.9.3",
  "rustls 0.20.8",
- "serde",
+ "serde 1.0.183",
  "tokio",
  "webpki 0.22.0",
 ]
@@ -3945,7 +3978,7 @@ dependencies = [
  "paste",
  "rmp-serde 0.15.5",
  "rustls 0.20.8",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "serde_json",
  "shrinkwraprs",
@@ -3998,7 +4031,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "rcgen 0.10.0",
- "serde",
+ "serde 1.0.183",
  "serde_json",
  "serde_yaml",
  "time 0.3.23",
@@ -4101,9 +4134,9 @@ dependencies = [
 
 [[package]]
 name = "libsodium-sys-stable"
-version = "1.19.29"
+version = "1.19.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cce7cd8e1c5101c39f30e791fa8f2e5713a2a49947440106a2467175895035"
+checksum = "2cf9c3bd17952580efd8f57e3d01d724cfb18d51fbd9dc00a65e5911f71521ba"
 dependencies = [
  "cc",
  "libc",
@@ -4162,9 +4195,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -4187,9 +4220,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
  "value-bag",
 ]
@@ -4211,7 +4244,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
 dependencies = [
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -4428,7 +4461,7 @@ checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -4444,7 +4477,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c624fa1b7aab6bd2aff6e9b18565cc0363b6d45cbcd7465c9ed5e3740ebf097"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "libc",
  "nix 0.26.2",
  "smallstr",
@@ -4470,9 +4503,9 @@ dependencies = [
  "matches",
  "reqwest",
  "rmp-serde 0.15.5",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
- "serde_derive",
+ "serde_derive 1.0.183",
  "serde_yaml",
  "tempfile",
  "thiserror",
@@ -4503,7 +4536,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -4541,7 +4574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -4718,9 +4751,9 @@ checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
 ]
@@ -4770,9 +4803,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg 1.1.0",
  "libm",
@@ -4805,7 +4838,7 @@ checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -4844,7 +4877,7 @@ checksum = "e81851974d8bb6cc9a643cca68afdce7f0a3b80e08a4620388836bb99a680554"
 dependencies = [
  "indexmap 1.9.3",
  "libc",
- "serde",
+ "serde 1.0.183",
  "serde_json",
 ]
 
@@ -4862,9 +4895,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.55"
+version = "0.10.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
@@ -4882,8 +4915,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -4894,18 +4927,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.26.0+1.1.1u"
+version = "111.27.0+1.1.1v"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.90"
+version = "0.9.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
 dependencies = [
  "cc",
  "libc",
@@ -4927,7 +4960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
 dependencies = [
  "log",
- "serde",
+ "serde 1.0.183",
  "winapi 0.3.9",
 ]
 
@@ -4956,7 +4989,7 @@ dependencies = [
  "Inflector",
  "proc-macro-error",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -5089,7 +5122,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec 1.11.0",
- "windows-targets 0.48.1",
+ "windows-targets 0.48.3",
 ]
 
 [[package]]
@@ -5121,9 +5154,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2d1d55045829d65aad9d389139882ad623b33b904e7c9f1b10c5b8927298e5"
+checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -5169,29 +5202,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pin-utils"
@@ -5362,7 +5395,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
  "version_check",
 ]
@@ -5374,7 +5407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "version_check",
 ]
 
@@ -5444,7 +5477,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -5528,9 +5561,15 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+
+[[package]]
+name = "quote"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -5901,13 +5940,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.3",
+ "regex-automata 0.3.6",
  "regex-syntax 0.7.4",
 ]
 
@@ -5922,9 +5961,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5997,7 +6036,7 @@ dependencies = [
  "once_cell",
  "percent-encoding 2.3.0",
  "pin-project-lite",
- "serde",
+ "serde 1.0.183",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -6058,7 +6097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -6070,9 +6109,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rmp"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
+checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
 dependencies = [
  "byteorder",
  "num-traits",
@@ -6087,18 +6126,18 @@ checksum = "723ecff9ad04f4ad92fe1c8ca6c20d2196d9286e9c60727c4cb5511629260e9d"
 dependencies = [
  "byteorder",
  "rmp",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
 name = "rmp-serde"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
+checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
 dependencies = [
  "byteorder",
  "rmp",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -6109,7 +6148,7 @@ checksum = "de8813b3a2f95c5138fe5925bfb8784175d88d6bff059ba8ce090aa891319754"
 dependencies = [
  "num-traits",
  "rmp",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
 ]
 
@@ -6150,7 +6189,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -6207,14 +6246,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys 0.4.5",
  "windows-sys 0.48.0",
 ]
 
@@ -6232,13 +6271,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.1",
+ "rustls-webpki 0.101.3",
  "sct",
 ]
 
@@ -6284,9 +6323,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.1"
+version = "0.101.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
 dependencies = [
  "ring",
  "untrusted",
@@ -6385,9 +6424,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -6398,9 +6437,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6421,7 +6460,7 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -6435,11 +6474,20 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
 dependencies = [
- "serde_derive",
+ "serde_derive 0.9.15",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+dependencies = [
+ "serde_derive 1.0.183",
 ]
 
 [[package]]
@@ -6448,7 +6496,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -6457,7 +6505,7 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -6467,30 +6515,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde",
+ "serde 1.0.183",
+]
+
+[[package]]
+name = "serde_codegen_internals"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc888bd283bd2420b16ad0d860e35ad8acb21941180a83a189bb2046f9d00400"
+dependencies = [
+ "syn 0.11.11",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "978fd866f4d4872084a81ccc35e275158351d3b9fe620074e7d7504b816b74ba"
+dependencies = [
+ "quote 0.3.15",
+ "serde_codegen_internals",
+ "syn 0.11.11",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
  "ryu",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -6499,7 +6567,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -6511,7 +6579,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -6520,7 +6588,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
- "serde",
+ "serde 1.0.183",
  "serde_with_macros",
 ]
 
@@ -6532,20 +6600,20 @@ checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
  "darling 0.13.4",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.24"
+version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5f51e3fdb5b9cdd1577e1cb7a733474191b1aca6a72c2e50913241632c1180"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
  "ryu",
- "serde",
+ "serde 1.0.183",
  "unsafe-libyaml",
 ]
 
@@ -6567,7 +6635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08338d8024b227c62bd68a12c7c9883f5c66780abaef15c550dc56f46ee6515"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -6648,7 +6716,7 @@ dependencies = [
  "bitflags 1.3.2",
  "itertools 0.8.2",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -6665,9 +6733,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b824b6e687aff278cdbf3b36f07aa52d4bd4099699324d5da86a2ebce3aa00b3"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -6681,7 +6749,7 @@ checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
  "mio 0.8.8",
- "signal-hook 0.3.16",
+ "signal-hook 0.3.17",
 ]
 
 [[package]]
@@ -6723,7 +6791,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -6908,7 +6976,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -6932,7 +7000,7 @@ checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck 0.3.3",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -6944,7 +7012,7 @@ checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -6976,24 +7044,44 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+dependencies = [
+ "quote 0.3.15",
+ "synom",
+ "unicode-xid 0.0.4",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "unicode-ident",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+dependencies = [
+ "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -7003,9 +7091,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
- "unicode-xid",
+ "unicode-xid 0.2.4",
 ]
 
 [[package]]
@@ -7046,9 +7134,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96d2ffad078296368d46ff1cb309be1c23c513b4ab0e22a45de0185275ac96"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
 dependencies = [
  "filetime",
  "libc",
@@ -7057,9 +7145,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.9"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8e77cb757a61f51b947ec4a7e3646efd825b73561db1c232a8ccb639e611a0"
+checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
 name = "task-motel"
@@ -7085,15 +7173,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
 dependencies = [
- "autocfg 1.1.0",
  "cfg-if 1.0.0",
- "fastrand",
+ "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.37.23",
+ "rustix 0.38.8",
  "windows-sys 0.48.0",
 ]
 
@@ -7143,7 +7230,7 @@ checksum = "e9e5f048404b43e8ae66dce036163515b6057024cf58c6377be501f250bd3c6a"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
  "version_check",
 ]
@@ -7166,7 +7253,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro-error",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -7176,7 +7263,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "125df852011c4f8f31df5620f4aea38ecddb5dfb4d9bc569b30485b15ffc3d4e"
 dependencies = [
- "serde",
+ "serde 1.0.183",
  "test-fuzz-internal",
  "test-fuzz-macro",
  "test-fuzz-runtime",
@@ -7190,8 +7277,8 @@ checksum = "58071dc2471840e9f374eeb0f6e405a31bccb3cc5d59bb4598f02cafc274b5c4"
 dependencies = [
  "cargo_metadata",
  "proc-macro2",
- "quote",
- "serde",
+ "quote 1.0.33",
+ "serde 1.0.183",
  "strum_macros 0.24.3",
 ]
 
@@ -7205,7 +7292,7 @@ dependencies = [
  "if_chain",
  "lazy_static",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "subprocess",
  "syn 1.0.109",
  "test-fuzz-internal",
@@ -7222,7 +7309,7 @@ dependencies = [
  "bincode",
  "hex",
  "num-traits",
- "serde",
+ "serde 1.0.183",
  "sha-1 0.10.1",
  "test-fuzz-internal",
 ]
@@ -7244,22 +7331,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -7301,7 +7388,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "itoa",
- "serde",
+ "serde 1.0.183",
  "time-core",
  "time-macros",
 ]
@@ -7336,7 +7423,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde",
+ "serde 1.0.183",
  "serde_json",
 ]
 
@@ -7357,11 +7444,10 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg 1.1.0",
  "backtrace",
  "bytes",
  "libc",
@@ -7370,7 +7456,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -7382,8 +7468,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -7470,7 +7556,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -7479,7 +7565,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
- "serde",
+ "serde 1.0.183",
  "serde_spanned",
  "toml_datetime",
  "toml_edit",
@@ -7491,7 +7577,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -7501,7 +7587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
- "serde",
+ "serde 1.0.183",
  "serde_spanned",
  "toml_datetime",
  "winnow",
@@ -7557,8 +7643,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -7598,7 +7684,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "serde",
+ "serde 1.0.183",
  "tracing-core",
 ]
 
@@ -7612,7 +7698,7 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
- "serde",
+ "serde 1.0.183",
  "serde_json",
  "sharded-slab",
  "smallvec 1.11.0",
@@ -7638,15 +7724,15 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "trybuild"
-version = "1.0.81"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04366e99ff743345622cd00af2af01d711dc2d1ef59250d7347698d21b546729"
+checksum = "6df60d81823ed9c520ee897489573da4b1d79ffbe006b8134f46de1a1aa03555"
 dependencies = [
  "basic-toml",
  "glob",
  "once_cell",
- "serde",
- "serde_derive",
+ "serde 1.0.183",
+ "serde_derive 1.0.183",
  "serde_json",
  "termcolor",
 ]
@@ -7734,7 +7820,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rand-utf8",
- "serde",
+ "serde 1.0.183",
  "serde_json",
  "tokio",
  "tracing",
@@ -7755,7 +7841,7 @@ dependencies = [
  "dirs 5.0.1",
  "once_cell",
  "rand 0.8.5",
- "serde",
+ "serde 1.0.183",
  "serde_json",
  "sha2 0.10.7",
  "tempfile",
@@ -7848,7 +7934,7 @@ version = "0.0.2-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd44a26819757459b14994e728adeeb05931ca95605e54eb7733d01f3f130f8"
 dependencies = [
- "clap 4.3.15",
+ "clap 4.3.22",
  "dirs 5.0.1",
  "futures",
  "if-addrs 0.10.1",
@@ -7925,6 +8011,12 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+
+[[package]]
+name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
@@ -7960,7 +8052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -7973,7 +8065,7 @@ dependencies = [
  "base64 0.21.2",
  "log",
  "once_cell",
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "rustls-webpki 0.100.1",
  "url 2.4.0",
  "webpki-roots",
@@ -7999,7 +8091,7 @@ dependencies = [
  "form_urlencoded",
  "idna 0.4.0",
  "percent-encoding 2.3.0",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -8008,7 +8100,7 @@ version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89cd13f1de9862d363308f5ffdadcd2b64b2a4a812fb296a80b7d3e80011b1e"
 dependencies = [
- "serde",
+ "serde 1.0.183",
  "url 2.4.0",
 ]
 
@@ -8018,7 +8110,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74e7d099f1ee52f823d4bdd60c93c3602043c728f5db3b97bdb548467f7bddea"
 dependencies = [
- "serde",
+ "serde 1.0.183",
  "url 1.7.2",
 ]
 
@@ -8047,7 +8139,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 dependencies = [
  "rand 0.6.5",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -8143,7 +8235,7 @@ dependencies = [
  "pin-project",
  "rustls-pemfile 1.0.3",
  "scoped-tls",
- "serde",
+ "serde 1.0.183",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -8192,8 +8284,8 @@ dependencies = [
  "log",
  "once_cell",
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -8215,7 +8307,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote",
+ "quote 1.0.33",
  "wasm-bindgen-macro-support",
 ]
 
@@ -8226,8 +8318,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8240,9 +8332,9 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a3d1b4a575ffb873679402b2aedb3117555eb65c27b1b86c8a91e574bc2a2a"
+checksum = "41763f20eafed1399fff1afb466496d3a959f58241436cfdc17e3f5ca954de16"
 dependencies = [
  "leb128",
 ]
@@ -8336,7 +8428,7 @@ dependencies = [
  "enumset",
  "loupe",
  "rkyv",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "smallvec 1.11.0",
  "target-lexicon",
@@ -8373,7 +8465,7 @@ checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
- "quote",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -8390,7 +8482,7 @@ dependencies = [
  "memmap2",
  "more-asserts",
  "rustc-demangle",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "target-lexicon",
  "thiserror",
@@ -8414,7 +8506,7 @@ dependencies = [
  "loupe",
  "object 0.28.4",
  "rkyv",
- "serde",
+ "serde 1.0.183",
  "tempfile",
  "tracing",
  "wasmer-artifact",
@@ -8498,7 +8590,7 @@ dependencies = [
  "loupe",
  "more-asserts",
  "rkyv",
- "serde",
+ "serde 1.0.183",
  "thiserror",
 ]
 
@@ -8523,7 +8615,7 @@ dependencies = [
  "region",
  "rkyv",
  "scopeguard",
- "serde",
+ "serde 1.0.183",
  "thiserror",
  "wasmer-artifact",
  "wasmer-types",
@@ -8538,9 +8630,9 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
-version = "62.0.0"
+version = "62.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f7ee878019d69436895f019b65f62c33da63595d8e857cbdc87c13ecb29a32"
+checksum = "b8ae06f09dbe377b889fbd620ff8fa21e1d49d1d9d364983c0cdbf9870cb9f1f"
 dependencies = [
  "leb128",
  "memchr",
@@ -8550,9 +8642,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295572bf24aa5b685a971a83ad3e8b6e684aaad8a9be24bc7bf59bed84cc1c08"
+checksum = "842e15861d203fb4a96d314b0751cdeaf0f6f8b35e8d81d2953af2af5e44e637"
 dependencies = [
  "wast",
 ]
@@ -8650,7 +8742,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets 0.48.3",
 ]
 
 [[package]]
@@ -8696,7 +8788,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets 0.48.3",
 ]
 
 [[package]]
@@ -8716,17 +8808,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "27f51fb4c64f8b770a823c043c7fad036323e1c48f55287b7bbb7987b2fcdf3b"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.48.3",
+ "windows_aarch64_msvc 0.48.3",
+ "windows_i686_gnu 0.48.3",
+ "windows_i686_msvc 0.48.3",
+ "windows_x86_64_gnu 0.48.3",
+ "windows_x86_64_gnullvm 0.48.3",
+ "windows_x86_64_msvc 0.48.3",
 ]
 
 [[package]]
@@ -8737,9 +8829,9 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "fde1bb55ae4ce76a597a8566d82c57432bc69c039449d61572a7a353da28f68c"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -8755,9 +8847,9 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "1513e8d48365a78adad7322fd6b5e4c4e99d92a69db8df2d435b25b1f1f286d4"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8773,9 +8865,9 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "60587c0265d2b842298f5858e1a5d79d146f9ee0c37be5782e92a6eb5e1d7a83"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -8791,9 +8883,9 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "224fe0e0ffff5d2ea6a29f82026c8f43870038a0ffc247aa95a52b47df381ac4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8809,9 +8901,9 @@ checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "62fc52a0f50a088de499712cbc012df7ebd94e2d6eb948435449d76a6287e7ad"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -8821,9 +8913,9 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "2093925509d91ea3d69bcd20238f4c2ecdb1a29d3c281d026a09705d0dd35f3d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8839,15 +8931,15 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "b6ade45bc8bf02ae2aa34a9d54ba660a1a58204da34ba793c00d83ca3730b5f1"
 
 [[package]]
 name = "winnow"
-version = "0.5.0"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fac9742fd1ad1bd9643b991319f72dd031016d44b77039a26977eb667141e7"
+checksum = "83817bbecf72c73bad717ee86820ebf286203d2e04c3951f3cd538869c897364"
 dependencies = [
  "memchr",
 ]
@@ -8872,9 +8964,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "0.2.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]
@@ -8910,8 +9002,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
- "quote",
- "syn 2.0.26",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.10",
  "once_cell",
- "serde 1.0.183",
+ "serde",
  "version_check",
 ]
 
@@ -243,7 +243,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -341,7 +341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -390,7 +390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -407,7 +407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -451,7 +451,7 @@ checksum = "b99d887f4066f8a1b4a713a8121fab07ff543863ac86177ebdee6b5cb18acf12"
 dependencies = [
  "cfg-if 1.0.0",
  "derive_more",
- "serde 1.0.183",
+ "serde",
  "shrinkwraprs",
 ]
 
@@ -488,7 +488,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -503,7 +503,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -521,7 +521,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -633,7 +633,7 @@ checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
  "regex-automata 0.3.6",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -660,7 +660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -700,7 +700,7 @@ version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -709,7 +709,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -721,7 +721,7 @@ dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.18",
- "serde 1.0.183",
+ "serde",
  "serde_json",
  "thiserror",
 ]
@@ -780,7 +780,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "serde 1.0.183",
+ "serde",
  "time 0.1.45",
  "wasm-bindgen",
  "winapi 0.3.9",
@@ -852,7 +852,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -864,7 +864,7 @@ checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -1107,9 +1107,9 @@ dependencies = [
  "plotters",
  "rayon",
  "regex",
- "serde 1.0.183",
+ "serde",
  "serde_cbor",
- "serde_derive 1.0.183",
+ "serde_derive",
  "serde_json",
  "tinytemplate",
  "tokio",
@@ -1271,7 +1271,7 @@ dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -1289,7 +1289,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1328,7 +1328,7 @@ dependencies = [
  "codespan-reporting",
  "once_cell",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "scratch",
  "syn 2.0.29",
 ]
@@ -1346,7 +1346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59d9ffb4193dd22180b8d5747b1e095c3d9c9c665ce39b0483a488948f437e06"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -1399,7 +1399,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "strsim 0.9.3",
  "syn 1.0.109",
 ]
@@ -1413,7 +1413,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -1427,7 +1427,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -1441,7 +1441,7 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -1452,7 +1452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1463,7 +1463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1474,7 +1474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core 0.14.4",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1485,7 +1485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -1525,7 +1525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1536,7 +1536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -1549,7 +1549,7 @@ dependencies = [
  "darling 0.10.2",
  "derive_builder_core",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1561,7 +1561,7 @@ checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling 0.10.2",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1573,7 +1573,7 @@ checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -1738,7 +1738,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "rand 0.7.3",
- "serde 1.0.183",
+ "serde",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -1774,7 +1774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1795,7 +1795,7 @@ checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
  "darling 0.20.3",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -1822,7 +1822,7 @@ checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "rustversion",
  "syn 1.0.109",
  "synstructure",
@@ -1857,7 +1857,7 @@ checksum = "768064bd3a0e2bedcba91dc87ace90beea91acc41b6a01a3ca8e9aa8827461bf"
 dependencies = [
  "log",
  "once_cell",
- "serde 1.0.183",
+ "serde",
  "serde_json",
 ]
 
@@ -1884,7 +1884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
  "synstructure",
 ]
@@ -1948,7 +1948,7 @@ dependencies = [
  "paste",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "serde 1.0.183",
+ "serde",
  "strum 0.18.0",
  "strum_macros 0.18.0",
 ]
@@ -2117,7 +2117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -2412,7 +2412,7 @@ dependencies = [
  "holochain_types",
  "rand 0.8.5",
  "rand-utf8",
- "serde 1.0.183",
+ "serde",
  "tempfile",
  "tokio",
  "tracing",
@@ -2430,7 +2430,7 @@ dependencies = [
  "one_err",
  "rmp-serde 1.1.2",
  "rmpv",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "sodoken",
 ]
@@ -2447,7 +2447,7 @@ dependencies = [
  "holochain_wasmer_guest",
  "mockall",
  "paste",
- "serde 0.9.15",
+ "serde",
  "serde_bytes",
  "subtle-encoding",
  "test-case 2.2.2",
@@ -2468,7 +2468,7 @@ dependencies = [
  "holochain_zome_types",
  "mockall",
  "paste",
- "serde 0.9.15",
+ "serde",
  "serde_bytes",
  "thiserror",
  "tracing",
@@ -2486,7 +2486,7 @@ dependencies = [
  "paste",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2567,7 +2567,7 @@ dependencies = [
  "must_future",
  "rand 0.8.5",
  "rusqlite",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "serde_json",
  "thiserror",
@@ -2649,8 +2649,7 @@ dependencies = [
  "rpassword 5.0.1",
  "rusqlite",
  "sd-notify",
- "serde 0.9.15",
- "serde 1.0.183",
+ "serde",
  "serde_json",
  "serde_yaml",
  "serial_test",
@@ -2706,8 +2705,8 @@ dependencies = [
  "matches",
  "mockall",
  "pretty_assertions 0.7.2",
- "serde 1.0.183",
- "serde_derive 1.0.183",
+ "serde",
+ "serde_derive",
  "test-case 2.2.2",
  "thiserror",
  "tokio",
@@ -2746,7 +2745,7 @@ dependencies = [
  "matches",
  "mr_bundle",
  "predicates 1.0.8",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "serde_json",
  "serde_yaml",
@@ -2791,7 +2790,7 @@ dependencies = [
  "matches",
  "nanoid 0.3.0",
  "once_cell",
- "serde 1.0.183",
+ "serde",
  "serde_json",
  "serde_yaml",
  "sodoken",
@@ -2818,8 +2817,8 @@ dependencies = [
  "holochain_zome_types",
  "kitsune_p2p",
  "matches",
- "serde 1.0.183",
- "serde_derive 1.0.183",
+ "serde",
+ "serde_derive",
  "serde_yaml",
  "structopt",
  "thiserror",
@@ -2855,7 +2854,7 @@ dependencies = [
  "kitsune_p2p_dht",
  "kitsune_p2p_timestamp",
  "paste",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "serde_json",
  "subtle",
@@ -2879,7 +2878,7 @@ dependencies = [
  "nanoid 0.4.0",
  "one_err",
  "parking_lot 0.11.2",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "serde_yaml",
  "sodoken",
@@ -2917,7 +2916,7 @@ dependencies = [
  "kitsune_p2p_types",
  "mockall",
  "rand 0.8.5",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "serde_json",
  "thiserror",
@@ -2934,7 +2933,7 @@ dependencies = [
  "arbitrary",
  "holochain_serialized_bytes_derive 0.0.51",
  "rmp-serde 0.15.5",
- "serde 1.0.183",
+ "serde",
  "serde-transcode",
  "serde_bytes",
  "serde_json",
@@ -2949,7 +2948,7 @@ checksum = "bac6151d65c9a6f26f1b1068046a98900214030924377a2142f60c279b091f51"
 dependencies = [
  "holochain_serialized_bytes_derive 0.0.52",
  "rmp-serde 0.15.5",
- "serde 1.0.183",
+ "serde",
  "serde-transcode",
  "serde_bytes",
  "serde_json",
@@ -2962,7 +2961,7 @@ version = "0.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1077232d0c427d64feb9e138fa22800e447eafb1810682d6c13beb95333cb32c"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2972,7 +2971,7 @@ version = "0.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17cec0d0c2317fcb87772d0a8b5b5e88c7276aef93bf3496931e89cb9231c129"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3016,8 +3015,8 @@ dependencies = [
  "rmp-serde 0.15.5",
  "rusqlite",
  "scheduled-thread-pool",
- "serde 1.0.183",
- "serde_derive 1.0.183",
+ "serde",
+ "serde_derive",
  "serde_json",
  "shrinkwraprs",
  "sqlformat 0.1.8",
@@ -3066,7 +3065,7 @@ dependencies = [
  "parking_lot 0.10.2",
  "pretty_assertions 0.6.1",
  "rand 0.8.5",
- "serde 1.0.183",
+ "serde",
  "serde_json",
  "shrinkwraprs",
  "tempfile",
@@ -3081,7 +3080,7 @@ name = "holochain_test_wasm_common"
 version = "0.2.1"
 dependencies = [
  "hdk",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -3093,7 +3092,7 @@ dependencies = [
  "holochain_serialized_bytes 0.0.52",
  "inferno",
  "once_cell",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "serde_json",
  "shrinkwraprs",
@@ -3151,9 +3150,9 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "rusqlite",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
- "serde_derive 1.0.183",
+ "serde_derive",
  "serde_json",
  "serde_with",
  "serde_yaml",
@@ -3203,7 +3202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "223daec7ca62d4e36841a99d8799b29cc616f5976ad0e2975e6ca6810de8f14f"
 dependencies = [
  "holochain_serialized_bytes 0.0.51",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "test-fuzz",
  "thiserror",
@@ -3221,7 +3220,7 @@ dependencies = [
  "holochain_wasmer_common",
  "parking_lot 0.12.1",
  "paste",
- "serde 1.0.183",
+ "serde",
  "tracing",
 ]
 
@@ -3237,7 +3236,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "rand 0.8.5",
- "serde 1.0.183",
+ "serde",
  "tracing",
  "wasmer",
 ]
@@ -3256,7 +3255,7 @@ dependencies = [
  "must_future",
  "nanoid 0.3.0",
  "net2",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "stream-cancel",
  "thiserror",
@@ -3294,7 +3293,7 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "rusqlite",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "serde_yaml",
  "shrinkwraprs",
@@ -3369,8 +3368,8 @@ dependencies = [
  "anstyle",
  "backtrace",
  "os_info",
- "serde 1.0.183",
- "serde_derive 1.0.183",
+ "serde",
+ "serde_derive",
  "toml 0.7.6",
  "uuid 1.4.1",
 ]
@@ -3512,7 +3511,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown 0.12.3",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -3706,7 +3705,7 @@ dependencies = [
  "percent-encoding 2.3.0",
  "regex",
  "reqwest",
- "serde 1.0.183",
+ "serde",
  "serde_json",
  "time 0.3.23",
  "url 2.4.0",
@@ -3750,7 +3749,7 @@ dependencies = [
  "pretty_assertions 0.7.2",
  "rand 0.8.5",
  "reqwest",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "serde_json",
  "shrinkwraprs",
@@ -3772,7 +3771,7 @@ dependencies = [
  "base64 0.13.1",
  "derive_more",
  "kitsune_p2p_dht_arc",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "shrinkwraprs",
 ]
@@ -3783,7 +3782,7 @@ version = "0.2.1"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_timestamp",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
 ]
 
@@ -3802,7 +3801,7 @@ dependencies = [
  "rand 0.8.5",
  "reqwest",
  "rmp-serde 0.15.5",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "serde_json",
  "tokio",
@@ -3831,7 +3830,7 @@ dependencies = [
  "pretty_assertions 0.7.2",
  "proptest",
  "rand 0.8.5",
- "serde 1.0.183",
+ "serde",
  "statrs",
  "test-case 1.2.3",
  "thiserror",
@@ -3851,7 +3850,7 @@ dependencies = [
  "pretty_assertions 0.7.2",
  "rand 0.8.5",
  "rusqlite",
- "serde 1.0.183",
+ "serde",
  "statrs",
  "tracing",
 ]
@@ -3874,7 +3873,7 @@ dependencies = [
  "num-traits",
  "pretty_assertions 0.7.2",
  "rand 0.8.5",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "test-case 1.2.3",
  "thiserror",
@@ -3914,7 +3913,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "rmp-serde 0.15.5",
  "rustls 0.20.8",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "structopt",
  "tokio",
@@ -3931,7 +3930,7 @@ dependencies = [
  "derive_more",
  "holochain_serialized_bytes 0.0.51",
  "rusqlite",
- "serde 1.0.183",
+ "serde",
  "serde_yaml",
 ]
 
@@ -3948,7 +3947,7 @@ dependencies = [
  "quinn",
  "rcgen 0.9.3",
  "rustls 0.20.8",
- "serde 1.0.183",
+ "serde",
  "tokio",
  "webpki 0.22.0",
 ]
@@ -3978,7 +3977,7 @@ dependencies = [
  "paste",
  "rmp-serde 0.15.5",
  "rustls 0.20.8",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "serde_json",
  "shrinkwraprs",
@@ -4031,7 +4030,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.1",
  "rcgen 0.10.0",
- "serde 1.0.183",
+ "serde",
  "serde_json",
  "serde_yaml",
  "time 0.3.23",
@@ -4244,7 +4243,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4461,7 +4460,7 @@ checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4503,9 +4502,9 @@ dependencies = [
  "matches",
  "reqwest",
  "rmp-serde 0.15.5",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
- "serde_derive 1.0.183",
+ "serde_derive",
  "serde_yaml",
  "tempfile",
  "thiserror",
@@ -4536,7 +4535,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -4574,7 +4573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4838,7 +4837,7 @@ checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -4877,7 +4876,7 @@ checksum = "e81851974d8bb6cc9a643cca68afdce7f0a3b80e08a4620388836bb99a680554"
 dependencies = [
  "indexmap 1.9.3",
  "libc",
- "serde 1.0.183",
+ "serde",
  "serde_json",
 ]
 
@@ -4915,7 +4914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -4960,7 +4959,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
 dependencies = [
  "log",
- "serde 1.0.183",
+ "serde",
  "winapi 0.3.9",
 ]
 
@@ -4989,7 +4988,7 @@ dependencies = [
  "Inflector",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -5216,7 +5215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -5395,7 +5394,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
  "version_check",
 ]
@@ -5407,7 +5406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "version_check",
 ]
 
@@ -5477,7 +5476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -5558,12 +5557,6 @@ dependencies = [
  "tokio",
  "tracing",
 ]
-
-[[package]]
-name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -6036,7 +6029,7 @@ dependencies = [
  "once_cell",
  "percent-encoding 2.3.0",
  "pin-project-lite",
- "serde 1.0.183",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -6097,7 +6090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6126,7 +6119,7 @@ checksum = "723ecff9ad04f4ad92fe1c8ca6c20d2196d9286e9c60727c4cb5511629260e9d"
 dependencies = [
  "byteorder",
  "rmp",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -6137,7 +6130,7 @@ checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
 dependencies = [
  "byteorder",
  "rmp",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -6148,7 +6141,7 @@ checksum = "de8813b3a2f95c5138fe5925bfb8784175d88d6bff059ba8ce090aa891319754"
 dependencies = [
  "num-traits",
  "rmp",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
 ]
 
@@ -6460,7 +6453,7 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -6474,20 +6467,11 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "0.9.15"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
+checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
 dependencies = [
- "serde_derive 0.9.15",
-]
-
-[[package]]
-name = "serde"
-version = "1.0.183"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
-dependencies = [
- "serde_derive 1.0.183",
+ "serde_derive",
 ]
 
 [[package]]
@@ -6496,7 +6480,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -6505,7 +6489,7 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -6515,37 +6499,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
- "serde 1.0.183",
-]
-
-[[package]]
-name = "serde_codegen_internals"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc888bd283bd2420b16ad0d860e35ad8acb21941180a83a189bb2046f9d00400"
-dependencies = [
- "syn 0.11.11",
+ "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "0.9.15"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978fd866f4d4872084a81ccc35e275158351d3b9fe620074e7d7504b816b74ba"
-dependencies = [
- "quote 0.3.15",
- "serde_codegen_internals",
- "syn 0.11.11",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.183"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -6558,7 +6522,7 @@ dependencies = [
  "indexmap 2.0.0",
  "itoa",
  "ryu",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -6567,7 +6531,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -6579,7 +6543,7 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -6588,7 +6552,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
 dependencies = [
- "serde 1.0.183",
+ "serde",
  "serde_with_macros",
 ]
 
@@ -6600,7 +6564,7 @@ checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
  "darling 0.13.4",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6613,7 +6577,7 @@ dependencies = [
  "indexmap 2.0.0",
  "itoa",
  "ryu",
- "serde 1.0.183",
+ "serde",
  "unsafe-libyaml",
 ]
 
@@ -6635,7 +6599,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08338d8024b227c62bd68a12c7c9883f5c66780abaef15c550dc56f46ee6515"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6716,7 +6680,7 @@ dependencies = [
  "bitflags 1.3.2",
  "itertools 0.8.2",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -6791,7 +6755,7 @@ version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -6976,7 +6940,7 @@ dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -7000,7 +6964,7 @@ checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck 0.3.3",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -7012,7 +6976,7 @@ checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -7044,23 +7008,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
-dependencies = [
- "quote 0.3.15",
- "synom",
- "unicode-xid 0.0.4",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "unicode-ident",
 ]
 
@@ -7071,17 +7024,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-dependencies = [
- "unicode-xid 0.0.4",
 ]
 
 [[package]]
@@ -7091,9 +7035,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
- "unicode-xid 0.2.4",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -7230,7 +7174,7 @@ checksum = "e9e5f048404b43e8ae66dce036163515b6057024cf58c6377be501f250bd3c6a"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
  "version_check",
 ]
@@ -7253,7 +7197,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -7263,7 +7207,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "125df852011c4f8f31df5620f4aea38ecddb5dfb4d9bc569b30485b15ffc3d4e"
 dependencies = [
- "serde 1.0.183",
+ "serde",
  "test-fuzz-internal",
  "test-fuzz-macro",
  "test-fuzz-runtime",
@@ -7277,8 +7221,8 @@ checksum = "58071dc2471840e9f374eeb0f6e405a31bccb3cc5d59bb4598f02cafc274b5c4"
 dependencies = [
  "cargo_metadata",
  "proc-macro2",
- "quote 1.0.33",
- "serde 1.0.183",
+ "quote",
+ "serde",
  "strum_macros 0.24.3",
 ]
 
@@ -7292,7 +7236,7 @@ dependencies = [
  "if_chain",
  "lazy_static",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "subprocess",
  "syn 1.0.109",
  "test-fuzz-internal",
@@ -7309,7 +7253,7 @@ dependencies = [
  "bincode",
  "hex",
  "num-traits",
- "serde 1.0.183",
+ "serde",
  "sha-1 0.10.1",
  "test-fuzz-internal",
 ]
@@ -7345,7 +7289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -7388,7 +7332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "itoa",
- "serde 1.0.183",
+ "serde",
  "time-core",
  "time-macros",
 ]
@@ -7423,7 +7367,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
- "serde 1.0.183",
+ "serde",
  "serde_json",
 ]
 
@@ -7468,7 +7412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -7556,7 +7500,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -7565,7 +7509,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
- "serde 1.0.183",
+ "serde",
  "serde_spanned",
  "toml_datetime",
  "toml_edit",
@@ -7577,7 +7521,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -7587,7 +7531,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
- "serde 1.0.183",
+ "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow",
@@ -7643,7 +7587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -7684,7 +7628,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "serde 1.0.183",
+ "serde",
  "tracing-core",
 ]
 
@@ -7698,7 +7642,7 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
- "serde 1.0.183",
+ "serde",
  "serde_json",
  "sharded-slab",
  "smallvec 1.11.0",
@@ -7731,8 +7675,8 @@ dependencies = [
  "basic-toml",
  "glob",
  "once_cell",
- "serde 1.0.183",
- "serde_derive 1.0.183",
+ "serde",
+ "serde_derive",
  "serde_json",
  "termcolor",
 ]
@@ -7820,7 +7764,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rand-utf8",
- "serde 1.0.183",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",
@@ -7841,7 +7785,7 @@ dependencies = [
  "dirs 5.0.1",
  "once_cell",
  "rand 0.8.5",
- "serde 1.0.183",
+ "serde",
  "serde_json",
  "sha2 0.10.7",
  "tempfile",
@@ -8011,12 +7955,6 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
@@ -8052,7 +7990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -8091,7 +8029,7 @@ dependencies = [
  "form_urlencoded",
  "idna 0.4.0",
  "percent-encoding 2.3.0",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -8100,7 +8038,7 @@ version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89cd13f1de9862d363308f5ffdadcd2b64b2a4a812fb296a80b7d3e80011b1e"
 dependencies = [
- "serde 1.0.183",
+ "serde",
  "url 2.4.0",
 ]
 
@@ -8110,7 +8048,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74e7d099f1ee52f823d4bdd60c93c3602043c728f5db3b97bdb548467f7bddea"
 dependencies = [
- "serde 1.0.183",
+ "serde",
  "url 1.7.2",
 ]
 
@@ -8139,7 +8077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 dependencies = [
  "rand 0.6.5",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -8235,7 +8173,7 @@ dependencies = [
  "pin-project",
  "rustls-pemfile 1.0.3",
  "scoped-tls",
- "serde 1.0.183",
+ "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
@@ -8284,7 +8222,7 @@ dependencies = [
  "log",
  "once_cell",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
@@ -8307,7 +8245,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -8318,7 +8256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -8428,7 +8366,7 @@ dependencies = [
  "enumset",
  "loupe",
  "rkyv",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "smallvec 1.11.0",
  "target-lexicon",
@@ -8465,7 +8403,7 @@ checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -8482,7 +8420,7 @@ dependencies = [
  "memmap2",
  "more-asserts",
  "rustc-demangle",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "target-lexicon",
  "thiserror",
@@ -8506,7 +8444,7 @@ dependencies = [
  "loupe",
  "object 0.28.4",
  "rkyv",
- "serde 1.0.183",
+ "serde",
  "tempfile",
  "tracing",
  "wasmer-artifact",
@@ -8590,7 +8528,7 @@ dependencies = [
  "loupe",
  "more-asserts",
  "rkyv",
- "serde 1.0.183",
+ "serde",
  "thiserror",
 ]
 
@@ -8615,7 +8553,7 @@ dependencies = [
  "region",
  "rkyv",
  "scopeguard",
- "serde 1.0.183",
+ "serde",
  "thiserror",
  "wasmer-artifact",
  "wasmer-types",
@@ -8937,9 +8875,9 @@ checksum = "b6ade45bc8bf02ae2aa34a9d54ba660a1a58204da34ba793c00d83ca3730b5f1"
 
 [[package]]
 name = "winnow"
-version = "0.5.12"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83817bbecf72c73bad717ee86820ebf286203d2e04c3951f3cd538869c897364"
+checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
 dependencies = [
  "memchr",
 ]
@@ -9002,7 +8940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2415,9 +2415,9 @@ dependencies = [
 
 [[package]]
 name = "hc_seed_bundle"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63bba5629a49d90007bb81a27a9ba8f9c597a82246d44e73126130617f11c52b"
+checksum = "ded13e388a81713db6919cd750e6113acf2fe5afbaedf8aff79780ec4fc47425"
 dependencies = [
  "futures",
  "one_err",
@@ -3114,7 +3114,7 @@ dependencies = [
  "nanoid 0.3.0",
  "one_err",
  "parking_lot 0.10.2",
- "pretty_assertions 0.6.1",
+ "pretty_assertions 0.7.2",
  "rand 0.8.5",
  "regex",
  "rusqlite",
@@ -3519,6 +3519,15 @@ dependencies = [
  "quick-xml",
  "rgb",
  "str_stack",
+]
+
+[[package]]
+name = "influxive-otel-atomic-obs"
+version = "0.0.1-alpha.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07bcce79167d27b8b2d639cf026029506ed3dfa7bf7ee402c29cab03a7afd16"
+dependencies = [
+ "ts_opentelemetry_api",
 ]
 
 [[package]]
@@ -3961,9 +3970,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d453c328fa04779277f6f4b8e4a71f2bd20e0f0566cb837e6f800bc58777e4a8"
+checksum = "843c7dbcbc8d75eef0b30397a7eb0d04549aabeff4ea69ebd272aea991555746"
 dependencies = [
  "lair_keystore_api",
  "pretty_assertions 1.4.0",
@@ -3977,9 +3986,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b379baacc103ee1939976fb8f32e6b8ae887a245fbde78bf1ef95e95b3035216"
+checksum = "5829f25d0eab6309ae4307aa645f123a64e568a41ec17c358dcbd65dec207e10"
 dependencies = [
  "base64 0.13.1",
  "dunce",
@@ -3992,6 +4001,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "time 0.3.23",
  "tokio",
  "toml 0.5.11",
  "toml 0.7.6",
@@ -7642,6 +7652,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ts_opentelemetry_api"
+version = "0.20.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d186495330f646b5881aeb3b83bac75b8a462d7ef32fda06a2a68f3869d5ba82"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "indexmap 1.9.3",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
 name = "tui"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7697,21 +7723,23 @@ dependencies = [
 
 [[package]]
 name = "tx5"
-version = "0.0.1-alpha.18"
+version = "0.0.2-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f5df4bf08ddcfd702f1b6a46f7ba81feaa55c4dc53685d02cb29c3fc1a0f2d"
+checksum = "a76decf02d813606a817a33793aa5b7bf3cbf8d85d1623157ca7b05ef939c5e1"
 dependencies = [
  "bytes",
  "futures",
+ "influxive-otel-atomic-obs",
  "once_cell",
  "parking_lot 0.12.1",
- "prometheus",
  "rand 0.8.5",
  "rand-utf8",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",
- "tx5-core",
+ "ts_opentelemetry_api",
+ "tx5-core 0.0.2-alpha",
  "tx5-go-pion",
  "tx5-signal",
  "url 2.4.0",
@@ -7736,10 +7764,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "tx5-go-pion"
-version = "0.0.1-alpha.11"
+name = "tx5-core"
+version = "0.0.2-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d7118da8a1353717e9a42b21d922933097c069e13ef8547c7be07efa8ea8a8"
+checksum = "062c8fa9036a5f4e2795e5d6abe1b2e4591f36d0480732ddc0e7405a7489d01f"
+dependencies = [
+ "base64 0.13.1",
+ "dirs 5.0.1",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "serde_json",
+ "sha2 0.10.7",
+ "tempfile",
+ "tracing",
+ "url 2.4.0",
+]
+
+[[package]]
+name = "tx5-go-pion"
+version = "0.0.2-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc0ceeb67c3c846ea7bb6f5d30088f75359a5a55646d80f6a01a3ec235a2eb5"
 dependencies = [
  "parking_lot 0.12.1",
  "tokio",
@@ -7750,9 +7796,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-sys"
-version = "0.0.1-alpha.12"
+version = "0.0.2-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b249cfddf59d1a7593017785f9b73cb396145166c0a3fd1bc39214757a416d7a"
+checksum = "a12b039d7f78e57ab84b7db1293cd194147895b7b43a6a8910f1e82268756fbe"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -7763,7 +7809,7 @@ dependencies = [
  "ouroboros",
  "sha2 0.10.7",
  "tracing",
- "tx5-core",
+ "tx5-core 0.0.2-alpha",
  "zip",
 ]
 
@@ -7781,15 +7827,15 @@ dependencies = [
  "sha2 0.10.7",
  "tokio",
  "tracing",
- "tx5-core",
+ "tx5-core 0.0.1-alpha.7",
  "zip",
 ]
 
 [[package]]
 name = "tx5-signal"
-version = "0.0.1-alpha.10"
+version = "0.0.2-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e26fee2c1c3e227c8bae711545c7536d17a508af0a5e317296cce18afaff5b7"
+checksum = "7698b18a456f298ae7c4bb3c2a5e76c7193242f0a53d91866cc9507e1ff4373b"
 dependencies = [
  "futures",
  "lair_keystore_api",
@@ -7809,7 +7855,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-tungstenite 0.18.0",
  "tracing",
- "tx5-core",
+ "tx5-core 0.0.2-alpha",
  "url 2.4.0",
  "webpki-roots",
 ]
@@ -7831,7 +7877,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "tx5-core",
+ "tx5-core 0.0.1-alpha.7",
  "warp",
 ]
 
@@ -7993,6 +8039,12 @@ dependencies = [
  "serde",
  "url 1.7.2",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7739,27 +7739,9 @@ dependencies = [
  "tokio",
  "tracing",
  "ts_opentelemetry_api",
- "tx5-core 0.0.2-alpha",
+ "tx5-core",
  "tx5-go-pion",
  "tx5-signal",
- "url 2.4.0",
-]
-
-[[package]]
-name = "tx5-core"
-version = "0.0.1-alpha.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6de3181cafaf2cd7d1cd60c3367db5daf53a818159afa596f420bc2da1d7243d"
-dependencies = [
- "base64 0.13.1",
- "dirs 5.0.1",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "sha2 0.10.7",
- "tempfile",
- "tracing",
  "url 2.4.0",
 ]
 
@@ -7809,15 +7791,15 @@ dependencies = [
  "ouroboros",
  "sha2 0.10.7",
  "tracing",
- "tx5-core 0.0.2-alpha",
+ "tx5-core",
  "zip",
 ]
 
 [[package]]
 name = "tx5-go-pion-turn"
-version = "0.0.1-alpha.7"
+version = "0.0.2-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925f258966cedc265cb2e1ba5a19be3007b562b203068d0c33967458695a680a"
+checksum = "8e0194742195d3676fa8c2907995676604cd3ebf8e17fe7f0e9a50495092b945"
 dependencies = [
  "base64 0.13.1",
  "dirs 5.0.1",
@@ -7827,7 +7809,7 @@ dependencies = [
  "sha2 0.10.7",
  "tokio",
  "tracing",
- "tx5-core 0.0.1-alpha.7",
+ "tx5-core",
  "zip",
 ]
 
@@ -7855,16 +7837,16 @@ dependencies = [
  "tokio-rustls",
  "tokio-tungstenite 0.18.0",
  "tracing",
- "tx5-core 0.0.2-alpha",
+ "tx5-core",
  "url 2.4.0",
  "webpki-roots",
 ]
 
 [[package]]
 name = "tx5-signal-srv"
-version = "0.0.1-alpha.9"
+version = "0.0.2-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8359558d90ae7c4b2ff885619fcd75186cccdb62f575252c95c0c06484ce7de0"
+checksum = "4dd44a26819757459b14994e728adeeb05931ca95605e54eb7733d01f3f130f8"
 dependencies = [
  "clap 4.3.15",
  "dirs 5.0.1",
@@ -7877,7 +7859,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "tx5-core 0.0.1-alpha.7",
+ "tx5-core",
  "warp",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,6 +1214,22 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi 0.9.1",
+ "libc",
+ "mio 0.8.8",
+ "parking_lot 0.12.1",
+ "signal-hook 0.3.17",
+ "signal-hook-mio",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
@@ -2832,7 +2848,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "arbitrary",
- "crossterm 0.27.0",
+ "crossterm 0.26.1",
  "holochain",
  "human-repr",
  "rand 0.8.5",

--- a/crates/hc_run_local_services/Cargo.toml
+++ b/crates/hc_run_local_services/Cargo.toml
@@ -22,4 +22,4 @@ if-addrs = "0.10.1"
 kitsune_p2p_bootstrap = { version = "^0.1.1", path = "../kitsune_p2p/bootstrap" }
 tokio = { version = "1.27", features = ["full"] }
 tracing = "0.1"
-tx5-signal-srv = "=0.0.1-alpha.9"
+tx5-signal-srv = "=0.0.2-alpha"

--- a/crates/hdi/Cargo.toml
+++ b/crates/hdi/Cargo.toml
@@ -18,7 +18,7 @@ holochain_wasmer_guest = "=0.0.84"
 # features, both here AND in hdk_derive, to reduce code bloat
 holochain_integrity_types = { version = "^0.2.1", path = "../holochain_integrity_types", default-features = false }
 paste = "1.0"
-serde = "1.0"
+serde = "<=1.0.166"
 serde_bytes = "0.11"
 # thiserror = "1.0.22"
 tracing = { version = "0.1", optional = true }

--- a/crates/hdi/Cargo.toml
+++ b/crates/hdi/Cargo.toml
@@ -18,7 +18,7 @@ holochain_wasmer_guest = "=0.0.84"
 # features, both here AND in hdk_derive, to reduce code bloat
 holochain_integrity_types = { version = "^0.2.1", path = "../holochain_integrity_types", default-features = false }
 paste = "1.0"
-serde = "<=1.0.166"
+serde = ">= 1.0, <= 1.0.166"
 serde_bytes = "0.11"
 # thiserror = "1.0.22"
 tracing = { version = "0.1", optional = true }

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -19,7 +19,7 @@ holochain_wasmer_guest = "=0.0.84"
 # features, both here AND in hdk_derive, to reduce code bloat
 holochain_zome_types = { version = "^0.2.1", path = "../holochain_zome_types", default-features = false }
 paste = "1.0"
-serde = "1.0"
+serde = "<=1.0.166"
 serde_bytes = "0.11"
 thiserror = "1.0.22"
 tracing = "0.1"

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -19,7 +19,7 @@ holochain_wasmer_guest = "=0.0.84"
 # features, both here AND in hdk_derive, to reduce code bloat
 holochain_zome_types = { version = "^0.2.1", path = "../holochain_zome_types", default-features = false }
 paste = "1.0"
-serde = "<=1.0.166"
+serde = ">= 1.0, <= 1.0.166"
 serde_bytes = "0.11"
 thiserror = "1.0.22"
 tracing = "0.1"

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -56,7 +56,7 @@ rand = "0.8.5"
 rand-utf8 = "0.0.1"
 rpassword = "5.0.1"
 rusqlite = { version = "0.29" }
-serde = { version = "<=1.0.166", features = [ "derive" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive" ] }
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 serde_yaml = "0.9"
 shrinkwraprs = "0.3.0"

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -56,7 +56,7 @@ rand = "0.8.5"
 rand-utf8 = "0.0.1"
 rpassword = "5.0.1"
 rusqlite = { version = "0.29" }
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = "<=1.0.166", features = [ "derive" ] }
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 serde_yaml = "0.9"
 shrinkwraprs = "0.3.0"

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -92,8 +92,8 @@ holochain_test_wasm_common = { version = "^0.2.1", path = "../test_utils/wasm_co
 kitsune_p2p_bootstrap = { version = "^0.1.1", path = "../kitsune_p2p/bootstrap", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
 itertools = { version = "0.10", optional = true }
-tx5-go-pion-turn = { version = "=0.0.1-alpha.7", optional = true }
-tx5-signal-srv = { version = "=0.0.1-alpha.9", optional = true }
+tx5-go-pion-turn = { version = "=0.0.2-alpha", optional = true }
+tx5-signal-srv = { version = "=0.0.2-alpha", optional = true }
 
 # chc deps
 bytes = { version = "1", optional = true }

--- a/crates/holochain_diagnostics/Cargo.toml
+++ b/crates/holochain_diagnostics/Cargo.toml
@@ -19,5 +19,5 @@ tracing = "0.1"
 tracing-appender = "0.2"
 tracing-subscriber = "0.3.16"
 
-crossterm = "*"
-tui = "*"
+crossterm = "0.26"
+tui = "0.19"

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Update to latest version of Lair keystore. This comes with a minor API change and some dependency
+  changes but is otherwise compatible with the 0.2 series of Lair.
+
 ## 0.2.1
 
 ## 0.2.1-beta-rc.0

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -17,7 +17,7 @@ holo_hash = { version = "^0.2.1", path = "../holo_hash", features = ["full"] }
 holochain_serialized_bytes = "=0.0.51"
 holochain_zome_types = { path = "../holochain_zome_types", version = "^0.2.1"}
 kitsune_p2p_types = { version = "^0.2.1", path = "../kitsune_p2p/types" }
-lair_keystore = { version = "0.2.4", default-features = false }
+lair_keystore = { version = "0.3.0", default-features = false }
 must_future = "0.1.2"
 nanoid = "0.4.0"
 one_err = "0.0.8"

--- a/crates/holochain_keystore/src/crude_mock_keystore.rs
+++ b/crates/holochain_keystore/src/crude_mock_keystore.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use futures::FutureExt;
-use kitsune_p2p_types::dependencies::lair_keystore_api::lair_client::traits::AsLairClient;
+use kitsune_p2p_types::dependencies::lair_keystore_api::lair_client::client_traits::AsLairClient;
 use kitsune_p2p_types::dependencies::lair_keystore_api::prelude::{LairApiEnum, LairClient};
 use kitsune_p2p_types::dependencies::lair_keystore_api::LairResult;
 

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -43,7 +43,7 @@ thiserror = "1.0.22"
 tokio = { version = "1.27", features = ["full"] }
 tracing = "0.1"
 tokio-stream = "0.1"
-tx5 = { version = "=0.0.1-alpha.18", optional = true }
+tx5 = { version = "=0.0.2-alpha", optional = true }
 url2 = "0.0.6"
 fixt = { path = "../../fixt", version = "^0.2.1"}
 

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -11,7 +11,7 @@ categories = [ "network-programming" ]
 edition = "2021"
 
 [dependencies]
-lair_keystore_api = "=0.2.4"
+lair_keystore_api = "=0.3.0"
 base64 = "0.13"
 derive_more = "0.99.7"
 futures = "0.3"

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
@@ -83,17 +83,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,7 +124,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -158,6 +147,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bitvec"
@@ -231,7 +226,7 @@ version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -240,7 +235,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -252,16 +247,19 @@ dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.18",
- "serde",
+ "serde 1.0.183",
  "serde_json",
  "thiserror",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -284,7 +282,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "serde",
+ "serde 1.0.183",
  "time",
  "winapi",
 ]
@@ -295,16 +293,16 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "colored"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+checksum = "5a5f741c91823341bebf717d4c71bda820630ce065443b58bd1b7451af008355"
 dependencies = [
- "atty",
+ "is-terminal",
  "lazy_static",
  "winapi",
 ]
@@ -538,7 +536,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -571,7 +569,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -593,7 +591,7 @@ checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -658,9 +656,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "enum-iterator"
@@ -700,7 +698,7 @@ dependencies = [
  "darling 0.20.3",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -711,9 +709,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -738,12 +736,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "fixt"
@@ -755,7 +750,7 @@ dependencies = [
  "paste",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "serde",
+ "serde 1.0.183",
  "strum",
  "strum_macros 0.18.0",
 ]
@@ -849,7 +844,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -965,7 +960,7 @@ dependencies = [
  "holochain_integrity_types",
  "holochain_wasmer_guest",
  "paste",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "tracing",
  "tracing-core",
@@ -983,7 +978,7 @@ dependencies = [
  "holochain_zome_types",
  "mockall",
  "paste",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "thiserror",
  "tracing",
@@ -1021,15 +1016,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
@@ -1055,7 +1041,7 @@ dependencies = [
  "kitsune_p2p_dht_arc",
  "must_future",
  "rand 0.8.5",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "thiserror",
 ]
@@ -1071,7 +1057,7 @@ dependencies = [
  "kitsune_p2p_dht",
  "kitsune_p2p_timestamp",
  "paste",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "subtle",
  "subtle-encoding",
@@ -1095,7 +1081,7 @@ dependencies = [
  "arbitrary",
  "holochain_serialized_bytes_derive",
  "rmp-serde",
- "serde",
+ "serde 1.0.183",
  "serde-transcode",
  "serde_bytes",
  "serde_json",
@@ -1117,7 +1103,7 @@ name = "holochain_test_wasm_common"
 version = "0.2.1"
 dependencies = [
  "hdk",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -1127,7 +1113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "223daec7ca62d4e36841a99d8799b29cc616f5976ad0e2975e6ca6810de8f14f"
 dependencies = [
  "holochain_serialized_bytes",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "test-fuzz",
  "thiserror",
@@ -1145,7 +1131,7 @@ dependencies = [
  "holochain_wasmer_common",
  "parking_lot 0.12.1",
  "paste",
- "serde",
+ "serde 1.0.183",
  "tracing",
 ]
 
@@ -1166,7 +1152,7 @@ dependencies = [
  "nanoid",
  "paste",
  "rand 0.8.5",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "serde_yaml",
  "shrinkwraprs",
@@ -1228,7 +1214,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown 0.12.3",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -1239,15 +1225,6 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1264,13 +1241,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
+name = "is-terminal"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
- "libc",
+ "hermit-abi",
+ "rustix",
  "windows-sys 0.48.0",
 ]
 
@@ -1314,7 +1291,7 @@ dependencies = [
  "base64",
  "derive_more",
  "kitsune_p2p_dht_arc",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "shrinkwraprs",
 ]
@@ -1325,7 +1302,7 @@ version = "0.2.1"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_timestamp",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
 ]
 
@@ -1345,7 +1322,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "rand 0.8.5",
- "serde",
+ "serde 1.0.183",
  "statrs",
  "thiserror",
  "tracing",
@@ -1359,7 +1336,7 @@ dependencies = [
  "gcollections",
  "intervallum",
  "num-traits",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -1369,7 +1346,7 @@ dependencies = [
  "arbitrary",
  "chrono",
  "derive_more",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -1408,9 +1385,9 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -1433,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "loupe"
@@ -1608,9 +1585,9 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-complex"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
 ]
@@ -1638,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg 1.1.0",
  "libm",
@@ -1652,7 +1629,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1738,9 +1715,9 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pest"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d2d1d55045829d65aad9d389139882ad623b33b904e7c9f1b10c5b8927298e5"
+checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -1748,9 +1725,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pin-utils"
@@ -1849,9 +1826,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -2057,7 +2034,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2073,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2085,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2106,7 +2083,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "mach",
  "winapi",
@@ -2151,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "rmp"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
+checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
 dependencies = [
  "byteorder",
  "num-traits",
@@ -2168,7 +2145,7 @@ checksum = "723ecff9ad04f4ad92fe1c8ca6c20d2196d9286e9c60727c4cb5511629260e9d"
 dependencies = [
  "byteorder",
  "rmp",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -2194,13 +2171,12 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.48.0",
@@ -2254,7 +2230,7 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -2268,9 +2244,15 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "0.9.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
+
+[[package]]
+name = "serde"
+version = "1.0.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
@@ -2281,7 +2263,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
@@ -2290,42 +2272,42 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
 dependencies = [
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
  "ryu",
- "serde",
+ "serde 1.0.183",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.24"
+version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5f51e3fdb5b9cdd1577e1cb7a733474191b1aca6a72c2e50913241632c1180"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
  "ryu",
- "serde",
+ "serde 1.0.183",
  "unsafe-libyaml",
 ]
 
@@ -2346,7 +2328,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e63e6744142336dfb606fe2b068afa2e1cca1ee6a5d8377277a92945d81fa331"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "itertools 0.8.2",
  "proc-macro2",
  "quote",
@@ -2486,9 +2468,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.26"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2503,17 +2485,16 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.9"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8e77cb757a61f51b947ec4a7e3646efd825b73561db1c232a8ccb639e611a0"
+checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "dc02fddf48964c42031a0b3fe0428320ecf3a73c401040fc0096f97794310651"
 dependencies = [
- "autocfg 1.1.0",
  "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall 0.3.5",
@@ -2533,7 +2514,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "125df852011c4f8f31df5620f4aea38ecddb5dfb4d9bc569b30485b15ffc3d4e"
 dependencies = [
- "serde",
+ "serde 1.0.183",
  "test-fuzz-internal",
  "test-fuzz-macro",
  "test-fuzz-runtime",
@@ -2548,7 +2529,7 @@ dependencies = [
  "cargo_metadata",
  "proc-macro2",
  "quote",
- "serde",
+ "serde 1.0.183",
  "strum_macros 0.24.3",
 ]
 
@@ -2579,7 +2560,7 @@ dependencies = [
  "bincode",
  "hex",
  "num-traits",
- "serde",
+ "serde 1.0.183",
  "sha-1",
  "test-fuzz-internal",
 ]
@@ -2591,7 +2572,7 @@ dependencies = [
  "fixt",
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2601,7 +2582,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2610,7 +2591,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2618,7 +2599,7 @@ name = "test_wasm_capability"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2627,7 +2608,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
  "test_wasm_integrity_zome",
 ]
 
@@ -2637,7 +2618,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
  "test_wasm_integrity_zome",
 ]
 
@@ -2648,7 +2629,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2659,7 +2640,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2669,7 +2650,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2679,7 +2660,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2688,7 +2669,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
  "tracing",
  "tracing-core",
 ]
@@ -2699,7 +2680,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2708,7 +2689,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2717,7 +2698,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2726,7 +2707,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2735,7 +2716,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2744,7 +2725,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2753,7 +2734,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2763,7 +2744,7 @@ dependencies = [
  "fixt",
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2772,7 +2753,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2781,7 +2762,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2789,7 +2770,7 @@ name = "test_wasm_init_fail"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2797,7 +2778,7 @@ name = "test_wasm_init_pass"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2806,7 +2787,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "holochain_mock_hdi",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2816,7 +2797,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2824,7 +2805,7 @@ name = "test_wasm_migrate_agent_fail"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2832,7 +2813,7 @@ name = "test_wasm_migrate_agent_pass"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2842,7 +2823,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2852,7 +2833,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
  "thiserror",
 ]
 
@@ -2861,7 +2842,7 @@ name = "test_wasm_post_commit_success"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2870,7 +2851,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2879,7 +2860,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2889,7 +2870,7 @@ dependencies = [
  "fixt",
  "hdk",
  "rand 0.8.5",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2899,7 +2880,7 @@ dependencies = [
  "fixt",
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2909,7 +2890,7 @@ dependencies = [
  "derive_more",
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2918,7 +2899,7 @@ version = "0.0.1"
 dependencies = [
  "fixt",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2926,7 +2907,7 @@ name = "test_wasm_sys_time"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2935,7 +2916,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2945,7 +2926,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2954,7 +2935,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2963,7 +2944,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2972,7 +2953,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2981,7 +2962,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2990,7 +2971,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -2999,7 +2980,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -3008,7 +2989,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -3016,7 +2997,7 @@ name = "test_wasm_x_salsa20_poly1305"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde",
+ "serde 0.9.15",
 ]
 
 [[package]]
@@ -3026,28 +3007,28 @@ dependencies = [
  "fixt",
  "hdi",
  "hdk",
- "serde",
+ "serde 0.9.15",
  "serde_yaml",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3110,7 +3091,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -3237,7 +3218,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -3259,7 +3240,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.26",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3272,9 +3253,9 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a3d1b4a575ffb873679402b2aedb3117555eb65c27b1b86c8a91e574bc2a2a"
+checksum = "41763f20eafed1399fff1afb466496d3a959f58241436cfdc17e3f5ca954de16"
 dependencies = [
  "leb128",
 ]
@@ -3328,7 +3309,7 @@ dependencies = [
  "enumset",
  "loupe",
  "rkyv",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "smallvec",
  "target-lexicon",
@@ -3382,7 +3363,7 @@ dependencies = [
  "memmap2",
  "more-asserts",
  "rustc-demangle",
- "serde",
+ "serde 1.0.183",
  "serde_bytes",
  "target-lexicon",
  "thiserror",
@@ -3406,7 +3387,7 @@ dependencies = [
  "loupe",
  "object 0.28.4",
  "rkyv",
- "serde",
+ "serde 1.0.183",
  "tempfile",
  "tracing",
  "wasmer-artifact",
@@ -3478,7 +3459,7 @@ dependencies = [
  "loupe",
  "more-asserts",
  "rkyv",
- "serde",
+ "serde 1.0.183",
  "thiserror",
 ]
 
@@ -3503,7 +3484,7 @@ dependencies = [
  "region",
  "rkyv",
  "scopeguard",
- "serde",
+ "serde 1.0.183",
  "thiserror",
  "wasmer-artifact",
  "wasmer-types",
@@ -3518,9 +3499,9 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
-version = "62.0.0"
+version = "62.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f7ee878019d69436895f019b65f62c33da63595d8e857cbdc87c13ecb29a32"
+checksum = "b8ae06f09dbe377b889fbd620ff8fa21e1d49d1d9d364983c0cdbf9870cb9f1f"
 dependencies = [
  "leb128",
  "memchr",
@@ -3530,9 +3511,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295572bf24aa5b685a971a83ad3e8b6e684aaad8a9be24bc7bf59bed84cc1c08"
+checksum = "842e15861d203fb4a96d314b0751cdeaf0f6f8b35e8d81d2953af2af5e44e637"
 dependencies = [
  "wast",
 ]
@@ -3612,24 +3593,24 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "27f51fb4c64f8b770a823c043c7fad036323e1c48f55287b7bbb7987b2fcdf3b"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
+ "windows_aarch64_msvc 0.48.3",
+ "windows_i686_gnu 0.48.3",
+ "windows_i686_msvc 0.48.3",
+ "windows_x86_64_gnu 0.48.3",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.48.0",
+ "windows_x86_64_msvc 0.48.3",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "fde1bb55ae4ce76a597a8566d82c57432bc69c039449d61572a7a353da28f68c"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3639,9 +3620,9 @@ checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "1513e8d48365a78adad7322fd6b5e4c4e99d92a69db8df2d435b25b1f1f286d4"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3651,9 +3632,9 @@ checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "60587c0265d2b842298f5858e1a5d79d146f9ee0c37be5782e92a6eb5e1d7a83"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3663,9 +3644,9 @@ checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "224fe0e0ffff5d2ea6a29f82026c8f43870038a0ffc247aa95a52b47df381ac4"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3675,15 +3656,15 @@ checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "62fc52a0f50a088de499712cbc012df7ebd94e2d6eb948435449d76a6287e7ad"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "2093925509d91ea3d69bcd20238f4c2ecdb1a29d3c281d026a09705d0dd35f3d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3693,9 +3674,9 @@ checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "b6ade45bc8bf02ae2aa34a9d54ba660a1a58204da34ba793c00d83ca3730b5f1"
 
 [[package]]
 name = "wyz"

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -124,7 +124,7 @@ version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -235,7 +235,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -247,7 +247,7 @@ dependencies = [
  "camino",
  "cargo-platform",
  "semver 1.0.18",
- "serde 1.0.183",
+ "serde",
  "serde_json",
  "thiserror",
 ]
@@ -282,7 +282,7 @@ dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "serde 1.0.183",
+ "serde",
  "time",
  "winapi",
 ]
@@ -750,7 +750,7 @@ dependencies = [
  "paste",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "serde 1.0.183",
+ "serde",
  "strum",
  "strum_macros 0.18.0",
 ]
@@ -960,7 +960,7 @@ dependencies = [
  "holochain_integrity_types",
  "holochain_wasmer_guest",
  "paste",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "tracing",
  "tracing-core",
@@ -978,7 +978,7 @@ dependencies = [
  "holochain_zome_types",
  "mockall",
  "paste",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "thiserror",
  "tracing",
@@ -1041,7 +1041,7 @@ dependencies = [
  "kitsune_p2p_dht_arc",
  "must_future",
  "rand 0.8.5",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "thiserror",
 ]
@@ -1057,7 +1057,7 @@ dependencies = [
  "kitsune_p2p_dht",
  "kitsune_p2p_timestamp",
  "paste",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "subtle",
  "subtle-encoding",
@@ -1081,7 +1081,7 @@ dependencies = [
  "arbitrary",
  "holochain_serialized_bytes_derive",
  "rmp-serde",
- "serde 1.0.183",
+ "serde",
  "serde-transcode",
  "serde_bytes",
  "serde_json",
@@ -1103,7 +1103,7 @@ name = "holochain_test_wasm_common"
 version = "0.2.1"
 dependencies = [
  "hdk",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -1113,7 +1113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "223daec7ca62d4e36841a99d8799b29cc616f5976ad0e2975e6ca6810de8f14f"
 dependencies = [
  "holochain_serialized_bytes",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "test-fuzz",
  "thiserror",
@@ -1131,7 +1131,7 @@ dependencies = [
  "holochain_wasmer_common",
  "parking_lot 0.12.1",
  "paste",
- "serde 1.0.183",
+ "serde",
  "tracing",
 ]
 
@@ -1152,7 +1152,7 @@ dependencies = [
  "nanoid",
  "paste",
  "rand 0.8.5",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "serde_yaml",
  "shrinkwraprs",
@@ -1214,7 +1214,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg 1.1.0",
  "hashbrown 0.12.3",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -1291,7 +1291,7 @@ dependencies = [
  "base64",
  "derive_more",
  "kitsune_p2p_dht_arc",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "shrinkwraprs",
 ]
@@ -1302,7 +1302,7 @@ version = "0.2.1"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_timestamp",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
 ]
 
@@ -1322,7 +1322,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "rand 0.8.5",
- "serde 1.0.183",
+ "serde",
  "statrs",
  "thiserror",
  "tracing",
@@ -1336,7 +1336,7 @@ dependencies = [
  "gcollections",
  "intervallum",
  "num-traits",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -1346,7 +1346,7 @@ dependencies = [
  "arbitrary",
  "chrono",
  "derive_more",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -2145,7 +2145,7 @@ checksum = "723ecff9ad04f4ad92fe1c8ca6c20d2196d9286e9c60727c4cb5511629260e9d"
 dependencies = [
  "byteorder",
  "rmp",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -2230,7 +2230,7 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -2244,15 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "0.9.15"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b623917345a631dc9608d5194cc206b3fe6c3554cd1c75b937e55e285254af"
-
-[[package]]
-name = "serde"
-version = "1.0.183"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
+checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
 dependencies = [
  "serde_derive",
 ]
@@ -2263,7 +2257,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "590c0e25c2a5bb6e85bf5c1bce768ceb86b316e7a01bdf07d2cb4ec2271990e2"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -2272,14 +2266,14 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
 dependencies = [
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.183"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
+checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2295,7 +2289,7 @@ dependencies = [
  "indexmap 2.0.0",
  "itoa",
  "ryu",
- "serde 1.0.183",
+ "serde",
 ]
 
 [[package]]
@@ -2307,7 +2301,7 @@ dependencies = [
  "indexmap 2.0.0",
  "itoa",
  "ryu",
- "serde 1.0.183",
+ "serde",
  "unsafe-libyaml",
 ]
 
@@ -2514,7 +2508,7 @@ version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "125df852011c4f8f31df5620f4aea38ecddb5dfb4d9bc569b30485b15ffc3d4e"
 dependencies = [
- "serde 1.0.183",
+ "serde",
  "test-fuzz-internal",
  "test-fuzz-macro",
  "test-fuzz-runtime",
@@ -2529,7 +2523,7 @@ dependencies = [
  "cargo_metadata",
  "proc-macro2",
  "quote",
- "serde 1.0.183",
+ "serde",
  "strum_macros 0.24.3",
 ]
 
@@ -2560,7 +2554,7 @@ dependencies = [
  "bincode",
  "hex",
  "num-traits",
- "serde 1.0.183",
+ "serde",
  "sha-1",
  "test-fuzz-internal",
 ]
@@ -2572,7 +2566,7 @@ dependencies = [
  "fixt",
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2582,7 +2576,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2591,7 +2585,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2599,7 +2593,7 @@ name = "test_wasm_capability"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2608,7 +2602,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
  "test_wasm_integrity_zome",
 ]
 
@@ -2618,7 +2612,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
  "test_wasm_integrity_zome",
 ]
 
@@ -2629,7 +2623,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2640,7 +2634,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2650,7 +2644,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2660,7 +2654,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2669,7 +2663,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
  "tracing",
  "tracing-core",
 ]
@@ -2680,7 +2674,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2689,7 +2683,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2698,7 +2692,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2707,7 +2701,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2716,7 +2710,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2725,7 +2719,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2734,7 +2728,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2744,7 +2738,7 @@ dependencies = [
  "fixt",
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2753,7 +2747,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2762,7 +2756,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2770,7 +2764,7 @@ name = "test_wasm_init_fail"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2778,7 +2772,7 @@ name = "test_wasm_init_pass"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2787,7 +2781,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "holochain_mock_hdi",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2797,7 +2791,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2805,7 +2799,7 @@ name = "test_wasm_migrate_agent_fail"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2813,7 +2807,7 @@ name = "test_wasm_migrate_agent_pass"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2823,7 +2817,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2833,7 +2827,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
  "thiserror",
 ]
 
@@ -2842,7 +2836,7 @@ name = "test_wasm_post_commit_success"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2851,7 +2845,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2860,7 +2854,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2870,7 +2864,7 @@ dependencies = [
  "fixt",
  "hdk",
  "rand 0.8.5",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2880,7 +2874,7 @@ dependencies = [
  "fixt",
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2890,7 +2884,7 @@ dependencies = [
  "derive_more",
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2899,7 +2893,7 @@ version = "0.0.1"
 dependencies = [
  "fixt",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2907,7 +2901,7 @@ name = "test_wasm_sys_time"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2916,7 +2910,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2926,7 +2920,7 @@ dependencies = [
  "hdi",
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2935,7 +2929,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2944,7 +2938,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2953,7 +2947,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2962,7 +2956,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2971,7 +2965,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2980,7 +2974,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2989,7 +2983,7 @@ version = "0.0.1"
 dependencies = [
  "hdk",
  "holochain_test_wasm_common",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -2997,7 +2991,7 @@ name = "test_wasm_x_salsa20_poly1305"
 version = "0.0.1"
 dependencies = [
  "hdk",
- "serde 0.9.15",
+ "serde",
 ]
 
 [[package]]
@@ -3007,7 +3001,7 @@ dependencies = [
  "fixt",
  "hdi",
  "hdk",
- "serde 0.9.15",
+ "serde",
  "serde_yaml",
 ]
 
@@ -3309,7 +3303,7 @@ dependencies = [
  "enumset",
  "loupe",
  "rkyv",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "smallvec",
  "target-lexicon",
@@ -3363,7 +3357,7 @@ dependencies = [
  "memmap2",
  "more-asserts",
  "rustc-demangle",
- "serde 1.0.183",
+ "serde",
  "serde_bytes",
  "target-lexicon",
  "thiserror",
@@ -3387,7 +3381,7 @@ dependencies = [
  "loupe",
  "object 0.28.4",
  "rkyv",
- "serde 1.0.183",
+ "serde",
  "tempfile",
  "tracing",
  "wasmer-artifact",
@@ -3459,7 +3453,7 @@ dependencies = [
  "loupe",
  "more-asserts",
  "rkyv",
- "serde 1.0.183",
+ "serde",
  "thiserror",
 ]
 
@@ -3484,7 +3478,7 @@ dependencies = [
  "region",
  "rkyv",
  "scopeguard",
- "serde 1.0.183",
+ "serde",
  "thiserror",
  "wasmer-artifact",
  "wasmer-types",

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.toml
@@ -54,7 +54,7 @@ members = [
 opt-level = "z"
 
 [workspace.dependencies]
-serde = "<=1.0.166"
+serde = ">= 1.0, <= 1.0.166"
 
 [patch.crates-io]
 # holochain_wasmer_common = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "develop" }

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.toml
@@ -53,6 +53,8 @@ members = [
 [profile.release]
 opt-level = "z"
 
+[workspace.dependencies]
+serde = "<=1.0.166"
 
 [patch.crates-io]
 # holochain_wasmer_common = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "develop" }

--- a/crates/test_utils/wasm/wasm_workspace/agent_info/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/agent_info/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 hdk = { path = "../../../../hdk", optional = true }
-serde = "1.0"
+serde = { workspace = true }
 hdi = { path = "../../../../hdi" }
 
 [dev-dependencies]

--- a/crates/test_utils/wasm/wasm_workspace/anchor/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/anchor/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 hdk = { path = "../../../../hdk", optional = true }
-serde = "1.0"
+serde = { workspace = true }
 hdi = { path = "../../../../hdi" }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 

--- a/crates/test_utils/wasm/wasm_workspace/bench/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/bench/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 hdk = { path = "../../../../hdk", optional = true }
-serde = "1.0"
+serde = { workspace = true }
 hdi = { path = "../../../../hdi" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/capability/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/capability/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk", optional = true }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/coordinator_zome/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/coordinator_zome/Cargo.toml
@@ -9,7 +9,7 @@ name = "test_wasm_coordinator_zome"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk" }
 test_wasm_integrity_zome = { path = "../integrity_zome" }

--- a/crates/test_utils/wasm/wasm_workspace/coordinator_zome_update/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/coordinator_zome_update/Cargo.toml
@@ -9,7 +9,7 @@ name = "test_wasm_coordinator_zome_update"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk" }
 test_wasm_integrity_zome = { path = "../integrity_zome" }

--- a/crates/test_utils/wasm/wasm_workspace/countersigning/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/countersigning/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 hdk = { path = "../../../../hdk", optional = true }
-serde = "1.0"
+serde = { workspace = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/crd/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/crd/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk", optional = true }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/create_entry/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/create_entry/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 holochain_test_wasm_common = { path = "../../../wasm_common", optional = true }
 hdk = { path = "../../../../hdk", optional = true }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/crud/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/crud/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk", optional = true }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/debug/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/debug/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 tracing = "0.1"
 tracing-core = "0.1"
 hdi = { path = "../../../../hdi", features = ["trace"] }

--- a/crates/test_utils/wasm/wasm_workspace/emit_signal/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/emit_signal/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 hdk = { path = "../../../../hdk" }
-serde = "1.0"
+serde = { workspace = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/entry_defs/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/entry_defs/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk", optional = true }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/foo/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/foo/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk" }
 

--- a/crates/test_utils/wasm/wasm_workspace/genesis_self_check_1/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/genesis_self_check_1/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/genesis_self_check_invalid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/genesis_self_check_invalid/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/genesis_self_check_legacy/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/genesis_self_check_legacy/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/genesis_self_check_valid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/genesis_self_check_valid/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/hash_entry/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/hash_entry/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk", optional = true }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/hash_path/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/hash_path/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 hdk = { path = "../../../../hdk" }
-serde = "1.0"
+serde = { workspace = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/hdk_extern/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/hdk_extern/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk" }
 

--- a/crates/test_utils/wasm/wasm_workspace/init_fail/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/init_fail/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/init_pass/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/init_pass/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/integrity_zome/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/integrity_zome/Cargo.toml
@@ -9,7 +9,7 @@ name = "test_wasm_integrity_zome"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdi = { path = "../../../../hdi" }
 holochain_mock_hdi = { path = "../../../../mock_hdi", optional = true }
 

--- a/crates/test_utils/wasm/wasm_workspace/link/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/link/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk", optional = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/migrate_agent_fail/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/migrate_agent_fail/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/migrate_agent_pass/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/migrate_agent_pass/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/multiple_calls/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/multiple_calls/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/must_get/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/must_get/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk" }
 thiserror = "1"

--- a/crates/test_utils/wasm/wasm_workspace/post_commit_success/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/post_commit_success/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/post_commit_volley/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/post_commit_volley/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/query/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/query/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 hdk = { path = "../../../../hdk" }
-serde = "1.0"
+serde = { workspace = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/random_bytes/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/random_bytes/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 hdk = { path = "../../../../hdk"}
-serde = "1.0"
+serde = { workspace = true }
 rand = "0.8.5"
 
 [dev-dependencies]

--- a/crates/test_utils/wasm/wasm_workspace/schedule/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/schedule/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 hdk = { path = "../../../../hdk" }
-serde = "1.0"
+serde = { workspace = true }
 hdi = { path = "../../../../hdi" }
 
 [dev-dependencies]

--- a/crates/test_utils/wasm/wasm_workspace/ser_regression/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/ser_regression/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 derive_more = "0.99.11"
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/sign/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/sign/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 hdk = { path = "../../../../hdk" }
-serde = "1.0"
+serde = { workspace = true }
 
 [dev-dependencies]
 hdk = { path = "../../../../hdk", features = ["fixturators"] }

--- a/crates/test_utils/wasm/wasm_workspace/sys_time/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/sys_time/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 hdk = { path = "../../../../hdk" }
-serde = "1.0"
+serde = { workspace = true }
 
 [dev-dependencies]
 hdk = { path = "../../../../hdk", features = ["fixturators"] }

--- a/crates/test_utils/wasm/wasm_workspace/the_incredible_halt/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/the_incredible_halt/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/update_entry/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/update_entry/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/validate/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/validate_invalid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_invalid/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/validate_link/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_link/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/validate_link_add_invalid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_link_add_invalid/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/validate_link_add_valid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_link_add_valid/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/validate_valid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_valid/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/integrity.rs"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = "1.0"
+serde = { workspace = true }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/whoami/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/whoami/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk" }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
-serde = "1.0"
+serde = { workspace = true }
 
 [features]
 default = []

--- a/crates/test_utils/wasm/wasm_workspace/x_salsa20_poly1305/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/x_salsa20_poly1305/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 hdk = { path = "../../../../hdk" }
-serde = "1.0"
+serde = { workspace = true }
 
 [features]
 default = []

--- a/crates/test_utils/wasm/wasm_workspace/zome_info/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/zome_info/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 hdk = { path = "../../../../hdk", features = ["properties"] }
-serde = "1.0"
+serde = { workspace = true }
 serde_yaml = "0.9"
 hdi = { path = "../../../../hdi" }
 


### PR DESCRIPTION
### Summary

This now also includes a serde pin and a dependencies lock update

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
