### PR TITLE
Add gossip op diff metrics

### DIFF
--- a/crates/holochain_metrics/src/lib.rs
+++ b/crates/holochain_metrics/src/lib.rs
@@ -87,6 +87,8 @@
 //! | ---------------- | ---- | --------------- | ----------- | ---------- |
 //! | `kitsune.peer.send.duration` | `f64_histogram` | `s` | When kitsune sends data to a remote peer. |- `remote_id`: the base64 remote peer id.<br />- `is_error`: if the send failed. |
 //! | `kitsune.peer.send.byte.count` | `u64_histogram` | `By` | When kitsune sends data to a remote peer. |- `remote_id`: the base64 remote peer id.<br />- `is_error`: if the send failed. |
+//! | `kitsune.gossip.generate_op_blooms.duration` | `f64_histogram` | `s` | The time taken to generate op blooms for gossip. | |
+//! | `kitsune.gossip.generate_op_region_set.duration` | `f64_histogram` | `s` | The time taken to generate op region sets for gossip. | |
 //! | `tx5.conn.ice.send` | `u64_observable_counter` | `By` | Bytes sent on ice channel. |- `remote_id`: the base64 remote peer id.<br />- `state_uniq`: endpoint identifier.<br />- `conn_uniq`: connection identifier. |
 //! | `tx5.conn.ice.recv` | `u64_observable_counter` | `By` | Bytes received on ice channel. |- `remote_id`: the base64 remote peer id.<br />- `state_uniq`: endpoint identifier.<br />- `conn_uniq`: connection identifier. |
 //! | `tx5.conn.data.send` | `u64_observable_counter` | `By` | Bytes sent on data channel. |- `remote_id`: the base64 remote peer id.<br />- `state_uniq`: endpoint identifier.<br />- `conn_uniq`: connection identifier. |

--- a/crates/holochain_metrics/src/lib.rs
+++ b/crates/holochain_metrics/src/lib.rs
@@ -87,8 +87,8 @@
 //! | ---------------- | ---- | --------------- | ----------- | ---------- |
 //! | `kitsune.peer.send.duration` | `f64_histogram` | `s` | When kitsune sends data to a remote peer. |- `remote_id`: the base64 remote peer id.<br />- `is_error`: if the send failed. |
 //! | `kitsune.peer.send.byte.count` | `u64_histogram` | `By` | When kitsune sends data to a remote peer. |- `remote_id`: the base64 remote peer id.<br />- `is_error`: if the send failed. |
-//! | `kitsune.gossip.generate_op_blooms.duration` | `f64_histogram` | `s` | The time taken to generate op blooms for gossip. | |
-//! | `kitsune.gossip.generate_op_region_set.duration` | `f64_histogram` | `s` | The time taken to generate op region sets for gossip. | |
+//! | `kitsune.gossip.generate_op_blooms.duration` | `f64_histogram` | `s` | The time taken to generate op blooms for gossip. | - `space`: The space (dna_hash representation) that gossip is being performed for.<br />- `batch_size`: The number of ops that were included in the bloom batch for this observation. |
+//! | `kitsune.gossip.generate_op_region_set.duration` | `f64_histogram` | `s` | The time taken to generate op region sets for gossip. | - `space`: The space (dna_hash representation) that gossip is being performed for. |
 //! | `tx5.conn.ice.send` | `u64_observable_counter` | `By` | Bytes sent on ice channel. |- `remote_id`: the base64 remote peer id.<br />- `state_uniq`: endpoint identifier.<br />- `conn_uniq`: connection identifier. |
 //! | `tx5.conn.ice.recv` | `u64_observable_counter` | `By` | Bytes received on ice channel. |- `remote_id`: the base64 remote peer id.<br />- `state_uniq`: endpoint identifier.<br />- `conn_uniq`: connection identifier. |
 //! | `tx5.conn.data.send` | `u64_observable_counter` | `By` | Bytes sent on data channel. |- `remote_id`: the base64 remote peer id.<br />- `state_uniq`: endpoint identifier.<br />- `conn_uniq`: connection identifier. |

--- a/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/gossip/sharded_gossip/ops.rs
@@ -175,7 +175,7 @@ impl ShardedGossipLocal {
             .flatten()
             .collect();
 
-        // // TODO: make region set diffing more robust to different times (arc power differences are already handled)
+        // TODO: make region set diffing more robust to different times (arc power differences are already handled)
 
         let finished_val = if finished { 2 } else { 1 };
         Ok(vec![ShardedGossipWire::missing_op_hashes(

--- a/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/metrics.rs
@@ -39,6 +39,24 @@ pub(crate) static METRIC_MSG_OUT_TIME: Lazy<opentelemetry_api::metrics::Histogra
             .init()
     });
 
+pub(crate) static GENERATE_OP_BLOOMS_TIME: Lazy<opentelemetry_api::metrics::Histogram<f64>> =
+    Lazy::new(|| {
+        opentelemetry_api::global::meter("kitsune")
+            .f64_histogram("kitsune.gossip.generate_op_blooms.duration")
+            .with_description("Time taken to generate op blooms for gossip")
+            .with_unit(opentelemetry_api::metrics::Unit::new("s"))
+            .init()
+    });
+
+pub(crate) static GENERATE_OP_REGION_SET_TIME: Lazy<opentelemetry_api::metrics::Histogram<f64>> =
+    Lazy::new(|| {
+        opentelemetry_api::global::meter("kitsune")
+            .f64_histogram("kitsune.gossip.generate_op_region_set.duration")
+            .with_description("Time taken to generate region set for gossip")
+            .with_unit(opentelemetry_api::metrics::Unit::new("s"))
+            .init()
+    });
+
 /// how long historical metric records should be kept
 /// (currently set to 1 week)
 const HISTORICAL_RECORD_EXPIRE_DURATION_MICROS: i64 = 1000 * 1000 * 60 * 60 * 24 * 7;


### PR DESCRIPTION
### Summary

Supporting change for https://github.com/holochain/wind-tunnel/issues/55. To finish that ticket we'll still need some way to retrieve metrics from a remote Holochain.

I think these are reasonable places to trace how much time we're spending looking up data from the Kitsune host and figuring out what ops need to be sent for recent and historical gossip.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs