### PR TITLE
[BACKPORT 0.2] Configure getrandom for WASM in the HDI (#3362)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2606,6 +2606,7 @@ version = "0.3.6"
 dependencies = [
  "arbitrary",
  "fixt",
+ "getrandom 0.2.12",
  "hdk_derive",
  "holo_hash",
  "holochain_integrity_types",

--- a/crates/hdi/Cargo.toml
+++ b/crates/hdi/Cargo.toml
@@ -25,6 +25,12 @@ tracing = { version = "0.1", optional = true }
 tracing-core = { version = "0.1", optional = true }
 mockall = { version = "0.11.3", optional = true }
 
+# When building for the WASM target, we need to configure getrandom
+# to use the host system for the source of crypto-secure randomness.
+# NOTE: This needs to be kept in sync with what is actually being pulled in via holo_hash and holochain_wasmer_guest
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.2", features = ["custom"] }
+
 [dev-dependencies]
 fixt = { path = "../fixt" }
 test-case = "2.1"


### PR DESCRIPTION
### Summary

Backport fix for #3361

### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
