### PR TITLE
5s network join timeout, and more info logs

### DIFF
--- a/crates/holochain/src/bin/holochain/main.rs
+++ b/crates/holochain/src/bin/holochain/main.rs
@@ -91,6 +91,8 @@ async fn async_main() {
 
     kitsune_p2p_types::metrics::init_sys_info_poll();
 
+    info!("Conductor startup: metrics loop spawned.");
+
     let conductor = conductor_handle_from_config(&opt, config).await;
 
     info!("Conductor successfully initialized.");

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -59,7 +59,7 @@ impl ConductorBuilder {
 
     /// Initialize a "production" Conductor
     pub async fn build(self) -> ConductorResult<ConductorHandle> {
-        tracing::info!(?self.config);
+        tracing::debug!(?self.config);
 
         let keystore = if let Some(keystore) = self.keystore {
             keystore
@@ -125,6 +125,8 @@ impl ConductorBuilder {
             }
         };
 
+        info!("Conductor startup: passphrase obtained.");
+
         let Self {
             ribosome_store,
             config,
@@ -154,6 +156,9 @@ impl ConductorBuilder {
                 cert_priv_key,
                 cert_digest,
             };
+
+        info!("Conductor startup: TLS cert created.");
+
         let strat = network_config.tuning_params.to_arq_strat();
 
         let host = KitsuneHostImpl::new(
@@ -173,6 +178,8 @@ impl ConductorBuilder {
                     return Err(err.into());
                 }
             };
+
+        info!("Conductor startup: networking started.");
 
         let (post_commit_sender, post_commit_receiver) =
             tokio::sync::mpsc::channel(POST_COMMIT_CHANNEL_BOUND);
@@ -286,7 +293,11 @@ impl ConductorBuilder {
             .start_scheduler(holochain_zome_types::schedule::SCHEDULER_INTERVAL)
             .await;
 
+        info!("Conductor startup: scheduler task started.");
+
         tokio::task::spawn(p2p_event_task(p2p_evt, conductor.clone()));
+
+        info!("Conductor startup: p2p event task started.");
 
         let tm = conductor.task_manager();
         let conductor2 = conductor.clone();


### PR DESCRIPTION
### Summary

Oops, somehow #3221 dropped the shorter timeout, and even though apps can start if network join fails, it still waits 60s. This brings it back down to 5s as intended. Also adds some more logs.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
