### PR TITLE
Deprecate precompiled wasm bundling for ios

### DIFF
--- a/crates/hc/src/bin/hc.rs
+++ b/crates/hc/src/bin/hc.rs
@@ -3,12 +3,9 @@ use holochain_cli as hc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // This is necessary to ensure deprecation warnings in holochain_cli_bundle are displayed by default
-    if std::env::var_os("RUST_LOG").is_none() {
-        std::env::set_var("RUST_LOG", "holochain_cli_bundle=warn");
+    if std::env::var_os("RUST_LOG").is_some() {
+        holochain_trace::init_fmt(holochain_trace::Output::Log).ok();
     }
-    holochain_trace::init_fmt(holochain_trace::Output::Log).ok();
-
     let cli = hc::Cli::parse();
     cli.subcommand.run().await
 }

--- a/crates/hc/src/bin/hc.rs
+++ b/crates/hc/src/bin/hc.rs
@@ -3,9 +3,12 @@ use holochain_cli as hc;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    if std::env::var_os("RUST_LOG").is_some() {
-        holochain_trace::init_fmt(holochain_trace::Output::Log).ok();
+    // This is necessary to ensure deprecation warnings in holochain_cli_bundle are displayed by default
+    if std::env::var_os("RUST_LOG").is_none() {
+        std::env::set_var("RUST_LOG", "holochain_cli_bundle=warn");
     }
+    holochain_trace::init_fmt(holochain_trace::Output::Log).ok();
+
     let cli = hc::Cli::parse();
     cli.subcommand.run().await
 }

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- The flag `--dylib-ios` in `hc bundle dna pack` has been **deprecated**. Please use the wasm interpreter instead.
+
 ## 0.5.0-dev.2
 
 ## 0.5.0-dev.1

--- a/crates/hc_bundle/src/cli.rs
+++ b/crates/hc_bundle/src/cli.rs
@@ -59,10 +59,10 @@ pub enum HcDnaBundleSubcommand {
         #[arg(short = 'o', long)]
         output: Option<PathBuf>,
 
-        /// **Deprecated** Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
+        /// DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
+        ///
         /// Output shared object "dylib" files
         /// that can be used to run this happ on iOS
-        #[deprecated(since="0.4.0", note="Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.")]
         #[arg(long)]
         dylib_ios: bool,
     },

--- a/crates/hc_bundle/src/cli.rs
+++ b/crates/hc_bundle/src/cli.rs
@@ -59,8 +59,10 @@ pub enum HcDnaBundleSubcommand {
         #[arg(short = 'o', long)]
         output: Option<PathBuf>,
 
+        /// **Deprecated** Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
         /// Output shared object "dylib" files
         /// that can be used to run this happ on iOS
+        #[deprecated(since="0.4.0", note="Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.")]
         #[arg(long)]
         dylib_ios: bool,
     },

--- a/crates/hc_bundle/src/packing.rs
+++ b/crates/hc_bundle/src/packing.rs
@@ -104,7 +104,7 @@ pub async fn pack<M: Manifest>(
     };
     bundle.write_to_file(&target_path).await?;
     if serialize_wasm {
-        warn!("Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.");
+        warn!("DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.");
         build_preserialized_wasm(&target_path, &bundle).await?;
     }
 

--- a/crates/hc_bundle/src/packing.rs
+++ b/crates/hc_bundle/src/packing.rs
@@ -8,7 +8,6 @@ use mr_bundle::RawBundle;
 use mr_bundle::{Bundle, Manifest};
 use std::path::Path;
 use std::path::PathBuf;
-use tracing::warn;
 
 #[cfg(feature = "wasmer_sys")]
 mod wasmer_sys;
@@ -104,7 +103,7 @@ pub async fn pack<M: Manifest>(
     };
     bundle.write_to_file(&target_path).await?;
     if serialize_wasm {
-        warn!("DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.");
+        eprintln!("DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.");
         build_preserialized_wasm(&target_path, &bundle).await?;
     }
 

--- a/crates/hc_bundle/src/packing.rs
+++ b/crates/hc_bundle/src/packing.rs
@@ -8,6 +8,7 @@ use mr_bundle::RawBundle;
 use mr_bundle::{Bundle, Manifest};
 use std::path::Path;
 use std::path::PathBuf;
+use tracing::warn;
 
 #[cfg(feature = "wasmer_sys")]
 mod wasmer_sys;
@@ -103,6 +104,7 @@ pub async fn pack<M: Manifest>(
     };
     bundle.write_to_file(&target_path).await?;
     if serialize_wasm {
+        warn!("Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.");
         build_preserialized_wasm(&target_path, &bundle).await?;
     }
 

--- a/crates/hc_bundle/src/packing/wasmer_sys.rs
+++ b/crates/hc_bundle/src/packing/wasmer_sys.rs
@@ -7,6 +7,7 @@ use mr_bundle::{Bundle, Manifest};
 use std::path::Path;
 use tracing::info;
 
+#[deprecated(since="0.4.0", note="Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.")]
 pub(super) async fn build_preserialized_wasm<M: Manifest>(
     target_path: &Path,
     bundle: &Bundle<M>,

--- a/crates/hc_bundle/src/packing/wasmer_sys.rs
+++ b/crates/hc_bundle/src/packing/wasmer_sys.rs
@@ -7,7 +7,7 @@ use mr_bundle::{Bundle, Manifest};
 use std::path::Path;
 use tracing::info;
 
-#[deprecated(since="0.4.0", note="Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.")]
+/// DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
 pub(super) async fn build_preserialized_wasm<M: Manifest>(
     target_path: &Path,
     bundle: &Bundle<M>,

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -6,6 +6,7 @@ default_semver_increment_mode: !pre_minor dev
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Use of WasmZome preserialized_path has been **deprecated**. Please use the wasm interpreter instead.
 
 ## 0.5.0-dev.2
 

--- a/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
@@ -8,6 +8,7 @@ use holochain_zome_types::prelude::WasmZome;
 use std::sync::Arc;
 use wasmer::{AsStoreMut, Module};
 use wasmer_middlewares::metering::{get_remaining_points, set_remaining_points, MeteringPoints};
+use tracing::warn;
 
 pub fn reset_metering_points(instance_with_store: Arc<InstanceWithStore>) {
     let mut store_lock = instance_with_store.store.lock();
@@ -32,6 +33,7 @@ pub fn get_used_metering_points(instance_with_store: Arc<InstanceWithStore>) -> 
 pub fn get_prebuilt_module(wasm_zome: &WasmZome) -> RibosomeResult<Option<Arc<Module>>> {
     match &wasm_zome.preserialized_path {
         Some(path) => {
+            warn!("**Deprecated** Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.");
             let module = holochain_wasmer_host::module::get_ios_module_from_file(path.as_path())?;
             Ok(Some(Arc::new(module)))
         }

--- a/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
@@ -6,9 +6,9 @@ use crate::{
 use holochain_wasmer_host::module::InstanceWithStore;
 use holochain_zome_types::prelude::WasmZome;
 use std::sync::Arc;
+use tracing::warn;
 use wasmer::{AsStoreMut, Module};
 use wasmer_middlewares::metering::{get_remaining_points, set_remaining_points, MeteringPoints};
-use tracing::warn;
 
 pub fn reset_metering_points(instance_with_store: Arc<InstanceWithStore>) {
     let mut store_lock = instance_with_store.store.lock();

--- a/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
@@ -30,6 +30,7 @@ pub fn get_used_metering_points(instance_with_store: Arc<InstanceWithStore>) -> 
     }
 }
 
+/// DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
 pub fn get_prebuilt_module(wasm_zome: &WasmZome) -> RibosomeResult<Option<Arc<Module>>> {
     match &wasm_zome.preserialized_path {
         Some(path) => {

--- a/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
@@ -33,7 +33,7 @@ pub fn get_used_metering_points(instance_with_store: Arc<InstanceWithStore>) -> 
 pub fn get_prebuilt_module(wasm_zome: &WasmZome) -> RibosomeResult<Option<Arc<Module>>> {
     match &wasm_zome.preserialized_path {
         Some(path) => {
-            warn!("**Deprecated** Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.");
+            warn!("DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.");
             let module = holochain_wasmer_host::module::get_ios_module_from_file(path.as_path())?;
             Ok(Some(Arc::new(module)))
         }

--- a/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
@@ -6,7 +6,6 @@ use crate::{
 use holochain_wasmer_host::module::InstanceWithStore;
 use holochain_zome_types::prelude::WasmZome;
 use std::sync::Arc;
-use tracing::warn;
 use wasmer::{AsStoreMut, Module};
 use wasmer_middlewares::metering::{get_remaining_points, set_remaining_points, MeteringPoints};
 
@@ -34,7 +33,7 @@ pub fn get_used_metering_points(instance_with_store: Arc<InstanceWithStore>) -> 
 pub fn get_prebuilt_module(wasm_zome: &WasmZome) -> RibosomeResult<Option<Arc<Module>>> {
     match &wasm_zome.preserialized_path {
         Some(path) => {
-            warn!("DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.");
+            eprintln!("DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.");
             let module = holochain_wasmer_host::module::get_ios_module_from_file(path.as_path())?;
             Ok(Some(Arc::new(module)))
         }

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- ZomeManifest dylib has been **deprecated**. Please use the wasm interpreter instead.
+
 ## 0.5.0-dev.2
 
 ## 0.5.0-dev.1

--- a/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
+++ b/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
@@ -177,10 +177,10 @@ pub struct ZomeManifest {
     /// are used in the zome.
     pub dependencies: Option<Vec<ZomeDependency>>,
 
-    /// **Deprecated** Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
+    /// DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
+    ///
     /// The location of the wasm dylib for this zome
     /// Useful for iOS.
-    #[deprecated(since="0.4.0", note="Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.")]
     #[serde(default)]
     pub dylib: Option<PathBuf>,
 }

--- a/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
+++ b/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
@@ -177,8 +177,10 @@ pub struct ZomeManifest {
     /// are used in the zome.
     pub dependencies: Option<Vec<ZomeDependency>>,
 
+    /// **Deprecated** Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
     /// The location of the wasm dylib for this zome
     /// Useful for iOS.
+    #[deprecated(since="0.4.0", note="Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.")]
     #[serde(default)]
     pub dylib: Option<PathBuf>,
 }

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- WasmZome preserialized_path has been **deprecated**. Please use the wasm interpreter instead.
+
 ## 0.5.0-dev.2
 
 ## 0.5.0-dev.1

--- a/crates/holochain_zome_types/src/zome.rs
+++ b/crates/holochain_zome_types/src/zome.rs
@@ -155,8 +155,10 @@ pub struct WasmZome {
     /// The zome dependencies
     pub dependencies: Vec<ZomeName>,
 
+    /// **Deprecated** Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
     /// The path to a preserialized wasmer module used as a "dynamic library" (dylib).
     /// Useful for iOS and other targets.
+    #[deprecated(since="0.4.0", note="Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.")]
     #[serde(default)]
     pub preserialized_path: Option<PathBuf>,
 }

--- a/crates/holochain_zome_types/src/zome.rs
+++ b/crates/holochain_zome_types/src/zome.rs
@@ -155,10 +155,10 @@ pub struct WasmZome {
     /// The zome dependencies
     pub dependencies: Vec<ZomeName>,
 
-    /// **Deprecated** Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
+    /// DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
+    ///
     /// The path to a preserialized wasmer module used as a "dynamic library" (dylib).
     /// Useful for iOS and other targets.
-    #[deprecated(since="0.4.0", note="Bundling precompiled & serialized wasm for iOS is deprecated. Please use the wasm interpreter instead.")]
     #[serde(default)]
     pub preserialized_path: Option<PathBuf>,
 }


### PR DESCRIPTION
### Summary
Resolves #4376

I did not use rust's `#[deprecated]` macro as it prints warnings at compile time by default. Instead just using doc comments and tracing::warn! when the --dylib-ios feature is used.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs