### PR TITLE
Fix Makefile recipes, nix devShell, and direnv watch list

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,6 +2,8 @@ if ! has nix_direnv_version || ! nix_direnv_version 3.0.4; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.4/direnvrc" "sha256-DzlYZ33mWF/Gs8DDeyjr8mnVmQGx7ASYqA5WlxwvBG4="
 fi
 
+watch_file nix/**
+
 use flake .#coreDev \
   --override-input versions ./versions/weekly \
   --override-input holochain .

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,10 @@ DEFAULT_FEATURES=chc,slow_tests,build_wasms,sqlite-encrypted,hc_demo_cli/build_d
 	test-workspace-wasmer_sys test-workspace-wasmer_wamr
 
 # default to running everything (first rule)
-default: build-workspace test-workspace
+default: build-workspace-wasmer_sys \
+	test-workspace-wasmer_sys \
+	build-workspace-wasmer_wamr \
+	test-workspace-wasmer_wamr
 
 # execute all static code validation
 static-all: static-fmt static-toml static-clippy static-doc

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ DEFAULT_FEATURES=chc,slow_tests,build_wasms,sqlite-encrypted,hc_demo_cli/build_d
 # mark everything as phony because it doesn't represent a file-system output
 .PHONY: default \
 	static-all static-fmt static-toml static-clippy static-doc \
-	build-workspace test-workspace
+	build-workspace-wasmer_sys build-workspace-wasmer_wamr \
+	test-workspace-wasmer_sys test-workspace-wasmer_wamr
 
 # default to running everything (first rule)
 default: build-workspace test-workspace

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - `session_rollback_with_chc_enabled`
     - `alice_can_recover_from_a_session_timeout`
     - `should_be_able_to_schedule_functions_during_session`
+- Update Makefile default recipe to use the new recipes that build and test the workspace with the feature flags `wasmer_sys` and `wasmer_wamr`. #4284
+- Add support for parsing the lint-level as a set in the Nix holochain module. e.g. `nursery = { level = "allow", priority = -1 }`. #4284
+- Add the `nix/` directory as a watch point for `direnv` so it reloads the `devShell` if a file changes in that directory. #4284
 
 ## 0.4.0-dev.26
 

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -130,9 +130,15 @@
               (name: value:
                 builtins.concatStringsSep " " [
                   (
-                    if value == "allow" then "-A"
-                    else if value == "deny" then "-D"
-                    else throw "unsupported lint: ${name} = ${value}"
+                    if builtins.typeOf value == "string" then
+                      if value == "allow" then "-A"
+                      else if value == "deny" then "-D"
+                      else throw "unsupported lint level: ${name} = ${value}"
+                    else if builtins.typeOf value == "set" && builtins.typeOf value.level == "string" then
+                      if value.level == "allow" then "-A"
+                      else if value.level == "deny" then "-D"
+                      else throw "unsupported lint level: ${name}.level = ${value.level}"
+                    else throw "unsupported value for lint: ${name}"
                   )
                   "clippy::${name}"
                 ]


### PR DESCRIPTION
### Summary
Some quality-of-life improvements:
* Fix the makefile recipes after a recent change removed the recipes that we referenced by `default`.
* Mark the new makefile recipes as phony and remove the old recipes.
* `direnv` now watches the `nix/` directory recursively for changes and reloads the `devShell` if a file changes.
* Fix the lint level parsing in Nix, this allows us to use the format `nursery = { level = "allow", priority = -1 }` that was recently added.


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs