### PR TITLE
feat(envrc): use online versions/0_2

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,3 @@
 use flake .#coreDev \
+  --override-input versions 'github:holochain/holochain?dir=versions/0_2' \
   --override-input holochain .


### PR DESCRIPTION
this is required because we don't backport the version bumps to the develop-0.2 branch.



### TODO:
- [ ] CHANGELOGs updated with appropriate info
