### PR TITLE
Delegate broadcast no return to source

### DIFF
--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Minor optimisation when delegate broadcasting ops, the delegated broadcasts will now avoid connecting back to the source. There is currently no way to prevent other agents that were delegated to from connecting to each other but this change takes care of one case.
+
 ## 0.3.0-beta-dev.29
 
 ## 0.3.0-beta-dev.28

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -517,8 +517,6 @@ impl SpaceInternalHandler for Space {
                         space: space.clone(),
                         source: FetchSource::Agent(source.clone()),
                         size: op_hash.maybe_size(),
-                        // TODO - get the author from somewhere
-                        author: None,
                         context: Some(context),
                         transfer_method: TransferMethod::Publish,
                     });

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -425,10 +425,10 @@ impl SpaceInternalHandler for Space {
             // i.e. if `agent.get_loc() % mod_cnt == mod_idx` we know we are
             // responsible for delegating the broadcast to that agent.
             let mut all = Vec::new();
-            for info in info_list
-                .into_iter()
-                .filter(|info| info.agent.get_loc().as_u32() % mod_cnt == mod_idx && Some(info.agent()) != broadcast_source)
-            {
+            for info in info_list.into_iter().filter(|info| {
+                info.agent.get_loc().as_u32() % mod_cnt == mod_idx
+                    && Some(info.agent()) != broadcast_source
+            }) {
                 let ro_inner = ro_inner.clone();
                 let space = space.clone();
                 let data = data.clone();

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -357,7 +357,7 @@ impl SpaceInternalHandler for Space {
         // local agents.
         let mut local_notify_events = Vec::new();
         let mut local_agent_info_events = Vec::new();
-        match &data {
+        let broadcast_source = match &data {
             BroadcastData::User(data) => {
                 for agent in self.local_joined_agents.keys() {
                     if let Some(arc) = self.agent_arcs.get(agent) {
@@ -375,6 +375,8 @@ impl SpaceInternalHandler for Space {
                         }
                     }
                 }
+
+                None
             }
             BroadcastData::AgentInfo(agent_info) => {
                 if self
@@ -395,13 +397,16 @@ impl SpaceInternalHandler for Space {
                         }
                     });
                 }
+
+                None
             }
-            BroadcastData::Publish { .. } => {
+            BroadcastData::Publish { source, .. } => {
                 // Don't do anything here. This case is handled by the actor
                 // invoking incoming_publish instead of
                 // incoming_delegate_broadcast.
+                Some(source.clone())
             }
-        }
+        };
 
         // next, gather a list of agents covering this data to be
         // published to.
@@ -422,7 +427,7 @@ impl SpaceInternalHandler for Space {
             let mut all = Vec::new();
             for info in info_list
                 .into_iter()
-                .filter(|info| info.agent.get_loc().as_u32() % mod_cnt == mod_idx)
+                .filter(|info| info.agent.get_loc().as_u32() % mod_cnt == mod_idx && Some(info.agent()) != broadcast_source)
             {
                 let ro_inner = ro_inner.clone();
                 let space = space.clone();
@@ -749,12 +754,19 @@ async fn update_single_agent_info(
             }
         }
         NetworkType::QuicBootstrap => {
-            kitsune_p2p_bootstrap_client::put(
+            match kitsune_p2p_bootstrap_client::put(
                 bootstrap_service.clone(),
                 agent_info_signed.clone(),
                 bootstrap_net,
             )
-            .await?;
+            .await {
+                Ok(_) => {
+                    tracing::debug!("Successfully publish agent info to the bootstrap service");
+                }
+                Err(err) => {
+                    tracing::warn!(?err, "Failed to publish agent info to the bootstrap service, will try again later");
+                }
+            }
         }
     }
     Ok(agent_info_signed)
@@ -1027,7 +1039,7 @@ impl KitsuneP2pHandler for Space {
             let task_permit = ro_inner
                 .parallel_notify_permit
                 .clone()
-                .acquire_owned()
+                .acquire_owned() // TODO only acquire one regardless of how many nodes we're planning to notify?
                 .await
                 .ok();
             tokio::task::spawn(async move {
@@ -1076,8 +1088,8 @@ impl KitsuneP2pHandler for Space {
 
                 let mut all = Vec::new();
 
-                // determine the total number of nodes we'll be publishing to
-                // we'll make each remote responsible for a subset of delegate
+                // Determine the total number of nodes we'll be publishing to.
+                // We'll make each remote responsible for a subset of delegate
                 // broadcasting by having them apply the formula:
                 // `agent.get_loc() % mod_cnt == mod_idx` -- if true,
                 // they'll be responsible for forwarding the data to that node.


### PR DESCRIPTION
### Summary

This is a rather small fix. This is when we receive a delegate broadcast and are about to pick other agents in our delegated segment to publish to. Those segments are non-overlapping so each delegated publish won't overlap with another agent's delegated publish. However, nothing is stopping delegated publishes going back to people who originally received the request to do a delegate publish. Not sure I'm describing that well but hopefully it makes sense.

What we can be sure of is that the original author doing the delegate publish will be in some agent's segment and therefore may get the message they just sent pushed back to them. That is the possibility that this change removes. Without sending the list of agents who the publish originally went to we can't currently eliminate the possibility of some agents being told about published hashes twice. This gets less likely the bigger the network gets through so I'm not too concerned about that.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
