### PR TITLE
ci: shorten holochain test build names

### DIFF
--- a/.github/workflows/holochain-build-and-test.yml
+++ b/.github/workflows/holochain-build-and-test.yml
@@ -30,18 +30,18 @@ jobs:
           # ensure functionality on multiple platforms
           - pkgs:
               - test-unit-all
-              - build-holonix-tests-integration
+              - holonix-test-integration
             extra_arg: "--override-input versions ./versions/weekly --override-input holochain ${{ inputs.repo_path }}"
 
           # ensure that any Nix changes on this branch don't cause problems for maintenance versions
           - pkgs:
-              - build-holonix-tests-integration
+              - holonix-test-integration
             extra_arg: "--override-input versions ./versions/0_1"
           - pkgs:
-              - build-holonix-tests-integration
+              - holonix-test-integration
             extra_arg: "--override-input versions ./versions/0_2"
           - pkgs:
-              - build-holonix-tests-integration
+              - holonix-test-integration
             extra_arg: "--override-input versions ./versions/weekly"
         platform:
           - system: aarch64-darwin

--- a/.github/workflows/holochain-build-and-test.yml
+++ b/.github/workflows/holochain-build-and-test.yml
@@ -29,7 +29,7 @@ jobs:
         cmd:
           # ensure functionality on multiple platforms
           - pkgs:
-              - build-holochain-tests-unit-all
+              - test-unit-all
               - build-holonix-tests-integration
             extra_arg: "--override-input versions ./versions/weekly --override-input holochain ${{ inputs.repo_path }}"
 
@@ -51,7 +51,7 @@ jobs:
           # x86_64-darwin currently fails the holonix tests, it should pass the unit tests
           - cmd:
               pkgs:
-                - build-holochain-tests-unit-all
+                - test-unit-all
               extra_arg: "--override-input versions ./versions/weekly --override-input holochain ${{ inputs.repo_path }}"
             platform:
               system: x86_64-darwin
@@ -59,7 +59,7 @@ jobs:
           # we only run repo consistency checks on x86_64-linux
           - cmd:
               pkgs:
-                - build-holochain-tests-static-all
+                - test-static-all
                 - build-release-automation-tests-unit
               extra_arg: "--override-input versions './versions/weekly' --override-input holochain ${{ inputs.repo_path }}"
             platform:

--- a/.github/workflows/holochain-build-and-test.yml
+++ b/.github/workflows/holochain-build-and-test.yml
@@ -60,7 +60,7 @@ jobs:
           - cmd:
               pkgs:
                 - test-static-all
-                - build-release-automation-tests-unit
+                - release-automation-test-unit
               extra_arg: "--override-input versions './versions/weekly' --override-input holochain ${{ inputs.repo_path }}"
             platform:
               system: x86_64-linux
@@ -68,7 +68,7 @@ jobs:
           # TODO: can this be skipped during a release run because it duplicates the release-prepare job?
           - cmd:
               pkgs:
-                - build-release-automation-tests-repo
+                - release-automation-test-repo
               extra_arg: "--override-input repo-git 'path:.git'"
             platform:
               system: x86_64-linux

--- a/.github/workflows/holonix-cache.yml
+++ b/.github/workflows/holonix-cache.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - develop
   workflow_dispatch:
-    inputs: { }
+    inputs: {}
 
 jobs:
   # ensures the cache is regularly updated for the supported versions on multiple platforms
@@ -14,20 +14,20 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - "github:holochain/holochain#packages.{0}.build-holonix-tests-integration"
+          - "github:holochain/holochain#packages.{0}.holonix-test-integration"
           - "github:holochain/holochain#devShells.{0}.holonix"
         extra_args:
-          - ''
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/0_1'
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/0_2'
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/0_2_rc'
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/weekly'
+          - ""
+          - "--refresh --override-input versions github:holochain/holochain?dir=versions/0_1"
+          - "--refresh --override-input versions github:holochain/holochain?dir=versions/0_2"
+          - "--refresh --override-input versions github:holochain/holochain?dir=versions/0_2_rc"
+          - "--refresh --override-input versions github:holochain/holochain?dir=versions/weekly"
         platform:
           - x86_64-darwin
           - aarch64-darwin
           - x86_64-linux
 
-    runs-on: [ self-hosted, multi-arch ]
+    runs-on: [self-hosted, multi-arch]
     steps:
       - name: Print matrix
         env:
@@ -68,11 +68,11 @@ jobs:
           - "github:holochain/holochain#devShells.{0}.holonix"
           - "github:holochain/holochain#packages.{0}.hc-scaffold"
         extra_args:
-          - ''
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/0_1'
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/0_2'
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/0_2_rc'
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/weekly'
+          - ""
+          - "--refresh --override-input versions github:holochain/holochain?dir=versions/0_1"
+          - "--refresh --override-input versions github:holochain/holochain?dir=versions/0_2"
+          - "--refresh --override-input versions github:holochain/holochain?dir=versions/0_2_rc"
+          - "--refresh --override-input versions github:holochain/holochain?dir=versions/weekly"
         platform:
           - x86_64-darwin
           - aarch64-darwin

--- a/docs/core_testing.md
+++ b/docs/core_testing.md
@@ -23,15 +23,15 @@ Either of these:
 CI runs all Holochain tests via the `nix build` command by referencing the various packages.
 As of 2023-03-02, we have the following test derivations:
 
-- build-holochain-tests-all
-- build-holochain-tests-static-all
-- build-holochain-tests-static-clippy
-- build-holochain-tests-static-doc
-- build-holochain-tests-static-fmt
-- build-holochain-tests-unit
-- build-holochain-tests-unit-all
-- build-holochain-tests-unit-tx5
-- build-holochain-tests-unit-wasm
+- test-all
+- test-static-all
+- test-static-clippy
+- test-static-doc
+- test-static-fmt
+- test-unit
+- test-unit-all
+- test-unit-tx5
+- test-unit-wasm
 
 The ones ending in *-all* are meta packages, combining all tests in the same category.
 
@@ -40,7 +40,7 @@ The following command builds the meta-package that incorporates all Holochain te
 ```
 nix build -L \
   --override-input holochain . \
-  .#build-holochain-tests-all
+  .#test-all
 ```
 
 ### Using test preconfigured impure test scripts
@@ -63,13 +63,13 @@ Or use `script-holochain-tests-unit-all` if you don't want to run the static che
 To run the tests for a specific package you can pass a filter to `nextest`
 
 ```shell
-env NEXTEST_EXTRA_ARGS="-E 'package(hdk)'" nix build --impure --override-input holochain . .#build-holochain-tests-unit
+env NEXTEST_EXTRA_ARGS="-E 'package(hdk)'" nix build --impure --override-input holochain . .#test-unit
 ```
 
 Or you can select a test by name
 
 ```shell
-env NEXTEST_EXTRA_ARGS="-E 'test(paths_exists)'" nix build --impure --override-input holochain . .#build-holochain-tests-unit
+env NEXTEST_EXTRA_ARGS="-E 'test(paths_exists)'" nix build --impure --override-input holochain . .#test-unit
 ```
 
 ### Using `cargo test` manually

--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -60,7 +60,7 @@
               (
                 lib.attrsets.filterAttrs
                   (name: package:
-                    (builtins.match "^build-holochain-tests.*" name) != null
+                    (builtins.match "^test.*" name) != null
                   )
                   self'.packages
               );

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -105,9 +105,9 @@
           '';
         });
 
-      build-holochain-tests-unit = lib.makeOverridable craneLib.cargoNextest holochainTestsNextestArgs;
+      test-unit = lib.makeOverridable craneLib.cargoNextest holochainTestsNextestArgs;
 
-      build-holochain-tests-static-fmt = craneLib.cargoFmt (commonArgs // {
+      test-static-fmt = craneLib.cargoFmt (commonArgs // {
         src = flake.config.srcCleanedHolochain;
         cargoArtifacts = null;
         doCheck = false;
@@ -116,7 +116,7 @@
         dontFixup = true;
       });
 
