### PR TITLE
Disable stale workflow for issue closing

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,8 @@
 name: Stale
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "37 2 * * *"
+#  schedule:
+#    - cron: "37 2 * * *"
 
 jobs:
   close-issues:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,8 @@
 name: Stale
 on:
   workflow_dispatch:
-#  schedule:
-#    - cron: "37 2 * * *"
+  schedule:
+    - cron: "37 2 * * *"
 
 jobs:
   close-issues:
@@ -13,8 +13,8 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-issue-stale: 30
-          days-before-issue-close: 14
+          days-before-issue-stale: -1 # Disabled
+          days-before-issue-close: -1 # Disabled
           stale-issue-label: "stale"
           stale-issue-message: "This item has been open for 30 days with no activity."
           close-issue-message: "This item has been inactive for 14 days since being marked as stale."


### PR DESCRIPTION
### Summary

I think we agreed to do this? We're actively managing issues on GitHub now and our PR list is a sensible length. I think this should now reduce work by not making us touch older issues or put `permanent` on all of them.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs