### PR TITLE
[BACKPORT 0.2] Do not assume host IP stack for websocket listeners

### DIFF
--- a/crates/hc_sandbox/src/ports.rs
+++ b/crates/hc_sandbox/src/ports.rs
@@ -1,5 +1,6 @@
 //! Helpers for working with websockets and ports.
 
+use std::net::ToSocketAddrs;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -56,7 +57,10 @@ async fn websocket_client_by_port(
 ) -> std::io::Result<(WebsocketSender, tokio::task::JoinHandle<()>)> {
     let (send, mut recv) = ws::connect(
         Arc::new(WebsocketConfig::default()),
-        ([127, 0, 0, 1], port).into(),
+        format!("localhost:{port}")
+            .to_socket_addrs()?
+            .next()
+            .ok_or_else(|| std::io::Error::other("Could not resolve localhost"))?,
     )
     .await?;
     let task = tokio::task::spawn(async move {

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -6,6 +6,7 @@ use holochain_websocket::{self as ws, WebsocketConfig, WebsocketReceiver, Websoc
 use matches::assert_matches;
 use once_cell::sync::Lazy;
 use std::future::Future;
+use std::net::ToSocketAddrs;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
@@ -66,7 +67,7 @@ async fn new_websocket_client_for_port(
 ) -> anyhow::Result<(WebsocketSender, WebsocketReceiver)> {
     Ok(ws::connect(
         Arc::new(WebsocketConfig::default()),
-        ([127, 0, 0, 1], port).into(),
+        format!("localhost:{port}").to_socket_addrs().unwrap().next().unwrap(),
     )
     .await?)
 }

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -67,7 +67,11 @@ async fn new_websocket_client_for_port(
 ) -> anyhow::Result<(WebsocketSender, WebsocketReceiver)> {
     Ok(ws::connect(
         Arc::new(WebsocketConfig::default()),
-        format!("localhost:{port}").to_socket_addrs().unwrap().next().unwrap(),
+        format!("localhost:{port}")
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap(),
     )
     .await?)
 }

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -38,7 +38,7 @@ pub async fn spawn_websocket_listener(port: u16) -> InterfaceResult<WebsocketLis
     trace!("Initializing Admin interface");
     let listener = WebsocketListener::bind(
         Arc::new(WebsocketConfig::default()),
-        format!("127.0.0.1:{}", port),
+        format!("localhost:{}", port),
     )
     .await?;
     trace!("LISTENING AT: {}", listener.local_addr()?);
@@ -113,7 +113,7 @@ pub async fn spawn_app_interface_task<A: InterfaceApi>(
     trace!("Initializing App interface");
     let listener = WebsocketListener::bind(
         Arc::new(WebsocketConfig::default()),
-        format!("127.0.0.1:{}", port),
+        format!("localhost:{}", port),
     )
     .await?;
     let addr = listener.local_addr()?;

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -1,7 +1,6 @@
 //! A wrapper around ConductorHandle with more convenient methods for testing
 // TODO [ B-03669 ] move to own crate
 
-use std::net::ToSocketAddrs;
 use super::{
     DynSweetRendezvous, SweetAgents, SweetApp, SweetAppBatch, SweetCell, SweetConductorConfig,
     SweetConductorHandle,
@@ -21,6 +20,7 @@ use holochain_state::test_utils::TestDir;
 use holochain_types::prelude::*;
 use holochain_websocket::*;
 use rand::Rng;
+use std::net::ToSocketAddrs;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -660,7 +660,10 @@ pub async fn websocket_client_by_port(
 ) -> std::io::Result<(WebsocketSender, WebsocketReceiver)> {
     holochain_websocket::connect(
         Arc::new(WebsocketConfig::default()),
-        format!("localhost:{port}").to_socket_addrs()?.next().ok_or_else(|| std::io::Error::other("Could not resolve localhost"))?,
+        format!("localhost:{port}")
+            .to_socket_addrs()?
+            .next()
+            .ok_or_else(|| std::io::Error::other("Could not resolve localhost"))?,
     )
     .await
 }

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -1,6 +1,7 @@
 //! A wrapper around ConductorHandle with more convenient methods for testing
 // TODO [ B-03669 ] move to own crate
 
+use std::net::ToSocketAddrs;
 use super::{
     DynSweetRendezvous, SweetAgents, SweetApp, SweetAppBatch, SweetCell, SweetConductorConfig,
     SweetConductorHandle,
@@ -659,7 +660,7 @@ pub async fn websocket_client_by_port(
 ) -> std::io::Result<(WebsocketSender, WebsocketReceiver)> {
     holochain_websocket::connect(
         Arc::new(WebsocketConfig::default()),
-        ([127, 0, 0, 1], port).into(),
+        format!("localhost:{port}").to_socket_addrs()?.next().ok_or_else(|| std::io::Error::other("Could not resolve localhost"))?,
     )
     .await
 }

--- a/crates/holochain/tests/send_signal.rs
+++ b/crates/holochain/tests/send_signal.rs
@@ -1,3 +1,4 @@
+use std::net::ToSocketAddrs;
 use std::sync::Arc;
 
 use holochain::sweettest::{
@@ -35,7 +36,7 @@ async fn send_signal_after_conductor_restart() {
     // connect app websocket
     let (_, mut app_ws_rx_1) = holochain_websocket::connect(
         Arc::new(WebsocketConfig::default()),
-        ([127, 0, 0, 1], app_interface_port_1).into(),
+        format!("localhost:{app_interface_port_1}").to_socket_addrs().unwrap().next().unwrap(),
     )
     .await
     .unwrap();
@@ -96,7 +97,7 @@ async fn send_signal_after_conductor_restart() {
     // reconnect app websocket
     let (_, mut app_ws_rx_1) = holochain_websocket::connect(
         Arc::new(WebsocketConfig::default()),
-        ([127, 0, 0, 1], app_interface_port_1).into(),
+        format!("localhost:{app_interface_port_1}").to_socket_addrs().unwrap().next().unwrap()
     )
     .await
     .unwrap();

--- a/crates/holochain/tests/send_signal.rs
+++ b/crates/holochain/tests/send_signal.rs
@@ -36,7 +36,11 @@ async fn send_signal_after_conductor_restart() {
     // connect app websocket
     let (_, mut app_ws_rx_1) = holochain_websocket::connect(
         Arc::new(WebsocketConfig::default()),
-        format!("localhost:{app_interface_port_1}").to_socket_addrs().unwrap().next().unwrap(),
+        format!("localhost:{app_interface_port_1}")
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap(),
     )
     .await
     .unwrap();
@@ -97,7 +101,11 @@ async fn send_signal_after_conductor_restart() {
     // reconnect app websocket
     let (_, mut app_ws_rx_1) = holochain_websocket::connect(
         Arc::new(WebsocketConfig::default()),
-        format!("localhost:{app_interface_port_1}").to_socket_addrs().unwrap().next().unwrap()
+        format!("localhost:{app_interface_port_1}")
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap(),
     )
     .await
     .unwrap();

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -1,4 +1,3 @@
-use std::net::ToSocketAddrs;
 use ::fixt::prelude::*;
 use anyhow::Result;
 use futures::future;
@@ -16,6 +15,7 @@ use holochain::{
     },
     fixt::*,
 };
+use std::net::ToSocketAddrs;
 
 use holochain_types::{
     prelude::*,
@@ -520,7 +520,11 @@ async fn list_app_interfaces_succeeds() -> Result<()> {
             default_request_timeout: std::time::Duration::from_secs(1),
             ..Default::default()
         }),
-        format!("localhost:{port}").to_socket_addrs().unwrap().next().unwrap(),
+        format!("localhost:{port}")
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap(),
     )
     .await?;
     let _rx = PollRecv::new::<AdminResponse>(rx);
@@ -560,7 +564,11 @@ async fn conductor_admin_interface_ends_with_shutdown_inner() -> Result<()> {
             default_request_timeout: std::time::Duration::from_secs(1),
             ..Default::default()
         }),
-        format!("localhost:{port}").to_socket_addrs().unwrap().next().unwrap(),
+        format!("localhost:{port}")
+            .to_socket_addrs()
+            .unwrap()
+            .next()
+            .unwrap(),
     )
     .await?;
 
@@ -617,7 +625,11 @@ async fn connection_limit_is_respected() {
     let conductor_handle = Conductor::builder().config(config).build().await.unwrap();
     let port = admin_port(&conductor_handle).await;
 
-    let addr = format!("localhost:{port}").to_socket_addrs().unwrap().next().unwrap();
+    let addr = format!("localhost:{port}")
+        .to_socket_addrs()
+        .unwrap()
+        .next()
+        .unwrap();
     let cfg = Arc::new(WebsocketConfig::default());
 
     // Retain handles so that the test can control when to disconnect clients

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -1,3 +1,4 @@
+use std::net::ToSocketAddrs;
 use ::fixt::prelude::*;
 use anyhow::Result;
 use futures::future;
@@ -519,7 +520,7 @@ async fn list_app_interfaces_succeeds() -> Result<()> {
             default_request_timeout: std::time::Duration::from_secs(1),
             ..Default::default()
         }),
-        ([127, 0, 0, 1], port).into(),
+        format!("localhost:{port}").to_socket_addrs().unwrap().next().unwrap(),
     )
     .await?;
     let _rx = PollRecv::new::<AdminResponse>(rx);
@@ -559,7 +560,7 @@ async fn conductor_admin_interface_ends_with_shutdown_inner() -> Result<()> {
             default_request_timeout: std::time::Duration::from_secs(1),
             ..Default::default()
         }),
-        ([127, 0, 0, 1], port).into(),
+        format!("localhost:{port}").to_socket_addrs().unwrap().next().unwrap(),
     )
     .await?;
 
@@ -616,7 +617,7 @@ async fn connection_limit_is_respected() {
     let conductor_handle = Conductor::builder().config(config).build().await.unwrap();
     let port = admin_port(&conductor_handle).await;
 
-    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let addr = format!("localhost:{port}").to_socket_addrs().unwrap().next().unwrap();
     let cfg = Arc::new(WebsocketConfig::default());
 
     // Retain handles so that the test can control when to disconnect clients

--- a/crates/holochain_websocket/benches/full_connect.rs
+++ b/crates/holochain_websocket/benches/full_connect.rs
@@ -1,7 +1,7 @@
-use std::net::ToSocketAddrs;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
+use std::net::ToSocketAddrs;
 
 use holochain_serialized_bytes::prelude::*;
 use holochain_websocket::*;

--- a/crates/holochain_websocket/benches/full_connect.rs
+++ b/crates/holochain_websocket/benches/full_connect.rs
@@ -1,3 +1,4 @@
+use std::net::ToSocketAddrs;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
@@ -29,7 +30,7 @@ fn full_connect(bench: &mut Criterion) {
 
     bench.bench_function("full_connect", |b| b.iter(|| {
         runtime.block_on(async move {
-            let bind_addr = std::net::SocketAddr::from(([127, 0, 0, 1], 0));
+            let bind_addr = "localhost:0".to_socket_addrs().unwrap().next().unwrap();
             let l = WebsocketListener::bind(config.clone(), bind_addr).await.unwrap();
 
             let port = l.local_addr().unwrap().port();
@@ -48,7 +49,7 @@ fn full_connect(bench: &mut Criterion) {
                 }
                 b1.wait().await;
             }, async {
-                let (s, mut r) = connect(config.clone(), ([127, 0, 0, 1], port).into()).await.unwrap();
+                let (s, mut r) = connect(config.clone(), format!("localhost:{port}").to_socket_addrs().unwrap().next().unwrap()).await.unwrap();
                 tokio::select! {
                     _ = r.recv::<TestMessage>() => (),
                     _ = async {


### PR DESCRIPTION
### Summary

Indirect backport of #3577, because there are a number of differences between `develop` and `develop-0.2` that made a cherry pick more complicated than just transplanting the relevant changes.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
