### PR TITLE
2023 10 06 backport cascade fix

### DIFF
--- a/crates/holochain/src/core/ribosome/host_fn/must_get_agent_activity.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_agent_activity.rs
@@ -135,6 +135,29 @@ pub mod test {
             .await;
     }
 
+    /// Test that validation can get the currently-being-validated agent's
+    /// previous action bounded activity.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ribosome_must_get_agent_activity_self_prev() {
+        holochain_trace::test_run().ok();
+        let RibosomeTestFixture {
+            conductor,
+            alice,
+            ..
+        } = RibosomeTestFixture::new(TestWasm::MustGet).await;
+
+        // This test is a repro of some issue where the init being inline with
+        // the commit being validated may or may not be important. For that
+        // reason this test should not be merged with other tests/assertions.
+        let _: () = conductor
+            .call(
+                &alice,
+                "commit_require_self_prev_agents_chain",
+                (),
+            )
+            .await;
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_must_get_agent_activity() {
         holochain_trace::test_run().ok();

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_agent_activity.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_agent_activity.rs
@@ -112,6 +112,29 @@ pub mod test {
     #[derive(serde::Serialize, serde::Deserialize, SerializedBytes, Debug, PartialEq)]
     struct Something(#[serde(with = "serde_bytes")] Vec<u8>);
 
+    /// Test that validation can get the currently-being-validated agent's
+    /// activity.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ribosome_must_get_agent_activity_self() {
+        holochain_trace::test_run().ok();
+        let RibosomeTestFixture {
+            conductor,
+            alice,
+            ..
+        } = RibosomeTestFixture::new(TestWasm::MustGet).await;
+
+        // This test is a repro of some issue where the init being inline with
+        // the commit being validated may or may not be important. For that
+        // reason this test should not be merged with other tests/assertions.
+        let _: () = conductor
+            .call(
+                &alice,
+                "commit_require_self_agents_chain",
+                (),
+            )
+            .await;
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_must_get_agent_activity() {
         holochain_trace::test_run().ok();

--- a/crates/holochain/src/core/workflow/call_zome_workflow.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow.rs
@@ -163,6 +163,9 @@ where
 
     let validation_result =
         inline_validation(workspace.clone(), network, conductor_handle, ribosome).await;
+
+    // If the validation failed remove any active chain lock that matches the
+    // entry that failed validation.
     if matches!(
         validation_result,
         Err(WorkflowError::SourceChainError(

--- a/crates/holochain_cascade/src/authority/get_agent_activity_query/must_get_agent_activity.rs
+++ b/crates/holochain_cascade/src/authority/get_agent_activity_query/must_get_agent_activity.rs
@@ -10,10 +10,10 @@ use holochain_sqlite::sql::sql_cell::must_get_agent_activity::*;
 use holochain_state::prelude::from_blob;
 use holochain_state::prelude::StateQueryResult;
 use holochain_state::scratch::Scratch;
-use holochain_types::chain::ChainFilterRange;
 use holochain_types::chain::MustGetAgentActivityResponse;
 use holochain_types::chain::Sequences;
 use holochain_types::dht_op::DhtOpType;
+use holochain_types::prelude::BoundedMustGetAgentActivityResponse;
 use holochain_zome_types::ActionHashed;
 use holochain_zome_types::ChainFilter;
 use holochain_zome_types::RegisterAgentActivity;
@@ -35,7 +35,7 @@ pub async fn must_get_agent_activity(
     let result = env
         .read_async(move |mut txn| get_bounded_activity(&mut txn, None, &author, filter))
         .await?;
-    filter_then_check(result)
+    Ok(filter_then_check(result))
 }
 
 pub fn get_bounded_activity(
@@ -43,38 +43,41 @@ pub fn get_bounded_activity(
     scratch: Option<&Scratch>,
     author: &AgentPubKey,
     filter: ChainFilter,
-) -> StateQueryResult<(MustGetAgentActivityResponse, Option<ChainFilterRange>)> {
+) -> StateQueryResult<BoundedMustGetAgentActivityResponse> {
     // Find the bounds of the range specified in the filter.
     match find_bounds(txn, scratch, author, filter)? {
         Sequences::Found(filter_range) => {
             // Get the full range of actions from the database.
-            get_activity(txn, scratch, author, filter_range.range()).map(|a| {
-                (
-                    MustGetAgentActivityResponse::Activity(a),
-                    Some(filter_range),
-                )
-            })
+            get_activity(txn, scratch, author, filter_range.range())
+                .map(|a| BoundedMustGetAgentActivityResponse::Activity(a, filter_range))
         }
         // One of the actions specified in the filter does not exist in the database.
         Sequences::ChainTopNotFound(a) => {
-            Ok((MustGetAgentActivityResponse::ChainTopNotFound(a), None))
+            Ok(BoundedMustGetAgentActivityResponse::ChainTopNotFound(a))
         }
         // The filter specifies a range that is empty.
-        Sequences::EmptyRange => Ok((MustGetAgentActivityResponse::EmptyRange, None)),
+        Sequences::EmptyRange => Ok(BoundedMustGetAgentActivityResponse::EmptyRange),
     }
 }
 
+/// Consume the chain filter (if present) from a bounded response to produce an
+/// unbounded response.
 pub fn filter_then_check(
-    response: (MustGetAgentActivityResponse, Option<ChainFilterRange>),
-) -> StateQueryResult<MustGetAgentActivityResponse> {
+    response: BoundedMustGetAgentActivityResponse,
+) -> MustGetAgentActivityResponse {
     match response {
-        (MustGetAgentActivityResponse::Activity(activity), Some(filter_range)) => {
+        BoundedMustGetAgentActivityResponse::Activity(activity, filter_range) => {
             // Filter the activity from the database and check the invariants of the
             // filter still hold.
-            Ok(filter_range.filter_then_check(activity))
+            filter_range.filter_then_check(activity)
         }
-        (MustGetAgentActivityResponse::Activity(_), None) => unreachable!(),
-        (r, _) => Ok(r),
+        BoundedMustGetAgentActivityResponse::IncompleteChain => {
+            MustGetAgentActivityResponse::IncompleteChain
+        }
+        BoundedMustGetAgentActivityResponse::ChainTopNotFound(a) => {
+            MustGetAgentActivityResponse::ChainTopNotFound(a)
+        }
+        BoundedMustGetAgentActivityResponse::EmptyRange => MustGetAgentActivityResponse::EmptyRange,
     }
 }
 

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -987,17 +987,48 @@ where
         })
             .await??;
 
-        // For each response run the chain filter and check the invariants hold.
-        for response in results {
-            let result =
-                authority::get_agent_activity_query::must_get_agent_activity::filter_then_check(
-                    response,
-                )?;
+        let mut merged_results = (MustGetAgentActivityResponse::EmptyRange, None);
 
-            // Short circuit if we have a result.
-            if matches!(result, MustGetAgentActivityResponse::Activity(_)) {
-                return Ok(result);
+        for result in &results {
+            match (&merged_results, result) {
+                ((_, None), (_, Some(_))) => {
+                    merged_results = result.to_owned();
+                }
+                (
+                    (MustGetAgentActivityResponse::Activity(responses), chain_filter),
+                    (MustGetAgentActivityResponse::Activity(more_responses), other_chain_filter),
+                ) => {
+                    if chain_filter == other_chain_filter {
+                        let mut merged_responses = responses.clone();
+                        merged_responses.extend(more_responses.to_owned());
+                        let mut merged_activity =
+                            MustGetAgentActivityResponse::Activity(merged_responses);
+                        merged_activity.normalize();
+                        merged_results = (merged_activity, chain_filter.clone());
+                    }
+                    // If the chain filters disagree on what the filter is we
+                    // have a problem.
+                    else {
+                        merged_results = (MustGetAgentActivityResponse::IncompleteChain, None);
+                    }
+                }
+                ((MustGetAgentActivityResponse::Activity(_), _), _) => {
+                    // Noop.
+                }
+                _ => {
+                    merged_results = result.to_owned();
+                }
             }
+        }
+
+        let result =
+            authority::get_agent_activity_query::must_get_agent_activity::filter_then_check(
+                merged_results,
+            )?;
+
+        // Short circuit if we have a result.
+        if matches!(result, MustGetAgentActivityResponse::Activity(_)) {
+            return Ok(result);
         }
 
         // If we are the authority then don't go to the network.

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -954,6 +954,7 @@ where
         Ok(links.len())
     }
 
+    /// Merges two agent activity responses, along with their chain filters.
     fn merge_agent_activity_responses(
         acc: (MustGetAgentActivityResponse, Option<ChainFilterRange>),
         next: &(MustGetAgentActivityResponse, Option<ChainFilterRange>),

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -954,6 +954,35 @@ where
         Ok(links.len())
     }
 
+    fn merge_agent_activity_responses(
+        acc: (MustGetAgentActivityResponse, Option<ChainFilterRange>),
+        next: &(MustGetAgentActivityResponse, Option<ChainFilterRange>),
+    ) -> (MustGetAgentActivityResponse, Option<ChainFilterRange>) {
+        match (&acc, next) {
+            ((_, None), (_, Some(_))) => next.clone(),
+            (
+                (MustGetAgentActivityResponse::Activity(responses), chain_filter),
+                (MustGetAgentActivityResponse::Activity(more_responses), other_chain_filter),
+            ) => {
+                if chain_filter == other_chain_filter {
+                    let mut merged_responses = responses.clone();
+                    merged_responses.extend(more_responses.to_owned());
+                    let mut merged_activity =
+                        MustGetAgentActivityResponse::Activity(merged_responses);
+                    merged_activity.normalize();
+                    (merged_activity, chain_filter.clone())
+                }
+                // If the chain filters disagree on what the filter is we
+                // have a problem.
+                else {
+                    (MustGetAgentActivityResponse::IncompleteChain, None)
+                }
+            }
+            ((MustGetAgentActivityResponse::Activity(_), _), _) => acc,
+            _ => next.clone(),
+        }
+    }
+
     /// Request a hash bounded chain query.
     pub async fn must_get_agent_activity(
         &self,
@@ -987,39 +1016,10 @@ where
         })
             .await??;
 
-        let mut merged_results = (MustGetAgentActivityResponse::EmptyRange, None);
-
-        for result in &results {
-            match (&merged_results, result) {
-                ((_, None), (_, Some(_))) => {
-                    merged_results = result.to_owned();
-                }
-                (
-                    (MustGetAgentActivityResponse::Activity(responses), chain_filter),
-                    (MustGetAgentActivityResponse::Activity(more_responses), other_chain_filter),
-                ) => {
-                    if chain_filter == other_chain_filter {
-                        let mut merged_responses = responses.clone();
-                        merged_responses.extend(more_responses.to_owned());
-                        let mut merged_activity =
-                            MustGetAgentActivityResponse::Activity(merged_responses);
-                        merged_activity.normalize();
-                        merged_results = (merged_activity, chain_filter.clone());
-                    }
-                    // If the chain filters disagree on what the filter is we
-                    // have a problem.
-                    else {
-                        merged_results = (MustGetAgentActivityResponse::IncompleteChain, None);
-                    }
-                }
-                ((MustGetAgentActivityResponse::Activity(_), _), _) => {
-                    // Noop.
-                }
-                _ => {
-                    merged_results = result.to_owned();
-                }
-            }
-        }
+        let merged_results = results.iter().fold(
+            (MustGetAgentActivityResponse::EmptyRange, None),
+            Self::merge_agent_activity_responses,
+        );
 
         let result =
             authority::get_agent_activity_query::must_get_agent_activity::filter_then_check(

--- a/crates/holochain_types/src/chain.rs
+++ b/crates/holochain_types/src/chain.rs
@@ -175,6 +175,20 @@ pub enum MustGetAgentActivityResponse {
     EmptyRange,
 }
 
+impl MustGetAgentActivityResponse {
+    /// Sort by the chain seq.
+    /// Dedupe by action hash.
+    pub fn normalize(&mut self) {
+        match self {
+            Self::Activity(activity) => {
+                activity.sort_unstable_by_key(|a| a.action.action().action_seq());
+                activity.dedup_by_key(|a| a.action.as_hash().clone());
+            }
+            _ => (),
+        }
+    }
+}
+
 impl<I: AsRef<A>, A: ChainItem> ChainFilterIter<I, A> {
     /// Create an iterator that filters an iterator of actions
     /// with a [`ChainFilter`].

--- a/crates/holochain_types/src/chain.rs
+++ b/crates/holochain_types/src/chain.rs
@@ -175,12 +175,27 @@ pub enum MustGetAgentActivityResponse {
     EmptyRange,
 }
 
-impl MustGetAgentActivityResponse {
+/// Identical structure to [`MustGetAgentActivityResponse`] except it includes
+/// the [`ChainFilterRange`] that was used to produce the response. Doesn't need
+/// to be serialized because it is only used internally.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BoundedMustGetAgentActivityResponse {
+    /// The activity was found.
+    Activity(Vec<RegisterAgentActivity>, ChainFilterRange),
+    /// The requested chain range was incomplete.
+    IncompleteChain,
+    /// The requested chain top was not found in the chain.
+    ChainTopNotFound(ActionHash),
+    /// The filter produces an empty range.
+    EmptyRange,
+}
+
+impl BoundedMustGetAgentActivityResponse {
     /// Sort by the chain seq.
     /// Dedupe by action hash.
     pub fn normalize(&mut self) {
         match self {
-            Self::Activity(activity) => {
+            Self::Activity(activity, _) => {
                 activity.sort_unstable_by_key(|a| a.action.action().action_seq());
                 activity.dedup_by_key(|a| a.action.as_hash().clone());
             }

--- a/crates/holochain_types/src/chain.rs
+++ b/crates/holochain_types/src/chain.rs
@@ -194,12 +194,9 @@ impl BoundedMustGetAgentActivityResponse {
     /// Sort by the chain seq.
     /// Dedupe by action hash.
     pub fn normalize(&mut self) {
-        match self {
-            Self::Activity(activity, _) => {
-                activity.sort_unstable_by_key(|a| a.action.action().action_seq());
-                activity.dedup_by_key(|a| a.action.as_hash().clone());
-            }
-            _ => (),
+        if let Self::Activity(activity, _) = self {
+            activity.sort_unstable_by_key(|a| a.action.action().action_seq());
+            activity.dedup_by_key(|a| a.action.as_hash().clone());
         }
     }
 }

--- a/crates/test_utils/wasm/wasm_workspace/must_get/src/coordinator.rs
+++ b/crates/test_utils/wasm/wasm_workspace/must_get/src/coordinator.rs
@@ -3,6 +3,7 @@ use hdk::prelude::*;
 use crate::integrity::AgentsChain;
 use crate::integrity::AgentsChainRec;
 use crate::integrity::SelfAgentsChain;
+use crate::integrity::SelfPrevAgentsChain;
 use crate::integrity::EntryTypes;
 use crate::integrity::Something;
 
@@ -53,5 +54,11 @@ fn commit_require_agents_chain_recursive(
 #[hdk_extern]
 fn commit_require_self_agents_chain(_: ()) -> ExternResult<()> {
     create_entry(EntryTypes::SelfAgentsChain(SelfAgentsChain))?;
+    Ok(())
+}
+
+#[hdk_extern]
+fn commit_require_self_prev_agents_chain(_: ()) -> ExternResult<()> {
+    create_entry(EntryTypes::SelfPrevAgentsChain(SelfPrevAgentsChain))?;
     Ok(())
 }

--- a/crates/test_utils/wasm/wasm_workspace/must_get/src/coordinator.rs
+++ b/crates/test_utils/wasm/wasm_workspace/must_get/src/coordinator.rs
@@ -2,6 +2,7 @@ use hdk::prelude::*;
 
 use crate::integrity::AgentsChain;
 use crate::integrity::AgentsChainRec;
+use crate::integrity::SelfAgentsChain;
 use crate::integrity::EntryTypes;
 use crate::integrity::Something;
 
@@ -47,4 +48,10 @@ fn commit_require_agents_chain_recursive(
     create_entry(EntryTypes::AgentsChainRec(AgentsChainRec(
         author, chain_top,
     )))
+}
+
+#[hdk_extern]
+fn commit_require_self_agents_chain(_: ()) -> ExternResult<()> {
+    create_entry(EntryTypes::SelfAgentsChain(SelfAgentsChain))?;
+    Ok(())
 }

--- a/crates/test_utils/wasm/wasm_workspace/must_get/src/coordinator.rs
+++ b/crates/test_utils/wasm/wasm_workspace/must_get/src/coordinator.rs
@@ -62,3 +62,8 @@ fn commit_require_self_prev_agents_chain(_: ()) -> ExternResult<()> {
     create_entry(EntryTypes::SelfPrevAgentsChain(SelfPrevAgentsChain))?;
     Ok(())
 }
+
+#[hdk_extern]
+fn noop(_: ()) -> ExternResult<()> {
+    Ok(())
+}

--- a/crates/test_utils/wasm/wasm_workspace/must_get/src/integrity.rs
+++ b/crates/test_utils/wasm/wasm_workspace/must_get/src/integrity.rs
@@ -11,18 +11,34 @@ pub struct AgentsChain(pub AgentPubKey, pub ChainFilter);
 #[hdk_entry_helper]
 pub struct AgentsChainRec(pub AgentPubKey, pub ActionHash);
 
+#[hdk_entry_helper]
+pub struct SelfAgentsChain;
+
 #[hdk_entry_defs]
 #[unit_enum(EntryTypesUnit)]
 pub enum EntryTypes {
     Something(Something),
     AgentsChain(AgentsChain),
     AgentsChainRec(AgentsChainRec),
+    /// The entry being validated must be found in the author's chain as it is
+    /// being validated.
+    SelfAgentsChain(SelfAgentsChain),
 }
 
 #[hdk_extern]
 fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
     match op.flattened::<_, ()>()? {
         FlatOp::StoreEntry(e) => match e {
+            OpEntry::CreateEntry {
+                app_entry: EntryTypes::SelfAgentsChain(_),
+                action
+            } => {
+                let _agent_activity = must_get_agent_activity(
+                    action.author.to_owned(),
+                    ChainFilter::new(hash_action(action.to_owned().into())?),
+                )?;
+                return Ok(ValidateCallbackResult::Valid);
+            }
             OpEntry::CreateEntry {
                 app_entry: EntryTypes::AgentsChain(AgentsChain(author, filter)),
                 ..

--- a/crates/test_utils/wasm/wasm_workspace/must_get/src/integrity.rs
+++ b/crates/test_utils/wasm/wasm_workspace/must_get/src/integrity.rs
@@ -14,6 +14,9 @@ pub struct AgentsChainRec(pub AgentPubKey, pub ActionHash);
 #[hdk_entry_helper]
 pub struct SelfAgentsChain;
 
+#[hdk_entry_helper]
+pub struct SelfPrevAgentsChain;
+
 #[hdk_entry_defs]
 #[unit_enum(EntryTypesUnit)]
 pub enum EntryTypes {
@@ -23,6 +26,7 @@ pub enum EntryTypes {
     /// The entry being validated must be found in the author's chain as it is
     /// being validated.
     SelfAgentsChain(SelfAgentsChain),
+    SelfPrevAgentsChain(SelfPrevAgentsChain),
 }
 
 #[hdk_extern]
@@ -36,6 +40,16 @@ fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
                 let _agent_activity = must_get_agent_activity(
                     action.author.to_owned(),
                     ChainFilter::new(hash_action(action.to_owned().into())?),
+                )?;
+                return Ok(ValidateCallbackResult::Valid);
+            }
+            OpEntry::CreateEntry {
+                app_entry: EntryTypes::SelfPrevAgentsChain(_),
+                action
+            } => {
+                let _agent_activity = must_get_agent_activity(
+                    action.author.to_owned(),
+                    ChainFilter::new(action.prev_action.to_owned()),
                 )?;
                 return Ok(ValidateCallbackResult::Valid);
             }


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
