### PR TITLE
[BACKPORT 0.2] Add Lair keystore version requirement to --build-info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,6 +2818,7 @@ dependencies = [
  "kitsune_p2p_block",
  "kitsune_p2p_bootstrap",
  "kitsune_p2p_types",
+ "lair_keystore",
  "lazy_static",
  "maplit",
  "matches",

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added `lair_keystore_version_req` to the output of `--build-info` for Holochain.
+
 ## 0.2.6
 
 ## 0.2.6-rc.0

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -131,7 +131,7 @@ serde_json = { version = "1.0.51" }
 toml = "0.5.6"
 chrono = { version = "0.4.6", features = [ "serde" ] }
 hostname = "0.3.1"
-lair_keystore = { workspace = true, features = [ "rusqlite-bundled-sqlcipher-vendored-openssl" ] }
+lair_keystore = { version = "0.4.2", features = [ "rusqlite-bundled-sqlcipher-vendored-openssl" ] }
 
 [[bench]]
 name = "bench"

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -131,6 +131,7 @@ serde_json = { version = "1.0.51" }
 toml = "0.5.6"
 chrono = { version = "0.4.6", features = [ "serde" ] }
 hostname = "0.3.1"
+lair_keystore = { workspace = true, features = [ "rusqlite-bundled-sqlcipher-vendored-openssl" ] }
 
 [[bench]]
 name = "bench"

--- a/crates/holochain/build.rs
+++ b/crates/holochain/build.rs
@@ -9,6 +9,7 @@ mod version_info {
         cargo_pkg_version: &'static str,
         hdk_version_req: &'static str,
         hdi_version_req: &'static str,
+        lair_keystore_version_req: &'static str,
 
         timestamp: DateTime<Utc>,
         hostname: String,
@@ -86,6 +87,7 @@ mod version_info {
                 git_info: GitInfo::maybe_retrieve(),
                 hdk_version_req: hdk::HDK_VERSION,
                 hdi_version_req: hdk::HDI_VERSION,
+                lair_keystore_version_req: lair_keystore::LAIR_VER,
 
                 timestamp: SystemTime::now().into(),
                 hostname,
@@ -106,8 +108,8 @@ mod version_info {
         }
     }
 
-    /// This will be used populate the VERSION_INFO environment variable,
-    /// which will be displayed as JSON when `holochain --version-info` is called.
+    /// This will be used to populate the BUILD_INFO environment variable,
+    /// which will be displayed as JSON when `holochain --build-info` is called.
     pub(crate) fn populate_env() {
         let json = BuildInfo::retrieve().as_json_string();
         println!("cargo:rustc-env=BUILD_INFO={}", json);


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
