### PR TITLE
Init tracing once in tests

### DIFF
--- a/crates/aitia/src/tests.rs
+++ b/crates/aitia/src/tests.rs
@@ -55,7 +55,7 @@ mod singleton {
     #[test_case( Singleton(true, false) => None ; "passing single isolated fact produces Pass")]
     #[test_case( Singleton(true, true) => None  ; "passing single self-referencing fact produces Pass")]
     fn singleton_deps(fact: Singleton) -> Option<HashSet<Dep<Singleton>>> {
-        holochain_trace::test_run().ok().unwrap();
+        holochain_trace::test_run();
         fact.clone()
             .traverse(&())
             .unwrap()
@@ -128,7 +128,7 @@ mod acyclic_single_path {
         ; "Countdown from 1 with 3 being true returns path from 1 to 0"
     )]
     fn single_path(countdown: Countdown, truths: HashSet<u8>) -> HashSet<u8> {
-        holochain_trace::test_run().ok().unwrap();
+        holochain_trace::test_run();
 
         let tr = countdown.traverse(&truths);
         report(&tr);
@@ -209,7 +209,7 @@ mod single_loop {
         ; "Countdown from 2 with 3 true returns path 2->1"
     )]
     fn single_loop(countdown: Countdown, truths: HashSet<u8>) -> (HashSet<u8>, usize) {
-        holochain_trace::test_run().ok().unwrap();
+        holochain_trace::test_run();
 
         let tr = countdown.traverse(&truths);
         report(&tr);
@@ -234,7 +234,7 @@ mod single_loop {
 /// Contrived test case involving graphs mostly consisting of ANY nodes
 #[test]
 fn branching_any() {
-    holochain_trace::test_run().ok().unwrap();
+    holochain_trace::test_run();
 
     #[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::Display)]
     struct Branching(u8);
@@ -358,7 +358,7 @@ mod recipes {
         ; "TunaMelt only requires tuna"
     )]
     fn every_dep_simple(item: Recipe, truths: HashSet<Recipe>) -> HashSet<Recipe> {
-        holochain_trace::test_run().ok().unwrap();
+        holochain_trace::test_run();
 
         // TODO:
         // - loops with Every might take some more thought.
@@ -374,7 +374,7 @@ mod recipes {
 
     #[test]
     fn happy_path() {
-        holochain_trace::test_run().ok().unwrap();
+        holochain_trace::test_run();
         use Recipe::*;
         let mut truths = hashset! {
             Eggs,
@@ -426,7 +426,7 @@ mod recipes {
 #[test]
 #[ignore = "should be run manually"]
 fn holochain_like() {
-    holochain_trace::test_run().ok().unwrap();
+    holochain_trace::test_run();
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, derive_more::Constructor)]
     struct F {

--- a/crates/diagnostic_tests/examples/commit_loop.rs
+++ b/crates/diagnostic_tests/examples/commit_loop.rs
@@ -17,7 +17,7 @@ use holochain_diagnostics::*;
 
 #[tokio::main]
 async fn main() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let start = Instant::now();
 
     // let config = config_no_networking();

--- a/crates/diagnostic_tests/examples/join_race.rs
+++ b/crates/diagnostic_tests/examples/join_race.rs
@@ -17,7 +17,7 @@ use tokio::time::Instant;
 
 #[tokio::main]
 async fn main() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     const NUM: usize = 10;
     const MIN_WAIT_MS: Duration = Duration::from_millis(100);

--- a/crates/diagnostic_tests/examples/link_storm.rs
+++ b/crates/diagnostic_tests/examples/link_storm.rs
@@ -70,7 +70,7 @@ fn config() -> ConductorConfig {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // holochain_trace::test_run().ok();
+    // holochain_trace::test_run();
 
     let show_ui = std::env::var("NOUI").is_err();
 

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -165,7 +165,7 @@ async fn generate_sandbox_and_connect() {
     clean_sandboxes().await;
     package_fixture_if_not_packaged().await;
 
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut cmd = get_sandbox_command();
     cmd.env("RUST_BACKTRACE", "1")
         .arg(format!(
@@ -203,7 +203,7 @@ async fn generate_sandbox_and_call_list_dna() {
     clean_sandboxes().await;
     package_fixture_if_not_packaged().await;
 
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut cmd = get_sandbox_command();
     cmd.env("RUST_BACKTRACE", "1")
         .arg(format!(

--- a/crates/holochain/benches/consistency.rs
+++ b/crates/holochain/benches/consistency.rs
@@ -21,7 +21,7 @@ criterion_group!(benches, consistency);
 criterion_main!(benches);
 
 fn consistency(bench: &mut Criterion) {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut group = bench.benchmark_group("consistency");
     group.sample_size(
         std::env::var_os("BENCH_SAMPLE_SIZE")

--- a/crates/holochain/benches/websocket.rs
+++ b/crates/holochain/benches/websocket.rs
@@ -20,7 +20,7 @@ use tracing::debug;
 
 // @todo fix after fixing new InstallApp tests
 // pub fn websocket_concurrent_install(c: &mut Criterion) {
-//     holochain_trace::test_run().ok();
+//     holochain_trace::test_run();
 
 //     static REQ_TIMEOUT_MS: u64 = 15000;
 //     static NUM_DNA_CONCURRENCY: &[(u16, usize)] = &[(1, 1), (8, 4), (64, 10)];

--- a/crates/holochain/examples/websocket_install_dna.rs
+++ b/crates/holochain/examples/websocket_install_dna.rs
@@ -15,7 +15,7 @@ pub async fn main() {
     //     static NUM_CONCURRENT_INSTALLS: usize = 2;
     //     static REQ_TIMEOUT_MS: u64 = 30000;
 
-    //     holochain_trace::test_run().ok();
+    //     holochain_trace::test_run();
     //     // NOTE: This is a full integration test that
     //     // actually runs the holochain binary
 

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -339,7 +339,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn register_list_dna_app() -> Result<()> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let env_dir = test_db_dir();
         let handle = Conductor::builder()
             .with_data_root_path(env_dir.path().to_path_buf().into())
@@ -469,7 +469,7 @@ mod test {
     // @todo fix test by using new InstallApp call
     // #[tokio::test(flavor = "multi_thread")]
     // async fn install_list_dna_app() {
-    // holochain_trace::test_run().ok();
+    // holochain_trace::test_run();
     // let db_dir = test_db_dir();
     // let handle = Conductor::builder().test(db_dir.path(), &[]).await.unwrap();
     // let shutdown = handle.take_shutdown_handle().unwrap();

--- a/crates/holochain/src/conductor/cell/gossip_test.rs
+++ b/crates/holochain/src/conductor/cell/gossip_test.rs
@@ -9,7 +9,7 @@ use kitsune_p2p_types::config::TransportConfig;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn gossip_test() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let config = SweetConductorConfig::standard().no_publish();
     let mut conductors = SweetConductorBatch::from_config(2, config).await;
 
@@ -38,7 +38,7 @@ async fn gossip_test() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn signature_smoke_test() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let rendezvous = SweetLocalRendezvous::new().await;
 
@@ -59,7 +59,7 @@ async fn signature_smoke_test() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn agent_info_test() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let config = SweetConductorConfig::standard().no_publish();
     let mut conductors = SweetConductorBatch::from_config(2, config).await;
 

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -167,7 +167,7 @@ async fn can_set_fake_state() {
             Keeping the test here to highlight the intention, 
             though it will have to be removed or totally rewritten some day."]
 async fn test_list_running_apps_for_dependent_cell_id() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let mk_dna = |name: &'static str| async move {
         let zome = InlineIntegrityZome::new_unique(Vec::new(), 0);
@@ -255,7 +255,7 @@ async fn common_genesis_test_app(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_uninstall_app() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let (dna, _, _) = mk_dna(simple_crud_zome()).await;
     let mut conductor = SweetConductor::from_standard_config().await;
 
@@ -345,7 +345,7 @@ async fn test_uninstall_app() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_reconciliation_idempotency() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let zome = InlineIntegrityZome::new_unique(Vec::new(), 0);
     let mut conductor = SweetConductor::from_standard_config().await;
     common_genesis_test_app(&mut conductor, ("custom", zome))
@@ -369,7 +369,7 @@ async fn test_reconciliation_idempotency() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_signing_error_during_genesis() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let bad_keystore = spawn_crude_mock_keystore(|| "test error".into()).await;
 
     let db_dir = test_db_dir();
@@ -455,7 +455,7 @@ async fn test_signing_error_during_genesis() {
 // @todo fix test by using new InstallApp call
 // #[tokio::test(flavor = "multi_thread")]
 // async fn test_signing_error_during_genesis_doesnt_bork_interfaces() {
-//     holochain_trace::test_run().ok();
+//     holochain_trace::test_run();
 //     let (keystore, keystore_control) = spawn_real_or_mock_keystore(|_| Err("test error".into()))
 //         .await
 //         .unwrap();
@@ -550,7 +550,7 @@ pub(crate) fn simple_create_entry_zome() -> InlineIntegrityZome {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_enable_disable_enable_app() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let zome = simple_create_entry_zome();
     let mut conductor = SweetConductor::from_standard_config().await;
     let app = common_genesis_test_app(&mut conductor, ("zome", zome))
@@ -634,7 +634,7 @@ async fn test_enable_disable_enable_app() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_enable_disable_enable_clone_cell() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let zome = simple_create_entry_zome();
     let mut conductor = SweetConductor::from_standard_config().await;
     let app = common_genesis_test_app(&mut conductor, ("zome", zome))
@@ -729,7 +729,7 @@ async fn test_enable_disable_enable_clone_cell() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn name_has_no_effect_on_dna_hash() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut conductor = SweetConductor::from_standard_config().await;
     let (agent1, agent2, agent3) = SweetAgents::three(conductor.keystore()).await;
     let dna = SweetDnaFile::unique_empty().await;
@@ -791,7 +791,7 @@ fn unwrap_cell_info_clone(cell_info: CellInfo) -> holochain_zome_types::clone::C
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_installation_fails_if_genesis_self_check_is_invalid() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let bad_zome = InlineZomeSet::new_unique_single("integrity", "custom", Vec::new(), 0).function(
         "integrity",
         "genesis_self_check",
@@ -818,7 +818,7 @@ async fn test_installation_fails_if_genesis_self_check_is_invalid() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_bad_entry_validation_after_genesis_returns_zome_call_error() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let unit_entry_def = EntryDef::default_from_id("unit");
     let bad_zome =
         InlineZomeSet::new_unique_single("integrity", "custom", vec![unit_entry_def.clone()], 0)
@@ -877,7 +877,7 @@ async fn test_bad_entry_validation_after_genesis_returns_zome_call_error() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "need to figure out how to write this test, i.e. to make genesis panic"]
 async fn test_apps_disable_on_panic_after_genesis() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let unit_entry_def = EntryDef::default_from_id("unit");
     let bad_zome =
         InlineZomeSet::new_unique_single("integrity", "custom", vec![unit_entry_def.clone()], 0)
@@ -928,7 +928,7 @@ async fn test_apps_disable_on_panic_after_genesis() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_app_status_states() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let zome = simple_create_entry_zome();
     let mut conductor = SweetConductor::from_standard_config().await;
     common_genesis_test_app(&mut conductor, ("zome", zome))
@@ -1001,7 +1001,7 @@ async fn test_app_status_states_multi_app() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_cell_and_app_status_reconciliation() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     use AppStatusFx::*;
     use AppStatusKind::*;
     let mk_zome = || ("zome", InlineIntegrityZome::new_unique(Vec::new(), 0));
@@ -1058,7 +1058,7 @@ async fn test_cell_and_app_status_reconciliation() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_app_status_filters() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let zome = InlineIntegrityZome::new_unique(Vec::new(), 0);
     let dnas = [mk_dna(("dna", zome)).await.0];
 
@@ -1126,7 +1126,7 @@ async fn test_app_status_filters() {
 /// concurrent initial zome function calls
 #[tokio::test(flavor = "multi_thread")]
 async fn test_init_concurrency() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let num_inits = Arc::new(AtomicU32::new(0));
     let num_calls = Arc::new(AtomicU32::new(0));
     let num_inits_clone = num_inits.clone();

--- a/crates/holochain/src/conductor/entry_def_store.rs
+++ b/crates/holochain/src/conductor/entry_def_store.rs
@@ -117,7 +117,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_store_entry_defs() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         // all the stuff needed to have a WasmBuf
         let db_dir = test_db_dir();

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -371,7 +371,7 @@ pub mod test {
             }
         }
 
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let db_dir = test_db_dir();
         let conductor_handle = ConductorBuilder::new()
             .with_data_root_path(db_dir.path().to_path_buf().into())
@@ -581,7 +581,7 @@ pub mod test {
     #[ignore]
     #[allow(unreachable_code, unused_variables)]
     async fn invalid_request() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let (_tmpdir, conductor_handle) = setup_admin().await;
         let admin_api = RealAdminInterfaceApi::new(conductor_handle.clone());
         let dna_payload = InstallAppDnaPayload::hash_only(fake_dna_hash(1), "".to_string());
@@ -608,7 +608,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn websocket_call_zome_function() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let uuid = Uuid::new_v4();
         let dna = fake_dna_zomes(
             &uuid.to_string(),
@@ -649,7 +649,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn gossip_info_request() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let uuid = Uuid::new_v4();
         let dna = fake_dna_zomes(
             &uuid.to_string(),
@@ -704,7 +704,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn storage_info() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let uuid_1 = Uuid::new_v4();
         let dna_1 = fake_dna_zomes(
             &uuid_1.to_string(),
@@ -794,7 +794,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn enable_disable_enable_app() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let agent_key = fake_agent_pubkey_1();
         let mut dnas = Vec::new();
         for _i in 0..2 as u32 {
@@ -977,7 +977,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn attach_app_interface() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let (_tmpdir, conductor_handle) = setup_admin().await;
         let admin_api = RealAdminInterfaceApi::new(conductor_handle.clone());
         let msg = AdminRequest::AttachAppInterface {
@@ -996,7 +996,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn dump_state() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let uuid = Uuid::new_v4();
         let dna = fake_dna_zomes(
             &uuid.to_string(),
@@ -1061,7 +1061,7 @@ pub mod test {
     /// across the admin websocket.
     #[tokio::test(flavor = "multi_thread")]
     async fn add_agent_info_via_admin() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let dnas = vec![
             make_dna("1", vec![TestWasm::Anchor]).await,
             make_dna("2", vec![TestWasm::Anchor]).await,

--- a/crates/holochain/src/conductor/manager/mod.rs
+++ b/crates/holochain/src/conductor/manager/mod.rs
@@ -436,7 +436,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn unrecoverable_error() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let db_dir = test_db_dir();
         let handle = Conductor::builder()
             .with_data_root_path(db_dir.path().to_path_buf().into())
@@ -469,7 +469,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "panics in tokio break other tests, this test is here to confirm behavior but cannot be run on ci"]
     async fn unrecoverable_panic() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let db_dir = test_db_dir();
         let handle = Conductor::builder()
             .with_data_root_path(db_dir.as_ref().to_path_buf().into())

--- a/crates/holochain/src/conductor/p2p_agent_store.rs
+++ b/crates/holochain/src/conductor/p2p_agent_store.rs
@@ -358,7 +358,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_store_agent_info_signed() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let test_db = test_p2p_agents_db();
         let db = test_db.to_db();
@@ -374,7 +374,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn add_agent_info_to_db() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let t_db = test_p2p_agents_db();
         let db = t_db.to_db();
 

--- a/crates/holochain/src/conductor/space/tests.rs
+++ b/crates/holochain/src/conductor/space/tests.rs
@@ -31,7 +31,7 @@ use super::Spaces;
 async fn test_region_queries() {
     const NUM_OPS: usize = 100;
 
-    // let _g = holochain_trace::test_run().ok();
+    // let _g = holochain_trace::test_run();
 
     let mut g = random_generator();
 

--- a/crates/holochain/src/conductor/tests/install_app_bundle.rs
+++ b/crates/holochain/src/conductor/tests/install_app_bundle.rs
@@ -12,7 +12,7 @@ use tempfile::{tempdir, TempDir};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn clone_only_provisioning_creates_no_cell_and_allows_cloning() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut conductor = SweetConductor::from_standard_config().await;
     let agent = SweetAgents::one(conductor.keystore()).await;

--- a/crates/holochain/src/conductor/tests/network_info.rs
+++ b/crates/holochain/src/conductor/tests/network_info.rs
@@ -7,7 +7,7 @@ use crate::sweettest::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn network_info() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
     let number_of_peers = 3;

--- a/crates/holochain/src/core/queue_consumer/tests.rs
+++ b/crates/holochain/src/core/queue_consumer/tests.rs
@@ -30,7 +30,7 @@ async fn test_trigger_send() {
 
 #[tokio::test]
 async fn test_trigger_only_permits_single_trigger() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let (tx, mut rx) = TriggerSender::new();
     let jh = tokio::spawn(async move {

--- a/crates/holochain/src/core/ribosome.rs
+++ b/crates/holochain/src/core/ribosome.rs
@@ -782,7 +782,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn verify_zome_call_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/guest_callback/entry_defs.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/entry_defs.rs
@@ -205,7 +205,7 @@ mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_entry_defs_index_lookup() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::EntryDefs).await;

--- a/crates/holochain/src/core/ribosome/guest_callback/post_commit.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/post_commit.rs
@@ -230,7 +230,7 @@ mod slow_tests {
     #[ignore = "flakey. Sometimes fails the second last assert with 3 instead of 5"]
     #[cfg(feature = "test_utils")]
     async fn post_commit_test_volley() -> anyhow::Result<()> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/guest_callback/validate.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validate.rs
@@ -308,7 +308,7 @@ mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn pass_validate_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Validate).await;

--- a/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
@@ -158,7 +158,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "slow_tests")]
     async fn unlock_timeout_session() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -395,7 +395,7 @@ pub mod wasm_test {
     async fn unlock_invalid_session() {
         use holochain_nonce::fresh_nonce;
 
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -515,7 +515,7 @@ pub mod wasm_test {
     #[cfg(feature = "slow_tests")]
     async fn lock_chain() {
         use holochain_nonce::fresh_nonce;
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -828,7 +828,7 @@ pub mod wasm_test {
     #[ignore = "countersigning_an_entry_before_bobs_zome_initialized_fails"]
     async fn lock_chain_failure() {
         use holochain_nonce::fresh_nonce;
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -1153,7 +1153,7 @@ pub mod wasm_test {
     }
 
     async fn enzymatic_session_success(force_init: bool) {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -1309,7 +1309,7 @@ pub mod wasm_test {
     #[cfg(feature = "slow_tests")]
     #[ignore = "countersigning_an_entry_before_bobs_zome_initialized_fails"]
     async fn enzymatic_session_failure() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let (dna_file, _, _) =
             SweetDnaFile::unique_from_test_wasms(vec![TestWasm::CounterSigning]).await;

--- a/crates/holochain/src/core/ribosome/host_fn/agent_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/agent_info.rs
@@ -61,7 +61,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn host_fn_agent_info_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
@@ -54,7 +54,7 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn zome_call_verify_block() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/call.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call.rs
@@ -237,7 +237,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn call_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let test_wasm = TestWasm::WhoAmI;
         let (dna_file_1, _, _) = SweetDnaFile::unique_from_test_wasms(vec![test_wasm]).await;
 
@@ -287,7 +287,7 @@ pub mod wasm_test {
     /// when they are both writing (moving the source chain forward)
     #[tokio::test(flavor = "multi_thread")]
     async fn call_the_same_cell() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let zomes = vec![TestWasm::WhoAmI, TestWasm::Create];
         let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(zomes).await;
@@ -342,7 +342,7 @@ pub mod wasm_test {
     //        not be supported.
     #[tokio::test(flavor = "multi_thread")]
     async fn bridge_call() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
 
@@ -389,7 +389,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     /// we can call a fn on a remote
     async fn call_remote_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/call_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call_info.rs
@@ -99,7 +99,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn call_info_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::ZomeInfo).await;
@@ -110,7 +110,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn call_info_provenance_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/capability_grants.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/capability_grants.rs
@@ -26,7 +26,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_capability_secret_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Capability).await;
@@ -36,7 +36,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_transferable_cap_grant() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Capability).await;
@@ -61,7 +61,7 @@ pub mod wasm_test {
     // MAYBE: [ B-03669 ] can move this to an integration test (may need to switch to using a RibosomeStore)
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_authorized_call() -> anyhow::Result<()> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/count_links.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/count_links.rs
@@ -62,7 +62,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn count_links() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -103,7 +103,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn count_links_filtered_by_author() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -172,7 +172,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn count_links_filtered_by_timestamp() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/create.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/create.rs
@@ -176,7 +176,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_create_entry_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Create).await;
@@ -206,7 +206,7 @@ pub mod wasm_test {
     fn ribosome_create_entry_network_test() {
         crate::big_stack_test!(
             async move {
-                holochain_trace::test_run().ok();
+                holochain_trace::test_run();
 
                 let mut network_topology = NetworkTopology::default();
 
@@ -310,7 +310,7 @@ pub mod wasm_test {
     async fn multiple_create_entry_limit_test() {
         const N: u32 = 50;
 
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         let mut conductor = SweetConductor::from_standard_config().await;
         let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::MultipleCalls]).await;
 
@@ -336,7 +336,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_serialize_bytes_hash() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         #[derive(Default, SerializedBytes, Serialize, Deserialize, Debug)]
         #[repr(transparent)]
         #[serde(transparent)]

--- a/crates/holochain/src/core/ribosome/host_fn/delete.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/delete.rs
@@ -114,7 +114,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_delete_entry_test<'a>() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Crd).await;

--- a/crates/holochain/src/core/ribosome/host_fn/delete_link.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/delete_link.rs
@@ -116,7 +116,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_delete_link_add_remove() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Link).await;

--- a/crates/holochain/src/core/ribosome/host_fn/dna_info_1.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/dna_info_1.rs
@@ -80,7 +80,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn dna_info_test_1() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         // let RibosomeTestFixture {
         //     conductor, alice, ..
         // } = RibosomeTestFixture::new(TestWasm::ZomeInfo).await;

--- a/crates/holochain/src/core/ribosome/host_fn/dna_info_2.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/dna_info_2.rs
@@ -80,7 +80,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn dna_info_test_2() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         // let RibosomeTestFixture {
         //     conductor, alice, ..
         // } = RibosomeTestFixture::new(TestWasm::ZomeInfo).await;

--- a/crates/holochain/src/core/ribosome/host_fn/ed_25519_x_salsa20_poly1305_encrypt.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/ed_25519_x_salsa20_poly1305_encrypt.rs
@@ -66,7 +66,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn invoke_import_ed_25519_x_salsa20_poly1305_encrypt_decrypt_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, alice_pubkey, bob_pubkey, ..
         } = RibosomeTestFixture::new(TestWasm::XSalsa20Poly1305).await;

--- a/crates/holochain/src/core/ribosome/host_fn/get.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get.rs
@@ -86,7 +86,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn get_action_entry_local_only() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         // agents should not pass around data
         let config = SweetConductorConfig::rendezvous(false).tune(|config| {
             config.disable_historical_gossip = true;

--- a/crates/holochain/src/core/ribosome/host_fn/get_details.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_details.rs
@@ -67,7 +67,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_get_details_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Crud).await;
@@ -213,7 +213,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn get_action_entry_local_only() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         // agents should not pass around data
         let config = SweetConductorConfig::rendezvous(false).tune(|config| {
             config.disable_historical_gossip = true;

--- a/crates/holochain/src/core/ribosome/host_fn/get_link_details.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_link_details.rs
@@ -91,7 +91,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_entry_hash_path_children_details() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::HashPath).await;
@@ -160,7 +160,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn get_link_details_local_only() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         // agents should not pass around data
         let config = SweetConductorConfig::rendezvous(false).tune(|config| {
             config.disable_historical_gossip = true;

--- a/crates/holochain/src/core/ribosome/host_fn/get_links.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_links.rs
@@ -113,7 +113,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_entry_hash_path_children() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::HashPath).await;
@@ -152,7 +152,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn hash_path_anchor_list_anchors() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Anchor).await;
@@ -237,7 +237,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn baseless_get_links() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Link).await;
@@ -254,7 +254,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn external_get_links() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Link).await;
@@ -269,7 +269,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn multi_get_links() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Link).await;
@@ -324,7 +324,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn dup_path_test() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Link).await;
@@ -339,7 +339,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn get_links_filtered_by_tag_prefix() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -451,7 +451,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn get_links_filtered_by_timestamp_and_author() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -564,7 +564,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn get_links_local_only() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         // agents should not pass around data
         let config = SweetConductorConfig::rendezvous(false).tune(|config| {
             config.disable_historical_gossip = true;

--- a/crates/holochain/src/core/ribosome/host_fn/hash.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/hash.rs
@@ -174,7 +174,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     /// we can get an entry hash out of the fn via. a wasm call
     async fn ribosome_hash_entry_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::HashEntry).await;

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_agent_activity.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_agent_activity.rs
@@ -121,7 +121,7 @@ pub mod test {
     /// activity.
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_must_get_agent_activity_self() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::MustGet).await;
@@ -138,7 +138,7 @@ pub mod test {
     /// previous action bounded activity.
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_must_get_agent_activity_self_prev() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::MustGet).await;
@@ -153,7 +153,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_must_get_agent_activity() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_entry.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_entry.rs
@@ -113,7 +113,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_must_get_entry_test<'a>() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/query.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/query.rs
@@ -51,7 +51,7 @@ pub mod slow_tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn query_smoke_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Query).await;

--- a/crates/holochain/src/core/ribosome/host_fn/random_bytes.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/random_bytes.rs
@@ -75,7 +75,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     /// we can get some random data out of the fn via. a wasm call
     async fn ribosome_random_bytes_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::RandomBytes).await;
@@ -88,7 +88,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     /// we can get some random data out of the fn via. a wasm call
     async fn ribosome_rand_random_bytes_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::RandomBytes).await;

--- a/crates/holochain/src/core/ribosome/host_fn/schedule.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/schedule.rs
@@ -58,7 +58,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "test_utils")]
     async fn schedule_test_low_level() -> anyhow::Result<()> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             alice_pubkey,
             alice_host_fn_caller,
@@ -198,7 +198,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "test_utils")]
     async fn schedule_test_wasm() -> anyhow::Result<()> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/send_remote_signal.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/send_remote_signal.rs
@@ -157,7 +157,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "test_utils")]
     async fn remote_signal_test() -> anyhow::Result<()> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         const NUM_CONDUCTORS: usize = 5;
 
         let num_signals = Arc::new(AtomicUsize::new(0));

--- a/crates/holochain/src/core/ribosome/host_fn/sign.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/sign.rs
@@ -46,7 +46,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_sign_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/sign_ephemeral.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/sign_ephemeral.rs
@@ -61,7 +61,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_sign_ephemeral_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Sign).await;

--- a/crates/holochain/src/core/ribosome/host_fn/sys_time.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/sys_time.rs
@@ -39,7 +39,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn invoke_import_sys_time_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::SysTime).await;

--- a/crates/holochain/src/core/ribosome/host_fn/trace.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/trace.rs
@@ -86,7 +86,7 @@ pub mod wasm_test {
     async fn wasm_trace_test() {
         use holochain_types::prelude::Level::*;
         CAPTURE.store(true, std::sync::atomic::Ordering::SeqCst);
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::Debug).await;

--- a/crates/holochain/src/core/ribosome/host_fn/verify_signature.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/verify_signature.rs
@@ -48,7 +48,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_verify_signature_raw_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,
@@ -172,7 +172,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_verify_signature_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor,
             alice,

--- a/crates/holochain/src/core/ribosome/host_fn/x_25519_x_salsa20_poly1305_encrypt.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/x_25519_x_salsa20_poly1305_encrypt.rs
@@ -64,7 +64,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn invoke_import_x_25519_x_salsa20_poly1305_encrypt_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::XSalsa20Poly1305).await;

--- a/crates/holochain/src/core/ribosome/host_fn/x_salsa20_poly1305_encrypt.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/x_salsa20_poly1305_encrypt.rs
@@ -60,7 +60,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg(feature = "test_utils")]
     async fn xsalsa20_poly1305_shared_secret_round_trip() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         // we need two conductors and two x25519 pub keys to do a round trip
 

--- a/crates/holochain/src/core/ribosome/host_fn/zome_info.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/zome_info.rs
@@ -43,7 +43,7 @@ pub mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn zome_info_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::EntryDefs).await;

--- a/crates/holochain/src/core/ribosome/real_ribosome.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome.rs
@@ -1090,7 +1090,7 @@ pub mod wasm_test {
     // guard to assure that response time to zome calls and concurrent zome calls
     // is not increasing disproportionally
     async fn concurrent_zome_call_response_time_guard() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let mut conductor = SweetConductor::from_config_rendezvous(
             SweetConductorConfig::rendezvous(true),
             SweetLocalRendezvous::new().await,
@@ -1182,7 +1182,7 @@ pub mod wasm_test {
     /// Basic checks that we can call externs internally and externally the way we want using the
     /// hdk macros rather than low level rust extern syntax.
     async fn ribosome_extern_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let (dna_file, _, _) =
             SweetDnaFile::unique_from_test_wasms(vec![TestWasm::HdkExtern]).await;
@@ -1242,7 +1242,7 @@ pub mod wasm_test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn wasm_tooling_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         assert_eq!(
             vec![
@@ -1311,7 +1311,7 @@ pub mod wasm_test {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore]
     async fn the_incredible_halt_test() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let RibosomeTestFixture {
             conductor, alice, ..
         } = RibosomeTestFixture::new(TestWasm::TheIncredibleHalt).await;

--- a/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/network_call_tests.rs
@@ -34,7 +34,7 @@ const DELAY_PER_ATTEMPT: std::time::Duration = std::time::Duration::from_millis(
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_agent_activity_test() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let zomes = vec![TestWasm::Create];
     let mut conductor_test = ConductorTestData::two_agents(zomes, false).await;
@@ -315,7 +315,7 @@ async fn get_agent_activity_test() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_agent_activity_host_fn_test() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let zomes = vec![TestWasm::Create];
     let mut conductor_test = ConductorTestData::two_agents(zomes, false).await;

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -39,7 +39,7 @@ use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn main_loop_app_validation_workflow() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let zomes =
         SweetInlineZomes::new(vec![], 0).integrity_function("validate", move |api, op: Op| {
@@ -216,7 +216,7 @@ async fn main_loop_app_validation_workflow() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "deal with the invalid data that leads to blocks being enforced"]
 async fn app_validation_workflow_test() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![
         TestWasm::Validate,
@@ -255,7 +255,7 @@ async fn app_validation_workflow_test() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_private_entries_are_passed_to_validation_only_when_authored_with_full_entry() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     #[hdk_entry_helper]
     pub struct Post(String);
@@ -408,7 +408,7 @@ async fn test_private_entries_are_passed_to_validation_only_when_authored_with_f
 #[tokio::test(flavor = "multi_thread")]
 async fn check_app_entry_def_test() {
     let mut u = unstructured_noise();
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let TestWasmPair::<DnaWasm> {
         integrity,
         coordinator,

--- a/crates/holochain/src/core/workflow/app_validation_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/unit_tests.rs
@@ -143,7 +143,7 @@ async fn validation_callback_must_get_action() {
 // instead of explicitly writing the missing op to the cache
 #[tokio::test(flavor = "multi_thread")]
 async fn validation_callback_awaiting_deps_hashes() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let zomes = SweetInlineZomes::new(vec![], 0).integrity_function("validate", {
         move |api, op: Op| {
@@ -249,7 +249,7 @@ async fn validation_callback_awaiting_deps_hashes() {
 // test that unresolved dependencies of an agent's chain are fetched
 #[tokio::test(flavor = "multi_thread")]
 async fn validation_callback_awaiting_deps_agent_activity() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let zomes = SweetInlineZomes::new(vec![], 0).integrity_function("validate", {
         move |api, op: Op| {
@@ -395,7 +395,7 @@ async fn validation_callback_awaiting_deps_agent_activity() {
 // they are an authority of
 #[tokio::test(flavor = "multi_thread")]
 async fn validation_callback_prevent_multiple_identical_hash_fetches() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let zomes = SweetInlineZomes::new(vec![], 0).integrity_function("validate", {
         move |api, op: Op| {
@@ -505,7 +505,7 @@ async fn validation_callback_prevent_multiple_identical_hash_fetches() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validation_callback_prevent_multiple_identical_agent_activity_fetches() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let zomes = SweetInlineZomes::new(vec![], 0).integrity_function("validate", {
         move |api, op: Op| {
@@ -643,7 +643,7 @@ async fn validation_callback_prevent_multiple_identical_agent_activity_fetches()
 
 #[tokio::test(flavor = "multi_thread")]
 async fn hashes_missing_for_op_are_updated_before_and_after_fetching_deps() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let zomes = SweetInlineZomes::new(vec![], 0).integrity_function("validate", {
         move |api, op: Op| {

--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
@@ -166,7 +166,7 @@ impl Expected {
 /// Test that all ops are created and the correct zomes
 /// are called for each op.
 async fn app_validation_ops() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let entry_def_a = EntryDef::default_from_id("a");
     let entry_def_b = EntryDef::default_from_id("b");
     let call_back_a = |_zome_name: &'static str| {

--- a/crates/holochain/src/core/workflow/call_zome_workflow/validation_test.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow/validation_test.rs
@@ -15,7 +15,7 @@ use std::convert::TryFrom;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn direct_validation_test() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let TestWasmPair::<DnaWasm> {
         integrity,

--- a/crates/holochain/src/core/workflow/genesis_workflow.rs
+++ b/crates/holochain/src/core/workflow/genesis_workflow.rs
@@ -193,7 +193,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn genesis_initializes_source_chain() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         let test_db = test_authored_db();
         let dht_db = test_dht_db();
         let dht_db_cache = DhtDbQueryCache::new(dht_db.to_db().into());

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow/tests.rs
@@ -7,7 +7,7 @@ use holochain_keystore::AgentPubKeyExt;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn incoming_ops_to_limbo() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let space = TestSpace::new(fixt!(DnaHash));
     let env = space.space.dht_db.clone();
@@ -52,7 +52,7 @@ async fn incoming_ops_to_limbo() {
 // reprocessing.
 #[tokio::test(flavor = "multi_thread")]
 async fn can_retry_failed_op() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let space = TestSpace::new(fixt!(DnaHash));
     let env = space.space.dht_db.clone();
@@ -104,7 +104,7 @@ async fn can_retry_failed_op() {
 // Verifies that an op which has been republished will allow a new validation receipt to be requested.
 #[tokio::test(flavor = "multi_thread")]
 async fn republish_to_request_validation_receipt() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let space = TestSpace::new(fixt!(DnaHash));
     let env = space.space.dht_db.clone();

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/query_tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/query_tests.rs
@@ -93,7 +93,7 @@ impl Scenario {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn integrate_query() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let db = test_dht_db();
     let expected = test_data(&db.to_db()).await;
     let (qt, _rx) = TriggerSender::new();

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
@@ -513,7 +513,7 @@ fn register_delete_link_missing_base(a: TestData) -> (Vec<Db>, Vec<Db>, &'static
 // This runs the above tests
 #[tokio::test(flavor = "multi_thread")]
 async fn test_ops_state() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let test_db = test_dht_db();
     let env = test_db.to_db();
 

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -284,7 +284,7 @@ mod tests {
     #[ignore = "(david.b) tests should be re-written using mock network"]
     fn test_sent_to_r_nodes(num_agents: u32, num_hash: u32) {
         tokio_helper::block_forever_on(async {
-            holochain_trace::test_run().ok();
+            holochain_trace::test_run();
 
             // Create test db
             let test_db = test_authored_db();
@@ -350,7 +350,7 @@ mod tests {
     fn test_private_entries(num_agents: u32) {
         tokio_helper::block_forever_on(
             async {
-                holochain_trace::test_run().ok();
+                holochain_trace::test_run();
 
                 // Create test db
                 let test_db = test_authored_db();

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
@@ -160,7 +160,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn publish_query() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let agent = fixt!(AgentPubKey);
         let db = test_authored_db();

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow/unit_tests.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, SystemTime};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn no_ops_to_publish() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let test_db = holochain_state::test_utils::test_authored_db();
     let vault = test_db.to_db();
@@ -39,7 +39,7 @@ async fn no_ops_to_publish() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn workflow_incomplete_on_routing_error() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let test_db = holochain_state::test_utils::test_authored_db();
     let vault = test_db.to_db();
@@ -71,7 +71,7 @@ async fn workflow_incomplete_on_routing_error() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn workflow_handles_publish_errors() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let test_db = holochain_state::test_utils::test_authored_db();
     let vault = test_db.to_db();
@@ -103,7 +103,7 @@ async fn workflow_handles_publish_errors() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn retry_publish_until_receipts_received() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let test_db = holochain_state::test_utils::test_authored_db();
     let vault = test_db.to_db();
@@ -148,7 +148,7 @@ async fn retry_publish_until_receipts_received() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn loop_resumes_on_new_data() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let test_db = holochain_state::test_utils::test_authored_db();
     let vault = test_db.to_db();
@@ -187,7 +187,7 @@ async fn loop_resumes_on_new_data() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn ignores_data_by_other_authors() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let test_db = holochain_state::test_utils::test_authored_db();
     let vault = test_db.to_db();

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
@@ -9,7 +9,7 @@ use crate::test_utils::inline_zomes::simple_create_read_zome;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "TODO: complete when chain validation returns actual error"]
 async fn sys_validation_agent_activity_test() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let mut conductors = SweetConductorBatch::from_standard_config(2).await;
 

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn sys_validation_workflow_test() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
 

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_op_with_no_dependency() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -70,7 +70,7 @@ async fn validate_op_with_no_dependency() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_op_with_dependency_held_in_cache() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -121,7 +121,7 @@ async fn validate_op_with_dependency_held_in_cache() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_op_with_dependency_not_held() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -176,7 +176,7 @@ async fn validate_op_with_dependency_not_held() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_op_with_dependency_not_found_on_the_dht() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -225,7 +225,7 @@ async fn validate_op_with_dependency_not_found_on_the_dht() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_op_with_wrong_sequence_number_rejected_and_not_forwarded_to_app_validation() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
@@ -19,7 +19,7 @@ use parking_lot::Mutex;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_valid_dna_op() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -41,7 +41,7 @@ async fn validate_valid_dna_op() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_dna_op_mismatched_dna_hash() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -77,7 +77,7 @@ async fn validate_dna_op_mismatched_dna_hash() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_dna_op_before_origin_time() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -111,7 +111,7 @@ async fn validate_dna_op_before_origin_time() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn non_dna_op_as_first_action() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -153,7 +153,7 @@ async fn non_dna_op_as_first_action() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_valid_agent_validation_package_op() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -191,7 +191,7 @@ async fn validate_valid_agent_validation_package_op() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_valid_create_op() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -237,7 +237,7 @@ async fn validate_valid_create_op() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_create_op_with_prev_from_network() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -295,7 +295,7 @@ async fn validate_create_op_with_prev_from_network() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_create_op_with_prev_action_not_found() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -337,7 +337,7 @@ async fn validate_create_op_with_prev_action_not_found() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_create_op_author_mismatch_with_prev() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -397,7 +397,7 @@ async fn validate_create_op_author_mismatch_with_prev() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_create_op_with_timestamp_same_as_prev() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -437,7 +437,7 @@ async fn validate_create_op_with_timestamp_same_as_prev() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_create_op_with_timestamp_before_prev() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -494,7 +494,7 @@ async fn validate_create_op_with_timestamp_before_prev() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_create_op_seq_number_decrements() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -543,7 +543,7 @@ async fn validate_create_op_seq_number_decrements() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_create_op_seq_number_reused() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -592,7 +592,7 @@ async fn validate_create_op_seq_number_reused() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_create_op_not_preceeded_by_avp() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -647,7 +647,7 @@ async fn validate_create_op_not_preceeded_by_avp() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_avp_op_not_followed_by_create() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -702,7 +702,7 @@ async fn validate_avp_op_not_followed_by_create() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_valid_store_record_with_no_entry() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -743,7 +743,7 @@ async fn validate_valid_store_record_with_no_entry() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_store_record_leaks_entry() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -787,7 +787,7 @@ async fn validate_store_record_leaks_entry() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_store_record_with_entry_having_wrong_entry_type() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -829,7 +829,7 @@ async fn validate_store_record_with_entry_having_wrong_entry_type() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_store_record_with_entry_having_wrong_entry_hash() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -886,7 +886,7 @@ async fn validate_store_record_with_entry_having_wrong_entry_hash() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_store_record_with_large_entry() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     use holochain_serialized_bytes::prelude::*;
     use serde::{Deserialize, Serialize};
@@ -946,7 +946,7 @@ async fn validate_store_record_with_large_entry() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_valid_store_record_update() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1021,7 +1021,7 @@ async fn validate_valid_store_record_update() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_store_record_update_prev_which_is_not_updateable() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1081,7 +1081,7 @@ async fn validate_store_record_update_prev_which_is_not_updateable() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_store_record_update_changes_entry_type() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1162,7 +1162,7 @@ async fn validate_store_record_update_changes_entry_type() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_store_entry_with_entry_having_wrong_entry_type() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1205,7 +1205,7 @@ async fn validate_store_entry_with_entry_having_wrong_entry_type() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_store_entry_with_entry_having_wrong_entry_hash() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1262,7 +1262,7 @@ async fn validate_store_entry_with_entry_having_wrong_entry_hash() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_store_entry_with_large_entry() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     use holochain_serialized_bytes::prelude::*;
     use serde::{Deserialize, Serialize};
@@ -1322,7 +1322,7 @@ async fn validate_store_entry_with_large_entry() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_valid_store_entry_update() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1393,7 +1393,7 @@ async fn validate_valid_store_entry_update() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_store_entry_update_prev_which_is_not_updateable() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1453,7 +1453,7 @@ async fn validate_store_entry_update_prev_which_is_not_updateable() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_store_entry_update_changes_entry_type() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1538,7 +1538,7 @@ async fn validate_store_entry_update_changes_entry_type() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_valid_register_updated_content() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1589,7 +1589,7 @@ async fn validate_valid_register_updated_content() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_register_updated_content_missing_updates_ref() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1645,7 +1645,7 @@ async fn validate_register_updated_content_missing_updates_ref() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_valid_register_updated_record() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1696,7 +1696,7 @@ async fn validate_valid_register_updated_record() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_register_updated_record_missing_updates_ref() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1752,7 +1752,7 @@ async fn validate_register_updated_record_missing_updates_ref() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_valid_register_deleted_by() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1790,7 +1790,7 @@ async fn validate_valid_register_deleted_by() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_register_deleted_by_with_missing_deletes_ref() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1834,7 +1834,7 @@ async fn validate_register_deleted_by_with_missing_deletes_ref() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_register_deleted_by_wrong_delete_target() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1866,7 +1866,7 @@ async fn validate_register_deleted_by_wrong_delete_target() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_valid_register_deleted_entry_action() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1904,7 +1904,7 @@ async fn validate_valid_register_deleted_entry_action() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_register_deleted_entry_action_with_missing_deletes_ref() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1948,7 +1948,7 @@ async fn validate_register_deleted_entry_action_with_missing_deletes_ref() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_register_deleted_entry_action_wrong_delete_target() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1980,7 +1980,7 @@ async fn validate_register_deleted_entry_action_wrong_delete_target() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_valid_add_link() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -1999,7 +1999,7 @@ async fn validate_valid_add_link() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_add_link_tag_too_large() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -2021,7 +2021,7 @@ async fn validate_add_link_tag_too_large() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_valid_remove_link() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -2049,7 +2049,7 @@ async fn validate_valid_remove_link() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_remove_link_missing_link_add_ref() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -2091,7 +2091,7 @@ async fn validate_remove_link_missing_link_add_ref() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn validate_remove_link_with_wrong_target_type() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut test_case = TestCase::new().await;
 
@@ -2126,7 +2126,7 @@ async fn validate_remove_link_with_wrong_target_type() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "TODO fix this test"]
 async fn crash_case() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let keystore = holochain_keystore::test_keystore();
 

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validation_query.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validation_query.rs
@@ -126,7 +126,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn sys_validation_query() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let db = test_dht_db();
         let expected = create_test_data(&db.to_db().into()).await;
         let ops = get_ops_to_sys_validate(&db.to_db().into()).await.unwrap();
@@ -142,7 +142,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn app_validation_query() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let db = test_dht_db();
         let expected = create_test_data(&db.to_db().into()).await;
         let ops = get_ops_to_app_validate(&db.to_db().into()).await.unwrap();
@@ -159,7 +159,7 @@ mod tests {
     /// Make sure both workflows can't pull in the same ops.
     #[tokio::test(flavor = "multi_thread")]
     async fn workflows_are_exclusive() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let db = test_dht_db();
         create_test_data(&db.to_db().into()).await;
         let app_validation_ops = get_ops_to_app_validate(&db.to_db().into()).await.unwrap();

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -11,7 +11,7 @@ use rusqlite::Transaction;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "flaky, doesn't take into account timing or retries"]
 async fn test_validation_receipt() {
-    let _g = holochain_trace::test_run().ok();
+    let _g = holochain_trace::test_run();
     const NUM_CONDUCTORS: usize = 3;
 
     let mut conductors = SweetConductorBatch::from_standard_config(NUM_CONDUCTORS).await;
@@ -129,7 +129,7 @@ macro_rules! wait_until {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn test_block_invalid_receipt() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let unit_entry_def = EntryDef::default_from_id("unit");
     let integrity_name = "integrity";
     let coordinator_name = "coordinator";

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/unit_tests.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn no_running_cells() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let test_db = holochain_state::test_utils::test_dht_db();
     let vault = test_db.to_db();
@@ -46,7 +46,7 @@ async fn no_running_cells() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn do_not_block_or_send_to_self() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let test_db = holochain_state::test_utils::test_dht_db();
     let vault = test_db.to_db();
@@ -95,7 +95,7 @@ async fn do_not_block_or_send_to_self() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn block_invalid_op_author() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let test_db = holochain_state::test_utils::test_dht_db();
     let vault = test_db.to_db();
@@ -155,7 +155,7 @@ async fn block_invalid_op_author() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn continues_if_receipt_cannot_be_signed() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let test_db = holochain_state::test_utils::test_dht_db();
     let vault = test_db.to_db();
@@ -193,7 +193,7 @@ async fn continues_if_receipt_cannot_be_signed() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn send_validation_receipt() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let test_db = holochain_state::test_utils::test_dht_db();
     let vault = test_db.to_db();
@@ -234,7 +234,7 @@ async fn send_validation_receipt() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn errors_for_some_ops_does_not_prevent_the_workflow_proceeding() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let test_db = holochain_state::test_utils::test_dht_db();
     let vault = test_db.to_db();

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -9,7 +9,7 @@ use test_case::test_case;
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn conductors_call_remote(num_conductors: usize) {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
 
@@ -246,7 +246,7 @@ async fn conductors_gossip_inner(
     network: KitsuneP2pConfig,
     share_peers: bool,
 ) {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let network_seed = nanoid::nanoid!().to_string();
 
     let zomes = vec![TestWasm::Create];

--- a/crates/holochain/tests/agent_scaling/mod.rs
+++ b/crates/holochain/tests/agent_scaling/mod.rs
@@ -43,7 +43,7 @@ fn links_zome() -> InlineIntegrityZome {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "slow_tests")]
 async fn many_agents_can_reach_consistency_agent_links() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     const NUM_AGENTS: usize = 20;
 
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(("links", links_zome())).await;
@@ -92,7 +92,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "slow_tests")]
 async fn many_agents_can_reach_consistency_normal_links() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     const NUM_AGENTS: usize = 30;
 
     let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Link]).await;
@@ -129,7 +129,7 @@ async fn many_agents_can_reach_consistency_normal_links() {
 // This could become a bench.
 #[ignore = "Slow test for CI that is only useful for timing"]
 async fn stuck_conductor_wasm_calls() -> anyhow::Result<()> {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     // Bundle the single zome into a DnaFile
     let (dna_file, _, _) =
         SweetDnaFile::unique_from_test_wasms(vec![TestWasm::MultipleCalls]).await;
@@ -195,7 +195,7 @@ async fn many_concurrent_zome_calls_dont_gunk_up_the_works() {
     use holochain_conductor_api::{AppRequest, AppResponse, ZomeCall};
     use std::time::Instant;
 
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     const NUM_AGENTS: usize = 30;
 
     let (dna_file, _, _) =

--- a/crates/holochain/tests/authored_test/mod.rs
+++ b/crates/holochain/tests/authored_test/mod.rs
@@ -15,7 +15,7 @@ use holochain_zome_types::prelude::*;
 /// - Bob commits the entry and it is now in their authored store
 #[tokio::test(flavor = "multi_thread")]
 async fn authored_test() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     // Check if the correct number of ops are integrated
     // every 100 ms for a maximum of 10 seconds but early exit
     // if they are there.

--- a/crates/holochain/tests/clone_cell/mod.rs
+++ b/crates/holochain/tests/clone_cell/mod.rs
@@ -5,7 +5,7 @@ use holochain_wasm_test_utils::TestWasm;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_clone_cell() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut conductor = SweetConductor::from_standard_config().await;
     let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Clone]).await;
@@ -51,7 +51,7 @@ async fn create_clone_cell() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn disable_enable_and_delete_clone_cell() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut conductor = SweetConductor::from_standard_config().await;
     let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Clone]).await;
@@ -147,7 +147,7 @@ async fn disable_enable_and_delete_clone_cell() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn prevents_cross_app_clone_operations() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut conductor = SweetConductor::from_standard_config().await;
     let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Clone]).await;
@@ -261,7 +261,7 @@ async fn prevents_cross_app_clone_operations() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_clone_cell_from_a_clone() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut conductor = SweetConductor::from_standard_config().await;
     let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Clone]).await;
@@ -321,7 +321,7 @@ async fn create_clone_cell_from_a_clone() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_clone_of_another_cell_in_same_app() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut conductor = SweetConductor::from_standard_config().await;
     let (dna_file_1, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Clone]).await;

--- a/crates/holochain/tests/inline_zome_spec/mod.rs
+++ b/crates/holochain/tests/inline_zome_spec/mod.rs
@@ -67,7 +67,7 @@ async fn inline_zome_2_agents_1_dna() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "test_utils")]
 async fn inline_zome_3_agents_2_dnas() -> anyhow::Result<()> {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut conductor = SweetConductor::from_standard_config().await;
 
     let (dna_foo, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
@@ -157,7 +157,7 @@ async fn inline_zome_3_agents_2_dnas() -> anyhow::Result<()> {
 // I can't remember what this test was for? Should we just delete?
 #[ignore = "Needs to be completed when HolochainP2pEvents is accessible"]
 async fn invalid_cell() -> anyhow::Result<()> {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut conductor = SweetConductor::from_standard_config().await;
 
     let (dna_foo, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
@@ -187,7 +187,7 @@ async fn invalid_cell() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "test_utils")]
 async fn get_deleted() -> anyhow::Result<()> {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     // Bundle the single zome into a DnaFile
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
 
@@ -256,7 +256,7 @@ async fn get_deleted() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "test_utils")]
 async fn signal_subscription() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     const N: usize = 10;
 
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
@@ -361,7 +361,7 @@ async fn simple_validation() -> anyhow::Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_call_real_zomes_too() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let mut conductor = SweetConductor::from_standard_config().await;
     let agent = SweetAgents::one(conductor.keystore()).await;

--- a/crates/holochain/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/multi_conductor/mod.rs
@@ -22,7 +22,7 @@ async fn test_publish() -> anyhow::Result<()> {
     use holochain::test_utils::inline_zomes::simple_create_read_zome;
     use kitsune_p2p_types::config::KitsuneP2pConfig;
 
-    let _g = holochain_trace::test_run().ok();
+    let _g = holochain_trace::test_run();
     const NUM_CONDUCTORS: usize = 3;
 
     let mut tuning =
@@ -79,7 +79,7 @@ async fn test_publish() -> anyhow::Result<()> {
 async fn multi_conductor() -> anyhow::Result<()> {
     use holochain::test_utils::inline_zomes::simple_create_read_zome;
 
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     const NUM_CONDUCTORS: usize = 3;
 
@@ -141,7 +141,7 @@ async fn sharded_consistency() {
         consistency::local_machine_session, inline_zomes::simple_create_read_zome,
     };
 
-    let _g = holochain_trace::test_run().ok();
+    let _g = holochain_trace::test_run();
     const NUM_CONDUCTORS: usize = 3;
     const NUM_CELLS: usize = 5;
 
@@ -192,7 +192,7 @@ async fn private_entries_dont_leak() {
     use holochain::sweettest::SweetInlineZomes;
     use holochain_types::inline_zome::InlineZomeSet;
 
-    let _g = holochain_trace::test_run().ok();
+    let _g = holochain_trace::test_run();
     let mut entry_def = EntryDef::default_from_id("entrydef");
     entry_def.visibility = EntryVisibility::Private;
 

--- a/crates/holochain/tests/network_tests/mod.rs
+++ b/crates/holochain/tests/network_tests/mod.rs
@@ -55,7 +55,7 @@ use holochain::test_utils::host_fn_caller::*;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "flaky"]
 async fn get_updates_cache() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     // Database setup
     let test_db = test_cell_db();
     let db = test_db.db();
@@ -99,7 +99,7 @@ async fn get_updates_cache() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "flaky!"]
 async fn get_meta_updates_meta_cache() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     // Database setup
     let test_db = test_cell_db();
     let db = test_db.db();
@@ -165,7 +165,7 @@ let mut reader = g.reader().unwrap();
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "flaky"]
 async fn get_from_another_agent() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let dna_file = DnaFile::new(
         DnaDef {
             name: "dht_get_test".to_string(),
@@ -297,7 +297,7 @@ async fn get_from_another_agent() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "flaky for some reason"]
 async fn get_links_from_another_agent() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let dna_file = DnaFile::new(
         DnaDef {
             name: "dht_get_test".to_string(),

--- a/crates/holochain/tests/publish/mod.rs
+++ b/crates/holochain/tests/publish/mod.rs
@@ -8,7 +8,7 @@ use holochain_wasm_test_utils::TestWasm;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "receipt completion is flaky, revise once integration logic is merged into app validation workflow"]
 async fn publish_terminates_after_receiving_required_validation_receipts() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     // Need DEFAULT_RECEIPT_BUNDLE_SIZE peers to send validation receipts back
     const NUM_CONDUCTORS: usize =

--- a/crates/holochain/tests/regression/mod.rs
+++ b/crates/holochain/tests/regression/mod.rs
@@ -5,7 +5,7 @@ use holochain_wasm_test_utils::TestWasm;
 // Intended to keep https://github.com/holochain/holochain/issues/2868 fixed.
 #[tokio::test(flavor = "multi_thread")]
 async fn zome_with_no_entry_types_does_not_prevent_deletes() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut conductor = SweetConductor::from_standard_config().await;
 
@@ -40,7 +40,7 @@ async fn zome_with_no_entry_types_does_not_prevent_deletes() {
 // Intended to keep https://github.com/holochain/holochain/issues/2868 fixed.
 #[tokio::test(flavor = "multi_thread")]
 async fn zome_with_no_link_types_does_not_prevent_delete_links() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut conductor = SweetConductor::from_standard_config().await;
 

--- a/crates/holochain/tests/regression/must_get_agent_activity_saturation.rs
+++ b/crates/holochain/tests/regression/must_get_agent_activity_saturation.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 #[cfg(feature = "slow_tests")]
 #[ignore = "temporarily while working on app validation refactor; to be reinstated along the refactor"]
 async fn must_get_agent_activity_saturation() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut rng = thread_rng();
     let (dna, _, _) =
         SweetDnaFile::unique_from_test_wasms(vec![TestWasm::MustGetAgentActivity]).await;

--- a/crates/holochain/tests/ser_regression/mod.rs
+++ b/crates/holochain/tests/ser_regression/mod.rs
@@ -23,7 +23,7 @@ pub struct ChannelName(String);
 
 #[tokio::test(flavor = "multi_thread")]
 async fn ser_entry_hash_test() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let eh = fixt!(EntryHash);
     let extern_io: ExternIO = ExternIO::encode(eh).unwrap();
     tracing::debug!(?extern_io);
@@ -36,7 +36,7 @@ async fn ser_entry_hash_test() {
 #[tokio::test(flavor = "multi_thread")]
 /// we can call a fn on a remote
 async fn ser_regression_test() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     // ////////////
     // START DNA
     // ////////////

--- a/crates/holochain/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/sharded_gossip/mod.rs
@@ -75,7 +75,7 @@ impl From<TestConfig> for SweetConductorConfig {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn fullsync_sharded_gossip_low_data() -> anyhow::Result<()> {
-    let _g = holochain_trace::test_run().ok();
+    let _g = holochain_trace::test_run();
     const NUM_CONDUCTORS: usize = 2;
 
     let mut conductors = SweetConductorBatch::from_config_rendezvous(
@@ -131,7 +131,7 @@ async fn fullsync_sharded_gossip_low_data() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     const NUM_CONDUCTORS: usize = 3;
     const NUM_OPS: usize = 100;
@@ -220,7 +220,7 @@ async fn fullsync_sharded_gossip_high_data() -> anyhow::Result<()> {
 #[cfg(feature = "slow_tests")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_zero_arc_get_links() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Standard config with arc clamped to zero
     let mut tuning = make_tuning(true, true, true, None);
@@ -250,7 +250,7 @@ async fn test_zero_arc_get_links() {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn test_zero_arc_no_gossip_2way() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Standard config
 
@@ -306,7 +306,7 @@ async fn test_zero_arc_no_gossip_2way() {
 async fn test_zero_arc_no_gossip_4way() {
     use futures::future::join_all;
 
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let configs = [
         // Standard config
@@ -455,7 +455,7 @@ async fn test_zero_arc_no_gossip_4way() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "deal with connections closing and banning for 10s"]
 async fn test_gossip_shutdown() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut conductors = SweetConductorBatch::from_config_rendezvous(
         2,
         TestConfig {
@@ -503,7 +503,7 @@ async fn test_gossip_shutdown() {
 #[ignore = "This test is potentially useful but uses sleeps and has never failed.
             Run it again in the future to see if it fails, and if so, rewrite it without sleeps."]
 async fn test_gossip_startup() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let config = || {
         SweetConductorConfig::standard().tune(|t| {
             t.danger_gossip_recent_threshold_secs = 1;
@@ -703,7 +703,7 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
 async fn fullsync_sharded_local_gossip() -> anyhow::Result<()> {
     use holochain::{sweettest::SweetConductor, test_utils::inline_zomes::simple_create_read_zome};
 
-    let _g = holochain_trace::test_run().ok();
+    let _g = holochain_trace::test_run();
 
     let mut conductor = SweetConductor::from_config_rendezvous(
         TestConfig {
@@ -791,7 +791,7 @@ async fn mock_network_sharded_gossip() {
     // Check if we should for new data to be generated even if it already exists.
     let force_new_data = std::env::var_os("FORCE_NEW_DATA").is_some();
 
-    let _g = holochain_trace::test_run().ok();
+    let _g = holochain_trace::test_run();
 
     // Generate or use cached test data.
     let (data, mut conn) = generate_test_data(num_agents, min_ops, false, force_new_data).await;
@@ -1327,7 +1327,7 @@ async fn mock_network_sharding() {
     // Check if we should for new data to be generated even if it already exists.
     let force_new_data = std::env::var_os("FORCE_NEW_DATA").is_some();
 
-    let _g = holochain_trace::test_run().ok();
+    let _g = holochain_trace::test_run();
 
     // Generate or use cached test data.
     let (data, mut conn) = generate_test_data(num_agents, min_ops, false, force_new_data).await;

--- a/crates/holochain/tests/signals/mod.rs
+++ b/crates/holochain/tests/signals/mod.rs
@@ -28,7 +28,7 @@ fn to_signal_message(signal: Signal) -> SignalMessage {
 #[cfg(feature = "slow_tests")]
 #[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn remote_signals_batch() -> anyhow::Result<()> {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let mut conductors =
         SweetConductorBatch::from_config_rendezvous(3, SweetConductorConfig::rendezvous(true))

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -56,7 +56,7 @@ impl PollRecv {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "slow_tests")]
 async fn call_admin() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     // NOTE: This is a full integration test that
     // actually runs the holochain binary
 
@@ -127,7 +127,7 @@ how_many: 42
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "slow_tests")]
 async fn call_zome() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // NOTE: This is a full integration test that
     // actually runs the holochain binary
@@ -276,7 +276,7 @@ async fn call_zome() {
 #[cfg(feature = "slow_tests")]
 #[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn remote_signals() -> anyhow::Result<()> {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     const NUM_CONDUCTORS: usize = 2;
 
     let mut conductors = SweetConductorBatch::from_standard_config(NUM_CONDUCTORS).await;
@@ -348,7 +348,7 @@ async fn remote_signals() -> anyhow::Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "slow_tests")]
 async fn emit_signals() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     // NOTE: This is a full integration test that
     // actually runs the holochain binary
 
@@ -483,7 +483,7 @@ async fn emit_signals() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn conductor_admin_interface_runs_from_config() -> Result<()> {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let tmp_dir = TempDir::new().unwrap();
     let environment_path = tmp_dir.path().to_path_buf();
     let config = create_config(0, environment_path.into());
@@ -508,7 +508,7 @@ async fn conductor_admin_interface_runs_from_config() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn list_app_interfaces_succeeds() -> Result<()> {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     info!("creating config");
     let tmp_dir = TempDir::new().unwrap();
@@ -553,7 +553,7 @@ async fn conductor_admin_interface_ends_with_shutdown() -> Result<()> {
 }
 
 async fn conductor_admin_interface_ends_with_shutdown_inner() -> Result<()> {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     info!("creating config");
     let tmp_dir = TempDir::new().unwrap();
@@ -621,7 +621,7 @@ async fn conductor_admin_interface_ends_with_shutdown_inner() -> Result<()> {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg(feature = "slow_tests")]
 async fn connection_limit_is_respected() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let tmp_dir = TempDir::new().unwrap();
     let environment_path = tmp_dir.path().to_path_buf();
@@ -692,7 +692,7 @@ async fn concurrent_install_dna() {
     static NUM_CONCURRENT_INSTALLS: u8 = 10;
     static REQ_TIMEOUT_MS: u64 = 15000;
 
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     // NOTE: This is a full integration test that
     // actually runs the holochain binary
 
@@ -765,7 +765,7 @@ async fn concurrent_install_dna() {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(target_os = "macos", ignore)]
 async fn network_stats() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let mut batch =
         SweetConductorBatch::from_config_rendezvous(2, SweetConductorConfig::rendezvous(true))
@@ -798,7 +798,7 @@ async fn network_stats() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn full_state_dump_cursor_works() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let mut conductor = SweetConductor::from_standard_config().await;
 
@@ -848,7 +848,7 @@ async fn full_state_dump_cursor_works() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn admin_allowed_origins() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let conductor = SweetConductor::from_standard_config().await;
 
@@ -901,7 +901,7 @@ async fn admin_allowed_origins() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn app_allowed_origins() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let conductor = SweetConductor::from_standard_config().await;
 
@@ -932,7 +932,7 @@ async fn app_allowed_origins() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn app_allowed_origins_independence() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let conductor = SweetConductor::from_standard_config().await;
 

--- a/crates/holochain_cascade/src/authority/get_agent_activity_query/deterministic.rs
+++ b/crates/holochain_cascade/src/authority/get_agent_activity_query/deterministic.rs
@@ -143,7 +143,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn agent_activity_query() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let test_db = test_dht_db();
         let db = test_db.to_db();
         let entry_type_1 = fixt!(EntryType);

--- a/crates/holochain_cascade/src/authority/test.rs
+++ b/crates/holochain_cascade/src/authority/test.rs
@@ -16,7 +16,7 @@ fn options() -> holochain_p2p::event::GetOptions {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_entry() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let db = test_dht_db();
 
     let td = EntryTestData::create();
@@ -64,7 +64,7 @@ async fn get_entry() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_record() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let db = test_dht_db();
 
     let td = RecordTestData::create();
@@ -130,7 +130,7 @@ async fn get_record() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn retrieve_record() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let db = test_dht_db();
 
     let td = RecordTestData::create();
@@ -154,7 +154,7 @@ async fn retrieve_record() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_links() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let db = test_dht_db();
 
     let td = EntryTestData::create();
@@ -190,7 +190,7 @@ async fn get_links() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_agent_activity() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let db = test_dht_db();
 
     let td = ActivityTestData::valid_chain_scenario();

--- a/crates/holochain_cascade/tests/count_links.rs
+++ b/crates/holochain_cascade/tests/count_links.rs
@@ -9,7 +9,7 @@ use holochain_types::test_utils::chain::action_hash;
 // Checks that links can be counted by asking a remote peer who is an authority on the base for the count
 #[tokio::test(flavor = "multi_thread")]
 async fn count_links_not_authority() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();
@@ -46,7 +46,7 @@ async fn count_links_not_authority() {
 // Checks that network access is not required for an authority, the agent can count links locally
 #[tokio::test(flavor = "multi_thread")]
 async fn count_links_authority() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();
@@ -89,7 +89,7 @@ async fn count_links_authority() {
 // seen by the agent doing the publish
 #[tokio::test(flavor = "multi_thread")]
 async fn count_links_authoring() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();
@@ -152,7 +152,7 @@ async fn count_links_authoring() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn count_links_with_filters() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();

--- a/crates/holochain_cascade/tests/get_activity.rs
+++ b/crates/holochain_cascade/tests/get_activity.rs
@@ -13,7 +13,7 @@ use test_case::test_case;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_activity() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();

--- a/crates/holochain_cascade/tests/get_entry.rs
+++ b/crates/holochain_cascade/tests/get_entry.rs
@@ -211,7 +211,7 @@ async fn assert_can_retrieve(td_entry: &EntryTestData, cascade: &CascadeImpl, op
 
 #[tokio::test(flavor = "multi_thread")]
 async fn entry_not_authority_or_authoring() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();
@@ -234,7 +234,7 @@ async fn entry_not_authority_or_authoring() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn entry_authoring() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();
@@ -272,7 +272,7 @@ async fn entry_authoring() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn entry_authority() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();
@@ -300,7 +300,7 @@ async fn entry_authority() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn content_not_authority_or_authoring() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();
@@ -328,7 +328,7 @@ async fn content_not_authority_or_authoring() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn content_authoring() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();
@@ -366,7 +366,7 @@ async fn content_authoring() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn content_authority() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();
@@ -392,7 +392,7 @@ async fn content_authority() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn rejected_ops() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();
@@ -414,7 +414,7 @@ async fn rejected_ops() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn check_can_handle_rejected_ops_in_cache() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();
@@ -458,7 +458,7 @@ async fn check_all_queries_still_work_with_scratch() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pending_data_isnt_returned() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();

--- a/crates/holochain_cascade/tests/get_links.rs
+++ b/crates/holochain_cascade/tests/get_links.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn links_not_authority() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();
@@ -62,7 +62,7 @@ async fn links_not_authority() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn links_authority() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();
@@ -103,7 +103,7 @@ async fn links_authority() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn links_authoring() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();
@@ -169,7 +169,7 @@ async fn links_authoring() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_links_can_match_a_partial_tag() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // Environments
     let cache = test_cache_db();

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn test_config_complete_config() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let yaml = r#"---
     data_root_path: /path/to/env

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -254,7 +254,7 @@ mod tests {
         holo_hash::AgentPubKey,
         holo_hash::AgentPubKey,
     ) {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
         (
             newhash!(DnaHash, 's'),
             fixt!(AgentPubKey, Predictable, 0),
@@ -507,7 +507,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_get_workflow() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let (dna, a1, a2, _a3) = test_setup();
 

--- a/crates/holochain_sqlite/tests/db_wrapper.rs
+++ b/crates/holochain_sqlite/tests/db_wrapper.rs
@@ -11,7 +11,7 @@ mod common;
 #[cfg(all(feature = "slow_tests", feature = "test_utils"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn async_read_respects_reader_permit_limits() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     set_acquire_timeout(100);
     set_connection_timeout(300);
@@ -83,7 +83,7 @@ async fn async_read_respects_reader_permit_limits() {
 #[cfg(all(feature = "slow_tests", feature = "test_utils"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn get_read_txn_respects_reader_permit_limits() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     set_acquire_timeout(100);
     set_connection_timeout(300);
@@ -154,7 +154,7 @@ async fn get_read_txn_respects_reader_permit_limits() {
 #[cfg(all(feature = "slow_tests", feature = "test_utils"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn read_async_releases_permits() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     set_acquire_timeout(100);
     set_connection_timeout(300);
@@ -185,7 +185,7 @@ async fn read_async_releases_permits() {
 #[cfg(all(feature = "slow_tests", feature = "test_utils"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn write_permits_can_be_released() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     set_acquire_timeout(100);
     set_connection_timeout(300);

--- a/crates/holochain_sqlite/tests/migrate_unencrypted.rs
+++ b/crates/holochain_sqlite/tests/migrate_unencrypted.rs
@@ -8,7 +8,7 @@ async fn migrate_unencrypted() {
     use rusqlite::Connection;
     use std::fs::create_dir_all;
 
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let tmp_dir = tempfile::TempDir::new().unwrap();
     create_dir_all(tmp_dir.path().join("conductor")).unwrap();

--- a/crates/holochain_state/src/query/chain_head.rs
+++ b/crates/holochain_state/src/query/chain_head.rs
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn test_chain_head_query() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let mut conn = Connection::open_in_memory().unwrap();
         SCHEMA_CELL.initialize(&mut conn, None).unwrap();
 

--- a/crates/holochain_state/src/query/live_entry/test.rs
+++ b/crates/holochain_state/src/query/live_entry/test.rs
@@ -10,7 +10,7 @@ use super::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_handle_update_in_scratch() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut scratch = Scratch::new();
     let mut conn = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn, None).unwrap();

--- a/crates/holochain_state/src/query/live_record/test.rs
+++ b/crates/holochain_state/src/query/live_record/test.rs
@@ -10,7 +10,7 @@ use super::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn can_handle_update_in_scratch() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut scratch = Scratch::new();
     let mut conn = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn, None).unwrap();

--- a/crates/holochain_state/src/query/tests.rs
+++ b/crates/holochain_state/src/query/tests.rs
@@ -30,7 +30,7 @@ mod sys_meta;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_links() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut scratch = Scratch::new();
     let mut conn = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn, None).unwrap();
@@ -111,7 +111,7 @@ async fn get_links() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn get_entry() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut scratch = Scratch::new();
     let mut conn = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn, None).unwrap();
@@ -177,7 +177,7 @@ async fn get_entry() {
 /// Test that `insert_op` also inserts an action and potentially an entry
 #[tokio::test(flavor = "multi_thread")]
 async fn insert_op_equivalence() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut conn1 = Connection::open_in_memory().unwrap();
     let mut conn2 = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn1, None).unwrap();

--- a/crates/holochain_state/src/query/tests/chain_sequence.rs
+++ b/crates/holochain_state/src/query/tests/chain_sequence.rs
@@ -6,7 +6,7 @@ use matches::assert_matches;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn chain_sequence_scratch_awareness() -> DatabaseResult<()> {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let test_db = test_cell_db();
     let arc = test_db.env();
     {

--- a/crates/holochain_state/src/query/tests/chain_test.rs
+++ b/crates/holochain_state/src/query/tests/chain_test.rs
@@ -9,7 +9,7 @@ use holochain_zome_types::test_utils::fake_agent_pubkey_1;
 use ChainStatus::*;
 
 fn setup() -> (TestEnv, MetadataBuf, Create, Create, AgentPubKey) {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let test_db = test_cell_db();
     let meta_buf = MetadataBuf::vault(test_db.env().into()).unwrap();
     let agent_pubkey = fake_agent_pubkey_1();

--- a/crates/holochain_state/src/query/tests/details.rs
+++ b/crates/holochain_state/src/query/tests/details.rs
@@ -9,7 +9,7 @@ use super::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn entry_scratch_same_as_sql() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut scratch = Scratch::new();
     let mut conn = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn, None).unwrap();
@@ -43,7 +43,7 @@ async fn entry_scratch_same_as_sql() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn record_scratch_same_as_sql() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut scratch = Scratch::new();
     let mut conn = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn, None).unwrap();

--- a/crates/holochain_state/src/query/tests/links_test.rs
+++ b/crates/holochain_state/src/query/tests/links_test.rs
@@ -654,7 +654,7 @@ async fn multiple_links() {
 }
 #[tokio::test(flavor = "multi_thread")]
 async fn duplicate_links() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let test_db = test_dht_db();
     let arc = test_db.to_db();
 
@@ -716,7 +716,7 @@ async fn duplicate_links() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn links_on_same_base() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let test_db = test_dht_db();
     let arc = test_db.to_db();
 
@@ -808,7 +808,7 @@ async fn links_on_same_base() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn links_on_same_tag() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let test_db = test_dht_db();
     let arc = test_db.to_db();
 
@@ -885,7 +885,7 @@ async fn links_on_same_tag() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn links_on_same_type() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let test_db = test_dht_db();
     let arc = test_db.to_db();
 
@@ -950,7 +950,7 @@ async fn links_on_same_type() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn link_type_ranges() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let test_db = test_dht_db();
     let arc = test_db.to_db();
 

--- a/crates/holochain_state/src/query/tests/store.rs
+++ b/crates/holochain_state/src/query/tests/store.rs
@@ -2,7 +2,7 @@ use super::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn exists() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut scratch = Scratch::new();
     let mut conn = Connection::open_in_memory().unwrap();
     SCHEMA_CELL.initialize(&mut conn, None).unwrap();

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -2065,7 +2065,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn source_chain_buffer_iter_back() -> SourceChainResult<()> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let test_db = test_authored_db();
         let dht_db = test_dht_db();
         let dht_db_cache = DhtDbQueryCache::new(dht_db.to_db().into());

--- a/crates/holochain_state/src/validation_receipts.rs
+++ b/crates/holochain_state/src/validation_receipts.rs
@@ -119,7 +119,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_validation_receipts_db_populate_and_list() -> StateMutationResult<()> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let test_db = crate::test_utils::test_authored_db();
         let env = test_db.to_db();
@@ -184,7 +184,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn no_pending_receipts() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let env = crate::test_utils::test_dht_db().to_db();
 
@@ -234,7 +234,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn filter_for_pending_validation_receipts() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let test_db = crate::test_utils::test_dht_db();
         let env = test_db.to_db();

--- a/crates/holochain_state/src/wasm.rs
+++ b/crates/holochain_state/src/wasm.rs
@@ -57,7 +57,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn wasm_store_round_trip() -> DatabaseResult<()> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         // all the stuff needed to have a WasmBuf
         let db = crate::test_utils::test_wasm_db();

--- a/crates/holochain_state/tests/corrupt_db/mod.rs
+++ b/crates/holochain_state/tests/corrupt_db/mod.rs
@@ -12,7 +12,7 @@ use tempfile::TempDir;
 /// Checks a corrupt cache will be wiped on load.
 async fn corrupt_cache_creates_new_db() {
     let mut u = arbitrary::Unstructured::new(&holochain_zome_types::prelude::NOISE);
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let kind = DbKindCache(Arc::new(DnaHash::arbitrary(&mut u).unwrap()));
 
@@ -36,7 +36,7 @@ async fn corrupt_cache_creates_new_db() {
 #[tokio::test(flavor = "multi_thread")]
 async fn corrupt_source_chain_panics() {
     let mut u = arbitrary::Unstructured::new(&holochain_zome_types::prelude::NOISE);
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let kind = DbKindAuthored(Arc::new(CellId::arbitrary(&mut u).unwrap()));
 

--- a/crates/holochain_trace/examples/metrics.rs
+++ b/crates/holochain_trace/examples/metrics.rs
@@ -6,7 +6,7 @@ metrics!(MyMetric, CounterA, CounterB);
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     holochain_trace::metrics::init();
     let span = debug_span!("span a");
     let _g = span.enter();

--- a/crates/holochain_trace/src/lib.rs
+++ b/crates/holochain_trace/src/lib.rs
@@ -157,12 +157,16 @@ impl FromStr for Output {
 /// Run logging in a unit test.
 ///
 /// RUST_LOG must be set or this is a no-op.
-pub fn test_run() -> Result<(), errors::TracingError> {
+pub fn test_run() {
     if std::env::var_os("RUST_LOG").is_none() {
-        return Ok(());
+        return;
     }
 
-    init_fmt(Output::Log)
+    static INIT_ONCE: std::sync::Once = std::sync::Once::new();
+
+    INIT_ONCE.call_once(|| {
+        init_fmt(Output::Log).unwrap();
+    });
 }
 
 /// Run tracing in a test that uses open telemetry to
@@ -325,6 +329,8 @@ where
     W: for<'writer> MakeWriter<'writer> + Send + Sync + 'static,
 {
     let filter = standard_filter()?;
+
+    println!("Initialising formatting with args {:?}", output);
 
     match output {
         Output::Json => Registry::default()

--- a/crates/holochain_types/src/app/app_bundle/tests.rs
+++ b/crates/holochain_types/src/app/app_bundle/tests.rs
@@ -37,7 +37,7 @@ async fn app_bundle_fixture(modifiers: DnaModifiersOpt<YamlProperties>) -> (AppB
 /// Test that an app with a single Created cell can be provisioned
 #[tokio::test]
 async fn provisioning_1_create() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let agent = fixt!(AgentPubKey);
     let modifiers = DnaModifiersOpt {
         properties: Some(app_manifest_properties_fixture()),

--- a/crates/holochain_types/src/dht_op/tests.rs
+++ b/crates/holochain_types/src/dht_op/tests.rs
@@ -198,7 +198,7 @@ impl RecordTest {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_all_ops() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let mut builder = RecordTest::new();
     let (record, expected) = builder.entry_create();
     let result = produce_ops_from_record(&record).unwrap();

--- a/crates/holochain_websocket/benches/bench.rs
+++ b/crates/holochain_websocket/benches/bench.rs
@@ -16,7 +16,7 @@ criterion_main!(benches);
 struct TestMessage(pub String);
 
 fn simple_bench(bench: &mut Criterion) {
-    let _g = holochain_trace::test_run().ok();
+    let _g = holochain_trace::test_run();
 
     let runtime = rt();
 

--- a/crates/holochain_websocket/benches/full_connect.rs
+++ b/crates/holochain_websocket/benches/full_connect.rs
@@ -16,7 +16,7 @@ criterion_main!(benches);
 struct TestMessage(String);
 
 fn full_connect(bench: &mut Criterion) {
-    let _g = holochain_trace::test_run().ok();
+    let _g = holochain_trace::test_run();
 
     let runtime = rt();
 

--- a/crates/holochain_websocket/src/test.rs
+++ b/crates/holochain_websocket/src/test.rs
@@ -4,7 +4,7 @@ use crate::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn sanity() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     #[derive(Debug, serde::Serialize, serde::Deserialize, SerializedBytes, PartialEq)]
     enum TestMsg {
@@ -70,7 +70,7 @@ async fn sanity() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn blocks_connect_with_mismatched_origin() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let (addr_s, addr_r) = tokio::sync::oneshot::channel();
 
@@ -119,7 +119,7 @@ async fn blocks_connect_with_mismatched_origin() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn blocks_connect_without_origin() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let (addr_s, addr_r) = tokio::sync::oneshot::channel();
 
@@ -166,7 +166,7 @@ async fn blocks_connect_without_origin() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn origin_is_required_on_listener() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let mut config = WebsocketConfig::LISTENER_DEFAULT;
     config.allowed_origins = None;

--- a/crates/kitsune_p2p/dht/src/arq/arq_set.rs
+++ b/crates/kitsune_p2p/dht/src/arq/arq_set.rs
@@ -221,7 +221,7 @@ mod tests {
 
     #[test]
     fn intersect_arqs() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let topo = Topology::unit_zero();
         let a = Arq::new(27, 536870912u32.into(), 11.into());
         let b = Arq::new(27, 805306368u32.into(), 11.into());
@@ -237,7 +237,7 @@ mod tests {
 
     #[test]
     fn intersect_arqs_multi() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let topo = Topology::unit_zero();
 
         let pow = 26;

--- a/crates/kitsune_p2p/dht/tests/arc_resizing.rs
+++ b/crates/kitsune_p2p/dht/tests/arc_resizing.rs
@@ -250,7 +250,7 @@ fn test_grow_by_multiple_chunks() {
 ///
 /// (not a very good test, probably)
 fn test_degenerate_asymmetrical_coverage() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let topo = Topology::unit_zero();
     let other = ArqBounds::from_interval(&topo, 4, DhtArcRange::from_bounds(0x0u32, 0x80))
         .unwrap()

--- a/crates/kitsune_p2p/dht/tests/arc_stability.rs
+++ b/crates/kitsune_p2p/dht/tests/arc_stability.rs
@@ -41,7 +41,7 @@ fn pass_redundancy(stats: &Stats, redundancy_target: f64) {
 /// Equilibrium test for a single distribution
 #[test]
 fn stability_test_case_near_ideal() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let topo = Topology::standard_zero();
     let detail = false;
@@ -62,7 +62,7 @@ fn stability_test_case_near_ideal() {
 
 #[test]
 fn stability_test_case_messy() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let topo = Topology::standard_zero();
     let detail = true;
@@ -87,7 +87,7 @@ proptest::proptest! {
     #[ignore = "takes a very long time. run sparingly."]
     fn stability_test(num_peers in 100u32..300, min_coverage in 50.0f64..100.0, j in 0.0..1.0) {
         std::env::set_var("RUST_LOG", "debug");
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let topo = Topology::unit_zero();
         let detail = false;

--- a/crates/kitsune_p2p/dht/tests/gossip.rs
+++ b/crates/kitsune_p2p/dht/tests/gossip.rs
@@ -156,7 +156,7 @@ fn test_mismatched_powers() {
 /// of the nodes after enough gossip rounds
 #[test]
 fn gossip_scenario_full_sync() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let topo = Topology::standard_zero();
     let gopa = GossipParams::new(1.into(), 0);
 

--- a/crates/kitsune_p2p/dht/tests/legacy_arc_stability.rs
+++ b/crates/kitsune_p2p/dht/tests/legacy_arc_stability.rs
@@ -39,7 +39,7 @@ fn pass_redundancy(stats: &Stats, redundancy_target: f64) -> bool {
 #[ignore = "Not suitable for ci"]
 fn single_agent_convergence_debug() {
     std::env::set_var("RUST_LOG", "debug");
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let n = 1000;
     let redundancy = 100;
@@ -112,7 +112,7 @@ pub fn run_report(
 #[cfg(feature = "slow_tests")]
 fn parameterized_battery() {
     std::env::set_var("RUST_LOG", "info");
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     use std::collections::HashSet;
 
     let n = 100;
@@ -176,7 +176,7 @@ fn parameterized_battery() {
 #[ignore = "Not suitable for ci"]
 fn parameterized_stability_test() {
     std::env::set_var("RUST_LOG", "debug");
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let mut rng = seeded_rng(None);
 
@@ -212,7 +212,7 @@ fn parameterized_stability_test() {
 #[test]
 #[ignore = "Not suitable for ci"]
 fn test_peer_view_beta() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let mut rng = seeded_rng(None);
 

--- a/crates/kitsune_p2p/fetch/src/pool.rs
+++ b/crates/kitsune_p2p/fetch/src/pool.rs
@@ -642,7 +642,7 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn remove_fetch_item() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
 
         let cfg = Arc::new(TestFetchConfig(1, 10));
         let mut q: State = {

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/bandwidth.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/bandwidth.rs
@@ -249,7 +249,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread", start_paused = true)]
     async fn test_limiter() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let clock = governor::clock::FakeRelativeClock::default();
         // max * 2 * 8 = 0.1 * 1_000_000 * burst_ratio => burst_ratio = max * 2 * 8 / 0.1 / 1_000_000
         let burst_ratio = MAX_SEND_BUF_BYTES as f64 * 2.0 * 8.0 / 1_000_000.0 / 0.1;

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/test_two_nodes.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/tests/test_two_nodes.rs
@@ -713,7 +713,7 @@ async fn initiate_after_target_is_set() {
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 /// Test the initiates timeout after the round timeout has elapsed.
 async fn initiate_times_out() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let agents = agents_with_infos(3).await;
     let all_agents: Vec<AgentInfoSigned> = agents.iter().map(|x| x.1.clone()).collect();

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net_task.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/meta_net_task.rs
@@ -1889,7 +1889,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn send_notify_push_op_data_fails_independently_on_receive_ops_error() {
-        holochain_trace::test_run().unwrap();
+        holochain_trace::test_run();
 
         let (mut ep_evt_send, _, _, host_receiver_stub, _, _, fetch_pool, _) = setup().await;
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space/rpc_multi_logic/test.rs
@@ -78,7 +78,7 @@ async fn build_ep_hnd(config: Arc<KitsuneP2pConfig>, m: MockBindAdapt) -> Tx2EpH
 
 #[tokio::test]
 async fn test_rpc_multi_logic_mocked() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     // allow fake timing during test
     tokio::time::pause();

--- a/crates/kitsune_p2p/kitsune_p2p/src/test.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test.rs
@@ -11,7 +11,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_transport_coms() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         holochain_trace::metrics::init();
         let (harness, _evt) = spawn_test_harness_mem().await.unwrap();
 
@@ -45,7 +45,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_peer_info_store() -> Result<(), KitsuneP2pError> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let (harness, evt) = spawn_test_harness_mem().await?;
         let mut recv = evt.receive();
@@ -75,7 +75,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_transport_binding() -> Result<(), KitsuneP2pError> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let (harness, _evt) = spawn_test_harness_quic().await?;
 
@@ -104,7 +104,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_request_workflow() -> Result<(), KitsuneP2pError> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let (harness, _evt) = spawn_test_harness_quic().await?;
         let space = harness.add_space().await?;
@@ -124,7 +124,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_multi_request_workflow() -> Result<(), KitsuneP2pError> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let (harness, _evt) = spawn_test_harness_quic().await?;
 
@@ -162,7 +162,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_single_agent_multi_request_workflow() -> Result<(), KitsuneP2pError> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let (harness, _evt) = spawn_test_harness_quic().await?;
 
@@ -193,7 +193,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_gossip_workflow() -> Result<(), KitsuneP2pError> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let (harness, _evt) = spawn_test_harness_quic().await?;
 
@@ -233,7 +233,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_peer_data_workflow() -> Result<(), KitsuneP2pError> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let (harness, _evt) = spawn_test_harness_quic().await?;
 
@@ -266,7 +266,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "(david.b) these tests are becoming irrelevant, worth it to maintain?"]
     async fn test_gossip_transport() -> Result<(), KitsuneP2pError> {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let (harness, _evt) = spawn_test_harness_mem().await?;
 
         harness.add_space().await?;
@@ -335,7 +335,7 @@ mod tests {
     // @freesig Can anyone think of a better way to do this?
     #[ignore = "Need a better way then waiting 6 minutes to test this"]
     async fn test_publish_agent_info() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let (harness, _evt) = spawn_test_harness_mem().await.unwrap();
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/test/switchboard/tests.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/test/switchboard/tests.rs
@@ -16,7 +16,7 @@ use pretty_assertions::assert_eq;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "(david.b) ignore until we write a switchboard fetch-queue impl"]
 async fn fullsync_3way_recent() {
-    // holochain_trace::test_run().ok();
+    // holochain_trace::test_run();
     let topo = Topology::standard_epoch_full();
     let sb = Switchboard::new(topo.clone(), GossipType::Recent);
 
@@ -64,7 +64,7 @@ async fn fullsync_3way_recent() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "(david.b) ignore until we write a switchboard fetch-queue impl"]
 async fn sharded_3way_recent() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let topo = Topology::standard_epoch_full();
     let sb = Switchboard::new(topo.clone(), GossipType::Recent);
 
@@ -110,7 +110,7 @@ async fn sharded_3way_recent() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn transitive_peer_gossip() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     let topo = Topology::standard_epoch_full();
     let sb = Switchboard::new(topo.clone(), GossipType::Recent);
 
@@ -179,7 +179,7 @@ async fn transitive_peer_gossip() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "(david.b) ignore until we write a switchboard fetch-queue impl"]
 async fn sharded_4way_recent() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let topo = Topology::standard_epoch_full();
     let sb = Switchboard::new(topo.clone(), GossipType::Recent);
@@ -266,7 +266,7 @@ async fn sharded_4way_recent() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "(david.b) ignore until we write a switchboard fetch-queue impl"]
 async fn sharded_4way_historical() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     let now = Timestamp::now().as_micros();
     // 1 year ago

--- a/crates/kitsune_p2p/kitsune_p2p/tests/peer_restart.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/tests/peer_restart.rs
@@ -16,7 +16,7 @@ use kitsune_p2p::fixt::KitsuneSpaceFixturator;
 #[cfg(feature = "tx5")]
 #[tokio::test(flavor = "multi_thread")]
 async fn connection_close_on_peer_restart() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let (bootstrap_addr, _bootstrap_handle) = start_bootstrap().await;
     let (signal_url, _signal_srv_handle) = start_signal_srv().await;

--- a/crates/kitsune_p2p/kitsune_p2p/tests/performance.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/tests/performance.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "flaky in CI"]
 async fn minimise_p2p_agent_store_host_calls() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let num_spaces = 10;
 

--- a/crates/kitsune_p2p/kitsune_p2p/tests/tests.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/tests/tests.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 #[cfg(feature = "tx5")]
 #[tokio::test(flavor = "multi_thread")]
 async fn two_agents_on_same_host_rpc_single() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let (bootstrap_addr, _bootstrap_handle) = start_bootstrap().await;
     let (signal_url, _signal_srv_handle) = start_signal_srv().await;
@@ -76,7 +76,7 @@ async fn two_agents_on_same_host_rpc_single() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "flaky on CI"]
 async fn two_nodes_publish_and_fetch() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let (bootstrap_addr, _bootstrap_handle) = start_bootstrap().await;
     let (signal_url, _signal_srv_handle) = start_signal_srv().await;
@@ -173,7 +173,7 @@ async fn two_nodes_publish_and_fetch() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "Takes nearly 5-10 minutes to run locally, that is far too slow for CI. Should it run quicker?"]
 async fn two_nodes_publish_and_fetch_large_number_of_ops() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     // Must be larger than ShardedGossipLocal::UPPER_HASHES_BOUND, to encourage batching. But I'm wondering if that's even useful because each op is
     // actually sent individually.
@@ -307,7 +307,7 @@ async fn two_nodes_publish_and_fetch_large_number_of_ops() {
 #[cfg(feature = "tx5")]
 #[tokio::test(flavor = "multi_thread")]
 async fn two_nodes_broadcast_agent_info() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let (bootstrap_addr, bootstrap_handle) = start_bootstrap().await;
     let (signal_url, _signal_srv_handle) = start_signal_srv().await;
@@ -405,7 +405,7 @@ async fn two_nodes_broadcast_agent_info() {
 #[cfg(feature = "tx5")]
 #[tokio::test(flavor = "multi_thread")]
 async fn two_nodes_gossip_agent_info() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let (bootstrap_addr, bootstrap_handle) = start_bootstrap().await;
     let (signal_url, _signal_srv_handle) = start_signal_srv().await;
@@ -501,7 +501,7 @@ async fn two_nodes_gossip_agent_info() {
 #[cfg(feature = "tx5")]
 #[tokio::test(flavor = "multi_thread")]
 async fn gossip_stops_when_agent_leaves_space() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let (bootstrap_addr, _bootstrap_handle) = start_bootstrap().await;
     let (signal_url, _signal_srv_handle) = start_signal_srv().await;
@@ -622,7 +622,7 @@ async fn gossip_stops_when_agent_leaves_space() {
 #[cfg(feature = "tx5")]
 #[tokio::test(flavor = "multi_thread")]
 async fn gossip_historical_ops() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let (bootstrap_addr, _bootstrap_handle) = start_bootstrap().await;
     let (signal_url, _signal_srv_handle) = start_signal_srv().await;
@@ -706,7 +706,7 @@ async fn gossip_historical_ops() {
 #[cfg(feature = "tx5")]
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_only_fetches_ops_once() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let (bootstrap_addr, _bootstrap_handle) = start_bootstrap().await;
     let (signal_url, _signal_srv_handle) = start_signal_srv().await;
@@ -888,7 +888,7 @@ async fn publish_only_fetches_ops_once() {
 #[cfg(feature = "tx5")]
 #[tokio::test(flavor = "multi_thread")]
 async fn delegate_publish() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let (bootstrap_addr, bootstrap_handle) = start_bootstrap().await;
     let (signal_url, _signal_srv_handle) = start_signal_srv().await;
@@ -1038,7 +1038,7 @@ async fn delegate_publish() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "This doesn't really work, the bandwidth limits are only applied to gossip directly and not the fetch mechanism so this test can't work as is"]
 async fn single_large_op_exceeds_gossip_rate_limit() {
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let (bootstrap_addr, _bootstrap_handle) = start_bootstrap().await;
     let (signal_url, _signal_srv_handle) = start_signal_srv().await;
@@ -1129,7 +1129,7 @@ async fn test_two_nodes_on_same_host_deadlock() {
 
     use kitsune_p2p::actor::KitsuneP2pSender;
 
-    holochain_trace::test_run().unwrap();
+    holochain_trace::test_run();
 
     let (bootstrap_addr, _bootstrap_handle) = start_bootstrap().await;
     let (signal_url, _signal_srv_handle) = start_signal_srv().await;

--- a/crates/kitsune_p2p/proxy/src/bin/kitsune-p2p-tx2-proxy.rs
+++ b/crates/kitsune_p2p/proxy/src/bin/kitsune-p2p-tx2-proxy.rs
@@ -30,7 +30,7 @@ pub struct Opt {
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
     kitsune_p2p_types::metrics::init_sys_info_poll();
 
     if let Err(e) = inner().await {

--- a/crates/kitsune_p2p/proxy/src/bin/proxy-tx2-cli.rs
+++ b/crates/kitsune_p2p/proxy/src/bin/proxy-tx2-cli.rs
@@ -19,7 +19,7 @@ pub struct Opt {
 
 #[tokio::main]
 async fn main() {
-    holochain_trace::test_run().ok();
+    holochain_trace::test_run();
 
     if let Err(e) = inner().await {
         eprintln!("{:?}", e);

--- a/crates/kitsune_p2p/proxy/src/tx2.rs
+++ b/crates/kitsune_p2p/proxy/src/tx2.rs
@@ -1076,7 +1076,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_tx2_route_err() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         let t = KitsuneTimeout::from_millis(5000);
         let mut all_tasks = Vec::new();
 
@@ -1109,7 +1109,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_tx2_proxy() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
 
         let t = KitsuneTimeout::from_millis(5000);
 

--- a/crates/kitsune_p2p/transport_quic/src/tx2.rs
+++ b/crates/kitsune_p2p/transport_quic/src/tx2.rs
@@ -472,7 +472,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "flaky"]
     async fn test_quic_tx2() {
-        kitsune_p2p_types::dependencies::holochain_trace::test_run().ok();
+        kitsune_p2p_types::dependencies::holochain_trace::test_run();
 
         let t = KitsuneTimeout::from_millis(5000);
 

--- a/crates/kitsune_p2p/types/src/metrics.rs
+++ b/crates/kitsune_p2p/types/src/metrics.rs
@@ -415,7 +415,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_sys_info() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         init_sys_info_poll();
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         let sys_info = get_sys_info();

--- a/crates/kitsune_p2p/types/src/tx2/tx2_api.rs
+++ b/crates/kitsune_p2p/types/src/tx2/tx2_api.rs
@@ -911,7 +911,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_tx2_api() {
-        holochain_trace::test_run().ok();
+        holochain_trace::test_run();
         tracing::trace!("bob");
 
         let t = KitsuneTimeout::from_millis(5000);


### PR DESCRIPTION
### Summary

Solution for #3476. We were doing exactly what the error message said - when multiple tests run in the same process and all enable tracing then setting the global handler more than once panics.

I was forced to absorb the error handling with this approach which isn't perfect but I've never seen this was the first failure I'd ever seen with this so hopefully that's not too serious to lose the location for. You'll still know which tests failed.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
