### PR TITLE
Fetch pool global timeout for sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,6 +551,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a6197b2120bb2185a267f6515038558b019e92b832bb0320e96d66268dcf9"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4331,14 +4343,15 @@ name = "kitsune_p2p_fetch"
 version = "0.3.0-beta-dev.21"
 dependencies = [
  "arbitrary",
+ "backon",
  "derive_more",
  "holochain_serialized_bytes",
  "holochain_trace",
  "human-repr",
+ "indexmap 2.1.0",
  "kitsune_p2p_fetch",
  "kitsune_p2p_timestamp",
  "kitsune_p2p_types",
- "linked-hash-map",
  "pretty_assertions",
  "proptest",
  "proptest-derive 0.4.0",
@@ -4633,12 +4646,6 @@ checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"

--- a/crates/kitsune_p2p/fetch/CHANGELOG.md
+++ b/crates/kitsune_p2p/fetch/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Enhance source backoff logic. The fetch pool used to give a source a 5 minute pause if it failed to serve an op before using the source again. Now the failures to serve by sources is tracked across the pool. Sources that fail too often will be put on a backoff to give them a chance to deal with their current workload before we use them again. For hosts that continue to not respond they will be dropped as sources for ops. Ops that end up with no sources will be dropped from the fetch pool. This means that we can stop using resources on ops we will never be able to fetch. If a source appears who is capable of serving the missing ops then they should be re-added to the fetch pool.
+
 ## 0.3.0-beta-dev.21
 
 ## 0.3.0-beta-dev.20

--- a/crates/kitsune_p2p/fetch/Cargo.toml
+++ b/crates/kitsune_p2p/fetch/Cargo.toml
@@ -18,7 +18,8 @@ kitsune_p2p_types = { version = "^0.3.0-beta-dev.19", path = "../types" }
 serde = { version = "1.0", features = [ "derive" ] }
 tokio = { version = "1.27", features = [ "full" ] }
 tracing = "0.1.29"
-linked-hash-map = "0.5.6"
+backon = "0.4.1"
+indexmap = "2.1.0"
 
 human-repr = { version = "1", optional = true}
 arbitrary = { version = "1", optional = true }

--- a/crates/kitsune_p2p/fetch/src/backoff.rs
+++ b/crates/kitsune_p2p/fetch/src/backoff.rs
@@ -3,7 +3,7 @@ use tokio::time::{Duration, Instant};
 use backon::{BackoffBuilder, FibonacciBackoff, FibonacciBuilder};
 
 /// The number of times to retry a fetch before giving up.
-pub const BACKOFF_RETRY_COUNT: usize = 10;
+pub const BACKOFF_RETRY_COUNT: usize = 8;
 
 /// A backoff strategy for use when fetching data from remote nodes that appear to not be responding.
 #[derive(Debug)]

--- a/crates/kitsune_p2p/fetch/src/backoff.rs
+++ b/crates/kitsune_p2p/fetch/src/backoff.rs
@@ -1,0 +1,110 @@
+use tokio::time::{Duration, Instant};
+
+use backon::{BackoffBuilder, FibonacciBackoff, FibonacciBuilder};
+
+/// The number of times to retry a fetch before giving up.
+pub const BACKOFF_RETRY_COUNT: usize = 10;
+
+/// A backoff strategy for use when fetching data from remote nodes that appear to not be responding.
+#[derive(Debug)]
+pub struct FetchBackoff {
+    backoff: FibonacciBackoff,
+    current_wait: Duration,
+    started_wait_at: Instant,
+    expired: bool,
+}
+
+impl FetchBackoff {
+    /// Create a new instance with the given initial delay.
+    pub fn new(initial_delay: Duration) -> Self {
+        let mut backoff = FibonacciBuilder::default()
+            .with_jitter()
+            .with_min_delay(initial_delay)
+            .with_max_delay(6 * initial_delay)
+            .with_max_times(BACKOFF_RETRY_COUNT)
+            .build();
+
+        Self {
+            current_wait: backoff.next().expect("At least one backoff period"),
+            started_wait_at: Instant::now(),
+            backoff,
+            expired: false,
+        }
+    }
+
+    /// Check whether the backoff is ready to try again. It will return true once each time it is
+    /// ready and then start the next delay so the consumer must make an attempt to use the backoff
+    /// before calling this again.
+    pub fn is_ready(&mut self) -> bool {
+        if self.expired {
+            return false;
+        }
+
+        if self.started_wait_at.elapsed() >= self.current_wait {
+            self.advance();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Check whether the backoff has expired.
+    pub fn is_expired(&self) -> bool {
+        self.expired
+    }
+
+    fn advance(&mut self) {
+        match self.backoff.next() {
+            Some(d) => {
+                self.current_wait = d;
+                self.started_wait_at = Instant::now();
+            }
+            None => {
+                self.expired = true;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::backoff::BACKOFF_RETRY_COUNT;
+
+    use super::FetchBackoff;
+    use std::time::Duration;
+
+    #[test]
+    fn first_delay_is_initial_delay() {
+        let initial_delay = Duration::from_secs(1);
+        let mut backoff = FetchBackoff::new(initial_delay);
+
+        // The backoff should not be ready due to the initial delay period
+        assert!(!backoff.is_ready());
+
+        // Account for jitter and check that the delay is roughly the initial delay
+        assert!(initial_delay <= backoff.current_wait && backoff.current_wait < initial_delay * 2);
+    }
+
+    #[test]
+    fn number_of_tries_is_limited() {
+        let mut backoff = FetchBackoff::new(Duration::from_nanos(1));
+        assert!(!backoff.is_expired());
+
+        let mut num_tries = 0;
+        for _ in 0..100 {
+            if backoff.is_expired() {
+                break;
+            }
+
+            while !backoff.is_ready() {
+                std::thread::sleep(Duration::from_nanos(10));
+            }
+
+            num_tries += 1;
+        }
+
+        assert!(backoff.is_expired());
+        assert!(!backoff.is_ready());
+        assert_eq!(BACKOFF_RETRY_COUNT, num_tries);
+    }
+}

--- a/crates/kitsune_p2p/fetch/src/lib.rs
+++ b/crates/kitsune_p2p/fetch/src/lib.rs
@@ -4,11 +4,14 @@
 
 //! Kitsune P2p Fetch Queue Logic
 
-use kitsune_p2p_types::{KAgent, KOpHash, KSpace};
+use kitsune_p2p_types::{KOpHash, KSpace};
 
+mod backoff;
 mod pool;
+mod queue;
 mod respond;
 mod rough_sized;
+mod source;
 
 #[cfg(any(test, feature = "test_utils"))]
 pub mod test_utils;
@@ -16,6 +19,7 @@ pub mod test_utils;
 pub use pool::*;
 pub use respond::*;
 pub use rough_sized::*;
+pub use source::FetchSource;
 
 /// Determine what should be fetched.
 #[derive(
@@ -48,14 +52,6 @@ pub struct FetchPoolPush {
 
     /// The approximate size of the item
     pub size: Option<RoughInt>,
-
-    /// If specified, the author of the op.
-    ///
-    /// NOTE: author is additive-only. That is, an op without an author
-    /// is the same as one *with* an author, but should be updated to
-    /// include the author. It is UB to have two FetchKeys with the
-    /// same op_hash, but different authors.
-    pub author: Option<KAgent>,
 
     /// Opaque "context" to be provided and interpreted by the host.
     pub context: Option<FetchContext>,

--- a/crates/kitsune_p2p/fetch/src/pool.rs
+++ b/crates/kitsune_p2p/fetch/src/pool.rs
@@ -5,24 +5,25 @@
 //! but also the source(s) to fetch it from, and other data including the last time
 //! a fetch was attempted.
 //!
-//! The consumer of the queue can read items whose last_fetch time is older than some interval
+//! The consumer of the queue can read items whose last fetch time is older than some interval
 //! from the current moment. The items thus returned are not guaranteed to be returned in
-//! order of last_fetch time, but they are guaranteed to be at least as old as the specified
+//! order of last fetch time, but they are guaranteed to be at least as old as the specified
 //! interval.
 
-use std::sync::Arc;
+use indexmap::map::Entry;
+use std::{collections::HashMap, sync::Arc};
 use tokio::time::{Duration, Instant};
 
-use kitsune_p2p_types::{tx2::tx2_utils::ShareOpen, KAgent, KSpace};
-use linked_hash_map::{Entry, LinkedHashMap};
+use kitsune_p2p_types::{tx2::tx2_utils::ShareOpen, KSpace};
 
-use crate::{FetchContext, FetchKey, FetchPoolPush, RoughInt, TransferMethod};
+use crate::{
+    queue::MapQueue,
+    source::{FetchSource, SourceState, Sources},
+    FetchContext, FetchKey, FetchPoolPush, RoughInt,
+};
 
 mod pool_reader;
 pub use pool_reader::*;
-
-/// Max number of queue items to check on each `next()` poll
-const NUM_ITEMS_PER_POLL: usize = 100;
 
 /// A FetchPool tracks a set of [`FetchKey`]s (op hashes) to be fetched,
 /// each of which can have multiple sources associated with it.
@@ -31,11 +32,11 @@ const NUM_ITEMS_PER_POLL: usize = 100;
 /// source to the front of the list of sources, and the contexts are merged by the
 /// method defined in [`FetchPoolConfig`].
 ///
-/// The queue items can be accessed only through its Iterator implementation.
-/// Each item contains a FetchKey and one Source agent from which to fetch it.
-/// Each time an item is obtained in this way, it is moved to the end of the list.
-/// It is important to use the iterator lazily, and only take what is needed.
-/// Accessing any item through iteration implies that a fetch was attempted.
+/// Each item consists a FetchKey (Op) and one or more sources (Agent) from which to fetch it.
+/// Items can be retrieved in batches using [`FetchPool::get_items_to_fetch`]. Any items which
+/// were considered while building the batch, either because they were still awaiting a response
+/// or because they were returned in the batch, will be moved to the end of the queue. This makes
+/// fetching items reasonably fair.
 #[derive(Clone)]
 pub struct FetchPool {
     config: FetchConfig,
@@ -66,17 +67,29 @@ pub trait FetchPoolConfig: 'static + Send + Sync {
         Duration::from_secs(90)
     }
 
-    /// How long between successive fetches from a particular source, for a particular item?
-    /// This protects us from wasting resources on a source which may be offline.
-    /// This will eventually be replaced with an exponential backoff which will be
-    /// tracked for this source across all items.
+    /// How long to put a source on a backoff if it fails to respond to a fetch.
+    /// This is an initial value for a backoff on the source and will be increased if the source remains unresponsive.
     fn source_retry_delay(&self) -> Duration {
-        Duration::from_secs(5 * 60)
+        Duration::from_secs(30)
     }
 
     /// When a fetch key is added twice, this determines how the two different contexts
     /// get reconciled.
     fn merge_fetch_contexts(&self, a: u32, b: u32) -> u32;
+
+    /// How many items should be returned for fetching per call to [`FetchPool::get_items_to_fetch`].
+    fn fetch_batch_size(&self) -> usize {
+        100
+    }
+
+    /// The number of times a source can fail to respond in time before it is put on a backoff.
+    ///
+    /// This is a total number of timeouts so if a source is unreliable over time then it will be put a backoff even if it is currently responding.
+    /// If the source responds after its timeout period then this counter will be reset and the source will be considered available again after
+    /// a single backoff period.
+    fn source_unavailable_timeout_threshold(&self) -> usize {
+        30
+    }
 }
 
 // TODO: move this to host, but for now, for convenience, we just use this one config
@@ -91,9 +104,15 @@ impl FetchPoolConfig for FetchPoolConfigBitwiseOr {
 
 /// The actual inner state of the FetchPool, from which items can be obtained
 #[derive(Debug, Default)]
-pub struct State {
-    /// Items ready to be fetched
-    queue: LinkedHashMap<FetchKey, FetchPoolItem>,
+pub(crate) struct State {
+    /// Items to be fetched, ordered by least recently considered for fetching.
+    queue: MapQueue<FetchKey, FetchPoolItem>,
+
+    /// The state of all sources that we have seen in [`FetchPoolPush`]es.
+    ///
+    /// Note that sources are put on a backoff if they fail to respond to enough fetches. If the backoff
+    /// expires and the source is still not responding, it will be removed from this map.
+    sources: HashMap<FetchSource, SourceState>,
 }
 
 impl FetchPool {
@@ -128,6 +147,14 @@ impl FetchPool {
         });
     }
 
+    /// Check if an item is in the fetch pool and what its context is.
+    pub fn check_item(&self, key: &FetchKey) -> (bool, Option<FetchContext>) {
+        self.state.share_ref(|s| match s.queue.get(key) {
+            Some(item) => (true, item.context),
+            None => (false, None),
+        })
+    }
+
     /// When an item has been successfully fetched, we can remove it from the queue.
     pub fn remove(&self, key: &FetchKey) -> Option<FetchPoolItem> {
         self.state.share_mut(|s| {
@@ -143,14 +170,15 @@ impl FetchPool {
     }
 
     /// Get a list of the next items that should be fetched.
-    pub fn get_items_to_fetch(&self) -> Vec<(FetchKey, KSpace, FetchSource, Option<FetchContext>)> {
+    pub fn get_batch(&self) -> Vec<(FetchKey, KSpace, FetchSource, Option<FetchContext>)> {
         self.state
-            .share_mut(|s| s.iter_mut(&*self.config).collect())
+            .share_mut(|s| s.get_batch(self.config.clone()).clone())
     }
 
     /// Get the current size of the fetch pool. This is the number of outstanding items
     /// and may be different to the size of response from `get_items_to_fetch` because it
     /// ignores retry delays.
+    #[cfg(any(test, feature = "test_utils"))]
     pub fn len(&self) -> usize {
         self.state.share_ref(|s| s.queue.len())
     }
@@ -158,6 +186,13 @@ impl FetchPool {
     /// Check whether the fetch pool is empty.
     pub fn is_empty(&self) -> bool {
         self.state.share_ref(|s| s.queue.is_empty())
+    }
+
+    /// Check the state of all sources and remove any that have expired. See the docs on [`State::check_sources`] for details.
+    pub fn check_sources(&self) {
+        self.state.share_mut(|s| {
+            s.check_sources(self.config.clone());
+        });
     }
 }
 
@@ -169,51 +204,33 @@ impl State {
     pub fn push(&mut self, config: &dyn FetchPoolConfig, args: FetchPoolPush) {
         let FetchPoolPush {
             key,
-            author,
             context,
             space,
             source,
             size,
-            transfer_method,
+            ..
         } = args;
+
+        // Register sources once as they are discovered, with a default initial state
+        self.sources
+            .entry(source.clone())
+            .or_insert_with(|| SourceState::default());
 
         match self.queue.entry(key) {
             Entry::Vacant(e) => {
-                let sources = if let Some(author) = author {
-                    // TODO This is currently not used. The idea is that the author will always be a valid alternative to fetch
-                    //      this data from. See one of the call sites for `push` to see where this was intended to be used from.
-                    Sources(
-                        [
-                            (source.clone(), SourceRecord::new(source, transfer_method)),
-                            (
-                                FetchSource::Agent(author.clone()),
-                                SourceRecord::agent(author, transfer_method),
-                            ),
-                        ]
-                        .into_iter()
-                        .collect(),
-                    )
-                } else {
-                    Sources(
-                        [(source.clone(), SourceRecord::new(source, transfer_method))]
-                            .into_iter()
-                            .collect(),
-                    )
-                };
+                let sources = Sources::new([source.clone()]);
                 let item = FetchPoolItem {
                     sources,
                     space,
                     size,
                     context,
-                    last_fetch: None,
+                    pending_response: None,
                 };
                 e.insert(item);
             }
             Entry::Occupied(mut e) => {
                 let v = e.get_mut();
-                v.sources
-                    .0
-                    .insert(source.clone(), SourceRecord::new(source, transfer_method));
+                v.sources.add(source.clone());
                 v.context = match (v.context.take(), context) {
                     (Some(a), Some(b)) => Some(config.merge_fetch_contexts(*a, *b).into()),
                     (Some(a), None) => Some(a),
@@ -224,24 +241,127 @@ impl State {
         }
     }
 
-    /// Access queue items through mutable iteration. Items accessed will be moved
-    /// to the end of the queue.
-    ///
-    /// Only items whose `last_fetch` is more than `interval` ago will be returned.
-    pub fn iter_mut<'a>(&'a mut self, config: &'a dyn FetchPoolConfig) -> StateIter {
-        StateIter {
-            state: self,
-            config,
+    /// Poll for a batch of queue items to fetch. The size of the batch is determined by [`FetchPoolConfig::fetch_batch_size`].
+    /// Items which are accessed while trying to fill the batch will be moved to the end of the queue. This is the case
+    /// even if the item was not returned in the batch because it was waiting for a response already.
+    pub fn get_batch(
+        &mut self,
+        config: Arc<dyn FetchPoolConfig>,
+    ) -> Vec<(FetchKey, KSpace, FetchSource, Option<FetchContext>)> {
+        let batch_size = config.fetch_batch_size();
+
+        let mut to_fetch = vec![];
+        // The queue provides a `front` method which will repeatedly loop over all the items it contains so bound the
+        // search by the size of the queue.
+        for _ in 0..self.queue.len() {
+            // If we have enough items, stop looking
+            if to_fetch.len() >= batch_size {
+                break;
+            }
+
+            // Get the next item from the queue
+            let (key, item) = match self.queue.front() {
+                Some(item) => item,
+                None => continue,
+            };
+
+            // Check for a pending response on this item
+            let should_fetch_item = match &item.pending_response {
+                Some(pending_response) => {
+                    if pending_response.when.elapsed() > config.item_retry_delay() {
+                        self.sources.get_mut(&pending_response.source).map(|state| {
+                            state.record_timeout();
+                        });
+                        true
+                    } else {
+                        false
+                    }
+                }
+                None => true,
+            };
+
+            if should_fetch_item {
+                // Clear the last fetch state if it was set. Even if there are no sources and we don't do a fetch, we want to forget
+                // the previous request if we're planning to make a new one.
+                item.pending_response = None;
+
+                // Find the next source for this item which is in good standing across other fetches
+                if let Some(source) = item.sources.next(|source| {
+                    match self.sources.get_mut(source) {
+                        Some(state) => {
+                            if state.should_use() {
+                                return true;
+                            }
+                        }
+                        _ => {
+                            tracing::warn!(
+                                "Not considering source because it is not registered: {:?}",
+                                source
+                            );
+                        }
+                    }
+
+                    false
+                }) {
+                    let space = item.space.clone();
+                    item.pending_response = Some(PendingItemResponse {
+                        when: Instant::now(),
+                        source: source.clone(),
+                    });
+                    to_fetch.push((key.clone(), space, source, item.context));
+                }
+            }
         }
+
+        to_fetch
     }
 
     /// When an item has been successfully fetched, we can remove it from the queue.
     pub fn remove(&mut self, key: &FetchKey) -> Option<FetchPoolItem> {
-        self.queue.remove(key)
+        match self.queue.remove(key) {
+            Some(item) => {
+                item.pending_response.as_ref().map(|pending| {
+                    self.sources.get_mut(&pending.source).map(|state| {
+                        state.record_response();
+                    });
+                });
+                Some(item)
+            }
+            None => None,
+        }
+    }
+
+    /// Check for sources which have expired and remove them from the list of sources. 
+    /// Any ops which don't have any sources left will be removed from the queue.
+    pub fn check_sources(&mut self, config: FetchConfig) {
+        self.sources
+            .retain(|_, source| source.check(config.clone()));
+
+        // Drop any sources we are no longer using from the sources used by items
+        let keys: Vec<_> = self.queue.keys().cloned().collect();
+        for key in keys {
+            self.queue
+                .get_mut(&key)
+                .expect("Iterating keys")
+                .sources
+                .retain(|s| self.sources.contains_key(s));
+
+            // If we've removed all sources from an item, remove the item
+            if self
+                .queue
+                .get(&key)
+                .expect("Iterating keys")
+                .sources
+                .is_empty()
+            {
+                self.queue.remove(&key);
+            }
+        }
     }
 
     /// Get a string summary of the queue's contents
     #[cfg(any(test, feature = "test_utils"))]
+    #[allow(dead_code)]
     pub fn summary(&self) -> String {
         use human_repr::HumanCount;
 
@@ -260,9 +380,10 @@ impl State {
                 format!(
                     "{:10}  {:^6} {:^6} {:>6}",
                     key,
-                    v.sources.0.len(),
-                    v.last_fetch
-                        .map(|t| format!("{:?}", t.elapsed()))
+                    v.sources.len(),
+                    v.pending_response
+                        .as_ref()
+                        .map(|t| format!("{:?}", t.when.elapsed()))
                         .unwrap_or_else(|| "-".to_string()),
                     size.human_count_bytes(),
                 )
@@ -274,46 +395,9 @@ impl State {
 
     /// The heading to go along with the summary
     #[cfg(any(test, feature = "test_utils"))]
+    #[allow(dead_code)]
     pub fn summary_heading() -> String {
         format!("{:10}  {:>6} {:>6} {}", "key", "#src", "last", "size")
-    }
-}
-
-/// A mutable iterator over the FetchPool State
-pub struct StateIter<'a> {
-    state: &'a mut State,
-    config: &'a dyn FetchPoolConfig,
-}
-
-impl<'a> Iterator for StateIter<'a> {
-    type Item = (FetchKey, KSpace, FetchSource, Option<FetchContext>);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let keys: Vec<_> = self
-            .state
-            .queue
-            .keys()
-            .take(NUM_ITEMS_PER_POLL)
-            .cloned()
-            .collect();
-
-        for key in keys {
-            let item = self.state.queue.get_refresh(&key)?;
-            let item_not_recently_fetched = item
-                .last_fetch
-                .map(|t| t.elapsed() >= self.config.item_retry_delay())
-                .unwrap_or(true); // true on the first fetch before `last_fetch` is set
-            if item_not_recently_fetched {
-                if let Some(source) = item.sources.next(self.config.source_retry_delay()) {
-                    // TODO what if we're recently tried to use this source and it's not available? The retry delay does not apply across items
-                    let space = item.space.clone();
-                    item.last_fetch = Some(Instant::now());
-                    return Some((key, space, source, item.context));
-                }
-            }
-        }
-
-        None
     }
 }
 
@@ -329,69 +413,27 @@ pub struct FetchPoolItem {
     size: Option<RoughInt>,
     /// Opaque user data specified by the host
     pub context: Option<FetchContext>,
-    /// The last time we tried fetching this item from any source
-    last_fetch: Option<Instant>,
+    /// If there is a response pending for this item then track the source and when the request was made.
+    pending_response: Option<PendingItemResponse>,
 }
 
+/// Tracks the source and when a request was made for a [`FetchPoolItem`]. This is used to track timeouts
+/// for sources that don't respond before the configured timeout.
 #[derive(Debug, PartialEq, Eq)]
-struct SourceRecord {
+pub struct PendingItemResponse {
+    when: Instant,
     source: FetchSource,
-    transfer_method: TransferMethod,
-    last_request: Option<Instant>,
-}
-
-impl SourceRecord {
-    fn new(source: FetchSource, transfer_method: TransferMethod) -> Self {
-        Self {
-            source,
-            transfer_method,
-            last_request: None,
-        }
-    }
-
-    fn agent(agent: KAgent, transfer_method: TransferMethod) -> Self {
-        Self::new(FetchSource::Agent(agent), transfer_method)
-    }
-}
-
-/// Fetch item within the fetch queue state.
-#[derive(Debug, PartialEq, Eq)]
-struct Sources(LinkedHashMap<FetchSource, SourceRecord>);
-
-impl Sources {
-    fn next(&mut self, interval: Duration) -> Option<FetchSource> {
-        let source_keys: Vec<FetchSource> = self.0.keys().cloned().collect();
-        for source in source_keys {
-            if let Some(sr) = self.0.get_refresh(&source) {
-                if sr
-                    .last_request
-                    .map(|t| t.elapsed() >= interval)
-                    .unwrap_or(true)
-                {
-                    sr.last_request = Some(Instant::now());
-                    return Some(source);
-                }
-            }
-        }
-
-        None
-    }
-}
-
-/// A source to fetch from: either a node, or an agent on a node
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum FetchSource {
-    /// An agent on a node
-    Agent(KAgent),
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::backoff::BACKOFF_RETRY_COUNT;
     use crate::test_utils::*;
+    use crate::TransferMethod;
     use arbitrary::Arbitrary;
     use arbitrary::Unstructured;
     use pretty_assertions::assert_eq;
-    use rand::{Rng, RngCore};
+    use rand::RngCore;
     use std::collections::HashSet;
     use std::{sync::Arc, time::Duration};
 
@@ -399,38 +441,17 @@ mod tests {
 
     use super::*;
 
-    pub(super) struct Config(pub u32, pub u32);
-
-    impl FetchPoolConfig for Config {
-        fn item_retry_delay(&self) -> Duration {
-            Duration::from_secs(self.0 as u64)
-        }
-
-        fn source_retry_delay(&self) -> Duration {
-            Duration::from_secs(self.1 as u64)
-        }
-
-        fn merge_fetch_contexts(&self, a: u32, b: u32) -> u32 {
-            (a + b).min(1)
-        }
-    }
-
     pub(super) fn item(
-        _cfg: &dyn FetchPoolConfig,
+        _cfg: Arc<dyn FetchPoolConfig>,
         sources: Vec<FetchSource>,
         context: Option<FetchContext>,
     ) -> FetchPoolItem {
         FetchPoolItem {
-            sources: Sources(
-                sources
-                    .into_iter()
-                    .map(|s| (s.clone(), SourceRecord::new(s, TransferMethod::Gossip)))
-                    .collect(),
-            ),
+            sources: Sources::new(sources.into_iter().map(|s| (s.clone()))),
             space: Arc::new(KitsuneSpace::new(vec![0; 36])),
             context,
             size: None,
-            last_fetch: None,
+            pending_response: None,
         }
     }
 
@@ -438,171 +459,10 @@ mod tests {
         test_sources(std::iter::repeat_with(|| u8::arbitrary(u).unwrap()).take(count))
     }
 
-    #[tokio::test(start_paused = true)]
-    async fn single_source() {
-        let source_delay = Duration::from_secs(10);
-        let mut sources = Sources(
-            [(
-                test_source(1),
-                SourceRecord {
-                    source: test_source(1),
-                    last_request: None,
-                    transfer_method: TransferMethod::Gossip,
-                },
-            )]
-            .into_iter()
-            .collect(),
-        );
-
-        assert_eq!(sources.next(source_delay), Some(test_source(1)));
-
-        tokio::time::advance(source_delay).await;
-
-        assert_eq!(sources.next(source_delay), Some(test_source(1)));
-        assert_eq!(sources.next(source_delay), None);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn source_rotation() {
-        let source_delay = Duration::from_secs(10);
-        let mut sources = Sources(
-            [
-                (
-                    test_source(1),
-                    SourceRecord {
-                        source: test_source(1),
-                        last_request: Some(Instant::now()),
-                        transfer_method: TransferMethod::Gossip,
-                    },
-                ),
-                (
-                    test_source(2),
-                    SourceRecord {
-                        source: test_source(2),
-                        last_request: None,
-                        transfer_method: TransferMethod::Gossip,
-                    },
-                ),
-            ]
-            .into_iter()
-            .collect(),
-        );
-
-        tokio::time::advance(Duration::from_secs(1)).await;
-
-        assert_eq!(sources.next(source_delay), Some(test_source(2)));
-        assert_eq!(sources.next(source_delay), None);
-
-        tokio::time::advance(Duration::from_secs(9)).await;
-
-        assert_eq!(sources.next(source_delay), Some(test_source(1)));
-
-        tokio::time::advance(Duration::from_secs(1)).await;
-
-        assert_eq!(sources.next(source_delay), Some(test_source(2)));
-        // source 1 has already had its delay backed off another 10s
-        // due to a retry, so it returns None
-        assert_eq!(sources.next(source_delay), None);
-
-        tokio::time::advance(Duration::from_secs(10)).await;
-
-        assert_eq!(sources.next(source_delay), Some(test_source(1)));
-        assert_eq!(sources.next(source_delay), Some(test_source(2)));
-        assert_eq!(sources.next(source_delay), None);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn source_rotation_prioritises_less_recently_tried() {
-        let source_delay = Duration::from_secs(10);
-        let mut sources = Sources(
-            [
-                (
-                    test_source(1),
-                    SourceRecord {
-                        source: test_source(1),
-                        last_request: Some(Instant::now()), // recently tried
-                        transfer_method: TransferMethod::Gossip,
-                    },
-                ),
-                (
-                    test_source(2),
-                    SourceRecord {
-                        source: test_source(2),
-                        last_request: None, // never checked
-                        transfer_method: TransferMethod::Gossip,
-                    },
-                ),
-                (
-                    test_source(3),
-                    SourceRecord {
-                        source: test_source(3),
-                        last_request: None, // never checked
-                        transfer_method: TransferMethod::Gossip,
-                    },
-                ),
-            ]
-            .into_iter()
-            .collect(),
-        );
-
-        assert_eq!(sources.next(source_delay), Some(test_source(2)));
-
-        // All sources now past their retry delay
-        tokio::time::advance(source_delay).await;
-
-        // Would expect source 1 to be tried next but trying 2 first rotated 1 and 2 to the end of the list
-        assert_eq!(sources.next(source_delay), Some(test_source(3)));
-        assert_eq!(sources.next(source_delay), Some(test_source(1)));
-        assert_eq!(sources.next(source_delay), Some(test_source(2)));
-        assert_eq!(sources.next(source_delay), None);
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn source_rotation_uses_all_sources() {
-        let mut noise = [0; 1_000];
-        rand::thread_rng().fill_bytes(&mut noise);
-        let mut u = Unstructured::new(&noise);
-
-        let source_delay = Duration::from_secs(rand::thread_rng().gen_range(1..50));
-
-        let v = std::iter::repeat_with(|| Duration::arbitrary(&mut u).unwrap())
-            .take(100)
-            .enumerate()
-            .map(|(i, duration)| {
-                (
-                    test_source(i as u8),
-                    SourceRecord {
-                        source: test_source(i as u8),
-                        last_request: Instant::now().checked_sub(duration),
-                        transfer_method: TransferMethod::Gossip,
-                    },
-                )
-            })
-            .collect();
-        let mut sources = Sources(v);
-
-        let mut seen_sources: HashSet<u8> = HashSet::new();
-        for _ in 0..100 {
-            if let Some(s) = sources.next(source_delay) {
-                match s {
-                    FetchSource::Agent(a) => {
-                        // The source agent key is a repeating byte array of the source number, so we can retrieve any
-                        // byte here to get the source number
-                        seen_sources.insert(a.0[0]);
-                    }
-                }
-            }
-
-            tokio::time::advance(source_delay).await;
-        }
-
-        assert_eq!(100, seen_sources.len());
-    }
-
     #[test]
     fn state_keeps_context_on_merge_if_new_is_none() {
         let mut q = State::default();
-        let cfg = Config(1, 1);
+        let cfg = TestFetchConfig(1, 1);
 
         q.push(&cfg, test_req_op(1, test_ctx(1), test_source(1)));
         assert_eq!(test_ctx(1), q.queue.front().unwrap().1.context);
@@ -615,7 +475,7 @@ mod tests {
     #[test]
     fn state_adds_context_on_merge_if_current_is_none() {
         let mut q = State::default();
-        let cfg = Config(1, 1);
+        let cfg = TestFetchConfig(1, 1);
 
         // Initially have no context
         q.push(&cfg, test_req_op(1, None, test_source(1)));
@@ -629,7 +489,7 @@ mod tests {
     #[test]
     fn state_can_merge_two_items_without_contexts() {
         let mut q = State::default();
-        let cfg = Config(1, 1);
+        let cfg = TestFetchConfig(1, 1);
 
         // Initially have no context
         q.push(&cfg, test_req_op(1, None, test_source(1)));
@@ -641,36 +501,39 @@ mod tests {
         // Still no context
         assert_eq!(None, q.queue.front().unwrap().1.context);
         // but both sources are present
-        assert_eq!(2, q.queue.front().unwrap().1.sources.0.len());
+        assert_eq!(2, q.queue.front().unwrap().1.sources.len());
     }
 
     #[test]
     fn state_ignores_duplicate_sources_on_merge() {
         let mut q = State::default();
-        let cfg = Config(1, 1);
+        let cfg = TestFetchConfig(1, 1);
 
         q.push(&cfg, test_req_op(1, test_ctx(1), test_source(1)));
-        assert_eq!(1, q.queue.front().unwrap().1.sources.0.len());
+        assert_eq!(1, q.queue.front().unwrap().1.sources.len());
 
         // Set a different context but otherwise the same operation as above
         q.push(&cfg, test_req_op(1, test_ctx(2), test_source(1)));
-        assert_eq!(1, q.queue.front().unwrap().1.sources.0.len());
+        assert_eq!(1, q.queue.front().unwrap().1.sources.len());
     }
 
     #[test]
     fn queue_push() {
         let mut q = State::default();
-        let c = Config(1, 1);
+        let cfg = Arc::new(TestFetchConfig(1, 1));
 
         // note: new sources get added to the back of the list
-        q.push(&c, test_req_op(1, test_ctx(0), test_source(0)));
-        q.push(&c, test_req_op(1, test_ctx(1), test_source(1)));
+        q.push(&*cfg, test_req_op(1, test_ctx(0), test_source(0)));
+        q.push(&*cfg, test_req_op(1, test_ctx(1), test_source(1)));
 
-        q.push(&c, test_req_op(2, test_ctx(0), test_source(0)));
+        q.push(&*cfg, test_req_op(2, test_ctx(0), test_source(0)));
 
         let expected_ready = [
-            (test_key_op(1), item(&c, test_sources(0..=1), test_ctx(1))),
-            (test_key_op(2), item(&c, test_sources([0]), test_ctx(0))),
+            (
+                test_key_op(1),
+                item(cfg.clone(), test_sources(0..=1), test_ctx(1)),
+            ),
+            (test_key_op(2), item(cfg, test_sources([0]), test_ctx(0))),
         ]
         .into_iter()
         .collect();
@@ -680,115 +543,84 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn queue_next() {
-        let cfg = Config(1, 10);
+        let cfg = Arc::new(TestFetchConfig(5, 10));
         let mut q = {
             let mut queue = [
-                (test_key_op(1), item(&cfg, test_sources(0..=2), test_ctx(1))),
-                (test_key_op(2), item(&cfg, test_sources(1..=3), test_ctx(1))),
-                (test_key_op(3), item(&cfg, test_sources(2..=4), test_ctx(1))),
+                (
+                    test_key_op(1),
+                    item(cfg.clone(), test_sources(0..=2), test_ctx(1)),
+                ),
+                (
+                    test_key_op(2),
+                    item(cfg.clone(), test_sources(1..=3), test_ctx(1)),
+                ),
+                (
+                    test_key_op(3),
+                    item(cfg.clone(), test_sources(2..=4), test_ctx(1)),
+                ),
             ];
-            // Set the last_fetch time of one of the sources to something a bit earlier,
-            // so it won't show up in next() right away
-            queue[1]
-                .1
-                .sources
-                .0
-                .get_mut(&test_source(2))
-                .unwrap()
-                .last_request = Some(Instant::now() - Duration::from_secs(3));
+
+            queue[1].1.pending_response = Some(PendingItemResponse {
+                when: Instant::now() - Duration::from_secs(3),
+                source: test_source(1),
+            });
 
             let queue = queue.into_iter().collect();
-            State { queue }
+            State {
+                queue,
+                sources: test_sources(0..=4)
+                    .into_iter()
+                    .map(|s| (s, SourceState::default()))
+                    .collect(),
+            }
         };
 
         // We can try fetching items one source at a time by waiting 1 sec in between
 
-        assert_eq!(q.iter_mut(&cfg).count(), 3);
+        assert_eq!(2, q.get_batch(cfg.clone()).len());
 
-        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::time::advance(Duration::from_secs(3)).await;
 
-        assert_eq!(q.iter_mut(&cfg).count(), 3);
+        assert_eq!(1, q.get_batch(cfg.clone()).len());
 
-        tokio::time::advance(Duration::from_secs(1)).await;
+        tokio::time::advance(Duration::from_secs(10)).await;
 
-        assert_eq!(q.iter_mut(&cfg).count(), 2);
-
-        // Wait for manually modified source to be ready
-        // (5 + 1 + 1 + 3 = 10)
-        tokio::time::advance(Duration::from_secs(5)).await;
-
-        // The next (and only) item will be the one with the timestamp explicitly set
-        assert_eq!(
-            q.iter_mut(&cfg).collect::<Vec<_>>(),
-            vec![(test_key_op(2), test_space(0), test_source(2), test_ctx(1))]
-        );
-        assert_eq!(q.iter_mut(&cfg).count(), 0);
-
-        // wait long enough for some items to be retryable
-        // (10 - 5 - 1 = 4)
-        tokio::time::advance(Duration::from_secs(4)).await;
-
-        assert_eq!(q.iter_mut(&cfg).count(), 3);
+        assert_eq!(3, q.get_batch(cfg.clone()).len());
     }
 
     #[tokio::test(start_paused = true)]
-    async fn state_iter_sees_all_items() {
-        let cfg = Config(1, 10);
-        let num_items = 2 * NUM_ITEMS_PER_POLL; // Must be greater than NUM_ITEMS_PER_POLL
-
-        let mut q = {
-            let mut queue = vec![];
-            for i in 0..(num_items) {
-                queue.push((
-                    test_key_op(i as u8),
-                    item(&cfg, test_sources([(i % 100) as u8]), test_ctx(1)),
-                ))
-            }
-
-            State {
-                queue: queue.into_iter().collect(),
-            }
-        };
-
-        // None fetched initially, should see all items
-        assert_eq!(num_items, q.iter_mut(&cfg).count());
-
-        // Everything seen, no time elapsed
-        assert_eq!(0, q.iter_mut(&cfg).count());
-
-        // Move time forwards so everything will be ready to retry
-        tokio::time::advance(Duration::from_secs(30)).await;
-
-        assert_eq!(num_items, q.iter_mut(&cfg).count());
-    }
-
-    #[tokio::test(start_paused = true)]
-    async fn state_iter_uses_all_sources() {
-        let cfg = Config(1, 10);
+    async fn uses_all_sources() {
+        let cfg = Arc::new(TestFetchConfig(1, 10));
         let num_items = 10;
 
         let mut q = {
             let mut queue = vec![];
+            let mut sources = vec![];
             for i in 0..num_items {
+                let these_sources =
+                    test_sources((i * num_items) as u8..(i * num_items + num_items) as u8);
                 queue.push((
                     test_key_op(i as u8),
                     // Give each item a different set of sources
-                    item(
-                        &cfg,
-                        test_sources((i * num_items) as u8..(i * num_items + num_items) as u8),
-                        test_ctx(1),
-                    ),
-                ))
+                    item(cfg.clone(), these_sources.clone(), test_ctx(1)),
+                ));
+
+                sources.extend(these_sources);
             }
 
             State {
                 queue: queue.into_iter().collect(),
+                sources: sources
+                    .into_iter()
+                    .map(|s| (s, SourceState::default()))
+                    .collect(),
             }
         };
 
         let mut seen_sources = HashSet::new();
         for _ in 0..num_items {
-            q.iter_mut(&cfg)
+            q.get_batch(cfg.clone())
+                .into_iter()
                 .map(|item| match item.2 {
                     FetchSource::Agent(a) => a.0.clone(),
                 })
@@ -805,21 +637,29 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn remove_fetch_item() {
-        let cfg = Config(1, 10);
-        let mut q = {
-            let queue = [(test_key_op(1), item(&cfg, test_sources([1]), test_ctx(1)))];
+        holochain_trace::test_run().unwrap();
 
+        let cfg = Arc::new(TestFetchConfig(1, 10));
+        let mut q: State = {
+            let queue = [(
+                test_key_op(1),
+                item(cfg.clone(), test_sources([1]), test_ctx(1)),
+            )];
             let queue = queue.into_iter().collect();
-            State { queue }
+
+            let sources = [(test_source(1), SourceState::default())]
+                .into_iter()
+                .collect();
+            State { queue, sources }
         };
 
-        assert_eq!(1, q.iter_mut(&cfg).count());
+        assert_eq!(1, q.get_batch(cfg.clone()).len());
         q.remove(&test_key_op(1));
 
         // Move time forwards to be able to retry the item
         tokio::time::advance(Duration::from_secs(30)).await;
 
-        assert_eq!(0, q.iter_mut(&cfg).count());
+        assert_eq!(0, q.get_batch(cfg).len());
     }
 
     #[tokio::test(start_paused = true)]
@@ -850,8 +690,7 @@ mod tests {
             key: test_key_op(220),
             space: test_space(u8::arbitrary(&mut u).unwrap()),
             source: unavailable_sources.iter().last().cloned().unwrap(),
-            size: None,   // Not important for this test
-            author: None, // Unused field, ignore
+            size: None, // Not important for this test
             context: test_ctx(u32::arbitrary(&mut u).unwrap()),
             transfer_method: TransferMethod::Gossip,
         });
@@ -864,15 +703,14 @@ mod tests {
                     key: test_key_op(i),
                     space: test_space(u8::arbitrary(&mut u).unwrap()),
                     source: test_source(u8::arbitrary(&mut u).unwrap()),
-                    size: None,   // Not important for this test
-                    author: None, // Unused field, ignore
+                    size: None, // Not important for this test
                     context: test_ctx(u32::arbitrary(&mut u).unwrap()),
                     transfer_method: TransferMethod::Gossip,
                 });
             }
 
             // Try to process all items (because that's how this is used in practice)
-            let items = fetch_pool.get_items_to_fetch();
+            let items = fetch_pool.get_batch();
             for item in items {
                 // If the source is available the fetch succeeds and we remove the item, otherwise leave it in the pool
                 if !unavailable_sources.contains(&item.2) {
@@ -888,7 +726,7 @@ mod tests {
 
         // We created an item that will always fail, so should have at least one left
         assert!(
-            !fetch_pool.get_items_to_fetch().is_empty(),
+            !fetch_pool.get_batch().is_empty(),
             "Pool should have had at least one item but got \n {}",
             fetch_pool.state.share_ref(|s| format!(
                 "{}\n{}",
@@ -904,6 +742,132 @@ mod tests {
             "At least 10 items should have failed to be fetched but was {}",
             failed_count
         );
+    }
+
+    #[test]
+    fn check_item_missing() {
+        let fetch_pool = FetchPool::new(Arc::new(TestFetchConfig(1, 1)));
+        assert_eq!((false, None), fetch_pool.check_item(&test_key_op(1)));
+    }
+
+    #[test]
+    fn drain_fetch_pool() {
+        // Use a nearly real fetch config.
+        struct TestFetchConfig {}
+        impl FetchPoolConfig for TestFetchConfig {
+            // Don't really care about this, but the default trait functions for timeouts are wanted for this test
+            fn merge_fetch_contexts(&self, a: u32, b: u32) -> u32 {
+                a | b
+            }
+        }
+
+        // Create a fetch pool to test
+        let fetch_pool = FetchPool::new(Arc::new(TestFetchConfig {}));
+
+        for i in (0..200).step_by(5) {
+            for j in 0..5 {
+                fetch_pool.push(FetchPoolPush {
+                    key: test_key_op(i),
+                    space: test_space(j),
+                    source: test_source(j),
+                    size: None, // Not important for this test
+                    context: test_ctx(0),
+                    transfer_method: TransferMethod::Gossip,
+                });
+            }
+        }
+
+        for _ in 0..2 {
+            for (key, _, _, _) in fetch_pool.get_batch() {
+                if fetch_pool.check_item(&key).0 {
+                    fetch_pool.remove(&key);
+                }
+            }
+        }
+
+        assert!(fetch_pool.is_empty());
+        assert_eq!(0, fetch_pool.get_batch().len());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drop_expired_sources() {
+        let config = Arc::new(TestFetchConfig(1, 1));
+        let fetch_pool = FetchPool::new(config.clone());
+
+        // First op with one source
+        fetch_pool.push(FetchPoolPush {
+            key: test_key_op(1),
+            space: test_space(1),
+            source: test_source(1),
+            size: None,
+            context: test_ctx(0),
+            transfer_method: TransferMethod::Gossip,
+        });
+
+        // Second op with two sources
+        fetch_pool.push(FetchPoolPush {
+            key: test_key_op(2),
+            space: test_space(1),
+            source: test_source(1),
+            size: None,
+            context: test_ctx(0),
+            transfer_method: TransferMethod::Gossip,
+        });
+
+        // Add the second source to the op above
+        fetch_pool.push(FetchPoolPush {
+            key: test_key_op(2),
+            space: test_space(1),
+            source: test_source(2),
+            size: None,
+            context: test_ctx(0),
+            transfer_method: TransferMethod::Gossip,
+        });
+
+        // Send enough ops for the first source to be put on a backoff
+        for _ in 0..(config.source_unavailable_timeout_threshold() + 1) {
+            fetch_pool.get_batch();
+
+            // Wait long enough for items to be retried
+            tokio::time::advance(2 * config.item_retry_delay()).await;
+        }
+
+        // Check sources to mark the first source on a backoff
+        fetch_pool.check_sources();
+
+        for _ in 0..BACKOFF_RETRY_COUNT {
+            // Need to wait by both the source and item retry delays, accounting for source delays being increased in the backoff
+            tokio::time::advance(1000 * config.source_retry_delay()).await;
+
+            assert_eq!(2, fetch_pool.get_batch().len());
+        }
+
+        let keep_source_two_alive_key = test_key_op(5);
+        fetch_pool.push(FetchPoolPush {
+            key: keep_source_two_alive_key.clone(),
+            space: test_space(1),
+            source: test_source(2),
+            size: None,
+            context: test_ctx(0),
+            transfer_method: TransferMethod::Gossip,
+        });
+
+        // Verify the item is in the pool and remove it again to mark a successful fetch for source 2
+        assert!(fetch_pool.check_item(&keep_source_two_alive_key).0);
+        fetch_pool.remove(&keep_source_two_alive_key);
+        
+        // Now check sources to remove source 1 which hasn't had a successful receive in the backoff period
+        fetch_pool.check_sources();
+
+        // Should have dropped source 1 from the pool, which means op 1 is gone and op 2 should only have 1 source
+        assert_eq!(1, fetch_pool.len());
+
+        // Wait for the first item to be ready again
+        tokio::time::advance(2 * config.item_retry_delay()).await;
+
+        let batch = fetch_pool.get_batch();
+        assert_eq!(1, batch.len());
+        assert_eq!(test_source(2), batch.first().unwrap().2);
     }
 
     #[test]

--- a/crates/kitsune_p2p/fetch/src/pool.rs
+++ b/crates/kitsune_p2p/fetch/src/pool.rs
@@ -32,7 +32,7 @@ pub use pool_reader::*;
 /// source to the front of the list of sources, and the contexts are merged by the
 /// method defined in [`FetchPoolConfig`].
 ///
-/// Each item consists a FetchKey (Op) and one or more sources (Agent) from which to fetch it.
+/// Each item consists of a FetchKey (Op) and one or more sources (Agent) from which to fetch it.
 /// Items can be retrieved in batches using [`FetchPool::get_items_to_fetch`]. Any items which
 /// were considered while building the batch, either because they were still awaiting a response
 /// or because they were returned in the batch, will be moved to the end of the queue. This makes

--- a/crates/kitsune_p2p/fetch/src/pool.rs
+++ b/crates/kitsune_p2p/fetch/src/pool.rs
@@ -330,7 +330,7 @@ impl State {
         }
     }
 
-    /// Check for sources which have expired and remove them from the list of sources. 
+    /// Check for sources which have expired and remove them from the list of sources.
     /// Any ops which don't have any sources left will be removed from the queue.
     pub fn check_sources(&mut self, config: FetchConfig) {
         self.sources
@@ -854,7 +854,7 @@ mod tests {
         // Verify the item is in the pool and remove it again to mark a successful fetch for source 2
         assert!(fetch_pool.check_item(&keep_source_two_alive_key).0);
         fetch_pool.remove(&keep_source_two_alive_key);
-        
+
         // Now check sources to remove source 1 which hasn't had a successful receive in the backoff period
         fetch_pool.check_sources();
 

--- a/crates/kitsune_p2p/fetch/src/pool.rs
+++ b/crates/kitsune_p2p/fetch/src/pool.rs
@@ -257,7 +257,7 @@ impl State {
         let batch_size = config.fetch_batch_size();
 
         let mut to_fetch = vec![];
-        // The queue provides a `front` method which will repeatedly loop over all the items it contains so bound the
+        // The queue provides a `front` method which will repeatedly loop over all the items it contains to bound the
         // search by the size of the queue.
         for _ in 0..self.queue.len() {
             // If we have enough items, stop looking

--- a/crates/kitsune_p2p/fetch/src/pool.rs
+++ b/crates/kitsune_p2p/fetch/src/pool.rs
@@ -84,9 +84,12 @@ pub trait FetchPoolConfig: 'static + Send + Sync {
 
     /// The number of times a source can fail to respond in time before it is put on a backoff.
     ///
-    /// This is a total number of timeouts so if a source is unreliable over time then it will be put a backoff even if it is currently responding.
+    /// This is a total number of timeouts so if a source is unreliable over time then it will be put on a backoff even if it is currently responding.
     /// If the source responds after its timeout period then this counter will be reset and the source will be considered available again after
     /// a single backoff period.
+    ///
+    /// The reasoning behind this parameter is that we want to limit the amount of resources we sink into an unresponsive source,
+    /// as well as limiting the load on the source itself, who may be unresponsive because they're already struggling with too much load.
     fn source_unavailable_timeout_threshold(&self) -> usize {
         30
     }

--- a/crates/kitsune_p2p/fetch/src/pool.rs
+++ b/crates/kitsune_p2p/fetch/src/pool.rs
@@ -342,7 +342,7 @@ impl State {
     /// Any ops which don't have any sources left will be removed from the queue.
     pub fn check_sources(&mut self, config: FetchConfig) {
         self.sources
-            .retain(|_, source| source.check(config.clone()));
+            .retain(|_, source| source.is_valid(config.clone()));
 
         // Drop any sources we are no longer using from the sources used by items
         let keys: Vec<_> = self.queue.keys().cloned().collect();

--- a/crates/kitsune_p2p/fetch/src/pool.rs
+++ b/crates/kitsune_p2p/fetch/src/pool.rs
@@ -69,6 +69,10 @@ pub trait FetchPoolConfig: 'static + Send + Sync {
 
     /// How long to put a source on a backoff if it fails to respond to a fetch.
     /// This is an initial value for a backoff on the source and will be increased if the source remains unresponsive.
+    /// 
+    /// With the default settings of 30s for this delay and 8 retries, the total retry period is around 20 minutes (with jitter) so that the 
+    /// time we keep sources in the pool is close to the default value for the TTL on agent info. This means if an agent goes offline then
+    /// they should be removed from the fetch pool in a similar amount of time to other communication with them ceasing.
     fn source_retry_delay(&self) -> Duration {
         Duration::from_secs(30)
     }

--- a/crates/kitsune_p2p/fetch/src/pool.rs
+++ b/crates/kitsune_p2p/fetch/src/pool.rs
@@ -187,7 +187,7 @@ impl FetchPool {
         self.state.share_ref(|s| s.queue.is_empty())
     }
 
-    /// Check the state of all sources and remove any that have expired. See the docs on [`State::check_sources`] for details.
+    /// Check the state of all sources and remove any that have expired. See the docs on State::check_sources for details.
     pub fn check_sources(&self) {
         self.state.share_mut(|s| {
             s.check_sources(self.config.clone());

--- a/crates/kitsune_p2p/fetch/src/pool.rs
+++ b/crates/kitsune_p2p/fetch/src/pool.rs
@@ -69,8 +69,8 @@ pub trait FetchPoolConfig: 'static + Send + Sync {
 
     /// How long to put a source on a backoff if it fails to respond to a fetch.
     /// This is an initial value for a backoff on the source and will be increased if the source remains unresponsive.
-    /// 
-    /// With the default settings of 30s for this delay and 8 retries, the total retry period is around 20 minutes (with jitter) so that the 
+    ///
+    /// With the default settings of 30s for this delay and 8 retries, the total retry period is around 20 minutes (with jitter) so that the
     /// time we keep sources in the pool is close to the default value for the TTL on agent info. This means if an agent goes offline then
     /// they should be removed from the fetch pool in a similar amount of time to other communication with them ceasing.
     fn source_retry_delay(&self) -> Duration {

--- a/crates/kitsune_p2p/fetch/src/pool/pool_reader.rs
+++ b/crates/kitsune_p2p/fetch/src/pool/pool_reader.rs
@@ -32,16 +32,13 @@ mod tests {
     use crate::test_utils::*;
     use crate::{pool::tests::*, State};
     use kitsune_p2p_types::tx2::tx2_utils::ShareOpen;
-    use linked_hash_map::LinkedHashMap;
     use std::sync::Arc;
 
     #[test]
     fn queue_info_empty() {
         let fetch_pool_reader = FetchPoolReader(FetchPool {
-            config: Arc::new(Config(1, 1)),
-            state: ShareOpen::new(State {
-                queue: LinkedHashMap::new(),
-            }),
+            config: Arc::new(TestFetchConfig(1, 1)),
+            state: ShareOpen::new(Default::default()),
         });
 
         let info = fetch_pool_reader.info([test_space(0), test_space(1)].into_iter().collect());
@@ -51,16 +48,22 @@ mod tests {
 
     #[test]
     fn queue_info_fetch_no_spaces() {
-        let cfg = Config(1, 1);
+        let cfg = Arc::new(TestFetchConfig(1, 1));
         let q = {
-            let mut queue = [(test_key_op(1), item(&cfg, test_sources(0..=2), test_ctx(1)))];
+            let mut queue = [(
+                test_key_op(1),
+                item(cfg.clone(), test_sources(0..=2), test_ctx(1)),
+            )];
 
             queue[0].1.size = Some(100.into());
 
             let queue = queue.into_iter().collect();
             FetchPoolReader(FetchPool {
-                config: Arc::new(cfg),
-                state: ShareOpen::new(State { queue }),
+                config: cfg,
+                state: ShareOpen::new(State {
+                    queue,
+                    ..Default::default()
+                }),
             })
         };
 
@@ -72,12 +75,21 @@ mod tests {
 
     #[test]
     fn queue_info() {
-        let cfg = Config(1, 1);
+        let cfg = Arc::new(TestFetchConfig(1, 1));
         let q = {
             let mut queue = [
-                (test_key_op(1), item(&cfg, test_sources(0..=2), test_ctx(1))),
-                (test_key_op(2), item(&cfg, test_sources(1..=3), test_ctx(1))),
-                (test_key_op(3), item(&cfg, test_sources(2..=4), test_ctx(1))),
+                (
+                    test_key_op(1),
+                    item(cfg.clone(), test_sources(0..=2), test_ctx(1)),
+                ),
+                (
+                    test_key_op(2),
+                    item(cfg.clone(), test_sources(1..=3), test_ctx(1)),
+                ),
+                (
+                    test_key_op(3),
+                    item(cfg.clone(), test_sources(2..=4), test_ctx(1)),
+                ),
             ];
 
             queue[0].1.size = Some(100.into());
@@ -85,8 +97,11 @@ mod tests {
 
             let queue = queue.into_iter().collect();
             FetchPoolReader(FetchPool {
-                config: Arc::new(cfg),
-                state: ShareOpen::new(State { queue }),
+                config: cfg,
+                state: ShareOpen::new(State {
+                    queue,
+                    ..Default::default()
+                }),
             })
         };
 
@@ -98,13 +113,13 @@ mod tests {
 
     #[test]
     fn queue_info_filter_spaces() {
-        let cfg = Config(1, 1);
+        let cfg = Arc::new(TestFetchConfig(1, 1));
         let q = {
-            let mut item_for_space_1 = item(&cfg, test_sources(0..=2), test_ctx(1));
+            let mut item_for_space_1 = item(cfg.clone(), test_sources(0..=2), test_ctx(1));
             item_for_space_1.space = test_space(1);
             item_for_space_1.size = Some(100.into());
 
-            let mut item_for_space_2 = item(&cfg, test_sources(0..=2), test_ctx(1));
+            let mut item_for_space_2 = item(cfg.clone(), test_sources(0..=2), test_ctx(1));
             item_for_space_2.space = test_space(2);
             item_for_space_2.size = Some(500.into());
 
@@ -115,8 +130,11 @@ mod tests {
 
             let queue = queue.into_iter().collect();
             FetchPoolReader(FetchPool {
-                config: Arc::new(cfg),
-                state: ShareOpen::new(State { queue }),
+                config: cfg,
+                state: ShareOpen::new(State {
+                    queue,
+                    ..Default::default()
+                }),
             })
         };
 

--- a/crates/kitsune_p2p/fetch/src/queue.rs
+++ b/crates/kitsune_p2p/fetch/src/queue.rs
@@ -1,0 +1,77 @@
+use std::ops::Deref;
+
+use indexmap::{map::Entry, IndexMap};
+
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct MapQueue<K: Eq + std::hash::Hash, V> {
+    inner: IndexMap<K, V>,
+    index: usize,
+}
+
+impl<K, V> Default for MapQueue<K, V>
+where
+    K: Eq + std::hash::Hash,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> Deref for MapQueue<K, V>
+where
+    K: Eq + std::hash::Hash,
+{
+    type Target = IndexMap<K, V>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<K, V> MapQueue<K, V>
+where
+    K: Eq + std::hash::Hash,
+{
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: IndexMap::new(),
+            index: 0,
+        }
+    }
+
+    pub(crate) fn front(&mut self) -> Option<(&K, &mut V)> {
+        if self.inner.is_empty() {
+            return None;
+        }
+
+        let fetch_index = self.index;
+        self.index = (self.index + 1) % self.inner.len();
+
+        self.inner.get_index_mut(fetch_index)
+    }
+
+    pub(crate) fn entry(&mut self, key: K) -> Entry<K, V> {
+        self.inner.entry(key)
+    }
+
+    pub(crate) fn remove(&mut self, key: &K) -> Option<V> {
+        // Fast but does change order so the element that is currently last will take the position of this element
+        self.inner.swap_remove(key)
+    }
+
+    pub(crate) fn get_mut(&mut self, key: &K) -> Option<&mut V> {
+        self.inner.get_mut(key)
+    }
+}
+
+impl<K, V> FromIterator<(K, V)> for MapQueue<K, V>
+where
+    K: Eq + std::hash::Hash,
+{
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        Self {
+            inner: iter.into_iter().collect(),
+            index: 0,
+        }
+    }
+}

--- a/crates/kitsune_p2p/fetch/src/respond.rs
+++ b/crates/kitsune_p2p/fetch/src/respond.rs
@@ -82,7 +82,6 @@ impl<C: FetchResponseConfig> FetchResponseQueue<C> {
 
         let len = len as u32;
 
-        // TODO - we should probably limit by caller, rather than globally. Anybody who wants to can prevent op fetching by keeping this semaphore full.
         let byte_permit = match self.byte_limit.clone().try_acquire_many_owned(len) {
             Err(_) => {
                 tracing::warn!(%len, "fetch responder overloaded, dropping op");

--- a/crates/kitsune_p2p/fetch/src/respond.rs
+++ b/crates/kitsune_p2p/fetch/src/respond.rs
@@ -82,6 +82,7 @@ impl<C: FetchResponseConfig> FetchResponseQueue<C> {
 
         let len = len as u32;
 
+        // TODO - we should probably limit by caller, rather than globally. Anybody who wants to can prevent op fetching by keeping this semaphore full.
         let byte_permit = match self.byte_limit.clone().try_acquire_many_owned(len) {
             Err(_) => {
                 tracing::warn!(%len, "fetch responder overloaded, dropping op");

--- a/crates/kitsune_p2p/fetch/src/source.rs
+++ b/crates/kitsune_p2p/fetch/src/source.rs
@@ -1,0 +1,344 @@
+use indexmap::IndexSet;
+use kitsune_p2p_types::KAgent;
+use std::{default, ops::Deref};
+
+use crate::{backoff::FetchBackoff, FetchConfig};
+
+/// The number of times to probe a source between backoff attempts. This needs to be enough to reasonably allow
+/// a source which might be slow to respond to one or two requests to respond to at least one of the probes but
+/// not so high that it wastes time for this node trying to talk to a source that is not responding.
+const NUM_PROBE_ATTEMPTS: u32 = 10;
+
+/// A source to fetch from: either a node, or an agent on a node
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FetchSource {
+    /// An agent on a node
+    Agent(KAgent),
+}
+
+/// Fetch item within the fetch queue state.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct Sources {
+    inner: IndexSet<FetchSource>,
+    index: usize,
+}
+
+impl Deref for Sources {
+    type Target = IndexSet<FetchSource>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl Sources {
+    pub(crate) fn new(queue: impl IntoIterator<Item = FetchSource>) -> Self {
+        Self {
+            inner: queue.into_iter().collect(),
+            index: 0,
+        }
+    }
+
+    pub(crate) fn next(
+        &mut self,
+        mut state_filter: impl FnMut(&FetchSource) -> bool,
+    ) -> Option<FetchSource> {
+        for _ in 0..self.inner.len() {
+            let fetch_index = self.index;
+            self.index = (self.index + 1) % self.inner.len();
+
+            match self.inner.get_index(fetch_index) {
+                Some(source) => {
+                    if state_filter(source) {
+                        return Some(source.clone());
+                    }
+                }
+                None => (),
+            }
+        }
+
+        None
+    }
+
+    pub(crate) fn add(&mut self, source: FetchSource) {
+        self.inner.insert(source);
+    }
+
+    pub(crate) fn retain(&mut self, filter: impl Fn(&FetchSource) -> bool) {
+        self.inner.retain(filter);
+
+        // Ensure the index is still valid
+        if !self.inner.is_empty() {
+            self.index = self.index % self.inner.len();
+        }
+    }
+}
+
+/// The state of a source
+#[derive(Debug, Default)]
+pub(crate) struct SourceState {
+    /// The current state of the source
+    current_state: SourceCurrentState,
+}
+
+impl SourceState {
+    /// Check whether this source should be used. If this source is currently considered available then it will always be usable.
+    /// Otherwise, when the source is in a backoff state, it will only be usable if the backoff is ready. The backoff will be ready
+    /// a fixed number of times to probe the source before going back into a backoff state. If any fetches from the
+    /// probe attempts succeed then the source will be considered available again.
+    pub fn should_use(&mut self) -> bool {
+        match &mut self.current_state {
+            SourceCurrentState::Available(_) => true,
+            SourceCurrentState::Backoff(backoff) => {
+                if backoff.is_ready() {
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    /// Check the state of this source. If the source has had too many timeouts then it is still considered valid but it will be put into a backoff state.
+    /// If the source is in a backoff state state and the backoff has expired then the check fails and this source should be dropped.
+    pub fn check(&mut self, config: FetchConfig) -> bool {
+        match &self.current_state {
+            SourceCurrentState::Available(num_timed_out) => {
+                if *num_timed_out > config.source_unavailable_timeout_threshold() {
+                    self.current_state = SourceCurrentState::Backoff(FetchSourceBackoff::new(
+                        FetchBackoff::new(config.source_retry_delay()),
+                        NUM_PROBE_ATTEMPTS,
+                    ));
+                }
+
+                true
+            }
+            SourceCurrentState::Backoff(ref backoff) => {
+                !backoff.is_expired()
+            }
+        }
+    }
+
+    /// Notify the state that a request to this source has timed out.
+    pub fn record_timeout(&mut self) {
+        match &mut self.current_state {
+            SourceCurrentState::Available(num_timeouts) => {
+                *num_timeouts += 1;
+            },
+            _ => (),
+        }
+    }
+
+    /// Notify the state that a request to this source has succeeded.
+    /// If the source is in a backoff state then it will be considered available again.
+    pub fn record_response(&mut self) {
+        match &self.current_state {
+            SourceCurrentState::Backoff(_) => {
+                self.current_state = SourceCurrentState::Available(0);
+            }
+            SourceCurrentState::Available(_) => (),
+        }
+    }
+}
+
+/// The state of a source
+#[derive(Debug)]
+pub enum SourceCurrentState {
+    /// As far as we know, this source is available and responding.
+    /// 
+    /// The inner value tracks the number of requests to this source that have timed out.
+    /// Note that these failures do not age out, so if a source is unreliable it will get put on a timeout
+    /// briefly after it fails to respond too many times. This isn't a bad thing if the source is
+    /// not responding because it is overwhelmed.
+    Available(usize),
+
+    /// The source has been unavailable and we're waiting for a backoff period to expire before trying again.
+    Backoff(FetchSourceBackoff),
+}
+
+impl default::Default for SourceCurrentState {
+    fn default() -> Self {
+        Self::Available(0)
+    }
+}
+
+/// a struct
+#[derive(Debug)]
+pub struct FetchSourceBackoff {
+    backoff: FetchBackoff,
+    probe_limit: u32,
+    probes: u32,
+}
+
+impl FetchSourceBackoff {
+    fn new(backoff: FetchBackoff, probe_limit: u32) -> Self {
+        Self {
+            backoff,
+            probe_limit,
+            probes: 0,
+        }
+    }
+
+    fn is_ready(&mut self) -> bool {
+        if self.backoff.is_ready() {
+            self.probes = self.probe_limit - 1; // Grant more probes for this retry
+            true
+        } else {
+            if self.probes > 0 {
+                self.probes -= 1;
+                true
+            } else {
+                // Probes exhausted, wait for the backoff to expire and grant more probes
+                false
+            }
+        }
+    }
+
+    fn is_expired(&self) -> bool {
+        self.backoff.is_expired()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{sync::Arc, time::Duration};
+    
+    #[allow(warnings)]
+    use super::{SourceState, Sources, NUM_PROBE_ATTEMPTS};
+    use crate::{backoff::{FetchBackoff, BACKOFF_RETRY_COUNT}, source::FetchSourceBackoff, test_utils::*, FetchPoolConfig};
+
+    #[test]
+    fn single_source() {
+        let mut sources = Sources::new([test_source(1)]);
+
+        // The first source is returned
+        assert_eq!(Some(test_source(1)), sources.next(|_| true));
+        // The first source is returned a second time with no delay
+        assert_eq!(Some(test_source(1)), sources.next(|_| true));
+        // The first source can be filtered out
+        assert_eq!(None, sources.next(|_| false));
+    }
+
+    #[test]
+    fn source_rotation() {
+        let mut sources = Sources::new([]);
+        sources.add(test_source(1));
+        sources.add(test_source(2));
+
+        assert_eq!(Some(test_source(1)), sources.next(|_| true));
+        assert_eq!(Some(test_source(2)), sources.next(|_| true));
+        assert_eq!(Some(test_source(1)), sources.next(|_| true));
+
+        sources.add(test_source(3));
+        assert_eq!(Some(test_source(2)), sources.next(|_| true));
+        assert_eq!(Some(test_source(3)), sources.next(|_| true));
+        assert_eq!(Some(test_source(1)), sources.next(|_| true));
+    }
+
+    #[tokio::test]
+    async fn fetch_source_backoff() {
+        let mut backoff = FetchSourceBackoff::new(FetchBackoff::new(Duration::from_millis(10)), 3);
+        assert!(!backoff.is_ready());
+
+        let mut num_tries = 0;
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if backoff.is_ready() {
+                    num_tries += 1;
+                } else if backoff.is_expired() {
+                    break;
+                }
+            }
+        })
+        .await
+        .unwrap();
+
+        // Number of probes per ready (3), multiplied by the number of attempts that FetchBackoff allows (BACKOFF_RETRY_COUNT)
+        assert_eq!(3 * BACKOFF_RETRY_COUNT, num_tries);
+    }
+
+    #[test]
+    fn happy_path_source_state() {
+        let mut source_state: SourceState = Default::default();
+        let config = Arc::new(TestFetchConfig(1, 1));
+
+        for i in 0..500 {
+            assert!(source_state.should_use());
+            source_state.record_response();
+
+            if i % 100 == 0 {
+                assert!(source_state.check(config.clone()));
+            }
+        }
+
+        assert!(source_state.should_use());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn source_state_single_backoff_then_recover() {
+        let mut source_state: SourceState = Default::default();
+        let config = Arc::new(TestFetchConfig(1, 1));
+
+        assert!(source_state.should_use());
+
+        // Exhaust the retries
+        for _ in 0..=config.source_unavailable_timeout_threshold() {
+            // The source should continue being used even with timeouts. It's only when we hit the limit that it shouldn't.
+            assert!(source_state.should_use());
+
+            // The check should keep passing
+            source_state.check(config.clone());
+
+            // Record another timeout
+            source_state.record_timeout();
+        }
+
+        // The source is still ready because it hasn't been checked
+        assert!(source_state.should_use());
+
+        // Now it goes into a backoff state
+        source_state.check(config.clone());
+        assert!(!source_state.should_use());
+
+        tokio::time::advance(Duration::from_secs(2)).await;
+
+        // Now the backoff should go into a ready state and permit a number of probes
+        for _ in 0..NUM_PROBE_ATTEMPTS {
+            assert!(source_state.should_use());
+        }
+
+        // The probes have all been used and the backoff should be waiting again
+        assert!(!source_state.should_use());
+
+        // Now get a single successful response
+        source_state.record_response();
+
+        // Go back to a ready state
+        assert!(source_state.should_use());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn source_state_backoff_to_expiry() {
+        let mut source_state: SourceState = Default::default();
+        let config = Arc::new(TestFetchConfig(1, 1));
+
+        assert!(source_state.should_use());
+
+        // Exhaust the retries
+        for _ in 0..=config.source_unavailable_timeout_threshold() {
+            source_state.record_timeout();
+        }
+        source_state.check(config.clone());
+        assert!(!source_state.should_use());
+
+        for _ in 0..BACKOFF_RETRY_COUNT {
+            // Just move by a lot to guarantee that we're back in a ready state, without hitting probes because that's irrelevant for this test
+            tokio::time::advance(100 * config.source_retry_delay()).await;
+
+            assert!(source_state.should_use());
+        }
+
+        // The source state is now dead and should be removed.
+        assert!(!source_state.check(config.clone()));
+    }
+}

--- a/crates/kitsune_p2p/fetch/src/source.rs
+++ b/crates/kitsune_p2p/fetch/src/source.rs
@@ -91,7 +91,7 @@ impl SourceState {
     }
 
     /// Check the state of this source. If the source has had too many timeouts then it is still considered valid but it will be put into a backoff state.
-    /// If the source is in a backoff state state and the backoff has expired then the check fails and this source should be dropped.
+    /// If the source is in a backoff state and the backoff has expired, then the check fails and this source should be dropped.
     pub fn check(&mut self, config: FetchConfig) -> bool {
         match &self.current_state {
             SourceCurrentState::Available(num_timed_out) => {

--- a/crates/kitsune_p2p/fetch/src/source.rs
+++ b/crates/kitsune_p2p/fetch/src/source.rs
@@ -256,7 +256,7 @@ mod tests {
             source_state.record_response();
 
             if i % 100 == 0 {
-                assert!(source_state.check(config.clone()));
+                assert!(source_state.is_valid(config.clone()));
             }
         }
 
@@ -276,7 +276,7 @@ mod tests {
             assert!(source_state.should_use());
 
             // The check should keep passing
-            source_state.check(config.clone());
+            source_state.is_valid(config.clone());
 
             // Record another timeout
             source_state.record_timeout();
@@ -286,7 +286,7 @@ mod tests {
         assert!(source_state.should_use());
 
         // Now it goes into a backoff state
-        source_state.check(config.clone());
+        source_state.is_valid(config.clone());
         assert!(!source_state.should_use());
 
         tokio::time::advance(Duration::from_secs(2)).await;
@@ -317,7 +317,7 @@ mod tests {
         for _ in 0..=config.source_unavailable_timeout_threshold() {
             source_state.record_timeout();
         }
-        source_state.check(config.clone());
+        source_state.is_valid(config.clone());
         assert!(!source_state.should_use());
 
         for _ in 0..BACKOFF_RETRY_COUNT {
@@ -328,6 +328,6 @@ mod tests {
         }
 
         // The source state is now dead and should be removed.
-        assert!(!source_state.check(config.clone()));
+        assert!(!source_state.is_valid(config.clone()));
     }
 }

--- a/crates/kitsune_p2p/fetch/src/source.rs
+++ b/crates/kitsune_p2p/fetch/src/source.rs
@@ -92,7 +92,7 @@ impl SourceState {
 
     /// Check the state of this source. If the source has had too many timeouts then it is still considered valid but it will be put into a backoff state.
     /// If the source is in a backoff state and the backoff has expired, then the check fails and this source should be dropped.
-    pub fn check(&mut self, config: FetchConfig) -> bool {
+    pub fn is_valid(&mut self, config: FetchConfig) -> bool {
         match &self.current_state {
             SourceCurrentState::Available(num_timed_out) => {
                 if *num_timed_out > config.source_unavailable_timeout_threshold() {

--- a/crates/kitsune_p2p/fetch/src/source.rs
+++ b/crates/kitsune_p2p/fetch/src/source.rs
@@ -113,9 +113,7 @@ impl SourceState {
 
                 true
             }
-            SourceCurrentState::Backoff(ref backoff) => {
-                !backoff.is_expired()
-            }
+            SourceCurrentState::Backoff(ref backoff) => !backoff.is_expired(),
         }
     }
 
@@ -124,7 +122,7 @@ impl SourceState {
         match &mut self.current_state {
             SourceCurrentState::Available(num_timeouts) => {
                 *num_timeouts += 1;
-            },
+            }
             _ => (),
         }
     }
@@ -145,7 +143,7 @@ impl SourceState {
 #[derive(Debug)]
 pub enum SourceCurrentState {
     /// As far as we know, this source is available and responding.
-    /// 
+    ///
     /// The inner value tracks the number of requests to this source that have timed out.
     /// Note that these failures do not age out, so if a source is unreliable it will get put on a timeout
     /// briefly after it fails to respond too many times. This isn't a bad thing if the source is
@@ -202,10 +200,15 @@ impl FetchSourceBackoff {
 #[cfg(test)]
 mod tests {
     use std::{sync::Arc, time::Duration};
-    
+
     #[allow(warnings)]
     use super::{SourceState, Sources, NUM_PROBE_ATTEMPTS};
-    use crate::{backoff::{FetchBackoff, BACKOFF_RETRY_COUNT}, source::FetchSourceBackoff, test_utils::*, FetchPoolConfig};
+    use crate::{
+        backoff::{FetchBackoff, BACKOFF_RETRY_COUNT},
+        source::FetchSourceBackoff,
+        test_utils::*,
+        FetchPoolConfig,
+    };
 
     #[test]
     fn single_source() {

--- a/crates/kitsune_p2p/fetch/src/test_utils.rs
+++ b/crates/kitsune_p2p/fetch/src/test_utils.rs
@@ -1,9 +1,27 @@
 //! Test utilities for the fetch crate.
 
-use crate::{FetchContext, FetchKey, FetchPoolPush, FetchSource, TransferMethod};
+use crate::source::FetchSource;
+use crate::{FetchContext, FetchKey, FetchPoolConfig, FetchPoolPush, TransferMethod};
 use kitsune_p2p_types::bin_types::{KitsuneAgent, KitsuneBinType, KitsuneOpHash, KitsuneSpace};
 use kitsune_p2p_types::{KOpHash, KSpace};
 use std::sync::Arc;
+use std::time::Duration;
+
+pub(super) struct TestFetchConfig(pub u32, pub u32);
+
+impl FetchPoolConfig for TestFetchConfig {
+    fn item_retry_delay(&self) -> Duration {
+        Duration::from_secs(self.0 as u64)
+    }
+
+    fn source_retry_delay(&self) -> Duration {
+        Duration::from_secs(self.1 as u64)
+    }
+
+    fn merge_fetch_contexts(&self, a: u32, b: u32) -> u32 {
+        (a + b).min(1)
+    }
+}
 
 /// Create a sample op hash.
 pub fn test_key_hash(n: u8) -> KOpHash {
@@ -19,7 +37,6 @@ pub fn test_key_op(n: u8) -> FetchKey {
 pub fn test_req_op(n: u8, context: Option<FetchContext>, source: FetchSource) -> FetchPoolPush {
     FetchPoolPush {
         key: test_key_op(n),
-        author: None,
         context,
         space: test_space(0),
         source,

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
@@ -303,7 +303,6 @@ impl ShardedGossipLocal {
             let (hash, size) = op_hash.into_inner();
             let request = FetchPoolPush {
                 key: FetchKey::Op(hash),
-                author: None,
                 context: None,
                 space: self.space.clone(),
                 source: source.clone(),

--- a/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/host_api/host_stub.rs
@@ -214,7 +214,8 @@ impl KitsuneHost for HostStub {
 
         async move {
             // Probably not important but we could compute a real hash here if a test needs it
-            Ok(Arc::new(KitsuneOpHash::new(vec![0; 36])))
+            let hash_byte = op_data.0.first().cloned().unwrap_or(0);
+            Ok(Arc::new(KitsuneOpHash::new(vec![hash_byte; 36])))
         }
         .boxed()
         .into()

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/fetch/fetch_task.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/fetch/fetch_task.rs
@@ -25,8 +25,12 @@ impl FetchTask {
         tokio::spawn({
             let this = this.clone();
             async move {
+                let mut fetch_call_count = 0;
                 'task_loop: loop {
-                    let list = fetch_pool.get_items_to_fetch();
+                    // Drop sources that aren't responding to fetch requests, and any items that have no remaining sources to fetch from.
+                    fetch_pool.check_sources();
+
+                    let list = fetch_pool.get_batch();
 
                     for (key, space, source, context) in list {
                         let FetchKey::Op(op_hash) = &key;
@@ -41,6 +45,17 @@ impl FetchTask {
                             }
                         }
 
+                        // TODO this line gets hit super often, it would be a lot nicer to batch fetches by source
+                        // TODO actually, there's meant to be a timeout on ops, why is it being hit so often?
+                        // tracing::info!("Sending fetch request while pool has size {}", fetch_pool.len());
+                        fetch_call_count += 1;
+                        if fetch_call_count % 100 == 0 {
+                            tracing::info!(
+                                "Sending fetch request while pool has size {} with fetch call count {}",
+                                fetch_pool.len(),
+                                fetch_call_count
+                            );
+                        }
                         if let Err(err) = internal_sender.fetch(key, space, source).await {
                             match err {
                                 KitsuneP2pError::GhostError(GhostError::Disconnected) => {

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net_task.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net_task.rs
@@ -509,7 +509,8 @@ impl MetaNetTask {
                         }
 
                         // Now that the host is holding the op, remove it from the fetch pool. Any sooner and we might queue the op for fetching again.
-                        // TODO we haven't waited for the op to finish validation, need to be careful about limbo state here?
+                        // We don't need to wait for validation to complete, at least with respect to gossip, because we don't ask for unvalidated
+                        // ops during gossip. (See crates/holochain/src/conductor/kitsune_host_impl/query_region_set.rs)
                         self.fetch_pool.remove(&key);
 
                         // trigger any delegation that is pending on having this data

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net_task.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net_task.rs
@@ -388,6 +388,7 @@ impl MetaNetTask {
                     op_hash_list,
                     context,
                 } => {
+                    tracing::trace!("incoming publish broadcast from {:?}", source);
                     if let Err(err) = self
                         .i_s
                         .incoming_publish(space, to_agent, source, op_hash_list, context, None)
@@ -477,7 +478,16 @@ impl MetaNetTask {
                         };
 
                         let key = FetchKey::Op(op_hash.clone());
-                        let fetch_context = self.fetch_pool.remove(&key).and_then(|i| i.context);
+                        let fetch_context = match self.fetch_pool.check_item(&key) {
+                            (true, maybe_fetch_context) => maybe_fetch_context,
+                            (false, _) => {
+                                tracing::warn!(
+                                    "Dropping incoming op because the fetch pool did not contain it, this may indicate a hashing mismatch or unsolicited pushes {:?}",
+                                    op
+                                );
+                                continue;
+                            }
+                        };
 
                         // forward the received op
                         if let Err(err) = self
@@ -498,6 +508,10 @@ impl MetaNetTask {
                             // In the case of an error we don't want to attempt to `resolve_publish_pending_delegates`
                             continue;
                         }
+
+                        // Now that the host is holding the op, remove it from the fetch pool. Any sooner and we might queue the op for fetching again.
+                        // TODO we haven't waited for the op to finish validation, need to be careful about limbo state here?
+                        self.fetch_pool.remove(&key);
 
                         // trigger any delegation that is pending on having this data
                         if let Err(err) = self
@@ -1796,7 +1810,7 @@ mod tests {
     async fn send_notify_push_op_data() {
         let (mut ep_evt_send, _, _, host_receiver_stub, _, _, fetch_pool, _) = setup().await;
 
-        fetch_pool.push(test_req_op(0, None, test_source(2)));
+        fetch_pool.push(test_req_op(1, None, test_source(2)));
         assert_eq!(1, fetch_pool.len());
 
         ep_evt_send
@@ -1843,14 +1857,14 @@ mod tests {
                         (
                             test_space(1),
                             vec![PushOpItem {
-                                op_data: KitsuneOpData::new(vec![1, 4, 10]),
+                                op_data: KitsuneOpData::new(vec![0, 4, 10]),
                                 region: None,
                             }],
                         ),
                         (
                             test_space(1),
                             vec![PushOpItem {
-                                op_data: KitsuneOpData::new(vec![1, 3, 90]),
+                                op_data: KitsuneOpData::new(vec![0, 3, 90]),
                                 region: None,
                             }],
                         ),
@@ -1880,6 +1894,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn send_notify_push_op_data_fails_independently_on_receive_ops_error() {
+        holochain_trace::test_run().unwrap();
+
         let (mut ep_evt_send, _, _, host_receiver_stub, _, _, fetch_pool, _) = setup().await;
 
         host_receiver_stub
@@ -1887,7 +1903,8 @@ mod tests {
             .store(true, Ordering::SeqCst);
 
         fetch_pool.push(test_req_op(0, None, test_source(2)));
-        assert_eq!(1, fetch_pool.len());
+        fetch_pool.push(test_req_op(1, None, test_source(3)));
+        assert_eq!(2, fetch_pool.len());
 
         ep_evt_send
             .send(MetaNetEvt::Notify {
@@ -1898,7 +1915,7 @@ mod tests {
                         (
                             test_space(1),
                             vec![PushOpItem {
-                                op_data: KitsuneOpData::new(vec![1, 4, 10]),
+                                op_data: KitsuneOpData::new(vec![0, 4, 10]),
                                 region: None,
                             }],
                         ),
@@ -1932,6 +1949,9 @@ mod tests {
                 .load(Ordering::Acquire)
         );
 
+        // Manually drop the item from the pool that we failed to receive
+        fetch_pool.remove(&test_key_op(0));
+
         // and also a successful op push
         wait_for_condition(|| {
             fetch_pool.is_empty() && !host_receiver_stub.receive_ops_calls.read().is_empty()
@@ -1961,7 +1981,7 @@ mod tests {
                     op_data_list: vec![(
                         test_space(1),
                         vec![PushOpItem {
-                            op_data: KitsuneOpData::new(vec![1, 4, 10]),
+                            op_data: KitsuneOpData::new(vec![0, 4, 10]),
                             region: None,
                         }],
                     )],
@@ -1994,7 +2014,7 @@ mod tests {
                     op_data_list: vec![(
                         test_space(1),
                         vec![PushOpItem {
-                            op_data: KitsuneOpData::new(vec![1, 4, 10]),
+                            op_data: KitsuneOpData::new(vec![0, 4, 10]),
                             region: None,
                         }],
                     )],

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net_task.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net_task.rs
@@ -388,7 +388,6 @@ impl MetaNetTask {
                     op_hash_list,
                     context,
                 } => {
-                    tracing::trace!("incoming publish broadcast from {:?}", source);
                     if let Err(err) = self
                         .i_s
                         .incoming_publish(space, to_agent, source, op_hash_list, context, None)

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -512,8 +512,6 @@ impl SpaceInternalHandler for Space {
                         space: space.clone(),
                         source: FetchSource::Agent(source.clone()),
                         size: op_hash.maybe_size(),
-                        // TODO - get the author from somewhere
-                        author: None,
                         context: Some(context),
                         transfer_method: TransferMethod::Publish,
                     });


### PR DESCRIPTION
### Summary

The changelog entry is probably the best description of this change but I'll add something details here

- Drop code that puts sources on 5m timeouts if they fail to respond
- Replace with code that tracks timeouts across the fetch pool for a source
- Sources that fail to respond in time are put on a global timeout that will prevent them from being used for any item in the pool until it expires
- I've limited the number of ops we fetch at once. It will fetch in batches of 100. Because the fetch task currently runs every second you are still fetching 6k ops per minute which seems like plenty for most use cases. I plan to immediately come back and work on integrating the existing bandwidth controls which is currently only respected by gossip and not the fetch pool.

I'm hoping this will address two things. 
- Drop ops we can't fetch. If we have no available sources for an op for hours at a time, then it's not useful to keep them in the fetch pool indefinitely and keep trying to fetch them every 90s. By dropping what we can't fetch I'm hoping to save some resources. It's a fairly slow recovery mechanism but at least it should recover without a restart.
- Fetch fewer ops at once. We've seen the fetch responder get overloaded in fairly small networks when something has gone wrong and the system gets out of control. By fetching fewer ops at once we should avoid overloading sources and stand a better chance of getting ops back. If we have a long list of ops we can't fetch for some reason but later ops can be fetched then overloading the remote source will cause it to drop requests for ops we might get back. Obviously, we also need to fix the reasons that we're continuing to request ops that we should have been able to fetch incrementally but this change should stop the fetch process from making the problem worse.
- Reduce the number of sends we know won't work. If a remote isn't responding then that's useful information we can apply across the pool. Reducing the amount of work we do by using this information should help reduce resource usage.
- Backoff rather than fixed delay. This should give sources a better chance to recover if something has gone wrong. I think 5 minutes was a reasonable default but if a source is serving a large number of ops to new peers catching up on a backlog of ops then it's entirely possible it won't be able to cope. By using backoff with jitter the chances of making good use of the sources available resources should be much higher.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
