### PR TITLE
feat(github/workflows/holonix-cache): use `nix develop --build`

### DIFF
--- a/.github/workflows/holonix-cache.yml
+++ b/.github/workflows/holonix-cache.yml
@@ -51,7 +51,7 @@ jobs:
           target=${{ matrix.target }}
 
           # See https://docs.cachix.org/pushing#id1
-          nix build -L \
+          nix develop --build -L \
             ${{ matrix.extra_args }} \
             ${target/PLATFORM/${{ matrix.platform}}}
 


### PR DESCRIPTION
seemingly this captures more dependencies than `nix build`

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
