### PR TITLE
build(nix): set flake false & pin lair 0.3.0

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,6 @@
 
     versions.url = "github:holochain/holochain?dir=versions/0_1";
 
-    # "empty" repo does not have a flake
     holochain.follows = "empty";
     holochain.flake = false;
     lair.follows = "empty";

--- a/flake.nix
+++ b/flake.nix
@@ -48,10 +48,15 @@
 
     versions.url = "github:holochain/holochain?dir=versions/0_1";
 
+    # "empty" repo does not have a flake
     holochain.follows = "empty";
+    holochain.flake = false;
     lair.follows = "empty";
+    lair.flake = false;
     launcher.follows = "empty";
+    launcher.flake = false;
     scaffolding.follows = "empty";
+    scaffolding.flake = false;
 
     cargo-chef = {
       url = "github:LukeMathWalker/cargo-chef/main";


### PR DESCRIPTION
### Summary
lair input is interpreted as a flake in nix flake, this is fixed. ~~Secondly lair is pinned to 0.3.0 for holochain 0.2.2.
The holochain version on `develop-0.2` is `-beta-dev.0` which is totally off. So I think the most correct thing is to set this to `-beta-0.2.1`, leave lair at `v0.2.4` and then~~ right after the release of v0.2.2 I'd create another PR which sets holochain to 0.2.2 in `versions/0_2` and lair to `0.3.0`.

Hahaaa, 0.2.2 was just released, so I'll skip fixing the former and proceed with the latter in this PR.
Overriding lair input in consuming flakes works using `holonix.inputs.lair.url = "..."`.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
