### PR TITLE
build: pin serde to <=1.0.166 in all crates

### DIFF
--- a/crates/fixt/Cargo.toml
+++ b/crates/fixt/Cargo.toml
@@ -17,7 +17,7 @@ parking_lot = "0.10"
 paste = "1.0.12"
 rand = "0.8.5"
 rand_core = "0.6"
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive" ] }
 strum = "0.18.0"
 strum_macros = "0.18.0"
 

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -27,7 +27,7 @@ holochain_util = { path = "../holochain_util", features = ["backtrace"], version
 holochain_serialized_bytes = "=0.0.51"
 holochain_types = { version = "^0.2.3-beta-rc.0", path = "../holochain_types" }
 mr_bundle = {version = "^0.2.2", path = "../mr_bundle"}
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive" ] }
 serde_bytes = "0.11"
 serde_yaml = "0.9"
 thiserror = "1.0.22"

--- a/crates/hc_demo_cli/Cargo.toml
+++ b/crates/hc_demo_cli/Cargo.toml
@@ -16,7 +16,7 @@ holochain_types = { path = "../holochain_types", version = "^0.2.3-beta-rc.0", o
 holochain_keystore = { path = "../holochain_keystore", version = "^0.2.3-beta-rc.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand-utf8 = { version = "0.0.1", optional = true }
-serde = { version = "1", optional = true }
+serde = { version = ">= 1.0, <= 1.0.166", optional = true }
 tokio = { version = "1.27", features = [ "full" ], optional = true }
 tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.16", optional = true }

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -28,7 +28,7 @@ holochain_util = { version = "^0.2.2", path = "../holochain_util", features = ["
 nanoid = "0.3"
 holochain_trace = { version = "^0.2.2", path = "../holochain_trace" }
 once_cell = "1.13.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = ">= 1.0, <= 1.0.166", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
 sodoken = "=0.0.9"

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -28,7 +28,7 @@ holochain_util = { version = "^0.2.2", path = "../holochain_util", default-featu
 must_future = { version = "0.1", optional = true }
 rand = { version = "0.8.5", optional = true }
 rusqlite = { version = "0.29", optional = true }
-serde = { version = "1", optional = true }
+serde = { version = ">= 1.0, <= 1.0.166", optional = true }
 serde_bytes = { version = "0.11", optional = true }
 tracing = { version = "0.1", optional = true }
 holochain_wasmer_common = { version = "=0.0.84", optional = true }

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -123,7 +123,7 @@ test-case = "1.2.1"
 
 [build-dependencies]
 hdk = { version = "^0.2.3-beta-rc.0", path = "../hdk"}
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive" ] }
 serde_json = { version = "1.0.51" }
 toml = "0.5.6"
 chrono = { version = "0.4.6", features = [ "serde" ] }

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -27,7 +27,7 @@ holochain_trace = { version = "^0.2.2", path = "../holochain_trace" }
 holochain_util = { version = "^0.2.2", path = "../holochain_util" }
 holochain_zome_types = { version = "^0.2.3-beta-rc.0", path = "../holochain_zome_types" }
 kitsune_p2p = { version = "^0.2.3-beta-rc.0", path = "../kitsune_p2p/kitsune_p2p" }
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive" ] }
 serde_derive = "1.0"
 tokio = { version = "1.27", features = ["full"] }
 thiserror = "1.0"

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -18,7 +18,7 @@ holochain_state = { version = "^0.2.3-beta-rc.0", path = "../holochain_state" }
 holochain_serialized_bytes = "=0.0.51"
 holochain_types = { version = "^0.2.3-beta-rc.0", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.2.3-beta-rc.0", path = "../holochain_zome_types" }
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_yaml = "0.9"
 structopt = "0.3"

--- a/crates/holochain_integrity_types/Cargo.toml
+++ b/crates/holochain_integrity_types/Cargo.toml
@@ -14,7 +14,7 @@ holo_hash = { version = "^0.2.3-beta-rc.0", path = "../holo_hash" }
 holochain_serialized_bytes = "=0.0.51"
 holochain_util = { version = "^0.2.2", path = "../holochain_util", default-features = false }
 paste = "1.0"
-serde = { version = "1.0", features = ["derive", "rc"] }
+serde = { version = ">= 1.0, <= 1.0.166", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 kitsune_p2p_dht = { version = "^0.2.3-beta-rc.0", path = "../kitsune_p2p/dht" }
 

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -22,7 +22,7 @@ must_future = "0.1.2"
 nanoid = "0.4.0"
 one_err = "0.0.8"
 parking_lot = "0.11"
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive" ] }
 serde_bytes = "0.11"
 sodoken = "=0.0.9"
 thiserror = "1.0.22"

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -26,7 +26,7 @@ kitsune_p2p_types = { version = "^0.2.3-beta-rc.0", path = "../kitsune_p2p/types
 mockall = "0.11.3"
 holochain_trace = { version = "^0.2.2", path = "../holochain_trace" }
 rand = "0.8.5"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = ">= 1.0, <= 1.0.166", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 thiserror = "1.0.22"

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -41,7 +41,7 @@ r2d2 = "0.8"
 r2d2_sqlite = { version = "0.1", package = "r2d2_sqlite_neonphog" }
 rmp-serde = "0.15"
 scheduled-thread-pool = "0.2"
-serde = "1.0"
+serde = ">= 1.0, <= 1.0.166"
 serde_derive = "1.0"
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 shrinkwraprs = "0.3.0"

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -31,7 +31,7 @@ mockall = "0.11.3"
 one_err = "0.0.8"
 parking_lot = "0.10"
 shrinkwraprs = "0.3.0"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = ">= 1.0, <= 1.0.166", features = ["derive"] }
 serde_json = { version = "1.0.51", features = ["preserve_order"] }
 thiserror = "1.0.22"
 tokio = { version = "1.27", features = ["full"] }

--- a/crates/holochain_trace/Cargo.toml
+++ b/crates/holochain_trace/Cargo.toml
@@ -29,7 +29,7 @@ tracing-subscriber = { version = "0.3.16", features = [ "env-filter", "time", "j
 # opentelemetry = { version = "0.8", default-features = false, features = ["trace", "serialize"], optional = true }
 # tracing-opentelemetry = { version = "0.8.0", optional = true }
 holochain_serialized_bytes = {version = "0.0", optional = true }
-serde = { version = "1", optional = true }
+serde = { version = ">= 1.0, <= 1.0.166", optional = true }
 serde_bytes = { version = "0.11", optional = true }
 tokio = { version = "1.27", features = [ "sync" ], optional = true }
 shrinkwraprs = { version = "0.3.0", optional = true }

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -46,7 +46,7 @@ parking_lot = "0.10"
 rand = "0.8.5"
 regex = "1.4"
 rusqlite = { version = "0.29" }
-serde = { version = "1.0", features = [ "derive", "rc" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -15,7 +15,7 @@ holochain_serialized_bytes = "=0.0.51"
 nanoid = "0.3"
 net2 = "0.2"
 must_future = "0.1"
-serde = { version = "1", features = [ "derive" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive" ] }
 serde_bytes = "0.11"
 stream-cancel = "0.8.0"
 thiserror = "1.0.22"

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -20,7 +20,7 @@ holo_hash = { version = "^0.2.3-beta-rc.0", path = "../holo_hash", features = ["
 holochain_integrity_types = { version = "^0.2.3-beta-rc.0", path = "../holochain_integrity_types", features = ["tracing"] }
 holochain_serialized_bytes = "=0.0.51"
 paste = "1.0.12"
-serde = { version = "1.0", features = [ "derive", "rc" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"
 serde_yaml = { version = "0.9", optional = true }
 subtle = "2"

--- a/crates/kitsune_p2p/bin_data/Cargo.toml
+++ b/crates/kitsune_p2p/bin_data/Cargo.toml
@@ -15,7 +15,7 @@ holochain_util = { version = "^0.2.2", path = "../../holochain_util", default-fe
 kitsune_p2p_dht_arc = { version = "^0.2.3-beta-rc.0", path = "../dht_arc" }
 shrinkwraprs = "0.3.0"
 derive_more = "0.99.7"
-serde = { version = "1", features = [ "derive", "rc" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive", "rc" ] }
 base64 = "0.13"
 serde_bytes = "0.11"
 arbitrary = { version = "1.0", features = ["derive"], optional = true}

--- a/crates/kitsune_p2p/block/Cargo.toml
+++ b/crates/kitsune_p2p/block/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 kitsune_p2p_timestamp = { version = "^0.2.3-beta-rc.0", path = "../timestamp", features = ["now"] }
 kitsune_p2p_bin_data = { version = "^0.2.3-beta-rc.0", path = "../bin_data" }
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = ">= 1.0, <= 1.0.166", features = ["derive"] }
 serde_bytes = "0.11"
 
 [features]

--- a/crates/kitsune_p2p/bootstrap/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap/Cargo.toml
@@ -20,7 +20,7 @@ once_cell = "1.7.2"
 parking_lot = "0.11"
 rand = "0.8.5"
 rmp-serde = "0.15"
-serde = { version = "1", features = [ "derive", "rc" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"
 serde_json = { version = "1", features = [ "preserve_order" ] }
 tokio = { version = "1", features = ["full"] }

--- a/crates/kitsune_p2p/dht/Cargo.toml
+++ b/crates/kitsune_p2p/dht/Cargo.toml
@@ -25,7 +25,7 @@ must_future = "0.1"
 num-traits = "0.2.14"
 once_cell = "1.8"
 rand = "0.8.4"
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive" ] }
 statrs = "0.15"
 thiserror = "1.0"
 tracing = "0.1.29"

--- a/crates/kitsune_p2p/fetch/Cargo.toml
+++ b/crates/kitsune_p2p/fetch/Cargo.toml
@@ -18,7 +18,7 @@ kitsune_p2p_types = { version = "^0.2.3-beta-rc.0", path = "../types" }
 kitsune_p2p_timestamp = { version = "^0.2.3-beta-rc.0", path = "../timestamp", features = ["now"]}
 must_future = "0.1"
 num-traits = "0.2.14"
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive" ] }
 serde_bytes = "0.11"
 thiserror = "1.0"
 tokio = { version = "1.27", features = [ "full" ] }

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -35,7 +35,7 @@ once_cell = "1.4.1"
 parking_lot = "0.11.1"
 rand = "0.8.5"
 reqwest = "0.11.2"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = ">= 1.0, <= 1.0.166", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = { version = "1.0.51", features = [ "preserve_order" ] }
 shrinkwraprs = "0.3.0"

--- a/crates/kitsune_p2p/proxy/Cargo.toml
+++ b/crates/kitsune_p2p/proxy/Cargo.toml
@@ -22,7 +22,7 @@ holochain_trace = { version = "^0.2.2", path = "../../holochain_trace" }
 parking_lot = "0.11"
 rmp-serde = "0.15"
 rustls = { version = "0.20.4", features = [ "dangerous_configuration" ] }
-serde = { version = "1", features = [ "derive" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive" ] }
 serde_bytes = "0.11"
 structopt = "0.3"
 tokio = { version = "1.27", features = [ "full" ] }

--- a/crates/kitsune_p2p/timestamp/Cargo.toml
+++ b/crates/kitsune_p2p/timestamp/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 derive_more = "0.99"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = ">= 1.0, <= 1.0.166", features = ["derive"] }
 
 # Dependencies not needed for integrity.
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"], optional = true }

--- a/crates/kitsune_p2p/transport_quic/Cargo.toml
+++ b/crates/kitsune_p2p/transport_quic/Cargo.toml
@@ -20,7 +20,7 @@ once_cell = "1.9.0"
 quinn = "0.8.1"
 rcgen = "0.9.2"
 rustls = { version = "0.20.4", features = [ "dangerous_configuration" ] }
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive" ] }
 tokio = { version = "1.27", features = [ "full" ] }
 webpki = "0.22.0"
 

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -29,7 +29,7 @@ parking_lot = "0.11"
 paste = "1.0.12"
 rmp-serde = "0.15"
 rustls = { version = "0.20.4", features = [ "dangerous_configuration" ] }
-serde = { version = "1", features = [ "derive", "rc" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"
 serde_json = { version = "1", features = [ "preserve_order" ] }
 shrinkwraprs = "0.3.0"

--- a/crates/mr_bundle/Cargo.toml
+++ b/crates/mr_bundle/Cargo.toml
@@ -17,7 +17,7 @@ holochain_util = { path = "../holochain_util", version = "^0.2.2"}
 futures = "0.3"
 reqwest = "0.11"
 rmp-serde = "0.15"
-serde = { version = "1.0", features = ["serde_derive", "derive"] }
+serde = { version = ">= 1.0, <= 1.0.166", features = ["serde_derive", "derive"] }
 serde_bytes = "0.11"
 serde_derive = "1.0"
 thiserror = "1.0"

--- a/crates/test_utils/wasm_common/Cargo.toml
+++ b/crates/test_utils/wasm_common/Cargo.toml
@@ -14,4 +14,4 @@ path = "src/lib.rs"
 
 [dependencies]
 hdk = { path = "../../hdk", version = "^0.2.3-beta-rc.0"}
-serde = "1.0"
+serde = ">= 1.0, <= 1.0.166"


### PR DESCRIPTION
### Summary
Same as #2946 but off develop-0.2


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
