### PR TITLE
Fix handling of partial lock updates

### DIFF
--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -43,12 +43,13 @@
           nix flake update --tarball-ttl 0
         )
 
+        ANY_CHANGED=0
         if [[ $(git diff -- "$VERSIONS_DIR"/flake.lock | grep -E '^[+-]\s+"' | grep -v lastModified --count) -eq 0 ]]; then
           echo got no actual source changes, reverting modifications..
           git checkout $VERSIONS_DIR/flake.lock
-          exit 0
         else
           git add "$VERSIONS_DIR"/flake.lock
+          ANY_CHANGED=1
         fi
 
         if [[ "$VERSIONS_DIR" == "$DEFAULT_VERSIONS_DIR" ]]; then
@@ -60,9 +61,13 @@
           git checkout flake.lock
         else
           git add flake.lock
+          ANY_CHANGED=1
         fi
 
-        git commit -m "chore(flakes): update $VERSIONS_DIR"
+        if [[ $ANY_CHANGED -eq 1 ]]; then
+          echo committing changes..
+          git commit -m "chore(flakes): update $VERSIONS_DIR"
+        fi
       '';
 
       scripts-release-automation-check-and-bump = pkgs.writeShellScriptBin "scripts-release-automation-check-and-bump" ''

--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -67,7 +67,7 @@
         set -e
         if [[ "$ANY_CHANGED" -eq 1 ]]; then
           echo committing changes..
-          # git commit -m "chore(flakes): update $VERSIONS_DIR"
+          git commit -m "chore(flakes): update $VERSIONS_DIR"
         fi
       '';
 

--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -43,13 +43,11 @@
           nix flake update --tarball-ttl 0
         )
 
-        ANY_CHANGED=0
         if [[ $(git diff -- "$VERSIONS_DIR"/flake.lock | grep -E '^[+-]\s+"' | grep -v lastModified --count) -eq 0 ]]; then
           echo got no actual source changes, reverting modifications..
           git checkout $VERSIONS_DIR/flake.lock
         else
           git add "$VERSIONS_DIR"/flake.lock
-          ANY_CHANGED=1
         fi
 
         if [[ "$VERSIONS_DIR" == "$DEFAULT_VERSIONS_DIR" ]]; then
@@ -61,12 +59,15 @@
           git checkout flake.lock
         else
           git add flake.lock
-          ANY_CHANGED=1
         fi
 
-        if [[ $ANY_CHANGED -eq 1 ]]; then
+        set +e
+        git diff --staged --quiet
+        ANY_CHANGED=$?
+        set -e
+        if [[ "$ANY_CHANGED" -eq 1 ]]; then
           echo committing changes..
-          git commit -m "chore(flakes): update $VERSIONS_DIR"
+          # git commit -m "chore(flakes): update $VERSIONS_DIR"
         fi
       '';
 


### PR DESCRIPTION
### Summary

Following up from the investigation on #3203 

Even if the inner versions flake.lock has been updated manually on a PR, this will update the root flake.lock when the automation runs. Otherwise we end up locked to an old versions flake and nothing tells us that has happened. Holonix has stayed on 0.1.6 since November 8th when we thought we'd moved to 0.1.7

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
