### PR TITLE
Add origin checks to holochain websocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3608,6 +3608,7 @@ dependencies = [
  "futures",
  "holochain_serialized_bytes",
  "holochain_trace",
+ "holochain_types",
  "serde",
  "serde_bytes",
  "tokio",

--- a/crates/hc_sandbox/examples/setup_5.rs
+++ b/crates/hc_sandbox/examples/setup_5.rs
@@ -55,6 +55,7 @@ async fn main() -> anyhow::Result<()> {
             source: AppBundleSource::Bundle(bundle),
             membrane_proofs: Default::default(),
             network_seed: None,
+            #[cfg(feature = "chc")]
             ignore_genesis_failure: false,
         };
 

--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -100,7 +100,7 @@ pub struct AddAdminWs {
     ///
     /// If not provided, defaults to `*` which allows any origin.
     #[arg(long, default_value_t = AllowedOrigins::Any)]
-    pub allowed_origins: AllowedOrigins
+    pub allowed_origins: AllowedOrigins,
 }
 
 /// Calls AdminRequest::AttachAppInterface
@@ -421,7 +421,10 @@ pub async fn add_admin_interface(cmd: &mut CmdRunner, args: AddAdminWs) -> anyho
     let resp = cmd
         .command(AdminRequest::AddAdminInterfaces(vec![
             AdminInterfaceConfig {
-                driver: InterfaceDriver::Websocket { port, allowed_origin: AllowedOrigins::Any },
+                driver: InterfaceDriver::Websocket {
+                    port,
+                    allowed_origins: AllowedOrigins::Any,
+                },
             },
         ]))
         .await?;
@@ -589,7 +592,10 @@ pub async fn disable_app(cmd: &mut CmdRunner, args: DisableApp) -> anyhow::Resul
 /// Calls [`AdminRequest::AttachAppInterface`] and adds another app interface.
 pub async fn attach_app_interface(cmd: &mut CmdRunner, args: AddAppWs) -> anyhow::Result<u16> {
     let resp = cmd
-        .command(AdminRequest::AttachAppInterface { port: args.port, allowed_origins: args.allowed_origins })
+        .command(AdminRequest::AttachAppInterface {
+            port: args.port,
+            allowed_origins: args.allowed_origins,
+        })
         .await?;
     tracing::debug!(?resp);
     match resp {

--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -33,7 +33,7 @@ use crate::expect_match;
 use crate::ports::get_admin_ports;
 use crate::run::run_async;
 use crate::CmdRunner;
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 use holochain_trace::Output;
 use holochain_types::websocket::AllowedOrigin;
 
@@ -57,7 +57,7 @@ pub struct Call {
 // Docs have different use for clap
 // so documenting everything doesn't make sense.
 #[allow(missing_docs)]
-#[derive(Debug, Parser, Clone)]
+#[derive(Debug, Subcommand, Clone)]
 pub enum AdminRequestCli {
     AddAdminWs(AddAdminWs),
     AddAppWs(AddAppWs),
@@ -87,25 +87,43 @@ pub enum AdminRequestCli {
 
 /// Calls AdminRequest::AddAdminInterfaces
 /// and adds another admin interface.
-#[derive(Debug, Parser, Clone)]
+#[derive(Debug, Args, Clone)]
 pub struct AddAdminWs {
     /// Optional port number.
     /// Defaults to assigned by OS.
     pub port: Option<u16>,
+
+    /// Optional allowed origins.
+    ///
+    /// This should be a comma separated list of origins, or `*` to allow any origin.
+    /// For example: `http://localhost:3000,http://localhost:3001`
+    ///
+    /// If not provided, defaults to `*` which allows any origin.
+    #[arg(long, default_value_t = "*")]
+    pub allowed_origins: String
 }
 
 /// Calls AdminRequest::AttachAppInterface
 /// and adds another app interface.
-#[derive(Debug, Parser, Clone)]
+#[derive(Debug, Args, Clone)]
 pub struct AddAppWs {
     /// Optional port number.
     /// Defaults to assigned by OS.
     pub port: Option<u16>,
+
+    /// Optional allowed origins.
+    ///
+    /// This should be a comma separated list of origins, or `*` to allow any origin.
+    /// For example: `http://localhost:3000,http://localhost:3001`
+    ///
+    /// If not provided, defaults to `*` which allows any origin.
+    #[arg(long, default_value_t = "*")]
+    pub allowed_origins: String
 }
 
 /// Calls AdminRequest::RegisterDna
 /// and registers a DNA. You can only use a path or a hash, not both.
-#[derive(Debug, Parser, Clone)]
+#[derive(Debug, Args, Clone)]
 pub struct RegisterDna {
     #[arg(short, long)]
     /// Network seed to override when installing this DNA
@@ -130,7 +148,7 @@ pub struct RegisterDna {
 /// Setting properties and membrane proofs is not
 /// yet supported.
 /// RoleNames are set to `my-app-0`, `my-app-1` etc.
-#[derive(Debug, Parser, Clone)]
+#[derive(Debug, Args, Clone)]
 pub struct InstallApp {
     /// Sets the InstalledAppId.
     #[arg(long)]
@@ -152,7 +170,7 @@ pub struct InstallApp {
 
 /// Calls AdminRequest::UninstallApp
 /// and uninstalls the specified app.
-#[derive(Debug, Parser, Clone)]
+#[derive(Debug, Args, Clone)]
 pub struct UninstallApp {
     /// The InstalledAppId to uninstall.
     pub app_id: String,
@@ -160,7 +178,7 @@ pub struct UninstallApp {
 
 /// Calls AdminRequest::EnableApp
 /// and activates the installed app.
-#[derive(Debug, Parser, Clone)]
+#[derive(Debug, Args, Clone)]
 pub struct EnableApp {
     /// The InstalledAppId to activate.
     pub app_id: String,
@@ -168,7 +186,7 @@ pub struct EnableApp {
 
 /// Calls AdminRequest::DisableApp
 /// and disables the installed app.
-#[derive(Debug, Parser, Clone)]
+#[derive(Debug, Args, Clone)]
 pub struct DisableApp {
     /// The InstalledAppId to disable.
     pub app_id: String,
@@ -178,7 +196,7 @@ pub struct DisableApp {
 /// and dumps the current cell's state.
 // TODO: Add pretty print.
 // TODO: Default to dumping all cell state.
-#[derive(Debug, Parser, Clone)]
+#[derive(Debug, Args, Clone)]
 pub struct DumpState {
     /// The DNA hash half of the cell ID to dump.
     #[arg(value_parser = parse_dna_hash)]
@@ -192,7 +210,7 @@ pub struct DumpState {
 /// Calls AdminRequest::RequestAgentInfo
 /// and pretty prints the agent info on
 /// this conductor.
-#[derive(Debug, Parser, Clone)]
+#[derive(Debug, Args, Clone)]
 pub struct ListAgents {
     /// Optionally request agent info for a particular cell ID.
     #[arg(short, long, value_parser = parse_agent_key, requires = "dna")]
@@ -206,7 +224,7 @@ pub struct ListAgents {
 /// Calls AdminRequest::ListApps
 /// and pretty prints the list of apps
 /// installed in this conductor.
-#[derive(Debug, Parser, Clone)]
+#[derive(Debug, Args, Clone)]
 pub struct ListApps {
     /// Optionally request agent info for a particular cell ID.
     #[arg(short, long, value_parser = parse_status_filter)]

--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -35,6 +35,7 @@ use crate::run::run_async;
 use crate::CmdRunner;
 use clap::Parser;
 use holochain_trace::Output;
+use holochain_types::websocket::AllowedOrigin;
 
 #[doc(hidden)]
 #[derive(Debug, Parser)]
@@ -402,7 +403,7 @@ pub async fn add_admin_interface(cmd: &mut CmdRunner, args: AddAdminWs) -> anyho
     let resp = cmd
         .command(AdminRequest::AddAdminInterfaces(vec![
             AdminInterfaceConfig {
-                driver: InterfaceDriver::Websocket { port },
+                driver: InterfaceDriver::Websocket { port, allowed_origin: AllowedOrigin::Any },
             },
         ]))
         .await?;

--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -35,7 +35,7 @@ use crate::run::run_async;
 use crate::CmdRunner;
 use clap::{Args, Parser, Subcommand};
 use holochain_trace::Output;
-use holochain_types::websocket::AllowedOrigin;
+use holochain_types::websocket::AllowedOrigins;
 
 #[doc(hidden)]
 #[derive(Debug, Parser)]
@@ -99,8 +99,8 @@ pub struct AddAdminWs {
     /// For example: `http://localhost:3000,http://localhost:3001`
     ///
     /// If not provided, defaults to `*` which allows any origin.
-    #[arg(long, default_value_t = "*")]
-    pub allowed_origins: String
+    #[arg(long, default_value_t = AllowedOrigins::Any)]
+    pub allowed_origins: AllowedOrigins
 }
 
 /// Calls AdminRequest::AttachAppInterface
@@ -117,8 +117,8 @@ pub struct AddAppWs {
     /// For example: `http://localhost:3000,http://localhost:3001`
     ///
     /// If not provided, defaults to `*` which allows any origin.
-    #[arg(long, default_value_t = "*")]
-    pub allowed_origins: String
+    #[arg(long, default_value_t = AllowedOrigins::Any)]
+    pub allowed_origins: AllowedOrigins,
 }
 
 /// Calls AdminRequest::RegisterDna
@@ -421,7 +421,7 @@ pub async fn add_admin_interface(cmd: &mut CmdRunner, args: AddAdminWs) -> anyho
     let resp = cmd
         .command(AdminRequest::AddAdminInterfaces(vec![
             AdminInterfaceConfig {
-                driver: InterfaceDriver::Websocket { port, allowed_origin: AllowedOrigin::Any },
+                driver: InterfaceDriver::Websocket { port, allowed_origin: AllowedOrigins::Any },
             },
         ]))
         .await?;
@@ -589,7 +589,7 @@ pub async fn disable_app(cmd: &mut CmdRunner, args: DisableApp) -> anyhow::Resul
 /// Calls [`AdminRequest::AttachAppInterface`] and adds another app interface.
 pub async fn attach_app_interface(cmd: &mut CmdRunner, args: AddAppWs) -> anyhow::Result<u16> {
     let resp = cmd
-        .command(AdminRequest::AttachAppInterface { port: args.port })
+        .command(AdminRequest::AttachAppInterface { port: args.port, allowed_origins: args.allowed_origins })
         .await?;
     tracing::debug!(?resp);
     match resp {

--- a/crates/hc_sandbox/src/ports.rs
+++ b/crates/hc_sandbox/src/ports.rs
@@ -84,7 +84,7 @@ pub(crate) fn random_admin_port(config: &mut ConductorConfig) {
         None => {
             let port = 0;
             config.admin_interfaces = Some(vec![AdminInterfaceConfig {
-                driver: InterfaceDriver::Websocket { port, allowed_origin: AllowedOrigins::Any },
+                driver: InterfaceDriver::Websocket { port, allowed_origins: AllowedOrigins::Any },
             }]);
         }
     }
@@ -93,7 +93,7 @@ pub(crate) fn random_admin_port(config: &mut ConductorConfig) {
 pub(crate) fn set_admin_port(config: &mut ConductorConfig, port: u16) {
     let p = port;
     let port = AdminInterfaceConfig {
-        driver: InterfaceDriver::Websocket { port, allowed_origin: AllowedOrigins::Any },
+        driver: InterfaceDriver::Websocket { port, allowed_origins: AllowedOrigins::Any },
     };
     match config
         .admin_interfaces

--- a/crates/hc_sandbox/src/ports.rs
+++ b/crates/hc_sandbox/src/ports.rs
@@ -84,7 +84,10 @@ pub(crate) fn random_admin_port(config: &mut ConductorConfig) {
         None => {
             let port = 0;
             config.admin_interfaces = Some(vec![AdminInterfaceConfig {
-                driver: InterfaceDriver::Websocket { port, allowed_origins: AllowedOrigins::Any },
+                driver: InterfaceDriver::Websocket {
+                    port,
+                    allowed_origins: AllowedOrigins::Any,
+                },
             }]);
         }
     }
@@ -93,7 +96,10 @@ pub(crate) fn random_admin_port(config: &mut ConductorConfig) {
 pub(crate) fn set_admin_port(config: &mut ConductorConfig, port: u16) {
     let p = port;
     let port = AdminInterfaceConfig {
-        driver: InterfaceDriver::Websocket { port, allowed_origins: AllowedOrigins::Any },
+        driver: InterfaceDriver::Websocket {
+            port,
+            allowed_origins: AllowedOrigins::Any,
+        },
     };
     match config
         .admin_interfaces

--- a/crates/hc_sandbox/src/ports.rs
+++ b/crates/hc_sandbox/src/ports.rs
@@ -7,7 +7,7 @@ use holochain_conductor_api::conductor::paths::ConfigRootPath;
 use holochain_conductor_api::{
     config::conductor::ConductorConfig, AdminInterfaceConfig, InterfaceDriver,
 };
-use holochain_types::websocket::AllowedOrigin;
+use holochain_types::websocket::AllowedOrigins;
 use holochain_websocket::{self as ws, WebsocketConfig, WebsocketSender};
 
 use crate::config::read_config;
@@ -84,7 +84,7 @@ pub(crate) fn random_admin_port(config: &mut ConductorConfig) {
         None => {
             let port = 0;
             config.admin_interfaces = Some(vec![AdminInterfaceConfig {
-                driver: InterfaceDriver::Websocket { port, allowed_origin: AllowedOrigin::Any },
+                driver: InterfaceDriver::Websocket { port, allowed_origin: AllowedOrigins::Any },
             }]);
         }
     }
@@ -93,7 +93,7 @@ pub(crate) fn random_admin_port(config: &mut ConductorConfig) {
 pub(crate) fn set_admin_port(config: &mut ConductorConfig, port: u16) {
     let p = port;
     let port = AdminInterfaceConfig {
-        driver: InterfaceDriver::Websocket { port, allowed_origin: AllowedOrigin::Any },
+        driver: InterfaceDriver::Websocket { port, allowed_origin: AllowedOrigins::Any },
     };
     match config
         .admin_interfaces

--- a/crates/hc_sandbox/src/ports.rs
+++ b/crates/hc_sandbox/src/ports.rs
@@ -7,6 +7,7 @@ use holochain_conductor_api::conductor::paths::ConfigRootPath;
 use holochain_conductor_api::{
     config::conductor::ConductorConfig, AdminInterfaceConfig, InterfaceDriver,
 };
+use holochain_types::websocket::AllowedOrigin;
 use holochain_websocket::{self as ws, WebsocketConfig, WebsocketSender};
 
 use crate::config::read_config;
@@ -33,7 +34,7 @@ pub async fn get_admin_ports(paths: Vec<PathBuf>) -> anyhow::Result<Vec<u16>> {
         if let Some(config) = read_config(ConfigRootPath::from(p))? {
             if let Some(ai) = config.admin_interfaces {
                 if let Some(AdminInterfaceConfig {
-                    driver: InterfaceDriver::Websocket { port },
+                    driver: InterfaceDriver::Websocket { port, .. },
                 }) = ai.first()
                 {
                     ports.push(*port)
@@ -56,11 +57,11 @@ pub(crate) async fn get_admin_api(
 async fn websocket_client_by_port(
     port: u16,
 ) -> std::io::Result<(WebsocketSender, tokio::task::JoinHandle<()>)> {
-    let (send, mut recv) = ws::connect(
-        Arc::new(WebsocketConfig::default()),
-        ([127, 0, 0, 1], port).into(),
-    )
-    .await?;
+    let req = holochain_websocket::ConnectRequest::new(([127, 0, 0, 1], port).into())
+        .try_set_header("Origin", "hc_sandbox")
+        .expect("Failed to set `Origin` header for websocket connection request");
+
+    let (send, mut recv) = ws::connect(Arc::new(WebsocketConfig::CLIENT_DEFAULT), req).await?;
     let task = tokio::task::spawn(async move {
         while recv
             .recv::<holochain_conductor_api::AdminResponse>()
@@ -74,7 +75,7 @@ async fn websocket_client_by_port(
 pub(crate) fn random_admin_port(config: &mut ConductorConfig) {
     match config.admin_interfaces.as_mut().and_then(|i| i.first_mut()) {
         Some(AdminInterfaceConfig {
-            driver: InterfaceDriver::Websocket { port },
+            driver: InterfaceDriver::Websocket { port, .. },
         }) => {
             if *port != 0 {
                 *port = 0;
@@ -83,7 +84,7 @@ pub(crate) fn random_admin_port(config: &mut ConductorConfig) {
         None => {
             let port = 0;
             config.admin_interfaces = Some(vec![AdminInterfaceConfig {
-                driver: InterfaceDriver::Websocket { port },
+                driver: InterfaceDriver::Websocket { port, allowed_origin: AllowedOrigin::Any },
             }]);
         }
     }
@@ -92,7 +93,7 @@ pub(crate) fn random_admin_port(config: &mut ConductorConfig) {
 pub(crate) fn set_admin_port(config: &mut ConductorConfig, port: u16) {
     let p = port;
     let port = AdminInterfaceConfig {
-        driver: InterfaceDriver::Websocket { port },
+        driver: InterfaceDriver::Websocket { port, allowed_origin: AllowedOrigin::Any },
     };
     match config
         .admin_interfaces

--- a/crates/hc_sandbox/src/run.rs
+++ b/crates/hc_sandbox/src/run.rs
@@ -13,6 +13,7 @@ use tokio::io::AsyncBufReadExt;
 use tokio::io::BufReader;
 use tokio::process::{Child, Command};
 use tokio::sync::oneshot;
+use holochain_types::websocket::AllowedOrigins;
 
 use crate::calls::attach_app_interface;
 use crate::calls::AddAppWs;
@@ -59,6 +60,7 @@ pub async fn run(
             &mut cmd,
             AddAppWs {
                 port: Some(app_port),
+                allowed_origins: AllowedOrigins::Any
             },
         )
         .await?;

--- a/crates/hc_sandbox/src/run.rs
+++ b/crates/hc_sandbox/src/run.rs
@@ -9,11 +9,11 @@ use holochain_conductor_api::conductor::paths::ConfigRootPath;
 use holochain_conductor_api::conductor::paths::KeystorePath;
 use holochain_conductor_api::conductor::{ConductorConfig, KeystoreConfig};
 use holochain_trace::Output;
+use holochain_types::websocket::AllowedOrigins;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::BufReader;
 use tokio::process::{Child, Command};
 use tokio::sync::oneshot;
-use holochain_types::websocket::AllowedOrigins;
 
 use crate::calls::attach_app_interface;
 use crate::calls::AddAppWs;
@@ -60,7 +60,7 @@ pub async fn run(
             &mut cmd,
             AddAppWs {
                 port: Some(app_port),
-                allowed_origins: AllowedOrigins::Any
+                allowed_origins: AllowedOrigins::Any,
             },
         )
         .await?;

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -2,7 +2,7 @@ use assert_cmd::prelude::*;
 use holochain_cli_sandbox::cli::LaunchInfo;
 use holochain_conductor_api::AppRequest;
 use holochain_conductor_api::AppResponse;
-use holochain_websocket::{self as ws, WebsocketConfig, WebsocketReceiver, WebsocketSender};
+use holochain_websocket::{self as ws, ConnectRequest, WebsocketConfig, WebsocketReceiver, WebsocketSender};
 use matches::assert_matches;
 use once_cell::sync::Lazy;
 use std::future::Future;
@@ -65,8 +65,8 @@ async fn new_websocket_client_for_port(
     port: u16,
 ) -> anyhow::Result<(WebsocketSender, WebsocketReceiver)> {
     Ok(ws::connect(
-        Arc::new(WebsocketConfig::default()),
-        ([127, 0, 0, 1], port).into(),
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        ConnectRequest::new(([127, 0, 0, 1], port).into()),
     )
     .await?)
 }

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -2,7 +2,9 @@ use assert_cmd::prelude::*;
 use holochain_cli_sandbox::cli::LaunchInfo;
 use holochain_conductor_api::AppRequest;
 use holochain_conductor_api::AppResponse;
-use holochain_websocket::{self as ws, ConnectRequest, WebsocketConfig, WebsocketReceiver, WebsocketSender};
+use holochain_websocket::{
+    self as ws, ConnectRequest, WebsocketConfig, WebsocketReceiver, WebsocketSender,
+};
 use matches::assert_matches;
 use once_cell::sync::Lazy;
 use std::future::Future;

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- BREAKING: Holochain websockets now require an `allowed_origins` configuration to be provided. When connecting to the websocket a matching origin must be specified in the connection request `Origin` header. [#3460](https://github.com/holochain/holochain/pull/3460)
+    - The `ConductorConfiguration` has been changed so that specifying an admin interface requires an `allowed_origins` as well as the port it already required.
+    - `AdminRequest::AddAdminInterfaces` has been updated as per the previous point.
+    - `AdminRequest::AttachAppInterface` has also been updated so that attaching app ports requires an `allowed_origins` as well as the port it already required.
 - BREAKING: Split the authored database by author. It was previous partitioned by DNA only and each agent that shared a DB because they were running the same DNA would have to share the write lock.
   This is a pretty serious bottleneck when the same app is being run for multiple agents on the same conductor. They are now separate files on disk and writes can proceed independently.
   There is no migration path for this change, if you have existing databases they will not be found. [#3450](https://github.com/holochain/holochain/pull/3450)

--- a/crates/holochain/src/bin/holochain/main.rs
+++ b/crates/holochain/src/bin/holochain/main.rs
@@ -40,7 +40,7 @@ struct Opt {
     config_path: Option<PathBuf>,
 
     /// Instead of the normal "interactive" method of passphrase
-    /// retreival, read the passphrase from stdin. Be careful
+    /// retrieval, read the passphrase from stdin. Be careful
     /// how you make use of this, as it could be less secure,
     /// for example, make sure it is not saved in your
     /// `~/.bash_history`.

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -219,12 +219,12 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     .await?;
                 Ok(AdminResponse::AppDisabled)
             }
-            AttachAppInterface { port } => {
+            AttachAppInterface { port, allowed_origins } => {
                 let port = port.unwrap_or(0);
                 let port = self
                     .conductor_handle
                     .clone()
-                    .add_app_interface(either::Either::Left(port))
+                    .add_app_interface(either::Either::Left(port), allowed_origins)
                     .await?;
                 Ok(AdminResponse::AppInterfaceAttached { port })
             }

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -219,7 +219,10 @@ impl AdminInterfaceApi for RealAdminInterfaceApi {
                     .await?;
                 Ok(AdminResponse::AppDisabled)
             }
-            AttachAppInterface { port, allowed_origins } => {
+            AttachAppInterface {
+                port,
+                allowed_origins,
+            } => {
                 let port = port.unwrap_or(0);
                 let port = self
                     .conductor_handle

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -411,8 +411,8 @@ mod interface_impls {
                 let tm = tm.clone();
                 async move {
                     match driver {
-                        InterfaceDriver::Websocket { port } => {
-                            let listener = spawn_websocket_listener(port).await?;
+                        InterfaceDriver::Websocket { port, allowed_origin } => {
+                            let listener = spawn_websocket_listener(port, allowed_origin).await?;
                             let port = listener.local_addr()?.port();
                             spawn_admin_interface_tasks(
                                 tm.clone(),

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 use tracing::*;
+use holochain_types::websocket::AllowedOrigin;
 
 /// Concurrency count for websocket message processing.
 /// This could represent a significant memory investment for
@@ -34,10 +35,14 @@ pub(crate) const SIGNAL_BUFFER_SIZE: usize = 50;
 pub const MAX_CONNECTIONS: usize = 400;
 
 /// Create a WebsocketListener to be used in interfaces
-pub async fn spawn_websocket_listener(port: u16) -> InterfaceResult<WebsocketListener> {
+pub async fn spawn_websocket_listener(port: u16, allowed_origin: AllowedOrigin) -> InterfaceResult<WebsocketListener> {
     trace!("Initializing Admin interface");
+
+    let mut config = WebsocketConfig::LISTENER_DEFAULT;
+    config.allowed_origin = Some(allowed_origin);
+
     let listener = WebsocketListener::bind(
-        Arc::new(WebsocketConfig::default()),
+        Arc::new(config),
         format!("127.0.0.1:{}", port),
     )
     .await?;
@@ -112,7 +117,7 @@ pub async fn spawn_app_interface_task<A: InterfaceApi>(
 ) -> InterfaceResult<u16> {
     trace!("Initializing App interface");
     let listener = WebsocketListener::bind(
-        Arc::new(WebsocketConfig::default()),
+        Arc::new(WebsocketConfig::LISTENER_DEFAULT),
         format!("127.0.0.1:{}", port),
     )
     .await?;

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -12,11 +12,11 @@ use holochain_websocket::WebsocketListener;
 use holochain_websocket::WebsocketReceiver;
 use holochain_websocket::WebsocketSender;
 
+use holochain_types::websocket::AllowedOrigins;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 use tracing::*;
-use holochain_types::websocket::AllowedOrigins;
 
 /// Concurrency count for websocket message processing.
 /// This could represent a significant memory investment for
@@ -35,17 +35,16 @@ pub(crate) const SIGNAL_BUFFER_SIZE: usize = 50;
 pub const MAX_CONNECTIONS: usize = 400;
 
 /// Create a WebsocketListener to be used in interfaces
-pub async fn spawn_websocket_listener(port: u16, allowed_origins: AllowedOrigins) -> InterfaceResult<WebsocketListener> {
+pub async fn spawn_websocket_listener(
+    port: u16,
+    allowed_origins: AllowedOrigins,
+) -> InterfaceResult<WebsocketListener> {
     trace!("Initializing Admin interface");
 
     let mut config = WebsocketConfig::LISTENER_DEFAULT;
     config.allowed_origins = Some(allowed_origins);
 
-    let listener = WebsocketListener::bind(
-        Arc::new(config),
-        format!("127.0.0.1:{}", port),
-    )
-    .await?;
+    let listener = WebsocketListener::bind(Arc::new(config), format!("127.0.0.1:{}", port)).await?;
     trace!("LISTENING AT: {}", listener.local_addr()?);
     Ok(listener)
 }
@@ -121,11 +120,7 @@ pub async fn spawn_app_interface_task<A: InterfaceApi>(
     let mut config = WebsocketConfig::LISTENER_DEFAULT;
     config.allowed_origins = Some(allowed_origins);
 
-    let listener = WebsocketListener::bind(
-        Arc::new(config),
-        format!("127.0.0.1:{}", port),
-    )
-    .await?;
+    let listener = WebsocketListener::bind(Arc::new(config), format!("127.0.0.1:{}", port)).await?;
     let addr = listener.local_addr()?;
     trace!("LISTENING AT: {}", addr);
     let port = addr.port();
@@ -388,7 +383,10 @@ pub mod test {
         conductor_handle
             .clone()
             .add_admin_interfaces(vec![AdminInterfaceConfig {
-                driver: InterfaceDriver::Websocket { port: admin_port, allowed_origins: AllowedOrigins::Any },
+                driver: InterfaceDriver::Websocket {
+                    port: admin_port,
+                    allowed_origins: AllowedOrigins::Any,
+                },
             }])
             .await
             .unwrap();
@@ -436,7 +434,10 @@ pub mod test {
         assert_matches!(response, AdminResponse::AppEnabled { .. });
 
         // Attach App Interface
-        let request = AdminRequest::AttachAppInterface { port: None, allowed_origins: AllowedOrigins::Any };
+        let request = AdminRequest::AttachAppInterface {
+            port: None,
+            allowed_origins: AllowedOrigins::Any,
+        };
         let response: AdminResponse = admin_tx.request(request).await.unwrap();
         let app_port = match response {
             AdminResponse::AppInterfaceAttached { port } => port,
@@ -979,7 +980,10 @@ pub mod test {
         holochain_trace::test_run().ok();
         let (_tmpdir, conductor_handle) = setup_admin().await;
         let admin_api = RealAdminInterfaceApi::new(conductor_handle.clone());
-        let msg = AdminRequest::AttachAppInterface { port: None, allowed_origins: AllowedOrigins::Any };
+        let msg = AdminRequest::AttachAppInterface {
+            port: None,
+            allowed_origins: AllowedOrigins::Any,
+        };
         let msg = msg.try_into().unwrap();
         let respond = |response: AdminResponse| {
             assert_matches!(response, AdminResponse::AppInterfaceAttached { .. });

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -388,7 +388,7 @@ pub mod test {
         conductor_handle
             .clone()
             .add_admin_interfaces(vec![AdminInterfaceConfig {
-                driver: InterfaceDriver::Websocket { port: admin_port },
+                driver: InterfaceDriver::Websocket { port: admin_port, allowed_origins: AllowedOrigins::Any },
             }])
             .await
             .unwrap();
@@ -436,7 +436,7 @@ pub mod test {
         assert_matches!(response, AdminResponse::AppEnabled { .. });
 
         // Attach App Interface
-        let request = AdminRequest::AttachAppInterface { port: None };
+        let request = AdminRequest::AttachAppInterface { port: None, allowed_origins: AllowedOrigins::Any };
         let response: AdminResponse = admin_tx.request(request).await.unwrap();
         let app_port = match response {
             AdminResponse::AppInterfaceAttached { port } => port,
@@ -979,7 +979,7 @@ pub mod test {
         holochain_trace::test_run().ok();
         let (_tmpdir, conductor_handle) = setup_admin().await;
         let admin_api = RealAdminInterfaceApi::new(conductor_handle.clone());
-        let msg = AdminRequest::AttachAppInterface { port: None };
+        let msg = AdminRequest::AttachAppInterface { port: None, allowed_origins: AllowedOrigins::Any };
         let msg = msg.try_into().unwrap();
         let respond = |response: AdminResponse| {
             assert_matches!(response, AdminResponse::AppInterfaceAttached { .. });

--- a/crates/holochain/src/conductor/state.rs
+++ b/crates/holochain/src/conductor/state.rs
@@ -9,6 +9,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Arc;
+use holochain_types::websocket::AllowedOrigin;
 
 use super::error::{ConductorError, ConductorResult};
 
@@ -239,7 +240,12 @@ impl AppInterfaceConfig {
     pub fn websocket(port: u16) -> Self {
         Self {
             signal_subscriptions: HashMap::new(),
-            driver: InterfaceDriver::Websocket { port },
+            driver: InterfaceDriver::Websocket {
+                port,
+                // No origin restrictions for app interfaces for now. Zome calls are protected by signing
+                // and no requirement for other protection on the app websocket has been raised.
+                allowed_origin: AllowedOrigin::Any
+            },
         }
     }
 }

--- a/crates/holochain/src/conductor/state.rs
+++ b/crates/holochain/src/conductor/state.rs
@@ -5,11 +5,11 @@ use holochain_conductor_api::config::InterfaceDriver;
 use holochain_conductor_api::signal_subscription::SignalSubscription;
 use holochain_p2p::NetworkCompatParams;
 use holochain_types::prelude::*;
+use holochain_types::websocket::AllowedOrigins;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Arc;
-use holochain_types::websocket::AllowedOrigins;
 
 use super::error::{ConductorError, ConductorResult};
 

--- a/crates/holochain/src/conductor/state.rs
+++ b/crates/holochain/src/conductor/state.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Arc;
-use holochain_types::websocket::AllowedOrigin;
+use holochain_types::websocket::AllowedOrigins;
 
 use super::error::{ConductorError, ConductorResult};
 
@@ -237,14 +237,12 @@ pub struct AppInterfaceConfig {
 
 impl AppInterfaceConfig {
     /// Create config for a websocket interface
-    pub fn websocket(port: u16) -> Self {
+    pub fn websocket(port: u16, allowed_origins: AllowedOrigins) -> Self {
         Self {
             signal_subscriptions: HashMap::new(),
             driver: InterfaceDriver::Websocket {
                 port,
-                // No origin restrictions for app interfaces for now. Zome calls are protected by signing
-                // and no requirement for other protection on the app websocket has been raised.
-                allowed_origin: AllowedOrigin::Any
+                allowed_origins,
             },
         }
     }

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -18,6 +18,7 @@ use holochain_keystore::MetaLairClient;
 use holochain_state::prelude::test_db_dir;
 use holochain_state::test_utils::TestDir;
 use holochain_types::prelude::*;
+use holochain_types::websocket::AllowedOrigins;
 use holochain_websocket::*;
 use nanoid::nanoid;
 use rand::Rng;
@@ -25,7 +26,6 @@ use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use holochain_types::websocket::AllowedOrigins;
 
 /// Standin until std::io::Error::other is stablized.
 pub fn err_other<E>(error: E) -> std::io::Error
@@ -736,9 +736,7 @@ impl SweetConductor {
 }
 
 /// Get a websocket client on localhost at the specified port
-pub async fn websocket_client_by_port(
-    port: u16,
-) -> Result<(WebsocketSender, WebsocketReceiver)> {
+pub async fn websocket_client_by_port(port: u16) -> Result<(WebsocketSender, WebsocketReceiver)> {
     connect(
         Arc::new(WebsocketConfig::CLIENT_DEFAULT),
         ConnectRequest::new(([127, 0, 0, 1], port).into()),

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -25,6 +25,7 @@ use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use holochain_types::websocket::AllowedOrigins;
 
 /// Standin until std::io::Error::other is stablized.
 pub fn err_other<E>(error: E) -> std::io::Error
@@ -530,7 +531,7 @@ impl SweetConductor {
     pub async fn app_ws_client(&self) -> (WebsocketSender, WebsocketReceiver) {
         let port = self
             .raw_handle()
-            .add_app_interface(either::Either::Left(0), )
+            .add_app_interface(either::Either::Left(0), AllowedOrigins::Any)
             .await
             .expect("Couldn't create app interface");
         websocket_client_by_port(port).await.unwrap()
@@ -737,10 +738,10 @@ impl SweetConductor {
 /// Get a websocket client on localhost at the specified port
 pub async fn websocket_client_by_port(
     port: u16,
-) -> std::io::Result<(WebsocketSender, WebsocketReceiver)> {
-    holochain_websocket::connect(
-        Arc::new(WebsocketConfig::default()),
-        ([127, 0, 0, 1], port).into(),
+) -> Result<(WebsocketSender, WebsocketReceiver)> {
+    connect(
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        ConnectRequest::new(([127, 0, 0, 1], port).into()),
     )
     .await
 }

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -530,7 +530,7 @@ impl SweetConductor {
     pub async fn app_ws_client(&self) -> (WebsocketSender, WebsocketReceiver) {
         let port = self
             .raw_handle()
-            .add_app_interface(either::Either::Left(0))
+            .add_app_interface(either::Either::Left(0), )
             .await
             .expect("Couldn't create app interface");
         websocket_client_by_port(port).await.unwrap()

--- a/crates/holochain/src/sweettest/sweet_conductor_config.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor_config.rs
@@ -27,7 +27,10 @@ impl From<KitsuneP2pConfig> for SweetConductorConfig {
         ConductorConfig {
             network,
             admin_interfaces: Some(vec![AdminInterfaceConfig {
-                driver: InterfaceDriver::Websocket { port: 0, allowed_origins: AllowedOrigins::Any },
+                driver: InterfaceDriver::Websocket {
+                    port: 0,
+                    allowed_origins: AllowedOrigins::Any,
+                },
             }]),
             tuning_params: Some(ConductorTuningParams {
                 sys_validation_retry_delay: Some(std::time::Duration::from_secs(1)),

--- a/crates/holochain/src/sweettest/sweet_conductor_config.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor_config.rs
@@ -5,6 +5,7 @@ use holochain_conductor_api::{
     conductor::{ConductorConfig, ConductorTuningParams},
     AdminInterfaceConfig, InterfaceDriver,
 };
+use holochain_types::websocket::AllowedOrigins;
 use kitsune_p2p_types::config::KitsuneP2pConfig;
 
 pub(crate) static NUM_CREATED: AtomicUsize = AtomicUsize::new(0);
@@ -26,7 +27,7 @@ impl From<KitsuneP2pConfig> for SweetConductorConfig {
         ConductorConfig {
             network,
             admin_interfaces: Some(vec![AdminInterfaceConfig {
-                driver: InterfaceDriver::Websocket { port: 0 },
+                driver: InterfaceDriver::Websocket { port: 0, allowed_origins: AllowedOrigins::Any },
             }]),
             tuning_params: Some(ConductorTuningParams {
                 sys_validation_retry_delay: Some(std::time::Duration::from_secs(1)),

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -67,6 +67,7 @@ mod big_stack_test;
 
 mod generate_records;
 pub use generate_records::*;
+use holochain_types::websocket::AllowedOrigins;
 
 pub use crate::sweettest::sweet_consistency::*;
 
@@ -443,7 +444,7 @@ pub async fn setup_app_inner(
     let config = ConductorConfig {
         data_root_path: Some(data_root_path.clone()),
         admin_interfaces: Some(vec![AdminInterfaceConfig {
-            driver: InterfaceDriver::Websocket { port: 0 },
+            driver: InterfaceDriver::Websocket { port: 0, allowed_origins: AllowedOrigins::Any },
         }]),
         network: network.unwrap_or_default(),
         ..Default::default()

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -444,7 +444,10 @@ pub async fn setup_app_inner(
     let config = ConductorConfig {
         data_root_path: Some(data_root_path.clone()),
         admin_interfaces: Some(vec![AdminInterfaceConfig {
-            driver: InterfaceDriver::Websocket { port: 0, allowed_origins: AllowedOrigins::Any },
+            driver: InterfaceDriver::Websocket {
+                port: 0,
+                allowed_origins: AllowedOrigins::Any,
+            },
         }]),
         network: network.unwrap_or_default(),
         ..Default::default()

--- a/crates/holochain/tests/new_lair/mod.rs
+++ b/crates/holochain/tests/new_lair/mod.rs
@@ -3,13 +3,13 @@ use holochain_conductor_api::config::conductor::ConductorConfig;
 use holochain_conductor_api::config::conductor::KeystoreConfig;
 use holochain_conductor_api::AdminInterfaceConfig;
 use holochain_conductor_api::InterfaceDriver;
+use holochain_types::websocket::AllowedOrigins;
 use kitsune_p2p_types::dependencies::lair_keystore_api;
 use lair_keystore_api::dependencies::*;
 use lair_keystore_api::ipc_keystore::*;
 use lair_keystore_api::mem_store::*;
 use lair_keystore_api::prelude::*;
 use std::sync::Arc;
-use holochain_types::websocket::AllowedOrigins;
 
 use super::test_utils::*;
 
@@ -41,7 +41,10 @@ async fn test_new_lair_conductor_integration() {
     // set up conductor config to use the started keystore
     let mut conductor_config = ConductorConfig::default();
     conductor_config.admin_interfaces = Some(vec![AdminInterfaceConfig {
-        driver: InterfaceDriver::Websocket { port: ADMIN_PORT, allowed_origins: AllowedOrigins::Any },
+        driver: InterfaceDriver::Websocket {
+            port: ADMIN_PORT,
+            allowed_origins: AllowedOrigins::Any,
+        },
     }]);
     conductor_config.data_root_path = Some(tmp.path().to_owned().into());
     conductor_config.keystore = KeystoreConfig::LairServer {

--- a/crates/holochain/tests/new_lair/mod.rs
+++ b/crates/holochain/tests/new_lair/mod.rs
@@ -9,6 +9,7 @@ use lair_keystore_api::ipc_keystore::*;
 use lair_keystore_api::mem_store::*;
 use lair_keystore_api::prelude::*;
 use std::sync::Arc;
+use holochain_types::websocket::AllowedOrigins;
 
 use super::test_utils::*;
 
@@ -40,7 +41,7 @@ async fn test_new_lair_conductor_integration() {
     // set up conductor config to use the started keystore
     let mut conductor_config = ConductorConfig::default();
     conductor_config.admin_interfaces = Some(vec![AdminInterfaceConfig {
-        driver: InterfaceDriver::Websocket { port: ADMIN_PORT },
+        driver: InterfaceDriver::Websocket { port: ADMIN_PORT, allowed_origins: AllowedOrigins::Any },
     }]);
     conductor_config.data_root_path = Some(tmp.path().to_owned().into());
     conductor_config.keystore = KeystoreConfig::LairServer {

--- a/crates/holochain/tests/send_signal.rs
+++ b/crates/holochain/tests/send_signal.rs
@@ -5,8 +5,9 @@ use holochain::sweettest::{
 };
 use holochain_conductor_api::AppResponse;
 use holochain_types::signal::Signal;
+use holochain_types::websocket::AllowedOrigins;
 use holochain_wasm_test_utils::TestWasm;
-use holochain_websocket::WebsocketConfig;
+use holochain_websocket::{ConnectRequest, WebsocketConfig};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn send_signal_after_conductor_restart() {
@@ -28,14 +29,14 @@ async fn send_signal_after_conductor_restart() {
     // add app interface
     let app_interface_port_1 = (*conductor)
         .clone()
-        .add_app_interface(either::Either::Left(0), )
+        .add_app_interface(either::Either::Left(0), AllowedOrigins::Any)
         .await
         .unwrap();
 
     // connect app websocket
     let (_, mut app_ws_rx_1) = holochain_websocket::connect(
-        Arc::new(WebsocketConfig::default()),
-        ([127, 0, 0, 1], app_interface_port_1).into(),
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        ConnectRequest::new(([127, 0, 0, 1], app_interface_port_1).into()),
     )
     .await
     .unwrap();
@@ -95,8 +96,8 @@ async fn send_signal_after_conductor_restart() {
 
     // reconnect app websocket
     let (_, mut app_ws_rx_1) = holochain_websocket::connect(
-        Arc::new(WebsocketConfig::default()),
-        ([127, 0, 0, 1], app_interface_port_1).into(),
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        ConnectRequest::new(([127, 0, 0, 1], app_interface_port_1).into()),
     )
     .await
     .unwrap();
@@ -104,7 +105,7 @@ async fn send_signal_after_conductor_restart() {
     // add a second app interface without websocket connection
     let _ = (*conductor)
         .clone()
-        .add_app_interface(either::Either::Left(0), )
+        .add_app_interface(either::Either::Left(0), AllowedOrigins::Any)
         .await
         .unwrap();
 

--- a/crates/holochain/tests/send_signal.rs
+++ b/crates/holochain/tests/send_signal.rs
@@ -28,7 +28,7 @@ async fn send_signal_after_conductor_restart() {
     // add app interface
     let app_interface_port_1 = (*conductor)
         .clone()
-        .add_app_interface(either::Either::Left(0))
+        .add_app_interface(either::Either::Left(0), )
         .await
         .unwrap();
 
@@ -104,7 +104,7 @@ async fn send_signal_after_conductor_restart() {
     // add a second app interface without websocket connection
     let _ = (*conductor)
         .clone()
-        .add_app_interface(either::Either::Left(0))
+        .add_app_interface(either::Either::Left(0), )
         .await
         .unwrap();
 

--- a/crates/holochain/tests/test_utils/mod.rs
+++ b/crates/holochain/tests/test_utils/mod.rs
@@ -47,6 +47,7 @@ use holochain::{
 };
 use holochain_conductor_api::AppResponse;
 use holochain_types::prelude::*;
+use holochain_types::websocket::AllowedOrigins;
 use holochain_util::tokio_helper;
 
 /// Wrapper that synchronously waits for the Child to terminate on drop.
@@ -160,7 +161,7 @@ pub async fn call_zome_fn<S>(
 }
 
 pub async fn attach_app_interface(client: &mut WebsocketSender, port: Option<u16>) -> u16 {
-    let request = AdminRequest::AttachAppInterface { port };
+    let request = AdminRequest::AttachAppInterface { port, allowed_origins: AllowedOrigins::Any };
     let response = client.request(request);
     let response = check_timeout(response, 3000).await;
     match response {
@@ -335,7 +336,7 @@ pub async fn check_started(holochain: &mut Child) {
 pub fn create_config(port: u16, data_root_path: DataRootPath) -> ConductorConfig {
     ConductorConfig {
         admin_interfaces: Some(vec![AdminInterfaceConfig {
-            driver: InterfaceDriver::Websocket { port },
+            driver: InterfaceDriver::Websocket { port, allowed_origins: AllowedOrigins::Any },
         }]),
         data_root_path: Some(data_root_path),
         keystore: KeystoreConfig::DangerTestKeystore,

--- a/crates/holochain/tests/test_utils/mod.rs
+++ b/crates/holochain/tests/test_utils/mod.rs
@@ -161,7 +161,10 @@ pub async fn call_zome_fn<S>(
 }
 
 pub async fn attach_app_interface(client: &mut WebsocketSender, port: Option<u16>) -> u16 {
-    let request = AdminRequest::AttachAppInterface { port, allowed_origins: AllowedOrigins::Any };
+    let request = AdminRequest::AttachAppInterface {
+        port,
+        allowed_origins: AllowedOrigins::Any,
+    };
     let response = client.request(request);
     let response = check_timeout(response, 3000).await;
     match response {
@@ -336,7 +339,10 @@ pub async fn check_started(holochain: &mut Child) {
 pub fn create_config(port: u16, data_root_path: DataRootPath) -> ConductorConfig {
     ConductorConfig {
         admin_interfaces: Some(vec![AdminInterfaceConfig {
-            driver: InterfaceDriver::Websocket { port, allowed_origins: AllowedOrigins::Any },
+            driver: InterfaceDriver::Websocket {
+                port,
+                allowed_origins: AllowedOrigins::Any,
+            },
         }]),
         data_root_path: Some(data_root_path),
         keystore: KeystoreConfig::DangerTestKeystore,

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -16,6 +16,7 @@ use holochain::{
     fixt::*,
 };
 
+use holochain_conductor_api::{AdminInterfaceConfig, AppRequest, InterfaceDriver};
 use holochain_types::{
     prelude::*,
     test_utils::{fake_dna_zomes, write_fake_dna_file},
@@ -825,4 +826,121 @@ async fn full_state_dump_cursor_works() {
         integrated_ops_count + validation_limbo_ops_count + integration_limbo_ops_count;
 
     assert_eq!(1, new_all_dht_ops_count);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn admin_allowed_origins() {
+    holochain_trace::test_run().ok();
+
+    let conductor = SweetConductor::from_standard_config().await;
+
+    let ports = conductor
+        .clone()
+        .add_admin_interfaces(vec![AdminInterfaceConfig {
+            driver: InterfaceDriver::Websocket {
+                port: 0,
+                allowed_origins: "http://localhost:3000".to_string().into(),
+            },
+        }])
+        .await
+        .unwrap();
+
+    assert!(connect(
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        ConnectRequest::new(([127, 0, 0, 1], *ports.first().unwrap()).into())
+    )
+    .await
+    .is_err());
+
+    let (client, rx) = connect(
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        ConnectRequest::new(([127, 0, 0, 1], *ports.first().unwrap()).into())
+            .try_set_header("origin", "http://localhost:3000")
+            .unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let _rx = PollRecv::new::<AdminResponse>(rx);
+
+    let request = AdminRequest::ListAppInterfaces;
+    let _: AdminResponse = client.request(request).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn app_allowed_origins() {
+    holochain_trace::test_run().ok();
+
+    let conductor = SweetConductor::from_standard_config().await;
+
+    let port = conductor
+        .clone()
+        .add_app_interface(either::Either::Left(0), "http://localhost:3000".to_string().into())
+        .await
+        .unwrap();
+
+    assert!(connect(
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        ConnectRequest::new(([127, 0, 0, 1], port).into())
+    )
+        .await
+        .is_err());
+
+    check_app_port(port, "http://localhost:3000").await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn app_allowed_origins_independence() {
+    holochain_trace::test_run().ok();
+
+    let conductor = SweetConductor::from_standard_config().await;
+
+    let port_1 = conductor
+        .clone()
+        .add_app_interface(either::Either::Left(0), "http://localhost:3001".to_string().into())
+        .await
+        .unwrap();
+
+    let port_2 = conductor
+        .clone()
+        .add_app_interface(either::Either::Left(0), "http://localhost:3002".to_string().into())
+        .await
+        .unwrap();
+
+    // Check that access to another port's origin is blocked
+
+    assert!(connect(
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        ConnectRequest::new(([127, 0, 0, 1], port_1).into()).try_set_header("origin", "http://localhost:3002").unwrap()
+    )
+        .await
+        .is_err());
+
+    assert!(connect(
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        ConnectRequest::new(([127, 0, 0, 1], port_2).into()).try_set_header("origin", "http://localhost:3001").unwrap()
+    )
+        .await
+        .is_err());
+
+    // Check that correct access is allowed
+
+    check_app_port(port_1, "http://localhost:3001").await;
+    check_app_port(port_2, "http://localhost:3002").await;
+}
+
+async fn check_app_port(port: u16, origin: &str) {
+    let (client, rx) = connect(
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        ConnectRequest::new(([127, 0, 0, 1], port).into())
+            .try_set_header("origin", origin)
+            .unwrap(),
+    )
+        .await
+        .unwrap();
+
+    let _rx = PollRecv::new::<AppResponse>(rx);
+
+    let request = AppRequest::ListWasmHostFunctions;
+    let _: AppResponse = client.request(request).await.unwrap();
 }

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -514,12 +514,11 @@ async fn list_app_interfaces_succeeds() -> Result<()> {
     let conductor_handle = Conductor::builder().config(config).build().await?;
     let port = admin_port(&conductor_handle).await;
     info!("building conductor");
-    let (client, rx): (WebsocketSender, WebsocketReceiver) = holochain_websocket::connect(
-        Arc::new(WebsocketConfig {
-            default_request_timeout: std::time::Duration::from_secs(1),
-            ..Default::default()
-        }),
-        ([127, 0, 0, 1], port).into(),
+    let mut ws_config = WebsocketConfig::CLIENT_DEFAULT;
+    ws_config.default_request_timeout = Duration::from_secs(1);
+    let (client, rx): (WebsocketSender, WebsocketReceiver) = connect(
+        Arc::new(ws_config),
+        ConnectRequest::new(([127, 0, 0, 1], port).into()),
     )
     .await?;
     let _rx = PollRecv::new::<AdminResponse>(rx);
@@ -554,12 +553,11 @@ async fn conductor_admin_interface_ends_with_shutdown_inner() -> Result<()> {
     let conductor_handle = Conductor::builder().config(config).build().await?;
     let port = admin_port(&conductor_handle).await;
     info!("building conductor");
+    let mut ws_config = WebsocketConfig::CLIENT_DEFAULT;
+    ws_config.default_request_timeout = Duration::from_secs(1);
     let (client, mut rx): (WebsocketSender, WebsocketReceiver) = holochain_websocket::connect(
-        Arc::new(WebsocketConfig {
-            default_request_timeout: std::time::Duration::from_secs(1),
-            ..Default::default()
-        }),
-        ([127, 0, 0, 1], port).into(),
+        Arc::new(ws_config),
+        ConnectRequest::new(([127, 0, 0, 1], port).into()),
     )
     .await?;
 
@@ -617,7 +615,7 @@ async fn connection_limit_is_respected() {
     let port = admin_port(&conductor_handle).await;
 
     let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
-    let cfg = Arc::new(WebsocketConfig::default());
+    let cfg = Arc::new(WebsocketConfig::CLIENT_DEFAULT);
 
     // Retain handles so that the test can control when to disconnect clients
     let mut handles = Vec::new();

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -875,7 +875,10 @@ async fn app_allowed_origins() {
 
     let port = conductor
         .clone()
-        .add_app_interface(either::Either::Left(0), "http://localhost:3000".to_string().into())
+        .add_app_interface(
+            either::Either::Left(0),
+            "http://localhost:3000".to_string().into(),
+        )
         .await
         .unwrap();
 
@@ -883,8 +886,8 @@ async fn app_allowed_origins() {
         Arc::new(WebsocketConfig::CLIENT_DEFAULT),
         ConnectRequest::new(([127, 0, 0, 1], port).into())
     )
-        .await
-        .is_err());
+    .await
+    .is_err());
 
     check_app_port(port, "http://localhost:3000").await;
 }
@@ -897,13 +900,19 @@ async fn app_allowed_origins_independence() {
 
     let port_1 = conductor
         .clone()
-        .add_app_interface(either::Either::Left(0), "http://localhost:3001".to_string().into())
+        .add_app_interface(
+            either::Either::Left(0),
+            "http://localhost:3001".to_string().into(),
+        )
         .await
         .unwrap();
 
     let port_2 = conductor
         .clone()
-        .add_app_interface(either::Either::Left(0), "http://localhost:3002".to_string().into())
+        .add_app_interface(
+            either::Either::Left(0),
+            "http://localhost:3002".to_string().into(),
+        )
         .await
         .unwrap();
 
@@ -911,17 +920,21 @@ async fn app_allowed_origins_independence() {
 
     assert!(connect(
         Arc::new(WebsocketConfig::CLIENT_DEFAULT),
-        ConnectRequest::new(([127, 0, 0, 1], port_1).into()).try_set_header("origin", "http://localhost:3002").unwrap()
+        ConnectRequest::new(([127, 0, 0, 1], port_1).into())
+            .try_set_header("origin", "http://localhost:3002")
+            .unwrap()
     )
-        .await
-        .is_err());
+    .await
+    .is_err());
 
     assert!(connect(
         Arc::new(WebsocketConfig::CLIENT_DEFAULT),
-        ConnectRequest::new(([127, 0, 0, 1], port_2).into()).try_set_header("origin", "http://localhost:3001").unwrap()
+        ConnectRequest::new(([127, 0, 0, 1], port_2).into())
+            .try_set_header("origin", "http://localhost:3001")
+            .unwrap()
     )
-        .await
-        .is_err());
+    .await
+    .is_err());
 
     // Check that correct access is allowed
 
@@ -936,8 +949,8 @@ async fn check_app_port(port: u16, origin: &str) {
             .try_set_header("origin", origin)
             .unwrap(),
     )
-        .await
-        .unwrap();
+    .await
+    .unwrap();
 
     let _rx = PollRecv::new::<AppResponse>(rx);
 

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -1,5 +1,6 @@
 use holo_hash::*;
 use holochain_types::prelude::*;
+use holochain_types::websocket::AllowedOrigins;
 use holochain_zome_types::cell::CellId;
 use kitsune_p2p_types::agent_info::AgentInfoSigned;
 
@@ -164,10 +165,23 @@ pub enum AdminRequest {
     /// Optionally a `port` parameter can be passed to this request. If it is `None`,
     /// a free port is chosen by the conductor.
     ///
+    /// An `allowed_origins` parameter to control which origins are allowed to connect
+    /// to the app interface.
+    ///
     /// [`AppRequest`]: super::AppRequest
     AttachAppInterface {
         /// Optional port number
         port: Option<u16>,
+
+        /// Allowed origins for this app interface.
+        ///
+        /// This should be one of:
+        /// - A comma separated list of origins - `http://localhost:3000,http://localhost:3001`,
+        /// - A single origin - `http://localhost:3000`,
+        /// - Any origin - `*`
+        ///
+        /// Connections from any origin which is not permitted by this config will be rejected.
+        allowed_origins: AllowedOrigins,
     },
 
     /// List all the app interfaces currently attached with [`AttachAppInterface`].

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -174,11 +174,11 @@ impl Default for ConductorTuningParams {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use holochain_types::websocket::AllowedOrigins;
     use kitsune_p2p_types::config::TransportConfig;
     use matches::assert_matches;
     use std::path::Path;
     use std::path::PathBuf;
-    use holochain_types::websocket::AllowedOrigins;
 
     #[test]
     fn test_config_load_yaml() {
@@ -297,7 +297,10 @@ mod tests {
                 }),
                 keystore: KeystoreConfig::LairServerInProc { lair_root: None },
                 admin_interfaces: Some(vec![AdminInterfaceConfig {
-                    driver: InterfaceDriver::Websocket { port: 1234, allowed_origins: AllowedOrigins::Any }
+                    driver: InterfaceDriver::Websocket {
+                        port: 1234,
+                        allowed_origins: AllowedOrigins::Any
+                    }
                 }]),
                 network: network_config,
                 db_sync_strategy: DbSyncStrategy::Fast,

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -178,6 +178,7 @@ mod tests {
     use matches::assert_matches;
     use std::path::Path;
     use std::path::PathBuf;
+    use holochain_types::websocket::AllowedOrigins;
 
     #[test]
     fn test_config_load_yaml() {
@@ -244,6 +245,7 @@ mod tests {
       - driver:
           type: websocket
           port: 1234
+          allowed_origins: "*"
 
     network:
       bootstrap_service: https://bootstrap-staging.holo.host
@@ -295,7 +297,7 @@ mod tests {
                 }),
                 keystore: KeystoreConfig::LairServerInProc { lair_root: None },
                 admin_interfaces: Some(vec![AdminInterfaceConfig {
-                    driver: InterfaceDriver::Websocket { port: 1234 }
+                    driver: InterfaceDriver::Websocket { port: 1234, allowed_origins: AllowedOrigins::Any }
                 }]),
                 network: network_config,
                 db_sync_strategy: DbSyncStrategy::Fast,

--- a/crates/holochain_conductor_api/src/config/interface.rs
+++ b/crates/holochain_conductor_api/src/config/interface.rs
@@ -7,9 +7,6 @@ pub struct AdminInterfaceConfig {
     /// By what means the interface will be exposed.
     /// Currently the only option is a local websocket running on a configurable port.
     pub driver: InterfaceDriver,
-    // How long will this interface be accessible between authentications?
-    // TODO: implement once we have authentication
-    // _session_duration_seconds: Option<u32>,
 }
 
 /// Configuration for interfaces, specifying the means by which an interface
@@ -28,6 +25,8 @@ pub enum InterfaceDriver {
     Websocket {
         /// The port on which to establish the WebsocketListener
         port: u16,
+
+        allowed_origin: holochain_types::websocket::AllowedOrigin
     },
 }
 
@@ -35,7 +34,7 @@ impl InterfaceDriver {
     /// Get the port for this driver.
     pub fn port(&self) -> u16 {
         match self {
-            InterfaceDriver::Websocket { port } => *port,
+            InterfaceDriver::Websocket { port, .. } => *port,
         }
     }
 }

--- a/crates/holochain_conductor_api/src/config/interface.rs
+++ b/crates/holochain_conductor_api/src/config/interface.rs
@@ -1,6 +1,6 @@
+use holochain_types::websocket::AllowedOrigins;
 use serde::Deserialize;
 use serde::Serialize;
-use holochain_types::websocket::AllowedOrigins;
 
 /// Information neeeded to spawn an admin interface
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq)]
@@ -50,7 +50,9 @@ impl InterfaceDriver {
     /// Get the allowed origins for this driver.
     pub fn allowed_origins(&self) -> &AllowedOrigins {
         match self {
-            InterfaceDriver::Websocket { allowed_origins, .. } => allowed_origins,
+            InterfaceDriver::Websocket {
+                allowed_origins, ..
+            } => allowed_origins,
         }
     }
 }

--- a/crates/holochain_conductor_api/src/config/interface.rs
+++ b/crates/holochain_conductor_api/src/config/interface.rs
@@ -1,5 +1,6 @@
 use serde::Deserialize;
 use serde::Serialize;
+use holochain_types::websocket::AllowedOrigins;
 
 /// Information neeeded to spawn an admin interface
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq)]
@@ -26,7 +27,15 @@ pub enum InterfaceDriver {
         /// The port on which to establish the WebsocketListener
         port: u16,
 
-        allowed_origin: holochain_types::websocket::AllowedOrigin
+        /// Allowed origins for this interface.
+        ///
+        /// This should be one of:
+        /// - A comma separated list of origins - `http://localhost:3000,http://localhost:3001`,
+        /// - A single origin - `http://localhost:3000`,
+        /// - Any origin - `*`
+        ///
+        /// Connections from any origin which is not permitted by this config will be rejected.
+        allowed_origins: AllowedOrigins,
     },
 }
 
@@ -35,6 +44,13 @@ impl InterfaceDriver {
     pub fn port(&self) -> u16 {
         match self {
             InterfaceDriver::Websocket { port, .. } => *port,
+        }
+    }
+
+    /// Get the allowed origins for this driver.
+    pub fn allowed_origins(&self) -> &AllowedOrigins {
+        match self {
+            InterfaceDriver::Websocket { allowed_origins, .. } => allowed_origins,
         }
     }
 }

--- a/crates/holochain_terminal/src/client.rs
+++ b/crates/holochain_terminal/src/client.rs
@@ -4,7 +4,7 @@ use holochain_conductor_api::{
     AdminRequest, AdminResponse, AppInfo, AppRequest, AppResponse, CellInfo, NetworkInfo,
 };
 use holochain_types::prelude::{InstalledAppId, NetworkInfoRequestPayload};
-use holochain_websocket::{connect, WebsocketConfig, WebsocketSender};
+use holochain_websocket::{connect, ConnectRequest, WebsocketConfig, WebsocketSender};
 use std::sync::Arc;
 
 pub struct AppClient {
@@ -21,7 +21,7 @@ impl Drop for AppClient {
 impl AppClient {
     /// Creates a App websocket client which can send messages but ignores any incoming messages
     async fn connect(addr: std::net::SocketAddr) -> anyhow::Result<Self> {
-        let (tx, mut rx) = connect(Arc::new(WebsocketConfig::default()), addr).await?;
+        let (tx, mut rx) = connect(Arc::new(WebsocketConfig::CLIENT_DEFAULT), ConnectRequest::new(addr).try_set_header("origin", "hc_term")?).await?;
 
         let rx = tokio::task::spawn(async move { while rx.recv::<AppResponse>().await.is_ok() {} });
 
@@ -108,7 +108,7 @@ impl Drop for AdminClient {
 impl AdminClient {
     /// Creates an Admin websocket client which can send messages but ignores any incoming messages
     pub async fn connect(addr: std::net::SocketAddr) -> anyhow::Result<Self> {
-        let (tx, mut rx) = connect(Arc::new(WebsocketConfig::default()), addr).await?;
+        let (tx, mut rx) = connect(Arc::new(WebsocketConfig::CLIENT_DEFAULT), addr).await?;
 
         let rx =
             tokio::task::spawn(async move { while rx.recv::<AdminResponse>().await.is_ok() {} });
@@ -139,7 +139,7 @@ impl AdminClient {
     }
 
     async fn attach_app_interface(&mut self, port: u16) -> anyhow::Result<u16> {
-        let msg = AdminRequest::AttachAppInterface { port: Some(port) };
+        let msg = AdminRequest::AttachAppInterface { port: Some(port), allowed_origins: "hc_term".to_string().into() };
         let response = self.send(msg).await?;
         match response {
             AdminResponse::AppInterfaceAttached { port } => Ok(port),

--- a/crates/holochain_terminal/src/client.rs
+++ b/crates/holochain_terminal/src/client.rs
@@ -21,7 +21,11 @@ impl Drop for AppClient {
 impl AppClient {
     /// Creates a App websocket client which can send messages but ignores any incoming messages
     async fn connect(addr: std::net::SocketAddr) -> anyhow::Result<Self> {
-        let (tx, mut rx) = connect(Arc::new(WebsocketConfig::CLIENT_DEFAULT), ConnectRequest::new(addr).try_set_header("origin", "hc_term")?).await?;
+        let (tx, mut rx) = connect(
+            Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+            ConnectRequest::new(addr).try_set_header("origin", "hcterm")?,
+        )
+        .await?;
 
         let rx = tokio::task::spawn(async move { while rx.recv::<AppResponse>().await.is_ok() {} });
 
@@ -139,7 +143,10 @@ impl AdminClient {
     }
 
     async fn attach_app_interface(&mut self, port: u16) -> anyhow::Result<u16> {
-        let msg = AdminRequest::AttachAppInterface { port: Some(port), allowed_origins: "hc_term".to_string().into() };
+        let msg = AdminRequest::AttachAppInterface {
+            port: Some(port),
+            allowed_origins: "hcterm".to_string().into(),
+        };
         let response = self.send(msg).await?;
         match response {
             AdminResponse::AppInterfaceAttached { port } => Ok(port),

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Added `AllowedOrigins` which is intended to be used with `holochain_websocket` for controlling access. It is placed here
+  for crates need to know about origins but don't depend on `holochain_websocket`.
+
 ## 0.3.0-beta-dev.37
 
 ## 0.3.0-beta-dev.36

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## \[Unreleased\]
 
 - Added `AllowedOrigins` which is intended to be used with `holochain_websocket` for controlling access. It is placed here
-  for crates need to know about origins but don't depend on `holochain_websocket`.
+  for crates need to know about origins but don't depend on `holochain_websocket`. [#3460](https://github.com/holochain/holochain/pull/3460)
 
 ## 0.3.0-beta-dev.37
 

--- a/crates/holochain_types/src/lib.rs
+++ b/crates/holochain_types/src/lib.rs
@@ -49,5 +49,6 @@ pub mod facts;
 pub mod inline_zome;
 #[cfg(feature = "test_utils")]
 pub mod test_utils;
+pub mod websocket;
 
 pub use holochain_zome_types::entry::EntryHashed;

--- a/crates/holochain_types/src/websocket.rs
+++ b/crates/holochain_types/src/websocket.rs
@@ -1,8 +1,8 @@
 //! Common types for WebSocket connections.
 
-use std::collections::HashSet;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 
 /// Access control for controlling WebSocket connections from browsers.
 /// Anywhere other than a browser can set the `Origin` header to any value, so this is only relevant for browser connections.
@@ -13,7 +13,7 @@ pub enum AllowedOrigins {
     /// Allow access from any origin.
     Any,
     /// Allow access from a specific origin.
-    Origins(HashSet<String>)
+    Origins(HashSet<String>),
 }
 
 impl Serialize for AllowedOrigins {
@@ -49,9 +49,7 @@ impl From<String> for AllowedOrigins {
     fn from(value: String) -> AllowedOrigins {
         match value.as_str() {
             "*" => AllowedOrigins::Any,
-            _ => {
-                AllowedOrigins::Origins(value.split(",").map(|s| s.trim().to_string()).collect())
-            },
+            _ => AllowedOrigins::Origins(value.split(',').map(|s| s.trim().to_string()).collect()),
         }
     }
 }
@@ -89,7 +87,8 @@ mod tests {
 
     #[test]
     fn single_origin_to_and_from_string() {
-        let allowed_origins = AllowedOrigins::Origins(["http://example.com".to_string()].iter().cloned().collect());
+        let allowed_origins =
+            AllowedOrigins::Origins(["http://example.com".to_string()].iter().cloned().collect());
         let str: String = allowed_origins.clone().into();
         let allowed_origins_2 = str.clone().into();
 
@@ -99,7 +98,15 @@ mod tests {
 
     #[test]
     fn multiple_origins_to_and_from_string() {
-        let allowed_origins = AllowedOrigins::Origins(["http://example1.com".to_string(), "http://example2.com".to_string()].iter().cloned().collect());
+        let allowed_origins = AllowedOrigins::Origins(
+            [
+                "http://example1.com".to_string(),
+                "http://example2.com".to_string(),
+            ]
+            .iter()
+            .cloned()
+            .collect(),
+        );
         let str: String = allowed_origins.clone().into();
         let allowed_origins_2 = str.into();
 
@@ -114,13 +121,15 @@ mod tests {
 
     #[test]
     fn specific_origin_is_allowed() {
-        let allowed_origins = AllowedOrigins::Origins(["http://example.com".to_string()].iter().cloned().collect());
+        let allowed_origins =
+            AllowedOrigins::Origins(["http://example.com".to_string()].iter().cloned().collect());
         assert!(allowed_origins.is_allowed("http://example.com"));
     }
 
     #[test]
     fn other_origin_is_not_allowed() {
-        let allowed_origins = AllowedOrigins::Origins(["http://example.com".to_string()].iter().cloned().collect());
+        let allowed_origins =
+            AllowedOrigins::Origins(["http://example.com".to_string()].iter().cloned().collect());
         assert!(!allowed_origins.is_allowed("http://example2.com"));
     }
 
@@ -136,7 +145,15 @@ mod tests {
 
     #[test]
     fn serialize_deserialize() {
-        let allowed_origins = AllowedOrigins::Origins(["http://example1.com".to_string(), "http://example2.com".to_string()].iter().cloned().collect());
+        let allowed_origins = AllowedOrigins::Origins(
+            [
+                "http://example1.com".to_string(),
+                "http://example2.com".to_string(),
+            ]
+            .iter()
+            .cloned()
+            .collect(),
+        );
         let serialized = serde_json::to_string(&allowed_origins).unwrap();
         let deserialized: AllowedOrigins = serde_json::from_str(&serialized).unwrap();
         assert_eq!(allowed_origins, deserialized);

--- a/crates/holochain_types/src/websocket.rs
+++ b/crates/holochain_types/src/websocket.rs
@@ -9,14 +9,14 @@ use serde::{Deserialize, Serialize};
 ///
 /// See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) for more information.
 #[derive(Clone, Debug, PartialEq)]
-pub enum AllowedOrigin {
+pub enum AllowedOrigins {
     /// Allow access from any origin.
     Any,
     /// Allow access from a specific origin.
     Origins(HashSet<String>)
 }
 
-impl Serialize for AllowedOrigin {
+impl Serialize for AllowedOrigins {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -26,8 +26,8 @@ impl Serialize for AllowedOrigin {
     }
 }
 
-impl<'de> Deserialize<'de> for AllowedOrigin {
-    fn deserialize<D>(deserializer: D) -> Result<AllowedOrigin, D::Error>
+impl<'de> Deserialize<'de> for AllowedOrigins {
+    fn deserialize<D>(deserializer: D) -> Result<AllowedOrigins, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
@@ -36,32 +36,39 @@ impl<'de> Deserialize<'de> for AllowedOrigin {
     }
 }
 
-impl From<AllowedOrigin> for String {
-    fn from(value: AllowedOrigin) -> String {
+impl From<AllowedOrigins> for String {
+    fn from(value: AllowedOrigins) -> String {
         match value {
-            AllowedOrigin::Any => "*".to_string(),
-            AllowedOrigin::Origins(origin) => origin.into_iter().join(","),
+            AllowedOrigins::Any => "*".to_string(),
+            AllowedOrigins::Origins(origin) => origin.into_iter().join(","),
         }
     }
 }
 
-impl From<String> for AllowedOrigin {
-    fn from(value: String) -> AllowedOrigin {
+impl From<String> for AllowedOrigins {
+    fn from(value: String) -> AllowedOrigins {
         match value.as_str() {
-            "*" => AllowedOrigin::Any,
+            "*" => AllowedOrigins::Any,
             _ => {
-                AllowedOrigin::Origins(value.split(",").map(|s| s.trim().to_string()).collect())
+                AllowedOrigins::Origins(value.split(",").map(|s| s.trim().to_string()).collect())
             },
         }
     }
 }
 
-impl AllowedOrigin {
+impl std::fmt::Display for AllowedOrigins {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str: String = self.clone().into();
+        write!(f, "{}", str)
+    }
+}
+
+impl AllowedOrigins {
     /// Check if the `Origin` header value is allowed.
     pub fn is_allowed(&self, origin: &str) -> bool {
         match self {
-            AllowedOrigin::Any => true,
-            AllowedOrigin::Origins(allowed) => allowed.contains(origin),
+            AllowedOrigins::Any => true,
+            AllowedOrigins::Origins(allowed) => allowed.contains(origin),
         }
     }
 }

--- a/crates/holochain_types/src/websocket.rs
+++ b/crates/holochain_types/src/websocket.rs
@@ -72,3 +72,73 @@ impl AllowedOrigins {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::AllowedOrigins;
+
+    #[test]
+    fn any_origin_to_and_from_string() {
+        let allowed_origins = AllowedOrigins::Any;
+        let str: String = allowed_origins.clone().into();
+        let allowed_origins_2 = str.clone().into();
+
+        assert_eq!("*".to_string(), str);
+        assert_eq!(allowed_origins, allowed_origins_2);
+    }
+
+    #[test]
+    fn single_origin_to_and_from_string() {
+        let allowed_origins = AllowedOrigins::Origins(["http://example.com".to_string()].iter().cloned().collect());
+        let str: String = allowed_origins.clone().into();
+        let allowed_origins_2 = str.clone().into();
+
+        assert_eq!("http://example.com".to_string(), str);
+        assert_eq!(allowed_origins, allowed_origins_2);
+    }
+
+    #[test]
+    fn multiple_origins_to_and_from_string() {
+        let allowed_origins = AllowedOrigins::Origins(["http://example1.com".to_string(), "http://example2.com".to_string()].iter().cloned().collect());
+        let str: String = allowed_origins.clone().into();
+        let allowed_origins_2 = str.into();
+
+        assert_eq!(allowed_origins, allowed_origins_2);
+    }
+
+    #[test]
+    fn any_origin_is_allowed() {
+        let allowed_origins = AllowedOrigins::Any;
+        assert!(allowed_origins.is_allowed("http://example.com"));
+    }
+
+    #[test]
+    fn specific_origin_is_allowed() {
+        let allowed_origins = AllowedOrigins::Origins(["http://example.com".to_string()].iter().cloned().collect());
+        assert!(allowed_origins.is_allowed("http://example.com"));
+    }
+
+    #[test]
+    fn other_origin_is_not_allowed() {
+        let allowed_origins = AllowedOrigins::Origins(["http://example.com".to_string()].iter().cloned().collect());
+        assert!(!allowed_origins.is_allowed("http://example2.com"));
+    }
+
+    #[test]
+    fn multiple_origins_ignores_whitespace() {
+        let str = " http://example1.com , http://example2.com,\thttp://example3.com\n";
+
+        let origins = AllowedOrigins::from(str.to_string());
+        assert!(origins.is_allowed("http://example1.com"));
+        assert!(origins.is_allowed("http://example2.com"));
+        assert!(origins.is_allowed("http://example3.com"));
+    }
+
+    #[test]
+    fn serialize_deserialize() {
+        let allowed_origins = AllowedOrigins::Origins(["http://example1.com".to_string(), "http://example2.com".to_string()].iter().cloned().collect());
+        let serialized = serde_json::to_string(&allowed_origins).unwrap();
+        let deserialized: AllowedOrigins = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(allowed_origins, deserialized);
+    }
+}

--- a/crates/holochain_types/src/websocket.rs
+++ b/crates/holochain_types/src/websocket.rs
@@ -1,0 +1,63 @@
+//! Common types for WebSocket connections.
+
+use serde::{Deserialize, Serialize};
+
+/// Access control for controlling WebSocket connections from browsers.
+/// Anywhere other than a browser can set the `Origin` header to any value, so this is only relevant for browser connections.
+///
+/// See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin) for more information.
+#[derive(Clone, Debug, PartialEq)]
+pub enum AllowedOrigin {
+    /// Allow access from any origin.
+    Any,
+    /// Allow access from a specific origin.
+    Origin(String)
+}
+
+impl Serialize for AllowedOrigin {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let str: String = self.clone().into();
+        serializer.serialize_str(&str)
+    }
+}
+
+impl<'de> Deserialize<'de> for AllowedOrigin {
+    fn deserialize<D>(deserializer: D) -> Result<AllowedOrigin, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(s.into())
+    }
+}
+
+impl From<AllowedOrigin> for String {
+    fn from(value: AllowedOrigin) -> String {
+        match value {
+            AllowedOrigin::Any => "*".to_string(),
+            AllowedOrigin::Origin(origin) => origin.to_string(),
+        }
+    }
+}
+
+impl From<String> for AllowedOrigin {
+    fn from(value: String) -> AllowedOrigin {
+        match value.as_str() {
+            "*" => AllowedOrigin::Any,
+            _ => AllowedOrigin::Origin(value),
+        }
+    }
+}
+
+impl AllowedOrigin {
+    /// Check if the `Origin` header value is allowed.
+    pub fn is_allowed(&self, origin: &str) -> bool {
+        match self {
+            AllowedOrigin::Any => true,
+            AllowedOrigin::Origin(allowed) => origin == *allowed,
+        }
+    }
+}

--- a/crates/holochain_websocket/CHANGELOG.md
+++ b/crates/holochain_websocket/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- `WebsocketListener` now requires an `allowed_origins` configuration to be provided. When connecting to the websocket
+  a matching origin must be specified in the connection request `Origin` header.
+
 ## 0.3.0-beta-dev.16
 
 ## 0.3.0-beta-dev.15

--- a/crates/holochain_websocket/CHANGELOG.md
+++ b/crates/holochain_websocket/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## \[Unreleased\]
 
 - `WebsocketListener` now requires an `allowed_origins` configuration to be provided. When connecting to the websocket
-  a matching origin must be specified in the connection request `Origin` header.
+  a matching origin must be specified in the connection request `Origin` header. [#3460](https://github.com/holochain/holochain/pull/3460)
 
 ## 0.3.0-beta-dev.16
 

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 [dependencies]
 futures = { workspace = true }
 holochain_serialized_bytes = { workspace = true }
+holochain_types = { version = "0.3.0-beta-dev.36", path = "../holochain_types" }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 tokio = { workspace = true }

--- a/crates/holochain_websocket/src/lib.rs
+++ b/crates/holochain_websocket/src/lib.rs
@@ -761,7 +761,10 @@ impl Callback for ConnectCallback {
                 }
             }
             None => {
-                tracing::warn!("Rejecting websocket connection request with missing `Origin` header: {:?}", request);
+                tracing::warn!(
+                    "Rejecting websocket connection request with missing `Origin` header: {:?}",
+                    request
+                );
                 let mut err_response =
                     ErrorResponse::new(Some("Missing `Origin` header".to_string()));
                 *err_response.status_mut() = StatusCode::BAD_REQUEST;

--- a/crates/holochain_websocket/src/lib.rs
+++ b/crates/holochain_websocket/src/lib.rs
@@ -738,6 +738,7 @@ impl Callback for ConnectCallback {
                 if self.allowed_origin.is_allowed(origin) {
                     Ok(response)
                 } else {
+                    tracing::warn!("Rejecting websocket connection request with disallowed `Origin` header: {:?}", request);
                     let allowed_origin: String = self.allowed_origin.as_ref().clone().into();
                     match HeaderValue::from_str(&allowed_origin) {
                         Ok(allowed_origin) => {
@@ -760,6 +761,7 @@ impl Callback for ConnectCallback {
                 }
             }
             None => {
+                tracing::warn!("Rejecting websocket connection request with missing `Origin` header: {:?}", request);
                 let mut err_response =
                     ErrorResponse::new(Some("Missing `Origin` header".to_string()));
                 *err_response.status_mut() = StatusCode::BAD_REQUEST;

--- a/crates/holochain_websocket/src/test.rs
+++ b/crates/holochain_websocket/src/test.rs
@@ -14,7 +14,7 @@ async fn sanity() {
     let (addr_s, addr_r) = tokio::sync::oneshot::channel();
 
     let l_task = tokio::task::spawn(async move {
-        let l = WebsocketListener::bind(Arc::new(WebsocketConfig::default()), "localhost:0")
+        let l = WebsocketListener::bind(Arc::new(WebsocketConfig::LISTENER_DEFAULT), "localhost:0")
             .await
             .unwrap();
 
@@ -43,7 +43,7 @@ async fn sanity() {
     println!("addr: {}", addr);
 
     let r_task = tokio::task::spawn(async move {
-        let (send, mut recv) = connect(Arc::new(WebsocketConfig::default()), addr)
+        let (send, mut recv) = connect(Arc::new(WebsocketConfig::CLIENT_DEFAULT), addr)
             .await
             .unwrap();
 
@@ -66,4 +66,102 @@ async fn sanity() {
 
     l_task.await.unwrap();
     r_task.await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn blocks_connect_with_mismatched_origin() {
+    holochain_trace::test_run().unwrap();
+
+    let (addr_s, addr_r) = tokio::sync::oneshot::channel();
+
+    let l_task = tokio::task::spawn(async move {
+        let mut config = WebsocketConfig::LISTENER_DEFAULT;
+        config.allowed_origins = Some(AllowedOrigins::Origins(["http://example.com".to_string()].into_iter().collect()));
+
+        let l = WebsocketListener::bind(Arc::new(config), "localhost:0")
+            .await
+            .unwrap();
+
+        let addr = l.local_addr().unwrap();
+        addr_s.send(addr).unwrap();
+
+        match l.accept().await {
+            Ok(_) => panic!("should not have accepted"),
+            Err(e) => {
+                assert_eq!(e.to_string(), "HTTP error: 400 Bad Request");
+            }
+        }
+    });
+
+    let addr = addr_r.await.unwrap();
+
+    let r_task = tokio::task::spawn(async move {
+        match connect(Arc::new(WebsocketConfig::CLIENT_DEFAULT), ConnectRequest::new(addr).try_set_header("Origin", "http://other.org").unwrap())
+            .await {
+                Ok(_) => panic!("should not have connected"),
+                Err(e) => {
+                    assert_eq!(e.to_string(), "HTTP error: 400 Bad Request");
+                }
+            }
+    });
+
+    l_task.await.unwrap();
+    r_task.await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn blocks_connect_without_origin() {
+    holochain_trace::test_run().unwrap();
+
+    let (addr_s, addr_r) = tokio::sync::oneshot::channel();
+
+    let l_task = tokio::task::spawn(async move {
+        let mut config = WebsocketConfig::LISTENER_DEFAULT;
+        config.allowed_origins = Some(AllowedOrigins::Origins(["http://example.com".to_string()].into_iter().collect()));
+
+        let l = WebsocketListener::bind(Arc::new(config), "localhost:0")
+            .await
+            .unwrap();
+
+        let addr = l.local_addr().unwrap();
+        addr_s.send(addr).unwrap();
+
+        match l.accept().await {
+            Ok(_) => panic!("should not have accepted"),
+            Err(e) => {
+                assert_eq!(e.to_string(), "HTTP error: 400 Bad Request");
+            }
+        }
+    });
+
+    let addr = addr_r.await.unwrap();
+
+    let r_task = tokio::task::spawn(async move {
+        match connect(Arc::new(WebsocketConfig::CLIENT_DEFAULT), ConnectRequest::new(addr).clear_headers())
+            .await {
+            Ok(_) => panic!("should not have connected"),
+            Err(e) => {
+                assert_eq!(e.to_string(), "HTTP error: 400 Bad Request");
+            }
+        }
+    });
+
+    l_task.await.unwrap();
+    r_task.await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn origin_is_required_on_listener() {
+    holochain_trace::test_run().unwrap();
+
+    let mut config = WebsocketConfig::LISTENER_DEFAULT;
+    config.allowed_origins = None;
+
+    match WebsocketListener::bind(Arc::new(config), "localhost:0")
+        .await {
+        Ok(_) => panic!("should have prevented bind"),
+        Err(e) => {
+            assert_eq!(e.to_string(), "WebsocketListener requires access control to be set in the config");
+        }
+    }
 }

--- a/crates/holochain_websocket/src/test.rs
+++ b/crates/holochain_websocket/src/test.rs
@@ -76,7 +76,9 @@ async fn blocks_connect_with_mismatched_origin() {
 
     let l_task = tokio::task::spawn(async move {
         let mut config = WebsocketConfig::LISTENER_DEFAULT;
-        config.allowed_origins = Some(AllowedOrigins::Origins(["http://example.com".to_string()].into_iter().collect()));
+        config.allowed_origins = Some(AllowedOrigins::Origins(
+            ["http://example.com".to_string()].into_iter().collect(),
+        ));
 
         let l = WebsocketListener::bind(Arc::new(config), "localhost:0")
             .await
@@ -96,13 +98,19 @@ async fn blocks_connect_with_mismatched_origin() {
     let addr = addr_r.await.unwrap();
 
     let r_task = tokio::task::spawn(async move {
-        match connect(Arc::new(WebsocketConfig::CLIENT_DEFAULT), ConnectRequest::new(addr).try_set_header("Origin", "http://other.org").unwrap())
-            .await {
-                Ok(_) => panic!("should not have connected"),
-                Err(e) => {
-                    assert_eq!(e.to_string(), "HTTP error: 400 Bad Request");
-                }
+        match connect(
+            Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+            ConnectRequest::new(addr)
+                .try_set_header("Origin", "http://other.org")
+                .unwrap(),
+        )
+        .await
+        {
+            Ok(_) => panic!("should not have connected"),
+            Err(e) => {
+                assert_eq!(e.to_string(), "HTTP error: 400 Bad Request");
             }
+        }
     });
 
     l_task.await.unwrap();
@@ -117,7 +125,9 @@ async fn blocks_connect_without_origin() {
 
     let l_task = tokio::task::spawn(async move {
         let mut config = WebsocketConfig::LISTENER_DEFAULT;
-        config.allowed_origins = Some(AllowedOrigins::Origins(["http://example.com".to_string()].into_iter().collect()));
+        config.allowed_origins = Some(AllowedOrigins::Origins(
+            ["http://example.com".to_string()].into_iter().collect(),
+        ));
 
         let l = WebsocketListener::bind(Arc::new(config), "localhost:0")
             .await
@@ -137,8 +147,12 @@ async fn blocks_connect_without_origin() {
     let addr = addr_r.await.unwrap();
 
     let r_task = tokio::task::spawn(async move {
-        match connect(Arc::new(WebsocketConfig::CLIENT_DEFAULT), ConnectRequest::new(addr).clear_headers())
-            .await {
+        match connect(
+            Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+            ConnectRequest::new(addr).clear_headers(),
+        )
+        .await
+        {
             Ok(_) => panic!("should not have connected"),
             Err(e) => {
                 assert_eq!(e.to_string(), "HTTP error: 400 Bad Request");
@@ -157,11 +171,13 @@ async fn origin_is_required_on_listener() {
     let mut config = WebsocketConfig::LISTENER_DEFAULT;
     config.allowed_origins = None;
 
-    match WebsocketListener::bind(Arc::new(config), "localhost:0")
-        .await {
+    match WebsocketListener::bind(Arc::new(config), "localhost:0").await {
         Ok(_) => panic!("should have prevented bind"),
         Err(e) => {
-            assert_eq!(e.to_string(), "WebsocketListener requires access control to be set in the config");
+            assert_eq!(
+                e.to_string(),
+                "WebsocketListener requires access control to be set in the config"
+            );
         }
     }
 }


### PR DESCRIPTION
### Summary

Proposed as a (partial) solution for #3437

By restricting what origins the websockets are available from we can prevent both random websites and other webapps running in Tauri/electron from accessing the admin ports. With the app ports this lets a framework like the launcher tune the access for app interfaces down to a single app.

This is not a complete security solution because it relies on browsers setting the Origin. That is good for stopping scripts in browsers accessing Holochain but it doesn't stop other software from connecting.

I think it is still a useful measure to employ. For one motivating benefit, it prevents random webapps from repeatedly attempting authentication with the admin websocket because a connection cannot be established when this feature is configured.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
