### PR TITLE
Improve conductor output on IO errors

### DIFF
--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -88,7 +88,13 @@ impl ConductorBuilder {
                 KeystoreConfig::LairServer { connection_url } => {
                     warn_no_encryption();
                     let passphrase = get_passphrase()?;
-                    spawn_lair_keystore(connection_url.clone(), passphrase).await?
+                    match spawn_lair_keystore(connection_url.clone(), passphrase).await {
+                        Ok(keystore) => keystore,
+                        Err(err) => {
+                            tracing::error!(?err, "Failed to spawn Lair keystore");
+                            return Err(err.into());
+                        }
+                    }
                 }
                 KeystoreConfig::LairServerInProc { lair_root } => {
                     warn_no_encryption();
@@ -107,7 +113,14 @@ impl ConductorBuilder {
                         .as_ref()
                         .join("lair-keystore-config.yaml");
                     let passphrase = get_passphrase()?;
-                    spawn_lair_keystore_in_proc(&keystore_config_path, passphrase).await?
+
+                    match spawn_lair_keystore_in_proc(&keystore_config_path, passphrase).await {
+                        Ok(keystore) => keystore,
+                        Err(err) => {
+                            tracing::error!(?err, "Failed to spawn Lair keystore in process");
+                            return Err(err.into());
+                        }
+                    }
                 }
             }
         };

--- a/crates/holochain/src/conductor/error.rs
+++ b/crates/holochain/src/conductor/error.rs
@@ -7,6 +7,7 @@ use holochain_conductor_api::conductor::ConductorConfigError;
 use holochain_sqlite::error::DatabaseError;
 use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::WasmErrorInner;
+use holochain_websocket::WebsocketError;
 use holochain_zome_types::cell::CellId;
 use thiserror::Error;
 
@@ -128,6 +129,9 @@ pub enum ConductorError {
 
     #[error(transparent)]
     RibosomeError(#[from] crate::core::ribosome::error::RibosomeError),
+
+    #[error(transparent)]
+    WebsocketError(#[from] WebsocketError),
 
     /// Other
     #[error("Other: {0}")]


### PR DESCRIPTION
### Summary

@alastairong is seeing 

```
Dec 15 09:58:57 hpos holochain-start[762911]: thread 'main' panicked at 'Could not initialize Conductor from configuration: Other({"error":"Connection refused (os error 111)"})', 
```

When starting a conductor at 0.2.4-rc.0. This is not the most helpful output because it doesn't tell you what the conductor was trying to do when it got an I/O error. The only two things I think we try to do on startup are add interface ports and connect to Lair. So I'm assuming it's one of these that's happening. This PR improves the log output for Lair errors and adds a specific error case for WebSocket errors so that they don't get wrapped as `Other` as a ConductorResult.

I think the most likely thing here is something to do with Lair keystore but it's hard to be sure from the current output so I'd like to get this in and keep an eye out for this problem showing up again.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
