### PR TITLE
Listen on either stack for websocket connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3432,6 +3432,7 @@ dependencies = [
 name = "holochain_websocket"
 version = "0.3.0-beta-dev.20"
 dependencies = [
+ "async-trait",
  "criterion",
  "futures",
  "holochain_serialized_bytes",

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -426,7 +426,7 @@ mod interface_impls {
                             allowed_origins,
                         } => {
                             let listener = spawn_websocket_listener(port, allowed_origins).await?;
-                            let port = listener.local_addr()?.port();
+                            let port = listener.local_addrs()?[0].port();
                             spawn_admin_interface_tasks(
                                 tm.clone(),
                                 listener,

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -470,17 +470,16 @@ pub mod test {
             .await
             .unwrap();
 
-        let admin_port = 65000;
-        conductor_handle
+        let admin_port = conductor_handle
             .clone()
             .add_admin_interfaces(vec![AdminInterfaceConfig {
                 driver: InterfaceDriver::Websocket {
-                    port: admin_port,
+                    port: 0,
                     allowed_origins: AllowedOrigins::Any,
                 },
             }])
             .await
-            .unwrap();
+            .unwrap()[0];
 
         let (admin_tx, rx) = websocket_client_by_port(admin_port).await.unwrap();
         let _rx = WsPollRecv::new::<AdminResponse>(rx);

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -11,6 +11,7 @@ use holochain_websocket::WebsocketConfig;
 use holochain_websocket::WebsocketListener;
 use holochain_websocket::WebsocketReceiver;
 use holochain_websocket::WebsocketSender;
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 use holochain_types::app::InstalledAppId;
 use holochain_types::websocket::AllowedOrigins;
@@ -45,8 +46,13 @@ pub async fn spawn_websocket_listener(
     let mut config = WebsocketConfig::LISTENER_DEFAULT;
     config.allowed_origins = Some(allowed_origins);
 
-    let listener = WebsocketListener::bind(Arc::new(config), format!("localhost:{}", port)).await?;
-    trace!("LISTENING AT: {}", listener.local_addr()?);
+    let listener = WebsocketListener::dual_bind(
+        Arc::new(config),
+        (Ipv4Addr::LOCALHOST, port),
+        (Ipv6Addr::LOCALHOST, port),
+    )
+    .await?;
+    trace!("LISTENING AT: {:?}", listener.local_addrs()?);
     Ok(listener)
 }
 
@@ -124,10 +130,15 @@ pub async fn spawn_app_interface_task<A: InterfaceApi<Auth = AppAuthentication>>
     let mut config = WebsocketConfig::LISTENER_DEFAULT;
     config.allowed_origins = Some(allowed_origins);
 
-    let listener = WebsocketListener::bind(Arc::new(config), format!("localhost:{}", port)).await?;
-    let addr = listener.local_addr()?;
-    trace!("LISTENING AT: {}", addr);
-    let port = addr.port();
+    let listener = WebsocketListener::dual_bind(
+        Arc::new(config),
+        (Ipv4Addr::LOCALHOST, port),
+        (Ipv6Addr::LOCALHOST, port),
+    )
+    .await?;
+    let addrs = listener.local_addrs()?;
+    trace!("LISTENING AT: {:?}", addrs);
+    let port = addrs[0].port();
 
     tm.add_conductor_task_ignored("app interface new connection handler", move || {
         async move {

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -11,7 +11,7 @@ use holochain_websocket::WebsocketConfig;
 use holochain_websocket::WebsocketListener;
 use holochain_websocket::WebsocketReceiver;
 use holochain_websocket::WebsocketSender;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
 use holochain_types::app::InstalledAppId;
 use holochain_types::websocket::AllowedOrigins;
@@ -48,8 +48,8 @@ pub async fn spawn_websocket_listener(
 
     let listener = WebsocketListener::dual_bind(
         Arc::new(config),
-        (Ipv4Addr::LOCALHOST, port),
-        (Ipv6Addr::LOCALHOST, port),
+        SocketAddrV4::new(Ipv4Addr::LOCALHOST, port),
+        SocketAddrV6::new(Ipv6Addr::LOCALHOST, port, 0, 0),
     )
     .await?;
     trace!("LISTENING AT: {:?}", listener.local_addrs()?);
@@ -132,8 +132,8 @@ pub async fn spawn_app_interface_task<A: InterfaceApi<Auth = AppAuthentication>>
 
     let listener = WebsocketListener::dual_bind(
         Arc::new(config),
-        (Ipv4Addr::LOCALHOST, port),
-        (Ipv6Addr::LOCALHOST, port),
+        SocketAddrV4::new(Ipv4Addr::LOCALHOST, port),
+        SocketAddrV6::new(Ipv6Addr::LOCALHOST, port, 0, 0),
     )
     .await?;
     let addrs = listener.local_addrs()?;

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -1071,6 +1071,7 @@ async fn holochain_websockets_listen_on_ipv4_and_ipv6() {
     .await
     .unwrap();
     let _rx4 = WsPollRecv::new::<AppResponse>(rx);
+    authenticate_app_ws_client(ipv4_app_sender.clone(), admin_port, "".to_string()).await;
 
     let response: AppResponse = ipv4_app_sender
         .request(AppRequest::AppInfo {
@@ -1090,6 +1091,7 @@ async fn holochain_websockets_listen_on_ipv4_and_ipv6() {
     .await
     .unwrap();
     let _rx6 = WsPollRecv::new::<AppResponse>(rx);
+    authenticate_app_ws_client(ipv6_app_sender.clone(), admin_port, "".to_string()).await;
 
     let response: AppResponse = ipv6_app_sender
         .request(AppRequest::AppInfo {

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -15,12 +15,14 @@ use holochain::{
     },
     fixt::*,
 };
-use std::net::ToSocketAddrs;
+use std::net::{Ipv4Addr, Ipv6Addr, ToSocketAddrs};
 
+use either::Either;
 use holochain_conductor_api::{
     AdminInterfaceConfig, AppAuthenticationRequest, AppAuthenticationToken, AppRequest,
     InterfaceDriver, IssueAppAuthenticationTokenPayload,
 };
+use holochain_types::websocket::AllowedOrigins;
 use holochain_types::{
     prelude::*,
     test_utils::{fake_dna_zomes, write_fake_dna_file},
@@ -1004,6 +1006,101 @@ async fn create_multi_use_token(conductor: &SweetConductor) -> AppAuthentication
     };
 
     token
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn holochain_websockets_listen_on_ipv4_and_ipv6() {
+    holochain_trace::test_run();
+
+    let conductor = SweetConductor::from_standard_config().await;
+
+    let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
+
+    //
+    // Connect to the admin interface on ipv4 and ipv6 localhost
+    //
+
+    let (ipv4_admin_sender, rx) = connect(
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        ConnectRequest::new((Ipv4Addr::LOCALHOST, admin_port).into()),
+    )
+    .await
+    .unwrap();
+    let _rx4 = PollRecv::new::<AdminResponse>(rx);
+
+    let response: AdminResponse = ipv4_admin_sender
+        .request(AdminRequest::ListCellIds)
+        .await
+        .unwrap();
+    match response {
+        AdminResponse::CellIdsListed(_) => (),
+        _ => panic!("unexpected response"),
+    }
+
+    let (ipv6_admin_sender, rx) = connect(
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        ConnectRequest::new((Ipv6Addr::LOCALHOST, admin_port).into()),
+    )
+    .await
+    .unwrap();
+    let _rx6 = PollRecv::new::<AdminResponse>(rx);
+
+    let response: AdminResponse = ipv6_admin_sender
+        .request(AdminRequest::ListCellIds)
+        .await
+        .unwrap();
+    match response {
+        AdminResponse::CellIdsListed(_) => (),
+        _ => panic!("unexpected response"),
+    }
+
+    //
+    // Do the same for an app interface
+    //
+
+    let app_port = conductor
+        .clone()
+        .add_app_interface(Either::Left(0), AllowedOrigins::Any)
+        .await
+        .unwrap();
+
+    let (ipv4_app_sender, rx) = connect(
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        ConnectRequest::new((Ipv4Addr::LOCALHOST, app_port).into()),
+    )
+    .await
+    .unwrap();
+    let _rx4 = PollRecv::new::<AppResponse>(rx);
+
+    let response: AppResponse = ipv4_app_sender
+        .request(AppRequest::AppInfo {
+            installed_app_id: "".to_string(),
+        })
+        .await
+        .unwrap();
+    match response {
+        AppResponse::AppInfo(_) => (),
+        _ => panic!("unexpected response"),
+    }
+
+    let (ipv6_app_sender, rx) = connect(
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        ConnectRequest::new((Ipv6Addr::LOCALHOST, app_port).into()),
+    )
+    .await
+    .unwrap();
+    let _rx6 = PollRecv::new::<AppResponse>(rx);
+
+    let response: AppResponse = ipv6_app_sender
+        .request(AppRequest::AppInfo {
+            installed_app_id: "".to_string(),
+        })
+        .await
+        .unwrap();
+    match response {
+        AppResponse::AppInfo(_) => (),
+        _ => panic!("unexpected response"),
+    }
 }
 
 async fn check_app_port(port: u16, origin: &str, token: AppAuthenticationToken) {

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -1026,7 +1026,7 @@ async fn holochain_websockets_listen_on_ipv4_and_ipv6() {
     )
     .await
     .unwrap();
-    let _rx4 = PollRecv::new::<AdminResponse>(rx);
+    let _rx4 = WsPollRecv::new::<AdminResponse>(rx);
 
     let response: AdminResponse = ipv4_admin_sender
         .request(AdminRequest::ListCellIds)
@@ -1043,7 +1043,7 @@ async fn holochain_websockets_listen_on_ipv4_and_ipv6() {
     )
     .await
     .unwrap();
-    let _rx6 = PollRecv::new::<AdminResponse>(rx);
+    let _rx6 = WsPollRecv::new::<AdminResponse>(rx);
 
     let response: AdminResponse = ipv6_admin_sender
         .request(AdminRequest::ListCellIds)
@@ -1060,7 +1060,7 @@ async fn holochain_websockets_listen_on_ipv4_and_ipv6() {
 
     let app_port = conductor
         .clone()
-        .add_app_interface(Either::Left(0), AllowedOrigins::Any)
+        .add_app_interface(Either::Left(0), AllowedOrigins::Any, None)
         .await
         .unwrap();
 
@@ -1070,7 +1070,7 @@ async fn holochain_websockets_listen_on_ipv4_and_ipv6() {
     )
     .await
     .unwrap();
-    let _rx4 = PollRecv::new::<AppResponse>(rx);
+    let _rx4 = WsPollRecv::new::<AppResponse>(rx);
 
     let response: AppResponse = ipv4_app_sender
         .request(AppRequest::AppInfo {
@@ -1089,7 +1089,7 @@ async fn holochain_websockets_listen_on_ipv4_and_ipv6() {
     )
     .await
     .unwrap();
-    let _rx6 = PollRecv::new::<AppResponse>(rx);
+    let _rx6 = WsPollRecv::new::<AppResponse>(rx);
 
     let response: AppResponse = ipv6_app_sender
         .request(AppRequest::AppInfo {

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -18,6 +18,7 @@ serde_bytes = "0.11.14"
 tokio = { version = "1.36.0", features = ["full"] }
 tokio-tungstenite = "0.21.0"
 tracing = "0.1"
+async-trait = "0.1"
 
 [dev-dependencies]
 holochain_trace = { version = "^0.3.0-beta-dev.10", path = "../holochain_trace" }

--- a/crates/holochain_websocket/benches/bench.rs
+++ b/crates/holochain_websocket/benches/bench.rs
@@ -77,7 +77,7 @@ async fn setup() -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
     .unwrap();
 
     // Get the address of the server
-    let addr = listener.local_addr().unwrap();
+    let addr = listener.local_addrs().unwrap();
 
     let jh = tokio::task::spawn(async move {
         let mut jhs = Vec::new();

--- a/crates/holochain_websocket/benches/full_connect.rs
+++ b/crates/holochain_websocket/benches/full_connect.rs
@@ -33,7 +33,7 @@ fn full_connect(bench: &mut Criterion) {
             let bind_addr = "localhost:0".to_socket_addrs().unwrap().next().unwrap();
             let l = WebsocketListener::bind(config.clone(), bind_addr).await.unwrap();
 
-            let port = l.local_addr().unwrap().port();
+            let port = l.local_addrs().unwrap().port();
 
             let b1 = std::sync::Arc::new(tokio::sync::Barrier::new(2));
             let b2 = b1.clone();

--- a/crates/holochain_websocket/src/lib.rs
+++ b/crates/holochain_websocket/src/lib.rs
@@ -819,7 +819,7 @@ impl WebsocketListener {
         let mut addr_v4: SocketAddr = addr_v4.into();
 
         // The point of dual_bind is to bind to the same port on both v4 and v6
-        if addr_v6.port() != 0 && addr_v6.port() == addr_v4.port() {
+        if addr_v6.port() != 0 && addr_v6.port() != addr_v4.port() {
             return Err(Error::other(
                 "dual_bind requires the same port for IPv4 and IPv6",
             ));

--- a/crates/holochain_websocket/src/test.rs
+++ b/crates/holochain_websocket/src/test.rs
@@ -178,7 +178,7 @@ async fn origin_is_required_on_listener() {
         Err(e) => {
             assert_eq!(
                 e.to_string(),
-                "WebsocketListener requires access control to be set in the config"
+                "WebsocketListener requires allowed_origins to be set in the config"
             );
         }
     }
@@ -198,8 +198,8 @@ async fn ipv6_or_ipv4_connect() {
     let l_task = tokio::task::spawn(async move {
         let l = WebsocketListener::dual_bind(
             Arc::new(WebsocketConfig::LISTENER_DEFAULT),
-            (Ipv4Addr::LOCALHOST, 0),
-            (Ipv6Addr::LOCALHOST, 0),
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0),
+            SocketAddrV6::new(Ipv6Addr::LOCALHOST, 0, 0, 0),
         )
         .await
         .unwrap();

--- a/crates/holochain_websocket/src/test.rs
+++ b/crates/holochain_websocket/src/test.rs
@@ -1,5 +1,7 @@
 //! holochain_websocket tests
 
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+
 use crate::*;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -18,7 +20,7 @@ async fn sanity() {
             .await
             .unwrap();
 
-        let addr = l.local_addr().unwrap();
+        let addr = l.local_addrs().unwrap();
         addr_s.send(addr).unwrap();
 
         let (_send, mut recv) = l.accept().await.unwrap();
@@ -39,7 +41,7 @@ async fn sanity() {
         }
     });
 
-    let addr = addr_r.await.unwrap();
+    let addr = addr_r.await.unwrap()[0];
     println!("addr: {}", addr);
 
     let r_task = tokio::task::spawn(async move {
@@ -84,7 +86,7 @@ async fn blocks_connect_with_mismatched_origin() {
             .await
             .unwrap();
 
-        let addr = l.local_addr().unwrap();
+        let addr = l.local_addrs().unwrap();
         addr_s.send(addr).unwrap();
 
         match l.accept().await {
@@ -95,7 +97,7 @@ async fn blocks_connect_with_mismatched_origin() {
         }
     });
 
-    let addr = addr_r.await.unwrap();
+    let addr = addr_r.await.unwrap()[0];
 
     let r_task = tokio::task::spawn(async move {
         match connect(
@@ -133,7 +135,7 @@ async fn blocks_connect_without_origin() {
             .await
             .unwrap();
 
-        let addr = l.local_addr().unwrap();
+        let addr = l.local_addrs().unwrap();
         addr_s.send(addr).unwrap();
 
         match l.accept().await {
@@ -144,7 +146,7 @@ async fn blocks_connect_without_origin() {
         }
     });
 
-    let addr = addr_r.await.unwrap();
+    let addr = addr_r.await.unwrap()[0];
 
     let r_task = tokio::task::spawn(async move {
         match connect(
@@ -180,4 +182,73 @@ async fn origin_is_required_on_listener() {
             );
         }
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ipv6_or_ipv4_connect() {
+    holochain_trace::test_run();
+
+    #[derive(Debug, serde::Serialize, serde::Deserialize, SerializedBytes, PartialEq)]
+    enum TestMsg {
+        Hello,
+    }
+
+    let (addr_s, addr_r) = tokio::sync::oneshot::channel();
+
+    let l_task = tokio::task::spawn(async move {
+        let l = WebsocketListener::dual_bind(
+            Arc::new(WebsocketConfig::LISTENER_DEFAULT),
+            (Ipv4Addr::LOCALHOST, 0),
+            (Ipv6Addr::LOCALHOST, 0),
+        )
+        .await
+        .unwrap();
+
+        addr_s.send(l.local_addrs().unwrap()).unwrap();
+
+        for _ in 0..2 {
+            let (_send, mut recv) = l.accept().await.unwrap();
+
+            let res = recv.recv::<TestMsg>().await.unwrap();
+            match res {
+                ReceiveMessage::Request(data, res) => {
+                    assert_eq!(TestMsg::Hello, data);
+                    res.respond(TestMsg::Hello).await.unwrap();
+                }
+                oth => panic!("unexpected: {oth:?}"),
+            }
+        }
+    });
+
+    let bound_addr = addr_r.await.unwrap();
+    let target_port = bound_addr[0].port();
+
+    let test_addrs: Vec<SocketAddr> = vec![
+        (Ipv4Addr::LOCALHOST, target_port).into(),
+        (Ipv6Addr::LOCALHOST, target_port).into(),
+    ];
+    for addr in test_addrs {
+        let r_task = tokio::task::spawn(async move {
+            let (send, mut recv) = connect(Arc::new(WebsocketConfig::CLIENT_DEFAULT), addr)
+                .await
+                .unwrap();
+
+            let s_task =
+                tokio::task::spawn(
+                    async move { while let Ok(_r) = recv.recv::<TestMsg>().await {} },
+                );
+
+            let res: TestMsg = send
+                .request_timeout(TestMsg::Hello, std::time::Duration::from_secs(5))
+                .await
+                .unwrap();
+
+            assert_eq!(TestMsg::Hello, res);
+
+            s_task.abort();
+        });
+        r_task.await.unwrap();
+    }
+
+    l_task.await.unwrap();
 }


### PR DESCRIPTION
### Summary

Apparently dual-stack for `localhost` just isn't a thing. The translation doesn't happen within machines, it is supposed to happen between machines so that machines running different IP versions can communicate. If you want to listen on either interface on localhost then you have to do that yourself.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
