### PR TITLE
fix(github/workflows/release-prepare): remove redudant readme generation, fix cargo-sweep (again)

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -188,10 +188,10 @@ jobs:
 
           cd ${HOLOCHAIN_REPO}
 
-          nix run .#cargo-sweep -s
-          nix run .#scripts-release-automation-check-and-bump $PWD
+          nix run .#cargo-sweep -- -s
+          nix run .#scripts-release-automation-check-and-bump -- $PWD
           nix run .#scripts-ci-generate-readmes
-          nix run .#cargo-sweep -f
+          nix run .#cargo-sweep -- -f
 
           if ! git diff --exit-code --quiet ${HOLOCHAIN_SOURCE_BRANCH}; then
             echo "releasable_crates=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -180,10 +180,10 @@ jobs:
 
           cd ${HOLOCHAIN_REPO}
 
-          nix run .#cargo-sweep -- -s
+          nix run .#cargo-sweep -- sweep -s
           nix run .#scripts-release-automation-check-and-bump -- $PWD
           nix run .#scripts-ci-generate-readmes
-          nix run .#cargo-sweep -- -f
+          nix run .#cargo-sweep -- sweep -f
 
           if ! git diff --exit-code --quiet ${HOLOCHAIN_SOURCE_BRANCH}; then
             echo "releasable_crates=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -169,14 +169,6 @@ jobs:
             ${{ runner.os }}
           required: false
 
-      - name: Generate crate READMEs from doc comments
-        if: ${{ inputs.skip_prepare_logic != 'true' }}
-        env:
-          HOLOCHAIN_REPO: ${{ inputs.HOLOCHAIN_REPO }}
-        run: |
-          cd "${HOLOCHAIN_REPO}"
-          nix run .#scripts-ci-generate-readmes
-
       - name: Bump the crate versions for the release
         id: bump-versions
         if: ${{ inputs.skip_prepare_logic != 'true' }}


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
