### PR TITLE
[0.1] Prepare for 0.1.6 release

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -214,7 +214,7 @@ jobs:
                 --force-tag-creation \
                 --force-branch-creation \
                 --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
-                --allowed-semver-increment-modes="!pre_patch beta-rc" \
+                --allowed-semver-increment-modes="!patch" \
                 --steps=CreateReleaseBranch,BumpReleaseVersions
 
             release-automation \

--- a/crates/fixt/CHANGELOG.md
+++ b/crates/fixt/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/fixt/CHANGELOG.md
+++ b/crates/fixt/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/fixt/test/CHANGELOG.md
+++ b/crates/fixt/test/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/fixt/test/CHANGELOG.md
+++ b/crates/fixt/test/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/hc_bundle/src/cli.rs
+++ b/crates/hc_bundle/src/cli.rs
@@ -475,3 +475,9 @@ async fn bundled_dnas_workdir_locations(
 
     Ok(dna_locations)
 }
+
+nix run .#release-automation -- --workspace-path=$PWD --log-level=debug --match-filter=".*" changelog set-frontmatter <(cat <<EOF
+default_semver_increment_mode: !pre_patch beta-rc
+semver_increment_mode: !minor
+EOF
+)

--- a/crates/hc_bundle/src/cli.rs
+++ b/crates/hc_bundle/src/cli.rs
@@ -475,9 +475,3 @@ async fn bundled_dnas_workdir_locations(
 
     Ok(dna_locations)
 }
-
-nix run .#release-automation -- --workspace-path=$PWD --log-level=debug --match-filter=".*" changelog set-frontmatter <(cat <<EOF
-default_semver_increment_mode: !pre_patch beta-rc
-semver_increment_mode: !minor
-EOF
-)

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/hdi/CHANGELOG.md
+++ b/crates/hdi/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/hdi/CHANGELOG.md
+++ b/crates/hdi/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/hdk_derive/CHANGELOG.md
+++ b/crates/hdk_derive/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/hdk_derive/CHANGELOG.md
+++ b/crates/hdk_derive/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holo_hash/CHANGELOG.md
+++ b/crates/holo_hash/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holo_hash/CHANGELOG.md
+++ b/crates/holo_hash/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_integrity_types/CHANGELOG.md
+++ b/crates/holochain_integrity_types/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_integrity_types/CHANGELOG.md
+++ b/crates/holochain_integrity_types/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_util/CHANGELOG.md
+++ b/crates/holochain_util/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_util/CHANGELOG.md
+++ b/crates/holochain_util/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_websocket/CHANGELOG.md
+++ b/crates/holochain_websocket/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_websocket/CHANGELOG.md
+++ b/crates/holochain_websocket/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/bootstrap/CHANGELOG.md
+++ b/crates/kitsune_p2p/bootstrap/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/bootstrap/CHANGELOG.md
+++ b/crates/kitsune_p2p/bootstrap/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/dht/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/dht/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/dht_arc/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht_arc/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/dht_arc/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht_arc/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/fetch/CHANGELOG.md
+++ b/crates/kitsune_p2p/fetch/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/fetch/CHANGELOG.md
+++ b/crates/kitsune_p2p/fetch/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/mdns/CHANGELOG.md
+++ b/crates/kitsune_p2p/mdns/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/mdns/CHANGELOG.md
+++ b/crates/kitsune_p2p/mdns/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/proxy/CHANGELOG.md
+++ b/crates/kitsune_p2p/proxy/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/proxy/CHANGELOG.md
+++ b/crates/kitsune_p2p/proxy/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/timestamp/CHANGELOG.md
+++ b/crates/kitsune_p2p/timestamp/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/timestamp/CHANGELOG.md
+++ b/crates/kitsune_p2p/timestamp/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/transport_quic/CHANGELOG.md
+++ b/crates/kitsune_p2p/transport_quic/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/transport_quic/CHANGELOG.md
+++ b/crates/kitsune_p2p/transport_quic/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/types/CHANGELOG.md
+++ b/crates/kitsune_p2p/types/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/kitsune_p2p/types/CHANGELOG.md
+++ b/crates/kitsune_p2p/types/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/mock_hdi/CHANGELOG.md
+++ b/crates/mock_hdi/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/mock_hdi/CHANGELOG.md
+++ b/crates/mock_hdi/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/mr_bundle/CHANGELOG.md
+++ b/crates/mr_bundle/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/mr_bundle/CHANGELOG.md
+++ b/crates/mr_bundle/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/test_utils/wasm/CHANGELOG.md
+++ b/crates/test_utils/wasm/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/test_utils/wasm/CHANGELOG.md
+++ b/crates/test_utils/wasm/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/test_utils/wasm_common/CHANGELOG.md
+++ b/crates/test_utils/wasm_common/CHANGELOG.md
@@ -1,4 +1,5 @@
 ---
+semver_increment_mode: minor
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog

--- a/crates/test_utils/wasm_common/CHANGELOG.md
+++ b/crates/test_utils/wasm_common/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-semver_increment_mode: minor
+semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch beta-rc
 ---
 # Changelog


### PR DESCRIPTION
### Summary

I've updated my own hApp project to use 0.1.6-beta-rc.0 and Lair 0.3.0 and everything runs like it should.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
