### PR TITLE
Expose validation receipt info for actions (#4049)

### DIFF
--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added a new HDK function `get_validation_receipts` which can be used to look up validation receipts for an action
+  that you have authored.
 - Adds two new HDK functions `close_chain` and `open_chain` that allow `Action::CloseChain` and `Action::OpenChain` respectively, to be created.
   These are intended to be used for DNA migrations. There is an example in the Holochain functions tests in 'migration.rs' #3804
 

--- a/crates/hdk/src/hdk.rs
+++ b/crates/hdk/src/hdk.rs
@@ -99,6 +99,11 @@ pub trait HdkT: HdiT {
     // Migrate DNA
     fn close_chain(&self, input: CloseChainInput) -> ExternResult<ActionHash>;
     fn open_chain(&self, input: OpenChainInput) -> ExternResult<ActionHash>;
+    // Validation receipts
+    fn get_validation_receipts(
+        &self,
+        input: GetValidationReceiptsInput,
+    ) -> ExternResult<Vec<ValidationReceiptSet>>;
 }
 
 #[cfg(feature = "mock")]
@@ -182,6 +187,7 @@ mockall::mock! {
         fn delete_clone_cell(&self, input: DeleteCloneCellInput) -> ExternResult<()>;
         fn close_chain(&self, input: CloseChainInput) -> ExternResult<ActionHash>;
         fn open_chain(&self, input: OpenChainInput) -> ExternResult<ActionHash>;
+        fn get_validation_receipts(&self, input: GetValidationReceiptsInput) -> ExternResult<Vec<ValidationReceiptSet>>;
     }
 
     impl HdiT for HdkT {
@@ -469,6 +475,14 @@ impl HdkT for ErrHdk {
     fn open_chain(&self, _input: OpenChainInput) -> ExternResult<ActionHash> {
         Self::err()
     }
+
+    // Validation receipts
+    fn get_validation_receipts(
+        &self,
+        _input: GetValidationReceiptsInput,
+    ) -> ExternResult<Vec<ValidationReceiptSet>> {
+        Self::err()
+    }
 }
 
 /// The HDK implemented as externs provided by the host.
@@ -722,6 +736,16 @@ impl HdkT for HostHdk {
 
     fn open_chain(&self, input: OpenChainInput) -> ExternResult<ActionHash> {
         host_call::<OpenChainInput, ActionHash>(__hc__open_chain_1, input)
+    }
+
+    fn get_validation_receipts(
+        &self,
+        input: GetValidationReceiptsInput,
+    ) -> ExternResult<Vec<ValidationReceiptSet>> {
+        host_call::<GetValidationReceiptsInput, Vec<ValidationReceiptSet>>(
+            __hc__get_validation_receipts_1,
+            input,
+        )
     }
 }
 

--- a/crates/hdk/src/lib.rs
+++ b/crates/hdk/src/lib.rs
@@ -581,3 +581,6 @@ pub mod clone;
 
 /// Tools for working with migrations from one DNA to another.
 mod migrate;
+
+/// Look up validation receipts for actions that a local agent has authored.
+pub mod validation_receipt;

--- a/crates/hdk/src/link/builder.rs
+++ b/crates/hdk/src/link/builder.rs
@@ -42,6 +42,7 @@ use holochain_zome_types::prelude::*;
 ///     let links = get_links(GetLinksInputBuilder::try_new(my_base, ..)?.get_options(GetStrategy::Local).build())?;
 /// #   Ok(())
 /// # }
+/// ```
 #[derive(PartialEq, Clone, Debug)]
 pub struct GetLinksInputBuilder(GetLinksInput);
 

--- a/crates/hdk/src/prelude.rs
+++ b/crates/hdk/src/prelude.rs
@@ -6,6 +6,7 @@ pub use crate::capability::update_cap_grant;
 pub use crate::chain::get_agent_activity;
 pub use crate::chain::must_get_agent_activity;
 pub use crate::chain::query;
+pub use crate::clone::*;
 pub use crate::countersigning::accept_countersigning_preflight_request;
 pub use crate::countersigning::session_times_from_millis;
 pub use crate::ed25519::sign;
@@ -48,6 +49,7 @@ pub use crate::link::GetLinksInputBuilder;
 pub use crate::link::LinkTypeFilterExt;
 pub use crate::map_extern;
 pub use crate::map_extern::ExternResult;
+pub use crate::migrate::*;
 pub use crate::p2p::call;
 pub use crate::p2p::call_remote;
 pub use crate::p2p::emit_signal;
@@ -56,9 +58,7 @@ pub use crate::random::*;
 pub use crate::time::schedule;
 pub use crate::time::sleep;
 pub use crate::time::sys_time;
-
-pub use crate::clone::*;
-pub use crate::migrate::*;
+pub use crate::validation_receipt::get_validation_receipts;
 pub use crate::x_salsa20_poly1305::create_x25519_keypair;
 pub use crate::x_salsa20_poly1305::ed_25519_x_salsa20_poly1305_decrypt;
 pub use crate::x_salsa20_poly1305::ed_25519_x_salsa20_poly1305_encrypt;
@@ -175,7 +175,8 @@ macro_rules! holochain_externs {
             enable_clone_cell:1,
             delete_clone_cell:1,
             close_chain:1,
-            open_chain:1
+            open_chain:1,
+            get_validation_receipts:1
         );
     };
 }

--- a/crates/hdk/src/validation_receipt.rs
+++ b/crates/hdk/src/validation_receipt.rs
@@ -1,0 +1,54 @@
+use crate::hdk::HDK;
+use hdi::map_extern::ExternResult;
+use holochain_zome_types::prelude::{GetValidationReceiptsInput, ValidationReceiptSet};
+
+/// Get validation receipts associated with an action.
+///
+/// When an action is created, it is represented as multiple DHT ops to be published on the network.
+/// Each op will be validated by other agents on the network and a receipt will be sent back to the
+/// author. The return value of this function is organized by DHT op hash. Each [ValidationReceiptSet]
+/// contains all the validation receipts that have been received for that DHT op.
+///
+/// Note: This function will permit you to look for validation receipts for any action hash, but you
+/// will only have receipts if the action was authored on the same conductor. Not necessarily the
+/// same agent, but it must be the same conductor.
+///
+/// ### Example
+/// ```rust,no_run
+/// use hdk::prelude::*;
+///
+/// #[derive(Serialize, Deserialize)]
+/// #[serde(tag = "type")]
+/// #[hdk_entry_types]
+/// #[unit_enum(UnitEntryTypes)]
+/// pub enum EntryTypes {
+///     MyType(MyType),
+/// }
+///
+/// #[hdk_entry_helper]
+/// pub struct MyType {
+///     value: String,
+/// }
+///
+/// #[hdk_extern]
+/// fn create_and_list() -> ExternResult<()> {
+///     let action_hash = create_entry(EntryTypes::MyType(MyType {
+///         value: "foo".into(),
+///     }))?;
+///
+///     // Later on
+///     let receipts = get_validation_receipts(GetValidationReceiptsInput::new(action_hash))?;
+///     let count = receipts
+///         .into_iter()
+///         .filter(|receipt_set| receipt_set.op_type == "RegisterAgentActivity")
+///         .flat_map(|receipt_set| receipt_set.receipts)
+///         .count();
+///     info!("Found {} receipts from agent activity authorities", count);
+///     Ok(())
+/// }
+/// ```
+pub fn get_validation_receipts(
+    input: GetValidationReceiptsInput,
+) -> ExternResult<Vec<ValidationReceiptSet>> {
+    HDK.with(|h| h.borrow().get_validation_receipts(input))
+}

--- a/crates/holo_hash/src/fixt.rs
+++ b/crates/holo_hash/src/fixt.rs
@@ -15,6 +15,8 @@ use crate::DnaHash;
 use crate::DnaHashB64;
 use crate::EntryHash;
 use crate::EntryHashB64;
+use crate::ExternalHash;
+use crate::ExternalHashB64;
 use crate::NetIdHash;
 use crate::NetIdHashB64;
 use crate::WasmHash;
@@ -170,4 +172,13 @@ fixturator!(
 fixturator!(
     AnyLinkableHashB64;
     constructor fn new(AnyLinkableHash);
+);
+
+fixturator!(
+    ExternalHash;
+    constructor fn from_raw_32(ThirtyTwoHashBytes);
+);
+fixturator!(
+    ExternalHashB64;
+    constructor fn new(ExternalHash);
 );

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -824,6 +824,15 @@ impl Cell {
                             |row| row.get(0),
                         )?;
 
+                        if receipt_count >= required_validation_count as usize {
+                            // If we have enough receipts then set receipts to complete.
+                            //
+                            // Don't fail here if this doesn't work, it's only informational. Getting
+                            // the same flag set in the authored db is what will stop the publish
+                            // workflow from republishing this op.
+                            set_receipts_complete(txn, &receipt_op_hash, true).ok();
+                        }
+
                         Ok(receipt_count)
                     }
                 })

--- a/crates/holochain/src/core/ribosome/host_fn.rs
+++ b/crates/holochain/src/core/ribosome/host_fn.rs
@@ -236,4 +236,7 @@ host_fn_api_impls! {
 
     // Open your chain, pointing to the previous DNA
     fn open_chain(zt::chain::OpenChainInput) -> holo_hash::ActionHash;
+
+    // Get validation receipts for an action
+    fn get_validation_receipts(zt::validate::GetValidationReceiptsInput) -> Vec<zt::validate::ValidationReceiptSet>;
 }

--- a/crates/holochain/src/core/ribosome/host_fn/get_validation_receipts.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_validation_receipts.rs
@@ -1,0 +1,102 @@
+use crate::core::ribosome::error::RibosomeError;
+use crate::core::ribosome::{CallContext, RibosomeT};
+use holochain_sqlite::prelude::DbRead;
+use holochain_state::prelude::validation_receipts_for_action;
+use holochain_types::access::{HostFnAccess, Permission};
+use holochain_util::tokio_helper;
+use holochain_wasmer_host::prelude::{wasm_error, WasmError, WasmErrorInner};
+use holochain_zome_types::prelude::{GetValidationReceiptsInput, ValidationReceiptSet};
+use std::sync::Arc;
+use wasmer::RuntimeError;
+use holochain_sqlite::db::DbKindDht;
+
+#[tracing::instrument(skip(_ribosome, call_context), fields(?call_context.zome, function = ?call_context.function_name))]
+pub fn get_validation_receipts(
+    _ribosome: Arc<impl RibosomeT>,
+    call_context: Arc<CallContext>,
+    input: GetValidationReceiptsInput,
+) -> Result<Vec<ValidationReceiptSet>, RuntimeError> {
+    match HostFnAccess::from(&call_context.host_context()) {
+        HostFnAccess {
+            read_workspace: Permission::Allow,
+            ..
+        } => {
+            let results = tokio_helper::block_forever_on(async move {
+                let dht_db: DbRead<DbKindDht> = call_context.host_context.workspace().databases().1;
+
+                dht_db
+                    .read_async(move |txn| {
+                        validation_receipts_for_action(
+                            &txn,
+                            input.action_hash.clone(),
+                        )
+                    })
+                    .await
+            })
+            .map_err(|e| wasm_error!(WasmErrorInner::Host(e.to_string())))?;
+
+            Ok(results)
+        }
+        _ => Err(wasm_error!(WasmErrorInner::Host(
+            RibosomeError::HostFnPermissions(
+                call_context.zome.zome_name().clone(),
+                call_context.function_name().clone(),
+                "get_validation_receipts".into(),
+            )
+            .to_string(),
+        ))
+        .into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::ribosome::host_fn::create::create;
+    use crate::core::ribosome::host_fn::get_validation_receipts::get_validation_receipts;
+    use crate::fixt::ZomeCallHostAccessFixturator;
+    use crate::fixt::{CallContextFixturator, RealRibosomeFixturator};
+    use ::fixt::Predictable;
+    use ::fixt::{fixt, Unpredictable};
+    use holochain_wasm_test_utils::{TestWasm, TestWasmPair};
+    use holochain_zome_types::prelude::*;
+    use std::sync::Arc;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn call_get_validation_receipts() {
+        let ribosome = RealRibosomeFixturator::new(crate::fixt::curve::Zomes(vec![TestWasm::Crd]))
+            .next()
+            .unwrap();
+        let mut call_context = CallContextFixturator::new(Unpredictable).next().unwrap();
+        call_context.zome = TestWasmPair::<IntegrityZome, CoordinatorZome>::from(TestWasm::Crd)
+            .coordinator
+            .erase_type();
+        let host_access = fixt!(ZomeCallHostAccess, Predictable);
+        call_context.host_context = host_access.into();
+
+        let app_entry = EntryFixturator::new(AppEntry).next().unwrap();
+        let input = CreateInput::new(
+            EntryDefLocation::app(0, 0),
+            EntryVisibility::Public,
+            app_entry.clone(),
+            ChainTopOrdering::default(),
+        );
+        let ribosome_handle = Arc::new(ribosome);
+        let action_hash = create(
+            ribosome_handle.clone(),
+            Arc::new(call_context.clone()),
+            input,
+        )
+        .unwrap();
+
+        let receipts = get_validation_receipts(
+            ribosome_handle.clone(),
+            Arc::new(call_context.clone()),
+            GetValidationReceiptsInput::new(action_hash),
+        )
+        .unwrap();
+
+        // Not the most useful test/assertion. Just checking that this doesn't error and checking
+        // that this gives back validation receipts will require an integration test.
+        assert!(receipts.is_empty());
+    }
+}

--- a/crates/holochain/src/core/ribosome/real_ribosome.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome.rs
@@ -103,6 +103,7 @@ use wasmer::Type;
 
 use crate::core::ribosome::host_fn::close_chain::close_chain;
 use crate::core::ribosome::host_fn::count_links::count_links;
+use crate::core::ribosome::host_fn::get_validation_receipts::get_validation_receipts;
 use crate::core::ribosome::host_fn::open_chain::open_chain;
 use crate::holochain_wasmer_host::module::WASM_METERING_LIMIT;
 use holochain_types::zome_types::GlobalZomeTypes;
@@ -605,7 +606,12 @@ impl RealRibosome {
             .with_host_function(&mut ns, "__hc__enable_clone_cell_1", enable_clone_cell)
             .with_host_function(&mut ns, "__hc__delete_clone_cell_1", delete_clone_cell)
             .with_host_function(&mut ns, "__hc__close_chain_1", close_chain)
-            .with_host_function(&mut ns, "__hc__open_chain_1", open_chain);
+            .with_host_function(&mut ns, "__hc__open_chain_1", open_chain)
+            .with_host_function(
+                &mut ns,
+                "__hc__get_validation_receipts_1",
+                get_validation_receipts,
+            );
 
         imports.register_namespace("env", ns);
 
@@ -1279,6 +1285,7 @@ pub mod wasm_test {
                 "__hc__get_details_1",
                 "__hc__get_link_details_1",
                 "__hc__get_links_1",
+                "__hc__get_validation_receipts_1",
                 "__hc__hash_1",
                 "__hc__must_get_action_1",
                 "__hc__must_get_agent_activity_1",

--- a/crates/holochain/tests/publish/mod.rs
+++ b/crates/holochain/tests/publish/mod.rs
@@ -2,11 +2,13 @@ use holo_hash::ActionHash;
 use holochain::core::workflow::publish_dht_ops_workflow::num_still_needing_publish;
 use holochain::sweettest::*;
 use holochain_wasm_test_utils::TestWasm;
+use holochain_zome_types::prelude::GetValidationReceiptsInput;
+use holochain_zome_types::validate::ValidationReceiptSet;
 
 /// Verifies that publishing terminates naturally when enough validation receipts are received.
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "receipt completion is flaky, revise once integration logic is merged into app validation workflow"]
+#[ignore = "receipt completion is flaky, which has been rechecked since the workflow reviews"]
 async fn publish_terminates_after_receiving_required_validation_receipts() {
     holochain_trace::test_run();
 
@@ -27,7 +29,7 @@ async fn publish_terminates_after_receiving_required_validation_receipts() {
 
     let ((alice,), (bobbo,), (carol,), (danny,), (emma,), (fred,)) = apps.into_tuples();
 
-    let _: ActionHash = conductors[0]
+    let action_hash: ActionHash = conductors[0]
         .call(&alice.zome(TestWasm::Create), "create_entry", ())
         .await;
 
@@ -36,18 +38,47 @@ async fn publish_terminates_after_receiving_required_validation_receipts() {
         .await
         .unwrap();
 
-    let ops_to_publish = alice
-        .authored_db()
-        .read_async({
-            let alice_pub_key = alice.agent_pubkey().clone();
-            // Note that this test is relying on this being the same check that the publish workflow uses.
-            // If this returns 0 then the publish workflow is expected to suspend. So the test isn't directly
-            // observing that behaviour but it's close enough given that there are unit tests for the actual
-            // behavior.
-            move |txn| num_still_needing_publish(&txn, alice_pub_key)
-        })
-        .await
-        .unwrap();
+    let ops_to_publish = tokio::time::timeout(std::time::Duration::from_secs(60), async {
+        let mut ops_to_publish = 1;
+        while ops_to_publish > 0 {
+            ops_to_publish = alice
+                .authored_db()
+                .read_async({
+                    let alice_pub_key = alice.agent_pubkey().clone();
+                    // Note that this test is relying on this being the same check that the publish workflow uses.
+                    // If this returns 0 then the publish workflow is expected to suspend. So the test isn't directly
+                    // observing that behaviour but it's close enough given that there are unit tests for the actual
+                    // behavior.
+                    move |txn| num_still_needing_publish(&txn, alice_pub_key)
+                })
+                .await
+                .unwrap();
+        }
+
+        ops_to_publish
+    })
+    .await
+    .expect("timed out waiting for all receipts to be received");
 
     assert_eq!(ops_to_publish, 0);
+
+    // Get the validation receipts to check that they are all complete
+    let receipt_sets: Vec<ValidationReceiptSet> = conductors[0]
+        .call(
+            &alice.zome(TestWasm::Create),
+            "get_validation_receipts",
+            GetValidationReceiptsInput::new(action_hash),
+        )
+        .await;
+    assert_eq!(receipt_sets.len(), 3);
+    assert!(receipt_sets.iter().all(|r| r.receipts_complete));
+
+    let agent_activity_receipt_set = receipt_sets
+        .into_iter()
+        .find(|r| r.op_type == "RegisterAgentActivity")
+        .unwrap();
+    assert_eq!(
+        agent_activity_receipt_set.receipts.len(),
+        holochain::core::workflow::publish_dht_ops_workflow::DEFAULT_RECEIPT_BUNDLE_SIZE as usize
+    );
 }

--- a/crates/holochain_sqlite/src/sql/cell/schema/0.sql
+++ b/crates/holochain_sqlite/src/sql/cell/schema/0.sql
@@ -117,7 +117,7 @@ CREATE TABLE IF NOT EXISTS DhtOp (
     -- 1: Successfully System Validated (And ready for app validation).
     -- 2: Awaiting App Validation Dependencies.
     -- 3: Awaiting integration.
-    -- Don't need the other stages (pending, awaiting itntegration) because:
+    -- Don't need the other stages (pending, awaiting integration) because:
     -- - pending = validation_stage null && validation_status null.
     -- We could make this an enum and use a Blob so we can capture which
     -- deps are being awaited for debugging.

--- a/crates/holochain_state/src/validation_receipts.rs
+++ b/crates/holochain_state/src/validation_receipts.rs
@@ -1,13 +1,16 @@
 //! Module for items related to aggregating validation_receipts
 
-use holo_hash::AgentPubKey;
 use holo_hash::DhtOpHash;
+use holo_hash::{ActionHash, AgentPubKey};
 use holochain_sqlite::prelude::*;
-use holochain_sqlite::rusqlite::named_params;
 use holochain_sqlite::rusqlite::OptionalExtension;
 use holochain_sqlite::rusqlite::Transaction;
+use holochain_sqlite::rusqlite::{named_params, Params, Statement};
+use holochain_types::dht_op::DhtOpType;
 use holochain_types::prelude::{SignedValidationReceipt, ValidationReceipt};
+use holochain_zome_types::prelude::{ValidationReceiptInfo, ValidationReceiptSet};
 use mutations::StateMutationResult;
+use std::collections::HashMap;
 
 use crate::mutations;
 use crate::prelude::from_blob;
@@ -91,6 +94,90 @@ pub fn get_pending_validation_receipts(
         .collect::<StateQueryResult<Vec<_>>>()?;
 
     Ok(ops)
+}
+
+/// Finds [DhtOp]s for the given [ActionHash] and returns the associated [ValidationReceiptSet]s.
+///
+/// Each [ValidationReceiptSet] contains the validation receipts we have received for a single [DhtOp].
+/// If we have received enough validation receipts for an op, then its validation receipt set will
+/// have the `receipts_complete` field set to `true`.
+pub fn validation_receipts_for_action(
+    txn: &Transaction,
+    action_hash: ActionHash,
+) -> StateQueryResult<Vec<ValidationReceiptSet>> {
+    let stmt = txn.prepare(
+        "
+            SELECT
+              ValidationReceipt.blob as receipt,
+              DhtOp.hash as op_hash,
+              DhtOp.type as op_type,
+              DhtOp.receipts_complete as op_receipts_complete
+            FROM
+              Action
+              INNER JOIN DhtOp ON DhtOp.action_hash = Action.hash
+              INNER JOIN ValidationReceipt ON DhtOp.hash = ValidationReceipt.op_hash
+            WHERE
+              Action.hash = :action_hash
+            ",
+    )?;
+
+    query_validation_receipts(
+        stmt,
+        named_params! {
+            ":action_hash": action_hash
+        },
+    )
+}
+
+fn query_validation_receipts<P: Params>(
+    mut stmt: Statement,
+    params: P,
+) -> StateQueryResult<Vec<ValidationReceiptSet>> {
+    let db_result = stmt
+        .query_and_then(params, |row| {
+            let receipt = from_blob::<SignedValidationReceipt>(row.get("receipt")?)?;
+            let op_hash: DhtOpHash = row.get("op_hash")?;
+            let op_type: DhtOpType = row.get("op_type")?;
+            let receipts_complete: Option<bool> = row.get("op_receipts_complete")?;
+
+            Ok((
+                receipt,
+                op_hash,
+                op_type,
+                receipts_complete.unwrap_or(false),
+            ))
+        })?
+        .collect::<StateQueryResult<Vec<_>>>()?;
+    Ok(db_result
+        .into_iter()
+        .filter_map(
+            |(receipt, op_hash, op_type, receipts_complete)| match op_type {
+                DhtOpType::Chain(op_type) => Some((
+                    op_hash,
+                    op_type.to_string(),
+                    receipts_complete,
+                    ValidationReceiptInfo {
+                        validation_status: receipt.receipt.validation_status,
+                        validators: receipt.receipt.validators,
+                    },
+                )),
+                _ => None,
+            },
+        )
+        .fold(HashMap::new(), |mut acc, item| {
+            acc.entry(item.0.clone())
+                .or_insert_with(|| ValidationReceiptSet {
+                    op_hash: item.0,
+                    op_type: item.1.clone(),
+                    receipts_complete: item.2,
+                    receipts: Vec::new(),
+                })
+                .receipts
+                .push(item.3);
+            acc
+        })
+        .into_values()
+        .collect())
 }
 
 #[cfg(test)]
@@ -321,5 +408,74 @@ mod tests {
         assert!(pending_ops.contains(&valid_op_hash));
         assert!(pending_ops.contains(&rejected_op_hash));
         assert!(pending_ops.contains(&abandoned_op_hash));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn validation_receipts_from_action() {
+        let test_db = test_dht_db();
+        let env = test_db.to_db();
+
+        let keystore = test_keystore();
+
+        let action = fixt!(Action);
+
+        let action_hash = ActionHash::with_data_sync(&action);
+        let op = DhtOpHashed::from_content_sync(ChainOp::RegisterAgentActivity(
+            fixt!(Signature),
+            action,
+        ));
+        let test_op_hash = op.as_hash().clone();
+        env.write_async(move |txn| insert_op(txn, &op))
+            .await
+            .unwrap();
+
+        let vr1 = fake_vr(&test_op_hash, &keystore).await;
+        let vr2 = fake_vr(&test_op_hash, &keystore).await;
+
+        env.write_async({
+            let put_vr1 = vr1.clone();
+            let put_vr2 = vr2.clone();
+
+            move |txn| -> StateMutationResult<()> {
+                add_if_unique(txn, put_vr1.clone())?;
+                add_if_unique(txn, put_vr2.clone())?;
+                Ok(())
+            }
+        })
+        .await
+        .unwrap();
+
+        let receipt_sets = env
+            .read_async(move |txn| validation_receipts_for_action(&txn, action_hash))
+            .await
+            .unwrap();
+
+        check_receipt_sets(receipt_sets, test_op_hash, vr1, vr2);
+    }
+
+    fn check_receipt_sets(
+        receipt_sets: Vec<ValidationReceiptSet>,
+        test_op_hash: DhtOpHash,
+        vr1: SignedValidationReceipt,
+        vr2: SignedValidationReceipt,
+    ) {
+        assert_eq!(receipt_sets.len(), 1);
+
+        assert_eq!(test_op_hash, receipt_sets[0].op_hash);
+        assert_eq!("RegisterAgentActivity", receipt_sets[0].op_type);
+
+        let receipts_count = receipt_sets[0].receipts.len();
+        assert_eq!(receipts_count, 2);
+
+        assert_eq!(
+            vr1.receipt.validation_status,
+            receipt_sets[0].receipts[0].validation_status
+        );
+        assert_eq!(1, receipt_sets[0].receipts[0].validators.len());
+        assert_eq!(
+            vr2.receipt.validation_status,
+            receipt_sets[0].receipts[1].validation_status
+        );
+        assert_eq!(1, receipt_sets[0].receipts[1].validators.len());
     }
 }

--- a/crates/holochain_zome_types/src/validate.rs
+++ b/crates/holochain_zome_types/src/validate.rs
@@ -61,3 +61,53 @@ impl rusqlite::types::FromSql for ValidationStatus {
         })
     }
 }
+
+/// Input for the get_validation_receipts host function.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct GetValidationReceiptsInput {
+    pub action_hash: ActionHash,
+}
+
+impl GetValidationReceiptsInput {
+    /// Create a new input to get validation receipts for an action.
+    pub fn new(action_hash: ActionHash) -> Self {
+        Self { action_hash }
+    }
+}
+
+/// A set of validation receipts, grouped by op.
+///
+/// This is intended to be returned as the result of a query for validation receipts by action.
+///
+/// It would also be valid to return this for a query that uniquely identified an op but those are
+/// generally not available to hApp developers.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ValidationReceiptSet {
+    /// The op hash that this receipt is for.
+    pub op_hash: DhtOpHash,
+
+    /// The type of the op that was validated.
+    ///
+    /// Note that the original type is discarded here because DhtOpType is part of `holochain_types`
+    /// and moving it would be a breaking change. For now this is just informational.
+    pub op_type: String,
+
+    /// Whether this op has received the required number of receipts.
+    pub receipts_complete: bool,
+
+    /// The validation receipts for this op.
+    pub receipts: Vec<ValidationReceiptInfo>,
+}
+
+/// Summary information for a validation receipt.
+///
+/// Currently, this is ignoring `dht_op_hash` because it's already on the parent type and
+/// `when_integrated` because that's not relevant to the validation receipt itself.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ValidationReceiptInfo {
+    /// the result of the validation.
+    pub validation_status: ValidationStatus,
+
+    /// the remote validators who signed the receipt.
+    pub validators: Vec<AgentPubKey>,
+}

--- a/crates/holochain_zome_types/src/zome_io.rs
+++ b/crates/holochain_zome_types/src/zome_io.rs
@@ -204,6 +204,9 @@ wasm_io_types! {
 
     // Open your chain, pointing to the previous DNA
     fn open_chain(zt::chain::OpenChainInput) -> holo_hash::ActionHash;
+
+    // Get validation receipts for an action
+    fn get_validation_receipts(zt::validate::GetValidationReceiptsInput) -> Vec<zt::validate::ValidationReceiptSet>;
 }
 
 /// Anything that can go wrong while calling a HostFnApi method

--- a/crates/test_utils/wasm/wasm_workspace/create_entry/src/coordinator.rs
+++ b/crates/test_utils/wasm/wasm_workspace/create_entry/src/coordinator.rs
@@ -226,3 +226,8 @@ fn call_create_entry_remotely_no_rec(agent: AgentPubKey) -> ExternResult<ActionH
         ))),
     }
 }
+
+#[hdk_extern]
+fn get_validation_receipts(input: GetValidationReceiptsInput) -> ExternResult<Vec<ValidationReceiptSet>> {
+    hdk::prelude::get_validation_receipts(input)
+}


### PR DESCRIPTION
* wip get receipts for action

* Return new model

* Lookups by action and entry hashes for validation receipts

* Add docs

* Add get_validation_receipts host function

* Add HDK access to new host function

* Format

* Test getting validation receipt info

* Rename variables for more clarity

* Format

* Fix receipts_complete

* Fix list of host functions test

* Make validation receipt test not flaky

* Give tests more time

* Disable on macos

* Disable test

* Revert timeout change

* Docs and changelog

* Remove use of entries

* Remove more doc references to entries

Tidy

Tidy

Tidy

### Summary



### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs