### PR TITLE
Fix rebinding the same port

### DIFF
--- a/crates/holochain_websocket/src/lib.rs
+++ b/crates/holochain_websocket/src/lib.rs
@@ -872,6 +872,7 @@ impl WebsocketListener {
                 v4: v4_listener,
                 v6: v6_listener,
             });
+            break;
         }
 
         // Gave up after a few retries, there's no point in continuing forever because there might be

--- a/crates/holochain_websocket/src/test.rs
+++ b/crates/holochain_websocket/src/test.rs
@@ -252,3 +252,73 @@ async fn ipv6_or_ipv4_connect() {
 
     l_task.await.unwrap();
 }
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "Requires a port to be free so should not run on CI"]
+async fn ipv6_or_ipv4_connect_on_specific_port() {
+    holochain_trace::test_run();
+
+    #[derive(Debug, serde::Serialize, serde::Deserialize, SerializedBytes, PartialEq)]
+    enum TestMsg {
+        Hello,
+    }
+
+    let (addr_s, addr_r) = tokio::sync::oneshot::channel();
+
+    let l_task = tokio::task::spawn(async move {
+        let l = WebsocketListener::dual_bind(
+            Arc::new(WebsocketConfig::LISTENER_DEFAULT),
+            SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1456),
+            SocketAddrV6::new(Ipv6Addr::LOCALHOST, 1456, 0, 0),
+        )
+            .await
+            .unwrap();
+
+        addr_s.send(l.local_addrs().unwrap()).unwrap();
+
+        for _ in 0..2 {
+            let (_send, mut recv) = l.accept().await.unwrap();
+
+            let res = recv.recv::<TestMsg>().await.unwrap();
+            match res {
+                ReceiveMessage::Request(data, res) => {
+                    assert_eq!(TestMsg::Hello, data);
+                    res.respond(TestMsg::Hello).await.unwrap();
+                }
+                oth => panic!("unexpected: {oth:?}"),
+            }
+        }
+    });
+
+    let bound_addr = addr_r.await.unwrap();
+    let target_port = bound_addr[0].port();
+
+    let test_addrs: Vec<SocketAddr> = vec![
+        (Ipv4Addr::LOCALHOST, target_port).into(),
+        (Ipv6Addr::LOCALHOST, target_port).into(),
+    ];
+    for addr in test_addrs {
+        let r_task = tokio::task::spawn(async move {
+            let (send, mut recv) = connect(Arc::new(WebsocketConfig::CLIENT_DEFAULT), addr)
+                .await
+                .unwrap();
+
+            let s_task =
+                tokio::task::spawn(
+                    async move { while let Ok(_r) = recv.recv::<TestMsg>().await {} },
+                );
+
+            let res: TestMsg = send
+                .request_timeout(TestMsg::Hello, std::time::Duration::from_secs(5))
+                .await
+                .unwrap();
+
+            assert_eq!(TestMsg::Hello, res);
+
+            s_task.abort();
+        });
+        r_task.await.unwrap();
+    }
+
+    l_task.await.unwrap();
+}

--- a/crates/holochain_websocket/src/test.rs
+++ b/crates/holochain_websocket/src/test.rs
@@ -271,8 +271,8 @@ async fn ipv6_or_ipv4_connect_on_specific_port() {
             SocketAddrV4::new(Ipv4Addr::LOCALHOST, 1456),
             SocketAddrV6::new(Ipv6Addr::LOCALHOST, 1456, 0, 0),
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
 
         addr_s.send(l.local_addrs().unwrap()).unwrap();
 


### PR DESCRIPTION
### Summary

Loops are dangerous, really important to stop when we get a successful bind

### TODO:
- [ ] CHANGELOGs updated with appropriate info
