### PR TITLE
Expose wasmer production compiler

### DIFF
--- a/.config/test-args.nix
+++ b/.config/test-args.nix
@@ -1,1 +1,1 @@
-"--workspace --features slow_tests,build_wasms,sqlite-encrypted,chc,unstable-dpki,unstable-sharding,unstable-warrants,unstable-functions,unstable-countersigning --lib --tests --bins"
+"--workspace --features slow_tests,build_wasms,sqlite-encrypted,chc,unstable-dpki,unstable-sharding,unstable-warrants,unstable-functions,unstable-countersigning,wasmer_compiler_production --lib --tests --bins"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4081,6 +4081,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "inkwell"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40fb405537710d51f6bdbc8471365ddd4cd6d3a3c3ad6e0c8291691031ba94b2"
+dependencies = [
+ "either",
+ "inkwell_internals",
+ "libc",
+ "llvm-sys",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "inkwell_internals"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd28cfd4cfba665d47d31c08a6ba637eed16770abca2eccbbc3ca831fef1e44"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4764,6 +4789,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "llvm-sys"
+version = "180.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778fa5fa02e32728e718f11eec147e6f134137399ab02fd2c13d32476337affa"
+dependencies = [
+ "anyhow",
+ "cc",
+ "lazy_static",
+ "libc",
+ "regex-lite",
+ "semver",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5328,6 +5367,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "object"
+version = "0.30.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -6452,6 +6500,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"
@@ -8877,6 +8931,7 @@ dependencies = [
  "wasm-bindgen",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
+ "wasmer-compiler-llvm",
  "wasmer-derive",
  "wasmer-types",
  "wasmer-vm",
@@ -8936,6 +8991,30 @@ dependencies = [
  "tracing",
  "wasmer-compiler",
  "wasmer-types",
+]
+
+[[package]]
+name = "wasmer-compiler-llvm"
+version = "5.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a8f2200f7bb3dd1cfd6d1f454b41cb92c8e73f2045764057703af13d8852a5b"
+dependencies = [
+ "byteorder",
+ "cc",
+ "inkwell",
+ "itertools 0.10.5",
+ "lazy_static",
+ "libc",
+ "object 0.30.4",
+ "rayon",
+ "regex",
+ "rustc_version",
+ "semver",
+ "smallvec",
+ "target-lexicon",
+ "wasmer-compiler",
+ "wasmer-types",
+ "wasmer-vm",
 ]
 
 [[package]]

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -294,10 +294,7 @@ wasmer_sys = [
   "holochain_wasmer_host/wasmer_sys_dev",
 ]
 
-wasmer_compiler_production = [
-  "wasmer_sys",
-  "wasmer/llvm"
-]
+wasmer_compiler_production = ["wasmer_sys", "wasmer/llvm"]
 
 # Enable wasm interpreter (experimental)
 # Incompatible with "wasmer_sys"

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -294,6 +294,11 @@ wasmer_sys = [
   "holochain_wasmer_host/wasmer_sys_dev",
 ]
 
+wasmer_compiler_production = [
+  "wasmer_sys",
+  "wasmer/llvm"
+]
+
 # Enable wasm interpreter (experimental)
 # Incompatible with "wasmer_sys"
 wasmer_wamr = ["wasmer/wamr", "holochain_wasmer_host/wasmer_wamr"]

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -191,9 +191,12 @@ path = "src/bin/holochain/main.rs"
 workspace = true
 
 [features]
-default = ["sqlite-encrypted", "tx5", "metrics_influxive", "wasmer_sys_dev"]
-
-prod = ["sqlite-encrypted", "tx5", "wasmer_sys_prod"]
+default = [
+  "sqlite-encrypted",
+  "tx5",
+  "metrics_influxive",
+  "wasmer_sys_cranelift",
+]
 
 tx5 = ["tx5-go-pion-turn"]
 
@@ -288,25 +291,27 @@ sqlite = [
 # Extremely verbose wasm memory read/write logging
 wasmer_debug_memory = ["holochain_wasmer_host/debug_memory"]
 
-# Enable wasm compiler
-# Incompatible with "wasmer_wamr"
 wasmer_sys = [
   "dep:wasmer-middlewares",
   "wasmer/default",
   "holochain_wasmer_host/wasmer_sys_dev",
 ]
 
-wasmer_sys_dev = [
-  "wasmer_sys",
-  "holochain_wasmer_host/wasmer_sys_dev",
-]
-wasmer_sys_prod = [
-  "wasmer_sys",
+# Enable wasm cranelift compiler
+# Incompatible with "wasmer_wamr"
+wasmer_sys_cranelift = ["wasmer_sys", "holochain_wasmer_host/wasmer_sys_dev"]
+
+# Enable wasm LLVM compiler
+# Incompatible with "wasmer_wamr"
+wasmer_sys_llvm = [
+  "dep:wasmer-middlewares",
+  "wasmer/sys",
+  "wasmer/wat",
   "holochain_wasmer_host/wasmer_sys_prod",
 ]
 
 # Enable wasm interpreter (experimental)
-# Incompatible with "wasmer_sys"
+# Incompatible with "wasmer_sys_cranelift" and "wasmer_sys_llvm"
 wasmer_wamr = ["wasmer/wamr", "holochain_wasmer_host/wasmer_wamr"]
 
 # Enable chain head coordination

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -191,7 +191,9 @@ path = "src/bin/holochain/main.rs"
 workspace = true
 
 [features]
-default = ["sqlite-encrypted", "tx5", "metrics_influxive", "wasmer_sys"]
+default = ["sqlite-encrypted", "tx5", "metrics_influxive", "wasmer_sys_dev"]
+
+prod = ["sqlite-encrypted", "tx5", "wasmer_sys_prod"]
 
 tx5 = ["tx5-go-pion-turn"]
 
@@ -294,7 +296,14 @@ wasmer_sys = [
   "holochain_wasmer_host/wasmer_sys_dev",
 ]
 
-wasmer_compiler_production = ["wasmer_sys", "wasmer/llvm"]
+wasmer_sys_dev = [
+  "wasmer_sys",
+  "holochain_wasmer_host/wasmer_sys_dev",
+]
+wasmer_sys_prod = [
+  "wasmer_sys",
+  "holochain_wasmer_host/wasmer_sys_prod",
+]
 
 # Enable wasm interpreter (experimental)
 # Incompatible with "wasmer_sys"

--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -138,6 +138,9 @@
             packages = with pkgs; [
               cargo-nextest
               graph-easy
+              llvm_15 # For running holochain with wasmer_compiler_production
+              libffi
+              libxml2
 
               self'.packages.scripts-cargo-regen-lockfiles
               self'.packages.scripts-cargo-update

--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -159,6 +159,8 @@
               export HC_WASM_CACHE_PATH="$CARGO_TARGET_DIR/.wasm_cache"
               mkdir -p $HC_WASM_CACHE_PATH
 
+              export LLVM_SYS_150_PREFIX="$(which llvm-config | xargs dirname | xargs dirname)"
+
               # Enables the pre-commit hooks
               ${config.pre-commit.installationScript}
             '';

--- a/scripts/format-toml.sh
+++ b/scripts/format-toml.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-23.11.tar.gz -i bash --pure --packages taplo
+#! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-24.11.tar.gz -i bash --pure --packages taplo
 
 # Usage to format: ./scripts/format-toml.sh
 # Usage to check: ./scripts/format-toml.sh --check


### PR DESCRIPTION
### Summary

Resolves #4814

This has been bugging me for a while. We see `cranelift` compiler logs even in release builds. That's only supposed to be used for development. The real "fast" wasmer runtime is supposed to use the `llvm` compiler.

See the documentation -> https://docs.rs/wasmer/latest/wasmer/

In my local testing, this is dramatically faster. I'd like to add the feature so I can do some more testing in Wind Tunnel. For now, I'm also enabling this for test runs because if we can get a decent speed up for test runs, that'd be helpful too.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs