### PR TITLE
Backport dna properties macro

### DIFF
--- a/crates/hdi/src/prelude.rs
+++ b/crates/hdi/src/prelude.rs
@@ -20,6 +20,7 @@ pub use crate::op::*;
 pub use crate::x_salsa20_poly1305::x_25519_x_salsa20_poly1305_decrypt;
 pub use crate::x_salsa20_poly1305::x_salsa20_poly1305_decrypt;
 pub use hdk_derive;
+pub use hdk_derive::dna_properties;
 pub use hdk_derive::hdk_entry_defs;
 pub use hdk_derive::hdk_entry_defs_conversions;
 pub use hdk_derive::hdk_entry_helper;

--- a/crates/hdk/src/prelude.rs
+++ b/crates/hdk/src/prelude.rs
@@ -70,6 +70,7 @@ pub use hdi::map_extern_infallible;
 pub use hdi::op::OpHelper;
 pub use hdi::prelude::app_entry;
 pub use hdk_derive;
+pub use hdk_derive::dna_properties;
 pub use hdk_derive::hdk_dependent_entry_types;
 pub use hdk_derive::hdk_dependent_link_types;
 pub use hdk_derive::hdk_entry_defs;

--- a/crates/hdk_derive/CHANGELOG.md
+++ b/crates/hdk_derive/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Added a macro `#![dna_properties]` which when applied to a struct, exposes a function `try_from_dna_properties()` on that struct
+
 ## 0.2.3
 
 ## 0.2.3-rc.1

--- a/crates/hdk_derive/src/dna_properties.rs
+++ b/crates/hdk_derive/src/dna_properties.rs
@@ -1,0 +1,28 @@
+use proc_macro::TokenStream;
+use proc_macro_error::abort;
+use syn::parse_macro_input;
+use syn::Item;
+use syn::ItemStruct;
+
+pub fn build(_attrs: TokenStream, input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as Item);
+    let ident = match &input {
+        Item::Struct(ItemStruct { ident, .. }) => ident,
+        _ => abort!(input, "dna_properties macro can only be used on Structs"),
+    };
+
+    let output = quote::quote! {
+        #[derive(Serialize, Deserialize, SerializedBytes, Debug)]
+        #input
+
+        impl TryFromDnaProperties for #ident {
+            type Error = WasmError;
+
+            fn try_from_dna_properties() -> Result<#ident, WasmError> {
+                #ident::try_from(dna_info()?.modifiers.properties)
+                    .map_err(|_| wasm_error!(WasmErrorInner::Guest(format!("Failed to deserialize DNA properties into {}", std::any::type_name::<#ident>()))))
+            }
+        }
+    };
+    output.into()
+}

--- a/crates/hdk_derive/src/lib.rs
+++ b/crates/hdk_derive/src/lib.rs
@@ -8,6 +8,7 @@ use syn::parse::ParseStream;
 use syn::parse::Result;
 use syn::punctuated::Punctuated;
 
+mod dna_properties;
 mod entry_def_registration;
 mod entry_defs;
 mod entry_defs_conversions;
@@ -283,4 +284,10 @@ pub fn hdk_dependent_link_types(attrs: TokenStream, code: TokenStream) -> TokenS
 #[proc_macro_attribute]
 pub fn hdk_entry_helper(attrs: TokenStream, code: TokenStream) -> TokenStream {
     entry_helper::build(attrs, code)
+}
+
+#[proc_macro_error]
+#[proc_macro_attribute]
+pub fn dna_properties(attrs: TokenStream, code: TokenStream) -> TokenStream {
+    dna_properties::build(attrs, code)
 }

--- a/crates/holochain/tests/dna_properties/mod.rs
+++ b/crates/holochain/tests/dna_properties/mod.rs
@@ -1,0 +1,83 @@
+use hdk::prelude::*;
+use holochain::sweettest::SweetAgents;
+use holochain::sweettest::SweetConductor;
+use holochain::sweettest::SweetDnaFile;
+use holochain_conductor_api::conductor::ConductorConfig;
+use holochain_test_wasm_common::MyValidDnaProperties;
+use holochain_types::prelude::DnaModifiersOpt;
+use holochain_wasm_test_utils::TestWasm;
+use serde::{Deserialize, Serialize};
+
+#[tokio::test(flavor = "multi_thread")]
+// Can specify dna properties and then read those properties via the #[dna_properties] helper macro
+async fn test_dna_properties_macro() {
+    let (dna_file, _, _) =
+        SweetDnaFile::unique_from_test_wasms(vec![TestWasm::DnaProperties]).await;
+
+    // Set DNA Properties
+    let properties = MyValidDnaProperties {
+        authority_agent: [0u8; 36].to_vec(),
+        max_count: 500,
+        contract_address: String::from("0x12345"),
+    };
+    let properties_sb: SerializedBytes = properties.clone().try_into().unwrap();
+    let dnas = &[dna_file.update_modifiers(DnaModifiersOpt {
+        network_seed: None,
+        properties: Some(properties_sb),
+        origin_time: None,
+        quantum_time: None,
+    })];
+
+    // Create a Conductor
+    let mut conductor = SweetConductor::from_config(ConductorConfig::default()).await;
+    let agent = SweetAgents::one(conductor.keystore()).await;
+    let app = conductor
+        .setup_app_for_agent("app", agent, dnas)
+        .await
+        .unwrap();
+    let alice_zome = app.cells()[0].zome(TestWasm::DnaProperties);
+
+    // Get DNA Properties via helper macro
+    let received_properties: MyValidDnaProperties =
+        conductor.call(&alice_zome, "get_dna_properties", ()).await;
+
+    assert_eq!(received_properties, properties)
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, SerializedBytes)]
+pub struct MyInvalidProperties {
+    bad_property: u32,
+}
+
+#[tokio::test(flavor = "multi_thread")]
+// Can specify dna properties and then read those properties via the #[dna_properties] helper macro
+async fn test_dna_properties_fails_with_invalid_properties() {
+    let (dna_file, _, _) =
+        SweetDnaFile::unique_from_test_wasms(vec![TestWasm::DnaProperties]).await;
+
+    // Set DNA Properties
+    let properties = MyInvalidProperties { bad_property: 500 };
+    let properties_sb: SerializedBytes = properties.try_into().unwrap();
+    let dnas = &[dna_file.update_modifiers(DnaModifiersOpt {
+        network_seed: None,
+        properties: Some(properties_sb),
+        origin_time: None,
+        quantum_time: None,
+    })];
+
+    // Create a Conductor
+    let mut conductor = SweetConductor::from_config(ConductorConfig::default()).await;
+    let agent = SweetAgents::one(conductor.keystore()).await;
+    let app = conductor
+        .setup_app_for_agent("app", agent, dnas)
+        .await
+        .unwrap();
+    let alice_zome = app.cells()[0].zome(TestWasm::DnaProperties);
+
+    // Fail to get DNA Properties via helper macro
+    let res: Result<MyValidDnaProperties, _> = conductor
+        .call_fallible(&alice_zome, "get_dna_properties", ())
+        .await;
+
+    assert!(res.is_err())
+}

--- a/crates/holochain/tests/integration.rs
+++ b/crates/holochain/tests/integration.rs
@@ -1,6 +1,7 @@
 mod agent_scaling;
 mod authored_test;
 mod dht_arc;
+mod dna_properties;
 mod inline_zome_spec;
 mod integrity_zome;
 mod multi_conductor;

--- a/crates/holochain_integrity_types/src/dna_properties.rs
+++ b/crates/holochain_integrity_types/src/dna_properties.rs
@@ -1,0 +1,12 @@
+//! # DNA Properties Support types
+
+/// Trait to convert from dna properties into specified type
+pub trait TryFromDnaProperties {
+    /// The error associated with this conversion.
+    type Error;
+
+    /// Attempts to deserialize DNA properties into specified type
+    fn try_from_dna_properties() -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+}

--- a/crates/holochain_integrity_types/src/lib.rs
+++ b/crates/holochain_integrity_types/src/lib.rs
@@ -15,6 +15,7 @@ pub mod action;
 pub mod capability;
 pub mod chain;
 pub mod countersigning;
+pub mod dna_properties;
 pub mod entry;
 #[allow(missing_docs)]
 pub mod entry_def;

--- a/crates/holochain_integrity_types/src/prelude.rs
+++ b/crates/holochain_integrity_types/src/prelude.rs
@@ -5,6 +5,7 @@ pub use crate::action::*;
 pub use crate::capability::*;
 pub use crate::chain::*;
 pub use crate::countersigning::*;
+pub use crate::dna_properties::*;
 pub use crate::entry::*;
 pub use crate::entry_def::*;
 pub use crate::genesis::*;

--- a/crates/test_utils/wasm/src/lib.rs
+++ b/crates/test_utils/wasm/src/lib.rs
@@ -28,6 +28,7 @@ pub enum TestWasm {
     Crd,
     Crud,
     Debug,
+    DnaProperties,
     EntryDefs,
     EmitSignal,
     HashEntry,
@@ -126,6 +127,7 @@ impl From<TestWasm> for ZomeName {
             TestWasm::Crd => "crd",
             TestWasm::Crud => "crud",
             TestWasm::Debug => "debug",
+            TestWasm::DnaProperties => "dna_properties",
             TestWasm::EntryDefs => "entry_defs",
             TestWasm::EmitSignal => "emit_signal",
             TestWasm::HashEntry => "hash_entry",
@@ -191,6 +193,9 @@ impl From<TestWasm> for PathBuf {
             TestWasm::Crd => "wasm32-unknown-unknown/release/test_wasm_crd.wasm",
             TestWasm::Crud => "wasm32-unknown-unknown/release/test_wasm_crud.wasm",
             TestWasm::Debug => "wasm32-unknown-unknown/release/test_wasm_debug.wasm",
+            TestWasm::DnaProperties => {
+                "wasm32-unknown-unknown/release/test_wasm_dna_properties.wasm"
+            }
             TestWasm::EntryDefs => "wasm32-unknown-unknown/release/test_wasm_entry_defs.wasm",
             TestWasm::EmitSignal => "wasm32-unknown-unknown/release/test_wasm_emit_signal.wasm",
             TestWasm::HashEntry => "wasm32-unknown-unknown/release/test_wasm_hash_entry.wasm",

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -2667,6 +2667,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_wasm_dna_properties"
+version = "0.0.1"
+dependencies = [
+ "fixt",
+ "hdi",
+ "hdk",
+ "holochain_test_wasm_common",
+ "serde",
+]
+
+[[package]]
 name = "test_wasm_emit_signal"
 version = "0.0.1"
 dependencies = [

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crd",
     "crud",
     "debug",
+    "dna_properties",
     "emit_signal",
     "entry_defs",
     "hash_entry",

--- a/crates/test_utils/wasm/wasm_workspace/dna_properties/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/dna_properties/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "test_wasm_dna_properties"
+version = "0.0.1"
+edition = "2021"
+
+[lib]
+name = "test_wasm_dna_properties"
+crate-type = [ "cdylib", "rlib" ]
+
+[[example]]
+name = "integrity_test_wasm_dna_properties"
+path = "src/integrity.rs"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+hdk = { path = "../../../../hdk", optional = true }
+serde = { workspace = true }
+hdi = { path = "../../../../hdi" }
+holochain_test_wasm_common = { path = "../../../wasm_common" }
+
+[dev-dependencies]
+hdk = { path = "../../../../hdk", features = ["fixturators"] }
+fixt = { path = "../../../../fixt" }
+
+[features]
+default = ["hdk"]
+integrity = []
+mock = ["hdk/mock"]

--- a/crates/test_utils/wasm/wasm_workspace/dna_properties/src/integrity.rs
+++ b/crates/test_utils/wasm/wasm_workspace/dna_properties/src/integrity.rs
@@ -1,0 +1,7 @@
+use hdi::prelude::*;
+use holochain_test_wasm_common::MyValidDnaProperties;
+
+#[hdk_extern]
+pub fn get_dna_properties(_: ()) -> ExternResult<MyValidDnaProperties> {
+    MyValidDnaProperties::try_from_dna_properties()
+}

--- a/crates/test_utils/wasm/wasm_workspace/dna_properties/src/lib.rs
+++ b/crates/test_utils/wasm/wasm_workspace/dna_properties/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod integrity;

--- a/crates/test_utils/wasm_common/src/lib.rs
+++ b/crates/test_utils/wasm_common/src/lib.rs
@@ -12,3 +12,11 @@ pub struct AgentActivitySearch {
     pub query: QueryFilter,
     pub request: ActivityRequest,
 }
+
+#[derive(Eq, PartialEq, Clone)]
+#[dna_properties]
+pub struct MyValidDnaProperties {
+    pub authority_agent: Vec<u8>,
+    pub max_count: u32,
+    pub contract_address: String,
+}


### PR DESCRIPTION
### Summary
Backport #2880


### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
