### PR TITLE
feat(github/worflows/test-holonix-setup): use `nix develop` for cache test

### DIFF
--- a/.github/workflows/test-holonix-setup.yml
+++ b/.github/workflows/test-holonix-setup.yml
@@ -68,7 +68,7 @@ jobs:
           
           # TODO replace with nix-cache-check
           function do_nix_build {
-            nix build -L --refresh -j0 \
+            nix develop --build -L --refresh -j0 \
               --override-input versions "github:holochain/holochain?dir=versions/0_1" \
               github:holochain/holochain#devShells.${nix_system}.holonix
           }


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
