### PR TITLE
MetaNet to send messages to Kitsune, not the host

### DIFF
--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn.rs
@@ -51,10 +51,21 @@ pub async fn spawn_kitsune_p2p(
         self_host_api,
         preflight_user_data,
     )
-        .await?;
+    .await?;
 
     tokio::task::spawn(
-        builder.spawn(KitsuneP2pActor::new(config, channel_factory, internal_sender, host, ep_hnd, ep_evt, bootstrap_net).await?),
+        builder.spawn(
+            KitsuneP2pActor::new(
+                config,
+                channel_factory,
+                internal_sender,
+                host,
+                ep_hnd,
+                ep_evt,
+                bootstrap_net,
+            )
+            .await?,
+        ),
     );
 
     Ok((sender, evt_recv))

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -129,14 +129,74 @@ pub(crate) struct KitsuneP2pActor {
 impl KitsuneP2pActor {
     pub async fn new(
         config: KitsuneP2pConfig,
-        tls_config: kitsune_p2p_types::tls::TlsConfig,
         channel_factory: ghost_actor::actor_builder::GhostActorChannelFactory<Self>,
         internal_sender: ghost_actor::GhostSender<Internal>,
-        host_api: HostApiLegacy,
-        preflight_user_data: PreflightUserData,
+        direct_host_api: HostApiLegacy,
+        ep_hnd: MetaNet,
+        ep_evt: MetaNetEvtRecv,
+        bootstrap_net: BootstrapNet,
     ) -> KitsuneP2pResult<Self> {
         crate::types::metrics::init();
 
+        let fetch_response_queue =
+            FetchResponseQueue::new(FetchResponseConfig::new(config.tuning_params.clone()));
+
+        // TODO - use a real config
+        let fetch_pool = FetchPool::new_bitwise_or();
+
+        // Start a loop to handle our fetch queue fetch items.
+        FetchTask::spawn(
+            config.clone(),
+            fetch_pool.clone(),
+            direct_host_api.clone(),
+            internal_sender.clone(),
+        );
+
+        let i_s = internal_sender.clone();
+
+        let bandwidth_throttles = BandwidthThrottles::new(&config.tuning_params);
+        let parallel_notify_permit = Arc::new(tokio::sync::Semaphore::new(
+            config.tuning_params.concurrent_limit_per_thread,
+        ));
+
+        MetaNetTask::new(
+            direct_host_api.clone(),
+            config.clone(),
+            fetch_pool.clone(),
+            fetch_response_queue,
+            ep_evt,
+            i_s,
+        )
+        .spawn();
+
+        Ok(Self {
+            channel_factory,
+            internal_sender,
+            ep_hnd,
+            host_api: direct_host_api,
+            spaces: HashMap::new(),
+            config: Arc::new(config),
+            bootstrap_net,
+            bandwidth_throttles,
+            parallel_notify_permit,
+            fetch_pool,
+        })
+    }
+}
+
+pub(super) async fn create_meta_net(
+    config: &KitsuneP2pConfig,
+    tls_config: tls::TlsConfig,
+    internal_sender: ghost_actor::GhostSender<Internal>,
+    host: HostApiLegacy,
+    preflight_user_data: PreflightUserData,
+) -> KitsuneP2pResult<(MetaNet, MetaNetEvtRecv, BootstrapNet)> {
+    let mut ep_hnd = None;
+    let mut ep_evt = None;
+    let mut bootstrap_net = None;
+
+    #[cfg(feature = "tx2")]
+    if ep_hnd.is_none() && config.is_tx2() {
         let metrics = Tx2ApiMetrics::default().set_write_len(|d, l| {
             let t = match d {
                 "Wire::Failure" => KitsuneMetrics::Failure,
@@ -154,76 +214,6 @@ impl KitsuneP2pActor {
             KitsuneMetrics::count(t, l);
         });
 
-        let (ep_hnd, ep_evt, bootstrap_net) = create_meta_net(
-            &config,
-            tls_config,
-            internal_sender.clone(),
-            host_api.clone(),
-            metrics,
-            preflight_user_data,
-        )
-        .await?;
-
-        let fetch_response_queue =
-            FetchResponseQueue::new(FetchResponseConfig::new(config.tuning_params.clone()));
-
-        // TODO - use a real config
-        let fetch_pool = FetchPool::new_bitwise_or();
-
-        // Start a loop to handle our fetch queue fetch items.
-        FetchTask::spawn(
-            config.clone(),
-            fetch_pool.clone(),
-            host_api.clone(),
-            internal_sender.clone(),
-        );
-
-        let i_s = internal_sender.clone();
-
-        let bandwidth_throttles = BandwidthThrottles::new(&config.tuning_params);
-        let parallel_notify_permit = Arc::new(tokio::sync::Semaphore::new(
-            config.tuning_params.concurrent_limit_per_thread,
-        ));
-
-        MetaNetTask::new(
-            host_api.clone(),
-            config.clone(),
-            fetch_pool.clone(),
-            fetch_response_queue,
-            ep_evt,
-            i_s,
-        )
-        .spawn();
-
-        Ok(Self {
-            channel_factory,
-            internal_sender,
-            ep_hnd,
-            host_api,
-            spaces: HashMap::new(),
-            config: Arc::new(config),
-            bootstrap_net,
-            bandwidth_throttles,
-            parallel_notify_permit,
-            fetch_pool,
-        })
-    }
-}
-
-async fn create_meta_net(
-    config: &KitsuneP2pConfig,
-    tls_config: tls::TlsConfig,
-    internal_sender: ghost_actor::GhostSender<Internal>,
-    host: HostApiLegacy,
-    metrics: Tx2ApiMetrics,
-    preflight_user_data: PreflightUserData,
-) -> KitsuneP2pResult<(MetaNet, MetaNetEvtRecv, BootstrapNet)> {
-    let mut ep_hnd = None;
-    let mut ep_evt = None;
-    let mut bootstrap_net = None;
-
-    #[cfg(feature = "tx2")]
-    if ep_hnd.is_none() && config.is_tx2() {
         tracing::trace!("tx2");
         let (h, e) = MetaNet::new_tx2(host.clone(), config.clone(), tls_config, metrics).await?;
         ep_hnd = Some(h);
@@ -1069,7 +1059,6 @@ mod tests {
             TlsConfig::new_ephemeral().await.unwrap(),
             internal_sender,
             HostStub::new().legacy(sender),
-            Tx2ApiMetrics::new(),
             PreflightUserData::default(),
         )
         .await


### PR DESCRIPTION
### Summary

There is a fiddly initialisation order problem with the `KitsuneP2pActor` and the `MetaNet`. 
- The `MetaNet` needs to be able to talk to the Kitsune host
- The `KitsuneP2pActor` needs a reference to the `MetaNet` so that it can close the network on shutdown and hand out cloned references to the `MetaNet` as spaces are created. Spaces do the actual talking to the network.

This is fine as it stands and the `KitsuneP2pActor` constructs the `MetaNet`, granting the `MetaNet` direct access to the Kitsune host. However, this means that any side-effects of talking to the host cannot be reflected in Kitsune. Kitsune is unaware of messages sent to the host by the `MetaNet` and there is no way to interact with the network or Kitsune state based on host responses.

This is very much an artifact of the way the types are being constructed as far as I can tell, rather than being deliberate.

The `KitsuneP2pActor` provides a relay for `KitsuneP2pEvent` messages from spaces to the host. Following this change, the `MetaNet` also routes its messages through the `KitsuneP2pActor` so that responses from the host can be processed by Kitsune *with* access to Kitsune state that the `MetaNet` cannot have access to.

This supports the work on #3481 by allowing me to modify the `KitsuneP2pActor` to close network connections when putting agent info in the peer store causes an old peer URL to become invalid. That is the best way to get consistent behavior in Kitsune rather than doing it everywhere we call `.put_agent_info_signed`. In the case of the pre-flight agent info exchange, it would actually be impossible without this change because the meta net config cannot access its outer meta net state.

The only slight downside to this change is that messages from the meta net have an extra hop to the host. I think the trade-off is worthwhile for consistency in message handling.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
