### PR TITLE
Update to Holochain 0.1.6 and Lair 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Updating the default version of Holochain 0.1 to be 0.1.6 and bumping Lair to 0.3.0. This is a maintenance release that resolves
   and issue with serde serialisation that was leading to the error `"invalid type: map, expected variant identifier"`. There were also
   some updated dependencies of the Lair keystore that weren't building on Rust 1.66.1 which is the reason for bumping the Lair keystore version.
-  Please `nix flake update` to take this change and update your HDI/HDK versions.
+  Please run `nix flake update` to take this change and update your HDI/HDK versions.
 
 # 20230823.003418
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 # \[Unreleased\]
 
 - Updating the default version of Holochain 0.1 to be 0.1.6 and bumping Lair to 0.3.0. This is a maintenance release that resolves
-  and issue with serde serialisation that was leading to the error `"invalid type: map, expected variant identifier"`. There were also
+  an issue with serde serialisation that was leading to the error `"invalid type: map, expected variant identifier"`. There were also
   some updated dependencies of the Lair keystore that weren't building on Rust 1.66.1 which is the reason for bumping the Lair keystore version.
   Please run `nix flake update` to take this change and update your HDI/HDK versions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # \[Unreleased\]
 
+- Updating the default version of Holochain 0.1 to be 0.1.6 and bumping Lair to 0.3.0. This is a maintenance release that resolves
+  and issue with serde serialisation that was leading to the error `"invalid type: map, expected variant identifier"`. There were also
+  some updated dependencies of the Lair keystore that weren't building on Rust 1.66.1 which is the reason for bumping the Lair keystore version.
+  Please `nix flake update` to take this change and update your HDI/HDK versions.
+
 # 20230823.003418
 
 ## [holochain\_cli-0.3.0-beta-dev.15](crates/holochain_cli/CHANGELOG.md#0.3.0-beta-dev.15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # \[Unreleased\]
 
-- Updating the default version of Holochain 0.1 to be 0.1.6 and bumping Lair to 0.3.0. This is a maintenance release that resolves
+- Updating the default version of Holochain 0.1 to be 0.1.6 and bumping Lair to 0.3.0. This is a maintenance release that resolves [PR#2712](https://github.com/holochain/holochain/pull/2712)
   an issue with serde serialisation that was leading to the error `"invalid type: map, expected variant identifier"`. There were also
   some updated dependencies of the Lair keystore that weren't building on Rust 1.66.1 which is the reason for bumping the Lair keystore version.
   Please run `nix flake update` to take this change and update your HDI/HDK versions.

--- a/versions/0_1/flake.lock
+++ b/versions/0_1/flake.lock
@@ -3,16 +3,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1686257124,
-        "narHash": "sha256-SvXGHOr96ob/NfQCeVJ2J4LWc83qkZn+/pnE9qVNB+I=",
+        "lastModified": 1692965835,
+        "narHash": "sha256-tylLGAliWQnnYjTdjTN8N7xxlcHgso085wkQ8NgmOpI=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "db5b8b27da3bf296958c3bf54ac3950dc60a39c8",
+        "rev": "6d424d347d5296bc8e92ff5233f5a6ed22ed736f",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.1.5",
+        "ref": "holochain-0.1.6",
         "repo": "holochain",
         "type": "github"
       }
@@ -20,16 +20,16 @@
     "lair": {
       "flake": false,
       "locked": {
-        "lastModified": 1682356264,
-        "narHash": "sha256-5ZYJ1gyyL3hLR8hCjcN5yremg8cSV6w1iKCOrpJvCmc=",
+        "lastModified": 1691746070,
+        "narHash": "sha256-CHsTI4yIlkfnYWx2sNgzAoDBvKTLIChybzyJNbB1sMU=",
         "owner": "holochain",
         "repo": "lair",
-        "rev": "43be404da0fd9d57bf4429c44def405bd6490f61",
+        "rev": "6ab41b60744515f1760669db6fc5272298a5f324",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "lair_keystore-v0.2.4",
+        "ref": "lair_keystore-v0.3.0",
         "repo": "lair",
         "type": "github"
       }

--- a/versions/0_1/flake.nix
+++ b/versions/0_1/flake.nix
@@ -2,12 +2,12 @@
   inputs =
     {
       holochain = {
-        url = "github:holochain/holochain/holochain-0.1.5";
+        url = "github:holochain/holochain/holochain-0.1.6";
         flake = false;
       };
 
       lair = {
-        url = "github:holochain/lair/lair_keystore-v0.2.4";
+        url = "github:holochain/lair/lair_keystore-v0.3.0";
         flake = false;
       };
 


### PR DESCRIPTION
### Summary

This contains the pin of serde to address issues with serialisation compatibility and a bump of Lair to address that not being able to build on the version of Rust we're currently shipping with Holonix.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
