### PR TITLE
Flaky tests for sharding (publish)

### DIFF
--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1993,10 +1993,7 @@ mod app_status_impls {
                     let p2p_agents_db = cell.p2p_agents_db().clone();
                     let cell_id = cell.id().clone();
                     let kagent = cell_id.agent_pubkey().to_kitsune();
-                    let maybe_agent_info = match p2p_agents_db.p2p_get_agent(&kagent).await {
-                        Ok(maybe_info) => maybe_info,
-                        _ => None,
-                    };
+                    let maybe_agent_info = p2p_agents_db.p2p_get_agent(&kagent).await.ok().flatten();
                     let maybe_initial_arq = maybe_agent_info.clone().map(|i| i.storage_arq);
                     let agent_pubkey = cell_id.agent_pubkey().clone();
 

--- a/crates/kitsune_p2p/dht/src/arq/strat.rs
+++ b/crates/kitsune_p2p/dht/src/arq/strat.rs
@@ -99,15 +99,16 @@ pub struct ArqStrat {
 #[cfg(feature = "test_utils")]
 impl Default for ArqStrat {
     fn default() -> Self {
-        Self::standard(LocalStorageConfig::default())
+        Self::standard(LocalStorageConfig::default(), DEFAULT_MIN_PEERS as f64)
     }
 }
 
 impl ArqStrat {
     /// Standard arq strat
-    pub fn standard(local_storage: LocalStorageConfig) -> Self {
+    pub fn standard(local_storage: LocalStorageConfig, min_coverage: f64) -> Self {
         Self {
-            min_coverage: DEFAULT_MIN_PEERS as f64,
+            // TODO This is refered to as min_coverage, min_peers and redundancy_target. Pick one name and make this consistent.
+            min_coverage,
             // this buffer implies min-max chunk count of 8-16
             buffer: 0.143,
             power_std_dev_threshold: 1.0,

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/initiate.rs
@@ -38,6 +38,7 @@ impl ShardedGossipLocal {
 
         // Choose a remote agent to gossip with.
         let remote_agent = self
+            // TODO want to set a test up so that we know who this should be
             .find_remote_agent_within_arcset(ArqSet::new(intervals.clone()), agent_info_session)
             .await?;
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -1588,14 +1588,16 @@ impl Space {
         // TODO: We are simply setting the initial arc to full.
         // In the future we may want to do something more intelligent.
         //
-        // In the case an initial_arc is passend into the join request,
+        // In the case an initial_arc is passed into the join request,
         // handle_join will initialize this agent_arcs map to that value.
-        let strat = self.config.tuning_params.to_arq_strat();
         self.agent_arqs.get(agent).cloned().unwrap_or_else(|| {
             let dim = SpaceDimension::standard();
             match self.config.tuning_params.arc_clamping() {
                 Some(ArqClamping::Empty) => Arq::new_empty(dim, agent.get_loc()),
-                Some(ArqClamping::Full) | None => Arq::new_full_max(dim, &strat, agent.get_loc()),
+                Some(ArqClamping::Full) | None => {
+                    let strat = self.config.tuning_params.to_arq_strat();
+                    Arq::new_full_max(dim, &strat, agent.get_loc())
+                }
             }
         })
     }

--- a/crates/kitsune_p2p/kitsune_p2p/tests/common/data.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/tests/common/data.rs
@@ -113,7 +113,6 @@ fn generated_hash() -> KitsuneOpHash {
 }
 
 // Ideally this would match the implementation in `holo_dht_location_bytes`
-#[cfg(feature = "test_utils")]
 pub fn dht_location(data: &[u8; 32]) -> [u8; 4] {
     let hash = blake2b_simd::Params::new()
         .hash_length(16)

--- a/crates/kitsune_p2p/kitsune_p2p/tests/common/test_legacy_host.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/tests/common/test_legacy_host.rs
@@ -4,7 +4,7 @@ use kitsune_p2p::event::{
     full_time_window, FetchOpDataEvt, FetchOpDataEvtQuery, KitsuneP2pEvent, PutAgentInfoSignedEvt,
     QueryAgentsEvt, QueryOpHashesEvt, SignNetworkDataEvt,
 };
-use kitsune_p2p_bin_data::{KitsuneAgent, KitsuneOpData, KitsuneSignature, KitsuneSpace};
+use kitsune_p2p_bin_data::{KitsuneAgent, KitsuneBinType, KitsuneOpData, KitsuneSignature, KitsuneSpace};
 use kitsune_p2p_fetch::FetchContext;
 use kitsune_p2p_timestamp::Timestamp;
 use kitsune_p2p_types::bootstrap::AgentInfoPut;
@@ -23,7 +23,7 @@ use std::{
     },
 };
 
-use super::TestHostOp;
+use super::{dht_location, TestHostOp};
 
 pub struct TestLegacyHost {
     handle: Option<tokio::task::JoinHandle<()>>,
@@ -334,7 +334,7 @@ impl TestLegacyHost {
                         }
                         KitsuneP2pEvent::SignNetworkData { respond, input, .. } => {
                             let mut key = [0; 32];
-                            key.copy_from_slice(input.agent.0.as_slice());
+                            key.copy_from_slice(&input.agent.0[0..32]);
                             let sig = keystore
                                 .sign_by_pub_key(
                                     key.into(),
@@ -379,7 +379,10 @@ impl TestLegacyHost {
             .new_seed(tag.into(), None, false)
             .await
             .unwrap();
-        Arc::new(KitsuneAgent(info.ed25519_pub_key.0.to_vec()))
+        let mut pub_key_bytes = info.ed25519_pub_key.0.to_vec();
+        let loc = dht_location(&pub_key_bytes[0..32].try_into().unwrap());
+        pub_key_bytes.extend(&loc);
+        Arc::new(KitsuneAgent::new(pub_key_bytes))
     }
 }
 

--- a/crates/kitsune_p2p/kitsune_p2p/tests/common/test_legacy_host.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/tests/common/test_legacy_host.rs
@@ -4,7 +4,9 @@ use kitsune_p2p::event::{
     full_time_window, FetchOpDataEvt, FetchOpDataEvtQuery, KitsuneP2pEvent, PutAgentInfoSignedEvt,
     QueryAgentsEvt, QueryOpHashesEvt, SignNetworkDataEvt,
 };
-use kitsune_p2p_bin_data::{KitsuneAgent, KitsuneBinType, KitsuneOpData, KitsuneSignature, KitsuneSpace};
+use kitsune_p2p_bin_data::{
+    KitsuneAgent, KitsuneBinType, KitsuneOpData, KitsuneSignature, KitsuneSpace,
+};
 use kitsune_p2p_fetch::FetchContext;
 use kitsune_p2p_timestamp::Timestamp;
 use kitsune_p2p_types::bootstrap::AgentInfoPut;

--- a/crates/kitsune_p2p/kitsune_p2p/tests/sharding.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/tests/sharding.rs
@@ -38,6 +38,8 @@ async fn publish_to_basis_from_inside() {
     let tuner = |mut params: tuning_params_struct::KitsuneP2pTuningParams| {
         params.gossip_arc_clamping = "none".to_string();
         params.gossip_dynamic_arcs = false; // Don't update the arcs dynamically, use the initial value
+        params.disable_recent_gossip = true;
+        params.disable_historical_gossip = true;
         params
     };
 
@@ -202,6 +204,8 @@ async fn publish_to_basis_from_outside() {
     let tuner = |mut params: tuning_params_struct::KitsuneP2pTuningParams| {
         params.gossip_arc_clamping = "none".to_string();
         params.gossip_dynamic_arcs = false; // Don't update the arcs dynamically, use the initial value
+        params.disable_recent_gossip = true;
+        params.disable_historical_gossip = true;
         params
     };
 

--- a/crates/kitsune_p2p/kitsune_p2p/tests/sharding.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/tests/sharding.rs
@@ -19,7 +19,7 @@ mod common;
 
 #[cfg(feature = "tx5")]
 #[tokio::test(flavor = "multi_thread")]
-async fn only_gossip_with_agents_having_overlapping_arc() {
+async fn publish_to_basis_from_inside() {
     holochain_trace::test_run();
 
     let (bootstrap_addr, _bootstrap_handle) = start_bootstrap().await;
@@ -63,10 +63,15 @@ async fn only_gossip_with_agents_having_overlapping_arc() {
             agent = harness.create_agent().await;
         }
 
-        assert!(found_loc, "Failed to find a location in the right range after 1000 tries");
+        assert!(
+            found_loc,
+            "Failed to find a location in the right range after 1000 tries"
+        );
 
         // Distance to the end of the segment, plus the length of the next segment. Guaranteed to
         // overlap with the next agent and not the one after that.
+        // Because of arc quantisation, the layout won't be perfect, but we can expect overlap at
+        // the start of the agent's arc, with the previous agent.
         let len =
             DhtLocation::new(base_len * (i + 1)) - agent.get_loc() + DhtLocation::new(base_len);
 
@@ -76,9 +81,8 @@ async fn only_gossip_with_agents_having_overlapping_arc() {
             agent.get_loc(),
             len.as_() / 2 + 1,
         );
-        println!("Agent {:?} is getting arc {:?}", agent, arc);
         sender
-            .join(space.clone(), agent.clone(), None, None) // Some(arc)
+            .join(space.clone(), agent.clone(), None, Some(arc))
             .await
             .unwrap();
 
@@ -96,41 +100,23 @@ async fn only_gossip_with_agents_having_overlapping_arc() {
     let sender_idx = 3;
     let should_recv_idx = 2;
 
-    let sender_location = &agents[sender_idx].2.0[32..];
+    let sender_location = &agents[sender_idx].2 .0[32..];
 
     let mut kitsune_basis = KitsuneBasis::new(vec![0; 36]);
     kitsune_basis.0[32..].copy_from_slice(&sender_location);
     let basis = Arc::new(kitsune_basis);
 
-    let test_data = TestHostOp::new(space.clone());
+    // If the location was copied correctly then the basis location should be the same as the sender
+    // location. Due to the logic above, the receiver should have the sender's location in its arc.
+    assert_eq!(agents[sender_idx].2.get_loc(), basis.get_loc());
 
-    let mut in_range_for_agent = vec![];
-    for i in 0..5 {
-        let agent_store_lock = agents[i].0.agent_store();
-        let agent_store = agent_store_lock.read();
-        let agent_info = agent_store.first().unwrap();
-        let edges = agent_info.storage_arq.to_edge_locs(dim);
-
-        if edges.0 < edges.1 {
-            if edges.0 >= test_data.location() && test_data.location() <= edges.1 {
-                in_range_for_agent.push(i);
-            }
-        } else {
-            if test_data.location() >= edges.0 || test_data.location() <= edges.1 {
-                in_range_for_agent.push(i);
-            }
-        }
-    }
-
-    assert_eq!(2, in_range_for_agent.len(), "Test op should have been in range for two agents but got: {}", in_range_for_agent.len());
-
-    println!("Expect to send to agents {:?}", in_range_for_agent);
+    let test_op = TestHostOp::new(space.clone());
 
     agents[sender_idx]
         .0
         .op_store()
         .write()
-        .push(test_data.clone());
+        .push(test_op.clone());
 
     agents[sender_idx]
         .1
@@ -140,7 +126,7 @@ async fn only_gossip_with_agents_having_overlapping_arc() {
             KitsuneTimeout::from_millis(5_000),
             BroadcastData::Publish {
                 source: agents[sender_idx].2.clone(),
-                op_hash_list: vec![test_data.into()],
+                op_hash_list: vec![test_op.into()],
                 context: FetchContext::default(),
             },
         )
@@ -170,6 +156,177 @@ async fn only_gossip_with_agents_having_overlapping_arc() {
 
         let store_lock = agents[i].0.op_store();
         let store = store_lock.read();
-        assert!(store.is_empty(), "Agent {} should not have received any data but has {} ops", i, store.len());
+        assert!(
+            store.is_empty(),
+            "Agent {} should not have received any data but has {} ops",
+            i,
+            store.len()
+        );
+    }
+}
+
+#[cfg(feature = "tx5")]
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_to_basis_from_outside() {
+    holochain_trace::test_run();
+
+    let (bootstrap_addr, _bootstrap_handle) = start_bootstrap().await;
+    let (signal_url, _signal_srv_handle) = start_signal_srv().await;
+
+    let space = Arc::new(fixt!(KitsuneSpace));
+
+    let tuner = |mut params: tuning_params_struct::KitsuneP2pTuningParams| {
+        params.gossip_arc_clamping = "none".to_string();
+        params.gossip_dynamic_arcs = false; // Don't update the arcs dynamically, use the initial value
+        params
+    };
+
+    // Arcs are this long by default, with an adjustment to ensure overlap.
+    let base_len = u32::MAX / 5;
+
+    let dim = SpaceDimension::standard();
+
+    let mut agents = Vec::new();
+
+    for i in 0..5 {
+        let mut harness = KitsuneTestHarness::try_new("")
+            .await
+            .expect("Failed to setup test harness")
+            .configure_tx5_network(signal_url)
+            .use_bootstrap_server(bootstrap_addr)
+            .update_tuning_params(tuner);
+
+        let sender = harness.spawn().await.expect("should be able to spawn node");
+
+        let mut agent = harness.create_agent().await;
+        let mut found_loc = false;
+        for _ in 0..1000 {
+            let loc = agent.get_loc().as_();
+            if loc > base_len * i && loc < base_len * (i + 1) {
+                found_loc = true;
+                break;
+            }
+
+            // If we didn't find a location in the right range, try again
+            agent = harness.create_agent().await;
+        }
+
+        assert!(
+            found_loc,
+            "Failed to find a location in the right range after 1000 tries"
+        );
+
+        // Distance to the end of the segment, plus the length of the next segment. Guaranteed to
+        // overlap with the next agent and not the one after that.
+        // Because of arc quantisation, the layout won't be perfect, but we can expect overlap at
+        // the start of the agent's arc, with the previous agent.
+        let len =
+            DhtLocation::new(base_len * (i + 1)) - agent.get_loc() + DhtLocation::new(base_len);
+
+        let arc = Arq::from_start_and_half_len_approximate(
+            dim,
+            &ArqStrat::standard(LocalStorageConfig::default(), 2.0),
+            agent.get_loc(),
+            len.as_() / 2 + 1,
+        );
+        sender
+            .join(space.clone(), agent.clone(), None, Some(arc))
+            .await
+            .unwrap();
+
+        agents.push((harness, sender, agent));
+    }
+
+    // Each agent should be connected to the next agent because that's how the arcs were set up
+    // above.
+    for i in 0..5 {
+        let next = (i + 1) % 5;
+
+        wait_for_connected(agents[i].1.clone(), agents[next].2.clone(), space.clone()).await
+    }
+
+    let sender_idx = 0;
+    let should_recv_idx_1 = 3;
+    let should_recv_idx_2 = 2;
+
+    let should_recv_location = &agents[should_recv_idx_1].2 .0[32..];
+
+    let mut kitsune_basis = KitsuneBasis::new(vec![0; 36]);
+    kitsune_basis.0[32..].copy_from_slice(&should_recv_location);
+    let basis = Arc::new(kitsune_basis);
+
+    // If the location was copied correctly then the basis location should be the same as the
+    // should_recv_idx_1 location. Due to the logic above, the receiver should have the sender's
+    // location in its arc.
+    assert_eq!(agents[should_recv_idx_1].2.get_loc(), basis.get_loc());
+
+    let test_op = TestHostOp::new(space.clone());
+
+    agents[sender_idx]
+        .0
+        .op_store()
+        .write()
+        .push(test_op.clone());
+
+    agents[sender_idx]
+        .1
+        .broadcast(
+            space.clone(),
+            basis,
+            KitsuneTimeout::from_millis(5_000),
+            BroadcastData::Publish {
+                source: agents[sender_idx].2.clone(),
+                op_hash_list: vec![test_op.into()],
+                context: FetchContext::default(),
+            },
+        )
+        .await
+        .unwrap();
+
+    tokio::time::timeout(std::time::Duration::from_secs(60), {
+        let op_store_recv = agents[should_recv_idx_1].0.op_store().clone();
+        async move {
+            loop {
+                if !op_store_recv.read().is_empty() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        }
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(1, agents[should_recv_idx_1].0.op_store().read().len());
+
+    tokio::time::timeout(std::time::Duration::from_secs(60), {
+        let op_store_recv = agents[should_recv_idx_2].0.op_store().clone();
+        async move {
+            loop {
+                if !op_store_recv.read().is_empty() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        }
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(1, agents[should_recv_idx_2].0.op_store().read().len());
+
+    for i in 0..5 {
+        if i == sender_idx || i == should_recv_idx_1 || i == should_recv_idx_2 {
+            continue;
+        }
+
+        let store_lock = agents[i].0.op_store();
+        let store = store_lock.read();
+        assert!(
+            store.is_empty(),
+            "Agent {} should not have received any data but has {} ops",
+            i,
+            store.len()
+        );
     }
 }

--- a/crates/kitsune_p2p/kitsune_p2p/tests/sharding.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/tests/sharding.rs
@@ -25,6 +25,7 @@ mod common;
 ///   5. Wait for the 3rd to receive the data.
 ///   6. Assert that the op was never published to the 1st, 2nd, or 5th agents. (Note that we cannot check if we sent it to ourselves because the op was already in our store)
 #[cfg(feature = "tx5")]
+#[ignore = "This test is flaky, possibly because what it is testing is flaky"]
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_to_basis_from_inside() {
     holochain_trace::test_run();
@@ -152,8 +153,8 @@ async fn publish_to_basis_from_inside() {
             }
         }
     })
-    .await
-    .unwrap();
+        .await
+        .unwrap();
 
     assert_eq!(1, agents[should_recv_idx].0.op_store().read().len());
 
@@ -188,6 +189,7 @@ async fn publish_to_basis_from_inside() {
 /// should still go to the correct agents. It also says with the publisher, so we need to account
 /// for that when checking the op stores at the end of the test.
 #[cfg(feature = "tx5")]
+#[ignore = "This test is flaky, possibly because what it is testing is flaky"]
 #[tokio::test(flavor = "multi_thread")]
 async fn publish_to_basis_from_outside() {
     holochain_trace::test_run();

--- a/crates/kitsune_p2p/kitsune_p2p/tests/sharding.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/tests/sharding.rs
@@ -1,0 +1,152 @@
+use crate::common::{
+    start_bootstrap, start_signal_srv, wait_for_connected, KitsuneTestHarness, TestHostOp,
+};
+use fixt::fixt;
+use kitsune_p2p::actor::{BroadcastData, KitsuneP2pSender};
+use kitsune_p2p::dht::arq::LocalStorageConfig;
+use kitsune_p2p::dht::prelude::SpaceDimension;
+use kitsune_p2p::dht_arc::DhtLocation;
+use kitsune_p2p_bin_data::fixt::KitsuneSpaceFixturator;
+use kitsune_p2p_bin_data::{KitsuneBasis, KitsuneBinType};
+use kitsune_p2p_fetch::FetchContext;
+use kitsune_p2p_types::config::tuning_params_struct;
+use kitsune_p2p_types::dht::{Arq, ArqStrat};
+use kitsune_p2p_types::KitsuneTimeout;
+use num_traits::AsPrimitive;
+use std::sync::Arc;
+
+mod common;
+
+#[cfg(feature = "tx5")]
+#[tokio::test(flavor = "multi_thread")]
+async fn only_gossip_with_agents_having_overlapping_arc() {
+    holochain_trace::test_run();
+
+    let (bootstrap_addr, _bootstrap_handle) = start_bootstrap().await;
+    let (signal_url, _signal_srv_handle) = start_signal_srv().await;
+
+    let space = Arc::new(fixt!(KitsuneSpace));
+
+    let tuner = |mut params: tuning_params_struct::KitsuneP2pTuningParams| {
+        params.gossip_arc_clamping = "none".to_string();
+        params.gossip_dynamic_arcs = false; // Don't update the arcs dynamically, use the initial value
+        params
+    };
+
+    // Arcs are this long by default, with an adjustment to ensure overlap.
+    let base_len = u32::MAX / 5;
+
+    let dim = SpaceDimension::standard();
+
+    let mut agents = Vec::new();
+
+    for i in 0..5 {
+        let mut harness = KitsuneTestHarness::try_new("")
+            .await
+            .expect("Failed to setup test harness")
+            .configure_tx5_network(signal_url)
+            .use_bootstrap_server(bootstrap_addr)
+            .update_tuning_params(tuner);
+
+        let sender = harness.spawn().await.expect("should be able to spawn node");
+
+        let mut agent = harness.create_agent().await;
+        let mut found_loc = false;
+        for _ in 0..1000 {
+            let loc = agent.get_loc().as_();
+            if loc > base_len * i && loc < base_len * (i + 1) {
+                found_loc = true;
+                break;
+            }
+
+            // If we didn't find a location in the right range, try again
+            agent = harness.create_agent().await;
+        }
+
+        assert!(found_loc, "Failed to find a location in the right range after 1000 tries");
+
+        // Distance to the end of the segment, plus the length of the next segment. Guaranteed to
+        // overlap with the next agent and not the one after that.
+        let len =
+            DhtLocation::new(base_len * (i + 1)) - agent.get_loc() + DhtLocation::new(base_len);
+
+        let arc = Arq::from_start_and_half_len_approximate(
+            dim,
+            &ArqStrat::standard(LocalStorageConfig::default(), 2.0),
+            agent.get_loc(),
+            len.as_() / 2 + 1,
+        );
+        println!("Agent {:?} is getting arc {:?}", agent, arc);
+        sender
+            .join(space.clone(), agent.clone(), None, None) // Some(arc)
+            .await
+            .unwrap();
+
+        agents.push((harness, sender, agent));
+    }
+
+    // Each agent should be connected to the next agent because that's how the arcs were set up
+    // above.
+    for i in 0..5 {
+        let next = (i + 1) % 5;
+
+        wait_for_connected(agents[i].1.clone(), agents[next].2.clone(), space.clone()).await
+    }
+
+    let sender_idx = 3;
+    let should_recv_idx = 2;
+
+    let sender_location = &agents[sender_idx].2.0[32..];
+
+    let mut kitsune_basis = KitsuneBasis::new(vec![0; 36]);
+    kitsune_basis.0[32..].copy_from_slice(&sender_location);
+    let basis = Arc::new(kitsune_basis);
+
+    let test_data = TestHostOp::new(space.clone());
+    agents[sender_idx]
+        .0
+        .op_store()
+        .write()
+        .push(test_data.clone());
+
+    agents[sender_idx]
+        .1
+        .broadcast(
+            space.clone(),
+            basis,
+            KitsuneTimeout::from_millis(5_000),
+            BroadcastData::Publish {
+                source: agents[sender_idx].2.clone(),
+                op_hash_list: vec![test_data.into()],
+                context: FetchContext::default(),
+            },
+        )
+        .await
+        .unwrap();
+
+    tokio::time::timeout(std::time::Duration::from_secs(60), {
+        let op_store_recv = agents[should_recv_idx].0.op_store().clone();
+        async move {
+            loop {
+                if !op_store_recv.read().is_empty() {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            }
+        }
+    })
+    .await
+    .unwrap();
+
+    assert_eq!(1, agents[should_recv_idx].0.op_store().read().len());
+
+    for i in 0..5 {
+        if i == sender_idx || i == should_recv_idx {
+            continue;
+        }
+
+        let store_lock = agents[i].0.op_store();
+        let store = store_lock.read();
+        assert!(store.is_empty(), "Agent {} should not have received any data but has {} ops", i, store.len());
+    }
+}

--- a/crates/kitsune_p2p/kitsune_p2p/tests/sharding.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/tests/sharding.rs
@@ -103,6 +103,29 @@ async fn only_gossip_with_agents_having_overlapping_arc() {
     let basis = Arc::new(kitsune_basis);
 
     let test_data = TestHostOp::new(space.clone());
+
+    let mut in_range_for_agent = vec![];
+    for i in 0..5 {
+        let agent_store_lock = agents[i].0.agent_store();
+        let agent_store = agent_store_lock.read();
+        let agent_info = agent_store.first().unwrap();
+        let edges = agent_info.storage_arq.to_edge_locs(dim);
+
+        if edges.0 < edges.1 {
+            if edges.0 >= test_data.location() && test_data.location() <= edges.1 {
+                in_range_for_agent.push(i);
+            }
+        } else {
+            if test_data.location() >= edges.0 || test_data.location() <= edges.1 {
+                in_range_for_agent.push(i);
+            }
+        }
+    }
+
+    assert_eq!(2, in_range_for_agent.len(), "Test op should have been in range for two agents but got: {}", in_range_for_agent.len());
+
+    println!("Expect to send to agents {:?}", in_range_for_agent);
+
     agents[sender_idx]
         .0
         .op_store()

--- a/crates/kitsune_p2p/types/src/config.rs
+++ b/crates/kitsune_p2p/types/src/config.rs
@@ -355,7 +355,7 @@ pub mod tuning_params_struct {
             let local_storage = LocalStorageConfig {
                 arc_clamping: self.arc_clamping(),
             };
-            ArqStrat::standard(local_storage)
+            ArqStrat::standard(local_storage, self.gossip_redundancy_target)
         }
     }
 }


### PR DESCRIPTION
### Summary

Putting this up for review to see if my test logic is reasonable. The tests are definitely flaky but they fail at the final step which I think means that:
- The tests are correctly assigning arcs
- Ops are sometimes published to agents who don't have the basis of the op being published within their arc

Note that this isn't actually about gossip as the branch suggests, I started with publish which is slightly simpler. These tests should extend nicely to gossip if we can get them working reliably.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
