### PR TITLE
change hc-launch repository

### DIFF
--- a/versions/0_1/flake.nix
+++ b/versions/0_1/flake.nix
@@ -13,7 +13,7 @@
 
       # holochain_cli_launch
       launcher = {
-        url = "github:holochain/launcher/holochain-0.1";
+        url = "github:holochain/hc-launch/holochain-0.1";
         flake = false;
       };
 

--- a/versions/0_2/flake.nix
+++ b/versions/0_2/flake.nix
@@ -13,7 +13,7 @@
 
       # holochain_cli_launch
       launcher = {
-        url = "github:holochain/launcher/holochain-0.2";
+        url = "github:holochain/hc-launch/holochain-0.2";
         flake = false;
       };
 

--- a/versions/0_2_rc/flake.nix
+++ b/versions/0_2_rc/flake.nix
@@ -13,7 +13,7 @@
 
       # holochain_cli_launch
       launcher = {
-        url = "github:holochain/launcher/holochain-0.2";
+        url = "github:holochain/hc-launch/holochain-0.2";
         flake = false;
       };
 

--- a/versions/0_3/flake.nix
+++ b/versions/0_3/flake.nix
@@ -13,7 +13,7 @@
 
       # holochain_cli_launch
       launcher = {
-        url = "github:holochain/launcher/holochain-0.3";
+        url = "github:holochain/hc-launch/holochain-0.3";
         flake = false;
       };
 

--- a/versions/0_3_rc/flake.nix
+++ b/versions/0_3_rc/flake.nix
@@ -13,7 +13,7 @@
 
       # holochain_cli_launch
       launcher = {
-        url = "github:holochain/launcher/holochain-0.3";
+        url = "github:holochain/hc-launch/holochain-0.3";
         flake = false;
       };
 

--- a/versions/weekly/flake.nix
+++ b/versions/weekly/flake.nix
@@ -13,7 +13,7 @@
 
       # holochain_cli_launch
       launcher = {
-        url = "github:holochain/launcher/holochain-weekly";
+        url = "github:holochain/hc-launch/holochain-weekly";
         flake = false;
       };
 


### PR DESCRIPTION
### Summary

Because the tauri based launcher Desktop app is being phased out and will not be further maintained, `hc-launch` (which will be further maintained) has been moved to its own repository and this PR reflects this in the holonix versions.

This PR is prerequisite to be able to move (rename) the new Electron based launcher's repository from `holochain/launcher-electron` to `holochain/launcher` and the old tauri based one from `holochain/launcher` to `holochain/launcher-tauri` and archive it.


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs