### PR TITLE
Allow Enabling app from app interface for special app status

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Adds a new `DisabledAppReason::MemproofsProvided` variant which effectively allows a new app status, corresponding to the specific state where a UI has just called `AppRequest::ProvideMemproofs`, but the app has not yet been Enabled for the first time.
+- Adds a new app interface method `AppRequest::EnableAfterMemproofsProvided`, which allows enabling an app only if the app is in the `AppStatus::Disabled(DisabledAppReason::MemproofsProvided)` state. Attempting to enable the app from other states (other than Running) will fail.
+
 ## 0.4.0-dev.10
 
 ## 0.4.0-dev.9

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,8 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Adds a new `DisabledAppReason::MemproofsProvided` variant which effectively allows a new app status, corresponding to the specific state where a UI has just called `AppRequest::ProvideMemproofs`, but the app has not yet been Enabled for the first time.
-- Adds a new app interface method `AppRequest::EnableAfterMemproofsProvided`, which allows enabling an app only if the app is in the `AppStatus::Disabled(DisabledAppReason::MemproofsProvided)` state. Attempting to enable the app from other states (other than Running) will fail.
+- Adds a new `DisabledAppReason::NotStartedAfterProvidingMemproofs` variant which effectively allows a new app status, corresponding to the specific state where a UI has just called `AppRequest::ProvideMemproofs`, but the app has not yet been Enabled for the first time.
+- Adds a new app interface method `AppRequest::EnableAfterMemproofsProvided`, which allows enabling an app only if the app is in the `AppStatus::Disabled(DisabledAppReason::NotStartedAfterProvidingMemproofs)` state. Attempting to enable the app from other states (other than Running) will fail.
 
 ## 0.4.0-dev.10
 

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -149,7 +149,8 @@ impl AppInterfaceApi {
                     .ok_or(ConductorApiError::other("app not found".to_string()))?
                     .status;
                 match status {
-                    AppInfoStatus::Disabled {
+                    AppInfoStatus::Running
+                    | AppInfoStatus::Disabled {
                         reason: DisabledAppReason::MemproofsProvided,
                     } => {
                         self.conductor_handle

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -141,7 +141,7 @@ impl AppInterfaceApi {
                     .await?;
                 Ok(AppResponse::Ok)
             }
-            AppRequest::EnableAfterMemproofsProvided => {
+            AppRequest::EnableApp => {
                 let status = self
                     .conductor_handle
                     .get_app_info(&installed_app_id)

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -151,7 +151,7 @@ impl AppInterfaceApi {
                 match status {
                     AppInfoStatus::Running
                     | AppInfoStatus::Disabled {
-                        reason: DisabledAppReason::MemproofsProvided,
+                        reason: DisabledAppReason::NotStartedAfterProvidingMemproofs,
                     } => {
                         self.conductor_handle
                             .clone()

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1709,7 +1709,8 @@ mod app_impls {
                 let installed_app_id = installed_app_id.clone();
                 move |mut state| {
                     let app = state.get_app_mut(&installed_app_id)?;
-                    app.status = AppStatus::Disabled(DisabledAppReason::MemproofsProvided);
+                    app.status =
+                        AppStatus::Disabled(DisabledAppReason::NotStartedAfterProvidingMemproofs);
                     Ok(state)
                 }
             })

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1709,7 +1709,7 @@ mod app_impls {
                 let installed_app_id = installed_app_id.clone();
                 move |mut state| {
                     let app = state.get_app_mut(&installed_app_id)?;
-                    app.status = AppStatus::Disabled(DisabledAppReason::NeverStarted);
+                    app.status = AppStatus::Disabled(DisabledAppReason::MemproofsProvided);
                     Ok(state)
                 }
             })

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -1177,7 +1177,7 @@ async fn test_init_concurrency() {
 /// - conductor can be restarted and app still in AwaitingMemproofs state,
 /// - app functions normally after memproofs provided
 #[tokio::test(flavor = "multi_thread")]
-async fn test_deferred_provisioning() {
+async fn test_deferred_memproof_provisioning() {
     holochain_trace::test_run();
     let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Foo]).await;
     let mut conductor = SweetConductor::from_standard_config().await;
@@ -1265,6 +1265,17 @@ async fn test_deferred_provisioning() {
         .await
         .unwrap();
 
+    //- Status is now Disabled with the special `MemproofsProvided` reason.
+    //    It's not tested in this test, but this status allows the app to be enabled
+    //    over the app interface.
+    let app_info = conductor.get_app_info(&app_id).await.unwrap().unwrap();
+    assert_eq!(
+        app_info.status,
+        AppInfoStatus::Disabled {
+            reason: DisabledAppReason::MemproofsProvided
+        }
+    );
+
     conductor.enable_app(app_id.clone()).await.unwrap();
 
     //- Status is now Running and there is 1 cell assignment
@@ -1277,7 +1288,7 @@ async fn test_deferred_provisioning() {
 
 /// Can uninstall an app with deferred memproofs before providing memproofs
 #[tokio::test(flavor = "multi_thread")]
-async fn test_deferred_provisioning_uninstall() {
+async fn test_deferred_memproof_provisioning_uninstall() {
     holochain_trace::test_run();
     let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Foo]).await;
     let conductor = SweetConductor::from_standard_config().await;

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -1265,14 +1265,14 @@ async fn test_deferred_memproof_provisioning() {
         .await
         .unwrap();
 
-    //- Status is now Disabled with the special `MemproofsProvided` reason.
+    //- Status is now Disabled with the special `NotStartedAfterProvidingMemproofs` reason.
     //    It's not tested in this test, but this status allows the app to be enabled
     //    over the app interface.
     let app_info = conductor.get_app_info(&app_id).await.unwrap().unwrap();
     assert_eq!(
         app_info.status,
         AppInfoStatus::Disabled {
-            reason: DisabledAppReason::MemproofsProvided
+            reason: DisabledAppReason::NotStartedAfterProvidingMemproofs
         }
     );
 

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_agent_activity.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_agent_activity.rs
@@ -160,6 +160,7 @@ pub mod test {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[cfg_attr(target_os = "macos", ignore = "flaky")]
     async fn ribosome_must_get_agent_activity() {
         holochain_trace::test_run();
         let RibosomeTestFixture {
@@ -220,6 +221,9 @@ pub mod test {
         let d: ActionHash = conductor
             .call(&bob, "commit_something", Something(vec![21]))
             .await;
+
+        // Give bob time to integrate
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
         let _: ActionHash = conductor
             .call(

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -169,7 +169,7 @@ async fn sys_validation_produces_forked_chain_warrant() {
         .trigger(&"test");
 
     //- Check that bob authored a chain fork warrant
-    crate::wait_for_10s!(
+    crate::wait_for_1m!(
         {
             let basis: AnyLinkableHash = alice_pubkey.clone().into();
             conductors[1]

--- a/crates/holochain/tests/tests/app_interface_security.rs
+++ b/crates/holochain/tests/tests/app_interface_security.rs
@@ -171,6 +171,7 @@ async fn app_interface_requires_auth() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn app_interface_can_handle_bad_auth_payload() {
     holochain_trace::test_run();
 

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -85,12 +85,14 @@ pub enum AppRequest {
     /// [`AppResponse::Ok`]
     ProvideMemproofs(MemproofMap),
 
-    /// Enable the app. Can only be called while the app is in the `MemproofsProvided` state.
+    /// Enable the app, only in special circumstances.
+    /// Can only be called while the app is in the `Disabled(MemproofsProvided)` state.
+    /// Cannot be used to enable the app if it's in any other state, or Disabled for any other reason.
     ///
     /// # Returns
     ///
     /// [`AppResponse::Ok`]
-    EnableAfterMemproofsProvided,
+    EnableApp,
     //
     // TODO: implement after DPKI lands
     // /// Replace the agent key associated with this app with a new one.

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -84,6 +84,13 @@ pub enum AppRequest {
     ///
     /// [`AppResponse::Ok`]
     ProvideMemproofs(MemproofMap),
+
+    /// Enable the app. Can only be called while the app is in the `MemproofsProvided` state.
+    ///
+    /// # Returns
+    ///
+    /// [`AppResponse::Ok`]
+    EnableAfterMemproofsProvided,
     //
     // TODO: implement after DPKI lands
     // /// Replace the agent key associated with this app with a new one.

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -86,7 +86,7 @@ pub enum AppRequest {
     ProvideMemproofs(MemproofMap),
 
     /// Enable the app, only in special circumstances.
-    /// Can only be called while the app is in the `Disabled(MemproofsProvided)` state.
+    /// Can only be called while the app is in the `Disabled(NotStartedAfterProvidingMemproofs)` state.
     /// Cannot be used to enable the app if it's in any other state, or Disabled for any other reason.
     ///
     /// # Returns

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -470,12 +470,10 @@ pub enum ScottyPanel {
     GossipInfo { last_round: Option<Timestamp> },
 }
 
-// once this is in stable, replace the pinned version in the URL by `latest``
-/// The request payload that should be sent in a [`WireMessage::Authenticate`](https://docs.rs/holochain_websocket/0.3.0-beta-dev.22/holochain_websocket/enum.WireMessage.html#variant.Authenticate) message.
+/// The request payload that should be sent in a [`holochain_websocket::WireMessage::Authenticate`]
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, SerializedBytes)]
 pub struct AppAuthenticationRequest {
-    // once this is in stable, replace the pinned version in the URL by `latest``
-    /// The authentication token that was provided by the conductor when [`AdminRequest::IssueAppInterfaceToken`](https://docs.rs/holochain_conductor_api/0.3.0-beta-dev.47/holochain_conductor_api/enum.AdminRequest.html#variant.IssueAppAuthenticationToken) was called.
+    /// The authentication token that was provided by the conductor when [`AdminRequest::IssueAppInterfaceToken`] was called.
     pub token: AppAuthenticationToken,
 }
 

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -966,6 +966,9 @@ pub enum StoppedAppReason {
 
     /// Same meaning as [`InstalledAppInfoStatus::Disabled`](https://docs.rs/holochain_conductor_api/0.0.33/holochain_conductor_api/enum.InstalledAppInfoStatus.html#variant.Disabled).
     Disabled(DisabledAppReason),
+
+    /// Same meaning as [`InstalledAppInfoStatus::AwaitingMemProofs`](https://docs.rs/holochain_conductor_api/0.0.33/holochain_conductor_api/enum.InstalledAppInfoStatus.html#variant.AwaitingMemProofs).
+    AwaitingMemproofs,
 }
 
 impl StoppedAppReason {
@@ -975,9 +978,7 @@ impl StoppedAppReason {
         match status {
             AppStatus::Paused(reason) => Some(Self::Paused(reason.clone())),
             AppStatus::Disabled(reason) => Some(Self::Disabled(reason.clone())),
-            AppStatus::AwaitingMemproofs => {
-                Some(Self::Disabled(DisabledAppReason::AwaitingMemproofs))
-            }
+            AppStatus::AwaitingMemproofs => Some(Self::AwaitingMemproofs),
             AppStatus::Running => None,
         }
     }
@@ -988,6 +989,7 @@ impl From<StoppedAppReason> for AppStatus {
         match reason {
             StoppedAppReason::Paused(reason) => Self::Paused(reason),
             StoppedAppReason::Disabled(reason) => Self::Disabled(reason),
+            StoppedAppReason::AwaitingMemproofs => Self::AwaitingMemproofs,
         }
     }
 }
@@ -1007,8 +1009,6 @@ pub enum PausedAppReason {
 pub enum DisabledAppReason {
     /// The app is freshly installed, and never started
     NeverStarted,
-    /// The app is partially installed, i.e. awaiting membrane proofs
-    AwaitingMemproofs,
     /// The app is fully installed and deferred memproofs have been provided by the UI,
     /// but the app has not been enabled. The app can be enabled via the app interface.
     MemproofsProvided,

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -961,13 +961,13 @@ impl AppStatusFx {
 )]
 #[serde(rename_all = "snake_case")]
 pub enum StoppedAppReason {
-    /// Same meaning as [`InstalledAppInfoStatus::Paused`](https://docs.rs/holochain_conductor_api/0.0.33/holochain_conductor_api/enum.InstalledAppInfoStatus.html#variant.Paused).
+    /// Same meaning as [`AppStatus::Paused`].
     Paused(PausedAppReason),
 
-    /// Same meaning as [`InstalledAppInfoStatus::Disabled`](https://docs.rs/holochain_conductor_api/0.0.33/holochain_conductor_api/enum.InstalledAppInfoStatus.html#variant.Disabled).
+    /// Same meaning as [`AppStatus::Disabled`].
     Disabled(DisabledAppReason),
 
-    /// Same meaning as [`InstalledAppInfoStatus::AwaitingMemProofs`](https://docs.rs/holochain_conductor_api/0.0.33/holochain_conductor_api/enum.InstalledAppInfoStatus.html#variant.AwaitingMemProofs).
+    /// Same meaning as [`AppStatus::AwaitingMemProofs`].
     AwaitingMemproofs,
 }
 

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -1009,6 +1009,9 @@ pub enum DisabledAppReason {
     NeverStarted,
     /// The app is partially installed, i.e. awaiting membrane proofs
     AwaitingMemproofs,
+    /// The app is fully installed and deferred memproofs have been provided by the UI,
+    /// but the app has not been enabled. The app can be enabled via the app interface.
+    MemproofsProvided,
     /// The disabling was done manually by the user (via admin interface)
     User,
     /// The disabling was due to an UNRECOVERABLE error

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -1010,8 +1010,10 @@ pub enum DisabledAppReason {
     /// The app is freshly installed, and never started
     NeverStarted,
     /// The app is fully installed and deferred memproofs have been provided by the UI,
-    /// but the app has not been enabled. The app can be enabled via the app interface.
-    MemproofsProvided,
+    /// but the app has not been enabled.
+    /// The app can be enabled via the app interface in this state, which is why this is
+    /// separate from other disabled states.
+    NotStartedAfterProvidingMemproofs,
     /// The disabling was done manually by the user (via admin interface)
     User,
     /// The disabling was due to an UNRECOVERABLE error


### PR DESCRIPTION
### Summary

When using deferred memproofs, there is a state where the UI has provided memproofs, but the app remains disabled, and the only way to enable it would be via the admin interface. This is awkward for the usual flow of UI-provided memproofs. So, this PR adds a new app state to differentiate the post-memproof-provisioning state from other flavors of Disabled, and in that state, allows a new app websocket method to be used to enable the app from the UI.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs