### PR TITLE
Extract and test pending validation receipts query

### DIFF
--- a/crates/holochain_state/src/validation_receipts.rs
+++ b/crates/holochain_state/src/validation_receipts.rs
@@ -152,14 +152,59 @@ pub fn add_if_unique(
     mutations::insert_validation_receipt(txn, receipt)
 }
 
+pub fn get_pending_validation_receipts(
+    txn: &Transaction,
+    validators: Vec<AgentPubKey>,
+) -> StateQueryResult<Vec<(ValidationReceipt, AgentPubKey, DhtOpHash)>> {
+    let mut stmt = txn.prepare(
+        "
+            SELECT Action.author, DhtOp.hash, DhtOp.validation_status,
+            DhtOp.when_integrated
+            From DhtOp
+            JOIN Action ON DhtOp.action_hash = Action.hash
+            WHERE
+            DhtOp.require_receipt = 1
+            AND
+            DhtOp.when_integrated IS NOT NULL
+            AND
+            DhtOp.validation_status IS NOT NULL
+            ",
+    )?;
+
+    let ops = stmt
+        .query_and_then([], |r| {
+            let author: AgentPubKey = r.get("author")?;
+            let dht_op_hash: DhtOpHash = r.get("hash")?;
+            let validation_status = r.get("validation_status")?;
+            // NB: timestamp will never be null, so this is OK
+            let when_integrated = r.get("when_integrated")?;
+            Ok((
+                ValidationReceipt {
+                    dht_op_hash: dht_op_hash.clone(),
+                    validation_status,
+                    validators: validators.clone(),
+                    when_integrated,
+                },
+                author,
+                dht_op_hash,
+            ))
+        })?
+        .collect::<StateQueryResult<Vec<_>>>()?;
+
+    Ok(ops)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mutations::set_when_integrated;
+    use crate::prelude::{set_require_receipt, set_validation_status};
     use fixt::prelude::*;
-    use holo_hash::HasHash;
+    use holo_hash::{HasHash, HoloHashOf};
     use holochain_types::dht_op::DhtOp;
     use holochain_types::dht_op::DhtOpHashed;
     use holochain_zome_types::fixt::*;
+    use std::collections::HashSet;
 
     async fn fake_vr(
         dht_op_hash: &DhtOpHash,
@@ -264,5 +309,148 @@ mod tests {
         let iter = (0..10).map(|_| async move { Result::<i32, String>::Err("test".to_string()) });
         let stream = futures::stream::iter(iter);
         assert_eq!(Err("test".to_string()), try_stream_of_results(stream).await);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn no_pending_receipts() {
+        holochain_trace::test_run().ok();
+
+        let env = crate::test_utils::test_dht_db().to_db();
+        let keystore = crate::test_utils::test_keystore();
+
+        // With no validators
+        let pending = env
+            .read_async(|txn| get_pending_validation_receipts(&txn, vec![]))
+            .await
+            .unwrap();
+
+        assert!(pending.is_empty());
+
+        // Same result with validators
+        let pending = env
+            .read_async(|txn| get_pending_validation_receipts(&txn, vec![fixt!(AgentPubKey)]))
+            .await
+            .unwrap();
+
+        assert!(pending.is_empty());
+    }
+
+    async fn create_modified_op(
+        vault: DbWrite<DbKindDht>,
+        keystore: &MetaLairClient,
+        modifier: fn(txn: &mut Transaction, op_hash: HoloHashOf<DhtOp>) -> StateMutationResult<()>,
+    ) -> StateMutationResult<DhtOpHash> {
+        // The actual op does not matter, just some of the status fields
+        let op = DhtOpHashed::from_content_sync(DhtOp::RegisterAgentActivity(
+            fixt!(Signature),
+            fixt!(Action),
+        ));
+
+        let test_op_hash = op.as_hash().clone();
+        vault
+            .write_async({
+                let test_op_hash = test_op_hash.clone();
+                move |txn| -> StateMutationResult<()> {
+                    mutations::insert_op(txn, &op)?;
+                    modifier(txn, test_op_hash)?;
+
+                    Ok(())
+                }
+            })
+            .await
+            .unwrap();
+
+        Ok(test_op_hash)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn filter_for_pending_validation_receipts() {
+        holochain_trace::test_run().ok();
+
+        let test_db = crate::test_utils::test_dht_db();
+        let env = test_db.to_db();
+        let keystore = crate::test_utils::test_keystore();
+
+        // Has not been integrated yet
+        create_modified_op(env.clone(), &keystore, |_txn, _hash| {
+            // Do nothing
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        // Is ready to have a receipt sent
+        let valid_op_hash = create_modified_op(env.clone(), &keystore, |txn, op_hash| {
+            set_require_receipt(txn, &op_hash, true)?;
+            set_when_integrated(txn, &op_hash, Timestamp::now())?;
+            set_validation_status(txn, &op_hash, ValidationStatus::Valid)?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        // Is ready to have a receipt sent, with rejected status
+        let rejected_op_hash = create_modified_op(env.clone(), &keystore, |txn, op_hash| {
+            set_require_receipt(txn, &op_hash, true)?;
+            set_when_integrated(txn, &op_hash, Timestamp::now())?;
+            set_validation_status(txn, &op_hash, ValidationStatus::Rejected)?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        // Is ready to have a receipt sent, with abandoned status
+        let abandoned_op_hash = create_modified_op(env.clone(), &keystore, |txn, op_hash| {
+            set_require_receipt(txn, &op_hash, true)?;
+            set_when_integrated(txn, &op_hash, Timestamp::now())?;
+            set_validation_status(txn, &op_hash, ValidationStatus::Abandoned)?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        // Is ready to have a receipt sent, but does not require one
+        create_modified_op(env.clone(), &keystore, |txn, op_hash| {
+            set_require_receipt(txn, &op_hash, false)?;
+            set_when_integrated(txn, &op_hash, Timestamp::now())?;
+            set_validation_status(txn, &op_hash, ValidationStatus::Valid)?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        // Is ready to have a receipt sent, but when_integrated was not set
+        create_modified_op(env.clone(), &keystore, |txn, op_hash| {
+            set_require_receipt(txn, &op_hash, true)?;
+            set_validation_status(txn, &op_hash, ValidationStatus::Valid)?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        // Is ready to have a receipt sent, but validation_status was not set
+        create_modified_op(env.clone(), &keystore, |txn, op_hash| {
+            set_require_receipt(txn, &op_hash, true)?;
+            set_when_integrated(txn, &op_hash, Timestamp::now())?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+
+        let pending = env
+            .read_async(
+                move |txn| -> StateQueryResult<Vec<(ValidationReceipt, AgentPubKey, DhtOpHash)>> {
+                    get_pending_validation_receipts(&txn, vec![])
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(3, pending.len());
+
+        let pending_ops: HashSet<DhtOpHash> = pending.into_iter().map(|p| p.2).collect();
+        assert!(pending_ops.contains(&valid_op_hash));
+        assert!(pending_ops.contains(&rejected_op_hash));
+        assert!(pending_ops.contains(&abandoned_op_hash));
     }
 }


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
