### PR TITLE
Push Holochain tag separately

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,6 +314,16 @@ jobs:
 
           git status
 
+          # Push just the Holochain tag initially, so that GitHub Actions will create an event based on it.
+          # Pushing a batch larger than 3 tags will cause the event to be ignored -> https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
+          # TODO Once this has been tested, removed the `set +eu` and `set -eu` lines. That is just to prevent this from making the workflow fail.
+          set +eu
+          SEARCH_PATTERN="^holochain-[0-9]"
+          ALL_HOLOCHAIN_TAGS=$(git -c 'versionsort.suffix=-beta-dev' -c 'versionsort.suffix=-dev' -c 'versionsort.suffix=-rc' tag --sort='v:refname' | cut --delimiter='/' --fields=3)
+          LATEST_MATCHING_TAG=$(echo "$ALL_HOLOCHAIN_TAGS" | grep -E "$SEARCH_PATTERN" | tail -n 1)
+          git push origin ${LATEST_MATCHING_TAG}
+          set -eu
+
           git push origin ${HOLOCHAIN_TARGET_BRANCH} --tags
 
       - name: Merge release branch into source branch


### PR DESCRIPTION
### Summary

I hope this can go again if we were just needing one tag. Given that we push loads, this is the only decent solution I can think of for now. This gets around a github actions limitation that prevented my tag trigger working on the last release

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs