### PR TITLE
[BACKPORT 0.2] Bump lair_keystore to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2598,6 +2598,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hc_seed_bundle"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397f372672597305f39af2b2abf389a077077489bc4f412e7ed574214c268208"
+dependencies = [
+ "futures",
+ "one_err",
+ "rmp-serde 0.15.5",
+ "rmpv",
+ "serde",
+ "serde_bytes",
+ "sodoken",
+]
+
+[[package]]
 name = "hdi"
 version = "0.3.5-rc.0"
 dependencies = [
@@ -3320,7 +3335,7 @@ dependencies = [
  "nanoid 0.3.0",
  "one_err",
  "parking_lot 0.10.2",
- "pretty_assertions 0.6.1",
+ "pretty_assertions 0.7.2",
  "rand 0.8.5",
  "regex",
  "rusqlite",
@@ -4275,7 +4290,7 @@ dependencies = [
  "kitsune_p2p_dht",
  "kitsune_p2p_dht_arc",
  "kitsune_p2p_types",
- "lair_keystore_api",
+ "lair_keystore_api 0.4.1",
  "lru 0.8.1",
  "mockall",
  "nanoid 0.3.0",
@@ -4310,11 +4325,11 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c7dbcbc8d75eef0b30397a7eb0d04549aabeff4ea69ebd272aea991555746"
+checksum = "fcbac7629f0f04caae576442599f4328402e1313989a57c66f343947ef1b4add"
 dependencies = [
- "lair_keystore_api",
+ "lair_keystore_api 0.4.1",
  "pretty_assertions 1.4.0",
  "rpassword 7.3.1",
  "rusqlite",
@@ -4332,7 +4347,34 @@ checksum = "5829f25d0eab6309ae4307aa645f123a64e568a41ec17c358dcbd65dec207e10"
 dependencies = [
  "base64 0.13.1",
  "dunce",
- "hc_seed_bundle",
+ "hc_seed_bundle 0.1.7",
+ "lru 0.10.1",
+ "nanoid 0.4.0",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "rcgen 0.10.0",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "time",
+ "tokio",
+ "toml 0.5.11",
+ "toml 0.7.8",
+ "tracing",
+ "url 2.5.0",
+ "winapi 0.3.9",
+ "zeroize",
+]
+
+[[package]]
+name = "lair_keystore_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111229e06eaf24ed8359fed70e37c2715efdafa6e26394e9bd7a4617722caa41"
+dependencies = [
+ "base64 0.13.1",
+ "dunce",
+ "hc_seed_bundle 0.2.0",
  "lru 0.10.1",
  "nanoid 0.4.0",
  "once_cell",
@@ -8276,7 +8318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c01b23ba903fc189bdbb38ec4726274f297b3b303c62daf029063478137a8af9"
 dependencies = [
  "futures",
- "lair_keystore_api",
+ "lair_keystore_api 0.3.0",
  "once_cell",
  "parking_lot 0.12.1",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2584,28 +2584,13 @@ dependencies = [
 
 [[package]]
 name = "hc_seed_bundle"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded13e388a81713db6919cd750e6113acf2fe5afbaedf8aff79780ec4fc47425"
-dependencies = [
- "futures",
- "one_err",
- "rmp-serde 1.1.2",
- "rmpv",
- "serde",
- "serde_bytes",
- "sodoken",
-]
-
-[[package]]
-name = "hc_seed_bundle"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "397f372672597305f39af2b2abf389a077077489bc4f412e7ed574214c268208"
 dependencies = [
  "futures",
  "one_err",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "rmpv",
  "serde",
  "serde_bytes",
@@ -3145,7 +3130,7 @@ dependencies = [
  "holochain_serialized_bytes_derive",
  "proptest",
  "proptest-derive",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "serde",
  "serde-transcode",
  "serde_bytes",
@@ -3201,7 +3186,7 @@ dependencies = [
  "r2d2",
  "r2d2_sqlite_neonphog",
  "rand 0.8.5",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "rusqlite",
  "scheduled-thread-pool",
  "serde",
@@ -4121,7 +4106,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "rand 0.8.5",
  "reqwest",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -4232,7 +4217,7 @@ dependencies = [
  "kitsune_p2p_types",
  "nanoid 0.3.0",
  "parking_lot 0.11.2",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "rustls",
  "sct",
  "serde",
@@ -4290,14 +4275,14 @@ dependencies = [
  "kitsune_p2p_dht",
  "kitsune_p2p_dht_arc",
  "kitsune_p2p_types",
- "lair_keystore_api 0.4.1",
+ "lair_keystore_api",
  "lru 0.8.1",
  "mockall",
  "nanoid 0.3.0",
  "once_cell",
  "parking_lot 0.11.2",
  "paste",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "rustls",
  "serde",
  "serde_bytes",
@@ -4329,7 +4314,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbac7629f0f04caae576442599f4328402e1313989a57c66f343947ef1b4add"
 dependencies = [
- "lair_keystore_api 0.4.1",
+ "lair_keystore_api",
  "pretty_assertions 1.4.0",
  "rpassword 7.3.1",
  "rusqlite",
@@ -4341,40 +4326,13 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5829f25d0eab6309ae4307aa645f123a64e568a41ec17c358dcbd65dec207e10"
-dependencies = [
- "base64 0.13.1",
- "dunce",
- "hc_seed_bundle 0.1.7",
- "lru 0.10.1",
- "nanoid 0.4.0",
- "once_cell",
- "parking_lot 0.12.1",
- "rcgen 0.10.0",
- "serde",
- "serde_json",
- "serde_yaml",
- "time",
- "tokio",
- "toml 0.5.11",
- "toml 0.7.8",
- "tracing",
- "url 2.5.0",
- "winapi 0.3.9",
- "zeroize",
-]
-
-[[package]]
-name = "lair_keystore_api"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "111229e06eaf24ed8359fed70e37c2715efdafa6e26394e9bd7a4617722caa41"
 dependencies = [
  "base64 0.13.1",
  "dunce",
- "hc_seed_bundle 0.2.0",
+ "hc_seed_bundle",
  "lru 0.10.1",
  "nanoid 0.4.0",
  "once_cell",
@@ -4836,7 +4794,7 @@ dependencies = [
  "maplit",
  "matches",
  "reqwest",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -6546,17 +6504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmp-serde"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
-]
-
-[[package]]
 name = "rmpv"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8220,9 +8167,9 @@ dependencies = [
 
 [[package]]
 name = "tx5"
-version = "0.0.4-alpha"
+version = "0.0.6-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68891d49fb7fdb4f0aedfe8347cf3dc9b8e28ab99cf6b6da5b1ae90682cafa21"
+checksum = "bd134f3accf5bb9027cf69de1fef04728d9459e22fecf520a18623bc13831f49"
 dependencies = [
  "bytes",
  "futures",
@@ -8244,9 +8191,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-core"
-version = "0.0.4-alpha"
+version = "0.0.6-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ce4d742f95206169d6d68dc47f2064e594bd755b882740218eb2db078125df"
+checksum = "d04199b3ea6873836b444fda70982bb5566a64b13ae9cebed64d0faac7d25892"
 dependencies = [
  "base64 0.13.1",
  "dirs 5.0.1",
@@ -8262,9 +8209,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion"
-version = "0.0.4-alpha"
+version = "0.0.6-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "344f080c69c305c7d3075c077799b66de47568f79577704622d28c33ef3dfdd2"
+checksum = "aec1c77232fe9307aa37749545c1722d54abc0a19b745cb6b0c4033f33042673"
 dependencies = [
  "futures",
  "parking_lot 0.12.1",
@@ -8276,9 +8223,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-sys"
-version = "0.0.4-alpha"
+version = "0.0.6-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa8e91c1a85f6b9de962c63a7086619d78cf4f876a2a1888be715091bc4a1c2"
+checksum = "f914c7e4724adc3061f12e449d36cefb1b476a07ca77da601bda645e8c3e58e5"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -8295,9 +8242,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-turn"
-version = "0.0.4-alpha"
+version = "0.0.6-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a2ee4982985842265529632f96751020ecd109e6e249662037eef2cdf2a881"
+checksum = "3af0ed5298942b171593fd1842e50f507da0aae34b64e80f55daad4c15e33a7b"
 dependencies = [
  "base64 0.13.1",
  "dirs 5.0.1",
@@ -8313,12 +8260,12 @@ dependencies = [
 
 [[package]]
 name = "tx5-signal"
-version = "0.0.4-alpha"
+version = "0.0.6-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01b23ba903fc189bdbb38ec4726274f297b3b303c62daf029063478137a8af9"
+checksum = "9324b127b0b0d63a723c4fd2d09b9d5491686878b02b1ccfbe61b898b045845c"
 dependencies = [
  "futures",
- "lair_keystore_api 0.3.0",
+ "lair_keystore_api",
  "once_cell",
  "parking_lot 0.12.1",
  "rand 0.8.5",
@@ -8342,9 +8289,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-signal-srv"
-version = "0.0.4-alpha"
+version = "0.0.6-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1041cf202eb8789aaa4fc70acdae424ea3ad361e4031aa14dc30fcf0a246f69"
+checksum = "95d19b62bad76105f28ae9aa5338a4d765546ffa6162223ad3204352a3afa2a2"
 dependencies = [
  "clap 4.4.18",
  "dirs 5.0.1",

--- a/crates/hc_run_local_services/Cargo.toml
+++ b/crates/hc_run_local_services/Cargo.toml
@@ -22,4 +22,4 @@ if-addrs = "0.10.1"
 kitsune_p2p_bootstrap = { version = "^0.1.5-rc.0", path = "../kitsune_p2p/bootstrap" }
 tokio = { version = "1.27", features = ["full"] }
 tracing = "0.1"
-tx5-signal-srv = "=0.0.4-alpha"
+tx5-signal-srv = "=0.0.6-alpha"

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -95,8 +95,8 @@ matches = {version = "0.1.8", optional = true }
 holochain_test_wasm_common = { version = "^0.2.5-rc.0", path = "../test_utils/wasm_common", optional = true  }
 kitsune_p2p_bootstrap = { version = "^0.1.5-rc.0", path = "../kitsune_p2p/bootstrap", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
-tx5-go-pion-turn = { version = "=0.0.4-alpha", optional = true }
-tx5-signal-srv = { version = "=0.0.4-alpha", optional = true }
+tx5-go-pion-turn = { version = "=0.0.6-alpha", optional = true }
+tx5-signal-srv = { version = "=0.0.6-alpha", optional = true }
 
 # chc deps
 bytes = { version = "1", optional = true }

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Update Lair version to 0.4.1, see the Lair changelog [here](https://github.com/holochain/lair/blob/main/crates/lair_keystore/CHANGELOG.md#041).
+
 ## 0.2.5-rc.0
 
 ## 0.2.4

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -17,7 +17,7 @@ holo_hash = { version = "^0.2.5-rc.0", path = "../holo_hash", features = ["full"
 holochain_serialized_bytes = "=0.0.53"
 holochain_zome_types = { path = "../holochain_zome_types", version = "^0.2.5-rc.0"}
 kitsune_p2p_types = { version = "^0.2.5-rc.0", path = "../kitsune_p2p/types" }
-lair_keystore = { version = "0.3.0", default-features = false }
+lair_keystore = { version = "0.4.1", default-features = false }
 must_future = "0.1.2"
 nanoid = "0.4.0"
 one_err = "0.0.8"

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -39,7 +39,7 @@ parking_lot = "0.10"
 rand = "0.8.5"
 r2d2 = "0.8"
 r2d2_sqlite = { version = "0.1", package = "r2d2_sqlite_neonphog" }
-rmp-serde = "0.15"
+rmp-serde = "=0.15.5"
 scheduled-thread-pool = "0.2"
 serde = ">= 1.0, <= 1.0.166"
 serde_derive = "1.0"

--- a/crates/kitsune_p2p/bootstrap/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap/Cargo.toml
@@ -19,7 +19,7 @@ kitsune_p2p_types = { version = "^0.2.5-rc.0", path = "../types" }
 once_cell = "1.7.2"
 parking_lot = "0.11"
 rand = "0.8.5"
-rmp-serde = "0.15"
+rmp-serde = "=0.15.5"
 serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"
 serde_json = { version = "1", features = [ "preserve_order" ] }

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -45,7 +45,7 @@ thiserror = "1.0.22"
 tokio = { version = "1.27", features = ["full"] }
 tracing = "0.1"
 tokio-stream = "0.1"
-tx5 = { version = "=0.0.4-alpha", optional = true }
+tx5 = { version = "=0.0.6-alpha", optional = true }
 url2 = "0.0.6"
 fixt = { path = "../../fixt", version = "^0.2.5-rc.0"}
 
@@ -71,7 +71,7 @@ pretty_assertions = "0.7"
 test-case = "1.0.0"
 tokio = { version = "1.11", features = ["full", "test-util"] }
 tracing-subscriber = "0.3.16"
-tx5-signal-srv = "=0.0.4-alpha"
+tx5-signal-srv = "=0.0.6-alpha"
 ed25519-dalek = "1"
 rand_dalek = { version = "0.7", package = "rand" } # Compatibility with dalek
 

--- a/crates/kitsune_p2p/proxy/Cargo.toml
+++ b/crates/kitsune_p2p/proxy/Cargo.toml
@@ -20,7 +20,7 @@ kitsune_p2p_transport_quic = { version = "^0.2.5-rc.0", path = "../transport_qui
 nanoid = "0.3"
 holochain_trace = { version = "^0.2.4", path = "../../holochain_trace" }
 parking_lot = "0.11"
-rmp-serde = "0.15"
+rmp-serde = "=0.15.5"
 rustls = { version = "0.20.4", features = [ "dangerous_configuration" ] }
 serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive" ] }
 serde_bytes = "0.11"

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -27,7 +27,7 @@ holochain_trace = { version = "^0.2.4", path = "../../holochain_trace" }
 once_cell = "1.4"
 parking_lot = "0.11"
 paste = "1.0.12"
-rmp-serde = "0.15"
+rmp-serde = "=0.15.5"
 rustls = { version = "0.20.4", features = [ "dangerous_configuration" ] }
 serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive", "rc" ] }
 serde_bytes = "0.11"

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -11,7 +11,7 @@ categories = [ "network-programming" ]
 edition = "2021"
 
 [dependencies]
-lair_keystore_api = "=0.3.0"
+lair_keystore_api = "=0.4.1"
 base64 = "0.13"
 derive_more = "0.99.7"
 futures = "0.3"

--- a/crates/mr_bundle/Cargo.toml
+++ b/crates/mr_bundle/Cargo.toml
@@ -16,7 +16,7 @@ flate2 = "1.0"
 holochain_util = { path = "../holochain_util", version = "^0.2.4"}
 futures = "0.3"
 reqwest = "0.11"
-rmp-serde = "0.15"
+rmp-serde = "=0.15.5"
 serde = { version = ">= 1.0, <= 1.0.166", features = ["serde_derive", "derive"] }
 serde_bytes = "0.11"
 serde_derive = "1.0"


### PR DESCRIPTION
### Summary

Backport for #3249

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
