### PR TITLE
Add a loom test to holochain_sqlite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3098,6 +3098,7 @@ dependencies = [
  "kitsune_p2p_dht_arc",
  "kitsune_p2p_timestamp",
  "kitsune_p2p_types",
+ "lazy_static",
  "loom",
  "nanoid 0.4.0",
  "num_cpus",
@@ -4443,9 +4444,9 @@ dependencies = [
 
 [[package]]
 name = "loom"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce9394216e2be01e607cf9e9e2b64c387506df1e768b14cbd2854a3650c3c03e"
+checksum = "86a17963e5073acf8d3e2637402657c6b467218f36fe10d696b3e1095ae019bf"
 dependencies = [
  "cfg-if 1.0.0",
  "generator",

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -19,9 +19,9 @@ fallible-iterator = "0.2.0"
 futures = "0.3.1"
 holo_hash = { path = "../holo_hash", version = "^0.3.0-beta-dev.6"}
 holochain_serialized_bytes = "=0.0.51"
-holochain_util = { version = "^0.2.0", path = "../holochain_util", features = ["backtrace"], optional = true }
+holochain_util = { version = "^0.2.0", path = "../holochain_util", features = ["tokio"], default-features = false, optional = true }
 holochain_zome_types = { version = "^0.3.0-beta-dev.10", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "^0.3.0-beta-dev.12", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "^0.3.0-beta-dev.12", path = "../kitsune_p2p/kitsune_p2p", optional = true }
 kitsune_p2p_types = { version = "^0.3.0-beta-dev.7", path = "../kitsune_p2p/types", optional = true }
 kitsune_p2p_dht_arc = { version = "0.3.0-beta-dev.3", path = "../kitsune_p2p/dht_arc" }
 kitsune_p2p_bin_data = { version = "0.3.0-beta-dev.4", path = "../kitsune_p2p/bin_data" }
@@ -43,6 +43,7 @@ thiserror = "1.0.22"
 tokio = { version = "1.27", features = [ "macros", "rt-multi-thread", "io-util", "sync", "time" ] }
 tracing = "0.1.18"
 getrandom = "0.2.7"
+lazy_static = "1.4.0"
 
 rusqlite = { version = "0.29", features = [
   "blob",        # better integration with blob types (Read, Write, etc)
@@ -57,7 +58,7 @@ rusqlite = { version = "0.29", features = [
 ] }
 
 [dev-dependencies]
-holochain_sqlite = { path = ".", features = ["test_utils", "slow_tests"] }
+holochain_sqlite = { path = ".", default-features = false, features = ["test_utils", "slow_tests"] }
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../holochain_trace" }
 nanoid = "0.4.0"
 rand = "0.8.5"
@@ -66,12 +67,11 @@ rand = "0.8.5"
 pretty_assertions = "0.7.2"
 sqlformat = "0.1.6"
 
-[target.'cfg(loom)'.dev-dependencies]
-loom = { version = "0.6", features = ["futures", "checkpoint"] }
-holochain_sqlite = { path = ".", default-features = false, features = ["test_utils"] }
+[target.'cfg(loom)'.dependencies]
+loom = { version = "0.7", features = ["futures", "checkpoint"] }
 
 [features]
-default = [ "test_utils", "sqlite", "kitsune_p2p_types", "holochain_util" ]
+default = [ "test_utils", "sqlite", "kitsune_p2p_types", "holochain_util", "kitsune_p2p" ]
 
 test_utils = [ ]
 
@@ -83,7 +83,7 @@ sqlite-encrypted = [
   "holo_hash/sqlite-encrypted",
   "holochain_zome_types/sqlite-encrypted",
   "kitsune_p2p_bin_data/sqlite-encrypted",
-  "kitsune_p2p_types/sqlite-encrypted",
+  "kitsune_p2p_types?/sqlite-encrypted",
   "kitsune_p2p_dht_arc/sqlite-encrypted",
 ]
 
@@ -94,6 +94,6 @@ sqlite = [
   "holochain_zome_types/sqlite",
   "kitsune_p2p_bin_data/sqlite",
   "kitsune_p2p_dht_arc/sqlite",
-  "kitsune_p2p_types/sqlite",
+  "kitsune_p2p_types?/sqlite",
   "r2d2_sqlite/bundled",
 ]

--- a/crates/holochain_sqlite/loom_tests.sh
+++ b/crates/holochain_sqlite/loom_tests.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-RUSTFLAGS="--cfg loom" cargo test --test loom --no-default-features
+RUSTFLAGS="--cfg loom" cargo test --test loom --no-default-features --features test_utils --release -- --nocapture

--- a/crates/holochain_sqlite/src/db/access.rs
+++ b/crates/holochain_sqlite/src/db/access.rs
@@ -6,18 +6,19 @@ use crate::db::pool::{
     initialize_connection, new_connection_pool, num_read_threads, ConnectionPool, DbSyncLevel,
 };
 use crate::error::{DatabaseError, DatabaseResult};
+use crate::sync::atomic::{AtomicUsize, Ordering};
+use crate::sync::Mutex;
 use derive_more::Into;
-use parking_lot::Mutex;
 use rusqlite::*;
 use shrinkwraprs::Shrinkwrap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::path::PathBuf;
+// Does not use crate::sync::Arc because tokio::sync::Semaphore::acquire_owned requires a std::sync::Arc<Self>
 use std::sync::Arc;
 use std::time::Instant;
 use std::{collections::HashMap, path::Path};
-use std::{path::PathBuf, sync::atomic::AtomicUsize};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
-static ACQUIRE_TIMEOUT_MS: AtomicU64 = AtomicU64::new(10_000);
+static ACQUIRE_TIMEOUT_MS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(10_000);
 
 #[async_trait::async_trait]
 /// A trait for being generic over [`DbWrite`] and [`DbRead`] that

--- a/crates/holochain_sqlite/src/lib.rs
+++ b/crates/holochain_sqlite/src/lib.rs
@@ -20,6 +20,7 @@ pub mod stats;
 pub mod store;
 pub mod swansong;
 
+mod sync;
 mod table;
 
 // Re-export rusqlite for use with `impl_to_sql_via_as_ref!` macro

--- a/crates/holochain_sqlite/src/sync.rs
+++ b/crates/holochain_sqlite/src/sync.rs
@@ -1,0 +1,43 @@
+#[cfg(not(loom))]
+pub use parking_lot::Mutex;
+
+#[cfg(not(loom))]
+pub use std::sync::Arc;
+
+#[cfg(not(loom))]
+pub mod atomic {
+    pub use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+}
+
+#[cfg(not(loom))]
+pub use lazy_static::lazy_static;
+
+#[cfg(loom)]
+pub struct Mutex<T> {
+    inner: loom::sync::Mutex<T>,
+}
+
+// Handles a loom API difference https://docs.rs/loom/latest/loom/#handling-loom-api-differences
+#[cfg(loom)]
+impl<T> Mutex<T> {
+    pub fn new(value: T) -> Self {
+        Self {
+            inner: loom::sync::Mutex::new(value),
+        }
+    }
+
+    pub fn lock(&self) -> loom::sync::MutexGuard<T> {
+        self.inner.lock().unwrap()
+    }
+}
+
+#[cfg(loom)]
+pub use loom::sync::Arc;
+
+#[cfg(loom)]
+pub mod atomic {
+    pub use loom::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+}
+
+#[cfg(loom)]
+pub use loom::lazy_static;

--- a/crates/holochain_sqlite/tests/loom.rs
+++ b/crates/holochain_sqlite/tests/loom.rs
@@ -1,17 +1,58 @@
-#[cfg(loom)]
-mod tests {
-    use loom::sync::atomic::AtomicUsize;
+#[cfg(feature = "test_utils")]
+mod common;
 
-    use std::sync::atomic::Ordering::SeqCst;
-    use std::sync::Arc;
+#[cfg(all(loom, feature = "test_utils"))]
+mod tests {
+    use crate::common::TestDatabaseKind;
+    use holochain_sqlite::db::DbWrite;
+    use holochain_sqlite::error::DatabaseResult;
+    use std::time::Duration;
 
     #[test]
-    fn test_concurrent_logic() {
+    fn multiple_readers() {
         loom::model(|| {
-            let v1 = Arc::new(AtomicUsize::new(0));
-            let v2 = v1.clone();
+            let tmp_dir = tempfile::TempDir::new().unwrap();
+            let db_handle = DbWrite::open(&tmp_dir.into_path(), TestDatabaseKind::new()).unwrap();
 
-            assert_eq!(0, v2.load(SeqCst));
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_time()
+                .build()
+                .unwrap();
+
+            rt.block_on(async move {
+                db_handle
+                    .write_async(|txn| -> DatabaseResult<()> {
+                        txn.execute("CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)", ())?;
+                        txn.execute("INSERT INTO test (name) VALUES (?)", ("Bob",))?;
+
+                        Ok(())
+                    })
+                    .await
+                    .unwrap();
+
+                for _ in 0..10 {
+                    tokio::task::spawn({
+                        let db_handle = db_handle.clone();
+                        async move {
+                            db_handle
+                                .read_async(|txn| -> DatabaseResult<()> {
+                                    let name = txn.query_row("SELECT * FROM test", (), |r| {
+                                        let name: String = r.get(0).unwrap();
+                                        Ok(name)
+                                    })?;
+
+                                    assert_eq!("Bob", name);
+
+                                    Ok(())
+                                })
+                                .await
+                                .unwrap();
+                        }
+                    });
+                }
+            });
+
+            rt.shutdown_timeout(Duration::from_millis(10));
         });
     }
 }


### PR DESCRIPTION
### Summary

A lot of this is about dealing with code that isn't safe to import under loom. I'd already done a pass over this code trying to get it in the right shape but a bit more was needed. The bit I really don't like is having the exclude dependencies. I still think the wrapper over rusqlite and r2d2 should be its own crate that we can build and test in isolation. Then everything else we're importing here isn't necessary, like all these kitsune deps that are only present for metrics which is a layer up from the sqlite wrapper code.

Anyway, this is a working test and opens the door to writing more which is the main thing!

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
