### PR TITLE
Configure VFS on Windows

### DIFF
--- a/crates/holochain_sqlite/src/db/access.rs
+++ b/crates/holochain_sqlite/src/db/access.rs
@@ -409,7 +409,7 @@ impl<Kind: DbKindT + Send + Sync + 'static> DbWrite<Kind> {
         path: &Path,
         sync_level: DbSyncLevel,
     ) -> rusqlite::Result<Option<PathBuf>> {
-        Connection::open(path)
+        Connection::open_with_flags_and_vfs(path, OpenFlags::default(), "win32-longpath")
             // For some reason calling pragma_update is necessary to prove the database file is valid.
             .and_then(|mut c| {
                 initialize_connection(&mut c, sync_level)?;

--- a/crates/holochain_sqlite/tests/tests/long_path.rs
+++ b/crates/holochain_sqlite/tests/tests/long_path.rs
@@ -1,0 +1,19 @@
+use std::fs::create_dir_all;
+use holochain_sqlite::db::{DbKindWasm, DbWrite};
+use holochain_sqlite::error::DatabaseResult;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn open_long_path() {
+    let tmp_dir = tempfile::TempDir::new().unwrap();
+    // 280 characters, split into segments
+    let path = tmp_dir.path().join("alskdjflaskdjflaskdjflaskdjfals/kdfjalsdkfjlasdkfjlasdfjalsdkfjasldkfjasldfkjalsdkfjalsdkfjasldkfjksaldfjslakdfjlskdfjlkskdjflasdj/fklasdfjklasdfsaldfkjlsdkfjalsdfjaklsdfjalskfjdlaskdjflsakjfklsadjlask/dflasjdfklsjdfklsdjfklasdjflsakdjlasdjfklsajdflkasdjflsakjfdlsdkjflskdfjlksdjfaaa");
+    create_dir_all(&path).unwrap();
+
+    let db = DbWrite::open(&path, DbKindWasm).unwrap();
+
+    db.write_async(|txn| -> DatabaseResult<()> {
+        txn.execute("CREATE TABLE test (name TEXT)", [])?;
+        txn.execute("INSERT INTO test (name) VALUES ('hello')", [])?;
+        Ok(())
+    }).await.unwrap();
+}

--- a/crates/holochain_sqlite/tests/tests/mod.rs
+++ b/crates/holochain_sqlite/tests/tests/mod.rs
@@ -2,3 +2,4 @@ mod common;
 mod db_wrapper;
 mod loom;
 mod migrate_unencrypted;
+mod long_path;


### PR DESCRIPTION
### Summary

Creating this as a reminder, we should look into enabling longer paths on Windows but just setting the VFS is not enough to fix the issue so we need to dig deeper and look at asking Windows to allow longer paths for the Holochain binary when we build it.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs