### PR TITLE
Cli lib exports

### DIFF
--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Export packing, unpacking & utility functions of `mr_bundle` in lib exports [\#2705](https://github.com/holochain/holochain/pull/2705)
+
 ## 0.3.0-beta-dev.13
 
 ## 0.3.0-beta-dev.12

--- a/crates/hc_bundle/src/cli.rs
+++ b/crates/hc_bundle/src/cli.rs
@@ -453,7 +453,7 @@ impl HcWebAppBundleSubcommand {
     }
 }
 
-async fn get_dna_name(manifest_path: &Path) -> HcBundleResult<String> {
+pub async fn get_dna_name(manifest_path: &Path) -> HcBundleResult<String> {
     let manifest_path = manifest_path.to_path_buf();
     let manifest_path = manifest_path.join(ValidatedDnaManifest::path());
     let manifest_yaml = ffs::read_to_string(&manifest_path).await?;
@@ -461,7 +461,7 @@ async fn get_dna_name(manifest_path: &Path) -> HcBundleResult<String> {
     Ok(manifest.name())
 }
 
-async fn get_app_name(manifest_path: &Path) -> HcBundleResult<String> {
+pub async fn get_app_name(manifest_path: &Path) -> HcBundleResult<String> {
     let manifest_path = manifest_path.to_path_buf();
     let manifest_path = manifest_path.join(AppManifest::path());
     let manifest_yaml = ffs::read_to_string(&manifest_path).await?;
@@ -469,7 +469,7 @@ async fn get_app_name(manifest_path: &Path) -> HcBundleResult<String> {
     Ok(manifest.app_name().to_string())
 }
 
-async fn get_web_app_name(manifest_path: &Path) -> HcBundleResult<String> {
+pub async fn get_web_app_name(manifest_path: &Path) -> HcBundleResult<String> {
     let manifest_path = manifest_path.to_path_buf();
     let manifest_path = manifest_path.join(WebAppManifest::path());
     let manifest_yaml = ffs::read_to_string(&manifest_path).await?;
@@ -478,7 +478,7 @@ async fn get_web_app_name(manifest_path: &Path) -> HcBundleResult<String> {
 }
 
 // Pack the app's manifest and all its DNAs if their location is bundled
-async fn web_app_pack_recursive(web_app_workdir_path: &PathBuf) -> anyhow::Result<()> {
+pub async fn web_app_pack_recursive(web_app_workdir_path: &PathBuf) -> anyhow::Result<()> {
     let canonical_web_app_workdir_path = ffs::canonicalize(web_app_workdir_path).await?;
 
     let web_app_manifest_path = canonical_web_app_workdir_path.join(WebAppManifest::path());
@@ -511,7 +511,7 @@ async fn web_app_pack_recursive(web_app_workdir_path: &PathBuf) -> anyhow::Resul
 }
 
 // Pack all the app's DNAs if their location is bundled
-async fn app_pack_recursive(app_workdir_path: &PathBuf) -> anyhow::Result<()> {
+pub async fn app_pack_recursive(app_workdir_path: &PathBuf) -> anyhow::Result<()> {
     let app_workdir_path = ffs::canonicalize(app_workdir_path).await?;
 
     let app_manifest_path = app_workdir_path.join(AppManifest::path());
@@ -536,7 +536,7 @@ async fn app_pack_recursive(app_workdir_path: &PathBuf) -> anyhow::Result<()> {
 }
 
 // Returns all the locations of the workdirs for the bundled DNAs in the given app manifest
-async fn bundled_dnas_workdir_locations(
+pub async fn bundled_dnas_workdir_locations(
     app_manifest_path: &Path,
     app_manifest: &AppManifest,
 ) -> anyhow::Result<Vec<PathBuf>> {

--- a/crates/hc_bundle/src/lib.rs
+++ b/crates/hc_bundle/src/lib.rs
@@ -3,4 +3,5 @@ mod error;
 mod init;
 mod packing;
 
-pub use cli::{HcAppBundle, HcDnaBundle, HcWebAppBundle};
+pub use cli::{HcAppBundle, HcDnaBundle, HcWebAppBundle, get_dna_name, get_app_name, get_web_app_name, web_app_pack_recursive, app_pack_recursive, bundled_dnas_workdir_locations};
+pub use packing::{pack, unpack, unpack_raw};

--- a/crates/hc_run_local_services/CHANGELOG.md
+++ b/crates/hc_run_local_services/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Adds function `new()` to `HcRunLocalServices` allowing consumption of `hc_run_local_services` as a lib [\#2705](https://github.com/holochain/holochain/pull/2705)
+
 ## 0.3.0-beta-dev.7
 
 ## 0.3.0-beta-dev.6

--- a/crates/hc_run_local_services/src/lib.rs
+++ b/crates/hc_run_local_services/src/lib.rs
@@ -76,6 +76,28 @@ impl AOut {
 }
 
 impl HcRunLocalServices {
+    pub fn new(
+        bootstrap_address_path: Option<std::path::PathBuf>, 
+        bootstrap_interface: String,
+        bootstrap_port: u16,
+        disable_bootstrap: bool,
+        signal_address_path: Option<std::path::PathBuf>,
+        signal_interfaces: String,
+        signal_port: u16, 
+        disable_signal: bool,
+    ) -> Self {
+        Self {
+            bootstrap_address_path,
+            bootstrap_interface,
+            bootstrap_port,
+            disable_bootstrap,
+            signal_address_path,
+            signal_interfaces,
+            signal_port,
+            disable_signal,
+        }
+    }
+
     pub async fn run(self) {
         if let Err(err) = self.run_err().await {
             eprintln!("run-local-services error");


### PR DESCRIPTION
### Summary

- Exports packing, unpacking & utility functions of `mr_bundle` in lib
- Adds functon `new()` to `HcRunLocalServices` allowing consumption of `hc_run_local_services` as a lib

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
