### PR TITLE
docs(github): simplify pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,4 @@
 
 
 ### TODO:
-- [ ] CHANGELOG(s) updated with appropriate info
-- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
+- [ ] CHANGELOGs updated with appropriate info


### PR DESCRIPTION
### Summary
I propose to remove the second todo as I believe it's rarely ever noticed/used.


### TODO:
- [ ] CHANGELOG(s) updated with appropriate info
- [ ] Just before pressing the merge button, ensure new entries to CHANGELOG(s) are still under the _UNRELEASED_ heading 
