### PR TITLE
refactor(nix): migrate inline scripts as standalone packages

### DIFF
--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -134,23 +134,8 @@
               cargo-nextest
               graph-easy
 
-              (pkgs.writeShellScriptBin "script-cargo-regen-lockfiles" ''
-                cargo fetch --locked
-                cargo generate-lockfile --offline --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml
-                cargo generate-lockfile --offline
-                cargo generate-lockfile --offline --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml
-              '')
-
-              (pkgs.writeShellScriptBin "scripts-cargo-update" ''
-                set -xeu -o pipefail
-
-                # Update the Holochain project Cargo.lock
-                cargo update --manifest-path Cargo.toml
-                # Update the release-automation crate's Cargo.lock
-                cargo update --manifest-path crates/release-automation/Cargo.toml
-                # Update the WASM workspace Cargo.lock
-                cargo update --manifest-path crates/test_utils/wasm/wasm_workspace/Cargo.toml
-              '')
+              self'.packages.scripts-cargo-regen-lockfiles
+              self'.packages.scripts-cargo-update
             ]
 
             # generate one script for each of the "holochain-tests-" prefixed derivations by reusing their checkPhase

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -64,7 +64,6 @@
                 rustc = final.rustToolchain;
                 cargo = final.rustToolchain;
               })
-
             ];
           };
 

--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -131,6 +131,40 @@
             git commit -m "docs(crate-level): generate readmes from doc comments" $changed_readmes
           fi
         '';
+
+      scripts-cargo-regen-lockfiles = pkgs.writeShellApplication {
+        name = "scripts-cargo-regen-lockfiles";
+        runtimeInputs = [
+          pkgs.cargo
+        ];
+        text = ''
+          set -xeu -o pipefail
+
+          cargo fetch --locked
+          cargo generate-lockfile --offline --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml
+          cargo generate-lockfile --offline
+          cargo generate-lockfile --offline --manifest-path=crates/test_utils/wasm/wasm_workspace/Cargo.toml
+        '';
+      };
+
+
+      scripts-cargo-update =
+        pkgs.writeShellApplication {
+          name = "scripts-cargo-update";
+          runtimeInputs = [
+            pkgs.cargo
+          ];
+          text = ''
+            set -xeu -o pipefail
+
+            # Update the Holochain project Cargo.lock
+            cargo update --manifest-path Cargo.toml
+            # Update the release-automation crate's Cargo.lock
+            cargo update --manifest-path crates/release-automation/Cargo.toml
+            # Update the WASM workspace Cargo.lock
+            cargo update --manifest-path crates/test_utils/wasm/wasm_workspace/Cargo.toml
+          '';
+        };
     };
 
   };


### PR DESCRIPTION
this makes them usable with `nix run .#scripts-...`. also make them environment independent by adding cargo as a runtime dependency.

### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
