### PR TITLE
get mock_network_sharding test running, but not working

### DIFF
--- a/crates/holochain_sqlite/src/db/kind.rs
+++ b/crates/holochain_sqlite/src/db/kind.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 /// The various types of database, used to specify the list of databases to initialize
-#[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::Display)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum DbKind {
     /// Specifies the environment used for authoring data by all cells on the same [`DnaHash`].
     Authored(Arc<DnaHash>),


### PR DESCRIPTION
### Summary

We noticed this long-ignored test which could help suss out sharded network issues, but it's really code-rotted:

1. It was written before we had any DB migrations, and it's not compatible with them.
2. It was written in the tx2 days, and there is an invalid proxy url problem
3. There was even a problem with one of the handwritten queries, which had nothing to do with code rot, but was just a mistake at the time of the last commit.

I fixed item 3 here, and I think 1 is fixed as well, in a hacky way. Item 2 remains unsolved. Also, the existence of problem 3 proves that at the time of the last commit, the test was not runnable, so I wonder how much confidence to have in this running correctly even if fully repaired.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
