### PR TITLE
Partial backport of fix-sql-fmt to develop-0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4556,9 +4556,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0da3e3e1bd2644dc2974ef622743cd83f2c661b3c6c67acb00cda4725646def"
+checksum = "1e3ce2bfd2af30dddc1cd4fd4f7b6ed098a949222c59ccb986162ecc41a96472"
 dependencies = [
  "lair_keystore_api",
  "pretty_assertions",
@@ -4572,9 +4572,9 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9519a48df54d2041f8697bba7c3957263a5f2bb720ae6c4954004bad51693c61"
+checksum = "433083f77dcae8f66bc06934c18e9ae2804bccfa74a6c75bb89a3f8057d93267"
 dependencies = [
  "base64 0.22.1",
  "dunce",
@@ -8390,9 +8390,9 @@ dependencies = [
 
 [[package]]
 name = "tx5"
-version = "0.0.14-alpha"
+version = "0.0.15-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051fbfe67420948106357c27a54f8bbe25a5f62e56a8f0192b11b2aae7e16a78"
+checksum = "26db071e98ea6e59b2f4776c3695f7ac76fe3e49e1831bc1c694aeb12132dff2"
 dependencies = [
  "bit_field",
  "bytes",
@@ -8415,9 +8415,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-core"
-version = "0.0.14-alpha"
+version = "0.0.15-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e51435e31233dc38b06ff3dc495f6ba027cd6ec917c3a15796c9aec6f3a433"
+checksum = "2ebfac463c45038a97f4680577dc4fa834e09cd8e71ee9afc885542e7f59e281"
 dependencies = [
  "app_dirs2",
  "base64 0.13.1",
@@ -8434,9 +8434,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion"
-version = "0.0.14-alpha"
+version = "0.0.15-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54f8ed72ab6ca33b4f70c81744cebc2690203df1544e07053185adb8b5b771d"
+checksum = "7671dfde166b4cd952ad4768514e3755253e0af72c24e1469c743e0f9a77f2a0"
 dependencies = [
  "futures",
  "parking_lot 0.12.3",
@@ -8448,9 +8448,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-sys"
-version = "0.0.14-alpha"
+version = "0.0.15-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad305853b0675d30b18183d072f4b3e326ea186ab38e2778a7a5d40072271853"
+checksum = "12c9feca91791769d1b25ba46efa89493a648572dce6b79fdde2dbad73deb45a"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -8467,9 +8467,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-go-pion-turn"
-version = "0.0.14-alpha"
+version = "0.0.15-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de1a96047debfde1da5e1ce230f4e4d39d18d707190c04ccec2fdd9ae356e24"
+checksum = "bb92ddd44e049708d79e4315bf1c44b6992cd3a3cf95296ad24afd446daa3746"
 dependencies = [
  "base64 0.13.1",
  "dirs",
@@ -8485,9 +8485,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-signal"
-version = "0.0.14-alpha"
+version = "0.0.15-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3036e0df28f280990fd12c569244c25c7ab6e3b9f436ca617fbf5b1d3a6dc761"
+checksum = "3f4c7f15970697c26916e3063266e20052056315077cf742d501f0c283ea02a2"
 dependencies = [
  "futures",
  "lair_keystore_api",
@@ -8514,9 +8514,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-signal-srv"
-version = "0.0.14-alpha"
+version = "0.0.15-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa882b51d1c4b4e86c9a43134674b856a8248c147d889c70c6d0f9d88541012"
+checksum = "fc6add3578c5b9f8c361629acec50d155593ed6da02971bb2385b43412a21d38"
 dependencies = [
  "clap 4.5.9",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7420,9 +7420,9 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f895e3734318cc55f1fe66258926c9b910c124d47520339efecbb6c59cec7c1f"
+checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
 dependencies = [
  "nom",
  "unicode_categories",

--- a/crates/hc_run_local_services/Cargo.toml
+++ b/crates/hc_run_local_services/Cargo.toml
@@ -23,7 +23,7 @@ if-addrs = "0.12"
 kitsune_p2p_bootstrap = { version = "^0.2.3", path = "../kitsune_p2p/bootstrap" }
 tokio = { version = "1.36.0", features = ["full"] }
 tracing = "0.1"
-tx5-signal-srv = "=0.0.14-alpha"
+tx5-signal-srv = "=0.0.15-alpha"
 
 [lints]
 workspace = true

--- a/crates/hc_service_check/Cargo.toml
+++ b/crates/hc_service_check/Cargo.toml
@@ -9,8 +9,8 @@ license = "Apache-2.0"
 clap = { version = "4.5.3", features = [ "derive", "wrap_help" ] }
 tokio = { version = "1.36.0", features = [ "full" ] }
 kitsune_p2p_bootstrap_client = { version = "^0.3.3", path = "../kitsune_p2p/bootstrap_client" }
-tx5-go-pion = { version = "0.0.14-alpha" }
-tx5-signal = { version = "0.0.14-alpha" }
+tx5-go-pion = { version = "0.0.15-alpha" }
+tx5-signal = { version = "0.0.15-alpha" }
 url2 = "0.0.6"
 
 [lints]

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -156,7 +156,7 @@ serde_json = { version = "1.0.51" }
 toml = "0.8"
 chrono = { version = "0.4.6", features = ["serde"] }
 hostname = "0.4"
-lair_keystore = { version = "0.4.5", default-features = false, features = [
+lair_keystore = { version = "0.4.6", default-features = false, features = [
   "rusqlite-bundled-sqlcipher-vendored-openssl",
 ] }
 

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -103,8 +103,8 @@ matches = { version = "0.1.8", optional = true }
 holochain_test_wasm_common = { version = "^0.3.3", path = "../test_utils/wasm_common", optional = true }
 kitsune_p2p_bootstrap = { version = "^0.2.3", path = "../kitsune_p2p/bootstrap", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
-tx5-go-pion-turn = { version = "=0.0.14-alpha", optional = true }
-tx5-signal-srv = { version = "=0.0.14-alpha", optional = true }
+tx5-go-pion-turn = { version = "=0.0.15-alpha", optional = true }
+tx5-signal-srv = { version = "=0.0.15-alpha", optional = true }
 
 # chc deps
 bytes = { version = "1", optional = true }

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -22,7 +22,7 @@ holochain_zome_types = { path = "../holochain_zome_types", version = "^0.3.3"}
 kitsune_p2p_types = { version = "^0.3.3", path = "../kitsune_p2p/types" }
 holochain_secure_primitive = { version = "^0.3.3", path = "../holochain_secure_primitive" }
 holochain_util = { version = "^0.3.3", path = "../holochain_util" }
-lair_keystore = { version = "0.4.5", default-features = false }
+lair_keystore = { version = "0.4.6", default-features = false }
 must_future = "0.1.2"
 nanoid = "0.4.0"
 one_err = "0.0.8"

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Fix sql formatting to resolve new complaints thrown by `sqlformat` 0.2.6. Pin `sqlformat` dependency to 0.2.4 to avoid these new complaints in upstream crates. 
+
 ## 0.3.3
 
 ## 0.3.3-rc.0

--- a/crates/holochain_sqlite/CHANGELOG.md
+++ b/crates/holochain_sqlite/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
-- Fix sql formatting to resolve new complaints thrown by `sqlformat` 0.2.6. Pin `sqlformat` dependency to 0.2.4 to avoid these new complaints in upstream crates. 
+- Fix sql formatting to resolve new complaints thrown by `sqlformat` 0.2.6. Pin `sqlformat` dependency to 0.2.6.
+- Bump `lair_keystore` & `lair_keystore_api` to 0.4.6
 
 ## 0.3.3
 

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -74,7 +74,7 @@ rand = "0.8.5"
 
 [build-dependencies]
 pretty_assertions = "1.4"
-sqlformat = "0.2"
+sqlformat = "=0.2.4"
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.7", features = ["futures", "checkpoint"] }

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -74,7 +74,7 @@ rand = "0.8.5"
 
 [build-dependencies]
 pretty_assertions = "1.4"
-sqlformat = "=0.2.4"
+sqlformat = "=0.2.6"
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.7", features = ["futures", "checkpoint"] }

--- a/crates/holochain_sqlite/src/sql/cell/fetch_op_region.sql
+++ b/crates/holochain_sqlite/src/sql/cell/fetch_op_region.sql
@@ -1,7 +1,7 @@
 SELECT
   COUNT(DhtOp.hash) AS count,
   REDUCE_XOR(DhtOp.hash) AS xor_hash,
-  TOTAL(LENGTH(Action.blob)) AS total_action_size,
+  TOTAL(LENGTH(Action.blob)) AS total_action_size, --
   -- We need to only account for entry data in the size count when the op contains the entry itself.
   -- Other ops refer to actions that refer to entries, but we don't want to include that in the size.
   TOTAL(

--- a/crates/holochain_sqlite/src/sql/cell/fetch_region_op_hashes.sql
+++ b/crates/holochain_sqlite/src/sql/cell/fetch_region_op_hashes.sql
@@ -1,6 +1,6 @@
 SELECT
   DhtOp.hash,
-  LENGTH(Action.blob) AS action_size,
+  LENGTH(Action.blob) AS action_size, --
   -- We need to only account for entry data in the size count when the op contains the entry itself.
   -- Other ops refer to actions that refer to entries, but we don't want to include that in the size.
   CASE

--- a/crates/holochain_sqlite/src/sql/conductor/schema/1.sql
+++ b/crates/holochain_sqlite/src/sql/conductor/schema/1.sql
@@ -1,11 +1,13 @@
 CREATE TABLE IF NOT EXISTS BlockSpan (
   id INTEGER PRIMARY KEY,
   target_id BLOB NOT NULL,
-  target_reason BLOB NOT NULL,
+  target_reason BLOB NOT NULL, --
   -- start and end micros
   -- literal integer from Timestamp in rust
   start_us INTEGER NOT NULL,
   end_us INTEGER NOT NULL
 );
+
 CREATE INDEX IF NOT EXISTS block_span_start_us_idx ON BlockSpan(start_us);
+
 CREATE INDEX IF NOT EXISTS block_span_end_us_idx ON BlockSpan(end_us);

--- a/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
+++ b/crates/kitsune_p2p/kitsune_p2p/Cargo.toml
@@ -45,7 +45,7 @@ thiserror = "1.0.22"
 tokio = { version = "1.36.0", features = ["full"] }
 tracing = "0.1"
 tokio-stream = "0.1"
-tx5 = { version = "=0.0.14-alpha", optional = true }
+tx5 = { version = "=0.0.15-alpha", optional = true }
 url2 = "0.0.6"
 fixt = { path = "../../fixt", version = "^0.3.3"}
 
@@ -72,7 +72,7 @@ pretty_assertions = "1.4.0"
 test-case = "3.3"
 tokio = { version = "1.11", features = ["full", "test-util"] }
 tracing-subscriber = "0.3.16"
-tx5-signal-srv = "=0.0.14-alpha"
+tx5-signal-srv = "=0.0.15-alpha"
 
 [lints]
 workspace = true

--- a/crates/kitsune_p2p/types/Cargo.toml
+++ b/crates/kitsune_p2p/types/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-lair_keystore_api = "=0.4.5"
+lair_keystore_api = "=0.4.6"
 base64 = "0.22"
 derive_more = "0.99"
 futures = "0.3"


### PR DESCRIPTION
### Summary
- Pin sqlformat to "=0.2.6" in `holochain_sqlite`
- Bump `lair_keystore` and `lair_keystore_api` to 0.4.6 
- Bump `tx5` and `tx5-*` crates to 0.0.15-alpha
- Partial backport of #4272 (everything except for changes to static linting Makefile script which does not exist in develop-0.3)

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs