### PR TITLE
Revoke app ws auth tokens

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Adds a new admin interface call `RevokeAppAuthenticationToken` to revoke issued app authentication tokens. #3765
 - App validation workflow: Validate ops in sequence instead of in parallel. Ops validated one after the other have a higher chance of being validated if they depend on earlier ops. When validated in parallel, they potentially needed to await a next workflow run when the dependent op would have been validated.
 
 ## 0.3.0-beta-dev.48

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -309,6 +309,11 @@ impl AdminInterfaceApi {
                         .issue_app_authentication_token(payload)?,
                 ))
             }
+            RevokeAppAuthenticationToken(token) => {
+                self.conductor_handle
+                    .revoke_app_authentication_token(token)?;
+                Ok(AdminResponse::AppAuthenticationTokenRevoked)
+            }
         }
     }
 }

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -2599,7 +2599,7 @@ mod accessor_impls {
 mod authenticate_token_impls {
     use super::*;
     use holochain_conductor_api::{
-        AppAuthenticationTokenIssued, IssueAppAuthenticationTokenPayload,
+        AppAuthenticationToken, AppAuthenticationTokenIssued, IssueAppAuthenticationTokenPayload,
     };
 
     impl Conductor {
@@ -2622,6 +2622,17 @@ mod authenticate_token_impls {
                     .and_then(|i| i.duration_since(std::time::UNIX_EPOCH).ok())
                     .map(|d| Timestamp::saturating_from_dur(&d)),
             })
+        }
+
+        /// Revoke an app interface authentication token.
+        pub fn revoke_app_authentication_token(
+            &self,
+            token: AppAuthenticationToken,
+        ) -> ConductorResult<()> {
+            self.app_auth_token_store
+                .share_mut(|app_connection_auth| app_connection_auth.revoke_token(token));
+
+            Ok(())
         }
 
         /// Authenticate the app interface authentication `token`, optionally requiring the token to

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -367,6 +367,13 @@ pub enum AdminRequest {
     ///
     /// [`AdminResponse::AppAuthenticationTokenIssued`]
     IssueAppAuthenticationToken(IssueAppAuthenticationTokenPayload),
+
+    /// Revoke an issued app authentication token.
+    ///
+    /// # Returns
+    ///
+    /// [`AdminResponse::AppAuthenticationTokenRevoked`]
+    RevokeAppAuthenticationToken(AppAuthenticationToken),
 }
 
 /// Represents the possible responses to an [`AdminRequest`]
@@ -511,6 +518,9 @@ pub enum AdminResponse {
 
     /// The successful response to an [`AdminRequest::IssueAppAuthenticationToken`].
     AppAuthenticationTokenIssued(AppAuthenticationTokenIssued),
+
+    /// The successful response to an [`AdminRequest::RevokeAppAuthenticationToken`].
+    AppAuthenticationTokenRevoked,
 }
 
 /// Error type that goes over the websocket wire.
@@ -580,7 +590,7 @@ pub struct IssueAppAuthenticationTokenPayload {
     /// token will no longer be accepted by the conductor.
     ///
     /// This is 30s by default which is reasonably high but with [IssueAppAuthenticationTokenPayload::single_use]
-    /// set to `false`, the token will be invalidated after the first use anyway.
+    /// set to `true`, the token will be invalidated after the first use anyway.
     ///
     /// Set this to 0 to create a token that does not expire.
     #[serde(default = "default_expiry_seconds")]


### PR DESCRIPTION
### Summary

- Deals with revoking tokens
- Fixes a bug where the documentation claimed you could pass `expires_at: 0` to create tokens that don't expire... but you couldn't!
- Corrects a mistake in the documentation `false`->`true`

Part of #3558

### TODO:
- [ ] CHANGELOGs updated with appropriate info
