### PR TITLE
Allow clippy::redundant_pattern_matching

### DIFF
--- a/.config/clippy-args.nix
+++ b/.config/clippy-args.nix
@@ -12,5 +12,6 @@
   -D clippy::correctness \
   -D clippy::dbg_macro \
   \
-  -A clippy::redundant_pattern_matching
+  -A clippy::redundant_pattern_matching \
+  -A clippy::collapsible_else_if
 ''

--- a/.config/clippy-args.nix
+++ b/.config/clippy-args.nix
@@ -1,3 +1,6 @@
+# Keep the high-level lints at the top of this list,
+# and add fine-grained exceptions to the bottom.
+
 ''
   -A clippy::nursery \
   -A clippy::cargo \
@@ -7,6 +10,7 @@
   -D clippy::complexity \
   -D clippy::perf \
   -D clippy::correctness \
-  \
   -D clippy::dbg_macro \
+  \
+  -A clippy::redundant_pattern_matching
 ''

--- a/crates/holochain/src/core/sys_validate.rs
+++ b/crates/holochain/src/core/sys_validate.rs
@@ -159,7 +159,7 @@ pub fn check_prev_action(action: &Action) -> SysValidationResult<()> {
     let is_dna = matches!(action, Action::Dna(_));
     let has_prev = action.prev_action().is_some();
     let is_first = action.action_seq() == 0;
-    #[allow(clippy::collapsible_else_if)]
+
     if is_first {
         if is_dna && !has_prev {
             Ok(())


### PR DESCRIPTION
### Summary

I never met a clippy lint I didn't like...until today. This one just seems harmful. It wants you to use `.is_ok()` instead of `if let Ok(()) = ...`, which would hide information if `()` ever changed to something else.

In general I'm inviting other clippy tweaks to be added. Hopefully this is not a can of worms.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
