### PR TITLE
test(app-validation-workflow): add unhappy op validation test

### DIFF
--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -234,6 +234,7 @@ async fn app_validation_workflow_inner(
     let accepted_ops = Arc::new(AtomicUsize::new(0));
     let awaiting_ops = Arc::new(AtomicUsize::new(0));
     let rejected_ops = Arc::new(AtomicUsize::new(0));
+    let failed_ops = Arc::new(Mutex::new(HashSet::new()));
     let mut agent_activity = Vec::new();
 
     // Validate ops sequentially
@@ -349,6 +350,7 @@ async fn app_validation_workflow_inner(
                     ?err,
                     "App validation error when validating dht op."
                 );
+                failed_ops.lock().insert(dht_op_hash);
             }
         }
     }
@@ -373,7 +375,10 @@ async fn app_validation_workflow_inner(
     let awaiting_ops = awaiting_ops.load(Ordering::SeqCst);
     let rejected_ops = rejected_ops.load(Ordering::SeqCst);
     let ops_validated = accepted_ops + rejected_ops;
-    tracing::info!("{ops_validated} out of {num_ops_to_validate} validated: {accepted_ops} accepted, {awaiting_ops} awaiting deps, {rejected_ops} rejected.");
+    let failed_ops = Arc::try_unwrap(failed_ops)
+        .expect("must be only reference")
+        .into_inner();
+    tracing::info!("{ops_validated} out of {num_ops_to_validate} validated: {accepted_ops} accepted, {awaiting_ops} awaiting deps, {rejected_ops} rejected, failed ops {failed_ops:?}.");
 
     let outcome_summary = OutcomeSummary {
         ops_to_validate: num_ops_to_validate,
@@ -381,6 +386,7 @@ async fn app_validation_workflow_inner(
         accepted: accepted_ops,
         missing: awaiting_ops,
         rejected: rejected_ops,
+        failed: failed_ops,
     };
     Ok(outcome_summary)
 }
@@ -861,6 +867,7 @@ struct OutcomeSummary {
     accepted: usize,
     missing: usize,
     rejected: usize,
+    failed: HashSet<DhtOpHash>,
 }
 
 impl OutcomeSummary {
@@ -871,6 +878,7 @@ impl OutcomeSummary {
             accepted: 0,
             missing: 0,
             rejected: 0,
+            failed: HashSet::new(),
         }
     }
 }

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -508,6 +508,119 @@ async fn validate_ops_in_sequence_must_get_action() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn handle_error_in_op_validation() {
+    holochain_trace::test_run();
+
+    let entry_def = EntryDef::default_from_id("entry_def_id");
+    let zomes = SweetInlineZomes::new(vec![entry_def], 0).integrity_function(
+        "validate",
+        move |_, op: Op| match op {
+            Op::RegisterAgentActivity(_) => Err(InlineZomeError::TestError("kaputt".to_string())),
+            _ => Ok(ValidateCallbackResult::Valid),
+        },
+    );
+
+    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(zomes).await;
+    let dna_hash = dna_file.dna_hash().clone();
+
+    let mut conductor = SweetConductor::from_config_rendezvous(
+        SweetConductorConfig::rendezvous(true),
+        SweetLocalRendezvous::new().await,
+    )
+    .await;
+    let app = conductor.setup_app("", &[dna_file.clone()]).await.unwrap();
+    let cell_id = app.cells()[0].cell_id().clone();
+
+    let app_validation_workspace = Arc::new(AppValidationWorkspace::new(
+        conductor
+            .get_or_create_authored_db(&dna_hash, cell_id.agent_pubkey().clone())
+            .unwrap()
+            .into(),
+        conductor.get_dht_db(&dna_hash).unwrap(),
+        conductor.get_dht_db_cache(&dna_hash).unwrap(),
+        conductor.get_cache_db(&cell_id).await.unwrap(),
+        conductor.keystore(),
+        Arc::new(dna_file.dna_def().clone()),
+    ));
+
+    // create register agent activity op that will return an error during validation
+    let mut create = fixt!(Create);
+    create.entry_type = EntryType::App(AppEntryDef {
+        entry_index: 0.into(),
+        zome_index: 0.into(),
+        visibility: Default::default(),
+    });
+    let create_action = Action::Create(create);
+    let dht_create_op = DhtOp::RegisterAgentActivity(fixt!(Signature), create_action.clone());
+    let dht_create_op_hash = DhtOpHash::with_data_sync(&dht_create_op);
+    let dht_create_op_hashed = DhtOpHashed::from_content_sync(dht_create_op);
+
+    // create another op that will be validated successfully
+    let mut create = fixt!(Create);
+    create.entry_type = EntryType::App(AppEntryDef {
+        entry_index: 0.into(),
+        zome_index: 0.into(),
+        visibility: Default::default(),
+    });
+    let entry = fixt!(Entry);
+    let dht_store_entry_op =
+        DhtOp::StoreEntry(fixt!(Signature), NewEntryAction::Create(create), entry);
+    let dht_store_entry_op_hash = DhtOpHash::with_data_sync(&dht_store_entry_op);
+    let dht_store_entry_op_hashed = DhtOpHashed::from_content_sync(dht_store_entry_op);
+
+    // insert both ops in dht db and mark ready for app validation
+    app_validation_workspace.dht_db.test_write(move |txn| {
+        insert_op(txn, &dht_create_op_hashed).unwrap();
+        put_validation_limbo(txn, &dht_create_op_hash, ValidationStage::SysValidated).unwrap();
+        insert_op(txn, &dht_store_entry_op_hashed).unwrap();
+        put_validation_limbo(txn, &dht_store_entry_op_hash, ValidationStage::SysValidated).unwrap();
+    });
+
+    // check ops are now counted as ops to validate
+    let ops_to_validate =
+        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
+            .await
+            .unwrap()
+            .len();
+    assert_eq!(ops_to_validate, 2);
+
+    let validation_dependencies = Arc::new(Mutex::new(ValidationDependencies::new()));
+
+    // running validation workflow should finish without errors
+    // outcome summary should show 1 validated and accepted op and the error-causing op as still to validate
+    let outcome_summary = app_validation_workflow_inner(
+        Arc::new(dna_hash.clone()),
+        app_validation_workspace.clone(),
+        conductor.raw_handle(),
+        &conductor.holochain_p2p().to_dna(dna_hash.clone(), None),
+        conductor
+            .get_or_create_space(&dna_hash)
+            .unwrap()
+            .dht_query_cache,
+        validation_dependencies.clone(),
+    )
+    .await
+    .unwrap();
+    assert_matches!(
+        outcome_summary,
+        OutcomeSummary {
+            ops_to_validate: 2,
+            validated: 1,
+            accepted: 1,
+            missing: 0,
+            rejected: 0
+        }
+    );
+
+    let ops_to_validate =
+        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
+            .await
+            .unwrap()
+            .len();
+    assert_eq!(ops_to_validate, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "deal with the invalid data that leads to blocks being enforced"]
 async fn app_validation_workflow_test() {
     holochain_trace::test_run();

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -65,11 +65,7 @@ async fn main_workflow() {
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(zomes).await;
     let dna_hash = dna_file.dna_hash().clone();
 
-    let mut conductor = SweetConductor::from_config_rendezvous(
-        SweetConductorConfig::rendezvous(true),
-        SweetLocalRendezvous::new().await,
-    )
-    .await;
+    let mut conductor = SweetConductor::from_standard_config().await;
     let app = conductor.setup_app("", &[dna_file.clone()]).await.unwrap();
     let cell_id = app.cells()[0].cell_id().clone();
 
@@ -275,11 +271,7 @@ async fn validate_ops_in_sequence_must_get_agent_activity() {
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(zomes).await;
     let dna_hash = dna_file.dna_hash().clone();
 
-    let mut conductor = SweetConductor::from_config_rendezvous(
-        SweetConductorConfig::rendezvous(true),
-        SweetLocalRendezvous::new().await,
-    )
-    .await;
+    let mut conductor = SweetConductor::from_standard_config().await;
     let app = conductor.setup_app("", &[dna_file.clone()]).await.unwrap();
     let cell_id = app.cells()[0].cell_id().clone();
 
@@ -400,11 +392,7 @@ async fn validate_ops_in_sequence_must_get_action() {
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(zomes).await;
     let dna_hash = dna_file.dna_hash().clone();
 
-    let mut conductor = SweetConductor::from_config_rendezvous(
-        SweetConductorConfig::rendezvous(true),
-        SweetLocalRendezvous::new().await,
-    )
-    .await;
+    let mut conductor = SweetConductor::from_standard_config().await;
     let app = conductor.setup_app("", &[dna_file.clone()]).await.unwrap();
     let cell_id = app.cells()[0].cell_id().clone();
 
@@ -523,11 +511,7 @@ async fn handle_error_in_op_validation() {
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(zomes).await;
     let dna_hash = dna_file.dna_hash().clone();
 
-    let mut conductor = SweetConductor::from_config_rendezvous(
-        SweetConductorConfig::rendezvous(true),
-        SweetLocalRendezvous::new().await,
-    )
-    .await;
+    let mut conductor = SweetConductor::from_standard_config().await;
     let app = conductor.setup_app("", &[dna_file.clone()]).await.unwrap();
     let cell_id = app.cells()[0].cell_id().clone();
 


### PR DESCRIPTION
### Summary
Test the unhappy path for an op validation. Workflow shouldn't be aborted and op shouldn't be counted as validated.


### TODO:
- [ ] CHANGELOGs updated with appropriate info
