### PR TITLE
Bump influxive, tx5 and opentelemetry_api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3034,8 +3034,8 @@ name = "holochain_metrics"
 version = "0.3.0-beta-dev.4"
 dependencies = [
  "influxive",
+ "opentelemetry_api",
  "tracing",
- "ts_opentelemetry_api",
 ]
 
 [[package]]
@@ -3299,7 +3299,7 @@ dependencies = [
  "nanoid 0.3.0",
  "one_err",
  "parking_lot 0.10.2",
- "pretty_assertions 0.6.1",
+ "pretty_assertions 0.7.2",
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
@@ -3752,9 +3752,9 @@ dependencies = [
 
 [[package]]
 name = "influxive"
-version = "0.0.1-alpha.11"
+version = "0.0.2-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e751ac3b2c3a7943237d176f43d051e81611ab60927ee0de778eef8eb8a9946"
+checksum = "b2e33972c836e620ade20e7c0c66062c60a90b222ed46f5f872f1a4721967191"
 dependencies = [
  "influxive-child-svc",
  "influxive-otel",
@@ -3763,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "influxive-child-svc"
-version = "0.0.1-alpha.11"
+version = "0.0.2-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304096e465620b1e8b8f126e385050d8a0071f20ad09d1dae240474fde52bb9"
+checksum = "0923b25ac29f6e2ac600b0d3762792c4cb86438c3f2c7daa1f6e65e66f7f0d4d"
 dependencies = [
  "hex-literal",
  "influxive-core",
@@ -3778,15 +3778,15 @@ dependencies = [
 
 [[package]]
 name = "influxive-core"
-version = "0.0.1-alpha.11"
+version = "0.0.2-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "361ab244896d34c02cdfb4fb90a0cf11d1db7e140f6d0f9eb872c335e3f7f602"
+checksum = "f5db78961ebb97b6d16ba61a65b38978a67cf7efaa91903c500b4771d1920d00"
 
 [[package]]
 name = "influxive-downloader"
-version = "0.0.1-alpha.11"
+version = "0.0.2-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2575384f9b4e5f94f316c69844f0a31e139694a530ffcc9cea6c98ce81627f"
+checksum = "264581af3b49d108e76382e301d4228f89a3995e373363b877bb42b1312ebba3"
 dependencies = [
  "base64 0.21.4",
  "digest 0.10.7",
@@ -3806,29 +3806,29 @@ dependencies = [
 
 [[package]]
 name = "influxive-otel"
-version = "0.0.1-alpha.11"
+version = "0.0.2-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a29ee9911b66e6f433734c900ed1d95b3cffeab1ea7dace3ecd3a3dd224e8be"
+checksum = "882f4ff61b099d34855841a6ea4d1890a1bd2aad2d07d8aaa63c99059d0f295c"
 dependencies = [
  "influxive-core",
+ "opentelemetry_api",
  "tokio",
- "ts_opentelemetry_api",
 ]
 
 [[package]]
 name = "influxive-otel-atomic-obs"
-version = "0.0.1-alpha.11"
+version = "0.0.2-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b07bcce79167d27b8b2d639cf026029506ed3dfa7bf7ee402c29cab03a7afd16"
+checksum = "1ac0ec101d28862a46c15d6140cec376b02725160dfcf57282952898a94cf35e"
 dependencies = [
- "ts_opentelemetry_api",
+ "opentelemetry_api",
 ]
 
 [[package]]
 name = "influxive-writer"
-version = "0.0.1-alpha.11"
+version = "0.0.2-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee73e5486492eafd6c50790545df7b73c81edf69b299f96183bdcb9371619951"
+checksum = "89db32ac1865b814d5f4109635226c1d89189852d88f9ae704c0b51d6d2a8f25"
 dependencies = [
  "influxdb",
  "influxive-core",
@@ -4040,6 +4040,7 @@ dependencies = [
  "nanoid 0.4.0",
  "num-traits",
  "once_cell",
+ "opentelemetry_api",
  "parking_lot 0.12.1",
  "pretty_assertions 1.4.0",
  "proptest",
@@ -4055,7 +4056,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
- "ts_opentelemetry_api",
  "tx5",
  "tx5-signal-srv",
  "url2",
@@ -5230,6 +5230,22 @@ dependencies = [
  "openssl-src",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "indexmap 1.9.3",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
 ]
 
 [[package]]
@@ -8119,22 +8135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ts_opentelemetry_api"
-version = "0.20.0-beta.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d186495330f646b5881aeb3b83bac75b8a462d7ef32fda06a2a68f3869d5ba82"
-dependencies = [
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror",
- "urlencoding",
-]
-
-[[package]]
 name = "tui"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8209,14 +8209,15 @@ dependencies = [
 
 [[package]]
 name = "tx5"
-version = "0.0.3-alpha"
+version = "0.0.4-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c20ea30df2cb7172c8410c51ae620cb61e8fb63c3f2b0e560646a81cbe6ac04d"
+checksum = "68891d49fb7fdb4f0aedfe8347cf3dc9b8e28ab99cf6b6da5b1ae90682cafa21"
 dependencies = [
  "bytes",
  "futures",
  "influxive-otel-atomic-obs",
  "once_cell",
+ "opentelemetry_api",
  "parking_lot 0.12.1",
  "rand 0.8.5",
  "rand-utf8",
@@ -8224,7 +8225,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
- "ts_opentelemetry_api",
  "tx5-core",
  "tx5-go-pion",
  "tx5-signal",
@@ -8233,9 +8233,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-core"
-version = "0.0.3-alpha"
+version = "0.0.4-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6c9332a03a5dec9bc20c227ca52d6918ad74472b37921252179f190dc5e312"
+checksum = "46ce4d742f95206169d6d68dc47f2064e594bd755b882740218eb2db078125df"
 dependencies = [
  "base64 0.13.1",
  "dirs 5.0.1",
@@ -8251,9 +8251,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion"
-version = "0.0.3-alpha"
+version = "0.0.4-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943dd802f81376a72a38a7eeaa7ee128bc221826495f0346b875358db2c53d56"
+checksum = "344f080c69c305c7d3075c077799b66de47568f79577704622d28c33ef3dfdd2"
 dependencies = [
  "futures",
  "parking_lot 0.12.1",
@@ -8265,9 +8265,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-sys"
-version = "0.0.3-alpha"
+version = "0.0.4-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f7f7a8f6dcf97e956cc8f899f01233b83e7a684b95a4ab9d501ec25596f6b7"
+checksum = "5aa8e91c1a85f6b9de962c63a7086619d78cf4f876a2a1888be715091bc4a1c2"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -8284,9 +8284,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-turn"
-version = "0.0.3-alpha"
+version = "0.0.4-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c585cb964f1bffba37ab1bfc4f372ede0c7906e2c92ce69231ecf2d8857613"
+checksum = "77a2ee4982985842265529632f96751020ecd109e6e249662037eef2cdf2a881"
 dependencies = [
  "base64 0.13.1",
  "dirs 5.0.1",
@@ -8302,9 +8302,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-signal"
-version = "0.0.3-alpha"
+version = "0.0.4-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ed634434030914bf893eb5d3c3f32b0c0516c9352ca14ccccbcc997178eb23"
+checksum = "c01b23ba903fc189bdbb38ec4726274f297b3b303c62daf029063478137a8af9"
 dependencies = [
  "futures",
  "lair_keystore_api",
@@ -8331,9 +8331,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-signal-srv"
-version = "0.0.3-alpha"
+version = "0.0.4-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "811e5205cef837d9aae13933a6b42677e193845d03ff708dbae29131b89e019e"
+checksum = "e1041cf202eb8789aaa4fc70acdae424ea3ad361e4031aa14dc30fcf0a246f69"
 dependencies = [
  "clap 4.4.6",
  "dirs 5.0.1",

--- a/crates/hc_run_local_services/Cargo.toml
+++ b/crates/hc_run_local_services/Cargo.toml
@@ -22,4 +22,4 @@ if-addrs = "0.10.1"
 kitsune_p2p_bootstrap = { version = "^0.2.0-beta-dev.11", path = "../kitsune_p2p/bootstrap" }
 tokio = { version = "1.27", features = ["full"] }
 tracing = "0.1"
-tx5-signal-srv = "=0.0.3-alpha"
+tx5-signal-srv = "=0.0.4-alpha"

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -100,8 +100,8 @@ matches = {version = "0.1.8", optional = true }
 holochain_test_wasm_common = { version = "^0.3.0-beta-dev.17", path = "../test_utils/wasm_common", optional = true  }
 kitsune_p2p_bootstrap = { version = "^0.2.0-beta-dev.11", path = "../kitsune_p2p/bootstrap", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
-tx5-go-pion-turn = { version = "=0.0.3-alpha", optional = true }
-tx5-signal-srv = { version = "=0.0.3-alpha", optional = true }
+tx5-go-pion-turn = { version = "=0.0.4-alpha", optional = true }
+tx5-signal-srv = { version = "=0.0.4-alpha", optional = true }
 
 # chc deps
 bytes = { version = "1", optional = true }

--- a/crates/holochain_metrics/Cargo.toml
+++ b/crates/holochain_metrics/Cargo.toml
@@ -9,8 +9,8 @@ documentation = "https://docs.rs/holochain_metrics"
 repository = "https://github.com/holochain/holochain"
 
 [dependencies]
-influxive = { version = "=0.0.1-alpha.11", optional = true }
-opentelemetry_api = { version = "=0.20.0-beta.1", features = [ "metrics" ], package = "ts_opentelemetry_api" }
+influxive = { version = "=0.0.2-alpha.1", optional = true }
+opentelemetry_api = { version = "=0.20.0", features = [ "metrics" ] }
 tracing = "0.1.37"
 
 [features]

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -34,7 +34,7 @@ nanoid = "0.4"
 num-traits = "0.2"
 holochain_trace = { version = "^0.3.0-beta-dev.1", path = "../../holochain_trace" }
 once_cell = "1.4.1"
-opentelemetry_api = { version = "=0.20.0-beta.1", features = [ "metrics" ], package = "ts_opentelemetry_api" }
+opentelemetry_api = { version = "=0.20.0", features = [ "metrics" ] }
 parking_lot = "0.12.1"
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
@@ -44,7 +44,7 @@ thiserror = "1.0.22"
 tokio = { version = "1.27", features = ["full"] }
 tracing = "0.1"
 tokio-stream = "0.1"
-tx5 = { version = "=0.0.3-alpha", optional = true }
+tx5 = { version = "=0.0.4-alpha", optional = true }
 url2 = "0.0.6"
 fixt = { path = "../../fixt", version = "^0.3.0-beta-dev.0"}
 
@@ -72,7 +72,7 @@ pretty_assertions = "1.4.0"
 test-case = "1.0.0"
 tokio = { version = "1.11", features = ["full", "test-util"] }
 tracing-subscriber = "0.3.16"
-tx5-signal-srv = "=0.0.3-alpha"
+tx5-signal-srv = "=0.0.4-alpha"
 ed25519-dalek = "1"
 rand_dalek = { version = "0.7", package = "rand" } # Compatibility with dalek
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net.rs
@@ -248,9 +248,7 @@ impl MetricSendGuard {
 
 impl Drop for MetricSendGuard {
     fn drop(&mut self) {
-        let cx = opentelemetry_api::Context::new();
         crate::metrics::METRIC_MSG_OUT_BYTE.record(
-            &cx,
             self.byte_count,
             &[
                 opentelemetry_api::KeyValue::new("remote_id", self.rem_id.to_string()),
@@ -258,7 +256,6 @@ impl Drop for MetricSendGuard {
             ],
         );
         crate::metrics::METRIC_MSG_OUT_TIME.record(
-            &cx,
             self.start_time.elapsed().as_secs_f64(),
             &[
                 opentelemetry_api::KeyValue::new("remote_id", self.rem_id.to_string()),


### PR DESCRIPTION
### Summary

Pulls in https://github.com/holochain/influxive/pull/10 and https://github.com/holochain/tx5/pull/64 then bumps the `opentelemetry_api` to match

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
