### PR TITLE
Fix symlink path mismatch

### DIFF
--- a/crates/holochain_sqlite/src/db/access.rs
+++ b/crates/holochain_sqlite/src/db/access.rs
@@ -254,13 +254,7 @@ impl<Kind: DbKindT + Send + Sync + 'static> DbWrite<Kind> {
                 }
                 // Check if the database is valid and take the appropriate
                 // action if it isn't.
-                match Connection::open(&path)
-                    // For some reason calling pragma_update is necessary to prove the database file is valid.
-                    .and_then(|mut c| {
-                        initialize_connection(&mut c, sync_level)?;
-                        c.pragma_update(None, "synchronous", "0".to_string())?;
-                        Ok(c.path().map(PathBuf::from))
-                    }) {
+                match Self::check_database_file(&path, sync_level) {
                     Ok(path) => path,
                     // These are the two errors that can
                     // occur if the database is not valid.
@@ -295,7 +289,11 @@ impl<Kind: DbKindT + Send + Sync + 'static> DbWrite<Kind> {
                             err?;
                         }
 
-                        None
+                        // Now that we've taken the appropriate action we can try again.
+                        match Self::check_database_file(&path, sync_level) {
+                            Ok(path) => path,
+                            Err(e) => return Err(e.into()),
+                        }
                     }
                     // Another error has occurred when trying to open the db.
                     Err(e) => return Err(e.into()),
@@ -405,6 +403,16 @@ impl<Kind: DbKindT + Send + Sync + 'static> DbWrite<Kind> {
             .entry(kind)
             .or_insert_with(|| Arc::new(Semaphore::new(num_read_threads())))
             .clone()
+    }
+
+    fn check_database_file(path: &Path, sync_level: DbSyncLevel) -> rusqlite::Result<Option<PathBuf>> {
+        Connection::open(&path)
+            // For some reason calling pragma_update is necessary to prove the database file is valid.
+            .and_then(|mut c| {
+                initialize_connection(&mut c, sync_level)?;
+                c.pragma_update(None, "synchronous", "0".to_string())?;
+                Ok(c.path().map(PathBuf::from))
+            })
     }
 
     /// Create a unique db in a temp dir with no static management of the

--- a/crates/holochain_sqlite/src/db/access.rs
+++ b/crates/holochain_sqlite/src/db/access.rs
@@ -259,7 +259,7 @@ impl<Kind: DbKindT + Send + Sync + 'static> DbWrite<Kind> {
                     .and_then(|mut c| {
                         initialize_connection(&mut c, sync_level)?;
                         c.pragma_update(None, "synchronous", "0".to_string())?;
-                        Ok(c.path().map(|p| PathBuf::from(p)))
+                        Ok(c.path().map(PathBuf::from))
                     }) {
                     Ok(path) => path,
                     // These are the two errors that can

--- a/crates/holochain_sqlite/src/db/access.rs
+++ b/crates/holochain_sqlite/src/db/access.rs
@@ -244,7 +244,7 @@ impl<Kind: DbKindT + Send + Sync + 'static> DbWrite<Kind> {
     ) -> DatabaseResult<Self> {
         let path = match path_prefix {
             Some(path_prefix) => {
-                let path = path_prefix.join(kind.filename());
+                let path = path_prefix.canonicalize()?.join(kind.filename());
                 let parent = path
                     .parent()
                     .ok_or_else(|| DatabaseError::DatabaseMissing(path_prefix.to_owned()))?;

--- a/crates/holochain_sqlite/src/db/access.rs
+++ b/crates/holochain_sqlite/src/db/access.rs
@@ -409,7 +409,7 @@ impl<Kind: DbKindT + Send + Sync + 'static> DbWrite<Kind> {
         path: &Path,
         sync_level: DbSyncLevel,
     ) -> rusqlite::Result<Option<PathBuf>> {
-        Connection::open(&path)
+        Connection::open(path)
             // For some reason calling pragma_update is necessary to prove the database file is valid.
             .and_then(|mut c| {
                 initialize_connection(&mut c, sync_level)?;

--- a/crates/holochain_sqlite/src/db/access.rs
+++ b/crates/holochain_sqlite/src/db/access.rs
@@ -405,7 +405,10 @@ impl<Kind: DbKindT + Send + Sync + 'static> DbWrite<Kind> {
             .clone()
     }
 
-    fn check_database_file(path: &Path, sync_level: DbSyncLevel) -> rusqlite::Result<Option<PathBuf>> {
+    fn check_database_file(
+        path: &Path,
+        sync_level: DbSyncLevel,
+    ) -> rusqlite::Result<Option<PathBuf>> {
         Connection::open(&path)
             // For some reason calling pragma_update is necessary to prove the database file is valid.
             .and_then(|mut c| {

--- a/crates/holochain_sqlite/tests/migrate_unencrypted.rs
+++ b/crates/holochain_sqlite/tests/migrate_unencrypted.rs
@@ -36,7 +36,7 @@ async fn migrate_unencrypted() {
     std::env::set_var("HOLOCHAIN_MIGRATE_UNENCRYPTED", "true");
 
     // Now it should open and read just fine, because it will be encrypted automatically
-    let db = DbWrite::open(&std::path::Path::new(tmp_dir.path()), DbKindConductor).unwrap();
+    let db: DbWrite<DbKindConductor> = DbWrite::open(&std::path::Path::new(tmp_dir.path()), DbKindConductor).unwrap();
     let msg = db
         .read_async(|txn| -> DatabaseResult<String> {
             Ok(txn.query_row(

--- a/crates/holochain_sqlite/tests/migrate_unencrypted.rs
+++ b/crates/holochain_sqlite/tests/migrate_unencrypted.rs
@@ -36,7 +36,8 @@ async fn migrate_unencrypted() {
     std::env::set_var("HOLOCHAIN_MIGRATE_UNENCRYPTED", "true");
 
     // Now it should open and read just fine, because it will be encrypted automatically
-    let db: DbWrite<DbKindConductor> = DbWrite::open(&std::path::Path::new(tmp_dir.path()), DbKindConductor).unwrap();
+    let db: DbWrite<DbKindConductor> =
+        DbWrite::open(&std::path::Path::new(tmp_dir.path()), DbKindConductor).unwrap();
     let msg = db
         .read_async(|txn| -> DatabaseResult<String> {
             Ok(txn.query_row(


### PR DESCRIPTION
### Summary

When we're setting up tests on macos we end up passing a symlink as the path for the database. This gets canonicalized by sqlite so that the path reported by a DbRead and the path reported by sqlite are different values.

Unfortunately, this code expects the two values to match -> https://github.com/holochain/holochain/blob/develop/crates/holochain_sqlite/src/store/p2p_agent_store.rs#L249-L270

This change fixes a bug where the agent store gets split in two in memory and should prevent further unexpected behavior when looking at paths.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