-      build-holochain-tests-static-clippy = craneLib.cargoClippy (commonArgs // {
+      test-static-clippy = craneLib.cargoClippy (commonArgs // {
         pname = "holochain-tests-clippy";
         src = flake.config.srcCleanedHolochain;
         cargoArtifacts = holochainDeps;
@@ -176,7 +176,7 @@
         cargoArtifacts = null;
       });
 
-      build-holochain-tests-unit-wasm = craneLib.cargoTest (holochainWasmArgs // {
+      test-unit-wasm = craneLib.cargoTest (holochainWasmArgs // {
         cargoArtifacts = holochainDepsWasm;
 
         dontPatchELF = true;
@@ -188,7 +188,7 @@
         '';
       });
 
-      build-holochain-tests-static-doc = craneLib.cargoDoc (commonArgs // {
+      test-static-doc = craneLib.cargoDoc (commonArgs // {
         pname = "holochain-tests-docs";
         cargoArtifacts = holochainDeps;
       });
@@ -196,20 +196,20 @@
 
 
       # meta packages to build multiple test packages at once
-      build-holochain-tests-unit-all = config.lib.mkMetaPkg "holochain-tests-unit-all" [
-        build-holochain-tests-unit
-        build-holochain-tests-unit-wasm
+      test-unit-all = config.lib.mkMetaPkg "holochain-tests-unit-all" [
+        test-unit
+        test-unit-wasm
       ];
 
-      build-holochain-tests-static-all = config.lib.mkMetaPkg "holochain-tests-static-all" [
-        build-holochain-tests-static-doc
-        build-holochain-tests-static-fmt
-        build-holochain-tests-static-clippy
+      test-static-all = config.lib.mkMetaPkg "holochain-tests-static-all" [
+        test-static-doc
+        test-static-fmt
+        test-static-clippy
       ];
 
-      build-holochain-tests-all = config.lib.mkMetaPkg "build-holochain-tests-all" [
-        build-holochain-tests-unit-all
-        build-holochain-tests-static-all
+      test-all = config.lib.mkMetaPkg "test-all" [
+        test-unit-all
+        test-static-all
       ];
 
     in
@@ -220,16 +220,16 @@
             holochain
             holochain_chc
 
-            build-holochain-tests-unit
-            build-holochain-tests-unit-wasm
-            build-holochain-tests-unit-all
+            test-unit
+            test-unit-wasm
+            test-unit-all
 
-            build-holochain-tests-static-doc
-            build-holochain-tests-static-fmt
-            build-holochain-tests-static-clippy
-            build-holochain-tests-static-all
+            test-static-doc
+            test-static-fmt
+            test-static-clippy
+            test-static-all
 
-            build-holochain-tests-all
+            test-all
             ;
         };
     };

--- a/nix/modules/holonix-integration-test.nix
+++ b/nix/modules/holonix-integration-test.nix
@@ -22,7 +22,7 @@
       };
     in
     {
-      packages.build-holonix-tests-integration = pkgs.mkShell {
+      packages.holonix-test-integration = pkgs.mkShell {
         inputsFrom = [ self'.devShells.holonix ];
         phases = [
           "buildPhase"

--- a/nix/modules/release-automation.nix
+++ b/nix/modules/release-automation.nix
@@ -87,7 +87,7 @@
       packages = {
         release-automation = package;
 
-        build-release-automation-tests-unit = tests;
+        release-automation-test-unit = tests;
 
         # check the state of the repository
         # this is using a dummy input like this:
@@ -96,7 +96,7 @@
         #     repo-git.flake = false;
         # ```
         # and then the test derivation is built it relies on that input being the local repo path. see the "holochain-build-and-test.yml" workflow.
-        build-release-automation-tests-repo =
+        release-automation-test-repo =
           let
             release-script = self'.packages.scripts-release-automation-check-and-bump;
             readmes-script = self'.packages.scripts-ci-generate-readmes;


### PR DESCRIPTION
### Summary
Test build names for nix are so long that they cannot be inspected in the workflow overview when looking at CI pipelines. This PR shortens the prefix
from
`build-holochain-tests-`
to
`test-`

### TODO:
- [ ] CHANGELOGs updated with appropriate info
