### PR TITLE
Rendezvous and exchange_peer_info don't mix

### DIFF
--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -12,7 +12,7 @@ async fn conductors_call_remote(num_conductors: usize) {
 
     let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
 
-    let config = SweetConductorConfig::standard();
+    let config = SweetConductorConfig::rendezvous(true);
 
     let mut conductors = SweetConductorBatch::from_config_rendezvous(num_conductors, config).await;
 

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -7,7 +7,6 @@ use test_case::test_case;
 #[test_case(2)]
 #[test_case(4)]
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn conductors_call_remote(num_conductors: usize) {
     holochain_trace::test_run();
 
@@ -23,8 +22,6 @@ async fn conductors_call_remote(num_conductors: usize) {
         .into_iter()
         .map(|c| c.into_cells().into_iter().next().unwrap())
         .collect();
-
-    conductors.exchange_peer_info().await;
 
     // Make sure that genesis records are integrated now that conductors have discovered each other. This makes it
     // more likely that Kitsune knows about all the agents in the network to be able to make remote calls to them.

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -636,6 +636,11 @@ impl SweetConductor {
     pub async fn exchange_peer_info(conductors: impl IntoIterator<Item = &Self>) {
         let mut all = Vec::new();
         for c in conductors.into_iter() {
+            if c.get_config().has_rendezvous_bootstrap() {
+                panic!(
+                    "exchange_peer_info cannot reliably be used with rendezvous bootstrap servers"
+                );
+            }
             for env in c.spaces.get_from_spaces(|s| s.p2p_agents_db.clone()) {
                 all.push(env.clone());
             }

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -735,6 +735,11 @@ impl SweetConductor {
             }
         }
     }
+
+    /// Getter
+    pub fn rendezvous(&self) -> Option<&Arc<dyn SweetRendezvous + Send + Sync>> {
+        self.rendezvous.as_ref()
+    }
 }
 
 /// You do not need to do anything with this type. While it is held it will keep polling a websocket

--- a/crates/holochain/src/sweettest/sweet_conductor_batch.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor_batch.rs
@@ -197,6 +197,11 @@ impl SweetConductorBatch {
 
     /// Let each conductor know about each others' agents so they can do networking
     pub async fn exchange_peer_info(&self) {
+        if self.0.iter().any(|c| c.rendezvous().is_some()) {
+            panic!(
+                "exchange_peer_info cannot reliably be used with rendezvous-configured conductors"
+            );
+        }
         SweetConductor::exchange_peer_info(&self.0).await
     }
 

--- a/crates/holochain/src/sweettest/sweet_conductor_batch.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor_batch.rs
@@ -197,13 +197,6 @@ impl SweetConductorBatch {
 
     /// Let each conductor know about each others' agents so they can do networking
     pub async fn exchange_peer_info(&self) {
-        if self
-            .0
-            .iter()
-            .any(|c| c.get_config().has_rendezvous_bootstrap())
-        {
-            panic!("exchange_peer_info cannot reliably be used with rendezvous bootstrap servers");
-        }
         SweetConductor::exchange_peer_info(&self.0).await
     }
 

--- a/crates/holochain/src/sweettest/sweet_conductor_batch.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor_batch.rs
@@ -197,10 +197,12 @@ impl SweetConductorBatch {
 
     /// Let each conductor know about each others' agents so they can do networking
     pub async fn exchange_peer_info(&self) {
-        if self.0.iter().any(|c| c.rendezvous().is_some()) {
-            panic!(
-                "exchange_peer_info cannot reliably be used with rendezvous-configured conductors"
-            );
+        if self
+            .0
+            .iter()
+            .any(|c| c.get_config().has_rendezvous_bootstrap())
+        {
+            panic!("exchange_peer_info cannot reliably be used with rendezvous bootstrap servers");
         }
         SweetConductor::exchange_peer_info(&self.0).await
     }

--- a/crates/holochain/tests/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/tests/multi_conductor/mod.rs
@@ -77,7 +77,6 @@ async fn test_publish() -> anyhow::Result<()> {
 
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn multi_conductor() -> anyhow::Result<()> {
     use holochain::test_utils::inline_zomes::simple_create_read_zome;
 
@@ -97,7 +96,6 @@ async fn multi_conductor() -> anyhow::Result<()> {
         SweetDnaFile::unique_from_inline_zomes(("simple", simple_create_read_zome())).await;
 
     let apps = conductors.setup_app("app", &[dna_file]).await.unwrap();
-    conductors.exchange_peer_info().await;
 
     let ((alice,), (bobbo,), (carol,)) = apps.into_tuples();
 

--- a/crates/holochain/tests/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/tests/sharded_gossip/mod.rs
@@ -593,11 +593,13 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
 
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
 
-    let cells: Vec<_> = futures::future::join_all(conductors.iter_mut().map(|c| async {
-        let (cell,) = c.setup_app("app", [&dna_file]).await.unwrap().into_tuple();
-        cell
-    }))
-    .await;
+    let cells = conductors
+        .setup_app("app", [&dna_file])
+        .await
+        .unwrap()
+        .cells_flattened();
+
+    conductors.exchange_peer_info().await;
 
     println!(
         "Initial agents: {:#?}",

--- a/crates/holochain/tests/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/tests/sharded_gossip/mod.rs
@@ -311,7 +311,6 @@ async fn test_zero_arc_no_gossip_2way() {
 /// Test that conductors with arcs clamped to zero do not gossip.
 #[cfg(feature = "slow_tests")]
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn test_zero_arc_no_gossip_4way() {
     use futures::future::join_all;
 
@@ -323,7 +322,7 @@ async fn test_zero_arc_no_gossip_4way() {
             publish: true,
             recent: true,
             historical: true,
-            bootstrap: true,
+            bootstrap: false,
             recent_threshold: None,
         })
         .tune_conductor(|params| {
@@ -335,7 +334,7 @@ async fn test_zero_arc_no_gossip_4way() {
             publish: false,
             recent: true,
             historical: true,
-            bootstrap: true,
+            bootstrap: false,
             recent_threshold: None,
         })
         .tune_conductor(|params| {
@@ -394,6 +393,8 @@ async fn test_zero_arc_no_gossip_4way() {
         .collect::<Vec<_>>();
         assert_eq!(stored_agents, vec![cell.agent_pubkey().clone()]);
     }
+
+    conductors.exchange_peer_info().await;
 
     // Ensure that each node has all agents in their local p2p store.
     for c in conductors.iter() {

--- a/crates/holochain/tests/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/tests/sharded_gossip/mod.rs
@@ -286,8 +286,6 @@ async fn test_zero_arc_no_gossip_2way() {
     let apps = conductors.setup_app("app", [&dna_file]).await.unwrap();
     let ((cell_0,), (cell_1,)) = apps.into_tuples();
 
-    conductors.exchange_peer_info().await;
-
     let zome_0 = cell_0.zome(SweetInlineZomes::COORDINATOR);
     let hash_0: ActionHash = conductors[0]
         .call(&zome_0, "create_string", "hi".to_string())
@@ -397,8 +395,6 @@ async fn test_zero_arc_no_gossip_4way() {
         assert_eq!(stored_agents, vec![cell.agent_pubkey().clone()]);
     }
 
-    conductors.exchange_peer_info().await;
-
     // Ensure that each node has all agents in their local p2p store.
     for c in conductors.iter() {
         let stored_agents = holochain::conductor::p2p_agent_store::all_agent_infos(
@@ -473,7 +469,7 @@ async fn test_gossip_shutdown() {
             publish: false,
             recent: true,
             historical: true,
-            bootstrap: true,
+            bootstrap: false,
             recent_threshold: None,
         },
     )
@@ -547,7 +543,6 @@ async fn test_gossip_startup() {
 
     // Wait a bit so that conductor 0 doesn't publish in the next step.
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-    SweetConductor::exchange_peer_info([&conductor0, &conductor1]).await;
 
     await_consistency(60, [&cell0, &cell1]).await.unwrap();
     let record: Option<Record> = conductor1.call(&zome1, "read", hash.clone()).await;
@@ -603,8 +598,6 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
         cell
     }))
     .await;
-
-    conductors.exchange_peer_info().await;
 
     println!(
         "Initial agents: {:#?}",
@@ -671,7 +664,6 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
         .unwrap()
         .into_tuple();
     let zome = cell.zome(SweetInlineZomes::COORDINATOR);
-    SweetConductor::exchange_peer_info([&conductors[1], &conductors[2]]).await;
 
     println!(
         "Newcomer agent joined: scope={}, agent={:#?}",

--- a/crates/holochain/tests/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/tests/sharded_gossip/mod.rs
@@ -666,6 +666,7 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
         .unwrap()
         .into_tuple();
     let zome = cell.zome(SweetInlineZomes::COORDINATOR);
+    SweetConductor::exchange_peer_info([&conductors[1], &conductors[2]]).await;
 
     println!(
         "Newcomer agent joined: scope={}, agent={:#?}",

--- a/crates/holochain/tests/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/tests/sharded_gossip/mod.rs
@@ -269,7 +269,7 @@ async fn test_zero_arc_no_gossip_2way() {
         publish: true,
         recent: true,
         historical: true,
-        bootstrap: true,
+        bootstrap: false,
         recent_threshold: None,
     }
     .into();
@@ -278,13 +278,15 @@ async fn test_zero_arc_no_gossip_2way() {
     // This should result in no publishing or gossip
     let mut tuning_1 = make_tuning(false, true, true, None);
     tuning_1.gossip_arc_clamping = "empty".into();
-    let config_1 = SweetConductorConfig::rendezvous(true).set_tuning_params(tuning_1);
+    let config_1 = SweetConductorConfig::rendezvous(false).set_tuning_params(tuning_1);
 
     let mut conductors = SweetConductorBatch::from_configs_rendezvous([config_0, config_1]).await;
 
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
     let apps = conductors.setup_app("app", [&dna_file]).await.unwrap();
     let ((cell_0,), (cell_1,)) = apps.into_tuples();
+
+    conductors.exchange_peer_info().await;
 
     let zome_0 = cell_0.zome(SweetInlineZomes::COORDINATOR);
     let hash_0: ActionHash = conductors[0]

--- a/crates/holochain/tests/tests/websocket/mod.rs
+++ b/crates/holochain/tests/tests/websocket/mod.rs
@@ -755,7 +755,6 @@ async fn concurrent_install_dna() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(target_os = "macos", ignore)]
 async fn network_stats() {
     holochain_trace::test_run();
 
@@ -766,7 +765,6 @@ async fn network_stats() {
     let dna_file = SweetDnaFile::unique_empty().await;
 
     let _ = batch.setup_app("app", &[dna_file]).await.unwrap();
-    batch.exchange_peer_info().await;
 
     let (client, _rx) = batch
         .get(0)

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -189,6 +189,11 @@ impl ConductorConfig {
     pub fn conductor_tuning_params(&self) -> ConductorTuningParams {
         self.tuning_params.clone().unwrap_or_default()
     }
+
+    /// Check if the config is set to use a rendezvous bootstrap server
+    pub fn has_rendezvous_bootstrap(&self) -> bool {
+        self.network.bootstrap_service == Some(url2::url2!("rendezvous:"))
+    }
 }
 
 /// Tuning parameters to adjust the behaviour of the conductor.


### PR DESCRIPTION
### Summary

I observed a test flaking on the DPKI branch which used exchange_peer_info with SweetConductors configured for a rendezvous bootstrap service. When I removed the call to `exchange_peer_info`, the test started passing.

Since we don't expect people to be directly injecting peers into their databases, let's just let `exchange_peer_info` start to fade away.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs