### PR TITLE
release: remove beta prefix from default semver increment

### DIFF
--- a/crates/fixt/CHANGELOG.md
+++ b/crates/fixt/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/fixt/CHANGELOG.md
+++ b/crates/fixt/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/fixt/test/CHANGELOG.md
+++ b/crates/fixt/test/CHANGELOG.md
@@ -1,9 +1,0 @@
----
-semver_increment_mode: patch
-default_semver_increment_mode: !pre_patch beta-rc
----
-# Changelog
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## \[Unreleased\]

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/hc_run_local_services/CHANGELOG.md
+++ b/crates/hc_run_local_services/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/hc_run_local_services/CHANGELOG.md
+++ b/crates/hc_run_local_services/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/hdi/CHANGELOG.md
+++ b/crates/hdi/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/hdi/CHANGELOG.md
+++ b/crates/hdi/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/hdk_derive/CHANGELOG.md
+++ b/crates/hdk_derive/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/hdk_derive/CHANGELOG.md
+++ b/crates/hdk_derive/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/holo_hash/CHANGELOG.md
+++ b/crates/holo_hash/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/holo_hash/CHANGELOG.md
+++ b/crates/holo_hash/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/holochain_integrity_types/CHANGELOG.md
+++ b/crates/holochain_integrity_types/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/holochain_integrity_types/CHANGELOG.md
+++ b/crates/holochain_integrity_types/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/holochain_trace/CHANGELOG.md
+++ b/crates/holochain_trace/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/holochain_trace/CHANGELOG.md
+++ b/crates/holochain_trace/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/holochain_util/CHANGELOG.md
+++ b/crates/holochain_util/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/holochain_util/CHANGELOG.md
+++ b/crates/holochain_util/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/holochain_websocket/CHANGELOG.md
+++ b/crates/holochain_websocket/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/holochain_websocket/CHANGELOG.md
+++ b/crates/holochain_websocket/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/bin_data/CHANGELOG.md
+++ b/crates/kitsune_p2p/bin_data/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/bin_data/CHANGELOG.md
+++ b/crates/kitsune_p2p/bin_data/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/block/CHANGELOG.md
+++ b/crates/kitsune_p2p/block/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/block/CHANGELOG.md
+++ b/crates/kitsune_p2p/block/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/bootstrap/CHANGELOG.md
+++ b/crates/kitsune_p2p/bootstrap/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/bootstrap/CHANGELOG.md
+++ b/crates/kitsune_p2p/bootstrap/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/dht/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/dht/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/dht_arc/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht_arc/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/dht_arc/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht_arc/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/fetch/CHANGELOG.md
+++ b/crates/kitsune_p2p/fetch/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/fetch/CHANGELOG.md
+++ b/crates/kitsune_p2p/fetch/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/mdns/CHANGELOG.md
+++ b/crates/kitsune_p2p/mdns/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/mdns/CHANGELOG.md
+++ b/crates/kitsune_p2p/mdns/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/proxy/CHANGELOG.md
+++ b/crates/kitsune_p2p/proxy/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/proxy/CHANGELOG.md
+++ b/crates/kitsune_p2p/proxy/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/timestamp/CHANGELOG.md
+++ b/crates/kitsune_p2p/timestamp/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/timestamp/CHANGELOG.md
+++ b/crates/kitsune_p2p/timestamp/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/transport_quic/CHANGELOG.md
+++ b/crates/kitsune_p2p/transport_quic/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/transport_quic/CHANGELOG.md
+++ b/crates/kitsune_p2p/transport_quic/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/types/CHANGELOG.md
+++ b/crates/kitsune_p2p/types/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/kitsune_p2p/types/CHANGELOG.md
+++ b/crates/kitsune_p2p/types/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/mock_hdi/CHANGELOG.md
+++ b/crates/mock_hdi/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
 semver_increment_mode: patch
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/mock_hdi/CHANGELOG.md
+++ b/crates/mock_hdi/CHANGELOG.md
@@ -1,6 +1,6 @@
 ---
 semver_increment_mode: patch
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/mr_bundle/CHANGELOG.md
+++ b/crates/mr_bundle/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/mr_bundle/CHANGELOG.md
+++ b/crates/mr_bundle/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/release-automation/src/lib/tests/cli.rs
+++ b/crates/release-automation/src/lib/tests/cli.rs
@@ -957,7 +957,7 @@ fn release_dry_run_fails_on_unallowed_conditions() {
             "--log-level=debug",
             "release",
             "--dry-run",
-            "--allowed-semver-increment-modes=!pre_patch dev",
+            "--allowed-semver-increment-modes=!pre_patch beta-dev",
             "--steps=BumpReleaseVersions",
         ]);
 

--- a/crates/release-automation/src/lib/tests/cli.rs
+++ b/crates/release-automation/src/lib/tests/cli.rs
@@ -957,7 +957,7 @@ fn release_dry_run_fails_on_unallowed_conditions() {
             "--log-level=debug",
             "release",
             "--dry-run",
-            "--allowed-semver-increment-modes=!pre_patch beta-dev",
+            "--allowed-semver-increment-modes=!pre_patch dev",
             "--steps=BumpReleaseVersions",
         ]);
 

--- a/crates/test_utils/wasm/CHANGELOG.md
+++ b/crates/test_utils/wasm/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/test_utils/wasm/CHANGELOG.md
+++ b/crates/test_utils/wasm/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/crates/test_utils/wasm_common/CHANGELOG.md
+++ b/crates/test_utils/wasm_common/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre_patch beta-rc
+default_semver_increment_mode: !pre-patch rc
 ---
 # Changelog
 

--- a/crates/test_utils/wasm_common/CHANGELOG.md
+++ b/crates/test_utils/wasm_common/CHANGELOG.md
@@ -1,5 +1,5 @@
 ---
-default_semver_increment_mode: !pre-patch rc
+default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog
 

--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -84,7 +84,7 @@
             --force-tag-creation \
             --force-branch-creation \
             --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
-            --allowed-semver-increment-modes="!pre_patch beta-rc" \
+            --allowed-semver-increment-modes="!pre_patch rc" \
             --steps=CreateReleaseBranch,BumpReleaseVersions
 
         ${self'.packages.release-automation}/bin/release-automation \


### PR DESCRIPTION
### Summary
We used to release RCs with a -beta prefix and agreed it was no longer applicable. This PR removes the prefix in the crates' frontmatter.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
