### PR TITLE
Fix HDK doc warnings

### DIFF
--- a/crates/hdk/src/hash_path.rs
+++ b/crates/hdk/src/hash_path.rs
@@ -1,4 +1,4 @@
-/// The anchor pattern implemented in terms of [ `path::Path` ]
+/// The anchor pattern implemented in terms of [Path](hdi::prelude::Path).
 ///
 /// The anchor pattern predates the path crate.
 ///
@@ -10,9 +10,9 @@
 /// - The second level is optional as `Option<String>`
 pub mod anchor;
 
-/// The generic [ `path::Path` ] pattern.
+/// The generic [Path](hdi::prelude::Path) pattern.
 ///
-/// As explained in the parent module documentation the [ `path::Path` ] defines a tree structure.
+/// As explained in the parent module documentation the [Path](hdi::prelude::Path) defines a tree structure.
 ///
 /// The path is _not_ an entire tree but simply one path from the root to the current depth of the tree.
 ///
@@ -29,10 +29,10 @@ pub mod anchor;
 ///
 /// Note:
 ///
-/// - The path must always start at the root
-/// - [ `path::Path` ] are sequential and contigious
-/// - [ `path::Path` ] may be empty
-/// - [ `path::Path` ] only track one branch
+/// - The [Path](hdi::prelude::Path) must always start at the root
+/// - [Path](hdi::prelude::Path)s are sequential and contigious
+/// - [Path](hdi::prelude::Path)s may be empty
+/// - [Path](hdi::prelude::Path)s only track one branch
 ///
 /// Applications can discover all links from a path to all children by constructing the known path components.
 ///

--- a/crates/hdk/src/lib.rs
+++ b/crates/hdk/src/lib.rs
@@ -50,20 +50,20 @@
 //! HDK implements several key features:
 //!
 //! - Base HDKT trait for standardisation, mocking, unit testing support: [`hdk`] module
-//! - Capabilities and function level access control: [`capability`](crate::capability) module
-//! - [Holochain Deterministic Integrity (HDI)](crate::hdi)
-//! - Application data and entry definitions for the source chain and DHT: [`entry`](crate::entry)
-//! module and [`entry_defs`](crate::prelude::entry_defs) callback
-//! - Referencing/linking entries on the DHT together into a graph structure: [`link`](crate::link) module
-//! - Defining tree-like structures out of links and entries for discoverability and scalability: [`hash_path`](crate::hash_path) module
+//! - Capabilities and function level access control: [`capability`] module
+//! - [Holochain Deterministic Integrity (HDI)]
+//! - Application data and entry definitions for the source chain and DHT: [`entry`]
+//! module and [entry_types] callback
+//! - Referencing/linking entries on the DHT together into a graph structure: [`link`] module
+//! - Defining tree-like structures out of links and entries for discoverability and scalability: [`hash_path`] module
 //! - Create, read, update, delete (CRUD) operations on the above
-//! - Libsodium compatible symmetric/secret (secretbox) and asymmetric/keypair (box) encryption: [`x_salsa20_poly1305`](crate::x_salsa20_poly1305) module
-//! - Ed25519 signing and verification of data: [`ed25519`](crate::ed25519) module
-//! - Exposing information about the current execution context such as zome name: [`info`](crate::info) module
+//! - Libsodium compatible symmetric/secret (secretbox) and asymmetric/keypair (box) encryption: [`x_salsa20_poly1305`] module
+//! - Ed25519 signing and verification of data: [`ed25519`] module
+//! - Exposing information about the current execution context such as zome name: [`info`] module
 //! - Other utility functions provided by the host such as generating randomness and timestamps that are impossible in WASM: utility module
 //! - Exposing functions to external processes and callbacks to the host: [`hdk_extern!`](macro@crate::prelude::hdk_extern) and [`map_extern!`](macro@crate::prelude::map_extern) macros
 //! - Integration with the Rust [tracing](https://docs.rs/tracing/0.1.23/tracing/) crate
-//! - Exposing a [`prelude`](crate::prelude) of common types and functions for convenience
+//! - Exposing a [`prelude`] of common types and functions for convenience
 //!
 //! Generally these features are structured logically into modules but there are some affordances to the layering of abstractions.
 //!
@@ -173,7 +173,6 @@
 //!   - Allows the guest to pass/fail/retry any operation.
 //!   - Only the originating zome is called.
 //!   - Failure overrides retry.
-//!   - See [`validate`](crate::hdi::prelude::validate) for more details.
 //!
 //! # HDK has layers 🧅
 //!

--- a/crates/holochain_zome_types/src/entry.rs
+++ b/crates/holochain_zome_types/src/entry.rs
@@ -22,8 +22,8 @@ pub use holochain_integrity_types::entry::*;
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
 /// Either an [`EntryDefIndex`] or one of:
-/// - [`EntryType::CapGrant`](crate::prelude::EntryType::CapGrant)
-/// - [`EntryType::CapClaim`](crate::prelude::EntryType::CapClaim)
+/// - [EntryType::CapGrant]
+/// - [EntryType::CapClaim]
 /// Which don't have an index.
 pub enum EntryDefLocation {
     /// App defined entries always have a unique [`u8`] index

--- a/crates/holochain_zome_types/src/link.rs
+++ b/crates/holochain_zome_types/src/link.rs
@@ -21,9 +21,9 @@ use kitsune_p2p_timestamp::Timestamp;
 pub struct Link {
     /// The author of this link
     pub author: holo_hash::AgentPubKey,
-    /// The [`AnyLinkableHash`](holo_hash::AnyLinkableHash) being linked from
+    /// The [AnyLinkableHash] being linked from
     pub base: holo_hash::AnyLinkableHash,
-    /// The [`AnyLinkableHash`](holo_hash::AnyLinkableHash) being linked to
+    /// The [AnyLinkableHash] being linked to
     pub target: holo_hash::AnyLinkableHash,
     /// When the link was added
     pub timestamp: Timestamp,


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
