### PR TITLE
fix default webrtc_config and ensure it is tested

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2947,6 +2947,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
+ "tx5",
  "tx5-go-pion-turn",
  "unwrap_to",
  "url",

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -151,6 +151,7 @@ reqwest = "0.12"
 serial_test = "3.0"
 test-case = "3.3"
 tokio-tungstenite = "0.21"
+tx5 = "0.1.1-beta"
 
 [build-dependencies]
 hdk = { version = "^0.4.0-dev.11", path = "../hdk" }

--- a/crates/holochain/tests/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/tests/multi_conductor/mod.rs
@@ -130,6 +130,13 @@ async fn multi_conductor() -> anyhow::Result<()> {
     let stats = conductors[1].dump_network_stats().await?;
     tracing::info!(target: "TEST", "@!@! - stats: {stats}");
 
+    let stats: tx5::stats::Stats = serde_json::from_str(&stats).unwrap();
+
+    // make sure that, by this point, we have upgraded connections to webrtc
+    for con in stats.connection_list {
+        assert!(con.is_webrtc);
+    }
+
     Ok(())
 }
 

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -311,8 +311,8 @@ mod tests {
           signal_url: wss://sbd-0.main.infra.holo.host
           webrtc_config: {
             "iceServers": [
-              { "urls": "stun:stun-0.main.infra.holo.host:443" },
-              { "urls": "stun:stun-1.main.infra.holo.host:443" }
+              { "urls": ["stun:stun-0.main.infra.holo.host:443"] },
+              { "urls": ["stun:stun-1.main.infra.holo.host:443"] }
             ]
           }
       tuning_params:
@@ -337,8 +337,8 @@ mod tests {
             signal_url: "wss://sbd-0.main.infra.holo.host".into(),
             webrtc_config: Some(serde_json::json!({
               "iceServers": [
-                { "urls": "stun:stun-0.main.infra.holo.host:443" },
-                { "urls": "stun:stun-1.main.infra.holo.host:443" }
+                { "urls": ["stun:stun-0.main.infra.holo.host:443"] },
+                { "urls": ["stun:stun-1.main.infra.holo.host:443"] }
               ]
             })),
         });

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor.rs
@@ -27,8 +27,8 @@ use std::sync::Arc;
 /// TODO - set this to holochain stun servers once they exist!
 const DEFAULT_WEBRTC_CONFIG: &str = r#"{
   "iceServers": [
-    { "urls": "stun:stun-0.main.infra.holo.host:443" },
-    { "urls": "stun:stun-1.main.infra.holo.host:443" }
+    { "urls": ["stun:stun-0.main.infra.holo.host:443"] },
+    { "urls": ["stun:stun-1.main.infra.holo.host:443"] }
   ]
 }"#;
 


### PR DESCRIPTION
RESOLVES: https://github.com/holochain/holochain/issues/3943

- Just added a quick check to the existing multi_conductor integration test.
- Turned out the default webrtc_config was incorrect, so fixed that.
- Created [an issue in the tx5 repo](https://github.com/holochain/tx5/issues/103) for something that would have made diagnosing this easier.