### PR TITLE
feat(holonix): Different Rust version per Holonix version

### DIFF
--- a/.github/workflows/holochain-build-and-test.yml
+++ b/.github/workflows/holochain-build-and-test.yml
@@ -59,7 +59,7 @@ jobs:
           - cmd:
               pkgs:
                 - build-release-automation-tests-repo
-              extra_arg: "--override-input repo-git 'path:.git'"
+              extra_arg: "--override-input versions ./versions/weekly --override-input repo-git 'path:.git'"
             platform:
               system: x86_64-linux
 

--- a/flake.lock
+++ b/flake.lock
@@ -101,16 +101,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1722347117,
-        "narHash": "sha256-Jv4DxaVtdbO+fOD4woFoepCCOtRN/HF94xJSwViz3ck=",
+        "lastModified": 1728056814,
+        "narHash": "sha256-OUVNmUCUk4G2ur+O/Q6Ji77iHQeN3PufmiPDz9MS8AY=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "97d86050b177829b623461970db5c3b64fbd74c1",
+        "rev": "63aeec5fd95b3263bc8ebce73c53b9f0e03bbf36",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.3.2",
+        "ref": "holochain-0.3.3",
         "repo": "holochain",
         "type": "github"
       }
@@ -270,11 +270,11 @@
     "scaffolding": {
       "flake": false,
       "locked": {
-        "lastModified": 1724073530,
-        "narHash": "sha256-PUM8otA5F5s8ZHxhjupn7R+RZAjh2rueYIFwu3UkK44=",
+        "lastModified": 1727691892,
+        "narHash": "sha256-8dMLmpYp19wZhxlR1uiSeR23nGAOhHnyiZ/5CPwOoAg=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "8a6d1dab0f1668c2781a46d93a5ad638fcf25598",
+        "rev": "d0290b88ac08e6811d57acb3294a177d107d2528",
         "type": "github"
       },
       "original": {
@@ -293,11 +293,11 @@
       },
       "locked": {
         "dir": "versions/0_3",
-        "lastModified": 1727887143,
-        "narHash": "sha256-DUSLg1zNuuHvZH+dDgFw7J5Gidq/C+wSsLkprWfyFGc=",
+        "lastModified": 1729095118,
+        "narHash": "sha256-BhTtTbORLLY7T6fobAZ5ow+UO95WJ6wMupeC760aiNU=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "d7ad1372ed8f9a8081d7dee0308e552b7decd0b6",
+        "rev": "22675b61bde27f050e693db923c1501053abdb97",
         "type": "github"
       },
       "original": {

--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -5,7 +5,7 @@
     let
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "1.77.2";
+        version = inputs.versions.rustVersion;
       };
 
       craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;

--- a/nix/modules/holonix-integration-test.nix
+++ b/nix/modules/holonix-integration-test.nix
@@ -14,7 +14,7 @@
 
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "1.77.2";
+        version = inputs.versions.rustVersion;
       };
       craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
       moldOpensslDeps = craneLib.vendorCargoDeps {

--- a/nix/modules/lair.nix
+++ b/nix/modules/lair.nix
@@ -5,7 +5,7 @@
     let
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "1.77.2";
+        version = inputs.versions.rustVersion;
       };
 
       craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;

--- a/nix/modules/launcher.nix
+++ b/nix/modules/launcher.nix
@@ -5,7 +5,7 @@
     let
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "1.77.2";
+        version = inputs.versions.rustVersion;
       };
 
       craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;

--- a/nix/modules/release-automation.nix
+++ b/nix/modules/release-automation.nix
@@ -5,7 +5,7 @@
     let
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "1.77.2";
+        version = inputs.versions.rustVersion;
       };
 
       craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;

--- a/nix/modules/release-automation.nix
+++ b/nix/modules/release-automation.nix
@@ -5,7 +5,7 @@
     let
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = inputs.versions.rustVersion;
+        version = "1.77.2";
       };
 
       craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;

--- a/nix/modules/scaffolding.nix
+++ b/nix/modules/scaffolding.nix
@@ -5,7 +5,7 @@
     let
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "1.77.2";
+        version = inputs.versions.rustVersion;
       };
       craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
 

--- a/versions/0_1/flake.nix
+++ b/versions/0_1/flake.nix
@@ -24,5 +24,7 @@
       };
     };
 
-  outputs = { ... }: { };
+  outputs = { ... }: {
+    rustVersion = "1.71.1";
+  };
 }

--- a/versions/0_2/flake.nix
+++ b/versions/0_2/flake.nix
@@ -24,5 +24,7 @@
       };
     };
 
-  outputs = { ... }: { };
+  outputs = { ... }: {
+    rustVersion = "1.77.2";
+  };
 }

--- a/versions/0_2_rc/flake.nix
+++ b/versions/0_2_rc/flake.nix
@@ -24,5 +24,7 @@
       };
     };
 
-  outputs = { ... }: { };
+  outputs = { ... }: {
+    rustVersion = "1.77.2";
+  };
 }

--- a/versions/0_3/flake.nix
+++ b/versions/0_3/flake.nix
@@ -24,5 +24,7 @@
       };
     };
 
-  outputs = { ... }: { };
+  outputs = { ... }: {
+    rustVersion = "1.78.0";
+  };
 }

--- a/versions/0_3_rc/flake.nix
+++ b/versions/0_3_rc/flake.nix
@@ -24,5 +24,7 @@
       };
     };
 
-  outputs = { ... }: { };
+  outputs = { ... }: {
+    rustVersion = "1.78.0";
+  };
 }

--- a/versions/0_4_rc/flake.nix
+++ b/versions/0_4_rc/flake.nix
@@ -24,5 +24,7 @@
       };
     };
 
-  outputs = { ... }: { };
+  outputs = { ... }: {
+    rustVersion = "1.80.1";
+  };
 }

--- a/versions/weekly/flake.lock
+++ b/versions/weekly/flake.lock
@@ -62,11 +62,11 @@
     "scaffolding": {
       "flake": false,
       "locked": {
-        "lastModified": 1727375207,
-        "narHash": "sha256-wGS+cOhvakLWscqPI0LaBZVZ3ryORV3YDvL+bfhI+WA=",
+        "lastModified": 1728659843,
+        "narHash": "sha256-3A15jw8uf5t8mONlAtJngDB+n0wNKA3cB+lZ2mHF/RY=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "b218f253a124b6e7b5be0600c3aab7a57344f0f2",
+        "rev": "d36abccbfbff833a8eb73b38be848856b0d38f53",
         "type": "github"
       },
       "original": {

--- a/versions/weekly/flake.nix
+++ b/versions/weekly/flake.nix
@@ -19,7 +19,7 @@
 
       # holochain_scaffolding_cli
       scaffolding = {
-        url = "github:holochain/scaffolding/8a6d1dab0f1668c2781a46d93a5ad638fcf25598";
+        url = "github:holochain/scaffolding/holochain-weekly";
         flake = false;
       };
     };

--- a/versions/weekly/flake.nix
+++ b/versions/weekly/flake.nix
@@ -24,5 +24,7 @@
       };
     };
 
-  outputs = { ... }: { };
+  outputs = { ... }: {
+    rustVersion = "1.81.0";
+  };
 }


### PR DESCRIPTION
### Summary

This isn't especially carefully thought through. I'm treating this as being on life support for now. 

The two layers of flakes should stay in sync as long as people run `nix flake update` and don't try to update one layer at a time... That will result in funky errors. I can't think why somebody would try to do that though.

It will also be an issue if people have stuff pinned that they shouldn't. It's valid to pin the Holochain version or the Lair version. It's no valid to pin Holonix/versions independently. I'm fine with that breaking for people because it's simple to explain that if they want to update one and it's become incompatible then they have to update the other. I don't think that will negatively affect anyone unless they don't come and ask us when they get stuck. So if you're reading this, please open an issue! :) 

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs