### PR TITLE
Add new signal tests using rendezvous

### DIFF
--- a/crates/holochain/tests/integration.rs
+++ b/crates/holochain/tests/integration.rs
@@ -9,6 +9,7 @@ mod new_lair;
 mod ser_regression;
 #[cfg(not(target_os = "macos"))]
 mod sharded_gossip;
+mod signals;
 mod speed_tests;
 mod test_cli;
 mod test_utils;

--- a/crates/holochain/tests/signals/mod.rs
+++ b/crates/holochain/tests/signals/mod.rs
@@ -1,7 +1,6 @@
 //! Tests for local and remote signals using rendezvous config
 //!
 
-use fallible_iterator::FallibleIterator;
 use futures::StreamExt;
 use hdk::prelude::ExternIO;
 use holochain::sweettest::{SweetCell, SweetConductorBatch, SweetConductorConfig, SweetDnaFile};
@@ -27,6 +26,7 @@ fn to_signal_message(signal: Signal) -> SignalMessage {
 
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "slow_tests")]
+#[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn remote_signals_batch() -> anyhow::Result<()> {
     holochain_trace::test_run().ok();
 
@@ -82,6 +82,7 @@ async fn remote_signals_batch() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "slow_tests")]
+#[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn remote_signals_broadcast() -> anyhow::Result<()> {
     holochain_trace::test_run().ok();
 

--- a/crates/holochain/tests/signals/mod.rs
+++ b/crates/holochain/tests/signals/mod.rs
@@ -47,8 +47,9 @@ async fn remote_signals_batch() -> anyhow::Result<()> {
         .require_initial_gossip_activity_for_cell(&bob, Duration::from_secs(90))
         .await;
 
-    // Listen for signals on Bon's conductor. These are all the signals on that conductor but Bob has the only app on
-    // that conductor for this test.
+    // Listen for signals on Bob's and Carol's conductors. 
+    // These are all the signals on that conductor but the only app installed
+    // is the one for this test.
     let mut conductor_1_signal_stream = conductors[1].signal_stream().await.map(to_signal_message);
     let mut conductor_2_signal_stream = conductors[2].signal_stream().await.map(to_signal_message);
 

--- a/crates/holochain/tests/signals/mod.rs
+++ b/crates/holochain/tests/signals/mod.rs
@@ -47,7 +47,7 @@ async fn remote_signals_batch() -> anyhow::Result<()> {
         .require_initial_gossip_activity_for_cell(&bob, Duration::from_secs(90))
         .await;
 
-    // Listen for signals on Bob's and Carol's conductors. 
+    // Listen for signals on Bob's and Carol's conductors.
     // These are all the signals on that conductor but the only app installed
     // is the one for this test.
     let mut conductor_1_signal_stream = conductors[1].signal_stream().await.map(to_signal_message);

--- a/crates/holochain/tests/signals/mod.rs
+++ b/crates/holochain/tests/signals/mod.rs
@@ -1,0 +1,135 @@
+//! Tests for local and remote signals using rendezvous config
+//!
+
+use fallible_iterator::FallibleIterator;
+use futures::StreamExt;
+use hdk::prelude::ExternIO;
+use holochain::sweettest::{SweetCell, SweetConductorBatch, SweetConductorConfig, SweetDnaFile};
+use holochain_types::signal::Signal;
+use holochain_wasm_test_utils::TestWasm;
+use holochain_zome_types::RemoteSignal;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize, Debug)]
+struct SignalMessage {
+    value: String,
+}
+
+fn to_signal_message(signal: Signal) -> SignalMessage {
+    match signal {
+        Signal::App { signal, .. } => signal.into_inner().decode().unwrap(),
+        _ => {
+            panic!("Only expected app signals");
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg(feature = "slow_tests")]
+async fn remote_signals_batch() -> anyhow::Result<()> {
+    holochain_trace::test_run().ok();
+
+    let mut conductors =
+        SweetConductorBatch::from_config_rendezvous(2, SweetConductorConfig::rendezvous()).await;
+
+    let dna_file = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::EmitSignal])
+        .await
+        .0;
+
+    let app_batch = conductors.setup_app("app", &[dna_file]).await.unwrap();
+
+    let ((alice,), (bob,)): ((SweetCell,), (SweetCell,)) = app_batch.into_tuples();
+
+    // Make sure the conductors are talking to each other before sending signals.
+    conductors
+        .require_initial_gossip_activity_for_cell(&bob, Duration::from_secs(90))
+        .await;
+
+    // Listen for signals on Bon's conductor. These are all the signals on that conductor but Bob has the only app on
+    // that conductor for this test.
+    let mut conductor_1_signal_stream = conductors[1].signal_stream().await.map(to_signal_message);
+
+    // Call `signal_others` multiple times as Alice to send signals to Bob.
+    for i in 0..6 {
+        let _: () = conductors[0]
+            .call(
+                &alice.zome(TestWasm::EmitSignal),
+                "signal_others",
+                RemoteSignal {
+                    agents: vec![bob.agent_pubkey().clone()],
+                    signal: ExternIO::encode(SignalMessage {
+                        value: format!("message {}", i),
+                    })
+                    .unwrap(),
+                },
+            )
+            .await;
+    }
+
+    // Check that Bob receives all the signals.
+    tokio::time::timeout(Duration::from_secs(60), async move {
+        for i in 0..6 {
+            let message = conductor_1_signal_stream.next().await.unwrap();
+            assert_eq!(format!("message {}", i), message.value);
+        }
+    })
+    .await
+    .unwrap();
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[cfg(feature = "slow_tests")]
+async fn remote_signals_broadcast() -> anyhow::Result<()> {
+    holochain_trace::test_run().ok();
+
+    let mut conductors =
+        SweetConductorBatch::from_config_rendezvous(3, SweetConductorConfig::rendezvous()).await;
+
+    let dna_file = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::EmitSignal])
+        .await
+        .0;
+
+    let app_batch = conductors.setup_app("app", &[dna_file]).await.unwrap();
+
+    let ((alice,), (bob,), (carol,)): ((SweetCell,), (SweetCell,), (SweetCell,)) =
+        app_batch.into_tuples();
+
+    // Make sure the conductors are talking to each other before sending signals.
+    conductors
+        .require_initial_gossip_activity_for_cell(&bob, Duration::from_secs(90))
+        .await;
+
+    // Listen for signals on Bob and Carol's conductors.
+    let mut conductor_1_signal_stream = conductors[1].signal_stream().await.map(to_signal_message);
+    let mut conductor_2_signal_stream = conductors[2].signal_stream().await.map(to_signal_message);
+
+    // Call `signal_others` multiple times as Alice to send signals to Bob.
+    let _: () = conductors[0]
+        .call(
+            &alice.zome(TestWasm::EmitSignal),
+            "signal_others",
+            RemoteSignal {
+                agents: vec![bob.agent_pubkey().clone(), carol.agent_pubkey().clone()],
+                signal: ExternIO::encode(SignalMessage {
+                    value: "message from alice".to_string(),
+                })
+                .unwrap(),
+            },
+        )
+        .await;
+
+    // Check that Bob and Carol receive their signals.
+    tokio::time::timeout(Duration::from_secs(60), async move {
+        let bob_message = conductor_1_signal_stream.next().await.unwrap();
+        assert_eq!("message from alice", bob_message.value);
+        let carol_message = conductor_2_signal_stream.next().await.unwrap();
+        assert_eq!("message from alice", carol_message.value);
+    })
+    .await
+    .unwrap();
+
+    Ok(())
+}

--- a/crates/holochain/tests/signals/mod.rs
+++ b/crates/holochain/tests/signals/mod.rs
@@ -31,62 +31,6 @@ async fn remote_signals_batch() -> anyhow::Result<()> {
     holochain_trace::test_run().ok();
 
     let mut conductors =
-        SweetConductorBatch::from_config_rendezvous(2, SweetConductorConfig::rendezvous()).await;
-
-    let dna_file = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::EmitSignal])
-        .await
-        .0;
-
-    let app_batch = conductors.setup_app("app", &[dna_file]).await.unwrap();
-
-    let ((alice,), (bob,)): ((SweetCell,), (SweetCell,)) = app_batch.into_tuples();
-
-    // Make sure the conductors are talking to each other before sending signals.
-    conductors
-        .require_initial_gossip_activity_for_cell(&bob, Duration::from_secs(90))
-        .await;
-
-    // Listen for signals on Bon's conductor. These are all the signals on that conductor but Bob has the only app on
-    // that conductor for this test.
-    let mut conductor_1_signal_stream = conductors[1].signal_stream().await.map(to_signal_message);
-
-    // Call `signal_others` multiple times as Alice to send signals to Bob.
-    for i in 0..6 {
-        let _: () = conductors[0]
-            .call(
-                &alice.zome(TestWasm::EmitSignal),
-                "signal_others",
-                RemoteSignal {
-                    agents: vec![bob.agent_pubkey().clone()],
-                    signal: ExternIO::encode(SignalMessage {
-                        value: format!("message {}", i),
-                    })
-                    .unwrap(),
-                },
-            )
-            .await;
-    }
-
-    // Check that Bob receives all the signals.
-    tokio::time::timeout(Duration::from_secs(60), async move {
-        for i in 0..6 {
-            let message = conductor_1_signal_stream.next().await.unwrap();
-            assert_eq!(format!("message {}", i), message.value);
-        }
-    })
-    .await
-    .unwrap();
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-#[cfg(feature = "slow_tests")]
-#[cfg_attr(target_os = "macos", ignore = "flaky")]
-async fn remote_signals_broadcast() -> anyhow::Result<()> {
-    holochain_trace::test_run().ok();
-
-    let mut conductors =
         SweetConductorBatch::from_config_rendezvous(3, SweetConductorConfig::rendezvous()).await;
 
     let dna_file = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::EmitSignal])
@@ -103,31 +47,37 @@ async fn remote_signals_broadcast() -> anyhow::Result<()> {
         .require_initial_gossip_activity_for_cell(&bob, Duration::from_secs(90))
         .await;
 
-    // Listen for signals on Bob and Carol's conductors.
+    // Listen for signals on Bon's conductor. These are all the signals on that conductor but Bob has the only app on
+    // that conductor for this test.
     let mut conductor_1_signal_stream = conductors[1].signal_stream().await.map(to_signal_message);
     let mut conductor_2_signal_stream = conductors[2].signal_stream().await.map(to_signal_message);
 
     // Call `signal_others` multiple times as Alice to send signals to Bob.
-    let _: () = conductors[0]
-        .call(
-            &alice.zome(TestWasm::EmitSignal),
-            "signal_others",
-            RemoteSignal {
-                agents: vec![bob.agent_pubkey().clone(), carol.agent_pubkey().clone()],
-                signal: ExternIO::encode(SignalMessage {
-                    value: "message from alice".to_string(),
-                })
-                .unwrap(),
-            },
-        )
-        .await;
+    for i in 0..6 {
+        let _: () = conductors[0]
+            .call(
+                &alice.zome(TestWasm::EmitSignal),
+                "signal_others",
+                RemoteSignal {
+                    agents: vec![bob.agent_pubkey().clone(), carol.agent_pubkey().clone()],
+                    signal: ExternIO::encode(SignalMessage {
+                        value: format!("message {}", i),
+                    })
+                    .unwrap(),
+                },
+            )
+            .await;
+    }
 
-    // Check that Bob and Carol receive their signals.
+    // Check that Bob receives all the signals.
     tokio::time::timeout(Duration::from_secs(60), async move {
-        let bob_message = conductor_1_signal_stream.next().await.unwrap();
-        assert_eq!("message from alice", bob_message.value);
-        let carol_message = conductor_2_signal_stream.next().await.unwrap();
-        assert_eq!("message from alice", carol_message.value);
+        for i in 0..6 {
+            let message = conductor_1_signal_stream.next().await.unwrap();
+            assert_eq!(format!("message {}", i), message.value);
+
+            let message = conductor_2_signal_stream.next().await.unwrap();
+            assert_eq!(format!("message {}", i), message.value);
+        }
     })
     .await
     .unwrap();

--- a/crates/holochain/tests/signals/mod.rs
+++ b/crates/holochain/tests/signals/mod.rs
@@ -69,7 +69,7 @@ async fn remote_signals_batch() -> anyhow::Result<()> {
             .await;
     }
 
-    // Check that Bob receives all the signals.
+    // Check that Bob and Carol receive all the signals.
     tokio::time::timeout(Duration::from_secs(60), async move {
         for i in 0..6 {
             let message = conductor_1_signal_stream.next().await.unwrap();


### PR DESCRIPTION
### Summary

Doing a couple of things at the same time here
- The current sweettests for signals use tx2, these new ones use tx5
- There aren't any sweettest examples of handling signals where you care about testing with the values received

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
