### PR TITLE
change 0_4_rc flake.nix to point to holochain-0.4 branch of hc-launch

### DIFF
--- a/versions/0_4_rc/flake.lock
+++ b/versions/0_4_rc/flake.lock
@@ -37,16 +37,16 @@
     "launcher": {
       "flake": false,
       "locked": {
-        "lastModified": 1727250978,
-        "narHash": "sha256-6u/VjFRV4eQQS4H0he7C0n7uNjzBBtkeoyN46jTO0mc=",
+        "lastModified": 1728477335,
+        "narHash": "sha256-W3Ad7qCeV4SX/SVAEWwdlIqLpJBcOeJyFSX1LKu+GPo=",
         "owner": "holochain",
         "repo": "hc-launch",
-        "rev": "92afce654187be5abef67d34df20bd6464524cf3",
+        "rev": "e15367be454764e107b696cc180eca357cf87993",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-weekly",
+        "ref": "holochain-0.4",
         "repo": "hc-launch",
         "type": "github"
       }

--- a/versions/0_4_rc/flake.nix
+++ b/versions/0_4_rc/flake.nix
@@ -13,7 +13,7 @@
 
       # holochain_cli_launch
       launcher = {
-        url = "github:holochain/hc-launch/holochain-weekly";
+        url = "github:holochain/hc-launch/holochain-0.4";
         flake = false;
       };
 


### PR DESCRIPTION
### Summary
Chnages the holonix source for hc-launch to the `holochain-0.4` branch.


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs