### PR TITLE
Clean up websocket connections

### DIFF
--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -465,11 +465,6 @@ async fn handle_incoming_app_message(
 #[cfg(any(test, feature = "test_utils"))]
 pub use crate::test_utils::setup_app_in_new_conductor;
 
-#[cfg(feature = "test_utils")]
-pub fn active_ws_tasks_count() -> usize {
-
-}
-
 #[cfg(test)]
 pub mod test {
     use super::*;

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -1,6 +1,7 @@
 //! Module for establishing Websocket-based Interfaces,
 //! i.e. those configured with `InterfaceDriver::Websocket`
 
+use std::io::ErrorKind;
 use super::error::InterfaceResult;
 use crate::conductor::conductor::app_broadcast::AppBroadcast;
 use crate::conductor::manager::TaskManagerClient;
@@ -20,6 +21,7 @@ use holochain_conductor_api::{
 use holochain_types::app::InstalledAppId;
 use holochain_types::websocket::AllowedOrigins;
 use std::sync::Arc;
+use tokio::pin;
 use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 use tracing::*;
@@ -322,26 +324,28 @@ fn spawn_app_signals_handler(
         }
     });
 
-    // TODO - metrics to indicate if we're getting overloaded here.
     task_list
         .lock()
-        .push(tokio::task::spawn(rx_from_cell.for_each_concurrent(
-            CONCURRENCY_COUNT,
-            move |signal| {
-                let tx_to_iface = tx_to_iface.clone();
-                async move {
+        .push(tokio::task::spawn(async move {
+            pin!(rx_from_cell);
+            loop {
+                if let Some(signal) = rx_from_cell.next().await {
                     trace!(msg = "Sending signal!", ?signal);
-                    if let Err(err) = async move {
-                        tx_to_iface.signal(signal).await?;
-                        InterfaceResult::Ok(())
-                    }
-                    .await
+                    if let Err(err) = tx_to_iface.signal(signal).await
                     {
-                        error!(?err, "error emitting signal");
+                        if err.kind() == ErrorKind::Other && err.to_string() == "WebsocketClosed" {
+                            info!("Client has closed their websocket connection, closing signal handler");
+                        } else {
+                            error!(?err, "failed to emit signal, closing emitter");
+                        }
+                        break;
                     }
+                } else {
+                    trace!("No more signals from this cell, closing signal handler");
+                    break;
                 }
-            },
-        )));
+            }
+        }));
 }
 
 /// Starts a task that listens for messages coming from the external client on `rx_from_iface`
@@ -460,6 +464,11 @@ async fn handle_incoming_app_message(
 /// Test items needed by other crates
 #[cfg(any(test, feature = "test_utils"))]
 pub use crate::test_utils::setup_app_in_new_conductor;
+
+#[cfg(feature = "test_utils")]
+pub fn active_ws_tasks_count() -> usize {
+
+}
 
 #[cfg(test)]
 pub mod test {

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -1,7 +1,6 @@
 //! Module for establishing Websocket-based Interfaces,
 //! i.e. those configured with `InterfaceDriver::Websocket`
 
-use std::io::ErrorKind;
 use super::error::InterfaceResult;
 use crate::conductor::conductor::app_broadcast::AppBroadcast;
 use crate::conductor::manager::TaskManagerClient;
@@ -12,6 +11,7 @@ use holochain_websocket::WebsocketConfig;
 use holochain_websocket::WebsocketListener;
 use holochain_websocket::WebsocketReceiver;
 use holochain_websocket::WebsocketSender;
+use std::io::ErrorKind;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6};
 
 use crate::conductor::api::{AdminInterfaceApi, AppAuthentication, AppInterfaceApi};
@@ -324,28 +324,27 @@ fn spawn_app_signals_handler(
         }
     });
 
