### PR TITLE
Add fuzzing feature

### DIFF
--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -45,6 +45,11 @@ full = [
     "sqlite"
 ]
 
+fuzzing = [
+    "arbitrary",
+    "holochain_serialized_bytes?/fuzzing",
+]
+
 fixturators = ["fixt", "rand", "hashing", "encoding"]
 hashing = ["futures", "must_future", "blake2b_simd", "serialization"]
 serialization = ["holochain_serialized_bytes", "serde", "serde_bytes"]

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -73,7 +73,7 @@ pub struct HoloHash<T: HashType> {
     hash_type: T,
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a, P: PrimitiveHashType> arbitrary::Arbitrary<'a> for HoloHash<P> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let mut buf = [0; HOLO_HASH_FULL_LEN];

--- a/crates/holo_hash/src/hash_b64.rs
+++ b/crates/holo_hash/src/hash_b64.rs
@@ -45,7 +45,7 @@ impl<T: HashType> serde::Serialize for HoloHashB64<T> {
     }
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a, P: PrimitiveHashType> arbitrary::Arbitrary<'a> for HoloHashB64<P> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(HoloHash::arbitrary(u)?.into())

--- a/crates/holo_hash/src/hash_type/composite.rs
+++ b/crates/holo_hash/src/hash_type/composite.rs
@@ -81,7 +81,7 @@ impl From<AnyDhtSerial> for AnyDht {
     derive(serde::Deserialize, serde::Serialize, SerializedBytes),
     serde(from = "AnyLinkableSerial", into = "AnyLinkableSerial")
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum AnyLinkable {
     /// The hash of an Entry
     Entry,
@@ -91,7 +91,7 @@ pub enum AnyLinkable {
     External,
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for crate::HoloHash<AnyLinkable> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let any_linkable = AnyLinkable::arbitrary(u)?;

--- a/crates/holo_hash/src/hash_type/primitive.rs
+++ b/crates/holo_hash/src/hash_type/primitive.rs
@@ -88,7 +88,7 @@ macro_rules! primitive_hash_type {
     ($name: ident, $display: ident, $visitor: ident, $prefix: ident) => {
         /// The $name PrimitiveHashType
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
-        #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+        #[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
         pub struct $name;
 
         impl PrimitiveHashType for $name {

--- a/crates/holo_hash/src/hashed.rs
+++ b/crates/holo_hash/src/hashed.rs
@@ -5,7 +5,7 @@ use crate::HoloHashOf;
 #[cfg(feature = "serialization")]
 use holochain_serialized_bytes::prelude::*;
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 use crate::PrimitiveHashType;
 
 /// Represents some piece of content along with its hash representation, so that
@@ -30,7 +30,7 @@ impl<C: HashableContent> HasHash<C::HashType> for HoloHashed<C> {
     }
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a, C> arbitrary::Arbitrary<'a> for HoloHashed<C>
 where
     C: HashableContent + arbitrary::Arbitrary<'a>,

--- a/crates/holochain_integrity_types/Cargo.toml
+++ b/crates/holochain_integrity_types/Cargo.toml
@@ -33,7 +33,7 @@ subtle-encoding = {version = "0.5", optional = true}
 tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
-holochain_integrity_types = { path = ".", features = ["test_utils"]}
+holochain_integrity_types = { path = ".", features = ["test_utils", "fuzzing"]}
 serde_json = "1"
 
 [features]
@@ -43,13 +43,16 @@ full = ["default", "subtle-encoding", "kitsune_p2p_timestamp/full"]
 
 full-dna-def = ["derive_builder"]
 
+fuzzing = [
+  "arbitrary",
+  "kitsune_p2p_timestamp/fuzzing",
+  "holochain_serialized_bytes/fuzzing",
+  "holo_hash/fuzzing",
+]
+
 test_utils = [
   "full",
-  "arbitrary",
-  "kitsune_p2p_timestamp/arbitrary",
   "kitsune_p2p_timestamp/now",
-  "holo_hash/arbitrary",
   "holo_hash/hashing",
   "holo_hash/test_utils",
-  "holochain_serialized_bytes/fuzzing",
 ]

--- a/crates/holochain_integrity_types/src/action.rs
+++ b/crates/holochain_integrity_types/src/action.rs
@@ -34,7 +34,7 @@ pub const POST_GENESIS_SEQ_THRESHOLD: u32 = 3;
 /// functions.
 #[allow(missing_docs)]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[serde(tag = "type")]
 pub enum Action {
     // The first action in a chain (for the DNA) doesn't have a previous action
@@ -116,7 +116,7 @@ macro_rules! write_into_action {
         /// A unit enum which just maps onto the different Action variants,
         /// without containing any extra data
         #[derive(serde::Serialize, serde::Deserialize, SerializedBytes, PartialEq, Eq, Clone, Debug)]
-        #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+        #[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
         pub enum ActionType {
             $($n,)*
         }
@@ -420,7 +420,7 @@ impl_hashable_content_for_ref!(Delete);
     Deserialize,
     SerializedBytes,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct ZomeIndex(pub u8);
 
 impl ZomeIndex {
@@ -442,12 +442,12 @@ impl ZomeIndex {
     Deserialize,
     SerializedBytes,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct EntryDefIndex(pub u8);
 
 /// The Dna Action is always the first action in a source chain
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct Dna {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -458,7 +458,7 @@ pub struct Dna {
 /// Action for an agent validation package, used to determine whether an agent
 /// is allowed to participate in this DNA
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct AgentValidationPkg {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -471,7 +471,7 @@ pub struct AgentValidationPkg {
 /// A action which declares that all zome init functions have successfully
 /// completed, and the chain is ready for commits. Contains no explicit data.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct InitZomesComplete {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -481,7 +481,7 @@ pub struct InitZomesComplete {
 
 /// Declares that a metadata Link should be made between two EntryHashes
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct CreateLink<W = RateWeight> {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -499,7 +499,7 @@ pub struct CreateLink<W = RateWeight> {
 
 /// Declares that a previously made Link should be nullified and considered removed.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct DeleteLink {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -517,7 +517,7 @@ pub struct DeleteLink {
 /// When migrating to a new version of a DNA, this action is committed to the
 /// new chain to declare the migration path taken. **Currently unused**
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct OpenChain {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -530,7 +530,7 @@ pub struct OpenChain {
 /// When migrating to a new version of a DNA, this action is committed to the
 /// old chain to declare the migration path taken. **Currently unused**
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct CloseChain {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -543,7 +543,7 @@ pub struct CloseChain {
 /// A action which "speaks" Entry content into being. The same content can be
 /// referenced by multiple such actions.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct Create<W = EntryRateWeight> {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -571,7 +571,7 @@ pub struct Create<W = EntryRateWeight> {
 /// so there can only be a linear history of action updates, even if the entry history
 /// experiences repeats.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct Update<W = EntryRateWeight> {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -594,7 +594,7 @@ pub struct Update<W = EntryRateWeight> {
 /// that a previously published Entry will become inaccessible if all of its
 /// Actions are marked deleted.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct Delete<W = RateWeight> {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -611,7 +611,7 @@ pub struct Delete<W = RateWeight> {
 /// Placeholder for future when we want to have updates on actions
 /// Not currently in use.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct UpdateAction {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -624,7 +624,7 @@ pub struct UpdateAction {
 /// Placeholder for future when we want to have deletes on actions
 /// Not currently in use.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct DeleteAction {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -639,7 +639,7 @@ pub struct DeleteAction {
 /// referencing. Useful for examining Actions without needing to fetch the
 /// corresponding Entries.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum EntryType {
     /// An AgentPubKey
     AgentPubKey,
@@ -680,7 +680,7 @@ impl std::fmt::Display for EntryType {
 
 /// Information about a class of Entries provided by the DNA
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct AppEntryDef {
     /// A unique u8 identifier within a zome for this
     /// entry type.

--- a/crates/holochain_integrity_types/src/capability/claim.rs
+++ b/crates/holochain_integrity_types/src/capability/claim.rs
@@ -6,7 +6,7 @@ use holochain_serialized_bytes::prelude::*;
 /// Stored by a claimant so they can remember what's necessary to exercise
 /// this capability by sending the secret to the grantor.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash, SerializedBytes)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct CapClaim {
     /// A string by which to later query for saved claims.
     /// This does not need to be unique within a source chain.

--- a/crates/holochain_integrity_types/src/capability/grant.rs
+++ b/crates/holochain_integrity_types/src/capability/grant.rs
@@ -37,7 +37,7 @@ impl From<holo_hash::AgentPubKey> for CapGrant {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 /// The entry for the ZomeCall capability grant.
 /// This data is committed to the callee's source chain as a private entry.
 /// The remote calling agent must provide a secret and we source their pubkey from the active
@@ -123,7 +123,7 @@ impl CapGrant {
 
 /// Represents access requirements for capability grants.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum CapAccess {
     /// No restriction: callable by anyone.
     Unrestricted,
@@ -188,7 +188,7 @@ pub type GrantedFunction = (ZomeName, FunctionName);
 /// A collection of zome/function pairs
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum GrantedFunctions {
     /// grant all zomes all functions
     All,

--- a/crates/holochain_integrity_types/src/capability/secret.rs
+++ b/crates/holochain_integrity_types/src/capability/secret.rs
@@ -19,7 +19,7 @@ pub type CapSecretBytes = [u8; CAP_SECRET_BYTES];
 #[derive(Clone, Copy, Hash, SerializedBytes)]
 pub struct CapSecret(CapSecretBytes);
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for CapSecret {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let mut buf = [0; CAP_SECRET_BYTES];

--- a/crates/holochain_integrity_types/src/countersigning.rs
+++ b/crates/holochain_integrity_types/src/countersigning.rs
@@ -28,7 +28,7 @@ mod error;
 
 /// Every countersigning session must complete a full set of actions between the start and end times to be valid.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct CounterSigningSessionTimes {
     /// The earliest allowable time for countersigning session responses to be valid.
     pub start: Timestamp,
@@ -85,13 +85,13 @@ impl CounterSigningSessionTimes {
 
 /// Every preflight request can have optional arbitrary bytes that can be agreed to.
 #[derive(Clone, serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct PreflightBytes(#[serde(with = "serde_bytes")] pub Vec<u8>);
 
 /// Agents can have a role specific to each countersigning session.
 /// The role is app defined and opaque to the subconscious.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct Role(pub u8);
 
 impl Role {
@@ -108,7 +108,7 @@ pub type CounterSigningAgents = Vec<(AgentPubKey, Vec<Role>)>;
 /// Each agent signs this data as part of their PreflightResponse.
 /// Every preflight must be identical and signed by every agent for a session to be valid.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct PreflightRequest {
     /// The hash of the app entry, as if it were not countersigned.
     /// The final entry hash will include the countersigning session.
@@ -250,7 +250,7 @@ impl PreflightRequest {
 /// Every agent must send back a preflight response.
 /// All the preflight response data is signed by each agent and included in the session data.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct PreflightResponse {
     /// The request this is a response to.
     pub request: PreflightRequest,
@@ -345,7 +345,7 @@ pub enum PreflightRequestAcceptance {
 /// Every countersigning agent must sign against their chain state.
 /// The chain must be frozen until each agent decides to sign or exit the session.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct CounterSigningAgentState {
     /// The index of the agent in the preflight request agent vector.
     agent_index: u8,
@@ -402,7 +402,7 @@ impl CounterSigningAgentState {
 /// Enum to mirror Action for all the shared data required to build session actions.
 /// Does NOT hold any agent specific information.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum ActionBase {
     /// Mirrors Action::Create.
     Create(CreateBase),
@@ -416,7 +416,7 @@ pub enum ActionBase {
 
 /// Base data for Create actions.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct CreateBase {
     entry_type: EntryType,
 }
@@ -430,7 +430,7 @@ impl CreateBase {
 
 /// Base data for Update actions.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct UpdateBase {
     /// The original action being updated.
     pub original_action_address: ActionHash,
@@ -476,7 +476,7 @@ impl Action {
 
 /// All the data required for a countersigning session.
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct CounterSigningSessionData {
     /// The preflight request that was agreed upon by all parties for the session.
     pub preflight_request: PreflightRequest,

--- a/crates/holochain_integrity_types/src/entry.rs
+++ b/crates/holochain_integrity_types/src/entry.rs
@@ -85,7 +85,7 @@ impl From<EntryHashed> for Entry {
 
 /// Structure holding the entry portion of a chain record.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash, SerializedBytes)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[serde(tag = "entry_type", content = "entry")]
 pub enum Entry {
     /// The `Agent` system entry, the third entry of every source chain,

--- a/crates/holochain_integrity_types/src/entry/app_entry_bytes.rs
+++ b/crates/holochain_integrity_types/src/entry/app_entry_bytes.rs
@@ -4,7 +4,7 @@ use holochain_serialized_bytes::prelude::*;
 
 /// Newtype for the bytes comprising an App entry
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct AppEntryBytes(pub SerializedBytes);
 
 impl std::fmt::Debug for AppEntryBytes {

--- a/crates/holochain_integrity_types/src/entry_def.rs
+++ b/crates/holochain_integrity_types/src/entry_def.rs
@@ -8,7 +8,7 @@ const DEFAULT_REQUIRED_VALIDATIONS: u8 = 5;
 #[derive(
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum EntryDefId {
     App(AppEntryName),
     CapClaim,
@@ -22,7 +22,7 @@ pub enum EntryDefId {
 /// This may be removed.
 pub struct AppEntryName(pub Cow<'static, str>);
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for AppEntryName {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self(Cow::Owned(String::arbitrary(u)?)))
@@ -46,13 +46,13 @@ pub trait EntryDefRegistration {
 )]
 /// The number of validations required for an entry to
 /// be considered published.
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct RequiredValidations(pub u8);
 
 #[derive(
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct EntryDef {
     /// Zome-unique identifier for this entry type
     pub id: EntryDefId,
@@ -84,7 +84,7 @@ pub struct EntryDefs(pub Vec<EntryDef>);
     Deserialize,
     SerializedBytes,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum EntryVisibility {
     Public,
     Private,

--- a/crates/holochain_integrity_types/src/info.rs
+++ b/crates/holochain_integrity_types/src/info.rs
@@ -67,7 +67,7 @@ const fn standard_quantum_time() -> Duration {
 /// opposed to the actual DNA code. These modifiers are included in the DNA
 /// hash computation.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "full-dna-def", derive(derive_builder::Builder))]
 pub struct DnaModifiers {
     /// The network seed of a DNA is included in the computation of the DNA hash.
@@ -109,7 +109,7 @@ impl DnaModifiers {
 
 /// [`DnaModifiers`] options of which all are optional.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct DnaModifiersOpt<P = SerializedBytes> {
     /// see [`DnaModifiers`]
     pub network_seed: Option<NetworkSeed>,

--- a/crates/holochain_integrity_types/src/link.rs
+++ b/crates/holochain_integrity_types/src/link.rs
@@ -14,7 +14,7 @@ use holochain_serialized_bytes::prelude::*;
     serde::Deserialize,
     SerializedBytes,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct LinkType(pub u8);
 
 impl LinkType {
@@ -41,7 +41,7 @@ impl LinkType {
     Eq,
     SerializedBytes,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct LinkTag(#[serde(with = "serde_bytes")] pub Vec<u8>);
 
 impl LinkTag {

--- a/crates/holochain_integrity_types/src/op.rs
+++ b/crates/holochain_integrity_types/src/op.rs
@@ -9,7 +9,7 @@ use holochain_serialized_bytes::prelude::*;
 use kitsune_p2p_timestamp::Timestamp;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes)]
-#[cfg_attr(feature = "test_utils", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 /// These are the operations that can be applied to Holochain data.
 /// Every [`Action`] produces a set of operations.
 /// These operations are each sent to an authority for validation.
@@ -119,7 +119,7 @@ pub enum Op {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes)]
-#[cfg_attr(feature = "test_utils", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 /// Stores a new [`Record`] in the DHT.
 /// This is the act of creating a new [`Action`]
 /// and publishing it to the DHT.
@@ -130,7 +130,7 @@ pub struct StoreRecord {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
-#[cfg_attr(feature = "test_utils", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 /// Stores a new [`Entry`] in the DHT.
 /// This is the act of creating a either a [`Action::Create`] or
 /// a [`Action::Update`] and publishing it to the DHT.
@@ -144,7 +144,7 @@ pub struct StoreEntry {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
-#[cfg_attr(feature = "test_utils", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 /// Registers an update from an instance of an [`Entry`] in the DHT.
 /// This is the act of creating a [`Action::Update`] and
 /// publishing it to the DHT.
@@ -170,7 +170,7 @@ pub struct RegisterUpdate {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
-#[cfg_attr(feature = "test_utils", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 /// Registers a deletion of an instance of an [`Entry`] in the DHT.
 /// This is the act of creating a [`Action::Delete`] and
 /// publishing it to the DHT.
@@ -187,7 +187,7 @@ pub struct RegisterDelete {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
-#[cfg_attr(feature = "test_utils", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 /// Registers a new [`Action`] on an agent source chain.
 /// This is the act of creating any [`Action`] and
 /// publishing it to the DHT.
@@ -208,7 +208,7 @@ impl AsRef<SignedActionHashed> for RegisterAgentActivity {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
-#[cfg_attr(feature = "test_utils", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 /// Registers a link between two [`Entry`]s.
 /// This is the act of creating a [`Action::CreateLink`] and
 /// publishing it to the DHT.
@@ -219,7 +219,7 @@ pub struct RegisterCreateLink {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
-#[cfg_attr(feature = "test_utils", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 /// Deletes a link between two [`Entry`]s.
 /// This is the act of creating a [`Action::DeleteLink`] and
 /// publishing it to the DHT.
@@ -338,7 +338,7 @@ impl Op {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes, Eq)]
-#[cfg_attr(feature = "test_utils", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 /// Either a [`Action::Create`] or a [`Action::Update`].
 /// These actions both create a new instance of an [`Entry`].
 pub enum EntryCreationAction {

--- a/crates/holochain_integrity_types/src/rate_limit.rs
+++ b/crates/holochain_integrity_types/src/rate_limit.rs
@@ -7,7 +7,7 @@ use crate::{Create, CreateLink, Delete, Entry, Update};
 /// Input to the `weigh` callback. Includes an "unweighed" action, and Entry
 /// if applicable.
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, SerializedBytes, Debug)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum WeighInput {
     /// A Link to be weighed
     Link(CreateLink<()>),
@@ -44,7 +44,7 @@ pub type RateBucketCapacity = u32;
     PartialOrd,
     Ord,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[allow(missing_docs)]
 pub struct RateWeight {
     pub bucket_id: RateBucketId,
@@ -73,7 +73,7 @@ impl Default for RateWeight {
     PartialOrd,
     Ord,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[allow(missing_docs)]
 pub struct EntryRateWeight {
     pub bucket_id: RateBucketId,

--- a/crates/holochain_integrity_types/src/record.rs
+++ b/crates/holochain_integrity_types/src/record.rs
@@ -20,7 +20,7 @@ use holochain_serialized_bytes::prelude::*;
 /// a chain record containing the signed action along with the
 /// entry if the action type has one.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct Record<A = SignedActionHashed> {
     /// The signed action for this record
     pub signed_action: A,
@@ -38,7 +38,7 @@ impl<A> AsRef<A> for Record<A> {
 /// Represents the different ways the entry_address reference within an action
 /// can be intepreted
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SerializedBytes)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum RecordEntry<E: Borrow<Entry> = Entry> {
     /// The Action has an entry_address reference, and the Entry is accessible.
     Present(E),
@@ -423,7 +423,7 @@ impl TryFrom<Record> for DeleteLink {
     }
 }
 
-#[cfg(feature = "test_utils")]
+#[cfg(feature = "fuzzing")]
 impl<'a, T> arbitrary::Arbitrary<'a> for SignedHashed<T>
 where
     T: HashableContent,

--- a/crates/holochain_integrity_types/src/signature.rs
+++ b/crates/holochain_integrity_types/src/signature.rs
@@ -13,7 +13,7 @@ pub const SIGNATURE_BYTES: usize = 64;
 #[allow(clippy::derive_hash_xor_eq)]
 pub struct Signature(pub [u8; SIGNATURE_BYTES]);
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for Signature {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let mut buf = [0; SIGNATURE_BYTES];

--- a/crates/holochain_integrity_types/src/zome.rs
+++ b/crates/holochain_integrity_types/src/zome.rs
@@ -15,7 +15,7 @@ use holochain_serialized_bytes::prelude::*;
 #[repr(transparent)]
 pub struct ZomeName(pub Cow<'static, str>);
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for ZomeName {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self(String::arbitrary(u)?.into()))
@@ -55,7 +55,7 @@ impl From<String> for ZomeName {
 /// A single function name.
 #[repr(transparent)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, PartialOrd, Ord, Eq, Hash)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct FunctionName(pub String);
 
 impl FunctionName {

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -84,13 +84,17 @@ tokio = { version = "1.11", features = [ "full" ] }
 default = ["fixturators", "test_utils"]
 
 fixturators = ["holochain_zome_types/fixturators"]
-test_utils = [
+
+fuzzing = [
   "arbitrary",
   "contrafact",
-  "holochain_zome_types/arbitrary",
-  "holo_hash/arbitrary",
+  "holo_hash/fuzzing",
+  "holochain_zome_types/fuzzing",
+  "mr_bundle/fuzzing",
+]
+test_utils = [
+  "fuzzing",
   "isotest",
-  "mr_bundle/arbitrary",
   "holochain_zome_types/test_utils",
 ]
 

--- a/crates/holochain_types/src/action.rs
+++ b/crates/holochain_types/src/action.rs
@@ -21,7 +21,7 @@ pub mod facts;
 #[derive(
     Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash, derive_more::From,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 /// A action of one of the two types that create a new entry.
 pub enum NewEntryAction {
     /// A action which simply creates a new entry

--- a/crates/holochain_types/src/app/app_manifest.rs
+++ b/crates/holochain_types/src/app/app_manifest.rs
@@ -22,7 +22,7 @@ use super::InstalledCell;
 /// Container struct which uses the `manifest_version` field to determine
 /// which manifest version to deserialize to.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, derive_more::From)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[serde(tag = "manifest_version")]
 #[allow(missing_docs)]
 pub enum AppManifest {

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_v1.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
     Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, derive_builder::Builder,
 )]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct AppManifestV1 {
     /// Name of the App. This may be used as the installed_app_id.
     pub name: String,
@@ -34,7 +34,7 @@ pub struct AppManifestV1 {
 /// potential runtime clones.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct AppRoleManifest {
     /// The ID which will be used to refer to:
     /// - this role,
@@ -64,7 +64,7 @@ impl AppRoleManifest {
 /// The DNA portion of an app role
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct AppRoleDnaManifest {
     /// Where to find this Dna. To specify a DNA included in a hApp Bundle,
     /// use a local relative path that corresponds with the bundle structure.
@@ -115,7 +115,7 @@ pub type DnaLocation = mr_bundle::Location;
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(tag = "strategy")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[allow(missing_docs)]
 pub enum CellProvisioning {
     /// Always create a new Cell when installing this App
@@ -245,7 +245,7 @@ pub mod tests {
     use ::fixt::prelude::*;
     use std::path::PathBuf;
 
-    #[cfg(feature = "arbitrary")]
+    #[cfg(feature = "fuzzing")]
     use arbitrary::Arbitrary;
 
     #[derive(serde::Serialize, serde::Deserialize)]

--- a/crates/holochain_types/src/dht_op.rs
+++ b/crates/holochain_types/src/dht_op.rs
@@ -27,7 +27,7 @@ pub mod error;
 #[cfg(test)]
 pub mod tests;
 
-#[cfg(feature = "test_utils")]
+#[cfg(feature = "fuzzing")]
 pub mod facts;
 
 /// A unit of DHT gossip. Used to notify an authority of new (meta)data to hold
@@ -35,7 +35,7 @@ pub mod facts;
 #[derive(
     Clone, Debug, Serialize, Deserialize, SerializedBytes, Eq, PartialEq, Hash, derive_more::Display,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub enum DhtOp {
     #[display(fmt = "StoreRecord")]
     /// Used to notify the authority for an action that it has been created.

--- a/crates/holochain_types/src/web_app/web_app_manifest/web_app_manifest_v1.rs
+++ b/crates/holochain_types/src/web_app/web_app_manifest/web_app_manifest_v1.rs
@@ -8,7 +8,7 @@
     Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, derive_builder::Builder,
 )]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct WebAppManifestV1 {
     /// Name of the App. This may be used as the installed_app_id.
     pub name: String,
@@ -23,7 +23,7 @@ pub struct WebAppManifestV1 {
 /// Web UI .zip file that should be associated with the happ
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct WebUI {
     /// Where to find this UI.
     ///
@@ -36,7 +36,7 @@ pub struct WebUI {
 /// Location of the happ bundle to bind with the Web UI
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct AppManifestLocation {
     /// Where to find the happ for this web-happ.
     ///

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -70,17 +70,21 @@ fixturators = ["fixt", "rand", "strum", "holo_hash/fixturators", "holochain_inte
 
 properties = ["serde_yaml"]
 
-test_utils = [
+fuzzing = [
   "arbitrary",
   "contrafact",
+  "kitsune_p2p_timestamp/fuzzing",
+  "holochain_integrity_types/fuzzing",
+  "holochain_serialized_bytes/fuzzing",
+]
+
+test_utils = [
   "once_cell",
-  "kitsune_p2p_timestamp/arbitrary",
   "kitsune_p2p_timestamp/now",
   "kitsune_p2p_block/sqlite",
-  "holo_hash/arbitrary",
+  "holo_hash/fuzzing",
   "holo_hash/hashing",
   "holo_hash/test_utils",
-  "holochain_serialized_bytes/fuzzing",
   "full-dna-def",
   "holochain_integrity_types/test_utils",
 ]

--- a/crates/holochain_zome_types/src/action.rs
+++ b/crates/holochain_zome_types/src/action.rs
@@ -7,10 +7,10 @@ use thiserror::Error;
 pub use holochain_integrity_types::action::builder::{ActionBuilder, ActionBuilderCommon};
 pub use holochain_integrity_types::action::*;
 
-#[cfg(any(test, feature = "test_utils"))]
+#[cfg(feature = "fuzzing")]
 pub use facts::*;
 
-#[cfg(any(test, feature = "test_utils"))]
+#[cfg(feature = "fuzzing")]
 pub mod facts;
 
 #[derive(Error, Debug)]

--- a/crates/holochain_zome_types/src/cell.rs
+++ b/crates/holochain_zome_types/src/cell.rs
@@ -22,7 +22,7 @@ use std::fmt;
     Ord,
     PartialOrd,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct CellId(DnaHash, AgentPubKey);
 
 /// Delimiter in a clone id that separates the base cell's role name from the

--- a/crates/holochain_zome_types/src/dna_def.rs
+++ b/crates/holochain_zome_types/src/dna_def.rs
@@ -28,7 +28,7 @@ pub type CoordinatorZomes = Vec<(ZomeName, zome::CoordinatorZomeDef)>;
 /// Hence, this type can basically be thought of as a fully validated, normalized
 /// `DnaManifest`
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, SerializedBytes)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "full-dna-def", derive(derive_builder::Builder))]
 #[cfg_attr(feature = "full-dna-def", builder(public))]
 pub struct DnaDef {

--- a/crates/holochain_zome_types/src/lib.rs
+++ b/crates/holochain_zome_types/src/lib.rs
@@ -78,7 +78,7 @@ pub mod fixt;
 #[cfg(feature = "test_utils")]
 pub mod test_utils;
 
-#[cfg(all(any(test, feature = "test_utils"), feature = "arbitrary"))]
+#[cfg(all(any(test, feature = "test_utils"), feature = "fuzzing"))]
 pub mod entropy;
 
 pub use action::Action;

--- a/crates/holochain_zome_types/src/prelude.rs
+++ b/crates/holochain_zome_types/src/prelude.rs
@@ -61,5 +61,5 @@ pub use crate::fixt::*;
 #[cfg(feature = "test_utils")]
 pub use crate::test_utils::*;
 
-#[cfg(all(any(test, feature = "test_utils"), feature = "arbitrary"))]
+#[cfg(all(any(test, feature = "test_utils"), feature = "fuzzing"))]
 pub use crate::entropy::*;

--- a/crates/holochain_zome_types/src/properties.rs
+++ b/crates/holochain_zome_types/src/properties.rs
@@ -43,7 +43,7 @@ impl Default for YamlProperties {
 }
 
 /// Not a great implementation: always returns null
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for YamlProperties {
     fn arbitrary(_: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(serde_yaml::Value::Null.into())

--- a/crates/holochain_zome_types/src/record.rs
+++ b/crates/holochain_zome_types/src/record.rs
@@ -9,14 +9,14 @@ use holochain_serialized_bytes::prelude::*;
 
 pub use holochain_integrity_types::record::*;
 
-#[cfg(feature = "test_utils")]
+#[cfg(feature = "fuzzing")]
 pub mod facts;
 
 /// A combination of an action and its signature.
 ///
 /// Has implementations From and Into its tuple form.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct SignedAction(pub Action, pub Signature);
 
 impl SignedAction {

--- a/crates/holochain_zome_types/src/zome.rs
+++ b/crates/holochain_zome_types/src/zome.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 /// A Holochain Zome. Includes the ZomeDef as well as the name of the Zome.
 #[derive(Serialize, Deserialize, Hash, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "full-dna-def", derive(shrinkwraprs::Shrinkwrap))]
-#[cfg_attr(feature = "test_utils", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct Zome<T = ZomeDef> {
     pub name: ZomeName,
     #[cfg_attr(feature = "full-dna-def", shrinkwrap(main_field))]
@@ -137,7 +137,7 @@ impl From<CoordinatorZome> for CoordinatorZomeDef {
 // TODO: move to `holochain_types`
 
 #[derive(Serialize, Deserialize, Hash, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "test_utils", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct WasmZome {
     /// The WasmHash representing the WASM byte code for this zome.
     pub wasm_hash: holo_hash::WasmHash,
@@ -320,21 +320,21 @@ impl From<ZomeDef> for CoordinatorZomeDef {
     }
 }
 
-#[cfg(feature = "test_utils")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for ZomeDef {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self::Wasm(WasmZome::arbitrary(u)?))
     }
 }
 
-#[cfg(feature = "test_utils")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for IntegrityZomeDef {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self(ZomeDef::Wasm(WasmZome::arbitrary(u)?)))
     }
 }
 
-#[cfg(feature = "test_utils")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for CoordinatorZomeDef {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self(ZomeDef::Wasm(WasmZome::arbitrary(u)?)))

--- a/crates/kitsune_p2p/bin_data/Cargo.toml
+++ b/crates/kitsune_p2p/bin_data/Cargo.toml
@@ -21,9 +21,11 @@ serde_bytes = "0.11"
 arbitrary = { version = "1.0", features = ["derive"], optional = true}
 
 [features]
-test_utils = [
+fuzzing = [
   "arbitrary"
 ]
+test_utils = [ ]
+
 sqlite-encrypted = [
   "kitsune_p2p_dht_arc/sqlite-encrypted"
 ]

--- a/crates/kitsune_p2p/bin_data/src/lib.rs
+++ b/crates/kitsune_p2p/bin_data/src/lib.rs
@@ -100,7 +100,7 @@ macro_rules! make_kitsune_bin_type {
                 }
             }
 
-            #[cfg(feature = "arbitrary")]
+            #[cfg(feature = "fuzzing")]
             impl<'a> arbitrary::Arbitrary<'a> for $name {
                 fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
                     // FIXME: there is no way to calculate location bytes right now,
@@ -188,7 +188,7 @@ pub type KOp = std::sync::Arc<KitsuneOpData>;
     serde::Deserialize,
     serde::Serialize,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[shrinkwrap(mutable)]
 pub struct KitsuneSignature(#[serde(with = "serde_bytes")] pub Vec<u8>);
 

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -47,8 +47,8 @@ tx5 = { version = "=0.0.2-alpha", optional = true }
 url2 = "0.0.6"
 fixt = { path = "../../fixt", version = "^0.2.0"}
 
-# arbitrary could be made optional
-arbitrary = { version = "1.0", features = ["derive"] }
+arbitrary = { version = "1.0", features = ["derive"], optional = true }
+contrafact = { version = "0.2.0-rc.1", optional = true }
 
 blake2b_simd = { version = "0.5.10", optional = true }
 maplit = { version = "1", optional = true }
@@ -56,10 +56,9 @@ mockall = { version = "0.11.3", optional = true }
 
 [dev-dependencies]
 # include self with test_utils feature, to allow integration tests to run properly
-kitsune_p2p = { path = ".", features = ["test_utils", "sqlite"]}
+kitsune_p2p = { path = ".", features = ["test_utils", "fuzzing", "sqlite"]}
 
 kitsune_p2p_fetch = { path = "../fetch", features = ["test_utils"] }
-contrafact = { version = "0.2.0-rc.1" }
 kitsune_p2p_bootstrap = { path = "../bootstrap", features = ["sqlite"] }
 kitsune_p2p_timestamp = { path = "../timestamp", features = ["now", "arbitrary"] }
 kitsune_p2p_types = { path = "../types", features = ["test_utils"] }
@@ -76,6 +75,13 @@ rand_dalek = { version = "0.7", package = "rand" } # Compatibility with dalek
 [features]
 default = [ "tx2", "tx5" ]
 
+fuzzing = [
+  "arbitrary",
+  "contrafact",
+  "kitsune_p2p_timestamp/fuzzing",
+  "kitsune_p2p_types/fuzzing",
+]
+
 test_utils = [
   "blake2b_simd",
   "tokio/test-util",
@@ -83,8 +89,8 @@ test_utils = [
   "kitsune_p2p_types/test_utils",
   "maplit",
   "mockall",
-  "kitsune_p2p_timestamp/arbitrary",
 ]
+
 mock_network = [
   "kitsune_p2p_types/test_utils",
   "mockall",

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -6,8 +6,8 @@ use crate::agent_store::AgentInfoSigned;
 use crate::gossip::{decode_bloom_filter, encode_bloom_filter};
 use crate::types::event::*;
 use crate::types::gossip::*;
+use crate::types::*;
 use crate::{meta_net::*, HostApiLegacy};
-use crate::{types::*, HostApi};
 use ghost_actor::dependencies::tracing;
 use governor::clock::DefaultClock;
 use governor::state::{InMemoryState, NotKeyed};
@@ -63,9 +63,7 @@ mod next_target;
 // code path due to test_utils, the helper functions defined in this module
 // are not used due to the tests themselves not being compiled, so it's easier
 // to do this than to annotate each function as `#[cfg(test)]`
-#[cfg(any(test, feature = "test_utils"))]
-#[allow(dead_code)]
-#[allow(unused_imports)]
+#[cfg(test)]
 pub(crate) mod tests;
 
 /// max send buffer size (keep it under 16384 with a little room for overhead)

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests.rs
@@ -4,10 +4,8 @@ use crate::{spawn::MockKitsuneP2pEventHandler, NOISE};
 
 use super::*;
 use crate::fixt::*;
-use arbitrary::Arbitrary;
 use fixt::prelude::*;
 
-#[cfg(test)]
 mod bloom;
 mod common;
 mod ops;
@@ -20,6 +18,7 @@ impl ShardedGossipLocal {
         host: HostApiLegacy,
         inner: ShardedGossipLocalState,
     ) -> Self {
+        use arbitrary::Arbitrary;
         let mut u = arbitrary::Unstructured::new(&NOISE);
         let space = KitsuneSpace::arbitrary(&mut u).unwrap();
         let space = Arc::new(space);

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/common.rs
@@ -1,6 +1,6 @@
 use crate::test_util::hash_op_data;
 pub use crate::test_util::spawn_handler;
-use crate::{HostStub, KitsuneHost};
+use crate::{HostApi, HostStub, KitsuneHost};
 use kitsune_p2p_fetch::FetchPoolConfig;
 use kitsune_p2p_types::box_fut;
 use kitsune_p2p_types::dht::prelude::{ArqSet, RegionCoordSetLtcs, RegionData};

--- a/crates/kitsune_p2p/timestamp/Cargo.toml
+++ b/crates/kitsune_p2p/timestamp/Cargo.toml
@@ -32,5 +32,7 @@ now = ["chrono"]
 
 full = ["now"]
 
+fuzzing = ["arbitrary"]
+
 sqlite-encrypted = [ "rusqlite", "rusqlite/bundled-sqlcipher-vendored-openssl" ]
 sqlite = [ "rusqlite", "rusqlite/bundled" ]

--- a/crates/kitsune_p2p/timestamp/src/lib.rs
+++ b/crates/kitsune_p2p/timestamp/src/lib.rs
@@ -43,7 +43,7 @@ pub const MM: i64 = 1_000_000;
 /// Supports +/- `chrono::Duration` directly.  There is no `Timestamp::now()` method, since this is not
 /// supported by WASM; however, `holochain_types` provides a `Timestamp::now()` method.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[cfg_attr(not(feature = "chrono"), derive(Debug))]
 pub struct Timestamp(
     /// Microseconds from UNIX Epoch, positive or negative

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -51,8 +51,12 @@ harness = false
 [features]
 default = [ "tx2" ]
 
-test_utils = [
+fuzzing = [
   "arbitrary",
+  "kitsune_p2p_bin_data/fuzzing",
+]
+
+test_utils = [
   "kitsune_p2p_bin_data/test_utils",
   "kitsune_p2p_dht_arc/test_utils",
   "ghost_actor/test_utils",

--- a/crates/kitsune_p2p/types/src/lib.rs
+++ b/crates/kitsune_p2p/types/src/lib.rs
@@ -94,7 +94,7 @@ impl From<Tx2Cert> for Arc<[u8; 32]> {
     }
 }
 
-#[cfg(feature = "arbitrary")]
+#[cfg(feature = "fuzzing")]
 impl<'a> arbitrary::Arbitrary<'a> for Tx2Cert {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self::from(u.bytes(32)?.to_vec()))

--- a/crates/mr_bundle/Cargo.toml
+++ b/crates/mr_bundle/Cargo.toml
@@ -35,4 +35,5 @@ tempfile = "3"
 
 [features]
 
+fuzzing = ["arbitrary"]
 packing = ["serde_yaml", "holochain_util/tokio"]

--- a/crates/mr_bundle/src/bundle.rs
+++ b/crates/mr_bundle/src/bundle.rs
@@ -20,7 +20,7 @@ pub type ResourceMap = BTreeMap<PathBuf, ResourceBytes>;
 ///
 /// The manifest may describe locations of resources not included in the Bundle.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct Bundle<M>
 where
     M: Manifest,
@@ -206,7 +206,7 @@ where
 /// The manifest may be of any format. This is useful for deserializing a bundle of
 /// an outdated format, so that it may be modified to fit the supported format.
 #[derive(Debug, PartialEq, Eq, Deserialize)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct RawBundle<M> {
     /// The manifest describing the resources that compose this bundle.
     #[serde(bound(deserialize = "M: DeserializeOwned"))]

--- a/crates/mr_bundle/src/location.rs
+++ b/crates/mr_bundle/src/location.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 /// being flattened.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 #[allow(missing_docs)]
 pub enum Location {
     /// Expect file to be part of this bundle

--- a/crates/mr_bundle/src/resource.rs
+++ b/crates/mr_bundle/src/resource.rs
@@ -9,7 +9,7 @@
     derive_more::From,
     derive_more::Deref,
 )]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "fuzzing", derive(arbitrary::Arbitrary))]
 pub struct ResourceBytes(#[serde(with = "serde_bytes")] Vec<u8>);
 
 impl ResourceBytes {

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -62,15 +62,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -209,8 +200,8 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -512,8 +503,8 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "strsim 0.9.3",
  "syn 1.0.109",
 ]
@@ -526,8 +517,8 @@ checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "strsim 0.10.0",
  "syn 1.0.109",
 ]
@@ -540,8 +531,8 @@ checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -552,7 +543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core 0.10.2",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -563,7 +554,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
  "darling_core 0.14.4",
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -574,7 +565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core 0.20.3",
- "quote 1.0.33",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -584,20 +575,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
-dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
- "syn 2.0.29",
 ]
 
 [[package]]
@@ -608,8 +588,8 @@ checksum = "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0"
 dependencies = [
  "darling 0.10.2",
  "derive_builder_core",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -620,8 +600,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef"
 dependencies = [
  "darling 0.10.2",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -632,8 +612,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
  "convert_case",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "rustc_version",
  "syn 1.0.109",
 ]
@@ -687,8 +667,8 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -708,8 +688,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
 dependencies = [
  "darling 0.20.3",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -871,8 +851,8 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -1023,8 +1003,8 @@ dependencies = [
  "holochain_integrity_types",
  "paste",
  "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1059,7 +1039,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 name = "holo_hash"
 version = "0.3.0-beta-dev.8"
 dependencies = [
- "arbitrary",
  "base64",
  "blake2b_simd",
  "derive_more",
@@ -1080,7 +1059,6 @@ dependencies = [
 name = "holochain_integrity_types"
 version = "0.3.0-beta-dev.11"
 dependencies = [
- "arbitrary",
  "derive_builder",
  "holo_hash",
  "holochain_serialized_bytes",
@@ -1108,10 +1086,7 @@ version = "0.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7a5fc7c745a107f8ebcb04caab7a6b7a8463e2811f07ced19c281977583de7"
 dependencies = [
- "arbitrary",
  "holochain_serialized_bytes_derive",
- "proptest",
- "proptest-derive",
  "rmp-serde",
  "serde",
  "serde-transcode",
@@ -1126,7 +1101,7 @@ version = "0.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3e0cf02005cbf0f514476d40e02125b26df6d4922d7a2c48a84fc588539d71"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1385,7 +1360,6 @@ dependencies = [
 name = "kitsune_p2p_timestamp"
 version = "0.3.0-beta-dev.2"
 dependencies = [
- "arbitrary",
  "chrono",
  "serde",
 ]
@@ -1472,7 +1446,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1559,8 +1533,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
  "cfg-if 1.0.0",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1604,8 +1578,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -1819,8 +1793,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
  "version_check",
 ]
@@ -1831,18 +1805,9 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "version_check",
-]
-
-[[package]]
-name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid",
 ]
 
 [[package]]
@@ -1852,37 +1817,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proptest"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
-dependencies = [
- "bit-set",
- "bitflags 1.3.2",
- "byteorder",
- "lazy_static",
- "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_xorshift 0.3.0",
- "regex-syntax 0.6.29",
- "rusty-fork",
- "tempfile",
- "unarray",
-]
-
-[[package]]
-name = "proptest-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90b46295382dc76166cb7cf2bb4a97952464e4b7ed5a43e6cd34e1fec3349ddc"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
 ]
 
 [[package]]
@@ -1900,24 +1834,9 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
-name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
 ]
 
 [[package]]
@@ -1926,7 +1845,7 @@ version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.66",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1950,7 +1869,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift 0.1.1",
+ "rand_xorshift",
  "winapi",
 ]
 
@@ -2082,15 +2001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xorshift"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "rawpointer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,7 +2072,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.7.4",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2173,14 +2083,8 @@ checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2232,8 +2136,8 @@ version = "0.7.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e06b915b5c230a17d7a736d1e2e63ee753c256a8614ef3f5147b13a4f5541d"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2298,18 +2202,6 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
 
 [[package]]
 name = "ryu"
@@ -2407,8 +2299,8 @@ version = "1.0.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc59dfdcbad1437773485e0367fea4b090a2e0a16d9ffc46af47764536a298ec"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -2456,8 +2348,8 @@ checksum = "e63e6744142336dfb606fe2b068afa2e1cca1ee6a5d8377277a92945d81fa331"
 dependencies = [
  "bitflags 1.3.2",
  "itertools 0.8.2",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2539,8 +2431,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck 0.3.3",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -2551,8 +2443,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
  "heck 0.4.1",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "rustversion",
  "syn 1.0.109",
 ]
@@ -2584,23 +2476,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid",
-]
-
-[[package]]
-name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -2610,8 +2491,8 @@ version = "2.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -2665,8 +2546,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58071dc2471840e9f374eeb0f6e405a31bccb3cc5d59bb4598f02cafc274b5c4"
 dependencies = [
  "cargo_metadata",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "serde",
  "strum_macros 0.24.3",
 ]
@@ -2680,8 +2561,8 @@ dependencies = [
  "darling 0.14.4",
  "if_chain",
  "lazy_static",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "subprocess",
  "syn 1.0.109",
  "test-fuzz-internal",
@@ -3164,8 +3045,8 @@ version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -3227,8 +3108,8 @@ version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
 ]
 
@@ -3261,12 +3142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
-name = "unarray"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3285,12 +3160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3302,8 +3171,8 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e7e85a0596447f0f2ac090e16bc4c516c6fe91771fb0c0ccf7fa3dae896b9c"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 
@@ -3324,15 +3193,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"
@@ -3375,8 +3235,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
  "wasm-bindgen-shared",
 ]
@@ -3387,7 +3247,7 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
- "quote 1.0.33",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3397,8 +3257,8 @@ version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 2.0.29",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -3504,8 +3364,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
 dependencies = [
  "proc-macro-error",
- "proc-macro2 1.0.66",
- "quote 1.0.33",
+ "proc-macro2",
+ "quote",
  "syn 1.0.109",
 ]
 


### PR DESCRIPTION
### Summary

Adds fuzzing feature for arbitrary and proptest (and contrafact).

This needs to be a distinct feature from `test_utils` because proptest cannot be compiled for wasm targets, and `test_utils` is sometimes used in the test wasms. Also I think this is needed for #2727 to actually build, for the same reason.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
