### PR TITLE
fix(github/workflows/release-prepare): use args seperator

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -188,10 +188,10 @@ jobs:
 
           cd ${HOLOCHAIN_REPO}
 
-          nix run .#cargo-sweep -s
-          nix run .#scripts-release-automation-check-and-bump $PWD
+          nix run .#cargo-sweep -- -s
+          nix run .#scripts-release-automation-check-and-bump -- $PWD
           nix run .#scripts-ci-generate-readmes
-          nix run .#cargo-sweep -f
+          nix run .#cargo-sweep -- -f
 
           if ! git diff --exit-code --quiet ${HOLOCHAIN_SOURCE_BRANCH}; then
             echo "releasable_crates=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
otherwise they'll be interpreted as arguments to `nix run`

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
