### PR TITLE
Always initialise the agent arc on network join

### DIFF
--- a/crates/hdk/src/hdk.rs
+++ b/crates/hdk/src/hdk.rs
@@ -224,6 +224,7 @@ mockall::mock! {
             &self,
             ed_25519_x_salsa20_poly1305_decrypt: Ed25519XSalsa20Poly1305Decrypt,
         ) -> ExternResult<XSalsa20Poly1305Data>;
+        fn is_same_agent(&self, key1: AgentPubKey, key2: AgentPubKey) -> ExternResult<bool>;
     }
 
 }

--- a/crates/holochain_state/src/integrate.rs
+++ b/crates/holochain_state/src/integrate.rs
@@ -98,7 +98,7 @@ fn insert_locally_validated_op(
     txn: &mut Transaction,
     op: DhtOpHashed,
 ) -> StateMutationResult<Option<DhtOpHashed>> {
-    // These checks are redundant but cheap and future proof this function
+    // These checks are redundant but cheap and future-proof this function
     // against anyone using it with private entries.
     if is_private_store_entry(op.as_content()) {
         return Ok(None);
@@ -114,7 +114,7 @@ fn insert_locally_validated_op(
     // Set the status to valid because we authored it.
     set_validation_status(txn, hash, ValidationStatus::Valid)?;
 
-    // If this is a `RegisterAgentActivity` or a warrant, we can mark it integrated immediately.
+    // If this op has no dependencies or is a warrant, we can mark it integrated immediately.
     if deps.is_empty() || matches!(op_type, DhtOpType::Warrant(_)) {
         // This set the validation stage to pending which is correct when
         // it's integrated.

--- a/crates/holochain_types/src/chain.rs
+++ b/crates/holochain_types/src/chain.rs
@@ -426,7 +426,7 @@ impl Sequences {
         // Track why the sequence start of the range was chosen.
         let mut chain_bottom_type = ChainBottomType::Genesis;
 
-        // If their are any until hashes in the filter,
+        // If there are any until hashes in the filter,
         // then find the highest sequence of the set
         // and find the distance from the position.
         let distance = match filter.get_until() {

--- a/crates/holochain_types/src/db_cache.rs
+++ b/crates/holochain_types/src/db_cache.rs
@@ -268,7 +268,7 @@ impl DhtDbQueryCache {
         .await
     }
 
-    /// Set activity to to integrated.
+    /// Set activity to be integrated.
     pub async fn set_activity_to_integrated(
         &self,
         agent: &AgentPubKey,
@@ -284,7 +284,7 @@ impl DhtDbQueryCache {
         .await
     }
 
-    /// Add an authors activity.
+    /// Add an author's activity.
     async fn new_activity_inner(
         &self,
         agent: &AgentPubKey,

--- a/crates/holochain_types/src/db_cache.rs
+++ b/crates/holochain_types/src/db_cache.rs
@@ -268,7 +268,7 @@ impl DhtDbQueryCache {
         .await
     }
 
-    /// Set activity to be integrated.
+    /// Set activity to integrated.
     pub async fn set_activity_to_integrated(
         &self,
         agent: &AgentPubKey,

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -843,13 +843,11 @@ impl KitsuneP2pHandler for Space {
             // This agent is new to the network and has no arc stored on the Kitsune host.
             // Get a default arc for the agent
             None => {
-                self.agent_arqs.insert(agent.clone(), self.default_arc_for_agent(agent.clone()));
+                self.agent_arqs
+                    .insert(agent.clone(), self.default_arc_for_agent(agent.clone()));
             }
         }
 
-        if let Some(initial_arq) = initial_arq {
-            self.agent_arqs.insert(agent.clone(), initial_arq);
-        }
         self.local_joined_agents
             .insert(agent.clone(), maybe_agent_info);
         for module in self.gossip_mod.values() {
@@ -1263,7 +1261,12 @@ impl KitsuneP2pHandler for Space {
         _space: Arc<KitsuneSpace>,
         basis: Arc<KitsuneBasis>,
     ) -> KitsuneP2pHandlerResult<bool> {
+        tracing::info!("Have local joined agents {:?}", self.local_joined_agents);
         let loc = basis.get_loc();
+        tracing::info!(
+            "Doing basis check against num arcs {}",
+            self.agent_arqs.len()
+        );
         let r = self
             .agent_arqs
             .values()

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -833,6 +833,20 @@ impl KitsuneP2pHandler for Space {
         initial_arq: Option<Arq>,
     ) -> KitsuneP2pHandlerResult<()> {
         tracing::debug!(?space, ?agent, ?initial_arq, "handle_join");
+
+        match initial_arq {
+            // This agent has been on the network before and has an arc stored on the Kitsune host.
+            // Respect the current storage settings and apply this arc.
+            Some(initial_arq) => {
+                self.agent_arqs.insert(agent.clone(), initial_arq);
+            }
+            // This agent is new to the network and has no arc stored on the Kitsune host.
+            // Get a default arc for the agent
+            None => {
+                self.agent_arqs.insert(agent.clone(), self.default_arc_for_agent(agent.clone()));
+            }
+        }
+
         if let Some(initial_arq) = initial_arq {
             self.agent_arqs.insert(agent.clone(), initial_arq);
         }
@@ -1620,15 +1634,25 @@ impl Space {
         // In the case an initial_arc is passed into the join request,
         // handle_join will initialize this agent_arcs map to that value.
         self.agent_arqs.get(agent).cloned().unwrap_or_else(|| {
-            let dim = SpaceDimension::standard();
-            match self.config.tuning_params.arc_clamping() {
-                Some(ArqClamping::Empty) => Arq::new_empty(dim, agent.get_loc()),
-                Some(ArqClamping::Full) | None => {
-                    let strat = self.config.tuning_params.to_arq_strat();
-                    Arq::new_full_max(dim, &strat, agent.get_loc())
-                }
-            }
+            tracing::warn!("Using default arc for agent, this should be configured by the host or initialised on network join");
+            self.default_arc_for_agent((*agent).clone())
         })
+    }
+
+    /// Get the default arc for an agent.
+    ///
+    /// The default arc depends on the Kitsune tuning parameters.
+    /// - Either arc clamping is set to empty and the arc is empty, or
+    /// - The arc clamping is set to full or not set, in which cases the arc is full.
+    fn default_arc_for_agent(&self, agent: Arc<KitsuneAgent>) -> Arq {
+        let dim = SpaceDimension::standard();
+        match self.config.tuning_params.arc_clamping() {
+            Some(ArqClamping::Empty) => Arq::new_empty(dim, agent.get_loc()),
+            Some(ArqClamping::Full) | None => {
+                let strat = self.config.tuning_params.to_arq_strat();
+                Arq::new_full_max(dim, &strat, agent.get_loc())
+            }
+        }
     }
 }
 

--- a/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
+++ b/crates/kitsune_p2p/kitsune_p2p/src/spawn/actor/space.rs
@@ -1261,12 +1261,7 @@ impl KitsuneP2pHandler for Space {
         _space: Arc<KitsuneSpace>,
         basis: Arc<KitsuneBasis>,
     ) -> KitsuneP2pHandlerResult<bool> {
-        tracing::info!("Have local joined agents {:?}", self.local_joined_agents);
         let loc = basis.get_loc();
-        tracing::info!(
-            "Doing basis check against num arcs {}",
-            self.agent_arqs.len()
-        );
         let r = self
             .agent_arqs
             .values()


### PR DESCRIPTION
### Summary

This is an expectation mismatch:
- Holochain expects to always be able to ask which hashes it is an authority for once it has joined the network. That means there needs to be an agent arc configured, otherwise a `.any().or_default(false)` check against the arcs will always return false.
- Kitsune thinks that it's only necessary to store the arc if there was one from the host. Otherwise it can always `get_agent_arc` and see the default. It won't put anything into arc state until there's a non-default arc.

So Kitsune is running along just fine but the host thinks it's not an authority for anything.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs