### PR TITLE
Fix root lockfile update

### DIFF
--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -35,8 +35,15 @@
         set -xeuo pipefail
         trap "cd $PWD" EXIT
 
-        export VERSIONS_DIR="./versions/''${1}"
-        export DEFAULT_VERSIONS_DIR="$(nix flake metadata --no-write-lock-file --json | jq --raw-output '.locks.nodes.versions.locked.path')"
+        # Check the version of the format, otherwise processing the output might fail silently, like using jq again below
+        FLAKES_LOCK_VERSION=$(nix flake metadata --no-write-lock-file --json | jq --raw-output '.locks.version')
+        if [[ "$FLAKES_LOCK_VERSION" != "7" ]]; then
+          echo "Flakes lock version has changed, refusing to update"
+          exit 1
+        fi
+
+        export VERSIONS_DIR="versions/''${1}"
+        export DEFAULT_VERSIONS_DIR="$(nix flake metadata --no-write-lock-file --json | jq --raw-output '.locks.nodes.versions.locked.dir')"
 
         (
           cd "$VERSIONS_DIR"
@@ -51,7 +58,7 @@
         fi
 
         if [[ "$VERSIONS_DIR" == "$DEFAULT_VERSIONS_DIR" ]]; then
-          nix flake lock --tarball-ttl 0 --update-input versions --override-input versions "path:$VERSIONS_DIR"
+          nix flake update versions
         fi
 
         if [[ $(git diff -- flake.lock | grep -E '^[+-]\s+"' | grep -v lastModified --count) -eq 0 ]]; then


### PR DESCRIPTION
### Summary

The flake update script has been failing silently, e.g. here -> https://github.com/holochain/holochain/pull/3588/files

That PR should have updated both `./versions/0_2/flake.lock` and `./flake.lock`, but it only updated the inner one. This has been broken for a while because the root lock hasn't been updated since Februrary when I happened to do a full `nix flake update`. I haven't looked how long this was failing before that but it's safe to say this has been a source of issues for a while.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
