### PR TITLE
build: make sqlite-encrypted a default feature

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Make sqlite-encrypted a default feature
+
 - Sys validation will no longer check the integrity with the previous action for StoreRecord or StoreEntry ops. These 'store record' checks are now only done for RegisterAgentActivity ops which we are sent when we are responsible for validating an agents whole chain. This avoids fetching and caching ops that we don't actually need.
 
 ## 0.3.0-beta-dev.32

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -169,7 +169,7 @@ name = "holochain"
 path = "src/bin/holochain/main.rs"
 
 [features]
-default = ["slow_tests", "glacial_tests", "sqlite", "tx2", "tx5", "metrics_influxive"]
+default = ["slow_tests", "glacial_tests", "sqlite-encrypted", "tx2", "tx5", "metrics_influxive"]
 
 tx2 = [ "kitsune_p2p/tx2" ]
 tx5 = [ "kitsune_p2p/tx5", "tx5-go-pion-turn", "tx5-signal-srv" ]

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -125,7 +125,7 @@ sd-notify = "0.3.0"
 
 
 [dev-dependencies]
-holochain = { path = ".", features = ["test_utils"] }
+holochain = { path = ".", default-features = false, features = ["test_utils", "slow_tests", "glacial_tests", "sqlite", "tx2", "tx5", "metrics_influxive"] }
 
 anyhow = "1.0.26"
 assert_cmd = "1.0.1"
@@ -169,7 +169,7 @@ name = "holochain"
 path = "src/bin/holochain/main.rs"
 
 [features]
-default = ["slow_tests", "glacial_tests", "sqlite-encrypted", "tx2", "tx5", "metrics_influxive"]
+default = ["sqlite-encrypted", "tx2", "tx5", "metrics_influxive"]
 
 tx2 = [ "kitsune_p2p/tx2" ]
 tx5 = [ "kitsune_p2p/tx5", "tx5-go-pion-turn", "tx5-signal-srv" ]

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -125,7 +125,7 @@ sd-notify = "0.3.0"
 
 
 [dev-dependencies]
-holochain = { path = ".", default-features = false, features = ["test_utils", "slow_tests", "glacial_tests", "sqlite", "tx2", "tx5", "metrics_influxive"] }
+holochain = { path = ".", default-features = false, features = ["test_utils", "slow_tests", "glacial_tests", "tx2", "tx5", "metrics_influxive"] }
 
 anyhow = "1.0.26"
 assert_cmd = "1.0.1"

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -220,8 +220,6 @@ impl SweetConductor {
             config.data_root_path = Some(dir.as_ref().to_path_buf().into());
         }
 
-        tracing::info!(?config);
-
         let handle = Self::handle_from_existing(
             keystore.unwrap_or_else(holochain_keystore::test_keystore),
             &config,

--- a/crates/holochain_diagnostics/Cargo.toml
+++ b/crates/holochain_diagnostics/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 arbitrary = { version = "1.0" }
-holochain = { path = "../holochain", features = ["sweetest", "hdk"] }
+holochain = { path = "../holochain", default-features = false, features = ["sweetest", "hdk"] }
 kitsune_p2p = { path = "../kitsune_p2p/kitsune_p2p" }
 human-repr = "1"
 rand = "0.8"

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Provide a mechanism to automatically encrypt databases which are currently unencrypted. This is useful if you are switching from a Holochain built with the `sqlite` feature, to a Holochain built with `sqlite-encrypted`. In order to enable this mechanism you will need to set the environment variable `HOLOCHAIN_MIGRATE_UNENCRYPTED=true`. *DANGER*: If you switch your Holochain without this environment variable then on first startup it will recognise your cache, dht, peer and kitsune metrics databases will be recognised as corrupt and automatically wiped. These databases may be rebuilt, assuming that the same data is still available from other peers, but please consider making a backup before attempting to make the switch.
+
 ## 0.3.0-beta-dev.29
 
 ## 0.3.0-beta-dev.28

--- a/crates/holochain_sqlite/src/db/access.rs
+++ b/crates/holochain_sqlite/src/db/access.rs
@@ -431,6 +431,7 @@ impl<Kind: DbKindT + Send + Sync + 'static> DbWrite<Kind> {
     }
 }
 
+// The method for this function is taken from https://discuss.zetetic.net/t/how-to-encrypt-a-plaintext-sqlite-database-to-use-sqlcipher-and-avoid-file-is-encrypted-or-is-not-a-database-errors/868
 #[cfg(feature = "sqlite-encrypted")]
 pub fn encrypt_unencrypted_database(path: &Path) -> DatabaseResult<()> {
     // e.g. conductor/conductor.sqlite3 -> conductor/conductor-encrypted.sqlite3

--- a/crates/holochain_sqlite/src/db/pool.rs
+++ b/crates/holochain_sqlite/src/db/pool.rs
@@ -118,7 +118,7 @@ pub(super) fn initialize_connection(
         }
         let _keyval = std::str::from_utf8(&hex).unwrap();
         // conn.pragma_update(None, "key", &keyval)?;
-        conn.pragma_update(None, "key", &FAKE_KEY)?;
+        conn.pragma_update(None, "key", FAKE_KEY)?;
     }
 
     // this is recommended to always be off:

--- a/crates/holochain_sqlite/src/db/pool.rs
+++ b/crates/holochain_sqlite/src/db/pool.rs
@@ -11,6 +11,9 @@ static CONNECTION_TIMEOUT_MS: AtomicU64 = AtomicU64::new(3_000);
 
 const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(30);
 
+#[cfg(feature = "sqlite-encrypted")]
+pub(super) const FAKE_KEY: &str = "x'98483C6EB40B6C31A448C22A66DED3B5E5E8D5119CAC8327B655C8B5C483648101010101010101010101010101010101'";
+
 static R2D2_THREADPOOL: Lazy<Arc<ScheduledThreadPool>> = Lazy::new(|| {
     let t = ScheduledThreadPool::new(1);
     Arc::new(t)
@@ -114,7 +117,6 @@ pub(super) fn initialize_connection(
                 .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
         }
         let _keyval = std::str::from_utf8(&hex).unwrap();
-        const FAKE_KEY: &str = "x'98483C6EB40B6C31A448C22A66DED3B5E5E8D5119CAC8327B655C8B5C483648101010101010101010101010101010101'";
         // conn.pragma_update(None, "key", &keyval)?;
         conn.pragma_update(None, "key", &FAKE_KEY)?;
     }

--- a/crates/holochain_sqlite/tests/migrate_unencrypted.rs
+++ b/crates/holochain_sqlite/tests/migrate_unencrypted.rs
@@ -1,0 +1,51 @@
+use holochain_sqlite::{
+    db::{DbKindConductor, DbWrite},
+    error::DatabaseResult,
+};
+use rusqlite::Connection;
+use std::fs::create_dir_all;
+
+#[cfg(feature = "sqlite-encrypted")]
+#[tokio::test]
+async fn migrate_unencrypted() {
+    holochain_trace::test_run().unwrap();
+
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    create_dir_all(tmp_dir.path().join("conductor")).unwrap();
+
+    // Set up an unencrypted database
+    {
+        let conn = Connection::open(tmp_dir.path().join("conductor/conductor.sqlite3")).unwrap();
+
+        // Needs to contain data otherwise encryption will just succeed!
+        conn.execute("CREATE TABLE migrate_me (name TEXT NOT NULL)", ())
+            .unwrap();
+        conn.execute(
+            "INSERT INTO migrate_me (name) VALUES ('hello_migrated')",
+            (),
+        )
+        .unwrap();
+
+        conn.close().unwrap();
+    }
+
+    // Without the HOLOCHAIN_MIGRATE_UNENCRYPTED variable set, it should fail to open
+    let err = DbWrite::open(&std::path::Path::new(tmp_dir.path()), DbKindConductor).unwrap_err();
+    assert_eq!(err.to_string(), "file is not a database");
+
+    std::env::set_var("HOLOCHAIN_MIGRATE_UNENCRYPTED", "true");
+
+    // Now it should open and read just fine, because it will be encrypted automatically
+    let db = DbWrite::open(&std::path::Path::new(tmp_dir.path()), DbKindConductor).unwrap();
+    let msg = db
+        .read_async(|txn| -> DatabaseResult<String> {
+            Ok(txn.query_row(
+                "SELECT name FROM migrate_me LIMIT 1",
+                (),
+                |row| -> Result<String, rusqlite::Error> { row.get(0) },
+            )?)
+        })
+        .await
+        .unwrap();
+    assert_eq!(msg, "hello_migrated".to_string());
+}


### PR DESCRIPTION
### Summary

Make `sqlite-encrypted` a default feature. I hoped you could override default features for specific build profiles, but I guess not.

Resolves #2957 

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
