### PR TITLE
refactor: replace do_callback! macro with generic function

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Replace the `do_callback!` private macro with a `do_callback` generic function. This change should not affect the user as the macro, now function, is only used internally in the `real_ribosome` module. #4283
+
 ## 0.4.0-dev.27
 
 - HC sandbox: Fix `--no-dpki` option which previously enabled DPKI in the conductor when set, instead of disabling it.

--- a/crates/holochain/src/core/ribosome.rs
+++ b/crates/holochain/src/core/ribosome.rs
@@ -737,7 +737,7 @@ pub trait RibosomeT: Sized + std::fmt::Debug + Send + Sync {
     ) -> RibosomeResult<()>;
 
     /// Helper function for running a validation callback. Calls
-    /// private fn `do_callback!` under the hood.
+    /// private fn `do_callback` under the hood.
     async fn run_validate(
         &self,
         access: ValidateHostAccess,


### PR DESCRIPTION
### Summary
This PR simply replaces the `do_callback!` macro with a function instead.

Opinion: functions are easier to read and follow than macros.

Functions also usually work nicer with tools such as `rust-analyzer` and LSP servers.


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs