### PR TITLE
Atomic Holonix updates

### DIFF
--- a/.github/workflows/command-listener.yml
+++ b/.github/workflows/command-listener.yml
@@ -19,21 +19,23 @@ jobs:
         run: |
           set -euo pipefail
           
-          if echo "$ALLOWED_USERS" | grep -q "${USER}"; then
-            echo "User $USER is allowed to run commands"
-          else
-            echo "User $USER is not allowed to run commands"
-            exit 0
-          fi
-          
           COMMAND=""
           if [[ "$COMMENT" == @hra* ]]; then
             echo "Comment is a command"
             COMMAND=$(echo "$COMMENT" | cut -b 6- | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+          else
+            echo "Comment is not a command"
+            exit 0
           fi
           
-          echo "Setting command '$COMMAND'"
-          
+          if echo "$ALLOWED_USERS" | grep -q "${USER}"; then
+            echo "User $USER is allowed to run commands"
+          else
+            echo "User $USER is not allowed to run commands"
+            exit 1
+          fi
+
+          echo "Setting command '$COMMAND'"  
           echo "action=${COMMAND}" >> "$GITHUB_OUTPUT"
     outputs:
       action: ${{ steps.dispatch.outputs.action }}

--- a/.github/workflows/command-listener.yml
+++ b/.github/workflows/command-listener.yml
@@ -10,7 +10,70 @@ jobs:
     if: ${{ github.event.issue.pull_request }}
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "A comment on PR $NUMBER"
+      - name: Dispatch
+        id: dispatch
         env:
-          NUMBER: ${{ github.event.issue.number }}
+          USER: ${{ github.event.sender.login }}
+          ALLOWED_USERS: ${{ join(fromJson('["ThetaSinner", "jost-s", "maackle", "thedavidmeister", "steveej", "neonphog", "matthme", "c12i"]'), '\n') }}
+          COMMENT: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          
+          if echo "$ALLOWED_USERS" | grep -q "${USER}"; then
+            echo "User $USER is allowed to run commands"
+          else
+            echo "User $USER is not allowed to run commands"
+            exit 0
+          fi
+          
+          COMMAND=""
+          if [[ "$COMMENT" == @hra* ]]; then
+            echo "Comment is a command"
+            COMMAND=$(echo "$COMMENT" | cut -b 6- | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+          fi
+          
+          echo "Setting command '$COMMAND'"
+          
+          echo "action=${COMMAND}" >> "$GITHUB_OUTPUT"
+    outputs:
+      action: ${{ steps.dispatch.outputs.action }}
+  holonix_update:
+    name: Holonix update
+    runs-on: ubuntu-latest
+    needs: [action_pr_comment]
+    if: ${{ startsWith(needs.action_pr_comment.outputs.action, 'holonix_update') }}
+    steps:
+      - name: Configure
+        id: configure
+        env:
+          ACTION: ${{ needs.action_pr_comment.outputs.action }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          RUN_ID: ${{ github.run_id }}
+          GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          
+          HOLONIX_VERSION=$(echo $ACTION | cut -b 14- | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+          gh pr comment $PR_NUMBER --repo holochain/holochain --body "Got it, will try to update inputs for Holonix version \`$HOLONIX_VERSION\` - [Workflow](https://github.com/holochain/holochain/actions/runs/$RUN_ID)"
+          
+          echo "holonix_version=${HOLONIX_VERSION}" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v26
+      - uses: cachix/cachix-action@v14
+        with:
+          name: holochain-ci
+      - name: set up git config
+        run: |
+          ./scripts/ci-git-config.sh
+      - name: Flake update
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+          HOLONIX_VERSION: ${{ steps.configure.outputs.holonix_version }}
+          GH_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          
+          gh pr checkout $PR_NUMBER --repo holochain/holochain
+          nix run .#scripts-repo-flake-update $HOLONIX_VERSION  
+          git pull --rebase
+          git push

--- a/.github/workflows/update-dispatch.yml
+++ b/.github/workflows/update-dispatch.yml
@@ -33,6 +33,8 @@ jobs:
           - name: ${{ github.ref_name }}
             skip: true
         update:
+          - source: "versions/weekly"
+            cmd: "nix run .#scripts-repo-flake-update weekly"
           - source: "rust-overlay"
             cmd: "nix flake lock --update-input rust-overlay"
           - source: "nixpkgs"

--- a/.github/workflows/update-dispatch.yml
+++ b/.github/workflows/update-dispatch.yml
@@ -33,14 +33,6 @@ jobs:
           - name: ${{ github.ref_name }}
             skip: true
         update:
-          - source: "versions/0_2"
-            cmd: "nix run .#scripts-repo-flake-update 0_2"
-          - source: "versions/0_2_rc"
-            cmd: "nix run .#scripts-repo-flake-update 0_2_rc"
-          - source: "versions/0_3_rc"
-            cmd: "nix run .#scripts-repo-flake-update 0_3_rc"
-          - source: "versions/weekly"
-            cmd: "nix run .#scripts-repo-flake-update weekly"
           - source: "rust-overlay"
             cmd: "nix flake lock --update-input rust-overlay"
           - source: "nixpkgs"


### PR DESCRIPTION
### Summary

This change has been tested here -> https://github.com/holochain/actions-test/pull/1#issuecomment-2102902630

The very last bit, that the flake update will work, hasn't been tested because I can't see how to test that without an actual upstream change for this repo to pull in. So we'll have to test it next time we're doing a Holonix update. Worst case scenario is that we have to run the script locally until I get this working - not too serious.

I've removed the automated updates for all Holonix versions. I thought those pulled in upstream updates too, but they don't, all they update is the inputs in the versions flakes. So this changes completely replaces those.

Instead, when we're updating Holonix we can:
1. Use the `update-holonix-version` workflow to create a PR that updates the Holochain versions
1. Comment on the PR with `@hra holonix_update <holonix-version>`, e.g. `@hra holonix_update weekly`. (*sharp edge warning, there's no check that you supply a valid value except the flake update script which should fail to make any changes with an invalid value*)
1. Repeat step 2. if needed, e.g. because Launcher and Scaffolding were ready at different times.
1. Wait for the Holonix tests to pass.
1. Merge all Holonix updates to that Holonix version in one go.

@matthme and @c12i note that this is self-service. You can write the comments on the PR to run the flake lock updates yourself. No need to make a separate PR on this repo or run the script yourself. All simple and automated I hope! 🤞🏻 

### TODO:
- [ ] CHANGELOGs updated with appropriate info
