### PR TITLE
augment network stats with holochain agent info correlation

### DIFF
--- a/crates/holochain/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/multi_conductor/mod.rs
@@ -77,9 +77,9 @@ async fn multi_conductor() -> anyhow::Result<()> {
     let _g = holochain_trace::test_run().ok();
     const NUM_CONDUCTORS: usize = 3;
 
-    let config = SweetConductorConfig::standard();
+    let config = SweetConductorConfig::rendezvous();
 
-    let mut conductors = SweetConductorBatch::from_config(NUM_CONDUCTORS, config).await;
+    let mut conductors = SweetConductorBatch::from_config_rendezvous(NUM_CONDUCTORS, config).await;
 
     let (dna_file, _, _) =
         SweetDnaFile::unique_from_inline_zomes(("simple", simple_create_read_zome())).await;
@@ -112,7 +112,11 @@ async fn multi_conductor() -> anyhow::Result<()> {
 
     // See if we can fetch metric data from bobbo
     let metrics = conductors[1].dump_network_metrics(None).await?;
-    println!("@!@! - metrics: {}", metrics);
+    println!("@!@! - metrics: {metrics}");
+
+    // See if we can fetch network stats from bobbo
+    let stats = conductors[1].dump_network_stats().await?;
+    println!("@!@! - stats: {stats}");
 
     Ok(())
 }

--- a/crates/holochain/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/multi_conductor/mod.rs
@@ -112,11 +112,11 @@ async fn multi_conductor() -> anyhow::Result<()> {
 
     // See if we can fetch metric data from bobbo
     let metrics = conductors[1].dump_network_metrics(None).await?;
-    println!("@!@! - metrics: {metrics}");
+    tracing::info!(target: "TEST", "@!@! - metrics: {metrics}");
 
     // See if we can fetch network stats from bobbo
     let stats = conductors[1].dump_network_stats().await?;
-    println!("@!@! - stats: {stats}");
+    tracing::info!(target: "TEST", "@!@! - stats: {stats}");
 
     Ok(())
 }

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Augment network stats with holochain agent info correlation [\#2953](https://github.com/holochain/holochain/pull/2953)
+
 ## 0.3.0-beta-dev.18
 
 ## 0.3.0-beta-dev.17

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -823,24 +823,14 @@ impl KitsuneP2pHandler for KitsuneP2pActor {
 
             let all_peers = futures::future::join_all(peer_fut_list).await;
 
-            let now_ms = std::time::SystemTime::UNIX_EPOCH
-                .elapsed()
-                .unwrap()
-                .as_millis() as f64;
-
             #[derive(serde::Serialize)]
             #[serde(rename_all = "camelCase")]
             struct Agent {
-                pub agent_pub_key: String,
-                pub dna_hash: String,
-                pub expires_in_seconds: f64,
+                pub expires_at_millis: u64,
             }
-
-            let mut correlation: HashMap<String, Vec<Agent>> = HashMap::new();
 
             for peer in all_peers {
                 for peer in peer? {
-                    use base64::Engine;
                     if let Some(net_key) = peer.url_list.get(0).map(|u| {
                         kitsune_p2p_proxy::ProxyUrl::from(u.as_url2())
                             .digest()
@@ -850,37 +840,45 @@ impl KitsuneP2pHandler for KitsuneP2pActor {
                             continue;
                         }
 
-                        let agent_pub_key = format!(
-                            "uhCAk{}",
-                            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&**peer.agent)
-                        );
+                        let r = stats
+                            .as_object_mut()
+                            .ok_or(KitsuneP2pError::from("InvalidStats"))?
+                            .entry(net_key)
+                            .or_insert_with(|| serde_json::json!({}));
+
+                        let r = r
+                            .as_object_mut()
+                            .ok_or(KitsuneP2pError::from("InvalidStats"))?
+                            .entry("hcDnaHashesToAgents".to_string())
+                            .or_insert_with(|| serde_json::json!({}));
+
+                        use base64::Engine;
+
                         let dna_hash = format!(
                             "uhC0k{}",
                             base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&**peer.space)
                         );
+
+                        let r = r
+                            .as_object_mut()
+                            .ok_or(KitsuneP2pError::from("InvalidStats"))?
+                            .entry(dna_hash)
+                            .or_insert_with(|| serde_json::json!({}));
+
+                        let agent_pub_key = format!(
+                            "uhCAk{}",
+                            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&**peer.agent)
+                        );
+
                         let agent = Agent {
-                            agent_pub_key,
-                            dna_hash,
-                            expires_in_seconds: (peer.expires_at_ms as f64 - now_ms) / 1000.0,
+                            expires_at_millis: peer.expires_at_ms,
                         };
 
-                        match correlation.entry(net_key) {
-                            Entry::Occupied(mut e) => {
-                                e.get_mut().push(agent);
-                            }
-                            Entry::Vacant(e) => {
-                                e.insert(vec![agent]);
-                            }
-                        }
+                        r.as_object_mut()
+                            .ok_or(KitsuneP2pError::from("InvalidStats"))?
+                            .insert(agent_pub_key, serde_json::json!(agent));
                     }
                 }
-            }
-
-            if let Some(obj) = stats.as_object_mut() {
-                obj.insert(
-                    "netToHcAgentCorrelation".to_string(),
-                    serde_json::json!(correlation),
-                );
             }
 
             Ok(stats)


### PR DESCRIPTION
### Summary

This info was already available via various api calls, but now you can easily correlate holochain agent infos with network statistics just by making a single dump_network_stats call. See the new `hcDnaHashesToAgents` key at the ends of the network key entries, and that in the second one there are no network stats in it because that connection is not currently open:

```
{
  "backend": "go-pion",
  "thisId": "v5ZbIIhGiqlVbxRUIRb145wW1pVSUYHfI0CcqW7M2Uw",
  "banned": {},
  "U5Ucs4UcEmfwccYDmpfRmLopN36rBRNtyeSYjN0JrSg": {
    "DataChannel-1697644690951131246": {
      "timestamp": 1697644692279,
      "type": "data-channel",
      "id": "DataChannel-1697644690951131246",
      "label": "data",
      "protocol": "",
      "dataChannelIdentifier": 1,
      "transportId": "",
      "state": "open",
      "messagesSent": 32,
      "bytesSent": 10531,
      "messagesReceived": 33,
      "bytesReceived": 11518
    },
    "PeerConnection-1697644690950227926": {
      "timestamp": 1697644692279,
      "type": "peer-connection",
      "id": "PeerConnection-1697644690950227926",
      "dataChannelsOpened": 1,
      "dataChannelsClosed": 0,
      "dataChannelsRequested": 1,
      "dataChannelsAccepted": 0
    },
    "iceTransport": {
      "timestamp": 1697644692279,
      "type": "transport",
      "id": "iceTransport",
      "packetsSent": 0,
      "packetsReceived": 0,
      "bytesSent": 14927,
      "bytesReceived": 15979,
      "rtcpTransportStatsId": "",
      "iceRole": "unknown",
      "dtlsState": "unknown",
      "selectedCandidatePairId": "",
      "localCertificateId": "",
      "remoteCertificateId": "",
      "dtlsCipher": "",
      "srtpCipher": ""
    },
    "sctpTransport": {
      "timestamp": 1697644692279,
      "type": "sctp-transport",
      "id": "sctpTransport",
      "transportId": "",
      "smoothedRoundTripTime": 0.03832115065089379,
      "congestionWindow": 4380,
      "receiverWindow": 1048181,
      "mtu": 1228,
      "unackData": 0,
      "bytesSent": 12188,
      "bytesReceived": 13168
    },
    "ageSeconds": 1.3302835210000001,
    "signalingTransport": {
      "offersSent": 1,
      "offerBytesSent": 480,
      "offersReceived": 1,
      "offerBytesReceived": 480,
      "answersSent": 0,
      "answerBytesSent": 0,
      "answersReceived": 1,
      "answerBytesReceived": 480,
      "iceMessagesSent": 15,
      "iceBytesSent": 2302,
      "iceMessagesReceived": 45,
      "iceBytesReceived": 6904
    },
    "hcDnaHashesToAgents": {
      "uhC0kf7sVNieD9HwZDfoTuRC6MS8daJ8ucB4JyiJ6sX8weHwn4e0j": {
        "uhCAkD7a6bGxe5Wsmry5nhj_y00fby1Mh9IW8fZKSWHq65GODd_vN": {
          "expiresAtMillis": 1697645890686
        }
      }
    }
  },
  "XMO7MZVsgfmzQmDJ1vJphDX1LeMKz27ch7I8wjgzvmQ": {
    "hcDnaHashesToAgents": {
      "uhC0kf7sVNieD9HwZDfoTuRC6MS8daJ8ucB4JyiJ6sX8weHwn4e0j": {
        "uhCAksMzn_IOfM0CG2uBmbscmDYO70lo_JhFEYfPqLGyrFMqscNT8": {
          "expiresAtMillis": 1697645890729
        }
      }
    }
  }
}
```

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
