### PR TITLE
Fix checks for allowed semver increment mode

### DIFF
--- a/crates/release-automation/src/lib/tests/cli.rs
+++ b/crates/release-automation/src/lib/tests/cli.rs
@@ -957,7 +957,7 @@ fn release_dry_run_fails_on_unallowed_conditions() {
             "--log-level=debug",
             "release",
             "--dry-run",
-            "--allowed-semver-increment-modes=patch",
+            "--allowed-semver-increment-modes=!pre_patch beta-rc",
             "--steps=BumpReleaseVersions",
         ]);
 


### PR DESCRIPTION
### Summary

I missed this when updating the semver increment mode for 0.1, fixing that here

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
