### PR TITLE
ci: remove holonix integration tests of version 0_1

### DIFF
--- a/.github/workflows/holochain-build-and-test.yml
+++ b/.github/workflows/holochain-build-and-test.yml
@@ -36,9 +36,6 @@ jobs:
           # ensure that any Nix changes on this branch don't cause problems for maintenance versions
           - pkgs:
               - build-holonix-tests-integration
-            extra_arg: "--override-input versions ./versions/0_1"
-          - pkgs:
-              - build-holonix-tests-integration
             extra_arg: "--override-input versions ./versions/0_2"
           - pkgs:
               - build-holonix-tests-integration

--- a/.github/workflows/holonix-cache.yml
+++ b/.github/workflows/holonix-cache.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - develop
   workflow_dispatch:
-    inputs: { }
+    inputs: {}
 
 jobs:
   # ensures the cache is regularly updated for the supported versions on multiple platforms
@@ -17,17 +17,16 @@ jobs:
           - "github:holochain/holochain#packages.{0}.build-holonix-tests-integration"
           - "github:holochain/holochain#devShells.{0}.holonix"
         extra_args:
-          - ''
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/0_1'
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/0_2'
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/0_2_rc'
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/weekly'
+          - ""
+          - "--refresh --override-input versions github:holochain/holochain?dir=versions/0_2"
+          - "--refresh --override-input versions github:holochain/holochain?dir=versions/0_2_rc"
+          - "--refresh --override-input versions github:holochain/holochain?dir=versions/weekly"
         platform:
           - x86_64-darwin
           - aarch64-darwin
           - x86_64-linux
 
-    runs-on: [ self-hosted, multi-arch ]
+    runs-on: [self-hosted, multi-arch]
     steps:
       - name: Print matrix
         env:
@@ -68,11 +67,10 @@ jobs:
           - "github:holochain/holochain#devShells.{0}.holonix"
           - "github:holochain/holochain#packages.{0}.hc-scaffold"
         extra_args:
-          - ''
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/0_1'
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/0_2'
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/0_2_rc'
-          - '--refresh --override-input versions github:holochain/holochain?dir=versions/weekly'
+          - ""
+          - "--refresh --override-input versions github:holochain/holochain?dir=versions/0_2"
+          - "--refresh --override-input versions github:holochain/holochain?dir=versions/0_2_rc"
+          - "--refresh --override-input versions github:holochain/holochain?dir=versions/weekly"
         platform:
           - x86_64-darwin
           - aarch64-darwin

--- a/.github/workflows/update-dispatch.yml
+++ b/.github/workflows/update-dispatch.yml
@@ -33,8 +33,6 @@ jobs:
           - name: ${{ github.ref_name }}
             skip: true
         update:
-          - source: "versions/0_1"
-            cmd: "nix run .#scripts-repo-flake-update 0_1"
           - source: "versions/0_2"
             cmd: "nix run .#scripts-repo-flake-update 0_2"
           - source: "versions/0_2_rc"

--- a/.github/workflows/update-holonix-version.yml
+++ b/.github/workflows/update-holonix-version.yml
@@ -9,7 +9,6 @@ on:
         default: "false"
         type: choice
         options:
-          - "0_1"
           - "0_2"
           - "0_2_rc"
           - "weekly"
@@ -34,9 +33,9 @@ jobs:
       - name: Run the update script
         run: |
           ./scripts/update-holonix-version.sh ${{ github.event.inputs.version }}
-          
+
           echo "Completed source update. Now updating the flake locks"
-          
+
           nix run .#scripts-repo-flake-update ${{ github.event.inputs.version }}
       - name: Create Pull Request
         id: cpr

--- a/holonix/README.md
+++ b/holonix/README.md
@@ -11,7 +11,7 @@ input override feature.
 
 ```nix
 inputs = {
-  holochain-versions.url = "github:holochain/holochain?dir=versions/0_1";
+  holochain-versions.url = "github:holochain/holochain?dir=versions/0_2";
 
   holochain-flake.url = "github:holochain/holochain";
   holochain-flake.inputs.versions.follows = "holochain-versions";
@@ -22,7 +22,8 @@ inputs = {
 
 ```nix
 inputs = {
-  holochain-versions.url = "github:holochain/holochain?dir=versions/0_1"; holochain-versions.inputs.holochain.url = "github:holochain/holochain/holochain-0.1.5-beta-rc.0";
+  holochain-versions.url = "github:holochain/holochain?dir=versions/0_2";
+  holochain-versions.inputs.holochain.url = "github:holochain/holochain/holochain-0.2.6";
 
   holochain-flake.url = "github:holochain/holochain";
   holochain-flake.inputs.versions.follows = "holochain-versions";
@@ -33,12 +34,12 @@ or via their the toplevel component input:
 
 ```nix
 inputs = {
-  holochain-versions.url = "github:holochain/holochain?dir=versions/0_1";
+  holochain-versions.url = "github:holochain/holochain?dir=versions/0_2";
 
   holochain-flake.url = "github:holochain/holochain";
   holochain-flake.inputs.versions.follows = "holochain-versions";
 
-  holochain-flake.inputs.holochain.url = "github:holochain/holochain/holochain-0.1.5-beta-rc.0";
+  holochain-flake.inputs.holochain.url = "github:holochain/holochain/holochain-0.2.6";
 };
 ```
 

--- a/holonix/examples/custom_versions/flake.nix
+++ b/holonix/examples/custom_versions/flake.nix
@@ -5,12 +5,12 @@
   #
   # nix develop \
   #   github:holochain/holochain#holonix \
-  #   --override-input versions 'github:holochain/holochain/?dir=versions/0_1' \
-  #   --override-input versions/holochain 'github:holochain/holochain/holochain-0.1.5-beta-rc.0'
+  #   --override-input versions 'github:holochain/holochain/?dir=versions/0_2' \
+  #   --override-input versions/holochain 'github:holochain/holochain/holochain-0.2.6'
 
   inputs = {
-    versions.url = "github:holochain/holochain?dir=versions/0_1";
-    versions.inputs.holochain.url = "github:holochain/holochain/holochain-0.1.5-beta-rc.0";
+    versions.url = "github:holochain/holochain?dir=versions/0_2";
+    versions.inputs.holochain.url = "github:holochain/holochain/holochain-0.2.6";
 
     holochain-flake.url = "github:holochain/holochain";
     holochain-flake.inputs.versions.follows = "versions";


### PR DESCRIPTION
### Summary
PR tests are still running against 0_1. We're no longer supporting version 0.1 and can remove those tests.


### TODO:
- [ ] CHANGELOGs updated with appropriate info
