### PR TITLE
Don't read Nix internal content which is not stable

### DIFF
--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -50,7 +50,7 @@
         fi
 
         # Want to update the root flake.lock if we're updating the version that is currently the default.
-        if grep -q "dir=$VERSIONS_DIR" flake.nix; then
+        if grep -qE "versions\.url = \".+\?dir=${VERSIONS_DIR}\"" flake.nix; then
           # TODO, once the Nix version on CI supports it -> nix flake update versions
           nix flake lock --tarball-ttl 0 --update-input versions --override-input versions "path:$VERSIONS_DIR"
         fi

--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -35,15 +35,7 @@
         set -xeuo pipefail
         trap "cd $PWD" EXIT
 
-        # Check the version of the format, otherwise processing the output might fail silently, like using jq again below
-        FLAKES_LOCK_VERSION=$(nix flake metadata --no-write-lock-file --json | jq --raw-output '.locks.version')
-        if [[ "$FLAKES_LOCK_VERSION" != "7" ]]; then
-          echo "Flakes lock version has changed, refusing to update"
-          exit 1
-        fi
-
         export VERSIONS_DIR="versions/''${1}"
-        export DEFAULT_VERSIONS_DIR="$(nix flake metadata --no-write-lock-file --json | jq --raw-output '.locks.nodes.versions.locked.dir')"
 
         (
           cd "$VERSIONS_DIR"
@@ -57,7 +49,8 @@
           git add "$VERSIONS_DIR"/flake.lock
         fi
 
-        if [[ "$VERSIONS_DIR" == "$DEFAULT_VERSIONS_DIR" ]]; then
+        # Want to update the root flake.lock if we're updating the version that is currently the default.
+        if grep -q "dir=$VERSIONS_DIR" flake.nix; then
           # TODO, once the Nix version on CI supports it -> nix flake update versions
           nix flake lock --tarball-ttl 0 --update-input versions --override-input versions "path:$VERSIONS_DIR"
         fi
@@ -75,7 +68,7 @@
         set -e
         if [[ "$ANY_CHANGED" -eq 1 ]]; then
           echo committing changes..
-          git commit -m "chore(flakes): update $VERSIONS_DIR"
+          # git commit -m "chore(flakes): update $VERSIONS_DIR"
         fi
       '';
 

--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -50,7 +50,7 @@
         fi
 
         # Want to update the root flake.lock if we're updating the version that is currently the default.
-        if grep -qE "versions\.url = \".+\?dir=${VERSIONS_DIR}\"" flake.nix; then
+        if grep -qE "versions\.url = \".+\?dir=''${VERSIONS_DIR}\"" flake.nix; then
           # TODO, once the Nix version on CI supports it -> nix flake update versions
           nix flake lock --tarball-ttl 0 --update-input versions --override-input versions "path:$VERSIONS_DIR"
         fi

--- a/nix/modules/scripts.nix
+++ b/nix/modules/scripts.nix
@@ -68,7 +68,7 @@
         set -e
         if [[ "$ANY_CHANGED" -eq 1 ]]; then
           echo committing changes..
-          # git commit -m "chore(flakes): update $VERSIONS_DIR"
+          git commit -m "chore(flakes): update $VERSIONS_DIR"
         fi
       '';
 


### PR DESCRIPTION
### Summary

Flip flops between `dir` and `path` depending on what command was run or what version of Nix we use. Read our source code rather than generated content. At least we know what's in that.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
