### PR TITLE
Prevent silent exit on cannot call

### DIFF
--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -246,6 +246,18 @@ pub async fn call(holochain_path: &Path, req: Call, structured: Output) -> anyho
                 }
             }
         }
+
+        if cmds.is_empty() {
+            bail!(
+                "No running conductors found by searching the current directory. \
+                You need to do one of \
+                    1. Start a new sandbox conductor from this directory, \
+                    2. Change directory to where your sandbox conductor is running, \
+                    3. Use the --running flag to connect to a running conductor\
+                "
+            );
+        }
+
         cmds
     } else {
         let mut cmds = Vec::with_capacity(running.len());

--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -250,10 +250,10 @@ pub async fn call(holochain_path: &Path, req: Call, structured: Output) -> anyho
         if cmds.is_empty() {
             bail!(
                 "No running conductors found by searching the current directory. \
-                You need to do one of \
-                    1. Start a new sandbox conductor from this directory, \
-                    2. Change directory to where your sandbox conductor is running, \
-                    3. Use the --running flag to connect to a running conductor\
+                \nYou need to do one of: \
+                    \n\t1. Start a new sandbox conductor from this directory, \
+                    \n\t2. Change directory to where your sandbox conductor is running, \
+                    \n\t3. Use the --running flag to connect to a running conductor\
                 "
             );
         }


### PR DESCRIPTION
### Summary

There's a lot of loops in here that are happy to deal with 0..n items which means you get silent exits with 0 items. It's not easy to guess as a user what happened. Hopefully this makes it a bit clearer if you aren't using the `call` command correctly

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
