### PR TITLE
[BACKPORT 0.2] Add network seed option to `hc sandbox generate` (#2902)

### DIFF
--- a/crates/hc_sandbox/src/cli.rs
+++ b/crates/hc_sandbox/src/cli.rs
@@ -75,6 +75,10 @@ pub enum HcSandboxSubcommand {
 
         /// A hApp bundle to install.
         happ: Option<PathBuf>,
+
+        /// Network seed to use when installing the provided hApp.
+        #[arg(long, short = 's')]
+        network_seed: Option<String>,
     },
 
     /// Run conductor(s) from existing sandbox(es).
@@ -123,12 +127,14 @@ impl HcSandbox {
                 create,
                 run,
                 happ,
+                network_seed,
             } => {
                 let paths = generate(
                     &self.holochain_path,
                     happ,
                     create,
                     app_id,
+                    network_seed,
                     self.structured.clone(),
                 )
                 .await?;
@@ -277,10 +283,19 @@ pub async fn generate(
     happ: Option<PathBuf>,
     create: Create,
     app_id: InstalledAppId,
+    network_seed: Option<String>,
     structured: Output,
 ) -> anyhow::Result<Vec<PathBuf>> {
     let happ = crate::bundles::parse_happ(happ)?;
-    let paths = crate::sandbox::default_n(holochain_path, create, happ, app_id, structured).await?;
+    let paths = crate::sandbox::default_n(
+        holochain_path,
+        create,
+        happ,
+        app_id,
+        network_seed,
+        structured,
+    )
+    .await?;
     crate::save::save(std::env::current_dir()?, paths.clone())?;
     Ok(paths)
 }

--- a/crates/hc_sandbox/src/sandbox.rs
+++ b/crates/hc_sandbox/src/sandbox.rs
@@ -20,6 +20,7 @@ pub async fn default_with_network(
     directory: Option<PathBuf>,
     happ: PathBuf,
     app_id: InstalledAppId,
+    network_seed: Option<String>,
     structured: Output,
 ) -> anyhow::Result<PathBuf> {
     let Create {
@@ -40,7 +41,7 @@ pub async fn default_with_network(
         app_id: Some(app_id),
         agent_key: None,
         path: happ,
-        network_seed: None,
+        network_seed,
     };
     crate::calls::install_app_bundle(&mut cmd, install_bundle).await?;
     Ok(path)
@@ -53,6 +54,7 @@ pub async fn default_n(
     create: Create,
     happ: PathBuf,
     app_id: InstalledAppId,
+    network_seed: Option<String>,
     structured: Output,
 ) -> anyhow::Result<Vec<PathBuf>> {
     let num_sandboxes = create.num_sandboxes;
@@ -68,6 +70,7 @@ pub async fn default_n(
             create.directories.get(i).cloned(),
             happ.clone(),
             app_id.clone(),
+            network_seed.clone(),
             structured.clone(),
         )
         .await?;


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
