### PR TITLE
Update HDK documentation for `get_links`

### DIFF
--- a/crates/hdk/src/link.rs
+++ b/crates/hdk/src/link.rs
@@ -114,13 +114,8 @@ pub fn delete_link(address: ActionHash) -> ExternResult<ActionHash> {
     })
 }
 
-/// Returns all links that reference a base hash, filtered by link type. Use a [ `GetLinksInputBuilder` ] to create the
-/// [ `GetLinksInput` ] and optionally filter links further.
-///
-/// Type can be filtered by providing a variant of the link types or the full range operator. Get links of
-/// all types like this: `get_links(base, .., None)`. Refer to the `get_links` function in
-/// [this coordinator zome](https://github.com/holochain/holochain/blob/develop/crates/test_utils/wasm/wasm_workspace/link/src/coordinator.rs)
-/// for examples.
+/// Returns all links that reference a base hash, filtered by link type and other criteria.
+/// Use a [ `GetLinksInputBuilder` ] to create the [ `GetLinksInput` ] and optionally filter links further.
 ///
 /// _Note this will only get links that are defined in dependent integrity zomes._
 ///

--- a/crates/hdk/src/link/builder.rs
+++ b/crates/hdk/src/link/builder.rs
@@ -3,7 +3,45 @@ use holo_hash::{AgentPubKey, AnyLinkableHash};
 use holochain_wasmer_guest::WasmError;
 use holochain_zome_types::prelude::*;
 
-/// A builder to streamline creating a `GetLinksInput`
+/// A builder to streamline creating a `GetLinksInput`.
+///
+/// Example: Get links of any time from a given base address.
+/// ```rust,no_run
+/// use hdk::prelude::*;
+///
+/// # fn main() -> ExternResult<()> {
+///     let my_base = ActionHash::from_raw_36(vec![0; 36]); // Some base address, this is a dummy address created for the example!
+///     let links = get_links(GetLinksInputBuilder::try_new(my_base, ..)?.build())?;
+/// #   Ok(())
+/// # }
+/// ```
+///
+/// Example: Get links of a specific type from a given base address.
+/// ```rust,no_run
+/// use hdk::prelude::*;
+///
+/// #[hdk_link_types]
+/// pub enum LinkTypes {
+///     Example,
+/// }
+///
+/// # fn main() -> ExternResult<()> {
+///     let my_base = ActionHash::from_raw_36(vec![0; 36]); // Some base address, this is a dummy address created for the example!
+///     let links = get_links(GetLinksInputBuilder::try_new(my_base, LinkTypes::Example)?.build())?;
+/// #   Ok(())
+/// # }
+/// ```
+///
+/// You can add additional filters using the functions defined on the builder.
+/// For example, to only fetch links that are available locally, without going to the network:
+/// ```rust,no_run
+/// use hdk::prelude::*;
+///
+/// # fn main() -> ExternResult<()> {
+///     let my_base = ActionHash::from_raw_36(vec![0; 36]); // Some base address, this is a dummy address created for the example!
+///     let links = get_links(GetLinksInputBuilder::try_new(my_base, ..)?.get_options(GetStrategy::Local).build())?;
+/// #   Ok(())
+/// # }
 #[derive(PartialEq, Clone, Debug)]
 pub struct GetLinksInputBuilder(GetLinksInput);
 

--- a/crates/hdk/src/link/builder.rs
+++ b/crates/hdk/src/link/builder.rs
@@ -46,7 +46,7 @@ use holochain_zome_types::prelude::*;
 pub struct GetLinksInputBuilder(GetLinksInput);
 
 impl GetLinksInputBuilder {
-    /// Create a new `GetLinksInputBuilder` from the required fields for a `GetLinksInput`
+    /// Create a new `GetLinksInputBuilder` from the required fields for a `GetLinksInput`.
     pub fn try_new(
         base_address: impl Into<AnyLinkableHash>,
         link_type: impl LinkTypeFilterExt,
@@ -92,7 +92,7 @@ impl GetLinksInputBuilder {
         self
     }
 
-    /// Construct the result of the builder
+    /// Construct the result of the builder.
     pub fn build(self) -> GetLinksInput {
         self.0
     }


### PR DESCRIPTION
### Summary

There we no examples of using the `GetLinksInputBuilder` and references to the old signature of `get_links` that were no longer usable.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
