### PR TITLE
build: optimize release profile for size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file conveniently consolidates all of the crates individual CHANGELOG.md fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # \[Unreleased\]
+- Optimize release build profile to minimize size
 
 ## Holonix
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,10 @@ overflow-checks = false
 incremental = false
 codegen-units = 16
 
+[profile.release]
+opt-level = "z"
+lto = true
+
 [patch.crates-io]
 # task-motel = { path = "../task-motel" }
 # proptest = { path = "/home/michael/gitfork/proptest/proptest" }


### PR DESCRIPTION
### Summary
Optimize builds to minimize size in the release profile.  On linux x86_64 this cuts the holochain binary in half.

It might make sense to put this in separate profile, maybe `release-optim` to avoid slowing down CI.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
