### PR TITLE
Bump Rust to 1.78

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,9 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_common"
-version = "0.0.93"
+version = "0.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e77c4d54b5bf86dfa0266588d43fc913b0442799f34c8fc04b0e8eda0260bd4"
+checksum = "c9f7d17668e4a4997b5e121c7a951ea9606331ef206b991f1e81420c84d98485"
 dependencies = [
  "holochain_serialized_bytes",
  "serde",
@@ -3407,9 +3407,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_guest"
-version = "0.0.93"
+version = "0.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10fcb10d7d455c5222a13b2343e2a438bcbbf3f97ef79f16c9e01203f6616dd0"
+checksum = "e292e12fda0716ce36b566c7cf3dad8443fdc7c56950e42c5a3ba81988e792d0"
 dependencies = [
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
@@ -3421,9 +3421,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_host"
-version = "0.0.93"
+version = "0.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae935ffa7f64a1f850388f9f16dc4d698935fe803da79d55e3442a35a059ca8"
+checksum = "0601fb78038adc299619b51420e66e41c0e986abaf5087df4ac00d742e14926c"
 dependencies = [
  "bimap",
  "bytes",

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/bin/hc-dna.rs"
 
 # reminder - do not use workspace deps
 [dependencies]
-holochain_wasmer_host = "=0.0.93"
+holochain_wasmer_host = "=0.0.94"
 wasmer = "=4.2.8"
 futures = "0.3"
 anyhow = "1.0"

--- a/crates/hdi/Cargo.toml
+++ b/crates/hdi/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 hdk_derive = { version = "^0.4.0-dev.3", path = "../hdk_derive" }
 holo_hash = { version = "^0.4.0-dev.3", path = "../holo_hash" }
-holochain_wasmer_guest = { version = "=0.0.93" }
+holochain_wasmer_guest = { version = "=0.0.94" }
 # it's important that we depend on holochain_integrity_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
 holochain_integrity_types = { version = "^0.4.0-dev.3", path = "../holochain_integrity_types", default-features = false }

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 hdi = { version = "=0.5.0-dev.3", path = "../hdi", features = ["trace"] }
 hdk_derive = { version = "^0.4.0-dev.3", path = "../hdk_derive" }
 holo_hash = { version = "^0.4.0-dev.3", path = "../holo_hash" }
-holochain_wasmer_guest = { version = "=0.0.93" }
+holochain_wasmer_guest = { version = "=0.0.94" }
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
 holochain_zome_types = { version = "^0.4.0-dev.3", path = "../holochain_zome_types", default-features = false }

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -34,7 +34,7 @@ rusqlite = { version = "0.29", optional = true }
 serde = { version = "1", optional = true }
 serde_bytes = { version = "0.11", optional = true }
 tracing = { version = "0.1", optional = true }
-holochain_wasmer_common = { version = "=0.0.93", optional = true }
+holochain_wasmer_common = { version = "=0.0.94", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1.0.51", features = ["preserve_order"] }

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update Holochain Wasmer to v0.0.94 to get a fix for a deallocation bug that was causing crashes when calling zome functions
+  on Rust 1.78. #3883
 - Rename feature `sweetest` in Holochain crate to `sweettest` to match the crate name.
 
 ## 0.4.0-dev.3

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -40,7 +40,7 @@ holochain_serialized_bytes = "=0.0.54"
 holochain_state = { version = "^0.4.0-dev.3", path = "../holochain_state" }
 holochain_types = { version = "^0.4.0-dev.3", path = "../holochain_types" }
 holochain_util = { version = "^0.4.0-dev.1", path = "../holochain_util" }
-holochain_wasmer_host = "=0.0.93"
+holochain_wasmer_host = "=0.0.94"
 holochain_websocket = { version = "^0.4.0-dev.3", path = "../holochain_websocket" }
 holochain_zome_types = { version = "^0.4.0-dev.3", path = "../holochain_zome_types", features = [
   "full",

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -28,7 +28,7 @@ serde_yaml = { version = "0.9", optional = true }
 subtle = "2"
 thiserror = "1.0.22"
 tracing = "0.1"
-holochain_wasmer_common = { version = "=0.0.93" }
+holochain_wasmer_common = { version = "=0.0.94" }
 derive_more = "0.99"
 
 # fixturator dependencies

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -1081,9 +1081,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_common"
-version = "0.0.93"
+version = "0.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e77c4d54b5bf86dfa0266588d43fc913b0442799f34c8fc04b0e8eda0260bd4"
+checksum = "c9f7d17668e4a4997b5e121c7a951ea9606331ef206b991f1e81420c84d98485"
 dependencies = [
  "holochain_serialized_bytes",
  "serde",
@@ -1095,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_guest"
-version = "0.0.93"
+version = "0.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10fcb10d7d455c5222a13b2343e2a438bcbbf3f97ef79f16c9e01203f6616dd0"
+checksum = "e292e12fda0716ce36b566c7cf3dad8443fdc7c56950e42c5a3ba81988e792d0"
 dependencies = [
  "holochain_serialized_bytes",
  "holochain_wasmer_common",

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -5,7 +5,7 @@
     let
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "1.77.2";
+        version = "1.78.0";
       };
 
       craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;

--- a/nix/modules/holonix-integration-test.nix
+++ b/nix/modules/holonix-integration-test.nix
@@ -14,7 +14,7 @@
 
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "1.77.2";
+        version = "1.78.0";
       };
       craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
       moldOpensslDeps = craneLib.vendorCargoDeps {

--- a/nix/modules/lair.nix
+++ b/nix/modules/lair.nix
@@ -5,7 +5,7 @@
     let
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "1.77.2";
+        version = "1.78.0";
       };
 
       craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;

--- a/nix/modules/launcher.nix
+++ b/nix/modules/launcher.nix
@@ -5,7 +5,7 @@
     let
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "1.77.2";
+        version = "1.78.0";
       };
 
       craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;

--- a/nix/modules/release-automation.nix
+++ b/nix/modules/release-automation.nix
@@ -5,7 +5,7 @@
     let
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "1.77.2";
+        version = "1.78.0";
       };
 
       craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -23,7 +23,7 @@
 
       config.rustHelper = {
         defaultTrack = "stable";
-        defaultVersion = "1.77.2";
+        defaultVersion = "1.78.0";
 
         defaultExtensions = [
           "rust-src"

--- a/nix/modules/scaffolding.nix
+++ b/nix/modules/scaffolding.nix
@@ -5,7 +5,7 @@
     let
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "1.77.2";
+        version = "1.78.0";
       };
       craneLib = inputs.crane.lib.${system}.overrideToolchain rustToolchain;
 


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOGs updated with appropriate info
