### PR TITLE
Extend meta net task tests

### DIFF
--- a/crates/hdi/src/ed25519.rs
+++ b/crates/hdi/src/ed25519.rs
@@ -16,7 +16,7 @@ where
 {
     HDI.with(|h| {
         h.borrow().verify_signature(
-            VerifySignature::new(key.into(), signature.into(), map_err(|e| wasm_error!(e))?,
+            VerifySignature::new(key.into(), signature.into(), data).map_err(|e| wasm_error!(e))?,
         )
     })
 }

--- a/crates/hdi/src/ed25519.rs
+++ b/crates/hdi/src/ed25519.rs
@@ -16,7 +16,7 @@ where
 {
     HDI.with(|h| {
         h.borrow().verify_signature(
-            VerifySignature::new(key.into(), signature.into(), data).map_err(|e| wasm_error!(e))?,
+            VerifySignature::new(key.into(), signature.into(), map_err(|e| wasm_error!(e))?,
         )
     })
 }

--- a/crates/kitsune_p2p/fetch/src/respond.rs
+++ b/crates/kitsune_p2p/fetch/src/respond.rs
@@ -13,7 +13,7 @@ impl FetchResponseGuard {
 }
 
 /// Customization by code making use of the FetchResponseQueue.
-pub trait FetchResponseConfig: 'static + Send + Sync {
+pub trait FetchResponseConfig: 'static + Clone + Send + Sync {
     /// Data that is forwarded.
     type User: 'static + Send;
 
@@ -40,10 +40,14 @@ pub trait FetchResponseConfig: 'static + Send + Sync {
 }
 
 /// Manage responding to requests for data.
+#[derive(Clone)]
 pub struct FetchResponseQueue<C: FetchResponseConfig> {
     byte_limit: Arc<tokio::sync::Semaphore>,
     concurrent_send_limit: Arc<tokio::sync::Semaphore>,
     config: Arc<C>,
+    /// For testing, track the number of bytes sent.
+    #[cfg(feature = "test_utils")]
+    pub bytes_sent: Arc<std::sync::atomic::AtomicUsize>,
 }
 
 impl<C: FetchResponseConfig> FetchResponseQueue<C> {
@@ -58,6 +62,8 @@ impl<C: FetchResponseConfig> FetchResponseQueue<C> {
             byte_limit,
             concurrent_send_limit,
             config,
+            #[cfg(feature = "test_utils")]
+            bytes_sent: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         }
     }
 
@@ -83,6 +89,10 @@ impl<C: FetchResponseConfig> FetchResponseQueue<C> {
             }
             Ok(permit) => permit,
         };
+
+        #[cfg(feature = "test_utils")]
+        self.bytes_sent
+            .fetch_add(len as usize, std::sync::atomic::Ordering::SeqCst);
 
         let c_limit = self.concurrent_send_limit.clone();
         let config = self.config.clone();

--- a/crates/kitsune_p2p/fetch/src/respond.rs
+++ b/crates/kitsune_p2p/fetch/src/respond.rs
@@ -169,6 +169,7 @@ mod tests {
 
     #[test]
     fn config_provides_defaults() {
+        #[derive(Clone)]
         struct DefaultConf;
         impl FetchResponseConfig for DefaultConf {
             type User = ();

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Resolves an issue where a `FetchOp` could skip processing op hashes if getting a topology for the space from the host failed [\#2737](https://github.com/holochain/holochain/pull/2737)
+- Adds a warning log if incoming op data pushes are dropped due to a hashing failure on the host [\#2737](https://github.com/holochain/holochain/pull/2737)
+- Fixes an issue where sending an unexpected request payload would cause the process to crash [\#2737](https://github.com/holochain/holochain/pull/2737)
+
 ## 0.3.0-beta-dev.13
 
 ## 0.3.0-beta-dev.12

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/fetch/response_config.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/fetch/response_config.rs
@@ -3,6 +3,7 @@ use crate::wire;
 use kitsune_p2p_types::config::KitsuneP2pTuningParams;
 use kitsune_p2p_types::{dht, KOpData, KSpace};
 
+#[derive(Clone)]
 pub struct FetchResponseConfig(KitsuneP2pTuningParams);
 
 impl FetchResponseConfig {

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net_task.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net_task.rs
@@ -1488,6 +1488,10 @@ mod tests {
                 .respond_with_error_count
                 .load(Ordering::Acquire)
         );
+        assert!(host_receiver_stub
+            .put_agent_info_signed_calls
+            .read()
+            .is_empty());
         assert!(!meta_net_task_finished.load(Ordering::Acquire));
     }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net_task.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net_task.rs
@@ -764,34 +764,17 @@ mod tests {
     async fn make_call_request() {
         let (mut ep_evt_send, _, _, _, _, _) = setup().await;
 
-        let (send_res, read_res) = futures::channel::oneshot::channel();
-
         let request_data = vec![2, 7];
-        ep_evt_send
-            .send(MetaNetEvt::Request {
-                remote_url: "".to_string(),
-                con: mk_test_con_with_id(1),
-                data: wire::Wire::Call(wire::Call {
-                    space: test_space(1),
-                    to_agent: test_agent(2),
-                    data: WireData(request_data.clone()),
-                }),
-                respond: Box::new(|r| {
-                    async move {
-                        send_res.send(r).unwrap();
-                        ()
-                    }
-                    .boxed()
-                    .into()
-                }),
-            })
-            .await
-            .unwrap();
 
-        let call_response = tokio::time::timeout(Duration::from_secs(1), read_res)
-            .await
-            .expect("Timed out while waiting for a response")
-            .unwrap();
+        let call_response = do_request(
+            ep_evt_send,
+            wire::Wire::Call(wire::Call {
+                space: test_space(1),
+                to_agent: test_agent(2),
+                data: WireData(request_data.clone()),
+            }),
+        )
+        .await;
 
         let response_data = match call_response {
             Wire::CallResp(res) => res.data.to_vec(),
@@ -810,34 +793,16 @@ mod tests {
 
         host_receiver_stub.abort();
 
-        let (send_res, read_res) = futures::channel::oneshot::channel();
-
         let request_data = vec![2, 7];
-        ep_evt_send
-            .send(MetaNetEvt::Request {
-                remote_url: "".to_string(),
-                con: mk_test_con_with_id(1),
-                data: wire::Wire::Call(wire::Call {
-                    space: test_space(1),
-                    to_agent: test_agent(2),
-                    data: WireData(request_data.clone()),
-                }),
-                respond: Box::new(|r| {
-                    async move {
-                        send_res.send(r).unwrap();
-                        ()
-                    }
-                    .boxed()
-                    .into()
-                }),
-            })
-            .await
-            .unwrap();
-
-        let call_response = tokio::time::timeout(Duration::from_secs(1), read_res)
-            .await
-            .expect("Timed out while waiting for a response")
-            .unwrap();
+        let call_response = do_request(
+            ep_evt_send,
+            wire::Wire::Call(wire::Call {
+                space: test_space(1),
+                to_agent: test_agent(2),
+                data: WireData(request_data.clone()),
+            }),
+        )
+        .await;
 
         let reason = match call_response {
             Wire::Failure(f) => f.reason,
@@ -851,32 +816,14 @@ mod tests {
     async fn make_peer_get_request() {
         let (mut ep_evt_send, _, _, _, _, _) = setup().await;
 
-        let (send_res, read_res) = futures::channel::oneshot::channel();
-
-        ep_evt_send
-            .send(MetaNetEvt::Request {
-                remote_url: "".to_string(),
-                con: mk_test_con_with_id(1),
-                data: wire::Wire::PeerGet(wire::PeerGet {
-                    space: test_space(1),
-                    agent: test_agent(1),
-                }),
-                respond: Box::new(|r| {
-                    async move {
-                        send_res.send(r).unwrap();
-                        ()
-                    }
-                    .boxed()
-                    .into()
-                }),
-            })
-            .await
-            .unwrap();
-
-        let call_response = tokio::time::timeout(Duration::from_secs(1), read_res)
-            .await
-            .expect("Timed out while waiting for a response")
-            .unwrap();
+        let call_response = do_request(
+            ep_evt_send,
+            wire::Wire::PeerGet(wire::PeerGet {
+                space: test_space(1),
+                agent: test_agent(1),
+            }),
+        )
+        .await;
 
         let agent_info_signed = match call_response {
             Wire::PeerGetResp(res) => res.agent_info_signed,
@@ -893,32 +840,14 @@ mod tests {
         // Set up the error response so that when we make a request we get an error
         host_stub.fail_next_request();
 
-        let (send_res, read_res) = futures::channel::oneshot::channel();
-
-        ep_evt_send
-            .send(MetaNetEvt::Request {
-                remote_url: "".to_string(),
-                con: mk_test_con_with_id(1),
-                data: wire::Wire::PeerGet(wire::PeerGet {
-                    space: test_space(1),
-                    agent: test_agent(1),
-                }),
-                respond: Box::new(|r| {
-                    async move {
-                        send_res.send(r).unwrap();
-                        ()
-                    }
-                    .boxed()
-                    .into()
-                }),
-            })
-            .await
-            .unwrap();
-
-        let call_response = tokio::time::timeout(Duration::from_secs(1), read_res)
-            .await
-            .expect("Timed out while waiting for a response")
-            .unwrap();
+        let call_response = do_request(
+            ep_evt_send,
+            wire::Wire::PeerGet(wire::PeerGet {
+                space: test_space(1),
+                agent: test_agent(1),
+            }),
+        )
+        .await;
 
         let reason = match call_response {
             Wire::Failure(f) => f.reason,
@@ -932,32 +861,14 @@ mod tests {
     async fn make_peer_query_request() {
         let (mut ep_evt_send, _, _, _, _, _) = setup().await;
 
-        let (send_res, read_res) = futures::channel::oneshot::channel();
-
-        ep_evt_send
-            .send(MetaNetEvt::Request {
-                remote_url: "".to_string(),
-                con: mk_test_con_with_id(1),
-                data: wire::Wire::PeerQuery(wire::PeerQuery {
-                    space: test_space(1),
-                    basis_loc: DhtLocation::new(1),
-                }),
-                respond: Box::new(|r| {
-                    async move {
-                        send_res.send(r).unwrap();
-                        ()
-                    }
-                    .boxed()
-                    .into()
-                }),
-            })
-            .await
-            .unwrap();
-
-        let response = tokio::time::timeout(Duration::from_secs(1), read_res)
-            .await
-            .expect("Timed out while waiting for a response")
-            .unwrap();
+        let response = do_request(
+            ep_evt_send,
+            wire::Wire::PeerQuery(wire::PeerQuery {
+                space: test_space(1),
+                basis_loc: DhtLocation::new(1),
+            }),
+        )
+        .await;
 
         let peer_list = match response {
             Wire::PeerQueryResp(r) => r.peer_list,
@@ -976,32 +887,14 @@ mod tests {
             .respond_with_error
             .store(true, Ordering::SeqCst);
 
-        let (send_res, read_res) = futures::channel::oneshot::channel();
-
-        ep_evt_send
-            .send(MetaNetEvt::Request {
-                remote_url: "".to_string(),
-                con: mk_test_con_with_id(1),
-                data: wire::Wire::PeerQuery(wire::PeerQuery {
-                    space: test_space(1),
-                    basis_loc: DhtLocation::new(1),
-                }),
-                respond: Box::new(|r| {
-                    async move {
-                        send_res.send(r).unwrap();
-                        ()
-                    }
-                    .boxed()
-                    .into()
-                }),
-            })
-            .await
-            .unwrap();
-
-        let response = tokio::time::timeout(Duration::from_secs(1), read_res)
-            .await
-            .expect("Timed out while waiting for a response")
-            .unwrap();
+        let response = do_request(
+            ep_evt_send,
+            wire::Wire::PeerQuery(wire::PeerQuery {
+                space: test_space(1),
+                basis_loc: DhtLocation::new(1),
+            }),
+        )
+        .await;
 
         let reason = match response {
             Wire::Failure(f) => f.reason,
@@ -1034,32 +927,14 @@ mod tests {
             .unwrap();
 
         // Now check that we can still use the task to send/receive messages.
-        let (send_res, read_res) = futures::channel::oneshot::channel();
-
-        ep_evt_send
-            .send(MetaNetEvt::Request {
-                remote_url: "".to_string(),
-                con: mk_test_con_with_id(1),
-                data: wire::Wire::PeerQuery(wire::PeerQuery {
-                    space: test_space(1),
-                    basis_loc: DhtLocation::new(1),
-                }),
-                respond: Box::new(|r| {
-                    async move {
-                        send_res.send(r).unwrap();
-                        ()
-                    }
-                    .boxed()
-                    .into()
-                }),
-            })
-            .await
-            .unwrap();
-
-        let response = tokio::time::timeout(Duration::from_secs(1), read_res)
-            .await
-            .expect("Timed out while waiting for a response")
-            .unwrap();
+        let response = do_request(
+            ep_evt_send,
+            wire::Wire::PeerQuery(wire::PeerQuery {
+                space: test_space(1),
+                basis_loc: DhtLocation::new(1),
+            }),
+        )
+        .await;
 
         let peer_list = match response {
             Wire::PeerQueryResp(r) => r.peer_list,
@@ -1442,6 +1317,32 @@ mod tests {
             host_stub,
             meta_net_task_finished,
         )
+    }
+
+    async fn do_request(mut ep_evt_send: Sender<MetaNetEvt>, data: wire::Wire) -> wire::Wire {
+        let (send_res, read_res) = futures::channel::oneshot::channel();
+
+        ep_evt_send
+            .send(MetaNetEvt::Request {
+                remote_url: "".to_string(),
+                con: mk_test_con_with_id(1),
+                data,
+                respond: Box::new(|r| {
+                    async move {
+                        send_res.send(r).unwrap();
+                        ()
+                    }
+                    .boxed()
+                    .into()
+                }),
+            })
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), read_res)
+            .await
+            .expect("Timed out while waiting for a response")
+            .unwrap()
     }
 
     fn mk_test_con() -> MetaNetCon {

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net_task.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net_task.rs
@@ -608,7 +608,7 @@ mod tests {
     use kitsune_p2p::KitsuneBinType;
     use kitsune_p2p_block::{Block, BlockTarget, NodeBlockReason, NodeId};
     use kitsune_p2p_fetch::test_utils::{test_key_op, test_req_op, test_source, test_space};
-    use kitsune_p2p_fetch::{FetchPool, FetchPoolPush, FetchResponseQueue};
+    use kitsune_p2p_fetch::{FetchPool, FetchResponseQueue};
     use kitsune_p2p_timestamp::{InclusiveTimestampInterval, Timestamp};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
@@ -777,7 +777,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn make_call_request() {
-        let (mut ep_evt_send, _, _, _, _, _, _, _) = setup().await;
+        let (ep_evt_send, _, _, _, _, _, _, _) = setup().await;
 
         let request_data = vec![2, 7];
 
@@ -804,7 +804,7 @@ mod tests {
     //      to test the behaviour this test is currently checking.
     #[tokio::test(flavor = "multi_thread")]
     async fn make_call_request_after_host_closed() {
-        let (mut ep_evt_send, _, _, host_receiver_stub, _, _, _, _) = setup().await;
+        let (ep_evt_send, _, _, host_receiver_stub, _, _, _, _) = setup().await;
 
         host_receiver_stub.abort();
 
@@ -829,7 +829,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn make_peer_get_request() {
-        let (mut ep_evt_send, _, _, _, _, _, _, _) = setup().await;
+        let (ep_evt_send, _, _, _, _, _, _, _) = setup().await;
 
         let call_response = do_request(
             ep_evt_send,
@@ -850,7 +850,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn handle_peer_get_request_error() {
-        let (mut ep_evt_send, _, _, _, host_stub, _, _, _) = setup().await;
+        let (ep_evt_send, _, _, _, host_stub, _, _, _) = setup().await;
 
         // Set up the error response so that when we make a request we get an error
         host_stub.fail_next_request();
@@ -874,7 +874,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn make_peer_query_request() {
-        let (mut ep_evt_send, _, _, _, _, _, _, _) = setup().await;
+        let (ep_evt_send, _, _, _, _, _, _, _) = setup().await;
 
         let response = do_request(
             ep_evt_send,
@@ -895,7 +895,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn handle_peer_query_request_error() {
-        let (mut ep_evt_send, _, _, host_receiver_stub, _, _, _, _) = setup().await;
+        let (ep_evt_send, _, _, host_receiver_stub, _, _, _, _) = setup().await;
 
         // Set up the error response so that when we make a request we get an error
         host_receiver_stub
@@ -1366,7 +1366,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn send_notify_broadcast_user() {
-        let (mut ep_evt_send, internal_stub, _, host_receiver_stub, _, _, _, _) = setup().await;
+        let (mut ep_evt_send, _, _, host_receiver_stub, _, _, _, _) = setup().await;
 
         ep_evt_send
             .send(MetaNetEvt::Notify {
@@ -1394,16 +1394,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn send_notify_broadcast_user_fails_to_forward() {
-        let (
-            mut ep_evt_send,
-            internal_stub,
-            _,
-            host_receiver_stub,
-            _,
-            _,
-            _,
-            meta_net_task_finished,
-        ) = setup().await;
+        let (mut ep_evt_send, _, _, host_receiver_stub, _, _, _, meta_net_task_finished) =
+            setup().await;
 
         host_receiver_stub
             .respond_with_error
@@ -1446,7 +1438,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn send_notify_broadcast_agent_info() {
-        let (mut ep_evt_send, internal_stub, _, mut host_receiver_stub, _, _, _, _) = setup().await;
+        let (mut ep_evt_send, _, _, mut host_receiver_stub, _, _, _, _) = setup().await;
 
         ep_evt_send
             .send(MetaNetEvt::Notify {
@@ -1473,16 +1465,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn send_notify_broadcast_agent_info_fails_to_forward() {
-        let (
-            mut ep_evt_send,
-            internal_stub,
-            _,
-            host_receiver_stub,
-            _,
-            _,
-            _,
-            meta_net_task_finished,
-        ) = setup().await;
+        let (mut ep_evt_send, _, _, host_receiver_stub, _, _, _, meta_net_task_finished) =
+            setup().await;
 
         host_receiver_stub
             .respond_with_error
@@ -1528,7 +1512,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn send_notify_gossip() {
-        let (mut ep_evt_send, internal_stub, _, mut host_receiver_stub, _, _, _, _) = setup().await;
+        let (mut ep_evt_send, internal_stub, _, _, _, _, _, _) = setup().await;
 
         ep_evt_send
             .send(MetaNetEvt::Notify {
@@ -1567,16 +1551,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn send_notify_fetch_op() {
-        let (
-            mut ep_evt_send,
-            internal_stub,
-            _,
-            mut host_receiver_stub,
-            _,
-            fetch_response_queue,
-            _,
-            _,
-        ) = setup().await;
+        let (mut ep_evt_send, _, _, _, _, fetch_response_queue, _, _) = setup().await;
 
         ep_evt_send
             .send(MetaNetEvt::Notify {
@@ -1602,16 +1577,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn send_notify_fetch_op_fail_independently() {
-        let (
-            mut ep_evt_send,
-            internal_stub,
-            _,
-            mut host_receiver_stub,
-            _,
-            fetch_response_queue,
-            _,
-            _,
-        ) = setup().await;
+        let (mut ep_evt_send, _, _, host_receiver_stub, _, fetch_response_queue, _, _) =
+            setup().await;
 
         // The first call will fail, subsequent calls succeed
         host_receiver_stub
@@ -1646,16 +1613,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn send_notify_push_op_data() {
-        let (
-            mut ep_evt_send,
-            internal_stub,
-            _,
-            mut host_receiver_stub,
-            _,
-            fetch_response_queue,
-            fetch_pool,
-            _,
-        ) = setup().await;
+        let (mut ep_evt_send, _, _, host_receiver_stub, _, _, fetch_pool, _) = setup().await;
 
         fetch_pool.push(test_req_op(0, None, test_source(2)));
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/test_util/host_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/test_util/host_stub.rs
@@ -128,6 +128,8 @@ impl HostStub {
                                 FetchOpDataEvtQuery::Hashes { op_hash_list, .. } => {
                                     let response = op_hash_list
                                         .into_iter()
+                                        // TODO why are we responding with hashes when they are part of the input? It's an atomic
+                                        //      operation in the sense that you get everything or an error so there is no matching to be done.
                                         .map(|h| (h, KitsuneOpData::new(vec![1, 2, 3])))
                                         .collect();
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/test_util/host_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/test_util/host_stub.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::task::AbortHandle;
 use tokio::time::error::Elapsed;
-use tracing_subscriber::filter::FilterExt;
 
 pub struct HostStub {
     pub respond_with_error: Arc<AtomicBool>,

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/test_util/host_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/test_util/host_stub.rs
@@ -1,9 +1,12 @@
-use crate::event::{KitsuneP2pEvent, PutAgentInfoSignedEvt};
+use crate::event::{KitsuneP2pEvent, KitsuneP2pEventHandlerResult, PutAgentInfoSignedEvt};
+use crate::spawn::actor::{KAgent, KSpace};
 use crate::test_util::data::mk_agent_info;
+use crate::types::event::Payload;
 use crate::KitsuneP2pError;
 use futures::channel::mpsc::{channel, Receiver};
 use futures::{FutureExt, SinkExt, StreamExt};
-use std::sync::atomic::{AtomicBool, Ordering};
+use ghost_actor::GhostRespond;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::task::AbortHandle;
@@ -11,6 +14,9 @@ use tokio::time::error::Elapsed;
 
 pub struct HostStub {
     pub respond_with_error: Arc<AtomicBool>,
+    pub respond_with_error_count: Arc<AtomicUsize>,
+    pub notify_calls: Arc<parking_lot::RwLock<Vec<(KSpace, KAgent, Payload)>>>,
+
     put_events: Receiver<PutAgentInfoSignedEvt>,
     abort_handle: AbortHandle,
 }
@@ -19,24 +25,31 @@ impl HostStub {
     pub fn start(mut host_receiver: Receiver<KitsuneP2pEvent>) -> Self {
         let (mut sender, receiver) = channel(10);
 
+        let notify_calls = Arc::new(parking_lot::RwLock::new(Vec::new()));
+
         let respond_with_error = Arc::new(AtomicBool::new(false));
+        let respond_with_error_count = Arc::new(AtomicUsize::new(0));
         let handle = tokio::spawn({
             let task_respond_with_error = respond_with_error.clone();
+            let task_respond_with_error_count = respond_with_error_count.clone();
+            let task_notify_calls = notify_calls.clone();
             async move {
                 while let Some(evt) = host_receiver.next().await {
                     match evt {
                         KitsuneP2pEvent::PutAgentInfoSigned { input, respond, .. } => {
-                            if task_respond_with_error.load(Ordering::SeqCst) {
-                                respond.respond(Ok(async move {
-                                    Err(KitsuneP2pError::other("a test error"))
-                                }
-                                .boxed()
-                                .into()));
+                            let respond = maybe_respond_error(
+                                task_respond_with_error.clone(),
+                                task_respond_with_error_count.clone(),
+                                respond,
+                            );
+                            if respond.is_none() {
                                 continue;
                             }
 
                             sender.send(input).await.unwrap();
-                            respond.respond(Ok(async move { Ok(()) }.boxed().into()));
+                            respond
+                                .unwrap()
+                                .respond(Ok(async move { Ok(()) }.boxed().into()));
                         }
                         KitsuneP2pEvent::Call {
                             payload, respond, ..
@@ -45,18 +58,18 @@ impl HostStub {
                             respond.respond(Ok(async move { Ok(payload.to_vec()) }.boxed().into()));
                         }
                         KitsuneP2pEvent::QueryAgents { input, respond, .. } => {
-                            if task_respond_with_error.load(Ordering::SeqCst) {
-                                respond.respond(Ok(async move {
-                                    Err(KitsuneP2pError::other("a test error"))
-                                }
-                                .boxed()
-                                .into()));
+                            let respond = maybe_respond_error(
+                                task_respond_with_error.clone(),
+                                task_respond_with_error_count.clone(),
+                                respond,
+                            );
+                            if respond.is_none() {
                                 continue;
                             }
 
                             let len = input.limit.unwrap();
 
-                            respond.respond(Ok(async move {
+                            respond.unwrap().respond(Ok(async move {
                                 let mut agents = vec![];
                                 for i in 0..len {
                                     agents.push(mk_agent_info(i as u8).await);
@@ -67,6 +80,28 @@ impl HostStub {
                             .boxed()
                             .into()))
                         }
+                        KitsuneP2pEvent::Notify {
+                            space,
+                            to_agent,
+                            payload,
+                            respond,
+                            ..
+                        } => {
+                            let respond = maybe_respond_error(
+                                task_respond_with_error.clone(),
+                                task_respond_with_error_count.clone(),
+                                respond,
+                            );
+                            if respond.is_none() {
+                                continue;
+                            }
+
+                            task_notify_calls.write().push((space, to_agent, payload));
+
+                            respond
+                                .unwrap()
+                                .respond(Ok(async move { Ok(()) }.boxed().into()))
+                        }
                         _ => panic!("Unexpected event - {:?}", evt),
                     }
                 }
@@ -75,6 +110,8 @@ impl HostStub {
 
         HostStub {
             respond_with_error,
+            respond_with_error_count,
+            notify_calls,
             put_events: receiver,
             abort_handle: handle.abort_handle(),
         }
@@ -96,5 +133,25 @@ impl HostStub {
 
     pub fn abort(&self) {
         self.abort_handle.abort();
+    }
+}
+
+fn maybe_respond_error<T>(
+    task_respond_with_error: Arc<AtomicBool>,
+    count: Arc<AtomicUsize>,
+    respond: GhostRespond<KitsuneP2pEventHandlerResult<T>>,
+) -> Option<GhostRespond<KitsuneP2pEventHandlerResult<T>>> {
+    if let Ok(true) =
+        task_respond_with_error.compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+    {
+        count.fetch_add(1, Ordering::SeqCst);
+        respond.respond(Ok(
+            async move { Err(KitsuneP2pError::other("a test error")) }
+                .boxed()
+                .into(),
+        ));
+        None
+    } else {
+        Some(respond)
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/test_util/internal_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/test_util/internal_stub.rs
@@ -145,7 +145,7 @@ impl InternalHandler for InternalStub {
         _space: crate::spawn::actor::KSpace,
         _op_hash: KOpHash,
     ) -> InternalHandlerResult<()> {
-        todo!()
+        Ok(async move { Ok(()) }.boxed().into())
     }
 
     fn handle_incoming_gossip(

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/test_util/internal_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/test_util/internal_stub.rs
@@ -1,31 +1,78 @@
 use crate::actor::BroadcastData;
+use crate::event::KitsuneP2pEvent;
 use crate::spawn::actor::{
     EvtRcv, InternalHandlerResult, KSpace, MaybeDelegate, OpHashList, VecMXM,
 };
 use crate::spawn::meta_net::MetaNetCon;
 use crate::spawn::{Internal, InternalHandler};
-use crate::GossipModuleType;
+use crate::{GossipModuleType, KitsuneP2pError};
 use futures::FutureExt;
 use ghost_actor::GhostError;
 use ghost_actor::{GhostControlHandler, GhostHandler};
 use kitsune_p2p_fetch::{FetchContext, FetchKey, FetchSource};
 use kitsune_p2p_types::agent_info::AgentInfoSigned;
 use kitsune_p2p_types::KOpHash;
+use parking_lot::lock_api::RwLock;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct InternalStub {
     fetch_calls: Vec<(FetchKey, KSpace, FetchSource)>,
+    pub incoming_publish_calls: Arc<
+        parking_lot::RwLock<
+            Vec<(
+                KSpace,
+                crate::spawn::actor::KAgent,
+                crate::spawn::actor::KAgent,
+                OpHashList,
+                FetchContext,
+                MaybeDelegate,
+            )>,
+        >,
+    >,
+    pub incoming_delegate_broadcast_calls: Arc<
+        parking_lot::RwLock<
+            Vec<(
+                crate::spawn::actor::KSpace,
+                crate::spawn::actor::KBasis,
+                crate::spawn::actor::KAgent,
+                u32,
+                u32,
+                BroadcastData,
+            )>,
+        >,
+    >,
     pub connections: Arc<parking_lot::RwLock<HashMap<String, MetaNetCon>>>,
+    pub respond_with_error_count: Arc<AtomicUsize>,
+    pub respond_with_error: Arc<AtomicBool>,
 }
 
 impl InternalStub {
     pub fn new() -> Self {
         InternalStub {
             fetch_calls: vec![],
+            incoming_publish_calls: Arc::new(RwLock::new(vec![])),
+            incoming_delegate_broadcast_calls: Arc::new(RwLock::new(vec![])),
             connections: Arc::new(parking_lot::RwLock::new(HashMap::new())),
+            respond_with_error_count: Arc::new(AtomicUsize::new(0)),
+            respond_with_error: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    fn maybe_error(&mut self) -> Result<(), KitsuneP2pError> {
+        if let Ok(true) = self.respond_with_error.compare_exchange(
+            true,
+            false,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ) {
+            self.respond_with_error_count.fetch_add(1, Ordering::SeqCst);
+            return Err("test error".into());
+        }
+
+        Ok(())
     }
 }
 
@@ -38,26 +85,47 @@ impl InternalHandler for InternalStub {
 
     fn handle_incoming_delegate_broadcast(
         &mut self,
-        _space: crate::spawn::actor::KSpace,
-        _basis: crate::spawn::actor::KBasis,
-        _to_agent: crate::spawn::actor::KAgent,
-        _mod_idx: u32,
-        _mod_cnt: u32,
-        _data: BroadcastData,
+        space: crate::spawn::actor::KSpace,
+        basis: crate::spawn::actor::KBasis,
+        to_agent: crate::spawn::actor::KAgent,
+        mod_idx: u32,
+        mod_cnt: u32,
+        data: BroadcastData,
     ) -> InternalHandlerResult<()> {
-        todo!()
+        if let Err(e) = self.maybe_error() {
+            return Ok(async move { Err(e) }.boxed().into());
+        }
+
+        self.incoming_delegate_broadcast_calls
+            .write()
+            .push((space, basis, to_agent, mod_idx, mod_cnt, data));
+
+        Ok(async move { Ok(()) }.boxed().into())
     }
 
     fn handle_incoming_publish(
         &mut self,
-        _space: crate::spawn::actor::KSpace,
-        _to_agent: crate::spawn::actor::KAgent,
-        _source: crate::spawn::actor::KAgent,
-        _op_hash_list: OpHashList,
-        _context: FetchContext,
-        _maybe_delegate: MaybeDelegate,
+        space: crate::spawn::actor::KSpace,
+        to_agent: crate::spawn::actor::KAgent,
+        source: crate::spawn::actor::KAgent,
+        op_hash_list: OpHashList,
+        context: FetchContext,
+        maybe_delegate: MaybeDelegate,
     ) -> InternalHandlerResult<()> {
-        todo!()
+        if let Err(e) = self.maybe_error() {
+            return Ok(async move { Err(e) }.boxed().into());
+        }
+
+        self.incoming_publish_calls.write().push((
+            space,
+            to_agent,
+            source,
+            op_hash_list,
+            context,
+            maybe_delegate,
+        ));
+
+        Ok(async move { Ok(()) }.boxed().into())
     }
 
     fn handle_resolve_publish_pending_delegates(

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/test_util/internal_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/test_util/internal_stub.rs
@@ -1,5 +1,4 @@
 use crate::actor::BroadcastData;
-use crate::event::KitsuneP2pEvent;
 use crate::spawn::actor::{
     EvtRcv, InternalHandlerResult, KSpace, MaybeDelegate, OpHashList, VecMXM,
 };

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
@@ -65,7 +65,7 @@ pub struct SignNetworkDataEvt {
 }
 
 /// Store the AgentInfo as signed by the agent themselves.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PutAgentInfoSignedEvt {
     /// The "space" context.
     pub space: KSpace,

--- a/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/types/event.rs
@@ -165,7 +165,7 @@ pub fn full_time_window_inclusive() -> TimeWindowInclusive {
 
 type KSpace = Arc<super::KitsuneSpace>;
 type KAgent = Arc<super::KitsuneAgent>;
-type Payload = Vec<u8>;
+pub(crate) type Payload = Vec<u8>;
 type Ops = Vec<KOp>;
 type MaybeContext = Option<kitsune_p2p_fetch::FetchContext>;
 


### PR DESCRIPTION
### Summary

I was hoping to finish this off with a second pass but no joy, there's still more here to do and I think the delta is big enough to need a pause here.

See below for a rough summary of what I think is still to deal with

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
