### PR TITLE
Initial script and untested workflow for Holonix version updates

### DIFF
--- a/.github/workflows/update-holonix-version.yml
+++ b/.github/workflows/update-holonix-version.yml
@@ -1,0 +1,45 @@
+name: "Update Holonix versions"
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: |
+          One of the directory names under ./versions
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "0_1"
+          - "0_2"
+          - "0_2_rc"
+          - "weekly"
+
+concurrency:
+  group: ${{ github.ref_name }}
+
+jobs:
+  update-holonix-version:
+    runs-on: [ self-hosted, multi-arch ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run the update script
+        run: |
+          ./scripts/update-holonix-version.sh ${{ github.event.inputs.version }}
+          nix run .#scripts-repo-flake-update ${{ github.event.inputs.version }}
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.HRA_GITHUB_TOKEN }}
+          title: "Update Holonix version for ${{ github.event.inputs.version }}"
+          branch: auto-update/${{ github.event.inputs.version }}
+          labels: |
+            autorebase:opt-in
+          draft: false
+          delete-branch: true
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-operation == 'created'
+        run: gh pr merge --merge --auto "${{ steps.cpr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}

--- a/scripts/update-holonix-version.sh
+++ b/scripts/update-holonix-version.sh
@@ -16,19 +16,19 @@ SEP_COUNT=$(echo "$VERSION_STR" | tr -d -c '_' | awk '{ print length; }')
 SEARCH_PATTERN="no-tag"
 if [ "$SEP_COUNT" == "1" ]; then
     # Matched format 0_X
-    SEARCH_PATTERN=$(echo "$VERSION_STR" | awk -F_ 'BEGIN { OFS="" } {print "^holochain-", $1, ".", $2, ".[0-9]+$"}')
+    SEARCH_PATTERN=$(echo "$VERSION_STR" | awk -F _ 'BEGIN { OFS="" } {print "^holochain-", $1, ".", $2, ".[0-9]+$"}')
 elif [ "$SEP_COUNT" == "2" ] && [[ "$VERSION_STR" =~ rc$ ]]; then
     # Matched format 0_X_rc
-  SEARCH_PATTERN=$(echo "$VERSION_STR" | awk -F_ 'BEGIN { OFS="" } {print "^holochain-", $1, ".", $2, ".[0-9]+-rc.[0-9]+$"}')
+  SEARCH_PATTERN=$(echo "$VERSION_STR" | awk -F _ 'BEGIN { OFS="" } {print "^holochain-", $1, ".", $2, ".[0-9]+-rc.[0-9]+$"}')
 elif [ "$VERSION_STR" == "weekly" ]; then
   # Special case, weekly tracks the latest pre-release version
-  SEARCH_PATTERN="holochain-[0-9]+.[0-9]+.[0-9]+-beta-dev.[0-9]+"
+  SEARCH_PATTERN="^holochain-[0-9]+.[0-9]+.[0-9]+-beta-dev.[0-9]+$"
 else
     echo "Invalid version format: $VERSION_STR"
     exit 1
 fi
 
-echo "$SEARCH_PATTERN"
+echo "Looking for tags matching pattern: $SEARCH_PATTERN"
 
 LATEST_MATCHING_TAG=$(git tag --list --sort=version:refname | { grep -E "$SEARCH_PATTERN" || printf ""; } | tail -n 1)
 
@@ -39,6 +39,4 @@ fi
 
 echo "Latest matching tag: $LATEST_MATCHING_TAG"
 
-sed -i -e "s#holochain/holochain/holochain-.*\"#holochain/holochain/$LATEST_MATCHING_TAG\"#" "./versions/$VERSION_STR/flake.nix"
-
-# nix run .#scripts-repo-flake-update "$VERSION_STR"
+sed --in-place --regexp-extended "s#holochain/holochain/holochain-.*\"#holochain/holochain/$LATEST_MATCHING_TAG\"#" "./versions/$VERSION_STR/flake.nix"

--- a/scripts/update-holonix-version.sh
+++ b/scripts/update-holonix-version.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VERSION_STR=$1
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [ ! -f "./versions/$VERSION_STR/flake.nix" ]; then
+    echo "File not found: ./versions/$VERSION_STR/flake.nix"
+    exit 1
+fi
+
+SEP_COUNT=$(echo "$VERSION_STR" | tr -d -c '_' | awk '{ print length; }')
+
+SEARCH_PATTERN="no-tag"
+if [ "$SEP_COUNT" == "1" ]; then
+    # Matched format 0_X
+    SEARCH_PATTERN=$(echo "$VERSION_STR" | awk -F_ 'BEGIN { OFS="" } {print "^holochain-", $1, ".", $2, ".[0-9]+$"}')
+elif [ "$SEP_COUNT" == "2" ] && [[ "$VERSION_STR" =~ rc$ ]]; then
+    # Matched format 0_X_rc
+  SEARCH_PATTERN=$(echo "$VERSION_STR" | awk -F_ 'BEGIN { OFS="" } {print "^holochain-", $1, ".", $2, ".[0-9]+-rc.[0-9]+$"}')
+elif [ "$VERSION_STR" == "weekly" ]; then
+  # Special case, weekly tracks the latest pre-release version
+  SEARCH_PATTERN="holochain-[0-9]+.[0-9]+.[0-9]+-beta-dev.[0-9]+"
+else
+    echo "Invalid version format: $VERSION_STR"
+    exit 1
+fi
+
+echo "$SEARCH_PATTERN"
+
+LATEST_MATCHING_TAG=$(git tag --list --sort=version:refname | { grep -E "$SEARCH_PATTERN" || printf ""; } | tail -n 1)
+
+if [ -z "$LATEST_MATCHING_TAG" ]; then
+    echo "No matching tag found for: $VERSION_STR"
+    exit 1
+fi
+
+echo "Latest matching tag: $LATEST_MATCHING_TAG"
+
+sed -i -e "s#holochain/holochain/holochain-.*\"#holochain/holochain/$LATEST_MATCHING_TAG\"#" "./versions/$VERSION_STR/flake.nix"
+
+# nix run .#scripts-repo-flake-update "$VERSION_STR"

--- a/scripts/update-holonix-version.sh
+++ b/scripts/update-holonix-version.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -euox pipefail
 
 VERSION_STR=$1
 

--- a/scripts/update-holonix-version.sh
+++ b/scripts/update-holonix-version.sh
@@ -39,4 +39,4 @@ fi
 
 echo "Latest matching tag: $LATEST_MATCHING_TAG"
 
-sed --in-place --regexp-extended "s#holochain/holochain/holochain-.*\"#holochain/holochain/$LATEST_MATCHING_TAG\"#" "./versions/$VERSION_STR/flake.nix"
+sed --in-place "s#holochain/holochain/holochain-.*\"#holochain/holochain/$LATEST_MATCHING_TAG\"#" "./versions/$VERSION_STR/flake.nix"


### PR DESCRIPTION
### Summary

For now this is:
- A script, that I have tested, which can update the Holochain version in the chosen versions `flake.nix`
- A CI job, that I cannot test because the file does not exist on develop (github restriction), which uses the script update the `flake.nix` then uses the existing Nix script to update the locks based on the changed `flake.nix`. This pipeline job creates a PR which has auto-merge enabled but requires explicit approval from one of the team before it will merge.

This could be made an automated job but we sometimes want to wait after a release before updating Holonix so for now at least I think this is best off as a manually run job. It still saves me some time creating the same PR every week!

### TODO:
- [ ] CHANGELOGs updated with appropriate info
