### PR TITLE
docs: Update hdk docs

### DIFF
--- a/crates/hdk/src/lib.rs
+++ b/crates/hdk/src/lib.rs
@@ -97,7 +97,7 @@
 //!
 //! To extend a Rust function so that it can be called by the host, add the [`hdk_extern!`](macro@crate::prelude::hdk_extern) attribute.
 //!
-//! - The function must take _one_ argument that implements `serde::Serialize + std::fmt::Debug`
+//! - The function may take _none_ or _one_ argument that, if provided, must implement `serde::Serialize + std::fmt::Debug`.
 //! - The function must return an `ExternResult` where the success value implements `serde::Serialize + std::fmt::Debug`
 //! - The function must have a unique name across all externs as they share a global namespace in WASM
 //! - Everything inside the function is Rust-as-usual including `?` to interact with `ExternResult` that fails as `WasmError`
@@ -138,7 +138,7 @@
 //!
 //! The callbacks are (see above for examples):
 //!
-//! - `fn entry_defs(_: ()) -> ExternResult<EntryDefsCallbackResult>`:
+//! - `fn entry_defs() -> ExternResult<EntryDefsCallbackResult>`:
 //!   - Typically implemented automatically by macros in the HDK so does NOT
 //!     require writing the extern for it manually.
 //!   - `EntryDefs` is a vector defining all entries used by this app.
@@ -152,7 +152,7 @@
 //!     key for the candidate source chain and the membrane proof.
 //!   - Runs _before the agent exists on the network_ so has no ability to use
 //!     the network and generally only has access to deterministic HDK functions.
-//! - `fn init(_: ()) -> ExternResult<InitCallbackResult>`:
+//! - `fn init() -> ExternResult<InitCallbackResult>`:
 //!   - Allows the guest to pass/fail/retry initialization with [`InitCallbackResult`](crate::prelude::holochain_zome_types::init::InitCallbackResult).
 //!   - Lazy execution - only runs when any zome of the DNA is first called.
 //!   - All zomes in a DNA init at the same time.


### PR DESCRIPTION
### Summary

This is a follow up PR from #3441 that updates the `hdk` docs on `hdk_extern` usage


### TODO:
- [ ] CHANGELOGs updated with appropriate info
