### PR TITLE
create a release from branch release-20240110.003625

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [holochain\_conductor\_api-0.3.0-beta-dev.30](crates/holochain_conductor_api/CHANGELOG.md#0.3.0-beta-dev.30)
 
-## [holochain\_services-0.2.0-beta-dev.1](crates/holochain_services/CHANGELOG.md#0.2.0-beta-dev.1)
+## [holochain\_conductor\_services-0.2.0-beta-dev.1](crates/holochain_conductor_services/CHANGELOG.md#0.2.0-beta-dev.1)
 
 ## [holochain\_test\_wasm\_common-0.3.0-beta-dev.25](crates/holochain_test_wasm_common/CHANGELOG.md#0.3.0-beta-dev.25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ Initial version
 
 ## [holochain\_cli\_sandbox-0.3.0-beta-dev.29](crates/holochain_cli_sandbox/CHANGELOG.md#0.3.0-beta-dev.29)
 
-## [holochain\_services-0.2.0-beta-dev.0](crates/holochain_services/CHANGELOG.md#0.2.0-beta-dev.0)
+## [holochain\_conductor\_services-0.2.0-beta-dev.0](crates/holochain_conductor_services/CHANGELOG.md#0.2.0-beta-dev.0)
 
 - Conductor services crate created
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,88 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Bump holonix rust version to 1.71.1. [\#2660](https://github.com/holochain/holochain/pull/2660)
 - Add `override` to `devSells.holonix` and `packages.holochain` [\#2862](https://github.com/holochain/holochain/pull/2862)
 
+# 20240110.003625
+
+## [hcterm-0.3.0-beta-dev.6](crates/hcterm/CHANGELOG.md#0.3.0-beta-dev.6)
+
+## [holochain\_cli-0.3.0-beta-dev.30](crates/holochain_cli/CHANGELOG.md#0.3.0-beta-dev.30)
+
+## [holochain-0.3.0-beta-dev.30](crates/holochain/CHANGELOG.md#0.3.0-beta-dev.30)
+
+## [holochain\_cli\_bundle-0.3.0-beta-dev.28](crates/holochain_cli_bundle/CHANGELOG.md#0.3.0-beta-dev.28)
+
+## [holochain\_cli\_run\_local\_services-0.3.0-beta-dev.18](crates/holochain_cli_run_local_services/CHANGELOG.md#0.3.0-beta-dev.18)
+
+## [holochain\_cli\_sandbox-0.3.0-beta-dev.30](crates/holochain_cli_sandbox/CHANGELOG.md#0.3.0-beta-dev.30)
+
+## [holochain\_cascade-0.3.0-beta-dev.30](crates/holochain_cascade/CHANGELOG.md#0.3.0-beta-dev.30)
+
+## [holochain\_conductor\_api-0.3.0-beta-dev.30](crates/holochain_conductor_api/CHANGELOG.md#0.3.0-beta-dev.30)
+
+## [holochain\_services-0.2.0-beta-dev.1](crates/holochain_services/CHANGELOG.md#0.2.0-beta-dev.1)
+
+## [holochain\_test\_wasm\_common-0.3.0-beta-dev.25](crates/holochain_test_wasm_common/CHANGELOG.md#0.3.0-beta-dev.25)
+
+## [holochain\_wasm\_test\_utils-0.3.0-beta-dev.28](crates/holochain_wasm_test_utils/CHANGELOG.md#0.3.0-beta-dev.28)
+
+## [holochain\_websocket-0.3.0-beta-dev.7](crates/holochain_websocket/CHANGELOG.md#0.3.0-beta-dev.7)
+
+## [hdk-0.3.0-beta-dev.25](crates/hdk/CHANGELOG.md#0.3.0-beta-dev.25)
+
+## [holochain\_state-0.3.0-beta-dev.29](crates/holochain_state/CHANGELOG.md#0.3.0-beta-dev.29)
+
+## [hdi-0.4.0-beta-dev.21](crates/hdi/CHANGELOG.md#0.4.0-beta-dev.21)
+
+## [holochain\_p2p-0.3.0-beta-dev.29](crates/holochain_p2p/CHANGELOG.md#0.3.0-beta-dev.29)
+
+## [hc\_sleuth-0.2.0-beta-dev.0](crates/hc_sleuth/CHANGELOG.md#0.2.0-beta-dev.0)
+
+Initial version
+
+## [hdk\_derive-0.3.0-beta-dev.20](crates/hdk_derive/CHANGELOG.md#0.3.0-beta-dev.20)
+
+## [aitia-0.2.0-beta-dev.0](crates/aitia/CHANGELOG.md#0.2.0-beta-dev.0)
+
+Initial version
+
+## [holochain\_state\_types-0.3.0-beta-dev.27](crates/holochain_state_types/CHANGELOG.md#0.3.0-beta-dev.27)
+
+## [holochain\_types-0.3.0-beta-dev.27](crates/holochain_types/CHANGELOG.md#0.3.0-beta-dev.27)
+
+## [holochain\_keystore-0.3.0-beta-dev.22](crates/holochain_keystore/CHANGELOG.md#0.3.0-beta-dev.22)
+
+## [holochain\_sqlite-0.3.0-beta-dev.27](crates/holochain_sqlite/CHANGELOG.md#0.3.0-beta-dev.27)
+
+## [holochain\_zome\_types-0.3.0-beta-dev.21](crates/holochain_zome_types/CHANGELOG.md#0.3.0-beta-dev.21)
+
+## [kitsune\_p2p-0.3.0-beta-dev.26](crates/kitsune_p2p/CHANGELOG.md#0.3.0-beta-dev.26)
+
+## [holochain\_integrity\_types-0.3.0-beta-dev.20](crates/holochain_integrity_types/CHANGELOG.md#0.3.0-beta-dev.20)
+
+## [kitsune\_p2p\_block-0.3.0-beta-dev.14](crates/kitsune_p2p_block/CHANGELOG.md#0.3.0-beta-dev.14)
+
+## [kitsune\_p2p\_bootstrap\_client-0.3.0-beta-dev.23](crates/kitsune_p2p_bootstrap_client/CHANGELOG.md#0.3.0-beta-dev.23)
+
+## [kitsune\_p2p\_fetch-0.3.0-beta-dev.19](crates/kitsune_p2p_fetch/CHANGELOG.md#0.3.0-beta-dev.19)
+
+## [kitsune\_p2p\_proxy-0.3.0-beta-dev.17](crates/kitsune_p2p_proxy/CHANGELOG.md#0.3.0-beta-dev.17)
+
+## [holo\_hash-0.3.0-beta-dev.17](crates/holo_hash/CHANGELOG.md#0.3.0-beta-dev.17)
+
+## [kitsune\_p2p\_bootstrap-0.2.0-beta-dev.17](crates/kitsune_p2p_bootstrap/CHANGELOG.md#0.2.0-beta-dev.17)
+
+## [kitsune\_p2p\_transport\_quic-0.3.0-beta-dev.17](crates/kitsune_p2p_transport_quic/CHANGELOG.md#0.3.0-beta-dev.17)
+
+## [kitsune\_p2p\_types-0.3.0-beta-dev.17](crates/kitsune_p2p_types/CHANGELOG.md#0.3.0-beta-dev.17)
+
+## [kitsune\_p2p\_bin\_data-0.3.0-beta-dev.12](crates/kitsune_p2p_bin_data/CHANGELOG.md#0.3.0-beta-dev.12)
+
+## [kitsune\_p2p\_dht-0.3.0-beta-dev.13](crates/kitsune_p2p_dht/CHANGELOG.md#0.3.0-beta-dev.13)
+
+## [kitsune\_p2p\_dht\_arc-0.3.0-beta-dev.11](crates/kitsune_p2p_dht_arc/CHANGELOG.md#0.3.0-beta-dev.11)
+
+## [holochain\_trace-0.3.0-beta-dev.4](crates/holochain_trace/CHANGELOG.md#0.3.0-beta-dev.4)
+
 # 20231222.142916
 
 ## [hcterm-0.3.0-beta-dev.5](crates/hcterm/CHANGELOG.md#0.3.0-beta-dev.5)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,11 +86,11 @@ dependencies = [
 
 [[package]]
 name = "aitia"
-version = "0.1.0"
+version = "0.2.0-beta-dev.0"
 dependencies = [
  "anyhow",
  "derive_more",
- "holochain_trace 0.3.0-beta-dev.4",
+ "holochain_trace 0.3.0-beta-dev.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "maplit",
  "parking_lot 0.10.2",
  "petgraph",
@@ -1720,7 +1720,7 @@ dependencies = [
  "crossterm 0.27.0",
  "futures",
  "holochain_diagnostics",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "tokio",
  "tokio-stream",
  "tui",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "hc_sleuth"
-version = "0.1.0"
+version = "0.2.0-beta-dev.0"
 dependencies = [
  "aitia",
  "anyhow",
@@ -2616,7 +2616,7 @@ dependencies = [
  "derive_more",
  "hc_sleuth",
  "holochain_state_types",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "holochain_types",
  "kitsune_p2p",
  "once_cell",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "hcterm"
-version = "0.3.0-beta-dev.5"
+version = "0.3.0-beta-dev.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "hdi"
-version = "0.4.0-beta-dev.20"
+version = "0.4.0-beta-dev.21"
 dependencies = [
  "arbitrary",
  "fixt",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.3.0-beta-dev.24"
+version = "0.3.0-beta-dev.25"
 dependencies = [
  "fixt",
  "getrandom 0.2.11",
@@ -2694,7 +2694,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.3.0-beta-dev.19"
+version = "0.3.0-beta-dev.20"
 dependencies = [
  "darling 0.14.4",
  "heck 0.4.1",
@@ -2783,7 +2783,7 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.3.0-beta-dev.16"
+version = "0.3.0-beta-dev.17"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0-beta-dev.30"
 dependencies = [
  "aitia",
  "anyhow",
@@ -2854,7 +2854,7 @@ dependencies = [
  "holochain_sqlite",
  "holochain_state",
  "holochain_test_wasm_common",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "holochain_types",
  "holochain_util",
  "holochain_wasm_test_utils",
@@ -2931,7 +2931,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0-beta-dev.30"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -2949,7 +2949,7 @@ dependencies = [
  "holochain_serialized_bytes",
  "holochain_sqlite",
  "holochain_state",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "holochain_types",
  "holochain_util",
  "holochain_zome_types",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0-beta-dev.30"
 dependencies = [
  "anyhow",
  "clap 4.4.11",
@@ -2979,14 +2979,14 @@ dependencies = [
  "holochain_cli_bundle",
  "holochain_cli_run_local_services",
  "holochain_cli_sandbox",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "lazy_static",
  "tokio",
 ]
 
 [[package]]
 name = "holochain_cli_bundle"
-version = "0.3.0-beta-dev.27"
+version = "0.3.0-beta-dev.28"
 dependencies = [
  "anyhow",
  "assert_cmd 1.0.8",
@@ -3014,11 +3014,11 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_run_local_services"
-version = "0.3.0-beta-dev.17"
+version = "0.3.0-beta-dev.18"
 dependencies = [
  "clap 4.4.11",
  "futures",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "if-addrs 0.10.2",
  "kitsune_p2p_bootstrap",
  "tokio",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_sandbox"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0-beta-dev.30"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -3039,7 +3039,7 @@ dependencies = [
  "futures",
  "holochain_conductor_api",
  "holochain_p2p",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "holochain_types",
  "holochain_util",
  "holochain_websocket",
@@ -3060,7 +3060,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0-beta-dev.30"
 dependencies = [
  "derive_more",
  "directories",
@@ -3068,7 +3068,7 @@ dependencies = [
  "holochain_keystore",
  "holochain_serialized_bytes",
  "holochain_state_types",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "holochain_types",
  "holochain_zome_types",
  "kitsune_p2p",
@@ -3089,7 +3089,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_services"
-version = "0.2.0-beta-dev.0"
+version = "0.2.0-beta-dev.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.3.0-beta-dev.19"
+version = "0.3.0-beta-dev.20"
 dependencies = [
  "arbitrary",
  "derive_builder",
@@ -3145,7 +3145,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.3.0-beta-dev.21"
+version = "0.3.0-beta-dev.22"
 dependencies = [
  "assert_cmd 2.0.12",
  "base64 0.13.1",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_p2p"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0-beta-dev.29"
 dependencies = [
  "aitia",
  "async-trait",
@@ -3217,7 +3217,7 @@ dependencies = [
  "holochain_nonce",
  "holochain_p2p",
  "holochain_serialized_bytes",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "holochain_types",
  "holochain_util",
  "holochain_zome_types",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.3.0-beta-dev.26"
+version = "0.3.0-beta-dev.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3285,7 +3285,7 @@ dependencies = [
  "holochain_nonce",
  "holochain_serialized_bytes",
  "holochain_sqlite",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "holochain_util",
  "holochain_zome_types",
  "kitsune_p2p",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0-beta-dev.29"
 dependencies = [
  "aitia",
  "anyhow",
@@ -3346,7 +3346,7 @@ dependencies = [
  "holochain_sqlite",
  "holochain_state",
  "holochain_state_types",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "holochain_types",
  "holochain_util",
  "holochain_wasm_test_utils",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_state_types"
-version = "0.3.0-beta-dev.26"
+version = "0.3.0-beta-dev.27"
 dependencies = [
  "holo_hash",
  "holochain_integrity_types",
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.3.0-beta-dev.24"
+version = "0.3.0-beta-dev.25"
 dependencies = [
  "hdk",
  "serde",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_trace"
-version = "0.3.0-beta-dev.3"
+version = "0.3.0-beta-dev.4"
 dependencies = [
  "chrono",
  "derive_more",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.3.0-beta-dev.26"
+version = "0.3.0-beta-dev.27"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3451,7 +3451,7 @@ dependencies = [
  "holochain_nonce",
  "holochain_serialized_bytes",
  "holochain_sqlite",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "holochain_types",
  "holochain_util",
  "holochain_wasmer_host",
@@ -3511,7 +3511,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_test_utils"
-version = "0.3.0-beta-dev.27"
+version = "0.3.0-beta-dev.28"
 dependencies = [
  "holochain_types",
  "holochain_util",
@@ -3570,13 +3570,13 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.3.0-beta-dev.6"
+version = "0.3.0-beta-dev.7"
 dependencies = [
  "criterion 0.3.6",
  "futures",
  "ghost_actor 0.4.0-alpha.5",
  "holochain_serialized_bytes",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "holochain_types",
  "linefeed",
  "must_future",
@@ -3598,7 +3598,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.3.0-beta-dev.20"
+version = "0.3.0-beta-dev.21"
 dependencies = [
  "arbitrary",
  "contrafact",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p"
-version = "0.3.0-beta-dev.25"
+version = "0.3.0-beta-dev.26"
 dependencies = [
  "arbitrary",
  "arrayref",
@@ -4199,7 +4199,7 @@ dependencies = [
  "futures",
  "ghost_actor 0.3.0-alpha.6",
  "governor",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "itertools 0.11.0",
  "kitsune_p2p",
  "kitsune_p2p_bin_data",
@@ -4241,7 +4241,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bin_data"
-version = "0.3.0-beta-dev.11"
+version = "0.3.0-beta-dev.12"
 dependencies = [
  "arbitrary",
  "base64 0.13.1",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_block"
-version = "0.3.0-beta-dev.13"
+version = "0.3.0-beta-dev.14"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_timestamp",
@@ -4267,7 +4267,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bootstrap"
-version = "0.2.0-beta-dev.16"
+version = "0.2.0-beta-dev.17"
 dependencies = [
  "clap 4.4.11",
  "criterion 0.5.1",
@@ -4289,7 +4289,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bootstrap_client"
-version = "0.3.0-beta-dev.22"
+version = "0.3.0-beta-dev.23"
 dependencies = [
  "ed25519-dalek",
  "fixt",
@@ -4308,7 +4308,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht"
-version = "0.3.0-beta-dev.12"
+version = "0.3.0-beta-dev.13"
 dependencies = [
  "arbitrary",
  "colored",
@@ -4316,7 +4316,7 @@ dependencies = [
  "derive_more",
  "futures",
  "holochain_serialized_bytes",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "kitsune_p2p_dht",
  "kitsune_p2p_dht_arc",
  "kitsune_p2p_timestamp",
@@ -4337,12 +4337,12 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht_arc"
-version = "0.3.0-beta-dev.10"
+version = "0.3.0-beta-dev.11"
 dependencies = [
  "arbitrary",
  "derive_more",
  "gcollections",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "intervallum",
  "kitsune_p2p_timestamp",
  "maplit",
@@ -4359,12 +4359,12 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_fetch"
-version = "0.3.0-beta-dev.18"
+version = "0.3.0-beta-dev.19"
 dependencies = [
  "arbitrary",
  "derive_more",
  "holochain_serialized_bytes",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "human-repr",
  "kitsune_p2p_fetch",
  "kitsune_p2p_timestamp",
@@ -4395,14 +4395,14 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_proxy"
-version = "0.3.0-beta-dev.16"
+version = "0.3.0-beta-dev.17"
 dependencies = [
  "base64 0.21.5",
  "criterion 0.5.1",
  "crossterm 0.27.0",
  "derive_more",
  "futures",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "kitsune_p2p_transport_quic",
  "kitsune_p2p_types",
  "serde",
@@ -4429,7 +4429,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_transport_quic"
-version = "0.3.0-beta-dev.16"
+version = "0.3.0-beta-dev.17"
 dependencies = [
  "blake2b_simd 1.0.2",
  "futures",
@@ -4443,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_types"
-version = "0.3.0-beta-dev.16"
+version = "0.3.0-beta-dev.17"
 dependencies = [
  "arbitrary",
  "base64 0.21.5",
@@ -4452,7 +4452,7 @@ dependencies = [
  "fixt",
  "futures",
  "ghost_actor 0.3.0-alpha.6",
- "holochain_trace 0.3.0-beta-dev.3",
+ "holochain_trace 0.3.0-beta-dev.4",
  "kitsune_p2p_bin_data",
  "kitsune_p2p_dht",
  "kitsune_p2p_dht_arc",

--- a/crates/aitia/CHANGELOG.md
+++ b/crates/aitia/CHANGELOG.md
@@ -7,4 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.2.0-beta-dev.0
+
 Initial version

--- a/crates/aitia/Cargo.toml
+++ b/crates/aitia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aitia"
-version = "0.1.0"
+version = "0.2.0-beta-dev.0"
 description = "Library for making sense of events in terms of causal graphs"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/diagnostic_tests/Cargo.toml
+++ b/crates/diagnostic_tests/Cargo.toml
@@ -12,7 +12,7 @@ chashmap = "2.2"
 colored = "2"
 futures = { workspace = true }
 holochain_diagnostics = { path = "../holochain_diagnostics" }
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../holochain_trace" }
 tokio = { version = "1.27", features = ["full"] }
 tokio-stream = "0.1"
 

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.3.0-beta-dev.30
+
 ## 0.3.0-beta-dev.29
 
 ## 0.3.0-beta-dev.28

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0-beta-dev.30"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
@@ -23,10 +23,10 @@ anyhow = "1.0"
 clap = { version = "4.0", features = [ "derive", "cargo" ] }
 futures = "0.3"
 lazy_static = "1.4"
-holochain_cli_bundle = { path = "../hc_bundle", version = "^0.3.0-beta-dev.27"}
-holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.3.0-beta-dev.29"}
-holochain_cli_run_local_services = { path = "../hc_run_local_services", version = "^0.3.0-beta-dev.17"}
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../holochain_trace" }
+holochain_cli_bundle = { path = "../hc_bundle", version = "^0.3.0-beta-dev.28"}
+holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.3.0-beta-dev.30"}
+holochain_cli_run_local_services = { path = "../hc_run_local_services", version = "^0.3.0-beta-dev.18"}
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../holochain_trace" }
 tokio = { version = "1.27", features = ["full"] }
 
 [features]

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.28
+
 ## 0.3.0-beta-dev.27
 
 ## 0.3.0-beta-dev.26

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_bundle"
-version = "0.3.0-beta-dev.27"
+version = "0.3.0-beta-dev.28"
 description = "DNA and hApp bundling functionality for the `hc` Holochain CLI utility"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -26,7 +26,7 @@ anyhow = "1.0"
 clap = { version = "4.0", features = [ "derive" ] }
 holochain_util = { path = "../holochain_util", features = ["backtrace"], version = "^0.3.0-beta-dev.3"}
 holochain_serialized_bytes = "=0.0.53"
-holochain_types = { version = "^0.3.0-beta-dev.26", path = "../holochain_types" }
+holochain_types = { version = "^0.3.0-beta-dev.27", path = "../holochain_types" }
 mr_bundle = {version = "^0.3.0-beta-dev.3", path = "../mr_bundle"}
 serde = { version = "1.0", features = [ "derive" ] }
 serde_bytes = "0.11"

--- a/crates/hc_demo_cli/Cargo.toml
+++ b/crates/hc_demo_cli/Cargo.toml
@@ -10,11 +10,11 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 clap = { version = "4.2.2", features = [ "derive", "wrap_help" ], optional = true }
 flate2 = { version = "1.0.25", optional = true }
-hdi = { path = "../hdi", version = "^0.4.0-beta-dev.20", optional = true }
-hdk = { path = "../hdk", version = "^0.3.0-beta-dev.24", optional = true }
-holochain = { path = "../holochain", version = "^0.3.0-beta-dev.29", optional = true }
-holochain_types = { path = "../holochain_types", version = "^0.3.0-beta-dev.26", optional = true }
-holochain_keystore = { path = "../holochain_keystore", version = "^0.3.0-beta-dev.21", optional = true }
+hdi = { path = "../hdi", version = "^0.4.0-beta-dev.21", optional = true }
+hdk = { path = "../hdk", version = "^0.3.0-beta-dev.25", optional = true }
+holochain = { path = "../holochain", version = "^0.3.0-beta-dev.30", optional = true }
+holochain_types = { path = "../holochain_types", version = "^0.3.0-beta-dev.27", optional = true }
+holochain_keystore = { path = "../holochain_keystore", version = "^0.3.0-beta-dev.22", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand-utf8 = { version = "0.0.1", optional = true }
 serde = { version = "1", optional = true }

--- a/crates/hc_run_local_services/CHANGELOG.md
+++ b/crates/hc_run_local_services/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.18
+
 ## 0.3.0-beta-dev.17
 
 ## 0.3.0-beta-dev.16

--- a/crates/hc_run_local_services/Cargo.toml
+++ b/crates/hc_run_local_services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_run_local_services"
-version = "0.3.0-beta-dev.17"
+version = "0.3.0-beta-dev.18"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli_run_local_services"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
@@ -17,9 +17,9 @@ path = "src/bin/hc-run-local-services.rs"
 [dependencies]
 clap = { version = "4.0", features = [ "derive" ] }
 futures = "0.3.28"
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../holochain_trace" }
 if-addrs = "0.10.1"
-kitsune_p2p_bootstrap = { version = "^0.2.0-beta-dev.16", path = "../kitsune_p2p/bootstrap" }
+kitsune_p2p_bootstrap = { version = "^0.2.0-beta-dev.17", path = "../kitsune_p2p/bootstrap" }
 tokio = { version = "1.27", features = ["full"] }
 tracing = "0.1"
 tx5-signal-srv = "=0.0.5-alpha"

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.30
+
 ## 0.3.0-beta-dev.29
 
 ## 0.3.0-beta-dev.28

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_sandbox"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0-beta-dev.30"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli_sandbox"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
@@ -20,14 +20,14 @@ ansi_term = "0.12"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 clap = { version = "4.0", features = [ "derive", "env" ] }
 futures = "0.3"
-holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.3.0-beta-dev.29", features = ["sqlite"] }
-holochain_types = { path = "../holochain_types", version = "^0.3.0-beta-dev.26", features = ["sqlite"] }
-holochain_websocket = { path = "../holochain_websocket", version = "^0.3.0-beta-dev.6"}
-holochain_p2p = { path = "../holochain_p2p", version = "^0.3.0-beta-dev.28", features = ["sqlite"] }
+holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.3.0-beta-dev.30", features = ["sqlite"] }
+holochain_types = { path = "../holochain_types", version = "^0.3.0-beta-dev.27", features = ["sqlite"] }
+holochain_websocket = { path = "../holochain_websocket", version = "^0.3.0-beta-dev.7"}
+holochain_p2p = { path = "../holochain_p2p", version = "^0.3.0-beta-dev.29", features = ["sqlite"] }
 holochain_util = { version = "^0.3.0-beta-dev.3", path = "../holochain_util", features = ["pw"] }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.16", path = "../kitsune_p2p/types" }
+kitsune_p2p_types = { version = "^0.3.0-beta-dev.17", path = "../kitsune_p2p/types" }
 nanoid = "0.3"
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../holochain_trace" }
 once_cell = "1.13.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"

--- a/crates/hc_sleuth/CHANGELOG.md
+++ b/crates/hc_sleuth/CHANGELOG.md
@@ -7,4 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.2.0-beta-dev.0
+
 Initial version

--- a/crates/hc_sleuth/Cargo.toml
+++ b/crates/hc_sleuth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hc_sleuth"
-version = "0.1.0"
+version = "0.2.0-beta-dev.0"
 description = "Tool for diagnosing problems with Holochain"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -11,12 +11,12 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-aitia = { version = "0.1.0", path = "../aitia" }
+aitia = { version = "^0.2.0-beta-dev.0", path = "../aitia" }
 derive_more = "0.99"
-holochain_state_types = { version = "^0.3.0-beta-dev.26", path = "../holochain_state_types" }
-holochain_types = { version = "^0.3.0-beta-dev.26", path = "../holochain_types" }
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../holochain_trace" }
-kitsune_p2p = { version = "^0.3.0-beta-dev.25", path = "../kitsune_p2p/kitsune_p2p" }
+holochain_state_types = { version = "^0.3.0-beta-dev.27", path = "../holochain_state_types" }
+holochain_types = { version = "^0.3.0-beta-dev.27", path = "../holochain_types" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../holochain_trace" }
+kitsune_p2p = { version = "^0.3.0-beta-dev.26", path = "../kitsune_p2p/kitsune_p2p" }
 once_cell = "1.18"
 parking_lot = "0.10"
 petgraph = "0.6"

--- a/crates/hdi/CHANGELOG.md
+++ b/crates/hdi/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.4.0-beta-dev.21
+
 ## 0.4.0-beta-dev.20
 
 ## 0.4.0-beta-dev.19

--- a/crates/hdi/Cargo.toml
+++ b/crates/hdi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdi"
-version = "0.4.0-beta-dev.20"
+version = "0.4.0-beta-dev.21"
 description = "The HDI"
 license = "CAL-1.0"
 homepage = "https://github.com/holochain/holochain/tree/develop/crates/hdi"
@@ -11,12 +11,12 @@ categories = ["cryptography"]
 edition = "2021"
 
 [dependencies]
-hdk_derive = { version = "^0.3.0-beta-dev.19", path = "../hdk_derive" }
-holo_hash = { version = "^0.3.0-beta-dev.16", path = "../holo_hash" }
+hdk_derive = { version = "^0.3.0-beta-dev.20", path = "../hdk_derive" }
+holo_hash = { version = "^0.3.0-beta-dev.17", path = "../holo_hash" }
 holochain_wasmer_guest = "=0.0.91"
 # it's important that we depend on holochain_integrity_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
-holochain_integrity_types = { version = "^0.3.0-beta-dev.19", path = "../holochain_integrity_types", default-features = false }
+holochain_integrity_types = { version = "^0.3.0-beta-dev.20", path = "../holochain_integrity_types", default-features = false }
 paste = "1.0"
 serde = "1.0"
 serde_bytes = "0.11"

--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.3.0-beta-dev.25
+
 ## 0.3.0-beta-dev.24
 
 ## 0.3.0-beta-dev.23

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk"
-version = "0.3.0-beta-dev.24"
+version = "0.3.0-beta-dev.25"
 description = "The Holochain HDK"
 license = "CAL-1.0"
 homepage = "https://github.com/holochain/holochain/tree/develop/crates/hdk"
@@ -11,13 +11,13 @@ categories = [ "cryptography" ]
 edition = "2021"
 
 [dependencies]
-hdi = { version = "=0.4.0-beta-dev.20", path = "../hdi", features = ["trace"] }
-hdk_derive = { version = "^0.3.0-beta-dev.19", path = "../hdk_derive" }
-holo_hash = { version = "^0.3.0-beta-dev.16", path = "../holo_hash" }
+hdi = { version = "=0.4.0-beta-dev.21", path = "../hdi", features = ["trace"] }
+hdk_derive = { version = "^0.3.0-beta-dev.20", path = "../hdk_derive" }
+holo_hash = { version = "^0.3.0-beta-dev.17", path = "../holo_hash" }
 holochain_wasmer_guest = "=0.0.91"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
-holochain_zome_types = { version = "^0.3.0-beta-dev.20", path = "../holochain_zome_types", default-features = false }
+holochain_zome_types = { version = "^0.3.0-beta-dev.21", path = "../holochain_zome_types", default-features = false }
 paste = "1.0"
 serde = "1.0"
 serde_bytes = "0.11"

--- a/crates/hdk_derive/CHANGELOG.md
+++ b/crates/hdk_derive/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.20
+
 ## 0.3.0-beta-dev.19
 
 ## 0.3.0-beta-dev.18

--- a/crates/hdk_derive/Cargo.toml
+++ b/crates/hdk_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk_derive"
-version = "0.3.0-beta-dev.19"
+version = "0.3.0-beta-dev.20"
 description = "derive macros for the holochain hdk"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -22,7 +22,7 @@ darling = "0.14.1"
 heck = "0.4"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdi, to reduce code bloat
-holochain_integrity_types = { version = "^0.3.0-beta-dev.19", path = "../holochain_integrity_types", default-features = false }
+holochain_integrity_types = { version = "^0.3.0-beta-dev.20", path = "../holochain_integrity_types", default-features = false }
 proc-macro-error = "1.0.4"
 
 [features]

--- a/crates/holo_hash/CHANGELOG.md
+++ b/crates/holo_hash/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.17
+
 ## 0.3.0-beta-dev.16
 
 ## 0.3.0-beta-dev.15

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holo_hash"
-version = "0.3.0-beta-dev.16"
+version = "0.3.0-beta-dev.17"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 keywords = ["holochain", "holo", "hash", "blake", "blake2b"]
 categories = ["cryptography"]
@@ -24,7 +24,7 @@ fixt = { version = "^0.3.0-beta-dev.0", path = "../fixt", optional = true }
 futures = { version = "0.3", optional = true }
 holochain_serialized_bytes = { version = "=0.0.53", optional = true }
 holochain_util = { version = "^0.3.0-beta-dev.3", path = "../holochain_util", default-features = false }
-kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.10", path = "../kitsune_p2p/dht_arc" }
+kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/dht_arc" }
 must_future = { version = "0.1", optional = true }
 proptest = { version = "1", optional = true }
 proptest-derive = { version = "0", optional = true }

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.3.0-beta-dev.30
+
 ## 0.3.0-beta-dev.29
 
 - Sys validation will now validate that a DeleteLink points to an action which is a CreateLink through the `link_add_address` of the delete.

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0-beta-dev.30"
 description = "Holochain, a framework for distributed applications"
 license = "CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -24,36 +24,36 @@ futures = "0.3.1"
 getrandom = "0.2.7"
 get_if_addrs = "0.5.3"
 ghost_actor = "0.3.0-alpha.6"
-holo_hash = { version = "^0.3.0-beta-dev.16", path = "../holo_hash", features = ["full"] }
-holochain_cascade = { version = "^0.3.0-beta-dev.29", path = "../holochain_cascade" }
-holochain_conductor_api = { version = "^0.3.0-beta-dev.29", path = "../holochain_conductor_api" }
-holochain_keystore = { version = "^0.3.0-beta-dev.21", path = "../holochain_keystore", default-features = false }
-holochain_p2p = { version = "^0.3.0-beta-dev.28", path = "../holochain_p2p" }
-holochain_sqlite = { version = "^0.3.0-beta-dev.26", path = "../holochain_sqlite" }
+holo_hash = { version = "^0.3.0-beta-dev.17", path = "../holo_hash", features = ["full"] }
+holochain_cascade = { version = "^0.3.0-beta-dev.30", path = "../holochain_cascade" }
+holochain_conductor_api = { version = "^0.3.0-beta-dev.30", path = "../holochain_conductor_api" }
+holochain_keystore = { version = "^0.3.0-beta-dev.22", path = "../holochain_keystore", default-features = false }
+holochain_p2p = { version = "^0.3.0-beta-dev.29", path = "../holochain_p2p" }
+holochain_sqlite = { version = "^0.3.0-beta-dev.27", path = "../holochain_sqlite" }
 holochain_serialized_bytes = "=0.0.53"
-holochain_state = { version = "^0.3.0-beta-dev.28", path = "../holochain_state" }
-holochain_types = { version = "^0.3.0-beta-dev.26", path = "../holochain_types" }
+holochain_state = { version = "^0.3.0-beta-dev.29", path = "../holochain_state" }
+holochain_types = { version = "^0.3.0-beta-dev.27", path = "../holochain_types" }
 holochain_util = { version = "^0.3.0-beta-dev.3", path = "../holochain_util", features = [ "pw" ] }
 holochain_wasmer_host = "=0.0.91"
-holochain_websocket = { version = "^0.3.0-beta-dev.6", path = "../holochain_websocket" }
-holochain_zome_types = { version = "^0.3.0-beta-dev.20", path = "../holochain_zome_types", features = ["full"] }
+holochain_websocket = { version = "^0.3.0-beta-dev.7", path = "../holochain_websocket" }
+holochain_zome_types = { version = "^0.3.0-beta-dev.21", path = "../holochain_zome_types", features = ["full"] }
 holochain_nonce = { version = "^0.3.0-beta-dev.22", path = "../holochain_nonce" }
 holochain_secure_primitive = { version = "^0.3.0-beta-dev.21", path = "../holochain_secure_primitive" }
-holochain_conductor_services = { version = "^0.2.0-beta-dev.0", path = "../holochain_conductor_services" }
+holochain_conductor_services = { version = "^0.2.0-beta-dev.1", path = "../holochain_conductor_services" }
 human-panic = "1.0.3"
 itertools = { version = "0.10" }
-kitsune_p2p = { version = "^0.3.0-beta-dev.25", path = "../kitsune_p2p/kitsune_p2p", default-features = false }
-kitsune_p2p_bootstrap_client = { version = "^0.3.0-beta-dev.22", path = "../kitsune_p2p/bootstrap_client" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/bin_data" }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.16", path = "../kitsune_p2p/types" }
-kitsune_p2p_block = { version = "^0.3.0-beta-dev.13", path = "../kitsune_p2p/block" }
+kitsune_p2p = { version = "^0.3.0-beta-dev.26", path = "../kitsune_p2p/kitsune_p2p", default-features = false }
+kitsune_p2p_bootstrap_client = { version = "^0.3.0-beta-dev.23", path = "../kitsune_p2p/bootstrap_client" }
+kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.12", path = "../kitsune_p2p/bin_data" }
+kitsune_p2p_types = { version = "^0.3.0-beta-dev.17", path = "../kitsune_p2p/types" }
+kitsune_p2p_block = { version = "^0.3.0-beta-dev.14", path = "../kitsune_p2p/block" }
 lazy_static = "1.4.0"
 mockall = "0.11.3"
 mr_bundle = { version = "^0.3.0-beta-dev.3", path = "../mr_bundle" }
 must_future = "0.1.1"
 nanoid = "0.3"
 num_cpus = "1.8"
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../holochain_trace" }
 holochain_metrics = { version = "^0.3.0-beta-dev.7", path = "../holochain_metrics", default_features = false }
 once_cell = "1.4.1"
 async-once-cell = "0.5"
@@ -87,7 +87,7 @@ url = "2.4"
 url2 = "0.0.6"
 url_serde = "0.2.0"
 uuid = { version = "0.7", features = [ "serde", "v4" ] }
-holochain_wasm_test_utils = { version = "^0.3.0-beta-dev.27", path = "../test_utils/wasm" }
+holochain_wasm_test_utils = { version = "^0.3.0-beta-dev.28", path = "../test_utils/wasm" }
 tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
 async-recursion = "0.3"
 wasmer = "=4.2.4"
@@ -98,10 +98,10 @@ opentelemetry_api = { version = "=0.20.0", features = [ "metrics" ] }
 arbitrary = { version = "1.0", features = ["derive"], optional = true }
 contrafact = {version = "0.2.0-rc.1", optional = true }
 diff = {version = "0.1", optional = true }
-hdk = { version = "^0.3.0-beta-dev.24", path = "../hdk", optional = true }
+hdk = { version = "^0.3.0-beta-dev.25", path = "../hdk", optional = true }
 matches = {version = "0.1.8", optional = true }
-holochain_test_wasm_common = { version = "^0.3.0-beta-dev.24", path = "../test_utils/wasm_common", optional = true  }
-kitsune_p2p_bootstrap = { version = "^0.2.0-beta-dev.16", path = "../kitsune_p2p/bootstrap", optional = true }
+holochain_test_wasm_common = { version = "^0.3.0-beta-dev.25", path = "../test_utils/wasm_common", optional = true  }
+kitsune_p2p_bootstrap = { version = "^0.2.0-beta-dev.17", path = "../kitsune_p2p/bootstrap", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
 tx5-go-pion-turn = { version = "=0.0.5-alpha", optional = true }
 tx5-signal-srv = { version = "=0.0.5-alpha", optional = true }
@@ -111,8 +111,8 @@ bytes = { version = "1", optional = true }
 reqwest = { version = "0.11.2", features = ["json"], optional = true }
 
 # TODO: make optional?
-aitia = { version = "0.1.0", path = "../aitia" }
-hc_sleuth = { version = "0.1.0", path = "../hc_sleuth" }
+aitia = { version = "^0.2.0-beta-dev.0", path = "../aitia" }
+hc_sleuth = { version = "^0.2.0-beta-dev.0", path = "../hc_sleuth" }
 
 # fact deps
 petgraph = { version = "0.6.0", features = ["quickcheck", "stable_graph"] }
@@ -145,7 +145,7 @@ test-case = "1.2.1"
 tokio-tungstenite = "0.13"
 
 [build-dependencies]
-hdk = { version = "^0.3.0-beta-dev.24", path = "../hdk"}
+hdk = { version = "^0.3.0-beta-dev.25", path = "../hdk"}
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = { version = "1.0.51" }
 toml = "0.5.6"

--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.30
+
 ## 0.3.0-beta-dev.29
 
 ## 0.3.0-beta-dev.28

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cascade"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0-beta-dev.30"
 description = "Logic for cascading updates to Holochain state and network interaction"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -15,19 +15,19 @@ fallible-iterator = "0.2"
 fixt = { version = "^0.3.0-beta-dev.0", path = "../fixt" }
 futures = "0.3"
 ghost_actor = "0.3.0-alpha.6"
-hdk = { version = "^0.3.0-beta-dev.24", path = "../hdk" }
-hdk_derive = { version = "^0.3.0-beta-dev.19", path = "../hdk_derive" }
-holo_hash = { version = "^0.3.0-beta-dev.16", path = "../holo_hash", features = ["full"] }
-holochain_sqlite = { version = "^0.3.0-beta-dev.26", path = "../holochain_sqlite" }
-holochain_p2p = { version = "^0.3.0-beta-dev.28", path = "../holochain_p2p" }
+hdk = { version = "^0.3.0-beta-dev.25", path = "../hdk" }
+hdk_derive = { version = "^0.3.0-beta-dev.20", path = "../hdk_derive" }
+holo_hash = { version = "^0.3.0-beta-dev.17", path = "../holo_hash", features = ["full"] }
+holochain_sqlite = { version = "^0.3.0-beta-dev.27", path = "../holochain_sqlite" }
+holochain_p2p = { version = "^0.3.0-beta-dev.29", path = "../holochain_p2p" }
 holochain_serialized_bytes = "=0.0.53"
-holochain_state = { version = "^0.3.0-beta-dev.28", path = "../holochain_state" }
-holochain_types = { version = "^0.3.0-beta-dev.26", path = "../holochain_types" }
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../holochain_trace" }
+holochain_state = { version = "^0.3.0-beta-dev.29", path = "../holochain_state" }
+holochain_types = { version = "^0.3.0-beta-dev.27", path = "../holochain_types" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../holochain_trace" }
 holochain_util = { version = "^0.3.0-beta-dev.3", path = "../holochain_util" }
-holochain_zome_types = { version = "^0.3.0-beta-dev.20", path = "../holochain_zome_types" }
+holochain_zome_types = { version = "^0.3.0-beta-dev.21", path = "../holochain_zome_types" }
 holochain_nonce = {version = "^0.3.0-beta-dev.22", path = "../holochain_nonce"}
-kitsune_p2p = { version = "^0.3.0-beta-dev.25", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p = { version = "^0.3.0-beta-dev.26", path = "../kitsune_p2p/kitsune_p2p" }
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 tokio = { version = "1.27", features = ["full"] }

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.30
+
 ## 0.3.0-beta-dev.29
 
 ## 0.3.0-beta-dev.28

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_conductor_api"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0-beta-dev.30"
 description = "Message types for Holochain admin and app interface protocols"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -11,13 +11,13 @@ edition = "2021"
 [dependencies]
 directories = "2.0.2"
 derive_more = { workspace = true }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.16", path = "../kitsune_p2p/types" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/bin_data" }
-holo_hash = { version = "^0.3.0-beta-dev.16", path = "../holo_hash", features = ["full"] }
-holochain_state_types = { version = "^0.3.0-beta-dev.26", path = "../holochain_state_types" }
+kitsune_p2p_types = { version = "^0.3.0-beta-dev.17", path = "../kitsune_p2p/types" }
+kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.12", path = "../kitsune_p2p/bin_data" }
+holo_hash = { version = "^0.3.0-beta-dev.17", path = "../holo_hash", features = ["full"] }
+holochain_state_types = { version = "^0.3.0-beta-dev.27", path = "../holochain_state_types" }
 holochain_serialized_bytes = "=0.0.53"
-holochain_types = { version = "^0.3.0-beta-dev.26", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.3.0-beta-dev.20", path = "../holochain_zome_types" }
+holochain_types = { version = "^0.3.0-beta-dev.27", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.3.0-beta-dev.21", path = "../holochain_zome_types" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = "1.0"
 serde_yaml = "0.9"
@@ -25,15 +25,15 @@ structopt = "0.3"
 tracing = "0.1.26"
 thiserror = "1.0.22"
 url2 = "0.0.6"
-holochain_keystore = { version = "^0.3.0-beta-dev.21", path = "../holochain_keystore" }
+holochain_keystore = { version = "^0.3.0-beta-dev.22", path = "../holochain_keystore" }
 shrinkwraprs = "0.3.0"
 
 [dev-dependencies]
 serde_json = "1.0"
 rmp-serde = "1.1"
 matches = {version = "0.1.8"}
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../holochain_trace" }
-kitsune_p2p = { version = "^0.3.0-beta-dev.25", path = "../kitsune_p2p/kitsune_p2p" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../holochain_trace" }
+kitsune_p2p = { version = "^0.3.0-beta-dev.26", path = "../kitsune_p2p/kitsune_p2p" }
 
 [features]
 chc = []

--- a/crates/holochain_conductor_services/CHANGELOG.md
+++ b/crates/holochain_conductor_services/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-dev.1
+
 ## 0.2.0-beta-dev.0
 
 - Conductor services crate created

--- a/crates/holochain_conductor_services/Cargo.toml
+++ b/crates/holochain_conductor_services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_conductor_services"
-version = "0.2.0-beta-dev.0"
+version = "0.2.0-beta-dev.1"
 description = "Holochain Conductor Services types"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain_integrity_types/CHANGELOG.md
+++ b/crates/holochain_integrity_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.3.0-beta-dev.20
+
 ## 0.3.0-beta-dev.19
 
 ## 0.3.0-beta-dev.18

--- a/crates/holochain_integrity_types/Cargo.toml
+++ b/crates/holochain_integrity_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_integrity_types"
-version = "0.3.0-beta-dev.19"
+version = "0.3.0-beta-dev.20"
 description = "Holochain integrity types"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -10,7 +10,7 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 
 [dependencies]
-holo_hash = { version = "^0.3.0-beta-dev.16", path = "../holo_hash" }
+holo_hash = { version = "^0.3.0-beta-dev.17", path = "../holo_hash" }
 holochain_serialized_bytes = "=0.0.53"
 holochain_util = { version = "^0.3.0-beta-dev.3", path = "../holochain_util", default-features = false }
 holochain_secure_primitive = { version = "^0.3.0-beta-dev.21", path = "../holochain_secure_primitive"}

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.22
+
 ## 0.3.0-beta-dev.21
 
 ## 0.3.0-beta-dev.20

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_keystore"
-version = "0.3.0-beta-dev.21"
+version = "0.3.0-beta-dev.22"
 description = "keystore for libsodium keypairs"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -13,10 +13,10 @@ edition = "2021"
 [dependencies]
 base64 = "0.13.0"
 futures = "0.3.23"
-holo_hash = { version = "^0.3.0-beta-dev.16", path = "../holo_hash", features = ["full"] }
+holo_hash = { version = "^0.3.0-beta-dev.17", path = "../holo_hash", features = ["full"] }
 holochain_serialized_bytes = "=0.0.53"
-holochain_zome_types = { path = "../holochain_zome_types", version = "^0.3.0-beta-dev.20"}
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.16", path = "../kitsune_p2p/types" }
+holochain_zome_types = { path = "../holochain_zome_types", version = "^0.3.0-beta-dev.21"}
+kitsune_p2p_types = { version = "^0.3.0-beta-dev.17", path = "../kitsune_p2p/types" }
 holochain_secure_primitive = { version = "^0.3.0-beta-dev.21", path = "../holochain_secure_primitive"}
 holochain_util = { version = "^0.3.0-beta-dev.3", path = "../holochain_util" }
 lair_keystore = { version = "0.3.0", default-features = false }

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.29
+
 ## 0.3.0-beta-dev.28
 
 ## 0.3.0-beta-dev.27

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_p2p"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0-beta-dev.29"
 description = "holochain specific wrapper around more generic p2p module"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -11,23 +11,23 @@ categories = [ "network-programming" ]
 edition = "2021"
 
 [dependencies]
-aitia = { version = "0.1.0", path = "../aitia" }
+aitia = { version = "^0.2.0-beta-dev.0", path = "../aitia" }
 async-trait = "0.1"
 derive_more = { workspace = true }
 fixt = { path = "../fixt", version = "^0.3.0-beta-dev.0"}
 futures = "0.3"
 ghost_actor = "0.3.0-alpha.6"
-hc_sleuth = { version = "0.1.0", path = "../hc_sleuth" }
-holo_hash = { version = "^0.3.0-beta-dev.16", path = "../holo_hash" }
-holochain_keystore = { version = "^0.3.0-beta-dev.21", path = "../holochain_keystore" }
+hc_sleuth = { version = "^0.2.0-beta-dev.0", path = "../hc_sleuth" }
+holo_hash = { version = "^0.3.0-beta-dev.17", path = "../holo_hash" }
+holochain_keystore = { version = "^0.3.0-beta-dev.22", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.53"
-holochain_types = { version = "^0.3.0-beta-dev.26", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.3.0-beta-dev.20", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "^0.3.0-beta-dev.25", path = "../kitsune_p2p/kitsune_p2p" }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.16", path = "../kitsune_p2p/types" }
+holochain_types = { version = "^0.3.0-beta-dev.27", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.3.0-beta-dev.21", path = "../holochain_zome_types" }
+kitsune_p2p = { version = "^0.3.0-beta-dev.26", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p_types = { version = "^0.3.0-beta-dev.17", path = "../kitsune_p2p/types" }
 holochain_nonce = {version = "^0.3.0-beta-dev.22", path = "../holochain_nonce"}
 mockall = "0.11.3"
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../holochain_trace" }
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.27
+
 ## 0.3.0-beta-dev.26
 
 ## 0.3.0-beta-dev.25

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_sqlite"
-version = "0.3.0-beta-dev.26"
+version = "0.3.0-beta-dev.27"
 description = "Abstractions for persistence of Holochain state via SQLite"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -17,16 +17,16 @@ chashmap = "=2.2.0"
 derive_more = { workspace = true }
 fallible-iterator = "0.2.0"
 futures = "0.3.1"
-holo_hash = { path = "../holo_hash", version = "^0.3.0-beta-dev.16"}
+holo_hash = { path = "../holo_hash", version = "^0.3.0-beta-dev.17"}
 holochain_serialized_bytes = "=0.0.53"
 holochain_util = { version = "^0.3.0-beta-dev.3", path = "../holochain_util", features = ["backtrace"], optional = true }
-holochain_zome_types = { version = "^0.3.0-beta-dev.20", path = "../holochain_zome_types" }
+holochain_zome_types = { version = "^0.3.0-beta-dev.21", path = "../holochain_zome_types" }
 holochain_nonce = {version = "^0.3.0-beta-dev.22", path = "../holochain_nonce"}
-kitsune_p2p = { version = "^0.3.0-beta-dev.25", path = "../kitsune_p2p/kitsune_p2p" }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.16", path = "../kitsune_p2p/types", optional = true }
-kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.10", path = "../kitsune_p2p/dht_arc" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/bin_data" }
-kitsune_p2p_dht = { version = "^0.3.0-beta-dev.12", path = "../kitsune_p2p/dht" }
+kitsune_p2p = { version = "^0.3.0-beta-dev.26", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p_types = { version = "^0.3.0-beta-dev.17", path = "../kitsune_p2p/types", optional = true }
+kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/dht_arc" }
+kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.12", path = "../kitsune_p2p/bin_data" }
+kitsune_p2p_dht = { version = "^0.3.0-beta-dev.13", path = "../kitsune_p2p/dht" }
 kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.5", path = "../kitsune_p2p/timestamp" }
 once_cell = "1.4.1"
 num_cpus = "1.13.0"
@@ -60,7 +60,7 @@ rusqlite = { version = "0.29", features = [
 
 [dev-dependencies]
 holochain_sqlite = { path = ".", features = ["test_utils", "slow_tests"] }
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../holochain_trace" }
 nanoid = "0.4.0"
 rand = "0.8.5"
 

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.29
+
 ## 0.3.0-beta-dev.28
 
 ## 0.3.0-beta-dev.27

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_state"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0-beta-dev.29"
 description = "Holochain persisted state datatypes and functions"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -9,27 +9,27 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 
 [dependencies]
-aitia = { version = "0.1.0", path = "../aitia" }
+aitia = { version = "^0.2.0-beta-dev.0", path = "../aitia" }
 byteorder = "1.3.4"
 cfg-if = "0.1"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 derive_more = { workspace = true }
 either = "1.5"
-holochain_sqlite = { version = "^0.3.0-beta-dev.26", path = "../holochain_sqlite" }
-holo_hash = { version = "^0.3.0-beta-dev.16", path = "../holo_hash", features = ["full"] }
+holochain_sqlite = { version = "^0.3.0-beta-dev.27", path = "../holochain_sqlite" }
+holo_hash = { version = "^0.3.0-beta-dev.17", path = "../holo_hash", features = ["full"] }
 fallible-iterator = "0.2.0"
 futures = "0.3"
-hc_sleuth = { version = "0.1.0", path = "../hc_sleuth" }
-holochain_keystore = { version = "^0.3.0-beta-dev.21", path = "../holochain_keystore" }
+hc_sleuth = { version = "^0.2.0-beta-dev.0", path = "../hc_sleuth" }
+holochain_keystore = { version = "^0.3.0-beta-dev.22", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.53"
-holochain_p2p = { version = "^0.3.0-beta-dev.28", path = "../holochain_p2p" }
-holochain_types = { version = "^0.3.0-beta-dev.26", path = "../holochain_types" }
+holochain_p2p = { version = "^0.3.0-beta-dev.29", path = "../holochain_p2p" }
+holochain_types = { version = "^0.3.0-beta-dev.27", path = "../holochain_types" }
 holochain_util = { version = "^0.3.0-beta-dev.3", path = "../holochain_util" }
-holochain_zome_types = { version = "^0.3.0-beta-dev.20", path = "../holochain_zome_types", features = [
+holochain_zome_types = { version = "^0.3.0-beta-dev.21", path = "../holochain_zome_types", features = [
     "full",
 ] }
-kitsune_p2p = { version = "^0.3.0-beta-dev.25", path = "../kitsune_p2p/kitsune_p2p" }
-holochain_state_types = { version = "^0.3.0-beta-dev.26", path = "../holochain_state_types" }
+kitsune_p2p = { version = "^0.3.0-beta-dev.26", path = "../kitsune_p2p/kitsune_p2p" }
+holochain_state_types = { version = "^0.3.0-beta-dev.27", path = "../holochain_state_types" }
 holochain_nonce = {version = "^0.3.0-beta-dev.22", path = "../holochain_nonce"}
 mockall = "0.11.3"
 one_err = "0.0.8"
@@ -60,7 +60,7 @@ arbitrary = "1.0"
 fixt = { path = "../fixt" }
 holochain_wasm_test_utils = { path = "../test_utils/wasm" }
 matches = "0.1.8"
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../holochain_trace" }
 pretty_assertions = "1.4"
 
 tempfile = "3.3"

--- a/crates/holochain_state_types/CHANGELOG.md
+++ b/crates/holochain_state_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.27
+
 ## 0.3.0-beta-dev.26
 
 ## 0.3.0-beta-dev.25

--- a/crates/holochain_state_types/Cargo.toml
+++ b/crates/holochain_state_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_state_types"
-version = "0.3.0-beta-dev.26"
+version = "0.3.0-beta-dev.27"
 description = "Types for the holochain_state crate"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -10,5 +10,5 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = [ "derive" ] }
-holochain_integrity_types = { version = "^0.3.0-beta-dev.19", path = "../holochain_integrity_types", default-features = false }
-holo_hash = { version = "^0.3.0-beta-dev.16", path = "../holo_hash" }
+holochain_integrity_types = { version = "^0.3.0-beta-dev.20", path = "../holochain_integrity_types", default-features = false }
+holo_hash = { version = "^0.3.0-beta-dev.17", path = "../holo_hash" }

--- a/crates/holochain_terminal/CHANGELOG.md
+++ b/crates/holochain_terminal/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.3.0-beta-dev.6
+
 ## 0.3.0-beta-dev.5
 
 ## 0.3.0-beta-dev.4

--- a/crates/holochain_terminal/Cargo.toml
+++ b/crates/holochain_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hcterm"
-version = "0.3.0-beta-dev.5"
+version = "0.3.0-beta-dev.6"
 description = "A terminal for Holochain"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -16,11 +16,11 @@ clap = { version = "4", features = ["derive"] }
 url = "2"
 once_cell = "1"
 chrono = "0.4"
-holo_hash = { version = "^0.3.0-beta-dev.16", path = "../holo_hash", features = ["encoding"] }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.16", path = "../kitsune_p2p/types" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/bin_data" }
-kitsune_p2p_bootstrap_client = { version = "^0.3.0-beta-dev.22", path = "../kitsune_p2p/bootstrap_client" }
+holo_hash = { version = "^0.3.0-beta-dev.17", path = "../holo_hash", features = ["encoding"] }
+kitsune_p2p_types = { version = "^0.3.0-beta-dev.17", path = "../kitsune_p2p/types" }
+kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.12", path = "../kitsune_p2p/bin_data" }
+kitsune_p2p_bootstrap_client = { version = "^0.3.0-beta-dev.23", path = "../kitsune_p2p/bootstrap_client" }
 holochain_util = { version = "^0.3.0-beta-dev.3", path = "../holochain_util" }
-holochain_conductor_api = { version = "^0.3.0-beta-dev.29", path = "../holochain_conductor_api" }
-holochain_websocket = { version = "^0.3.0-beta-dev.6", path = "../holochain_websocket" }
-holochain_types = { version = "^0.3.0-beta-dev.26", path = "../holochain_types" }
+holochain_conductor_api = { version = "^0.3.0-beta-dev.30", path = "../holochain_conductor_api" }
+holochain_websocket = { version = "^0.3.0-beta-dev.7", path = "../holochain_websocket" }
+holochain_types = { version = "^0.3.0-beta-dev.27", path = "../holochain_types" }

--- a/crates/holochain_trace/CHANGELOG.md
+++ b/crates/holochain_trace/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.4
+
 ## 0.3.0-beta-dev.3
 
 ## 0.3.0-beta-dev.2

--- a/crates/holochain_trace/Cargo.toml
+++ b/crates/holochain_trace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_trace"
-version = "0.3.0-beta-dev.3"
+version = "0.3.0-beta-dev.4"
 authors = ["freesig <tom.gowan@holo.host>", "Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 description = "tracing helpers"

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.27
+
 ## 0.3.0-beta-dev.26
 
 ## 0.3.0-beta-dev.25

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_types"
-version = "0.3.0-beta-dev.26"
+version = "0.3.0-beta-dev.27"
 description = "Holochain common types"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -27,22 +27,22 @@ flate2 = "1.0.14"
 futures = "0.3"
 getrandom = { version = "0.2.7" }
 one_err = "0.0.8"
-holo_hash = { version = "^0.3.0-beta-dev.16", path = "../holo_hash", features = ["encoding"] }
-holochain_keystore = { version = "^0.3.0-beta-dev.21", path = "../holochain_keystore" }
+holo_hash = { version = "^0.3.0-beta-dev.17", path = "../holo_hash", features = ["encoding"] }
+holochain_keystore = { version = "^0.3.0-beta-dev.22", path = "../holochain_keystore" }
 holochain_nonce = {version = "^0.3.0-beta-dev.22", path = "../holochain_nonce"}
 holochain_serialized_bytes = "=0.0.53"
-holochain_sqlite = { path = "../holochain_sqlite", version = "^0.3.0-beta-dev.26"}
+holochain_sqlite = { path = "../holochain_sqlite", version = "^0.3.0-beta-dev.27"}
 holochain_wasmer_host = "=0.0.91"
 holochain_util = { version = "^0.3.0-beta-dev.3", path = "../holochain_util", features = ["backtrace"] }
-holochain_zome_types = { path = "../holochain_zome_types", version = "^0.3.0-beta-dev.20", features = ["full"] }
+holochain_zome_types = { path = "../holochain_zome_types", version = "^0.3.0-beta-dev.21", features = ["full"] }
 itertools = { version = "0.10" }
-kitsune_p2p_dht = { version = "^0.3.0-beta-dev.12", path = "../kitsune_p2p/dht" }
+kitsune_p2p_dht = { version = "^0.3.0-beta-dev.13", path = "../kitsune_p2p/dht" }
 lazy_static = "1.4.0"
 mockall = "0.11.3"
 mr_bundle = { path = "../mr_bundle", features = ["packing"], version = "^0.3.0-beta-dev.3"}
 must_future = "0.1.1"
 nanoid = "0.3"
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../holochain_trace" }
 parking_lot = "0.10"
 rand = "0.8.5"
 regex = "1.4"

--- a/crates/holochain_websocket/CHANGELOG.md
+++ b/crates/holochain_websocket/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.7
+
 ## 0.3.0-beta-dev.6
 
 ## 0.3.0-beta-dev.5

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_websocket"
-version = "0.3.0-beta-dev.6"
+version = "0.3.0-beta-dev.7"
 description = "Holochain utilities for serving and connection with websockets"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -31,7 +31,7 @@ url2 = "0.0.6"
 holochain_types = { path = "../holochain_types", features = ["sqlite"] }
 linefeed = "0.6"
 unwrap_to = "0.1.0"
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../holochain_trace" }
 criterion = "0.3.4"
 
 [features]

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.21
+
 ## 0.3.0-beta-dev.20
 
 ## 0.3.0-beta-dev.19

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_zome_types"
-version = "0.3.0-beta-dev.20"
+version = "0.3.0-beta-dev.21"
 description = "Holochain zome types"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -12,12 +12,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kitsune_p2p_dht = { version = "^0.3.0-beta-dev.12", path = "../kitsune_p2p/dht", optional = true }
+kitsune_p2p_dht = { version = "^0.3.0-beta-dev.13", path = "../kitsune_p2p/dht", optional = true }
 kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.5", path = "../kitsune_p2p/timestamp" }
-kitsune_p2p_block = { version = "^0.3.0-beta-dev.13", path = "../kitsune_p2p/block" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.11", path = "../kitsune_p2p/bin_data" }
-holo_hash = { version = "^0.3.0-beta-dev.16", path = "../holo_hash", features = ["encoding"] }
-holochain_integrity_types = { version = "^0.3.0-beta-dev.19", path = "../holochain_integrity_types", features = ["tracing"] }
+kitsune_p2p_block = { version = "^0.3.0-beta-dev.14", path = "../kitsune_p2p/block" }
+kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.12", path = "../kitsune_p2p/bin_data" }
+holo_hash = { version = "^0.3.0-beta-dev.17", path = "../holo_hash", features = ["encoding"] }
+holochain_integrity_types = { version = "^0.3.0-beta-dev.20", path = "../holochain_integrity_types", features = ["tracing"] }
 holochain_serialized_bytes = "=0.0.53"
 holochain_secure_primitive = { version = "^0.3.0-beta-dev.21", path = "../holochain_secure_primitive"}
 holochain_nonce = {version = "^0.3.0-beta-dev.22", path = "../holochain_nonce"}

--- a/crates/kitsune_p2p/bin_data/CHANGELOG.md
+++ b/crates/kitsune_p2p/bin_data/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.12
+
 ## 0.3.0-beta-dev.11
 
 ## 0.3.0-beta-dev.10

--- a/crates/kitsune_p2p/bin_data/Cargo.toml
+++ b/crates/kitsune_p2p/bin_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_bin_data"
-version = "0.3.0-beta-dev.11"
+version = "0.3.0-beta-dev.12"
 description = "Binary data types for kitsune_p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 holochain_util = { version = "^0.3.0-beta-dev.3", path = "../../holochain_util", default-features = false }
-kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.10", path = "../dht_arc" }
+kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.11", path = "../dht_arc" }
 shrinkwraprs = "0.3.0"
 derive_more = { workspace = true }
 serde = { version = "1", features = [ "derive", "rc" ] }

--- a/crates/kitsune_p2p/block/CHANGELOG.md
+++ b/crates/kitsune_p2p/block/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.14
+
 ## 0.3.0-beta-dev.13
 
 ## 0.3.0-beta-dev.12

--- a/crates/kitsune_p2p/block/Cargo.toml
+++ b/crates/kitsune_p2p/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_block"
-version = "0.3.0-beta-dev.13"
+version = "0.3.0-beta-dev.14"
 description = "(un)Block datatype for kitsune_p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.5", path = "../timestamp" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.11", path = "../bin_data" }
+kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.12", path = "../bin_data" }
 serde = { version = "1.0", features = ["derive"] }
 
 [features]

--- a/crates/kitsune_p2p/bootstrap/CHANGELOG.md
+++ b/crates/kitsune_p2p/bootstrap/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0-beta-dev.17
+
 ## 0.2.0-beta-dev.16
 
 ## 0.2.0-beta-dev.15

--- a/crates/kitsune_p2p/bootstrap/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_bootstrap"
-version = "0.2.0-beta-dev.16"
+version = "0.2.0-beta-dev.17"
 description = "Bootstrap server written in rust for kitsune nodes to find each other"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -13,8 +13,8 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.3.21", features = [ "derive" ] }
 futures = "0.3.15"
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.16", path = "../types" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.11", path = "../bin_data" }
+kitsune_p2p_types = { version = "^0.3.0-beta-dev.17", path = "../types" }
+kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.12", path = "../bin_data" }
 parking_lot = "0.12.1"
 rand = "0.8.5"
 reqwest = "0.11.2"

--- a/crates/kitsune_p2p/bootstrap_client/CHANGELOG.md
+++ b/crates/kitsune_p2p/bootstrap_client/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.23
+
 ## 0.3.0-beta-dev.22
 
 ## 0.3.0-beta-dev.21

--- a/crates/kitsune_p2p/bootstrap_client/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_bootstrap_client"
-version = "0.3.0-beta-dev.22"
+version = "0.3.0-beta-dev.23"
 description = "a client library for the bootstrap service used by Kitsune P2P"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -11,9 +11,9 @@ categories = ["network-programming"]
 edition = "2021"
 
 [dependencies]
-kitsune_p2p_bootstrap = { version = "^0.2.0-beta-dev.16", path = "../bootstrap", features = ["sqlite"] }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.16", path = "../types" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.11", path = "../bin_data" }
+kitsune_p2p_bootstrap = { version = "^0.2.0-beta-dev.17", path = "../bootstrap", features = ["sqlite"] }
+kitsune_p2p_types = { version = "^0.3.0-beta-dev.17", path = "../types" }
+kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.12", path = "../bin_data" }
 tokio = "1"
 serde_bytes = "0.11"
 serde = "1"

--- a/crates/kitsune_p2p/dht/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.13
+
 ## 0.3.0-beta-dev.12
 
 ## 0.3.0-beta-dev.11

--- a/crates/kitsune_p2p/dht/Cargo.toml
+++ b/crates/kitsune_p2p/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_dht"
-version = "0.3.0-beta-dev.12"
+version = "0.3.0-beta-dev.13"
 description = "Kitsune P2p DHT definition"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -15,7 +15,7 @@ colored = { version = "2.0.4", optional = true }
 derivative = "2.2.0"
 derive_more = { workspace = true }
 futures = "0.3"
-kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.10", path = "../dht_arc"}
+kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.11", path = "../dht_arc"}
 kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.5", path = "../timestamp"}
 must_future = "0.1"
 num-traits = "0.2.14"
@@ -37,7 +37,7 @@ kitsune_p2p_dht = { path = ".", features = ["test_utils", "sqlite"]}
 kitsune_p2p_dht_arc = { path = "../dht_arc", features = ["test_utils"]}
 holochain_serialized_bytes = "0.0.53"
 maplit = "1"
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../../holochain_trace" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../../holochain_trace" }
 pretty_assertions = "1.4.0"
 proptest = "1"
 rand = "0.8"

--- a/crates/kitsune_p2p/dht_arc/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht_arc/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.11
+
 ## 0.3.0-beta-dev.10
 
 ## 0.3.0-beta-dev.9

--- a/crates/kitsune_p2p/dht_arc/Cargo.toml
+++ b/crates/kitsune_p2p/dht_arc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_dht_arc"
-version = "0.3.0-beta-dev.10"
+version = "0.3.0-beta-dev.11"
 description = "Kitsune P2p Dht Arc Utils"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -25,7 +25,7 @@ rusqlite = { version = "0.29", optional = true }
 
 [dev-dependencies]
 maplit = "1"
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../../holochain_trace" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../../holochain_trace" }
 pretty_assertions = "1.4.0"
 rand = "0.8.5"
 statrs = "0.16.0"

--- a/crates/kitsune_p2p/fetch/CHANGELOG.md
+++ b/crates/kitsune_p2p/fetch/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.19
+
 ## 0.3.0-beta-dev.18
 
 ## 0.3.0-beta-dev.17

--- a/crates/kitsune_p2p/fetch/Cargo.toml
+++ b/crates/kitsune_p2p/fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_fetch"
-version = "0.3.0-beta-dev.18"
+version = "0.3.0-beta-dev.19"
 description = "Kitsune P2p Fetch Queue Logic"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 derive_more = { workspace = true }
 kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.5", path = "../timestamp"}
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.16", path = "../types" }
+kitsune_p2p_types = { version = "^0.3.0-beta-dev.17", path = "../types" }
 serde = { version = "1.0", features = [ "derive" ] }
 tokio = { version = "1.27", features = [ "full" ] }
 tracing = "0.1.29"
@@ -29,7 +29,7 @@ proptest-derive = { version = "0", optional = true }
 kitsune_p2p_fetch = { path = ".", features = ["test_utils", "sqlite", "fuzzing"]}
 
 holochain_serialized_bytes = "0.0.53"
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../../holochain_trace" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../../holochain_trace" }
 pretty_assertions = "1.4.0"
 test-case = "1.2"
 tokio = { version = "1.27", features = [ "full", "test-util" ] }

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.26
+
 ## 0.3.0-beta-dev.25
 
 ## 0.3.0-beta-dev.24

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p"
-version = "0.3.0-beta-dev.25"
+version = "0.3.0-beta-dev.26"
 description = "p2p / dht communication framework"
 license = "CAL-1.0"
 homepage = "https://github.com/holochain/holochain"
@@ -20,19 +20,19 @@ futures = "0.3"
 ghost_actor = "=0.3.0-alpha.6"
 governor = "0.3.2"
 itertools = "0.11.0"
-kitsune_p2p_fetch = { version = "^0.3.0-beta-dev.18", path = "../fetch" }
+kitsune_p2p_fetch = { version = "^0.3.0-beta-dev.19", path = "../fetch" }
 kitsune_p2p_mdns = { version = "^0.3.0-beta-dev.1", path = "../mdns" }
-kitsune_p2p_proxy = { version = "^0.3.0-beta-dev.16", path = "../proxy" }
+kitsune_p2p_proxy = { version = "^0.3.0-beta-dev.17", path = "../proxy" }
 kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.5", path = "../timestamp", features = ["now"] }
-kitsune_p2p_block = { version = "^0.3.0-beta-dev.13", path = "../block" }
-kitsune_p2p_bootstrap_client = { version = "^0.3.0-beta-dev.22", path = "../bootstrap_client" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.11", path = "../bin_data" }
-kitsune_p2p_transport_quic = { version = "^0.3.0-beta-dev.16", path = "../transport_quic", optional = true }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.16", path = "../types", default-features = false }
+kitsune_p2p_block = { version = "^0.3.0-beta-dev.14", path = "../block" }
+kitsune_p2p_bootstrap_client = { version = "^0.3.0-beta-dev.23", path = "../bootstrap_client" }
+kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.12", path = "../bin_data" }
+kitsune_p2p_transport_quic = { version = "^0.3.0-beta-dev.17", path = "../transport_quic", optional = true }
+kitsune_p2p_types = { version = "^0.3.0-beta-dev.17", path = "../types", default-features = false }
 must_future = "0.1.1"
 nanoid = "0.4"
 num-traits = "0.2"
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../../holochain_trace" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../../holochain_trace" }
 once_cell = "1.4.1"
 opentelemetry_api = { version = "=0.20.0", features = [ "metrics" ] }
 parking_lot = "0.12.1"

--- a/crates/kitsune_p2p/proxy/CHANGELOG.md
+++ b/crates/kitsune_p2p/proxy/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.17
+
 ## 0.3.0-beta-dev.16
 
 ## 0.3.0-beta-dev.15

--- a/crates/kitsune_p2p/proxy/Cargo.toml
+++ b/crates/kitsune_p2p/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_proxy"
-version = "0.3.0-beta-dev.16"
+version = "0.3.0-beta-dev.17"
 description = "Proxy transport module for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -14,9 +14,9 @@ edition = "2021"
 base64 = "0.21.2"
 derive_more = { workspace = true }
 futures = "0.3"
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.16", path = "../types" }
-kitsune_p2p_transport_quic = { version = "^0.3.0-beta-dev.16", path = "../transport_quic" }
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../../holochain_trace" }
+kitsune_p2p_types = { version = "^0.3.0-beta-dev.17", path = "../types" }
+kitsune_p2p_transport_quic = { version = "^0.3.0-beta-dev.17", path = "../transport_quic" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../../holochain_trace" }
 serde = { version = "1", features = [ "derive" ] }
 serde_bytes = "0.11"
 structopt = "0.3"

--- a/crates/kitsune_p2p/transport_quic/CHANGELOG.md
+++ b/crates/kitsune_p2p/transport_quic/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.17
+
 ## 0.3.0-beta-dev.16
 
 ## 0.3.0-beta-dev.15

--- a/crates/kitsune_p2p/transport_quic/Cargo.toml
+++ b/crates/kitsune_p2p/transport_quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_transport_quic"
-version = "0.3.0-beta-dev.16"
+version = "0.3.0-beta-dev.17"
 description = "QUIC transport module for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -14,7 +14,7 @@ edition = "2021"
 blake2b_simd = "1.0.0"
 futures = "0.3.21"
 if-addrs = "0.8"
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.16", path = "../types" }
+kitsune_p2p_types = { version = "^0.3.0-beta-dev.17", path = "../types" }
 quinn = "0.8.1"
 webpki = "=0.22.2" # pinned until other libraries upgrade to ring 0.17
 rustls = { version = "0.20.4", features = [ "dangerous_configuration" ] }

--- a/crates/kitsune_p2p/types/CHANGELOG.md
+++ b/crates/kitsune_p2p/types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.17
+
 ## 0.3.0-beta-dev.16
 
 ## 0.3.0-beta-dev.15

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_types"
-version = "0.3.0-beta-dev.16"
+version = "0.3.0-beta-dev.17"
 description = "types subcrate for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
@@ -16,12 +16,12 @@ base64 = "0.21.2"
 derive_more = { workspace = true }
 futures = "0.3"
 ghost_actor = "=0.3.0-alpha.6"
-kitsune_p2p_dht = { version = "^0.3.0-beta-dev.12", path = "../dht" }
-kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.10", path = "../dht_arc" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.11", path = "../bin_data" }
+kitsune_p2p_dht = { version = "^0.3.0-beta-dev.13", path = "../dht" }
+kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.11", path = "../dht_arc" }
+kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.12", path = "../bin_data" }
 kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.5", path = "../timestamp" }
 mockall = { version = "0.11.3", optional = true }
-holochain_trace = { version = "^0.3.0-beta-dev.3", path = "../../holochain_trace" }
+holochain_trace = { version = "^0.3.0-beta-dev.4", path = "../../holochain_trace" }
 once_cell = "1.4"
 parking_lot = "0.12.1"
 paste = "1.0.12"

--- a/crates/test_utils/wasm/CHANGELOG.md
+++ b/crates/test_utils/wasm/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.28
+
 ## 0.3.0-beta-dev.27
 
 ## 0.3.0-beta-dev.26

--- a/crates/test_utils/wasm/Cargo.toml
+++ b/crates/test_utils/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_wasm_test_utils"
-version = "0.3.0-beta-dev.27"
+version = "0.3.0-beta-dev.28"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2021"
 description = "Utilities for Wasm testing for Holochain"
@@ -19,7 +19,7 @@ only_check = []
 
 
 [dependencies]
-holochain_types = { path = "../../holochain_types", version = "^0.3.0-beta-dev.26"}
+holochain_types = { path = "../../holochain_types", version = "^0.3.0-beta-dev.27"}
 strum = "0.18.0"
 strum_macros = "0.18.0"
 holochain_util = { version = "^0.3.0-beta-dev.3", path = "../../holochain_util" }

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -966,7 +966,7 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hdi"
-version = "0.4.0-beta-dev.20"
+version = "0.4.0-beta-dev.21"
 dependencies = [
  "hdk_derive",
  "holo_hash",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.3.0-beta-dev.24"
+version = "0.3.0-beta-dev.25"
 dependencies = [
  "getrandom",
  "hdi",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.3.0-beta-dev.19"
+version = "0.3.0-beta-dev.20"
 dependencies = [
  "darling 0.14.4",
  "heck 0.4.1",
@@ -1041,7 +1041,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "holo_hash"
-version = "0.3.0-beta-dev.16"
+version = "0.3.0-beta-dev.17"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.3.0-beta-dev.19"
+version = "0.3.0-beta-dev.20"
 dependencies = [
  "derive_builder",
  "holo_hash",
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.3.0-beta-dev.24"
+version = "0.3.0-beta-dev.25"
 dependencies = [
  "hdk",
  "serde",
@@ -1179,7 +1179,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.3.0-beta-dev.20"
+version = "0.3.0-beta-dev.21"
 dependencies = [
  "derive_builder",
  "fixt",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bin_data"
-version = "0.3.0-beta-dev.11"
+version = "0.3.0-beta-dev.12"
 dependencies = [
  "base64",
  "derive_more",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_block"
-version = "0.3.0-beta-dev.13"
+version = "0.3.0-beta-dev.14"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_timestamp",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht"
-version = "0.3.0-beta-dev.12"
+version = "0.3.0-beta-dev.13"
 dependencies = [
  "derivative",
  "derive_more",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht_arc"
-version = "0.3.0-beta-dev.10"
+version = "0.3.0-beta-dev.11"
 dependencies = [
  "derive_more",
  "gcollections",

--- a/crates/test_utils/wasm_common/CHANGELOG.md
+++ b/crates/test_utils/wasm_common/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0-beta-dev.25
+
 ## 0.3.0-beta-dev.24
 
 ## 0.3.0-beta-dev.23

--- a/crates/test_utils/wasm_common/Cargo.toml
+++ b/crates/test_utils/wasm_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_test_wasm_common"
-version = "0.3.0-beta-dev.24"
+version = "0.3.0-beta-dev.25"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2021"
 description = "Common code for Wasm testing for Holochain"
@@ -13,5 +13,5 @@ crate-type = [ "cdylib", "rlib" ]
 path = "src/lib.rs"
 
 [dependencies]
-hdk = { path = "../../hdk", version = "^0.3.0-beta-dev.24"}
+hdk = { path = "../../hdk", version = "^0.3.0-beta-dev.25"}
 serde = "1.0"


### PR DESCRIPTION
the following crates are part of this release:

- holochain_trace-0.3.0-beta-dev.4
- kitsune_p2p_dht_arc-0.3.0-beta-dev.11
- kitsune_p2p_dht-0.3.0-beta-dev.13
- kitsune_p2p_bin_data-0.3.0-beta-dev.12
- kitsune_p2p_types-0.3.0-beta-dev.17
- kitsune_p2p_transport_quic-0.3.0-beta-dev.17
- kitsune_p2p_bootstrap-0.2.0-beta-dev.17
- holo_hash-0.3.0-beta-dev.17
- kitsune_p2p_proxy-0.3.0-beta-dev.17
- kitsune_p2p_fetch-0.3.0-beta-dev.19
- kitsune_p2p_bootstrap_client-0.3.0-beta-dev.23
- kitsune_p2p_block-0.3.0-beta-dev.14
- holochain_integrity_types-0.3.0-beta-dev.20
- kitsune_p2p-0.3.0-beta-dev.26
- holochain_zome_types-0.3.0-beta-dev.21
- holochain_sqlite-0.3.0-beta-dev.27
- holochain_keystore-0.3.0-beta-dev.22
- holochain_types-0.3.0-beta-dev.27
- holochain_state_types-0.3.0-beta-dev.27
- aitia-0.2.0-beta-dev.0
- hdk_derive-0.3.0-beta-dev.20
- hc_sleuth-0.2.0-beta-dev.0
- holochain_p2p-0.3.0-beta-dev.29
- hdi-0.4.0-beta-dev.21
- holochain_state-0.3.0-beta-dev.29
- hdk-0.3.0-beta-dev.25
- holochain_websocket-0.3.0-beta-dev.7
- holochain_wasm_test_utils-0.3.0-beta-dev.28
- holochain_test_wasm_common-0.3.0-beta-dev.25
- holochain_services-0.2.0-beta-dev.1
- holochain_conductor_api-0.3.0-beta-dev.30
- holochain_cascade-0.3.0-beta-dev.30
- holochain_cli_sandbox-0.3.0-beta-dev.30
- holochain_cli_run_local_services-0.3.0-beta-dev.18
- holochain_cli_bundle-0.3.0-beta-dev.28
- holochain-0.3.0-beta-dev.30
- holochain_cli-0.3.0-beta-dev.30
- hcterm-0.3.0-beta-dev.6

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
