### PR TITLE
Strange behaviour with private entry

### DIFF
--- a/crates/holochain/tests/integration.rs
+++ b/crates/holochain/tests/integration.rs
@@ -18,3 +18,4 @@ mod speed_tests;
 mod test_cli;
 mod test_utils;
 mod websocket;
+mod must_get_linked_entry;

--- a/crates/holochain/tests/must_get_linked_entry/mod.rs
+++ b/crates/holochain/tests/must_get_linked_entry/mod.rs
@@ -1,0 +1,48 @@
+use holo_hash::ActionHash;
+use holochain::sweettest::{SweetConductorBatch, SweetConductorConfig, SweetDnaFile};
+use holochain_wasm_test_utils::TestWasm;
+use holochain_zome_types::prelude::Record;
+use rand::{thread_rng, Rng};
+use std::time::Duration;
+use holochain::test_utils::consistency_60s;
+use holochain_types::prelude::Link;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn must_get_linked_entry() {
+    holochain_trace::test_run().unwrap();
+
+    let (dna, _, _) =
+        SweetDnaFile::unique_from_test_wasms(vec![TestWasm::MustGetLinkedEntry]).await;
+    let mut conductors =
+        SweetConductorBatch::from_config_rendezvous(2, SweetConductorConfig::rendezvous(true))
+            .await;
+
+    let apps = conductors
+        .setup_app("", &[dna])
+        .await
+        .unwrap()
+        .cells_flattened();
+
+    let alice_app = &apps[0];
+    let bob_app = &apps[1];
+
+    conductors
+        .require_initial_gossip_activity_for_cell(bob_app, Duration::from_secs(90))
+        .await;
+
+    let record: Record = conductors[0].call(
+        &alice_app.zome(TestWasm::MustGetLinkedEntry.coordinator_zome_name()),
+        "create_linked",
+        5,
+    ).await;
+
+    consistency_60s([alice_app, bob_app]).await;
+
+    let record: Vec<Link> = conductors[0].call(
+        &alice_app.zome(TestWasm::MustGetLinkedEntry.coordinator_zome_name()),
+        "get_linked",
+        (),
+    ).await;
+
+    assert_eq!(1, record.len());
+}

--- a/crates/test_utils/wasm/src/lib.rs
+++ b/crates/test_utils/wasm/src/lib.rs
@@ -51,6 +51,7 @@ pub enum TestWasm {
     MultipleCalls,
     MustGet,
     MustGetAgentActivity,
+    MustGetLinkedEntry,
     PostCommitSuccess,
     PostCommitVolley,
     Query,
@@ -158,6 +159,7 @@ impl From<TestWasm> for ZomeName {
             TestWasm::MultipleCalls => "multiple_calls",
             TestWasm::MustGet => "must_get",
             TestWasm::MustGetAgentActivity => "must_get_agent_activity",
+            TestWasm::MustGetLinkedEntry => "must_get_linked_entry",
             TestWasm::PostCommitSuccess => "post_commit_success",
             TestWasm::PostCommitVolley => "post_commit_volley",
             TestWasm::Query => "query",
@@ -246,6 +248,7 @@ impl From<TestWasm> for PathBuf {
             }
             TestWasm::MustGet => "wasm32-unknown-unknown/release/test_wasm_must_get.wasm",
             TestWasm::MustGetAgentActivity => "wasm32-unknown-unknown/release/test_wasm_must_get_agent_activity.wasm",
+            TestWasm::MustGetLinkedEntry => "wasm32-unknown-unknown/release/test_wasm_must_get_linked_entry.wasm",
             TestWasm::PostCommitSuccess => {
                 "wasm32-unknown-unknown/release/test_wasm_post_commit_success.wasm"
             }

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -2871,6 +2871,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_wasm_must_get_linked_entry"
+version = "0.1.0"
+dependencies = [
+ "hdi",
+ "hdk",
+ "serde",
+]
+
+[[package]]
 name = "test_wasm_post_commit_success"
 version = "0.0.1"
 dependencies = [

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.toml
@@ -35,6 +35,7 @@ members = [
     "multiple_calls",
     "must_get",
     "must_get_agent_activity",
+    "must_get_linked_entry",
     "post_commit_success",
     "post_commit_volley",
     "query",

--- a/crates/test_utils/wasm/wasm_workspace/must_get_linked_entry/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/must_get_linked_entry/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "test_wasm_must_get_linked_entry"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "test_wasm_must_get_linked_entry"
+crate-type = [ "cdylib", "rlib" ]
+
+[[example]]
+name = "integrity_test_wasm_must_get_linked_entry"
+path = "src/integrity.rs"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+serde = { workspace = true }
+hdk = { path = "../../../../hdk" }
+hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/must_get_linked_entry/src/coordinator.rs
+++ b/crates/test_utils/wasm/wasm_workspace/must_get_linked_entry/src/coordinator.rs
@@ -1,0 +1,40 @@
+use crate::integrity::*;
+use hdk::prelude::*;
+
+#[hdk_extern]
+pub fn create_linked(content: u32) -> ExternResult<Record> {
+    let thing = Thing { content };
+    let thing_hash = create_entry(EntryTypes::Thing(thing))?;
+    let record = get(thing_hash.clone(), GetOptions::content())?.ok_or(wasm_error!(
+        WasmErrorInner::Guest(String::from("Could not find the newly created Thing"))
+    ))?;
+
+    let entry_hash = hash_entry(
+        record
+            .entry()
+            .as_option()
+            .ok_or_else(|| wasm_error!(WasmErrorInner::Guest(String::from("Missing entry hash"))))?
+            .clone(),
+    )?;
+
+    tracing::info!("Creating link to {:?}", entry_hash);
+
+    let my_agent_info = agent_info()?;
+    create_link(
+        my_agent_info.agent_latest_pubkey,
+        entry_hash,
+        LinkTypes::SomeLink,
+        (),
+    )?;
+
+    Ok(record)
+}
+
+#[hdk_extern]
+pub fn get_linked(_: ()) -> ExternResult<Vec<Link>> {
+    let my_agent_info = agent_info()?;
+
+    let links = get_links(GetLinksInputBuilder::try_new(my_agent_info.agent_latest_pubkey, LinkTypes::SomeLink)?.build())?;
+
+    Ok(links)
+}

--- a/crates/test_utils/wasm/wasm_workspace/must_get_linked_entry/src/integrity.rs
+++ b/crates/test_utils/wasm/wasm_workspace/must_get_linked_entry/src/integrity.rs
@@ -1,0 +1,96 @@
+use hdi::prelude::*;
+
+#[hdk_entry_helper]
+#[derive(Clone, PartialEq)]
+pub struct Thing {
+    pub content: u32,
+}
+
+#[derive(Serialize, Deserialize)]
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+    #[entry_type(visibility = "private")]
+    Thing(Thing),
+}
+
+#[hdk_link_types]
+pub enum LinkTypes {
+    SomeLink,
+}
+
+fn validate_create_thing(action: EntryCreationAction) -> ExternResult<ValidateCallbackResult> {
+    let author = action.author().clone();
+    if let EntryCreationAction::Create(action) = action {
+        let action_hash = hash_action(action.into_action().clone())?;
+        let filter = ChainFilter::new(action_hash);
+        let result = must_get_agent_activity(author.clone(), filter)?;
+        debug!("Agent Activity Count: {}", result.len());
+    }
+    Ok(ValidateCallbackResult::Valid)
+}
+
+#[hdk_extern]
+pub fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+    match op.flattened::<EntryTypes, LinkTypes>()? {
+        FlatOp::StoreEntry(store_entry) => match store_entry {
+            OpEntry::CreateEntry { app_entry, action } => match app_entry {
+                EntryTypes::Thing(_) => validate_create_thing(EntryCreationAction::Create(action)),
+            },
+            _ => Ok(ValidateCallbackResult::Valid),
+        },
+        FlatOp::StoreRecord(store_record) => match store_record {
+            OpRecord::CreateEntry { app_entry, action } => match app_entry {
+                EntryTypes::Thing(_) => validate_create_thing(EntryCreationAction::Create(action)),
+            },
+            _ => Ok(ValidateCallbackResult::Valid),
+        },
+        FlatOp::RegisterCreateLink {
+            target_address,
+            link_type,
+            ..
+        } => {
+            validate_thing_some_link(
+                target_address,
+                link_type,
+            )
+        }
+        _ => Ok(ValidateCallbackResult::Valid),
+    }
+}
+
+fn validate_thing_some_link(
+    target_address: AnyLinkableHash,
+    link_type: LinkTypes,
+) -> ExternResult<ValidateCallbackResult> {
+    let entry_hash = match target_address.clone().try_into() {
+        Ok(entry_hash) => entry_hash,
+        Err(_) => {
+            return Ok(ValidateCallbackResult::Invalid(format!(
+                "The target address for {:?} must be an entry hash",
+                link_type
+            )));
+        }
+    };
+    tracing::info!("Searching for target address {:?}", entry_hash);
+    let entry = must_get_entry(entry_hash)?;
+    tracing::info!("Got entry {:?}", entry);
+    match entry.as_app_entry() {
+        Some(app_entry) => {
+            match <SerializedBytes as TryInto<Thing>>::try_into(
+                app_entry.clone().into_sb(),
+            ) {
+                Ok(_) => Ok(ValidateCallbackResult::Valid),
+                Err(_) => Ok(ValidateCallbackResult::Invalid(format!(
+                    "The target for {:?} must be a {}",
+                    link_type,
+                    std::any::type_name::<Thing>()
+                ))),
+            }
+        }
+        None => Ok(ValidateCallbackResult::Invalid(format!(
+            "The target for {:?} must be an app entry",
+            link_type
+        ))),
+    }
+}

--- a/crates/test_utils/wasm/wasm_workspace/must_get_linked_entry/src/lib.rs
+++ b/crates/test_utils/wasm/wasm_workspace/must_get_linked_entry/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod integrity;
+
+#[cfg(not(feature = "integrity"))]
+pub mod coordinator;
+
+#[cfg(not(feature = "integrity"))]
+pub use coordinator::*;


### PR DESCRIPTION
### Summary

Nowhere in the docs does it tell me I can't do this, but purely intuitvely this seems like it should be possible to make the assertion I'm trying to make.

I'm linking TO a private entry. Then in validation I try to verify that the target of this link type is actually an entry of the expected type. But remote agents can never find the entry hash dependency. Why not? The entry hash and type should absolutely be available, just with the entry data missing.

I want to link to the entry because that's the pattern my happ code uses for finding the entry content again later. Yes that could also use `get_details` to get a record, but that is fiddly to convert back to my actual entry type. I ideally shouldn't have to make multiple calls to achieve something that ought to be straight forward.

If `must_get_entry` actually returned a record instead of an entry and searched for actions with the right entry_hash referenced rather than just looking at entries then it'd be able to tell me that my validation logic isn't supported. That feels like it'd be more useful than having a rule that succeeds for a single node but will never succeed for anybody else.

I was only able to figure this out by writing a test in Holochain. I happened to miss adding the `#[entry_type(visibility = "private")]` which meant the test passed.

Either the host function implementations should try to be more helpful with private entries or the documentation needs improving. Because although my validation check my not be super useful (checking that somebody else's private data is well-formed, does that really affect me much?), it shouldn't suck this much of my time to try and figure out why validation is failing.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
