### PR TITLE
Missing deps should be retryable for countersigning

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -10,10 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - *BREAKING* Introduced a new workflow error, `IncompleteCommit`. When inline validation fails with missing dependencies. 
   I.e. Validation for actions that are being committed to the source chain during a zome call discovers missing dependencies. 
   The generic `InvalidCommit` is replaced by this new error. That allows the caller to distinguish between errors that are
-  fatal and errors that can be retried. For now, the only retryable error is caused by missing dependencies.
+  fatal and errors that can be retried. For now, the only retryable error is caused by missing dependencies. #4129
 - *BREAKING* CountersigningSuccess signal that is emitted when a countersigning session is successfully completed now includes the 
   `app_entry_hash` from the `PreflightRequest` rather than the `EntryHash` that is created when you commit the countersigned entry.
-  This value is easier for clients to get at and use to check that the countersigning session they joined has succeeded.
+  This value is easier for clients to get at and use to check that the countersigning session they joined has succeeded. #4124
 
 ## 0.4.0-dev.14
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,7 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- CountersigningSuccess signal that is emitted when a countersigning session is successfully completed now includes the 
+- *BREAKING* Introduced a new workflow error, `IncompleteCommit`. When inline validation fails with missing dependencies. 
+  I.e. Validation for actions that are being committed to the source chain during a zome call discovers missing dependencies. 
+  The generic `InvalidCommit` is replaced by this new error. That allows the caller to distinguish between errors that are
+  fatal and errors that can be retried. For now, the only retryable error is caused by missing dependencies.
+- *BREAKING* CountersigningSuccess signal that is emitted when a countersigning session is successfully completed now includes the 
   `app_entry_hash` from the `PreflightRequest` rather than the `EntryHash` that is created when you commit the countersigned entry.
   This value is easier for clients to get at and use to check that the countersigning session they joined has succeeded.
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   I.e. Validation for actions that are being committed to the source chain during a zome call discovers missing dependencies. 
   The generic `InvalidCommit` is replaced by this new error. That allows the caller to distinguish between errors that are
   fatal and errors that can be retried. For now, the only retryable error is caused by missing dependencies. #4129
+- Based on the change above, about adding `IncompleteCommit`, a countersigning session will no longer terminate on missing dependencies.
+  You may retry committing the countersigned entry if you get this error. #4129
 - *BREAKING* CountersigningSuccess signal that is emitted when a countersigning session is successfully completed now includes the 
   `app_entry_hash` from the `PreflightRequest` rather than the `EntryHash` that is created when you commit the countersigned entry.
   This value is easier for clients to get at and use to check that the countersigning session they joined has succeeded. #4124

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -12,12 +12,14 @@
 //! users in a testing environment.
 //!
 //! ```rust, no_run
-//! async fn async_main () {
+//!  async fn async_main () {
 //! use holochain_state::test_utils::test_db_dir;
 //! use holochain::conductor::{Conductor, ConductorBuilder};
+//! use holochain::conductor::ConductorHandle;
+//!
 //! let env_dir = test_db_dir();
-//! let conductor: Conductor = ConductorBuilder::new()
-//!    .test(env_dir.path(), &[])
+//! let conductor: ConductorHandle = ConductorBuilder::new()
+//!    .test(&[])
 //!    .await
 //!    .unwrap();
 //!

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -12,7 +12,7 @@
 //! users in a testing environment.
 //!
 //! ```rust, no_run
-//!  async fn async_main () {
+//! async fn async_main () {
 //! use holochain_state::test_utils::test_db_dir;
 //! use holochain::conductor::{Conductor, ConductorBuilder};
 //! use holochain::conductor::ConductorHandle;
@@ -29,7 +29,7 @@
 //! assert_eq!(conductor.list_dnas(), vec![]);
 //! conductor.shutdown();
 //!
-//! # }
+//! }
 //! ```
 
 /// Name of the wasm cache folder within the data root directory.

--- a/crates/holochain/src/core/validation.rs
+++ b/crates/holochain/src/core/validation.rs
@@ -1,10 +1,10 @@
 //! Types needed for all validation
-use std::convert::TryFrom;
-use holochain_state::prelude::IncompleteCommitReason;
 use super::workflow::WorkflowResult;
 use super::SourceChainError;
 use super::SysValidationError;
 use super::ValidationOutcome;
+use holochain_state::prelude::IncompleteCommitReason;
+use std::convert::TryFrom;
 
 /// Exit early with either an outcome or an error
 #[derive(Debug)]
@@ -56,12 +56,11 @@ impl OutcomeOrError<ValidationOutcome, SysValidationError> {
     pub fn to_workflow_error<T>(self) -> WorkflowResult<T> {
         let outcome = ValidationOutcome::try_from(self)?;
         match outcome {
-            ValidationOutcome::DepMissingFromDht(deps) => {
-                Err(SourceChainError::IncompleteCommit(IncompleteCommitReason::DepMissingFromDht(vec![deps])).into())
-            }
-            outcome => {
-                Err(SourceChainError::InvalidCommit(outcome.to_string()).into())
-            }
+            ValidationOutcome::DepMissingFromDht(deps) => Err(SourceChainError::IncompleteCommit(
+                IncompleteCommitReason::DepMissingFromDht(vec![deps]),
+            )
+            .into()),
+            outcome => Err(SourceChainError::InvalidCommit(outcome.to_string()).into()),
         }
     }
 }

--- a/crates/holochain/src/core/validation.rs
+++ b/crates/holochain/src/core/validation.rs
@@ -1,6 +1,6 @@
 //! Types needed for all validation
 use std::convert::TryFrom;
-
+use holochain_state::prelude::IncompleteCommitReason;
 use super::workflow::WorkflowResult;
 use super::SourceChainError;
 use super::SysValidationError;
@@ -48,8 +48,20 @@ macro_rules! from_sub_error {
 
 impl OutcomeOrError<ValidationOutcome, SysValidationError> {
     /// Convert an OutcomeOrError<ValidationOutcome, SysValidationError> into
-    /// a InvalidCommit and exit the call zome workflow early
-    pub fn invalid_call_zome_commit<T>(self) -> WorkflowResult<T> {
-        Err(SourceChainError::InvalidCommit(ValidationOutcome::try_from(self)?.to_string()).into())
+    /// a [crate::core::workflow::error::WorkflowError].
+    ///
+    /// The inner error will be a [SourceChainError] if sys validation ran successfully but produced
+    /// an unsuccessful validation outcome. Otherwise, the error will be [SysValidationError] to
+    /// explain why sys validation was not able to complete the validation request.
+    pub fn to_workflow_error<T>(self) -> WorkflowResult<T> {
+        let outcome = ValidationOutcome::try_from(self)?;
+        match outcome {
+            ValidationOutcome::DepMissingFromDht(deps) => {
+                Err(SourceChainError::IncompleteCommit(IncompleteCommitReason::DepMissingFromDht(vec![deps])).into())
+            }
+            outcome => {
+                Err(SourceChainError::InvalidCommit(outcome.to_string()).into())
+            }
+        }
     }
 }

--- a/crates/holochain/src/core/validation.rs
+++ b/crates/holochain/src/core/validation.rs
@@ -53,7 +53,7 @@ impl OutcomeOrError<ValidationOutcome, SysValidationError> {
     /// The inner error will be a [SourceChainError] if sys validation ran successfully but produced
     /// an unsuccessful validation outcome. Otherwise, the error will be [SysValidationError] to
     /// explain why sys validation was not able to complete the validation request.
-    pub fn to_workflow_error<T>(self) -> WorkflowResult<T> {
+    pub fn into_workflow_error<T>(self) -> WorkflowResult<T> {
         let outcome = ValidationOutcome::try_from(self)?;
         match outcome {
             ValidationOutcome::DepMissingFromDht(deps) => Err(SourceChainError::IncompleteCommit(

--- a/crates/holochain/src/core/workflow/call_zome_workflow.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow.rs
@@ -24,6 +24,7 @@ use parking_lot::Mutex;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use tracing::instrument;
+use holochain_state::prelude::IncompleteCommitReason;
 
 #[cfg(test)]
 mod validation_test;
@@ -164,6 +165,8 @@ where
 
     // If the validation failed remove any active chain lock that matches the
     // entry that failed validation.
+    // Note that missing dependencies will not produce an `InvalidCommit` but an `IncompleteCommit`
+    // so that the commit can be retried later without terminating the countersigning session.
     if matches!(
         validation_result,
         Err(WorkflowError::SourceChainError(
@@ -250,8 +253,9 @@ where
                 .await
                 // If the was en error exit
                 // If the validation failed, exit with an InvalidCommit
+                // If the validation failed with a retryable error, exit with an IncompleteCommit
                 // If it was ok continue
-                .or_else(|outcome_or_err| outcome_or_err.invalid_call_zome_commit())?;
+                .or_else(|outcome_or_err| outcome_or_err.to_workflow_error())?;
             to_app_validate.push(record);
         }
 
@@ -260,10 +264,10 @@ where
 
     for mut chain_record in to_app_validate {
         for op_type in action_to_op_types(chain_record.action()) {
-            let op =
+            let outcome =
                 app_validation_workflow::record_to_op(chain_record, op_type, cascade.clone()).await;
 
-            let (op, dht_op_hash, omitted_entry) = match op {
+            let (op, dht_op_hash, omitted_entry) = match outcome {
                 Ok(op) => op,
                 Err(outcome_or_err) => return map_outcome(Outcome::try_from(outcome_or_err)),
             };
@@ -326,26 +330,23 @@ fn op_to_record(op: Op, omitted_entry: Option<Entry>) -> Record {
 }
 
 fn map_outcome(
-    outcome: Result<app_validation_workflow::Outcome, AppValidationError>,
+    outcome: Result<Outcome, AppValidationError>,
 ) -> WorkflowResult<()> {
     match outcome.map_err(SourceChainError::other)? {
-        app_validation_workflow::Outcome::Accepted => {}
-        app_validation_workflow::Outcome::Rejected(reason) => {
+        Outcome::Accepted => {}
+        Outcome::Rejected(reason) => {
             return Err(SourceChainError::InvalidCommit(reason).into());
         }
-        // when the wasm is being called directly in a zome invocation any
-        // state other than valid is not allowed for new entries
-        // e.g. we require that all dependencies are met when committing an
-        // entry to a local source chain
-        // this is different to the case where we are validating data coming in
-        // from the network where unmet dependencies would need to be
-        // rescheduled to attempt later due to partitions etc.
-        app_validation_workflow::Outcome::AwaitingDeps(hashes) => {
-            return Err(SourceChainError::InvalidCommit(format!(
-                "Awaiting deps {:?} but this is not allowed when committing entries to the source chain",
-                hashes
-            ))
-            .into());
+        // When the wasm is being called directly in a zome invocation, any state other than valid
+        // is not allowed for new entries. E.g. we require that all dependencies are met when
+        // committing an entry to a local source chain.
+        // This is different to the case where we are validating data coming in from the network
+        // where unmet dependencies would be rescheduled to attempt later due to partitions etc.
+        // To allow the client to decide whether to retry later, we return a different error
+        // variant here. This indicates that the validation did not fail because the data is
+        // definitely invalid, but because validation could not make a decision yet.
+        Outcome::AwaitingDeps(hashes) => {
+            return Err(SourceChainError::IncompleteCommit(IncompleteCommitReason::DepMissingFromDht(hashes)).into());
         }
     }
     Ok(())

--- a/crates/holochain/src/core/workflow/call_zome_workflow.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow.rs
@@ -255,7 +255,7 @@ where
                 // If the validation failed, exit with an InvalidCommit
                 // If the validation failed with a retryable error, exit with an IncompleteCommit
                 // If it was ok continue
-                .or_else(|outcome_or_err| outcome_or_err.to_workflow_error())?;
+                .or_else(|outcome_or_err| outcome_or_err.into_workflow_error())?;
             to_app_validate.push(record);
         }
 

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -2,6 +2,7 @@
 // TODO [ B-03669 ] move to own crate
 
 use super::*;
+use crate::conductor::api::error::ConductorApiError;
 use crate::conductor::ConductorHandle;
 use crate::conductor::{
     api::error::ConductorApiResult, config::ConductorConfig, error::ConductorResult, CellError,
@@ -12,6 +13,7 @@ use hdk::prelude::*;
 use holo_hash::DnaHash;
 use holochain_conductor_api::{AdminRequest, AdminResponse, AppAuthenticationRequest};
 use holochain_keystore::MetaLairClient;
+use holochain_p2p::AgentPubKeyExt;
 use holochain_state::prelude::test_db_dir;
 use holochain_state::test_utils::TestDir;
 use holochain_types::prelude::*;
@@ -739,6 +741,42 @@ impl SweetConductor {
                 );
             }
         }
+    }
+
+    /// Retries getting a list of peers from the conductor until all the given peers are in the response.
+    ///
+    /// You can optionally filter by `cell_id`. That is used in the `get_agent_infos` call to the conductor, so you
+    /// can see how that works in the conductor docs.
+    ///
+    /// If the max_wait is reached then this function will return a "Timeout" error.
+    pub async fn wait_for_peer_visible<P: IntoIterator<Item = AgentPubKey>>(
+        &self,
+        peers: P,
+        cell_id: Option<CellId>,
+        max_wait: Duration,
+    ) -> ConductorApiResult<()> {
+        let handle = self.raw_handle();
+
+        let peers = peers.into_iter().collect::<HashSet<_>>();
+
+        tokio::time::timeout(max_wait, async move {
+            loop {
+                let infos = handle
+                    .get_agent_infos(cell_id.clone())
+                    .await?
+                    .into_iter()
+                    .map(|p| AgentPubKey::from_kitsune(&p.agent))
+                    .collect::<HashSet<_>>();
+                if infos.is_superset(&peers) {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+
+            Ok(())
+        })
+        .await
+        .map_err(|_| ConductorApiError::other("Timeout"))?
     }
 
     /// Getter

--- a/crates/holochain/tests/tests/countersigning.rs
+++ b/crates/holochain/tests/tests/countersigning.rs
@@ -258,7 +258,6 @@ async fn retry_countersigning_commit_on_missing_deps() {
     // Bring Bob's app back online
     conductors[1].enable_app("app".into()).await.unwrap();
 
-
     // Bob should be able to get Alice's chain head when we commit, so let's do that.
     let (_, _): (ActionHash, EntryHash) = conductors[1]
         .call_fallible(

--- a/crates/holochain/tests/tests/countersigning.rs
+++ b/crates/holochain/tests/tests/countersigning.rs
@@ -280,6 +280,9 @@ async fn retry_countersigning_commit_on_missing_deps() {
         .await
         .unwrap();
 
+    // Listen for the session to complete, which it should in spite of the error that
+    // Alice had initially.
+
     let alice_rx = conductors[0].subscribe_to_app_signals("app".into());
     let bob_rx = conductors[1].subscribe_to_app_signals("app".into());
 

--- a/crates/holochain/tests/tests/countersigning.rs
+++ b/crates/holochain/tests/tests/countersigning.rs
@@ -1,8 +1,12 @@
 use hdk::prelude::{PreflightRequest, PreflightRequestAcceptance};
 use holo_hash::{ActionHash, EntryHash};
+use holochain::conductor::api::error::{ConductorApiError, ConductorApiResult};
+use holochain::conductor::CellError;
+use holochain::core::workflow::WorkflowError;
 use holochain::sweettest::{
     await_consistency, SweetConductorBatch, SweetConductorConfig, SweetDnaFile,
 };
+use holochain_state::prelude::{IncompleteCommitReason, SourceChainError};
 use holochain_types::prelude::Signal;
 use holochain_types::signal::SystemSignal;
 use holochain_wasm_test_utils::TestWasm;
@@ -117,6 +121,159 @@ async fn listen_for_countersigning_completion() {
     let (_, _): (ActionHash, EntryHash) = conductors[1]
         .call_fallible(
             &bob_zome,
+            "create_a_countersigned_thing_with_entry_hash",
+            vec![alice_response.clone(), bob_response.clone()],
+        )
+        .await
+        .unwrap();
+
+    let alice_rx = conductors[0].subscribe_to_app_signals("app".into());
+    let bob_rx = conductors[1].subscribe_to_app_signals("app".into());
+
+    wait_for_completion(alice_rx, preflight_request.app_entry_hash.clone()).await;
+    wait_for_completion(bob_rx, preflight_request.app_entry_hash).await;
+}
+
+// Regression test to check that it's possible to continue a countersigning session following
+// a failed commit that required dependencies that couldn't be fetched.
+#[tokio::test(flavor = "multi_thread")]
+async fn retry_countersigning_commit_on_missing_deps() {
+    holochain_trace::test_run();
+
+    // Allow bootstrapping so that peers can find each other, but disable publish and recent gossip.
+    // The only way peers can get data is through get requests!
+    let config = SweetConductorConfig::rendezvous(true).historical_only();
+    let mut conductors = SweetConductorBatch::from_config_rendezvous(2, config).await;
+
+    let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::CounterSigning]).await;
+    let apps = conductors.setup_app("app", &[dna]).await.unwrap();
+    let cells = apps.cells_flattened();
+    let alice = &cells[0];
+    let bob = &cells[1];
+
+    // Need an initialised source chain for countersigning, so commit anything
+    let alice_zome = alice.zome(TestWasm::CounterSigning);
+    let _: ActionHash = conductors[0]
+        .call_fallible(&alice_zome, "create_a_thing", ())
+        .await
+        .unwrap();
+    let bob_zome = bob.zome(TestWasm::CounterSigning);
+    let _: ActionHash = conductors[1]
+        .call_fallible(&bob_zome, "create_a_thing", ())
+        .await
+        .unwrap();
+
+    // Set up the session and accept it for both agents
+    let preflight_request: PreflightRequest = conductors[0]
+        .call_fallible(
+            &alice_zome,
+            "generate_countersigning_preflight_request_fast",
+            vec![
+                (alice.agent_pubkey().clone(), vec![Role(0)]),
+                (bob.agent_pubkey().clone(), vec![]),
+            ],
+        )
+        .await
+        .unwrap();
+    let alice_acceptance: PreflightRequestAcceptance = conductors[0]
+        .call_fallible(
+            &alice_zome,
+            "accept_countersigning_preflight_request",
+            preflight_request.clone(),
+        )
+        .await
+        .unwrap();
+    let alice_response =
+        if let PreflightRequestAcceptance::Accepted(ref response) = alice_acceptance {
+            response
+        } else {
+            unreachable!();
+        };
+    let bob_acceptance: PreflightRequestAcceptance = conductors[1]
+        .call_fallible(
+            &bob_zome,
+            "accept_countersigning_preflight_request",
+            preflight_request.clone(),
+        )
+        .await
+        .unwrap();
+    let bob_response = if let PreflightRequestAcceptance::Accepted(ref response) = bob_acceptance {
+        response
+    } else {
+        unreachable!();
+    };
+
+    // Alice shouldn't be able to commit
+    let result: ConductorApiResult<()> = conductors[0]
+        .call_fallible(
+            &alice_zome,
+            "create_a_countersigned_thing_with_entry_hash",
+            vec![alice_response.clone(), bob_response.clone()],
+        )
+        .await;
+    match result {
+        Ok(_) => {
+            panic!("Expected commit to fail due to missing dependencies");
+        }
+        Err(ConductorApiError::CellError(CellError::WorkflowError(e))) => {
+            match *e {
+                WorkflowError::SourceChainError(SourceChainError::IncompleteCommit(
+                    IncompleteCommitReason::DepMissingFromDht(_),
+                )) => {
+                    // Expected
+                }
+                _ => {
+                    panic!("Expected IncompleteCommit error, got: {:?}", e);
+                }
+            }
+        }
+        _ => {
+            panic!("Expected CellError::WorkflowError, got: {:?}", result);
+        }
+    }
+
+    // Let's make sure Bob will have Alice's activity before committing his countersigning entry
+    let _: AgentActivity = conductors[1]
+        .call_fallible(
+            &bob_zome,
+            "get_agent_activity",
+            GetAgentActivityInput {
+                agent_pubkey: alice.agent_pubkey().clone(),
+                chain_query_filter: ChainQueryFilter::new(),
+                activity_request: ActivityRequest::Full,
+            },
+        )
+        .await
+        .unwrap();
+
+    // But Bob can commit, so let's do that.
+    let (_, _): (ActionHash, EntryHash) = conductors[1]
+        .call_fallible(
+            &bob_zome,
+            "create_a_countersigned_thing_with_entry_hash",
+            vec![alice_response.clone(), bob_response.clone()],
+        )
+        .await
+        .unwrap();
+
+    // Now let's sort out Alice's situation, by getting Bob's activity
+    let _: AgentActivity = conductors[0]
+        .call_fallible(
+            &alice_zome,
+            "get_agent_activity",
+            GetAgentActivityInput {
+                agent_pubkey: bob.agent_pubkey().clone(),
+                chain_query_filter: ChainQueryFilter::new(),
+                activity_request: ActivityRequest::Full,
+            },
+        )
+        .await
+        .unwrap();
+
+    // and retrying the commit
+    let (_, _): (ActionHash, EntryHash) = conductors[0]
+        .call_fallible(
+            &alice_zome,
             "create_a_countersigned_thing_with_entry_hash",
             vec![alice_response.clone(), bob_response.clone()],
         )

--- a/crates/holochain/tests/tests/countersigning.rs
+++ b/crates/holochain/tests/tests/countersigning.rs
@@ -203,7 +203,7 @@ async fn retry_countersigning_commit_on_missing_deps() {
         unreachable!();
     };
 
-    // Alice shouldn't be able to commit
+    // Alice shouldn't be able to commit yet, because she doesn't have Bob's activity
     let result: ConductorApiResult<()> = conductors[0]
         .call_fallible(
             &alice_zome,
@@ -246,7 +246,7 @@ async fn retry_countersigning_commit_on_missing_deps() {
         .await
         .unwrap();
 
-    // But Bob can commit, so let's do that.
+    // Now Bob can commit, so let's do that.
     let (_, _): (ActionHash, EntryHash) = conductors[1]
         .call_fallible(
             &bob_zome,

--- a/crates/holochain/tests/tests/countersigning.rs
+++ b/crates/holochain/tests/tests/countersigning.rs
@@ -258,21 +258,8 @@ async fn retry_countersigning_commit_on_missing_deps() {
     // Bring Bob's app back online
     conductors[1].enable_app("app".into()).await.unwrap();
 
-    // Let's make sure Bob will have Alice's activity before committing his countersigning entry
-    let _: AgentActivity = conductors[1]
-        .call_fallible(
-            &bob_zome,
-            "get_agent_activity",
-            GetAgentActivityInput {
-                agent_pubkey: alice.agent_pubkey().clone(),
-                chain_query_filter: ChainQueryFilter::new(),
-                activity_request: ActivityRequest::Full,
-            },
-        )
-        .await
-        .unwrap();
 
-    // Now Bob can commit, so let's do that.
+    // Bob should be able to get Alice's chain head when we commit, so let's do that.
     let (_, _): (ActionHash, EntryHash) = conductors[1]
         .call_fallible(
             &bob_zome,
@@ -282,21 +269,8 @@ async fn retry_countersigning_commit_on_missing_deps() {
         .await
         .unwrap();
 
-    // Now let's sort out Alice's situation, by getting Bob's activity
-    let _: AgentActivity = conductors[0]
-        .call_fallible(
-            &alice_zome,
-            "get_agent_activity",
-            GetAgentActivityInput {
-                agent_pubkey: bob.agent_pubkey().clone(),
-                chain_query_filter: ChainQueryFilter::new(),
-                activity_request: ActivityRequest::Full,
-            },
-        )
-        .await
-        .unwrap();
-
-    // and retrying the commit
+    // Now that Bob is available again, Alice should also be able to get his chain head and complete
+    // her commit
     let (_, _): (ActionHash, EntryHash) = conductors[0]
         .call_fallible(
             &alice_zome,

--- a/crates/holochain_state/src/source_chain/error.rs
+++ b/crates/holochain_state/src/source_chain/error.rs
@@ -82,6 +82,9 @@ pub enum SourceChainError {
     #[error("InvalidCommit error: {0}")]
     InvalidCommit(String),
 
+    #[error("The commit could not be completed but may be retried: {0:?}")]
+    IncompleteCommit(IncompleteCommitReason),
+
     #[error("InvalidLink error: {0}")]
     InvalidLink(String),
 
@@ -162,6 +165,19 @@ pub enum ChainInvalidReason {
 
     #[error("Content was expected to definitely exist at this address, but didn't: {0}")]
     MissingData(EntryHash),
+}
+
+/// The reason that a commit could not be completed.
+///
+/// These errors are required to be retryable. They may not succeed in the future, so it is up to
+/// the caller to decide whether to retry, but they are not fatal errors.
+#[derive(Debug)]
+pub enum IncompleteCommitReason {
+    /// Inline validation failed because of missing dependencies.
+    ///
+    /// This may happen if you depend on something that has been created but not widely published
+    /// yet, so that doing a `get` for it might miss it.
+    DepMissingFromDht(Vec<AnyDhtHash>),
 }
 
 pub type SourceChainResult<T> = Result<T, SourceChainError>;


### PR DESCRIPTION
### Summary

The fix here might not be too obvious. When an invalid commit happens during a countersigning session, then that's considered fatal to the session and the chain is unlocked, effectively ending the session. That's fine for all other errors apart from missing dependencies. Missing dependencies is acceptable because we might not succeed on getting them on the first attempt. I've had to force that in a test but in a larger network, it's quite common. I've split the error enum up between errors that can and can't be retried. So now missing dependencies won't cause the countersigning session to be terminated.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs