### PR TITLE
[BACKPORT 0.2] fetch respond tests

### DIFF
--- a/crates/kitsune_p2p/fetch/src/respond.rs
+++ b/crates/kitsune_p2p/fetch/src/respond.rs
@@ -54,12 +54,16 @@ impl<C: FetchResponseConfig> FetchResponseQueue<C> {
     }
 
     /// Enqueue an op to be sent to a remote.
-    pub fn enqueue_op(&self, space: KSpace, user: C::User, op: KOpData) {
+    pub fn enqueue_op(&self, space: KSpace, user: C::User, op: KOpData) -> bool {
         let len = op.size();
 
-        if len > u32::MAX as usize {
-            tracing::error!("op size > u32::MAX");
-            return;
+        // Don't try to take more permits than the byte_limit has.
+        if len > self.config.byte_limit() as usize {
+            tracing::error!(
+                "op size is over configured limit {}",
+                self.config.byte_limit()
+            );
+            return false;
         }
 
         let len = len as u32;
@@ -67,7 +71,7 @@ impl<C: FetchResponseConfig> FetchResponseQueue<C> {
         let byte_permit = match self.byte_limit.clone().try_acquire_many_owned(len) {
             Err(_) => {
                 tracing::warn!(%len, "fetch responder overloaded, dropping op");
-                return;
+                return false;
             }
             Ok(permit) => permit,
         };
@@ -78,7 +82,10 @@ impl<C: FetchResponseConfig> FetchResponseQueue<C> {
             let _byte_permit = byte_permit;
 
             let _c_permit = match c_limit.acquire_owned().await {
-                Err(_) => return,
+                Err(_) => {
+                    tracing::error!("Unexpected closed semaphore for concurrent_send_limit");
+                    return;
+                }
                 Ok(permit) => permit,
             };
 
@@ -92,6 +99,8 @@ impl<C: FetchResponseConfig> FetchResponseQueue<C> {
             // it's *always* an error, because we drop it.
             let _ = r.await;
         });
+
+        true
     }
 }
 
@@ -107,15 +116,16 @@ mod tests {
         pub responds: Vec<(KSpace, &'static str, FetchResponseGuard, KOpData)>,
     }
 
-    struct TestConf(Mutex<TestConfInner>);
+    #[derive(Clone)]
+    struct TestConf(Arc<Mutex<TestConfInner>>);
 
     impl TestConf {
         pub fn new(byte_limit: u32, concurrent_send_limit: u32) -> Self {
-            Self(Mutex::new(TestConfInner {
+            Self(Arc::new(Mutex::new(TestConfInner {
                 byte_limit,
                 concurrent_send_limit,
                 responds: Vec::new(),
-            }))
+            })))
         }
 
         pub fn drain_responds(&self) -> Vec<(KSpace, &'static str, FetchResponseGuard, KOpData)> {
@@ -123,7 +133,7 @@ mod tests {
         }
     }
 
-    impl FetchResponseConfig for Arc<TestConf> {
+    impl FetchResponseConfig for TestConf {
         type User = &'static str;
 
         fn byte_limit(&self) -> u32 {
@@ -139,21 +149,134 @@ mod tests {
         }
     }
 
+    #[test]
+    fn config_provides_defaults() {
+        struct DefaultConf;
+        impl FetchResponseConfig for DefaultConf {
+            type User = ();
+
+            fn respond(
+                &self,
+                _space: KSpace,
+                _user: Self::User,
+                _completion_guard: FetchResponseGuard,
+                _op: KOpData,
+            ) {
+                unreachable!()
+            }
+        }
+
+        let config = DefaultConf;
+        assert!(config.byte_limit() > 0);
+        assert!(config.concurrent_send_limit() > 0);
+    }
+
+    #[test]
+    fn queue_uses_input_config() {
+        let config = TestConf::new(1024, 1);
+        let queue = FetchResponseQueue::new(config.clone());
+
+        // Check that the queue config is based on the input config.
+        assert_eq!(
+            config.byte_limit(),
+            queue.byte_limit.available_permits() as u32
+        );
+        assert_eq!(
+            config.concurrent_send_limit(),
+            queue.concurrent_send_limit.available_permits() as u32
+        );
+
+        // Check that updating the input config DOES NOT update the queue config.
+        // TODO They may as well be properties rather than functions
+        config.0.lock().unwrap().byte_limit = 1;
+        config.0.lock().unwrap().concurrent_send_limit = 2;
+
+        assert_ne!(
+            config.byte_limit(),
+            queue.byte_limit.available_permits() as u32
+        );
+        assert_ne!(
+            config.concurrent_send_limit(),
+            queue.concurrent_send_limit.available_permits() as u32
+        );
+    }
+
     #[tokio::test(flavor = "multi_thread")]
-    async fn test() {
-        let config = Arc::new(TestConf::new(1024, 1));
+    async fn enqueue_op_single() {
+        let config = TestConf::new(1024, 1);
 
         let q = FetchResponseQueue::new(config.clone());
         assert_eq!(0, config.drain_responds().len());
 
-        q.enqueue_op(
+        assert!(q.enqueue_op(
             Arc::new(KitsuneSpace::new(vec![0; 36])),
             "noodle",
             Arc::new(b"hello".to_vec().into()),
-        );
+        ));
 
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
 
+        assert_eq!(1, config.drain_responds().len());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enqueue_op_drops_large_op() {
+        let config = TestConf::new(1024, 1);
+        let q = FetchResponseQueue::new(config.clone());
+
+        assert!(!q.enqueue_op(
+            Arc::new(KitsuneSpace::new(vec![0; 36])),
+            "lots-of-bytes",
+            Arc::new([0; 1040].to_vec().into()),
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn enqueue_op_with_insufficient_capacity_remaining() {
+        let config = TestConf::new(1024, 1);
+        let q = FetchResponseQueue::new(config.clone());
+
+        assert!(q.enqueue_op(
+            Arc::new(KitsuneSpace::new(vec![0; 36])),
+            "lots-of-bytes",
+            Arc::new([0; 1000].to_vec().into()),
+        ));
+
+        assert!(!q.enqueue_op(
+            Arc::new(KitsuneSpace::new(vec![0; 36])),
+            "lots-of-bytes",
+            Arc::new([0; 100].to_vec().into()),
+        ));
+    }
+
+    // TODO This situation is never communicated back to the caller because `enqueue_op` is effectively fire and forget
+    //      but it is actually a fatal condition.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn handles_closed_semaphore() {
+        let config = TestConf::new(1024, 1);
+        let q = FetchResponseQueue::new(config.clone());
+
+        assert!(q.enqueue_op(
+            Arc::new(KitsuneSpace::new(vec![0; 36])),
+            "lots-of-bytes",
+            Arc::new([0; 100].to_vec().into()),
+        ));
+
+        // Give the op time to queue
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        q.concurrent_send_limit.close();
+
+        // The semaphore is closed but we only find that out inside the inner task so the enqueue should succeed.
+        assert!(q.enqueue_op(
+            Arc::new(KitsuneSpace::new(vec![0; 36])),
+            "lots-of-bytes",
+            Arc::new([0; 100].to_vec().into()),
+        ));
+
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+        // But there will only be one op in the queue
         assert_eq!(1, config.drain_responds().len());
     }
 }


### PR DESCRIPTION
### Summary

Backport #2655 

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
