### PR TITLE
Update doc for the force option on the sandbox

### DIFF
--- a/crates/hc_sandbox/src/cli.rs
+++ b/crates/hc_sandbox/src/cli.rs
@@ -30,7 +30,9 @@ pub struct HcSandbox {
     #[arg(long, default_value_t = Output::Log)]
     structured: Output,
 
-    /// Force the admin port(s) that hc uses to talk to Holochain to a specific value.
+    /// Force the admin port(s) that Holochain will use to a specific value.
+    /// This option updates the conductor config file before starting Holochain
+    /// and is only available with the `generate` and `run` commands.
     /// For example `hc sandbox -f=9000,9001 run`
     /// This must be set on each run or the port will change if it's in use.
     #[arg(short, long, value_delimiter = ',')]


### PR DESCRIPTION
### Summary

I find it confusing that this isn't available for `call` because the docs says it overrides the ports that `hc` uses to communicate with Holochain which isn't accurate. It's actually overriding what port Holochain runs on and then connecting on those ports.

To do a call on a different port you actually need to do `hc sandbox call -r <port> <action>`, but you see this option documented first and the sandbox fails to make the call silently (which is a separate issue I think)

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
