### PR TITLE
refactor(app_validation_wf): simplify main loop

### DIFF
--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -47,8 +47,6 @@ mod validation_tests;
 mod error;
 mod types;
 
-const NUM_CONCURRENT_OPS: usize = 50;
-
 #[instrument(skip(
     workspace,
     trigger_integration,
@@ -91,11 +89,9 @@ async fn app_validation_workflow_inner(
     let sorted_ops = validation_query::get_ops_to_app_validate(&db).await?;
     let num_ops_to_validate = sorted_ops.len();
     tracing::debug!("validating {num_ops_to_validate} ops");
-    let start = (num_ops_to_validate >= NUM_CONCURRENT_OPS).then(std::time::Instant::now);
-    let saturated = start.is_some();
     let sleuth_id = conductor.config.sleuth_id();
 
-    // Validate all the ops
+    // Build an iterator of all op validations
     let iter = sorted_ops.into_iter().map({
         let network = network.clone();
         let workspace = workspace.clone();
@@ -133,146 +129,99 @@ async fn app_validation_workflow_inner(
         }
     });
 
-    // Create a stream of concurrent validation futures.
-    // This will run NUM_CONCURRENT_OPS validation futures concurrently and
-    // return up to NUM_CONCURRENT_OPS * 100 results.
-    let mut iter = futures::stream::iter(iter)
-        .buffer_unordered(NUM_CONCURRENT_OPS)
-        .ready_chunks(NUM_CONCURRENT_OPS * 100);
+    let validation_results = futures::future::join_all(iter).await;
 
-    // Spawn a task to actually drive the stream.
-    // This allows the stream to make progress in the background while
-    // we are committing previous results to the database.
-    let (tx, rx) = tokio::sync::mpsc::channel(NUM_CONCURRENT_OPS * 100);
-    let jh = tokio::spawn(async move {
-        while let Some(op) = iter.next().await {
-            // Send the result to task that will commit to the database.
-            if tx
-                .send_timeout(op, std::time::Duration::from_secs(10))
-                .await
-                .is_err()
-            {
-                tracing::warn!("app validation task has failed to send ops. This is not a problem if the conductor is shutting down");
-                break;
-            }
-        }
-    });
-
-    // Create a stream that will chunk up to NUM_CONCURRENT_OPS * 100 ready results.
-    let mut iter =
-        tokio_stream::wrappers::ReceiverStream::new(rx).ready_chunks(NUM_CONCURRENT_OPS * 100);
-
+    tracing::debug!("Committing {} ops", validation_results.len());
     let mut ops_validated = 0;
-    let mut round_time = start.is_some().then(std::time::Instant::now);
-    // Pull in a chunk of results.
-    while let Some(chunk) = iter.next().await {
-        tracing::debug!(
-            "Committing {} ops",
-            chunk.iter().map(|c| c.len()).sum::<usize>()
-        );
-        let sleuth_id = sleuth_id.clone();
-        let (accepted_ops, awaiting_ops, rejected_ops, activity) = workspace
-            .dht_db
-            .write_async(move |txn| {
-                let mut accepted = 0;
-                let mut awaiting = 0;
-                let mut rejected = 0;
-                let mut agent_activity = Vec::new();
-                for outcome in chunk.into_iter().flatten() {
-                    let (op_hash, dependency, op_lite, outcome, activity) = outcome;
-                    // Get the outcome or return the error
-                    let outcome = outcome.or_else(|outcome_or_err| outcome_or_err.try_into())?;
+    let sleuth_id = sleuth_id.clone();
+    let (accepted_ops, awaiting_ops, rejected_ops, activity) = workspace
+        .dht_db
+        .write_async(move |txn| {
+            let mut accepted = 0;
+            let mut awaiting = 0;
+            let mut rejected = 0;
+            let mut agent_activity = Vec::new();
+            for outcome in validation_results {
+                let (op_hash, dependency, op_lite, outcome, activity) = outcome;
+                // Get the outcome or return the error
+                let outcome = outcome.or_else(|outcome_or_err| outcome_or_err.try_into())?;
 
-                    // Collect all agent activity.
-                    if let Some(activity) = activity {
-                        // If the activity is accepted or rejected then it's ready to integrate.
-                        if matches!(&outcome, Outcome::Accepted | Outcome::Rejected(_)) {
-                            agent_activity.push(activity);
-                        }
+                // Collect all agent activity.
+                if let Some(activity) = activity {
+                    // If the activity is accepted or rejected then it's ready to integrate.
+                    if matches!(&outcome, Outcome::Accepted | Outcome::Rejected(_)) {
+                        agent_activity.push(activity);
                     }
+                }
 
-                    if let Outcome::AwaitingDeps(_) | Outcome::Rejected(_) = &outcome {
-                        warn!(
-                            msg = "DhtOp has failed app validation",
-                            outcome = ?outcome,
-                        );
-                    }
-                    match outcome {
-                        Outcome::Accepted => {
-                            accepted += 1;
-                            aitia::trace!(&hc_sleuth::Event::AppValidated {
+                if let Outcome::AwaitingDeps(_) | Outcome::Rejected(_) = &outcome {
+                    warn!(
+                        msg = "DhtOp has failed app validation",
+                        outcome = ?outcome,
+                    );
+                }
+                match outcome {
+                    Outcome::Accepted => {
+                        accepted += 1;
+                        aitia::trace!(&hc_sleuth::Event::AppValidated {
+                            by: sleuth_id.clone(),
+                            op: op_hash.clone()
+                        });
+
+                        if dependency.is_none() {
+                            aitia::trace!(&hc_sleuth::Event::Integrated {
                                 by: sleuth_id.clone(),
                                 op: op_hash.clone()
                             });
 
-                            if dependency.is_none() {
-                                aitia::trace!(&hc_sleuth::Event::Integrated {
-                                    by: sleuth_id.clone(),
-                                    op: op_hash.clone()
-                                });
-
-                                put_integrated(txn, &op_hash, ValidationStatus::Valid)?;
-                            } else {
-                                put_integration_limbo(txn, &op_hash, ValidationStatus::Valid)?;
-                            }
+                            put_integrated(txn, &op_hash, ValidationStatus::Valid)?;
+                        } else {
+                            put_integration_limbo(txn, &op_hash, ValidationStatus::Valid)?;
                         }
-                        Outcome::AwaitingDeps(deps) => {
-                            awaiting += 1;
-                            let status = ValidationStage::AwaitingAppDeps(deps);
-                            put_validation_limbo(txn, &op_hash, status)?;
-                        }
-                        Outcome::Rejected(_) => {
-                            rejected += 1;
-                            tracing::info!(
-                                "Received invalid op. The op author will be blocked.\nOp: {:?}",
-                                op_lite
-                            );
-                            if dependency.is_none() {
-                                put_integrated(txn, &op_hash, ValidationStatus::Rejected)?;
-                            } else {
-                                put_integration_limbo(txn, &op_hash, ValidationStatus::Rejected)?;
-                            }
+                    }
+                    Outcome::AwaitingDeps(deps) => {
+                        awaiting += 1;
+                        let status = ValidationStage::AwaitingAppDeps(deps);
+                        put_validation_limbo(txn, &op_hash, status)?;
+                    }
+                    Outcome::Rejected(_) => {
+                        rejected += 1;
+                        tracing::info!(
+                            "Received invalid op. The op author will be blocked.\nOp: {:?}",
+                            op_lite
+                        );
+                        if dependency.is_none() {
+                            put_integrated(txn, &op_hash, ValidationStatus::Rejected)?;
+                        } else {
+                            put_integration_limbo(txn, &op_hash, ValidationStatus::Rejected)?;
                         }
                     }
                 }
-                WorkflowResult::Ok((accepted, awaiting, rejected, agent_activity))
-            })
-            .await?;
-
-        // Once the database transaction is committed, add agent activity to the cache
-        // that is ready for integration.
-        for (author, seq, has_no_dependency) in activity {
-            // Any activity with no dependency is integrated in this workflow.
-            // TODO: This will no longer be true when [#1212](https://github.com/holochain/holochain/pull/1212) lands.
-            if has_no_dependency {
-                dht_query_cache
-                    .set_activity_to_integrated(&author, seq)
-                    .await?;
-            } else {
-                dht_query_cache
-                    .set_activity_ready_to_integrate(&author, seq)
-                    .await?;
             }
+            WorkflowResult::Ok((accepted, awaiting, rejected, agent_activity))
+        })
+        .await?;
+
+    // Once the database transaction is committed, add agent activity to the cache
+    // that is ready for integration.
+    for (author, seq, has_no_dependency) in activity {
+        // Any activity with no dependency is integrated in this workflow.
+        // TODO: This will no longer be true when [#1212](https://github.com/holochain/holochain/pull/1212) lands.
+        if has_no_dependency {
+            dht_query_cache
+                .set_activity_to_integrated(&author, seq)
+                .await?;
+        } else {
+            dht_query_cache
+                .set_activity_ready_to_integrate(&author, seq)
+                .await?;
         }
-        ops_validated += accepted_ops;
-        ops_validated += rejected_ops;
-        if let (Some(start), Some(round_time)) = (start, &mut round_time) {
-            let round_el = round_time.elapsed();
-            *round_time = std::time::Instant::now();
-            let avg_ops_ps =
-                ops_validated as f64 / start.elapsed().as_micros() as f64 * 1_000_000.0;
-            let ops_ps = accepted_ops as f64 / round_el.as_micros() as f64 * 1_000_000.0;
-            tracing::warn!(
-                "App validation is saturated. Util {:.2}%. OPS/s avg {:.2}, this round {:.2}",
-                (num_ops_to_validate - ops_validated) as f64 / NUM_CONCURRENT_OPS as f64 * 100.0,
-                avg_ops_ps,
-                ops_ps
-            );
-        }
-        tracing::debug!("{accepted_ops} accepted, {awaiting_ops} awaiting deps, {rejected_ops} rejected. {ops_validated} validated in total so far out of {num_ops_to_validate} ops to validate in this workflow run");
     }
-    jh.await?;
-    Ok(if saturated || ops_validated < num_ops_to_validate {
+    ops_validated += accepted_ops;
+    ops_validated += rejected_ops;
+    tracing::debug!("{accepted_ops} accepted, {awaiting_ops} awaiting deps, {rejected_ops} rejected. {ops_validated} validated in total so far out of {num_ops_to_validate} ops to validate in this workflow run");
+
+    Ok(if ops_validated < num_ops_to_validate {
         // trigger app validation workflow again in 10 seconds
         WorkComplete::Incomplete(Some(Duration::from_secs(10)))
     } else {

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -1,40 +1,155 @@
-use crate::conductor::Conductor;
-use crate::conductor::ConductorHandle;
+use crate::conductor::{Conductor, ConductorHandle};
+use crate::core::queue_consumer::WorkComplete;
 use crate::core::ribosome::guest_callback::validate::ValidateResult;
 use crate::core::ribosome::ZomeCallInvocation;
-use crate::core::workflow::app_validation_workflow::check_app_entry_def;
-use crate::core::SysValidationError;
-use crate::core::ValidationOutcome;
-use crate::sweettest::SweetConductorBatch;
-use crate::sweettest::SweetDnaFile;
-use crate::test_utils::consistency_10s;
-use crate::test_utils::host_fn_caller::*;
-use crate::test_utils::new_invocation;
-use crate::test_utils::new_zome_call;
-use crate::test_utils::wait_for_integration;
+use crate::core::workflow::app_validation_workflow::{
+    app_validation_workflow_inner, check_app_entry_def, put_validation_limbo,
+    AppValidationWorkspace,
+};
+use crate::core::workflow::sys_validation_workflow::validation_query;
+use crate::core::{SysValidationError, ValidationOutcome};
+use crate::sweettest::{
+    SweetConductor, SweetConductorBatch, SweetConductorConfig, SweetDnaFile, SweetLocalRendezvous,
+};
+use crate::test_utils::{
+    consistency_10s, host_fn_caller::*, new_invocation, new_zome_call, wait_for_integration,
+};
+use ::fixt::fixt;
 use arbitrary::Arbitrary;
 use hdk::hdi::test_utils::set_zome_types;
 use hdk::prelude::*;
-use holo_hash::ActionHash;
-use holo_hash::AnyDhtHash;
-use holo_hash::EntryHash;
+use holo_hash::{fixt::AgentPubKeyFixturator, ActionHash, AnyDhtHash, DhtOpHash, EntryHash};
 use holochain_conductor_api::conductor::paths::DataRootPath;
-use holochain_state::prelude::from_blob;
-use holochain_state::prelude::StateQueryResult;
+use holochain_p2p::actor::HolochainP2pRefToDna;
+use holochain_sqlite::error::DatabaseResult;
+use holochain_state::mutations::insert_op;
+use holochain_state::prelude::{from_blob, StateQueryResult};
 use holochain_state::test_utils::test_db_dir;
+use holochain_state::validation_db::ValidationStage;
+use holochain_types::dht_op::{DhtOp, DhtOpHashed};
 use holochain_types::inline_zome::InlineZomeSet;
 use holochain_types::prelude::*;
-use holochain_wasm_test_utils::TestWasm;
-
-use holochain_sqlite::error::DatabaseResult;
-use holochain_wasm_test_utils::TestWasmPair;
-use holochain_wasm_test_utils::TestZomes;
+use holochain_wasm_test_utils::{TestWasm, TestWasmPair, TestZomes};
+use holochain_zome_types::action::Dna;
+use holochain_zome_types::fixt::SignatureFixturator;
+use holochain_zome_types::timestamp::Timestamp;
+use holochain_zome_types::Action;
 use matches::assert_matches;
-use rusqlite::named_params;
-use rusqlite::Transaction;
-use std::convert::TryFrom;
-use std::convert::TryInto;
+use rusqlite::{named_params, Transaction};
+use std::convert::{TryFrom, TryInto};
+use std::sync::Arc;
 use std::time::Duration;
+
+#[cfg(test)]
+#[tokio::test(flavor = "multi_thread")]
+async fn main_loop_app_validation_workflow() {
+    use holochain_sqlite::error::DatabaseError;
+    use rusqlite::params;
+
+    holochain_trace::test_run().ok();
+
+    let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Validate]).await;
+    let dna_hash = dna_file.dna_hash().clone();
+
+    let mut conductor = SweetConductor::from_config_rendezvous(
+        SweetConductorConfig::rendezvous(true),
+        SweetLocalRendezvous::new().await,
+    )
+    .await;
+    let app = conductor.setup_app("", &[dna_file.clone()]).await.unwrap();
+    let cell_id = app.cells()[0].cell_id().clone();
+
+    let app_validation_workspace = Arc::new(AppValidationWorkspace::new(
+        conductor.get_authored_db(&dna_hash).unwrap().into(),
+        conductor.get_dht_db(&dna_hash).unwrap(),
+        conductor.get_dht_db_cache(&dna_hash).unwrap(),
+        conductor.get_cache_db(&cell_id).await.unwrap(),
+        conductor.keystore(),
+        Arc::new(dna_file.dna_def().clone()),
+    ));
+    // check there are no ops to app validate
+    let ops_to_validate =
+        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
+            .await
+            .unwrap();
+    assert_eq!(ops_to_validate.len(), 0);
+
+    // create ops to validate
+    let action = Action::Dna(Dna {
+        author: fixt!(AgentPubKey),
+        timestamp: Timestamp::now(),
+        hash: dna_hash.clone(),
+    });
+    let dht_op = DhtOp::RegisterAgentActivity(fixt!(Signature), action.clone());
+    let dht_op_hash = DhtOpHash::with_data_sync(&dht_op);
+    let dht_op_hashed = DhtOpHashed::with_pre_hashed(dht_op, dht_op_hash.clone());
+
+    let dht_op_2 = DhtOp::StoreEntry(fixt!(Signature), fixt!(NewEntryAction), fixt!(Entry));
+    let dht_op_hash_2 = DhtOpHash::with_data_sync(&dht_op_2);
+    let dht_op_hashed_2 = DhtOpHashed::with_pre_hashed(dht_op_2, dht_op_hash_2.clone());
+
+    app_validation_workspace
+        .dht_db
+        .write_async({
+            let dht_op_hash = dht_op_hash.clone();
+            let dht_op_hash_2 = dht_op_hash_2.clone();
+            move |txn| {
+                insert_op(txn, &dht_op_hashed).unwrap();
+                put_validation_limbo(txn, &dht_op_hash, ValidationStage::SysValidated).unwrap();
+                insert_op(txn, &dht_op_hashed_2).unwrap();
+                put_validation_limbo(txn, &dht_op_hash_2, ValidationStage::SysValidated)
+            }
+        })
+        .await
+        .unwrap();
+
+    // check there is one op to validate now
+    let ops_to_validate =
+        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
+            .await
+            .unwrap();
+    assert_eq!(ops_to_validate.len(), 2);
+
+    // run validation workflow
+    // outcome should be complete - all ops should have been validated
+    let app_validation_result = app_validation_workflow_inner(
+        Arc::new(dna_hash.clone()),
+        app_validation_workspace.clone(),
+        conductor.raw_handle(),
+        &conductor.holochain_p2p().to_dna(dna_hash.clone(), None),
+        conductor
+            .get_or_create_space(&dna_hash)
+            .unwrap()
+            .dht_query_cache,
+    )
+    .await;
+    assert_matches!(app_validation_result, Ok(WorkComplete::Complete));
+
+    // check that previously inserted ops have been validated
+    // and are valid
+    let num_pending_ops: usize = app_validation_workspace
+        .dht_db
+        .read_async(move |txn| {
+            txn.query_row(
+                &format!(
+                    "SELECT count(*)
+                    from DhtOp
+                    WHERE validation_stage = NULL
+                    AND validation_status = 0
+                    AND (
+                        hash = ?1
+                        OR hash = ?2
+                    )"
+                ),
+                params![dht_op_hash, dht_op_hash_2],
+                |row| row.get(0),
+            )
+            .map_err(DatabaseError::SqliteError)
+        })
+        .await
+        .unwrap();
+    assert_eq!(num_pending_ops, 0);
+}
 
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "deal with the invalid data that leads to blocks being enforced"]


### PR DESCRIPTION
### Summary
The app validation workflow has a main loop which employs two-fold breaking up of ops into chunks and processing them in background threads. Chunks are limited to 50 ops, so a maximum of 50 ops is validated in parallel. While ops are being validated, completed chunks of max. 5000 validation results are written to the database.

The logic in the code is difficult to wrap one's head around and probably not needed in normal scenarios where app validation is triggered every time by incoming ops. Further the actual bottleneck of app validation is not produced by too little parallel validation, but by awaiting op dependencies and processing incoming ops out of order.

This PR makes a first step toward a simple and local only app validation workflow by reducing the complexity of the main loop. Instead of chunking and threading validations, all ops to validate are awaited.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
