### PR TITLE
Ensure `init()` has run before attempting `GrantZomeCallCapability`

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Added `lair_keystore_version_req` to the output of `--build-info` for Holochain.
+- Fixed a bug during the admin call `GrantZomeCallCapability`, where if the source chain had not yet been initialized, it was possible to create a capability grant before the `init()` callback runs. Now, `init()` is guaranteed to run before any cap grants are created.
 
 ## 0.3.0-beta-dev.35
 

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -943,7 +943,7 @@ impl Cell {
 
     /// Check if each Zome's init callback has been run, and if not, run it.
     #[tracing::instrument(skip(self))]
-    async fn check_or_run_zome_init(&self) -> CellResult<()> {
+    pub(crate) async fn check_or_run_zome_init(&self) -> CellResult<()> {
         // Ensure that only one init check is run at a time
         let _guard = tokio::time::timeout(
             std::time::Duration::from_secs(INIT_MUTEX_TIMEOUT_SECS),

--- a/crates/holochain_conductor_api/src/state_dump.rs
+++ b/crates/holochain_conductor_api/src/state_dump.rs
@@ -1,6 +1,6 @@
 use holo_hash::AgentPubKey;
 use holo_hash::DnaHash;
-use holochain_state_types::SourceChainJsonDump;
+use holochain_state_types::SourceChainDump;
 use holochain_types::dht_op::DhtOp;
 use kitsune_p2p_bin_data::{KitsuneAgent, KitsuneSpace};
 use serde::Deserialize;
@@ -10,14 +10,14 @@ use std::sync::Arc;
 #[derive(Serialize, Deserialize)]
 pub struct JsonDump {
     pub peer_dump: P2pAgentsDump,
-    pub source_chain_dump: SourceChainJsonDump,
+    pub source_chain_dump: SourceChainDump,
     pub integration_dump: IntegrationStateDump,
 }
 
 #[derive(Serialize, Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct FullStateDump {
     pub peer_dump: P2pAgentsDump,
-    pub source_chain_dump: SourceChainJsonDump,
+    pub source_chain_dump: SourceChainDump,
     pub integration_dump: FullIntegrationStateDump,
 }
 

--- a/crates/holochain_state_types/src/lib.rs
+++ b/crates/holochain_state_types/src/lib.rs
@@ -5,13 +5,13 @@ use serde::{Deserialize, Serialize};
 // TODO fix this.  We shouldn't really have nil values but this would
 // show if the database is corrupted and doesn't have a record
 #[derive(Serialize, Debug, Clone, Deserialize, PartialEq, Eq)]
-pub struct SourceChainJsonDump {
-    pub records: Vec<SourceChainJsonRecord>,
+pub struct SourceChainDump {
+    pub records: Vec<SourceChainDumpRecord>,
     pub published_ops_count: usize,
 }
 
 #[derive(Serialize, Debug, Clone, Deserialize, PartialEq, Eq)]
-pub struct SourceChainJsonRecord {
+pub struct SourceChainDumpRecord {
     pub signature: Signature,
     pub action_address: ActionHash,
     pub action: Action,


### PR DESCRIPTION
### Summary

It was possible to commit a cap grant before init had run, messing up the expected order. This ensures that init runs before committing the new cap grant through this admin call.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
