### PR TITLE
dynamic db encryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,6 +3493,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shrinkwraprs",
+ "sodoken 0.0.11",
  "sqlformat",
  "tempfile",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,13 +862,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.4"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9711f33475c22aab363b05564a17d7b789bf3dfec5ebabb586adee56f0e271b5"
+checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -2633,9 +2633,9 @@ dependencies = [
 
 [[package]]
 name = "hc_r2d2_sqlite"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a95a4a8a02468f63e725a3881594a6720933f4e620087e5c2e34681d14cef05"
+checksum = "7f4044c2cadf3d960fa91a7ef91590da202797fe82cf687b029235f98be5ff49"
 dependencies = [
  "r2d2",
  "rusqlite",
@@ -4606,9 +4606,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0da3e3e1bd2644dc2974ef622743cd83f2c661b3c6c67acb00cda4725646def"
+checksum = "db43da034583683b3a25d473e6024c7f529c31115418a7b95e609d5b0f090e5b"
 dependencies = [
  "lair_keystore_api",
  "pretty_assertions",
@@ -4622,9 +4622,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9519a48df54d2041f8697bba7c3957263a5f2bb720ae6c4954004bad51693c61"
+checksum = "2da1e0069976825273a8ba0e36b09785dc83812a9b0cf2c5eef3d85351534592"
 dependencies = [
  "base64 0.22.1",
  "dunce",
@@ -4753,9 +4753,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "openssl-sys",
@@ -5464,9 +5464,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
@@ -6653,9 +6653,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
  "bitflags 2.6.0",
  "fallible-iterator 0.3.0",
@@ -7275,6 +7275,12 @@ dependencies = [
  "bytes",
  "memmap2 0.6.2",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shrinkwraprs"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3337,6 +3337,7 @@ version = "0.4.0-dev.17"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "derive_more",
  "fallible-iterator 0.3.0",
  "futures",

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -30,7 +30,7 @@ must_future = { version = "0.1", optional = true }
 proptest = { version = "1", optional = true }
 proptest-derive = { version = "0", optional = true }
 rand = { version = "0.8.5", optional = true }
-rusqlite = { version = "0.31", optional = true }
+rusqlite = { version = "0.32.1", optional = true }
 serde = { version = "1", optional = true }
 serde_bytes = { version = "0.11", optional = true }
 tracing = { version = "0.1", optional = true }

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- **BREAKING!** Enables dynamic database encryption. (as opposed to the hard-coded key that was previously being used.) NOTE - this is incompatible with all previous holochain databases, they will not open, and must be deleted. NOTE - this is incompatible with all previous lair databases, they will not open and must be deleted. [\#4198](https://github.com/holochain/holochain/pull/4198)
+
 ## 0.4.0-dev.19
 
 - Adds DPKI support. This is not fully hooked up, so the main implication for this particular implementation is that you must be using the same DPKI implementation as all other nodes on the network that you wish to talk to. If the DPKI version mismatches, you cannot establish connections, and will see so as an error in the logs. This work is in preparation for future work which will make it possible to restore your keys if you lose your device, and to revoke and replace your keys if your device is stolen or compromised.

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -70,7 +70,7 @@ predicates = "3.1"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rand-utf8 = "0.0.1"
-rusqlite = { version = "0.31" }
+rusqlite = { version = "0.32.1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.12"
 serde_json = { version = "1.0.51", features = ["preserve_order"] }
@@ -164,7 +164,7 @@ serde_json = { version = "1.0.51" }
 toml = "0.8"
 chrono = { version = "0.4.6", features = ["serde"] }
 hostname = "0.4"
-lair_keystore = { version = "0.4.5", default-features = false, features = [
+lair_keystore = { version = "0.5.0", default-features = false, features = [
   "rusqlite-bundled-sqlcipher-vendored-openssl",
 ] }
 

--- a/crates/holochain/src/bin/holochain/main.rs
+++ b/crates/holochain/src/bin/holochain/main.rs
@@ -52,6 +52,13 @@ struct Opt {
         help = "Display version information such as git revision and HDK version"
     )]
     build_info: bool,
+
+    /// WARNING!! DANGER!! This exposes your database decryption secrets!
+    /// Print the database decryption secrets to stderr.
+    /// With these PRAGMA commands, you'll be able to run sqlcipher
+    /// directly to manipulate holochain databases.
+    #[structopt(long)]
+    pub danger_print_db_secrets: bool,
 }
 
 fn main() {
@@ -149,6 +156,7 @@ async fn conductor_handle_from_config(opt: &Opt, config: ConductorConfig) -> Con
     match Conductor::builder()
         .config(config)
         .passphrase(passphrase)
+        .danger_print_db_secrets(opt.danger_print_db_secrets)
         .build()
         .await
     {

--- a/crates/holochain/src/conductor/cell/test.rs
+++ b/crates/holochain/src/conductor/cell/test.rs
@@ -21,7 +21,7 @@ async fn test_cell_handle_publish() {
     let dna = cell_id.dna_hash().clone();
     let agent = cell_id.agent_pubkey().clone();
 
-    let spaces = TestSpaces::new([dna.clone()]);
+    let spaces = TestSpaces::new([dna.clone()]).await;
     let db = spaces.test_spaces[&dna]
         .space
         .get_or_create_authored_db(cell_id.agent_pubkey().clone())

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -3853,7 +3853,7 @@ fn query_dht_ops_from_statement(
     dht_ops_cursor: Option<u64>,
 ) -> ConductorApiResult<Vec<DhtOp>> {
     let final_stmt_str = match dht_ops_cursor {
-        Some(cursor) => format!("{} AND rowid > {}", stmt_str, cursor),
+        Some(cursor) => format!("{} AND DhtOp.rowid > {}", stmt_str, cursor),
         None => stmt_str.into(),
     };
 

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -73,6 +73,11 @@ impl ConductorBuilder {
     pub async fn build(self) -> ConductorResult<ConductorHandle> {
         tracing::debug!(?self.config);
 
+        let passphrase = match &self.passphrase {
+            Some(p) => p.clone(),
+            None => sodoken::BufRead::new_no_lock(&[]),
+        };
+
         let keystore = if let Some(keystore) = self.keystore {
             keystore
         } else {
@@ -149,7 +154,7 @@ impl ConductorBuilder {
 
         let ribosome_store = RwShare::new(ribosome_store);
 
-        let spaces = Spaces::new(config.clone())?;
+        let spaces = Spaces::new(config.clone(), passphrase)?;
         let tag = spaces.get_state().await?.tag().clone();
 
         let tag_ed: Arc<str> = format!("{}_ed", tag.0).into_boxed_str().into();
@@ -423,7 +428,7 @@ impl ConductorBuilder {
             .unwrap_or_else(holochain_keystore::test_keystore);
 
         let config = Arc::new(self.config);
-        let spaces = Spaces::new(config.clone())?;
+        let spaces = Spaces::new(config.clone(), sodoken::BufRead::new_no_lock(&[]))?;
         let tag = spaces.get_state().await?.tag().clone();
 
         let tag_ed: Arc<str> = format!("{}_ed", tag.0).into_boxed_str().into();

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -154,7 +154,7 @@ impl ConductorBuilder {
 
         let ribosome_store = RwShare::new(ribosome_store);
 
-        let spaces = Spaces::new(config.clone(), passphrase)?;
+        let spaces = Spaces::new(config.clone(), passphrase).await?;
         let tag = spaces.get_state().await?.tag().clone();
 
         let tag_ed: Arc<str> = format!("{}_ed", tag.0).into_boxed_str().into();

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -34,6 +34,12 @@ pub struct ConductorBuilder {
 
     /// Skip printing setup info to stdout
     pub no_print_setup: bool,
+
+    /// WARNING!! DANGER!! This exposes your database decryption secrets!
+    /// Print the database decryption secrets to stderr.
+    /// With these PRAGMA commands, you'll be able to run sqlcipher
+    /// directly to manipulate holochain databases.
+    pub danger_print_db_secrets: bool,
 }
 
 impl ConductorBuilder {
@@ -59,6 +65,15 @@ impl ConductorBuilder {
     /// Set up the builder to skip printing setup
     pub fn no_print_setup(mut self) -> Self {
         self.no_print_setup = true;
+        self
+    }
+
+    /// WARNING!! DANGER!! This exposes your database decryption secrets!
+    /// Print the database decryption secrets to stderr.
+    /// With these PRAGMA commands, you'll be able to run sqlcipher
+    /// directly to manipulate holochain databases.
+    pub fn danger_print_db_secrets(mut self, v: bool) -> Self {
+        self.danger_print_db_secrets = v;
         self
     }
 
@@ -154,6 +169,7 @@ impl ConductorBuilder {
 
         let ribosome_store = RwShare::new(ribosome_store);
 
+        crate::conductor::space::set_danger_print_db_secrets(self.danger_print_db_secrets);
         let spaces = Spaces::new(config.clone(), passphrase).await?;
         let tag = spaces.get_state().await?.tag().clone();
 

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -428,7 +428,8 @@ impl ConductorBuilder {
             .unwrap_or_else(holochain_keystore::test_keystore);
 
         let config = Arc::new(self.config);
-        let spaces = Spaces::new(config.clone(), sodoken::BufRead::new_no_lock(&[]))?;
+        let spaces =
+            Spaces::new(config.clone(), sodoken::BufRead::new_no_lock(b"passphrase")).await?;
         let tag = spaces.get_state().await?.tag().clone();
 
         let tag_ed: Arc<str> = format!("{}_ed", tag.0).into_boxed_str().into();

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -47,7 +47,9 @@ async fn can_update_state() {
             ..Default::default()
         }
         .into(),
+        sodoken::BufRead::new_no_lock(b"passphrase"),
     )
+    .await
     .unwrap();
     let conductor = Conductor::new(
         Default::default(),
@@ -101,7 +103,9 @@ async fn app_ids_are_unique() {
             ..Default::default()
         }
         .into(),
+        sodoken::BufRead::new_no_lock(b"passphrase"),
     )
+    .await
     .unwrap();
     let conductor = Conductor::new(
         Default::default(),

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -166,7 +166,6 @@ impl Spaces {
                 PoolConfig {
                     synchronous_level: db_sync_level,
                     key: db_key.clone(),
-                    ..Default::default()
                 },
             )?;
             let wasm_db = DbWrite::open_with_pool_config(
@@ -175,7 +174,6 @@ impl Spaces {
                 PoolConfig {
                     synchronous_level: db_sync_level,
                     key: db_key.clone(),
-                    ..Default::default()
                 },
             )?;
             ConductorResult::Ok((conductor_db, wasm_db))
@@ -738,7 +736,6 @@ impl Space {
                     PoolConfig {
                         synchronous_level: db_sync_level,
                         key: db_key.clone(),
-                        ..Default::default()
                     },
                 )?;
                 let dht_db = DbWrite::open_with_pool_config(
@@ -747,7 +744,6 @@ impl Space {
                     PoolConfig {
                         synchronous_level: db_sync_level,
                         key: db_key.clone(),
-                        ..Default::default()
                     },
                 )?;
                 let p2p_agents_db = DbWrite::open_with_pool_config(
@@ -756,7 +752,6 @@ impl Space {
                     PoolConfig {
                         synchronous_level: db_sync_level,
                         key: db_key.clone(),
-                        ..Default::default()
                     },
                 )?;
                 let p2p_metrics_db = DbWrite::open_with_pool_config(
@@ -765,7 +760,6 @@ impl Space {
                     PoolConfig {
                         synchronous_level: db_sync_level,
                         key: db_key.clone(),
-                        ..Default::default()
                     },
                 )?;
                 let conductor_db: DbWrite<DbKindConductor> = DbWrite::open_with_pool_config(
@@ -774,7 +768,6 @@ impl Space {
                     PoolConfig {
                         synchronous_level: db_sync_level,
                         key: db_key.clone(),
-                        ..Default::default()
                     },
                 )?;
                 DatabaseResult::Ok((cache, dht_db, p2p_agents_db, p2p_metrics_db, conductor_db))
@@ -860,7 +853,6 @@ impl Space {
                         PoolConfig {
                             synchronous_level: DbSyncLevel::Normal,
                             key: self.db_key.clone(),
-                            ..Default::default()
                         },
                     )
                 })?;
@@ -898,12 +890,12 @@ pub async fn query_conductor_state(
 
 #[cfg(test)]
 impl TestSpaces {
-    pub fn new(dna_hashes: impl IntoIterator<Item = DnaHash>) -> Self {
+    pub async fn new(dna_hashes: impl IntoIterator<Item = DnaHash>) -> Self {
         let queue_consumer_map = QueueConsumerMap::new();
-        Self::with_queue_consumer(dna_hashes, queue_consumer_map)
+        Self::with_queue_consumer(dna_hashes, queue_consumer_map).await
     }
 
-    pub fn with_queue_consumer(
+    pub async fn with_queue_consumer(
         dna_hashes: impl IntoIterator<Item = DnaHash>,
         queue_consumer_map: QueueConsumerMap,
     ) -> Self {
@@ -921,7 +913,9 @@ impl TestSpaces {
                 ..Default::default()
             }
             .into(),
+            sodoken::BufRead::new_no_lock(b"passphrase"),
         )
+        .await
         .unwrap();
         spaces.map.share_mut(|map| {
             map.extend(
@@ -950,6 +944,7 @@ impl TestSpace {
             space: Space::new(
                 Arc::new(dna_hash),
                 temp_dir.path().to_path_buf(),
+                Default::default(),
                 Default::default(),
             )
             .unwrap(),

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -132,7 +132,7 @@ pub struct TestSpace {
     _temp_dir: tempfile::TempDir,
 }
 
-thread_local!(static DANGER_PRINT_DB_SECRETS: Cell<bool> = Cell::new(false));
+thread_local!(static DANGER_PRINT_DB_SECRETS: Cell<bool> = const { Cell::new(false) });
 
 /// WARNING!! DANGER!! This exposes your database decryption secrets!
 /// Print the database decryption secrets to stderr.

--- a/crates/holochain/src/conductor/space/tests.rs
+++ b/crates/holochain/src/conductor/space/tests.rs
@@ -42,7 +42,9 @@ async fn test_region_queries() {
             ..Default::default()
         }
         .into(),
+        sodoken::BufRead::new_no_lock(b"passphrase"),
     )
+    .await
     .unwrap();
     let keystore = test_keystore();
     let agent = keystore.new_sign_keypair_random().await.unwrap();

--- a/crates/holochain/src/core/sys_validate/tests.rs
+++ b/crates/holochain/src/core/sys_validate/tests.rs
@@ -686,7 +686,7 @@ async fn incoming_ops_filters_private_entry() {
     let mut g = random_generator();
 
     let dna = DnaHash::arbitrary(&mut g).unwrap();
-    let spaces = TestSpaces::new([dna.clone()]);
+    let spaces = TestSpaces::new([dna.clone()]).await;
     let space = Arc::new(spaces.test_spaces[&dna].space.clone());
     let vault = space.dht_db.clone();
     let keystore = test_keystore();

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -22,7 +22,7 @@ holochain_zome_types = { path = "../holochain_zome_types", version = "^0.4.0-dev
 kitsune_p2p_types = { version = "^0.4.0-dev.11", path = "../kitsune_p2p/types" }
 holochain_secure_primitive = { version = "^0.4.0-dev.1", path = "../holochain_secure_primitive" }
 holochain_util = { version = "^0.4.0-dev.3", path = "../holochain_util" }
-lair_keystore = { version = "0.4.5", default-features = false }
+lair_keystore = { version = "0.5.0", default-features = false }
 must_future = "0.1.2"
 nanoid = "0.4"
 one_err = "0.0.8"

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -41,6 +41,7 @@ scheduled-thread-pool = "0.2"
 serde = "1.0"
 serde_json = { version = "1.0.51", features = ["preserve_order"] }
 shrinkwraprs = "0.3.0"
+sodoken = "=0.0.11"
 tempfile = "3.3"
 thiserror = "1.0.22"
 tokio = { version = "1.27", features = [

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -35,7 +35,7 @@ once_cell = "1.4.1"
 num_cpus = "1.13.0"
 parking_lot = "0.12"
 r2d2 = "0.8"
-r2d2_sqlite = { version = "0.24.0", package = "hc_r2d2_sqlite" }
+r2d2_sqlite = { version = "0.25.0", package = "hc_r2d2_sqlite" }
 rmp-serde = "=1.3.0"
 scheduled-thread-pool = "0.2"
 serde = "1.0"
@@ -55,7 +55,7 @@ tracing = "0.1.18"
 getrandom = "0.2.7"
 opentelemetry_api = { version = "=0.20.0", features = ["metrics"] }
 
-rusqlite = { version = "0.31", features = [
+rusqlite = { version = "0.32.1", features = [
   "blob",      # better integration with blob types (Read, Write, etc)
   "backup",
   "trace",

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 [dependencies]
 async-trait = "0.1"
 anyhow = "1.0"
+base64 = "0.22"
 derive_more = "0.99"
 fallible-iterator = "0.3.0"
 futures = "0.3"

--- a/crates/holochain_sqlite/src/db/access.rs
+++ b/crates/holochain_sqlite/src/db/access.rs
@@ -455,6 +455,9 @@ pub fn encrypt_unencrypted_database(path: &Path, pool_config: &PoolConfig) -> Da
                 "ATTACH DATABASE :db_name AS encrypted KEY :key",
                 rusqlite::named_params! {
                     ":db_name": encrypted_path.to_str(),
+                    // we have to pull out the hex encoded key
+                    // with the x'..' but NOT the surrounding
+                    // double quotes.
                     ":key": &lock[15..82],
                 },
             )?;

--- a/crates/holochain_sqlite/src/db/key.rs
+++ b/crates/holochain_sqlite/src/db/key.rs
@@ -1,0 +1,205 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use sodoken::hash::argon2id::*;
+use sodoken::secretbox::xchacha20poly1305::*;
+use std::io::Error;
+
+const PRAGMA_LEN: usize = 220;
+const PRAGMA: &[u8; PRAGMA_LEN] = br#"
+PRAGMA key = "x'----------------------------------------------------------------'";
+PRAGMA cipher_salt = "x'--------------------------------'";
+PRAGMA cipher_compatibility = 4;
+PRAGMA cipher_plaintext_header_size = 32;
+"#;
+
+pub type Result<T> = std::io::Result<T>;
+
+/// Secure database access.
+#[derive(Clone)]
+pub struct DbKey {
+    /// The full unlocked sqlcipher PRAGMA command set to unlock a database.
+    pub unlocked: sodoken::BufRead,
+
+    /// The unlocked key.
+    pub key: sodoken::BufReadSized<32>,
+
+    /// The salt.
+    pub salt: sodoken::BufReadSized<16>,
+
+    /// The encrypted key and salt to store on disk.
+    pub locked: String,
+}
+
+impl std::fmt::Debug for DbKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DbKey").finish()
+    }
+}
+
+impl Default for DbKey {
+    fn default() -> Self {
+        Self::priv_new(
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABfEkbuZZnisvvyc5OIofAk1cHNw7UWbmvKbCmm3QrDjJr5Ox33KnvqRb8F7Z2fM_AAAAAAAAAAAAAAAAAAAAAA".to_string(),
+            sodoken::BufReadSized::new_no_lock([0; 32]),
+            sodoken::BufReadSized::new_no_lock([0; 16]),
+        )
+    }
+}
+
+impl DbKey {
+    fn priv_new(
+        locked: String,
+        key: sodoken::BufReadSized<32>,
+        salt: sodoken::BufReadSized<16>,
+    ) -> Self {
+        let unlocked = sodoken::BufWrite::new_mem_locked(PRAGMA_LEN)
+            .expect("failed to allocate secure db key memory");
+
+        {
+            let mut lock = unlocked.write_lock();
+            lock.copy_from_slice(PRAGMA);
+            for (i, b) in key.read_lock().iter().enumerate() {
+                let c = format!("{b:02X}");
+                let idx = 17 + (i * 2);
+                lock[idx..idx + 2].copy_from_slice(c.as_bytes())
+            }
+            for (i, b) in salt.read_lock().iter().enumerate() {
+                let c = format!("{b:02X}");
+                let idx = 109 + (i * 2);
+                lock[idx..idx + 2].copy_from_slice(c.as_bytes())
+            }
+        }
+
+        Self {
+            unlocked: unlocked.into(),
+            key,
+            salt,
+            locked,
+        }
+    }
+
+    async fn priv_gen(
+        nonce: sodoken::BufReadSized<NONCEBYTES>,
+        key: sodoken::BufReadSized<32>,
+        salt: sodoken::BufReadSized<16>,
+        passphrase: sodoken::BufRead,
+    ) -> Result<Self> {
+        let secret = <sodoken::BufWriteSized<32>>::new_mem_locked()?;
+        hash(
+            secret.clone(),
+            passphrase,
+            salt.clone(),
+            OPSLIMIT_MODERATE,
+            MEMLIMIT_MODERATE,
+        )
+        .await?;
+
+        let cipher = easy(nonce.clone(), key.clone(), secret).await?;
+
+        let mut buf = Vec::with_capacity(NONCEBYTES + 32 + MACBYTES + 16);
+        buf.extend_from_slice(&*nonce.read_lock());
+        buf.extend_from_slice(&*cipher.read_lock());
+        buf.extend_from_slice(&*salt.read_lock());
+
+        let locked = URL_SAFE_NO_PAD.encode(&buf);
+
+        Ok(Self::priv_new(locked, key, salt))
+    }
+
+    /// Load a database key encrypted by passphrase.
+    pub async fn load(locked: String, passphrase: sodoken::BufRead) -> Result<Self> {
+        let buf = URL_SAFE_NO_PAD.decode(&locked).map_err(Error::other)?;
+
+        let salt = <sodoken::BufWriteSized<16>>::new_no_lock();
+        salt.write_lock()
+            .copy_from_slice(&buf[NONCEBYTES + 32 + MACBYTES..NONCEBYTES + 32 + MACBYTES + 16]);
+
+        let secret = <sodoken::BufWriteSized<32>>::new_mem_locked()?;
+        hash(
+            secret.clone(),
+            passphrase,
+            salt.clone(),
+            OPSLIMIT_MODERATE,
+            MEMLIMIT_MODERATE,
+        )
+        .await?;
+
+        let nonce = <sodoken::BufWriteSized<NONCEBYTES>>::new_no_lock();
+        nonce.write_lock().copy_from_slice(&buf[..NONCEBYTES]);
+
+        let cipher = <sodoken::BufWriteSized<{ 32 + MACBYTES }>>::new_no_lock();
+        cipher
+            .write_lock()
+            .copy_from_slice(&buf[NONCEBYTES..NONCEBYTES + 32 + MACBYTES]);
+
+        let key = <sodoken::BufWriteSized<32>>::new_mem_locked()?;
+        open_easy(nonce, key.clone(), cipher, secret).await?;
+
+        Ok(Self::priv_new(locked, key.into(), salt.into()))
+    }
+
+    /// Generate a new random database key encrypted by passphrase.
+    pub async fn generate(passphrase: sodoken::BufRead) -> Result<Self> {
+        let nonce = <sodoken::BufWriteSized<NONCEBYTES>>::new_no_lock();
+        sodoken::random::bytes_buf(nonce.clone()).await?;
+
+        let key = <sodoken::BufWriteSized<32>>::new_mem_locked()?;
+        sodoken::random::bytes_buf(key.clone()).await?;
+
+        let salt = <sodoken::BufWriteSized<16>>::new_no_lock();
+        sodoken::random::bytes_buf(salt.clone()).await?;
+
+        Self::priv_gen(nonce.into(), key.into(), salt.into(), passphrase).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn db_key_sanity() {
+        let test1 = DbKey::default();
+
+        let test2 = DbKey::priv_gen(
+            sodoken::BufReadSized::new_no_lock([0; NONCEBYTES]),
+            sodoken::BufReadSized::new_no_lock([0; 32]),
+            sodoken::BufReadSized::new_no_lock([0; 16]),
+            sodoken::BufRead::new_no_lock(b"passphrase"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            String::from_utf8_lossy(&*test1.unlocked.read_lock()),
+            String::from_utf8_lossy(&*test2.unlocked.read_lock()),
+        );
+
+        assert_eq!(
+            r#"
+PRAGMA key = "x'0000000000000000000000000000000000000000000000000000000000000000'";
+PRAGMA cipher_salt = "x'00000000000000000000000000000000'";
+PRAGMA cipher_compatibility = 4;
+PRAGMA cipher_plaintext_header_size = 32;
+"#,
+            &String::from_utf8_lossy(&*test2.unlocked.read_lock()),
+        );
+
+        let test3 = DbKey::generate(sodoken::BufRead::new_no_lock(b"passphrase"))
+            .await
+            .unwrap();
+
+        assert_ne!(
+            String::from_utf8_lossy(&*test1.unlocked.read_lock()),
+            String::from_utf8_lossy(&*test3.unlocked.read_lock()),
+        );
+
+        let test4 = DbKey::load(test3.locked, sodoken::BufRead::new_no_lock(b"passphrase"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            String::from_utf8_lossy(&*test3.unlocked.read_lock()),
+            String::from_utf8_lossy(&*test4.unlocked.read_lock()),
+        );
+    }
+}

--- a/crates/holochain_sqlite/src/db/key.rs
+++ b/crates/holochain_sqlite/src/db/key.rs
@@ -96,9 +96,9 @@ impl DbKey {
         let cipher = easy(nonce.clone(), key.clone(), secret).await?;
 
         let mut buf = Vec::with_capacity(NONCEBYTES + 32 + MACBYTES + 16);
-        buf.extend_from_slice(&*nonce.read_lock());
-        buf.extend_from_slice(&*cipher.read_lock());
-        buf.extend_from_slice(&*salt.read_lock());
+        buf.extend_from_slice(&nonce.read_lock());
+        buf.extend_from_slice(&cipher.read_lock());
+        buf.extend_from_slice(&salt.read_lock());
 
         let locked = URL_SAFE_NO_PAD.encode(&buf);
 
@@ -170,8 +170,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            String::from_utf8_lossy(&*test1.unlocked.read_lock()),
-            String::from_utf8_lossy(&*test2.unlocked.read_lock()),
+            String::from_utf8_lossy(&test1.unlocked.read_lock()),
+            String::from_utf8_lossy(&test2.unlocked.read_lock()),
         );
 
         assert_eq!(
@@ -181,7 +181,7 @@ PRAGMA cipher_salt = "x'00000000000000000000000000000000'";
 PRAGMA cipher_compatibility = 4;
 PRAGMA cipher_plaintext_header_size = 32;
 "#,
-            &String::from_utf8_lossy(&*test2.unlocked.read_lock()),
+            &String::from_utf8_lossy(&test2.unlocked.read_lock()),
         );
 
         let test3 = DbKey::generate(sodoken::BufRead::new_no_lock(b"passphrase"))
@@ -189,8 +189,8 @@ PRAGMA cipher_plaintext_header_size = 32;
             .unwrap();
 
         assert_ne!(
-            String::from_utf8_lossy(&*test1.unlocked.read_lock()),
-            String::from_utf8_lossy(&*test3.unlocked.read_lock()),
+            String::from_utf8_lossy(&test1.unlocked.read_lock()),
+            String::from_utf8_lossy(&test3.unlocked.read_lock()),
         );
 
         let test4 = DbKey::load(test3.locked, sodoken::BufRead::new_no_lock(b"passphrase"))
@@ -198,8 +198,8 @@ PRAGMA cipher_plaintext_header_size = 32;
             .unwrap();
 
         assert_eq!(
-            String::from_utf8_lossy(&*test3.unlocked.read_lock()),
-            String::from_utf8_lossy(&*test4.unlocked.read_lock()),
+            String::from_utf8_lossy(&test3.unlocked.read_lock()),
+            String::from_utf8_lossy(&test4.unlocked.read_lock()),
         );
     }
 }

--- a/crates/holochain_sqlite/src/db/mod.rs
+++ b/crates/holochain_sqlite/src/db/mod.rs
@@ -4,6 +4,7 @@ mod access;
 mod conn;
 mod databases;
 mod guard;
+mod key;
 mod kind;
 mod metrics;
 mod pool;
@@ -13,6 +14,7 @@ mod tests;
 
 pub use access::{DbRead, DbWrite, ReadAccess};
 pub use guard::PTxnGuard;
+pub use key::DbKey;
 pub use kind::{
     DbKind, DbKindAuthored, DbKindCache, DbKindConductor, DbKindDht, DbKindOp, DbKindP2pAgents,
     DbKindP2pMetrics, DbKindT, DbKindWasm,

--- a/crates/holochain_sqlite/src/db/mod.rs
+++ b/crates/holochain_sqlite/src/db/mod.rs
@@ -17,7 +17,7 @@ pub use kind::{
     DbKind, DbKindAuthored, DbKindCache, DbKindConductor, DbKindDht, DbKindOp, DbKindP2pAgents,
     DbKindP2pMetrics, DbKindT, DbKindWasm,
 };
-pub use pool::{DbSyncLevel, DbSyncStrategy};
+pub use pool::{DbSyncLevel, DbSyncStrategy, PoolConfig};
 
 #[cfg(feature = "test_utils")]
 pub use access::set_acquire_timeout;

--- a/crates/holochain_sqlite/src/db/pool.rs
+++ b/crates/holochain_sqlite/src/db/pool.rs
@@ -109,7 +109,7 @@ pub(super) fn initialize_connection(conn: &mut Connection, config: &PoolConfig) 
     conn.busy_timeout(SQLITE_BUSY_TIMEOUT)?;
 
     #[cfg(feature = "sqlite-encrypted")]
-    conn.execute_batch(&String::from_utf8_lossy(&*config.key.unlocked.read_lock()))?;
+    conn.execute_batch(&String::from_utf8_lossy(&config.key.unlocked.read_lock()))?;
 
     // this is recommended to always be off:
     // https://sqlite.org/pragma.html#pragma_trusted_schema

--- a/crates/holochain_sqlite/src/lib.rs
+++ b/crates/holochain_sqlite/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! Unpack and run the build commands per the README.md:
 //!
-//! ```
+//! ```text
 //! ./configure --enable-tempstore=yes CFLAGS="-DSQLITE_HAS_CODEC" LDFLAGS="-lcrypto"
 //! make
 //! ```
@@ -25,13 +25,13 @@
 //!
 //! Connect to your encrypted holochain database:
 //!
-//! ```
+//! ```text
 //! ./sqlcipher /tmp/holochain-test-environmentsyQCJLKxtXcDuglEQNVAerzPBUCM/databases/conductor/conductor
 //! ```
 //!
 //! At the `sqlite>` prompt, input your key:
 //!
-//! ```
+//! ```text
 //! PRAGMA key = "x'98483C6EB40B6C31A448C22A66DED3B5E5E8D5119CAC8327B655C8B5C483648101010101010101010101010101010101'";
 //! ```
 //!
@@ -39,7 +39,7 @@
 //!
 //! You should now be able to make sqlite queries:
 //!
-//! ```
+//! ```text
 //! select count(id) from ConductorState;
 //! ```
 

--- a/crates/holochain_sqlite/src/lib.rs
+++ b/crates/holochain_sqlite/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! Unpack and run the build commands per the README.md:
 //!
-//! ```text
+//! ```sh
 //! ./configure --enable-tempstore=yes CFLAGS="-DSQLITE_HAS_CODEC" LDFLAGS="-lcrypto"
 //! make
 //! ```
@@ -25,7 +25,7 @@
 //!
 //! Connect to your encrypted holochain database:
 //!
-//! ```text
+//! ```sh
 //! ./sqlcipher /tmp/holochain-test-environmentsyQCJLKxtXcDuglEQNVAerzPBUCM/databases/conductor/conductor
 //! ```
 //!

--- a/crates/holochain_sqlite/tests/tests/db_wrapper.rs
+++ b/crates/holochain_sqlite/tests/tests/db_wrapper.rs
@@ -16,7 +16,7 @@ async fn async_read_respects_reader_permit_limits() {
     set_connection_timeout(300);
 
     let tmp_dir = tempfile::TempDir::new().unwrap();
-    let db_handle = DbWrite::open(&tmp_dir.into_path(), TestDatabaseKind::new()).unwrap();
+    let db_handle = DbWrite::test(&tmp_dir.into_path(), TestDatabaseKind::new()).unwrap();
 
     let num_readers = num_read_threads();
 
@@ -88,7 +88,7 @@ async fn get_read_txn_respects_reader_permit_limits() {
     set_connection_timeout(300);
 
     let tmp_dir = tempfile::TempDir::new().unwrap();
-    let db_handle = DbWrite::open(&tmp_dir.into_path(), TestDatabaseKind::new()).unwrap();
+    let db_handle = DbWrite::test(&tmp_dir.into_path(), TestDatabaseKind::new()).unwrap();
 
     let num_readers = num_read_threads();
 
@@ -159,7 +159,7 @@ async fn read_async_releases_permits() {
     set_connection_timeout(300);
 
     let tmp_dir = tempfile::TempDir::new().unwrap();
-    let db_handle = DbWrite::open(&tmp_dir.into_path(), TestDatabaseKind::new()).unwrap();
+    let db_handle = DbWrite::test(&tmp_dir.into_path(), TestDatabaseKind::new()).unwrap();
 
     let num_readers = num_read_threads();
 
@@ -190,7 +190,7 @@ async fn write_permits_can_be_released() {
     set_connection_timeout(300);
 
     let tmp_dir = tempfile::TempDir::new().unwrap();
-    let db_handle = DbWrite::open(&tmp_dir.into_path(), TestDatabaseKind::new()).unwrap();
+    let db_handle = DbWrite::test(&tmp_dir.into_path(), TestDatabaseKind::new()).unwrap();
 
     let ran_count = Arc::new(AtomicUsize::new(0));
     for _ in 0..3 {

--- a/crates/holochain_sqlite/tests/tests/migrate_unencrypted.rs
+++ b/crates/holochain_sqlite/tests/tests/migrate_unencrypted.rs
@@ -30,14 +30,14 @@ async fn migrate_unencrypted() {
     }
 
     // Without the HOLOCHAIN_MIGRATE_UNENCRYPTED variable set, it should fail to open
-    let err = DbWrite::open(std::path::Path::new(tmp_dir.path()), DbKindConductor).unwrap_err();
+    let err = DbWrite::test(std::path::Path::new(tmp_dir.path()), DbKindConductor).unwrap_err();
     assert_eq!(err.to_string(), "file is not a database");
 
     std::env::set_var("HOLOCHAIN_MIGRATE_UNENCRYPTED", "true");
 
     // Now it should open and read just fine, because it will be encrypted automatically
     let db: DbWrite<DbKindConductor> =
-        DbWrite::open(std::path::Path::new(tmp_dir.path()), DbKindConductor).unwrap();
+        DbWrite::test(std::path::Path::new(tmp_dir.path()), DbKindConductor).unwrap();
     let msg = db
         .read_async(|txn| -> DatabaseResult<String> {
             Ok(txn.query_row(

--- a/crates/holochain_sqlite/tests/tests/migrate_unencrypted.rs
+++ b/crates/holochain_sqlite/tests/tests/migrate_unencrypted.rs
@@ -30,8 +30,7 @@ async fn migrate_unencrypted() {
     }
 
     // Without the HOLOCHAIN_MIGRATE_UNENCRYPTED variable set, it should fail to open
-    let err = DbWrite::test(std::path::Path::new(tmp_dir.path()), DbKindConductor).unwrap_err();
-    assert_eq!(err.to_string(), "file is not a database");
+    DbWrite::test(std::path::Path::new(tmp_dir.path()), DbKindConductor).unwrap_err();
 
     std::env::set_var("HOLOCHAIN_MIGRATE_UNENCRYPTED", "true");
 

--- a/crates/holochain_state/src/mutations.rs
+++ b/crates/holochain_state/src/mutations.rs
@@ -956,7 +956,7 @@ mod tests {
         let op1 = make_op(warrant1.clone());
         let op2 = make_op(warrant2.clone());
 
-        let db = DbWrite::<DbKindAuthored>::open(dir.as_ref(), DbKindAuthored(cell_id)).unwrap();
+        let db = DbWrite::<DbKindAuthored>::test(dir.as_ref(), DbKindAuthored(cell_id)).unwrap();
         db.test_write({
             let op1 = op1.clone();
             let op2 = op2.clone();

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -55,7 +55,7 @@ nanoid = "0.4"
 parking_lot = "0.12"
 rand = "0.8.5"
 regex = "1.4"
-rusqlite = { version = "0.31" }
+rusqlite = { version = "0.32.1" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 serde_derive = "1.0"

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -37,7 +37,7 @@ strum = { version = "0.18.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 
 # sqlite dependencies
-rusqlite = { version = "0.31", optional = true }
+rusqlite = { version = "0.32.1", optional = true }
 num_enum = { version = "0.7", optional = true }
 
 # full-dna-def dependencies

--- a/crates/kitsune_p2p/dht_arc/Cargo.toml
+++ b/crates/kitsune_p2p/dht_arc/Cargo.toml
@@ -22,7 +22,7 @@ kitsune_p2p_timestamp = { version = "^0.4.0-dev.3", path = "../timestamp" }
 arbitrary = { version = "1", features = ["derive"], optional = true }
 proptest = { version = "1", optional = true }
 proptest-derive = { version = "0", optional = true }
-rusqlite = { version = "0.31", optional = true }
+rusqlite = { version = "0.32.1", optional = true }
 
 [dev-dependencies]
 maplit = "1"

--- a/crates/kitsune_p2p/timestamp/Cargo.toml
+++ b/crates/kitsune_p2p/timestamp/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4.22", default-features = false, features = [
 ], optional = true }
 
 # Dependencies only needed for full.
-rusqlite = { version = "0.31", optional = true }
+rusqlite = { version = "0.32.1", optional = true }
 
 # Dependencies only needed for testing by downstream crates.
 arbitrary = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-lair_keystore_api = "=0.4.5"
+lair_keystore_api = "=0.5.0"
 base64 = "0.22"
 derive_more = "0.99"
 futures = "0.3"


### PR DESCRIPTION
changelog:

- **BREAKING!** Enables dynamic database encryption. (as opposed to the hard-coded key that was previously being used.) NOTE - this is incompatible with all previous holochain databases, they will not open, and must be deleted. NOTE - this is incompatible with all previous lair databases, they will not open and must be deleted. [\#4198](https://github.com/holochain/holochain/pull/4198)
