### PR TITLE
build: set semver increment mode to pre patch rc

### DIFF
--- a/crates/mock_hdi/CHANGELOG.md
+++ b/crates/mock_hdi/CHANGELOG.md
@@ -1,5 +1,4 @@
 ---
-semver_increment_mode: patch
 default_semver_increment_mode: !pre_patch rc
 ---
 # Changelog

--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -84,7 +84,7 @@
             --force-tag-creation \
             --force-branch-creation \
             --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
-            --allowed-semver-increment-modes="!patch" \
+            --allowed-semver-increment-modes="!pre_patch rc" \
             --steps=CreateReleaseBranch,BumpReleaseVersions
 
         ${self'.packages.release-automation}/bin/release-automation \


### PR DESCRIPTION
### Summary
Switch back to pre patch rc releases.


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
