### PR TITLE
[BACKPORT 0.2] fix symlink path mismatch in agent store

### DIFF
--- a/crates/holochain_sqlite/tests/migrate_unencrypted.rs
+++ b/crates/holochain_sqlite/tests/migrate_unencrypted.rs
@@ -36,7 +36,8 @@ async fn migrate_unencrypted() {
     std::env::set_var("HOLOCHAIN_MIGRATE_UNENCRYPTED", "true");
 
     // Now it should open and read just fine, because it will be encrypted automatically
-    let db = DbWrite::open(&std::path::Path::new(tmp_dir.path()), DbKindConductor).unwrap();
+    let db: DbWrite<DbKindConductor> =
+        DbWrite::open(&std::path::Path::new(tmp_dir.path()), DbKindConductor).unwrap();
     let msg = db
         .read_async(|txn| -> DatabaseResult<String> {
             Ok(txn.query_row(


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
