### PR TITLE
Switch default Holonix version to 0_2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -140,16 +140,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1706624893,
-        "narHash": "sha256-J/MfVeLO9K4XXNEt1yqu7NdTA3REX014NZg0TjD5IHU=",
+        "lastModified": 1707245081,
+        "narHash": "sha256-l9WHMlD9IDuEv/N/3WDCsP3XLUUnZFrOBEZjbWnC+/Y=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "48e239689b4e6a3c0b8b6d9c09608cfabe2b0ab5",
+        "rev": "0a3b2408b2d6482b913b9f0faf58a39b567f763a",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.1.8",
+        "ref": "holochain-0.2.6",
         "repo": "holochain",
         "type": "github"
       }
@@ -174,16 +174,16 @@
     "launcher": {
       "flake": false,
       "locked": {
-        "lastModified": 1677270906,
-        "narHash": "sha256-/xT//6nqhjpKLMMv41JE0W3H5sE9jKMr8Dedr88D4N8=",
+        "lastModified": 1684183666,
+        "narHash": "sha256-rOE/W/BBYyZKOyypKb8X9Vpc4ty1TNRoI/fV5+01JPw=",
         "owner": "holochain",
         "repo": "launcher",
-        "rev": "1ad188a43900c139e52df10a21e3722f41dfb967",
+        "rev": "75ecdd0aa191ed830cc209a984a6030e656042ff",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.1",
+        "ref": "holochain-0.2",
         "repo": "launcher",
         "type": "github"
       }
@@ -317,16 +317,16 @@
     "scaffolding": {
       "flake": false,
       "locked": {
-        "lastModified": 1708195673,
-        "narHash": "sha256-laG52M49vVUUTiB0B75MOz4rk4N6K7lNFc/CBg8R2gA=",
+        "lastModified": 1708376918,
+        "narHash": "sha256-zjjAmu8t566/PUxo2g0EFZ4GAdUu/UbkGA8hsVbFEoQ=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "31d0a1189b282058ec5da29968cc53aaca71f0e5",
+        "rev": "ddb8b5a950e7be81d704000e662564696bef5d6b",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.1",
+        "ref": "holochain-0.2",
         "repo": "scaffolding",
         "type": "github"
       }
@@ -354,13 +354,16 @@
         "scaffolding": "scaffolding"
       },
       "locked": {
-        "lastModified": 1708217548,
-        "narHash": "sha256-MzI/MEZ7x8lYVb9RQNdG01L2ZO8kmE1vyg7pcitVO+M=",
-        "path": "./versions/0_1",
-        "type": "path"
+        "dir": "versions/0_2",
+        "lastModified": 1708423819,
+        "narHash": "sha256-/Z0Yg+raaBqlYvH4W7wOrcUrtTUeJXXhLx1DEoGL9SM=",
+        "owner": "holochain",
+        "repo": "holochain",
+        "rev": "58df5bebca1564f3b4c340326aeaf4d5df7e3c39",
+        "type": "github"
       },
       "original": {
-        "dir": "versions/0_1",
+        "dir": "versions/0_2",
         "owner": "holochain",
         "repo": "holochain",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    versions.url = "github:holochain/holochain?dir=versions/0_1";
+    versions.url = "github:holochain/holochain?dir=versions/0_2";
 
     holochain.follows = "empty";
     holochain.flake = false;


### PR DESCRIPTION
### Summary

When I ran `nix develop .#holonix` with this change it didn't do any rebuilding, so my best guess is that this won't have to update the cache. That's good!

I see the right versions of Holochain binaries and tools in the resulting shell.

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
