### PR TITLE
[BACKPORT 0.2] Downgrade error to info for pool free (#2835)

### DIFF
--- a/crates/holochain_sqlite/src/db/access.rs
+++ b/crates/holochain_sqlite/src/db/access.rs
@@ -166,7 +166,8 @@ impl<Kind: DbKindT> DbRead<Kind> {
         let r = Ok(PConn::new(self.connection_pool.get()?));
         let el = now.elapsed();
         if el.as_millis() > 20 {
-            tracing::error!("Connection pool took {:?} to be free'd", el);
+            // TODO Convert to a metric
+            tracing::info!("Connection pool took {:?} to be freed", el);
         }
         r
     }


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