-    task_list
-        .lock()
-        .push(tokio::task::spawn(async move {
-            pin!(rx_from_cell);
-            loop {
-                if let Some(signal) = rx_from_cell.next().await {
-                    trace!(msg = "Sending signal!", ?signal);
-                    if let Err(err) = tx_to_iface.signal(signal).await
-                    {
-                        if err.kind() == ErrorKind::Other && err.to_string() == "WebsocketClosed" {
-                            info!("Client has closed their websocket connection, closing signal handler");
-                        } else {
-                            error!(?err, "failed to emit signal, closing emitter");
-                        }
-                        break;
+    task_list.lock().push(tokio::task::spawn(async move {
+        pin!(rx_from_cell);
+        loop {
+            if let Some(signal) = rx_from_cell.next().await {
+                trace!(msg = "Sending signal!", ?signal);
+                if let Err(err) = tx_to_iface.signal(signal).await {
+                    if err.kind() == ErrorKind::Other && err.to_string() == "WebsocketClosed" {
+                        info!(
+                            "Client has closed their websocket connection, closing signal handler"
+                        );
+                    } else {
+                        error!(?err, "failed to emit signal, closing emitter");
                     }
-                } else {
-                    trace!("No more signals from this cell, closing signal handler");
                     break;
                 }
+            } else {
+                trace!("No more signals from this cell, closing signal handler");
+                break;
             }
-        }));
+        }
+    }));
 }
 
 /// Starts a task that listens for messages coming from the external client on `rx_from_iface`

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -994,7 +994,10 @@ async fn emit_signal_after_app_connection_closed() {
         .await
         .0;
     let installed_app_id: InstalledAppId = "app".into();
-    let app = conductor.setup_app(&installed_app_id, &[dna_file]).await.unwrap();
+    let app = conductor
+        .setup_app(&installed_app_id, &[dna_file])
+        .await
+        .unwrap();
     let cells = app.into_cells();
     let cell = cells.first().unwrap();
 
@@ -1008,19 +1011,16 @@ async fn emit_signal_after_app_connection_closed() {
 
     authenticate_app_ws_client(
         tx.clone(),
-        conductor.get_arbitrary_admin_websocket_port()
+        conductor
+            .get_arbitrary_admin_websocket_port()
             .expect("No admin ports on this conductor"),
         installed_app_id.clone(),
     )
-        .await;
+    .await;
 
     // Emit a signal
     let _: () = conductor
-        .call(
-            &cell.zome(TestWasm::EmitSignal),
-            "emit",
-            (),
-        )
+        .call(&cell.zome(TestWasm::EmitSignal), "emit", ())
         .await;
 
     // That should be received because the app interface is connected
@@ -1033,11 +1033,7 @@ async fn emit_signal_after_app_connection_closed() {
 
     // Emit another signal
     let _: () = conductor
-        .call(
-            &cell.zome(TestWasm::EmitSignal),
-            "emit",
-            (),
-        )
+        .call(&cell.zome(TestWasm::EmitSignal), "emit", ())
         .await;
 
     // That should not be received because the app interface is disconnected

--- a/crates/holochain/tests/websocket/mod.rs
+++ b/crates/holochain/tests/websocket/mod.rs
@@ -982,3 +982,65 @@ async fn holochain_websockets_listen_on_ipv4_and_ipv6() {
         _ => panic!("unexpected response"),
     }
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn emit_signal_after_app_connection_closed() {
+    holochain_trace::test_run();
+
+    let mut conductor = SweetConductor::from_standard_config().await;
+
+    // Install an app to emit signals from
+    let dna_file = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::EmitSignal])
+        .await
+        .0;
+    let installed_app_id: InstalledAppId = "app".into();
+    let app = conductor.setup_app(&installed_app_id, &[dna_file]).await.unwrap();
+    let cells = app.into_cells();
+    let cell = cells.first().unwrap();
+
+    // Connect to the app interface
+    let port = conductor
+        .clone()
+        .add_app_interface(Either::Left(0), AllowedOrigins::Any, None)
+        .await
+        .expect("Couldn't create app interface");
+    let (tx, mut rx) = websocket_client_by_port(port).await.unwrap();
+
+    authenticate_app_ws_client(
+        tx.clone(),
+        conductor.get_arbitrary_admin_websocket_port()
+            .expect("No admin ports on this conductor"),
+        installed_app_id.clone(),
+    )
+        .await;
+
+    // Emit a signal
+    let _: () = conductor
+        .call(
+            &cell.zome(TestWasm::EmitSignal),
+            "emit",
+            (),
+        )
+        .await;
+
+    // That should be received because the app interface is connected
+    let received = rx.recv::<AppResponse>().await.unwrap();
+    assert_matches!(received, ReceiveMessage::Signal(_));
+
+    // Drop the app interface connection
+    drop(tx);
+    drop(rx);
+
+    // Emit another signal
+    let _: () = conductor
+        .call(
+            &cell.zome(TestWasm::EmitSignal),
+            "emit",
+            (),
+        )
+        .await;
+
+    // That should not be received because the app interface is disconnected
+    // TODO assert that the tasks for this connection were shutdown and removed by this point.
+    //      Can't currently do that with TaskMotel which I think is the right thing to query here.
+}

--- a/crates/holochain_websocket/src/test.rs
+++ b/crates/holochain_websocket/src/test.rs
@@ -349,9 +349,7 @@ async fn handle_client_close() {
 
         let (send, mut recv) = l.accept().await.unwrap();
         let s_task =
-            tokio::task::spawn(
-                async move { while let Ok(_r) = recv.recv::<TestMsg>().await {} },
-            );
+            tokio::task::spawn(async move { while let Ok(_r) = recv.recv::<TestMsg>().await {} });
 
         let sender = tokio::task::spawn(async move {
             loop {
@@ -359,7 +357,9 @@ async fn handle_client_close() {
                     Ok(_) => {
                         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
                     }
-                    Err(e) if e.kind() == ErrorKind::Other && e.to_string() == "WebsocketClosed" => {
+                    Err(e)
+                        if e.kind() == ErrorKind::Other && e.to_string() == "WebsocketClosed" =>
+                    {
                         break;
                     }
                     Err(e) => {
@@ -391,7 +391,8 @@ async fn handle_client_close() {
     // Listens for one signal then stops listening without closing the connection
     r_task.await.unwrap();
 
-    tokio::time::timeout(std::time::Duration::from_secs(5), l_task).await
+    tokio::time::timeout(std::time::Duration::from_secs(5), l_task)
+        .await
         .expect("Timeout waiting for shutdown")
         .expect("Error joining the signal sender task")
         .expect("Other error than WebsocketClosed while sending signals");

--- a/crates/holochain_websocket/src/test.rs
+++ b/crates/holochain_websocket/src/test.rs
@@ -1,6 +1,7 @@
 //! holochain_websocket tests
 
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use tokio::task::JoinHandle;
 
 use crate::*;
 
@@ -321,4 +322,77 @@ async fn ipv6_or_ipv4_connect_on_specific_port() {
     }
 
     l_task.await.unwrap();
+}
+
+// This test is meant to cover the case of a client dropping their connection without closing it.
+// We should respond to this by shutting down tasks on our side and the senders that were hooked
+// into those tasks should be able to detect that the receiver has dropped so that the caller knows
+// to drop that send handle.
+#[tokio::test(flavor = "multi_thread")]
+async fn handle_client_close() {
+    holochain_trace::test_run();
+
+    #[derive(Debug, serde::Serialize, serde::Deserialize, SerializedBytes, PartialEq)]
+    enum TestMsg {
+        Hello,
+    }
+
+    let (addr_s, addr_r) = tokio::sync::oneshot::channel();
+
+    let l_task: JoinHandle<Result<()>> = tokio::task::spawn(async move {
+        let l = WebsocketListener::bind(Arc::new(WebsocketConfig::LISTENER_DEFAULT), "localhost:0")
+            .await
+            .unwrap();
+
+        let addr = l.local_addrs().unwrap();
+        addr_s.send(addr).unwrap();
+
+        let (send, mut recv) = l.accept().await.unwrap();
+        let s_task =
+            tokio::task::spawn(
+                async move { while let Ok(_r) = recv.recv::<TestMsg>().await {} },
+            );
+
+        let sender = tokio::task::spawn(async move {
+            loop {
+                match send.signal(TestMsg::Hello).await {
+                    Ok(_) => {
+                        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    }
+                    Err(e) if e.kind() == ErrorKind::Other && e.to_string() == "WebsocketClosed" => {
+                        break;
+                    }
+                    Err(e) => {
+                        panic!("unexpected error: {:?}", e);
+                    }
+                };
+            }
+        });
+
+        sender.await?;
+
+        s_task.abort();
+
+        Ok(())
+    });
+
+    let addr = addr_r.await.unwrap()[0];
+    println!("addr: {}", addr);
+
+    let r_task = tokio::task::spawn(async move {
+        let (_send, mut recv) = connect(Arc::new(WebsocketConfig::CLIENT_DEFAULT), addr)
+            .await
+            .unwrap();
+
+        let signal = recv.recv::<TestMsg>().await.unwrap();
+        assert!(matches!(signal, ReceiveMessage::Signal(_)));
+    });
+
+    // Listens for one signal then stops listening without closing the connection
+    r_task.await.unwrap();
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), l_task).await
+        .expect("Timeout waiting for shutdown")
+        .expect("Error joining the signal sender task")
+        .expect("Other error than WebsocketClosed while sending signals");
 }


### PR DESCRIPTION
### Summary

This solves the problem I set out to solve but I can't write a satisfactory test because I can't get at what's running in the Holochain interface. I think what we want to see when a connection ends is the managed task in TaskMotel shutting down but that doesn't have an interface for querying back what's been submitted to it. Is that something we could consider as a feature @maackle?

### TODO:
- [ ] CHANGELOGs updated with appropriate info
