### PR TITLE
Fix GITHUB_TOKEN not available in dispatched workflows

### DIFF
--- a/.github/workflows/holochain-build-and-test.yml
+++ b/.github/workflows/holochain-build-and-test.yml
@@ -14,7 +14,7 @@ on:
         type: boolean
         default: false
     secrets:
-      GITHUB_TOKEN:
+      GITHUB_ACCESS_TOKEN:
         description: "A GitHub access toekn which can be used for cloning the project"
         required: true
       CACHIX_AUTH_TOKEN_HOLOCHAIN_CI_INTERNAL:

--- a/.github/workflows/holochain-build-and-test.yml
+++ b/.github/workflows/holochain-build-and-test.yml
@@ -14,6 +14,9 @@ on:
         type: boolean
         default: false
     secrets:
+      GITHUB_TOKEN:
+        description: "A GitHub access toekn which can be used for cloning the project"
+        required: true
       CACHIX_AUTH_TOKEN_HOLOCHAIN_CI_INTERNAL:
         description: "The Cachix token for `holochain-ci-internal` to be used for caching Holochain CI runs"
         required: true

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -14,6 +14,7 @@ jobs:
   test:
     uses: ./.github/workflows/holochain-build-and-test.yml
     secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CACHIX_AUTH_TOKEN_HOLOCHAIN_CI_INTERNAL: ${{ secrets.CACHIX_AUTH_TOKEN_HOLOCHAIN_CI_INTERNAL }}
 
   github-actions-ci-jobs-succeed:

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     uses: ./.github/workflows/holochain-build-and-test.yml
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CACHIX_AUTH_TOKEN_HOLOCHAIN_CI_INTERNAL: ${{ secrets.CACHIX_AUTH_TOKEN_HOLOCHAIN_CI_INTERNAL }}
 
   github-actions-ci-jobs-succeed:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,7 @@ jobs:
     with:
       repo_path: ${{ needs.prepare.outputs.repo_nix_store_path }}
     secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CACHIX_AUTH_TOKEN_HOLOCHAIN_CI_INTERNAL: ${{ secrets.CACHIX_AUTH_TOKEN_HOLOCHAIN_CI_INTERNAL }}
 
   finalize:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,7 @@ jobs:
     with:
       repo_path: ${{ needs.prepare.outputs.repo_nix_store_path }}
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CACHIX_AUTH_TOKEN_HOLOCHAIN_CI_INTERNAL: ${{ secrets.CACHIX_AUTH_TOKEN_HOLOCHAIN_CI_INTERNAL }}
 
   finalize:


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
