### PR TITLE
Fix some flakes

### DIFF
--- a/crates/holochain/src/core/ribosome/host_fn/create.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/create.rs
@@ -298,7 +298,7 @@ pub mod wasm_test {
 
                 assert_eq!(record.unwrap().action_address(), &action_hash);
             },
-            4_000_000
+            11_000_000
         );
     }
 

--- a/crates/holochain/tests/tests/app_interface_security.rs
+++ b/crates/holochain/tests/tests/app_interface_security.rs
@@ -138,7 +138,7 @@ async fn app_interface_requires_auth() {
         .request::<_, AppResponse>(AppRequest::AppInfo)
         .await
         .unwrap_err();
-    assert_eq!("ConnectionClosed", err.to_string());
+    assert!(correct_error(&err));
 
     let token = create_token(&conductor, "test-app".into()).await;
 
@@ -149,7 +149,7 @@ async fn app_interface_requires_auth() {
         })
         .await
         .unwrap_err();
-    assert_eq!("WebsocketClosed", err.to_string());
+    assert!(correct_error(&err));
 
     // Token didn't get used above, so create a new connection and try to use it
     let (app_tx, app_rx) = websocket_client_by_port(app_port).await.unwrap();
@@ -198,7 +198,7 @@ async fn app_interface_can_handle_bad_auth_payload() {
         })
         .await
         .unwrap_err();
-    assert_eq!("WebsocketClosed", err.to_string());
+    assert!(correct_error(&err));
 
     // Open a new connection
     let (app_tx, app_rx) = websocket_client_by_port(app_port).await.unwrap();
@@ -256,7 +256,7 @@ async fn app_interfaces_can_be_bound_to_apps() {
         .request::<_, AppResponse>(AppRequest::ListWasmHostFunctions)
         .await
         .unwrap_err();
-    assert_eq!("ConnectionClosed", err.to_string());
+    assert!(correct_error(&err));
 
     // Now create a token for the correct app and try again
     let token = create_token(&conductor, "test-app".into()).await;


### PR DESCRIPTION
### Summary

These websocket tests seem to get confused about which flavor of closed connection they should encounter. Assuming this is not actually a problem, let's just make both OK.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs