### PR TITLE
Avoid printing or tracing the ribosome store

### DIFF
--- a/crates/holochain/src/conductor/ribosome_store.rs
+++ b/crates/holochain/src/conductor/ribosome_store.rs
@@ -5,7 +5,7 @@ use tracing::*;
 
 use crate::core::ribosome::{real_ribosome::RealRibosome, RibosomeT};
 
-#[derive(Default, Debug)]
+#[derive(Default)]
 pub struct RibosomeStore {
     ribosomes: HashMap<DnaHash, RealRibosome>,
     entry_defs: HashMap<EntryDefBufferKey, EntryDef>,
@@ -30,12 +30,12 @@ impl RibosomeStore {
         self.ribosomes.extend(ribosomes);
     }
 
-    #[instrument]
+    #[instrument(skip(self))]
     pub fn list(&self) -> Vec<DnaHash> {
         self.ribosomes.keys().cloned().collect()
     }
 
-    #[instrument]
+    #[instrument(skip(self))]
     pub fn get_dna_def(&self, hash: &DnaHash) -> Option<DnaDef> {
         self.ribosomes
             .get(hash)


### PR DESCRIPTION
### Summary

I made a change [here](https://github.com/holochain/holochain/pull/3025/commits/4549d9abf09381c60ba2d32965c57f6d6e8cc5ef#diff-c8745fcdf9e637fcb0d55805c56c0b680ed7fa7f1b4db1807e138b04f2d67a0bR46) to avoid tracing `self` in the `RibosomeStore` because it's a large struct. It was to solve a specific problem with that function call being shockingly slow (seconds rather than milliseconds) once the store was populated. It only occurred to me today that we should expand that fix to the other `instrument` usage in the impl for this type. It would also be a bad thing to debug print so I've removed that derive too. It appears unused anyway.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
