### PR TITLE
Bump 0_2_rc to 0.2.5-rc.0

### DIFF
--- a/versions/0_2_rc/flake.nix
+++ b/versions/0_2_rc/flake.nix
@@ -2,12 +2,12 @@
   inputs =
     {
       holochain = {
-        url = "github:holochain/holochain/holochain-0.2.4-rc.0";
+        url = "github:holochain/holochain/holochain-0.2.5-rc.0";
         flake = false;
       };
 
       lair = {
-        url = "github:holochain/lair/lair_keystore-v0.3.0";
+        url = "github:holochain/lair/lair_keystore-v0.4.0";
         flake = false;
       };
 


### PR DESCRIPTION
### Summary

Note that I've deliberately not modified the lock files, the CI should do this

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
