### PR TITLE
Fix flaky zome_call_get_block

### DIFF
--- a/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
@@ -103,6 +103,8 @@ mod test {
             tune.gossip_peer_on_success_next_gossip_delay_ms = 1000;
             tune.gossip_peer_on_error_next_gossip_delay_ms = 1000;
             tune.gossip_round_timeout_ms = 3000;
+        }).tune_conductor(|c| {
+            c.sys_validation_retry_delay = Some(std::time::Duration::from_secs(1));
         });
         let mut conductors = SweetConductorBatch::from_config(3, config).await;
         let apps = conductors


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
