### PR TITLE
fix(signal-send): log errors instead of returning them

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -214,7 +214,7 @@ jobs:
                 --force-tag-creation \
                 --force-branch-creation \
                 --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
-                --allowed-semver-increment-modes="!patch" \
+                --allowed-semver-increment-modes="!pre_patch beta-rc" \
                 --steps=CreateReleaseBranch,BumpReleaseVersions
 
             release-automation \

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -6,6 +6,7 @@ default_semver_increment_mode: !pre_patch beta-rc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Fix: App interfaces are persisted when shutting down conductor. After restart, app interfaces without connected receiver websocket had signal emission fail altogether. Send errors are only logged now instead.
 
 ## 0.1.6
 

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1451,6 +1451,8 @@ mod clone_cell_impls {
 
 /// Methods related to management of app and cell status
 mod app_status_impls {
+    use std::borrow::Borrow;
+
     use super::*;
 
     impl Conductor {
@@ -1737,7 +1739,7 @@ mod app_status_impls {
         pub(crate) fn update_cell_status(&self, cell_ids: &[CellId], status: CellStatus) {
             for cell_id in cell_ids {
                 self.running_cells.share_mut(|cells| {
-                    if let Some(mut cell) = cells.get_mut(cell_id) {
+                    if let Some(cell) = cells.get_mut(cell_id.borrow()) {
                         cell.status = status.clone();
                     }
                 });

--- a/crates/holochain/tests/send_signal.rs
+++ b/crates/holochain/tests/send_signal.rs
@@ -1,0 +1,110 @@
+use std::sync::Arc;
+
+use futures::StreamExt;
+use holochain::sweettest::{SweetConductor, SweetDnaFile, SweetZome};
+use holochain_types::signal::Signal;
+use holochain_wasm_test_utils::TestWasm;
+use holochain_websocket::WebsocketConfig;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn send_signal_after_conductor_restart() {
+    let mut conductor = SweetConductor::from_standard_config().await;
+    let (dna_file, _, _) = SweetDnaFile::from_test_wasms(
+        "network_seed".to_string(),
+        vec![TestWasm::EmitSignal],
+        Default::default(),
+    )
+    .await;
+    let app = conductor.setup_app("app_id", &[dna_file]).await.unwrap();
+    let alice = app.agent();
+    let alice_cell_id = app.cells()[0].cell_id().to_owned();
+
+    // add app interface
+    let app_interface_port_1 = (*conductor)
+        .clone()
+        .add_app_interface(either::Either::Left(0))
+        .await
+        .unwrap();
+
+    // connect app websocket
+    let (_, mut app_ws_rx_1) = holochain_websocket::connect(
+        url2::url2!("ws://127.0.0.1:{}", app_interface_port_1),
+        Arc::new(WebsocketConfig::default()),
+    )
+    .await
+    .unwrap();
+
+    // emit a signal
+    let alice_zome = SweetZome::new(
+        alice_cell_id.clone(),
+        TestWasm::EmitSignal.coordinator_zome_name(),
+    );
+    let _: () = conductor
+        .call_from(alice, None, &alice_zome, "emit", ())
+        .await;
+
+    let (received_signal_1, _) = app_ws_rx_1.next().await.unwrap();
+    let received_signal_1: Signal =
+        holochain_serialized_bytes::decode(received_signal_1.bytes()).unwrap();
+    if let Signal::App {
+        cell_id,
+        zome_name,
+        signal,
+    } = received_signal_1
+    {
+        assert_eq!(cell_id, alice_cell_id);
+        assert_eq!(zome_name, TestWasm::EmitSignal.coordinator_zome_name());
+        assert_eq!(signal.into_inner().decode::<()>().unwrap(), ());
+    } else {
+        panic!("not the expected app signal")
+    };
+
+    // restart conductor
+    conductor.shutdown().await;
+    conductor.startup().await;
+
+    // emitting signal without connected app ws must not produce an error
+    let _: () = conductor
+        .call_from(alice, None, &alice_zome, "emit", ())
+        .await;
+
+    let app_interfaces = conductor.list_app_interfaces().await.unwrap();
+    let app_interface_port_1 = app_interfaces[0];
+
+    // reconnect app websocket
+    let (_, mut app_ws_rx_1) = holochain_websocket::connect(
+        url2::url2!("ws://127.0.0.1:{}", app_interface_port_1),
+        Arc::new(WebsocketConfig::default()),
+    )
+    .await
+    .unwrap();
+
+    // add a second app interface without websocket connection
+    let _ = (*conductor)
+        .clone()
+        .add_app_interface(either::Either::Left(0))
+        .await
+        .unwrap();
+
+    // emitting signal again must not produce an error
+    let _: () = conductor
+        .call_from(alice, None, &alice_zome, "emit", ())
+        .await;
+
+    // signal can be received by connected websocket
+    let (received_signal_2, _) = app_ws_rx_1.next().await.unwrap();
+    let received_signal_2: Signal =
+        holochain_serialized_bytes::decode(received_signal_2.bytes()).unwrap();
+    if let Signal::App {
+        cell_id,
+        zome_name,
+        signal,
+    } = received_signal_2
+    {
+        assert_eq!(cell_id, alice_cell_id);
+        assert_eq!(zome_name, TestWasm::EmitSignal.coordinator_zome_name());
+        assert_eq!(signal.into_inner().decode::<()>().unwrap(), ());
+    } else {
+        panic!("not the expected app signal")
+    };
+}

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -147,9 +147,13 @@ pub enum AdminRequest {
         installed_app_id: InstalledAppId,
     },
 
-    /// Open up a new websocket for processing [`AppRequest`]s.
+    /// Open up a new websocket for processing [`AppRequest`]s. Any active app will be
+    /// callable via the attached app interface.
     ///
-    /// Any active app will be callable via the attached app interface.
+    /// **NB:** App interfaces are persisted when shutting down the conductor and are
+    /// restored when restarting the conductor. Unused app interfaces are _not_ cleaned
+    /// up. It is therefore recommended to reuse existing interfaces. They can be queried
+    /// with the call [`AdminRequest::ListAppInterfaces`].
     ///
     /// # Returns
     ///
@@ -159,7 +163,6 @@ pub enum AdminRequest {
     ///
     /// Optionally a `port` parameter can be passed to this request. If it is `None`,
     /// a free port is chosen by the conductor.
-    /// The response will contain the port chosen by the conductor if `None` was passed.
     ///
     /// [`AppRequest`]: super::AppRequest
     AttachAppInterface {
@@ -386,9 +389,7 @@ pub enum AdminResponse {
 
     /// The successful response to an [`AdminRequest::AttachAppInterface`].
     ///
-    /// `AppInterfaceApi` successfully attached.
-    /// If no port was specified in the request, contains the port number that was
-    /// selected by the conductor for running this app interface.
+    /// Contains the port number of the attached app interface.
     AppInterfaceAttached {
         /// Networking port of the new `AppInterfaceApi`
         port: u16,

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -69,6 +69,10 @@ pub enum AppRequest {
     EnableCloneCell(Box<EnableCloneCellPayload>),
 
     /// Info about networking processes
+    ///
+    /// # Returns
+    ///
+    /// [`AppResponse::NetworkInfo`]
     NetworkInfo(Box<NetworkInfoRequestPayload>),
 }
 


### PR DESCRIPTION
* fix: clippy unneeded mut

* fix(signal): log send error but do not return to caller

* docs(app): add NetworkInfo response link

* test(signal): add signal send test

* docs(changelog): update with fix

* docs(admin-api): mention app interface persistence

* clippy does not like a single match any more =(

* give test more descriptive name

* clippy hammers it in, no single match statements

* move note about app interface persistence higher up

* let others understand signal send error

* trace signal send error as info

### Summary



### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
