### PR TITLE
Stop publishing when enough validation receipts have been received

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix an issue where enough validation receipts being received would not prevent the publish workflow from continuing to run. This was a terrible waste of data and compute and would build up over time as Holochain is used. [2931](https://github.com/holochain/holochain/pull/2931)
 - Improve log output for op publishing to accurately reflect the number of ops to be published. The number published which is logged later is accurate and it was confusing to see more ops published than were supposed to be. [2922](https://github.com/holochain/holochain/pull/2922)
 - Fix an issue which prevented the publish loop for a cell from suspending if there was either 1. publish activity pending for other cells or 2. enough validation receipts received. [2922](https://github.com/holochain/holochain/pull/2922)
 

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow/incoming_ops_batch.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow/incoming_ops_batch.rs
@@ -118,7 +118,7 @@ mod tests {
         let (mut batch_entry, first_recv) = batch.check_insert(false, vec![]);
         assert!(batch.is_running());
 
-        let handle = tokio::spawn({
+        tokio::spawn({
             let batch = batch.clone();
             async move {
                 while let Some(entry) = batch_entry {

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow/tests.rs
@@ -109,7 +109,7 @@ async fn republish_to_request_validation_receipt() {
     let space = TestSpace::new(fixt!(DnaHash));
     let env = space.space.dht_db.clone();
     let keystore = test_keystore();
-    let (sys_validation_trigger, mut sys_validation_rx) = TriggerSender::new();
+    let (sys_validation_trigger, _sys_validation_rx) = TriggerSender::new();
 
     let author = keystore.new_sign_keypair_random().await.unwrap();
 
@@ -120,7 +120,7 @@ async fn republish_to_request_validation_receipt() {
     let op = DhtOp::RegisterAgentActivity(signature, action);
     let hash = DhtOpHash::with_data_sync(&op);
 
-    let workflow_result = incoming_dht_ops_workflow(
+    incoming_dht_ops_workflow(
         space.space.clone(),
         sys_validation_trigger.clone(),
         vec![op.clone()],
@@ -135,7 +135,7 @@ async fn republish_to_request_validation_receipt() {
     clear_requires_receipt(env.clone(), vec![hash.clone()]).await;
 
     // Run the incoming workflow again with the same input
-    let workflow_result = incoming_dht_ops_workflow(
+    incoming_dht_ops_workflow(
         space.space.clone(),
         sys_validation_trigger.clone(),
         vec![op],

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -23,7 +23,7 @@ use std::time;
 use tracing::*;
 
 mod publish_query;
-pub use publish_query::get_ops_to_publish;
+pub use publish_query::{get_ops_to_publish, num_still_needing_publish};
 
 #[cfg(test)]
 mod unit_tests;

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow/unit_tests.rs
@@ -129,7 +129,7 @@ async fn retry_publish_until_receipts_received() {
 
     let network = Arc::new(network);
 
-    for i in 0..3 {
+    for _ in 0..3 {
         let work_complete =
             publish_dht_ops_workflow(vault.clone(), network.clone(), tx.clone(), agent.clone())
                 .await
@@ -182,7 +182,7 @@ async fn loop_resumes_on_new_data() {
     assert!(rx.is_paused()); // No work to do, so it should pause
 
     // Now create an op and try to publish again
-    let op_hash = create_op(vault.clone(), agent.clone()).await.unwrap();
+    create_op(vault.clone(), agent.clone()).await.unwrap();
 
     let work_complete = publish_dht_ops_workflow(vault, network, tx, agent.clone())
         .await
@@ -248,7 +248,6 @@ async fn create_op(
     let test_op_hash = op.as_hash().clone();
     vault
         .write_async({
-            let test_op_hash = test_op_hash.clone();
             move |txn| -> StateMutationResult<()> {
                 holochain_state::mutations::insert_op(txn, &op)?;
                 Ok(())

--- a/crates/holochain/tests/integration.rs
+++ b/crates/holochain/tests/integration.rs
@@ -6,6 +6,7 @@ mod integrity_zome;
 mod multi_conductor;
 mod network_tests;
 mod new_lair;
+mod publish;
 mod ser_regression;
 #[cfg(not(target_os = "macos"))]
 mod sharded_gossip;

--- a/crates/holochain/tests/publish/mod.rs
+++ b/crates/holochain/tests/publish/mod.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 /// Verifies that publishing terminates naturally when enough validation receipts are received.
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn publish_termination() {
     let _g = holochain_trace::test_run().unwrap();
     const NUM_CONDUCTORS: usize = 6; // Need 5 peers to send validation receipts back

--- a/crates/holochain/tests/publish/mod.rs
+++ b/crates/holochain/tests/publish/mod.rs
@@ -1,0 +1,53 @@
+use holo_hash::ActionHash;
+use holochain::core::workflow::publish_dht_ops_workflow::get_ops_to_publish;
+use holochain::sweettest::{
+    consistency_60s, SweetConductorBatch, SweetConductorConfig, SweetDnaFile,
+};
+use holochain_wasm_test_utils::TestWasm;
+use std::time::Duration;
+
+/// Verifies that publishing terminates naturally when enough validation receipts are received.
+#[cfg(feature = "test_utils")]
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_termination() {
+    let _g = holochain_trace::test_run().unwrap();
+    const NUM_CONDUCTORS: usize = 6; // Need 5 peers to send validation receipts back
+
+    let mut conductors = SweetConductorBatch::from_config_rendezvous(
+        NUM_CONDUCTORS,
+        SweetConductorConfig::rendezvous(),
+    )
+    .await;
+
+    let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+
+    let apps = conductors.setup_app("app", &[dna_file]).await.unwrap();
+
+    let ((alice,), (bobbo,), (carol,), (danny,), (emma,), (fred,)) = apps.into_tuples();
+
+    let _: ActionHash = conductors[0]
+        .call(&alice.zome(TestWasm::Create), "create_entry", ())
+        .await;
+
+    // Wait until they all see the created entry, at that point validation receipts should be getting sent soon
+    consistency_60s([&alice, &bobbo, &carol, &danny, &emma, &fred]).await;
+
+    let ops_to_publish = tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            let ops_to_publish =
+                get_ops_to_publish(alice.agent_pubkey().clone(), alice.authored_db())
+                    .await
+                    .unwrap();
+
+            if ops_to_publish.is_empty() {
+                return ops_to_publish;
+            }
+
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+
+    assert!(ops_to_publish.is_empty());
+}


### PR DESCRIPTION
### Summary

Nice to make it up to the top level and see this working in a sweettest :) Actually feels like a bugfix now!

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
