### PR TITLE
[BACKPORT 0.3] Reduce interval to re-trigger app validation workflow to 100-1000 milliseconds

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- App validation workflow: Reduce interval to re-trigger when dependencies are missing from 10 seconds to 100-1000 ms, according to number of missing dependencies.
+
 ## 0.3.1-rc.1
 
 - Update Holochain Wasmer to v0.0.94 to get a fix for a deallocation bug that was causing crashes when calling zome functions on Rust 1.78. \#3900

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -87,22 +87,24 @@ pub async fn app_validation_workflow(
     .await?;
     // --- END OF WORKFLOW, BEGIN FINISHER BOILERPLATE ---
 
-    // if ops have been accepted or rejected, trigger integration
+    // If ops have been accepted or rejected, trigger integration.
     if outcome_summary.validated > 0 {
         trigger_integration.trigger(&"app_validation_workflow");
     }
 
+    let validations_dependencies = validation_dependencies.lock();
     Ok(
         // If not all ops have been validated
         // and fetching missing hashes has not timed out,
         // trigger app validation workflow again.
         if outcome_summary.validated < outcome_summary.ops_to_validate
-            && !validation_dependencies
-                .lock()
-                .fetch_missing_hashes_timed_out()
+            && !validations_dependencies.fetch_missing_hashes_timed_out()
         {
-            // trigger app validation workflow again in 10 seconds
-            WorkComplete::Incomplete(Some(Duration::from_secs(10)))
+            // Trigger app validation workflow again in 100-1000 milliseconds.
+            let interval = 900u64
+                .saturating_sub(validations_dependencies.missing_hashes.len() as u64 * 100)
+                + 100;
+            WorkComplete::Incomplete(Some(Duration::from_millis(interval)))
         } else {
             WorkComplete::Complete
         },


### PR DESCRIPTION
### Summary

Backport of #3884

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs