### PR TITLE
build(dev-setup): upgrade nix to v2.17.0

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@ set -e
 
 # bump this to the most recent version when the following bugs have been resolved
 # - https://github.com/NixOS/nix/issues/7984
-export NIX_INSTALLER_URL=${NIX_INSTALLER_URL:-https://releases.nixos.org/nix/nix-2.13.3/install}
+export NIX_INSTALLER_URL=${NIX_INSTALLER_URL:-https://releases.nixos.org/nix/nix-2.16.1/install}
 
 run_cmd() {
     echo "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@ set -e
 
 # bump this to the most recent version when the following bugs have been resolved
 # - https://github.com/NixOS/nix/issues/7984
-export NIX_INSTALLER_URL=${NIX_INSTALLER_URL:-https://releases.nixos.org/nix/nix-2.16.1/install}
+export NIX_INSTALLER_URL=${NIX_INSTALLER_URL:-https://releases.nixos.org/nix/nix-2.17.0/install}
 
 run_cmd() {
     echo "$@"


### PR DESCRIPTION
### Summary
Update the Nix version in the setup script to 2.16.1. The current one is 2.18.0, this is a conservatively informed guess upgrade.


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
