### PR TITLE
Warrant-friendly consistency awaiting

### DIFF
--- a/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
@@ -143,7 +143,9 @@ mod test {
         let action1: ActionHash = alice_conductor.call(&alice, "create_entry", ()).await;
 
         // Now that bob is blocked by alice he cannot get data from alice.
-        await_consistency(10, [&alice_cell]).await.unwrap();
+        await_consistency_advanced(10, vec![], [(&alice_cell, true), (&bob_cell, false)])
+            .await
+            .unwrap();
         let bob_get1: Option<Record> = bob_conductor.call(&bob, "get_post", action1.clone()).await;
 
         assert!(bob_get1.is_none());

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -157,14 +157,6 @@ async fn test_block_invalid_receipt() {
         ))?;
         Ok(hash)
     });
-    // .function(
-    //     coordinator_name,
-    //     get_function_name,
-    //     move |api, hash: AnyDhtHash| {
-    //         let records = api.get(vec![GetInput::new(hash, Default::default())])?;
-    //         Ok(records[0])
-    //     },
-    // );
 
     let zomes_that_check = InlineZomeSet::new_single(
         integrity_name,
@@ -217,7 +209,7 @@ async fn test_block_invalid_receipt() {
         .call(&alice_cell.zome(coordinator_name), create_function_name, ())
         .await;
 
-    await_consistency(10, [&alice_cell, &bob_cell])
+    await_consistency_conditional(10, Some(1), [&alice_cell, &bob_cell])
         .await
         .unwrap();
 

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -208,7 +208,7 @@ async fn test_block_invalid_receipt() {
         .call(&alice_cell.zome(coordinator_name), create_function_name, ())
         .await;
 
-    // await_consistency_conditional(60, vec![(alice_pubkey, 1)], [&alice_cell, &bob_cell])
+    // Don't check alice's integrated ops, since she gets blocked during gossip
     await_consistency_advanced(
         10,
         vec![(alice_pubkey, 1)],

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -209,7 +209,7 @@ async fn test_block_invalid_receipt() {
         .call(&alice_cell.zome(coordinator_name), create_function_name, ())
         .await;
 
-    await_consistency_conditional(10, Some(1), [&alice_cell, &bob_cell])
+    await_consistency_conditional(60, vec![(alice_pubkey, 1)], [&alice_cell, &bob_cell])
         .await
         .unwrap();
 

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -170,7 +170,6 @@ async fn test_block_invalid_receipt() {
         Op::StoreEntry(StoreEntry { action, .. })
             if action.hashed.content.app_entry_def().is_some() =>
         {
-            dbg!("entry defs ARE bad!");
             Ok(ValidateResult::Invalid("Entry defs are bad".into()))
         }
         _ => Ok(ValidateResult::Valid),
@@ -209,9 +208,14 @@ async fn test_block_invalid_receipt() {
         .call(&alice_cell.zome(coordinator_name), create_function_name, ())
         .await;
 
-    await_consistency_conditional(60, vec![(alice_pubkey, 1)], [&alice_cell, &bob_cell])
-        .await
-        .unwrap();
+    // await_consistency_conditional(60, vec![(alice_pubkey, 1)], [&alice_cell, &bob_cell])
+    await_consistency_advanced(
+        10,
+        vec![(alice_pubkey, 1)],
+        [(&alice_cell, false), (&bob_cell, true)],
+    )
+    .await
+    .unwrap();
 
     let alice_block_target = BlockTargetId::Cell(alice_cell.cell_id().to_owned());
     let bob_block_target = BlockTargetId::Cell(bob_cell.cell_id().to_owned());

--- a/crates/holochain/src/sweettest/sweet_consistency.rs
+++ b/crates/holochain/src/sweettest/sweet_consistency.rs
@@ -35,7 +35,7 @@ pub async fn await_consistency<'a, I: IntoIterator<Item = &'a SweetCell>>(
     timeout: impl Into<DurationOrSeconds>,
     all_cells: I,
 ) -> ConsistencyResult {
-    await_consistency_advanced(timeout, None, all_cells.into_iter().map(|c| (c, true))).await
+    await_consistency_advanced(timeout, (), all_cells.into_iter().map(|c| (c, true))).await
 }
 
 /// Wait for all cells to reach consistency

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -513,7 +513,7 @@ async fn delay(elapsed: Duration) {
 /// However, in cases where more publishing is expected, such as when warrants will be authored
 /// due to recently publishing invalid ops, these conditions can be used to make sure that
 /// the consistency check will not proceed until all publishing expectations have occurred.
-#[derive(Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ConsistencyConditions {
     /// This many warrants must have been published against the keyed agent.
     warrants_issued: HashMap<AgentPubKey, usize>,

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -507,7 +507,7 @@ async fn delay(elapsed: Duration) {
 }
 
 /// Extra conditions that must be satisfied for consistency to be reached.
-/// 
+///
 /// Without supplying extra conditions, it's expected that at the time of beginning
 /// the consistency awaiting, all ops which will be published have already been published.
 /// However, in cases where more publishing is expected, such as when warrants will be authored
@@ -555,7 +555,7 @@ impl ConsistencyConditions {
                         )
                     .into());
                     }
-                }    
+                }
             }
         }
 
@@ -566,7 +566,6 @@ impl ConsistencyConditions {
         self.warrants_issued.values().sum()
     }
 }
-
 
 /// Wait for all cell envs to reach consistency, meaning that every op
 /// published by every cell has been integrated by every node
@@ -586,7 +585,6 @@ where
     let mut publish_complete = false;
 
     while start.elapsed() < timeout {
-        
         if !publish_complete {
             published = HashSet::new();
             for (_, _author, db, _) in cells.iter() {
@@ -596,7 +594,7 @@ where
                     .unwrap()
                     .into_iter()
                     .map(|(_, _, op)| op);
-    
+
                 // Assert that there are no duplicates
                 let expected = p.len() + published.len();
                 published.extend(p);
@@ -606,7 +604,7 @@ where
 
         let prev_publish_complete = publish_complete;
         publish_complete = conditions.check(published.iter())?;
-        
+
         if publish_complete {
             if !prev_publish_complete {
                 tracing::info!("*** All expected ops were published ***");
@@ -655,10 +653,13 @@ where
     );
 
     if !publish_complete {
-        let published = published.iter().map(display_op).collect::<Vec<_>>().join("\n");
+        let published = published
+            .iter()
+            .map(display_op)
+            .collect::<Vec<_>>()
+            .join("\n");
         return Err(format!("There are still ops which were expected to have been published which weren't:\n{header}\n{published}").into());
     }
-
 
     let mut report = String::new();
     let not_consistent = (0..cells.len())
@@ -670,7 +671,8 @@ where
         "{} cells did not reach consistency: {:?}",
         not_consistent.len(),
         not_consistent
-    ).unwrap();
+    )
+    .unwrap();
 
     let c = *not_consistent
         .first()
@@ -683,13 +685,10 @@ where
     if integrated.len() > published.len() {
         Err(format!("{report}\nnum integrated ops ({}) > num published ops ({}), meaning you may not be accounting for all nodes in this test. Consistency may not be complete. Report:\n\n{header}\n{diff}", integrated.len(), published.len()).into())
     } else if integrated.len() < published.len() {
-
-        
         let db = cells[c].3.as_ref().expect("DhtDb must be provided");
         let integration_dump = integration_dump(*db).await.unwrap();
-            
+
         Err(format!(
-            
 "{}\nConsistency not achieved after {:?}. Expected {} ops, but only {} integrated. Report:\n\n{}\n{}\n\n{:?}",
 report,
         timeout,
@@ -701,7 +700,6 @@ report,
 
 
         ).into())
-
     } else {
         unreachable!()
     }

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -583,7 +583,8 @@ where
         
         if !publish_complete {
             published = HashSet::new();
-            for (_, author, db, _) in cells.iter() {
+            for (_, _author, db, _) in cells.iter() {
+                // Providing the author is redundant
                 let p = request_published_ops(*db, None /*Some((*author).to_owned())*/)
                     .await
                     .unwrap()
@@ -605,28 +606,12 @@ where
                 println!("*** All expected ops were published ***");
             }
             // Compare the published ops to the integrated ops for each node
-            for (i, (_node_id, author, _, dht_db)) in cells.iter().enumerate() {
+            for (i, (_node_id, _, _, dht_db)) in cells.iter().enumerate() {
                 if done.contains(&i) {
                     continue;
                 }
                 if let Some(db) = dht_db.as_ref() {
                     integrated[i] = get_integrated_ops(*db).await.into_iter().collect();
-
-                    // // We don't expect warrants which were issued against an agent to be integrated
-                    // // by that agent, since typically the agent will have been blocked
-                    // let mut num_warrants_to_skip = conditions.warrants_issued.get(author).cloned().unwrap_or_default();
-                    // let published = published.iter().filter(|op| {
-                    //     if let DhtOp::WarrantOp(w) = op {
-                    //         if num_warrants_to_skip > 0 && w.action_author() == *author {
-                    //             num_warrants_to_skip -= 1;
-                    //             false
-                    //         } else {
-                    //             true
-                    //         }
-                    //     } else {
-                    //         true
-                    //     }
-                    // }).cloned().collect::<HashSet<_>>();
 
                     if integrated[i] == published {
                         done.insert(i);

--- a/crates/holochain/tests/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/tests/sharded_gossip/mod.rs
@@ -688,9 +688,13 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
         start.elapsed()
     );
 
-    await_consistency_advanced(10, [(&cells[0], false), (&cells[1], true), (&cell, true)])
-        .await
-        .unwrap();
+    await_consistency_advanced(
+        10,
+        None,
+        [(&cells[0], false), (&cells[1], true), (&cell, true)],
+    )
+    .await
+    .unwrap();
 
     println!(
         "Done waiting for consistency between last two nodes. Elapsed: {:?}",

--- a/crates/holochain/tests/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/tests/sharded_gossip/mod.rs
@@ -690,7 +690,7 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
 
     await_consistency_advanced(
         10,
-        None,
+        (),
         [(&cells[0], false), (&cells[1], true), (&cell, true)],
     )
     .await

--- a/crates/holochain_zome_types/src/warrant.rs
+++ b/crates/holochain_zome_types/src/warrant.rs
@@ -159,14 +159,15 @@ impl WarrantProof {
     /// Warrants always have the authoring agent as a basis, so that warrants
     /// can be accumulated by the agent activity authorities.
     pub fn dht_basis(&self) -> OpBasis {
+        self.action_author().clone().into()
+    }
+
+    /// The author of the action which led to this warrant, i.e. the target of the warrant
+    pub fn action_author(&self) -> &AgentPubKey {
         match self {
             Self::ChainIntegrity(w) => match w {
-                ChainIntegrityWarrant::InvalidChainOp { action_author, .. } => {
-                    action_author.clone().into()
-                }
-                ChainIntegrityWarrant::ChainFork { chain_author, .. } => {
-                    chain_author.clone().into()
-                }
+                ChainIntegrityWarrant::InvalidChainOp { action_author, .. } => action_author,
+                ChainIntegrityWarrant::ChainFork { chain_author, .. } => chain_author,
             },
         }
     }


### PR DESCRIPTION
### Summary

Before the addition of warrants, it was easy to know exactly which ops were expected to be published, and to await integration of all published ops by all nodes in a sweettest. With the addition of warrants, new publishes can happen at any time, as invalid data is integrated and new warrants are published.

In this PR I opted to add an optional set of conditions to the consistency check which can specify expectations about what additional ops must be published for the check to proceed.

I also used an "advanced" consistency check in a case where alice is blocked by bob mid-gossip so that we don't expect alice to integrate anything that bob has published, since the moment of blocking becomes a race condition. This should be done for any other consistency test which involves blocking.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs