### PR TITLE
Minor fixes to standalone bootstrap server implementation

### DIFF
--- a/crates/kitsune_p2p/bootstrap/src/put.rs
+++ b/crates/kitsune_p2p/bootstrap/src/put.rs
@@ -16,8 +16,11 @@ pub(crate) fn put(
 }
 
 async fn put_info(peer: Bytes, store: Store) -> Result<impl warp::Reply, warp::Rejection> {
+    #[derive(Debug)]
+    struct BadDecode(String);
+    impl warp::reject::Reject for BadDecode {}
     let peer: AgentInfoSigned =
-        rmp_decode(&mut AsRef::<[u8]>::as_ref(&peer)).map_err(|_| warp::reject())?;
+        rmp_decode(&mut AsRef::<[u8]>::as_ref(&peer)).map_err(|e| BadDecode(format!("{e:?}")))?;
     if !valid(&peer) {
         #[derive(Debug)]
         struct Invalid;

--- a/crates/kitsune_p2p/bootstrap/src/random.rs
+++ b/crates/kitsune_p2p/bootstrap/src/random.rs
@@ -91,10 +91,12 @@ mod tests {
             .reply(&filter)
             .await;
         assert_eq!(res.status(), 200);
-        let result: Vec<Vec<u8>> = rmp_decode(&mut res.body().as_ref()).unwrap();
+        #[derive(Debug, serde::Deserialize)]
+        struct Bytes(#[serde(with = "serde_bytes")] Vec<u8>);
+        let result: Vec<Bytes> = rmp_decode(&mut res.body().as_ref()).unwrap();
         let result: Vec<AgentInfoSigned> = result
             .into_iter()
-            .map(|bytes| rmp_decode(&mut AsRef::<[u8]>::as_ref(&bytes)).unwrap())
+            .map(|bytes| rmp_decode(&mut AsRef::<[u8]>::as_ref(&bytes.0)).unwrap())
             .collect();
         for peer in &result {
             assert!(peers.iter().any(|p| p == peer));

--- a/crates/kitsune_p2p/bootstrap/src/random.rs
+++ b/crates/kitsune_p2p/bootstrap/src/random.rs
@@ -18,7 +18,9 @@ pub(crate) fn random(
 async fn random_info(query: Bytes, store: Store) -> Result<impl warp::Reply, warp::Rejection> {
     let query: RandomQuery =
         rmp_decode(&mut AsRef::<[u8]>::as_ref(&query)).map_err(|_| warp::reject())?;
-    let result = store.random(query);
+    #[derive(serde::Serialize)]
+    struct Bin(#[serde(with = "serde_bytes")] Vec<u8>);
+    let result = store.random(query).into_iter().map(Bin).collect::<Vec<_>>();
     let mut buf = Vec::with_capacity(result.len());
     rmp_encode(&mut buf, result).map_err(|_| warp::reject())?;
     RANDOM.fetch_add(1, std::sync::atomic::Ordering::Relaxed);


### PR DESCRIPTION
### Summary

- Previously gave a blank "Error" message on agent info decoding failures, now reports the actual decode error
- "random" was outputting arrays of individual bytes instead of actual binary output. Now it is correctly binary inline with the cloudflare implementation.