### PR TITLE
test(websocket): add failing test that emits signal post commit

### DIFF
--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -235,6 +235,9 @@ pub mod test {
     use crate::conductor::Conductor;
     use crate::conductor::ConductorHandle;
     use crate::fixt::RealRibosomeFixturator;
+    use crate::sweettest::app_bundle_from_dnas;
+    use crate::sweettest::websocket_client_by_port;
+    use crate::sweettest::SweetDnaFile;
     use crate::test_utils::conductor_setup::ConductorTestData;
     use crate::test_utils::install_app_in_conductor;
     use ::fixt::prelude::*;
@@ -257,8 +260,10 @@ pub mod test {
     use kitsune_p2p_types::fixt::*;
     use matches::assert_matches;
     use pretty_assertions::assert_eq;
+    use std::collections::BTreeMap;
     use std::collections::{HashMap, HashSet};
     use std::convert::TryInto;
+    use std::time::Duration;
     use tempfile::TempDir;
     use uuid::Uuid;
 
@@ -267,6 +272,96 @@ pub mod test {
     // NB: intentionally misspelled to test for serialization errors :)
     enum AdmonRequest {
         InstallsDna(String),
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn signal_in_post_commit() {
+        holochain_trace::test_run().ok();
+        let db_dir = test_db_dir();
+        let conductor_handle = ConductorBuilder::new()
+            .with_data_root_path(db_dir.path().to_path_buf().into())
+            .test(&[])
+            .await
+            .unwrap();
+
+        let admin_port = 65000;
+        conductor_handle
+            .clone()
+            .add_admin_interfaces(vec![AdminInterfaceConfig {
+                driver: InterfaceDriver::Websocket { port: admin_port },
+            }])
+            .await
+            .unwrap();
+
+        let (mut admin_tx, _) = websocket_client_by_port(admin_port).await.unwrap();
+
+        let agent_key = conductor_handle
+            .keystore()
+            .new_sign_keypair_random()
+            .await
+            .unwrap();
+
+        let (dna_file, _, _) =
+            SweetDnaFile::unique_from_test_wasms(vec![TestWasm::EmitSignal]).await;
+        let app_bundle = app_bundle_from_dnas([&dna_file]).await;
+        let request = AdminRequest::InstallApp(Box::new(InstallAppPayload {
+            source: AppBundleSource::Bundle(app_bundle),
+            agent_key: agent_key.clone(),
+            installed_app_id: None,
+            membrane_proofs: HashMap::new(),
+            network_seed: None,
+        }));
+        let response: AdminResponse = admin_tx.request(request).await.unwrap();
+        let app_info = match response {
+            AdminResponse::AppInstalled(app_info) => app_info,
+            _ => panic!("didn't install app"),
+        };
+        let cell_id = match &app_info
+            .cell_info
+            .get(&dna_file.dna_hash().to_string())
+            .unwrap()[0]
+        {
+            CellInfo::Provisioned(cell) => cell.cell_id.clone(),
+            _ => panic!("emit_signal cell not available"),
+        };
+
+        // Activate cells
+        let request = AdminRequest::EnableApp {
+            installed_app_id: app_info.installed_app_id.clone(),
+        };
+        let response: AdminResponse = admin_tx.request(request).await.unwrap();
+        assert_matches!(response, AdminResponse::AppEnabled { .. });
+
+        // Attach App Interface
+        let request = AdminRequest::AttachAppInterface { port: None };
+        let response: AdminResponse = admin_tx.request(request).await.unwrap();
+        let app_port = match response {
+            AdminResponse::AppInterfaceAttached { port } => port,
+            _ => panic!("app interface couldn't be attached"),
+        };
+
+        let (mut app_tx, _) = websocket_client_by_port(app_port).await.unwrap();
+
+        // Call Zome
+        let (nonce, expires_at) = holochain_nonce::fresh_nonce(Timestamp::now()).unwrap();
+        let request = AppRequest::CallZome(Box::new(
+            ZomeCall::try_from_unsigned_zome_call(
+                conductor_handle.keystore(),
+                ZomeCallUnsigned {
+                    provenance: agent_key.clone(),
+                    cell_id: cell_id.clone(),
+                    zome_name: TestWasm::EmitSignal.coordinator_zome_name(),
+                    fn_name: "commit_entry_and_emit_signal_post_commit".into(),
+                    cap_secret: None,
+                    payload: ExternIO::encode(()).unwrap(),
+                    nonce,
+                    expires_at,
+                },
+            )
+            .await
+            .unwrap(),
+        ));
+        let _: AppResponse = app_tx.request(request).await.unwrap();
     }
 
     async fn setup_admin() -> (Arc<TempDir>, ConductorHandle) {

--- a/crates/test_utils/wasm/wasm_workspace/emit_signal/src/integrity.rs
+++ b/crates/test_utils/wasm/wasm_workspace/emit_signal/src/integrity.rs
@@ -1,0 +1,11 @@
+use hdk::prelude::*;
+
+#[hdk_entry_helper]
+pub struct TestEntry(pub String);
+
+#[derive(Serialize, Deserialize)]
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+    TestEntry(TestEntry),
+}

--- a/crates/test_utils/wasm/wasm_workspace/emit_signal/src/lib.rs
+++ b/crates/test_utils/wasm/wasm_workspace/emit_signal/src/lib.rs
@@ -1,4 +1,6 @@
 use hdk::prelude::*;
+use integrity::{EntryTypes, TestEntry};
+mod integrity;
 
 #[hdk_extern]
 fn emit(_: ()) -> ExternResult<()> {
@@ -29,4 +31,21 @@ fn init(_: ()) -> ExternResult<InitCallbackResult> {
     })?;
 
     Ok(InitCallbackResult::Pass)
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(tag = "type")]
+pub enum Signal {
+    Tested,
+}
+
+#[hdk_extern]
+fn commit_entry_and_emit_signal_post_commit(_: ()) -> ExternResult<()> {
+    create_entry(EntryTypes::TestEntry(TestEntry("test".to_string())))?;
+    Ok(())
+}
+
+#[hdk_extern]
+fn post_commit(_: Vec<SignedActionHashed>) -> ExternResult<()> {
+    emit_signal(Signal::Tested)
 }


### PR DESCRIPTION
### Summary
Websocket fails to send response and shuts down when zome fn emits signal in post commit.


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
