### PR TITLE
Prepare release 0.3.1-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "aitia"
-version = "0.2.0-beta-dev.9"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2000,7 +2000,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixt"
-version = "0.3.0-beta-dev.4"
+version = "0.3.0"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -2533,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "hc_sleuth"
-version = "0.2.0-beta-dev.17"
+version = "0.2.0"
 dependencies = [
  "aitia",
  "anyhow",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "hcterm"
-version = "0.3.0-beta-dev.23"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "hdi"
-version = "0.4.0-beta-dev.36"
+version = "0.4.0"
 dependencies = [
  "arbitrary",
  "fixt",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.3.0-beta-dev.41"
+version = "0.3.0"
 dependencies = [
  "fixt",
  "getrandom 0.2.14",
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.3.0-beta-dev.34"
+version = "0.3.0"
 dependencies = [
  "darling 0.14.4",
  "heck 0.5.0",
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "base64 0.22.0",
@@ -2730,7 +2730,7 @@ dependencies = [
  "kitsune_p2p_dht_arc",
  "must_future",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rand 0.8.5",
  "rusqlite",
  "serde",
@@ -2742,7 +2742,7 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.3.0-beta-dev.48"
+version = "0.3.0"
 dependencies = [
  "aitia",
  "anyhow",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.3.0-beta-dev.47"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "fixt",
@@ -2885,7 +2885,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli"
-version = "0.3.0-beta-dev.47"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "clap 4.5.4",
@@ -2899,7 +2899,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_bundle"
-version = "0.3.0-beta-dev.44"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2925,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_run_local_services"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0"
 dependencies = [
  "clap 4.5.4",
  "futures",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_sandbox"
-version = "0.3.0-beta-dev.47"
+version = "0.3.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.3.0-beta-dev.47"
+version = "0.3.0"
 dependencies = [
  "derive_more",
  "holo_hash",
@@ -2996,7 +2996,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_services"
-version = "0.2.0-beta-dev.17"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3025,7 +3025,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.3.0-beta-dev.33"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "derive_builder",
@@ -3036,7 +3036,7 @@ dependencies = [
  "holochain_util",
  "kitsune_p2p_timestamp",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.3.0-beta-dev.37"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "base64 0.22.0",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_metrics"
-version = "0.3.0-beta-dev.12"
+version = "0.3.0"
 dependencies = [
  "influxive",
  "opentelemetry_api",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.3.0-beta-dev.27"
+version = "0.3.0"
 dependencies = [
  "getrandom 0.2.14",
  "holochain_secure_primitive",
@@ -3103,7 +3103,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_p2p"
-version = "0.3.0-beta-dev.46"
+version = "0.3.0"
 dependencies = [
  "aitia",
  "async-trait",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_secure_primitive"
-version = "0.3.0-beta-dev.23"
+version = "0.3.0"
 dependencies = [
  "paste",
  "serde",
@@ -3150,7 +3150,7 @@ dependencies = [
  "arbitrary",
  "holochain_serialized_bytes_derive",
  "proptest",
- "proptest-derive 0.3.0",
+ "proptest-derive",
  "rmp-serde 1.1.2",
  "serde",
  "serde-transcode",
@@ -3171,7 +3171,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.3.0-beta-dev.43"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.3.0-beta-dev.46"
+version = "0.3.0"
 dependencies = [
  "aitia",
  "anyhow",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_state_types"
-version = "0.3.0-beta-dev.40"
+version = "0.3.0"
 dependencies = [
  "holo_hash",
  "holochain_integrity_types",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.3.0-beta-dev.41"
+version = "0.3.0"
 dependencies = [
  "hdk",
  "serde",
@@ -3275,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_trace"
-version = "0.3.0-beta-dev.11"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "derive_more",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.3.0-beta-dev.43"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3331,7 +3331,7 @@ dependencies = [
  "parking_lot 0.12.2",
  "pretty_assertions",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rand 0.8.5",
  "regex",
  "rusqlite",
@@ -3353,7 +3353,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.3.0-beta-dev.8"
+version = "0.3.0"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_test_utils"
-version = "0.3.0-beta-dev.45"
+version = "0.3.0"
 dependencies = [
  "holochain_types",
  "holochain_util",
@@ -3429,7 +3429,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.3.0-beta-dev.22"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -3446,7 +3446,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.3.0-beta-dev.36"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "contrafact",
@@ -3467,7 +3467,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rand 0.8.5",
  "rusqlite",
  "serde",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p"
-version = "0.3.0-beta-dev.40"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "arrayref",
@@ -4158,7 +4158,7 @@ dependencies = [
  "parking_lot 0.12.2",
  "pretty_assertions",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rand 0.8.5",
  "serde",
  "serde_bytes",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bin_data"
-version = "0.3.0-beta-dev.21"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "base64 0.22.0",
@@ -4185,7 +4185,7 @@ dependencies = [
  "holochain_util",
  "kitsune_p2p_dht_arc",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "serde",
  "serde_bytes",
  "shrinkwraprs",
@@ -4193,7 +4193,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_block"
-version = "0.3.0-beta-dev.23"
+version = "0.3.0"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_timestamp",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bootstrap"
-version = "0.2.0-beta-dev.28"
+version = "0.2.0"
 dependencies = [
  "clap 4.5.4",
  "criterion",
@@ -4224,7 +4224,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bootstrap_client"
-version = "0.3.0-beta-dev.34"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "ed25519-dalek",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht"
-version = "0.3.0-beta-dev.24"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "colored",
@@ -4260,7 +4260,7 @@ dependencies = [
  "num-traits",
  "pretty_assertions",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rand 0.8.5",
  "serde",
  "statrs",
@@ -4271,7 +4271,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht_arc"
-version = "0.3.0-beta-dev.20"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "derive_more",
@@ -4283,7 +4283,7 @@ dependencies = [
  "num-traits",
  "pretty_assertions",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rand 0.8.5",
  "rusqlite",
  "serde",
@@ -4293,7 +4293,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_fetch"
-version = "0.3.0-beta-dev.31"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "backon",
@@ -4307,7 +4307,7 @@ dependencies = [
  "kitsune_p2p_types",
  "pretty_assertions",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rand 0.8.5",
  "serde",
  "test-case",
@@ -4317,7 +4317,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_mdns"
-version = "0.3.0-beta-dev.4"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.0",
  "err-derive 0.3.1",
@@ -4330,7 +4330,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_proxy"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.0",
  "criterion",
@@ -4348,14 +4348,14 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_timestamp"
-version = "0.3.0-beta-dev.10"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "chrono",
  "holochain_serialized_bytes",
  "once_cell",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rand 0.8.5",
  "rusqlite",
  "serde",
@@ -4364,7 +4364,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_transport_quic"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0"
 dependencies = [
  "blake2b_simd",
  "futures",
@@ -4378,7 +4378,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_types"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0"
 dependencies = [
  "arbitrary",
  "base64 0.22.0",
@@ -4399,7 +4399,7 @@ dependencies = [
  "parking_lot 0.12.2",
  "paste",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "rmp-serde 1.1.2",
  "rustls 0.20.9",
  "serde",
@@ -4859,7 +4859,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mr_bundle"
-version = "0.3.0-beta-dev.10"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4870,7 +4870,7 @@ dependencies = [
  "maplit",
  "matches",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive",
  "reqwest 0.12.4",
  "rmp-serde 1.1.2",
  "serde",
@@ -5757,17 +5757,6 @@ dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
-]
-
-[[package]]
-name = "proptest-derive"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
-dependencies = [
- "proc-macro2 1.0.81",
- "quote 1.0.36",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/crates/aitia/CHANGELOG.md
+++ b/crates/aitia/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.2.0
+
 ## 0.2.0-beta-dev.9
 
 ## 0.2.0-beta-dev.8

--- a/crates/aitia/Cargo.toml
+++ b/crates/aitia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aitia"
-version = "0.2.0-beta-dev.9"
+version = "0.2.0"
 description = "Library for making sense of events in terms of causal graphs"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/aitia/Cargo.toml
+++ b/crates/aitia/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 derive_more = "0.99"
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0", path = "../holochain_trace" }
 parking_lot = "0.12"
 petgraph = "0.6"
 regex = "1"

--- a/crates/diagnostic_tests/Cargo.toml
+++ b/crates/diagnostic_tests/Cargo.toml
@@ -14,7 +14,7 @@ chashmap = "2.2"
 colored = "2.1"
 futures = "0.3"
 holochain_diagnostics = { path = "../holochain_diagnostics" }
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0", path = "../holochain_trace" }
 tokio = { version = "1.36.0", features = ["full"] }
 tokio-stream = "0.1"
 

--- a/crates/fixt/CHANGELOG.md
+++ b/crates/fixt/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/holochain/holochain/compare/fixt-v0.0.2-alpha.1...HEAD)
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.4
 
 ## 0.3.0-beta-dev.3

--- a/crates/fixt/Cargo.toml
+++ b/crates/fixt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixt"
-version = "0.3.0-beta-dev.4"
+version = "0.3.0"
 description = "minimum viable fixtures"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.47
 
 ## 0.3.0-beta-dev.46

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -23,10 +23,10 @@ path = "src/lib.rs"
 anyhow = "1.0"
 clap = { version = "4.0", features = [ "derive", "cargo" ] }
 lazy_static = "1.4"
-holochain_cli_bundle = { path = "../hc_bundle", version = "^0.3.0-beta-dev.44"}
-holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.3.0-beta-dev.47"}
-holochain_cli_run_local_services = { path = "../hc_run_local_services", version = "^0.3.0-beta-dev.29"}
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../holochain_trace" }
+holochain_cli_bundle = { path = "../hc_bundle", version = "^0.3.0"}
+holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.3.0"}
+holochain_cli_run_local_services = { path = "../hc_run_local_services", version = "^0.3.0"}
+holochain_trace = { version = "^0.3.0", path = "../holochain_trace" }
 tokio = { version = "1.36.0", features = ["full"] }
 
 [lints]

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli"
-version = "0.3.0-beta-dev.47"
+version = "0.3.0"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.44
 
 ## 0.3.0-beta-dev.43

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -31,10 +31,10 @@ anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 holochain_util = { path = "../holochain_util", features = [
     "backtrace",
-], version = "^0.3.0-beta-dev.8" }
+], version = "^0.3.0" }
 holochain_serialized_bytes = "=0.0.54"
-holochain_types = { version = "^0.3.0-beta-dev.43", path = "../holochain_types" }
-mr_bundle = { version = "^0.3.0-beta-dev.10", path = "../mr_bundle" }
+holochain_types = { version = "^0.3.0", path = "../holochain_types" }
+mr_bundle = { version = "^0.3.0", path = "../mr_bundle" }
 serde_yaml = "0.9"
 thiserror = "1.0.22"
 tracing = "0.1"

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_bundle"
-version = "0.3.0-beta-dev.44"
+version = "0.3.0"
 description = "DNA and hApp bundling functionality for the `hc` Holochain CLI utility"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/hc_demo_cli/Cargo.toml
+++ b/crates/hc_demo_cli/Cargo.toml
@@ -12,11 +12,11 @@ crate-type = ["cdylib", "rlib"]
 cfg-if = "1.0"
 clap = { version = "4.2.2", features = [ "derive", "wrap_help" ], optional = true }
 flate2 = { version = "1.0.25", optional = true }
-hdi = { path = "../hdi", version = "^0.4.0-beta-dev.36", optional = true }
-hdk = { path = "../hdk", version = "^0.3.0-beta-dev.41", optional = true }
-holochain = { path = "../holochain", version = "^0.3.0-beta-dev.48", optional = true }
-holochain_types = { path = "../holochain_types", version = "^0.3.0-beta-dev.43", optional = true }
-holochain_keystore = { path = "../holochain_keystore", version = "^0.3.0-beta-dev.37", optional = true }
+hdi = { path = "../hdi", version = "^0.4.0", optional = true }
+hdk = { path = "../hdk", version = "^0.3.0", optional = true }
+holochain = { path = "../holochain", version = "^0.3.0", optional = true }
+holochain_types = { path = "../holochain_types", version = "^0.3.0", optional = true }
+holochain_keystore = { path = "../holochain_keystore", version = "^0.3.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 rand-utf8 = { version = "0.0.1", optional = true }
 serde = { version = "1", optional = true }

--- a/crates/hc_run_local_services/CHANGELOG.md
+++ b/crates/hc_run_local_services/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.29
 
 ## 0.3.0-beta-dev.28

--- a/crates/hc_run_local_services/Cargo.toml
+++ b/crates/hc_run_local_services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_run_local_services"
-version = "0.3.0-beta-dev.29"
+version = "0.3.0"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli_run_local_services"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]

--- a/crates/hc_run_local_services/Cargo.toml
+++ b/crates/hc_run_local_services/Cargo.toml
@@ -18,9 +18,9 @@ path = "src/bin/hc-run-local-services.rs"
 [dependencies]
 clap = { version = "4.0", features = [ "derive" ] }
 futures = "0.3"
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0", path = "../holochain_trace" }
 if-addrs = "0.12"
-kitsune_p2p_bootstrap = { version = "^0.2.0-beta-dev.28", path = "../kitsune_p2p/bootstrap" }
+kitsune_p2p_bootstrap = { version = "^0.2.0", path = "../kitsune_p2p/bootstrap" }
 tokio = { version = "1.36.0", features = ["full"] }
 tracing = "0.1"
 tx5-signal-srv = "=0.0.9-alpha"

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.47
 
 ## 0.3.0-beta-dev.46

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -21,14 +21,14 @@ ansi_term = "0.12"
 chrono = { version = "0.4.22", default-features = false, features = ["clock", "std", "oldtime", "serde"] }
 clap = { version = "4.0", features = [ "derive", "env" ] }
 futures = "0.3"
-holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.3.0-beta-dev.47", features = ["sqlite"] }
-holochain_types = { path = "../holochain_types", version = "^0.3.0-beta-dev.43", features = ["sqlite"] }
-holochain_websocket = { path = "../holochain_websocket", version = "^0.3.0-beta-dev.22"}
-holochain_p2p = { path = "../holochain_p2p", version = "^0.3.0-beta-dev.46", features = ["sqlite"] }
-holochain_util = { version = "^0.3.0-beta-dev.8", path = "../holochain_util", features = ["pw"] }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.28", path = "../kitsune_p2p/types" }
+holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.3.0", features = ["sqlite"] }
+holochain_types = { path = "../holochain_types", version = "^0.3.0", features = ["sqlite"] }
+holochain_websocket = { path = "../holochain_websocket", version = "^0.3.0"}
+holochain_p2p = { path = "../holochain_p2p", version = "^0.3.0", features = ["sqlite"] }
+holochain_util = { version = "^0.3.0", path = "../holochain_util", features = ["pw"] }
+kitsune_p2p_types = { version = "^0.3.0", path = "../kitsune_p2p/types" }
 nanoid = "0.4"
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0", path = "../holochain_trace" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_sandbox"
-version = "0.3.0-beta-dev.47"
+version = "0.3.0"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli_sandbox"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]

--- a/crates/hc_service_check/Cargo.toml
+++ b/crates/hc_service_check/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [dependencies]
 clap = { version = "4.5.3", features = [ "derive", "wrap_help" ] }
 tokio = { version = "1.36.0", features = [ "full" ] }
-kitsune_p2p_bootstrap_client = { version = "^0.3.0-beta-dev.34", path = "../kitsune_p2p/bootstrap_client" }
+kitsune_p2p_bootstrap_client = { version = "^0.3.0", path = "../kitsune_p2p/bootstrap_client" }
 tx5-go-pion = { version = "0.0.9-alpha" }
 tx5-signal = { version = "0.0.9-alpha" }
 url2 = "0.0.6"

--- a/crates/hc_sleuth/CHANGELOG.md
+++ b/crates/hc_sleuth/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.2.0
+
 ## 0.2.0-beta-dev.17
 
 ## 0.2.0-beta-dev.16

--- a/crates/hc_sleuth/Cargo.toml
+++ b/crates/hc_sleuth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hc_sleuth"
-version = "0.2.0-beta-dev.17"
+version = "0.2.0"
 description = "Tool for diagnosing problems with Holochain"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/hc_sleuth/Cargo.toml
+++ b/crates/hc_sleuth/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2021"
 # reminder - do not use workspace deps
 [dependencies]
 anyhow = "1.0"
-aitia = { version = "^0.2.0-beta-dev.9", path = "../aitia" }
+aitia = { version = "^0.2.0", path = "../aitia" }
 derive_more = "0.99"
-holochain_state_types = { version = "^0.3.0-beta-dev.40", path = "../holochain_state_types" }
-holochain_types = { version = "^0.3.0-beta-dev.43", path = "../holochain_types" }
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../holochain_trace" }
-kitsune_p2p = { version = "^0.3.0-beta-dev.40", path = "../kitsune_p2p/kitsune_p2p" }
+holochain_state_types = { version = "^0.3.0", path = "../holochain_state_types" }
+holochain_types = { version = "^0.3.0", path = "../holochain_types" }
+holochain_trace = { version = "^0.3.0", path = "../holochain_trace" }
+kitsune_p2p = { version = "^0.3.0", path = "../kitsune_p2p/kitsune_p2p" }
 once_cell = "1.18"
 parking_lot = "0.12"
 petgraph = "0.6"

--- a/crates/hdi/CHANGELOG.md
+++ b/crates/hdi/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.4.0
+
 ## 0.4.0-beta-dev.36
 
 - **BREAKING**: Original action and entry have been removed from relevant variants of `Op`. To use original action and entry during validation, they can be explicitly fetched with HDK calls `must_get_action` and `must_get_entry`. Op is passed into the app validation callback `validate` where validation rules of an app can be implemented. For update and delete operations original action and original entry used to be prefetched, regardless of whether they were used in `validate` or not. Particularly for an update or delete of an entry it is not common to employ the original entry in validation. It is therefore removed from those variants of `Op` which means a potential performance increase for not having to fetch original actions and entries for all ops to be validated.

--- a/crates/hdi/Cargo.toml
+++ b/crates/hdi/Cargo.toml
@@ -12,12 +12,12 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-hdk_derive = { version = "^0.3.0-beta-dev.34", path = "../hdk_derive" }
-holo_hash = { version = "^0.3.0-beta-dev.28", path = "../holo_hash" }
+hdk_derive = { version = "^0.3.0", path = "../hdk_derive" }
+holo_hash = { version = "^0.3.0", path = "../holo_hash" }
 holochain_wasmer_guest = { version = "=0.0.93" }
 # it's important that we depend on holochain_integrity_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
-holochain_integrity_types = { version = "^0.3.0-beta-dev.33", path = "../holochain_integrity_types", default-features = false }
+holochain_integrity_types = { version = "^0.3.0", path = "../holochain_integrity_types", default-features = false }
 paste = "1.0"
 serde = "1.0"
 serde_bytes = "0.11"

--- a/crates/hdi/Cargo.toml
+++ b/crates/hdi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdi"
-version = "0.4.0-beta-dev.36"
+version = "0.4.0"
 description = "The HDI"
 license = "CAL-1.0"
 homepage = "https://github.com/holochain/holochain/tree/develop/crates/hdi"

--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.41
 
 ## 0.3.0-beta-dev.40

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -12,13 +12,13 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-hdi = { version = "=0.4.0-beta-dev.36", path = "../hdi", features = ["trace"] }
-hdk_derive = { version = "^0.3.0-beta-dev.34", path = "../hdk_derive" }
-holo_hash = { version = "^0.3.0-beta-dev.28", path = "../holo_hash" }
+hdi = { version = "=0.4.0", path = "../hdi", features = ["trace"] }
+hdk_derive = { version = "^0.3.0", path = "../hdk_derive" }
+holo_hash = { version = "^0.3.0", path = "../holo_hash" }
 holochain_wasmer_guest = { version = "=0.0.93" }
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
-holochain_zome_types = { version = "^0.3.0-beta-dev.36", path = "../holochain_zome_types", default-features = false }
+holochain_zome_types = { version = "^0.3.0", path = "../holochain_zome_types", default-features = false }
 paste = "1.0"
 serde = "1.0"
 serde_bytes = "0.11"

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk"
-version = "0.3.0-beta-dev.41"
+version = "0.3.0"
 description = "The Holochain HDK"
 license = "CAL-1.0"
 homepage = "https://github.com/holochain/holochain/tree/develop/crates/hdk"

--- a/crates/hdk_derive/CHANGELOG.md
+++ b/crates/hdk_derive/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.34
 
 ## 0.3.0-beta-dev.33

--- a/crates/hdk_derive/Cargo.toml
+++ b/crates/hdk_derive/Cargo.toml
@@ -23,7 +23,7 @@ darling = "0.14.1"
 heck = "0.5"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdi, to reduce code bloat
-holochain_integrity_types = { version = "^0.3.0-beta-dev.33", path = "../holochain_integrity_types", default-features = false }
+holochain_integrity_types = { version = "^0.3.0", path = "../holochain_integrity_types", default-features = false }
 proc-macro-error = "1.0.4"
 
 [lints]

--- a/crates/hdk_derive/Cargo.toml
+++ b/crates/hdk_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk_derive"
-version = "0.3.0-beta-dev.34"
+version = "0.3.0"
 description = "derive macros for the holochain hdk"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holo_hash/CHANGELOG.md
+++ b/crates/holo_hash/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.28
 
 ## 0.3.0-beta-dev.27

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holo_hash"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 keywords = ["holochain", "holo", "hash", "blake", "blake2b"]
 categories = ["cryptography"]

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -21,11 +21,11 @@ arbitrary = { version = "1.0", optional = true }
 base64 = { version = "0.22", optional = true }
 blake2b_simd = { version = "1.0", optional = true }
 derive_more = { version = "0.99", optional = true }
-fixt = { version = "^0.3.0-beta-dev.4", path = "../fixt", optional = true }
+fixt = { version = "^0.3.0", path = "../fixt", optional = true }
 futures = { version = "0.3", optional = true }
 holochain_serialized_bytes = { version = "=0.0.54", optional = true }
-holochain_util = { version = "^0.3.0-beta-dev.8", path = "../holochain_util", default-features = false }
-kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.20", path = "../kitsune_p2p/dht_arc" }
+holochain_util = { version = "^0.3.0", path = "../holochain_util", default-features = false }
+kitsune_p2p_dht_arc = { version = "^0.3.0", path = "../kitsune_p2p/dht_arc" }
 must_future = { version = "0.1", optional = true }
 proptest = { version = "1", optional = true }
 proptest-derive = { version = "0", optional = true }

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -43,6 +43,8 @@ Now it serializes to
 - App validation workflow: Validate ops in sequence instead of in parallel. Ops validated one after the other have a higher chance of being validated if they depend on earlier ops. When validated in parallel, they potentially needed to await a next workflow run when the dependent op would have been validated.
 - App validation workflow: Fix bug where ops were stuck in app validation when multiple ops were requiring the same action or entry hash. Such ops were erroneously filtered out from validation for being marked as ops awaiting hashes and not unmarked as awaiting once the hashes had arrived.
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.48
 
 ## 0.3.0-beta-dev.47

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain"
-version = "0.3.0-beta-dev.48"
+version = "0.3.0"
 description = "Holochain, a framework for distributed applications"
 license = "CAL-1.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -23,42 +23,42 @@ chrono = { version = "0.4.22", default-features = false, features = [
 derive_more = "0.99"
 either = "1.5.0"
 fallible-iterator = "0.3.0"
-fixt = { version = "^0.3.0-beta-dev.4", path = "../fixt" }
+fixt = { version = "^0.3.0", path = "../fixt" }
 futures = "0.3"
 getrandom = "0.2.7"
 get_if_addrs = "0.5.3"
 ghost_actor = "0.3.0-alpha.6"
-holo_hash = { version = "^0.3.0-beta-dev.28", path = "../holo_hash", features = [
+holo_hash = { version = "^0.3.0", path = "../holo_hash", features = [
   "full",
 ] }
-holochain_cascade = { version = "^0.3.0-beta-dev.47", path = "../holochain_cascade" }
-holochain_conductor_api = { version = "^0.3.0-beta-dev.47", path = "../holochain_conductor_api" }
-holochain_keystore = { version = "^0.3.0-beta-dev.37", path = "../holochain_keystore", default-features = false }
-holochain_p2p = { version = "^0.3.0-beta-dev.46", path = "../holochain_p2p" }
-holochain_sqlite = { version = "^0.3.0-beta-dev.43", path = "../holochain_sqlite" }
+holochain_cascade = { version = "^0.3.0", path = "../holochain_cascade" }
+holochain_conductor_api = { version = "^0.3.0", path = "../holochain_conductor_api" }
+holochain_keystore = { version = "^0.3.0", path = "../holochain_keystore", default-features = false }
+holochain_p2p = { version = "^0.3.0", path = "../holochain_p2p" }
+holochain_sqlite = { version = "^0.3.0", path = "../holochain_sqlite" }
 holochain_serialized_bytes = "=0.0.54"
-holochain_state = { version = "^0.3.0-beta-dev.46", path = "../holochain_state" }
-holochain_types = { version = "^0.3.0-beta-dev.43", path = "../holochain_types" }
-holochain_util = { version = "^0.3.0-beta-dev.8", path = "../holochain_util" }
+holochain_state = { version = "^0.3.0", path = "../holochain_state" }
+holochain_types = { version = "^0.3.0", path = "../holochain_types" }
+holochain_util = { version = "^0.3.0", path = "../holochain_util" }
 holochain_wasmer_host = "=0.0.93"
-holochain_websocket = { version = "^0.3.0-beta-dev.22", path = "../holochain_websocket" }
-holochain_zome_types = { version = "^0.3.0-beta-dev.36", path = "../holochain_zome_types", features = [
+holochain_websocket = { version = "^0.3.0", path = "../holochain_websocket" }
+holochain_zome_types = { version = "^0.3.0", path = "../holochain_zome_types", features = [
   "full",
 ] }
-holochain_nonce = { version = "^0.3.0-beta-dev.27", path = "../holochain_nonce" }
-holochain_secure_primitive = { version = "^0.3.0-beta-dev.23", path = "../holochain_secure_primitive" }
-holochain_conductor_services = { version = "^0.2.0-beta-dev.17", path = "../holochain_conductor_services" }
+holochain_nonce = { version = "^0.3.0", path = "../holochain_nonce" }
+holochain_secure_primitive = { version = "^0.3.0", path = "../holochain_secure_primitive" }
+holochain_conductor_services = { version = "^0.2.0", path = "../holochain_conductor_services" }
 human-panic = "2.0"
 itertools = { version = "0.12" }
-kitsune_p2p = { version = "^0.3.0-beta-dev.40", path = "../kitsune_p2p/kitsune_p2p", default-features = false }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.21", path = "../kitsune_p2p/bin_data" }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.28", path = "../kitsune_p2p/types" }
-kitsune_p2p_block = { version = "^0.3.0-beta-dev.23", path = "../kitsune_p2p/block" }
+kitsune_p2p = { version = "^0.3.0", path = "../kitsune_p2p/kitsune_p2p", default-features = false }
+kitsune_p2p_bin_data = { version = "^0.3.0", path = "../kitsune_p2p/bin_data" }
+kitsune_p2p_types = { version = "^0.3.0", path = "../kitsune_p2p/types" }
+kitsune_p2p_block = { version = "^0.3.0", path = "../kitsune_p2p/block" }
 mockall = "0.11.3"
-mr_bundle = { version = "^0.3.0-beta-dev.10", path = "../mr_bundle" }
+mr_bundle = { version = "^0.3.0", path = "../mr_bundle" }
 nanoid = "0.4"
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../holochain_trace" }
-holochain_metrics = { version = "^0.3.0-beta-dev.12", path = "../holochain_metrics", default_features = false }
+holochain_trace = { version = "^0.3.0", path = "../holochain_trace" }
+holochain_metrics = { version = "^0.3.0", path = "../holochain_metrics", default_features = false }
 once_cell = "1.4.1"
 async-once-cell = "0.5"
 one_err = "0.0.8"
@@ -88,7 +88,7 @@ tracing-subscriber = "0.3.16"
 url = "2.4"
 url2 = "0.0.6"
 uuid = { version = "1.8", features = ["serde", "v4"] }
-holochain_wasm_test_utils = { version = "^0.3.0-beta-dev.45", path = "../test_utils/wasm" }
+holochain_wasm_test_utils = { version = "^0.3.0", path = "../test_utils/wasm" }
 tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
 wasmer = "=4.2.8"
 wasmer-middlewares = "=4.2.8"
@@ -100,8 +100,8 @@ contrafact = { version = "0.2.0-rc.1", optional = true }
 diff = { version = "0.1", optional = true }
 hdk = { version = "^0.3.0-beta-dev.41", path = "../hdk", optional = true }
 matches = { version = "0.1.8", optional = true }
-holochain_test_wasm_common = { version = "^0.3.0-beta-dev.41", path = "../test_utils/wasm_common", optional = true }
-kitsune_p2p_bootstrap = { version = "^0.2.0-beta-dev.28", path = "../kitsune_p2p/bootstrap", optional = true }
+holochain_test_wasm_common = { version = "^0.3.0", path = "../test_utils/wasm_common", optional = true }
+kitsune_p2p_bootstrap = { version = "^0.2.0", path = "../kitsune_p2p/bootstrap", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
 tx5-go-pion-turn = { version = "=0.0.9-alpha", optional = true }
 tx5-signal-srv = { version = "=0.0.9-alpha", optional = true }
@@ -111,8 +111,8 @@ bytes = { version = "1", optional = true }
 reqwest = { version = "0.12", features = ["json"], optional = true }
 
 # TODO: make optional?
-aitia = { version = "^0.2.0-beta-dev.9", path = "../aitia" }
-hc_sleuth = { version = "^0.2.0-beta-dev.17", path = "../hc_sleuth" }
+aitia = { version = "^0.2.0", path = "../aitia" }
+hc_sleuth = { version = "^0.2.0", path = "../hc_sleuth" }
 
 # fact deps
 petgraph = { version = "0.6.0", features = ["quickcheck", "stable_graph"] }
@@ -150,7 +150,7 @@ test-case = "3.3"
 tokio-tungstenite = "0.21"
 
 [build-dependencies]
-hdk = { version = "^0.3.0-beta-dev.41", path = "../hdk" }
+hdk = { version = "^0.3.0", path = "../hdk" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.51" }
 toml = "0.8"

--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.47
 
 ## 0.3.0-beta-dev.46

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -10,21 +10,21 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-fixt = { version = "^0.3.0-beta-dev.4", path = "../fixt" }
+fixt = { version = "^0.3.0", path = "../fixt" }
 futures = "0.3"
-holo_hash = { version = "^0.3.0-beta-dev.28", path = "../holo_hash", features = [
+holo_hash = { version = "^0.3.0", path = "../holo_hash", features = [
     "full",
 ] }
-holochain_sqlite = { version = "^0.3.0-beta-dev.43", path = "../holochain_sqlite" }
-holochain_p2p = { version = "^0.3.0-beta-dev.46", path = "../holochain_p2p" }
+holochain_sqlite = { version = "^0.3.0", path = "../holochain_sqlite" }
+holochain_p2p = { version = "^0.3.0", path = "../holochain_p2p" }
 holochain_serialized_bytes = "=0.0.54"
-holochain_state = { version = "^0.3.0-beta-dev.46", path = "../holochain_state" }
-holochain_types = { version = "^0.3.0-beta-dev.43", path = "../holochain_types" }
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../holochain_trace" }
-holochain_util = { version = "^0.3.0-beta-dev.8", path = "../holochain_util" }
-holochain_zome_types = { version = "^0.3.0-beta-dev.36", path = "../holochain_zome_types" }
-holochain_nonce = { version = "^0.3.0-beta-dev.27", path = "../holochain_nonce" }
-kitsune_p2p = { version = "^0.3.0-beta-dev.40", path = "../kitsune_p2p/kitsune_p2p" }
+holochain_state = { version = "^0.3.0", path = "../holochain_state" }
+holochain_types = { version = "^0.3.0", path = "../holochain_types" }
+holochain_trace = { version = "^0.3.0", path = "../holochain_trace" }
+holochain_util = { version = "^0.3.0", path = "../holochain_util" }
+holochain_zome_types = { version = "^0.3.0", path = "../holochain_zome_types" }
+holochain_nonce = { version = "^0.3.0", path = "../holochain_nonce" }
+kitsune_p2p = { version = "^0.3.0", path = "../kitsune_p2p/kitsune_p2p" }
 tokio = { version = "1.36.0", features = ["full"] }
 thiserror = "1.0"
 tracing = "0.1"

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cascade"
-version = "0.3.0-beta-dev.47"
+version = "0.3.0"
 description = "Logic for cascading updates to Holochain state and network interaction"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.47
 
 ## 0.3.0-beta-dev.46

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_conductor_api"
-version = "0.3.0-beta-dev.47"
+version = "0.3.0"
 description = "Message types for Holochain admin and app interface protocols"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -11,29 +11,29 @@ edition = "2021"
 # reminder - do not use workspace deps
 [dependencies]
 derive_more = "0.99"
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.28", path = "../kitsune_p2p/types" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.21", path = "../kitsune_p2p/bin_data" }
-holo_hash = { version = "^0.3.0-beta-dev.28", path = "../holo_hash", features = [
+kitsune_p2p_types = { version = "^0.3.0", path = "../kitsune_p2p/types" }
+kitsune_p2p_bin_data = { version = "^0.3.0", path = "../kitsune_p2p/bin_data" }
+holo_hash = { version = "^0.3.0", path = "../holo_hash", features = [
     "full",
 ] }
-holochain_state_types = { version = "^0.3.0-beta-dev.40", path = "../holochain_state_types" }
+holochain_state_types = { version = "^0.3.0", path = "../holochain_state_types" }
 holochain_serialized_bytes = "=0.0.54"
-holochain_types = { version = "^0.3.0-beta-dev.43", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.3.0-beta-dev.36", path = "../holochain_zome_types" }
+holochain_types = { version = "^0.3.0", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.3.0", path = "../holochain_zome_types" }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 tracing = "0.1.26"
 thiserror = "1.0.22"
 url2 = "0.0.6"
-holochain_keystore = { version = "^0.3.0-beta-dev.37", path = "../holochain_keystore" }
+holochain_keystore = { version = "^0.3.0", path = "../holochain_keystore" }
 shrinkwraprs = "0.3.0"
 
 [dev-dependencies]
 serde_json = "1.0"
 rmp-serde = "1.1"
 matches = { version = "0.1.8" }
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../holochain_trace" }
-kitsune_p2p = { version = "^0.3.0-beta-dev.40", path = "../kitsune_p2p/kitsune_p2p" }
+holochain_trace = { version = "^0.3.0", path = "../holochain_trace" }
+kitsune_p2p = { version = "^0.3.0", path = "../kitsune_p2p/kitsune_p2p" }
 
 [lints]
 workspace = true

--- a/crates/holochain_conductor_services/CHANGELOG.md
+++ b/crates/holochain_conductor_services/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0
+
 ## 0.2.0-beta-dev.17
 
 ## 0.2.0-beta-dev.16

--- a/crates/holochain_conductor_services/Cargo.toml
+++ b/crates/holochain_conductor_services/Cargo.toml
@@ -18,8 +18,8 @@ futures = "0.3"
 mockall = "0.11"
 thiserror = "1.0"
 
-holochain_keystore = { version = "^0.3.0-beta-dev.37", path = "../holochain_keystore" }
-holochain_types = { version = "^0.3.0-beta-dev.43", path = "../holochain_types" }
+holochain_keystore = { version = "^0.3.0", path = "../holochain_keystore" }
+holochain_types = { version = "^0.3.0", path = "../holochain_types" }
 
 [lints]
 workspace = true

--- a/crates/holochain_conductor_services/Cargo.toml
+++ b/crates/holochain_conductor_services/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_conductor_services"
-version = "0.2.0-beta-dev.17"
+version = "0.2.0"
 description = "Holochain Conductor Services types"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain_integrity_types/CHANGELOG.md
+++ b/crates/holochain_integrity_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.33
 
 - **BREAKING**: Original action and entry have been removed from relevant variants of `Op`. To use original action and entry during validation, they can be explicitly fetched with HDK calls `must_get_action` and `must_get_entry`. Op is passed into the app validation callback `validate` where validation rules of an app can be implemented. For update and delete operations original action and original entry used to be prefetched, regardless of whether they were used in `validate` or not. Particularly for an update or delete of an entry it is not common to employ the original entry in validation. It is therefore removed from those variants of `Op` which means a potential performance increase for not having to fetch original actions and entries for all ops to be validated.

--- a/crates/holochain_integrity_types/Cargo.toml
+++ b/crates/holochain_integrity_types/Cargo.toml
@@ -11,16 +11,16 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-holo_hash = { version = "^0.3.0-beta-dev.28", path = "../holo_hash" }
+holo_hash = { version = "^0.3.0", path = "../holo_hash" }
 holochain_serialized_bytes = "=0.0.54"
-holochain_util = { version = "^0.3.0-beta-dev.8", path = "../holochain_util", default-features = false }
-holochain_secure_primitive = { version = "^0.3.0-beta-dev.23", path = "../holochain_secure_primitive" }
+holochain_util = { version = "^0.3.0", path = "../holochain_util", default-features = false }
+holochain_secure_primitive = { version = "^0.3.0", path = "../holochain_secure_primitive" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 
 # Just the bare minimum timestamp with no extra features.
 # TODO: This needs to point to a published version of this crate and be pinned.
-kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.10", path = "../kitsune_p2p/timestamp", default-features = false }
+kitsune_p2p_timestamp = { version = "^0.3.0", path = "../kitsune_p2p/timestamp", default-features = false }
 
 # TODO: Figure out how to remove these dependencies.
 subtle = "2"

--- a/crates/holochain_integrity_types/Cargo.toml
+++ b/crates/holochain_integrity_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_integrity_types"
-version = "0.3.0-beta-dev.33"
+version = "0.3.0"
 description = "Holochain integrity types"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.37
 
 ## 0.3.0-beta-dev.36

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_keystore"
-version = "0.3.0-beta-dev.37"
+version = "0.3.0"
 description = "keystore for libsodium keypairs"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -14,14 +14,14 @@ edition = "2021"
 [dependencies]
 base64 = "0.22"
 futures = "0.3"
-holo_hash = { version = "^0.3.0-beta-dev.28", path = "../holo_hash", features = [
+holo_hash = { version = "^0.3.0", path = "../holo_hash", features = [
     "full",
 ] }
 holochain_serialized_bytes = "=0.0.54"
-holochain_zome_types = { path = "../holochain_zome_types", version = "^0.3.0-beta-dev.36" }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.28", path = "../kitsune_p2p/types" }
-holochain_secure_primitive = { version = "^0.3.0-beta-dev.23", path = "../holochain_secure_primitive" }
-holochain_util = { version = "^0.3.0-beta-dev.8", path = "../holochain_util" }
+holochain_zome_types = { path = "../holochain_zome_types", version = "^0.3.0" }
+kitsune_p2p_types = { version = "^0.3.0", path = "../kitsune_p2p/types" }
+holochain_secure_primitive = { version = "^0.3.0", path = "../holochain_secure_primitive" }
+holochain_util = { version = "^0.3.0", path = "../holochain_util" }
 lair_keystore = { version = "0.4.4", default-features = false }
 must_future = "0.1.2"
 nanoid = "0.4.0"

--- a/crates/holochain_metrics/CHANGELOG.md
+++ b/crates/holochain_metrics/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.12
 
 ## 0.3.0-beta-dev.11

--- a/crates/holochain_metrics/Cargo.toml
+++ b/crates/holochain_metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_metrics"
-version = "0.3.0-beta-dev.12"
+version = "0.3.0"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 description = "metrics helpers"

--- a/crates/holochain_nonce/CHANGELOG.md
+++ b/crates/holochain_nonce/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.27
 
 ## 0.3.0-beta-dev.26

--- a/crates/holochain_nonce/Cargo.toml
+++ b/crates/holochain_nonce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_nonce"
-version = "0.3.0-beta-dev.27"
+version = "0.3.0"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
 edition = "2021"
 description = "This crate is for generating nonces."

--- a/crates/holochain_nonce/Cargo.toml
+++ b/crates/holochain_nonce/Cargo.toml
@@ -11,8 +11,8 @@ documentation = "https://docs.rs/holochain_nonces"
 # reminder - do not use workspace deps
 [dependencies]
 getrandom = { version = "0.2.7", default-features = false, features = ["std"] }
-kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.10", path = "../kitsune_p2p/timestamp" }
-holochain_secure_primitive = { version = "^0.3.0-beta-dev.23", path = "../holochain_secure_primitive", default-features = false }
+kitsune_p2p_timestamp = { version = "^0.3.0", path = "../kitsune_p2p/timestamp" }
+holochain_secure_primitive = { version = "^0.3.0", path = "../holochain_secure_primitive", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.46
 
 ## 0.3.0-beta-dev.45

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -12,23 +12,23 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-aitia = { version = "^0.2.0-beta-dev.9", path = "../aitia" }
+aitia = { version = "^0.2.0", path = "../aitia" }
 async-trait = "0.1"
 derive_more = "0.99"
-fixt = { path = "../fixt", version = "^0.3.0-beta-dev.4" }
+fixt = { path = "../fixt", version = "^0.3.0" }
 futures = "0.3"
 ghost_actor = "0.3.0-alpha.6"
-hc_sleuth = { version = "^0.2.0-beta-dev.17", path = "../hc_sleuth" }
-holo_hash = { version = "^0.3.0-beta-dev.28", path = "../holo_hash" }
-holochain_keystore = { version = "^0.3.0-beta-dev.37", path = "../holochain_keystore" }
+hc_sleuth = { version = "^0.2.0", path = "../hc_sleuth" }
+holo_hash = { version = "^0.3.0", path = "../holo_hash" }
+holochain_keystore = { version = "^0.3.0", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.54"
-holochain_types = { version = "^0.3.0-beta-dev.43", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.3.0-beta-dev.36", path = "../holochain_zome_types" }
-kitsune_p2p = { version = "^0.3.0-beta-dev.40", path = "../kitsune_p2p/kitsune_p2p" }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.28", path = "../kitsune_p2p/types" }
-holochain_nonce = { version = "^0.3.0-beta-dev.27", path = "../holochain_nonce" }
+holochain_types = { version = "^0.3.0", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.3.0", path = "../holochain_zome_types" }
+kitsune_p2p = { version = "^0.3.0", path = "../kitsune_p2p/kitsune_p2p" }
+kitsune_p2p_types = { version = "^0.3.0", path = "../kitsune_p2p/types" }
+holochain_nonce = { version = "^0.3.0", path = "../holochain_nonce" }
 mockall = "0.11.3"
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0", path = "../holochain_trace" }
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_p2p"
-version = "0.3.0-beta-dev.46"
+version = "0.3.0"
 description = "holochain specific wrapper around more generic p2p module"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain_secure_primitive/CHANGELOG.md
+++ b/crates/holochain_secure_primitive/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.23
 
 ## 0.3.0-beta-dev.22

--- a/crates/holochain_secure_primitive/Cargo.toml
+++ b/crates/holochain_secure_primitive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "holochain_secure_primitive"
 description = "Crate for the secure primitive macros"
-version = "0.3.0-beta-dev.23"
+version = "0.3.0"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_secure_primitive"

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.43
 
 ## 0.3.0-beta-dev.42

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -15,19 +15,19 @@ anyhow = "1.0"
 derive_more = "0.99"
 fallible-iterator = "0.2.0"
 futures = "0.3"
-holo_hash = { path = "../holo_hash", version = "^0.3.0-beta-dev.28" }
+holo_hash = { path = "../holo_hash", version = "^0.3.0" }
 holochain_serialized_bytes = "=0.0.54"
-holochain_util = { version = "^0.3.0-beta-dev.8", path = "../holochain_util", features = [
+holochain_util = { version = "^0.3.0", path = "../holochain_util", features = [
   "backtrace",
   "time",
 ], optional = true }
-holochain_zome_types = { version = "^0.3.0-beta-dev.36", path = "../holochain_zome_types" }
-holochain_nonce = { version = "^0.3.0-beta-dev.27", path = "../holochain_nonce" }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.28", path = "../kitsune_p2p/types", optional = true }
-kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.20", path = "../kitsune_p2p/dht_arc" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.21", path = "../kitsune_p2p/bin_data" }
-kitsune_p2p_dht = { version = "^0.3.0-beta-dev.24", path = "../kitsune_p2p/dht" }
-kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.10", path = "../kitsune_p2p/timestamp" }
+holochain_zome_types = { version = "^0.3.0", path = "../holochain_zome_types" }
+holochain_nonce = { version = "^0.3.0", path = "../holochain_nonce" }
+kitsune_p2p_types = { version = "^0.3.0", path = "../kitsune_p2p/types", optional = true }
+kitsune_p2p_dht_arc = { version = "^0.3.0", path = "../kitsune_p2p/dht_arc" }
+kitsune_p2p_bin_data = { version = "^0.3.0", path = "../kitsune_p2p/bin_data" }
+kitsune_p2p_dht = { version = "^0.3.0", path = "../kitsune_p2p/dht" }
+kitsune_p2p_timestamp = { version = "^0.3.0", path = "../kitsune_p2p/timestamp" }
 nanoid = "0.4"
 once_cell = "1.4.1"
 num_cpus = "1.13.0"
@@ -66,7 +66,7 @@ rusqlite = { version = "0.29", features = [
 
 [dev-dependencies]
 holochain_sqlite = { path = ".", features = ["test_utils", "slow_tests"] }
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../holochain_trace" }
+holochain_trace = { path = "../holochain_trace" }
 nanoid = "0.4.0"
 rand = "0.8.5"
 

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_sqlite"
-version = "0.3.0-beta-dev.43"
+version = "0.3.0"
 description = "Abstractions for persistence of Holochain state via SQLite"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.46
 
 ## 0.3.0-beta-dev.45

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -10,29 +10,29 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-aitia = { version = "^0.2.0-beta-dev.9", path = "../aitia" }
+aitia = { version = "^0.2.0", path = "../aitia" }
 chrono = { version = "0.4.22", default-features = false, features = [
     "clock",
     "std",
     "oldtime",
     "serde",
 ] }
-holochain_sqlite = { version = "^0.3.0-beta-dev.43", path = "../holochain_sqlite" }
-holo_hash = { version = "^0.3.0-beta-dev.28", path = "../holo_hash", features = [
+holochain_sqlite = { version = "^0.3.0", path = "../holochain_sqlite" }
+holo_hash = { version = "^0.3.0", path = "../holo_hash", features = [
     "full",
 ] }
 fallible-iterator = "0.2.0"
-hc_sleuth = { version = "^0.2.0-beta-dev.17", path = "../hc_sleuth" }
-holochain_keystore = { version = "^0.3.0-beta-dev.37", path = "../holochain_keystore" }
+hc_sleuth = { version = "^0.2.0", path = "../hc_sleuth" }
+holochain_keystore = { version = "^0.3.0", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.54"
-holochain_p2p = { version = "^0.3.0-beta-dev.46", path = "../holochain_p2p" }
-holochain_types = { version = "^0.3.0-beta-dev.43", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.3.0-beta-dev.36", path = "../holochain_zome_types", features = [
+holochain_p2p = { version = "^0.3.0", path = "../holochain_p2p" }
+holochain_types = { version = "^0.3.0", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.3.0", path = "../holochain_zome_types", features = [
     "full",
 ] }
-kitsune_p2p = { version = "^0.3.0-beta-dev.40", path = "../kitsune_p2p/kitsune_p2p" }
-holochain_state_types = { version = "^0.3.0-beta-dev.40", path = "../holochain_state_types" }
-holochain_nonce = { version = "^0.3.0-beta-dev.27", path = "../holochain_nonce" }
+kitsune_p2p = { version = "^0.3.0", path = "../kitsune_p2p/kitsune_p2p" }
+holochain_state_types = { version = "^0.3.0", path = "../holochain_state_types" }
+holochain_nonce = { version = "^0.3.0", path = "../holochain_nonce" }
 one_err = "0.0.8"
 parking_lot = "0.12"
 shrinkwraprs = "0.3.0"
@@ -59,7 +59,7 @@ arbitrary = "1.0"
 fixt = { path = "../fixt" }
 holochain_wasm_test_utils = { path = "../test_utils/wasm" }
 matches = "0.1.8"
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../holochain_trace" }
+holochain_trace = { path = "../holochain_trace" }
 pretty_assertions = "1.4"
 
 tempfile = "3.3"

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_state"
-version = "0.3.0-beta-dev.46"
+version = "0.3.0"
 description = "Holochain persisted state datatypes and functions"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain_state_types/CHANGELOG.md
+++ b/crates/holochain_state_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.40
 
 ## 0.3.0-beta-dev.39

--- a/crates/holochain_state_types/Cargo.toml
+++ b/crates/holochain_state_types/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2021"
 # reminder - do not use workspace deps
 [dependencies]
 serde = { version = "1.0", features = [ "derive" ] }
-holochain_integrity_types = { version = "^0.3.0-beta-dev.33", path = "../holochain_integrity_types", default-features = false }
-holo_hash = { version = "^0.3.0-beta-dev.28", path = "../holo_hash" }
+holochain_integrity_types = { version = "^0.3.0", path = "../holochain_integrity_types", default-features = false }
+holo_hash = { version = "^0.3.0", path = "../holo_hash" }
 
 [lints]
 workspace = true

--- a/crates/holochain_state_types/Cargo.toml
+++ b/crates/holochain_state_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_state_types"
-version = "0.3.0-beta-dev.40"
+version = "0.3.0"
 description = "Types for the holochain_state crate"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain_terminal/CHANGELOG.md
+++ b/crates/holochain_terminal/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.23
 
 ## 0.3.0-beta-dev.22

--- a/crates/holochain_terminal/Cargo.toml
+++ b/crates/holochain_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hcterm"
-version = "0.3.0-beta-dev.23"
+version = "0.3.0"
 description = "A terminal for Holochain"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain_terminal/Cargo.toml
+++ b/crates/holochain_terminal/Cargo.toml
@@ -17,14 +17,14 @@ clap = { version = "4", features = ["derive"] }
 url = "2"
 once_cell = "1"
 chrono = "0.4"
-holo_hash = { version = "^0.3.0-beta-dev.28", path = "../holo_hash", features = ["encoding"] }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.28", path = "../kitsune_p2p/types" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.21", path = "../kitsune_p2p/bin_data" }
-kitsune_p2p_bootstrap_client = { version = "^0.3.0-beta-dev.34", path = "../kitsune_p2p/bootstrap_client" }
-holochain_util = { version = "^0.3.0-beta-dev.8", path = "../holochain_util" }
-holochain_conductor_api = { version = "^0.3.0-beta-dev.47", path = "../holochain_conductor_api" }
-holochain_websocket = { version = "^0.3.0-beta-dev.22", path = "../holochain_websocket" }
-holochain_types = { version = "^0.3.0-beta-dev.43", path = "../holochain_types" }
+holo_hash = { version = "^0.3.0", path = "../holo_hash", features = ["encoding"] }
+kitsune_p2p_types = { version = "^0.3.0", path = "../kitsune_p2p/types" }
+kitsune_p2p_bin_data = { version = "^0.3.0", path = "../kitsune_p2p/bin_data" }
+kitsune_p2p_bootstrap_client = { version = "^0.3.0", path = "../kitsune_p2p/bootstrap_client" }
+holochain_util = { version = "^0.3.0", path = "../holochain_util" }
+holochain_conductor_api = { version = "^0.3.0", path = "../holochain_conductor_api" }
+holochain_websocket = { version = "^0.3.0", path = "../holochain_websocket" }
+holochain_types = { version = "^0.3.0", path = "../holochain_types" }
 tokio = { version = "1.36.0", features = ["full"] }
 
 [lints]

--- a/crates/holochain_trace/CHANGELOG.md
+++ b/crates/holochain_trace/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.11
 
 ## 0.3.0-beta-dev.10

--- a/crates/holochain_trace/Cargo.toml
+++ b/crates/holochain_trace/Cargo.toml
@@ -29,7 +29,7 @@ tracing-subscriber = { version = "0.3.16", features = [ "env-filter", "time", "j
 
 # opentelemetry = { version = "0.8", default-features = false, features = ["trace", "serialize"], optional = true }
 # tracing-opentelemetry = { version = "0.8.0", optional = true }
-holochain_serialized_bytes = {version = "0.0", optional = true }
+holochain_serialized_bytes = {version = "0.0.54", optional = true }
 serde_bytes = { version = "0.11", optional = true }
 tokio = { version = "1.27", features = [ "sync" ], optional = true }
 shrinkwraprs = { version = "0.3.0", optional = true }

--- a/crates/holochain_trace/Cargo.toml
+++ b/crates/holochain_trace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_trace"
-version = "0.3.0-beta-dev.11"
+version = "0.3.0"
 authors = ["freesig <tom.gowan@holo.host>", "Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 description = "tracing helpers"

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.43
 
 ## 0.3.0-beta-dev.42

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_types"
-version = "0.3.0-beta-dev.43"
+version = "0.3.0"
 description = "Holochain common types"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -17,32 +17,32 @@ automap = { version = "0.1", features = ["serde"] }
 backtrace = "0.3.27"
 derive_builder = "0.20"
 derive_more = "0.99"
-fixt = { path = "../fixt", version = "^0.3.0-beta-dev.4" }
+fixt = { path = "../fixt", version = "^0.3.0" }
 flate2 = "1.0.14"
 futures = "0.3"
 getrandom = { version = "0.2.7" }
 one_err = "0.0.8"
-holo_hash = { version = "^0.3.0-beta-dev.28", path = "../holo_hash", features = [
+holo_hash = { version = "^0.3.0", path = "../holo_hash", features = [
   "encoding",
 ] }
-holochain_keystore = { version = "^0.3.0-beta-dev.37", path = "../holochain_keystore" }
-holochain_nonce = { version = "^0.3.0-beta-dev.27", path = "../holochain_nonce" }
+holochain_keystore = { version = "^0.3.0", path = "../holochain_keystore" }
+holochain_nonce = { version = "^0.3.0", path = "../holochain_nonce" }
 holochain_serialized_bytes = "=0.0.54"
-holochain_sqlite = { path = "../holochain_sqlite", version = "^0.3.0-beta-dev.43" }
-holochain_util = { version = "^0.3.0-beta-dev.8", path = "../holochain_util", features = [
+holochain_sqlite = { path = "../holochain_sqlite", version = "^0.3.0" }
+holochain_util = { version = "^0.3.0", path = "../holochain_util", features = [
   "backtrace",
 ] }
-holochain_zome_types = { path = "../holochain_zome_types", version = "^0.3.0-beta-dev.36", features = [
+holochain_zome_types = { path = "../holochain_zome_types", version = "^0.3.0", features = [
   "full",
 ] }
 itertools = { version = "0.12" }
-kitsune_p2p_dht = { version = "^0.3.0-beta-dev.24", path = "../kitsune_p2p/dht" }
+kitsune_p2p_dht = { version = "^0.3.0", path = "../kitsune_p2p/dht" }
 mr_bundle = { path = "../mr_bundle", features = [
   "packing",
-], version = "^0.3.0-beta-dev.10" }
+], version = "^0.3.0" }
 must_future = "0.1.1"
 nanoid = "0.4"
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../holochain_trace" }
+holochain_trace = { version = "^0.3.0", path = "../holochain_trace" }
 parking_lot = "0.12"
 rand = "0.8.5"
 regex = "1.4"
@@ -70,7 +70,7 @@ proptest-derive = { version = "0", optional = true }
 contrafact = { version = "0.2.0-rc.1", optional = true }
 
 [dev-dependencies]
-holochain_types = { version = "^0.3.0-beta-dev.27", path = ".", features = [
+holochain_types = { path = ".", features = [
   "test_utils",
   "fuzzing",
 ] }

--- a/crates/holochain_util/CHANGELOG.md
+++ b/crates/holochain_util/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.8
 
 ## 0.3.0-beta-dev.7

--- a/crates/holochain_util/Cargo.toml
+++ b/crates/holochain_util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_util"
-version = "0.3.0-beta-dev.8"
+version = "0.3.0"
 authors = [ "Holochain Core Dev Team <devcore@holochain.org>" ]
 edition = "2021"
 description = "This crate is a collection of various utility functions that are used in the other crates in the holochain repository."

--- a/crates/holochain_websocket/CHANGELOG.md
+++ b/crates/holochain_websocket/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.22
 
 ## 0.3.0-beta-dev.21

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 futures = "0.3"
 holochain_serialized_bytes = "=0.0.54"
-holochain_types = { version = "^0.3.0-beta-dev.43", path = "../holochain_types" }
+holochain_types = { version = "^0.3.0", path = "../holochain_types" }
 serde = "1.0"
 serde_bytes = "0.11.14"
 tokio = { version = "1.36.0", features = ["full"] }
@@ -21,7 +21,7 @@ tracing = "0.1"
 async-trait = "0.1"
 
 [dev-dependencies]
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../holochain_trace" }
+holochain_trace = { path = "../holochain_trace" }
 criterion = "0.5"
 
 [lints]

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_websocket"
-version = "0.3.0-beta-dev.22"
+version = "0.3.0"
 description = "Holochain utilities for serving and connection with websockets"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.36
 
 ## 0.3.0-beta-dev.35

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -11,16 +11,16 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-kitsune_p2p_dht = { version = "^0.3.0-beta-dev.24", path = "../kitsune_p2p/dht", optional = true }
-kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.10", path = "../kitsune_p2p/timestamp" }
-kitsune_p2p_block = { version = "^0.3.0-beta-dev.23", path = "../kitsune_p2p/block" }
-holo_hash = { version = "^0.3.0-beta-dev.28", path = "../holo_hash", features = [
+kitsune_p2p_dht = { version = "^0.3.0", path = "../kitsune_p2p/dht", optional = true }
+kitsune_p2p_timestamp = { version = "^0.3.0", path = "../kitsune_p2p/timestamp" }
+kitsune_p2p_block = { version = "^0.3.0", path = "../kitsune_p2p/block" }
+holo_hash = { version = "^0.3.0", path = "../holo_hash", features = [
   "encoding",
 ] }
-holochain_integrity_types = { version = "^0.3.0-beta-dev.33", path = "../holochain_integrity_types", features = [
+holochain_integrity_types = { version = "^0.3.0", path = "../holochain_integrity_types", features = [
   "tracing",
 ] }
-holochain_nonce = { version = "^0.3.0-beta-dev.27", path = "../holochain_nonce" }
+holochain_nonce = { version = "^0.3.0", path = "../holochain_nonce" }
 holochain_serialized_bytes = "=0.0.54"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11"
@@ -32,7 +32,7 @@ holochain_wasmer_common = { version = "=0.0.93" }
 derive_more = "0.99"
 
 # fixturator dependencies
-fixt = { version = "^0.3.0-beta-dev.4", path = "../fixt", optional = true }
+fixt = { version = "^0.3.0", path = "../fixt", optional = true }
 strum = { version = "0.18.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_zome_types"
-version = "0.3.0-beta-dev.36"
+version = "0.3.0"
 description = "Holochain zome types"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/bin_data/CHANGELOG.md
+++ b/crates/kitsune_p2p/bin_data/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.21
 
 ## 0.3.0-beta-dev.20

--- a/crates/kitsune_p2p/bin_data/Cargo.toml
+++ b/crates/kitsune_p2p/bin_data/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-holochain_util = { version = "^0.3.0-beta-dev.8", path = "../../holochain_util", default-features = false }
-kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.20", path = "../dht_arc" }
+holochain_util = { version = "^0.3.0", path = "../../holochain_util", default-features = false }
+kitsune_p2p_dht_arc = { version = "^0.3.0", path = "../dht_arc" }
 shrinkwraprs = "0.3.0"
 derive_more = "0.99"
 serde = { version = "1", features = [ "derive", "rc" ] }
@@ -23,7 +23,7 @@ serde_bytes = "0.11"
 arbitrary = { version = "1.0", features = ["derive"], optional = true}
 proptest = { version = "1", optional = true }
 proptest-derive = { version = "0", optional = true }
-fixt = { version = "^0.3.0-beta-dev.4", path = "../../fixt", optional = true }
+fixt = { version = "^0.3.0", path = "../../fixt", optional = true }
 
 [lints]
 workspace = true

--- a/crates/kitsune_p2p/bin_data/Cargo.toml
+++ b/crates/kitsune_p2p/bin_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_bin_data"
-version = "0.3.0-beta-dev.21"
+version = "0.3.0"
 description = "Binary data types for kitsune_p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/block/CHANGELOG.md
+++ b/crates/kitsune_p2p/block/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.23
 
 ## 0.3.0-beta-dev.22

--- a/crates/kitsune_p2p/block/Cargo.toml
+++ b/crates/kitsune_p2p/block/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_block"
-version = "0.3.0-beta-dev.23"
+version = "0.3.0"
 description = "(un)Block datatype for kitsune_p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/block/Cargo.toml
+++ b/crates/kitsune_p2p/block/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.10", path = "../timestamp" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.21", path = "../bin_data" }
+kitsune_p2p_timestamp = { version = "^0.3.0", path = "../timestamp" }
+kitsune_p2p_bin_data = { version = "^0.3.0", path = "../bin_data" }
 serde = { version = "1.0", features = ["derive"] }
 
 [lints]

--- a/crates/kitsune_p2p/bootstrap/CHANGELOG.md
+++ b/crates/kitsune_p2p/bootstrap/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.2.0
+
 ## 0.2.0-beta-dev.28
 
 ## 0.2.0-beta-dev.27

--- a/crates/kitsune_p2p/bootstrap/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_bootstrap"
-version = "0.2.0-beta-dev.28"
+version = "0.2.0"
 description = "Bootstrap server written in rust for kitsune nodes to find each other"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/bootstrap/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.3.21", features = [ "derive" ] }
 futures = "0.3"
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.28", path = "../types" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.21", path = "../bin_data" }
+kitsune_p2p_types = { version = "^0.3.0", path = "../types" }
+kitsune_p2p_bin_data = { version = "^0.3.0", path = "../bin_data" }
 parking_lot = "0.12.1"
 rand = "0.8.5"
 reqwest = "0.12"
@@ -28,7 +28,7 @@ warp = "0.3"
 [dev-dependencies]
 kitsune_p2p_bootstrap = { path = ".", features = ["test_utils"] }
 kitsune_p2p = { path = "../kitsune_p2p", features = ["sqlite"] }
-fixt = { path = "../../fixt" ,version = "^0.3.0-beta-dev.4"}
+fixt = { path = "../../fixt" }
 criterion = "0.5.1"
 reqwest = "0.12"
 

--- a/crates/kitsune_p2p/bootstrap_client/CHANGELOG.md
+++ b/crates/kitsune_p2p/bootstrap_client/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.34
 
 ## 0.3.0-beta-dev.33

--- a/crates/kitsune_p2p/bootstrap_client/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_bootstrap_client"
-version = "0.3.0-beta-dev.34"
+version = "0.3.0"
 description = "a client library for the bootstrap service used by Kitsune P2P"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/bootstrap_client/Cargo.toml
+++ b/crates/kitsune_p2p/bootstrap_client/Cargo.toml
@@ -12,9 +12,9 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-kitsune_p2p_bootstrap = { version = "^0.2.0-beta-dev.28", path = "../bootstrap", features = ["sqlite"] }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.28", path = "../types" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.21", path = "../bin_data" }
+kitsune_p2p_bootstrap = { version = "^0.2.0", path = "../bootstrap", features = ["sqlite"] }
+kitsune_p2p_types = { version = "^0.3.0", path = "../types" }
+kitsune_p2p_bin_data = { version = "^0.3.0", path = "../bin_data" }
 serde_bytes = "0.11"
 serde = "1"
 reqwest = "0.12"
@@ -23,7 +23,7 @@ url2 = "0.0.6"
 [dev-dependencies]
 arbitrary = { version = "1.0", features = ["derive"] }
 kitsune_p2p_bootstrap_client = { path = ".", features = ["tx2", "test_utils"] }
-fixt = { version = "^0.3.0-beta-dev.4", path = "../../fixt" }
+fixt = { path = "../../fixt" }
 tokio = "1"
 ed25519-dalek = { version = "2.1", features = ["rand_core"] }
 rand = "0.8.5"

--- a/crates/kitsune_p2p/dht/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.24
 
 ## 0.3.0-beta-dev.23

--- a/crates/kitsune_p2p/dht/Cargo.toml
+++ b/crates/kitsune_p2p/dht/Cargo.toml
@@ -16,8 +16,8 @@ colored = { version = "2.1", optional = true }
 derivative = "2.2.0"
 derive_more = "0.99"
 futures = "0.3"
-kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.20", path = "../dht_arc" }
-kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.10", path = "../timestamp" }
+kitsune_p2p_dht_arc = { version = "^0.3.0", path = "../dht_arc" }
+kitsune_p2p_timestamp = { version = "^0.3.0", path = "../timestamp" }
 must_future = "0.1"
 num-traits = "0.2.14"
 rand = "0.8.4"
@@ -36,7 +36,7 @@ kitsune_p2p_dht = { path = ".", features = ["test_utils", "sqlite"] }
 kitsune_p2p_dht_arc = { path = "../dht_arc", features = ["test_utils"] }
 holochain_serialized_bytes = "=0.0.54"
 maplit = "1"
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../../holochain_trace" }
+holochain_trace = { path = "../../holochain_trace" }
 pretty_assertions = "1.4.0"
 proptest = "1"
 test-case = "3.3"

--- a/crates/kitsune_p2p/dht/Cargo.toml
+++ b/crates/kitsune_p2p/dht/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_dht"
-version = "0.3.0-beta-dev.24"
+version = "0.3.0"
 description = "Kitsune P2p DHT definition"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/dht_arc/CHANGELOG.md
+++ b/crates/kitsune_p2p/dht_arc/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.20
 
 ## 0.3.0-beta-dev.19

--- a/crates/kitsune_p2p/dht_arc/Cargo.toml
+++ b/crates/kitsune_p2p/dht_arc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_dht_arc"
-version = "0.3.0-beta-dev.20"
+version = "0.3.0"
 description = "Kitsune P2p Dht Arc Utils"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/dht_arc/Cargo.toml
+++ b/crates/kitsune_p2p/dht_arc/Cargo.toml
@@ -17,7 +17,7 @@ gcollections = "1.5.0"
 intervallum = "1.4.0"
 num-traits = "0.2"
 serde = {version = "1.0", features = ["derive"]}
-kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.10", path = "../timestamp" }
+kitsune_p2p_timestamp = { version = "^0.3.0", path = "../timestamp" }
 
 arbitrary = { version = "1", features = ["derive"], optional = true }
 proptest = { version = "1", optional = true }
@@ -26,7 +26,7 @@ rusqlite = { version = "0.29", optional = true }
 
 [dev-dependencies]
 maplit = "1"
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../../holochain_trace" }
+holochain_trace = { path = "../../holochain_trace" }
 pretty_assertions = "1.4.0"
 rand = "0.8.5"
 statrs = "0.16.0"

--- a/crates/kitsune_p2p/fetch/CHANGELOG.md
+++ b/crates/kitsune_p2p/fetch/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.31
 
 ## 0.3.0-beta-dev.30

--- a/crates/kitsune_p2p/fetch/Cargo.toml
+++ b/crates/kitsune_p2p/fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_fetch"
-version = "0.3.0-beta-dev.31"
+version = "0.3.0"
 description = "Kitsune P2p Fetch Queue Logic"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/fetch/Cargo.toml
+++ b/crates/kitsune_p2p/fetch/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2021"
 # reminder - do not use workspace deps
 [dependencies]
 derive_more = "0.99"
-kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.10", path = "../timestamp" }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.28", path = "../types" }
+kitsune_p2p_timestamp = { version = "^0.3.0", path = "../timestamp" }
+kitsune_p2p_types = { version = "^0.3.0", path = "../types" }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.27", features = ["full"] }
 tracing = "0.1.29"
@@ -35,7 +35,7 @@ kitsune_p2p_fetch = { path = ".", features = [
 ] }
 
 holochain_serialized_bytes = "=0.0.54"
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../../holochain_trace" }
+holochain_trace = { version = "^0.3.0", path = "../../holochain_trace" }
 pretty_assertions = "1.4.0"
 test-case = "3.3"
 tokio = { version = "1.27", features = ["full", "test-util"] }

--- a/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
+++ b/crates/kitsune_p2p/kitsune_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.40
 
 - **BREAKING** - AgentInfo uses a quantized arc instead of an arc half-length to represent DHT coverage. This is a breaking protocol change, nodes on different versions will not be able to gossip with each other.

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p"
-version = "0.3.0-beta-dev.40"
+version = "0.3.0"
 description = "p2p / dht communication framework"
 license = "CAL-1.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -21,19 +21,19 @@ futures = "0.3"
 ghost_actor = "=0.3.0-alpha.6"
 governor = "0.3.2"
 itertools = "0.12"
-kitsune_p2p_fetch = { version = "^0.3.0-beta-dev.31", path = "../fetch" }
-kitsune_p2p_mdns = { version = "^0.3.0-beta-dev.4", path = "../mdns" }
-kitsune_p2p_proxy = { version = "^0.3.0-beta-dev.28", path = "../proxy" }
-kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.10", path = "../timestamp", features = ["now"] }
-kitsune_p2p_block = { version = "^0.3.0-beta-dev.23", path = "../block" }
-kitsune_p2p_bootstrap_client = { version = "^0.3.0-beta-dev.34", path = "../bootstrap_client" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.21", path = "../bin_data" }
-kitsune_p2p_transport_quic = { version = "^0.3.0-beta-dev.28", path = "../transport_quic", optional = true }
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.28", path = "../types", default-features = false }
+kitsune_p2p_fetch = { version = "^0.3.0", path = "../fetch" }
+kitsune_p2p_mdns = { version = "^0.3.0", path = "../mdns" }
+kitsune_p2p_proxy = { version = "^0.3.0", path = "../proxy" }
+kitsune_p2p_timestamp = { version = "^0.3.0", path = "../timestamp", features = ["now"] }
+kitsune_p2p_block = { version = "^0.3.0", path = "../block" }
+kitsune_p2p_bootstrap_client = { version = "^0.3.0", path = "../bootstrap_client" }
+kitsune_p2p_bin_data = { version = "^0.3.0", path = "../bin_data" }
+kitsune_p2p_transport_quic = { version = "^0.3.0", path = "../transport_quic", optional = true }
+kitsune_p2p_types = { version = "^0.3.0", path = "../types", default-features = false }
 must_future = "0.1.1"
 nanoid = "0.4"
 num-traits = "0.2"
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../../holochain_trace" }
+holochain_trace = { version = "^0.3.0", path = "../../holochain_trace" }
 once_cell = "1.4.1"
 opentelemetry_api = { version = "=0.20.0", features = [ "metrics" ] }
 parking_lot = "0.12.1"
@@ -47,7 +47,7 @@ tracing = "0.1"
 tokio-stream = "0.1"
 tx5 = { version = "=0.0.9-alpha", optional = true }
 url2 = "0.0.6"
-fixt = { path = "../../fixt", version = "^0.3.0-beta-dev.4"}
+fixt = { path = "../../fixt", version = "^0.3.0"}
 
 # fuzzing
 arbitrary = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/kitsune_p2p/mdns/CHANGELOG.md
+++ b/crates/kitsune_p2p/mdns/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.4
 
 ## 0.3.0-beta-dev.3

--- a/crates/kitsune_p2p/mdns/Cargo.toml
+++ b/crates/kitsune_p2p/mdns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_mdns"
-version = "0.3.0-beta-dev.4"
+version = "0.3.0"
 description = "p2p / mdns discovery framework"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/proxy/CHANGELOG.md
+++ b/crates/kitsune_p2p/proxy/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.28
 
 ## 0.3.0-beta-dev.27

--- a/crates/kitsune_p2p/proxy/Cargo.toml
+++ b/crates/kitsune_p2p/proxy/Cargo.toml
@@ -15,9 +15,9 @@ edition = "2021"
 base64 = "0.22"
 derive_more = "0.99"
 futures = "0.3"
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.28", path = "../types" }
-kitsune_p2p_transport_quic = { version = "^0.3.0-beta-dev.28", path = "../transport_quic" }
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../../holochain_trace" }
+kitsune_p2p_types = { version = "^0.3.0", path = "../types" }
+kitsune_p2p_transport_quic = { version = "^0.3.0", path = "../transport_quic" }
+holochain_trace = { version = "^0.3.0", path = "../../holochain_trace" }
 serde = { version = "1", features = [ "derive" ] }
 serde_bytes = "0.11"
 structopt = "0.3"

--- a/crates/kitsune_p2p/proxy/Cargo.toml
+++ b/crates/kitsune_p2p/proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_proxy"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0"
 description = "Proxy transport module for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/timestamp/CHANGELOG.md
+++ b/crates/kitsune_p2p/timestamp/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.10
 
 ## 0.3.0-beta-dev.9

--- a/crates/kitsune_p2p/timestamp/Cargo.toml
+++ b/crates/kitsune_p2p/timestamp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_timestamp"
-version = "0.3.0-beta-dev.10"
+version = "0.3.0"
 description = "Microsecond-precision timestamp datatype for kitsune_p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/transport_quic/CHANGELOG.md
+++ b/crates/kitsune_p2p/transport_quic/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.28
 
 ## 0.3.0-beta-dev.27

--- a/crates/kitsune_p2p/transport_quic/Cargo.toml
+++ b/crates/kitsune_p2p/transport_quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_transport_quic"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0"
 description = "QUIC transport module for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/transport_quic/Cargo.toml
+++ b/crates/kitsune_p2p/transport_quic/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 blake2b_simd = "1.0.0"
 futures = "0.3"
 if-addrs = "0.12"
-kitsune_p2p_types = { version = "^0.3.0-beta-dev.28", path = "../types" }
+kitsune_p2p_types = { version = "^0.3.0", path = "../types" }
 quinn = "0.8.1"
 webpki = "=0.22.2" # pinned until other libraries upgrade to ring 0.17
 rustls = { version = "0.20.4", features = [ "dangerous_configuration" ] }

--- a/crates/kitsune_p2p/types/CHANGELOG.md
+++ b/crates/kitsune_p2p/types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.28
 
 ## 0.3.0-beta-dev.27

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitsune_p2p_types"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0"
 description = "types subcrate for kitsune-p2p"
 license = "Apache-2.0"
 homepage = "https://github.com/holochain/holochain"

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -17,12 +17,12 @@ base64 = "0.22"
 derive_more = "0.99"
 futures = "0.3"
 ghost_actor = "=0.3.0-alpha.6"
-kitsune_p2p_dht = { version = "^0.3.0-beta-dev.24", path = "../dht" }
-kitsune_p2p_dht_arc = { version = "^0.3.0-beta-dev.20", path = "../dht_arc" }
-kitsune_p2p_bin_data = { version = "^0.3.0-beta-dev.21", path = "../bin_data" }
-kitsune_p2p_timestamp = { version = "^0.3.0-beta-dev.10", path = "../timestamp" }
+kitsune_p2p_dht = { version = "^0.3.0", path = "../dht" }
+kitsune_p2p_dht_arc = { version = "^0.3.0", path = "../dht_arc" }
+kitsune_p2p_bin_data = { version = "^0.3.0", path = "../bin_data" }
+kitsune_p2p_timestamp = { version = "^0.3.0", path = "../timestamp" }
 mockall = { version = "0.11.3", optional = true }
-holochain_trace = { version = "^0.3.0-beta-dev.11", path = "../../holochain_trace" }
+holochain_trace = { version = "^0.3.0", path = "../../holochain_trace" }
 once_cell = "1.4"
 parking_lot = "0.12.1"
 paste = "1.0.12"

--- a/crates/mr_bundle/CHANGELOG.md
+++ b/crates/mr_bundle/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.10
 
 ## 0.3.0-beta-dev.9

--- a/crates/mr_bundle/Cargo.toml
+++ b/crates/mr_bundle/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/mr_bundle"
 [dependencies]
 derive_more = "0.99"
 flate2 = "1.0"
-holochain_util = { path = "../holochain_util", version = "^0.3.0-beta-dev.8" }
+holochain_util = { path = "../holochain_util", version = "^0.3.0" }
 futures = "0.3"
 reqwest = "0.12"
 rmp-serde = "=1.1.2"

--- a/crates/mr_bundle/Cargo.toml
+++ b/crates/mr_bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mr_bundle"
-version = "0.3.0-beta-dev.10"
+version = "0.3.0"
 authors = ["Michael Dougherty <maackle.d@gmail.com>"]
 edition = "2021"
 description = "Implements the un-/packing of bundles that either embed or reference a set of resources"

--- a/crates/test_utils/wasm/CHANGELOG.md
+++ b/crates/test_utils/wasm/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.45
 
 ## 0.3.0-beta-dev.44

--- a/crates/test_utils/wasm/Cargo.toml
+++ b/crates/test_utils/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_wasm_test_utils"
-version = "0.3.0-beta-dev.45"
+version = "0.3.0"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2021"
 description = "Utilities for Wasm testing for Holochain"
@@ -20,10 +20,10 @@ only_check = []
 
 # reminder - do not use workspace deps
 [dependencies]
-holochain_types = { path = "../../holochain_types", version = "^0.3.0-beta-dev.43"}
+holochain_types = { path = "../../holochain_types", version = "^0.3.0"}
 strum = "0.18.0"
 strum_macros = "0.18.0"
-holochain_util = { version = "^0.3.0-beta-dev.8", path = "../../holochain_util" }
+holochain_util = { version = "^0.3.0", path = "../../holochain_util" }
 
 [build-dependencies]
 toml = "0.8"

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "fixt"
-version = "0.3.0-beta-dev.4"
+version = "0.3.0"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -897,7 +897,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hdi"
-version = "0.4.0-beta-dev.36"
+version = "0.4.0"
 dependencies = [
  "getrandom",
  "hdk_derive",
@@ -913,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.3.0-beta-dev.41"
+version = "0.3.0"
 dependencies = [
  "getrandom",
  "hdi",
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.3.0-beta-dev.34"
+version = "0.3.0"
 dependencies = [
  "darling 0.14.4",
  "heck 0.5.0",
@@ -973,7 +973,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "holo_hash"
-version = "0.3.0-beta-dev.28"
+version = "0.3.0"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.3.0-beta-dev.33"
+version = "0.3.0"
 dependencies = [
  "derive_builder",
  "holo_hash",
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.3.0-beta-dev.27"
+version = "0.3.0"
 dependencies = [
  "getrandom",
  "holochain_secure_primitive",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_secure_primitive"
-version = "0.3.0-beta-dev.23"
+version = "0.3.0"
 dependencies = [
  "paste",
  "serde",
@@ -1061,7 +1061,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.3.0-beta-dev.41"
+version = "0.3.0"
 dependencies = [
  "hdk",
  "serde",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.3.0-beta-dev.8"
+version = "0.3.0"
 dependencies = [
  "cfg-if",
  "colored",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.3.0-beta-dev.36"
+version = "0.3.0"
 dependencies = [
  "derive_builder",
  "derive_more",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bin_data"
-version = "0.3.0-beta-dev.21"
+version = "0.3.0"
 dependencies = [
  "base64",
  "derive_more",
@@ -1259,7 +1259,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_block"
-version = "0.3.0-beta-dev.23"
+version = "0.3.0"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_timestamp",
@@ -1268,7 +1268,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht"
-version = "0.3.0-beta-dev.24"
+version = "0.3.0"
 dependencies = [
  "derivative",
  "derive_more",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht_arc"
-version = "0.3.0-beta-dev.20"
+version = "0.3.0"
 dependencies = [
  "derive_more",
  "gcollections",
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_timestamp"
-version = "0.3.0-beta-dev.10"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "serde",

--- a/crates/test_utils/wasm_common/CHANGELOG.md
+++ b/crates/test_utils/wasm_common/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.3.0
+
 ## 0.3.0-beta-dev.41
 
 ## 0.3.0-beta-dev.40

--- a/crates/test_utils/wasm_common/Cargo.toml
+++ b/crates/test_utils/wasm_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_test_wasm_common"
-version = "0.3.0-beta-dev.41"
+version = "0.3.0"
 authors = [ "thedavidmeister", "thedavidmeister@gmail.com" ]
 edition = "2021"
 description = "Common code for Wasm testing for Holochain"
@@ -14,5 +14,5 @@ path = "src/lib.rs"
 
 # reminder - do not use workspace deps
 [dependencies]
-hdk = { path = "../../hdk", version = "^0.3.0-beta-dev.41"}
+hdk = { path = "../../hdk", version = "^0.3.0"}
 serde = "1.0"


### PR DESCRIPTION
### Summary

Have tested locally and I'm seeing 0.3.1-rc.0 versions produced for all relevant crates.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
