### PR TITLE
fix(app-validation): retrigger when not all ops were validated (#2968)

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -6,6 +6,7 @@ default_semver_increment_mode: !pre_patch rc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Fix: App validation would not be retriggered for ops that failed validation. The app validation workflow had only been retriggered when the number of concurrent ops to be validated (50) was reached. Now the workflow will be re-triggered after a 10 second delay whenever any ops could not be validated.
 
 ## 0.2.3-rc.1
 

--- a/crates/holochain/src/core/queue_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer.rs
@@ -631,8 +631,8 @@ impl BackOff {
 pub enum WorkComplete {
     /// The queue has been exhausted
     Complete,
-    /// Items still remain on the queue
-    Incomplete,
+    /// Items still remain on the queue. Optionally specify a delay in ms before retriggering.
+    Incomplete(Option<Duration>),
 }
 
 /// The only error possible when attempting to trigger: the channel is closed
@@ -661,8 +661,12 @@ async fn queue_consumer_main_task_impl<
     loop {
         if let Some(()) = triggers.next().await {
             match fut().await {
-                Ok(WorkComplete::Incomplete) => {
-                    tracing::debug!("Work incomplete, retriggering workflow");
+                Ok(WorkComplete::Incomplete(delay)) => {
+                    tracing::info!("Work incomplete, re-triggering workflow.");
+                    if let Some(dly) = delay {
+                        tracing::info!("Sleeping for {} ms before re-triggering.", dly.as_millis());
+                        tokio::time::sleep(dly).await;
+                    }
                     tx.trigger(&"retrigger")
                 }
                 Err(err) => handle_workflow_error(&name, err)?,

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -2,6 +2,7 @@
 
 use std::convert::TryInto;
 use std::sync::Arc;
+use std::time::Duration;
 
 use super::error::WorkflowResult;
 use super::sys_validation_workflow::validation_query;
@@ -93,9 +94,9 @@ async fn app_validation_workflow_inner(
 ) -> WorkflowResult<WorkComplete> {
     let db = workspace.dht_db.clone().into();
     let sorted_ops = validation_query::get_ops_to_app_validate(&db).await?;
-    let start_len = sorted_ops.len();
-    tracing::debug!("validating {} ops", start_len);
-    let start = (start_len >= NUM_CONCURRENT_OPS).then(std::time::Instant::now);
+    let num_ops_to_validate = sorted_ops.len();
+    tracing::debug!("validating {num_ops_to_validate} ops");
+    let start = (num_ops_to_validate >= NUM_CONCURRENT_OPS).then(std::time::Instant::now);
     let saturated = start.is_some();
 
     // Validate all the ops
@@ -165,7 +166,7 @@ async fn app_validation_workflow_inner(
     let mut iter =
         tokio_stream::wrappers::ReceiverStream::new(rx).ready_chunks(NUM_CONCURRENT_OPS * 100);
 
-    let mut total = 0;
+    let mut ops_validated = 0;
     let mut round_time = start.is_some().then(std::time::Instant::now);
     // Pull in a chunk of results.
     while let Some(chunk) = iter.next().await {
@@ -173,10 +174,10 @@ async fn app_validation_workflow_inner(
             "Committing {} ops",
             chunk.iter().map(|c| c.len()).sum::<usize>()
         );
-        let (t, a, r, activity) = workspace
+        let (accepted_ops, awaiting_ops, rejected_ops, activity) = workspace
             .dht_db
             .write_async(move |txn| {
-                let mut total = 0;
+                let mut accepted = 0;
                 let mut awaiting = 0;
                 let mut rejected = 0;
                 let mut agent_activity = Vec::new();
@@ -201,7 +202,7 @@ async fn app_validation_workflow_inner(
                     }
                     match outcome {
                         Outcome::Accepted => {
-                            total += 1;
+                            accepted += 1;
                             if let Dependency::Null = dependency {
                                 put_integrated(txn, &op_hash, ValidationStatus::Valid)?;
                             } else {
@@ -227,7 +228,7 @@ async fn app_validation_workflow_inner(
                         }
                     }
                 }
-                WorkflowResult::Ok((total, awaiting, rejected, agent_activity))
+                WorkflowResult::Ok((accepted, awaiting, rejected, agent_activity))
             })
             .await?;
 
@@ -246,31 +247,27 @@ async fn app_validation_workflow_inner(
                     .await?;
             }
         }
-        total += t;
+        ops_validated += accepted_ops;
+        ops_validated += rejected_ops;
         if let (Some(start), Some(round_time)) = (start, &mut round_time) {
             let round_el = round_time.elapsed();
             *round_time = std::time::Instant::now();
-            let avg_ops_ps = total as f64 / start.elapsed().as_micros() as f64 * 1_000_000.0;
-            let ops_ps = t as f64 / round_el.as_micros() as f64 * 1_000_000.0;
+            let avg_ops_ps =
+                ops_validated as f64 / start.elapsed().as_micros() as f64 * 1_000_000.0;
+            let ops_ps = accepted_ops as f64 / round_el.as_micros() as f64 * 1_000_000.0;
             tracing::warn!(
                 "App validation is saturated. Util {:.2}%. OPS/s avg {:.2}, this round {:.2}",
-                (start_len - total) as f64 / NUM_CONCURRENT_OPS as f64 * 100.0,
+                (num_ops_to_validate - ops_validated) as f64 / NUM_CONCURRENT_OPS as f64 * 100.0,
                 avg_ops_ps,
                 ops_ps
             );
         }
-        tracing::debug!(
-            "{} committed, {} awaiting sys dep, {} rejected. {} committed this round",
-            t,
-            a,
-            r,
-            total
-        );
+        tracing::debug!("{accepted_ops} accepted, {awaiting_ops} awaiting deps, {rejected_ops} rejected. {ops_validated} validated in total so far out of {num_ops_to_validate} ops to validate in this workflow run");
     }
     jh.await?;
-    tracing::debug!("accepted {} ops", total);
-    Ok(if saturated {
-        WorkComplete::Incomplete
+    Ok(if saturated || ops_validated < num_ops_to_validate {
+        // trigger app validation workflow again in 10 seconds
+        WorkComplete::Incomplete(Some(Duration::from_secs(10)))
     } else {
         WorkComplete::Complete
     })

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -98,7 +98,7 @@ pub async fn integrate_dht_ops_workflow(
     if changed > 0 {
         trigger_receipt.trigger(&"integrate_dht_ops_workflow");
         network.new_integrated_data().await?;
-        Ok(WorkComplete::Incomplete)
+        Ok(WorkComplete::Incomplete(None))
     } else {
         Ok(WorkComplete::Complete)
     }

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -68,7 +68,7 @@ pub async fn publish_dht_ops_workflow(
                 // If we get a routing error it means the space hasn't started yet and we should try publishing again.
                 if let holochain_p2p::HolochainP2pError::RoutingDnaError(_) = e {
                     // TODO if this doesn't change what is the loop terminate condition?
-                    complete = WorkComplete::Incomplete;
+                    complete = WorkComplete::Incomplete(None);
                 }
                 warn!(failed_to_send_publish = ?e);
             }

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow/unit_tests.rs
@@ -71,7 +71,7 @@ async fn workflow_incomplete_on_routing_error() {
 
     let publish_timestamp = get_publish_time(vault, op_hash).await;
 
-    assert_eq!(WorkComplete::Incomplete, work_complete);
+    assert_eq!(WorkComplete::Incomplete(None), work_complete);
     assert!(!rx.is_paused());
     assert!(publish_timestamp.is_none());
 }

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -210,7 +210,7 @@ async fn sys_validation_workflow_inner(
     jh.await?;
     tracing::debug!("Accepted {} ops", total);
     Ok(if saturated {
-        WorkComplete::Incomplete
+        WorkComplete::Incomplete(None)
     } else {
         WorkComplete::Complete
     })


### PR DESCRIPTION
### Summary
Backporting the app validation workflow re-trigger after a 10 second delay.


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
