### PR TITLE
NETAUDIT cross-crate tracing target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6692,9 +6692,9 @@ dependencies = [
 
 [[package]]
 name = "sbd-client"
-version = "0.0.4-alpha"
+version = "0.0.5-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0085c09324634c08502f332f979b5b6c5a6d26f55333a271abfde1d5e2c8342c"
+checksum = "2bff8b5e22ff3d13f41b3b8318dcfb5303eb9903399ce82d25bcbf84742a0509"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -6705,25 +6705,27 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.25.0",
  "tokio-tungstenite",
+ "tracing",
  "webpki-roots 0.26.2",
 ]
 
 [[package]]
 name = "sbd-e2e-crypto-client"
-version = "0.0.4-alpha"
+version = "0.0.5-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f371aef1df1d87cb916a3bb03858df6bcf56b26f837e3b16d6f5706366854dd"
+checksum = "d7f9e9ed5e1e817c0b57cf9625b0a823109267d3bfb06d5feec69e626bde59e8"
 dependencies = [
  "sbd-client",
  "sodoken 0.0.901-alpha",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "sbd-server"
-version = "0.0.4-alpha"
+version = "0.0.5-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7bb03d0e6d48afb63182446c53c103d66a3095dc0bab60e4d94e7b9efd1349"
+checksum = "39c6ba716e669f658476cf3c0924b8970f23937601e8c5bb8d03f1a7a8b638ea"
 dependencies = [
  "anstyle",
  "base64 0.22.1",
@@ -8224,9 +8226,9 @@ dependencies = [
 
 [[package]]
 name = "tx5"
-version = "0.0.12-alpha"
+version = "0.0.13-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ede483a3017108ff72aef3d3c0226d859a9aac81c11aa743557647be9ddd11"
+checksum = "4f3fa6f0662915bdc6e50ead429b24c42b9aa8d3f8e4f2c3cfc5974203cd31b8"
 dependencies = [
  "base64 0.22.1",
  "influxive-otel-atomic-obs",
@@ -8240,9 +8242,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-connection"
-version = "0.0.12-alpha"
+version = "0.0.13-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e6afe0d5e49c119edf0437e780d49062d4371554163773f2b232a9f147099f"
+checksum = "4af97cb5c4ef5c2c1c3a02a3b6025d7eacbfff0c7cc69c8ff49682668b7a1281"
 dependencies = [
  "bit_field",
  "tokio",
@@ -8254,9 +8256,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-core"
-version = "0.0.12-alpha"
+version = "0.0.13-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee5ec5a8a1e7a18f6b3a7c0ce6d9a356e853602740647e1b931c5fdf36a16fd7"
+checksum = "5dbcda1421f6ffc361133d90d3ad8b9df813c62b3a2b0bd205dfc33205162bdf"
 dependencies = [
  "app_dirs2",
  "base64 0.22.1",
@@ -8273,9 +8275,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion"
-version = "0.0.12-alpha"
+version = "0.0.13-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe0d39b45bd4c75ded5e75cae0f1eac04cf2259da9d8b1f71951690a320dc09"
+checksum = "8d18eeb48190fe7f1e2ae7a58802ef3cc8f6a3c8164550bd7a0bb6d9015a537a"
 dependencies = [
  "futures",
  "parking_lot 0.12.3",
@@ -8287,9 +8289,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-sys"
-version = "0.0.12-alpha"
+version = "0.0.13-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b7ae44b8e8eb8189509cbbd43738f44337440e931b779e82842b709310e956"
+checksum = "594e080a0c0883f526337ffeed768908a711e5eddddeeec7b65851faf0c3d211"
 dependencies = [
  "Inflector",
  "base64 0.22.1",
@@ -8306,9 +8308,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-turn"
-version = "0.0.12-alpha"
+version = "0.0.13-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c181e7ef2d58881cc2042c841a0308214224e97dea4ea56f6130c12fc16b8fe"
+checksum = "d8a35d3a876ab999f2ba39246676061ca1b2c24f0e3f632535c3e68bdc65f666"
 dependencies = [
  "base64 0.22.1",
  "dirs",
@@ -8324,9 +8326,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-signal"
-version = "0.0.12-alpha"
+version = "0.0.13-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21137a90c60e602a7672473ec22b06b5a948232ad644bf80f4949dac814756fb"
+checksum = "509f9e2ab94e4513084a34c1f89d23a2935206ed65c5ea14afbb3b286f7af47b"
 dependencies = [
  "rand 0.8.5",
  "sbd-e2e-crypto-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,8 @@ lto = true
 # tx5-go-pion-sys = { path = "../tx5/crates/tx5-go-pion-sys" }
 # tx5-go-pion-turn = { path = "../tx5/crates/tx5-go-pion-turn" }
 # tx5-signal = { path = "../tx5/crates/tx5-signal" }
+# sbd-e2e-crypto-client = { path = "../sbd/rust/sbd-e2e-crypto-client" }
+# sbd-server = { path = "../sbd/rust/sbd-server" }
 # tx5 = { git = "https://github.com/holochain/tx5.git", rev = "f0f009f77a84c96c2acded6b27df27ece3f7dbbb" }
 # tx5-signal = { git = "https://github.com/holochain/tx5.git", rev = "f0f009f77a84c96c2acded6b27df27ece3f7dbbb" }
 # tx5-go-pion-turn = { git = "https://github.com/holochain/tx5.git", rev = "f0f009f77a84c96c2acded6b27df27ece3f7dbbb" }

--- a/crates/hc_run_local_services/Cargo.toml
+++ b/crates/hc_run_local_services/Cargo.toml
@@ -25,7 +25,7 @@ futures = "0.3"
 holochain_trace = { version = "^0.4.0-dev.3", path = "../holochain_trace" }
 if-addrs = "0.12"
 kitsune_p2p_bootstrap = { version = "^0.3.0-dev.8", path = "../kitsune_p2p/bootstrap" }
-sbd-server = "=0.0.4-alpha"
+sbd-server = "=0.0.5-alpha"
 tokio = { version = "1.36.0", features = ["full"] }
 tracing = "0.1"
 

--- a/crates/hc_service_check/Cargo.toml
+++ b/crates/hc_service_check/Cargo.toml
@@ -10,8 +10,8 @@ license = "Apache-2.0"
 clap = { version = "4.5.3", features = ["derive", "wrap_help"] }
 tokio = { version = "1.36.0", features = ["full"] }
 kitsune_p2p_bootstrap_client = { version = "^0.4.0-dev.8", path = "../kitsune_p2p/bootstrap_client" }
-tx5-go-pion = { version = "0.0.12-alpha" }
-tx5-signal = { version = "0.0.12-alpha" }
+tx5-go-pion = { version = "0.0.13-alpha" }
+tx5-signal = { version = "0.0.13-alpha" }
 url2 = "0.0.6"
 
 [lints]

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -103,8 +103,8 @@ matches = { version = "0.1.8", optional = true }
 holochain_test_wasm_common = { version = "^0.4.0-dev.7", path = "../test_utils/wasm_common", optional = true }
 kitsune_p2p_bootstrap = { version = "^0.3.0-dev.8", path = "../kitsune_p2p/bootstrap", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
-sbd-server = { version = "=0.0.4-alpha", optional = true }
-tx5-go-pion-turn = { version = "=0.0.12-alpha", optional = true }
+sbd-server = { version = "=0.0.5-alpha", optional = true }
+tx5-go-pion-turn = { version = "=0.0.13-alpha", optional = true }
 
 # chc deps
 bytes = { version = "1", optional = true }

--- a/crates/holochain/src/docs.rs
+++ b/crates/holochain/src/docs.rs
@@ -1,0 +1,43 @@
+//! Holochain conductor usage documentation.
+
+/// How holochain conductor makes use of rust tracing/logging.
+///
+/// ### `RUST_LOG` Environment Variable
+///
+/// See the [tracing-subscriber](https://crates.io/crates/tracing-subscriber)
+/// crate's documentation for usage of the EnvFilter. Essentially you can
+/// specify tracing/logging levels via the environment variable RUST_LOG.
+///
+/// Examples:
+/// - `RUST_LOG=warn` - only print warn and error levels
+/// - `RUST_LOG=trace` - print ALL very verbose tracing logs
+/// - `RUST_LOG=off,NETAUDIT=trace` - print ONLY the "NETAUDIT" target tracing
+///
+/// ### Conductor Config `tracing_override` Field
+///
+/// If, for some reason you cannot specify an environment variable, you
+/// can also set the tracing level via the conductor config
+/// `tracing_override` field.
+///
+/// ### `NETAUDIT` Target
+///
+/// The special `NETAUDIT` target is a cross-crate tracing target for
+/// getting a handle on what conductor is doing with remote communications
+/// under the hood. Specific traces are output in:
+/// - sbd-client
+/// - tx5-connection
+/// - tx5
+/// - kitsune_p2p
+/// - and holochain itself
+///
+/// Where appropriate, try to set some standardized properties on the trace:
+///
+/// - `m` - module or crate in which the trace is defined
+/// - `t` - type or additional internal context for making sense of the trace
+/// - `a` - action or event described by the trace
+///
+/// E.g.: `m="tx5" t="signal" a="connected"`
+///
+/// To see the output, use a tracing configuration such as
+/// `RUST_LOG=off,NETAUDIT=trace`.
+pub mod tracing {}

--- a/crates/holochain/src/lib.rs
+++ b/crates/holochain/src/lib.rs
@@ -6,6 +6,9 @@
 #![allow(clippy::ptr_arg)]
 #![recursion_limit = "256"]
 
+#[cfg(doc)]
+pub mod docs;
+
 #[cfg(feature = "hdk")]
 pub use hdk::HDI_VERSION;
 

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -46,7 +46,7 @@ thiserror = "1.0.22"
 tokio = { version = "1.36.0", features = ["full"] }
 tracing = "0.1"
 tokio-stream = "0.1"
-tx5 = { version = "=0.0.12-alpha", optional = true }
+tx5 = { version = "=0.0.13-alpha", optional = true }
 url2 = "0.0.6"
 fixt = { path = "../../fixt", version = "^0.4.0-dev.2"}
 
@@ -73,7 +73,7 @@ kitsune_p2p_timestamp = { path = "../timestamp", features = [
 kitsune_p2p_types = { path = "../types", features = ["test_utils"] }
 maplit = "1"
 pretty_assertions = "1.4.0"
-sbd-server = "=0.0.4-alpha"
+sbd-server = "=0.0.5-alpha"
 test-case = "3.3"
 tokio = { version = "1.11", features = ["full", "test-util"] }
 tracing-subscriber = "0.3.16"

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs
@@ -297,6 +297,7 @@ impl ShardedGossip {
             }
             HowToConnect::Url(url) => self.ep_hnd.get_connection(url, timeout).await?,
         };
+
         // Wait for enough available outgoing bandwidth here before
         // actually sending the gossip.
         con.notify(&wire, timeout).await?;
@@ -325,7 +326,12 @@ impl ShardedGossip {
         };
 
         if let Some(msg) = outgoing.as_ref() {
-            tracing::debug!(
+            let remote_url = match &msg.1 {
+                HowToConnect::Con(_, url) => url.clone(),
+                HowToConnect::Url(url) => url.clone(),
+            };
+            tracing::trace!(
+                target: "NETAUDIT",
                 "OUTGOING GOSSIP [{}]  => {:17} ({:10}) : this -> {:?} [{}]",
                 gossip_type_char,
                 msg.2
@@ -333,7 +339,7 @@ impl ShardedGossip {
                     .to_string()
                     .replace("ShardedGossipWire::", ""),
                 msg.2.encode_vec().expect("can't encode msg").len(),
-                &msg.0,
+                remote_url,
                 self.gossip
                     .inner
                     .share_mut(|s, _| Ok(s.round_map.current_rounds().len()))
@@ -354,12 +360,13 @@ impl ShardedGossip {
                 .await
             {
                 Ok(r) => {
-                    tracing::debug!(
+                    tracing::trace!(
+                        target: "NETAUDIT",
                         "INCOMING GOSSIP [{}] <=  {:17} ({:10}) : {:?} -> this [{}]",
                         gossip_type_char,
                         variant_type,
                         len,
-                        con.peer_id(),
+                        remote_url,
                         self.gossip
                             .inner
                             .share_mut(|s, _| Ok(s.round_map.current_rounds().len()))


### PR DESCRIPTION
Includes changes:
- https://github.com/holochain/sbd/pull/30
- https://github.com/holochain/tx5/pull/95

Allows tracing in the form: `RUST_LOG=off,NETAUDIT=debug` resulting in logs like:

```
2024-06-17T21:11:31.160492Z DEBUG NETAUDIT: /home/neonphog/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tx5-0.0.13-alpha/src/sig.rs:96: config=Config { signal_allow_plain_text: true, initial_webrtc_config: "{\n  \"iceServers\": [\n    { \"urls\": \"stun:stun-0.main.infra.holo.host:443\" },\n    { \"urls\": \"stun:stun-1.main.infra.holo.host:443\" }\n  ]\n}", connection_count_max: 4096, send_buffer_bytes_max: 65536, recv_buffer_bytes_max: 65536, incoming_message_bytes_max: 536870912, message_size_max: 16777216, internal_event_channel_size: 1024, timeout: 60s, backoff_start: 5s, backoff_max: 60s } sig_url=SigUrl("ws://127.0.0.1:44107") listener=true m="tx5" t="signal" a="try_connect"
2024-06-17T21:11:31.204539Z DEBUG NETAUDIT: /home/neonphog/.cargo/registry/src/index.crates.io-6f17d22bba15001f/sbd-client-0.0.5-alpha/src/send_buf.rs:28: full_url="ws://127.0.0.1:44107/14jG3kF0f8CbFPqW5qb_104gFtIcIq61E3DMCk8rnLY" kbps=8000000 m="sbd-client" a="initial_rate_limit"
2024-06-17T21:11:31.204716Z DEBUG NETAUDIT: /home/neonphog/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tx5-0.0.13-alpha/src/sig.rs:226: local_url=PeerUrl("ws://127.0.0.1:44107/14jG3kF0f8CbFPqW5qb_104gFtIcIq61E3DMCk8rnLY") m="tx5" t="signal" a="connected"
```

Or `RUST_LOG=off,NETAUDIT=trace`:

```
2024-06-17T21:16:37.955398Z TRACE kitsune metric task{scope="1.BlKk-"}: NETAUDIT: /home/neonphog/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tx5-connection-0.0.13-alpha/src/framed.rs:193: pub_key=imq9MsBD2E2taS1iyIqiqVWo9LMUKqK1roreClSYhKU byte_count=431 m="tx5-connection" a="send_framed_success"
2024-06-17T21:16:37.960501Z TRACE kitsune metric task{scope="0.MS8Lg"}: NETAUDIT: crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs:363: INCOMING GOSSIP [H] <=  OpRegions         (      8095) : "ws://127.0.0.1:38531/ZXntngET01xKyjk_QUy7gvmixxQ7Z_w8Kb9-tIuZ0U0" -> this [1]
2024-06-17T21:16:37.966342Z TRACE NETAUDIT: /home/neonphog/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tx5-connection-0.0.13-alpha/src/framed.rs:83: pub_key=ZXntngET01xKyjk_QUy7gvmixxQ7Z_w8Kb9-tIuZ0U0 byte_count=431 m="tx5-connection" a="recv_framed"
2024-06-17T21:16:38.062768Z TRACE kitsune metric task{scope="0.MS8Lg"}: NETAUDIT: crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip.rs:333: OUTGOING GOSSIP [H]  => MissingOpHashes   (       778) : this -> "ws://127.0.0.1:38531/ZXntngET01xKyjk_QUy7gvmixxQ7Z_w8Kb9-tIuZ0U0" [1]
```