### PR TITLE
Allow ValidationDependencies to track generic hashable types

### DIFF
--- a/crates/holo_hash/src/has_hash.rs
+++ b/crates/holo_hash/src/has_hash.rs
@@ -4,10 +4,13 @@ use crate::HashType;
 use crate::HoloHash;
 
 /// Anything which has an owned HoloHashOf.
-pub trait HasHash<T: HashType> {
+pub trait HasHash {
+    /// The type of the hash which is had.
+    type HashType: HashType;
+
     /// Get the hash by reference
-    fn as_hash(&self) -> &HoloHash<T>;
+    fn as_hash(&self) -> &HoloHash<Self::HashType>;
 
     /// Convert to the owned hash
-    fn into_hash(self) -> HoloHash<T>;
+    fn into_hash(self) -> HoloHash<Self::HashType>;
 }

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -251,7 +251,9 @@ impl<T: HashType> IntoIterator for HoloHash<T> {
     }
 }
 
-impl<T: HashType> HasHash<T> for HoloHash<T> {
+impl<T: HashType> HasHash for HoloHash<T> {
+    type HashType = T;
+
     fn as_hash(&self) -> &HoloHash<T> {
         self
     }

--- a/crates/holo_hash/src/hashed.rs
+++ b/crates/holo_hash/src/hashed.rs
@@ -20,7 +20,9 @@ pub struct HoloHashed<C: HashableContent> {
     pub hash: HoloHashOf<C>,
 }
 
-impl<C: HashableContent> HasHash<C::HashType> for HoloHashed<C> {
+impl<C: HashableContent> HasHash for HoloHashed<C> {
+    type HashType = C::HashType;
+
     fn as_hash(&self) -> &HoloHashOf<C> {
         &self.hash
     }

--- a/crates/holochain/src/core/queue_consumer/sys_validation_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/sys_validation_consumer.rs
@@ -2,9 +2,8 @@
 
 use super::*;
 use crate::core::workflow::sys_validation_workflow::sys_validation_workflow;
-use crate::core::workflow::sys_validation_workflow::validation_deps::ValidationDependencies;
+use crate::core::workflow::sys_validation_workflow::validation_deps::ValDeps;
 use crate::core::workflow::sys_validation_workflow::SysValidationWorkspace;
-use parking_lot::Mutex;
 use tracing::*;
 
 /// Spawn the QueueConsumer for SysValidation workflow
@@ -22,7 +21,7 @@ pub fn spawn_sys_validation_consumer(
     let space = Arc::new(space);
     let config = conductor.config.clone();
 
-    let current_validation_dependencies = Arc::new(Mutex::new(ValidationDependencies::new()));
+    let current_validation_dependencies = ValDeps::new();
 
     super::queue_consumer_dna_bound(
         "sys_validation_consumer",

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
@@ -1,4 +1,5 @@
 use super::sys_validation_workflow;
+use super::validation_deps::ValDeps;
 use super::validation_query::get_ops_to_app_validate;
 use super::SysValidationWorkspace;
 use super::ValidationDependencies;
@@ -278,7 +279,7 @@ struct TestCase {
     test_space: TestSpace,
     keystore: MetaLairClient,
     agent: AgentPubKey,
-    current_validation_dependencies: Arc<Mutex<ValidationDependencies>>,
+    current_validation_dependencies: ValDeps,
     app_validation_trigger: (TriggerSender, TriggerReceiver),
     self_trigger: (TriggerSender, TriggerReceiver),
     actual_network: Option<MockHolochainP2pDnaT>,
@@ -300,7 +301,7 @@ impl TestCase {
             test_space,
             keystore,
             agent,
-            current_validation_dependencies: Arc::new(Mutex::new(Default::default())),
+            current_validation_dependencies: ValDeps::new(),
             app_validation_trigger: TriggerSender::new(),
             self_trigger: TriggerSender::new(),
             actual_network: None,

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
@@ -2,7 +2,6 @@ use super::sys_validation_workflow;
 use super::validation_deps::ValDeps;
 use super::validation_query::get_ops_to_app_validate;
 use super::SysValidationWorkspace;
-use super::ValidationDependencies;
 use crate::conductor::space::TestSpace;
 use crate::core::queue_consumer::TriggerReceiver;
 use crate::core::queue_consumer::TriggerSender;
@@ -39,7 +38,6 @@ use holochain_zome_types::judged::Judged;
 use holochain_zome_types::record::SignedActionHashed;
 use holochain_zome_types::timestamp::Timestamp;
 use holochain_zome_types::Action;
-use parking_lot::Mutex;
 use std::collections::HashSet;
 use std::sync::Arc;
 

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
@@ -279,7 +279,7 @@ async fn validate_create_op_with_prev_from_network() {
     // Simulate the dep being found on the network
     test_case
         .current_validation_dependencies
-        .local
+        .same_dht
         .lock()
         .insert(previous_action, CascadeSource::Network);
 

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use super::retrieve_previous_actions_for_ops;
+use super::validation_deps::ValDeps;
 use super::ValidationDependencies;
 use crate::core::workflow::sys_validation_workflow::types::Outcome;
 use crate::core::workflow::sys_validation_workflow::validate_op;
@@ -280,6 +281,7 @@ async fn validate_create_op_with_prev_from_network() {
     // Simulate the dep being found on the network
     test_case
         .current_validation_dependencies
+        .local
         .lock()
         .insert(previous_action, CascadeSource::Network);
 
@@ -2174,13 +2176,7 @@ async fn crash_case() {
             .boxed()
         });
 
-    let validation_outcome = validate_op(
-        &op,
-        &dna_def,
-        Arc::new(Mutex::new(ValidationDependencies::new())),
-    )
-    .await
-    .unwrap();
+    let validation_outcome = validate_op(&op, &dna_def, ValDeps::new()).await.unwrap();
 
     assert!(matches!(validation_outcome, Outcome::Accepted));
 }
@@ -2189,7 +2185,7 @@ struct TestCase {
     op: Option<DhtOp>,
     keystore: holochain_keystore::MetaLairClient,
     cascade: MockCascade,
-    current_validation_dependencies: Arc<Mutex<ValidationDependencies>>,
+    current_validation_dependencies: ValDeps,
     dna_def: DnaDef,
     agent: AgentPubKey,
 }
@@ -2205,7 +2201,7 @@ impl TestCase {
             op: None,
             keystore,
             cascade: MockCascade::new(),
-            current_validation_dependencies: Arc::new(Mutex::new(ValidationDependencies::new())),
+            current_validation_dependencies: ValDeps::new(),
             dna_def,
             agent,
         }

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use super::retrieve_previous_actions_for_ops;
 use super::validation_deps::ValDeps;
-use super::ValidationDependencies;
 use crate::core::workflow::sys_validation_workflow::types::Outcome;
 use crate::core::workflow::sys_validation_workflow::validate_op;
 use crate::core::workflow::WorkflowResult;
@@ -16,7 +15,6 @@ use hdk::prelude::Dna as HdkDna;
 use holochain_cascade::CascadeSource;
 use holochain_cascade::MockCascade;
 use holochain_serialized_bytes::prelude::SerializedBytes;
-use parking_lot::Mutex;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_valid_dna_op() {

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validation_deps.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validation_deps.rs
@@ -1,29 +1,54 @@
-use holo_hash::ActionHash;
+use holo_hash::HoloHash;
 use holochain_cascade::CascadeSource;
-use holochain_zome_types::{
-    record::{Record, SignedActionHashed},
-    Action,
+use holochain_types::prelude::*;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
 };
-use std::collections::{HashMap, HashSet};
+
+/// Cache for tracking dependencies which are fetched during sys validation.
+#[derive(Clone)]
+pub struct ValDeps {
+    /// Dependencies found in the same DHT as the dependent
+    pub local: Arc<parking_lot::Mutex<ValidationDependencies<SignedActionHashed>>>,
+    /// Dependencies found in the DPKI service's Deepkey DNA
+    /// (this is not generic for all possible DPKI implementations, only Deepkey)
+    pub deepkey: Arc<parking_lot::Mutex<ValidationDependencies<EntryHashed>>>,
+}
+
+impl ValDeps {
+    pub fn new() -> Self {
+        Self {
+            local: Arc::new(parking_lot::Mutex::new(ValidationDependencies::new())),
+            deepkey: Arc::new(parking_lot::Mutex::new(ValidationDependencies::new())),
+        }
+    }
+}
 
 /// A collection of validation dependencies for the current set of DHT ops requiring validation.
 /// This is used as an in-memory cache of dependency info, held across all validation workflow calls,
 /// to minimize the amount of network and database calls needed to check if dependencies have been satisfied
-pub struct ValidationDependencies {
+pub struct ValidationDependencies<T: HasHash = SignedActionHashed> {
     /// The state of each dependency, keyed by its hash.
-    states: HashMap<ActionHash, ValidationDependencyState>,
+    states: HashMap<HoloHash<T::HashType>, ValidationDependencyState<T>>,
     /// Tracks which dependencies have been accessed during a search for dependencies. Anything which
     /// isn't in this set is no longer needed for validation and can be dropped from [`states`].
-    retained_deps: HashSet<ActionHash>,
+    retained_deps: HashSet<HoloHash<T::HashType>>,
 }
 
-impl Default for ValidationDependencies {
+impl<T> Default for ValidationDependencies<T>
+where
+    T: holo_hash::HasHash,
+{
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl ValidationDependencies {
+impl<T> ValidationDependencies<T>
+where
+    T: holo_hash::HasHash,
+{
     pub fn new() -> Self {
         Self {
             states: HashMap::new(),
@@ -31,10 +56,32 @@ impl ValidationDependencies {
         }
     }
 
+    // impl<T> From<(T, CascadeSource)> for ValidationDependencyState<T> {
+    //     fn from((signed_action, fetched_from): (T, CascadeSource)) -> Self {
+    //         Self {
+    //             dependency: Some(ValidationDependency {
+    //                 signed_action,
+    //                 fetched_from,
+    //             }),
+    //         }
+    //     }
+    // }
+
+    // impl From<(Record, CascadeSource)> for ValidationDependencyState {
+    //     fn from((record, fetched_from): (Record, CascadeSource)) -> Self {
+    //         Self {
+    //             dependency: Some(ValidationDependency {
+    //                 signed_action: record.signed_action,
+    //                 fetched_from,
+    //             }),
+    //         }
+    //     }
+    // }
+
     /// Check whether a given dependency is currently held.
     /// Note that we may have this dependency as a key but the state won't contain the dependency because
     /// this is how we're tracking ops we know we need to fetch from the network.
-    pub fn has(&mut self, hash: &ActionHash) -> bool {
+    pub fn has(&mut self, hash: &HoloHash<T::HashType>) -> bool {
         self.retained_deps.insert(hash.clone());
         self.states
             .get(hash)
@@ -44,7 +91,10 @@ impl ValidationDependencies {
 
     /// Get the state of a given dependency. This should always return a value because we should know about the depdendency
     /// by examining the ops that are being validated. However, the dependency may not be found on the DHT yet.
-    pub fn get(&mut self, hash: &ActionHash) -> Option<&mut ValidationDependencyState> {
+    pub fn get(
+        &mut self,
+        hash: &HoloHash<T::HashType>,
+    ) -> Option<&mut ValidationDependencyState<T>> {
         match self.states.get_mut(hash) {
             Some(dep) => Some(dep),
             None => {
@@ -55,7 +105,7 @@ impl ValidationDependencies {
     }
 
     /// Get the hashes of all dependencies that are currently missing from the DHT.
-    pub fn get_missing_hashes(&self) -> Vec<ActionHash> {
+    pub fn get_missing_hashes(&self) -> Vec<HoloHash<T::HashType>> {
         self.states
             .iter()
             .filter_map(|(hash, state)| {
@@ -70,7 +120,7 @@ impl ValidationDependencies {
 
     /// Get the hashes of all dependencies that have been fetched from the network.
     /// We need to let the incoming dht ops workflow know about these so that it can ingest them and get them validated.
-    pub fn get_network_fetched_hashes(&self) -> Vec<ActionHash> {
+    pub fn get_network_fetched_hashes(&self) -> Vec<HoloHash<T::HashType>> {
         self.states
             .iter()
             .filter_map(|(hash, state)| match state {
@@ -88,7 +138,7 @@ impl ValidationDependencies {
     }
 
     /// Insert a record which was found after this set of dependencies was created.
-    pub fn insert(&mut self, action: SignedActionHashed, source: CascadeSource) -> bool {
+    pub fn insert(&mut self, action: T, source: CascadeSource) -> bool {
         let hash = action.as_hash();
 
         // Note that `has` is checking that the dependency is actually set, not just that we have the key!
@@ -100,7 +150,7 @@ impl ValidationDependencies {
         self.retained_deps.insert(hash.clone());
 
         if let Some(s) = self.states.get_mut(hash) {
-            s.set_action(action);
+            s.set_dep(action);
             s.set_source(source);
             return true;
         }
@@ -124,10 +174,12 @@ impl ValidationDependencies {
         self.retained_deps.extend(other.states.keys().cloned());
         self.states.extend(other.states);
     }
-}
 
-impl FromIterator<(ActionHash, ValidationDependencyState)> for ValidationDependencies {
-    fn from_iter<T: IntoIterator<Item = (ActionHash, ValidationDependencyState)>>(iter: T) -> Self {
+    pub fn from_iter<
+        I: IntoIterator<Item = (HoloHash<T::HashType>, ValidationDependencyState<T>)>,
+    >(
+        iter: I,
+    ) -> Self {
         Self {
             states: iter.into_iter().collect(),
             retained_deps: HashSet::new(),
@@ -136,21 +188,27 @@ impl FromIterator<(ActionHash, ValidationDependencyState)> for ValidationDepende
 }
 
 #[derive(Clone, Debug)]
-pub struct ValidationDependencyState {
+pub struct ValidationDependencyState<T> {
     /// The dependency if we've been able to fetch it, otherwise None until we manage to find it.
-    dependency: Option<ValidationDependency>,
+    dependency: Option<ValidationDependency<T>>,
 }
 
-impl ValidationDependencyState {
-    pub fn new(dependency: Option<ValidationDependency>) -> Self {
+impl<T> ValidationDependencyState<T> {
+    pub fn new(dependency: Option<ValidationDependency<T>>) -> Self {
         Self { dependency }
     }
 
-    pub fn set_action(&mut self, action: SignedActionHashed) {
+    pub fn single(dep: T, fetched_from: CascadeSource) -> Self {
+        Self {
+            dependency: Some(ValidationDependency { dep, fetched_from }),
+        }
+    }
+
+    pub fn set_dep(&mut self, dep: T) {
         match self.dependency {
             None => {
                 self.dependency = Some(ValidationDependency {
-                    signed_action: action,
+                    dep,
                     fetched_from: CascadeSource::Network,
                 });
             }
@@ -168,38 +226,18 @@ impl ValidationDependencyState {
             None => {}
         }
     }
+}
 
+impl ValidationDependencyState<SignedActionHashed> {
     pub fn as_action(&self) -> Option<&Action> {
-        self.dependency.as_ref().map(|d| d.signed_action.action())
+        self.dependency.as_ref().map(|d| d.dep.action())
     }
 }
 
 /// A validation dependency which is either an Action or a Record, and the source of the dependency.
 #[derive(Clone, Debug)]
 #[allow(clippy::large_enum_variant)]
-pub struct ValidationDependency {
-    signed_action: SignedActionHashed,
+pub struct ValidationDependency<T> {
+    dep: T,
     fetched_from: CascadeSource,
-}
-
-impl From<(SignedActionHashed, CascadeSource)> for ValidationDependencyState {
-    fn from((signed_action, fetched_from): (SignedActionHashed, CascadeSource)) -> Self {
-        Self {
-            dependency: Some(ValidationDependency {
-                signed_action,
-                fetched_from,
-            }),
-        }
-    }
-}
-
-impl From<(Record, CascadeSource)> for ValidationDependencyState {
-    fn from((record, fetched_from): (Record, CascadeSource)) -> Self {
-        Self {
-            dependency: Some(ValidationDependency {
-                signed_action: record.signed_action,
-                fetched_from,
-            }),
-        }
-    }
 }

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validation_deps.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validation_deps.rs
@@ -10,17 +10,17 @@ use std::{
 #[derive(Clone)]
 pub struct ValDeps {
     /// Dependencies found in the same DHT as the dependent
-    pub local: Arc<parking_lot::Mutex<ValidationDependencies<SignedActionHashed>>>,
+    pub same_dht: Arc<parking_lot::Mutex<ValidationDependencies<SignedActionHashed>>>,
     /// Dependencies found in the DPKI service's Deepkey DNA
     /// (this is not generic for all possible DPKI implementations, only Deepkey)
-    pub deepkey: Arc<parking_lot::Mutex<ValidationDependencies<EntryHashed>>>,
+    pub deepkey_dht: Arc<parking_lot::Mutex<ValidationDependencies<EntryHashed>>>,
 }
 
 impl ValDeps {
     pub fn new() -> Self {
         Self {
-            local: Arc::new(parking_lot::Mutex::new(ValidationDependencies::new())),
-            deepkey: Arc::new(parking_lot::Mutex::new(ValidationDependencies::new())),
+            same_dht: Arc::new(parking_lot::Mutex::new(ValidationDependencies::new())),
+            deepkey_dht: Arc::new(parking_lot::Mutex::new(ValidationDependencies::new())),
         }
     }
 }
@@ -55,28 +55,6 @@ where
             retained_deps: HashSet::new(),
         }
     }
-
-    // impl<T> From<(T, CascadeSource)> for ValidationDependencyState<T> {
-    //     fn from((signed_action, fetched_from): (T, CascadeSource)) -> Self {
-    //         Self {
-    //             dependency: Some(ValidationDependency {
-    //                 signed_action,
-    //                 fetched_from,
-    //             }),
-    //         }
-    //     }
-    // }
-
-    // impl From<(Record, CascadeSource)> for ValidationDependencyState {
-    //     fn from((record, fetched_from): (Record, CascadeSource)) -> Self {
-    //         Self {
-    //             dependency: Some(ValidationDependency {
-    //                 signed_action: record.signed_action,
-    //                 fetched_from,
-    //             }),
-    //         }
-    //     }
-    // }
 
     /// Check whether a given dependency is currently held.
     /// Note that we may have this dependency as a key but the state won't contain the dependency because

--- a/crates/holochain_integrity_types/src/record.rs
+++ b/crates/holochain_integrity_types/src/record.rs
@@ -11,6 +11,7 @@ use crate::signature::Signature;
 use crate::Action;
 use crate::Entry;
 use holo_hash::ActionHash;
+use holo_hash::HasHash;
 use holo_hash::HashableContent;
 use holo_hash::HoloHashOf;
 use holo_hash::HoloHashed;
@@ -373,8 +374,19 @@ impl<C: HashableContent<HashType = T>, T: PrimitiveHashType> HashableContent for
     }
 
     fn hashable_content(&self) -> holo_hash::HashableContentBytes {
-        use holo_hash::HasHash;
         holo_hash::HashableContentBytes::Prehashed39(self.hashed.as_hash().get_raw_39().to_vec())
+    }
+}
+
+impl<C: HashableContent> HasHash for SignedHashed<C> {
+    type HashType = C::HashType;
+
+    fn as_hash(&self) -> &HoloHashOf<C> {
+        &self.hashed.as_hash()
+    }
+
+    fn into_hash(self) -> HoloHashOf<C> {
+        self.hashed.into_hash()
     }
 }
 

--- a/crates/holochain_integrity_types/src/record.rs
+++ b/crates/holochain_integrity_types/src/record.rs
@@ -382,7 +382,7 @@ impl<C: HashableContent> HasHash for SignedHashed<C> {
     type HashType = C::HashType;
 
     fn as_hash(&self) -> &HoloHashOf<C> {
-        &self.hashed.as_hash()
+        self.hashed.as_hash()
     }
 
     fn into_hash(self) -> HoloHashOf<C> {


### PR DESCRIPTION
### Summary

I'm going to need to track EntryHashed dependencies for DPKI validation, so this is groundwork for that.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
