### PR TITLE
fix(nix/devShells/rustDev): only use mold for x86_64-linux targets

### DIFF
--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -194,7 +194,7 @@
             export DYLD_FALLBACK_LIBRARY_PATH="$(rustc --print sysroot)/lib"
           '')
           + (lib.strings.optionalString pkgs.stdenv.isLinux ''
-            export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="mold"
+            export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS="$RUSTFLAGS -Clink-arg=-fuse-ld=mold"
           '')
           ;
         };

--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -194,7 +194,7 @@
             export DYLD_FALLBACK_LIBRARY_PATH="$(rustc --print sysroot)/lib"
           '')
           + (lib.strings.optionalString pkgs.stdenv.isLinux ''
-            export RUSTFLAGS="$RUSTFLAGS -Clink-arg=-fuse-ld=mold"
+            export CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER="mold"
           '')
           ;
         };


### PR DESCRIPTION
### Summary

fixes the error observed on the [holochain-client-js CI](https://github.com/holochain/holochain-client-js/actions/runs/6884230410/job/18726313113#step:7:479) cc @jost-s 


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
