### PR TITLE
Cachix update to report failures

### DIFF
--- a/.github/workflows/holonix-cache.yml
+++ b/.github/workflows/holonix-cache.yml
@@ -56,7 +56,7 @@ jobs:
           # Don't exit if this fails so we can clean up the profile
           total_status=0
           for i in result-*; do
-            if ! grep -t "$i"; then
+            if ! cachix push holochain-ci $i; then
               total_status=$((total_status+1))
             fi
           done

--- a/.github/workflows/holonix-cache.yml
+++ b/.github/workflows/holonix-cache.yml
@@ -56,10 +56,9 @@ jobs:
           # Don't exit if this fails so we can clean up the profile
           total_status=0
           for i in result-*; do
-            set +e
-            cachix push holochain-ci $i
-            total_status=$((total_status + $?))
-            set -e
+            if ! grep -t "$i"; then
+              total_status=$((total_status+1))
+            fi
           done
 
           rm result*

--- a/.github/workflows/holonix-cache.yml
+++ b/.github/workflows/holonix-cache.yml
@@ -54,11 +54,17 @@ jobs:
             ${{ format(matrix.target, matrix.platform) }}
 
           # Don't exit if this fails so we can clean up the profile
+          total_status=0
           for i in result-*; do
-            cachix push holochain-ci $i || true
+            set +e
+            cachix push holochain-ci $i
+            total_status=$((total_status + $?))
+            set -e
           done
 
           rm result*
+          
+          exit $total_status
   cache-check:
     needs:
       - cache-update


### PR DESCRIPTION
### Summary

There is a good reason to catch errors during the push loop. We want to get as much as possible onto cachix and it's important that we clean up symlinks created by Nix. If we don't then the disk on our runner can fill up. In theory... the working directories for the runner should get cleaned up, but anyway.

We are now summing the status codes so that if any of them aren't `0` then the step will fail. That would have been much clearer and got me looking at the right logs to see what was going wrong with the cache update.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs