### PR TITLE
Fix unused import warnings

### DIFF
--- a/crates/holochain/src/core/ribosome/error.rs
+++ b/crates/holochain/src/core/ribosome/error.rs
@@ -8,7 +8,6 @@ use holochain_secure_primitive::SecurePrimitiveError;
 use holochain_serialized_bytes::prelude::SerializedBytesError;
 use holochain_state::source_chain::SourceChainError;
 use holochain_types::prelude::*;
-use holochain_wasmer_host::prelude::*;
 use thiserror::Error;
 use tokio::task::JoinError;
 use wasmer::DeserializeError;

--- a/crates/holochain/src/core/ribosome/host_fn/capability_claims.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/capability_claims.rs
@@ -1,7 +1,6 @@
 use crate::core::ribosome::CallContext;
 use crate::core::ribosome::RibosomeT;
 use std::sync::Arc;
-use holochain_wasmer_host::prelude::*;
 use wasmer::RuntimeError;
 
 /// lists all the local claims filtered by tag

--- a/crates/holochain/src/core/ribosome/host_fn/capability_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/capability_info.rs
@@ -1,7 +1,6 @@
 use crate::core::ribosome::CallContext;
 use crate::core::ribosome::RibosomeT;
 use std::sync::Arc;
-use holochain_wasmer_host::prelude::*;
 use wasmer::RuntimeError;
 
 /// return the access info used for this call

--- a/crates/holochain/src/core/ribosome/host_fn/sleep.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/sleep.rs
@@ -1,7 +1,6 @@
 use crate::core::ribosome::CallContext;
 use crate::core::ribosome::RibosomeT;
 use std::sync::Arc;
-use holochain_wasmer_host::prelude::*;
 use wasmer::RuntimeError;
 
 pub fn sleep(

--- a/crates/holochain/src/core/ribosome/host_fn/trace.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/trace.rs
@@ -1,7 +1,6 @@
 use crate::core::ribosome::CallContext;
 use crate::core::ribosome::RibosomeT;
 use holochain_types::prelude::*;
-use holochain_wasmer_host::prelude::*;
 use once_cell::unsync::Lazy;
 use std::sync::Arc;
 use tracing::*;

--- a/crates/holochain/src/core/ribosome/host_fn/version.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/version.rs
@@ -1,7 +1,6 @@
 use crate::core::ribosome::CallContext;
 use crate::core::ribosome::RibosomeT;
 use std::sync::Arc;
-use holochain_wasmer_host::prelude::*;
 use holochain_zome_types::version::ZomeApiVersion;
 use wasmer::RuntimeError;
 

--- a/crates/kitsune_p2p/types/src/metrics.rs
+++ b/crates/kitsune_p2p/types/src/metrics.rs
@@ -1,7 +1,6 @@
 //! Utilities for helping with metric tracking.
 
 use crate::tracing;
-use futures::FutureExt;
 use holochain_trace::tracing::Instrument;
 use kitsune_p2p_bin_data::KitsuneAgent;
 use kitsune_p2p_timestamp::Timestamp;


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
