### PR TITLE
Make `publish_termination` less flaky

### DIFF
--- a/crates/holochain/tests/publish/mod.rs
+++ b/crates/holochain/tests/publish/mod.rs
@@ -37,10 +37,10 @@ async fn publish_termination() {
     // Wait until they all see the created entry, at that point validation receipts should be getting sent soon
     consistency_60s([&alice, &bobbo, &carol, &danny, &emma, &fred]).await;
 
-    let ops_to_publish = tokio::time::timeout(Duration::from_secs(30), async {
+    let ops_to_publish = tokio::time::timeout(Duration::from_secs(60), async {
         let alice_pub_key = alice.agent_pubkey().clone();
         loop {
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
 
             let ops_to_publish = alice
                 .authored_db()


### PR DESCRIPTION
### Summary

I think the timeout on this one is just a bit aggressive and running too fast on CI. Slowed it down a little and gave it more time. I'd rather it passes slower first time than having to run multiple times to try and pass quickly

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
