### PR TITLE
Rework PeerAgentHistory::current_round

### DIFF
--- a/crates/holochain_diagnostics/src/ui/gossip_dashboard/widgets/gossip_agent_history.rs
+++ b/crates/holochain_diagnostics/src/ui/gossip_dashboard/widgets/gossip_agent_history.rs
@@ -26,7 +26,12 @@ pub fn _ui_gossip_agent_history_table(
 }
 
 fn _row(info: &PeerAgentHistory, own: bool) -> Row<'static> {
-    let active = if info.current_round { "*" } else { " " }.to_string();
+    let active = if info.current_rounds.is_empty() {
+        " "
+    } else {
+        "*"
+    }
+    .to_string();
 
     // let latency = format!("{:3}", *info.latency_micros / 1000.0);
     if own {

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Update to a tx5 version that includes go code that is statically linked for all platform that support it. Windows and Android will remain dynamically linked. [\#2967](https://github.com/holochain/holochain/pull/2967)
 - Change the license from Apache-2.0 to CAL-1.0.
+- Fixed spammy "Recorded initiate|accept with current round already set" warning. [#3060](https://github.com/holochain/holochain/pull/3060)
 
 ## 0.3.0-beta-dev.21
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -88,7 +88,7 @@ struct TimedBloomFilter {
 
 /// Gossip has two distinct variants which share a lot of similarities but
 /// are fundamentally different and serve different purposes
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GossipType {
     /// The Recent gossip type is aimed at rapidly syncing the most recent
     /// data. It runs frequently and expects frequent diffs at each round.
@@ -1461,6 +1461,15 @@ impl From<GossipType> for GossipModuleType {
         match g {
             GossipType::Recent => GossipModuleType::ShardedRecent,
             GossipType::Historical => GossipModuleType::ShardedHistorical,
+        }
+    }
+}
+
+impl From<GossipModuleType> for GossipType {
+    fn from(g: GossipModuleType) -> Self {
+        match g {
+            GossipModuleType::ShardedRecent => GossipType::Recent,
+            GossipModuleType::ShardedHistorical => GossipType::Historical,
         }
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
@@ -1,12 +1,14 @@
 //! metrics tracked by kitsune_p2p spaces
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
 
 use tokio::time::Instant;
 
+use crate::gossip::sharded_gossip::GossipType;
 use crate::gossip::sharded_gossip::NodeId;
 use crate::gossip::sharded_gossip::RegionDiffs;
 use crate::gossip::sharded_gossip::RoundState;
@@ -146,7 +148,7 @@ pub struct PeerAgentHistory {
     /// Times we recorded errors for this node.
     pub errors: VecDeque<RoundMetric>,
     /// Is this node currently in an active round?
-    pub current_round: bool,
+    pub current_rounds: HashSet<GossipType>,
 }
 
 /// Detailed info about the history of gossip with this node
@@ -472,10 +474,11 @@ impl Metrics {
                 gossip_type,
             };
             record_item(&mut history.initiates, round);
-            if history.current_round {
-                tracing::info!("Recorded initiate with current round already set");
+            if history.current_rounds.contains(&gossip_type.into()) {
+                tracing::warn!("Recorded initiate with current round already set");
+            } else {
+                history.current_rounds.insert(gossip_type.into());
             }
-            history.current_round = true;
         }
     }
 
@@ -495,10 +498,11 @@ impl Metrics {
                 gossip_type,
             };
             record_item(&mut history.accepts, round);
-            if history.current_round {
-                tracing::info!("Recorded accept with current round already set");
+            if history.current_rounds.contains(&gossip_type.into()) {
+                tracing::warn!("Recorded accept with current round already set");
+            } else {
+                history.current_rounds.insert(gossip_type.into());
             }
-            history.current_round = true;
         }
     }
 
@@ -521,7 +525,12 @@ impl Metrics {
                 gossip_type,
             };
             record_item(&mut history.successes, round);
-            history.current_round = false;
+
+            let removed = history.current_rounds.remove(&gossip_type.into());
+            if !removed {
+                tracing::warn!("Recorded success without record of gossip round");
+            }
+
             if history.is_initiate_round() {
                 should_dec_force_initiates = true;
             }
@@ -554,7 +563,11 @@ impl Metrics {
                 gossip_type,
             };
             record_item(&mut history.errors, round);
-            history.current_round = false;
+
+            let removed = history.current_rounds.remove(&gossip_type.into());
+            if !removed {
+                tracing::warn!("Recorded error without record of gossip round");
+            }
         }
         tracing::debug!(
             "recorded error in metrics. force_initiates={}",
@@ -624,7 +637,7 @@ impl Metrics {
         remote_agent_list
             .into_iter()
             .filter_map(|agent_info| self.agent_history.get(agent_info.into().agent()))
-            .any(|info| info.current_round)
+            .any(|info| !info.current_rounds.is_empty())
     }
 
     /// What was the last outcome for this node's gossip round?
@@ -782,7 +795,7 @@ impl std::fmt::Display for Metrics {
                     last_completion,
                     completion_frequency
                 )?;
-                write!(f, "\n\t\tCurrent Round: {:?}", info.current_round)?;
+                write!(f, "\n\t\tCurrent Rounds: {:?}", info.current_rounds)?;
             }
         }
         write!(


### PR DESCRIPTION
### Summary

This should fix the spammy warnings of this variety:

```
... kitsune_p2p::metrics: Recorded initiate with current round already set
... kitsune_p2p::metrics: Recorded accept with current round already set
```

I finally looked into it to see if it's a real problem. If this PR fixes it, then it's not: it's just that we weren't differentiating between gossip rounds of different types, so whenever a node had both a Recent round and a Historical round with the same node, they'd get this warning.

FYI I used `RUST_LOG=debug cargo run --package diagnostic_tests --example link_storm` to reproduce and diagnose this.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [x] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
