### PR TITLE
Ignore flaky `valid_chain_fact_test`

### DIFF
--- a/crates/holochain/src/core/sys_validate/tests.rs
+++ b/crates/holochain/src/core/sys_validate/tests.rs
@@ -982,6 +982,11 @@ async fn test_dpki_agent_update() {
 /// Test that the valid_chain contrafact matches our chain validation function,
 /// since many other tests will depend on this constraint
 #[tokio::test(flavor = "multi_thread")]
+// XXX: the valid_arbitrary_chain as used here can't handle actions with
+// sys validation dependencies, so we filter out those action types.
+// Also, there are several other problems here that need to be addressed
+// to make this not flaky.
+#[ignore = "flaky"]
 async fn valid_chain_fact_test() {
     let n = 100;
     let keystore = SweetConductor::from_standard_config().await.keystore();

--- a/crates/holochain_state/src/mutations.rs
+++ b/crates/holochain_state/src/mutations.rs
@@ -33,7 +33,6 @@ mod error;
 #[derive(Debug)]
 pub enum Dependency {
     Action(ActionHash),
-    Entry(AnyDhtHash),
     Null,
 }
 
@@ -417,11 +416,6 @@ pub fn set_dependency(
 ) -> StateMutationResult<()> {
     match dependency {
         Dependency::Action(dep) => {
-            dht_op_update!(txn, hash, {
-                "dependency": dep,
-            })?;
-        }
-        Dependency::Entry(dep) => {
             dht_op_update!(txn, hash, {
                 "dependency": dep,
             })?;


### PR DESCRIPTION
### Summary

I attempted to fix the test by whacking one mole, but there are still at least a few other moles to whack, having to do with ensuring the correct sys validation deps are present.

The effect of ignoring this test rather than fixing the problem is that any other tests which use this contrafact may run into false negatives. The only other test using this in CI doesn't care about the validity of the chain, so it will be unaffected.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
