### PR TITLE
Do not assume host IP stack for websocket listeners

### DIFF
--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -8,6 +8,7 @@ use holochain_websocket::{
 use matches::assert_matches;
 use once_cell::sync::Lazy;
 use std::future::Future;
+use std::net::ToSocketAddrs;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
@@ -66,9 +67,16 @@ static HOLOCHAIN_BUILT_PATH: Lazy<PathBuf> = Lazy::new(|| {
 async fn new_websocket_client_for_port(
     port: u16,
 ) -> anyhow::Result<(WebsocketSender, WebsocketReceiver)> {
+    println!("Client for address: {:?}", format!("localhost:{port}"));
     Ok(ws::connect(
         Arc::new(WebsocketConfig::CLIENT_DEFAULT),
-        ConnectRequest::new(([127, 0, 0, 1], port).into()),
+        ConnectRequest::new(
+            format!("localhost:{port}")
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap(),
+        ),
     )
     .await?)
 }

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -44,7 +44,7 @@ pub async fn spawn_websocket_listener(
     let mut config = WebsocketConfig::LISTENER_DEFAULT;
     config.allowed_origins = Some(allowed_origins);
 
-    let listener = WebsocketListener::bind(Arc::new(config), format!("127.0.0.1:{}", port)).await?;
+    let listener = WebsocketListener::bind(Arc::new(config), format!("localhost:{}", port)).await?;
     trace!("LISTENING AT: {}", listener.local_addr()?);
     Ok(listener)
 }
@@ -120,7 +120,7 @@ pub async fn spawn_app_interface_task<A: InterfaceApi>(
     let mut config = WebsocketConfig::LISTENER_DEFAULT;
     config.allowed_origins = Some(allowed_origins);
 
-    let listener = WebsocketListener::bind(Arc::new(config), format!("127.0.0.1:{}", port)).await?;
+    let listener = WebsocketListener::bind(Arc::new(config), format!("localhost:{}", port)).await?;
     let addr = listener.local_addr()?;
     trace!("LISTENING AT: {}", addr);
     let port = addr.port();

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -22,6 +22,7 @@ use holochain_types::websocket::AllowedOrigins;
 use holochain_websocket::*;
 use nanoid::nanoid;
 use rand::Rng;
+use std::net::ToSocketAddrs;
 use std::path::Path;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -739,7 +740,12 @@ impl SweetConductor {
 pub async fn websocket_client_by_port(port: u16) -> Result<(WebsocketSender, WebsocketReceiver)> {
     connect(
         Arc::new(WebsocketConfig::CLIENT_DEFAULT),
-        ConnectRequest::new(([127, 0, 0, 1], port).into()),
+        ConnectRequest::new(
+            format!("localhost:{port}")
+                .to_socket_addrs()?
+                .next()
+                .ok_or_else(|| Error::other("Could not resolve localhost"))?,
+        ),
     )
     .await
 }

--- a/crates/holochain/tests/send_signal.rs
+++ b/crates/holochain/tests/send_signal.rs
@@ -1,3 +1,4 @@
+use std::net::ToSocketAddrs;
 use std::sync::Arc;
 
 use holochain::sweettest::{
@@ -36,7 +37,13 @@ async fn send_signal_after_conductor_restart() {
     // connect app websocket
     let (_, mut app_ws_rx_1) = holochain_websocket::connect(
         Arc::new(WebsocketConfig::CLIENT_DEFAULT),
-        ConnectRequest::new(([127, 0, 0, 1], app_interface_port_1).into()),
+        ConnectRequest::new(
+            format!("localhost:{app_interface_port_1}")
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap(),
+        ),
     )
     .await
     .unwrap();
@@ -97,7 +104,13 @@ async fn send_signal_after_conductor_restart() {
     // reconnect app websocket
     let (_, mut app_ws_rx_1) = holochain_websocket::connect(
         Arc::new(WebsocketConfig::CLIENT_DEFAULT),
-        ConnectRequest::new(([127, 0, 0, 1], app_interface_port_1).into()),
+        ConnectRequest::new(
+            format!("localhost:{app_interface_port_1}")
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap(),
+        ),
     )
     .await
     .unwrap();

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -15,6 +15,7 @@ use holochain::{
     },
     fixt::*,
 };
+use std::net::ToSocketAddrs;
 
 use holochain_conductor_api::{AdminInterfaceConfig, AppRequest, InterfaceDriver};
 use holochain_types::{
@@ -519,7 +520,13 @@ async fn list_app_interfaces_succeeds() -> Result<()> {
     ws_config.default_request_timeout = Duration::from_secs(1);
     let (client, rx): (WebsocketSender, WebsocketReceiver) = connect(
         Arc::new(ws_config),
-        ConnectRequest::new(([127, 0, 0, 1], port).into()),
+        ConnectRequest::new(
+            format!("localhost:{port}")
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap(),
+        ),
     )
     .await?;
     let _rx = PollRecv::new::<AdminResponse>(rx);
@@ -558,7 +565,13 @@ async fn conductor_admin_interface_ends_with_shutdown_inner() -> Result<()> {
     ws_config.default_request_timeout = Duration::from_secs(1);
     let (client, mut rx): (WebsocketSender, WebsocketReceiver) = holochain_websocket::connect(
         Arc::new(ws_config),
-        ConnectRequest::new(([127, 0, 0, 1], port).into()),
+        ConnectRequest::new(
+            format!("localhost:{port}")
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap(),
+        ),
     )
     .await?;
 
@@ -615,7 +628,11 @@ async fn connection_limit_is_respected() {
     let conductor_handle = Conductor::builder().config(config).build().await.unwrap();
     let port = admin_port(&conductor_handle).await;
 
-    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let addr = format!("localhost:{port}")
+        .to_socket_addrs()
+        .unwrap()
+        .next()
+        .unwrap();
     let cfg = Arc::new(WebsocketConfig::CLIENT_DEFAULT);
 
     // Retain handles so that the test can control when to disconnect clients
@@ -845,18 +862,32 @@ async fn admin_allowed_origins() {
         .await
         .unwrap();
 
+    let port = *ports.first().unwrap();
     assert!(connect(
         Arc::new(WebsocketConfig::CLIENT_DEFAULT),
-        ConnectRequest::new(([127, 0, 0, 1], *ports.first().unwrap()).into())
+        ConnectRequest::new(
+            format!("localhost:{port}")
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap()
+        )
     )
     .await
     .is_err());
 
+    let port = *ports.first().unwrap();
     let (client, rx) = connect(
         Arc::new(WebsocketConfig::CLIENT_DEFAULT),
-        ConnectRequest::new(([127, 0, 0, 1], *ports.first().unwrap()).into())
-            .try_set_header("origin", "http://localhost:3000")
-            .unwrap(),
+        ConnectRequest::new(
+            format!("localhost:{port}")
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap(),
+        )
+        .try_set_header("origin", "http://localhost:3000")
+        .unwrap(),
     )
     .await
     .unwrap();
@@ -884,7 +915,13 @@ async fn app_allowed_origins() {
 
     assert!(connect(
         Arc::new(WebsocketConfig::CLIENT_DEFAULT),
-        ConnectRequest::new(([127, 0, 0, 1], port).into())
+        ConnectRequest::new(
+            format!("localhost:{port}")
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap()
+        )
     )
     .await
     .is_err());
@@ -920,18 +957,30 @@ async fn app_allowed_origins_independence() {
 
     assert!(connect(
         Arc::new(WebsocketConfig::CLIENT_DEFAULT),
-        ConnectRequest::new(([127, 0, 0, 1], port_1).into())
-            .try_set_header("origin", "http://localhost:3002")
-            .unwrap()
+        ConnectRequest::new(
+            format!("localhost:{port_1}")
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap()
+        )
+        .try_set_header("origin", "http://localhost:3002")
+        .unwrap()
     )
     .await
     .is_err());
 
     assert!(connect(
         Arc::new(WebsocketConfig::CLIENT_DEFAULT),
-        ConnectRequest::new(([127, 0, 0, 1], port_2).into())
-            .try_set_header("origin", "http://localhost:3001")
-            .unwrap()
+        ConnectRequest::new(
+            format!("localhost:{port_2}")
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap()
+        )
+        .try_set_header("origin", "http://localhost:3001")
+        .unwrap()
     )
     .await
     .is_err());
@@ -945,9 +994,15 @@ async fn app_allowed_origins_independence() {
 async fn check_app_port(port: u16, origin: &str) {
     let (client, rx) = connect(
         Arc::new(WebsocketConfig::CLIENT_DEFAULT),
-        ConnectRequest::new(([127, 0, 0, 1], port).into())
-            .try_set_header("origin", origin)
-            .unwrap(),
+        ConnectRequest::new(
+            format!("localhost:{port}")
+                .to_socket_addrs()
+                .unwrap()
+                .next()
+                .unwrap(),
+        )
+        .try_set_header("origin", origin)
+        .unwrap(),
     )
     .await
     .unwrap();

--- a/crates/holochain_websocket/benches/bench.rs
+++ b/crates/holochain_websocket/benches/bench.rs
@@ -70,8 +70,8 @@ async fn client_response(recv: &mut tokio::sync::mpsc::Receiver<ReceiveMessage<T
 async fn setup() -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
     // Create a new server listening for connections
     let listener = WebsocketListener::bind(
-        std::sync::Arc::new(WebsocketConfig::default()),
-        "127.0.0.1:0",
+        std::sync::Arc::new(WebsocketConfig::LISTENER_DEFAULT),
+        "localhost:0",
     )
     .await
     .unwrap();
@@ -125,7 +125,7 @@ async fn setup_client(
     let (r_send, r_recv) = tokio::sync::mpsc::channel(32);
 
     // Connect the client to the server
-    let (send, mut recv) = connect(std::sync::Arc::new(WebsocketConfig::default()), addr)
+    let (send, mut recv) = connect(std::sync::Arc::new(WebsocketConfig::CLIENT_DEFAULT), addr)
         .await
         .unwrap();
 

--- a/crates/holochain_websocket/benches/full_connect.rs
+++ b/crates/holochain_websocket/benches/full_connect.rs
@@ -1,6 +1,7 @@
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
+use std::net::ToSocketAddrs;
 
 use holochain_serialized_bytes::prelude::*;
 use holochain_websocket::*;
@@ -19,7 +20,7 @@ fn full_connect(bench: &mut Criterion) {
 
     let runtime = rt();
 
-    let config = std::sync::Arc::new(WebsocketConfig::default());
+    let config = std::sync::Arc::new(WebsocketConfig::LISTENER_DEFAULT);
     let config = &config;
 
     let hello = TestMessage("hello".to_string());
@@ -29,7 +30,7 @@ fn full_connect(bench: &mut Criterion) {
 
     bench.bench_function("full_connect", |b| b.iter(|| {
         runtime.block_on(async move {
-            let bind_addr = std::net::SocketAddr::from(([127, 0, 0, 1], 0));
+            let bind_addr = "localhost:0".to_socket_addrs().unwrap().next().unwrap();
             let l = WebsocketListener::bind(config.clone(), bind_addr).await.unwrap();
 
             let port = l.local_addr().unwrap().port();
@@ -48,7 +49,7 @@ fn full_connect(bench: &mut Criterion) {
                 }
                 b1.wait().await;
             }, async {
-                let (s, mut r) = connect(config.clone(), ([127, 0, 0, 1], port).into()).await.unwrap();
+                let (s, mut r) = connect(config.clone(), format!("localhost:{port}").to_socket_addrs().unwrap().next().unwrap()).await.unwrap();
                 tokio::select! {
                     _ = r.recv::<TestMessage>() => (),
                     _ = async {


### PR DESCRIPTION
### Summary

This is a quick solution for https://github.com/holochain/holochain/issues/3571 which will mean that hosts that resolve `localhost` to `::1` will listen/connect using IPv6 and hosts that resolve it to `127.0.0.1` will listen/connect using IPv4. As we only work on `localhost` for these websockets I think this is good enough for now. If we were binding to any other address then I would prefer either IPv6 or dual-stack support.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
