### PR TITLE
feat(nix): add rust helper and pin crate2nix toolchain

### DIFF
--- a/nix/modules/cargo-chef.nix
+++ b/nix/modules/cargo-chef.nix
@@ -3,7 +3,7 @@
 { self, inputs, lib, ... }@flake: {
   perSystem = { config, self', inputs', system, pkgs, ... }:
     let
-      rustToolchain = config.rust.mkRust {
+      rustToolchain = config.rustHelper.mkRust {
         track = "stable";
         version = "latest";
       };

--- a/nix/modules/cargo-rdme.nix
+++ b/nix/modules/cargo-rdme.nix
@@ -3,7 +3,7 @@
 { self, inputs, lib, ... }@flake: {
   perSystem = { config, self', inputs', system, pkgs, ... }:
     let
-      rustToolchain = config.rust.mkRust {
+      rustToolchain = config.rustHelper.mkRust {
         track = "stable";
         version = "latest";
       };

--- a/nix/modules/holochain-crate2nix.nix
+++ b/nix/modules/holochain-crate2nix.nix
@@ -4,7 +4,10 @@
       cargoNix = config.rustHelper.mkCargoNix {
         name = "holochain-generated-crate2nix";
         src = flake.config.srcCleanedHolochain;
-        pkgs = config.rustHelper.mkRustPkgs { };
+        pkgs = config.rustHelper.mkRustPkgs {
+          track = "stable";
+          version = "1.66.1";
+        };
       };
     in
     {

--- a/nix/modules/holochain-crate2nix.nix
+++ b/nix/modules/holochain-crate2nix.nix
@@ -1,44 +1,20 @@
 { self, lib, inputs, ... } @ flake: {
   perSystem = { config, self', inputs', pkgs, system, ... }:
     let
-      crate2nixTools = import "${inputs.crate2nix}/tools.nix" {
-        inherit pkgs;
-      };
-      customBuildRustCrateForPkgs = pkgs: pkgs.buildRustCrate.override {
-        defaultCrateOverrides = pkgs.defaultCrateOverrides // {
-          tx5-go-pion-sys = _: { nativeBuildInputs = with pkgs; [ go ]; };
-          tx5-go-pion-turn = _: { nativeBuildInputs = with pkgs; [ go ]; };
-          holochain = attrs: {
-            codegenUnits = 8;
-          };
-        };
-      };
-      generated = crate2nixTools.generatedCargoNix {
+      cargoNix = config.rustHelper.mkCargoNix {
         name = "holochain-generated-crate2nix";
         src = flake.config.srcCleanedHolochain;
-      };
-      cargoNix = pkgs.callPackage "${generated}/default.nix" {
-        buildRustCrateForPkgs = customBuildRustCrateForPkgs;
-      };
-
-      # `nix flake show` is incompatible with IFD by default
-      # This works around the issue by making the name of the package
-      #   discoverable without IFD.
-      mkNoIfdPackage = name: pkg: {
-        inherit name;
-        inherit (pkg) drvPath outPath;
-        type = "derivation";
-        orig = pkg;
+        pkgs = config.rustHelper.mkRustPkgs { };
       };
     in
     {
       packages = {
         build-holochain-build-crates-standalone =
-          mkNoIfdPackage "holochain" cargoNix.allWorkspaceMembers;
+          config.rustHelper.mkNoIfdPackage "holochain" cargoNix.allWorkspaceMembers;
 
         # exposed just for manual debugging
         holochain-crate2nix =
-          mkNoIfdPackage "holochain" cargoNix.workspaceMembers.holochain.build;
+          config.rustHelper.mkNoIfdPackage "holochain" cargoNix.workspaceMembers.holochain.build;
       };
     };
 }

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -10,12 +10,6 @@
 
       craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
 
-      opensslStatic =
-        if system == "x86_64-darwin"
-        then pkgs.openssl # pkgsStatic is considered a cross build
-        # and this is not yet supported
-        else pkgs.pkgsStatic.openssl;
-
       commonArgs = {
         RUST_SODIUM_LIB_DIR = "${pkgs.libsodium}/lib";
         RUST_SODIUM_SHARED = "1";
@@ -28,10 +22,10 @@
         CARGO_PROFILE = "";
 
         OPENSSL_NO_VENDOR = "1";
-        OPENSSL_LIB_DIR = "${opensslStatic.out}/lib";
-        OPENSSL_INCLUDE_DIR = "${opensslStatic.dev}/include";
+        OPENSSL_LIB_DIR = "${self'.packages.opensslStatic.out}/lib";
+        OPENSSL_INCLUDE_DIR = "${self'.packages.opensslStatic.dev}/include";
 
-        buildInputs = (with pkgs; [ openssl opensslStatic sqlcipher ])
+        buildInputs = (with pkgs; [ openssl self'.packages.opensslStatic sqlcipher ])
           ++ (lib.optionals pkgs.stdenv.isDarwin
           (with pkgs.darwin.apple_sdk_11_0.frameworks; [
             AppKit

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -10,10 +10,11 @@
 
       craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
 
-      opensslStatic = if system == "x86_64-darwin"
-                      then pkgs.openssl # pkgsStatic is considered a cross build
-                                        # and this is not yet supported
-                      else pkgs.pkgsStatic.openssl;
+      opensslStatic =
+        if system == "x86_64-darwin"
+        then pkgs.openssl # pkgsStatic is considered a cross build
+        # and this is not yet supported
+        else pkgs.pkgsStatic.openssl;
 
       commonArgs = {
         RUST_SODIUM_LIB_DIR = "${pkgs.libsodium}/lib";

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -3,7 +3,7 @@
 { self, inputs, lib, ... }@flake: {
   perSystem = { config, self', inputs', system, pkgs, ... }:
     let
-      rustToolchain = config.rust.mkRust {
+      rustToolchain = config.rustHelper.mkRust {
         track = "stable";
         version = "1.66.1";
       };

--- a/nix/modules/lair.nix
+++ b/nix/modules/lair.nix
@@ -3,7 +3,7 @@
 { self, inputs, lib, ... }@flake: {
   perSystem = { config, self', inputs', system, pkgs, ... }:
     let
-      rustToolchain = config.rust.mkRust {
+      rustToolchain = config.rustHelper.mkRust {
         track = "stable";
         version = "1.66.1";
       };

--- a/nix/modules/launcher.nix
+++ b/nix/modules/launcher.nix
@@ -3,7 +3,7 @@
 { self, inputs, lib, ... }@flake: {
   perSystem = { config, self', inputs', system, pkgs, ... }:
     let
-      rustToolchain = config.rust.mkRust {
+      rustToolchain = config.rustHelper.mkRust {
         track = "stable";
         version = "1.66.1";
       };

--- a/nix/modules/release-automation.nix
+++ b/nix/modules/release-automation.nix
@@ -23,7 +23,7 @@
 
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "1.66.1";
+        version = "1.67.0";
       };
       craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
 

--- a/nix/modules/release-automation.nix
+++ b/nix/modules/release-automation.nix
@@ -21,7 +21,7 @@
   perSystem = { config, self', inputs', system, pkgs, ... }:
     let
 
-      rustToolchain = config.rust.mkRust {
+      rustToolchain = config.rustHelper.mkRust {
         track = "stable";
         version = "latest";
       };

--- a/nix/modules/release-automation.nix
+++ b/nix/modules/release-automation.nix
@@ -23,7 +23,7 @@
 
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "latest";
+        version = "1.66.1";
       };
       craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
 

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -22,7 +22,6 @@
       options.rustHelper = lib.mkOption { type = lib.types.raw; };
 
       config.rustHelper = {
-
         defaultTrack = "stable";
         defaultVersion = "1.66.1";
 

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -133,15 +133,6 @@
           type = "derivation";
           orig = pkg;
         };
-
-        apple_sdk =
-          lib.attrsets.optionalAttrs pkgs.stdenv.isDarwin
-            (
-              # aarch64 only uses 11.0 and x86_64 mixes them
-              if system == "x86_64-darwin"
-              then pkgs.darwin.apple_sdk_10_12
-              else pkgs.darwin.apple_sdk_11_0
-            );
       };
     };
 }

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -11,41 +11,130 @@
     , pkgs
     , ...
     }: {
-      options.rust = lib.mkOption { type = lib.types.raw; };
-      config.rust =
-        let
-          rustPkgs = import pkgs.path {
+      options.rustHelper = lib.mkOption { type = lib.types.raw; };
+
+      config.rustHelper = {
+        defaultTrack = "stable";
+        defaultVersion = "1.66.1";
+
+        defaultExtensions = [ "rust-src" ];
+
+        defaultTargets = [
+          "aarch64-unknown-linux-musl"
+          "wasm32-unknown-unknown"
+          "x86_64-pc-windows-gnu"
+          "x86_64-unknown-linux-musl"
+          "x86_64-apple-darwin"
+          "aarch64-apple-darwin"
+        ];
+
+        mkRustPkgs =
+          { track ? config.rustHelper.defaultTrack
+          , version ? config.rustHelper.defaultVersion
+          , extensions ? config.rustHelper.defaultExtensions
+          , targets ? config.rustHelper.defaultTargets
+          }:
+          import inputs.nixpkgs {
             inherit system;
+
             overlays = [
               inputs.rust-overlay.overlays.default
 
-              (self: super: {
-                rust =
-                  super.rust
-                  // {
-                    defaultExtensions = [ "rust-src" ];
+              (final: prev: {
+                rustToolchain =
+                  (prev.rust-bin."${track}"."${version}".default.override ({
+                    inherit extensions targets;
+                  }));
 
-                    defaultTargets = [
-                      "aarch64-unknown-linux-musl"
-                      "wasm32-unknown-unknown"
-                      "x86_64-pc-windows-gnu"
-                      "x86_64-unknown-linux-musl"
-                      "x86_64-apple-darwin"
-                    ];
-
-                    mkRust =
-                      { track
-                      , version
-                      ,
-                      }: (self.rust-bin."${track}"."${version}".default.override {
-                        extensions = self.rust.defaultExtensions;
-                        targets = self.rust.defaultTargets;
-                      });
-                  };
+                rustc = final.rustToolchain;
+                cargo = final.rustToolchain;
               })
+
+              (final: prev: {
+                buildRustCrate = arg: prev.buildRustCrate (arg // {
+                  dontStrip = prev.stdenv.isDarwin;
+                });
+              })
+
             ];
           };
-        in
-        rustPkgs.rust;
+
+        mkRust =
+          { track ? config.rustHelper.defaultTrack
+          , version ? config.rustHelper.defaultVersion
+          }: (config.rustHelper.mkRustPkgs { inherit track version; }).rustToolchain;
+
+        crate2nixTools = { pkgs }: import "${inputs.crate2nix}/tools.nix" {
+          inherit pkgs;
+        };
+        customBuildRustCrateForPkgs = _: pkgs.buildRustCrate.override {
+          defaultCrateOverrides = pkgs.lib.attrsets.recursiveUpdate pkgs.defaultCrateOverrides
+            ({
+              # this regular module named `build.rs` confuses crate2nix which tries to build and run it as a build script.
+              build-fs-tree = _: {
+                prePatch = ''
+                  mv build.rs build/mod.rs
+                '';
+              };
+
+              openssl-sys = _:
+                let
+                  opensslStatic = pkgs.pkgsStatic.openssl;
+                in
+                {
+                  OPENSSL_NO_VENDOR = "1";
+                  OPENSSL_LIB_DIR = "${opensslStatic.out}/lib";
+                  OPENSSL_INCLUDE_DIR = "${opensslStatic.dev}/include";
+
+                  nativeBuildInputs = [
+                    pkgs.pkg-config
+                  ];
+
+                  buildInputs = [
+                    pkgs.openssl
+                    opensslStatic
+                  ];
+                };
+              tx5-go-pion-sys = _: { nativeBuildInputs = with pkgs; [ go ]; };
+              tx5-go-pion-turn = _: { nativeBuildInputs = with pkgs; [ go ]; };
+              holochain = attrs: {
+                codegenUnits = 8;
+              };
+
+              gobject-sys = _: { buildInputs = with pkgs; [ pkg-config glib ]; };
+            });
+        };
+
+
+        mkCargoNix = { name, src, pkgs, buildRustCrateForPkgs ? config.rustHelper.customBuildRustCrateForPkgs }:
+          let
+            generated = (config.rustHelper.crate2nixTools {
+              inherit pkgs;
+            }).generatedCargoNix {
+              inherit name src;
+            };
+          in
+          pkgs.callPackage "${generated}/default.nix" { inherit buildRustCrateForPkgs; };
+
+
+        # `nix flake show` is incompatible with IFD by default
+        # This works around the issue by making the name of the package
+        #   discoverable without IFD.
+        mkNoIfdPackage = name: pkg: {
+          inherit name;
+          inherit (pkg) drvPath outPath;
+          type = "derivation";
+          orig = pkg;
+        };
+
+        apple_sdk =
+          lib.attrsets.optionalAttrs pkgs.stdenv.isDarwin
+            (
+              # aarch64 only uses 11.0 and x86_64 mixes them
+              if system == "x86_64-darwin"
+              then pkgs.darwin.apple_sdk_10_12
+              else pkgs.darwin.apple_sdk_11_0
+            );
+      };
     };
 }

--- a/nix/modules/scaffolding.nix
+++ b/nix/modules/scaffolding.nix
@@ -3,7 +3,7 @@
 { self, inputs, lib, ... }@flake: {
   perSystem = { config, self', inputs', system, pkgs, ... }:
     let
-      rustToolchain = config.rust.mkRust {
+      rustToolchain = config.rustHelper.mkRust {
         track = "stable";
         version = "1.66.1";
       };


### PR DESCRIPTION
this effectively pins the rust version used with crate2nix which is not the case so far.

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
