### PR TITLE
chore(holonix): fix versions 0_2 input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -354,10 +354,13 @@
         "scaffolding": "scaffolding"
       },
       "locked": {
-        "lastModified": 1717662147,
-        "narHash": "sha256-X1LklxVNn2g3g9xUXF/u8iL/VPdrJC4c6+TH9xBh1H4=",
-        "path": "versions/0_2",
-        "type": "path"
+        "dir": "versions/0_2",
+        "lastModified": 1717702827,
+        "narHash": "sha256-I5Vk6AZSQak61tXtY1GhHOLBuCXeosA/vyh0MQbSuAg=",
+        "owner": "holochain",
+        "repo": "holochain",
+        "rev": "2ecbb8eca4c226e4b3bc5e9d41622c72e75c8fda",
+        "type": "github"
       },
       "original": {
         "dir": "versions/0_2",


### PR DESCRIPTION
### Summary
Fix a problem with Nix flake that automation must have introduced here https://github.com/holochain/holochain/commit/b3e182914b11e10f0c8cc1654ab3fbcc6b53e9bf#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9cR357


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs