### PR TITLE
Consistency waiting macro for easier errors

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - BREAKING: Split the authored database by author. It was previous partitioned by DNA only and each agent that shared a DB because they were running the same DNA would have to share the write lock.
   This is a pretty serious bottleneck when the same app is being run for multiple agents on the same conductor. They are now separate files on disk and writes can proceed independently.
   There is no migration path for this change, if you have existing databases they will not be found. [#3450](https://github.com/holochain/holochain/pull/3450)
+- `consistency_10s` and `consistency_60s` from `holochain::sweettest` are deprecated. Use `await_consistency` instead.
 
 ## 0.3.0-beta-dev.42
 

--- a/crates/holochain/benches/consistency.rs
+++ b/crates/holochain/benches/consistency.rs
@@ -45,7 +45,8 @@ fn consistency(bench: &mut Criterion) {
                 num_tries,
                 std::time::Duration::from_millis(500),
             )
-            .await;
+            .await
+            .unwrap();
             // holochain_state::prelude::dump_tmp(consumer.cell.env());
         });
     }
@@ -145,7 +146,8 @@ impl Consumer {
                         1,
                         std::time::Duration::from_millis(10),
                     )
-                    .await;
+                    .await
+                    .unwrap();
                 }
             }
             // dump_tmp(self.cell.env());

--- a/crates/holochain/src/conductor/cell/gossip_test.rs
+++ b/crates/holochain/src/conductor/cell/gossip_test.rs
@@ -25,7 +25,7 @@ async fn gossip_test() {
         .call(&cell_1.zome(TestWasm::Anchor), "anchor", anchor)
         .await;
 
-    consistency!(60, [&cell_1, &cell_2]);
+    await_consistency!(60, [&cell_1, &cell_2]);
 
     let hashes: EntryHashes = conductors[1]
         .call(
@@ -81,7 +81,7 @@ async fn agent_info_test() {
         })
         .collect();
 
-    consistency!(10, [&cell_1, &cell_2]);
+    await_consistency!(10, [&cell_1, &cell_2]);
     for p2p_agents_db in p2p_agents_dbs {
         let len = p2p_agents_db.p2p_count_agents().await.unwrap();
         assert_eq!(len, 2);

--- a/crates/holochain/src/conductor/cell/gossip_test.rs
+++ b/crates/holochain/src/conductor/cell/gossip_test.rs
@@ -25,7 +25,7 @@ async fn gossip_test() {
         .call(&cell_1.zome(TestWasm::Anchor), "anchor", anchor)
         .await;
 
-    consistency_60s([&cell_1, &cell_2]).await;
+    consistency_60s([&cell_1, &cell_2]).await.unwrap();
 
     let hashes: EntryHashes = conductors[1]
         .call(
@@ -81,7 +81,7 @@ async fn agent_info_test() {
         })
         .collect();
 
-    consistency_10s([&cell_1, &cell_2]).await;
+    consistency_10s([&cell_1, &cell_2]).await.unwrap();
     for p2p_agents_db in p2p_agents_dbs {
         let len = p2p_agents_db.p2p_count_agents().await.unwrap();
         assert_eq!(len, 2);

--- a/crates/holochain/src/conductor/cell/gossip_test.rs
+++ b/crates/holochain/src/conductor/cell/gossip_test.rs
@@ -25,7 +25,7 @@ async fn gossip_test() {
         .call(&cell_1.zome(TestWasm::Anchor), "anchor", anchor)
         .await;
 
-    consistency_60s([&cell_1, &cell_2]).await.unwrap();
+    consistency!(60, [&cell_1, &cell_2]).await.unwrap();
 
     let hashes: EntryHashes = conductors[1]
         .call(
@@ -81,7 +81,7 @@ async fn agent_info_test() {
         })
         .collect();
 
-    consistency_10s([&cell_1, &cell_2]).await.unwrap();
+    consistency!(10, [&cell_1, &cell_2]).await.unwrap();
     for p2p_agents_db in p2p_agents_dbs {
         let len = p2p_agents_db.p2p_count_agents().await.unwrap();
         assert_eq!(len, 2);

--- a/crates/holochain/src/conductor/cell/gossip_test.rs
+++ b/crates/holochain/src/conductor/cell/gossip_test.rs
@@ -25,7 +25,7 @@ async fn gossip_test() {
         .call(&cell_1.zome(TestWasm::Anchor), "anchor", anchor)
         .await;
 
-    consistency!(60, [&cell_1, &cell_2]).await.unwrap();
+    consistency!(60, [&cell_1, &cell_2]);
 
     let hashes: EntryHashes = conductors[1]
         .call(
@@ -81,7 +81,7 @@ async fn agent_info_test() {
         })
         .collect();
 
-    consistency!(10, [&cell_1, &cell_2]).await.unwrap();
+    consistency!(10, [&cell_1, &cell_2]);
     for p2p_agents_db in p2p_agents_dbs {
         let len = p2p_agents_db.p2p_count_agents().await.unwrap();
         assert_eq!(len, 2);

--- a/crates/holochain/src/conductor/cell/gossip_test.rs
+++ b/crates/holochain/src/conductor/cell/gossip_test.rs
@@ -24,7 +24,7 @@ async fn gossip_test() {
         .call(&cell_1.zome(TestWasm::Anchor), "anchor", anchor)
         .await;
 
-    await_consistency!(60, [&cell_1, &cell_2]);
+    await_consistency(60, [&cell_1, &cell_2]).await.unwrap();
 
     let hashes: EntryHashes = conductors[1]
         .call(
@@ -80,7 +80,7 @@ async fn agent_info_test() {
         })
         .collect();
 
-    await_consistency!(10, [&cell_1, &cell_2]);
+    await_consistency(10, [&cell_1, &cell_2]).await.unwrap();
     for p2p_agents_db in p2p_agents_dbs {
         let len = p2p_agents_db.p2p_count_agents().await.unwrap();
         assert_eq!(len, 2);

--- a/crates/holochain/src/conductor/cell/gossip_test.rs
+++ b/crates/holochain/src/conductor/cell/gossip_test.rs
@@ -1,6 +1,5 @@
 use crate::sweettest::*;
 use crate::test_utils::inline_zomes::simple_create_read_zome;
-use crate::test_utils::{consistency_10s, consistency_60s};
 use hdk::prelude::*;
 use holochain_conductor_api::conductor::ConductorConfig;
 use holochain_sqlite::store::AsP2pStateReadExt;

--- a/crates/holochain/src/conductor/tests/network_info.rs
+++ b/crates/holochain/src/conductor/tests/network_info.rs
@@ -54,7 +54,7 @@ async fn network_info() {
     );
     let _: ActionHash = conductors[0].call(&zome, "create_entry", ()).await;
 
-    consistency_10s(&cells).await;
+    consistency_10s(&cells).await.unwrap();
 
     // wait_for_integration(
     //     &conductors[1].get_dht_db(dna.dna_hash()).unwrap(),

--- a/crates/holochain/src/conductor/tests/network_info.rs
+++ b/crates/holochain/src/conductor/tests/network_info.rs
@@ -3,7 +3,7 @@ use holochain_types::prelude::{InstalledAppId, NetworkInfoRequestPayload};
 use holochain_wasm_test_utils::TestWasm;
 use holochain_zome_types::prelude::Timestamp;
 
-use crate::sweettest::{consistency_10s, SweetConductorBatch, SweetDnaFile, SweetZome};
+use crate::sweettest::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn network_info() {
@@ -54,7 +54,7 @@ async fn network_info() {
     );
     let _: ActionHash = conductors[0].call(&zome, "create_entry", ()).await;
 
-    consistency!(10, &cells);
+    await_consistency!(10, &cells);
 
     // wait_for_integration(
     //     &conductors[1].get_dht_db(dna.dna_hash()).unwrap(),

--- a/crates/holochain/src/conductor/tests/network_info.rs
+++ b/crates/holochain/src/conductor/tests/network_info.rs
@@ -54,7 +54,7 @@ async fn network_info() {
     );
     let _: ActionHash = conductors[0].call(&zome, "create_entry", ()).await;
 
-    await_consistency!(10, &cells);
+    await_consistency(10, &cells).await.unwrap();
 
     // wait_for_integration(
     //     &conductors[1].get_dht_db(dna.dna_hash()).unwrap(),

--- a/crates/holochain/src/conductor/tests/network_info.rs
+++ b/crates/holochain/src/conductor/tests/network_info.rs
@@ -54,7 +54,7 @@ async fn network_info() {
     );
     let _: ActionHash = conductors[0].call(&zome, "create_entry", ()).await;
 
-    consistency_10s(&cells).await.unwrap();
+    consistency!(10, &cells).await.unwrap();
 
     // wait_for_integration(
     //     &conductors[1].get_dht_db(dna.dna_hash()).unwrap(),

--- a/crates/holochain/src/conductor/tests/network_info.rs
+++ b/crates/holochain/src/conductor/tests/network_info.rs
@@ -54,7 +54,7 @@ async fn network_info() {
     );
     let _: ActionHash = conductors[0].call(&zome, "create_entry", ()).await;
 
-    consistency!(10, &cells).await.unwrap();
+    consistency!(10, &cells);
 
     // wait_for_integration(
     //     &conductors[1].get_dht_db(dna.dna_hash()).unwrap(),

--- a/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
@@ -795,7 +795,9 @@ pub mod wasm_test {
             )
             .await;
 
-        await_consistency!(10, [&alice_cell, &bob_cell]);
+        await_consistency(10, [&alice_cell, &bob_cell])
+            .await
+            .unwrap();
 
         assert_eq!(alice_activity.valid_activity.len(), 7);
         assert_eq!(
@@ -1104,7 +1106,9 @@ pub mod wasm_test {
             )
             .await;
 
-        await_consistency!(10, [&alice_cell, &bob_cell]);
+        await_consistency(10, [&alice_cell, &bob_cell])
+            .await
+            .unwrap();
 
         assert_eq!(alice_activity.valid_activity.len(), 8);
         assert_eq!(
@@ -1262,7 +1266,9 @@ pub mod wasm_test {
             )
             .await;
 
-        await_consistency!(10, [&alice_cell, &bob_cell]);
+        await_consistency(10, [&alice_cell, &bob_cell])
+            .await
+            .unwrap();
 
         // Now the action appears in alice's activty.
         let alice_activity: AgentActivity = conductor
@@ -1332,7 +1338,9 @@ pub mod wasm_test {
 
         // NON ENZYMATIC
         {
-            await_consistency!(10, [&alice_cell, &bob_cell, &carol_cell]);
+            await_consistency(10, [&alice_cell, &bob_cell, &carol_cell])
+                .await
+                .unwrap();
 
             // The countersigned entry does NOT appear in alice's activity yet.
             let alice_activity_pre: AgentActivity = bob_conductor
@@ -1402,7 +1410,9 @@ pub mod wasm_test {
                     unreachable!();
                 };
 
-            await_consistency!(10, [&alice_cell, &bob_cell, &carol_cell]);
+            await_consistency(10, [&alice_cell, &bob_cell, &carol_cell])
+                .await
+                .unwrap();
 
             // Alice commits the action.
             let _countersigned_action_hash_alice: ActionHash = alice_conductor
@@ -1422,7 +1432,9 @@ pub mod wasm_test {
                 )
                 .await;
 
-            await_consistency!(10, [&alice_cell, &bob_cell, &carol_cell]);
+            await_consistency(10, [&alice_cell, &bob_cell, &carol_cell])
+                .await
+                .unwrap();
 
             // Now the action appears in alice's activty.
             let alice_activity: AgentActivity = bob_conductor

--- a/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
@@ -797,7 +797,7 @@ pub mod wasm_test {
             )
             .await;
 
-        consistency_10s([&alice_cell, &bob_cell]).await.unwrap();
+        consistency!(10, [&alice_cell, &bob_cell]).await.unwrap();
 
         assert_eq!(alice_activity.valid_activity.len(), 7);
         assert_eq!(
@@ -1106,7 +1106,7 @@ pub mod wasm_test {
             )
             .await;
 
-        consistency_10s([&alice_cell, &bob_cell]).await.unwrap();
+        consistency!(10, [&alice_cell, &bob_cell]).await.unwrap();
 
         assert_eq!(alice_activity.valid_activity.len(), 8);
         assert_eq!(
@@ -1264,7 +1264,7 @@ pub mod wasm_test {
             )
             .await;
 
-        consistency_10s([&alice_cell, &bob_cell]).await.unwrap();
+        consistency!(10, [&alice_cell, &bob_cell]).await.unwrap();
 
         // Now the action appears in alice's activty.
         let alice_activity: AgentActivity = conductor
@@ -1334,7 +1334,7 @@ pub mod wasm_test {
 
         // NON ENZYMATIC
         {
-            consistency_10s([&alice_cell, &bob_cell, &carol_cell])
+            consistency!(10, [&alice_cell, &bob_cell, &carol_cell])
                 .await
                 .unwrap();
 
@@ -1406,7 +1406,7 @@ pub mod wasm_test {
                     unreachable!();
                 };
 
-            consistency_10s([&alice_cell, &bob_cell, &carol_cell])
+            consistency!(10, [&alice_cell, &bob_cell, &carol_cell])
                 .await
                 .unwrap();
 
@@ -1428,7 +1428,7 @@ pub mod wasm_test {
                 )
                 .await;
 
-            consistency_10s([&alice_cell, &bob_cell, &carol_cell])
+            consistency!(10, [&alice_cell, &bob_cell, &carol_cell])
                 .await
                 .unwrap();
 

--- a/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
@@ -797,7 +797,7 @@ pub mod wasm_test {
             )
             .await;
 
-        consistency!(10, [&alice_cell, &bob_cell]).await.unwrap();
+        consistency!(10, [&alice_cell, &bob_cell]);
 
         assert_eq!(alice_activity.valid_activity.len(), 7);
         assert_eq!(
@@ -1106,7 +1106,7 @@ pub mod wasm_test {
             )
             .await;
 
-        consistency!(10, [&alice_cell, &bob_cell]).await.unwrap();
+        consistency!(10, [&alice_cell, &bob_cell]);
 
         assert_eq!(alice_activity.valid_activity.len(), 8);
         assert_eq!(
@@ -1264,7 +1264,7 @@ pub mod wasm_test {
             )
             .await;
 
-        consistency!(10, [&alice_cell, &bob_cell]).await.unwrap();
+        consistency!(10, [&alice_cell, &bob_cell]);
 
         // Now the action appears in alice's activty.
         let alice_activity: AgentActivity = conductor

--- a/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
@@ -797,7 +797,7 @@ pub mod wasm_test {
             )
             .await;
 
-        consistency_10s([&alice_cell, &bob_cell]).await;
+        consistency_10s([&alice_cell, &bob_cell]).await.unwrap();
 
         assert_eq!(alice_activity.valid_activity.len(), 7);
         assert_eq!(
@@ -1106,7 +1106,7 @@ pub mod wasm_test {
             )
             .await;
 
-        consistency_10s([&alice_cell, &bob_cell]).await;
+        consistency_10s([&alice_cell, &bob_cell]).await.unwrap();
 
         assert_eq!(alice_activity.valid_activity.len(), 8);
         assert_eq!(
@@ -1264,7 +1264,7 @@ pub mod wasm_test {
             )
             .await;
 
-        consistency_10s([&alice_cell, &bob_cell]).await;
+        consistency_10s([&alice_cell, &bob_cell]).await.unwrap();
 
         // Now the action appears in alice's activty.
         let alice_activity: AgentActivity = conductor
@@ -1334,7 +1334,9 @@ pub mod wasm_test {
 
         // NON ENZYMATIC
         {
-            consistency_10s([&alice_cell, &bob_cell, &carol_cell]).await;
+            consistency_10s([&alice_cell, &bob_cell, &carol_cell])
+                .await
+                .unwrap();
 
             // The countersigned entry does NOT appear in alice's activity yet.
             let alice_activity_pre: AgentActivity = bob_conductor
@@ -1404,7 +1406,9 @@ pub mod wasm_test {
                     unreachable!();
                 };
 
-            consistency_10s([&alice_cell, &bob_cell, &carol_cell]).await;
+            consistency_10s([&alice_cell, &bob_cell, &carol_cell])
+                .await
+                .unwrap();
 
             // Alice commits the action.
             let _countersigned_action_hash_alice: ActionHash = alice_conductor
@@ -1424,7 +1428,9 @@ pub mod wasm_test {
                 )
                 .await;
 
-            consistency_10s([&alice_cell, &bob_cell, &carol_cell]).await;
+            consistency_10s([&alice_cell, &bob_cell, &carol_cell])
+                .await
+                .unwrap();
 
             // Now the action appears in alice's activty.
             let alice_activity: AgentActivity = bob_conductor

--- a/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
@@ -117,9 +117,7 @@ pub mod wasm_test {
     use crate::core::ribosome::error::RibosomeError;
     use crate::core::ribosome::wasm_test::RibosomeTestFixture;
     use crate::core::workflow::WorkflowError;
-    use crate::sweettest::SweetConductorBatch;
-    use crate::sweettest::SweetDnaFile;
-    use crate::test_utils::consistency_10s;
+    use crate::sweettest::*;
     use hdk::prelude::*;
     use holochain_state::source_chain::SourceChainError;
     use holochain_wasm_test_utils::TestWasm;
@@ -797,7 +795,7 @@ pub mod wasm_test {
             )
             .await;
 
-        consistency!(10, [&alice_cell, &bob_cell]);
+        await_consistency!(10, [&alice_cell, &bob_cell]);
 
         assert_eq!(alice_activity.valid_activity.len(), 7);
         assert_eq!(
@@ -1106,7 +1104,7 @@ pub mod wasm_test {
             )
             .await;
 
-        consistency!(10, [&alice_cell, &bob_cell]);
+        await_consistency!(10, [&alice_cell, &bob_cell]);
 
         assert_eq!(alice_activity.valid_activity.len(), 8);
         assert_eq!(
@@ -1264,7 +1262,7 @@ pub mod wasm_test {
             )
             .await;
 
-        consistency!(10, [&alice_cell, &bob_cell]);
+        await_consistency!(10, [&alice_cell, &bob_cell]);
 
         // Now the action appears in alice's activty.
         let alice_activity: AgentActivity = conductor
@@ -1334,9 +1332,7 @@ pub mod wasm_test {
 
         // NON ENZYMATIC
         {
-            consistency!(10, [&alice_cell, &bob_cell, &carol_cell])
-                .await
-                .unwrap();
+            await_consistency!(10, [&alice_cell, &bob_cell, &carol_cell]);
 
             // The countersigned entry does NOT appear in alice's activity yet.
             let alice_activity_pre: AgentActivity = bob_conductor
@@ -1406,9 +1402,7 @@ pub mod wasm_test {
                     unreachable!();
                 };
 
-            consistency!(10, [&alice_cell, &bob_cell, &carol_cell])
-                .await
-                .unwrap();
+            await_consistency!(10, [&alice_cell, &bob_cell, &carol_cell]);
 
             // Alice commits the action.
             let _countersigned_action_hash_alice: ActionHash = alice_conductor
@@ -1428,9 +1422,7 @@ pub mod wasm_test {
                 )
                 .await;
 
-            consistency!(10, [&alice_cell, &bob_cell, &carol_cell])
-                .await
-                .unwrap();
+            await_consistency!(10, [&alice_cell, &bob_cell, &carol_cell]);
 
             // Now the action appears in alice's activty.
             let alice_activity: AgentActivity = bob_conductor

--- a/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
@@ -128,12 +128,12 @@ mod test {
 
         let action0: ActionHash = alice_conductor.call(&alice, "create_entry", ()).await;
 
-        consistency_10s([&alice_cell, &bob_cell]).await.unwrap();
+        consistency!(10, [&alice_cell, &bob_cell]).await.unwrap();
 
         // Before bob is blocked he can get posts just fine.
         let bob_get0: Option<Record> = bob_conductor.call(&bob, "get_post", action0).await;
         // Await bob's init to propagate to alice.
-        consistency_10s([&alice_cell, &bob_cell]).await.unwrap();
+        consistency!(10, [&alice_cell, &bob_cell]).await.unwrap();
         assert!(bob_get0.is_some());
 
         // Bob gets blocked by alice.
@@ -144,7 +144,7 @@ mod test {
         let action1: ActionHash = alice_conductor.call(&alice, "create_entry", ()).await;
 
         // Now that bob is blocked by alice he cannot get data from alice.
-        consistency_10s([&alice_cell]).await.unwrap();
+        consistency!(10, [&alice_cell]).await.unwrap();
         let bob_get1: Option<Record> = bob_conductor.call(&bob, "get_post", action1.clone()).await;
 
         assert!(bob_get1.is_none());
@@ -154,7 +154,7 @@ mod test {
 
         conductors.exchange_peer_info().await;
 
-        consistency_60s([&alice_cell, &bob_cell, &carol_cell])
+        consistency!(60, [&alice_cell, &bob_cell, &carol_cell])
             .await
             .unwrap();
 

--- a/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
@@ -128,12 +128,12 @@ mod test {
 
         let action0: ActionHash = alice_conductor.call(&alice, "create_entry", ()).await;
 
-        consistency_10s([&alice_cell, &bob_cell]).await;
+        consistency_10s([&alice_cell, &bob_cell]).await.unwrap();
 
         // Before bob is blocked he can get posts just fine.
         let bob_get0: Option<Record> = bob_conductor.call(&bob, "get_post", action0).await;
         // Await bob's init to propagate to alice.
-        consistency_10s([&alice_cell, &bob_cell]).await;
+        consistency_10s([&alice_cell, &bob_cell]).await.unwrap();
         assert!(bob_get0.is_some());
 
         // Bob gets blocked by alice.
@@ -144,7 +144,7 @@ mod test {
         let action1: ActionHash = alice_conductor.call(&alice, "create_entry", ()).await;
 
         // Now that bob is blocked by alice he cannot get data from alice.
-        consistency_10s([&alice_cell]).await;
+        consistency_10s([&alice_cell]).await.unwrap();
         let bob_get1: Option<Record> = bob_conductor.call(&bob, "get_post", action1.clone()).await;
 
         assert!(bob_get1.is_none());
@@ -154,7 +154,9 @@ mod test {
 
         conductors.exchange_peer_info().await;
 
-        consistency_60s([&alice_cell, &bob_cell, &carol_cell]).await;
+        consistency_60s([&alice_cell, &bob_cell, &carol_cell])
+            .await
+            .unwrap();
 
         // Bob can get data from alice via. carol.
         let bob_get2: Option<Record> = bob_conductor.call(&bob, "get_post", action1).await;

--- a/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
@@ -124,12 +124,16 @@ mod test {
 
         let action0: ActionHash = alice_conductor.call(&alice, "create_entry", ()).await;
 
-        await_consistency!(10, [&alice_cell, &bob_cell]);
+        await_consistency(10, [&alice_cell, &bob_cell])
+            .await
+            .unwrap();
 
         // Before bob is blocked he can get posts just fine.
         let bob_get0: Option<Record> = bob_conductor.call(&bob, "get_post", action0).await;
         // Await bob's init to propagate to alice.
-        await_consistency!(10, [&alice_cell, &bob_cell]);
+        await_consistency(10, [&alice_cell, &bob_cell])
+            .await
+            .unwrap();
         assert!(bob_get0.is_some());
 
         // Bob gets blocked by alice.
@@ -140,7 +144,7 @@ mod test {
         let action1: ActionHash = alice_conductor.call(&alice, "create_entry", ()).await;
 
         // Now that bob is blocked by alice he cannot get data from alice.
-        await_consistency!(10, [&alice_cell]);
+        await_consistency(10, [&alice_cell]).await.unwrap();
         let bob_get1: Option<Record> = bob_conductor.call(&bob, "get_post", action1.clone()).await;
 
         assert!(bob_get1.is_none());
@@ -150,7 +154,9 @@ mod test {
 
         conductors.exchange_peer_info().await;
 
-        await_consistency!(60, [&alice_cell, &bob_cell, &carol_cell]);
+        await_consistency(60, [&alice_cell, &bob_cell, &carol_cell])
+            .await
+            .unwrap();
 
         // Bob can get data from alice via. carol.
         let bob_get2: Option<Record> = bob_conductor.call(&bob, "get_post", action1).await;

--- a/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
@@ -41,11 +41,7 @@ pub fn block_agent(
 mod test {
     use crate::conductor::api::error::ConductorApiResult;
     use crate::core::ribosome::wasm_test::RibosomeTestFixture;
-    use crate::sweettest::consistency_60s;
-    use crate::sweettest::SweetConductorBatch;
-    use crate::sweettest::SweetConductorConfig;
-    use crate::sweettest::SweetDnaFile;
-    use crate::test_utils::consistency_10s;
+    use crate::sweettest::*;
     use holo_hash::ActionHash;
     use holo_hash::AgentPubKey;
     use holochain_types::prelude::CapSecret;
@@ -128,12 +124,12 @@ mod test {
 
         let action0: ActionHash = alice_conductor.call(&alice, "create_entry", ()).await;
 
-        consistency!(10, [&alice_cell, &bob_cell]);
+        await_consistency!(10, [&alice_cell, &bob_cell]);
 
         // Before bob is blocked he can get posts just fine.
         let bob_get0: Option<Record> = bob_conductor.call(&bob, "get_post", action0).await;
         // Await bob's init to propagate to alice.
-        consistency!(10, [&alice_cell, &bob_cell]);
+        await_consistency!(10, [&alice_cell, &bob_cell]);
         assert!(bob_get0.is_some());
 
         // Bob gets blocked by alice.
@@ -144,7 +140,7 @@ mod test {
         let action1: ActionHash = alice_conductor.call(&alice, "create_entry", ()).await;
 
         // Now that bob is blocked by alice he cannot get data from alice.
-        consistency!(10, [&alice_cell]);
+        await_consistency!(10, [&alice_cell]);
         let bob_get1: Option<Record> = bob_conductor.call(&bob, "get_post", action1.clone()).await;
 
         assert!(bob_get1.is_none());
@@ -154,9 +150,7 @@ mod test {
 
         conductors.exchange_peer_info().await;
 
-        consistency!(60, [&alice_cell, &bob_cell, &carol_cell])
-            .await
-            .unwrap();
+        await_consistency!(60, [&alice_cell, &bob_cell, &carol_cell]);
 
         // Bob can get data from alice via. carol.
         let bob_get2: Option<Record> = bob_conductor.call(&bob, "get_post", action1).await;

--- a/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
@@ -128,12 +128,12 @@ mod test {
 
         let action0: ActionHash = alice_conductor.call(&alice, "create_entry", ()).await;
 
-        consistency!(10, [&alice_cell, &bob_cell]).await.unwrap();
+        consistency!(10, [&alice_cell, &bob_cell]);
 
         // Before bob is blocked he can get posts just fine.
         let bob_get0: Option<Record> = bob_conductor.call(&bob, "get_post", action0).await;
         // Await bob's init to propagate to alice.
-        consistency!(10, [&alice_cell, &bob_cell]).await.unwrap();
+        consistency!(10, [&alice_cell, &bob_cell]);
         assert!(bob_get0.is_some());
 
         // Bob gets blocked by alice.
@@ -144,7 +144,7 @@ mod test {
         let action1: ActionHash = alice_conductor.call(&alice, "create_entry", ()).await;
 
         // Now that bob is blocked by alice he cannot get data from alice.
-        consistency!(10, [&alice_cell]).await.unwrap();
+        consistency!(10, [&alice_cell]);
         let bob_get1: Option<Record> = bob_conductor.call(&bob, "get_post", action1.clone()).await;
 
         assert!(bob_get1.is_none());

--- a/crates/holochain/src/core/ribosome/host_fn/get_details.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_details.rs
@@ -243,10 +243,6 @@ pub mod slow_tests {
         // now make both agents aware of each other
         conductors.exchange_peer_info().await;
 
-        await_consistency(1, apps.cells_flattened().as_slice())
-            .await
-            .unwrap();
-
         // bob gets details by action hash from local databases
         let zome_bob = apps[1].cells()[0].zome(TestWasm::Crud.coordinator_zome_name());
         let local_entries_with_details: Vec<Option<Details>> = conductors[1]

--- a/crates/holochain/src/core/ribosome/host_fn/get_details.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_details.rs
@@ -206,7 +206,9 @@ pub mod wasm_test {
 #[cfg(test)]
 #[cfg(feature = "slow_tests")]
 pub mod slow_tests {
-    use crate::sweettest::{SweetConductorBatch, SweetConductorConfig, SweetDnaFile};
+    use crate::sweettest::{
+        await_consistency, SweetConductorBatch, SweetConductorConfig, SweetDnaFile,
+    };
     use holo_hash::ActionHash;
     use holochain_wasm_test_utils::TestWasm;
     use holochain_zome_types::metadata::Details;
@@ -240,6 +242,10 @@ pub mod slow_tests {
 
         // now make both agents aware of each other
         conductors.exchange_peer_info().await;
+
+        await_consistency(1, apps.cells_flattened().as_slice())
+            .await
+            .unwrap();
 
         // bob gets details by action hash from local databases
         let zome_bob = apps[1].cells()[0].zome(TestWasm::Crud.coordinator_zome_name());

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -290,7 +290,7 @@ async fn test_private_entries_are_passed_to_validation_only_when_authored_with_f
         .call(&alice.zome("coordinator"), "create", ())
         .await;
 
-    consistency!(10, [&alice, &bob]).await.unwrap();
+    consistency!(10, [&alice, &bob]);
 
     {
         let vfs = validation_failures.lock();

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -290,7 +290,7 @@ async fn test_private_entries_are_passed_to_validation_only_when_authored_with_f
         .call(&alice.zome("coordinator"), "create", ())
         .await;
 
-    consistency_10s([&alice, &bob]).await.unwrap();
+    consistency!(10, [&alice, &bob]).await.unwrap();
 
     {
         let vfs = validation_failures.lock();

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -290,7 +290,7 @@ async fn test_private_entries_are_passed_to_validation_only_when_authored_with_f
         .call(&alice.zome("coordinator"), "create", ())
         .await;
 
-    consistency_10s([&alice, &bob]).await;
+    consistency_10s([&alice, &bob]).await.unwrap();
 
     {
         let vfs = validation_failures.lock();

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -286,7 +286,7 @@ async fn test_private_entries_are_passed_to_validation_only_when_authored_with_f
         .call(&alice.zome("coordinator"), "create", ())
         .await;
 
-    await_consistency!(10, [&alice, &bob]);
+    await_consistency(10, [&alice, &bob]).await.unwrap();
 
     {
         let vfs = validation_failures.lock();

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -8,12 +8,8 @@ use crate::core::workflow::app_validation_workflow::{
 };
 use crate::core::workflow::sys_validation_workflow::validation_query;
 use crate::core::{SysValidationError, ValidationOutcome};
-use crate::sweettest::{
-    SweetConductor, SweetConductorBatch, SweetConductorConfig, SweetDnaFile, SweetLocalRendezvous,
-};
-use crate::test_utils::{
-    consistency_10s, host_fn_caller::*, new_invocation, new_zome_call, wait_for_integration,
-};
+use crate::sweettest::*;
+use crate::test_utils::{host_fn_caller::*, new_invocation, new_zome_call, wait_for_integration};
 use ::fixt::fixt;
 use arbitrary::Arbitrary;
 use hdk::hdi::test_utils::set_zome_types;
@@ -290,7 +286,7 @@ async fn test_private_entries_are_passed_to_validation_only_when_authored_with_f
         .call(&alice.zome("coordinator"), "create", ())
         .await;
 
-    consistency!(10, [&alice, &bob]);
+    await_consistency!(10, [&alice, &bob]);
 
     {
         let vfs = validation_failures.lock();

--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
@@ -6,10 +6,7 @@ use std::{
 use holo_hash::{ActionHash, AgentPubKey};
 use holochain_types::{inline_zome::InlineZomeSet, prelude::*};
 
-use crate::{
-    core::ribosome::guest_callback::validate::ValidateResult, sweettest::*,
-    test_utils::consistency_10s,
-};
+use crate::{core::ribosome::guest_callback::validate::ValidateResult, sweettest::*};
 
 const ZOME_A_0: &'static str = "ZOME_A_0";
 const ZOME_A_1: &'static str = "ZOME_A_1";
@@ -395,7 +392,7 @@ async fn app_validation_ops() {
         .call(&alice.zome("zome1"), "create_a", ())
         .await;
 
-    consistency!(10, [&alice, &bob]);
+    await_consistency!(10, [&alice, &bob]);
 
     let mut expected = Expected(HashSet::new());
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
@@ -392,7 +392,7 @@ async fn app_validation_ops() {
         .call(&alice.zome("zome1"), "create_a", ())
         .await;
 
-    await_consistency!(10, [&alice, &bob]);
+    await_consistency(10, [&alice, &bob]).await.unwrap();
 
     let mut expected = Expected(HashSet::new());
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
@@ -395,7 +395,7 @@ async fn app_validation_ops() {
         .call(&alice.zome("zome1"), "create_a", ())
         .await;
 
-    consistency_10s([&alice, &bob]).await;
+    consistency_10s([&alice, &bob]).await.unwrap();
 
     let mut expected = Expected(HashSet::new());
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
@@ -395,7 +395,7 @@ async fn app_validation_ops() {
         .call(&alice.zome("zome1"), "create_a", ())
         .await;
 
-    consistency_10s([&alice, &bob]).await.unwrap();
+    consistency!(10, [&alice, &bob]).await.unwrap();
 
     let mut expected = Expected(HashSet::new());
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
@@ -395,7 +395,7 @@ async fn app_validation_ops() {
         .call(&alice.zome("zome1"), "create_a", ())
         .await;
 
-    consistency!(10, [&alice, &bob]).await.unwrap();
+    consistency!(10, [&alice, &bob]);
 
     let mut expected = Expected(HashSet::new());
 

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
@@ -42,5 +42,5 @@ async fn sys_validation_agent_activity_test() {
     assert_eq!(changed, 2);
 
     conductors.exchange_peer_info().await;
-    consistency!(10, [&cell_1, &cell_2]).await.unwrap();
+    consistency!(10, [&cell_1, &cell_2]);
 }

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
@@ -41,5 +41,5 @@ async fn sys_validation_agent_activity_test() {
     assert_eq!(changed, 2);
 
     conductors.exchange_peer_info().await;
-    await_consistency!(10, [&cell_1, &cell_2]);
+    await_consistency(10, [&cell_1, &cell_2]).await.unwrap();
 }

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::sweettest::*;
-use crate::test_utils::consistency_10s;
 use crate::test_utils::inline_zomes::simple_create_read_zome;
 
 /// Unfortunately this test doesn't do anything yet because

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
@@ -42,5 +42,5 @@ async fn sys_validation_agent_activity_test() {
     assert_eq!(changed, 2);
 
     conductors.exchange_peer_info().await;
-    consistency!(10, [&cell_1, &cell_2]);
+    await_consistency!(10, [&cell_1, &cell_2]);
 }

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
@@ -42,5 +42,5 @@ async fn sys_validation_agent_activity_test() {
     assert_eq!(changed, 2);
 
     conductors.exchange_peer_info().await;
-    consistency_10s([&cell_1, &cell_2]).await;
+    consistency_10s([&cell_1, &cell_2]).await.unwrap();
 }

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
@@ -42,5 +42,5 @@ async fn sys_validation_agent_activity_test() {
     assert_eq!(changed, 2);
 
     conductors.exchange_peer_info().await;
-    consistency_10s([&cell_1, &cell_2]).await.unwrap();
+    consistency!(10, [&cell_1, &cell_2]).await.unwrap();
 }

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -29,7 +29,9 @@ async fn test_validation_receipt() {
         .call(&alice.zome("simple"), "create", ())
         .await;
 
-    await_consistency!(10, [&alice, &bobbo, &carol]);
+    await_consistency(10, [&alice, &bobbo, &carol])
+        .await
+        .unwrap();
 
     // Get op hashes
     let vault = alice.dht_db();
@@ -216,7 +218,9 @@ async fn test_block_invalid_receipt() {
         .call(&alice_cell.zome(coordinator_name), create_function_name, ())
         .await;
 
-    await_consistency!(10, [&alice_cell, &bob_cell]);
+    await_consistency(10, [&alice_cell, &bob_cell])
+        .await
+        .unwrap();
 
     let alice_block_target = BlockTargetId::Cell(alice_cell.cell_id().to_owned());
     let bob_block_target = BlockTargetId::Cell(bob_cell.cell_id().to_owned());

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -30,7 +30,7 @@ async fn test_validation_receipt() {
         .call(&alice.zome("simple"), "create", ())
         .await;
 
-    consistency!(10, [&alice, &bobbo, &carol]);
+    await_consistency!(10, [&alice, &bobbo, &carol]);
 
     // Get op hashes
     let vault = alice.dht_db();
@@ -218,7 +218,7 @@ async fn test_block_invalid_receipt() {
         .await;
 
     consistency!(10, [&alice_cell, &bob_cell]);
-
+await_consistency
     let alice_block_target = BlockTargetId::Cell(alice_cell.cell_id().to_owned());
     let bob_block_target = BlockTargetId::Cell(bob_cell.cell_id().to_owned());
 

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -30,7 +30,7 @@ async fn test_validation_receipt() {
         .call(&alice.zome("simple"), "create", ())
         .await;
 
-    consistency_10s([&alice, &bobbo, &carol]).await;
+    consistency_10s([&alice, &bobbo, &carol]).await.unwrap();
 
     // Get op hashes
     let vault = alice.dht_db();
@@ -217,7 +217,7 @@ async fn test_block_invalid_receipt() {
         .call(&alice_cell.zome(coordinator_name), create_function_name, ())
         .await;
 
-    consistency_10s([&alice_cell, &bob_cell]).await;
+    consistency_10s([&alice_cell, &bob_cell]).await.unwrap();
 
     let alice_block_target = BlockTargetId::Cell(alice_cell.cell_id().to_owned());
     let bob_block_target = BlockTargetId::Cell(bob_cell.cell_id().to_owned());

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -30,7 +30,7 @@ async fn test_validation_receipt() {
         .call(&alice.zome("simple"), "create", ())
         .await;
 
-    consistency!(10, [&alice, &bobbo, &carol]).await.unwrap();
+    consistency!(10, [&alice, &bobbo, &carol]);
 
     // Get op hashes
     let vault = alice.dht_db();
@@ -217,7 +217,7 @@ async fn test_block_invalid_receipt() {
         .call(&alice_cell.zome(coordinator_name), create_function_name, ())
         .await;
 
-    consistency!(10, [&alice_cell, &bob_cell]).await.unwrap();
+    consistency!(10, [&alice_cell, &bob_cell]);
 
     let alice_block_target = BlockTargetId::Cell(alice_cell.cell_id().to_owned());
     let bob_block_target = BlockTargetId::Cell(bob_cell.cell_id().to_owned());

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -1,7 +1,6 @@
 use crate::core::ribosome::guest_callback::validate::ValidateResult;
 use crate::prelude::InlineZomeSet;
 use crate::sweettest::*;
-use crate::test_utils::consistency_10s;
 use crate::test_utils::inline_zomes::simple_create_read_zome;
 use hdk::prelude::*;
 use holo_hash::DhtOpHash;
@@ -217,8 +216,8 @@ async fn test_block_invalid_receipt() {
         .call(&alice_cell.zome(coordinator_name), create_function_name, ())
         .await;
 
-    consistency!(10, [&alice_cell, &bob_cell]);
-await_consistency
+    await_consistency!(10, [&alice_cell, &bob_cell]);
+
     let alice_block_target = BlockTargetId::Cell(alice_cell.cell_id().to_owned());
     let bob_block_target = BlockTargetId::Cell(bob_cell.cell_id().to_owned());
 

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -30,7 +30,7 @@ async fn test_validation_receipt() {
         .call(&alice.zome("simple"), "create", ())
         .await;
 
-    consistency_10s([&alice, &bobbo, &carol]).await.unwrap();
+    consistency!(10, [&alice, &bobbo, &carol]).await.unwrap();
 
     // Get op hashes
     let vault = alice.dht_db();
@@ -217,7 +217,7 @@ async fn test_block_invalid_receipt() {
         .call(&alice_cell.zome(coordinator_name), create_function_name, ())
         .await;
 
-    consistency_10s([&alice_cell, &bob_cell]).await.unwrap();
+    consistency!(10, [&alice_cell, &bob_cell]).await.unwrap();
 
     let alice_block_target = BlockTargetId::Cell(alice_cell.cell_id().to_owned());
     let bob_block_target = BlockTargetId::Cell(bob_cell.cell_id().to_owned());

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -51,7 +51,7 @@ async fn conductors_call_remote(num_conductors: usize) {
 
     // Make sure that genesis records are integrated now that conductors have discovered each other. This makes it
     // more likely that Kitsune knows about all the agents in the network to be able to make remote calls to them.
-    await_consistency!(60, cells.iter());
+    await_consistency(60, cells.iter()).await.unwrap();
 
     let agents: Vec<_> = cells.iter().map(|c| c.agent_pubkey().clone()).collect();
 
@@ -83,7 +83,7 @@ async fn conductors_call_remote(num_conductors: usize) {
         .await;
 
     // Ensure that all the create requests were received and published.
-    await_consistency!(60, cells.iter());
+    await_consistency(60, cells.iter()).await.unwrap();
 }
 
 // TODO - rewrite all these tests to use local sweettest

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -51,7 +51,7 @@ async fn conductors_call_remote(num_conductors: usize) {
 
     // Make sure that genesis records are integrated now that conductors have discovered each other. This makes it
     // more likely that Kitsune knows about all the agents in the network to be able to make remote calls to them.
-    consistency_60s(cells.iter()).await;
+    consistency_60s(cells.iter()).await.unwrap();
 
     let agents: Vec<_> = cells.iter().map(|c| c.agent_pubkey().clone()).collect();
 
@@ -83,7 +83,7 @@ async fn conductors_call_remote(num_conductors: usize) {
         .await;
 
     // Ensure that all the create requests were received and published.
-    consistency_60s(cells.iter()).await;
+    consistency_60s(cells.iter()).await.unwrap();
 }
 
 // TODO - rewrite all these tests to use local sweettest

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -51,7 +51,7 @@ async fn conductors_call_remote(num_conductors: usize) {
 
     // Make sure that genesis records are integrated now that conductors have discovered each other. This makes it
     // more likely that Kitsune knows about all the agents in the network to be able to make remote calls to them.
-    consistency!(60, cells.iter()).await.unwrap();
+    consistency!(60, cells.iter());
 
     let agents: Vec<_> = cells.iter().map(|c| c.agent_pubkey().clone()).collect();
 
@@ -83,7 +83,7 @@ async fn conductors_call_remote(num_conductors: usize) {
         .await;
 
     // Ensure that all the create requests were received and published.
-    consistency!(60, cells.iter()).await.unwrap();
+    consistency!(60, cells.iter());
 }
 
 // TODO - rewrite all these tests to use local sweettest

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -51,7 +51,7 @@ async fn conductors_call_remote(num_conductors: usize) {
 
     // Make sure that genesis records are integrated now that conductors have discovered each other. This makes it
     // more likely that Kitsune knows about all the agents in the network to be able to make remote calls to them.
-    consistency_60s(cells.iter()).await.unwrap();
+    consistency!(60, cells.iter()).await.unwrap();
 
     let agents: Vec<_> = cells.iter().map(|c| c.agent_pubkey().clone()).collect();
 
@@ -83,7 +83,7 @@ async fn conductors_call_remote(num_conductors: usize) {
         .await;
 
     // Ensure that all the create requests were received and published.
-    consistency_60s(cells.iter()).await.unwrap();
+    consistency!(60, cells.iter()).await.unwrap();
 }
 
 // TODO - rewrite all these tests to use local sweettest

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -51,7 +51,7 @@ async fn conductors_call_remote(num_conductors: usize) {
 
     // Make sure that genesis records are integrated now that conductors have discovered each other. This makes it
     // more likely that Kitsune knows about all the agents in the network to be able to make remote calls to them.
-    consistency!(60, cells.iter());
+    await_consistency!(60, cells.iter());
 
     let agents: Vec<_> = cells.iter().map(|c| c.agent_pubkey().clone()).collect();
 
@@ -83,7 +83,7 @@ async fn conductors_call_remote(num_conductors: usize) {
         .await;
 
     // Ensure that all the create requests were received and published.
-    consistency!(60, cells.iter());
+    await_consistency!(60, cells.iter());
 }
 
 // TODO - rewrite all these tests to use local sweettest

--- a/crates/holochain/src/sweettest/mod.rs
+++ b/crates/holochain/src/sweettest/mod.rs
@@ -27,6 +27,7 @@ mod sweet_dna;
 pub mod sweet_topos;
 mod sweet_zome;
 
+pub use crate::consistency;
 pub use sweet_agents::*;
 pub use sweet_app::*;
 pub use sweet_app_installation::*;

--- a/crates/holochain/src/sweettest/mod.rs
+++ b/crates/holochain/src/sweettest/mod.rs
@@ -27,7 +27,6 @@ mod sweet_dna;
 pub mod sweet_topos;
 mod sweet_zome;
 
-pub use crate::{await_consistency, await_consistency_advanced};
 pub use sweet_agents::*;
 pub use sweet_app::*;
 pub use sweet_app_installation::*;

--- a/crates/holochain/src/sweettest/mod.rs
+++ b/crates/holochain/src/sweettest/mod.rs
@@ -27,7 +27,7 @@ mod sweet_dna;
 pub mod sweet_topos;
 mod sweet_zome;
 
-pub use crate::consistency;
+pub use crate::await_consistency;
 pub use sweet_agents::*;
 pub use sweet_app::*;
 pub use sweet_app_installation::*;

--- a/crates/holochain/src/sweettest/mod.rs
+++ b/crates/holochain/src/sweettest/mod.rs
@@ -27,7 +27,7 @@ mod sweet_dna;
 pub mod sweet_topos;
 mod sweet_zome;
 
-pub use crate::await_consistency;
+pub use crate::{await_consistency, await_consistency_advanced};
 pub use sweet_agents::*;
 pub use sweet_app::*;
 pub use sweet_app_installation::*;

--- a/crates/holochain/src/sweettest/sweet_consistency.rs
+++ b/crates/holochain/src/sweettest/sweet_consistency.rs
@@ -72,3 +72,15 @@ pub async fn await_consistency_advanced<'a, I: IntoIterator<Item = (&'a SweetCel
         .collect();
     consistency_dbs(&all_cell_dbs[..], timeout.into().into_duration()).await
 }
+
+/// Wait for all cells to reach consistency for 10 seconds
+#[deprecated = "Use `await_consistency()` with a timeout of `10` instead"]
+pub async fn consistency_10s<'a, I: IntoIterator<Item = &'a SweetCell>>(all_cells: I) {
+    await_consistency(10, all_cells).await.unwrap()
+}
+
+/// Wait for all cells to reach consistency for 60 seconds
+#[deprecated = "Use `await_consistency()` with a timeout of `60` instead"]
+pub async fn consistency_60s<'a, I: IntoIterator<Item = &'a SweetCell>>(all_cells: I) {
+    await_consistency(60, all_cells).await.unwrap()
+}

--- a/crates/holochain/src/sweettest/sweet_consistency.rs
+++ b/crates/holochain/src/sweettest/sweet_consistency.rs
@@ -10,13 +10,13 @@ use super::*;
 /// Wait for all cells to reach consistency for 10 seconds
 #[macro_export]
 macro_rules! consistency {
-    ($secs:literal, $cells:expr) => {
+    ($secs:literal, $cells:expr) => {{
         let dur = std::time::Duration::from_secs($secs);
-        if let Err(err) = consistency(dur, $cells).await {
+        if let Err(err) = $crate::sweettest::consistency(dur, $cells).await {
             println!("{err}");
             panic!("`consistency!()` failure. Error printed above.");
         }
-    };
+    }};
 }
 
 /// Wait for all cells to reach consistency for 10 seconds
@@ -24,7 +24,7 @@ macro_rules! consistency {
 macro_rules! consistency_advanced {
     ($secs:literal, $cells:expr) => {
         let dur = std::time::Duration::from_secs($secs);
-        if let Err(err) = consistency_advanced(dur, $cells).await {
+        if let Err(err) = $crate::sweettest::consistency_advanced(dur, $cells).await {
             println!("{err}");
             panic!("`consistency_advanced!()` failure. Error printed above.");
         }
@@ -33,7 +33,7 @@ macro_rules! consistency_advanced {
 
 /// Wait for all cells to reach consistency
 #[tracing::instrument(skip(all_cells))]
-pub(super) async fn consistency<'a, I: IntoIterator<Item = &'a SweetCell>>(
+pub async fn consistency<'a, I: IntoIterator<Item = &'a SweetCell>>(
     timeout: Duration,
     all_cells: I,
 ) -> Result<(), String> {
@@ -47,7 +47,7 @@ pub(super) async fn consistency<'a, I: IntoIterator<Item = &'a SweetCell>>(
 /// but not their integrated ops (since they are not online to integrate things).
 /// This is useful for tests where nodes go offline.
 #[tracing::instrument(skip(all_cells))]
-pub(super) async fn consistency_advanced<'a, I: IntoIterator<Item = (&'a SweetCell, bool)>>(
+pub async fn consistency_advanced<'a, I: IntoIterator<Item = (&'a SweetCell, bool)>>(
     timeout: Duration,
     all_cells: I,
 ) -> Result<(), String> {

--- a/crates/holochain/src/sweettest/sweet_consistency.rs
+++ b/crates/holochain/src/sweettest/sweet_consistency.rs
@@ -9,24 +9,26 @@ use super::*;
 
 /// Wait for all cells to reach consistency for 10 seconds
 #[macro_export]
-macro_rules! consistency {
-    ($secs:literal, $cells:expr) => {{
+macro_rules! await_consistency {
+    ($secs:literal, $cells:expr $(,)?) => {{
         let dur = std::time::Duration::from_secs($secs);
-        if let Err(err) = $crate::sweettest::consistency(dur, $cells).await {
+        if let Err(err) = $crate::sweettest::sweet_consistency::consistency(dur, $cells).await {
             println!("{err}");
-            panic!("`consistency!()` failure. Error printed above.");
+            panic!("`await_consistency!()` failure. Error printed above.");
         }
     }};
 }
 
 /// Wait for all cells to reach consistency for 10 seconds
 #[macro_export]
-macro_rules! consistency_advanced {
-    ($secs:literal, $cells:expr) => {
+macro_rules! await_consistency_advanced {
+    ($secs:literal, $cells:expr $(,)?) => {
         let dur = std::time::Duration::from_secs($secs);
-        if let Err(err) = $crate::sweettest::consistency_advanced(dur, $cells).await {
+        if let Err(err) =
+            $crate::sweettest::sweet_consistency::consistency_advanced(dur, $cells).await
+        {
             println!("{err}");
-            panic!("`consistency_advanced!()` failure. Error printed above.");
+            panic!("`await_consistency_advanced!()` failure. Error printed above.");
         }
     };
 }

--- a/crates/holochain/src/sweettest/sweet_consistency.rs
+++ b/crates/holochain/src/sweettest/sweet_consistency.rs
@@ -20,38 +20,20 @@ macro_rules! consistency {
 }
 
 /// Wait for all cells to reach consistency for 10 seconds
-pub async fn consistency_10s<'a, I: IntoIterator<Item = &'a SweetCell>>(
-    all_cells: I,
-) -> Result<(), String> {
-    consistency(Duration::from_secs(10), all_cells).await
-}
-
-/// Wait for all cells to reach consistency for 10 seconds,
-/// with the option to specify that some cells are offline.
-pub async fn consistency_10s_advanced<'a, I: IntoIterator<Item = (&'a SweetCell, bool)>>(
-    all_cells: I,
-) -> Result<(), String> {
-    consistency_advanced(Duration::from_secs(10), all_cells).await
-}
-
-/// Wait for all cells to reach consistency for 60 seconds
-pub async fn consistency_60s<'a, I: IntoIterator<Item = &'a SweetCell>>(
-    all_cells: I,
-) -> Result<(), String> {
-    consistency(Duration::from_secs(60), all_cells).await
-}
-
-/// Wait for all cells to reach consistency for 60 seconds,
-/// with the option to specify that some cells are offline.
-pub async fn consistency_60s_advanced<'a, I: IntoIterator<Item = (&'a SweetCell, bool)>>(
-    all_cells: I,
-) -> Result<(), String> {
-    consistency_advanced(Duration::from_secs(60), all_cells).await
+#[macro_export]
+macro_rules! consistency_advanced {
+    ($secs:literal, $cells:expr) => {
+        let dur = std::time::Duration::from_secs($secs);
+        if let Err(err) = consistency_advanced(dur, $cells).await {
+            println!("{err}");
+            panic!("`consistency_advanced!()` failure. Error printed above.");
+        }
+    };
 }
 
 /// Wait for all cells to reach consistency
 #[tracing::instrument(skip(all_cells))]
-pub async fn consistency<'a, I: IntoIterator<Item = &'a SweetCell>>(
+pub(super) async fn consistency<'a, I: IntoIterator<Item = &'a SweetCell>>(
     timeout: Duration,
     all_cells: I,
 ) -> Result<(), String> {
@@ -65,7 +47,7 @@ pub async fn consistency<'a, I: IntoIterator<Item = &'a SweetCell>>(
 /// but not their integrated ops (since they are not online to integrate things).
 /// This is useful for tests where nodes go offline.
 #[tracing::instrument(skip(all_cells))]
-pub async fn consistency_advanced<'a, I: IntoIterator<Item = (&'a SweetCell, bool)>>(
+pub(super) async fn consistency_advanced<'a, I: IntoIterator<Item = (&'a SweetCell, bool)>>(
     timeout: Duration,
     all_cells: I,
 ) -> Result<(), String> {

--- a/crates/holochain/src/sweettest/sweet_consistency.rs
+++ b/crates/holochain/src/sweettest/sweet_consistency.rs
@@ -2,18 +2,25 @@
 
 use hc_sleuth::SleuthId;
 
-use crate::{prelude::*, test_utils::consistency_dbs};
+use crate::{
+    prelude::*,
+    test_utils::{consistency_dbs, ConsistencyResult},
+};
 use std::time::Duration;
 
 use super::*;
 
+/// A duration expressed properly, or just as seconds
 #[derive(derive_more::From, Debug)]
 pub enum DurationOrSeconds {
+    /// Proper duration
     Duration(Duration),
+    /// Just seconds
     Seconds(u64),
 }
 
 impl DurationOrSeconds {
+    /// Get the proper duration
     pub fn into_duration(self) -> Duration {
         match self {
             Self::Duration(d) => d,
@@ -23,12 +30,12 @@ impl DurationOrSeconds {
 }
 
 /// Wait for all cells to reach consistency
-#[tracing::instrument(skip(all_cells))]
+#[tracing::instrument(skip_all)]
 pub async fn await_consistency<'a, I: IntoIterator<Item = &'a SweetCell>>(
     timeout: impl Into<DurationOrSeconds>,
     all_cells: I,
 ) -> ConsistencyResult {
-    consistency_advanced(timeout, all_cells.into_iter().map(|c| (c, true))).await
+    await_consistency_advanced(timeout, all_cells.into_iter().map(|c| (c, true))).await
 }
 
 /// Wait for all cells to reach consistency,
@@ -37,7 +44,7 @@ pub async fn await_consistency<'a, I: IntoIterator<Item = &'a SweetCell>>(
 /// Cells paired with a `false` value will have their authored ops counted towards the total,
 /// but not their integrated ops (since they are not online to integrate things).
 /// This is useful for tests where nodes go offline.
-#[tracing::instrument(skip(all_cells))]
+#[tracing::instrument(skip_all)]
 pub async fn await_consistency_advanced<'a, I: IntoIterator<Item = (&'a SweetCell, bool)>>(
     timeout: impl Into<DurationOrSeconds>,
     all_cells: I,

--- a/crates/holochain/src/sweettest/sweet_consistency.rs
+++ b/crates/holochain/src/sweettest/sweet_consistency.rs
@@ -12,7 +12,10 @@ use super::*;
 macro_rules! consistency {
     ($secs:literal, $cells:expr) => {
         let dur = std::time::Duration::from_secs($secs);
-        consistency(dur, $cells).await.unwrap();
+        if let Err(err) = consistency(dur, $cells).await {
+            println!("{err}");
+            panic!("`consistency!()` failure. Error printed above.");
+        }
     };
 }
 

--- a/crates/holochain/src/sweettest/sweet_consistency.rs
+++ b/crates/holochain/src/sweettest/sweet_consistency.rs
@@ -12,7 +12,7 @@ use super::*;
 macro_rules! consistency {
     ($secs:literal, $cells:expr) => {
         let dur = std::time::Duration::from_secs($secs);
-        consistency(dur, $cells).await
+        consistency(dur, $cells).await.unwrap();
     };
 }
 

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -69,8 +69,6 @@ mod generate_records;
 pub use generate_records::*;
 use holochain_types::websocket::AllowedOrigins;
 
-pub use crate::{await_consistency, await_consistency_advanced};
-
 use self::consistency::request_published_ops;
 
 /// Produce file and line number info at compile-time
@@ -483,6 +481,7 @@ pub fn warm_wasm_tests() {
     }
 }
 
+/// Consistency was failed to be reached. Here's a report.
 #[derive(derive_more::From)]
 pub struct ConsistencyError(String);
 
@@ -492,6 +491,7 @@ impl std::fmt::Debug for ConsistencyError {
     }
 }
 
+/// Alias
 pub type ConsistencyResult = Result<(), ConsistencyError>;
 
 /// Wait for all cell envs to reach consistency, meaning that every op
@@ -534,7 +534,7 @@ where
     )
     .await
     .into_iter()
-    .collect::<Result<Vec<()>, String>>()?;
+    .collect::<Result<Vec<()>, ConsistencyError>>()?;
     Ok(())
 }
 
@@ -594,7 +594,7 @@ async fn wait_for_integration_diff<Db: ReadAccess<DbKindDht>>(
     // Timeout has been reached at this point, so print a helpful report
 
     if published.is_empty() {
-        return Err(format!("No ops were published in {timeout:?}"));
+        return Err(format!("No ops were published in {timeout:?}").into());
     }
 
     // Otherwise just print a report of which ops were not integrated
@@ -654,7 +654,7 @@ async fn wait_for_integration_diff<Db: ReadAccess<DbKindDht>>(
         header,
         unintegrated.join("\n"),
         integration_dump,
-    ))
+    ).into())
 }
 
 /// Wait for num_attempts * delay, or until all published ops have been integrated.

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -69,7 +69,7 @@ mod generate_records;
 pub use generate_records::*;
 use holochain_types::websocket::AllowedOrigins;
 
-pub use crate::{consistency, consistency_advanced};
+pub use crate::{await_consistency, await_consistency_advanced};
 
 use self::consistency::request_published_ops;
 

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -487,9 +487,9 @@ pub fn warm_wasm_tests() {
 /// published by every cell has been integrated by every node
 pub async fn consistency_dbs<AuthorDb, DhtDb>(
     all_cell_dbs: &[(&SleuthId, &AgentPubKey, &AuthorDb, Option<&DhtDb>)],
-    num_attempts: usize,
-    delay: Duration,
-) where
+    timeout: Duration,
+) -> Result<(), String>
+where
     AuthorDb: ReadAccess<DbKindAuthored>,
     DhtDb: ReadAccess<DbKindDht>,
 {
@@ -503,34 +503,44 @@ pub async fn consistency_dbs<AuthorDb, DhtDb>(
                 .map(|(_, _, op)| op),
         );
     }
-    let published = published.into_iter().collect::<Vec<_>>();
+    let published = Arc::new(published.into_iter().collect::<Vec<_>>());
     let all_node_ids: HashSet<_> = all_cell_dbs
         .iter()
         .map(|(node_id, _, _, _)| node_id)
         .collect();
-    for (&db, node_id) in all_cell_dbs
-        .iter()
-        .flat_map(|(node_id, _, _, d)| Some((d.as_ref()?, node_id)))
-    {
-        let others: Vec<String> = all_node_ids
-            .difference(&[node_id].into_iter().collect())
-            .map(|n| n.to_string())
-            .collect();
-        wait_for_integration_diff(&others, db, &published, num_attempts, delay).await
-    }
+
+    futures::future::join_all(
+        all_cell_dbs
+            .iter()
+            .flat_map(|(node_id, _, _, d)| Some((d.as_ref()?, node_id)))
+            .map(move |(&db, node_id)| {
+                let others: Vec<String> = all_node_ids
+                    .difference(&[node_id].into_iter().collect())
+                    .map(|n| n.to_string())
+                    .collect();
+                wait_for_integration_diff(others, db.clone(), published.clone(), timeout)
+            }),
+    )
+    .await
+    .into_iter()
+    .collect::<Result<Vec<()>, String>>()?;
+    Ok(())
 }
+
+const CONSISTENCY_DELAY_LOW: Duration = Duration::from_millis(100);
+const CONSISTENCY_DELAY_MID: Duration = Duration::from_millis(500);
+const CONSISTENCY_DELAY_HIGH: Duration = Duration::from_millis(1000);
 
 /// Wait for num_attempts * delay, or until all published ops have been integrated.
 /// If the timeout is reached, print a report including a diff of all published ops
 /// which were not integrated.
 #[tracing::instrument(skip(db, published))]
 async fn wait_for_integration_diff<Db: ReadAccess<DbKindDht>>(
-    node_ids: &[SleuthId],
-    db: &Db,
-    published: &[DhtOp],
-    num_attempts: usize,
-    delay: Duration,
-) {
+    node_ids: Vec<SleuthId>,
+    db: Db,
+    published: Arc<Vec<DhtOp>>,
+    timeout: Duration,
+) -> Result<(), String> {
     fn display_op(op: &DhtOp) -> String {
         format!(
             "{} {:>3}  {} ({})",
@@ -543,21 +553,31 @@ async fn wait_for_integration_diff<Db: ReadAccess<DbKindDht>>(
     }
 
     let header = format!("{:54} {:>3}  {}", "author", "seq", "op_type (action_type)",);
+    let start = tokio::time::Instant::now();
 
     let num_published = published.len();
     let mut num_integrated = 0;
-    for i in 0..num_attempts {
-        num_integrated = get_integrated_count(db).await;
-        if num_integrated >= num_published {
+    while start.elapsed() < timeout {
+        num_integrated = get_integrated_count(&db).await;
+        let delay = if num_integrated >= num_published {
             if num_integrated > num_published {
                 tracing::warn!("num integrated ops ({}) > num published ops ({}), meaning you may not be accounting for all nodes in this test.
                 Consistency may not be complete.", num_integrated, num_published)
             }
-            return;
+            return Ok(());
         } else {
-            let total_time_waited = delay * i as u32;
-            tracing::debug!(?num_integrated, ?total_time_waited, counts = ?query_integration(db).await);
-        }
+            let total_time_waited = start.elapsed();
+            let queries = query_integration(&db).await;
+            tracing::debug!(?num_integrated, ?total_time_waited, counts = ?queries, "consistency-status");
+
+            if total_time_waited > Duration::from_secs(10) {
+                CONSISTENCY_DELAY_HIGH
+            } else if total_time_waited > Duration::from_secs(1) {
+                CONSISTENCY_DELAY_MID
+            } else {
+                CONSISTENCY_DELAY_LOW
+            }
+        };
         tokio::time::sleep(delay).await;
     }
 
@@ -565,7 +585,7 @@ async fn wait_for_integration_diff<Db: ReadAccess<DbKindDht>>(
 
     // Otherwise just print a report of which ops were not integrated
     let mut published_displays: Vec<_> = published.iter().map(display_op).collect();
-    let mut integrated: Vec<_> = get_integrated_ops(db)
+    let mut integrated: Vec<_> = get_integrated_ops(&db)
         .await
         .iter()
         .map(display_op)
@@ -610,19 +630,17 @@ async fn wait_for_integration_diff<Db: ReadAccess<DbKindDht>>(
         }
     }
 
-    let timeout = delay * num_attempts as u32;
+    let integration_dump = integration_dump(&db).await.unwrap();
 
-    let integration_dump = integration_dump(db).await.unwrap();
-
-    panic!(
-            "Consistency not achieved after {:?}ms. Expected {} ops, but only {} integrated. Unintegrated ops:\n\n{}\n{}\n\n{:?}",
-            timeout.as_millis(),
-            num_published,
-            num_integrated,
-            header,
-            unintegrated.join("\n"),
-            integration_dump,
-        );
+    Err(format!(
+        "Consistency not achieved after {:?}. Expected {} ops, but only {} integrated. Unintegrated ops:\n\n{}\n{}\n\n{:?}",
+        timeout,
+        num_published,
+        num_integrated,
+        header,
+        unintegrated.join("\n"),
+        integration_dump,
+    ))
 }
 
 /// Wait for num_attempts * delay, or until all published ops have been integrated.

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -69,7 +69,7 @@ mod generate_records;
 pub use generate_records::*;
 use holochain_types::websocket::AllowedOrigins;
 
-pub use crate::sweettest::sweet_consistency::*;
+pub use crate::{consistency, consistency_advanced};
 
 use self::consistency::request_published_ops;
 

--- a/crates/holochain/tests/agent_scaling/mod.rs
+++ b/crates/holochain/tests/agent_scaling/mod.rs
@@ -61,7 +61,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
     let alice = cells[0].zome("links");
 
     // Must have integrated or be able to get the agent key to link from it
-    consistency_10s(&cells[..]).await;
+    consistency_10s(&cells[..]).await.unwrap();
 
     let base: AnyLinkableHash = cells[0].agent_pubkey().clone().into();
     let target: AnyLinkableHash = cells[1].agent_pubkey().clone().into();
@@ -74,7 +74,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
         )
         .await;
 
-    consistency_10s(&cells[..]).await;
+    consistency_10s(&cells[..]).await.unwrap();
 
     let mut seen = [0usize; NUM_AGENTS];
 
@@ -111,7 +111,7 @@ async fn many_agents_can_reach_consistency_normal_links() {
 
     let _: ActionHash = conductor.call(&alice, "create_link", ()).await;
 
-    consistency_10s(&cells[..]).await;
+    consistency_10s(&cells[..]).await.unwrap();
 
     let mut num_seen = 0;
 

--- a/crates/holochain/tests/agent_scaling/mod.rs
+++ b/crates/holochain/tests/agent_scaling/mod.rs
@@ -60,7 +60,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
     let alice = cells[0].zome("links");
 
     // Must have integrated or be able to get the agent key to link from it
-    consistency!(10, &cells[..]);
+    await_consistency!(10, &cells[..]);
 
     let base: AnyLinkableHash = cells[0].agent_pubkey().clone().into();
     let target: AnyLinkableHash = cells[1].agent_pubkey().clone().into();
@@ -73,7 +73,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
         )
         .await;
 
-    consistency!(10, &cells[..]);
+    await_consistency!(10, &cells[..]);
 
     let mut seen = [0usize; NUM_AGENTS];
 
@@ -110,7 +110,7 @@ async fn many_agents_can_reach_consistency_normal_links() {
 
     let _: ActionHash = conductor.call(&alice, "create_link", ()).await;
 
-    consistency!(10, &cells[..]);
+    await_consistency!(10, &cells[..]);
 
     let mut num_seen = 0;
 

--- a/crates/holochain/tests/agent_scaling/mod.rs
+++ b/crates/holochain/tests/agent_scaling/mod.rs
@@ -4,7 +4,6 @@ use futures::future;
 use futures::FutureExt;
 use hdk::prelude::GetLinksInputBuilder;
 use holochain::sweettest::*;
-use holochain::test_utils::consistency_10s;
 use holochain_serialized_bytes::prelude::*;
 use holochain_types::inline_zome::InlineZomeSet;
 use holochain_types::prelude::*;
@@ -61,7 +60,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
     let alice = cells[0].zome("links");
 
     // Must have integrated or be able to get the agent key to link from it
-    consistency!(10, &cells[..]).await.unwrap();
+    consistency!(10, &cells[..]);
 
     let base: AnyLinkableHash = cells[0].agent_pubkey().clone().into();
     let target: AnyLinkableHash = cells[1].agent_pubkey().clone().into();
@@ -74,7 +73,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
         )
         .await;
 
-    consistency!(10, &cells[..]).await.unwrap();
+    consistency!(10, &cells[..]);
 
     let mut seen = [0usize; NUM_AGENTS];
 
@@ -111,7 +110,7 @@ async fn many_agents_can_reach_consistency_normal_links() {
 
     let _: ActionHash = conductor.call(&alice, "create_link", ()).await;
 
-    consistency!(10, &cells[..]).await.unwrap();
+    consistency!(10, &cells[..]);
 
     let mut num_seen = 0;
 

--- a/crates/holochain/tests/agent_scaling/mod.rs
+++ b/crates/holochain/tests/agent_scaling/mod.rs
@@ -60,7 +60,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
     let alice = cells[0].zome("links");
 
     // Must have integrated or be able to get the agent key to link from it
-    await_consistency!(10, &cells[..]);
+    await_consistency(10, &cells[..]).await.unwrap();
 
     let base: AnyLinkableHash = cells[0].agent_pubkey().clone().into();
     let target: AnyLinkableHash = cells[1].agent_pubkey().clone().into();
@@ -73,7 +73,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
         )
         .await;
 
-    await_consistency!(10, &cells[..]);
+    await_consistency(10, &cells[..]).await.unwrap();
 
     let mut seen = [0usize; NUM_AGENTS];
 
@@ -110,7 +110,7 @@ async fn many_agents_can_reach_consistency_normal_links() {
 
     let _: ActionHash = conductor.call(&alice, "create_link", ()).await;
 
-    await_consistency!(10, &cells[..]);
+    await_consistency(10, &cells[..]).await.unwrap();
 
     let mut num_seen = 0;
 

--- a/crates/holochain/tests/agent_scaling/mod.rs
+++ b/crates/holochain/tests/agent_scaling/mod.rs
@@ -61,7 +61,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
     let alice = cells[0].zome("links");
 
     // Must have integrated or be able to get the agent key to link from it
-    consistency_10s(&cells[..]).await.unwrap();
+    consistency!(10, &cells[..]).await.unwrap();
 
     let base: AnyLinkableHash = cells[0].agent_pubkey().clone().into();
     let target: AnyLinkableHash = cells[1].agent_pubkey().clone().into();
@@ -74,7 +74,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
         )
         .await;
 
-    consistency_10s(&cells[..]).await.unwrap();
+    consistency!(10, &cells[..]).await.unwrap();
 
     let mut seen = [0usize; NUM_AGENTS];
 
@@ -111,7 +111,7 @@ async fn many_agents_can_reach_consistency_normal_links() {
 
     let _: ActionHash = conductor.call(&alice, "create_link", ()).await;
 
-    consistency_10s(&cells[..]).await.unwrap();
+    consistency!(10, &cells[..]).await.unwrap();
 
     let mut num_seen = 0;
 

--- a/crates/holochain/tests/inline_zome_spec/mod.rs
+++ b/crates/holochain/tests/inline_zome_spec/mod.rs
@@ -2,14 +2,8 @@
 
 use hdk::prelude::*;
 use holochain::core::ribosome::guest_callback::validate::ValidateResult;
-use holochain::test_utils::{
-    consistency_10s,
-    inline_zomes::{simple_crud_zome, AppString},
-};
-use holochain::{
-    conductor::api::error::ConductorApiResult,
-    sweettest::{SweetAgents, SweetConductor, SweetDnaFile, SweetInlineZomes},
-};
+use holochain::test_utils::inline_zomes::{simple_crud_zome, AppString};
+use holochain::{conductor::api::error::ConductorApiResult, sweettest::*};
 use holochain::{
     conductor::{api::error::ConductorApiError, CellError},
     core::workflow::WorkflowError,
@@ -51,7 +45,7 @@ async fn inline_zome_2_agents_1_dna() -> anyhow::Result<()> {
         )
         .await;
 
-    consistency!(10, [&alice, &bobbo]).await.unwrap();
+    consistency!(10, [&alice, &bobbo]);
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let records: Option<Record> = conductor
@@ -115,12 +109,8 @@ async fn inline_zome_3_agents_2_dnas() -> anyhow::Result<()> {
     assert_ne!(hash_foo, hash_bar);
 
     // Wait long enough for others to receive gossip
-    consistency!(10, [&alice_foo, &bobbo_foo, &carol_foo])
-        .await
-        .unwrap();
-    consistency!(10, [&alice_bar, &bobbo_bar, &carol_bar])
-        .await
-        .unwrap();
+    consistency!(10, [&alice_foo, &bobbo_foo, &carol_foo]);
+    consistency!(10, [&alice_bar, &bobbo_bar, &carol_bar]);
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     // on the "foo" DNA
@@ -219,7 +209,7 @@ async fn get_deleted() -> anyhow::Result<()> {
         )
         .await;
 
-    consistency!(10, [&alice]).await.unwrap();
+    consistency!(10, [&alice]);
 
     let records: Option<Record> = conductor
         .call(
@@ -245,7 +235,7 @@ async fn get_deleted() -> anyhow::Result<()> {
         )
         .await;
 
-    consistency!(10, [&alice]).await.unwrap();
+    consistency!(10, [&alice]);
 
     let records: Vec<Option<Record>> = conductor
         .call(

--- a/crates/holochain/tests/inline_zome_spec/mod.rs
+++ b/crates/holochain/tests/inline_zome_spec/mod.rs
@@ -45,7 +45,7 @@ async fn inline_zome_2_agents_1_dna() -> anyhow::Result<()> {
         )
         .await;
 
-    await_consistency!(10, [&alice, &bobbo]);
+    await_consistency(10, [&alice, &bobbo]).await.unwrap();
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let records: Option<Record> = conductor
@@ -109,8 +109,12 @@ async fn inline_zome_3_agents_2_dnas() -> anyhow::Result<()> {
     assert_ne!(hash_foo, hash_bar);
 
     // Wait long enough for others to receive gossip
-    await_consistency!(10, [&alice_foo, &bobbo_foo, &carol_foo]);
-    await_consistency!(10, [&alice_bar, &bobbo_bar, &carol_bar]);
+    await_consistency(10, [&alice_foo, &bobbo_foo, &carol_foo])
+        .await
+        .unwrap();
+    await_consistency(10, [&alice_bar, &bobbo_bar, &carol_bar])
+        .await
+        .unwrap();
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     // on the "foo" DNA
@@ -209,7 +213,7 @@ async fn get_deleted() -> anyhow::Result<()> {
         )
         .await;
 
-    await_consistency!(10, [&alice]);
+    await_consistency(10, [&alice]).await.unwrap();
 
     let records: Option<Record> = conductor
         .call(
@@ -235,7 +239,7 @@ async fn get_deleted() -> anyhow::Result<()> {
         )
         .await;
 
-    await_consistency!(10, [&alice]);
+    await_consistency(10, [&alice]).await.unwrap();
 
     let records: Vec<Option<Record>> = conductor
         .call(

--- a/crates/holochain/tests/inline_zome_spec/mod.rs
+++ b/crates/holochain/tests/inline_zome_spec/mod.rs
@@ -45,7 +45,7 @@ async fn inline_zome_2_agents_1_dna() -> anyhow::Result<()> {
         )
         .await;
 
-    consistency!(10, [&alice, &bobbo]);
+    await_consistency!(10, [&alice, &bobbo]);
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let records: Option<Record> = conductor
@@ -109,8 +109,8 @@ async fn inline_zome_3_agents_2_dnas() -> anyhow::Result<()> {
     assert_ne!(hash_foo, hash_bar);
 
     // Wait long enough for others to receive gossip
-    consistency!(10, [&alice_foo, &bobbo_foo, &carol_foo]);
-    consistency!(10, [&alice_bar, &bobbo_bar, &carol_bar]);
+    await_consistency!(10, [&alice_foo, &bobbo_foo, &carol_foo]);
+    await_consistency!(10, [&alice_bar, &bobbo_bar, &carol_bar]);
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     // on the "foo" DNA
@@ -209,7 +209,7 @@ async fn get_deleted() -> anyhow::Result<()> {
         )
         .await;
 
-    consistency!(10, [&alice]);
+    await_consistency!(10, [&alice]);
 
     let records: Option<Record> = conductor
         .call(
@@ -235,7 +235,7 @@ async fn get_deleted() -> anyhow::Result<()> {
         )
         .await;
 
-    consistency!(10, [&alice]);
+    await_consistency!(10, [&alice]);
 
     let records: Vec<Option<Record>> = conductor
         .call(

--- a/crates/holochain/tests/inline_zome_spec/mod.rs
+++ b/crates/holochain/tests/inline_zome_spec/mod.rs
@@ -51,7 +51,7 @@ async fn inline_zome_2_agents_1_dna() -> anyhow::Result<()> {
         )
         .await;
 
-    consistency_10s([&alice, &bobbo]).await.unwrap();
+    consistency!(10, [&alice, &bobbo]).await.unwrap();
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let records: Option<Record> = conductor
@@ -115,10 +115,10 @@ async fn inline_zome_3_agents_2_dnas() -> anyhow::Result<()> {
     assert_ne!(hash_foo, hash_bar);
 
     // Wait long enough for others to receive gossip
-    consistency_10s([&alice_foo, &bobbo_foo, &carol_foo])
+    consistency!(10, [&alice_foo, &bobbo_foo, &carol_foo])
         .await
         .unwrap();
-    consistency_10s([&alice_bar, &bobbo_bar, &carol_bar])
+    consistency!(10, [&alice_bar, &bobbo_bar, &carol_bar])
         .await
         .unwrap();
 
@@ -219,7 +219,7 @@ async fn get_deleted() -> anyhow::Result<()> {
         )
         .await;
 
-    consistency_10s([&alice]).await.unwrap();
+    consistency!(10, [&alice]).await.unwrap();
 
     let records: Option<Record> = conductor
         .call(
@@ -245,7 +245,7 @@ async fn get_deleted() -> anyhow::Result<()> {
         )
         .await;
 
-    consistency_10s([&alice]).await.unwrap();
+    consistency!(10, [&alice]).await.unwrap();
 
     let records: Vec<Option<Record>> = conductor
         .call(

--- a/crates/holochain/tests/inline_zome_spec/mod.rs
+++ b/crates/holochain/tests/inline_zome_spec/mod.rs
@@ -51,7 +51,7 @@ async fn inline_zome_2_agents_1_dna() -> anyhow::Result<()> {
         )
         .await;
 
-    consistency_10s([&alice, &bobbo]).await;
+    consistency_10s([&alice, &bobbo]).await.unwrap();
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let records: Option<Record> = conductor
@@ -115,8 +115,12 @@ async fn inline_zome_3_agents_2_dnas() -> anyhow::Result<()> {
     assert_ne!(hash_foo, hash_bar);
 
     // Wait long enough for others to receive gossip
-    consistency_10s([&alice_foo, &bobbo_foo, &carol_foo]).await;
-    consistency_10s([&alice_bar, &bobbo_bar, &carol_bar]).await;
+    consistency_10s([&alice_foo, &bobbo_foo, &carol_foo])
+        .await
+        .unwrap();
+    consistency_10s([&alice_bar, &bobbo_bar, &carol_bar])
+        .await
+        .unwrap();
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     // on the "foo" DNA
@@ -215,7 +219,7 @@ async fn get_deleted() -> anyhow::Result<()> {
         )
         .await;
 
-    consistency_10s([&alice]).await;
+    consistency_10s([&alice]).await.unwrap();
 
     let records: Option<Record> = conductor
         .call(
@@ -241,7 +245,7 @@ async fn get_deleted() -> anyhow::Result<()> {
         )
         .await;
 
-    consistency_10s([&alice]).await;
+    consistency_10s([&alice]).await.unwrap();
 
     let records: Vec<Option<Record>> = conductor
         .call(

--- a/crates/holochain/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/multi_conductor/mod.rs
@@ -1,5 +1,4 @@
 use hdk::prelude::*;
-use holochain::await_consistency;
 use holochain::conductor::config::ConductorConfig;
 use holochain::sweettest::SweetConductorConfig;
 use holochain::sweettest::*;
@@ -54,7 +53,9 @@ async fn test_publish() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    await_consistency!(10, [&alice, &bobbo, &carol]);
+    await_consistency(10, [&alice, &bobbo, &carol])
+        .await
+        .unwrap();
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let record: Option<Record> = conductors[1]
@@ -104,7 +105,9 @@ async fn multi_conductor() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    await_consistency!(10, [&alice, &bobbo, &carol]);
+    await_consistency(10, [&alice, &bobbo, &carol])
+        .await
+        .unwrap();
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let record: Option<Record> = conductors[1]
@@ -232,7 +235,7 @@ async fn private_entries_dont_leak() {
         .call(&alice.zome(SweetInlineZomes::COORDINATOR), "create", ())
         .await;
 
-    await_consistency!(60, [&alice, &bobbo]);
+    await_consistency(60, [&alice, &bobbo]).await.unwrap();
 
     let entry_hash =
         EntryHash::with_data_sync(&Entry::app(PrivateEntry {}.try_into().unwrap()).unwrap());
@@ -256,7 +259,7 @@ async fn private_entries_dont_leak() {
     let bob_hash: ActionHash = conductors[1]
         .call(&bobbo.zome(SweetInlineZomes::COORDINATOR), "create", ())
         .await;
-    await_consistency!(60, [&alice, &bobbo]);
+    await_consistency(60, [&alice, &bobbo]).await.unwrap();
 
     check_all_gets_for_private_entry(
         &conductors[0],

--- a/crates/holochain/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/multi_conductor/mod.rs
@@ -227,9 +227,6 @@ async fn private_entries_dont_leak() {
 
     conductors.exchange_peer_info().await;
 
-    // let dpki_cells = conductors.dpki_cells();
-    // consistency!(10, dpki_cells.as_slice());
-
     // Call the "create" zome fn on Alice's app
     let hash: ActionHash = conductors[0]
         .call(&alice.zome(SweetInlineZomes::COORDINATOR), "create", ())

--- a/crates/holochain/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/multi_conductor/mod.rs
@@ -1,9 +1,8 @@
 use hdk::prelude::*;
 use holochain::conductor::config::ConductorConfig;
+use holochain::consistency;
 use holochain::sweettest::SweetConductorConfig;
-use holochain::sweettest::{SweetConductor, SweetZome};
-use holochain::sweettest::{SweetConductorBatch, SweetDnaFile};
-use holochain::test_utils::consistency_10s;
+use holochain::sweettest::*;
 use holochain_conductor_api::conductor::ConductorTuningParams;
 use holochain_sqlite::db::{DbKindT, DbWrite};
 use holochain_sqlite::prelude::DatabaseResult;
@@ -21,7 +20,7 @@ struct AppString(String);
 async fn test_publish() -> anyhow::Result<()> {
     use std::sync::Arc;
 
-    use holochain::test_utils::{consistency_10s, inline_zomes::simple_create_read_zome};
+    use holochain::test_utils::inline_zomes::simple_create_read_zome;
     use kitsune_p2p_types::config::KitsuneP2pConfig;
 
     let _g = holochain_trace::test_run().ok();
@@ -55,7 +54,7 @@ async fn test_publish() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    consistency_10s([&alice, &bobbo, &carol]).await;
+    consistency!(10, [&alice, &bobbo, &carol]);
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let record: Option<Record> = conductors[1]
@@ -105,7 +104,7 @@ async fn multi_conductor() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    consistency_10s([&alice, &bobbo, &carol]).await;
+    consistency!(10, [&alice, &bobbo, &carol]);
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let record: Option<Record> = conductors[1]
@@ -188,7 +187,6 @@ async fn sharded_consistency() {
 #[tokio::test(flavor = "multi_thread")]
 async fn private_entries_dont_leak() {
     use holochain::sweettest::SweetInlineZomes;
-    use holochain::test_utils::consistency_60s;
     use holochain_types::inline_zome::InlineZomeSet;
 
     let _g = holochain_trace::test_run().ok();
@@ -228,12 +226,16 @@ async fn private_entries_dont_leak() {
     let ((alice,), (bobbo,)) = apps.into_tuples();
 
     conductors.exchange_peer_info().await;
+
+    // let dpki_cells = conductors.dpki_cells();
+    // consistency!(10, dpki_cells.as_slice());
+
     // Call the "create" zome fn on Alice's app
     let hash: ActionHash = conductors[0]
         .call(&alice.zome(SweetInlineZomes::COORDINATOR), "create", ())
         .await;
 
-    consistency_60s([&alice, &bobbo]).await;
+    consistency!(60, [&alice, &bobbo]);
 
     let entry_hash =
         EntryHash::with_data_sync(&Entry::app(PrivateEntry {}.try_into().unwrap()).unwrap());
@@ -257,7 +259,7 @@ async fn private_entries_dont_leak() {
     let bob_hash: ActionHash = conductors[1]
         .call(&bobbo.zome(SweetInlineZomes::COORDINATOR), "create", ())
         .await;
-    consistency_60s([&alice, &bobbo]).await;
+    consistency!(60, [&alice, &bobbo]);
 
     check_all_gets_for_private_entry(
         &conductors[0],

--- a/crates/holochain/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/multi_conductor/mod.rs
@@ -1,6 +1,6 @@
 use hdk::prelude::*;
+use holochain::await_consistency;
 use holochain::conductor::config::ConductorConfig;
-use holochain::consistency;
 use holochain::sweettest::SweetConductorConfig;
 use holochain::sweettest::*;
 use holochain_conductor_api::conductor::ConductorTuningParams;
@@ -54,7 +54,7 @@ async fn test_publish() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    consistency!(10, [&alice, &bobbo, &carol]);
+    await_consistency!(10, [&alice, &bobbo, &carol]);
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let record: Option<Record> = conductors[1]
@@ -104,7 +104,7 @@ async fn multi_conductor() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    consistency!(10, [&alice, &bobbo, &carol]);
+    await_consistency!(10, [&alice, &bobbo, &carol]);
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let record: Option<Record> = conductors[1]
@@ -232,7 +232,7 @@ async fn private_entries_dont_leak() {
         .call(&alice.zome(SweetInlineZomes::COORDINATOR), "create", ())
         .await;
 
-    consistency!(60, [&alice, &bobbo]);
+    await_consistency!(60, [&alice, &bobbo]);
 
     let entry_hash =
         EntryHash::with_data_sync(&Entry::app(PrivateEntry {}.try_into().unwrap()).unwrap());
@@ -256,7 +256,7 @@ async fn private_entries_dont_leak() {
     let bob_hash: ActionHash = conductors[1]
         .call(&bobbo.zome(SweetInlineZomes::COORDINATOR), "create", ())
         .await;
-    consistency!(60, [&alice, &bobbo]);
+    await_consistency!(60, [&alice, &bobbo]);
 
     check_all_gets_for_private_entry(
         &conductors[0],

--- a/crates/holochain/tests/publish/mod.rs
+++ b/crates/holochain/tests/publish/mod.rs
@@ -34,7 +34,7 @@ async fn publish_terminates_after_receiving_required_validation_receipts() {
         .await;
 
     // Wait until they all see the created entry, at that point validation receipts should be getting sent soon
-    consistency_60s([&alice, &bobbo, &carol, &danny, &emma, &fred])
+    consistency!(60, [&alice, &bobbo, &carol, &danny, &emma, &fred])
         .await
         .unwrap();
 

--- a/crates/holochain/tests/publish/mod.rs
+++ b/crates/holochain/tests/publish/mod.rs
@@ -34,7 +34,9 @@ async fn publish_terminates_after_receiving_required_validation_receipts() {
         .await;
 
     // Wait until they all see the created entry, at that point validation receipts should be getting sent soon
-    consistency_60s([&alice, &bobbo, &carol, &danny, &emma, &fred]).await;
+    consistency_60s([&alice, &bobbo, &carol, &danny, &emma, &fred])
+        .await
+        .unwrap();
 
     let ops_to_publish = alice
         .authored_db()

--- a/crates/holochain/tests/publish/mod.rs
+++ b/crates/holochain/tests/publish/mod.rs
@@ -32,7 +32,7 @@ async fn publish_terminates_after_receiving_required_validation_receipts() {
         .await;
 
     // Wait until they all see the created entry, at that point validation receipts should be getting sent soon
-    consistency!(60, [&alice, &bobbo, &carol, &danny, &emma, &fred]);
+    await_consistency!(60, [&alice, &bobbo, &carol, &danny, &emma, &fred]);
 
     let ops_to_publish = alice
         .authored_db()

--- a/crates/holochain/tests/publish/mod.rs
+++ b/crates/holochain/tests/publish/mod.rs
@@ -1,8 +1,6 @@
 use holo_hash::ActionHash;
 use holochain::core::workflow::publish_dht_ops_workflow::num_still_needing_publish;
-use holochain::sweettest::{
-    consistency_60s, SweetConductorBatch, SweetConductorConfig, SweetDnaFile,
-};
+use holochain::sweettest::*;
 use holochain_wasm_test_utils::TestWasm;
 
 /// Verifies that publishing terminates naturally when enough validation receipts are received.
@@ -34,9 +32,7 @@ async fn publish_terminates_after_receiving_required_validation_receipts() {
         .await;
 
     // Wait until they all see the created entry, at that point validation receipts should be getting sent soon
-    consistency!(60, [&alice, &bobbo, &carol, &danny, &emma, &fred])
-        .await
-        .unwrap();
+    consistency!(60, [&alice, &bobbo, &carol, &danny, &emma, &fred]);
 
     let ops_to_publish = alice
         .authored_db()

--- a/crates/holochain/tests/publish/mod.rs
+++ b/crates/holochain/tests/publish/mod.rs
@@ -32,7 +32,9 @@ async fn publish_terminates_after_receiving_required_validation_receipts() {
         .await;
 
     // Wait until they all see the created entry, at that point validation receipts should be getting sent soon
-    await_consistency!(60, [&alice, &bobbo, &carol, &danny, &emma, &fred]);
+    await_consistency(60, [&alice, &bobbo, &carol, &danny, &emma, &fred])
+        .await
+        .unwrap();
 
     let ops_to_publish = alice
         .authored_db()

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -8,7 +8,7 @@ use holochain::test_utils::inline_zomes::{
     batch_create_zome, simple_create_read_zome, simple_crud_zome,
 };
 use holochain::test_utils::network_simulation::{data_zome, generate_test_data};
-use holochain::test_utils::{consistency_advanced, WaitFor};
+use holochain::test_utils::{await_consistency_advanced, WaitFor};
 use holochain::{
     conductor::ConductorBuilder, test_utils::consistency::local_machine_session_with_hashes,
 };
@@ -107,7 +107,7 @@ async fn fullsync_sharded_gossip_low_data() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    consistency!(60, [&alice, &bobbo]);
+    await_consistency!(60, [&alice, &bobbo]);
     // let p2p = conductors[0].envs().p2p().lock().values().next().cloned().unwrap();
     // holochain_state::prelude::dump_tmp(&p2p);
     // holochain_state::prelude::dump_tmp(&alice.env());
@@ -170,7 +170,7 @@ async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    consistency!(10, [&alice, &bobbo, &carol]);
+    await_consistency!(10, [&alice, &bobbo, &carol]);
 
     let mut all_op_hashes = vec![];
 
@@ -490,7 +490,7 @@ async fn test_gossip_shutdown() {
     // Ensure that gossip loops resume upon startup
     conductors[0].startup().await;
 
-    consistency!(60, [&cell_0, &cell_1]);
+    await_consistency!(60, [&cell_0, &cell_1]);
     let record: Option<Record> = conductors[1].call(&zome_1, "read", hash.clone()).await;
     assert_eq!(record.unwrap().action_address(), &hash);
 }
@@ -536,7 +536,7 @@ async fn test_gossip_startup() {
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     SweetConductor::exchange_peer_info([&conductor0, &conductor1]).await;
 
-    consistency!(60, [&cell0, &cell1]);
+    await_consistency!(60, [&cell0, &cell1]);
     let record: Option<Record> = conductor1.call(&zome1, "read", hash.clone()).await;
     assert_eq!(record.unwrap().action_address(), &hash);
 }
@@ -614,7 +614,7 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
         hashes.push(hash);
     }
 
-    consistency!(10, [&cells[0], &cells[1]]);
+    await_consistency!(10, [&cells[0], &cells[1]]);
 
     println!(
         "Done waiting for consistency between first two nodes. Elapsed: {:?}",
@@ -673,12 +673,7 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
         start.elapsed()
     );
 
-    consistency_advanced(
-        std::time::Duration::from_secs(10),
-        [(&cells[0], false), (&cells[1], true), (&cell, true)],
-    )
-    .await
-    .unwrap();
+    await_consistency_advanced!(10, [(&cells[0], false), (&cells[1], true), (&cell, true)]);
 
     println!(
         "Done waiting for consistency between last two nodes. Elapsed: {:?}",
@@ -732,7 +727,7 @@ async fn fullsync_sharded_local_gossip() -> anyhow::Result<()> {
     let hash: ActionHash = conductor.call(&alice.zome("simple"), "create", ()).await;
 
     // Wait long enough for Bob to receive gossip
-    consistency!(10, [&alice, &bobbo]);
+    await_consistency!(10, [&alice, &bobbo]);
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let record: Option<Record> = conductor.call(&bobbo.zome("simple"), "read", hash).await;

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -8,7 +8,7 @@ use holochain::test_utils::inline_zomes::{
     batch_create_zome, simple_create_read_zome, simple_crud_zome,
 };
 use holochain::test_utils::network_simulation::{data_zome, generate_test_data};
-use holochain::test_utils::{consistency_10s, consistency_60s, consistency_advanced, WaitFor};
+use holochain::test_utils::{consistency_advanced, WaitFor};
 use holochain::{
     conductor::ConductorBuilder, test_utils::consistency::local_machine_session_with_hashes,
 };
@@ -107,7 +107,7 @@ async fn fullsync_sharded_gossip_low_data() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    consistency!(60, [&alice, &bobbo]).await.unwrap();
+    consistency!(60, [&alice, &bobbo]);
     // let p2p = conductors[0].envs().p2p().lock().values().next().cloned().unwrap();
     // holochain_state::prelude::dump_tmp(&p2p);
     // holochain_state::prelude::dump_tmp(&alice.env());
@@ -170,7 +170,7 @@ async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    consistency!(10, [&alice, &bobbo, &carol]).await.unwrap();
+    consistency!(10, [&alice, &bobbo, &carol]);
 
     let mut all_op_hashes = vec![];
 
@@ -490,7 +490,7 @@ async fn test_gossip_shutdown() {
     // Ensure that gossip loops resume upon startup
     conductors[0].startup().await;
 
-    consistency!(60, [&cell_0, &cell_1]).await.unwrap();
+    consistency!(60, [&cell_0, &cell_1]);
     let record: Option<Record> = conductors[1].call(&zome_1, "read", hash.clone()).await;
     assert_eq!(record.unwrap().action_address(), &hash);
 }
@@ -536,7 +536,7 @@ async fn test_gossip_startup() {
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     SweetConductor::exchange_peer_info([&conductor0, &conductor1]).await;
 
-    consistency!(60, [&cell0, &cell1]).await.unwrap();
+    consistency!(60, [&cell0, &cell1]);
     let record: Option<Record> = conductor1.call(&zome1, "read", hash.clone()).await;
     assert_eq!(record.unwrap().action_address(), &hash);
 }
@@ -614,7 +614,7 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
         hashes.push(hash);
     }
 
-    consistency!(10, [&cells[0], &cells[1]]).await.unwrap();
+    consistency!(10, [&cells[0], &cells[1]]);
 
     println!(
         "Done waiting for consistency between first two nodes. Elapsed: {:?}",
@@ -732,7 +732,7 @@ async fn fullsync_sharded_local_gossip() -> anyhow::Result<()> {
     let hash: ActionHash = conductor.call(&alice.zome("simple"), "create", ()).await;
 
     // Wait long enough for Bob to receive gossip
-    consistency!(10, [&alice, &bobbo]).await.unwrap();
+    consistency!(10, [&alice, &bobbo]);
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let record: Option<Record> = conductor.call(&bobbo.zome("simple"), "read", hash).await;

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -107,7 +107,7 @@ async fn fullsync_sharded_gossip_low_data() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    consistency_60s([&alice, &bobbo]).await;
+    consistency_60s([&alice, &bobbo]).await.unwrap();
     // let p2p = conductors[0].envs().p2p().lock().values().next().cloned().unwrap();
     // holochain_state::prelude::dump_tmp(&p2p);
     // holochain_state::prelude::dump_tmp(&alice.env());
@@ -170,7 +170,7 @@ async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    consistency_10s([&alice, &bobbo, &carol]).await;
+    consistency_10s([&alice, &bobbo, &carol]).await.unwrap();
 
     let mut all_op_hashes = vec![];
 
@@ -490,7 +490,7 @@ async fn test_gossip_shutdown() {
     // Ensure that gossip loops resume upon startup
     conductors[0].startup().await;
 
-    consistency_60s([&cell_0, &cell_1]).await;
+    consistency_60s([&cell_0, &cell_1]).await.unwrap();
     let record: Option<Record> = conductors[1].call(&zome_1, "read", hash.clone()).await;
     assert_eq!(record.unwrap().action_address(), &hash);
 }
@@ -536,7 +536,7 @@ async fn test_gossip_startup() {
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     SweetConductor::exchange_peer_info([&conductor0, &conductor1]).await;
 
-    consistency_60s([&cell0, &cell1]).await;
+    consistency_60s([&cell0, &cell1]).await.unwrap();
     let record: Option<Record> = conductor1.call(&zome1, "read", hash.clone()).await;
     assert_eq!(record.unwrap().action_address(), &hash);
 }
@@ -614,7 +614,7 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
         hashes.push(hash);
     }
 
-    consistency_10s([&cells[0], &cells[1]]).await;
+    consistency_10s([&cells[0], &cells[1]]).await.unwrap();
 
     println!(
         "Done waiting for consistency between first two nodes. Elapsed: {:?}",
@@ -677,7 +677,8 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
         std::time::Duration::from_secs(10),
         [(&cells[0], false), (&cells[1], true), (&cell, true)],
     )
-    .await;
+    .await
+    .unwrap();
 
     println!(
         "Done waiting for consistency between last two nodes. Elapsed: {:?}",
@@ -731,7 +732,7 @@ async fn fullsync_sharded_local_gossip() -> anyhow::Result<()> {
     let hash: ActionHash = conductor.call(&alice.zome("simple"), "create", ()).await;
 
     // Wait long enough for Bob to receive gossip
-    consistency_10s([&alice, &bobbo]).await;
+    consistency_10s([&alice, &bobbo]).await.unwrap();
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let record: Option<Record> = conductor.call(&bobbo.zome("simple"), "read", hash).await;

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -674,9 +674,8 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
     );
 
     consistency_advanced(
+        std::time::Duration::from_secs(10),
         [(&cells[0], false), (&cells[1], true), (&cell, true)],
-        10,
-        std::time::Duration::from_secs(1),
     )
     .await;
 

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -107,7 +107,7 @@ async fn fullsync_sharded_gossip_low_data() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    consistency_60s([&alice, &bobbo]).await.unwrap();
+    consistency!(60, [&alice, &bobbo]).await.unwrap();
     // let p2p = conductors[0].envs().p2p().lock().values().next().cloned().unwrap();
     // holochain_state::prelude::dump_tmp(&p2p);
     // holochain_state::prelude::dump_tmp(&alice.env());
@@ -170,7 +170,7 @@ async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    consistency_10s([&alice, &bobbo, &carol]).await.unwrap();
+    consistency!(10, [&alice, &bobbo, &carol]).await.unwrap();
 
     let mut all_op_hashes = vec![];
 
@@ -490,7 +490,7 @@ async fn test_gossip_shutdown() {
     // Ensure that gossip loops resume upon startup
     conductors[0].startup().await;
 
-    consistency_60s([&cell_0, &cell_1]).await.unwrap();
+    consistency!(60, [&cell_0, &cell_1]).await.unwrap();
     let record: Option<Record> = conductors[1].call(&zome_1, "read", hash.clone()).await;
     assert_eq!(record.unwrap().action_address(), &hash);
 }
@@ -536,7 +536,7 @@ async fn test_gossip_startup() {
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     SweetConductor::exchange_peer_info([&conductor0, &conductor1]).await;
 
-    consistency_60s([&cell0, &cell1]).await.unwrap();
+    consistency!(60, [&cell0, &cell1]).await.unwrap();
     let record: Option<Record> = conductor1.call(&zome1, "read", hash.clone()).await;
     assert_eq!(record.unwrap().action_address(), &hash);
 }
@@ -614,7 +614,7 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
         hashes.push(hash);
     }
 
-    consistency_10s([&cells[0], &cells[1]]).await.unwrap();
+    consistency!(10, [&cells[0], &cells[1]]).await.unwrap();
 
     println!(
         "Done waiting for consistency between first two nodes. Elapsed: {:?}",
@@ -732,7 +732,7 @@ async fn fullsync_sharded_local_gossip() -> anyhow::Result<()> {
     let hash: ActionHash = conductor.call(&alice.zome("simple"), "create", ()).await;
 
     // Wait long enough for Bob to receive gossip
-    consistency_10s([&alice, &bobbo]).await.unwrap();
+    consistency!(10, [&alice, &bobbo]).await.unwrap();
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let record: Option<Record> = conductor.call(&bobbo.zome("simple"), "read", hash).await;


### PR DESCRIPTION
### Summary

Just uses a macro to await consistency, so that when there is a test failure, the actual instance of consistency failure is displayed. Also allows actually specifying the total timeout as a value rather than separate functions for 10s, 60s, etc.

Also eases up on the retries for consistency a bit: 100ms retry interval for the first 1 second, then 500ms interval for the next 9s, then 1000ms interval beyond that.

### TODO:
- [x] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
