### PR TITLE
create a release from branch release-20230816.003329

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # \[Unreleased\]
 
+# 20230816.003329
+
+## [holochain\_cli-0.3.0-beta-dev.14](crates/holochain_cli/CHANGELOG.md#0.3.0-beta-dev.14)
+
+## [holochain\_cli\_sandbox-0.3.0-beta-dev.14](crates/holochain_cli_sandbox/CHANGELOG.md#0.3.0-beta-dev.14)
+
+## [holochain-0.3.0-beta-dev.14](crates/holochain/CHANGELOG.md#0.3.0-beta-dev.14)
+
+## [holochain\_conductor\_api-0.3.0-beta-dev.14](crates/holochain_conductor_api/CHANGELOG.md#0.3.0-beta-dev.14)
+
+## [holochain\_cascade-0.3.0-beta-dev.14](crates/holochain_cascade/CHANGELOG.md#0.3.0-beta-dev.14)
+
+## [holochain\_state-0.3.0-beta-dev.13](crates/holochain_state/CHANGELOG.md#0.3.0-beta-dev.13)
+
+## [holochain\_p2p-0.3.0-beta-dev.13](crates/holochain_p2p/CHANGELOG.md#0.3.0-beta-dev.13)
+
+## [kitsune\_p2p-0.3.0-beta-dev.11](crates/kitsune_p2p/CHANGELOG.md#0.3.0-beta-dev.11)
+
+## [kitsune\_p2p\_fetch-0.3.0-beta-dev.7](crates/kitsune_p2p_fetch/CHANGELOG.md#0.3.0-beta-dev.7)
+
+- Fix an issue with merging fetch contexts where merging an item with a context with an item that did not could result in the removal of the context.
+- Fix an issue where duplicate fetch sources would be permitted for a single item.
+
 # 20230809.004243
 
 ## [holochain\_cli-0.3.0-beta-dev.13](crates/holochain_cli/CHANGELOG.md#0.3.0-beta-dev.13)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.3.0-beta-dev.13"
