### PR TITLE
feat(github/workflows/holonix-cache): also nix build

### DIFF
--- a/.github/workflows/holonix-cache.yml
+++ b/.github/workflows/holonix-cache.yml
@@ -57,7 +57,7 @@ jobs:
             ${{ format(matrix.target, matrix.platform) }}
 
           # Don't exit if this fails so we can clean up the profile
-          for i in result*; do
+          for i in result-*; do
             cachix push holochain-ci $i || true
           done
 

--- a/.github/workflows/holonix-cache.yml
+++ b/.github/workflows/holonix-cache.yml
@@ -48,7 +48,11 @@ jobs:
           target=${{ matrix.target }}
 
           # See https://docs.cachix.org/pushing#id1
-          nix develop --build -L --profile result \
+          nix develop --build -L --profile result-develop \
+            ${{ matrix.extra_args }} \
+            ${{ format(matrix.target, matrix.platform) }}
+
+          nix build -L --profile result-build \
             ${{ matrix.extra_args }} \
             ${{ format(matrix.target, matrix.platform) }}
 


### PR DESCRIPTION
### Summary
the CI checks on the setup.sh shows failures, and [changing it to `nix develop`](https://github.com/holochain/holochain/pull/2921) is not a solution.

there were also failures on the automatic caching checks leading me to believe there is a systematic issue [failed example run](https://github.com/holochain/holochain/actions/runs/6438061002).

a [triggered run of the caching workflow](https://github.com/holochain/holochain/actions/runs/6460320433) shows that this PR is a potential solution.

https://github.com/holochain/holochain/commit/530e44968de908b817fa76d99f905521ffda7cab is a contender for the breaking change but i'm not confident if and why.


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
