### PR TITLE
Pin serde for hc-sandbox on 0.1

### DIFF
--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -27,7 +27,7 @@ holochain_util = { version = "^0.1.4", path = "../holochain_util", features = [ 
 nanoid = "0.3"
 observability = "0.1.3"
 once_cell = "1.13.0"
-serde = { version = "1.0", features = [ "derive" ] }
+serde = { version = ">= 1.0, <= 1.0.166", features = [ "derive" ] }
 serde_yaml = "0.9"
 sodoken = "=0.0.9"
 tokio = { version = "1.11", features = [ "full" ] }


### PR DESCRIPTION
### Summary

Unlikely we'll fix this now but leaving this open for visibility. You can't use `hc-sandbox 0.1.8` with `holochain 0.1.8` if you've built `hc-sandbox` outside of Nix. You just get the very unhelpful 'msgpack wrong marker FixStr(5)' error

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
