### PR TITLE
[0.1] Bump Lair to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,13 +2130,13 @@ dependencies = [
 
 [[package]]
 name = "hc_seed_bundle"
-version = "0.1.7"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded13e388a81713db6919cd750e6113acf2fe5afbaedf8aff79780ec4fc47425"
+checksum = "397f372672597305f39af2b2abf389a077077489bc4f412e7ed574214c268208"
 dependencies = [
  "futures",
  "one_err",
- "rmp-serde 1.1.2",
+ "rmp-serde",
  "rmpv",
  "serde",
  "serde_bytes",
@@ -2589,7 +2589,7 @@ checksum = "9805b3e01e7b5c144782a0823db4dc895fec18a9ccd45a492ce7c7bf157a9e38"
 dependencies = [
  "arbitrary",
  "holochain_serialized_bytes_derive 0.0.51",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "serde",
  "serde-transcode",
  "serde_bytes",
@@ -2604,7 +2604,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bac6151d65c9a6f26f1b1068046a98900214030924377a2142f60c279b091f51"
 dependencies = [
  "holochain_serialized_bytes_derive 0.0.52",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "serde",
  "serde-transcode",
  "serde_bytes",
@@ -2667,7 +2667,7 @@ dependencies = [
  "r2d2",
  "r2d2_sqlite",
  "rand 0.8.5",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "rusqlite",
  "scheduled-thread-pool",
  "serde",
@@ -2777,7 +2777,7 @@ dependencies = [
  "observability",
  "one_err",
  "parking_lot 0.10.2",
- "pretty_assertions 0.6.1",
+ "pretty_assertions 0.7.2",
  "rand 0.8.5",
  "regex",
  "rusqlite",
@@ -3334,7 +3334,7 @@ dependencies = [
  "parking_lot 0.11.2",
  "rand 0.8.5",
  "reqwest",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -3493,7 +3493,7 @@ dependencies = [
  "nanoid 0.3.0",
  "observability",
  "parking_lot 0.11.2",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "rustls 0.20.8",
  "serde",
  "serde_bytes",
@@ -3555,7 +3555,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.11.2",
  "paste",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "rustls 0.20.8",
  "serde",
  "serde_bytes",
@@ -3582,9 +3582,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c7dbcbc8d75eef0b30397a7eb0d04549aabeff4ea69ebd272aea991555746"
+checksum = "fcbac7629f0f04caae576442599f4328402e1313989a57c66f343947ef1b4add"
 dependencies = [
  "lair_keystore_api",
  "pretty_assertions 1.4.0",
@@ -3598,9 +3598,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5829f25d0eab6309ae4307aa645f123a64e568a41ec17c358dcbd65dec207e10"
+checksum = "111229e06eaf24ed8359fed70e37c2715efdafa6e26394e9bd7a4617722caa41"
 dependencies = [
  "base64 0.13.1",
  "dunce",
@@ -4095,7 +4095,7 @@ dependencies = [
  "maplit",
  "matches",
  "reqwest",
- "rmp-serde 0.15.5",
+ "rmp-serde",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -5709,17 +5709,6 @@ name = "rmp-serde"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "723ecff9ad04f4ad92fe1c8ca6c20d2196d9286e9c60727c4cb5511629260e9d"
-dependencies = [
- "byteorder",
- "rmp",
- "serde",
-]
-
-[[package]]
-name = "rmp-serde"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffea85eea980d8a74453e5d02a8d93028f3c34725de143085a844ebe953258a"
 dependencies = [
  "byteorder",
  "rmp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2130,9 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "hc_seed_bundle"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397f372672597305f39af2b2abf389a077077489bc4f412e7ed574214c268208"
+checksum = "617899e4db04c1c5edf234004aef010543f4684690d1eae0690672ebbd845567"
 dependencies = [
  "futures",
  "one_err",
@@ -3582,9 +3582,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbac7629f0f04caae576442599f4328402e1313989a57c66f343947ef1b4add"
+checksum = "c7e973eb3f86bb833b87c15f389758b4ddd1b98c8bc0cf9e7c8138e01dd7bea6"
 dependencies = [
  "lair_keystore_api",
  "pretty_assertions 1.4.0",
@@ -3598,9 +3598,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111229e06eaf24ed8359fed70e37c2715efdafa6e26394e9bd7a4617722caa41"
+checksum = "ec8c930d24c7c4125471400d1534ab36a0c935eec1c70e0a733ea6f7350747c6"
 dependencies = [
  "base64 0.13.1",
  "dunce",

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -17,7 +17,7 @@ holo_hash = { version = "^0.1.5", path = "../holo_hash", features = ["full"] }
 holochain_serialized_bytes = "=0.0.51"
 holochain_zome_types = { path = "../holochain_zome_types", version = "^0.1.5"}
 kitsune_p2p_types = { version = "^0.1.5", path = "../kitsune_p2p/types" }
-lair_keystore = { version = "0.4.1", default-features = false }
+lair_keystore = { version = "0.4.2", default-features = false }
 must_future = "0.1.2"
 nanoid = "0.4.0"
 one_err = "0.0.8"

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -17,7 +17,7 @@ holo_hash = { version = "^0.1.5", path = "../holo_hash", features = ["full"] }
 holochain_serialized_bytes = "=0.0.51"
 holochain_zome_types = { path = "../holochain_zome_types", version = "^0.1.5"}
 kitsune_p2p_types = { version = "^0.1.5", path = "../kitsune_p2p/types" }
-lair_keystore = { version = "0.3.0", default-features = false }
+lair_keystore = { version = "0.4.1", default-features = false }
 must_future = "0.1.2"
 nanoid = "0.4.0"
 one_err = "0.0.8"

--- a/crates/kitsune_p2p/direct/src/lib.rs
+++ b/crates/kitsune_p2p/direct/src/lib.rs
@@ -1,5 +1,4 @@
 //! Kitsune P2p Direct Application Framework
-#![deny(warnings)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 

--- a/crates/kitsune_p2p/direct_api/src/lib.rs
+++ b/crates/kitsune_p2p/direct_api/src/lib.rs
@@ -1,5 +1,4 @@
 //! Kitsune P2p Direct Application Framework Test Harness Common API Types
-#![deny(warnings)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 

--- a/crates/kitsune_p2p/direct_test/src/lib.rs
+++ b/crates/kitsune_p2p/direct_test/src/lib.rs
@@ -1,6 +1,5 @@
 //! Kitsune P2p Direct Application Framework Test Harness
 
-#![deny(warnings)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 #![allow(clippy::blocks_in_if_conditions)]

--- a/crates/kitsune_p2p/fetch/src/lib.rs
+++ b/crates/kitsune_p2p/fetch/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
-#![deny(warnings)]
 
 //! Kitsune P2p Fetch Queue Logic
 

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -11,7 +11,7 @@ categories = [ "network-programming" ]
 edition = "2021"
 
 [dependencies]
-lair_keystore_api = "=0.3.0"
+lair_keystore_api = "=0.4.1"
 base64 = "0.13"
 derive_more = "0.99.7"
 futures = "0.3"

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -11,7 +11,7 @@ categories = [ "network-programming" ]
 edition = "2021"
 
 [dependencies]
-lair_keystore_api = "=0.4.1"
+lair_keystore_api = "=0.4.2"
 base64 = "0.13"
 derive_more = "0.99.7"
 futures = "0.3"

--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -84,7 +84,7 @@
             --force-tag-creation \
             --force-branch-creation \
             --additional-manifests="crates/test_utils/wasm/wasm_workspace/Cargo.toml" \
-            --allowed-semver-increment-modes="!patch" \
+            --allowed-semver-increment-modes="!pre_patch rc" \
             --steps=CreateReleaseBranch,BumpReleaseVersions
 
         ${self'.packages.release-automation}/bin/release-automation \


### PR DESCRIPTION
### Summary

Lair 0.3.0 doesn't build on Rust 1.75.1, this latest version of Lair both fixes the problem warning that's preventing the code from building and also removes the `deny(warnings)` so that we won't need a release next time to deal with changes in clippy as we upgrade our Rust version

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
