### PR TITLE
Reduce interval to re-trigger app validation workflow to 20-2000 ms

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Rename feature `sweetest` in Holochain crate to `sweettest` to match the crate name.
+- App validation workflow: Reduce interval to re-trigger when dependencies are missing from 10 seconds to 0-2 seconds, according to number of missing dependencies.
 
 ## 0.4.0-dev.3
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Rename feature `sweetest` in Holochain crate to `sweettest` to match the crate name.
-- App validation workflow: Reduce interval to re-trigger when dependencies are missing from 10 seconds to 0-2 seconds, according to number of missing dependencies.
+- App validation workflow: Reduce interval to re-trigger when dependencies are missing from 10 seconds to 100-1000 ms, according to number of missing dependencies.
 
 ## 0.4.0-dev.3
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -130,7 +130,6 @@ use holochain_state::prelude::*;
 
 use parking_lot::Mutex;
 use rusqlite::Transaction;
-use std::cmp::max;
 use std::collections::HashSet;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -199,11 +198,10 @@ pub async fn app_validation_workflow(
             && !validations_dependencies.fetch_missing_hashes_timed_out()
         {
             // Trigger app validation workflow again in 100-1000 milliseconds.
-            let interval = max(
-                1000 - validations_dependencies.missing_hashes.len() * 100,
-                100,
-            );
-            WorkComplete::Incomplete(Some(Duration::from_millis(interval as u64)))
+            let interval = 900u64
+                .saturating_sub(validations_dependencies.missing_hashes.len() as u64 * 100)
+                + 100;
+            WorkComplete::Incomplete(Some(Duration::from_millis(interval)))
         } else {
             WorkComplete::Complete
         },

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -198,8 +198,11 @@ pub async fn app_validation_workflow(
         if outcome_summary.validated < outcome_summary.ops_to_validate
             && !validations_dependencies.fetch_missing_hashes_timed_out()
         {
-            // Trigger app validation workflow again in 20-2000 milliseconds.
-            let interval = max(101 - validations_dependencies.missing_hashes.len(), 1) * 20;
+            // Trigger app validation workflow again in 100-1000 milliseconds.
+            let interval = max(
+                1000 - validations_dependencies.missing_hashes.len() * 100,
+                100,
+            );
             WorkComplete::Incomplete(Some(Duration::from_millis(interval as u64)))
         } else {
             WorkComplete::Complete

--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_dependencies.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_dependencies.rs
@@ -27,7 +27,7 @@ impl Default for ValidationDependencies {
 }
 
 impl ValidationDependencies {
-    const FETCH_TIMEOUT: Duration = Duration::from_secs(60);
+    const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
 
     pub fn new() -> Self {
         Self {

--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_dependencies.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_dependencies.rs
@@ -27,7 +27,7 @@ impl Default for ValidationDependencies {
 }
 
 impl ValidationDependencies {
-    const FETCH_TIMEOUT: Duration = Duration::from_secs(30);
+    const FETCH_TIMEOUT: Duration = Duration::from_secs(60);
 
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
### Summary
I think the title is a summary of this small PR.


### TODO:
- [x] CHANGELOGs updated with appropriate info
