### PR TITLE
build: pin serde to 1.0.166 in all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,7 +3276,7 @@ dependencies = [
  "nanoid 0.3.0",
  "one_err",
  "parking_lot 0.10.2",
- "pretty_assertions 0.6.1",
+ "pretty_assertions 0.7.2",
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
@@ -6793,9 +6793,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "d01b7404f9d441d3ad40e6a636a7782c377d2abdbe4fa2440e2edcc2f4f10db8"
 dependencies = [
  "serde_derive",
 ]
@@ -6830,9 +6830,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "5dd83d6dde2b6b2d466e14d9d1acce8816dedee94f735eac6395808b3483c6d6"
 dependencies = [
  "proc-macro2 1.0.67",
  "quote 1.0.33",

--- a/crates/fixt/Cargo.toml
+++ b/crates/fixt/Cargo.toml
@@ -17,7 +17,7 @@ parking_lot = "0.10"
 paste = "1.0.12"
 rand = "0.8.5"
 rand_core = "0.6"
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">=1.0, <=1.0.166", features = [ "derive" ] }
 strum = "0.18.0"
 strum_macros = "0.18.0"
 

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -27,7 +27,7 @@ holochain_util = { path = "../holochain_util", features = ["backtrace"], version
 holochain_serialized_bytes = "=0.0.53"
 holochain_types = { version = "^0.3.0-beta-dev.18", path = "../holochain_types" }
 mr_bundle = {version = "^0.3.0-beta-dev.2", path = "../mr_bundle"}
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">=1.0, <=1.0.166", features = [ "derive" ] }
 serde_bytes = "0.11"
 serde_yaml = "0.9"
 thiserror = "1.0.22"

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -29,7 +29,7 @@ kitsune_p2p_types = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/typ
 nanoid = "0.3"
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../holochain_trace" }
 once_cell = "1.13.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = ">=1.0, <=1.0.166", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
 sodoken = "=0.0.9"

--- a/crates/hdi/Cargo.toml
+++ b/crates/hdi/Cargo.toml
@@ -18,7 +18,7 @@ holochain_wasmer_guest = "=0.0.85"
 # features, both here AND in hdk_derive, to reduce code bloat
 holochain_integrity_types = { version = "^0.3.0-beta-dev.13", path = "../holochain_integrity_types", default-features = false }
 paste = "1.0"
-serde = "1.0"
+serde = ">=1.0, <=1.0.166"
 serde_bytes = "0.11"
 # thiserror = "1.0.22"
 tracing = { version = "0.1", optional = true }

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -19,7 +19,7 @@ holochain_wasmer_guest = "=0.0.85"
 # features, both here AND in hdk_derive, to reduce code bloat
 holochain_zome_types = { version = "^0.3.0-beta-dev.14", path = "../holochain_zome_types", default-features = false }
 paste = "1.0"
-serde = "1.0"
+serde = ">=1.0, <=1.0.166"
 serde_bytes = "0.11"
 thiserror = "1.0.22"
 tracing = "0.1"

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -64,7 +64,7 @@ rand_chacha = "0.3.1"
 rand-utf8 = "0.0.1"
 rpassword = "5.0.1"
 rusqlite = { version = "0.29" }
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">=1.0, <=1.0.166", features = [ "derive" ] }
 serde_bytes = "0.11.12"
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 serde_yaml = "0.9"
@@ -139,7 +139,7 @@ tokio-tungstenite = "0.13"
 
 [build-dependencies]
 hdk = { version = "^0.3.0-beta-dev.17", path = "../hdk"}
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">=1.0, <=1.0.166", features = [ "derive" ] }
 serde_json = { version = "1.0.51" }
 toml = "0.5.6"
 chrono = { version = "0.4.6", features = [ "serde" ] }

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -28,7 +28,7 @@ holochain_util = { version = "^0.3.0-beta-dev.2", path = "../holochain_util" }
 holochain_zome_types = { version = "^0.3.0-beta-dev.14", path = "../holochain_zome_types" }
 holochain_nonce = {version = "^0.3.0-beta-dev.20", path = "../holochain_nonce"}
 kitsune_p2p = { version = "^0.3.0-beta-dev.18", path = "../kitsune_p2p/kitsune_p2p" }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = ">=1.0, <=1.0.166", features = ["derive"] }
 serde_derive = "1.0"
 tokio = { version = "1.27", features = ["full"] }
 thiserror = "1.0"

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -18,7 +18,7 @@ holochain_state_types = { version = "^0.3.0-beta-dev.20", path = "../holochain_s
 holochain_serialized_bytes = "=0.0.53"
 holochain_types = { version = "^0.3.0-beta-dev.18", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.3.0-beta-dev.14", path = "../holochain_zome_types" }
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">=1.0, <=1.0.166", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_yaml = "0.9"
 structopt = "0.3"

--- a/crates/holochain_integrity_types/Cargo.toml
+++ b/crates/holochain_integrity_types/Cargo.toml
@@ -15,7 +15,7 @@ holochain_serialized_bytes = "=0.0.53"
 holochain_util = { version = "^0.3.0-beta-dev.2", path = "../holochain_util", default-features = false }
 holochain_secure_primitive = { version = "^0.3.0-beta-dev.20", path = "../holochain_secure_primitive"}
 paste = "1.0"
-serde = { version = "1.0", features = ["derive", "rc"] }
+serde = { version = ">=1.0, <=1.0.166", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 
 # Just the bare minimum timestamp with no extra features.

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -23,7 +23,7 @@ must_future = "0.1.2"
 nanoid = "0.4.0"
 one_err = "0.0.8"
 parking_lot = "0.11"
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">=1.0, <=1.0.166", features = [ "derive" ] }
 serde_bytes = "0.11"
 sodoken = "=0.0.9"
 thiserror = "1.0.22"

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -27,7 +27,7 @@ holochain_nonce = {version = "^0.3.0-beta-dev.20", path = "../holochain_nonce"}
 mockall = "0.11.3"
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../holochain_trace" }
 rand = "0.8.5"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = ">=1.0, <=1.0.166", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 thiserror = "1.0.22"

--- a/crates/holochain_secure_primitive/Cargo.toml
+++ b/crates/holochain_secure_primitive/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">=1.0, <=1.0.166", features = [ "derive" ] }
 paste = "1.0"
 
 # TODO: Figure out if we can keep this dependency behind a feature flag,

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -35,7 +35,7 @@ r2d2 = "0.8"
 r2d2_sqlite = { version = "0.1", package = "r2d2_sqlite_neonphog" }
 rmp-serde = "0.15"
 scheduled-thread-pool = "0.2"
-serde = "1.0"
+serde = ">=1.0, <=1.0.166"
 serde_derive = "1.0"
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 shrinkwraprs = "0.3.0"

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -33,7 +33,7 @@ mockall = "0.11.3"
 one_err = "0.0.8"
 parking_lot = "0.10"
 shrinkwraprs = "0.3.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = ">=1.0, <=1.0.166", features = ["derive"] }
 serde_json = { version = "1.0.51", features = ["preserve_order"] }
 thiserror = "1.0.22"
 tokio = { version = "1.27", features = ["full"] }

--- a/crates/holochain_state_types/Cargo.toml
+++ b/crates/holochain_state_types/Cargo.toml
@@ -9,6 +9,6 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">=1.0, <=1.0.166", features = [ "derive" ] }
 holochain_integrity_types = { version = "^0.3.0-beta-dev.13", path = "../holochain_integrity_types", default-features = false }
 holo_hash = { version = "^0.3.0-beta-dev.10", path = "../holo_hash" }

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -47,7 +47,7 @@ parking_lot = "0.10"
 rand = "0.8.5"
 regex = "1.4"
 rusqlite = { version = "0.29" }
-serde = { version = "1.0", features = [ "derive", "rc" ] }
+serde = { version = ">=1.0, <=1.0.166", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -22,7 +22,7 @@ holochain_serialized_bytes = "=0.0.53"
 holochain_secure_primitive = { version = "^0.3.0-beta-dev.20", path = "../holochain_secure_primitive"}
 holochain_nonce = {version = "^0.3.0-beta-dev.20", path = "../holochain_nonce"}
 paste = "1.0.12"
-serde = { version = "1.0", features = [ "derive", "rc" ] }
+serde = { version = ">=1.0, <=1.0.166", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"
 serde_yaml = { version = "0.9", optional = true }
 subtle = "2"

--- a/crates/kitsune_p2p/block/Cargo.toml
+++ b/crates/kitsune_p2p/block/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.4", path = "../timestamp", features = ["now"] }
 kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.8", path = "../bin_data" }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = ">=1.0, <=1.0.166", features = ["derive"] }
 
 [features]
 sqlite-encrypted = [

--- a/crates/kitsune_p2p/dht/Cargo.toml
+++ b/crates/kitsune_p2p/dht/Cargo.toml
@@ -21,7 +21,7 @@ must_future = "0.1"
 num-traits = "0.2.14"
 once_cell = "1.8"
 rand = "0.8.4"
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">=1.0, <=1.0.166", features = [ "derive" ] }
 statrs = "0.16.0"
 thiserror = "1.0"
 tracing = "0.1.29"

--- a/crates/kitsune_p2p/fetch/Cargo.toml
+++ b/crates/kitsune_p2p/fetch/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 derive_more = "0.99"
 kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.4", path = "../timestamp"}
 kitsune_p2p_types = { version = "^0.3.0-beta-dev.11", path = "../types" }
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">=1.0, <=1.0.166", features = [ "derive" ] }
 tokio = { version = "1.27", features = [ "full" ] }
 tracing = "0.1.29"
 linked-hash-map = "0.5.6"

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -37,7 +37,7 @@ once_cell = "1.4.1"
 opentelemetry_api = { version = "=0.20.0-beta.1", features = [ "metrics" ], package = "ts_opentelemetry_api" }
 parking_lot = "0.12.1"
 rand = "0.8.5"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = ">=1.0, <=1.0.166", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 thiserror = "1.0.22"

--- a/crates/kitsune_p2p/timestamp/Cargo.toml
+++ b/crates/kitsune_p2p/timestamp/Cargo.toml
@@ -11,7 +11,7 @@ categories = [ "network-programming" ]
 edition = "2021"
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = ">=1.0, <=1.0.166", features = ["derive"] }
 
 # Dependencies not needed for integrity.
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"], optional = true }

--- a/crates/mr_bundle/Cargo.toml
+++ b/crates/mr_bundle/Cargo.toml
@@ -17,7 +17,7 @@ holochain_util = { path = "../holochain_util", version = "^0.3.0-beta-dev.2"}
 futures = "0.3"
 reqwest = "0.11"
 rmp-serde = "0.15"
-serde = { version = "1.0", features = ["serde_derive", "derive"] }
+serde = { version = ">=1.0, <=1.0.166", features = ["serde_derive", "derive"] }
 serde_bytes = "0.11"
 serde_derive = "1.0"
 thiserror = "1.0"

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.toml
@@ -56,7 +56,7 @@ members = [
 opt-level = "z"
 
 [workspace.dependencies]
-serde = "1.0"
+serde = ">=1.0, <=1.0.166"
 hdi = { path = "../../../hdi" }
 hdk = { path = "../../../hdk" }
 

--- a/crates/test_utils/wasm_common/Cargo.toml
+++ b/crates/test_utils/wasm_common/Cargo.toml
@@ -14,4 +14,4 @@ path = "src/lib.rs"
 
 [dependencies]
 hdk = { path = "../../hdk", version = "^0.3.0-beta-dev.17"}
-serde = "1.0"
+serde = ">=1.0, <=1.0.166"


### PR DESCRIPTION
### Summary

When installing hc directly from cargo via `cargo install holochain_cli`, it pulls in serde v1.0.189. This results in serialization errors when making hc sandbox calls.

When building directly from within the holochain workspace, serde is pinned to 1.0.166 as expected.

This PR pins serde to `version = ">=1.0, <=1.0.166"` for all crates. Not sure if you want to take this approach, or only pin it for the dependencies of holochain_cli.

Also not sure if you want to keep this syntax of pinning to a version range, or just explicitly specify `version = "=1.0.166"`, I'm just copying how it was pinned in hdi and hdk.

Also not sure if you want to make the breaking serde version bump in 0.3.x and just keep this for 0.2.x.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
