### PR TITLE
Deepkey hookup, put instrumentation behind feature

### DIFF
--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -285,3 +285,7 @@ dpki = []
 sweettest = ["test_utils", "sqlite"]
 
 deepkey-wasm-cache = []
+
+# Enables tracing instrumentation 
+# (we experience segfaults in some tests if there is too much instrumentation)
+instrument = []

--- a/crates/holochain/benches/consistency.rs
+++ b/crates/holochain/benches/consistency.rs
@@ -99,7 +99,7 @@ impl Producer {
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     async fn fill(&mut self, num_ops: usize) {
         let inputs: Vec<_> = (0..num_ops)
             .map(|i| AnchorInput("alice_fill".to_string(), i.to_string()))

--- a/crates/holochain/src/conductor/api/api_cell.rs
+++ b/crates/holochain/src/conductor/api/api_cell.rs
@@ -99,7 +99,7 @@ impl CellConductorApiT for CellConductorApi {
             .get_ribosome(self.cell_id.dna_hash())?)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     fn get_zome(&self, dna_hash: &DnaHash, zome_name: &ZomeName) -> ConductorApiResult<Zome> {
         let dna = self
             .get_dna(dna_hash)

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -374,7 +374,7 @@ impl Cell {
         }
     }
 
-    #[instrument(skip(self, evt))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, evt)))]
     /// Entry point for incoming messages from the network that need to be handled
     //
     // TODO: when we had CellStatus to track whether a cell had joined the network or not,
@@ -587,7 +587,7 @@ impl Cell {
         Ok(())
     }
 
-    #[instrument(skip(self, message))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, message)))]
     /// we are receiving a response from a countersigning authority
     async fn handle_countersigning_session_negotiation(
         &self,
@@ -625,7 +625,7 @@ impl Cell {
         }
     }
 
-    #[instrument(skip(self, options))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, options)))]
     /// a remote node is asking us for entry data
     async fn handle_get(
         &self,
@@ -653,7 +653,7 @@ impl Cell {
         r
     }
 
-    #[instrument(skip(self, options))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, options)))]
     async fn handle_get_entry(
         &self,
         hash: EntryHash,
@@ -665,7 +665,7 @@ impl Cell {
             .map_err(Into::into)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     async fn handle_get_record(
         &self,
         hash: ActionHash,
@@ -677,7 +677,7 @@ impl Cell {
             .map_err(Into::into)
     }
 
-    #[instrument(skip(self, _dht_hash, _options))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, _dht_hash, _options)))]
     /// a remote node is asking us for metadata
     async fn handle_get_meta(
         &self,
@@ -687,7 +687,7 @@ impl Cell {
         unimplemented!()
     }
 
-    #[instrument(skip(self, options))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, options)))]
     /// a remote node is asking us for links
     // TODO: Right now we are returning all the full actions
     // We could probably send some smaller types instead of the full actions
@@ -705,7 +705,7 @@ impl Cell {
     }
 
     /// a remote node is asking us to count links
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     async fn handle_count_links(&self, query: WireLinkQuery) -> CellResult<CountLinksResponse> {
         let db = self.space.dht_db.clone();
         Ok(CountLinksResponse::new(
@@ -717,7 +717,7 @@ impl Cell {
         ))
     }
 
-    #[instrument(skip(self, options))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, options)))]
     async fn handle_get_agent_activity(
         &self,
         agent: AgentPubKey,
@@ -730,7 +730,7 @@ impl Cell {
             .map_err(Into::into)
     }
 
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     async fn handle_must_get_agent_activity(
         &self,
         author: AgentPubKey,
@@ -743,7 +743,7 @@ impl Cell {
     }
 
     /// A remote agent is sending us a validation receipt bundle.
-    #[tracing::instrument(skip(self, receipts))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, receipts)))]
     async fn handle_validation_receipts(
         &self,
         receipts: ValidationReceiptBundle,
@@ -854,12 +854,12 @@ impl Cell {
     }
 
     /// the network module would like this cell/agent to sign some data
-    #[tracing::instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     async fn handle_sign_network_data(&self) -> CellResult<Signature> {
         Ok([0; 64].into())
     }
 
-    #[instrument(skip(self, from_agent, fn_name, cap_secret, payload))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, from_agent, fn_name, cap_secret, payload)))]
     #[allow(clippy::too_many_arguments)]
     /// a remote agent is attempting a "call_remote" on this cell.
     async fn handle_call_remote(
@@ -957,7 +957,7 @@ impl Cell {
     }
 
     /// Check if each Zome's init callback has been run, and if not, run it.
-    #[tracing::instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     pub(crate) async fn check_or_run_zome_init(&self) -> CellResult<()> {
         // Ensure that only one init check is run at a time
         let _guard = tokio::time::timeout(
@@ -1016,7 +1016,7 @@ impl Cell {
     }
 
     /// Clean up long-running managed tasks.
-    #[tracing::instrument(skip_all, fields(cell_id = ?self.id()))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(cell_id = ?self.id())))]
     pub async fn cleanup(&self) -> CellResult<()> {
         use holochain_p2p::HolochainP2pDnaT;
         let shutdown = self

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -366,7 +366,7 @@ mod startup_shutdown_impls {
             })
         }
 
-        #[tracing::instrument(skip_all, fields(scope=self.config.network.tracing_scope))]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(scope=self.config.network.tracing_scope)))]
         pub(crate) async fn initialize_conductor(
             self: Arc<Self>,
             outcome_rx: OutcomeReceiver,
@@ -415,7 +415,7 @@ mod interface_impls {
     impl Conductor {
         /// Spawn all admin interface tasks, register them with the TaskManager,
         /// and modify the conductor accordingly, based on the config passed in
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub async fn add_admin_interfaces(
             self: Arc<Self>,
             configs: Vec<AdminInterfaceConfig>,
@@ -469,7 +469,7 @@ mod interface_impls {
         /// and modify the conductor accordingly, based on the config passed in.
         ///
         /// Returns the given or auto-chosen port number if giving an Ok Result
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub async fn add_app_interface(
             self: Arc<Self>,
             port: either::Either<u16, AppInterfaceId>,
@@ -516,7 +516,7 @@ mod interface_impls {
         }
 
         /// Give a list of networking ports taken up as running app interface tasks
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub async fn list_app_interfaces(&self) -> ConductorResult<Vec<AppInterfaceInfo>> {
             Ok(self
                 .get_state()
@@ -534,7 +534,7 @@ mod interface_impls {
         /// Start all app interfaces currently in state.
         /// This should only be run at conductor initialization.
         #[allow(irrefutable_let_patterns)]
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn startup_app_interfaces(self: Arc<Self>) -> ConductorResult<()> {
             for (id, config) in &self.get_state().await?.app_interfaces {
                 debug!("Starting up app interface: {:?}", id);
@@ -725,7 +725,7 @@ mod dna_impls {
         }
 
         /// Restart every paused app
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn start_paused_apps(&self) -> ConductorResult<AppStatusFx> {
             let (_, delta) = self
                 .update_state_prime(|mut state| {
@@ -760,7 +760,7 @@ mod dna_impls {
             self.put_wasm_code(dna_def, code, zome_defs).await
         }
 
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn put_wasm_code(
             &self,
             dna: DnaDefHashed,
@@ -796,7 +796,7 @@ mod dna_impls {
             Ok(zome_defs)
         }
 
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn load_dnas(&self) -> ConductorResult<()> {
             let (ribosomes, entry_defs) = self.load_wasms_into_dna_files().await?;
             self.ribosome_store().share_mut(|ds| {
@@ -807,7 +807,7 @@ mod dna_impls {
         }
 
         /// Install a [`DnaFile`] in this Conductor
-        #[instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub async fn register_dna(&self, dna: DnaFile) -> ConductorResult<()> {
             if self.get_ribosome(dna.dna_hash()).is_ok() {
                 // ribosome for dna is already registered in store
@@ -1083,7 +1083,7 @@ mod network_impls {
             .collect::<Result<Vec<_>, _>>()
         }
 
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn storage_info(&self) -> ConductorResult<StorageInfo> {
             let state = self.get_state().await?;
 
@@ -1164,7 +1164,7 @@ mod network_impls {
             }))
         }
 
-        #[instrument(skip(self))]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
         pub(crate) async fn dispatch_holochain_p2p_event(
             &self,
             event: holochain_p2p::event::HolochainP2pEvent,
@@ -1433,7 +1433,7 @@ mod app_impls {
         /// Install an app from minimal elements, without needing construct a whole AppBundle.
         /// (This function constructs a bundle under the hood.)
         /// This is just a convenience for testing.
-        #[instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn install_app_minimal(
             self: Arc<Self>,
             installed_app_id: InstalledAppId,
@@ -1466,7 +1466,7 @@ mod app_impls {
             Ok(app.agent_key().clone())
         }
 
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         async fn install_app_common(
             self: Arc<Self>,
             installed_app_id: InstalledAppId,
@@ -1655,7 +1655,7 @@ mod app_impls {
         }
 
         /// Install DNAs and set up Cells as specified by an AppBundle
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub async fn install_app_bundle(
             self: Arc<Self>,
             payload: InstallAppPayload,
@@ -1716,7 +1716,7 @@ mod app_impls {
         }
 
         /// Uninstall an app
-        #[tracing::instrument(skip(self))]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
         pub async fn uninstall_app(
             self: Arc<Self>,
             installed_app_id: &InstalledAppId,
@@ -1754,7 +1754,7 @@ mod app_impls {
         }
 
         /// List Apps with their information
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub async fn list_apps(
             &self,
             status_filter: Option<AppStatusFilter>,
@@ -1807,7 +1807,7 @@ mod app_impls {
         }
 
         /// Get the IDs of all active installed Apps which use this Cell
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub async fn list_running_apps_for_dependent_cell_id(
             &self,
             cell_id: &CellId,
@@ -1823,7 +1823,7 @@ mod app_impls {
         }
 
         /// Find the ID of the first active installed App which uses this Cell
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub async fn find_cell_with_role_alongside_cell(
             &self,
             cell_id: &CellId,
@@ -1847,7 +1847,7 @@ mod app_impls {
         }
 
         /// Get the IDs of all active installed Apps which use this Dna
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub async fn list_running_apps_for_dependent_dna_hash(
             &self,
             dna_hash: &DnaHash,
@@ -2127,7 +2127,7 @@ mod clone_cell_impls {
         }
 
         /// Disable a clone cell.
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn disable_clone_cell(
             &self,
             installed_app_id: &InstalledAppId,
@@ -2152,7 +2152,7 @@ mod clone_cell_impls {
         }
 
         /// Enable a disabled clone cell.
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub async fn enable_clone_cell(
             self: Arc<Self>,
             installed_app_id: &InstalledAppId,
@@ -2192,7 +2192,7 @@ mod clone_cell_impls {
         }
 
         /// Delete a clone cell.
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn delete_clone_cell(
             &self,
             DeleteCloneCellPayload {
@@ -2228,7 +2228,7 @@ mod app_status_impls {
         /// needed) to match the current reality of all app statuses.
         /// - If a Cell is used by at least one Running app, then ensure it is added
         /// - If a Cell is used by no running apps, then ensure it is removed.
-        #[tracing::instrument(skip(self))]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
         pub async fn reconcile_cell_status_with_app_status(
             self: Arc<Self>,
         ) -> ConductorResult<CellStartupErrors> {
@@ -2241,7 +2241,7 @@ mod app_status_impls {
         }
 
         /// Enable an app
-        #[tracing::instrument(skip(self))]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
         pub async fn enable_app(
             self: Arc<Self>,
             app_id: InstalledAppId,
@@ -2256,7 +2256,7 @@ mod app_status_impls {
         }
 
         /// Disable an app
-        #[tracing::instrument(skip(self))]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
         pub async fn disable_app(
             self: Arc<Self>,
             app_id: InstalledAppId,
@@ -2271,7 +2271,7 @@ mod app_status_impls {
         }
 
         /// Start an app
-        #[tracing::instrument(skip(self))]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
         pub async fn start_app(
             self: Arc<Self>,
             app_id: InstalledAppId,
@@ -2285,7 +2285,7 @@ mod app_status_impls {
         }
 
         /// Register an app as disabled in the database
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn add_disabled_app_to_db(
             &self,
             app: InstalledAppCommon,
@@ -2300,7 +2300,7 @@ mod app_status_impls {
         }
 
         /// Transition an app's status to a new state.
-        #[tracing::instrument(skip(self))]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
         pub(crate) async fn transition_app_status(
             &self,
             app_id: InstalledAppId,
@@ -2317,7 +2317,7 @@ mod app_status_impls {
         }
 
         /// Pause an app
-        #[tracing::instrument(skip(self))]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
         #[cfg(any(test, feature = "test_utils"))]
         pub async fn pause_app(
             self: Arc<Self>,
@@ -2334,7 +2334,7 @@ mod app_status_impls {
 
         /// Create any Cells which are missing for any running apps, then initialize
         /// and join them. (Joining could take a while.)
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn create_and_add_initialized_cells_for_running_apps(
             self: Arc<Self>,
             app_id: Option<&InstalledAppId>,
@@ -2418,7 +2418,7 @@ mod app_status_impls {
         ///     then set it to Running
         /// - If an app is Running but at least one of its (required) Cells are off,
         ///     then set it to Paused
-        #[tracing::instrument(skip(self))]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
         pub(crate) async fn reconcile_app_status_with_cell_status(
             &self,
             app_ids: Option<HashSet<InstalledAppId>>,
@@ -2512,13 +2512,13 @@ mod service_impls {
             &self.running_services
         }
 
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn initialize_services(self: Arc<Self>) -> ConductorResult<()> {
             self.initialize_service_dpki().await?;
             Ok(())
         }
 
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn initialize_service_dpki(self: Arc<Self>) -> ConductorResult<()> {
             if let Some(installation) = self.get_state().await?.conductor_services.dpki {
                 self.running_services.share_mut(|s| {
@@ -2535,7 +2535,7 @@ mod service_impls {
         /// Note, this currently is done automatically when the conductor is first initialized,
         /// using the DpkiConfig in the conductor config. We may also provide this as an admin
         /// method some day.
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub async fn install_dpki(
             self: Arc<Self>,
             dna: DnaFile,
@@ -2624,13 +2624,13 @@ mod state_impls {
     use super::*;
 
     impl Conductor {
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn get_state(&self) -> ConductorResult<ConductorState> {
             self.spaces.get_state().await
         }
 
         /// Update the internal state with a pure function mapping old state to new
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn update_state<F>(&self, f: F) -> ConductorResult<ConductorState>
         where
             F: Send + FnOnce(ConductorState) -> ConductorResult<ConductorState> + 'static,
@@ -2641,7 +2641,7 @@ mod state_impls {
         /// Update the internal state with a pure function mapping old state to new,
         /// which may also produce an output value which will be the output of
         /// this function
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub(crate) async fn update_state_prime<F, O>(
             &self,
             f: F,
@@ -2674,7 +2674,7 @@ mod scheduler_impls {
         /// - Delete/unschedule all ephemeral scheduled functions GLOBALLY
         /// - Add an interval that runs IN ADDITION to previous invocations
         /// So ideally this would be called ONCE per conductor lifecycle ONLY.
-        #[tracing::instrument(skip(self))]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
         pub(crate) async fn start_scheduler(
             self: Arc<Self>,
             interval_period: std::time::Duration,
@@ -2784,7 +2784,7 @@ mod misc_impls {
         }
 
         /// Create a JSON dump of the cell's state
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub async fn dump_cell_state(&self, cell_id: &CellId) -> ConductorApiResult<String> {
             let cell = self.cell_by_id(cell_id).await?;
             let authored_db = cell.get_or_create_authored_db()?;
@@ -3078,7 +3078,7 @@ mod accessor_impls {
         }
 
         /// Find the app which contains the given cell by its [CellId].
-        #[tracing::instrument(skip_all)]
+        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub async fn find_app_containing_cell(
             &self,
             cell_id: &CellId,
@@ -3190,7 +3190,7 @@ impl Conductor {
 
     /// Add fully constructed cells to the cell map in the Conductor
     #[allow(deprecated)]
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     fn add_and_initialize_cells(&self, cells: Vec<(Cell, InitialQueueTriggers)>) {
         let (new_cells, triggers): (Vec<_>, Vec<_>) = cells.into_iter().unzip();
         self.running_cells.share_mut(|cells| {
@@ -3216,7 +3216,7 @@ impl Conductor {
     ///
     /// Additionally, if the cell is being removed because the last app referencing it was uninstalled,
     /// all data used by that cell (across Authored, DHT, and Cache databases) will also be removed.
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn remove_dangling_cells(&self) -> ConductorResult<()> {
         let state = self.get_state().await?;
 
@@ -3336,7 +3336,7 @@ impl Conductor {
     ///
     /// Returns a Result for each attempt so that successful creations can be
     /// handled alongside the failures.
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     #[allow(clippy::complexity)]
     async fn create_cells_for_running_apps(
         self: Arc<Self>,
@@ -3410,7 +3410,7 @@ impl Conductor {
     }
 
     /// Deal with the side effects of an app status state transition
-    #[tracing::instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     async fn process_app_status_fx(
         self: Arc<Self>,
         delta: AppStatusFx,
@@ -3456,7 +3456,7 @@ impl Conductor {
     }
 
     /// Entirely remove an app from the database, returning the removed app.
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn remove_app_from_db(&self, app_id: &InstalledAppId) -> ConductorResult<InstalledApp> {
         let (_state, app) = self
             .update_state_prime({
@@ -3471,7 +3471,7 @@ impl Conductor {
     }
 
     /// Associate a new clone cell with an existing app.
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn add_clone_cell_to_app(
         &self,
         app_id: InstalledAppId,
@@ -3628,7 +3628,7 @@ mod test_utils_impls {
     }
 }
 
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 fn purge_data(txn: &mut Transaction) -> DatabaseResult<()> {
     txn.execute("DELETE FROM DhtOp", ())?;
     txn.execute("DELETE FROM Action", ())?;
@@ -3837,7 +3837,7 @@ fn query_dht_ops_from_statement(
     Ok(r)
 }
 
-#[instrument(skip(p2p_evt, handle))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(p2p_evt, handle)))]
 async fn p2p_event_task(
     p2p_evt: holochain_p2p::event::HolochainP2pEventReceiver,
     handle: ConductorHandle,

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -69,7 +69,7 @@ impl ConductorBuilder {
     }
 
     /// Initialize a "production" Conductor
-    #[tracing::instrument(skip_all, fields(scope = self.config.network.tracing_scope))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(scope = self.config.network.tracing_scope)))]
     pub async fn build(self) -> ConductorResult<ConductorHandle> {
         tracing::debug!(?self.config);
 
@@ -326,7 +326,7 @@ impl ConductorBuilder {
             .await;
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub(crate) async fn finish(
         conductor: ConductorHandle,
         config: Arc<ConductorConfig>,
@@ -408,7 +408,7 @@ impl ConductorBuilder {
     }
 
     #[cfg(any(test, feature = "test_utils"))]
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub(crate) async fn update_fake_state(
         state: Option<ConductorState>,
         conductor: Conductor,
@@ -421,7 +421,7 @@ impl ConductorBuilder {
 
     /// Build a Conductor with a test environment
     #[cfg(any(test, feature = "test_utils"))]
-    #[tracing::instrument(skip_all, fields(scope = self.config.network.tracing_scope))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(scope = self.config.network.tracing_scope)))]
     pub async fn test(self, extra_dnas: &[DnaFile]) -> ConductorResult<ConductorHandle> {
         let keystore = self
             .keystore

--- a/crates/holochain/src/conductor/conductor/graft_records_onto_source_chain.rs
+++ b/crates/holochain/src/conductor/conductor/graft_records_onto_source_chain.rs
@@ -3,7 +3,7 @@ use holochain_types::prelude::ChainItem;
 
 use super::*;
 
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub(crate) async fn graft_records_onto_source_chain(
     conductor: ConductorHandle,
     cell_id: CellId,

--- a/crates/holochain/src/conductor/entry_def_store.rs
+++ b/crates/holochain/src/conductor/entry_def_store.rs
@@ -49,7 +49,7 @@ pub(crate) async fn get_entry_def(
     }
 }
 
-#[tracing::instrument(skip(ribosome))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(ribosome)))]
 /// Get all the [EntryDef] for this dna
 pub(crate) async fn get_entry_defs(
     ribosome: RealRibosome,

--- a/crates/holochain/src/conductor/kitsune_host_impl.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl.rs
@@ -123,7 +123,7 @@ impl KitsuneHost for KitsuneHostImpl {
         .into()
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     fn record_metrics(
         &self,
         space: std::sync::Arc<kitsune_p2p::KitsuneSpace>,
@@ -241,7 +241,7 @@ impl KitsuneHost for KitsuneHostImpl {
         .into()
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     fn check_op_data(
         &self,
         space: Arc<kitsune_p2p::KitsuneSpace>,

--- a/crates/holochain/src/conductor/kitsune_host_impl/query_size_limited_regions.rs
+++ b/crates/holochain/src/conductor/kitsune_host_impl/query_size_limited_regions.rs
@@ -11,7 +11,7 @@ use super::query_region_set::query_region_data;
 /// Regions larger than size_limit will be quadrisected, and the size of each subregion
 /// will be fetched from the database. The quadrisecting is recursive until either all
 /// regions are either small enough, or cannot be further subdivided.
-#[tracing::instrument(skip(db, topology))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(db, topology)))]
 pub async fn query_size_limited_regions(
     db: DbWrite<DbKindDht>,
     topology: Topology,

--- a/crates/holochain/src/conductor/manager/mod.rs
+++ b/crates/holochain/src/conductor/manager/mod.rs
@@ -53,7 +53,7 @@ pub enum TaskOutcome {
 
 /// Spawn a task which performs some action after each task has completed,
 /// as recieved by the outcome channel produced by the task manager.
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub fn spawn_task_outcome_handler(
     conductor: ConductorHandle,
     mut outcomes: OutcomeReceiver,
@@ -207,7 +207,7 @@ pub fn spawn_task_outcome_handler(
     }.instrument(span))
 }
 
-#[tracing::instrument(skip(kind))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(kind)))]
 fn produce_task_outcome(kind: &TaskKind, result: ManagedTaskResult, name: String) -> TaskOutcome {
     use TaskOutcome::*;
     match kind {
@@ -299,7 +299,7 @@ impl TaskManagerClient {
     }
 
     /// Stop all tasks for a Cell and await their completion.
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     pub fn stop_cell_tasks(&self, cell_id: CellId) -> ShutdownHandle {
         if let Some(tm) = self.tm.lock().as_mut() {
             tokio::spawn(tm.stop_group(&TaskGroup::Cell(cell_id)).in_current_span())

--- a/crates/holochain/src/conductor/p2p_agent_store.rs
+++ b/crates/holochain/src/conductor/p2p_agent_store.rs
@@ -47,7 +47,7 @@ pub async fn inject_agent_infos<'iter, I: IntoIterator<Item = &'iter AgentInfoSi
 }
 
 /// Inject multiple agent info entries into the peer store in batches.
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub async fn p2p_put_all_batch(
     env: DbWrite<DbKindP2pAgents>,
     rx: tokio::sync::mpsc::Receiver<P2pBatch>,

--- a/crates/holochain/src/conductor/ribosome_store.rs
+++ b/crates/holochain/src/conductor/ribosome_store.rs
@@ -1,7 +1,6 @@
 use holochain_types::{prelude::*, share::RwShare};
 use holochain_zome_types::entry_def::EntryDef;
 use std::collections::HashMap;
-use tracing::*;
 
 use crate::core::ribosome::{real_ribosome::RealRibosome, RibosomeT};
 
@@ -30,12 +29,12 @@ impl RibosomeStore {
         self.ribosomes.extend(ribosomes);
     }
 
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     pub fn list(&self) -> Vec<DnaHash> {
         self.ribosomes.keys().cloned().collect()
     }
 
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     pub fn get_dna_def(&self, hash: &DnaHash) -> Option<DnaDef> {
         self.ribosomes
             .get(hash)
@@ -43,7 +42,7 @@ impl RibosomeStore {
     }
 
     // TODO: use Arc, eliminate cloning
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     pub fn get_dna_file(&self, hash: &DnaHash) -> Option<DnaFile> {
         self.ribosomes.get(hash).map(|r| r.dna_file().clone())
     }

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -50,7 +50,6 @@ use kitsune_p2p_types::agent_info::AgentInfoSigned;
 use rusqlite::{named_params, OptionalExtension};
 use std::convert::TryInto;
 use std::path::PathBuf;
-use tracing::instrument;
 
 #[cfg(test)]
 mod tests;
@@ -256,7 +255,7 @@ impl Spaces {
     }
 
     /// Get the holochain conductor state
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub async fn get_state(&self) -> ConductorResult<ConductorState> {
         timed!([1, 10, 1000], "get_state", {
             match query_conductor_state(&self.conductor_db).await? {
@@ -270,7 +269,7 @@ impl Spaces {
     }
 
     /// Update the internal state with a pure function mapping old state to new
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub async fn update_state<F>(&self, f: F) -> ConductorResult<ConductorState>
     where
         F: Send + FnOnce(ConductorState) -> ConductorResult<ConductorState> + 'static,
@@ -282,7 +281,7 @@ impl Spaces {
     /// Update the internal state with a pure function mapping old state to new,
     /// which may also produce an output value which will be the output of
     /// this function
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub async fn update_state_prime<F, O>(&self, f: F) -> ConductorResult<(ConductorState, O)>
     where
         F: FnOnce(ConductorState) -> ConductorResult<(ConductorState, O)> + Send + 'static,
@@ -391,7 +390,7 @@ impl Spaces {
         self.get_or_create_space_ref(dna_hash, |space| space.p2p_batch_sender.clone())
     }
 
-    #[instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     /// the network module is requesting a list of dht op hashes
     /// Get the [`DhtOpHash`]es and authored timestamps for a given time window.
     pub async fn handle_query_op_hashes(
@@ -488,7 +487,7 @@ impl Spaces {
         Ok(results)
     }
 
-    #[instrument(skip(self, query))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, query)))]
     /// The network module is requesting the content for dht ops
     pub async fn handle_fetch_op_data(
         &self,
@@ -510,7 +509,7 @@ impl Spaces {
         }
     }
 
-    #[instrument(skip(self, regions))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, regions)))]
     /// The network module is requesting the content for dht ops
     pub async fn handle_fetch_op_data_by_regions(
         &self,
@@ -554,7 +553,7 @@ impl Spaces {
             .await?)
     }
 
-    #[instrument(skip(self, op_hashes))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, op_hashes)))]
     /// The network module is requesting the content for dht ops
     pub async fn handle_fetch_op_data_by_hashes(
         &self,
@@ -607,7 +606,7 @@ impl Spaces {
         Ok(results)
     }
 
-    #[instrument(skip(self, request_validation_receipt, ops))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, request_validation_receipt, ops)))]
     /// we are receiving a "publish" event from the network
     pub async fn handle_publish(
         &self,
@@ -803,7 +802,7 @@ impl Space {
 }
 
 /// Get the holochain conductor state
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub async fn query_conductor_state(
     db: &DbRead<DbKindConductor>,
 ) -> ConductorResult<Option<ConductorState>> {

--- a/crates/holochain/src/core/queue_consumer/countersigning_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/countersigning_consumer.rs
@@ -3,10 +3,12 @@
 use super::*;
 use crate::conductor::manager::TaskManagerClient;
 use crate::core::workflow::countersigning_workflow::countersigning_workflow;
-use tracing::*;
 
 /// Spawn the QueueConsumer for countersigning workflow
-#[instrument(skip(space, tm, dna_network, trigger_sys))]
+#[cfg_attr(
+    feature = "instrument",
+    tracing::instrument(skip(space, tm, dna_network, trigger_sys))
+)]
 pub(crate) fn spawn_countersigning_consumer(
     space: Space,
     tm: TaskManagerClient,

--- a/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
@@ -5,10 +5,12 @@ use crate::conductor::manager::TaskManagerClient;
 use crate::core::workflow::integrate_dht_ops_workflow::integrate_dht_ops_workflow;
 use holochain_types::db_cache::DhtDbQueryCache;
 
-use tracing::*;
 
 /// Spawn the QueueConsumer for DhtOpIntegration workflow
-#[instrument(skip(env, trigger_receipt, tm, network, dht_query_cache))]
+#[cfg_attr(
+    feature = "instrument",
+    tracing::instrument(skip(env, trigger_receipt, tm, network, dht_query_cache))
+)]
 pub fn spawn_integrate_dht_ops_consumer(
     dna_hash: Arc<DnaHash>,
     env: DbWrite<DbKindDht>,

--- a/crates/holochain/src/core/queue_consumer/publish_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/publish_dht_ops_consumer.rs
@@ -3,10 +3,9 @@
 use super::*;
 
 use crate::core::workflow::publish_dht_ops_workflow::publish_dht_ops_workflow;
-use tracing::*;
 
 /// Spawn the QueueConsumer for Publish workflow
-#[instrument(skip(env, conductor, network))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(env, conductor, network)))]
 pub fn spawn_publish_dht_ops_consumer(
     cell_id: CellId,
     env: DbWrite<DbKindAuthored>,

--- a/crates/holochain/src/core/queue_consumer/sys_validation_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/sys_validation_consumer.rs
@@ -7,10 +7,9 @@ use crate::core::workflow::sys_validation_workflow::{
     get_representative_agent, sys_validation_workflow,
 };
 use holochain_keystore::MetaLairClient;
-use tracing::*;
 
 /// Spawn the QueueConsumer for SysValidation workflow
-#[instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub fn spawn_sys_validation_consumer(
     workspace: SysValidationWorkspace,
     space: Space,

--- a/crates/holochain/src/core/queue_consumer/validation_receipt_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/validation_receipt_consumer.rs
@@ -3,10 +3,9 @@
 use super::*;
 use crate::core::workflow::validation_receipt_workflow::validation_receipt_workflow;
 use futures::FutureExt;
-use tracing::*;
 
 /// Spawn the QueueConsumer for validation receipt workflow
-#[instrument(skip(env, conductor, network))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(env, conductor, network)))]
 pub fn spawn_validation_receipt_consumer(
     dna_hash: Arc<DnaHash>,
     env: DbWrite<DbKindDht>,

--- a/crates/holochain/src/core/ribosome.rs
+++ b/crates/holochain/src/core/ribosome.rs
@@ -631,7 +631,6 @@ pub trait RibosomeT: Sized + std::fmt::Debug + Send + Sync {
 
     fn zome_info(&self, zome: Zome) -> RibosomeResult<ZomeInfo>;
 
-    #[tracing::instrument(skip_all)]
     fn zomes_to_invoke(&self, zomes_to_invoke: ZomesToInvoke) -> Vec<Zome> {
         match zomes_to_invoke {
             ZomesToInvoke::AllIntegrity => self

--- a/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
@@ -9,7 +9,10 @@ use tracing::error;
 use wasmer::RuntimeError;
 
 #[allow(clippy::extra_unused_lifetimes)]
-#[tracing::instrument(skip(_ribosome, call_context))]
+#[cfg_attr(
+    feature = "instrument",
+    tracing::instrument(skip(_ribosome, call_context))
+)]
 pub fn accept_countersigning_preflight_request<'a>(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/count_links.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/count_links.rs
@@ -10,7 +10,7 @@ use wasmer::RuntimeError;
 
 /// Count links
 #[allow(clippy::extra_unused_lifetimes)]
-#[tracing::instrument(skip(_ribosome, call_context), fields(? call_context.zome, function = ? call_context.function_name))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(_ribosome, call_context), fields(? call_context.zome, function = ? call_context.function_name)))]
 pub fn count_links<'a>(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/create_clone_cell.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/create_clone_cell.rs
@@ -13,7 +13,7 @@ use holochain_wasmer_host::prelude::*;
 use holochain_zome_types::clone::{ClonedCell, CreateCloneCellInput};
 use wasmer::RuntimeError;
 
-#[tracing::instrument(skip(_ribosome, call_context), fields(? call_context.zome, function = ? call_context.function_name))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(_ribosome, call_context), fields(? call_context.zome, function = ? call_context.function_name)))]
 pub fn create_clone_cell<'a>(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/delete_clone_cell.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/delete_clone_cell.rs
@@ -13,7 +13,7 @@ use holochain_wasmer_host::prelude::*;
 use holochain_zome_types::clone::DeleteCloneCellInput;
 use wasmer::RuntimeError;
 
-#[tracing::instrument(skip(_ribosome, call_context), fields(? call_context.zome, function = ? call_context.function_name))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(_ribosome, call_context), fields(? call_context.zome, function = ? call_context.function_name)))]
 pub fn delete_clone_cell<'a>(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/disable_clone_cell.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/disable_clone_cell.rs
@@ -13,7 +13,7 @@ use holochain_wasmer_host::prelude::*;
 use holochain_zome_types::clone::DisableCloneCellInput;
 use wasmer::RuntimeError;
 
-#[tracing::instrument(skip(_ribosome, call_context), fields(? call_context.zome, function = ? call_context.function_name))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(_ribosome, call_context), fields(? call_context.zome, function = ? call_context.function_name)))]
 pub fn disable_clone_cell<'a>(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/enable_clone_cell.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/enable_clone_cell.rs
@@ -13,7 +13,7 @@ use holochain_wasmer_host::prelude::*;
 use holochain_zome_types::clone::{ClonedCell, EnableCloneCellInput};
 use wasmer::RuntimeError;
 
-#[tracing::instrument(skip(_ribosome, call_context), fields(? call_context.zome, function = ? call_context.function_name))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(_ribosome, call_context), fields(? call_context.zome, function = ? call_context.function_name)))]
 pub fn enable_clone_cell<'a>(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/get.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use wasmer::RuntimeError;
 
 #[allow(clippy::extra_unused_lifetimes)]
-#[tracing::instrument(skip(_ribosome, call_context), fields(?call_context.zome, function = ?call_context.function_name))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(_ribosome, call_context), fields(?call_context.zome, function = ?call_context.function_name)))]
 pub fn get<'a>(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/get_links.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_links.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use wasmer::RuntimeError;
 
 #[allow(clippy::extra_unused_lifetimes)]
-#[tracing::instrument(skip(_ribosome, call_context), fields(?call_context.zome, function = ?call_context.function_name))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(_ribosome, call_context), fields(?call_context.zome, function = ?call_context.function_name)))]
 pub fn get_links<'a>(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/get_validation_receipts.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_validation_receipts.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use wasmer::RuntimeError;
 use holochain_sqlite::db::DbKindDht;
 
-#[tracing::instrument(skip(_ribosome, call_context), fields(?call_context.zome, function = ?call_context.function_name))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(_ribosome, call_context), fields(?call_context.zome, function = ?call_context.function_name)))]
 pub fn get_validation_receipts(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_action.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_action.rs
@@ -10,7 +10,10 @@ use std::sync::Arc;
 use wasmer::RuntimeError;
 
 #[allow(clippy::extra_unused_lifetimes)]
-#[tracing::instrument(skip(_ribosome, call_context))]
+#[cfg_attr(
+    feature = "instrument",
+    tracing::instrument(skip(_ribosome, call_context))
+)]
 pub fn must_get_action<'a>(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_agent_activity.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_agent_activity.rs
@@ -10,7 +10,7 @@ use holochain_wasmer_host::prelude::*;
 use std::sync::Arc;
 use wasmer::RuntimeError;
 
-#[tracing::instrument(skip(_ribosome, call_context))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(_ribosome, call_context)))]
 pub fn must_get_agent_activity(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_entry.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_entry.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use wasmer::RuntimeError;
 
 #[allow(clippy::extra_unused_lifetimes)]
-#[tracing::instrument(skip(_ribosome, call_context))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(_ribosome, call_context)))]
 pub fn must_get_entry<'a>(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_valid_record.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_valid_record.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use wasmer::RuntimeError;
 
 #[allow(clippy::extra_unused_lifetimes)]
-#[tracing::instrument(skip(_ribosome, call_context))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(_ribosome, call_context)))]
 pub fn must_get_valid_record<'a>(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/send_remote_signal.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/send_remote_signal.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use tracing::Instrument;
 use wasmer::RuntimeError;
 
-#[tracing::instrument(skip(_ribosome, call_context, input))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(_ribosome, call_context, input)))]
 pub fn send_remote_signal(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/sign.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/sign.rs
@@ -7,7 +7,7 @@ use holochain_wasmer_host::prelude::*;
 use std::sync::Arc;
 use wasmer::RuntimeError;
 
-#[tracing::instrument(skip(_ribosome, call_context))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(_ribosome, call_context)))]
 pub fn sign(
     _ribosome: Arc<impl RibosomeT>,
     call_context: Arc<CallContext>,

--- a/crates/holochain/src/core/ribosome/host_fn/trace.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/trace.rs
@@ -3,7 +3,6 @@ use crate::core::ribosome::RibosomeT;
 use holochain_types::prelude::*;
 use once_cell::unsync::Lazy;
 use std::sync::Arc;
-use tracing::*;
 use wasmer::RuntimeError;
 
 #[cfg(test)]
@@ -17,7 +16,7 @@ static CAPTURE: AtomicBool = AtomicBool::new(false);
 static CAPTURED: SyncLazy<Arc<std::sync::Mutex<Vec<TraceMsg>>>> =
     SyncLazy::new(|| Arc::new(std::sync::Mutex::new(Vec::new())));
 
-#[instrument(skip(input))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(input)))]
 pub fn wasm_trace(input: TraceMsg) {
     match input.level {
         holochain_types::prelude::Level::TRACE => tracing::trace!("{}", input.msg),

--- a/crates/holochain/src/core/ribosome/real_ribosome.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome.rs
@@ -243,7 +243,7 @@ impl RealRibosome {
     }
 
     /// Create a new instance
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub async fn new(
         dna_file: DnaFile,
         wasmer_module_cache: Arc<ModuleCacheLock>,
@@ -366,7 +366,7 @@ impl RealRibosome {
         }
     }
 
-    #[tracing::instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     pub async fn runtime_compiled_module(
         &self,
         zome_name: &ZomeName,
@@ -389,7 +389,7 @@ impl RealRibosome {
     // Create a key for module cache.
     // Format: [WasmHash] as bytes
     // watch out for cache misses in the tests that make things slooow if you change this!
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub fn get_module_cache_key(&self, zome_name: &ZomeName) -> Result<CacheKey, DnaError> {
         let mut key = [0; 32];
         let wasm_zome_hash = self.dna_file.dna().get_wasm_zome_hash(zome_name)?;
@@ -398,7 +398,7 @@ impl RealRibosome {
         Ok(key)
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub async fn get_module_for_zome(&self, zome: &Zome<ZomeDef>) -> RibosomeResult<Arc<Module>> {
         match &zome.def {
             ZomeDef::Wasm(wasm_zome) => {
@@ -415,7 +415,7 @@ impl RealRibosome {
         }
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub fn build_instance_with_store(
         &self,
         module: Arc<Module>,
@@ -471,7 +471,7 @@ impl RealRibosome {
         }))
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     fn next_context_key() -> u64 {
         CONTEXT_KEY.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
     }
@@ -938,7 +938,7 @@ impl RibosomeT for RealRibosome {
         }
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn get_const_fn(&self, zome: &Zome, name: &str) -> Result<Option<i32>, RibosomeError> {
         match zome.zome_def() {
             ZomeDef::Wasm(_) => {

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -149,7 +149,7 @@ pub(crate) async fn countersigning_workflow(
 }
 
 /// An incoming countersigning session success.
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub(crate) async fn countersigning_success(
     space: Space,
     network: &HolochainP2pDna,

--- a/crates/holochain/src/core/workflow/genesis_workflow.rs
+++ b/crates/holochain/src/core/workflow/genesis_workflow.rs
@@ -38,7 +38,7 @@ where
     chc: Option<ChcImpl>,
 }
 
-// #[instrument(skip(workspace, api, args))]
+// #[cfg_attr(feature = "instrument", tracing::instrument(skip(workspace, api, args)))]
 pub async fn genesis_workflow<'env, Api: CellConductorApiT, Ribosome>(
     mut workspace: GenesisWorkspace,
     api: Api,

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
@@ -9,7 +9,6 @@ use holochain_sqlite::prelude::*;
 use holochain_state::prelude::*;
 use incoming_ops_batch::InOpBatchEntry;
 use std::{collections::HashSet, sync::Arc};
-use tracing::instrument;
 
 mod incoming_ops_batch;
 
@@ -68,7 +67,7 @@ impl Drop for OpsClaim {
     }
 }
 
-#[instrument(skip(txn, ops))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(txn, ops)))]
 fn batch_process_entry(
     txn: &mut rusqlite::Transaction<'_>,
     request_validation_receipt: bool,
@@ -93,7 +92,10 @@ fn batch_process_entry(
 #[derive(Default, Clone)]
 pub struct IncomingOpHashes(Arc<parking_lot::Mutex<HashSet<DhtOpHash>>>);
 
-#[instrument(skip(space, sys_validation_trigger, ops))]
+#[cfg_attr(
+    feature = "instrument",
+    tracing::instrument(skip(space, sys_validation_trigger, ops))
+)]
 pub async fn incoming_dht_ops_workflow(
     space: Space,
     sys_validation_trigger: TriggerSender,
@@ -207,7 +209,7 @@ pub async fn incoming_dht_ops_workflow(
         .map_err(|_| super::error::WorkflowError::RecvError)?
 }
 
-#[instrument(skip(op))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(op)))]
 /// If this op fails the counterfeit check it should be dropped
 async fn should_keep(op: &DhtOp) -> WorkflowResult<()> {
     match op {

--- a/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
+++ b/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
@@ -37,7 +37,7 @@ where
     }
 }
 
-// #[instrument(skip(network, keystore, workspace, args))]
+// #[cfg_attr(feature = "instrument", tracing::instrument(skip(network, keystore, workspace, args)))]
 pub async fn initialize_zomes_workflow<Ribosome>(
     workspace: SourceChainWorkspace,
     network: HolochainP2pDna,

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -7,14 +7,15 @@ use holochain_p2p::HolochainP2pDna;
 use holochain_p2p::HolochainP2pDnaT;
 use holochain_state::prelude::*;
 
-use tracing::*;
-
 #[cfg(test)]
 mod query_tests;
 #[cfg(feature = "test_utils")]
 mod tests;
 
-#[instrument(skip(vault, trigger_receipt, network, dht_query_cache))]
+#[cfg_attr(
+    feature = "instrument",
+    tracing::instrument(skip(vault, trigger_receipt, network, dht_query_cache))
+)]
 pub async fn integrate_dht_ops_workflow(
     vault: DbWrite<DbKindDht>,
     dht_query_cache: DhtDbQueryCache,

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/query_tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/query_tests.rs
@@ -120,7 +120,7 @@ async fn integrate_query() {
         .unwrap();
     let diff = hashes.symmetric_difference(&expected.hashes);
     for d in diff {
-        debug!(?d, missing = ?expected.ops.get(d));
+        tracing::debug!(?d, missing = ?expected.ops.get(d));
     }
     assert_eq!(hashes, expected.hashes);
 }

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
@@ -35,7 +35,7 @@ impl TestData {
         Self::new_inner(original_entry, new_entry)
     }
 
-    #[instrument()]
+    #[cfg_attr(feature = "instrument", tracing::instrument())]
     fn new_inner(original_entry: Entry, new_entry: Entry) -> Self {
         // original entry
         let original_entry_hash =
@@ -46,7 +46,7 @@ impl TestData {
 
         // Original entry and action for updates
         let mut original_action = fixt!(NewEntryAction, PublicCurve);
-        debug!(?original_action);
+        tracing::debug!(?original_action);
 
         match &mut original_action {
             NewEntryAction::Create(c) => c.entry_hash = original_entry_hash.clone(),
@@ -136,7 +136,7 @@ enum Db {
 
 impl Db {
     /// Checks that the database is in a state
-    #[instrument(skip(expects, env))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(expects, env)))]
     async fn check(expects: Vec<Self>, env: DbWrite<DbKindDht>, here: String) {
         env.read_async(move |txn| -> DatabaseResult<()> {
             for expect in expects {
@@ -315,7 +315,7 @@ impl Db {
     }
 
     // Sets the database to a certain state
-    #[instrument(skip(pre_state, env))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(pre_state, env)))]
     async fn set<'env>(pre_state: Vec<Self>, env: DbWrite<DbKindDht>) {
         env.write_async(move |txn| -> DatabaseResult<()> {
             for state in pre_state {

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -36,7 +36,10 @@ pub const DEFAULT_RECEIPT_BUNDLE_SIZE: u8 = 5;
 /// flooding the network with spurious publishes.
 pub const MIN_PUBLISH_INTERVAL: time::Duration = time::Duration::from_secs(60 * 5);
 
-#[instrument(skip(db, network, trigger_self))]
+#[cfg_attr(
+    feature = "instrument",
+    tracing::instrument(skip(db, network, trigger_self))
+)]
 pub async fn publish_dht_ops_workflow(
     db: DbWrite<DbKindAuthored>,
     network: Arc<impl HolochainP2pDnaT>,

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -120,7 +120,7 @@ mod unit_tests;
 mod validate_op_tests;
 
 /// The sys validation worfklow. It is described in the module level documentation.
-#[instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 #[allow(clippy::too_many_arguments)]
 pub async fn sys_validation_workflow<Network: HolochainP2pDnaT + 'static>(
     workspace: Arc<SysValidationWorkspace>,
@@ -1256,7 +1256,7 @@ impl SysValidationWorkspace {
         }
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub async fn is_chain_empty(&self, author: &AgentPubKey) -> SourceChainResult<bool> {
         // If we have a query cache then this is an authority node and
         // we can quickly check if the chain is empty from the cache.

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validation_query.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validation_query.rs
@@ -6,7 +6,7 @@ use crate::core::workflow::WorkflowResult;
 /// Get all ops that need to sys or app validated in order.
 /// - Sys validated or awaiting app dependencies.
 /// - Ordered by type then timestamp (See [`OpOrder`])
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub async fn get_ops_to_app_validate(db: &DbRead<DbKindDht>) -> WorkflowResult<Vec<DhtOpHashed>> {
     get_ops_to_validate(db, false).await
 }
@@ -14,7 +14,7 @@ pub async fn get_ops_to_app_validate(db: &DbRead<DbKindDht>) -> WorkflowResult<V
 /// Get all ops that need to sys or app validated in order.
 /// - Pending or awaiting sys dependencies.
 /// - Ordered by type then timestamp (See [`OpOrder`])
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub async fn get_ops_to_sys_validate(db: &DbRead<DbKindDht>) -> WorkflowResult<Vec<DhtOpHashed>> {
     get_ops_to_validate(db, true).await
 }

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
@@ -21,7 +21,10 @@ mod tests;
 #[cfg(test)]
 mod unit_tests;
 
-#[instrument(skip(vault, network, keystore, apply_block))]
+#[cfg_attr(
+    feature = "instrument",
+    tracing::instrument(skip(vault, network, keystore, apply_block))
+)]
 /// Send validation receipts to their authors in serial and without waiting for responses.
 pub async fn validation_receipt_workflow<B>(
     dna_hash: Arc<DnaHash>,
@@ -188,7 +191,7 @@ where
     Ok(())
 }
 
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 async fn pending_receipts(
     vault: &DbRead<DbKindDht>,
     validators: Vec<AgentPubKey>,

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -415,7 +415,7 @@ async fn check_gossip(
     }
 }
 
-#[tracing::instrument(skip(envs))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(envs)))]
 async fn check_peers(envs: Vec<DbWrite<DbKindP2pAgents>>) {
     for (i, a) in envs.iter().enumerate() {
         let peers = all_agent_infos(a.clone().into()).await.unwrap();

--- a/crates/holochain/src/sweettest/sweet_app.rs
+++ b/crates/holochain/src/sweettest/sweet_app.rs
@@ -13,7 +13,7 @@ pub struct SweetApp {
 
 impl SweetApp {
     /// Constructor
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub(super) fn new(installed_app_id: InstalledAppId, cells: Vec<SweetCell>) -> Self {
         // Ensure that all Agents are the same
         assert!(

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -288,7 +288,7 @@ impl SweetConductor {
     /// Install the dna first.
     /// This allows a big speed up when
     /// installing many apps with the same dna
-    #[instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn setup_app_1_register_dna(
         &mut self,
         dna_files: impl IntoIterator<Item = &DnaFile>,
@@ -303,7 +303,7 @@ impl SweetConductor {
     /// Install the app and enable it
     // TODO: make this take a more flexible config for specifying things like
     // membrane proofs
-    #[instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn setup_app_2_install_and_enable(
         &mut self,
         installed_app_id: &str,
@@ -336,7 +336,7 @@ impl SweetConductor {
     /// are not available until after `setup_cells` has run, and it is
     /// better to do that once for all apps in the case of multiple apps being
     /// set up at once.
-    #[instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn setup_app_3_create_sweet_app(
         &self,
         installed_app_id: &str,
@@ -387,7 +387,7 @@ impl SweetConductor {
     /// Opinionated app setup.
     /// Creates an app for the given agent, if specified, using the given DnaFiles,
     /// with no extra configuration.
-    #[instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn setup_app_for_optional_agent<'a>(
         &mut self,
         installed_app_id: &str,
@@ -436,7 +436,7 @@ impl SweetConductor {
     /// Opinionated app setup.
     /// Creates an app using the given DnaFiles, with no extra configuration.
     /// An AgentPubKey will be generated, and is accessible via the returned SweetApp.
-    #[instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub async fn setup_app<'a>(
         &mut self,
         installed_app_id: &str,

--- a/crates/holochain/src/sweettest/sweet_conductor_batch.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor_batch.rs
@@ -154,7 +154,7 @@ impl SweetConductorBatch {
     /// Opinionated app setup.
     /// Creates one app on each Conductor in this batch, creating a new AgentPubKey for each.
     /// The created AgentPubKeys can be retrieved via each SweetApp.
-    #[instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub async fn setup_app<'a>(
         &mut self,
         installed_app_id: &str,

--- a/crates/holochain/src/sweettest/sweet_consistency.rs
+++ b/crates/holochain/src/sweettest/sweet_consistency.rs
@@ -30,7 +30,7 @@ impl DurationOrSeconds {
 }
 
 /// Wait for all cells to reach consistency
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub async fn await_consistency<'a, I: IntoIterator<Item = &'a SweetCell>>(
     timeout: impl Into<DurationOrSeconds>,
     all_cells: I,
@@ -39,7 +39,7 @@ pub async fn await_consistency<'a, I: IntoIterator<Item = &'a SweetCell>>(
 }
 
 /// Wait for all cells to reach consistency
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub async fn await_consistency_conditional<'a, I: IntoIterator<Item = &'a SweetCell>>(
     timeout: impl Into<DurationOrSeconds>,
     conditions: impl Into<ConsistencyConditions>,
@@ -59,7 +59,7 @@ pub async fn await_consistency_conditional<'a, I: IntoIterator<Item = &'a SweetC
 /// Cells paired with a `false` value will have their authored ops counted towards the total,
 /// but not their integrated ops (since they are not online to integrate things).
 /// This is useful for tests where nodes go offline.
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub async fn await_consistency_advanced<'a, I: IntoIterator<Item = (&'a SweetCell, bool)>>(
     timeout: impl Into<DurationOrSeconds>,
     conditions: impl Into<ConsistencyConditions>,

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -807,7 +807,7 @@ fn display_op(op: &DhtOp) -> String {
 }
 
 /// Wait for num_attempts * delay, or until all published ops have been integrated.
-#[tracing::instrument(skip(db))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(db)))]
 pub async fn wait_for_integration<Db: ReadAccess<DbKindDht>>(
     db: &Db,
     num_published: usize,
@@ -835,7 +835,7 @@ pub async fn wait_for_integration<Db: ReadAccess<DbKindDht>>(
     ))
 }
 
-#[tracing::instrument(skip(envs))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(envs)))]
 /// Show authored data for each cell environment
 pub async fn show_authored<Db: ReadAccess<DbKindAuthored>>(envs: &[&Db]) {
     for (i, &db) in envs.iter().enumerate() {

--- a/crates/holochain/src/test_utils/consistency.rs
+++ b/crates/holochain/src/test_utils/consistency.rs
@@ -202,7 +202,7 @@ impl Reporter {
 
 /// Wait for all agents to report success, timeout or failure.
 /// Additionally print out debug tracing with some statistics.
-#[tracing::instrument(skip(rx, agents))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(rx, agents)))]
 async fn wait_for_consistency(
     mut rx: tokio::sync::mpsc::Receiver<SessionMessage>,
     mut agents: HashSet<Arc<KitsuneAgent>>,
@@ -596,7 +596,7 @@ async fn check_agents<'iter>(
 }
 
 /// Check the op hashes we are meant to be holding.
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 async fn check_hashes(
     dht_db: &DbRead<DbKindDht>,
     expected_hashes: &mut Vec<KitsuneOpHash>,

--- a/crates/holochain/src/test_utils/host_fn_caller.rs
+++ b/crates/holochain/src/test_utils/host_fn_caller.rs
@@ -163,7 +163,7 @@ impl HostFnCaller {
         self.dht_db.clone()
     }
 
-    #[instrument(skip(self), fields(cell_id = %self.zome_path.cell_id()))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self), fields(cell_id = %self.zome_path.cell_id())))]
     pub async fn unpack(&self) -> (Arc<RealRibosome>, Arc<CallContext>, SourceChainWorkspace) {
         let HostFnCaller {
             authored_db,

--- a/crates/holochain/src/test_utils/wait_for.rs
+++ b/crates/holochain/src/test_utils/wait_for.rs
@@ -130,7 +130,7 @@ impl WaitFor {
 
     /// Wait for some time before trying again.
     /// Will return false when you should stop waiting.
-    #[tracing::instrument(skip(self))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     pub async fn wait_any(&mut self) -> bool {
         if self.attempt >= self.num_attempts {
             return false;

--- a/crates/holochain/tests/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/tests/multi_conductor/mod.rs
@@ -331,7 +331,7 @@ async fn private_entries_dont_leak() {
     check_for_private_entries(conductors[1].get_cache_db(bobbo.cell_id()).await.unwrap()).await;
 }
 
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 async fn check_for_private_entries<Kind: DbKindT>(env: DbWrite<Kind>) {
     let count: usize = env.read_async(move |txn| -> DatabaseResult<usize> {
         Ok(txn.query_row(

--- a/crates/holochain/tests/tests/test_utils/mod.rs
+++ b/crates/holochain/tests/tests/test_utils/mod.rs
@@ -38,7 +38,6 @@ use tokio::io::AsyncBufReadExt;
 use tokio::io::BufReader;
 use tokio::process::Child;
 use tokio::process::Command;
-use tracing::instrument;
 
 use hdk::prelude::*;
 use holochain::{
@@ -361,7 +360,7 @@ pub fn write_config(mut path: PathBuf, config: &ConductorConfig) -> PathBuf {
     path
 }
 
-#[instrument(skip(response))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(response)))]
 pub async fn check_timeout<T>(
     response: impl Future<Output = std::io::Result<T>>,
     timeout_ms: u64,
@@ -369,7 +368,7 @@ pub async fn check_timeout<T>(
     check_timeout_named("<unnamed>", response, timeout_ms).await
 }
 
-#[instrument(skip(response))]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(response)))]
 async fn check_timeout_named<T>(
     name: &'static str,
     response: impl Future<Output = std::io::Result<T>>,

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -67,3 +67,7 @@ sqlite = [
   "kitsune_p2p/sqlite",
   "kitsune_p2p_types/sqlite",
 ]
+
+# Enables tracing instrumentation 
+# (we experience segfaults in some tests if there is too much instrumentation)
+instrument = []

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -19,7 +19,6 @@ use crate::types::AgentPubKeyExt;
 use ghost_actor::dependencies::tracing;
 use ghost_actor::dependencies::tracing_futures::Instrument;
 
-use holochain_trace::tracing::warn;
 use holochain_zome_types::zome::FunctionName;
 use kitsune_p2p::actor::KitsuneP2pSender;
 use kitsune_p2p::agent_store::AgentInfoSigned;
@@ -477,7 +476,10 @@ impl HolochainP2pActor {
     }
 
     /// receiving an incoming get request from a remote node
-    #[tracing::instrument(skip(self, dna_hash, to_agent, dht_hash, options), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self, dna_hash, to_agent, dht_hash, options), level = "trace")
+    )]
     fn handle_incoming_get(
         &mut self,
         dna_hash: DnaHash,
@@ -665,7 +667,10 @@ impl ghost_actor::GhostHandler<kitsune_p2p::event::KitsuneP2pEvent> for Holochai
 
 impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
     /// We need to store signed agent info.
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_put_agent_info_signed(
         &mut self,
         input: kitsune_p2p::event::PutAgentInfoSignedEvt,
@@ -708,7 +713,10 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
     /// on the query object to determine which query path to take. The reason for
     /// this is that Holochain is optimized for these three query types, while
     /// kitsune has a more general interface.
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_query_agents(
         &mut self,
         input: kitsune_p2p::event::QueryAgentsEvt,
@@ -773,7 +781,10 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
         .into())
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_query_peer_density(
         &mut self,
         space: Arc<kitsune_p2p::KitsuneSpace>,
@@ -791,7 +802,10 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
     }
 
     /// Handle an incoming call.
-    #[tracing::instrument(skip(self, space, to_agent, payload), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self, space, to_agent, payload), level = "trace")
+    )]
     fn handle_call(
         &mut self,
         space: Arc<kitsune_p2p::KitsuneSpace>,
@@ -878,7 +892,10 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
     }
 
     /// Handle an incoming notify.
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_notify(
         &mut self,
         space: Arc<kitsune_p2p::KitsuneSpace>,
@@ -967,7 +984,10 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
         }
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_receive_ops(
         &mut self,
         space: Arc<kitsune_p2p::KitsuneSpace>,
@@ -1008,7 +1028,10 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
         }
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_query_op_hashes(
         &mut self,
         input: kitsune_p2p::event::QueryOpHashesEvt,
@@ -1036,7 +1059,10 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
     }
 
     #[allow(clippy::needless_collect)]
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_fetch_op_data(
         &mut self,
         input: kitsune_p2p::event::FetchOpDataEvt,
@@ -1065,7 +1091,10 @@ impl kitsune_p2p::event::KitsuneP2pEventHandler for HolochainP2pActor {
         .into())
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_sign_network_data(
         &mut self,
         input: kitsune_p2p::event::SignNetworkDataEvt,
@@ -1121,7 +1150,10 @@ macro_rules! timing_trace_out {
 impl ghost_actor::GhostHandler<HolochainP2p> for HolochainP2pActor {}
 
 impl HolochainP2pHandler for HolochainP2pActor {
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_join(
         &mut self,
         dna_hash: DnaHash,
@@ -1142,7 +1174,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
         .into())
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_leave(
         &mut self,
         dna_hash: DnaHash,
@@ -1158,7 +1193,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
     }
 
     /// Dispatch an outgoing remote call.
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_call_remote(
         &mut self,
         dna_hash: DnaHash,
@@ -1197,7 +1235,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
     }
 
     /// Dispatch an outgoing signal.
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_send_remote_signal(
         &mut self,
         dna_hash: DnaHash,
@@ -1244,7 +1285,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
         )
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_publish(
         &mut self,
         dna_hash: DnaHash,
@@ -1320,7 +1364,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
         )
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_publish_countersign(
         &mut self,
         dna_hash: DnaHash,
@@ -1345,7 +1392,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
         .into())
     }
 
-    #[tracing::instrument(skip(self, dna_hash, dht_hash, options), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self, dna_hash, dht_hash, options), level = "trace")
+    )]
     fn handle_get(
         &mut self,
         dna_hash: DnaHash,
@@ -1381,7 +1431,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
         )
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_get_meta(
         &mut self,
         dna_hash: DnaHash,
@@ -1414,7 +1467,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
         )
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_get_links(
         &mut self,
         dna_hash: DnaHash,
@@ -1483,7 +1539,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
         )
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_get_agent_activity(
         &mut self,
         dna_hash: DnaHash,
@@ -1525,7 +1584,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
         )
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_must_get_agent_activity(
         &mut self,
         dna_hash: DnaHash,
@@ -1564,7 +1626,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
         )
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_send_validation_receipts(
         &mut self,
         dna_hash: DnaHash,
@@ -1590,7 +1655,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
         )
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_new_integrated_data(&mut self, dna_hash: DnaHash) -> HolochainP2pHandlerResult<()> {
         let space = dna_hash.into_kitsune();
 
@@ -1602,7 +1670,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
         )
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_authority_for_hash(
         &mut self,
         dna_hash: DnaHash,
@@ -1619,7 +1690,10 @@ impl HolochainP2pHandler for HolochainP2pActor {
         )
     }
 
-    #[tracing::instrument(skip(self), level = "trace")]
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self), level = "trace")
+    )]
     fn handle_countersigning_session_negotiation(
         &mut self,
         dna_hash: DnaHash,

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -113,3 +113,7 @@ sqlite = [
   "kitsune_p2p_dht_arc/sqlite",
   "kitsune_p2p_types/sqlite",
 ]
+
+# Enables tracing instrumentation 
+# (we experience segfaults in some tests if there is too much instrumentation)
+instrument = []

--- a/crates/holochain_sqlite/src/db/access.rs
+++ b/crates/holochain_sqlite/src/db/access.rs
@@ -41,7 +41,7 @@ pub trait ReadAccess<Kind: DbKindT>: Clone + Into<DbRead<Kind>> {
 
 #[async_trait::async_trait]
 impl<Kind: DbKindT> ReadAccess<Kind> for DbWrite<Kind> {
-    #[tracing::instrument(skip_all, fields(kind = ?self.kind))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(kind = ?self.kind)))]
     async fn read_async<E, R, F>(&self, f: F) -> Result<R, E>
     where
         E: From<DatabaseError> + Send + 'static,
@@ -59,7 +59,7 @@ impl<Kind: DbKindT> ReadAccess<Kind> for DbWrite<Kind> {
 
 #[async_trait::async_trait]
 impl<Kind: DbKindT> ReadAccess<Kind> for DbRead<Kind> {
-    #[tracing::instrument(skip_all, fields(kind = ?self.kind))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(kind = ?self.kind)))]
     async fn read_async<E, R, F>(&self, f: F) -> Result<R, E>
     where
         E: From<DatabaseError> + Send + 'static,
@@ -117,7 +117,7 @@ impl<Kind: DbKindT> DbRead<Kind> {
     ///
     /// Note that it is not enforced that your closure runs read-only operations or that it finishes quickly so it is
     /// up to the caller to use this function as intended.
-    #[tracing::instrument(skip_all, fields(kind = ?self.kind))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(kind = ?self.kind)))]
     pub async fn read_async<E, R, F>(&self, f: F) -> Result<R, E>
     where
         E: From<DatabaseError> + Send + 'static,
@@ -150,7 +150,7 @@ impl<Kind: DbKindT> DbRead<Kind> {
     /// reason.
     ///
     /// A valid reason for this is holding read transactions across multiple databases as part of a cascade query.
-    #[tracing::instrument]
+    #[cfg_attr(feature = "instrument", tracing::instrument)]
     pub async fn get_read_txn(&self) -> DatabaseResult<PTxnGuard> {
         let conn = self
             .checkout_connection(self.long_read_semaphore.clone())
@@ -158,7 +158,7 @@ impl<Kind: DbKindT> DbRead<Kind> {
         Ok(conn.into())
     }
 
-    #[tracing::instrument]
+    #[cfg_attr(feature = "instrument", tracing::instrument)]
     async fn checkout_connection(&self, semaphore: Arc<Semaphore>) -> DatabaseResult<PConnGuard> {
         // TODO: use semaphore for this message
         let waiting = self.num_readers.fetch_add(1, Ordering::Relaxed);
@@ -188,7 +188,7 @@ impl<Kind: DbKindT> DbRead<Kind> {
 
     /// Get a connection from the pool.
     /// TODO: We should eventually swap this for an async solution.
-    #[tracing::instrument]
+    #[cfg_attr(feature = "instrument", tracing::instrument)]
     fn get_connection_from_pool(&self) -> DatabaseResult<PConn> {
         let now = Instant::now();
         let r = Ok(PConn::new(self.connection_pool.get()?));
@@ -338,7 +338,7 @@ impl<Kind: DbKindT + Send + Sync + 'static> DbWrite<Kind> {
         Ok(DbWrite(db_read))
     }
 
-    #[tracing::instrument(skip_all, fields(kind = ?self.kind))]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(kind = ?self.kind)))]
     pub async fn write_async<E, R, F>(&self, f: F) -> Result<R, E>
     where
         E: From<DatabaseError> + Send + 'static,
@@ -499,7 +499,7 @@ pub fn set_acquire_timeout(timeout_ms: u64) {
     ACQUIRE_TIMEOUT_MS.store(timeout_ms, Ordering::Relaxed);
 }
 
-#[tracing::instrument]
+#[cfg_attr(feature = "instrument", tracing::instrument)]
 async fn acquire_semaphore_permit(
     semaphore: Arc<Semaphore>,
 ) -> DatabaseResult<OwnedSemaphorePermit> {

--- a/crates/holochain_sqlite/src/db/conn.rs
+++ b/crates/holochain_sqlite/src/db/conn.rs
@@ -29,7 +29,7 @@ impl<'e> PConn {
         Self { inner }
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub(super) fn execute_in_read_txn<E, R, F>(&'e mut self, f: F) -> Result<R, E>
     where
         E: From<DatabaseError>,
@@ -49,7 +49,7 @@ impl<'e> PConn {
     /// transaction, and commit the transaction after the closure has run.
     /// If there is a SQLite error, recover from it and re-run the closure.
     // FIXME: B-01566: implement write failure detection
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub(super) fn execute_in_exclusive_rw_txn<E, R, F>(&'e mut self, f: F) -> Result<R, E>
     where
         E: From<DatabaseError>,

--- a/crates/holochain_sqlite/src/store/p2p_agent_store.rs
+++ b/crates/holochain_sqlite/src/store/p2p_agent_store.rs
@@ -316,7 +316,7 @@ impl AgentStoreByPath {
         }
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn get_async(&self, db: &DbRead<DbKindP2pAgents>) -> DatabaseResult<AgentStore> {
         let store_key = db.clone().into();
         {
@@ -354,7 +354,7 @@ async fn cache_get_async(db: &DbRead<DbKindP2pAgents>) -> DatabaseResult<AgentSt
 }
 
 /// Put an AgentInfoSigned record into the p2p_store
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub async fn p2p_put(
     db: &DbWrite<DbKindP2pAgents>,
     signed: &AgentInfoSigned,
@@ -364,7 +364,7 @@ pub async fn p2p_put(
 }
 
 /// Put an iterator of AgentInfoSigned records into the p2p_store
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub async fn p2p_put_all(
     db: &DbWrite<DbKindP2pAgents>,
     signed: impl Iterator<Item = &AgentInfoSigned>,
@@ -425,7 +425,7 @@ fn tx_p2p_put(txn: &mut Transaction, record: P2pRecord) -> DatabaseResult<()> {
 }
 
 /// Prune all expired AgentInfoSigned records from the p2p_store
-#[tracing::instrument(skip_all)]
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub async fn p2p_prune(
     db: &DbWrite<DbKindP2pAgents>,
     local_agents: Vec<Arc<KitsuneAgent>>,
@@ -496,7 +496,7 @@ impl AsP2pStateReadExt for DbRead<DbKindP2pAgents> {
         cache_get_async(self).await?.query_near_basis(basis, limit)
     }
 
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn p2p_extrapolated_coverage(&self, dht_arc_set: DhtArcSet) -> DatabaseResult<Vec<f64>> {
         self.read_async(|txn| txn.p2p_extrapolated_coverage(dht_arc_set))
             .await
@@ -505,7 +505,7 @@ impl AsP2pStateReadExt for DbRead<DbKindP2pAgents> {
 
 #[async_trait::async_trait]
 impl AsP2pStateWriteExt for DbWrite<DbKindP2pAgents> {
-    #[tracing::instrument(skip_all)]
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn p2p_remove_agent(&self, agent: &KitsuneAgent) -> DatabaseResult<bool> {
         let space = self.kind().0.clone();
         let agent = agent.clone();


### PR DESCRIPTION
### Summary

Fixes segfault.

Just puts all `tracing::instrument` instances in 3 crates behind a new feature "instrument". This feature is never enabled.

Without this PR, the `lock_chain` test segfaults in debug mode. Note that that test passes in release mode without this PR.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs