### PR TITLE
Improve bundle decode error messages

### DIFF
--- a/crates/mr_bundle/src/encoding.rs
+++ b/crates/mr_bundle/src/encoding.rs
@@ -17,7 +17,7 @@ pub fn decode<T: serde::de::DeserializeOwned>(compressed: &[u8]) -> MrBundleResu
     let mut gz = flate2::read::GzDecoder::new(compressed);
     let mut bytes = Vec::new();
     gz.read_to_end(&mut bytes)?;
-    Ok(rmp_serde::from_read_ref(&bytes).map_err(|e| {
+    rmp_serde::from_read_ref(&bytes).map_err(|e| {
         MrBundleError::MsgpackDecodeError(std::any::type_name::<T>().to_string(), e)
-    })?)
+    })
 }

--- a/crates/mr_bundle/src/encoding.rs
+++ b/crates/mr_bundle/src/encoding.rs
@@ -1,3 +1,5 @@
+use crate::error::MrBundleError;
+
 use super::error::MrBundleResult;
 use std::io::Read;
 use std::io::Write;
@@ -15,5 +17,7 @@ pub fn decode<T: serde::de::DeserializeOwned>(compressed: &[u8]) -> MrBundleResu
     let mut gz = flate2::read::GzDecoder::new(compressed);
     let mut bytes = Vec::new();
     gz.read_to_end(&mut bytes)?;
-    Ok(rmp_serde::from_read_ref(&bytes)?)
+    Ok(rmp_serde::from_read_ref(&bytes).map_err(|e| {
+        MrBundleError::MsgpackDecodeError(std::any::type_name::<T>().to_string(), e)
+    })?)
 }

--- a/crates/mr_bundle/src/encoding.rs
+++ b/crates/mr_bundle/src/encoding.rs
@@ -17,7 +17,6 @@ pub fn decode<T: serde::de::DeserializeOwned>(compressed: &[u8]) -> MrBundleResu
     let mut gz = flate2::read::GzDecoder::new(compressed);
     let mut bytes = Vec::new();
     gz.read_to_end(&mut bytes)?;
-    rmp_serde::from_read_ref(&bytes).map_err(|e| {
-        MrBundleError::MsgpackDecodeError(std::any::type_name::<T>().to_string(), e)
-    })
+    rmp_serde::from_read_ref(&bytes)
+        .map_err(|e| MrBundleError::MsgpackDecodeError(std::any::type_name::<T>().to_string(), e))
 }

--- a/crates/mr_bundle/src/error.rs
+++ b/crates/mr_bundle/src/error.rs
@@ -28,8 +28,8 @@ pub enum MrBundleError {
     #[error(transparent)]
     MsgpackEncodeError(#[from] rmp_serde::encode::Error),
 
-    #[error(transparent)]
-    MsgpackDecodeError(#[from] rmp_serde::decode::Error),
+    #[error("Failed to decode bundle to [{0}] due to a deserialization error: {1}")]
+    MsgpackDecodeError(String, rmp_serde::decode::Error),
 
     #[error("This bundle failed to validate because: {0}")]
     BundleValidationError(String),


### PR DESCRIPTION
### Summary

When I do a silly thing and mix up bundle types, I get a conductor API error that is barely distinguishable from an error message that I'd get if my actual request had invalid fields - 

```
{'type': 'error', 'data': {'type': 'internal_error', 'data': 'unknown field `manifest_version`, expected `zomes`'}}
```

Now, instead, it's clear that there was something wrong with the bundle that was specified by path in the request and not the request itself. I can also easily see what type I should be targeting, because it's included in the error message.

```
{'type': 'error', 'data': {'type': 'internal_error', 'data': 'Failed to decode bundle to [mr_bundle::bundle::Bundle<holochain_types::dna::dna_manifest::dna_manifest_v1::CoordinatorManifest>] due to a deserialization error: unknown field `manifest_version`, expected `zomes`'}}
```

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
