### PR TITLE
Correct docs for call_info

### DIFF
--- a/crates/hdk/src/info.rs
+++ b/crates/hdk/src/info.rs
@@ -8,25 +8,21 @@ pub use hdi::info::*;
 /// let agent_info = agent_info()?;
 /// ```
 ///
-/// the [ `AgentInfo` ] is the current agent's original pubkey/address that they joined the network with
+/// the [AgentInfo] is the current agent's original pubkey/address that they joined the network with
 /// and their most recent pubkey/address.
 pub fn agent_info() -> ExternResult<AgentInfo> {
     HDK.with(|h| h.borrow().agent_info(()))
 }
 
-/// Trivial wrapper for `__agent_info` host function.
+/// Get the context for a zome call, including the provenance and chain head.
+///
+/// See [CallInfo] for more details of what is returned.
+/// 
 /// Call info input struct is `()` so the function call simply looks like this:
 ///
 /// ```ignore
 /// let call_info = call_info()?;
 /// ```
-///
-/// the [ `CallInfo` ] is
-/// - the provenance of the call
-/// - function name that was the extern/entrypoint into the wasm
-/// - the chain head as at the start of the call, won't change even if the chain
-///   is written to during the call
-/// - the [ `CapGrant` ] used to authorize the call
 pub fn call_info() -> ExternResult<CallInfo> {
     HDK.with(|h| h.borrow().call_info(()))
 }

--- a/crates/hdk/src/info.rs
+++ b/crates/hdk/src/info.rs
@@ -17,7 +17,7 @@ pub fn agent_info() -> ExternResult<AgentInfo> {
 /// Get the context for a zome call, including the provenance and chain head.
 ///
 /// See [CallInfo] for more details of what is returned.
-/// 
+///
 /// Call info input struct is `()` so the function call simply looks like this:
 ///
 /// ```ignore

--- a/crates/holochain_zome_types/src/info.rs
+++ b/crates/holochain_zome_types/src/info.rs
@@ -35,10 +35,14 @@ impl AgentInfo {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CallInfo {
+    /// The provenance identifies the agent who made the call. 
+    /// This is the author of the chain for local calls, and the assignee of a capability for remote calls.
     pub provenance: AgentPubKey,
+    /// The function name that was the entrypoint into the wasm.
     pub function_name: FunctionName,
     /// Chain head as at the call start.
     /// This will not change within a call even if the chain is written to.
     pub as_at: (ActionHash, u32, Timestamp),
+    /// The capability grant used to authorize the call.
     pub cap_grant: CapGrant,
 }

--- a/crates/holochain_zome_types/src/info.rs
+++ b/crates/holochain_zome_types/src/info.rs
@@ -35,7 +35,7 @@ impl AgentInfo {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CallInfo {
-    /// The provenance identifies the agent who made the call. 
+    /// The provenance identifies the agent who made the call.
     /// This is the author of the chain for local calls, and the assignee of a capability for remote calls.
     pub provenance: AgentPubKey,
     /// The function name that was the entrypoint into the wasm.


### PR DESCRIPTION
### Summary

The provenance lookup is done in the `call_info` implementation [here](https://github.com/holochain/holochain/blob/develop/crates/holochain/src/core/ribosome/host_fn/call_info.rs#L23).  There are tests in the same file.

The only thing which seems to be an issue is bridged calls. The check for those would correctly use the loopback case but the security for those calls appears to be [broken](https://github.com/holochain/holochain/blob/develop/crates/holochain/src/core/ribosome/host_fn/call.rs#L337)...

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
