### PR TITLE
Add proptest::Arbitrary impls in many places, to complement arbitrary::Arbitrary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,6 +3003,7 @@ dependencies = [
 [[package]]
 name = "holochain_serialized_bytes"
 version = "0.0.52"
+source = "git+https://github.com/holochain/holochain-serialization.git?branch=proptest#b1ab125e6310ecc53712c118bef0d582fd858a9b"
 dependencies = [
  "arbitrary",
  "holochain_serialized_bytes_derive",
@@ -3019,6 +3020,7 @@ dependencies = [
 [[package]]
 name = "holochain_serialized_bytes_derive"
 version = "0.0.52"
+source = "git+https://github.com/holochain/holochain-serialization.git?branch=proptest#b1ab125e6310ecc53712c118bef0d582fd858a9b"
 dependencies = [
  "quote 1.0.33",
  "syn 1.0.109",
@@ -3242,6 +3244,7 @@ dependencies = [
 [[package]]
 name = "holochain_wasmer_common"
 version = "0.0.84"
+source = "git+https://github.com/holochain/holochain-wasmer.git?branch=bump-hsb#1f87aadaa4335d1f09eb9aaa07f1cc801692bf1e"
 dependencies = [
  "holochain_serialized_bytes",
  "serde",
@@ -3255,6 +3258,7 @@ dependencies = [
 [[package]]
 name = "holochain_wasmer_guest"
 version = "0.0.84"
+source = "git+https://github.com/holochain/holochain-wasmer.git?branch=bump-hsb#1f87aadaa4335d1f09eb9aaa07f1cc801692bf1e"
 dependencies = [
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
@@ -3267,6 +3271,7 @@ dependencies = [
 [[package]]
 name = "holochain_wasmer_host"
 version = "0.0.84"
+source = "git+https://github.com/holochain/holochain-wasmer.git?branch=bump-hsb#1f87aadaa4335d1f09eb9aaa07f1cc801692bf1e"
 dependencies = [
  "bimap",
  "holochain_serialized_bytes",
@@ -5663,6 +5668,7 @@ dependencies = [
 [[package]]
 name = "proptest"
 version = "1.2.0"
+source = "git+https://github.com/maackle/proptest?branch=arbitrary-pathbuf#0736d405d7545d585141e439ee7cae8271533741"
 dependencies = [
  "bit-set",
  "bitflags 2.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
@@ -91,9 +91,9 @@ checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56fc6cf8dc8c4158eed8649f9b8b0ea1518eb62b544fe9490d66fa0b349eafe9"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "android-tzdata"
@@ -169,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
 dependencies = [
  "anstyle",
  "windows-sys 0.48.0",
@@ -179,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "approx"
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d6b683edf8d1119fe420a94f8a7e389239666aa72e65495d91c00462510151"
+checksum = "88903cb14723e4d4003335bb7f8a14f27691649105346a0f0957466c096adfe6"
 dependencies = [
  "anstyle",
  "bstr 1.6.0",
@@ -254,7 +254,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
 dependencies = [
- "quote 1.0.29",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -278,7 +278,7 @@ dependencies = [
  "async-lock",
  "async-task",
  "concurrent-queue",
- "fastrand",
+ "fastrand 1.9.0",
  "futures-lite",
  "slab",
 ]
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
 dependencies = [
  "event-listener",
 ]
@@ -341,7 +341,7 @@ dependencies = [
  "event-listener",
  "futures-lite",
  "rustix 0.37.23",
- "signal-hook 0.3.15",
+ "signal-hook 0.3.17",
  "windows-sys 0.48.0",
 ]
 
@@ -351,8 +351,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -400,8 +400,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -413,13 +413,13 @@ checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
-version = "0.1.71"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -501,9 +501,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "basic-toml"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f838d03a705d72b12389b8930bd14cacf493be1380bfb15720d4d12db5ab03ac"
+checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
 dependencies = [
  "serde",
 ]
@@ -549,9 +549,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bitvec"
@@ -615,7 +615,7 @@ dependencies = [
  "async-lock",
  "async-task",
  "atomic-waker",
- "fastrand",
+ "fastrand 1.9.0",
  "futures-lite",
  "log",
 ]
@@ -649,7 +649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
 dependencies = [
  "memchr",
- "regex-automata 0.3.2",
+ "regex-automata 0.3.6",
  "serde",
 ]
 
@@ -676,8 +676,8 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -734,18 +734,18 @@ checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "camino"
-version = "1.1.4"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
 dependencies = [
  "serde",
 ]
@@ -758,7 +758,7 @@ checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.17",
+ "semver 1.0.18",
  "serde",
  "serde_json",
  "thiserror",
@@ -778,11 +778,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -867,20 +868,20 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.11"
+version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
+checksum = "03aef18ddf7d879c15ce20f04826ef8418101c7e528014c3eeea13321047dca3"
 dependencies = [
  "clap_builder",
- "clap_derive 4.3.2",
+ "clap_derive 4.3.12",
  "once_cell",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.11"
+version = "4.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
+checksum = "f8ce6fffb678c9b80a70b6b6de0aad31df727623a70fd9a842c30cd573e2fa98"
 dependencies = [
  "anstream",
  "anstyle",
@@ -898,21 +899,21 @@ checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -957,11 +958,11 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
+checksum = "5a5f741c91823341bebf717d4c71bda820630ce065443b58bd1b7451af008355"
 dependencies = [
- "atty",
+ "is-terminal",
  "lazy_static",
  "winapi 0.3.9",
 ]
@@ -1254,23 +1255,23 @@ dependencies = [
  "libc",
  "mio 0.8.8",
  "parking_lot 0.12.1",
- "signal-hook 0.3.15",
+ "signal-hook 0.3.17",
  "signal-hook-mio",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "crossterm"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "crossterm_winapi 0.9.1",
  "libc",
  "mio 0.8.8",
  "parking_lot 0.12.1",
- "signal-hook 0.3.15",
+ "signal-hook 0.3.17",
  "signal-hook-mio",
  "winapi 0.3.9",
 ]
@@ -1336,7 +1337,7 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
- "quote 1.0.29",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1355,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.100"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e928d50d5858b744d1ea920b790641129c347a770d1530c3a85b77705a5ee031"
+checksum = "28403c86fc49e3401fdf45499ba37fad6493d9329449d6449d7f0e10f4654d28"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -1367,34 +1368,34 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.100"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8332ba63f8a8040ca479de693150129067304a3496674477fff6d0c372cc34ae"
+checksum = "78da94fef01786dc3e0c76eafcd187abcaa9972c78e05ff4041e24fdf059c285"
 dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "scratch",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.100"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5966a5a87b6e9bb342f5fab7170a93c77096efe199872afffc4b477cfeb86957"
+checksum = "e2a6f5e1dfb4b34292ad4ea1facbfdaa1824705b231610087b00b17008641809"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.100"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b2dab6991c7ab1572fea8cb049db819b1aeea1e2dac74c0869f244d9f21a7c"
+checksum = "50c49547d73ba8dcfd4ad7325d64c6d5391ff4224d498fc39a6f3f49825a530d"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1429,12 +1430,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
 dependencies = [
- "darling_core 0.20.1",
- "darling_macro 0.20.1",
+ "darling_core 0.20.3",
+ "darling_macro 0.20.3",
 ]
 
 [[package]]
@@ -1445,8 +1446,8 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "strsim 0.9.3",
  "syn 1.0.109",
 ]
@@ -1459,8 +1460,8 @@ checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -1473,23 +1474,23 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1499,7 +1500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
- "quote 1.0.29",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1510,7 +1511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
- "quote 1.0.29",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1521,19 +1522,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core 0.14.4",
- "quote 1.0.29",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
- "darling_core 0.20.1",
- "quote 1.0.29",
- "syn 2.0.25",
+ "darling_core 0.20.3",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1571,8 +1572,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1582,9 +1583,9 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1595,8 +1596,8 @@ checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
  "darling 0.10.2",
  "derive_builder_core",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1607,8 +1608,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling 0.10.2",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1619,8 +1620,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -1631,7 +1632,7 @@ version = "0.1.0"
 dependencies = [
  "chashmap",
  "colored 2.0.4",
- "crossterm 0.26.1",
+ "crossterm 0.27.0",
  "futures",
  "holochain_diagnostics",
  "holochain_trace",
@@ -1793,9 +1794,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "encoding_rs"
@@ -1821,8 +1822,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -1841,10 +1842,10 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
- "darling 0.20.1",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "darling 0.20.3",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1869,8 +1870,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "rustversion",
  "syn 1.0.109",
  "synstructure",
@@ -1878,9 +1879,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1899,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "escargot"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5584ba17d7ab26a8a7284f13e5bd196294dd2f2d79773cff29b9e9edef601a6"
+checksum = "768064bd3a0e2bedcba91dc87ace90beea91acc41b6a01a3ca8e9aa8827461bf"
 dependencies = [
  "log",
  "once_cell",
@@ -1947,14 +1948,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.21"
+name = "fastrand"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "filetime"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall 0.2.16",
+ "redox_syscall 0.3.5",
  "windows-sys 0.48.0",
 ]
 
@@ -1968,7 +1975,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 name = "fixt"
 version = "0.2.0"
 dependencies = [
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "lazy_static",
  "parking_lot 0.10.2",
  "paste",
@@ -1989,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2127,7 +2134,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
- "fastrand",
+ "fastrand 1.9.0",
  "futures-core",
  "futures-io",
  "memchr",
@@ -2142,9 +2149,9 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -2442,7 +2449,7 @@ dependencies = [
 name = "hc_demo_cli"
 version = "0.2.0-beta-rc.0"
 dependencies = [
- "clap 4.3.11",
+ "clap 4.3.23",
  "flate2",
  "hdi",
  "hdk",
@@ -2467,7 +2474,7 @@ checksum = "ded13e388a81713db6919cd750e6113acf2fe5afbaedf8aff79780ec4fc47425"
 dependencies = [
  "futures",
  "one_err",
- "rmp-serde 1.1.1",
+ "rmp-serde 1.1.2",
  "rmpv",
  "serde",
  "serde_bytes",
@@ -2524,8 +2531,8 @@ dependencies = [
  "holochain_integrity_types",
  "paste",
  "proc-macro-error",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -2615,10 +2622,12 @@ dependencies = [
  "derive_more",
  "fixt",
  "futures",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_wasmer_common",
  "kitsune_p2p_dht_arc",
  "must_future",
+ "proptest",
+ "proptest-derive",
  "rand 0.8.5",
  "rusqlite",
  "serde",
@@ -2663,7 +2672,7 @@ dependencies = [
  "holochain_keystore",
  "holochain_metrics",
  "holochain_p2p",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_sqlite",
  "holochain_state",
  "holochain_test_wasm_common",
@@ -2750,7 +2759,7 @@ dependencies = [
  "hdk_derive",
  "holo_hash",
  "holochain_p2p",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_sqlite",
  "holochain_state",
  "holochain_trace",
@@ -2775,7 +2784,7 @@ name = "holochain_cli"
 version = "0.3.0-beta-dev.14"
 dependencies = [
  "anyhow",
- "clap 4.3.11",
+ "clap 4.3.23",
  "futures",
  "holochain_cli_bundle",
  "holochain_cli_run_local_services",
@@ -2791,9 +2800,9 @@ version = "0.3.0-beta-dev.12"
 dependencies = [
  "anyhow",
  "assert_cmd 1.0.8",
- "clap 4.3.11",
+ "clap 4.3.23",
  "futures",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_types",
  "holochain_util",
  "holochain_wasmer_host",
@@ -2816,7 +2825,7 @@ dependencies = [
 name = "holochain_cli_run_local_services"
 version = "0.3.0-beta-dev.6"
 dependencies = [
- "clap 4.3.11",
+ "clap 4.3.23",
  "futures",
  "holochain_trace",
  "if-addrs 0.10.1",
@@ -2834,7 +2843,7 @@ dependencies = [
  "anyhow",
  "assert_cmd 1.0.8",
  "chrono",
- "clap 4.3.11",
+ "clap 4.3.23",
  "escargot",
  "futures",
  "holochain_conductor_api",
@@ -2866,7 +2875,7 @@ dependencies = [
  "holo_hash",
  "holochain_keystore",
  "holochain_p2p",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_state",
  "holochain_trace",
  "holochain_types",
@@ -2888,7 +2897,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "arbitrary",
- "crossterm 0.26.1",
+ "crossterm 0.27.0",
  "holochain",
  "human-repr",
  "rand 0.8.5",
@@ -2906,10 +2915,12 @@ dependencies = [
  "derive_builder",
  "holo_hash",
  "holochain_integrity_types",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "kitsune_p2p_dht",
  "kitsune_p2p_timestamp",
  "paste",
+ "proptest",
+ "proptest-derive",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -2922,11 +2933,11 @@ dependencies = [
 name = "holochain_keystore"
 version = "0.3.0-beta-dev.10"
 dependencies = [
- "assert_cmd 2.0.11",
+ "assert_cmd 2.0.12",
  "base64 0.13.1",
  "futures",
  "holo_hash",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_zome_types",
  "kitsune_p2p_types",
  "lair_keystore",
@@ -2972,7 +2983,7 @@ dependencies = [
  "ghost_actor 0.3.0-alpha.6",
  "holo_hash",
  "holochain_keystore",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_trace",
  "holochain_types",
  "holochain_util",
@@ -2991,27 +3002,12 @@ dependencies = [
 
 [[package]]
 name = "holochain_serialized_bytes"
-version = "0.0.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9805b3e01e7b5c144782a0823db4dc895fec18a9ccd45a492ce7c7bf157a9e38"
+version = "0.0.52"
 dependencies = [
  "arbitrary",
- "holochain_serialized_bytes_derive 0.0.51",
- "rmp-serde 0.15.5",
- "serde",
- "serde-transcode",
- "serde_bytes",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "holochain_serialized_bytes"
-version = "0.0.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bac6151d65c9a6f26f1b1068046a98900214030924377a2142f60c279b091f51"
-dependencies = [
- "holochain_serialized_bytes_derive 0.0.52",
+ "holochain_serialized_bytes_derive",
+ "proptest",
+ "proptest-derive",
  "rmp-serde 0.15.5",
  "serde",
  "serde-transcode",
@@ -3022,21 +3018,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_serialized_bytes_derive"
-version = "0.0.51"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1077232d0c427d64feb9e138fa22800e447eafb1810682d6c13beb95333cb32c"
-dependencies = [
- "quote 1.0.29",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "holochain_serialized_bytes_derive"
 version = "0.0.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cec0d0c2317fcb87772d0a8b5b5e88c7276aef93bf3496931e89cb9231c129"
 dependencies = [
- "quote 1.0.29",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -3052,7 +3036,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.10",
  "holo_hash",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_sqlite",
  "holochain_trace",
  "holochain_util",
@@ -3108,7 +3092,7 @@ dependencies = [
  "holo_hash",
  "holochain_keystore",
  "holochain_p2p",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_sqlite",
  "holochain_trace",
  "holochain_types",
@@ -3147,7 +3131,7 @@ version = "0.3.0-beta-dev.1"
 dependencies = [
  "chrono",
  "derive_more",
- "holochain_serialized_bytes 0.0.52",
+ "holochain_serialized_bytes",
  "inferno",
  "once_cell",
  "serde",
@@ -3185,7 +3169,7 @@ dependencies = [
  "getrandom 0.2.10",
  "holo_hash",
  "holochain_keystore",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_sqlite",
  "holochain_trace",
  "holochain_types",
@@ -3205,6 +3189,8 @@ dependencies = [
  "one_err",
  "parking_lot 0.10.2",
  "pretty_assertions 0.7.2",
+ "proptest",
+ "proptest-derive",
  "rand 0.8.5",
  "regex",
  "rusqlite",
@@ -3256,10 +3242,8 @@ dependencies = [
 [[package]]
 name = "holochain_wasmer_common"
 version = "0.0.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223daec7ca62d4e36841a99d8799b29cc616f5976ad0e2975e6ca6810de8f14f"
 dependencies = [
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "serde",
  "serde_bytes",
  "test-fuzz",
@@ -3271,10 +3255,8 @@ dependencies = [
 [[package]]
 name = "holochain_wasmer_guest"
 version = "0.0.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b2026e44595cb16108464973622577936605582aa22932933a5130ad32ce42"
 dependencies = [
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_wasmer_common",
  "parking_lot 0.12.1",
  "paste",
@@ -3285,11 +3267,9 @@ dependencies = [
 [[package]]
 name = "holochain_wasmer_host"
 version = "0.0.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65912ef579fa53ca4ad7713f13379fae53a0d79ef2d91b87670201044eae0d5e"
 dependencies = [
  "bimap",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_wasmer_common",
  "once_cell",
  "parking_lot 0.12.1",
@@ -3306,7 +3286,7 @@ dependencies = [
  "criterion",
  "futures",
  "ghost_actor 0.4.0-alpha.5",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_trace",
  "holochain_types",
  "linefeed",
@@ -3337,8 +3317,9 @@ dependencies = [
  "fixt",
  "holo_hash",
  "holochain_integrity_types",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_wasmer_common",
+ "holochain_zome_types",
  "kitsune_p2p_bin_data",
  "kitsune_p2p_block",
  "kitsune_p2p_dht",
@@ -3349,6 +3330,7 @@ dependencies = [
  "once_cell",
  "paste",
  "proptest",
+ "proptest-derive",
  "rand 0.8.5",
  "rusqlite",
  "serde",
@@ -3412,9 +3394,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "human-panic"
@@ -3429,7 +3411,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "toml 0.7.6",
- "uuid 1.4.0",
+ "uuid 1.4.1",
 ]
 
 [[package]]
@@ -3471,7 +3453,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -3604,17 +3586,17 @@ checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "inferno"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb7c1b80a1dfa604bb4a649a5c5aeef3d913f7c520cb42b40e534e8a61bcdfc"
+checksum = "73c0fefcb6d409a6587c07515951495d482006f89a21daa0f2f783aa4fd5e027"
 dependencies = [
  "ahash 0.8.3",
- "clap 4.3.11",
+ "clap 4.3.23",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap 5.5.0",
  "env_logger",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "is-terminal",
  "itoa",
  "log",
@@ -3792,7 +3774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.4",
+ "rustix 0.38.8",
  "windows-sys 0.48.0",
 ]
 
@@ -3835,9 +3817,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "jobserver"
@@ -3867,7 +3849,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.2",
  "bytecount",
- "clap 4.3.11",
+ "clap 4.3.23",
  "fancy-regex",
  "fraction",
  "getrandom 0.2.10",
@@ -3884,7 +3866,7 @@ dependencies = [
  "serde_json",
  "time 0.3.23",
  "url 2.4.0",
- "uuid 1.4.0",
+ "uuid 1.4.1",
 ]
 
 [[package]]
@@ -3923,6 +3905,8 @@ dependencies = [
  "once_cell",
  "parking_lot 0.11.2",
  "pretty_assertions 0.7.2",
+ "proptest",
+ "proptest-derive",
  "rand 0.7.3",
  "rand 0.8.5",
  "reqwest",
@@ -3950,6 +3934,8 @@ dependencies = [
  "base64 0.13.1",
  "derive_more",
  "kitsune_p2p_dht_arc",
+ "proptest",
+ "proptest-derive",
  "serde",
  "serde_bytes",
  "shrinkwraprs",
@@ -3991,12 +3977,13 @@ dependencies = [
 name = "kitsune_p2p_dht"
 version = "0.3.0-beta-dev.4"
 dependencies = [
- "colored 1.9.3",
+ "arbitrary",
+ "colored 1.9.4",
  "derivative",
  "derive_more",
  "futures",
  "gcollections",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_trace",
  "intervallum",
  "kitsune_p2p_dht",
@@ -4008,6 +3995,7 @@ dependencies = [
  "once_cell",
  "pretty_assertions 0.7.2",
  "proptest",
+ "proptest-derive",
  "rand 0.8.5",
  "serde",
  "statrs",
@@ -4020,13 +4008,17 @@ dependencies = [
 name = "kitsune_p2p_dht_arc"
 version = "0.3.0-beta-dev.3"
 dependencies = [
+ "arbitrary",
  "derive_more",
  "gcollections",
  "holochain_trace",
  "intervallum",
+ "kitsune_p2p_timestamp",
  "maplit",
  "num-traits",
  "pretty_assertions 0.7.2",
+ "proptest",
+ "proptest-derive",
  "rand 0.8.5",
  "rusqlite",
  "serde",
@@ -4041,7 +4033,7 @@ dependencies = [
  "arbitrary",
  "derive_more",
  "futures",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
  "holochain_trace",
  "human-repr",
  "kitsune_p2p_fetch",
@@ -4051,6 +4043,8 @@ dependencies = [
  "must_future",
  "num-traits",
  "pretty_assertions 0.7.2",
+ "proptest",
+ "proptest-derive",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
@@ -4106,7 +4100,9 @@ dependencies = [
  "arbitrary",
  "chrono",
  "derive_more",
- "holochain_serialized_bytes 0.0.51",
+ "holochain_serialized_bytes",
+ "proptest",
+ "proptest-derive",
  "rusqlite",
  "serde",
  "serde_yaml",
@@ -4154,6 +4150,8 @@ dependencies = [
  "once_cell",
  "parking_lot 0.11.2",
  "paste",
+ "proptest",
+ "proptest-derive",
  "rmp-serde 0.15.5",
  "rustls 0.20.8",
  "serde",
@@ -4311,9 +4309,9 @@ dependencies = [
 
 [[package]]
 name = "libsodium-sys-stable"
-version = "1.19.29"
+version = "1.19.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cce7cd8e1c5101c39f30e791fa8f2e5713a2a49947440106a2467175895035"
+checksum = "2cf9c3bd17952580efd8f57e3d01d724cfb18d51fbd9dc00a65e5911f71521ba"
 dependencies = [
  "cc",
  "libc",
@@ -4372,9 +4370,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -4397,9 +4395,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 dependencies = [
  "value-bag",
 ]
@@ -4437,7 +4435,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
 dependencies = [
- "quote 1.0.29",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -4653,8 +4651,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if 1.0.0",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -4670,7 +4668,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c624fa1b7aab6bd2aff6e9b18565cc0363b6d45cbcd7465c9ed5e3740ebf097"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "libc",
  "nix 0.26.2",
  "smallstr",
@@ -4694,6 +4692,8 @@ dependencies = [
  "holochain_util",
  "maplit",
  "matches",
+ "proptest",
+ "proptest-derive",
  "reqwest",
  "rmp-serde 0.15.5",
  "serde",
@@ -4766,8 +4766,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -4913,9 +4913,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
  "num-bigint",
  "num-complex",
@@ -4944,9 +4944,9 @@ checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "num-traits",
 ]
@@ -4996,9 +4996,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg 1.1.0",
  "libm",
@@ -5030,8 +5030,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro-crate",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -5088,9 +5088,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.55"
+version = "0.10.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
@@ -5107,9 +5107,9 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -5120,18 +5120,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.26.0+1.1.1u"
+version = "111.27.0+1.1.1v"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.90"
+version = "0.9.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
 dependencies = [
  "cc",
  "libc",
@@ -5181,8 +5181,8 @@ checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -5305,7 +5305,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec 1.11.0",
- "windows-targets 0.48.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -5321,9 +5321,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pbkdf2"
@@ -5360,9 +5360,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
+checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -5418,29 +5418,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.10"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pin-utils"
@@ -5610,8 +5610,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
  "version_check",
 ]
@@ -5622,8 +5622,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "version_check",
 ]
 
@@ -5638,9 +5638,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -5663,18 +5663,16 @@ dependencies = [
 [[package]]
 name = "proptest"
 version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
+ "bitflags 2.4.0",
  "byteorder",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift 0.3.0",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.4",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -5712,8 +5710,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -5806,11 +5804,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.64",
+ "proc-macro2 1.0.66",
 ]
 
 [[package]]
@@ -6179,13 +6177,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.2",
+ "regex-automata 0.3.6",
  "regex-syntax 0.7.4",
 ]
 
@@ -6200,9 +6198,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6276,7 +6274,7 @@ dependencies = [
  "once_cell",
  "percent-encoding 2.3.0",
  "pin-project-lite",
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "rustls-pemfile 1.0.3",
  "serde",
  "serde_json",
@@ -6333,7 +6331,7 @@ dependencies = [
  "rkyv_derive",
  "seahash",
  "tinyvec",
- "uuid 1.4.0",
+ "uuid 1.4.1",
 ]
 
 [[package]]
@@ -6342,8 +6340,8 @@ version = "0.7.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -6355,9 +6353,9 @@ checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
 name = "rmp"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
+checksum = "7f9860a6cc38ed1da53456442089b4dfa35e7cedaa326df63017af88385e6b20"
 dependencies = [
  "byteorder",
  "num-traits",
@@ -6377,9 +6375,9 @@ dependencies = [
 
 [[package]]
 name = "rmp-serde"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
+checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
 dependencies = [
  "byteorder",
  "rmp",
@@ -6435,7 +6433,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -6473,7 +6471,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.17",
+ "semver 1.0.18",
 ]
 
 [[package]]
@@ -6492,14 +6490,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys 0.4.5",
  "windows-sys 0.48.0",
 ]
 
@@ -6517,13 +6515,13 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.1",
+ "rustls-webpki 0.101.3",
  "sct",
 ]
 
@@ -6569,9 +6567,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.1"
+version = "0.101.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+checksum = "261e9e0888cba427c3316e6322805653c9425240b6fd96cee7cb671ab70ab8d0"
 dependencies = [
  "ring",
  "untrusted",
@@ -6579,9 +6577,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "rusty-fork"
@@ -6597,9 +6595,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "same-file"
@@ -6636,15 +6634,15 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scratch"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764cad9e7e1ca5fe15b552859ff5d96a314e6ed2934f2260168cd5dfa5891409"
+checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
 
 [[package]]
 name = "sct"
@@ -6670,9 +6668,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -6683,9 +6681,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6702,9 +6700,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 dependencies = [
  "serde",
 ]
@@ -6720,9 +6718,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
@@ -6738,9 +6736,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a16be4fe5320ade08736447e3198294a5ea9a6d44dde6f35f0a5e06859c427a"
+checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
 dependencies = [
  "serde",
 ]
@@ -6757,20 +6755,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.100"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1e14e89be7aa4c4b78bdbdc9eb5bf8517829a600ae8eaa39a6e1d960b5185c"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -6816,16 +6814,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
  "darling 0.13.4",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.22"
+version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "452e67b9c20c37fa79df53201dc03839651086ed9bbe92b3ca585ca9fdaa7d85"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
  "indexmap 2.0.0",
  "itoa",
@@ -6851,8 +6849,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08338d8024b227c62bd68a12c7c9883f5c66780abaef15c550dc56f46ee6515"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -6932,8 +6930,8 @@ checksum = "e63e6744142336dfb606fe2b068afa2e1cca1ee6a5d8377277a92945d81fa331"
 dependencies = [
  "bitflags 1.3.2",
  "itertools 0.8.2",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -6950,9 +6948,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -6966,7 +6964,7 @@ checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
  "mio 0.8.8",
- "signal-hook 0.3.15",
+ "signal-hook 0.3.17",
 ]
 
 [[package]]
@@ -7162,10 +7160,10 @@ version = "0.1.0"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "stef",
- "syn 2.0.25",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -7222,8 +7220,8 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck 0.3.3",
  "proc-macro-error",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -7246,8 +7244,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -7258,8 +7256,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -7306,19 +7304,19 @@ version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.25"
+version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "unicode-ident",
 ]
 
@@ -7328,8 +7326,8 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
  "unicode-xid 0.2.4",
 ]
@@ -7372,9 +7370,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.38"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
 dependencies = [
  "filetime",
  "libc",
@@ -7383,9 +7381,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.9"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8e77cb757a61f51b947ec4a7e3646efd825b73561db1c232a8ccb639e611a0"
+checksum = "9d0e916b1148c8e263850e1ebcbd046f333e0683c724876bb0da63ea4373dc8a"
 
 [[package]]
 name = "task-motel"
@@ -7411,15 +7409,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
- "autocfg 1.1.0",
  "cfg-if 1.0.0",
- "fastrand",
+ "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.37.23",
+ "rustix 0.38.8",
  "windows-sys 0.48.0",
 ]
 
@@ -7468,8 +7465,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e5f048404b43e8ae66dce036163515b6057024cf58c6377be501f250bd3c6a"
 dependencies = [
  "cfg-if 1.0.0",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
  "version_check",
 ]
@@ -7491,8 +7488,8 @@ checksum = "e45b7bf6e19353ddd832745c8fcf77a17a93171df7151187f26623f2b75b5b26"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro-error",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -7515,8 +7512,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58071dc2471840e9f374eeb0f6e405a31bccb3cc5d59bb4598f02cafc274b5c4"
 dependencies = [
  "cargo_metadata",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "serde",
  "strum_macros 0.24.3",
 ]
@@ -7530,8 +7527,8 @@ dependencies = [
  "darling 0.14.4",
  "if_chain",
  "lazy_static",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "subprocess",
  "syn 1.0.109",
  "test-fuzz-internal",
@@ -7570,22 +7567,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -7683,11 +7680,10 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.1"
+version = "1.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
 dependencies = [
- "autocfg 1.1.0",
  "backtrace",
  "bytes",
  "libc",
@@ -7696,7 +7692,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys 0.48.0",
 ]
@@ -7707,9 +7703,9 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -7739,7 +7735,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "tokio",
 ]
 
@@ -7832,9 +7828,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.12"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -7892,9 +7888,9 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -7974,9 +7970,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "trybuild"
-version = "1.0.81"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04366e99ff743345622cd00af2af01d711dc2d1ef59250d7347698d21b546729"
+checksum = "6df60d81823ed9c520ee897489573da4b1d79ffbe006b8134f46de1a1aa03555"
 dependencies = [
  "basic-toml",
  "glob",
@@ -8199,7 +8195,7 @@ version = "0.0.1-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8359558d90ae7c4b2ff885619fcd75186cccdb62f575252c95c0c06484ce7de0"
 dependencies = [
- "clap 4.3.11",
+ "clap 4.3.23",
  "dirs 5.0.1",
  "futures",
  "if-addrs 0.10.1",
@@ -8220,7 +8216,7 @@ version = "0.0.2-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd44a26819757459b14994e728adeeb05931ca95605e54eb7733d01f3f130f8"
 dependencies = [
- "clap 4.3.11",
+ "clap 4.3.23",
  "dirs 5.0.1",
  "futures",
  "if-addrs 0.10.1",
@@ -8270,9 +8266,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -8315,9 +8311,9 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "untrusted"
@@ -8337,8 +8333,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -8351,7 +8347,7 @@ dependencies = [
  "base64 0.21.2",
  "log",
  "once_cell",
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "rustls-webpki 0.100.1",
  "url 2.4.0",
  "webpki-roots 0.23.1",
@@ -8402,9 +8398,9 @@ dependencies = [
 
 [[package]]
 name = "urlencoding"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -8430,9 +8426,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
  "getrandom 0.2.10",
 ]
@@ -8569,9 +8565,9 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
 
@@ -8593,7 +8589,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote 1.0.29",
+ "quote 1.0.33",
  "wasm-bindgen-macro-support",
 ]
 
@@ -8603,9 +8599,9 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8618,9 +8614,9 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.30.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f8e9778e04cbf44f58acc301372577375a666b966c50b03ef46144f80436a8"
+checksum = "41763f20eafed1399fff1afb466496d3a959f58241436cfdc17e3f5ca954de16"
 dependencies = [
  "leb128",
 ]
@@ -8763,8 +8759,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.64",
- "quote 1.0.29",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
  "syn 1.0.109",
 ]
 
@@ -8929,9 +8925,9 @@ checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "wast"
-version = "61.0.0"
+version = "63.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6b347851b52fd500657d301155c79e8c67595501d179cef87b6f04ebd25ac4"
+checksum = "2560471f60a48b77fccefaf40796fda61c97ce1e790b59dfcec9dc3995c9f63a"
 dependencies = [
  "leb128",
  "memchr",
@@ -8941,9 +8937,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.67"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459e764d27c3ab7beba1ebd617cc025c7e76dea6e7c5ce3189989a970aea3491"
+checksum = "3bdc306c2c4c2f2bf2ba69e083731d0d2a77437fc6a350a19db139636e7e416c"
 dependencies = [
  "wast",
 ]
@@ -9050,7 +9046,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -9096,7 +9092,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -9116,17 +9112,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -9137,9 +9133,9 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -9155,9 +9151,9 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9173,9 +9169,9 @@ checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9191,9 +9187,9 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9209,9 +9205,9 @@ checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9221,9 +9217,9 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -9239,15 +9235,15 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "winnow"
-version = "0.4.9"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
+checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
 dependencies = [
  "memchr",
 ]
@@ -9272,9 +9268,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "0.2.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]
@@ -9309,9 +9305,9 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
- "proc-macro2 1.0.64",
- "quote 1.0.29",
- "syn 2.0.25",
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1975,7 +1975,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 name = "fixt"
 version = "0.2.0"
 dependencies = [
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "lazy_static",
  "parking_lot 0.10.2",
  "paste",
@@ -2622,7 +2622,7 @@ dependencies = [
  "derive_more",
  "fixt",
  "futures",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_wasmer_common",
  "kitsune_p2p_dht_arc",
  "must_future",
@@ -2672,7 +2672,7 @@ dependencies = [
  "holochain_keystore",
  "holochain_metrics",
  "holochain_p2p",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_sqlite",
  "holochain_state",
  "holochain_test_wasm_common",
@@ -2759,7 +2759,7 @@ dependencies = [
  "hdk_derive",
  "holo_hash",
  "holochain_p2p",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_sqlite",
  "holochain_state",
  "holochain_trace",
@@ -2802,7 +2802,7 @@ dependencies = [
  "assert_cmd 1.0.8",
  "clap 4.3.23",
  "futures",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_types",
  "holochain_util",
  "holochain_wasmer_host",
@@ -2875,7 +2875,7 @@ dependencies = [
  "holo_hash",
  "holochain_keystore",
  "holochain_p2p",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_state",
  "holochain_trace",
  "holochain_types",
@@ -2915,7 +2915,7 @@ dependencies = [
  "derive_builder",
  "holo_hash",
  "holochain_integrity_types",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "kitsune_p2p_dht",
  "kitsune_p2p_timestamp",
  "paste",
@@ -2937,7 +2937,7 @@ dependencies = [
  "base64 0.13.1",
  "futures",
  "holo_hash",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_zome_types",
  "kitsune_p2p_types",
  "lair_keystore",
@@ -2983,7 +2983,7 @@ dependencies = [
  "ghost_actor 0.3.0-alpha.6",
  "holo_hash",
  "holochain_keystore",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_trace",
  "holochain_types",
  "holochain_util",
@@ -3003,10 +3003,26 @@ dependencies = [
 [[package]]
 name = "holochain_serialized_bytes"
 version = "0.0.52"
-source = "git+https://github.com/holochain/holochain-serialization.git?branch=proptest#b1ab125e6310ecc53712c118bef0d582fd858a9b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac6151d65c9a6f26f1b1068046a98900214030924377a2142f60c279b091f51"
+dependencies = [
+ "holochain_serialized_bytes_derive 0.0.52",
+ "rmp-serde 0.15.5",
+ "serde",
+ "serde-transcode",
+ "serde_bytes",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "holochain_serialized_bytes"
+version = "0.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7a5fc7c745a107f8ebcb04caab7a6b7a8463e2811f07ced19c281977583de7"
 dependencies = [
  "arbitrary",
- "holochain_serialized_bytes_derive",
+ "holochain_serialized_bytes_derive 0.0.53",
  "proptest",
  "proptest-derive",
  "rmp-serde 0.15.5",
@@ -3020,7 +3036,18 @@ dependencies = [
 [[package]]
 name = "holochain_serialized_bytes_derive"
 version = "0.0.52"
-source = "git+https://github.com/holochain/holochain-serialization.git?branch=proptest#b1ab125e6310ecc53712c118bef0d582fd858a9b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cec0d0c2317fcb87772d0a8b5b5e88c7276aef93bf3496931e89cb9231c129"
+dependencies = [
+ "quote 1.0.33",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "holochain_serialized_bytes_derive"
+version = "0.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3e0cf02005cbf0f514476d40e02125b26df6d4922d7a2c48a84fc588539d71"
 dependencies = [
  "quote 1.0.33",
  "syn 1.0.109",
@@ -3038,7 +3065,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.10",
  "holo_hash",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_sqlite",
  "holochain_trace",
  "holochain_util",
@@ -3094,7 +3121,7 @@ dependencies = [
  "holo_hash",
  "holochain_keystore",
  "holochain_p2p",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_sqlite",
  "holochain_trace",
  "holochain_types",
@@ -3133,7 +3160,7 @@ version = "0.3.0-beta-dev.1"
 dependencies = [
  "chrono",
  "derive_more",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "inferno",
  "once_cell",
  "serde",
@@ -3171,7 +3198,7 @@ dependencies = [
  "getrandom 0.2.10",
  "holo_hash",
  "holochain_keystore",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_sqlite",
  "holochain_trace",
  "holochain_types",
@@ -3246,7 +3273,7 @@ name = "holochain_wasmer_common"
 version = "0.0.84"
 source = "git+https://github.com/holochain/holochain-wasmer.git?branch=bump-hsb#1f87aadaa4335d1f09eb9aaa07f1cc801692bf1e"
 dependencies = [
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.52",
  "serde",
  "serde_bytes",
  "test-fuzz",
@@ -3260,7 +3287,7 @@ name = "holochain_wasmer_guest"
 version = "0.0.84"
 source = "git+https://github.com/holochain/holochain-wasmer.git?branch=bump-hsb#1f87aadaa4335d1f09eb9aaa07f1cc801692bf1e"
 dependencies = [
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.52",
  "holochain_wasmer_common",
  "parking_lot 0.12.1",
  "paste",
@@ -3274,7 +3301,7 @@ version = "0.0.84"
 source = "git+https://github.com/holochain/holochain-wasmer.git?branch=bump-hsb#1f87aadaa4335d1f09eb9aaa07f1cc801692bf1e"
 dependencies = [
  "bimap",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.52",
  "holochain_wasmer_common",
  "once_cell",
  "parking_lot 0.12.1",
@@ -3291,7 +3318,7 @@ dependencies = [
  "criterion",
  "futures",
  "ghost_actor 0.4.0-alpha.5",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_trace",
  "holochain_types",
  "linefeed",
@@ -3322,7 +3349,7 @@ dependencies = [
  "fixt",
  "holo_hash",
  "holochain_integrity_types",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_wasmer_common",
  "holochain_zome_types",
  "kitsune_p2p_bin_data",
@@ -3988,7 +4015,7 @@ dependencies = [
  "derive_more",
  "futures",
  "gcollections",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_trace",
  "intervallum",
  "kitsune_p2p_dht",
@@ -4038,7 +4065,7 @@ dependencies = [
  "arbitrary",
  "derive_more",
  "futures",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_trace",
  "human-repr",
  "kitsune_p2p_fetch",
@@ -4105,7 +4132,7 @@ dependencies = [
  "arbitrary",
  "chrono",
  "derive_more",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "proptest",
  "proptest-derive",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,8 @@ incremental = false
 codegen-units = 16
 
 [patch.crates-io]
-proptest = { path = "/home/michael/gitfork/proptest/proptest" }
+# proptest = { path = "/home/michael/gitfork/proptest/proptest" }
+proptest = { git = "https://github.com/maackle/proptest", branch = "arbitrary-pathbuf" }
 
 # influxive-child-svc = { path = "../influxive/crates/influxive-child-svc" }
 # influxive-otel = { path = "../influxive/crates/influxive-otel" }
@@ -86,14 +87,10 @@ proptest = { path = "/home/michael/gitfork/proptest/proptest" }
 # tx5-signal-srv = { git = "https://github.com/holochain/tx5.git", rev = "f0f009f77a84c96c2acded6b27df27ece3f7dbbb" }
 # tx5-go-pion-turn = { git = "https://github.com/holochain/tx5.git", rev = "f0f009f77a84c96c2acded6b27df27ece3f7dbbb" }
 # isotest = { git = "https://github.com/maackle/isotest-rs.git" }
-# holochain_wasmer_guest = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "pr/bump-serde" }
-# holochain_wasmer_host = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "pr/bump-serde" }
-# holochain_wasmer_common = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "pr/bump-serde" }
-holochain_wasmer_guest = { path = "../holochain-wasmer/crates/guest" }
-holochain_wasmer_host = { path = "../holochain-wasmer/crates/host" }
-holochain_wasmer_common = { path = "../holochain-wasmer/crates/common" }
-holochain_serialized_bytes = { path = "../holochain-serialization/crates/holochain_serialized_bytes" }
-# holochain_serialized_bytes = { git = "https://github.com/holochain/holochain-serialization.git", branch = "proptest" }
+holochain_wasmer_guest = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "bump-hsb" }
+holochain_wasmer_host = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "bump-hsb" }
+holochain_wasmer_common = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "bump-hsb" }
+holochain_serialized_bytes = { git = "https://github.com/holochain/holochain-serialization.git", branch = "proptest" }
 # holochain_serialized_bytes_derive = { git = "https://github.com/holochain/holochain-serialization.git", branch = "develop" }
 #ghost_actor = { path = "../ghost_actor/crates/ghost_actor" }
 #lair_keystore_api = { path = "../lair/crates/lair_keystore_api" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,8 @@ incremental = false
 codegen-units = 16
 
 [patch.crates-io]
+proptest = { path = "/home/michael/gitfork/proptest/proptest" }
+
 # influxive-child-svc = { path = "../influxive/crates/influxive-child-svc" }
 # influxive-otel = { path = "../influxive/crates/influxive-otel" }
 # contrafact = { git = "https://github.com/maackle/contrafact-rs.git", branch = "lambda" }
@@ -87,7 +89,11 @@ codegen-units = 16
 # holochain_wasmer_guest = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "pr/bump-serde" }
 # holochain_wasmer_host = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "pr/bump-serde" }
 # holochain_wasmer_common = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "pr/bump-serde" }
-# holochain_serialized_bytes = { git = "https://github.com/holochain/holochain-serialization.git", branch = "develop" }
+holochain_wasmer_guest = { path = "../holochain-wasmer/crates/guest" }
+holochain_wasmer_host = { path = "../holochain-wasmer/crates/host" }
+holochain_wasmer_common = { path = "../holochain-wasmer/crates/common" }
+holochain_serialized_bytes = { path = "../holochain-serialization/crates/holochain_serialized_bytes" }
+# holochain_serialized_bytes = { git = "https://github.com/holochain/holochain-serialization.git", branch = "proptest" }
 # holochain_serialized_bytes_derive = { git = "https://github.com/holochain/holochain-serialization.git", branch = "develop" }
 #ghost_actor = { path = "../ghost_actor/crates/ghost_actor" }
 #lair_keystore_api = { path = "../lair/crates/lair_keystore_api" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ proptest = { git = "https://github.com/maackle/proptest", branch = "arbitrary-pa
 holochain_wasmer_guest = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "bump-hsb" }
 holochain_wasmer_host = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "bump-hsb" }
 holochain_wasmer_common = { git = "https://github.com/holochain/holochain-wasmer.git", branch = "bump-hsb" }
-holochain_serialized_bytes = { git = "https://github.com/holochain/holochain-serialization.git", branch = "proptest" }
+# holochain_serialized_bytes = { git = "https://github.com/holochain/holochain-serialization.git", branch = "proptest" }
 # holochain_serialized_bytes_derive = { git = "https://github.com/holochain/holochain-serialization.git", branch = "develop" }
 #ghost_actor = { path = "../ghost_actor/crates/ghost_actor" }
 #lair_keystore_api = { path = "../lair/crates/lair_keystore_api" }

--- a/crates/fixt/Cargo.toml
+++ b/crates/fixt/Cargo.toml
@@ -11,7 +11,7 @@ categories = [ "fixtures" ]
 edition = "2021"
 
 [dependencies]
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 lazy_static = "1.4"
 parking_lot = "0.10"
 paste = "1.0.12"

--- a/crates/fixt/Cargo.toml
+++ b/crates/fixt/Cargo.toml
@@ -11,7 +11,7 @@ categories = [ "fixtures" ]
 edition = "2021"
 
 [dependencies]
-holochain_serialized_bytes = "=0.0.52"
+holochain_serialized_bytes = "=0.0.53"
 lazy_static = "1.4"
 parking_lot = "0.10"
 paste = "1.0.12"

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -24,7 +24,7 @@ futures = "0.3"
 anyhow = "1.0"
 clap = { version = "4.0", features = [ "derive" ] }
 holochain_util = { path = "../holochain_util", features = ["backtrace"], version = "^0.2.0"}
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 mr_bundle = {version = "^0.2.0", path = "../mr_bundle"}
 serde = { version = "1.0", features = [ "derive" ] }

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -24,7 +24,7 @@ futures = "0.3"
 anyhow = "1.0"
 clap = { version = "4.0", features = [ "derive" ] }
 holochain_util = { path = "../holochain_util", features = ["backtrace"], version = "^0.2.0"}
-holochain_serialized_bytes = "=0.0.52"
+holochain_serialized_bytes = "=0.0.53"
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 mr_bundle = {version = "^0.2.0", path = "../mr_bundle"}
 serde = { version = "1.0", features = [ "derive" ] }

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -22,9 +22,11 @@ blake2b_simd = { version = "0.5.10", optional = true }
 derive_more = { version = "0.99", optional = true }
 fixt = { version = "^0.2.0", path = "../fixt", optional = true }
 futures = { version = "0.3", optional = true }
-holochain_serialized_bytes = { version = "=0.0.51", optional = true }
+holochain_serialized_bytes = { version = "=0.0.52", optional = true }
 kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.3", path = "../kitsune_p2p/dht_arc" }
 must_future = { version = "0.1", optional = true }
+proptest = { version = "1", optional = true }
+proptest-derive = { version = "0", optional = true }
 rand = { version = "0.8.5", optional = true }
 rusqlite = { version = "0.29", optional = true }
 serde = { version = "1", optional = true }
@@ -45,6 +47,7 @@ full = [
 ]
 
 fixturators = ["fixt", "rand", "hashing", "encoding"]
+fuzzing = ["arbitrary", "proptest", "proptest-derive"]
 hashing = ["futures", "must_future", "blake2b_simd", "serialization"]
 serialization = ["holochain_serialized_bytes", "serde", "serde_bytes"]
 encoding = ["base64", "blake2b_simd", "derive_more"]

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -22,7 +22,7 @@ blake2b_simd = { version = "0.5.10", optional = true }
 derive_more = { version = "0.99", optional = true }
 fixt = { version = "^0.2.0", path = "../fixt", optional = true }
 futures = { version = "0.3", optional = true }
-holochain_serialized_bytes = { version = "=0.0.52", optional = true }
+holochain_serialized_bytes = { version = "=0.0.53", optional = true }
 kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.3", path = "../kitsune_p2p/dht_arc" }
 must_future = { version = "0.1", optional = true }
 proptest = { version = "1", optional = true }

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -24,6 +24,8 @@
 //! The complete 39 bytes together are known as the "full" hash
 
 use kitsune_p2p_dht_arc::DhtLocation;
+use proptest::strategy::BoxedStrategy;
+use proptest::strategy::Strategy;
 
 use crate::error::HoloHashResult;
 use crate::has_hash::HasHash;
@@ -73,7 +75,7 @@ pub struct HoloHash<T: HashType> {
     hash_type: T,
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a, P: PrimitiveHashType> arbitrary::Arbitrary<'a> for HoloHash<P> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let mut buf = [0; HOLO_HASH_FULL_LEN];
@@ -84,6 +86,30 @@ impl<'a, P: PrimitiveHashType> arbitrary::Arbitrary<'a> for HoloHash<P> {
             hash: buf.to_vec(),
             hash_type: P::new(),
         })
+    }
+}
+
+#[cfg(feature = "fuzzing")]
+impl<T: HashType + proptest::arbitrary::Arbitrary> proptest::arbitrary::Arbitrary for HoloHash<T>
+where
+    T::Strategy: 'static,
+{
+    type Parameters = ();
+    type Strategy = BoxedStrategy<HoloHash<T>>;
+
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
+        let strat = T::arbitrary().prop_flat_map(move |hash_type| {
+            let gen_strat = proptest::string::bytes_regex(r".[39]").unwrap();
+            gen_strat.prop_map(move |mut buf| {
+                assert_eq!(buf.len(), 39);
+                buf[0..HOLO_HASH_PREFIX_LEN].copy_from_slice(hash_type.get_prefix());
+                HoloHash {
+                    hash: buf.to_vec(),
+                    hash_type,
+                }
+            })
+        });
+        strat.boxed()
     }
 }
 

--- a/crates/holo_hash/src/hash_b64.rs
+++ b/crates/holo_hash/src/hash_b64.rs
@@ -4,6 +4,8 @@
 //! array or a base-64 string. This type just specifies how serialization should
 //! be done.
 
+use proptest::strategy::{BoxedStrategy, Strategy};
+
 use super::*;
 use crate::HoloHash;
 use crate::{error::HoloHashResult, HashType};
@@ -45,10 +47,24 @@ impl<T: HashType> serde::Serialize for HoloHashB64<T> {
     }
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a, P: PrimitiveHashType> arbitrary::Arbitrary<'a> for HoloHashB64<P> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(HoloHash::arbitrary(u)?.into())
+    }
+}
+
+#[cfg(feature = "fuzzing")]
+impl<T: HashType + proptest::arbitrary::Arbitrary + 'static> proptest::arbitrary::Arbitrary
+    for HoloHashB64<T>
+where
+    T::Strategy: 'static,
+{
+    type Parameters = ();
+    type Strategy = BoxedStrategy<HoloHashB64<T>>;
+
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
+        HoloHash::arbitrary().prop_map(Into::into).boxed()
     }
 }
 

--- a/crates/holo_hash/src/hash_type/composite.rs
+++ b/crates/holo_hash/src/hash_type/composite.rs
@@ -81,7 +81,10 @@ impl From<AnyDhtSerial> for AnyDht {
     derive(serde::Deserialize, serde::Serialize, SerializedBytes),
     serde(from = "AnyLinkableSerial", into = "AnyLinkableSerial")
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub enum AnyLinkable {
     /// The hash of an Entry
     Entry,
@@ -91,7 +94,7 @@ pub enum AnyLinkable {
     External,
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for crate::HoloHash<AnyLinkable> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let any_linkable = AnyLinkable::arbitrary(u)?;

--- a/crates/holo_hash/src/hash_type/primitive.rs
+++ b/crates/holo_hash/src/hash_type/primitive.rs
@@ -88,7 +88,10 @@ macro_rules! primitive_hash_type {
     ($name: ident, $display: ident, $visitor: ident, $prefix: ident) => {
         /// The $name PrimitiveHashType
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-        #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+        #[cfg_attr(
+            feature = "fuzzing",
+            derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+        )]
         pub struct $name;
 
         impl PrimitiveHashType for $name {

--- a/crates/holo_hash/src/hashed.rs
+++ b/crates/holo_hash/src/hashed.rs
@@ -5,7 +5,7 @@ use crate::HoloHashOf;
 #[cfg(feature = "serialization")]
 use holochain_serialized_bytes::prelude::*;
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 use crate::PrimitiveHashType;
 
 /// Represents some piece of content along with its hash representation, so that
@@ -30,7 +30,7 @@ impl<C: HashableContent> HasHash<C::HashType> for HoloHashed<C> {
     }
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a, C> arbitrary::Arbitrary<'a> for HoloHashed<C>
 where
     C: HashableContent + arbitrary::Arbitrary<'a>,

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -30,7 +30,7 @@ holochain_conductor_api = { version = "^0.3.0-beta-dev.14", path = "../holochain
 holochain_keystore = { version = "^0.3.0-beta-dev.10", path = "../holochain_keystore", default-features = false }
 holochain_p2p = { version = "^0.3.0-beta-dev.13", path = "../holochain_p2p" }
 holochain_sqlite = { version = "^0.3.0-beta-dev.12", path = "../holochain_sqlite" }
-holochain_serialized_bytes = "=0.0.52"
+holochain_serialized_bytes = "=0.0.53"
 holochain_state = { version = "^0.3.0-beta-dev.13", path = "../holochain_state" }
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_util = { version = "^0.2.0", path = "../holochain_util", features = [ "pw" ] }

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -30,7 +30,7 @@ holochain_conductor_api = { version = "^0.3.0-beta-dev.14", path = "../holochain
 holochain_keystore = { version = "^0.3.0-beta-dev.10", path = "../holochain_keystore", default-features = false }
 holochain_p2p = { version = "^0.3.0-beta-dev.13", path = "../holochain_p2p" }
 holochain_sqlite = { version = "^0.3.0-beta-dev.12", path = "../holochain_sqlite" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_state = { version = "^0.3.0-beta-dev.13", path = "../holochain_state" }
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_util = { version = "^0.2.0", path = "../holochain_util", features = [ "pw" ] }

--- a/crates/holochain/src/core/ribosome/host_fn/get_links.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_links.rs
@@ -95,7 +95,6 @@ pub fn get_links<'a>(
 #[cfg(test)]
 #[cfg(feature = "slow_tests")]
 pub mod slow_tests {
-    use crate::core::ribosome::host_fn::hash::hash;
     use crate::core::ribosome::wasm_test::RibosomeTestFixture;
     use hdk::prelude::*;
     use holochain_test_wasm_common::*;
@@ -204,7 +203,6 @@ pub mod slow_tests {
             .call(&alice, "list_anchor_addresses", "foo".to_string())
             .await;
 
-        // should be 2 anchors under "foo" sorted by hash
         assert_eq!(list_anchor_addresses_output.0.len(), 2);
         assert_eq!(
             (list_anchor_addresses_output.0)[0].get_raw_32().to_vec(),

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -20,7 +20,7 @@ hdk_derive = { version = "^0.3.0-beta-dev.8", path = "../hdk_derive" }
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = ["full"] }
 holochain_sqlite = { version = "^0.3.0-beta-dev.12", path = "../holochain_sqlite" }
 holochain_p2p = { version = "^0.3.0-beta-dev.13", path = "../holochain_p2p" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_state = { version = "^0.3.0-beta-dev.13", path = "../holochain_state" }
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../holochain_trace" }

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -20,7 +20,7 @@ hdk_derive = { version = "^0.3.0-beta-dev.8", path = "../hdk_derive" }
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = ["full"] }
 holochain_sqlite = { version = "^0.3.0-beta-dev.12", path = "../holochain_sqlite" }
 holochain_p2p = { version = "^0.3.0-beta-dev.13", path = "../holochain_p2p" }
-holochain_serialized_bytes = "=0.0.52"
+holochain_serialized_bytes = "=0.0.53"
 holochain_state = { version = "^0.3.0-beta-dev.13", path = "../holochain_state" }
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../holochain_trace" }

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -15,7 +15,7 @@ kitsune_p2p = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/kitsune_p
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = ["full"] }
 holochain_p2p = { version = "^0.3.0-beta-dev.13", path = "../holochain_p2p" }
 holochain_state = { version = "^0.3.0-beta-dev.13", path = "../holochain_state" }
-holochain_serialized_bytes = "=0.0.52"
+holochain_serialized_bytes = "=0.0.53"
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.3.0-beta-dev.9", path = "../holochain_zome_types" }
 serde = { version = "1.0", features = [ "derive" ] }

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -15,7 +15,7 @@ kitsune_p2p = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/kitsune_p
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = ["full"] }
 holochain_p2p = { version = "^0.3.0-beta-dev.13", path = "../holochain_p2p" }
 holochain_state = { version = "^0.3.0-beta-dev.13", path = "../holochain_state" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.3.0-beta-dev.9", path = "../holochain_zome_types" }
 serde = { version = "1.0", features = [ "derive" ] }

--- a/crates/holochain_diagnostics/src/terminal.rs
+++ b/crates/holochain_diagnostics/src/terminal.rs
@@ -42,10 +42,10 @@ pub fn tui_crossterm_setup<
     Ok(res?)
 }
 
-pub fn enter_tui(stdout: &mut io::Stdout) -> Result<(), crossterm::ErrorKind> {
+pub fn enter_tui(stdout: &mut io::Stdout) -> Result<(), std::io::Error> {
     execute!(stdout, EnterAlternateScreen /* , EnableMouseCapture */)
 }
 
-pub fn exit_tui<B: Backend + io::Write>(backend: &mut B) -> Result<(), crossterm::ErrorKind> {
+pub fn exit_tui<B: Backend + io::Write>(backend: &mut B) -> Result<(), std::io::Error> {
     execute!(backend, LeaveAlternateScreen)
 }

--- a/crates/holochain_integrity_types/Cargo.toml
+++ b/crates/holochain_integrity_types/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash" }
-holochain_serialized_bytes = "=0.0.52"
+holochain_serialized_bytes = "=0.0.53"
 paste = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11"

--- a/crates/holochain_integrity_types/Cargo.toml
+++ b/crates/holochain_integrity_types/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 paste = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11"
@@ -29,6 +29,8 @@ derive_builder = { version = "0.9", optional = true }
 
 # Optional
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
+proptest = {version = "1", optional = true}
+proptest-derive = {version = "0", optional = true}
 subtle-encoding = {version = "0.5", optional = true}
 tracing = { version = "0.1", optional = true }
 
@@ -43,13 +45,19 @@ full = ["default", "subtle-encoding", "kitsune_p2p_timestamp/full"]
 
 full-dna-def = ["derive_builder"]
 
+fuzzing = [
+  "arbitrary", 
+  "proptest", 
+  "proptest-derive",
+  "kitsune_p2p_timestamp/fuzzing",
+  "holochain_serialized_bytes/fuzzing",
+  "holo_hash/fuzzing",
+]
+
 test_utils = [
   "full",
-  "arbitrary",
-  "kitsune_p2p_timestamp/arbitrary",
+  "fuzzing",
   "kitsune_p2p_timestamp/now",
-  "holo_hash/arbitrary",
   "holo_hash/hashing",
   "holo_hash/test_utils",
-  "holochain_serialized_bytes/arbitrary",
 ]

--- a/crates/holochain_integrity_types/src/action.rs
+++ b/crates/holochain_integrity_types/src/action.rs
@@ -17,6 +17,7 @@ use holo_hash::EntryHash;
 use holo_hash::HashableContent;
 use holo_hash::HoloHashed;
 use holochain_serialized_bytes::prelude::*;
+use kitsune_p2p_timestamp::ArbitraryFuzzing;
 
 pub mod builder;
 pub mod conversions;
@@ -34,7 +35,10 @@ pub const POST_GENESIS_SEQ_THRESHOLD: u32 = 3;
 /// functions.
 #[allow(missing_docs)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 #[serde(tag = "type")]
 pub enum Action {
     // The first action in a chain (for the DNA) doesn't have a previous action
@@ -116,7 +120,7 @@ macro_rules! write_into_action {
         /// A unit enum which just maps onto the different Action variants,
         /// without containing any extra data
         #[derive(serde::Serialize, serde::Deserialize, SerializedBytes, PartialEq, Eq, Clone, Debug)]
-        #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+        #[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary, proptest_derive::Arbitrary))]
         pub enum ActionType {
             $($n,)*
         }
@@ -420,7 +424,10 @@ impl_hashable_content_for_ref!(Delete);
     Deserialize,
     SerializedBytes,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct ZomeIndex(pub u8);
 
 impl ZomeIndex {
@@ -442,12 +449,18 @@ impl ZomeIndex {
     Deserialize,
     SerializedBytes,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct EntryDefIndex(pub u8);
 
 /// The Dna Action is always the first action in a source chain
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct Dna {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -458,7 +471,10 @@ pub struct Dna {
 /// Action for an agent validation package, used to determine whether an agent
 /// is allowed to participate in this DNA
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct AgentValidationPkg {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -471,7 +487,10 @@ pub struct AgentValidationPkg {
 /// A action which declares that all zome init functions have successfully
 /// completed, and the chain is ready for commits. Contains no explicit data.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct InitZomesComplete {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -481,7 +500,10 @@ pub struct InitZomesComplete {
 
 /// Declares that a metadata Link should be made between two EntryHashes
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct CreateLink<W = RateWeight> {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -499,7 +521,10 @@ pub struct CreateLink<W = RateWeight> {
 
 /// Declares that a previously made Link should be nullified and considered removed.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct DeleteLink {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -517,7 +542,10 @@ pub struct DeleteLink {
 /// When migrating to a new version of a DNA, this action is committed to the
 /// new chain to declare the migration path taken. **Currently unused**
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct OpenChain {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -530,7 +558,10 @@ pub struct OpenChain {
 /// When migrating to a new version of a DNA, this action is committed to the
 /// old chain to declare the migration path taken. **Currently unused**
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct CloseChain {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -543,8 +574,11 @@ pub struct CloseChain {
 /// A action which "speaks" Entry content into being. The same content can be
 /// referenced by multiple such actions.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-pub struct Create<W = EntryRateWeight> {
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
+pub struct Create<W: ArbitraryFuzzing = EntryRateWeight> {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
     pub action_seq: u32,
@@ -571,8 +605,11 @@ pub struct Create<W = EntryRateWeight> {
 /// so there can only be a linear history of action updates, even if the entry history
 /// experiences repeats.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-pub struct Update<W = EntryRateWeight> {
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
+pub struct Update<W: ArbitraryFuzzing = EntryRateWeight> {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
     pub action_seq: u32,
@@ -594,8 +631,11 @@ pub struct Update<W = EntryRateWeight> {
 /// that a previously published Entry will become inaccessible if all of its
 /// Actions are marked deleted.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-pub struct Delete<W = RateWeight> {
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
+pub struct Delete<W: ArbitraryFuzzing = RateWeight> {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
     pub action_seq: u32,
@@ -611,7 +651,10 @@ pub struct Delete<W = RateWeight> {
 /// Placeholder for future when we want to have updates on actions
 /// Not currently in use.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct UpdateAction {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -624,7 +667,10 @@ pub struct UpdateAction {
 /// Placeholder for future when we want to have deletes on actions
 /// Not currently in use.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct DeleteAction {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -639,7 +685,10 @@ pub struct DeleteAction {
 /// referencing. Useful for examining Actions without needing to fetch the
 /// corresponding Entries.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub enum EntryType {
     /// An AgentPubKey
     AgentPubKey,
@@ -680,7 +729,10 @@ impl std::fmt::Display for EntryType {
 
 /// Information about a class of Entries provided by the DNA
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct AppEntryDef {
     /// A unique u8 identifier within a zome for this
     /// entry type.

--- a/crates/holochain_integrity_types/src/capability/claim.rs
+++ b/crates/holochain_integrity_types/src/capability/claim.rs
@@ -6,7 +6,10 @@ use holochain_serialized_bytes::prelude::*;
 /// Stored by a claimant so they can remember what's necessary to exercise
 /// this capability by sending the secret to the grantor.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, SerializedBytes)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct CapClaim {
     /// A string by which to later query for saved claims.
     /// This does not need to be unique within a source chain.

--- a/crates/holochain_integrity_types/src/capability/grant.rs
+++ b/crates/holochain_integrity_types/src/capability/grant.rs
@@ -37,7 +37,10 @@ impl From<holo_hash::AgentPubKey> for CapGrant {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 /// The entry for the ZomeCall capability grant.
 /// This data is committed to the callee's source chain as a private entry.
 /// The remote calling agent must provide a secret and we source their pubkey from the active
@@ -123,7 +126,10 @@ impl CapGrant {
 
 /// Represents access requirements for capability grants.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub enum CapAccess {
     /// No restriction: callable by anyone.
     Unrestricted,
@@ -188,7 +194,10 @@ pub type GrantedFunction = (ZomeName, FunctionName);
 /// A collection of zome/function pairs
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub enum GrantedFunctions {
     /// grant all zomes all functions
     All,

--- a/crates/holochain_integrity_types/src/capability/secret.rs
+++ b/crates/holochain_integrity_types/src/capability/secret.rs
@@ -17,9 +17,10 @@ pub type CapSecretBytes = [u8; CAP_SECRET_BYTES];
 // The PartialEq impl by subtle *should* be compatible with default Hash impl
 #[allow(clippy::derive_hash_xor_eq)]
 #[derive(Clone, Copy, Hash, SerializedBytes)]
+#[cfg_attr(feature = "fuzzing", derive(proptest_derive::Arbitrary))]
 pub struct CapSecret(CapSecretBytes);
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for CapSecret {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let mut buf = [0; CAP_SECRET_BYTES];

--- a/crates/holochain_integrity_types/src/countersigning.rs
+++ b/crates/holochain_integrity_types/src/countersigning.rs
@@ -28,7 +28,10 @@ mod error;
 
 /// Every countersigning session must complete a full set of actions between the start and end times to be valid.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct CounterSigningSessionTimes {
     /// The earliest allowable time for countersigning session responses to be valid.
     pub start: Timestamp,
@@ -85,13 +88,19 @@ impl CounterSigningSessionTimes {
 
 /// Every preflight request can have optional arbitrary bytes that can be agreed to.
 #[derive(Clone, serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct PreflightBytes(#[serde(with = "serde_bytes")] pub Vec<u8>);
 
 /// Agents can have a role specific to each countersigning session.
 /// The role is app defined and opaque to the subconscious.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct Role(pub u8);
 
 impl Role {
@@ -108,7 +117,10 @@ pub type CounterSigningAgents = Vec<(AgentPubKey, Vec<Role>)>;
 /// Each agent signs this data as part of their PreflightResponse.
 /// Every preflight must be identical and signed by every agent for a session to be valid.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct PreflightRequest {
     /// The hash of the app entry, as if it were not countersigned.
     /// The final entry hash will include the countersigning session.
@@ -250,7 +262,10 @@ impl PreflightRequest {
 /// Every agent must send back a preflight response.
 /// All the preflight response data is signed by each agent and included in the session data.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct PreflightResponse {
     /// The request this is a response to.
     pub request: PreflightRequest,
@@ -345,7 +360,10 @@ pub enum PreflightRequestAcceptance {
 /// Every countersigning agent must sign against their chain state.
 /// The chain must be frozen until each agent decides to sign or exit the session.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct CounterSigningAgentState {
     /// The index of the agent in the preflight request agent vector.
     agent_index: u8,
@@ -402,7 +420,10 @@ impl CounterSigningAgentState {
 /// Enum to mirror Action for all the shared data required to build session actions.
 /// Does NOT hold any agent specific information.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub enum ActionBase {
     /// Mirrors Action::Create.
     Create(CreateBase),
@@ -416,7 +437,10 @@ pub enum ActionBase {
 
 /// Base data for Create actions.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct CreateBase {
     entry_type: EntryType,
 }
@@ -430,7 +454,10 @@ impl CreateBase {
 
 /// Base data for Update actions.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct UpdateBase {
     /// The original action being updated.
     pub original_action_address: ActionHash,
@@ -476,7 +503,10 @@ impl Action {
 
 /// All the data required for a countersigning session.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct CounterSigningSessionData {
     /// The preflight request that was agreed upon by all parties for the session.
     pub preflight_request: PreflightRequest,

--- a/crates/holochain_integrity_types/src/entry.rs
+++ b/crates/holochain_integrity_types/src/entry.rs
@@ -85,7 +85,10 @@ impl From<EntryHashed> for Entry {
 
 /// Structure holding the entry portion of a chain record.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, SerializedBytes)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 #[serde(tag = "entry_type", content = "entry")]
 pub enum Entry {
     /// The `Agent` system entry, the third entry of every source chain,

--- a/crates/holochain_integrity_types/src/entry/app_entry_bytes.rs
+++ b/crates/holochain_integrity_types/src/entry/app_entry_bytes.rs
@@ -5,7 +5,10 @@ use holochain_serialized_bytes::prelude::*;
 
 /// Newtype for the bytes comprising an App entry
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct AppEntryBytes(pub SerializedBytes);
 
 impl std::fmt::Debug for AppEntryBytes {

--- a/crates/holochain_integrity_types/src/entry_def.rs
+++ b/crates/holochain_integrity_types/src/entry_def.rs
@@ -8,21 +8,25 @@ const DEFAULT_REQUIRED_VALIDATIONS: u8 = 5;
 #[derive(
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub enum EntryDefId {
     App(AppEntryName),
     CapClaim,
     CapGrant,
 }
 
+/// Identifier for an entry definition.
+/// This may be removed.
 #[derive(
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
-/// Identifier for an entry definition.
-/// This may be removed.
+#[cfg_attr(feature = "fuzzing", derive(proptest_derive::Arbitrary))]
 pub struct AppEntryName(pub Cow<'static, str>);
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for AppEntryName {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self(Cow::Owned(String::arbitrary(u)?)))
@@ -46,13 +50,19 @@ pub trait EntryDefRegistration {
 )]
 /// The number of validations required for an entry to
 /// be considered published.
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct RequiredValidations(pub u8);
 
 #[derive(
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct EntryDef {
     /// Zome-unique identifier for this entry type
     pub id: EntryDefId,
@@ -84,7 +94,10 @@ pub struct EntryDefs(pub Vec<EntryDef>);
     Deserialize,
     SerializedBytes,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub enum EntryVisibility {
     Public,
     Private,

--- a/crates/holochain_integrity_types/src/info.rs
+++ b/crates/holochain_integrity_types/src/info.rs
@@ -61,7 +61,10 @@ const fn standard_quantum_time() -> Duration {
 /// opposed to the actual DNA code. These modifiers are included in the DNA
 /// hash computation.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 #[cfg_attr(feature = "full-dna-def", derive(derive_builder::Builder))]
 pub struct DnaModifiers {
     /// The network seed of a DNA is included in the computation of the DNA hash.
@@ -103,7 +106,10 @@ impl DnaModifiers {
 
 /// [`DnaModifiers`] options of which all are optional.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct DnaModifiersOpt<P = SerializedBytes> {
     /// see [`DnaModifiers`]
     pub network_seed: Option<NetworkSeed>,

--- a/crates/holochain_integrity_types/src/link.rs
+++ b/crates/holochain_integrity_types/src/link.rs
@@ -14,7 +14,10 @@ use holochain_serialized_bytes::prelude::*;
     serde::Deserialize,
     SerializedBytes,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct LinkType(pub u8);
 
 impl LinkType {
@@ -41,7 +44,10 @@ impl LinkType {
     Eq,
     SerializedBytes,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct LinkTag(#[serde(with = "serde_bytes")] pub Vec<u8>);
 
 impl LinkTag {

--- a/crates/holochain_integrity_types/src/rate_limit.rs
+++ b/crates/holochain_integrity_types/src/rate_limit.rs
@@ -7,7 +7,10 @@ use crate::{Create, CreateLink, Delete, Entry, Update};
 /// Input to the `weigh` callback. Includes an "unweighed" action, and Entry
 /// if applicable.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, SerializedBytes, Debug)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub enum WeighInput {
     /// A Link to be weighed
     Link(CreateLink<()>),
@@ -44,7 +47,10 @@ pub type RateBucketCapacity = u32;
     PartialOrd,
     Ord,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 #[allow(missing_docs)]
 pub struct RateWeight {
     pub bucket_id: RateBucketId,
@@ -73,7 +79,10 @@ impl Default for RateWeight {
     PartialOrd,
     Ord,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 #[allow(missing_docs)]
 pub struct EntryRateWeight {
     pub bucket_id: RateBucketId,

--- a/crates/holochain_integrity_types/src/record.rs
+++ b/crates/holochain_integrity_types/src/record.rs
@@ -20,7 +20,10 @@ use holochain_serialized_bytes::prelude::*;
 /// a chain record containing the signed action along with the
 /// entry if the action type has one.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct Record<A = SignedActionHashed> {
     /// The signed action for this record
     pub signed_action: A,
@@ -38,7 +41,10 @@ impl<A> AsRef<A> for Record<A> {
 /// Represents the different ways the entry_address reference within an action
 /// can be intepreted
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SerializedBytes)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub enum RecordEntry<E: Borrow<Entry> = Entry> {
     /// The Action has an entry_address reference, and the Entry is accessible.
     Present(E),

--- a/crates/holochain_integrity_types/src/signature.rs
+++ b/crates/holochain_integrity_types/src/signature.rs
@@ -7,13 +7,14 @@ pub const SIGNATURE_BYTES: usize = 64;
 
 /// The raw bytes of a signature.
 #[derive(Clone, PartialOrd, Hash, Ord)]
+#[cfg_attr(feature = "fuzzing", derive(proptest_derive::Arbitrary))]
 // The equality is not different, it's just constant time, so we can derive a hash.
 // For an actually secure thing we wouldn't want to just assume a safe default hashing
 // But that is not what clippy is complaining about here.
 #[allow(clippy::derive_hash_xor_eq)]
 pub struct Signature(pub [u8; SIGNATURE_BYTES]);
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for Signature {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let mut buf = [0; SIGNATURE_BYTES];

--- a/crates/holochain_integrity_types/src/zome.rs
+++ b/crates/holochain_integrity_types/src/zome.rs
@@ -12,10 +12,11 @@ use holochain_serialized_bytes::prelude::*;
 
 /// ZomeName as a String.
 #[derive(Clone, Debug, Serialize, Hash, Deserialize, Ord, Eq, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "fuzzing", derive(proptest_derive::Arbitrary))]
 #[repr(transparent)]
 pub struct ZomeName(pub Cow<'static, str>);
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for ZomeName {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self(String::arbitrary(u)?.into()))
@@ -55,7 +56,10 @@ impl From<String> for ZomeName {
 /// A single function name.
 #[repr(transparent)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, PartialOrd, Ord, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct FunctionName(pub String);
 
 impl FunctionName {

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 base64 = "0.13.0"
 futures = "0.3.23"
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = ["full"] }
-holochain_serialized_bytes = "=0.0.52"
+holochain_serialized_bytes = "=0.0.53"
 holochain_zome_types = { path = "../holochain_zome_types", version = "^0.3.0-beta-dev.9"}
 kitsune_p2p_types = { version = "^0.3.0-beta-dev.6", path = "../kitsune_p2p/types" }
 lair_keystore = { version = "0.3.0", default-features = false }

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 base64 = "0.13.0"
 futures = "0.3.23"
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = ["full"] }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_zome_types = { path = "../holochain_zome_types", version = "^0.3.0-beta-dev.9"}
 kitsune_p2p_types = { version = "^0.3.0-beta-dev.6", path = "../kitsune_p2p/types" }
 lair_keystore = { version = "0.3.0", default-features = false }

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3"
 ghost_actor = "0.3.0-alpha.6"
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash" }
 holochain_keystore = { version = "^0.3.0-beta-dev.10", path = "../holochain_keystore" }
-holochain_serialized_bytes = "=0.0.52"
+holochain_serialized_bytes = "=0.0.53"
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.3.0-beta-dev.9", path = "../holochain_zome_types" }
 kitsune_p2p = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/kitsune_p2p" }

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3"
 ghost_actor = "0.3.0-alpha.6"
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash" }
 holochain_keystore = { version = "^0.3.0-beta-dev.10", path = "../holochain_keystore" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.3.0-beta-dev.9", path = "../holochain_zome_types" }
 kitsune_p2p = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/kitsune_p2p" }

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -18,7 +18,7 @@ derive_more = "0.99.3"
 fallible-iterator = "0.2.0"
 futures = "0.3.1"
 holo_hash = { path = "../holo_hash", version = "^0.3.0-beta-dev.6"}
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_util = { version = "^0.2.0", path = "../holochain_util", features = ["backtrace"], optional = true }
 holochain_zome_types = { version = "^0.3.0-beta-dev.9", path = "../holochain_zome_types" }
 kitsune_p2p_types = { version = "^0.3.0-beta-dev.6", path = "../kitsune_p2p/types", optional = true }

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -18,7 +18,7 @@ derive_more = "0.99.3"
 fallible-iterator = "0.2.0"
 futures = "0.3.1"
 holo_hash = { path = "../holo_hash", version = "^0.3.0-beta-dev.6"}
-holochain_serialized_bytes = "=0.0.52"
+holochain_serialized_bytes = "=0.0.53"
 holochain_util = { version = "^0.2.0", path = "../holochain_util", features = ["backtrace"], optional = true }
 holochain_zome_types = { version = "^0.3.0-beta-dev.9", path = "../holochain_zome_types" }
 kitsune_p2p_types = { version = "^0.3.0-beta-dev.6", path = "../kitsune_p2p/types", optional = true }

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -19,7 +19,7 @@ holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = [
 fallible-iterator = "0.2.0"
 futures = "0.3"
 holochain_keystore = { version = "^0.3.0-beta-dev.10", path = "../holochain_keystore" }
-holochain_serialized_bytes = "=0.0.52"
+holochain_serialized_bytes = "=0.0.53"
 holochain_p2p = { version = "^0.3.0-beta-dev.13", path = "../holochain_p2p" }
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_util = { version = "^0.2.0", path = "../holochain_util" }

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -19,7 +19,7 @@ holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = [
 fallible-iterator = "0.2.0"
 futures = "0.3"
 holochain_keystore = { version = "^0.3.0-beta-dev.10", path = "../holochain_keystore" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_p2p = { version = "^0.3.0-beta-dev.13", path = "../holochain_p2p" }
 holochain_types = { version = "^0.3.0-beta-dev.12", path = "../holochain_types" }
 holochain_util = { version = "^0.2.0", path = "../holochain_util" }

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -29,7 +29,7 @@ getrandom = { version = "0.2.7" }
 one_err = "0.0.8"
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = ["encoding"] }
 holochain_keystore = { version = "^0.3.0-beta-dev.10", path = "../holochain_keystore" }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 holochain_sqlite = { path = "../holochain_sqlite", version = "^0.3.0-beta-dev.12"}
 holochain_wasmer_host = { version = "0.0.84", features = ["dylib"] }
 holochain_util = { version = "^0.2.0", path = "../holochain_util", features = ["backtrace"] }
@@ -63,6 +63,8 @@ wasmer-middlewares = "2"
 
 arbitrary = { version = "1.0", features = ["derive"], optional = true}
 isotest = { version = "0", optional = true }
+proptest = { version = "1", optional = true }
+proptest-derive = { version = "0", optional = true }
 
 
 # contrafact
@@ -85,13 +87,19 @@ default = ["fixturators", "test_utils"]
 
 fixturators = ["holochain_zome_types/fixturators"]
 test_utils = [
-  "arbitrary",
   "contrafact",
-  "holochain_zome_types/arbitrary",
-  "holo_hash/arbitrary",
+  "fuzzing",
+  "holochain_zome_types/fuzzing",
+  "holo_hash/fuzzing",
   "isotest",
-  "mr_bundle/arbitrary",
+  "mr_bundle/fuzzing",
   "holochain_zome_types/test_utils",
+]
+
+fuzzing = [
+  "arbitrary",
+  "proptest",
+  "proptest-derive",
 ]
 
 sqlite-encrypted = [

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -29,7 +29,7 @@ getrandom = { version = "0.2.7" }
 one_err = "0.0.8"
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = ["encoding"] }
 holochain_keystore = { version = "^0.3.0-beta-dev.10", path = "../holochain_keystore" }
-holochain_serialized_bytes = "=0.0.52"
+holochain_serialized_bytes = "=0.0.53"
 holochain_sqlite = { path = "../holochain_sqlite", version = "^0.3.0-beta-dev.12"}
 holochain_wasmer_host = { version = "0.0.84", features = ["dylib"] }
 holochain_util = { version = "^0.2.0", path = "../holochain_util", features = ["backtrace"] }

--- a/crates/holochain_types/src/action.rs
+++ b/crates/holochain_types/src/action.rs
@@ -21,7 +21,10 @@ pub mod facts;
 #[derive(
     Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash, derive_more::From,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 /// A action of one of the two types that create a new entry.
 pub enum NewEntryAction {
     /// A action which simply creates a new entry

--- a/crates/holochain_types/src/app/app_manifest.rs
+++ b/crates/holochain_types/src/app/app_manifest.rs
@@ -22,7 +22,7 @@ use super::InstalledCell;
 /// Container struct which uses the `manifest_version` field to determine
 /// which manifest version to deserialize to.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, derive_more::From)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[serde(tag = "manifest_version")]
 #[allow(missing_docs)]
 pub enum AppManifest {

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
@@ -17,7 +17,10 @@ use std::collections::HashMap;
     Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, derive_builder::Builder,
 )]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct AppManifestV1 {
     /// Name of the App. This may be used as the installed_app_id.
     pub name: String,
@@ -34,7 +37,10 @@ pub struct AppManifestV1 {
 /// potential runtime clones.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct AppRoleManifest {
     /// The ID which will be used to refer to:
     /// - this role,
@@ -64,7 +70,10 @@ impl AppRoleManifest {
 /// The DNA portion of an app role
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct AppRoleDnaManifest {
     /// Where to find this Dna. To specify a DNA included in a hApp Bundle,
     /// use a local relative path that corresponds with the bundle structure.
@@ -115,7 +124,10 @@ pub type DnaLocation = mr_bundle::Location;
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "strategy")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 #[allow(missing_docs)]
 pub enum CellProvisioning {
     /// Always create a new Cell when installing this App
@@ -245,7 +257,7 @@ pub mod tests {
     use ::fixt::prelude::*;
     use std::path::PathBuf;
 
-    #[cfg(feature = "arbitrary")]
+    #[cfg(feature = "fuzzing")]
     use arbitrary::Arbitrary;
 
     #[derive(serde::Serialize, serde::Deserialize)]

--- a/crates/holochain_types/src/dht_op.rs
+++ b/crates/holochain_types/src/dht_op.rs
@@ -35,7 +35,10 @@ pub mod facts;
 #[derive(
     Clone, Debug, Serialize, Deserialize, SerializedBytes, Eq, PartialEq, Hash, derive_more::Display,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub enum DhtOp {
     #[display(fmt = "StoreRecord")]
     /// Used to notify the authority for an action that it has been created.

--- a/crates/holochain_types/src/web_app/web_app_manifest/web_app_manifest_v1.rs
+++ b/crates/holochain_types/src/web_app/web_app_manifest/web_app_manifest_v1.rs
@@ -8,7 +8,7 @@
     Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, derive_builder::Builder,
 )]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct WebAppManifestV1 {
     /// Name of the App. This may be used as the installed_app_id.
     pub name: String,
@@ -23,7 +23,7 @@ pub struct WebAppManifestV1 {
 /// Web UI .zip file that should be associated with the happ
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct WebUI {
     /// Where to find this UI.
     ///
@@ -36,7 +36,7 @@ pub struct WebUI {
 /// Location of the happ bundle to bind with the Web UI
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct AppManifestLocation {
     /// Where to find the happ for this web-happ.
     ///

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 futures = "0.3"
 ghost_actor = "0.4.0-alpha.5"
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 nanoid = "0.3"
 net2 = "0.2"
 must_future = "0.1"

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 futures = "0.3"
 ghost_actor = "0.4.0-alpha.5"
-holochain_serialized_bytes = "=0.0.52"
+holochain_serialized_bytes = "=0.0.53"
 nanoid = "0.3"
 net2 = "0.2"
 must_future = "0.1"

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -18,7 +18,7 @@ kitsune_p2p_block = { version = "^0.3.0-beta-dev.5", path = "../kitsune_p2p/bloc
 kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.4", path = "../kitsune_p2p/bin_data" }
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = ["encoding"] }
 holochain_integrity_types = { version = "^0.3.0-beta-dev.8", path = "../holochain_integrity_types", features = ["tracing"] }
-holochain_serialized_bytes = "=0.0.52"
+holochain_serialized_bytes = "=0.0.53"
 paste = "1.0.12"
 serde = { version = "1.0", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -18,7 +18,7 @@ kitsune_p2p_block = { version = "^0.3.0-beta-dev.5", path = "../kitsune_p2p/bloc
 kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.4", path = "../kitsune_p2p/bin_data" }
 holo_hash = { version = "^0.3.0-beta-dev.6", path = "../holo_hash", features = ["encoding"] }
 holochain_integrity_types = { version = "^0.3.0-beta-dev.8", path = "../holochain_integrity_types", features = ["tracing"] }
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 paste = "1.0.12"
 serde = { version = "1.0", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"
@@ -42,8 +42,10 @@ derive_builder = { version = "0.9", optional = true }
 nanoid = { version = "0.3", optional = true }
 shrinkwraprs = { version = "0.3", optional = true }
 
-# arbitrary
+# fuzzing
 arbitrary = { version = "1.0", features = ["derive"], optional = true}
+proptest = { version = "1", optional = true }
+proptest-derive = { version = "0", optional = true }
 
 # contrafact
 contrafact = { version = "0.2.0-rc.1", optional = true }
@@ -53,9 +55,9 @@ once_cell = { version = "1.4", optional = true }
 subtle-encoding = {version = "0.5", optional = true}
 
 [dev-dependencies]
+holochain_zome_types = { path = ".", features = ["test_utils"] }
 once_cell = { version = "1.4", optional = false }
 matches = "0.1"
-proptest = "1"
 
 [features]
 default = ["full-dna-def", "fixturators", "test_utils", "subtle-encoding"]
@@ -70,17 +72,23 @@ fixturators = ["fixt", "rand", "strum", "holo_hash/fixturators", "holochain_inte
 
 properties = ["serde_yaml"]
 
-test_utils = [
+fuzzing = [
   "arbitrary",
+  "proptest",
+  "proptest-derive",
+  "holochain_serialized_bytes/fuzzing",
+  "holo_hash/fuzzing",
+  "kitsune_p2p_timestamp/fuzzing",
+]
+
+test_utils = [
+  "fuzzing",
   "contrafact",
   "once_cell",
-  "kitsune_p2p_timestamp/arbitrary",
   "kitsune_p2p_timestamp/now",
   "kitsune_p2p_block/sqlite",
-  "holo_hash/arbitrary",
   "holo_hash/hashing",
   "holo_hash/test_utils",
-  "holochain_serialized_bytes/arbitrary",
   "full-dna-def",
   "holochain_integrity_types/test_utils",
 ]

--- a/crates/holochain_zome_types/src/dna_def.rs
+++ b/crates/holochain_zome_types/src/dna_def.rs
@@ -28,7 +28,7 @@ pub type CoordinatorZomes = Vec<(ZomeName, zome::CoordinatorZomeDef)>;
 /// Hence, this type can basically be thought of as a fully validated, normalized
 /// `DnaManifest`
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, SerializedBytes)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "full-dna-def", derive(derive_builder::Builder))]
 #[cfg_attr(feature = "full-dna-def", builder(public))]
 pub struct DnaDef {

--- a/crates/holochain_zome_types/src/init.rs
+++ b/crates/holochain_zome_types/src/init.rs
@@ -7,7 +7,7 @@
 use crate::CallbackResult;
 use holochain_integrity_types::UnresolvedDependencies;
 use holochain_serialized_bytes::prelude::*;
-use holochain_wasmer_common::*;
+use holochain_wasmer_common::{WasmError, WasmErrorInner};
 
 /// The result of the DNA initialization callback.
 ///

--- a/crates/holochain_zome_types/src/lib.rs
+++ b/crates/holochain_zome_types/src/lib.rs
@@ -78,7 +78,7 @@ pub mod fixt;
 #[cfg(feature = "test_utils")]
 pub mod test_utils;
 
-#[cfg(all(any(test, feature = "test_utils"), feature = "arbitrary"))]
+#[cfg(all(any(test, feature = "test_utils"), feature = "fuzzing"))]
 pub mod entropy;
 
 pub use action::Action;

--- a/crates/holochain_zome_types/src/migrate_agent.rs
+++ b/crates/holochain_zome_types/src/migrate_agent.rs
@@ -1,5 +1,4 @@
 use crate::CallbackResult;
-use holochain_serialized_bytes::prelude::*;
 use holochain_wasmer_common::*;
 
 #[derive(Clone, Serialize, Deserialize, SerializedBytes, Debug)]

--- a/crates/holochain_zome_types/src/prelude.rs
+++ b/crates/holochain_zome_types/src/prelude.rs
@@ -61,5 +61,5 @@ pub use crate::fixt::*;
 #[cfg(feature = "test_utils")]
 pub use crate::test_utils::*;
 
-#[cfg(all(any(test, feature = "test_utils"), feature = "arbitrary"))]
+#[cfg(all(any(test, feature = "test_utils"), feature = "fuzzing"))]
 pub use crate::entropy::*;

--- a/crates/holochain_zome_types/src/properties.rs
+++ b/crates/holochain_zome_types/src/properties.rs
@@ -2,6 +2,7 @@
 //! represent "properties" of a DNA
 
 use holochain_serialized_bytes::prelude::*;
+use proptest::strategy::{BoxedStrategy, Just, Strategy};
 
 /// A type to allow json values to be used as [`derive@SerializedBytes`]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize, SerializedBytes)]
@@ -43,9 +44,19 @@ impl Default for YamlProperties {
 }
 
 /// Not a great implementation: always returns null
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for YamlProperties {
     fn arbitrary(_: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(serde_yaml::Value::Null.into())
+    }
+}
+
+#[cfg(feature = "fuzzing")]
+impl proptest::arbitrary::Arbitrary for YamlProperties {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
+        Just(YamlProperties(serde_yaml::Value::Null)).boxed()
     }
 }

--- a/crates/holochain_zome_types/src/record.rs
+++ b/crates/holochain_zome_types/src/record.rs
@@ -16,7 +16,7 @@ pub mod facts;
 ///
 /// Has implementations From and Into its tuple form.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct SignedAction(pub Action, pub Signature);
 
 impl SignedAction {

--- a/crates/kitsune_p2p/bin_data/Cargo.toml
+++ b/crates/kitsune_p2p/bin_data/Cargo.toml
@@ -17,11 +17,19 @@ derive_more = "0.99.7"
 serde = { version = "1", features = [ "derive", "rc" ] }
 base64 = "0.13"
 serde_bytes = "0.11"
+
 arbitrary = { version = "1.0", features = ["derive"], optional = true}
+proptest = { version = "1", optional = true }
+proptest-derive = { version = "0", optional = true }
 
 [features]
 test_utils = [
-  "arbitrary"
+  "fuzzing",
+]
+fuzzing = [
+  "arbitrary",
+  "proptest",
+  "proptest-derive",
 ]
 sqlite-encrypted = [
   "kitsune_p2p_dht_arc/sqlite-encrypted"

--- a/crates/kitsune_p2p/bin_data/src/lib.rs
+++ b/crates/kitsune_p2p/bin_data/src/lib.rs
@@ -2,6 +2,13 @@
 
 use kitsune_p2p_dht_arc::DhtLocation;
 
+pub mod dependencies {
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub use ::proptest;
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub use ::proptest_derive;
+}
+
 /// Kitsune hashes are expected to be 36 bytes.
 /// The first 32 bytes are the proper hash.
 /// The final 4 bytes are a hash-of-the-hash that can be treated like a u32 "location".
@@ -52,8 +59,12 @@ macro_rules! make_kitsune_bin_type {
                 serde::Serialize,
                 serde::Deserialize,
             )]
+            #[cfg_attr(any(test, feature = "fuzzing"), derive($crate::dependencies::proptest_derive::Arbitrary))]
             #[shrinkwrap(mutable)]
-            pub struct $name(#[serde(with = "serde_bytes")] pub Vec<u8>);
+            pub struct $name(
+                #[serde(with = "serde_bytes")]
+                #[cfg_attr(any(test, feature = "fuzzing"), proptest(strategy = "proptest::collection::vec(0u8..128, 36)"))]
+                pub Vec<u8>);
 
             impl KitsuneBinType for $name {
 
@@ -99,7 +110,7 @@ macro_rules! make_kitsune_bin_type {
                 }
             }
 
-            #[cfg(feature = "arbitrary")]
+            #[cfg(feature = "fuzzing")]
             impl<'a> arbitrary::Arbitrary<'a> for $name {
                 fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
                     // FIXME: there is no way to calculate location bytes right now,
@@ -118,6 +129,19 @@ macro_rules! make_kitsune_bin_type {
     };
 }
 
+// #[derive(Debug)]
+// pub struct BT(Vec<u8>);
+
+// #[cfg(feature = "fuzzing")]
+// impl proptest::arbitrary::Arbitrary for BT {
+//     type Parameters = ();
+//     type Strategy = proptest::collection::VecStrategy<proptest::num::u8::Any>;
+
+//     fn arbitrary_with(args: Self::Parameters) -> Self::Strategy {
+//         todo!()
+//     }
+// }
+
 make_kitsune_bin_type! {
     "Distinguish multiple categories of communication within the same network module.",
     KitsuneSpace,
@@ -135,6 +159,10 @@ These metadata "Operations" each also have unique OpHashes."#,
 
 /// The op data with its location
 #[derive(PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 #[repr(transparent)]
 #[serde(transparent)]
 pub struct KitsuneOpData(
@@ -213,7 +241,10 @@ pub type KOp = std::sync::Arc<KitsuneOpData>;
     serde::Deserialize,
     serde::Serialize,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 #[shrinkwrap(mutable)]
 pub struct KitsuneSignature(#[serde(with = "serde_bytes")] pub Vec<u8>);
 

--- a/crates/kitsune_p2p/dht/Cargo.toml
+++ b/crates/kitsune_p2p/dht/Cargo.toml
@@ -30,21 +30,31 @@ statrs = "0.15"
 thiserror = "1.0"
 tracing = "0.1.29"
 
+arbitrary = { version = "1", features = ["derive"], optional = true }
+proptest = { version = "1", optional = true }
+proptest-derive = { version = "0", optional = true }
+
+
 [dev-dependencies]
 kitsune_p2p_dht = { path = ".", features = ["test_utils", "sqlite"]}
 kitsune_p2p_dht_arc = { path = "../dht_arc", features = ["test_utils"]}
-holochain_serialized_bytes = "0.0.51"
+holochain_serialized_bytes = "0.0.52"
 maplit = "1"
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../../holochain_trace" }
 pretty_assertions = "0.7.2"
-proptest = "1"
 rand = "0.8"
 test-case = "1.2"
 
 [features]
 default = ["test_utils"]
 test_utils = [
-  "colored"
+  "colored",
+  "fuzzing",
+]
+fuzzing = [
+  "arbitrary",
+  "proptest",
+  "proptest-derive",
 ]
 sqlite-encrypted = [
   "kitsune_p2p_timestamp/sqlite-encrypted",

--- a/crates/kitsune_p2p/dht/Cargo.toml
+++ b/crates/kitsune_p2p/dht/Cargo.toml
@@ -38,7 +38,7 @@ proptest-derive = { version = "0", optional = true }
 [dev-dependencies]
 kitsune_p2p_dht = { path = ".", features = ["test_utils", "sqlite"]}
 kitsune_p2p_dht_arc = { path = "../dht_arc", features = ["test_utils"]}
-holochain_serialized_bytes = "0.0.52"
+holochain_serialized_bytes = "0.0.53"
 maplit = "1"
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../../holochain_trace" }
 pretty_assertions = "0.7.2"

--- a/crates/kitsune_p2p/dht/src/arq.rs
+++ b/crates/kitsune_p2p/dht/src/arq.rs
@@ -117,6 +117,7 @@ impl ArqStart for SpaceOffset {
 /// In this case, there is no definite location associated, so we want to forget
 /// about the original Location data associated with each Arq.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "fuzzing", derive(proptest_derive::Arbitrary))]
 pub struct Arq<S: ArqStart = Loc> {
     /// The "start" defines the left edge of the arq
     pub start: S,

--- a/crates/kitsune_p2p/dht/src/arq/arq_set.rs
+++ b/crates/kitsune_p2p/dht/src/arq/arq_set.rs
@@ -26,6 +26,7 @@ use super::{power_and_count_from_length, power_and_count_from_length_exact, Arq,
     serde::Serialize,
     serde::Deserialize,
 )]
+#[cfg_attr(feature = "fuzzing", derive(proptest_derive::Arbitrary))]
 pub struct ArqSet<S: ArqStart = SpaceOffset> {
     #[into_iterator]
     #[deref]

--- a/crates/kitsune_p2p/dht/src/hash.rs
+++ b/crates/kitsune_p2p/dht/src/hash.rs
@@ -71,6 +71,7 @@ impl AgentKey {
     serde::Serialize,
     serde::Deserialize,
 )]
+#[cfg_attr(feature = "fuzzing", derive(proptest_derive::Arbitrary))]
 pub struct RegionHash(pub Hash32);
 
 impl RegionHash {

--- a/crates/kitsune_p2p/dht/src/lib.rs
+++ b/crates/kitsune_p2p/dht/src/lib.rs
@@ -177,4 +177,5 @@ pub mod prelude {
     pub use super::region::*;
     pub use super::region_set::*;
     pub use super::spacetime::*;
+    pub use ::kitsune_p2p_timestamp::ArbitraryFuzzing;
 }

--- a/crates/kitsune_p2p/dht/src/region.rs
+++ b/crates/kitsune_p2p/dht/src/region.rs
@@ -18,6 +18,7 @@
 mod region_coords;
 mod region_data;
 
+use kitsune_p2p_timestamp::ArbitraryFuzzing;
 pub use region_coords::*;
 pub use region_data::*;
 
@@ -51,6 +52,7 @@ pub trait RegionDataConstraints:
     + std::fmt::Debug
     + serde::Serialize
     + serde::de::DeserializeOwned
+    + ArbitraryFuzzing
 {
     /// The number of ops in this region
     fn count(&self) -> u32;

--- a/crates/kitsune_p2p/dht/src/region/region_coords.rs
+++ b/crates/kitsune_p2p/dht/src/region/region_coords.rs
@@ -19,6 +19,10 @@ use crate::spacetime::{SpaceSegment, SpacetimeQuantumCoords, TimeSegment, Topolo
     serde::Deserialize,
     serde::Serialize,
 )]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct RegionCoords {
     /// The space segment
     pub space: SpaceSegment,

--- a/crates/kitsune_p2p/dht/src/region/region_data.rs
+++ b/crates/kitsune_p2p/dht/src/region/region_data.rs
@@ -65,6 +65,7 @@ impl From<OpHash> for RegionHash {
 /// gossip algorithm, although currently they are unused (except for the purpose
 /// of disambiguation in the rare case of an XOR hash collision).
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(feature = "fuzzing", derive(proptest_derive::Arbitrary))]
 #[serde(from = "RegionDataCompact")]
 #[serde(into = "RegionDataCompact")]
 pub struct RegionData {

--- a/crates/kitsune_p2p/dht/src/region_set/ltcs.rs
+++ b/crates/kitsune_p2p/dht/src/region_set/ltcs.rs
@@ -1,5 +1,3 @@
-use once_cell::sync::OnceCell;
-
 use crate::{
     arq::*,
     error::{GossipError, GossipResult},
@@ -17,6 +15,7 @@ use super::{Region, RegionCoords, RegionData, RegionDataConstraints};
 /// LTCS stands for Logarithmic Time, Constant Space.
 #[derive(Debug, PartialEq, Eq, derive_more::Constructor, serde::Serialize, serde::Deserialize)]
 #[cfg_attr(feature = "test_utils", derive(Clone))]
+#[cfg_attr(feature = "fuzzing", derive(proptest_derive::Arbitrary))]
 pub struct RegionCoordSetLtcs {
     pub(super) times: TelescopingTimes,
     pub(super) arq_set: ArqSet,
@@ -110,14 +109,10 @@ impl RegionCoordSetLtcs {
 #[derive(serde::Serialize, serde::Deserialize, Derivative)]
 #[derivative(PartialEq, Eq)]
 #[cfg_attr(feature = "test_utils", derive(Clone))]
+#[cfg_attr(feature = "fuzzing", derive(proptest_derive::Arbitrary))]
 pub struct RegionSetLtcs<D: RegionDataConstraints = RegionData> {
     /// The generator for the coordinates
     pub coords: RegionCoordSetLtcs,
-
-    /// the actual coordinates as generated
-    #[derivative(PartialEq = "ignore")]
-    #[serde(skip)]
-    pub(crate) _region_coords: OnceCell<Vec<RegionCoords>>,
 
     /// The outermost vec corresponds to arqs in the ArqSet;
     /// The middle vecs correspond to the spatial segments per arq;
@@ -143,18 +138,13 @@ impl<D: RegionDataConstraints> RegionSetLtcs<D> {
         Self {
             coords: RegionCoordSetLtcs::empty(),
             data: vec![],
-            _region_coords: OnceCell::new(),
         }
     }
 
     /// Construct the region set from existing data.
     /// The data must match the coords!
     pub fn from_data(coords: RegionCoordSetLtcs, data: Vec<Vec<Vec<D>>>) -> Self {
-        Self {
-            coords,
-            data,
-            _region_coords: OnceCell::new(),
-        }
+        Self { coords, data }
     }
 
     /// The total number of regions represented in this region set

--- a/crates/kitsune_p2p/dht/src/spacetime/quantum.rs
+++ b/crates/kitsune_p2p/dht/src/spacetime/quantum.rs
@@ -48,6 +48,7 @@ impl SpaceQuantum {
     serde::Serialize,
     serde::Deserialize,
 )]
+#[cfg_attr(feature = "fuzzing", derive(proptest_derive::Arbitrary))]
 pub struct TimeQuantum(u32);
 
 impl TimeQuantum {

--- a/crates/kitsune_p2p/dht/src/spacetime/segment.rs
+++ b/crates/kitsune_p2p/dht/src/spacetime/segment.rs
@@ -1,3 +1,5 @@
+use kitsune_p2p_timestamp::ArbitraryFuzzing;
+
 use super::*;
 
 /// An Offset represents the position of the left edge of some Segment.
@@ -6,7 +8,9 @@ use super::*;
 /// context, and topology of the space, by:
 ///
 ///   dht_location = offset * 2^pow * quantum_size
-pub trait Offset: Sized + Copy + Clone + Deref<Target = u32> + From<u32> {
+pub trait Offset:
+    Sized + Copy + Clone + Deref<Target = u32> + From<u32> + ArbitraryFuzzing
+{
     /// The type of quantum to map to, which also implies the absolute coordinates
     type Quantum: Quantum;
 
@@ -45,6 +49,10 @@ pub trait Offset: Sized + Copy + Clone + Deref<Target = u32> + From<u32> {
     serde::Serialize,
     serde::Deserialize,
 )]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 #[serde(transparent)]
 pub struct SpaceOffset(pub u32);
 
@@ -68,6 +76,10 @@ pub struct SpaceOffset(pub u32);
     derive_more::Into,
     serde::Serialize,
     serde::Deserialize,
+)]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
 )]
 #[serde(transparent)]
 pub struct TimeOffset(pub u32);
@@ -121,6 +133,10 @@ impl Offset for TimeOffset {
 /// is at (offset * length).
 #[derive(
     Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Deserialize, serde::Serialize,
+)]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
 )]
 pub struct Segment<O: Offset> {
     /// The exponent, where length = 2^power

--- a/crates/kitsune_p2p/dht/src/spacetime/telescoping_times.rs
+++ b/crates/kitsune_p2p/dht/src/spacetime/telescoping_times.rs
@@ -11,6 +11,7 @@ use super::*;
 /// to be covered.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Derivative, serde::Serialize, serde::Deserialize)]
 #[derivative(PartialOrd, Ord)]
+#[cfg_attr(feature = "fuzzing", derive(proptest_derive::Arbitrary))]
 pub struct TelescopingTimes {
     time: TimeQuantum,
 

--- a/crates/kitsune_p2p/dht_arc/Cargo.toml
+++ b/crates/kitsune_p2p/dht_arc/Cargo.toml
@@ -16,7 +16,11 @@ gcollections = "1.5.0"
 intervallum = "1.4.0"
 num-traits = "0.2"
 serde = {version = "1.0", features = ["derive"]}
+kitsune_p2p_timestamp = { path = "../timestamp"}
 
+arbitrary = { version = "1", features = ["derive"], optional = true }
+proptest = { version = "1", optional = true }
+proptest-derive = { version = "0", optional = true }
 rusqlite = { version = "0.29", optional = true }
 
 [dev-dependencies]
@@ -37,4 +41,14 @@ sqlite = [
     "rusqlite/bundled",
 ]
 slow_tests = []
-test_utils = []
+
+fuzzing = [
+    "arbitrary",
+    "proptest",
+    "proptest-derive",
+    "kitsune_p2p_timestamp/fuzzing"
+]
+
+test_utils = [
+    "fuzzing"
+]

--- a/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_arc.rs
@@ -72,6 +72,10 @@ impl RangeBounds<u32> for ArcRange {
 /// Contrast to [`DhtArcRange`], which is used for cases where the arc is not
 /// associated with any particular Agent, and so the agent's Location cannot be known.
 #[derive(Copy, Clone, Debug, derive_more::Deref, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(
+    any(test, feature = "fuzzing"),
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct DhtArc(#[deref] DhtArcRange, Option<DhtLocation>);
 
 impl DhtArc {
@@ -181,6 +185,10 @@ impl From<&DhtArc> for DhtArcRange {
 /// This type exists to make sure we don't accidentally intepret the starting
 /// point of such a "derived" arc as a legitimate agent location.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub enum DhtArcRange<T = DhtLocation> {
     Empty,
     Full,

--- a/crates/kitsune_p2p/dht_arc/src/dht_location.rs
+++ b/crates/kitsune_p2p/dht_arc/src/dht_location.rs
@@ -22,6 +22,10 @@ use std::num::Wrapping;
     derive_more::Deref,
     derive_more::Display,
 )]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct DhtLocation(pub Wrapping<u32>);
 
 impl DhtLocation {

--- a/crates/kitsune_p2p/dht_arc/src/loc8.rs
+++ b/crates/kitsune_p2p/dht_arc/src/loc8.rs
@@ -1,5 +1,7 @@
 use std::collections::BTreeSet;
 
+use kitsune_p2p_timestamp::ArbitraryFuzzing;
+
 use crate::{loc_downscale, loc_upscale, DhtArcRange, DhtLocation};
 
 /// A representation of DhtLocation in the u8 space. Useful for writing tests
@@ -10,6 +12,10 @@ use crate::{loc_downscale, loc_upscale, DhtArcRange, DhtLocation};
 ///
 /// Loc8 has custom `Eq`, `Ord`, and other impls which disregard the `sign`.
 #[derive(Copy, Clone)]
+#[cfg_attr(
+    any(test, feature = "fuzzing"),
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct Loc8 {
     /// The unsigned value
     val: u8,
@@ -150,7 +156,7 @@ impl DhtArcRange {
     }
 }
 
-impl<L> DhtArcRange<L>
+impl<L: Copy + ArbitraryFuzzing> DhtArcRange<L>
 where
     Loc8: From<L>,
 {

--- a/crates/kitsune_p2p/fetch/Cargo.toml
+++ b/crates/kitsune_p2p/fetch/Cargo.toml
@@ -25,19 +25,27 @@ tracing = "0.1.29"
 linked-hash-map = "0.5.6"
 
 human-repr = { version = "1", optional = true}
+arbitrary = { version = "1", optional = true }
+proptest = { version = "1", optional = true }
+proptest-derive = { version = "0", optional = true }
 
 [dev-dependencies]
 kitsune_p2p_fetch = { path = ".", features = ["test_utils", "sqlite"]}
-holochain_serialized_bytes = "0.0.51"
+holochain_serialized_bytes = "0.0.52"
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../../holochain_trace" }
 pretty_assertions = "0.7.2"
 test-case = "1.2"
 tokio = { version = "1.27", features = [ "full", "test-util" ] }
-arbitrary = "1"
 rand = "0.8.5"
 
 [features]
-test_utils = ["human-repr"]
+fuzzing = [
+    "arbitrary",
+    "proptest",
+    "proptest-derive",
+    "kitsune_p2p_types/fuzzing"
+]
+test_utils = ["human-repr", "fuzzing", "kitsune_p2p_types/test_utils"]
 default = ["test_utils"]
 sqlite-encrypted = [
     "kitsune_p2p_timestamp/sqlite-encrypted",

--- a/crates/kitsune_p2p/fetch/Cargo.toml
+++ b/crates/kitsune_p2p/fetch/Cargo.toml
@@ -31,7 +31,7 @@ proptest-derive = { version = "0", optional = true }
 
 [dev-dependencies]
 kitsune_p2p_fetch = { path = ".", features = ["test_utils", "sqlite"]}
-holochain_serialized_bytes = "0.0.52"
+holochain_serialized_bytes = "0.0.53"
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../../holochain_trace" }
 pretty_assertions = "0.7.2"
 test-case = "1.2"

--- a/crates/kitsune_p2p/fetch/src/lib.rs
+++ b/crates/kitsune_p2p/fetch/src/lib.rs
@@ -18,6 +18,10 @@ pub use rough_sized::*;
 #[derive(
     Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Deserialize, serde::Serialize,
 )]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 #[serde(tag = "type", content = "key", rename_all = "camelCase")]
 pub enum FetchKey {
     /// Fetch via region.
@@ -65,5 +69,9 @@ pub struct FetchPoolPush {
     serde::Deserialize,
     derive_more::Deref,
     derive_more::From,
+)]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
 )]
 pub struct FetchContext(pub u32);

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -48,8 +48,10 @@ tx5 = { version = "=0.0.2-alpha", optional = true }
 url2 = "0.0.6"
 fixt = { path = "../../fixt", version = "^0.2.0"}
 
-# arbitrary could be made optional
-arbitrary = { version = "1.0", features = ["derive"] }
+# fuzzing
+arbitrary = { version = "1.0", features = ["derive"], optional = true }
+proptest = { version = "1", optional = true }
+proptest-derive = { version = "0", optional = true }
 
 blake2b_simd = { version = "0.5.10", optional = true }
 maplit = { version = "1", optional = true }
@@ -76,6 +78,13 @@ rand_dalek = { version = "0.7", package = "rand" } # Compatibility with dalek
 [features]
 default = [ "tx2", "tx5" ]
 
+fuzzing = [
+  "arbitrary",
+  "proptest",
+  "proptest-derive",
+  "kitsune_p2p_timestamp/fuzzing",
+]
+
 test_utils = [
   "blake2b_simd",
   "tokio/test-util",
@@ -83,7 +92,7 @@ test_utils = [
   "kitsune_p2p_types/test_utils",
   "maplit",
   "mockall",
-  "kitsune_p2p_timestamp/arbitrary",
+  "fuzzing",
 ]
 mock_network = [
   "kitsune_p2p_types/test_utils",

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -1148,8 +1148,12 @@ fn time_range(start: Duration, end: Duration) -> TimeWindow {
     start..end
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
 /// An encoded timed bloom filter of missing op hashes.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub enum EncodedTimedBloomFilter {
     /// I have no overlap with your agents
     /// Please don't send any ops.

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/actor.rs
@@ -65,6 +65,10 @@ pub struct RpcMultiResponse {
 /// Data to broadcast to the remote.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[serde(tag = "type", content = "value", rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub enum BroadcastData {
     /// User broadcast.
     User(#[serde(with = "serde_bytes")] Vec<u8>),

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/gossip.rs
@@ -8,6 +8,11 @@ use kitsune_p2p_types::*;
 use std::sync::Arc;
 
 #[derive(Clone, Debug, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
+
 /// The type of gossip module running this gossip.
 pub enum GossipModuleType {
     /// Recent sharded gossip.

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/wire.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/wire.rs
@@ -22,11 +22,19 @@ use std::sync::Arc;
     serde::Serialize,
     serde::Deserialize,
 )]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct WireData(#[serde(with = "serde_bytes")] pub Vec<u8>);
 
 /// Enum containing the individual metric exchange messages used by clients
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub enum MetricExchangeMsg {
     /// To start off, let's use a naive single message sending
     /// everything we care about.
@@ -46,6 +54,10 @@ pub enum MetricExchangeMsg {
 /// An individual op item within a "PushOpData" wire message.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct PushOpItem {
     /// The payload of this op.
     pub op_data: Arc<KitsuneOpData>,

--- a/crates/kitsune_p2p/timestamp/Cargo.toml
+++ b/crates/kitsune_p2p/timestamp/Cargo.toml
@@ -26,7 +26,7 @@ proptest = { version = "1", optional = true }
 proptest-derive = { version = "0", optional = true }
 
 [dev-dependencies]
-holochain_serialized_bytes = "=0.0.52"
+holochain_serialized_bytes = "=0.0.53"
 serde_yaml = "0.9"
 
 [features]

--- a/crates/kitsune_p2p/timestamp/Cargo.toml
+++ b/crates/kitsune_p2p/timestamp/Cargo.toml
@@ -22,9 +22,11 @@ rusqlite = { version = "0.29", optional = true }
 
 # Dependencies only needed for testing by downstream crates.
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
+proptest = { version = "1", optional = true }
+proptest-derive = { version = "0", optional = true }
 
 [dev-dependencies]
-holochain_serialized_bytes = "=0.0.51"
+holochain_serialized_bytes = "=0.0.52"
 serde_yaml = "0.9"
 
 [features]
@@ -35,3 +37,9 @@ full = ["now"]
 
 sqlite-encrypted = [ "rusqlite", "rusqlite/bundled-sqlcipher-vendored-openssl" ]
 sqlite = [ "rusqlite", "rusqlite/bundled" ]
+
+fuzzing = [
+    "arbitrary",
+    "proptest",
+    "proptest-derive",
+]

--- a/crates/kitsune_p2p/timestamp/src/lib.rs
+++ b/crates/kitsune_p2p/timestamp/src/lib.rs
@@ -9,6 +9,9 @@ mod human;
 #[cfg(feature = "chrono")]
 pub use human::*;
 
+mod util;
+pub use util::*;
+
 use core::ops::{Add, Sub};
 use serde::{Deserialize, Serialize};
 use std::convert::{TryFrom, TryInto};
@@ -43,7 +46,8 @@ pub const MM: i64 = 1_000_000;
 /// Supports +/- `chrono::Duration` directly.  There is no `Timestamp::now()` method, since this is not
 /// supported by WASM; however, `holochain_types` provides a `Timestamp::now()` method.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(proptest_derive::Arbitrary))]
 #[cfg_attr(not(feature = "chrono"), derive(Debug))]
 pub struct Timestamp(
     /// Microseconds from UNIX Epoch, positive or negative

--- a/crates/kitsune_p2p/timestamp/src/util.rs
+++ b/crates/kitsune_p2p/timestamp/src/util.rs
@@ -1,0 +1,18 @@
+// The following are a convenience used in various downstream crates.
+// It is included here because it is the most upstream crate in the kitsune
+// crate set which makes use of it. It could make more sense to put this
+// into some kind of utility crate, but that doesn't exist yet.
+
+/// Add the Arbitrary constraint if feature "fuzzing" is enabled.
+/// Otherwise, no constraint added
+#[cfg(feature = "fuzzing")]
+pub trait ArbitraryFuzzing: proptest::arbitrary::Arbitrary {}
+#[cfg(feature = "fuzzing")]
+impl<T> ArbitraryFuzzing for T where T: proptest::arbitrary::Arbitrary {}
+
+/// Add the Arbitrary constraint if feature "fuzzing" is enabled.
+/// Otherwise, no constraint added
+#[cfg(not(feature = "fuzzing"))]
+pub trait ArbitraryFuzzing {}
+#[cfg(not(feature = "fuzzing"))]
+impl<T> ArbitraryFuzzing for T {}

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -44,6 +44,10 @@ webpki = "0.22.0"
 # arbitrary
 arbitrary = { version = "1.0", features = ["derive"], optional = true}
 
+# proptest
+proptest = { version = "1", optional = true }
+proptest-derive = { version = "0", optional = true }
+
 [dev-dependencies]
 kitsune_p2p_types = {path = ".", features = ["test_utils", "sqlite"]}
 criterion = "0.3.4"
@@ -56,12 +60,18 @@ harness = false
 [features]
 default = [ "tx2" ]
 
-test_utils = [
+fuzzing = [
   "arbitrary",
+  "proptest",
+  "proptest-derive",
+]
+
+test_utils = [
   "kitsune_p2p_bin_data/test_utils",
   "kitsune_p2p_dht_arc/test_utils",
   "ghost_actor/test_utils",
   "mockall",
+  "fuzzing",
 ]
 
 tx2 = []

--- a/crates/kitsune_p2p/types/src/agent_info.rs
+++ b/crates/kitsune_p2p/types/src/agent_info.rs
@@ -57,6 +57,10 @@ pub mod agent_info_helper {
 }
 
 /// The inner constructable AgentInfo struct
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct AgentInfoInner {
     /// The space this agent info is relevant to.
     pub space: Arc<KitsuneSpace>,
@@ -124,6 +128,10 @@ impl std::hash::Hash for AgentInfoInner {
 
 /// Value in the peer database that tracks an Agent's representation as signed by that agent.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct AgentInfoSigned(pub Arc<AgentInfoInner>);
 
 impl std::ops::Deref for AgentInfoSigned {

--- a/crates/kitsune_p2p/types/src/codec.rs
+++ b/crates/kitsune_p2p/types/src/codec.rs
@@ -105,7 +105,9 @@ macro_rules! write_codec_enum {
         $crate::dependencies::paste::item! {
             $(
                 $(#[doc = $var_doc])*
-                #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+                #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+                // NOTE: calling crate must depend on kitsune_p2p_types with feature fuzzing
+                #[cfg_attr(any(test, feature = "fuzzing"), derive($crate::dependencies::proptest_derive::Arbitrary))]
                 pub struct [< $var_name:camel >] {
                     $(
                         $(#[doc = $type_doc])* pub [< $type_name:snake >]: $type_ty,
@@ -162,7 +164,9 @@ macro_rules! write_codec_enum {
             )*
 
             $(#[doc = $codec_doc])*
-            #[derive(Clone, Debug, PartialEq)]
+            #[derive(Clone, Debug, PartialEq, Eq)]
+            // NOTE: calling crate must depend on kitsune_p2p_types with feature fuzzing
+            #[cfg_attr(any(test, feature = "fuzzing"), derive($crate::dependencies::proptest_derive::Arbitrary))]
             pub enum [< $codec_name:camel >] {
                 $(
                     $(#[doc = $var_doc])*
@@ -236,7 +240,15 @@ mod tests {
     use super::*;
     use std::sync::Arc;
 
-    #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+    #[derive(
+        Clone,
+        Debug,
+        PartialEq,
+        Eq,
+        serde::Serialize,
+        serde::Deserialize,
+        proptest_derive::Arbitrary,
+    )]
     pub struct Sub(pub Vec<u8>);
 
     write_codec_enum! {

--- a/crates/kitsune_p2p/types/src/lib.rs
+++ b/crates/kitsune_p2p/types/src/lib.rs
@@ -14,6 +14,11 @@ pub mod dependencies {
     pub use ::thiserror;
     pub use ::tokio;
     pub use ::url2;
+
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub use ::proptest;
+    #[cfg(any(test, feature = "fuzzing"))]
+    pub use ::proptest_derive;
 }
 
 /// Typedef for result of `proc_count_now()`.
@@ -94,7 +99,7 @@ impl From<Tx2Cert> for Arc<[u8; 32]> {
     }
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for Tx2Cert {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self::from(u.bytes(32)?.to_vec()))

--- a/crates/kitsune_p2p/types/src/tx2/tx2_utils/pool_buf.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_utils/pool_buf.rs
@@ -25,6 +25,10 @@ pub(crate) const POOL_BUF_PRE_WRITE_SPACE: usize = 128;
 ///
 /// We avoid initialization by using `extend_from_slice()`.
 #[derive(Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 pub struct PoolBuf(Option<(usize, Vec<u8>)>);
 
 impl std::fmt::Debug for PoolBuf {

--- a/crates/kitsune_p2p/types/src/tx2/tx2_utils/tx_url.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_utils/tx_url.rs
@@ -1,5 +1,7 @@
 use std::sync::Arc;
 
+use proptest::strategy::{BoxedStrategy, Strategy};
+
 /// New-type for sync ref-counted Urls
 /// to make passing around tx2 more efficient.
 #[derive(Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -71,5 +73,25 @@ impl From<&String> for TxUrl {
 impl From<&str> for TxUrl {
     fn from(r: &str) -> Self {
         Self(Arc::new(url2::Url2::parse(r)))
+    }
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+impl<'a> arbitrary::Arbitrary<'a> for TxUrl {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        String::arbitrary(u).map(Into::into)
+    }
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+impl proptest::arbitrary::Arbitrary for TxUrl {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<TxUrl>;
+
+    fn arbitrary_with((): Self::Parameters) -> Self::Strategy {
+        proptest::string::string_regex(r"http://\w+")
+            .unwrap()
+            .prop_map(|s| TxUrl::from(s))
+            .boxed()
     }
 }

--- a/crates/mr_bundle/Cargo.toml
+++ b/crates/mr_bundle/Cargo.toml
@@ -23,6 +23,8 @@ serde_derive = "1.0"
 thiserror = "1.0"
 
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
+proptest = { version = "1", optional = true }
+proptest-derive = { version = "0", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 
 [dev-dependencies]
@@ -36,3 +38,9 @@ tempfile = "3"
 [features]
 
 packing = ["serde_yaml", "holochain_util/tokio"]
+
+fuzzing = [
+    "arbitrary",
+    "proptest",
+    "proptest-derive",
+]

--- a/crates/mr_bundle/src/bundle.rs
+++ b/crates/mr_bundle/src/bundle.rs
@@ -20,7 +20,7 @@ pub type ResourceMap = BTreeMap<PathBuf, ResourceBytes>;
 ///
 /// The manifest may describe locations of resources not included in the Bundle.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct Bundle<M>
 where
     M: Manifest,
@@ -206,7 +206,7 @@ where
 /// The manifest may be of any format. This is useful for deserializing a bundle of
 /// an outdated format, so that it may be modified to fit the supported format.
 #[derive(Debug, PartialEq, Eq, Deserialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct RawBundle<M> {
     /// The manifest describing the resources that compose this bundle.
     #[serde(bound(deserialize = "M: DeserializeOwned"))]

--- a/crates/mr_bundle/src/location.rs
+++ b/crates/mr_bundle/src/location.rs
@@ -12,7 +12,10 @@ use std::path::{Path, PathBuf};
 /// being flattened.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    feature = "fuzzing",
+    derive(arbitrary::Arbitrary, proptest_derive::Arbitrary)
+)]
 #[allow(missing_docs)]
 pub enum Location {
     /// Expect file to be part of this bundle

--- a/crates/mr_bundle/src/resource.rs
+++ b/crates/mr_bundle/src/resource.rs
@@ -10,7 +10,7 @@
     derive_more::From,
     derive_more::Deref,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct ResourceBytes(#[serde(with = "serde_bytes")] Vec<u8>);
 
 impl ResourceBytes {

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_serialized_bytes"
-version = "0.0.51"
+version = "0.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9805b3e01e7b5c144782a0823db4dc895fec18a9ccd45a492ce7c7bf157a9e38"
 dependencies = [
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_serialized_bytes_derive"
-version = "0.0.51"
+version = "0.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1077232d0c427d64feb9e138fa22800e447eafb1810682d6c13beb95333cb32c"
 dependencies = [

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -214,8 +214,8 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -508,8 +508,8 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "strsim 0.9.3",
  "syn 1.0.109",
 ]
@@ -522,8 +522,8 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -536,8 +536,8 @@ checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 2.0.25",
 ]
 
@@ -548,7 +548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
- "quote",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -559,7 +559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core 0.14.4",
- "quote",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -570,7 +570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
 dependencies = [
  "darling_core 0.20.1",
- "quote",
+ "quote 1.0.29",
  "syn 2.0.25",
 ]
 
@@ -580,8 +580,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -591,8 +591,8 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 2.0.25",
 ]
 
@@ -604,8 +604,8 @@ checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
  "darling 0.10.2",
  "derive_builder_core",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -616,8 +616,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling 0.10.2",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -628,8 +628,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -677,8 +677,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -698,8 +698,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
  "darling 0.20.1",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 2.0.25",
 ]
 
@@ -749,7 +749,7 @@ dependencies = [
 name = "fixt"
 version = "0.2.0"
 dependencies = [
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "lazy_static",
  "parking_lot 0.10.2",
  "paste",
@@ -847,8 +847,8 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 2.0.25",
 ]
 
@@ -999,8 +999,8 @@ dependencies = [
  "holochain_integrity_types",
  "paste",
  "proc-macro-error",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -1050,10 +1050,12 @@ dependencies = [
  "derive_more",
  "fixt",
  "futures",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_wasmer_common",
  "kitsune_p2p_dht_arc",
  "must_future",
+ "proptest",
+ "proptest-derive 0.4.0",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
@@ -1067,10 +1069,12 @@ dependencies = [
  "arbitrary",
  "derive_builder",
  "holo_hash",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "kitsune_p2p_dht",
  "kitsune_p2p_timestamp",
  "paste",
+ "proptest",
+ "proptest-derive 0.4.0",
  "serde",
  "serde_bytes",
  "subtle",
@@ -1088,12 +1092,29 @@ dependencies = [
 
 [[package]]
 name = "holochain_serialized_bytes"
-version = "0.0.52"
+version = "0.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9805b3e01e7b5c144782a0823db4dc895fec18a9ccd45a492ce7c7bf157a9e38"
 dependencies = [
+ "holochain_serialized_bytes_derive 0.0.51",
+ "rmp-serde",
+ "serde",
+ "serde-transcode",
+ "serde_bytes",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "holochain_serialized_bytes"
+version = "0.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7a5fc7c745a107f8ebcb04caab7a6b7a8463e2811f07ced19c281977583de7"
+dependencies = [
  "arbitrary",
- "holochain_serialized_bytes_derive",
+ "holochain_serialized_bytes_derive 0.0.53",
+ "proptest",
+ "proptest-derive 0.3.0",
  "rmp-serde",
  "serde",
  "serde-transcode",
@@ -1104,11 +1125,21 @@ dependencies = [
 
 [[package]]
 name = "holochain_serialized_bytes_derive"
-version = "0.0.52"
+version = "0.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1077232d0c427d64feb9e138fa22800e447eafb1810682d6c13beb95333cb32c"
 dependencies = [
- "quote",
+ "quote 1.0.29",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "holochain_serialized_bytes_derive"
+version = "0.0.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3e0cf02005cbf0f514476d40e02125b26df6d4922d7a2c48a84fc588539d71"
+dependencies = [
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -1126,7 +1157,7 @@ version = "0.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "223daec7ca62d4e36841a99d8799b29cc616f5976ad0e2975e6ca6810de8f14f"
 dependencies = [
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "serde",
  "serde_bytes",
  "test-fuzz",
@@ -1141,7 +1172,7 @@ version = "0.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b2026e44595cb16108464973622577936605582aa22932933a5130ad32ce42"
 dependencies = [
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.51",
  "holochain_wasmer_common",
  "parking_lot 0.12.1",
  "paste",
@@ -1157,7 +1188,7 @@ dependencies = [
  "fixt",
  "holo_hash",
  "holochain_integrity_types",
- "holochain_serialized_bytes",
+ "holochain_serialized_bytes 0.0.53",
  "holochain_wasmer_common",
  "kitsune_p2p_bin_data",
  "kitsune_p2p_block",
@@ -1333,6 +1364,7 @@ dependencies = [
 name = "kitsune_p2p_dht"
 version = "0.3.0-beta-dev.4"
 dependencies = [
+ "arbitrary",
  "colored",
  "derivative",
  "derive_more",
@@ -1344,6 +1376,8 @@ dependencies = [
  "must_future",
  "num-traits",
  "once_cell",
+ "proptest",
+ "proptest-derive 0.4.0",
  "rand 0.8.5",
  "serde",
  "statrs",
@@ -1358,6 +1392,7 @@ dependencies = [
  "derive_more",
  "gcollections",
  "intervallum",
+ "kitsune_p2p_timestamp",
  "num-traits",
  "serde",
 ]
@@ -1369,6 +1404,8 @@ dependencies = [
  "arbitrary",
  "chrono",
  "derive_more",
+ "proptest",
+ "proptest-derive 0.4.0",
  "serde",
 ]
 
@@ -1454,7 +1491,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
 dependencies = [
- "quote",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -1541,8 +1578,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if 1.0.0",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -1586,8 +1623,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -1801,8 +1838,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
  "version_check",
 ]
@@ -1813,9 +1850,18 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+dependencies = [
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1825,6 +1871,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift 0.3.0",
+ "regex-syntax 0.6.29",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "syn 0.15.44",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
+dependencies = [
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1842,9 +1930,24 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quote"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
+dependencies = [
+ "proc-macro2 0.4.30",
 ]
 
 [[package]]
@@ -1853,7 +1956,7 @@ version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
- "proc-macro2",
+ "proc-macro2 1.0.64",
 ]
 
 [[package]]
@@ -1877,7 +1980,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi",
 ]
 
@@ -2009,6 +2112,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,7 +2192,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -2091,8 +2203,14 @@ checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2144,8 +2262,8 @@ version = "0.7.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -2211,6 +2329,18 @@ name = "rustversion"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "ryu"
@@ -2299,8 +2429,8 @@ version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 2.0.25",
 ]
 
@@ -2348,8 +2478,8 @@ checksum = "e63e6744142336dfb606fe2b068afa2e1cca1ee6a5d8377277a92945d81fa331"
 dependencies = [
  "bitflags",
  "itertools 0.8.2",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -2430,8 +2560,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -2442,8 +2572,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -2475,12 +2605,23 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "0.15.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
+dependencies = [
+ "proc-macro2 0.4.30",
+ "quote 0.6.13",
+ "unicode-xid",
+]
+
+[[package]]
+name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "unicode-ident",
 ]
 
@@ -2490,8 +2631,8 @@ version = "2.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "unicode-ident",
 ]
 
@@ -2546,8 +2687,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58071dc2471840e9f374eeb0f6e405a31bccb3cc5d59bb4598f02cafc274b5c4"
 dependencies = [
  "cargo_metadata",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "serde",
  "strum_macros 0.24.3",
 ]
@@ -2561,8 +2702,8 @@ dependencies = [
  "darling 0.14.4",
  "if_chain",
  "lazy_static",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "subprocess",
  "syn 1.0.109",
  "test-fuzz-internal",
@@ -3045,8 +3186,8 @@ version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 2.0.25",
 ]
 
@@ -3108,8 +3249,8 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 2.0.25",
 ]
 
@@ -3142,6 +3283,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3160,6 +3307,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3171,8 +3324,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 
@@ -3193,6 +3346,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"
@@ -3235,8 +3397,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
@@ -3247,7 +3409,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote",
+ "quote 1.0.29",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3257,8 +3419,8 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -3364,8 +3526,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
 dependencies = [
  "proc-macro-error",
- "proc-macro2",
- "quote",
+ "proc-macro2 1.0.64",
+ "quote 1.0.29",
  "syn 1.0.109",
 ]
 


### PR DESCRIPTION
### Summary

Looks like proptest is way more suitable for our testing needs. This is part of a transition to proptest's version of Arbitrary.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
