### PR TITLE
Detect bad version specs in version bumps

### DIFF
--- a/crates/release-automation/src/lib/crate_selection/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/mod.rs
@@ -168,11 +168,11 @@ impl<'a> Crate<'a> {
                 {
                     let extracted_version_req = match &manifest[key][name] {
                         toml_edit::Item::Value(toml_edit::Value::String(_)) => {
-                            return Err(anyhow::anyhow!("{} has a dependency on {} with a version req that is simple but must be detailed and include a path.", self.name(), name));
+                            bail!("{} has a dependency on {} with a version req that is simple but must be detailed and include a path.", self.name(), name);
                         }
                         toml_edit::Item::Value(toml_edit::Value::InlineTable(t)) => {
                             if t.get("path").is_none() {
-                                return Err(anyhow::anyhow!("{} has a dependency on {} that doesn't include a path.", self.name(), name));
+                                bail!("{} has a dependency on {} that doesn't include a path.", self.name(), name);
                             }
 
                             t.get("version").and_then(|v| v.as_str()).map(|version| {
@@ -184,7 +184,7 @@ impl<'a> Crate<'a> {
                             })
                         }
                         _ => {
-                            return Err(anyhow::anyhow!("{} has a dependency on {} with a version req that is in a format that wasn't recognised.", self.name(), name));
+                            bail!("{} has a dependency on {} with a version req that is in a format that wasn't recognised.", self.name(), name);
                         }
                     };
 

--- a/crates/release-automation/src/lib/crate_selection/mod.rs
+++ b/crates/release-automation/src/lib/crate_selection/mod.rs
@@ -166,16 +166,32 @@ impl<'a> Crate<'a> {
                         .expect("manifest is already verified")
                         .contains_key(name)
                 {
-                    let existing_version_req = if let Some(Ok(existing_version_req)) =
-                        manifest[key][name]["version"].as_str().map(|version| {
-                            VersionReq::parse(version).context(anyhow::anyhow!(
-                                "parsing version {:?} for dependency {} ",
-                                version,
-                                self.name()
-                            ))
-                        }) {
+                    let extracted_version_req = match &manifest[key][name] {
+                        toml_edit::Item::Value(toml_edit::Value::String(_)) => {
+                            return Err(anyhow::anyhow!("{} has a dependency on {} with a version req that is simple but must be detailed and include a path.", self.name(), name));
+                        }
+                        toml_edit::Item::Value(toml_edit::Value::InlineTable(t)) => {
+                            if t.get("path").is_none() {
+                                return Err(anyhow::anyhow!("{} has a dependency on {} that doesn't include a path.", self.name(), name));
+                            }
+
+                            t.get("version").and_then(|v| v.as_str()).map(|version| {
+                                VersionReq::parse(version).context(anyhow::anyhow!(
+                                    "parsing version {:?} for dependency {} ",
+                                    version,
+                                    self.name()
+                                ))
+                            })
+                        }
+                        _ => {
+                            return Err(anyhow::anyhow!("{} has a dependency on {} with a version req that is in a format that wasn't recognised.", self.name(), name));
+                        }
+                    };
+
+                    let existing_version_req = if let Some(Ok(existing_version_req)) = extracted_version_req {
                         existing_version_req
                     } else {
+                        // TODO We've already checked the key and name are present so hitting this is actually serious and shouldn't just log and continue
                         debug!(
                             "could not parse {}'s {} version req to string: {:?}",
                             name, key, manifest[key][name]["version"]


### PR DESCRIPTION
### Summary

This corrects a silent failure when attempting to set a version requirement. Unlike what I thought, that the release-automation wasn't finding the dependency link between `aitia` and `holochain_trace`, is it finding it. It's just then silently not setting a version because the file format isn't as expected.

All I've really done here is detect the problem file formats and reject them. Otherwise this behaves exactly as it did before.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
