### PR TITLE
create a release from branch release-20231004.152803

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,74 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # \[Unreleased\]
 
+# 20231004.152803
+
+## [holochain\_cli-0.1.7-rc.0](crates/holochain_cli/CHANGELOG.md#0.1.7-rc.0)
+
+## [holochain\_cli\_sandbox-0.1.7-rc.0](crates/holochain_cli_sandbox/CHANGELOG.md#0.1.7-rc.0)
+
+## [holochain\_cli\_bundle-0.1.7-rc.0](crates/holochain_cli_bundle/CHANGELOG.md#0.1.7-rc.0)
+
+## [holochain-0.1.7-rc.0](crates/holochain/CHANGELOG.md#0.1.7-rc.0)
+
+- Fix: App interfaces are persisted when shutting down conductor. After restart, app interfaces without connected receiver websocket had signal emission fail altogether. Send errors are only logged now instead.
+
+## [holochain\_websocket-0.1.3-rc.0](crates/holochain_websocket/CHANGELOG.md#0.1.3-rc.0)
+
+## [holochain\_test\_wasm\_common-0.1.5-rc.0](crates/holochain_test_wasm_common/CHANGELOG.md#0.1.5-rc.0)
+
+## [holochain\_conductor\_api-0.1.7-rc.0](crates/holochain_conductor_api/CHANGELOG.md#0.1.7-rc.0)
+
+## [holochain\_wasm\_test\_utils-0.1.7-rc.0](crates/holochain_wasm_test_utils/CHANGELOG.md#0.1.7-rc.0)
+
+## [holochain\_cascade-0.1.7-rc.0](crates/holochain_cascade/CHANGELOG.md#0.1.7-rc.0)
+
+## [holochain\_state-0.1.7-rc.0](crates/holochain_state/CHANGELOG.md#0.1.7-rc.0)
+
+## [holochain\_p2p-0.1.7-rc.0](crates/holochain_p2p/CHANGELOG.md#0.1.7-rc.0)
+
+## [holochain\_types-0.1.7-rc.0](crates/holochain_types/CHANGELOG.md#0.1.7-rc.0)
+
+## [holochain\_keystore-0.1.7-rc.0](crates/holochain_keystore/CHANGELOG.md#0.1.7-rc.0)
+
+## [holochain\_sqlite-0.1.7-rc.0](crates/holochain_sqlite/CHANGELOG.md#0.1.7-rc.0)
+
+## [kitsune\_p2p-0.1.6-rc.0](crates/kitsune_p2p/CHANGELOG.md#0.1.6-rc.0)
+
+## [kitsune\_p2p\_proxy-0.1.5-rc.0](crates/kitsune_p2p_proxy/CHANGELOG.md#0.1.5-rc.0)
+
+## [kitsune\_p2p\_transport\_quic-0.1.5-rc.0](crates/kitsune_p2p_transport_quic/CHANGELOG.md#0.1.5-rc.0)
+
+## [kitsune\_p2p\_mdns-0.1.3-rc.0](crates/kitsune_p2p_mdns/CHANGELOG.md#0.1.3-rc.0)
+
+## [kitsune\_p2p\_fetch-0.1.5-rc.0](crates/kitsune_p2p_fetch/CHANGELOG.md#0.1.5-rc.0)
+
+## [kitsune\_p2p\_types-0.1.5-rc.0](crates/kitsune_p2p_types/CHANGELOG.md#0.1.5-rc.0)
+
+## [mr\_bundle-0.1.3-rc.0](crates/mr_bundle/CHANGELOG.md#0.1.3-rc.0)
+
+## [holochain\_util-0.1.3-rc.0](crates/holochain_util/CHANGELOG.md#0.1.3-rc.0)
+
+## [hdk-0.1.5-rc.0](crates/hdk/CHANGELOG.md#0.1.5-rc.0)
+
+## [holochain\_zome\_types-0.1.5-rc.0](crates/holochain_zome_types/CHANGELOG.md#0.1.5-rc.0)
+
+## [kitsune\_p2p\_dht-0.1.3-rc.0](crates/kitsune_p2p_dht/CHANGELOG.md#0.1.3-rc.0)
+
+## [hdi-0.2.5-rc.0](crates/hdi/CHANGELOG.md#0.2.5-rc.0)
+
+## [hdk\_derive-0.1.5-rc.0](crates/hdk_derive/CHANGELOG.md#0.1.5-rc.0)
+
+## [holochain\_integrity\_types-0.1.5-rc.0](crates/holochain_integrity_types/CHANGELOG.md#0.1.5-rc.0)
+
+## [kitsune\_p2p\_timestamp-0.1.3-rc.0](crates/kitsune_p2p_timestamp/CHANGELOG.md#0.1.3-rc.0)
+
+## [holo\_hash-0.1.5-rc.0](crates/holo_hash/CHANGELOG.md#0.1.5-rc.0)
+
+## [kitsune\_p2p\_dht\_arc-0.1.3-rc.0](crates/kitsune_p2p_dht_arc/CHANGELOG.md#0.1.3-rc.0)
+
+## [fixt-0.1.4-rc.0](crates/fixt/CHANGELOG.md#0.1.4-rc.0)
+
 # 20230825.121713
 
 ## [holochain\_cli-0.1.6](crates/holochain_cli/CHANGELOG.md#0.1.6)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "fixt"
-version = "0.1.3"
+version = "0.1.4-rc.0"
 dependencies = [
  "holochain_serialized_bytes 0.0.51",
  "lazy_static",
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "hdi"
-version = "0.2.4"
+version = "0.2.5-rc.0"
 dependencies = [
  "arbitrary",
  "fixt",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "fixt",
  "getrandom 0.2.10",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "darling 0.14.4",
  "heck 0.4.1",
@@ -2261,7 +2261,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "holo_hash"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",
@@ -2283,7 +2283,7 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2416,7 +2416,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -2429,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_bundle"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 dependencies = [
  "anyhow",
  "assert_cmd 1.0.8",
@@ -2450,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_sandbox"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 dependencies = [
  "derive_more",
  "directories",
@@ -2504,7 +2504,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "arbitrary",
  "holo_hash",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 dependencies = [
  "assert_cmd 2.0.12",
  "base64 0.13.1",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_p2p"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2634,7 +2634,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "hdk",
  "serde",
@@ -2740,7 +2740,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2799,7 +2799,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 dependencies = [
  "backtrace",
  "cfg-if 0.1.10",
@@ -2815,7 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_test_utils"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 dependencies = [
  "holochain_types",
  "holochain_util",
@@ -2873,7 +2873,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 dependencies = [
  "criterion",
  "futures",
@@ -2901,7 +2901,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "arbitrary",
  "contrafact",
@@ -3274,7 +3274,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p"
-version = "0.1.5"
+version = "0.1.6-rc.0"
 dependencies = [
  "arbitrary",
  "arrayref",
@@ -3344,7 +3344,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 dependencies = [
  "colored",
  "derivative",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht_arc"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 dependencies = [
  "derive_more",
  "gcollections",
@@ -3442,7 +3442,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_fetch"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "derive_more",
  "futures",
@@ -3465,7 +3465,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_mdns"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 dependencies = [
  "async-stream",
  "base64 0.13.1",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_proxy"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "base64 0.13.1",
  "blake2b_simd 0.5.11",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_timestamp"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -3518,7 +3518,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_transport_quic"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "blake2b_simd 1.0.1",
  "futures",
@@ -3536,7 +3536,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_types"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",
@@ -4082,7 +4082,7 @@ dependencies = [
 
 [[package]]
 name = "mr_bundle"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/crates/fixt/CHANGELOG.md
+++ b/crates/fixt/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/holochain/holochain/compare/fixt-v0.0.2-alpha.1...HEAD)
 
+## 0.1.4-rc.0
+
 ## 0.1.3
 
 ## 0.1.3-beta-rc.0

--- a/crates/fixt/Cargo.toml
+++ b/crates/fixt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixt"
-version = "0.1.3"
+version = "0.1.4-rc.0"
 description = "minimum viable fixtures"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/fixt/test/Cargo.toml
+++ b/crates/fixt/test/Cargo.toml
@@ -11,5 +11,5 @@ categories = [ "fixtures" ]
 edition = "2021"
 
 [dependencies]
-fixt = { path = ".." ,version = "^0.1.3"}
+fixt = { path = ".." ,version = "^0.1.4-rc.0"}
 paste = "1.0.5"

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.1.7-rc.0
+
 ## 0.1.6
 
 ## 0.1.6-beta-rc.0

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
@@ -21,8 +21,8 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1.0"
 futures = "0.3"
-holochain_cli_bundle = { path = "../hc_bundle", version = "^0.1.6"}
-holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.1.6"}
+holochain_cli_bundle = { path = "../hc_bundle", version = "^0.1.7-rc.0"}
+holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.1.7-rc.0"}
 observability = "0.1.3"
 structopt = "0.3"
 tokio = { version = "1.11", features = [ "full" ] }

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.7-rc.0
+
 ## 0.1.6
 
 ## 0.1.6-beta-rc.0

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_bundle"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 description = "DNA and hApp bundling functionality for the `hc` Holochain CLI utility"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -20,10 +20,10 @@ path = "src/bin/hc-dna.rs"
 
 [dependencies]
 anyhow = "1.0"
-holochain_util = { path = "../holochain_util", features = ["backtrace"], version = "^0.1.2"}
+holochain_util = { path = "../holochain_util", features = ["backtrace"], version = "^0.1.3-rc.0"}
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "^0.1.6", path = "../holochain_types" }
-mr_bundle = {version = "^0.1.2", path = "../mr_bundle"}
+holochain_types = { version = "^0.1.7-rc.0", path = "../holochain_types" }
+mr_bundle = {version = "^0.1.3-rc.0", path = "../mr_bundle"}
 serde = { version = "1.0", features = [ "derive" ] }
 serde_bytes = "0.11"
 serde_yaml = "0.9"

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.7-rc.0
+
 ## 0.1.6
 
 ## 0.1.6-beta-rc.0

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_sandbox"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli_sandbox"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
@@ -19,11 +19,11 @@ anyhow = "1.0"
 ansi_term = "0.12"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 futures = "0.3"
-holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.1.6", features = ["sqlite"] }
-holochain_types = { path = "../holochain_types", version = "^0.1.6", features = ["sqlite"] }
-holochain_websocket = { path = "../holochain_websocket", version = "^0.1.2"}
-holochain_p2p = { path = "../holochain_p2p", version = "^0.1.6", features = ["sqlite"] }
-holochain_util = { version = "^0.1.2", path = "../holochain_util", features = [ "pw" ] }
+holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.1.7-rc.0", features = ["sqlite"] }
+holochain_types = { path = "../holochain_types", version = "^0.1.7-rc.0", features = ["sqlite"] }
+holochain_websocket = { path = "../holochain_websocket", version = "^0.1.3-rc.0"}
+holochain_p2p = { path = "../holochain_p2p", version = "^0.1.7-rc.0", features = ["sqlite"] }
+holochain_util = { version = "^0.1.3-rc.0", path = "../holochain_util", features = [ "pw" ] }
 nanoid = "0.3"
 observability = "0.1.3"
 once_cell = "1.13.0"

--- a/crates/hdi/CHANGELOG.md
+++ b/crates/hdi/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.2.5-rc.0
+
 ## 0.2.4
 
 ## 0.2.4-beta-rc.0

--- a/crates/hdi/Cargo.toml
+++ b/crates/hdi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdi"
-version = "0.2.4"
+version = "0.2.5-rc.0"
 description = "The HDI"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain/tree/develop/crates/hdi"
@@ -19,12 +19,12 @@ test_utils = [
 ]
 
 [dependencies]
-hdk_derive = { version = "^0.1.4", path = "../hdk_derive" }
-holo_hash = { version = "^0.1.4", path = "../holo_hash" }
+hdk_derive = { version = "^0.1.5-rc.0", path = "../hdk_derive" }
+holo_hash = { version = "^0.1.5-rc.0", path = "../holo_hash" }
 holochain_wasmer_guest = "=0.0.83"
 # it's important that we depend on holochain_integrity_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
-holochain_integrity_types = { version = "^0.1.4", path = "../holochain_integrity_types", default-features = false }
+holochain_integrity_types = { version = "^0.1.5-rc.0", path = "../holochain_integrity_types", default-features = false }
 paste = "=1.0.5"
 serde = ">= 1.0, <= 1.0.166"
 serde_bytes = "0.11"

--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.1.5-rc.0
+
 ## 0.1.4
 
 ## 0.1.4-beta-rc.0

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 description = "The Holochain HDK"
 license = "CAL-1.0"
 homepage = "https://github.com/holochain/holochain/tree/develop/crates/hdk"
@@ -24,13 +24,13 @@ test_utils = [
 properties = ["holochain_zome_types/properties"]
 
 [dependencies]
-hdi = { version = "=0.2.4", path = "../hdi", features = ["trace"] }
-hdk_derive = { version = "^0.1.4", path = "../hdk_derive" }
-holo_hash = { version = "^0.1.4", path = "../holo_hash" }
+hdi = { version = "=0.2.5-rc.0", path = "../hdi", features = ["trace"] }
+hdk_derive = { version = "^0.1.5-rc.0", path = "../hdk_derive" }
+holo_hash = { version = "^0.1.5-rc.0", path = "../holo_hash" }
 holochain_wasmer_guest = "=0.0.83"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
-holochain_zome_types = { version = "^0.1.4", path = "../holochain_zome_types", default-features = false }
+holochain_zome_types = { version = "^0.1.5-rc.0", path = "../holochain_zome_types", default-features = false }
 paste = "=1.0.5"
 serde = ">= 1.0, <= 1.0.166"
 serde_bytes = "0.11"

--- a/crates/hdk_derive/CHANGELOG.md
+++ b/crates/hdk_derive/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-rc.0
+
 ## 0.1.4
 
 ## 0.1.4-beta-rc.0

--- a/crates/hdk_derive/Cargo.toml
+++ b/crates/hdk_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk_derive"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 description = "derive macros for the holochain hdk"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -22,7 +22,7 @@ darling = "0.14.1"
 heck = "0.4"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdi, to reduce code bloat
-holochain_integrity_types = { version = "^0.1.4", path = "../holochain_integrity_types", default-features = false }
+holochain_integrity_types = { version = "^0.1.5-rc.0", path = "../holochain_integrity_types", default-features = false }
 proc-macro-error = "1.0.4"
 
 [features]

--- a/crates/holo_hash/CHANGELOG.md
+++ b/crates/holo_hash/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-rc.0
+
 ## 0.1.4
 
 ## 0.1.4-beta-rc.0

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holo_hash"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
 keywords = [ "holochain", "holo", "hash", "blake", "blake2b" ]
 categories = [ "cryptography" ]
@@ -20,10 +20,10 @@ arbitrary = {version = "1.0", optional = true}
 base64 = {version = "0.13", optional = true}
 blake2b_simd = {version = "0.5.10", optional = true}
 derive_more = { version = "0.99", optional = true }
-fixt = { version = "^0.1.3", path = "../fixt", optional = true }
+fixt = { version = "^0.1.4-rc.0", path = "../fixt", optional = true }
 futures = {version = "0.3", optional = true}
 holochain_serialized_bytes = {version = "=0.0.51", optional = true }
-kitsune_p2p_dht_arc = { version = "^0.1.2", path = "../kitsune_p2p/dht_arc" }
+kitsune_p2p_dht_arc = { version = "^0.1.3-rc.0", path = "../kitsune_p2p/dht_arc" }
 must_future = {version = "0.1", optional = true}
 rand = {version = "0.8.5", optional = true}
 rusqlite = { version = "0.29", optional = true }

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -6,6 +6,9 @@ default_semver_increment_mode: !pre_patch rc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+## 0.1.7-rc.0
+
 - Fix: App interfaces are persisted when shutting down conductor. After restart, app interfaces without connected receiver websocket had signal emission fail altogether. Send errors are only logged now instead.
 
 ## 0.1.6

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 description = "Holochain, a framework for distributed applications"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -19,29 +19,29 @@ derive_more = "0.99.3"
 directories = "2.0.2"
 either = "1.5.0"
 fallible-iterator = "0.2.0"
-fixt = { version = "^0.1.3", path = "../fixt" }
+fixt = { version = "^0.1.4-rc.0", path = "../fixt" }
 futures = "0.3.1"
 getrandom = "0.2.7"
 ghost_actor = "0.3.0-alpha.4"
-holo_hash = { version = "^0.1.4", path = "../holo_hash", features = ["full"] }
-holochain_cascade = { version = "^0.1.6", path = "../holochain_cascade" }
-holochain_conductor_api = { version = "^0.1.6", path = "../holochain_conductor_api" }
-holochain_keystore = { version = "^0.1.6", path = "../holochain_keystore", default-features = false }
-holochain_p2p = { version = "^0.1.6", path = "../holochain_p2p" }
-holochain_sqlite = { version = "^0.1.6", path = "../holochain_sqlite" }
+holo_hash = { version = "^0.1.5-rc.0", path = "../holo_hash", features = ["full"] }
+holochain_cascade = { version = "^0.1.7-rc.0", path = "../holochain_cascade" }
+holochain_conductor_api = { version = "^0.1.7-rc.0", path = "../holochain_conductor_api" }
+holochain_keystore = { version = "^0.1.7-rc.0", path = "../holochain_keystore", default-features = false }
+holochain_p2p = { version = "^0.1.7-rc.0", path = "../holochain_p2p" }
+holochain_sqlite = { version = "^0.1.7-rc.0", path = "../holochain_sqlite" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_state = { version = "^0.1.6", path = "../holochain_state" }
-holochain_types = { version = "^0.1.6", path = "../holochain_types" }
-holochain_util = { version = "^0.1.2", path = "../holochain_util", features = [ "pw" ] }
+holochain_state = { version = "^0.1.7-rc.0", path = "../holochain_state" }
+holochain_types = { version = "^0.1.7-rc.0", path = "../holochain_types" }
+holochain_util = { version = "^0.1.3-rc.0", path = "../holochain_util", features = [ "pw" ] }
 holochain_wasmer_host = "=0.0.83"
-holochain_websocket = { version = "^0.1.2", path = "../holochain_websocket" }
-holochain_zome_types = { version = "^0.1.4", path = "../holochain_zome_types", features = ["full"] }
+holochain_websocket = { version = "^0.1.3-rc.0", path = "../holochain_websocket" }
+holochain_zome_types = { version = "^0.1.5-rc.0", path = "../holochain_zome_types", features = ["full"] }
 human-panic = "1.0.3"
-kitsune_p2p = { version = "^0.1.5", path = "../kitsune_p2p/kitsune_p2p", default-features = false }
-kitsune_p2p_types = { version = "^0.1.4", path = "../kitsune_p2p/types" }
+kitsune_p2p = { version = "^0.1.6-rc.0", path = "../kitsune_p2p/kitsune_p2p", default-features = false }
+kitsune_p2p_types = { version = "^0.1.5-rc.0", path = "../kitsune_p2p/types" }
 lazy_static = "1.4.0"
 mockall = "0.10.2"
-mr_bundle = { version = "^0.1.2", path = "../mr_bundle" }
+mr_bundle = { version = "^0.1.3-rc.0", path = "../mr_bundle" }
 must_future = "0.1.1"
 nanoid = "0.3"
 num_cpus = "1.8"
@@ -75,15 +75,15 @@ url = "1.7.2"
 url2 = "0.0.6"
 url_serde = "0.2.0"
 uuid = { version = "0.7", features = [ "serde", "v4" ] }
-holochain_wasm_test_utils = { version = "^0.1.6", path = "../test_utils/wasm" }
+holochain_wasm_test_utils = { version = "^0.1.7-rc.0", path = "../test_utils/wasm" }
 tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
 async-recursion = "0.3"
 wasmer-middlewares = "2"
 
 # Dependencies for test_utils: keep in sync with below
-hdk = { version = "^0.1.4", path = "../hdk", optional = true }
+hdk = { version = "^0.1.5-rc.0", path = "../hdk", optional = true }
 matches = {version = "0.1.8", optional = true }
-holochain_test_wasm_common = { version = "^0.1.4", path = "../test_utils/wasm_common", optional = true  }
+holochain_test_wasm_common = { version = "^0.1.5-rc.0", path = "../test_utils/wasm_common", optional = true  }
 unwrap_to = { version = "0.1.0", optional = true }
 itertools = { version = "0.10", optional = false }
 
@@ -113,14 +113,14 @@ serial_test = "0.4.0"
 test-case = "1.2.1"
 
 # Dependencies for test_utils: keep in sync with above
-hdk = { version = "^0.1.4", path = "../hdk", optional = false }
+hdk = { version = "^0.1.5-rc.0", path = "../hdk", optional = false }
 matches = {version = "0.1.8", optional = false }
-holochain_test_wasm_common = { version = "^0.1.4", path = "../test_utils/wasm_common", optional = false  }
+holochain_test_wasm_common = { version = "^0.1.5-rc.0", path = "../test_utils/wasm_common", optional = false  }
 unwrap_to = { version = "0.1.0", optional = false }
 arbitrary = { version = "1.0", features = ["derive"] }
 
 [build-dependencies]
-hdk = { version = "^0.1.4", path = "../hdk"}
+hdk = { version = "^0.1.5-rc.0", path = "../hdk"}
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0.51" }
 toml = "0.5.6"

--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.7-rc.0
+
 ## 0.1.6
 
 ## 0.1.6-beta-rc.0

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cascade"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 description = "Logic for cascading updates to Holochain state and network interaction"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -12,20 +12,20 @@ edition = "2021"
 derive_more = "0.99.3"
 either = "1.5"
 fallible-iterator = "0.2"
-fixt = { version = "^0.1.3", path = "../fixt" }
+fixt = { version = "^0.1.4-rc.0", path = "../fixt" }
 futures = "0.3"
 ghost_actor = "=0.3.0-alpha.4"
-hdk = { version = "^0.1.4", path = "../hdk" }
-hdk_derive = { version = "^0.1.4", path = "../hdk_derive" }
-holo_hash = { version = "^0.1.4", path = "../holo_hash", features = ["full"] }
-holochain_sqlite = { version = "^0.1.6", path = "../holochain_sqlite" }
-holochain_p2p = { version = "^0.1.6", path = "../holochain_p2p" }
+hdk = { version = "^0.1.5-rc.0", path = "../hdk" }
+hdk_derive = { version = "^0.1.5-rc.0", path = "../hdk_derive" }
+holo_hash = { version = "^0.1.5-rc.0", path = "../holo_hash", features = ["full"] }
+holochain_sqlite = { version = "^0.1.7-rc.0", path = "../holochain_sqlite" }
+holochain_p2p = { version = "^0.1.7-rc.0", path = "../holochain_p2p" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_state = { version = "^0.1.6", path = "../holochain_state" }
-holochain_types = { version = "^0.1.6", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.1.4", path = "../holochain_zome_types" }
+holochain_state = { version = "^0.1.7-rc.0", path = "../holochain_state" }
+holochain_types = { version = "^0.1.7-rc.0", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.1.5-rc.0", path = "../holochain_zome_types" }
 observability = "0.1.3"
-kitsune_p2p = { version = "^0.1.5", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "^0.1.6-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 tokio = { version = "1.11", features = ["full"] }

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.7-rc.0
+
 ## 0.1.6
 
 ## 0.1.6-beta-rc.0

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_conductor_api"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 description = "Message types for Holochain admin and app interface protocols"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -11,13 +11,13 @@ edition = "2021"
 [dependencies]
 directories = "2.0.2"
 derive_more = "0.99.3"
-kitsune_p2p = { version = "^0.1.5", path = "../kitsune_p2p/kitsune_p2p" }
-holo_hash = { version = "^0.1.4", path = "../holo_hash", features = ["full"] }
-holochain_p2p = { version = "^0.1.6", path = "../holochain_p2p" }
-holochain_state = { version = "^0.1.6", path = "../holochain_state" }
+kitsune_p2p = { version = "^0.1.6-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
+holo_hash = { version = "^0.1.5-rc.0", path = "../holo_hash", features = ["full"] }
+holochain_p2p = { version = "^0.1.7-rc.0", path = "../holochain_p2p" }
+holochain_state = { version = "^0.1.7-rc.0", path = "../holochain_state" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "^0.1.6", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.1.4", path = "../holochain_zome_types" }
+holochain_types = { version = "^0.1.7-rc.0", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.1.5-rc.0", path = "../holochain_zome_types" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_yaml = "0.9"
@@ -25,7 +25,7 @@ structopt = "0.3"
 tracing = "0.1.26"
 thiserror = "1.0.22"
 url2 = "0.0.6"
-holochain_keystore = { version = "^0.1.6", path = "../holochain_keystore" }
+holochain_keystore = { version = "^0.1.7-rc.0", path = "../holochain_keystore" }
 
 [dev-dependencies]
 matches = {version = "0.1.8"}

--- a/crates/holochain_integrity_types/CHANGELOG.md
+++ b/crates/holochain_integrity_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.1.5-rc.0
+
 ## 0.1.4
 
 ## 0.1.4-beta-rc.0

--- a/crates/holochain_integrity_types/Cargo.toml
+++ b/crates/holochain_integrity_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_integrity_types"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 description = "Holochain integrity types"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -10,7 +10,7 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 
 [dependencies]
-holo_hash = { version = "^0.1.4", path = "../holo_hash" }
+holo_hash = { version = "^0.1.5-rc.0", path = "../holo_hash" }
 holochain_serialized_bytes = "=0.0.51"
 paste = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
@@ -18,7 +18,7 @@ serde_bytes = "0.11"
 
 # Just the bare minimum timestamp with no extra features.
 # TODO: This needs to point to a published version of this crate and be pinned.
-kitsune_p2p_timestamp = { version = "^0.1.2", path = "../kitsune_p2p/timestamp", default-features = false }
+kitsune_p2p_timestamp = { version = "^0.1.3-rc.0", path = "../kitsune_p2p/timestamp", default-features = false }
 
 # TODO: Figure out how to remove these dependencies.
 subtle = "2"

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.7-rc.0
+
 ## 0.1.6
 
 ## 0.1.6-beta-rc.0

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_keystore"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 description = "keystore for libsodium keypairs"
 license = "CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -13,10 +13,10 @@ edition = "2021"
 [dependencies]
 base64 = "0.13.0"
 futures = "0.3.23"
-holo_hash = { version = "^0.1.4", path = "../holo_hash", features = ["full"] }
+holo_hash = { version = "^0.1.5-rc.0", path = "../holo_hash", features = ["full"] }
 holochain_serialized_bytes = "=0.0.51"
-holochain_zome_types = { path = "../holochain_zome_types", version = "^0.1.4"}
-kitsune_p2p_types = { version = "^0.1.4", path = "../kitsune_p2p/types" }
+holochain_zome_types = { path = "../holochain_zome_types", version = "^0.1.5-rc.0"}
+kitsune_p2p_types = { version = "^0.1.5-rc.0", path = "../kitsune_p2p/types" }
 lair_keystore = { version = "0.3.0", default-features = false }
 must_future = "0.1.2"
 nanoid = "0.4.0"
@@ -31,7 +31,7 @@ tracing = "0.1"
 
 # This is a redundant dependency.
 # It's included only to set the proper feature flag for database encryption.
-holochain_sqlite = { version = "^0.1.6", path = "../holochain_sqlite" }
+holochain_sqlite = { version = "^0.1.7-rc.0", path = "../holochain_sqlite" }
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.7-rc.0
+
 ## 0.1.6
 
 ## 0.1.6-beta-rc.0

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_p2p"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 description = "holochain specific wrapper around more generic p2p module"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -13,16 +13,16 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 derive_more = "0.99"
-fixt = { path = "../fixt", version = "^0.1.3"}
+fixt = { path = "../fixt", version = "^0.1.4-rc.0"}
 futures = "0.3"
 ghost_actor = "=0.3.0-alpha.4"
-holo_hash = { version = "^0.1.4", path = "../holo_hash" }
-holochain_keystore = { version = "^0.1.6", path = "../holochain_keystore" }
+holo_hash = { version = "^0.1.5-rc.0", path = "../holo_hash" }
+holochain_keystore = { version = "^0.1.7-rc.0", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_types = { version = "^0.1.6", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.1.4", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "^0.1.5", path = "../kitsune_p2p/kitsune_p2p" }
-kitsune_p2p_types = { version = "^0.1.4", path = "../kitsune_p2p/types" }
+holochain_types = { version = "^0.1.7-rc.0", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.1.5-rc.0", path = "../holochain_zome_types" }
+kitsune_p2p = { version = "^0.1.6-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p_types = { version = "^0.1.5-rc.0", path = "../kitsune_p2p/types" }
 mockall = "0.10.2"
 observability = "0.1.3"
 rand = "0.8.5"
@@ -32,7 +32,7 @@ serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 thiserror = "1.0.22"
 tokio = { version = "1.11", features = [ "full" ] }
 tokio-stream = "0.1"
-holochain_util = { version = "^0.1.2", path = "../holochain_util" }
+holochain_util = { version = "^0.1.3-rc.0", path = "../holochain_util" }
 
 [features]
 mock_network = [

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.7-rc.0
+
 ## 0.1.6
 
 ## 0.1.6-beta-rc.0

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_sqlite"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 description = "Abstractions for persistence of Holochain state via SQLite"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -21,13 +21,13 @@ derive_more = "0.99.3"
 either = "1.5.0"
 fallible-iterator = "0.2.0"
 failure = "0.1.6"
-fixt = { version = "^0.1.3", path = "../fixt" }
+fixt = { version = "^0.1.4-rc.0", path = "../fixt" }
 futures = "0.3.1"
-holo_hash = { path = "../holo_hash", version = "^0.1.4"}
+holo_hash = { path = "../holo_hash", version = "^0.1.5-rc.0"}
 holochain_serialized_bytes = "=0.0.51"
-holochain_util = { version = "^0.1.2", path = "../holochain_util", features = ["backtrace"] }
-holochain_zome_types = { version = "^0.1.4", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "^0.1.5", path = "../kitsune_p2p/kitsune_p2p" }
+holochain_util = { version = "^0.1.3-rc.0", path = "../holochain_util", features = ["backtrace"] }
+holochain_zome_types = { version = "^0.1.5-rc.0", path = "../holochain_zome_types" }
+kitsune_p2p = { version = "^0.1.6-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
 lazy_static = "1.4.0"
 once_cell = "1.4.1"
 must_future = "0.1.1"

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.7-rc.0
+
 ## 0.1.6
 
 ## 0.1.6-beta-rc.0

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_state"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 description = "TODO minimize deps"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -14,19 +14,19 @@ cfg-if = "0.1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 derive_more = "0.99.3"
 either = "1.5"
-holochain_sqlite = { version = "^0.1.6", path = "../holochain_sqlite" }
-holo_hash = { version = "^0.1.4", path = "../holo_hash", features = ["full"] }
+holochain_sqlite = { version = "^0.1.7-rc.0", path = "../holochain_sqlite" }
+holo_hash = { version = "^0.1.5-rc.0", path = "../holo_hash", features = ["full"] }
 fallible-iterator = "0.2.0"
 futures = "0.3"
-holochain_keystore = { version = "^0.1.6", path = "../holochain_keystore" }
+holochain_keystore = { version = "^0.1.7-rc.0", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_p2p = { version = "^0.1.6", path = "../holochain_p2p" }
-holochain_types = { version = "^0.1.6", path = "../holochain_types" }
-holochain_util = { version = "^0.1.2", path = "../holochain_util" }
-holochain_zome_types = { version = "^0.1.4", path = "../holochain_zome_types", features = [
+holochain_p2p = { version = "^0.1.7-rc.0", path = "../holochain_p2p" }
+holochain_types = { version = "^0.1.7-rc.0", path = "../holochain_types" }
+holochain_util = { version = "^0.1.3-rc.0", path = "../holochain_util" }
+holochain_zome_types = { version = "^0.1.5-rc.0", path = "../holochain_zome_types", features = [
     "full",
 ] }
-kitsune_p2p = { version = "^0.1.5", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "^0.1.6-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
 mockall = "0.10.2"
 one_err = "0.0.8"
 parking_lot = "0.10"

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.7-rc.0
+
 ## 0.1.6
 
 ## 0.1.6-beta-rc.0

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_types"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 description = "Holochain common types"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -21,20 +21,20 @@ cfg-if = "0.1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 derive_more = "0.99.3"
 either = "1.5"
-fixt = { path = "../fixt", version = "^0.1.3"}
+fixt = { path = "../fixt", version = "^0.1.4-rc.0"}
 flate2 = "1.0.14"
 futures = "0.3"
 one_err = "0.0.8"
-holo_hash = { version = "^0.1.4", path = "../holo_hash", features = ["encoding"] }
-holochain_keystore = { version = "^0.1.6", path = "../holochain_keystore" }
+holo_hash = { version = "^0.1.5-rc.0", path = "../holo_hash", features = ["encoding"] }
+holochain_keystore = { version = "^0.1.7-rc.0", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.51"
-holochain_sqlite = { path = "../holochain_sqlite", version = "^0.1.6"}
-holochain_zome_types = { path = "../holochain_zome_types", version = "^0.1.4", features = ["full"] }
+holochain_sqlite = { path = "../holochain_sqlite", version = "^0.1.7-rc.0"}
+holochain_zome_types = { path = "../holochain_zome_types", version = "^0.1.5-rc.0", features = ["full"] }
 itertools = { version = "0.10" }
-kitsune_p2p_dht = { version = "^0.1.2", path = "../kitsune_p2p/dht" }
+kitsune_p2p_dht = { version = "^0.1.3-rc.0", path = "../kitsune_p2p/dht" }
 lazy_static = "1.4.0"
 mockall = "0.10.2"
-mr_bundle = { path = "../mr_bundle", features = ["packing"], version = "^0.1.2"}
+mr_bundle = { path = "../mr_bundle", features = ["packing"], version = "^0.1.3-rc.0"}
 must_future = "0.1.1"
 nanoid = "0.3"
 observability = "0.1.3"
@@ -53,7 +53,7 @@ strum_macros = "0.18.0"
 tempfile = "3"
 thiserror = "1.0.22"
 tokio = { version = "1.11", features = [ "rt" ] }
-holochain_util = { version = "^0.1.2", path = "../holochain_util", features = ["backtrace"] }
+holochain_util = { version = "^0.1.3-rc.0", path = "../holochain_util", features = ["backtrace"] }
 tracing = "0.1.26"
 derive_builder = "0.9.0"
 

--- a/crates/holochain_util/CHANGELOG.md
+++ b/crates/holochain_util/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.3-rc.0
+
 ## 0.1.2
 
 ## 0.1.1

--- a/crates/holochain_util/Cargo.toml
+++ b/crates/holochain_util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_util"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
 edition = "2021"
 description = "This crate is a collection of various utility functions that are used in the other crates in the holochain repository."

--- a/crates/holochain_websocket/CHANGELOG.md
+++ b/crates/holochain_websocket/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.3-rc.0
+
 ## 0.1.2
 
 ## 0.1.1

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_websocket"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 description = "Holochain utilities for serving and connection with websockets"
 license-file = "LICENSE_CAL-1.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-rc.0
+
 ## 0.1.4
 
 ## 0.1.4-beta-rc.0

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_zome_types"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 description = "Holochain zome types"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -12,9 +12,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kitsune_p2p_timestamp = { version = "^0.1.2", path = "../kitsune_p2p/timestamp" }
-holo_hash = { version = "^0.1.4", path = "../holo_hash", features = ["encoding"] }
-holochain_integrity_types = { version = "^0.1.4", path = "../holochain_integrity_types", features = ["tracing"] }
+kitsune_p2p_timestamp = { version = "^0.1.3-rc.0", path = "../kitsune_p2p/timestamp" }
+holo_hash = { version = "^0.1.5-rc.0", path = "../holo_hash", features = ["encoding"] }
+holochain_integrity_types = { version = "^0.1.5-rc.0", path = "../holochain_integrity_types", features = ["tracing"] }
 holochain_serialized_bytes = "=0.0.51"
 paste = "=1.0.5"
 serde = { version = "1.0", features = [ "derive", "rc" ] }
@@ -26,7 +26,7 @@ tracing = "0.1"
 holochain_wasmer_common = "=0.0.83"
 
 # fixturator dependencies
-fixt = { version = "^0.1.3", path = "../fixt", optional = true }
+fixt = { version = "^0.1.4-rc.0", path = "../fixt", optional = true }
 strum = { version = "0.18.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 
@@ -36,7 +36,7 @@ num_enum = { version = "0.5", optional = true }
 
 # full-dna-def dependencies
 derive_builder = { version = "0.9", optional = true }
-kitsune_p2p_dht = { version = "^0.1.2", path = "../kitsune_p2p/dht", optional = true }
+kitsune_p2p_dht = { version = "^0.1.3-rc.0", path = "../kitsune_p2p/dht", optional = true }
 nanoid = { version = "0.3", optional = true }
 shrinkwraprs = { version = "0.3", optional = true }
 

--- a/crates/kitsune_p2p/bootstrap/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 [dependencies]
 clap = "=3.1.18"
 futures = "0.3.15"
-kitsune_p2p_types = { version = "^0.1.4", path = "../types" }
+kitsune_p2p_types = { version = "^0.1.5-rc.0", path = "../types" }
 once_cell = "1.7.2"
 parking_lot = "0.11"
 rand = "0.8.5"
@@ -28,7 +28,7 @@ warp = "0.3"
 
 [dev-dependencies]
 kitsune_p2p = { path = "../kitsune_p2p", features = ["sqlite"] }
-fixt = { path = "../../fixt" ,version = "^0.1.3"}
+fixt = { path = "../../fixt" ,version = "^0.1.4-rc.0"}
 criterion = "0.3"
 reqwest = "0.11.2"
 

--- a/crates/kitsune_p2p/dht/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.3-rc.0
+
 ## 0.1.2
 
 ## 0.1.1

--- a/crates/kitsune_p2p/dht/Cargo.toml
+++ b/crates/kitsune_p2p/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_dht"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 description = "Kitsune P2p DHT definition"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -18,8 +18,8 @@ derivative = "2.2.0"
 derive_more = "0.99"
 futures = "0.3"
 gcollections = "1.5"
-kitsune_p2p_dht_arc = { version = "^0.1.2", path = "../dht_arc"}
-kitsune_p2p_timestamp = { version = "^0.1.2", path = "../timestamp", features = ["now"]}
+kitsune_p2p_dht_arc = { version = "^0.1.3-rc.0", path = "../dht_arc"}
+kitsune_p2p_timestamp = { version = "^0.1.3-rc.0", path = "../timestamp", features = ["now"]}
 intervallum = "1.4"
 must_future = "0.1"
 num-traits = "0.2.14"

--- a/crates/kitsune_p2p/dht_arc/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht_arc/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.3-rc.0
+
 ## 0.1.2
 
 ## 0.1.1

--- a/crates/kitsune_p2p/dht_arc/Cargo.toml
+++ b/crates/kitsune_p2p/dht_arc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_dht_arc"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 description = "Kitsune P2p Dht Arc Utils"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/direct/Cargo.toml
+++ b/crates/kitsune_p2p/direct/Cargo.toml
@@ -19,10 +19,10 @@ hyper = { version = "0.14", features = ["server","http1","http2","tcp"] }
 if-addrs = "0.6"
 kitsune_p2p_bootstrap = { version = "0.0.12-dev.0", path = "../bootstrap" }
 kitsune_p2p_direct_api = { version = "0.0.1", path = "../direct_api" }
-kitsune_p2p_types = { version = "^0.1.4", path = "../types" }
-kitsune_p2p = { version = "^0.1.5", path = "../kitsune_p2p", features = ["test_utils"] }
-kitsune_p2p_transport_quic = { version = "^0.1.4", path = "../transport_quic" }
-kitsune_p2p_proxy = { version = "^0.1.4", path = "../proxy" }
+kitsune_p2p_types = { version = "^0.1.5-rc.0", path = "../types" }
+kitsune_p2p = { version = "^0.1.6-rc.0", path = "../kitsune_p2p", features = ["test_utils"] }
+kitsune_p2p_transport_quic = { version = "^0.1.5-rc.0", path = "../transport_quic" }
+kitsune_p2p_proxy = { version = "^0.1.5-rc.0", path = "../proxy" }
 rand = "0.8.5"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/crates/kitsune_p2p/direct_api/Cargo.toml
+++ b/crates/kitsune_p2p/direct_api/Cargo.toml
@@ -13,6 +13,6 @@ edition = "2021"
 [dependencies]
 arrayref = "0.3.6"
 base64 = "0.13"
-kitsune_p2p_dht_arc = { version = "^0.1.2", path = "../dht_arc" }
+kitsune_p2p_dht_arc = { version = "^0.1.3-rc.0", path = "../dht_arc" }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = { version = "1", features = ["preserve_order"] }

--- a/crates/kitsune_p2p/direct_test/Cargo.toml
+++ b/crates/kitsune_p2p/direct_test/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2021"
 
 [dependencies]
 kitsune_p2p_direct = { version = "0.0.1", path = "../direct" }
-kitsune_p2p_transport_quic = { version = "^0.1.4", path = "../transport_quic" }
-kitsune_p2p_proxy = { version = "^0.1.4", path = "../proxy" }
+kitsune_p2p_transport_quic = { version = "^0.1.5-rc.0", path = "../transport_quic" }
+kitsune_p2p_proxy = { version = "^0.1.5-rc.0", path = "../proxy" }
 rand = "0.8.5"
 structopt = "0.3.21"
 tokio = { version = "1.11", features = ["full"] }

--- a/crates/kitsune_p2p/fetch/CHANGELOG.md
+++ b/crates/kitsune_p2p/fetch/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-rc.0
+
 ## 0.1.4
 
 ## 0.1.4-beta-rc.0

--- a/crates/kitsune_p2p/fetch/Cargo.toml
+++ b/crates/kitsune_p2p/fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_fetch"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 description = "Kitsune P2p Fetch Queue Logic"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -14,8 +14,8 @@ edition = "2021"
 [dependencies]
 derive_more = "0.99"
 futures = "0.3"
-kitsune_p2p_types = { version = "^0.1.4", path = "../types" }
-kitsune_p2p_timestamp = { version = "^0.1.2", path = "../timestamp", features = ["now"]}
+kitsune_p2p_types = { version = "^0.1.5-rc.0", path = "../types" }
+kitsune_p2p_timestamp = { version = "^0.1.3-rc.0", path = "../timestamp", features = ["now"]}
 must_future = "0.1"
 num-traits = "0.2.14"
 serde = { version = "1.0", features = [ "derive" ] }

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.6-rc.0
+
 ## 0.1.5
 
 ## 0.1.5-beta-rc.0

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p"
-version = "0.1.5"
+version = "0.1.6-rc.0"
 description = "p2p / dht communication framework"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -19,12 +19,12 @@ futures = "0.3"
 ghost_actor = "=0.3.0-alpha.4"
 governor = "0.3.2"
 itertools = "0.10"
-kitsune_p2p_fetch = { version = "^0.1.4", path = "../fetch" }
-kitsune_p2p_mdns = { version = "^0.1.2", path = "../mdns" }
-kitsune_p2p_proxy = { version = "^0.1.4", path = "../proxy" }
-kitsune_p2p_timestamp = { version = "^0.1.2", path = "../timestamp", features = ["now"] }
-kitsune_p2p_transport_quic = { version = "^0.1.4", path = "../transport_quic", optional = true }
-kitsune_p2p_types = { version = "^0.1.4", path = "../types", default-features = false }
+kitsune_p2p_fetch = { version = "^0.1.5-rc.0", path = "../fetch" }
+kitsune_p2p_mdns = { version = "^0.1.3-rc.0", path = "../mdns" }
+kitsune_p2p_proxy = { version = "^0.1.5-rc.0", path = "../proxy" }
+kitsune_p2p_timestamp = { version = "^0.1.3-rc.0", path = "../timestamp", features = ["now"] }
+kitsune_p2p_transport_quic = { version = "^0.1.5-rc.0", path = "../transport_quic", optional = true }
+kitsune_p2p_types = { version = "^0.1.5-rc.0", path = "../types", default-features = false }
 must_future = "0.1.1"
 nanoid = "0.4"
 num-traits = "0.2"
@@ -43,7 +43,7 @@ tracing = "0.1"
 tokio-stream = "0.1"
 # tx5 = { version = "0.0.1-alpha.3", optional = true }
 url2 = "0.0.6"
-fixt = { path = "../../fixt", version = "^0.1.3"}
+fixt = { path = "../../fixt", version = "^0.1.4-rc.0"}
 
 # arbitrary could be made optional
 arbitrary = { version = "1.0", features = ["derive"] }

--- a/crates/kitsune_p2p/mdns/CHANGELOG.md
+++ b/crates/kitsune_p2p/mdns/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.3-rc.0
+
 ## 0.1.2
 
 ## 0.1.1

--- a/crates/kitsune_p2p/mdns/Cargo.toml
+++ b/crates/kitsune_p2p/mdns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_mdns"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 description = "p2p / mdns discovery framework"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/proxy/CHANGELOG.md
+++ b/crates/kitsune_p2p/proxy/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-rc.0
+
 ## 0.1.4
 
 ## 0.1.4-beta-rc.0

--- a/crates/kitsune_p2p/proxy/Cargo.toml
+++ b/crates/kitsune_p2p/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_proxy"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 description = "Proxy transport module for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -15,8 +15,8 @@ base64 = "0.13"
 blake2b_simd = "0.5.10"
 derive_more = "0.99.7"
 futures = "0.3"
-kitsune_p2p_types = { version = "^0.1.4", path = "../types" }
-kitsune_p2p_transport_quic = { version = "^0.1.4", path = "../transport_quic" }
+kitsune_p2p_types = { version = "^0.1.5-rc.0", path = "../types" }
+kitsune_p2p_transport_quic = { version = "^0.1.5-rc.0", path = "../transport_quic" }
 nanoid = "0.3"
 observability = "0.1.3"
 parking_lot = "0.11"

--- a/crates/kitsune_p2p/timestamp/CHANGELOG.md
+++ b/crates/kitsune_p2p/timestamp/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.3-rc.0
+
 ## 0.1.2
 
 ## 0.1.1

--- a/crates/kitsune_p2p/timestamp/Cargo.toml
+++ b/crates/kitsune_p2p/timestamp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_timestamp"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 description = "Microsecond-precision timestamp datatype for kitsune_p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/transport_quic/CHANGELOG.md
+++ b/crates/kitsune_p2p/transport_quic/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-rc.0
+
 ## 0.1.4
 
 ## 0.1.4-beta-rc.0

--- a/crates/kitsune_p2p/transport_quic/Cargo.toml
+++ b/crates/kitsune_p2p/transport_quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_transport_quic"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 description = "QUIC transport module for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -14,7 +14,7 @@ edition = "2021"
 blake2b_simd = "1.0.0"
 futures = "0.3.21"
 if-addrs = "0.7.0"
-kitsune_p2p_types = { version = "^0.1.4", path = "../types" }
+kitsune_p2p_types = { version = "^0.1.5-rc.0", path = "../types" }
 nanoid = "0.4.0"
 once_cell = "1.9.0"
 quinn = "0.8.1"

--- a/crates/kitsune_p2p/types/CHANGELOG.md
+++ b/crates/kitsune_p2p/types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-rc.0
+
 ## 0.1.4
 
 ## 0.1.4-beta-rc.0

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_types"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 description = "types subcrate for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -16,8 +16,8 @@ base64 = "0.13"
 derive_more = "0.99.7"
 futures = "0.3"
 ghost_actor = "=0.3.0-alpha.4"
-kitsune_p2p_dht = { version = "^0.1.2", path = "../dht" }
-kitsune_p2p_dht_arc = { version = "^0.1.2", path = "../dht_arc" }
+kitsune_p2p_dht = { version = "^0.1.3-rc.0", path = "../dht" }
+kitsune_p2p_dht_arc = { version = "^0.1.3-rc.0", path = "../dht_arc" }
 lru = "0.8.1"
 mockall = { version = "0.10.2", optional = true }
 nanoid = "0.3"

--- a/crates/mr_bundle/CHANGELOG.md
+++ b/crates/mr_bundle/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.3-rc.0
+
 ## 0.1.2
 
 ## 0.1.1

--- a/crates/mr_bundle/Cargo.toml
+++ b/crates/mr_bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mr_bundle"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 authors = ["Michael Dougherty <maackle.d@gmail.com>"]
 edition = "2021"
 description = "Implements the un-/packing of bundles that either embed or reference a set of resources"
@@ -13,7 +13,7 @@ bytes = "1.0"
 derive_more = "0.99"
 either = "1.5"
 flate2 = "1.0"
-holochain_util = { path = "../holochain_util", version = "^0.1.2"}
+holochain_util = { path = "../holochain_util", version = "^0.1.3-rc.0"}
 futures = "0.3"
 reqwest = "0.11"
 rmp-serde = "0.15"

--- a/crates/test_utils/wasm/CHANGELOG.md
+++ b/crates/test_utils/wasm/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.7-rc.0
+
 ## 0.1.6
 
 ## 0.1.6-beta-rc.0

--- a/crates/test_utils/wasm/Cargo.toml
+++ b/crates/test_utils/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_wasm_test_utils"
-version = "0.1.6"
+version = "0.1.7-rc.0"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2021"
 description = "Utilities for Wasm testing for Holochain"
@@ -19,10 +19,10 @@ only_check = []
 
 
 [dependencies]
-holochain_types = { path = "../../holochain_types", version = "^0.1.6"}
+holochain_types = { path = "../../holochain_types", version = "^0.1.7-rc.0"}
 strum = "0.18.0"
 strum_macros = "0.18.0"
-holochain_util = { version = "^0.1.2", path = "../../holochain_util" }
+holochain_util = { version = "^0.1.3-rc.0", path = "../../holochain_util" }
 
 [build-dependencies]
 toml = "0.5"

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -742,7 +742,7 @@ checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "fixt"
-version = "0.1.3"
+version = "0.1.4-rc.0"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -953,7 +953,7 @@ checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
 name = "hdi"
-version = "0.2.4"
+version = "0.2.5-rc.0"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "getrandom",
  "hdi",
@@ -987,7 +987,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "darling 0.14.4",
  "heck 0.4.1",
@@ -1028,7 +1028,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "holo_hash"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "arbitrary",
  "base64",
@@ -1047,7 +1047,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "arbitrary",
  "holo_hash",
@@ -1096,7 +1096,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "hdk",
  "serde",
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 dependencies = [
  "derive_builder",
  "fixt",
@@ -1280,7 +1280,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 dependencies = [
  "colored",
  "derivative",
@@ -1302,7 +1302,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht_arc"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 dependencies = [
  "derive_more",
  "gcollections",
@@ -1313,7 +1313,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_timestamp"
-version = "0.1.2"
+version = "0.1.3-rc.0"
 dependencies = [
  "arbitrary",
  "chrono",

--- a/crates/test_utils/wasm_common/CHANGELOG.md
+++ b/crates/test_utils/wasm_common/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.1.5-rc.0
+
 ## 0.1.4
 
 ## 0.1.4-beta-rc.0

--- a/crates/test_utils/wasm_common/Cargo.toml
+++ b/crates/test_utils/wasm_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_test_wasm_common"
-version = "0.1.4"
+version = "0.1.5-rc.0"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2021"
 description = "Common code for Wasm testing for Holochain"
@@ -13,5 +13,5 @@ crate-type = [ "cdylib", "rlib" ]
 path = "src/lib.rs"
 
 [dependencies]
-hdk = { path = "../../hdk", version = "^0.1.4"}
+hdk = { path = "../../hdk", version = "^0.1.5-rc.0"}
 serde = "1.0"


### PR DESCRIPTION
the following crates are part of this release:

- fixt-0.1.4-rc.0
- kitsune_p2p_dht_arc-0.1.3-rc.0
- holo_hash-0.1.5-rc.0
- kitsune_p2p_timestamp-0.1.3-rc.0
- holochain_integrity_types-0.1.5-rc.0
- hdk_derive-0.1.5-rc.0
- hdi-0.2.5-rc.0
- kitsune_p2p_dht-0.1.3-rc.0
- holochain_zome_types-0.1.5-rc.0
- hdk-0.1.5-rc.0
- holochain_util-0.1.3-rc.0
- mr_bundle-0.1.3-rc.0
- kitsune_p2p_types-0.1.5-rc.0
- kitsune_p2p_fetch-0.1.5-rc.0
- kitsune_p2p_mdns-0.1.3-rc.0
- kitsune_p2p_transport_quic-0.1.5-rc.0
- kitsune_p2p_proxy-0.1.5-rc.0
- kitsune_p2p-0.1.6-rc.0
- holochain_sqlite-0.1.7-rc.0
- holochain_keystore-0.1.7-rc.0
- holochain_types-0.1.7-rc.0
- holochain_p2p-0.1.7-rc.0
- holochain_state-0.1.7-rc.0
- holochain_cascade-0.1.7-rc.0
- holochain_wasm_test_utils-0.1.7-rc.0
- holochain_conductor_api-0.1.7-rc.0
- holochain_test_wasm_common-0.1.5-rc.0
- holochain_websocket-0.1.3-rc.0
- holochain-0.1.7-rc.0
- holochain_cli_bundle-0.1.7-rc.0
- holochain_cli_sandbox-0.1.7-rc.0
- holochain_cli-0.1.7-rc.0

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
