### PR TITLE
[BACKPORT 0.2] Put ignore_genesis_failure behind chc feature (#2758)

### DIFF
--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Adds `chc` feature which is recommended if you want to work with a Holochain instance that is built with its `chc` feature.
+  If you are not using CHC you can safely ignore this feature.
+
 ## 0.2.2-beta-rc.1
 
 ## 0.2.2-beta-rc.0

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -28,3 +28,9 @@ holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.2.2-beta-rc.1"}
 holochain_cli_run_local_services = { path = "../hc_run_local_services", version = "^0.2.2-beta-rc.1"}
 holochain_trace = { version = "^0.2.1", path = "../holochain_trace" }
 tokio = { version = "1.27", features = ["full"] }
+
+[features]
+
+chc = [
+    "holochain_cli_sandbox/chc"
+]

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -42,3 +42,10 @@ assert_cmd = "1.0.1"
 matches = "0.1"
 escargot = "0.5.7"
 which = "4.4.0"
+
+[features]
+
+chc = [
+    "holochain_types/chc",
+    "holochain_conductor_api/chc",
+]

--- a/crates/hc_sandbox/examples/setup_5.rs
+++ b/crates/hc_sandbox/examples/setup_5.rs
@@ -55,7 +55,6 @@ async fn main() -> anyhow::Result<()> {
             source: AppBundleSource::Bundle(bundle),
             membrane_proofs: Default::default(),
             network_seed: None,
-            ignore_genesis_failure: false,
         };
 
         let r = AdminRequest::InstallApp(Box::new(payload));

--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -451,6 +451,7 @@ pub async fn install_app_bundle(cmd: &mut CmdRunner, args: InstallApp) -> anyhow
         source: AppBundleSource::Path(path),
         membrane_proofs: Default::default(),
         network_seed,
+        #[cfg(feature = "chc")]
         ignore_genesis_failure: false,
     };
 

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -230,6 +230,7 @@ chc = [
   "bytes",
   "reqwest",
   "holochain_conductor_api/chc",
+  "holochain_types/chc",
 ]
 
 # Transitional feature flag for code that is only ready when DPKI integration lands.

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1349,13 +1349,18 @@ mod app_impls {
             self: Arc<Self>,
             payload: InstallAppPayload,
         ) -> ConductorResult<StoppedApp> {
+            #[cfg(feature = "chc")]
+            let ignore_genesis_failure = payload.ignore_genesis_failure;
+            #[cfg(not(feature = "chc"))]
+            let ignore_genesis_failure = false;
+
             let InstallAppPayload {
                 source,
                 agent_key,
                 installed_app_id,
                 membrane_proofs,
                 network_seed,
-                ignore_genesis_failure,
+                ..
             } = payload;
 
             let bundle = {

--- a/crates/holochain/src/conductor/tests/install_app_bundle.rs
+++ b/crates/holochain/src/conductor/tests/install_app_bundle.rs
@@ -53,6 +53,7 @@ async fn clone_only_provisioning_creates_no_cell_and_allows_cloning() {
             installed_app_id: Some("app_1".into()),
             network_seed: None,
             membrane_proofs: HashMap::new(),
+            #[cfg(feature = "chc")]
             ignore_genesis_failure: false,
         }
     }
@@ -161,6 +162,7 @@ async fn reject_duplicate_app_for_same_agent() {
             installed_app_id: Some("app_1".into()),
             network_seed: None,
             membrane_proofs: HashMap::new(),
+            #[cfg(feature = "chc")]
             ignore_genesis_failure: false,
         })
         .await
@@ -177,6 +179,7 @@ async fn reject_duplicate_app_for_same_agent() {
             agent_key: alice.clone(),
             installed_app_id: Some("app_2".into()),
             membrane_proofs: HashMap::new(),
+            #[cfg(feature = "chc")]
             ignore_genesis_failure: false,
             network_seed: None,
         })
@@ -200,6 +203,7 @@ async fn reject_duplicate_app_for_same_agent() {
             agent_key: alice.clone(),
             installed_app_id: Some("app_2".into()),
             membrane_proofs: HashMap::new(),
+            #[cfg(feature = "chc")]
             ignore_genesis_failure: false,
             network_seed: None,
         })
@@ -220,6 +224,7 @@ async fn reject_duplicate_app_for_same_agent() {
             agent_key: alice.clone(),
             installed_app_id: Some("app_2".into()),
             membrane_proofs: HashMap::new(),
+            #[cfg(feature = "chc")]
             ignore_genesis_failure: false,
             network_seed: Some("network".into()),
         })
@@ -271,6 +276,7 @@ async fn can_install_app_a_second_time_using_nothing_but_the_manifest_from_app_i
             installed_app_id: Some("app_1".into()),
             network_seed: Some("final seed".into()),
             membrane_proofs: HashMap::new(),
+            #[cfg(feature = "chc")]
             ignore_genesis_failure: false,
         })
         .await
@@ -314,6 +320,7 @@ async fn can_install_app_a_second_time_using_nothing_but_the_manifest_from_app_i
             installed_app_id: Some("app_2".into()),
             network_seed: None,
             membrane_proofs: HashMap::new(),
+            #[cfg(feature = "chc")]
             ignore_genesis_failure: false,
         })
         .await
@@ -378,6 +385,7 @@ async fn network_seed_regression() {
             installed_app_id: Some("no-seed".into()),
             network_seed: None,
             membrane_proofs: HashMap::new(),
+            #[cfg(feature = "chc")]
             ignore_genesis_failure: false,
         })
         .await
@@ -391,6 +399,7 @@ async fn network_seed_regression() {
             installed_app_id: Some("yes-seed".into()),
             network_seed: Some("seed".into()),
             membrane_proofs: HashMap::new(),
+            #[cfg(feature = "chc")]
             ignore_genesis_failure: false,
         })
         .await
@@ -641,6 +650,7 @@ impl TestCase {
                 installed_app_id: Some(case_str.clone()),
                 network_seed,
                 membrane_proofs: HashMap::new(),
+                #[cfg(feature = "chc")]
                 ignore_genesis_failure: false,
             })
             .await

--- a/crates/holochain/src/sweettest/sweet_app_installation.rs
+++ b/crates/holochain/src/sweettest/sweet_app_installation.rs
@@ -51,6 +51,7 @@ pub async fn get_install_app_payload_from_dnas(
         installed_app_id: Some(installed_app_id.into()),
         network_seed: None,
         membrane_proofs: Default::default(),
+        #[cfg(feature = "chc")]
         ignore_genesis_failure: false,
     }
 }

--- a/crates/holochain/tests/graft_records_onto_source_chain.rs
+++ b/crates/holochain/tests/graft_records_onto_source_chain.rs
@@ -3,7 +3,6 @@
 use ::fixt::prelude::*;
 use hdk::prelude::*;
 use holochain::conductor::api::error::ConductorApiError;
-use holochain::conductor::chc::CHC_LOCAL_MAGIC_URL;
 use holochain::sweettest::{DynSweetRendezvous, SweetConductor, SweetDnaFile, SweetInlineZomes};
 use holochain::test_utils::inline_zomes::simple_crud_zome;
 use holochain_conductor_api::conductor::ConductorConfig;
@@ -13,12 +12,15 @@ use holochain_sqlite::error::DatabaseResult;
 use holochain_state::prelude::{StateMutationError, Store, Txn};
 use holochain_types::record::SignedActionHashedExt;
 
-#[tokio::test(flavor = "multi_thread")]
 /// Test that records can be manually grafted onto a source chain.
+#[cfg(feature = "chc")]
+#[tokio::test(flavor = "multi_thread")]
 async fn grafting() {
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
     let mut config = ConductorConfig::default();
-    config.chc_url = Some(url2::Url2::parse(CHC_LOCAL_MAGIC_URL));
+    config.chc_url = Some(url2::Url2::parse(
+        holochain::conductor::chc::CHC_LOCAL_MAGIC_URL,
+    ));
     let mut conductor = SweetConductor::from_config(config.clone()).await;
     let keystore = conductor.keystore();
 

--- a/crates/holochain/tests/test_utils/mod.rs
+++ b/crates/holochain/tests/test_utils/mod.rs
@@ -277,6 +277,7 @@ pub async fn register_and_install_dna_named(
         installed_app_id: Some(name),
         network_seed: None,
         membrane_proofs: std::collections::HashMap::new(),
+        #[cfg(feature = "chc")]
         ignore_genesis_failure: false,
     };
     let request = AdminRequest::InstallApp(Box::new(payload));

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Adds `ignore_genesis_failure` field to InstallApp arguments. The default is `false`, and can only use this with the CHC feature. [2612](https://github.com/holochain/holochain/pull/2612)
+
 ## 0.2.2-beta-rc.1
 
 ## 0.2.2-beta-rc.0

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -110,3 +110,5 @@ sqlite = [
   "holochain_zome_types/sqlite",
   "kitsune_p2p_dht/sqlite",
 ]
+
+chc = []

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -152,6 +152,7 @@ pub struct InstallAppPayload {
     /// Optional: If app installation fails due to genesis failure, normally the app will be
     /// immediately uninstalled. When this flag is set, the app is left installed with empty cells intact.
     /// This can be useful for using `graft_records_onto_source_chain`, or for diagnostics.
+    #[cfg(feature = "chc")]
     #[serde(default)]
     pub ignore_genesis_failure: bool,
 }


### PR DESCRIPTION
* Put ignore_genesis_failure behind chc feature

* Deal with the sandbox

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