+version = "0.3.0-beta-dev.14"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2731,7 +2731,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.3.0-beta-dev.13"
+version = "0.3.0-beta-dev.14"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2766,7 +2766,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli"
-version = "0.3.0-beta-dev.13"
+version = "0.3.0-beta-dev.14"
 dependencies = [
  "anyhow",
  "clap 4.3.11",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_sandbox"
-version = "0.3.0-beta-dev.13"
+version = "0.3.0-beta-dev.14"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -2853,7 +2853,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.3.0-beta-dev.13"
+version = "0.3.0-beta-dev.14"
 dependencies = [
  "derive_more",
  "directories",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_p2p"
-version = "0.3.0-beta-dev.12"
+version = "0.3.0-beta-dev.13"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.3.0-beta-dev.12"
+version = "0.3.0-beta-dev.13"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p"
-version = "0.3.0-beta-dev.10"
+version = "0.3.0-beta-dev.11"
 dependencies = [
  "arbitrary",
  "arrayref",
@@ -4030,7 +4030,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_fetch"
-version = "0.3.0-beta-dev.6"
+version = "0.3.0-beta-dev.7"
 dependencies = [
  "arbitrary",
  "derive_more",

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.3.0-beta-dev.14
+
 ## 0.3.0-beta-dev.13
 
 ## 0.3.0-beta-dev.12

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli"
-version = "0.3.0-beta-dev.13"
+version = "0.3.0-beta-dev.14"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
@@ -24,7 +24,7 @@ clap = { version = "4.0", features = [ "derive", "cargo" ] }
 futures = "0.3"
 lazy_static = "1.4"
 holochain_cli_bundle = { path = "../hc_bundle", version = "^0.3.0-beta-dev.12"}
-holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.3.0-beta-dev.13"}
+holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.3.0-beta-dev.14"}
 holochain_cli_run_local_services = { path = "../hc_run_local_services", version = "^0.3.0-beta-dev.6"}
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../holochain_trace" }
 tokio = { version = "1.27", features = ["full"] }

--- a/crates/hc_demo_cli/Cargo.toml
+++ b/crates/hc_demo_cli/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "4.2.2", features = [ "derive", "wrap_help" ], optional = tru
 flate2 = { version = "1.0.25", optional = true }
 hdi = { path = "../hdi", version = "^0.4.0-beta-dev.8", optional = true }
 hdk = { path = "../hdk", version = "^0.3.0-beta-dev.12", optional = true }
-holochain = { path = "../holochain", version = "^0.3.0-beta-dev.13", optional = true }
+holochain = { path = "../holochain", version = "^0.3.0-beta-dev.14", optional = true }
 holochain_types = { path = "../holochain_types", version = "^0.3.0-beta-dev.12", optional = true }
 holochain_keystore = { path = "../holochain_keystore", version = "^0.3.0-beta-dev.10", optional = true }
 rand = { version = "0.8.5", optional = true }

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.14
+
 ## 0.3.0-beta-dev.13
 
 ## 0.3.0-beta-dev.12

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_sandbox"
-version = "0.3.0-beta-dev.13"
+version = "0.3.0-beta-dev.14"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli_sandbox"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
@@ -20,10 +20,10 @@ ansi_term = "0.12"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 clap = { version = "4.0", features = [ "derive", "env" ] }
 futures = "0.3"
-holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.3.0-beta-dev.13", features = ["sqlite"] }
+holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.3.0-beta-dev.14", features = ["sqlite"] }
 holochain_types = { path = "../holochain_types", version = "^0.3.0-beta-dev.12", features = ["sqlite"] }
 holochain_websocket = { path = "../holochain_websocket", version = "^0.3.0-beta-dev.3"}
-holochain_p2p = { path = "../holochain_p2p", version = "^0.3.0-beta-dev.12", features = ["sqlite"] }
+holochain_p2p = { path = "../holochain_p2p", version = "^0.3.0-beta-dev.13", features = ["sqlite"] }
 holochain_util = { version = "^0.2.0", path = "../holochain_util", features = ["pw"] }
 nanoid = "0.3"
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../holochain_trace" }

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.3.0-beta-dev.14
+
 ## 0.3.0-beta-dev.13
 
 ## 0.3.0-beta-dev.12

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain"
-version = "0.3.0-beta-dev.13"
+version = "0.3.0-beta-dev.14"
 description = "Holochain, a framework for distributed applications"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -25,20 +25,20 @@ getrandom = "0.2.7"
 get_if_addrs = "0.5.3"
 ghost_actor = "0.3.0-alpha.6"
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = ["full"] }
-holochain_cascade = { version = "^0.3.0-beta-dev.13", path = "../holochain_cascade" }
-holochain_conductor_api = { version = "^0.3.0-beta-dev.13", path = "../holochain_conductor_api" }
+holochain_cascade = { version = "^0.3.0-beta-dev.14", path = "../holochain_cascade" }
+holochain_conductor_api = { version = "^0.3.0-beta-dev.14", path = "../holochain_conductor_api" }
 holochain_keystore = { version = "^0.3.0-beta-dev.10", path = "../holochain_keystore", default-features = false }
-holochain_p2p = { version = "^0.3.0-beta-dev.12", path = "../holochain_p2p" }
+holochain_p2p = { version = "^0.3.0-beta-dev.13", path = "../holochain_p2p" }
 holochain_sqlite = { version = "^0.3.0-beta-dev.12", path = "../holochain_sqlite" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_state = { version = "^0.3.0-beta-dev.12", path = "../holochain_state" }
+holochain_state = { version = "^0.3.0-beta-dev.13", path = "../holochain_state" }
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_util = { version = "^0.2.0", path = "../holochain_util", features = [ "pw" ] }
 holochain_wasmer_host = "=0.0.84"
 holochain_websocket = { version = "^0.3.0-beta-dev.3", path = "../holochain_websocket" }
 holochain_zome_types = { version = "^0.3.0-beta-dev.9", path = "../holochain_zome_types", features = ["full"] }
 human-panic = "1.0.3"
-kitsune_p2p = { version = "^0.3.0-beta-dev.10", path = "../kitsune_p2p/kitsune_p2p", default-features = false }
+kitsune_p2p = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/kitsune_p2p", default-features = false }
 kitsune_p2p_types = { version = "^0.3.0-beta-dev.6", path = "../kitsune_p2p/types" }
 kitsune_p2p_block = { version = "^0.3.0-beta-dev.5", path = "../kitsune_p2p/block" }
 lazy_static = "1.4.0"

--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.14
+
 ## 0.3.0-beta-dev.13
 
 ## 0.3.0-beta-dev.12

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cascade"
-version = "0.3.0-beta-dev.13"
+version = "0.3.0-beta-dev.14"
 description = "Logic for cascading updates to Holochain state and network interaction"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -19,13 +19,13 @@ hdk = { version = "^0.3.0-beta-dev.12", path = "../hdk" }
 hdk_derive = { version = "^0.3.0-beta-dev.8", path = "../hdk_derive" }
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = ["full"] }
 holochain_sqlite = { version = "^0.3.0-beta-dev.12", path = "../holochain_sqlite" }
-holochain_p2p = { version = "^0.3.0-beta-dev.12", path = "../holochain_p2p" }
+holochain_p2p = { version = "^0.3.0-beta-dev.13", path = "../holochain_p2p" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_state = { version = "^0.3.0-beta-dev.12", path = "../holochain_state" }
+holochain_state = { version = "^0.3.0-beta-dev.13", path = "../holochain_state" }
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../holochain_trace" }
 holochain_zome_types = { version = "^0.3.0-beta-dev.9", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "^0.3.0-beta-dev.10", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/kitsune_p2p" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 tokio = { version = "1.27", features = ["full"] }

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.14
+
 ## 0.3.0-beta-dev.13
 
 ## 0.3.0-beta-dev.12

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_conductor_api"
-version = "0.3.0-beta-dev.13"
+version = "0.3.0-beta-dev.14"
 description = "Message types for Holochain admin and app interface protocols"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -11,10 +11,10 @@ edition = "2021"
 [dependencies]
 directories = "2.0.2"
 derive_more = "0.99.3"
-kitsune_p2p = { version = "^0.3.0-beta-dev.10", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/kitsune_p2p" }
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = ["full"] }
-holochain_p2p = { version = "^0.3.0-beta-dev.12", path = "../holochain_p2p" }
-holochain_state = { version = "^0.3.0-beta-dev.12", path = "../holochain_state" }
+holochain_p2p = { version = "^0.3.0-beta-dev.13", path = "../holochain_p2p" }
+holochain_state = { version = "^0.3.0-beta-dev.13", path = "../holochain_state" }
 holochain_serialized_bytes = "=0.0.51"
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.3.0-beta-dev.9", path = "../holochain_zome_types" }

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.13
+
 ## 0.3.0-beta-dev.12
 
 ## 0.3.0-beta-dev.11

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_p2p"
-version = "0.3.0-beta-dev.12"
+version = "0.3.0-beta-dev.13"
 description = "holochain specific wrapper around more generic p2p module"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -21,7 +21,7 @@ holochain_keystore = { version = "^0.3.0-beta-dev.10", path = "../holochain_keys
 holochain_serialized_bytes = "=0.0.51"
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.3.0-beta-dev.9", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "^0.3.0-beta-dev.10", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/kitsune_p2p" }
 kitsune_p2p_types = { version = "^0.3.0-beta-dev.6", path = "../kitsune_p2p/types" }
 mockall = "0.11.3"
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../holochain_trace" }

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.13
+
 ## 0.3.0-beta-dev.12
 
 ## 0.3.0-beta-dev.11

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_state"
-version = "0.3.0-beta-dev.12"
+version = "0.3.0-beta-dev.13"
 description = "TODO minimize deps"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -20,13 +20,13 @@ fallible-iterator = "0.2.0"
 futures = "0.3"
 holochain_keystore = { version = "^0.3.0-beta-dev.10", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_p2p = { version = "^0.3.0-beta-dev.12", path = "../holochain_p2p" }
+holochain_p2p = { version = "^0.3.0-beta-dev.13", path = "../holochain_p2p" }
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_util = { version = "^0.2.0", path = "../holochain_util" }
 holochain_zome_types = { version = "^0.3.0-beta-dev.9", path = "../holochain_zome_types", features = [
     "full",
 ] }
-kitsune_p2p = { version = "^0.3.0-beta-dev.10", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/kitsune_p2p" }
 mockall = "0.11.3"
 one_err = "0.0.8"
 parking_lot = "0.10"

--- a/crates/kitsune_p2p/fetch/CHANGELOG.md
+++ b/crates/kitsune_p2p/fetch/CHANGELOG.md
@@ -7,8 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
-- Fix an issue with merging fetch contexts where merging an item with a context with an item that did not could result
-  in the removal of the context.
+## 0.3.0-beta-dev.7
+
+- Fix an issue with merging fetch contexts where merging an item with a context with an item that did not could result in the removal of the context.
 - Fix an issue where duplicate fetch sources would be permitted for a single item.
 
 ## 0.3.0-beta-dev.6

--- a/crates/kitsune_p2p/fetch/Cargo.toml
+++ b/crates/kitsune_p2p/fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_fetch"
-version = "0.3.0-beta-dev.6"
+version = "0.3.0-beta-dev.7"
 description = "Kitsune P2p Fetch Queue Logic"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.11
+
 ## 0.3.0-beta-dev.10
 
 ## 0.3.0-beta-dev.9

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p"
-version = "0.3.0-beta-dev.10"
+version = "0.3.0-beta-dev.11"
 description = "p2p / dht communication framework"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -20,7 +20,7 @@ futures = "0.3"
 ghost_actor = "=0.3.0-alpha.6"
 governor = "0.3.2"
 itertools = "0.10"
-kitsune_p2p_fetch = { version = "^0.3.0-beta-dev.6", path = "../fetch" }
+kitsune_p2p_fetch = { version = "^0.3.0-beta-dev.7", path = "../fetch" }
 kitsune_p2p_mdns = { version = "^0.2.0", path = "../mdns" }
 kitsune_p2p_proxy = { version = "^0.3.0-beta-dev.6", path = "../proxy" }
 kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.0", path = "../timestamp", features = ["now"] }


### PR DESCRIPTION
note that this release failed midway

```
[DEBUG release_automation::release] Running command: "cargo" "publish" "--locked" "--verbose" "--no-verify" "--registry" "crates-io" "--manifest-path=/var/tmp/holochain_repo/crates/kitsune_p2p/fetch/Cargo.toml"
[DEBUG release_automation::release] Found recently published kitsune_p2p_fetch-0.3.0-beta-dev.7 on crates.io!
[INFO  release_automation::release] successfully published kitsune_p2p_fetch-0.3.0-beta-dev.7
[DEBUG release_automation::release] Running command: "cargo" "publish" "--locked" "--verbose" "--no-verify" "--registry" "crates-io" "--manifest-path=/var/tmp/holochain_repo/crates/kitsune_p2p/kitsune_p2p/Cargo.toml"
[DEBUG release_automation::release] Found recently published kitsune_p2p-0.3.0-beta-dev.11 on crates.io!
[INFO  release_automation::release] successfully published kitsune_p2p-0.3.0-beta-dev.11
[DEBUG release_automation::release] Running command: "cargo" "publish" "--locked" "--verbose" "--no-verify" "--registry" "crates-io" "--manifest-path=/var/tmp/holochain_repo/crates/holochain_p2p/Cargo.toml"
[DEBUG release_automation::release] Found recently published holochain_p2p-0.3.0-beta-dev.13 on crates.io!
[INFO  release_automation::release] successfully published holochain_p2p-0.3.0-beta-dev.13
[DEBUG release_automation::release] Running command: "cargo" "publish" "--locked" "--verbose" "--no-verify" "--registry" "crates-io" "--manifest-path=/var/tmp/holochain_repo/crates/holochain_state/Cargo.toml"
[DEBUG release_automation::release] Found recently published holochain_state-0.3.0-beta-dev.13 on crates.io!
[INFO  release_automation::release] successfully published holochain_state-0.3.0-beta-dev.13
[DEBUG release_automation::release] Running command: "cargo" "publish" "--locked" "--verbose" "--no-verify" "--registry" "crates-io" "--manifest-path=/var/tmp/holochain_repo/crates/holochain_cascade/Cargo.toml"
[DEBUG release_automation::release] Found recently published holochain_cascade-0.3.0-beta-dev.14 on crates.io!
[INFO  release_automation::release] successfully published holochain_cascade-0.3.0-beta-dev.14
[DEBUG release_automation::release] Running command: "cargo" "publish" "--locked" "--verbose" "--no-verify" "--registry" "crates-io" "--manifest-path=/var/tmp/holochain_repo/crates/holochain_conductor_api/Cargo.toml"
[DEBUG release_automation::release] Found recently published holochain_conductor_api-0.3.0-beta-dev.14 on crates.io!
[INFO  release_automation::release] successfully published holochain_conductor_api-0.3.0-beta-dev.14
[DEBUG release_automation::release] Running command: "cargo" "publish" "--locked" "--verbose" "--no-verify" "--registry" "crates-io" "--manifest-path=/var/tmp/holochain_repo/crates/holochain/Cargo.toml"
[WARN  release_automation::release] package mismatch. got 'kitsune_p2p' expected 'holochain'
[WARN  release_automation::release] version mismatch. got '0.3.0-beta-dev.11' expected '0.3.0-beta-dev.14'
[ERROR release_automation::release] holochain@: 'tx5' dependency by kitsune_p2p not found at registry `crates-io`
[DEBUG release_automation::release] Running command: "cargo" "publish" "--locked" "--verbose" "--no-verify" "--registry" "crates-io" "--manifest-path=/var/tmp/holochain_repo/crates/hc_sandbox/Cargo.toml"
[WARN  release_automation::release] package mismatch. got 'kitsune_p2p' expected 'holochain_cli_sandbox'
[WARN  release_automation::release] version mismatch. got '0.3.0-beta-dev.11' expected '0.3.0-beta-dev.14'
[ERROR release_automation::release] holochain_cli_sandbox@: 'tx5' dependency by kitsune_p2p not found at registry `crates-io`
[DEBUG release_automation::release] Running command: "cargo" "publish" "--locked" "--verbose" "--no-verify" "--registry" "crates-io" "--manifest-path=/var/tmp/holochain_repo/crates/hc/Cargo.toml"
[ERROR release_automation::release] holochain_cli@: 'holochain_cli_sandbox = "^0.3.0-beta-dev.14"' dependency by holochain_cli-0.3.0-beta-dev.14 not found at crates.io index
[INFO  release_automation::release] crates processed: 9, consistent: 0, published: 6, skipped: 0, tolerated: 0
Error: holochain@: 'tx5' dependency by kitsune_p2p not found at registry `crates-io`
```

---

the following crates are part of this release:

- kitsune_p2p_fetch-0.3.0-beta-dev.7
- kitsune_p2p-0.3.0-beta-dev.11
- holochain_p2p-0.3.0-beta-dev.13
- holochain_state-0.3.0-beta-dev.13
- holochain_cascade-0.3.0-beta-dev.14
- holochain_conductor_api-0.3.0-beta-dev.14
- holochain-0.3.0-beta-dev.14
- holochain_cli_sandbox-0.3.0-beta-dev.14
- holochain_cli-0.3.0-beta-dev.14

### Summary



### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
- [ ] once the PR is ready merge it manually by pushing the merged branch from a local repo
