### PR TITLE
Reject unknown fields in DNA manfests

### DIFF
--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- **BREAKING CHANGE**: A `DnaManifest` and all its sub-fields will now reject unknown fields when deserialized. This will make it harder to provide an invalid DNA manifest to Holochain without relising. For example, coordinator zomes not appearing in your installed hApp because their field was indented to the wrong place. This is not a breaking change for valid manifests but Holochain will now reject more invalid manifests.
+
 ## 0.3.0-beta-dev.23
 
 ## 0.3.0-beta-dev.22

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
-- **BREAKING CHANGE**: A `DnaManifest` and all its sub-fields will now reject unknown fields when deserialized. This will make it harder to provide an invalid DNA manifest to Holochain without relising. For example, coordinator zomes not appearing in your installed hApp because their field was indented to the wrong place. This is not a breaking change for valid manifests but Holochain will now reject more invalid manifests.
+- **BREAKING CHANGE**: A `DnaManifest` and all its sub-fields will now reject unknown fields when deserialized. This will make it harder to provide an invalid DNA manifest to Holochain without realising. For example, coordinator zomes not appearing in your installed hApp because their field was indented to the wrong place. This is not a breaking change for valid manifests but Holochain will now reject more invalid manifests.
 
 ## 0.3.0-beta-dev.23
 

--- a/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
+++ b/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
@@ -70,7 +70,7 @@ use serde_with::serde_as;
     derive_more::Constructor,
     derive_builder::Builder,
 )]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct DnaManifestV1 {
     /// The friendly "name" of a Holochain DNA.
     pub name: String,
@@ -108,7 +108,7 @@ impl DnaManifestV1 {
     derive_more::Constructor,
     derive_builder::Builder,
 )]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
 /// Manifest for all items that will change the [`DnaHash`].
 pub struct IntegrityManifest {
     /// A network seed for uniquifying this DNA. See [`DnaDef`].
@@ -130,7 +130,7 @@ pub struct IntegrityManifest {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
 /// Coordinator zomes.
 pub struct CoordinatorManifest {
     /// Coordinator zomes to install with this dna.
@@ -139,7 +139,7 @@ pub struct CoordinatorManifest {
 
 /// Manifest for an individual Zome
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct ZomeManifest {
     /// Just a friendly name, no semantic meaning.
     pub name: ZomeName,
@@ -165,7 +165,7 @@ pub struct ZomeManifest {
 /// Manifest for integrity zomes that another zome
 /// depends on.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct ZomeDependency {
     /// The name of the integrity zome this zome depends on.
     pub name: ZomeName,

--- a/crates/holochain_types/src/dna/dna_manifest/test.rs
+++ b/crates/holochain_types/src/dna/dna_manifest/test.rs
@@ -72,3 +72,198 @@ coordinator:
     serde_yaml::from_str::<DnaManifest>(&manifest_yaml)
         .expect_err("This should fail because integrity zomes are required");
 }
+
+#[test]
+fn rejects_manifest_with_unknown_fields() {
+    let manifest_yaml = r#"
+---
+manifest_version: "1"
+name: test_dna
+integrity:
+  network_seed: blablabla
+  origin_time: 2022-02-11T23:29:00.789576Z
+  properties: ~
+  zomes:
+    - name: zome1
+      bundled: zome-1.wasm
+    - name: zome2
+      bundled: nested/zome-2.wasm
+    - name: zome3
+      path: ../zome-3.wasm
+not_a_real_field: ~"#;
+
+    let err = serde_yaml::from_str::<DnaManifest>(&manifest_yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("unknown field `not_a_real_field`"),
+        "Should have rejected unknown field but actually got: {}",
+        err.to_string(),
+    );
+}
+
+#[test]
+fn rejects_manifest_with_coordinators_defined_under_integrity() {
+    let manifest_yaml = r#"
+---
+manifest_version: "1"
+name: test_dna
+integrity:
+  network_seed: blablabla
+  origin_time: 2022-02-11T23:29:00.789576Z
+  properties: ~
+  zomes:
+    - name: zome1
+      bundled: zome-1.wasm
+    - name: zome2
+      bundled: nested/zome-2.wasm
+    - name: zome3
+      path: ../zome-3.wasm
+  # Should be indented left once, this is actually nested under `integrity`
+  coordinator:
+    zomes:
+      - name: zome4
+        bundled: zome-4.wasm
+      - name: zome5
+        path: ../zome-5.wasm"#;
+
+    let err = serde_yaml::from_str::<DnaManifest>(&manifest_yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("unknown field `coordinator`"),
+        "Should have rejected coordinator zomes nested under integrity but actually got: {}",
+        err.to_string(),
+    );
+}
+
+#[test]
+fn rejects_manifest_with_integrity_defined_under_coordinators() {
+    let manifest_yaml = r#"
+---
+manifest_version: "1"
+name: test_dna
+coordinator:
+  zomes:
+    - name: zome4
+      bundled: zome-4.wasm
+    - name: zome5
+      path: ../zome-5.wasm
+  # Should be indented left once, this is actually nested under `coordinator`
+  integrity:
+    network_seed: blablabla
+    origin_time: 2022-02-11T23:29:00.789576Z
+    properties: ~
+    zomes:
+      - name: zome1
+        bundled: zome-1.wasm
+      - name: zome2
+        bundled: nested/zome-2.wasm
+      - name: zome3
+        path: ../zome-3.wasm"#;
+
+    let err = serde_yaml::from_str::<DnaManifest>(&manifest_yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("unknown field `integrity`"),
+        "Should have rejected integrity zomes nested under coordinators but actually got: {}",
+        err.to_string(),
+    );
+}
+
+#[test]
+fn rejects_manifest_with_unknown_integrity_fields() {
+    let manifest_yaml = r#"
+---
+manifest_version: "1"
+name: test_dna
+integrity:
+  network_seed: blablabla
+  origin_time: 2022-02-11T23:29:00.789576Z
+  properties: ~
+  not_a_real_field: ~
+  zomes:
+    - name: zome1
+      bundled: zome-1.wasm
+    - name: zome2
+      bundled: nested/zome-2.wasm
+    - name: zome3
+      path: ../zome-3.wasm
+"#;
+
+    let err = serde_yaml::from_str::<DnaManifest>(&manifest_yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("unknown field `not_a_real_field`"),
+        "Should have rejected unknown field but actually got: {}",
+        err.to_string(),
+    );
+}
+
+#[test]
+fn rejects_manifest_with_unknown_coordinator_fields() {
+    let manifest_yaml = r#"
+---
+manifest_version: "1"
+name: test_dna
+coordinator:
+  not_a_real_field: ~
+  zomes:
+    - name: zome4
+      bundled: zome-4.wasm
+    - name: zome5
+      path: ../zome-5.wasm
+        "#;
+
+  let err = serde_yaml::from_str::<DnaManifest>(&manifest_yaml).unwrap_err();
+  assert!(
+      err.to_string().contains("unknown field `not_a_real_field`"),
+      "Should have rejected unknown field but actually got: {}",
+      err.to_string(),
+  );
+}
+
+#[test]
+fn rejects_manifest_with_unknown_zome_fields_in_integrity() {
+    let manifest_yaml = r#"
+---
+manifest_version: "1"
+name: test_dna
+integrity:
+  network_seed: blablabla
+  origin_time: 2022-02-11T23:29:00.789576Z
+  properties: ~
+  zomes:
+    - name: zome1
+      bundled: zome-1.wasm
+    - name: zome2
+      bundled: nested/zome-2.wasm
+      not_a_real_field: ~
+    - name: zome3
+      path: ../zome-3.wasm
+"#;
+
+    let err = serde_yaml::from_str::<DnaManifest>(&manifest_yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("unknown field `not_a_real_field`"),
+        "Should have rejected unknown field but actually got: {}",
+        err.to_string(),
+    );
+}
+
+#[test]
+fn rejects_manifest_with_unknown_zome_field_in_coordinator() {
+    let manifest_yaml = r#"
+---
+manifest_version: "1"
+name: test_dna
+coordinator:
+  zomes:
+    - name: zome4
+      bundled: zome-4.wasm
+    - name: zome5
+      path: ../zome-5.wasm
+      not_a_real_field: ~
+        "#;
+
+  let err = serde_yaml::from_str::<DnaManifest>(&manifest_yaml).unwrap_err();
+  assert!(
+      err.to_string().contains("unknown field `not_a_real_field`"),
+      "Should have rejected unknown field but actually got: {}",
+      err.to_string(),
+  );
+}

--- a/crates/holochain_types/src/dna/dna_manifest/test.rs
+++ b/crates/holochain_types/src/dna/dna_manifest/test.rs
@@ -209,12 +209,12 @@ coordinator:
       path: ../zome-5.wasm
         "#;
 
-  let err = serde_yaml::from_str::<DnaManifest>(&manifest_yaml).unwrap_err();
-  assert!(
-      err.to_string().contains("unknown field `not_a_real_field`"),
-      "Should have rejected unknown field but actually got: {}",
-      err.to_string(),
-  );
+    let err = serde_yaml::from_str::<DnaManifest>(&manifest_yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("unknown field `not_a_real_field`"),
+        "Should have rejected unknown field but actually got: {}",
+        err.to_string(),
+    );
 }
 
 #[test]
@@ -260,10 +260,10 @@ coordinator:
       not_a_real_field: ~
         "#;
 
-  let err = serde_yaml::from_str::<DnaManifest>(&manifest_yaml).unwrap_err();
-  assert!(
-      err.to_string().contains("unknown field `not_a_real_field`"),
-      "Should have rejected unknown field but actually got: {}",
-      err.to_string(),
-  );
+    let err = serde_yaml::from_str::<DnaManifest>(&manifest_yaml).unwrap_err();
+    assert!(
+        err.to_string().contains("unknown field `not_a_real_field`"),
+        "Should have rejected unknown field but actually got: {}",
+        err.to_string(),
+    );
 }


### PR DESCRIPTION
### Summary

Fixes #2710

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
