### PR TITLE
Countersigning success signal includes app entry hash

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- CountersigningSuccess signal that is emitted when a countersigning session is successfully completed now includes the 
+  `app_entry_hash` from the `PreflightRequest` rather than the `EntryHash` that is created when you commit the countersigned entry.
+  This value is easier for clients to get at and use to check that the countersigning session they joined has succeeded.
+
 ## 0.4.0-dev.14
 
 ## 0.4.0-dev.13

--- a/crates/holochain/tests/tests/countersigning.rs
+++ b/crates/holochain/tests/tests/countersigning.rs
@@ -1,0 +1,149 @@
+use hdk::prelude::{PreflightRequest, PreflightRequestAcceptance};
+use holo_hash::{ActionHash, EntryHash};
+use holochain::sweettest::{
+    await_consistency, SweetConductorBatch, SweetConductorConfig, SweetDnaFile,
+};
+use holochain_types::prelude::Signal;
+use holochain_types::signal::SystemSignal;
+use holochain_wasm_test_utils::TestWasm;
+use holochain_zome_types::countersigning::Role;
+use holochain_zome_types::prelude::{
+    ActivityRequest, AgentActivity, ChainQueryFilter, GetAgentActivityInput,
+};
+use tokio::sync::broadcast::Receiver;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn listen_for_countersigning_completion() {
+    holochain_trace::test_run();
+
+    let config = SweetConductorConfig::rendezvous(true);
+    let mut conductors = SweetConductorBatch::from_config_rendezvous(2, config).await;
+
+    let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::CounterSigning]).await;
+    let apps = conductors.setup_app("app", &[dna]).await.unwrap();
+    let cells = apps.cells_flattened();
+    let alice = &cells[0];
+    let bob = &cells[1];
+
+    // Need an initialised source chain for countersigning, so commit anything
+    let alice_zome = alice.zome(TestWasm::CounterSigning);
+    let _: ActionHash = conductors[0]
+        .call_fallible(&alice_zome, "create_a_thing", ())
+        .await
+        .unwrap();
+    let bob_zome = bob.zome(TestWasm::CounterSigning);
+    let _: ActionHash = conductors[1]
+        .call_fallible(&bob_zome, "create_a_thing", ())
+        .await
+        .unwrap();
+
+    await_consistency(30, vec![alice, bob]).await.unwrap();
+
+    // Need chain head for each other, so get agent activity before starting a session
+    let _: AgentActivity = conductors[0]
+        .call_fallible(
+            &alice_zome,
+            "get_agent_activity",
+            GetAgentActivityInput {
+                agent_pubkey: bob.agent_pubkey().clone(),
+                chain_query_filter: ChainQueryFilter::new(),
+                activity_request: ActivityRequest::Full,
+            },
+        )
+        .await
+        .unwrap();
+    let _: AgentActivity = conductors[1]
+        .call_fallible(
+            &bob_zome,
+            "get_agent_activity",
+            GetAgentActivityInput {
+                agent_pubkey: alice.agent_pubkey().clone(),
+                chain_query_filter: ChainQueryFilter::new(),
+                activity_request: ActivityRequest::Full,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Set up the session and accept it for both agents
+    let preflight_request: PreflightRequest = conductors[0]
+        .call_fallible(
+            &alice_zome,
+            "generate_countersigning_preflight_request_fast",
+            vec![
+                (alice.agent_pubkey().clone(), vec![Role(0)]),
+                (bob.agent_pubkey().clone(), vec![]),
+            ],
+        )
+        .await
+        .unwrap();
+    let alice_acceptance: PreflightRequestAcceptance = conductors[0]
+        .call_fallible(
+            &alice_zome,
+            "accept_countersigning_preflight_request",
+            preflight_request.clone(),
+        )
+        .await
+        .unwrap();
+    let alice_response =
+        if let PreflightRequestAcceptance::Accepted(ref response) = alice_acceptance {
+            response
+        } else {
+            unreachable!();
+        };
+    let bob_acceptance: PreflightRequestAcceptance = conductors[1]
+        .call_fallible(
+            &bob_zome,
+            "accept_countersigning_preflight_request",
+            preflight_request.clone(),
+        )
+        .await
+        .unwrap();
+    let bob_response = if let PreflightRequestAcceptance::Accepted(ref response) = bob_acceptance {
+        response
+    } else {
+        unreachable!();
+    };
+
+    let (_, _): (ActionHash, EntryHash) = conductors[0]
+        .call_fallible(
+            &alice_zome,
+            "create_a_countersigned_thing_with_entry_hash",
+            vec![alice_response.clone(), bob_response.clone()],
+        )
+        .await
+        .unwrap();
+
+    let (_, _): (ActionHash, EntryHash) = conductors[1]
+        .call_fallible(
+            &bob_zome,
+            "create_a_countersigned_thing_with_entry_hash",
+            vec![alice_response.clone(), bob_response.clone()],
+        )
+        .await
+        .unwrap();
+
+    let alice_rx = conductors[0].subscribe_to_app_signals("app".into());
+    let bob_rx = conductors[1].subscribe_to_app_signals("app".into());
+
+    wait_for_completion(alice_rx, preflight_request.app_entry_hash.clone()).await;
+    wait_for_completion(bob_rx, preflight_request.app_entry_hash).await;
+}
+
+async fn wait_for_completion(mut signal_rx: Receiver<Signal>, expected_hash: EntryHash) {
+    let signal = tokio::time::timeout(std::time::Duration::from_secs(30), signal_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    match signal {
+        Signal::System(SystemSignal::SuccessfulCountersigning(hash)) => {
+            assert_eq!(expected_hash, hash);
+        }
+        _ => {
+            panic!(
+                "Expected SuccessfulCountersigning signal, got: {:?}",
+                signal
+            );
+        }
+    }
+}

--- a/crates/holochain/tests/tests/mod.rs
+++ b/crates/holochain/tests/tests/mod.rs
@@ -2,6 +2,7 @@ mod agent_scaling;
 mod app_interface_security;
 mod authored_test;
 mod clone_cell;
+mod countersigning;
 mod dht_arc;
 mod dna_properties;
 mod graft_records_onto_source_chain;


### PR DESCRIPTION
### Summary

I now realize you can get the other EntryHash, you just have to do several quite unclean steps to get it -> https://github.com/holochain/holochain/blob/develop/crates/test_utils/wasm/wasm_workspace/countersigning/src/coordinator.rs#L50

I think a value that is simple to get at that you can listen for from before you commit the CS entry is easier to use.

The docs really need updating so that this signal is mentioned somewhere. I started this on #4067 and plan to continue there, instead of adding docs here.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs