### PR TITLE
Fix holonix warnings coming from Crane

### DIFF
--- a/nix/modules/lair.nix
+++ b/nix/modules/lair.nix
@@ -10,10 +10,17 @@
 
       craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
 
+      crateInfo = craneLib.crateNameFromCargoToml { cargoToml = flake.config.reconciledInputs.lair + "/crates/lair_keystore/Cargo.toml"; };
+
       commonArgs = {
 
         pname = "lair-keystore";
         src = flake.config.reconciledInputs.lair;
+
+        # We are asking Crane to build a binary from the workspace and that's the only way we can build it because
+        # the workspace defines the dependencies, so we can't just build the member crate. But then we need to tell
+        # Crate what the version is, so we look it up directly from the member's Cargo.toml.
+        version = crateInfo.version;
 
         CARGO_PROFILE = "release";
 

--- a/nix/modules/launcher.nix
+++ b/nix/modules/launcher.nix
@@ -7,12 +7,20 @@
         track = "stable";
         version = "1.75.0";
       };
+
       craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
+
+      crateInfo = craneLib.crateNameFromCargoToml { cargoToml = flake.config.reconciledInputs.launcher + "/crates/hc_launch/src-tauri/Cargo.toml"; };
 
       commonArgs = {
 
         pname = "hc-launch";
         src = flake.config.reconciledInputs.launcher;
+
+        # We are asking Crane to build a binary from the workspace and that's the only way we can build it because
+        # the workspace defines the dependencies, so we can't just build the member crate. But then we need to tell
+        # Crate what the version is, so we look it up directly from the member's Cargo.toml.
+        version = crateInfo.version;
 
         CARGO_PROFILE = "release";
 


### PR DESCRIPTION
### Summary

Both for Lair and for Scaffolding we were getting the following warning in Holonix

```
trace: warning: crane will use a placeholder value since `version` cannot be found in /nix/store/8hwirqkqjsqm1291rdd8q709m8fi4cvc-source/Cargo.toml
to silence this warning consider one of the following:
- setting `version = "...";` in the derivation arguments explicitly
- setting `package.version = "..."` or `workspace.package.version = "..."` in the root Cargo.toml
- explicitly looking up the values from a different Cargo.toml via 
  `craneLib.crateNameFromCargoToml { cargoToml = ./path/to/Cargo.toml; }`

To find the source of this warning, rerun nix with:
`NIX_ABORT_ON_WARN=1 nix --option pure-eval false --show-trace ...`
```

I've gone for the last option which appears to be what the API docs for Crane recommends.

Note: This is a cache-busting change, both affected binaries will need to be rebuilt for the cache although they haven't changed. They were currently sitting at version `0.0.1` because Crane couldn't figure out a version.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
