### PR TITLE
Add missing docs in hc sandbox

### DIFF
--- a/crates/hc_sandbox/src/cli.rs
+++ b/crates/hc_sandbox/src/cli.rs
@@ -236,6 +236,7 @@ impl LaunchInfo {
     }
 }
 
+/// Run a conductor for each path
 pub async fn run_n(
     holochain_path: &Path,
     paths: Vec<PathBuf>,
@@ -282,6 +283,7 @@ pub async fn run_n(
     Ok(())
 }
 
+/// Perform the `generate` subcommand
 pub async fn generate(
     holochain_path: &Path,
     happ: Option<PathBuf>,


### PR DESCRIPTION
### Summary

Split #2587 to get this warning addressed separately from other warnings from the later versions of clippy

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
