### PR TITLE
feat: rename --dylib-ios cli flag, variables and output dir

### DIFF
--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- **BREAKING** rename cli flag in `hc pack` from `--dylib-ios` to `--precompile` to clarify that it is not an ios-specific feature.
+
 - Add feature flags `wasmer_sys` and `wasmer_wamr` to toggle between using the current wasm compiler and the new, experimental wasm interpreter. Bundling pre-compiled and pre-serialized DNAs is not supported in the `wasmer_wamr` feature.
 
 ## 0.4.0-dev.21

--- a/crates/hc_bundle/src/packing.rs
+++ b/crates/hc_bundle/src/packing.rs
@@ -86,7 +86,7 @@ pub async fn pack<M: Manifest>(
     dir_path: &std::path::Path,
     target_path: Option<PathBuf>,
     name: String,
-    serialize_wasm: bool,
+    precompile: bool,
 ) -> HcBundleResult<(PathBuf, Bundle<M>)> {
     let dir_path = ffs::canonicalize(dir_path).await?;
     let manifest_path = dir_path.join(M::path());
@@ -102,8 +102,8 @@ pub async fn pack<M: Manifest>(
         None => dir_to_bundle_path(&dir_path, name, M::bundle_extension())?,
     };
     bundle.write_to_file(&target_path).await?;
-    if serialize_wasm {
-        build_preserialized_wasm(&target_path, &bundle).await?;
+    if prebuild {
+        precompile_wasm(&target_path, &bundle).await?;
     }
 
     Ok((target_path, bundle))

--- a/crates/holochain_zome_types/src/zome.rs
+++ b/crates/holochain_zome_types/src/zome.rs
@@ -155,10 +155,11 @@ pub struct WasmZome {
     /// The zome dependencies
     pub dependencies: Vec<ZomeName>,
 
-    /// The path to a preserialized wasmer module used as a "dynamic library" (dylib).
-    /// Useful for iOS and other targets.
+    /// The path to a pre-compliled and seriailized wasmer module used as a "dynamic library" (dylib).
+    /// Useful in contexts where JIT compilation is not allowed (i.e. iOS apps),
+    /// or to avoid the performance cost of compilation at runtime.
     #[serde(default)]
-    pub preserialized_path: Option<PathBuf>,
+    pub precompiled_path: Option<PathBuf>,
 }
 
 /// Just the definition of a Zome, without the name included. This exists


### PR DESCRIPTION
### Summary
The functionality to precompile and serialize a wasm to a file that is specified in the dna manifest is generally useful and should not be ios-specific. It allows you to avoid the performance cost of compiling wasm at runtime.

This renames the cli flag and variables to remove reference to ios and add docs clarify the functionality.


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs