### PR TITLE
HoloHash from functions avoid panicking unless desired

### DIFF
--- a/crates/hc_bundle/tests/test_cli.rs
+++ b/crates/hc_bundle/tests/test_cli.rs
@@ -178,11 +178,11 @@ async fn test_multi_integrity() {
     let (dna, _) = pack_dna("tests/fixtures/my-app/dnas/dna5").await;
 
     // The actual wasm hashes of the fake zomes.
-    let wasm_hash = WasmHash::from_raw_39_panicky(vec![
+    let wasm_hash = WasmHash::from_raw_39(vec![
         132, 42, 36, 217, 5, 131, 6, 203, 162, 51, 6, 34, 63, 247, 21, 77, 60, 106, 98, 53, 59, 98,
         172, 222, 143, 105, 210, 10, 5, 56, 152, 102, 178, 159, 162, 69, 249, 162, 67,
     ]);
-    let wasm_hash2 = WasmHash::from_raw_39_panicky(vec![
+    let wasm_hash2 = WasmHash::from_raw_39(vec![
         132, 42, 36, 235, 225, 55, 255, 141, 140, 72, 148, 154, 141, 124, 248, 185, 142, 62, 218,
         220, 85, 73, 201, 54, 10, 30, 191, 206, 93, 108, 142, 140, 201, 164, 225, 20, 241, 98, 16,
     ]);
@@ -191,12 +191,12 @@ async fn test_multi_integrity() {
     let s = "2022-02-11T23:05:19.470323Z";
     let origin_time = Timestamp::from_str(s).unwrap();
     let lineage = vec![
-        DnaHash::from_raw_39(
+        DnaHash::try_from_raw_39(
             holo_hash_decode_unchecked("uhC0kWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm")
                 .unwrap(),
         )
         .unwrap(),
-        DnaHash::from_raw_39(
+        DnaHash::try_from_raw_39(
             holo_hash_decode_unchecked("uhC0k39SDf7rynCg5bYgzroGaOJKGKrloI1o57Xao6S-U5KNZ0dUH")
                 .unwrap(),
         )

--- a/crates/holo_hash/CHANGELOG.md
+++ b/crates/holo_hash/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- **BREAKING** Renamed `from_raw_39_panicky` to `from_raw_39`.
+- Added function `try_from_raw_39` which returns an Err instead of panicking.
+- Added function `try_from_raw_36_and_type` which returns an Err instead of panicking.
+
 ## 0.5.0-dev.1
 
 ## 0.5.0-dev.0

--- a/crates/holo_hash/src/encode.rs
+++ b/crates/holo_hash/src/encode.rs
@@ -15,7 +15,7 @@ impl<P: PrimitiveHashType> TryFrom<&str> for HoloHash<P> {
     type Error = HoloHashError;
     fn try_from(s: &str) -> Result<Self, HoloHashError> {
         let hash_type = P::new();
-        HoloHash::from_raw_39(holo_hash_decode(hash_type.get_prefix(), s)?)
+        HoloHash::try_from_raw_39(holo_hash_decode(hash_type.get_prefix(), s)?)
     }
 }
 

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -25,7 +25,7 @@
 
 use kitsune_p2p_dht_arc::DhtLocation;
 
-use crate::error::{HoloHashResult, HoloHashError};
+use crate::error::{HoloHashError, HoloHashResult};
 use crate::has_hash::HasHash;
 use crate::HashType;
 use crate::PrimitiveHashType;
@@ -367,7 +367,6 @@ mod tests {
         DnaHash::from_raw_39(vec![0xdb; 39]);
     }
 
-
     #[test]
     fn test_try_from_raw_36_and_type_errors_with_bad_size() {
         let res = HoloHash::try_from_raw_36_and_type(vec![0xdb; 35], hash_type::Dna);
@@ -407,5 +406,4 @@ mod tests {
 
         DnaHash::from_raw_39(raw);
     }
-
 }

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -25,7 +25,7 @@
 
 use kitsune_p2p_dht_arc::DhtLocation;
 
-use crate::error::HoloHashResult;
+use crate::error::{HoloHashResult, HoloHashError};
 use crate::has_hash::HasHash;
 use crate::HashType;
 use crate::PrimitiveHashType;
@@ -116,25 +116,37 @@ where
 impl<T: HashType> HoloHash<T> {
     /// Raw constructor: Create a HoloHash from 39 bytes, using the prefix
     /// bytes to determine the hash_type
-    pub fn from_raw_39(hash: Vec<u8>) -> HoloHashResult<Self> {
-        assert_length!(HOLO_HASH_FULL_LEN, &hash);
+    pub fn try_from_raw_39(hash: Vec<u8>) -> HoloHashResult<Self> {
+        if hash.len() != HOLO_HASH_FULL_LEN {
+            return Err(HoloHashError::BadSize);
+        }
         let hash_type = T::try_from_prefix(&hash[0..3])?;
         Ok(Self { hash, hash_type })
     }
+
     /// Raw constructor: Create a HoloHash from 39 bytes, using the prefix
-    /// bytes to determine the hash_type. Panics if hash_type does not match.
-    pub fn from_raw_39_panicky(hash: Vec<u8>) -> Self {
-        Self::from_raw_39(hash).expect("the specified hash_type does not match the prefix bytes")
+    /// bytes to determine the hash_type.
+    /// Panics if hash_type does not match or hash is incorrect length.
+    pub fn from_raw_39(hash: Vec<u8>) -> Self {
+        Self::try_from_raw_39(hash).unwrap()
     }
 
     /// Use a precomputed hash + location byte array in vec form,
-    /// along with a type, to construct a hash. Used in this crate only, for testing.
-    pub fn from_raw_36_and_type(mut bytes: Vec<u8>, hash_type: T) -> Self {
-        assert_length!(HOLO_HASH_UNTYPED_LEN, &bytes);
+    /// along with a type, to construct a hash.
+    pub fn try_from_raw_36_and_type(mut bytes: Vec<u8>, hash_type: T) -> HoloHashResult<Self> {
+        if bytes.len() != HOLO_HASH_UNTYPED_LEN {
+            return Err(HoloHashError::BadSize);
+        }
         let mut hash = hash_type.get_prefix().to_vec();
         hash.append(&mut bytes);
-        assert_length!(HOLO_HASH_FULL_LEN, &hash);
-        Self { hash, hash_type }
+        Ok(Self { hash, hash_type })
+    }
+
+    /// Use a precomputed hash + location byte array in vec form,
+    /// along with a type, to construct a hash.
+    /// Panics hash is incorrect length.
+    pub fn from_raw_36_and_type(bytes: Vec<u8>, hash_type: T) -> Self {
+        Self::try_from_raw_36_and_type(bytes, hash_type).unwrap()
     }
 
     /// Change the type of this HoloHash, keeping the same bytes
@@ -237,7 +249,7 @@ impl<T: HashType> rusqlite::ToSql for HoloHash<T> {
 impl<T: HashType> rusqlite::types::FromSql for HoloHash<T> {
     fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
         Vec::<u8>::column_result(value).and_then(|bytes| {
-            Self::from_raw_39(bytes).map_err(|_| rusqlite::types::FromSqlError::InvalidType)
+            Self::try_from_raw_39(bytes).map_err(|_| rusqlite::types::FromSqlError::InvalidType)
         })
     }
 }
@@ -321,7 +333,79 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn test_fails_with_bad_size() {
+    fn test_from_raw_36_panics_with_bad_size() {
         DnaHash::from_raw_36(vec![0xdb; 35]);
     }
+
+    #[test]
+    fn test_try_from_raw_39_errors_with_bad_size() {
+        let mut raw = vec![132, 45, 36];
+        raw.extend(vec![0xdb; 35]);
+
+        let res = DnaHash::try_from_raw_39(raw);
+        assert_eq!(res, Err(HoloHashError::BadSize));
+    }
+
+    #[test]
+    fn test_try_from_raw_39_errors_with_bad_prefix() {
+        let res = DnaHash::try_from_raw_39(vec![0xdb; 39]);
+        assert!(matches!(res, Err(HoloHashError::BadPrefix { .. })));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_from_raw_39_panics_with_bad_size() {
+        let mut raw = vec![132, 45, 36];
+        raw.extend(vec![0xdb; 35]);
+
+        DnaHash::from_raw_39(raw);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_from_raw_39_panics_with_bad_prefix() {
+        DnaHash::from_raw_39(vec![0xdb; 39]);
+    }
+
+
+    #[test]
+    fn test_try_from_raw_36_and_type_errors_with_bad_size() {
+        let res = HoloHash::try_from_raw_36_and_type(vec![0xdb; 35], hash_type::Dna);
+        assert_eq!(res, Err(HoloHashError::BadSize));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_from_raw_36_and_type_panics_with_bad_size() {
+        HoloHash::from_raw_36_and_type(vec![0xdb; 35], hash_type::Dna);
+    }
+
+    #[test]
+    fn test_try_from_raw_36_and_type() {
+        let res = HoloHash::try_from_raw_36_and_type(vec![0xdb; 36], hash_type::Dna);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_from_raw_36_and_type() {
+        HoloHash::from_raw_36_and_type(vec![0xdb; 36], hash_type::Dna);
+    }
+
+    #[test]
+    fn test_try_from_raw_39() {
+        let mut raw = vec![132, 45, 36];
+        raw.extend(vec![0xdb; 36]);
+
+        let res = DnaHash::try_from_raw_39(raw);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn test_from_raw_39() {
+        let mut raw = vec![132, 45, 36];
+        raw.extend(vec![0xdb; 36]);
+
+        DnaHash::from_raw_39(raw);
+    }
+
 }

--- a/crates/holo_hash/src/hash_b64.rs
+++ b/crates/holo_hash/src/hash_b64.rs
@@ -32,7 +32,7 @@ impl<T: HashType> HoloHashB64<T> {
     /// Read a HoloHash from base64 string
     pub fn from_b64_str(str: &str) -> HoloHashResult<Self> {
         let bytes = holo_hash_decode_unchecked(str)?;
-        HoloHash::from_raw_39(bytes).map(Into::into)
+        HoloHash::try_from_raw_39(bytes).map(Into::into)
     }
 }
 

--- a/crates/holo_hash/src/hash_ext.rs
+++ b/crates/holo_hash/src/hash_ext.rs
@@ -103,7 +103,7 @@ fn hash_from_content<T: HashType, C: HashableContent<HashType = T>>(content: &C)
             assert_length!(HOLO_HASH_CORE_LEN, &hash);
             HoloHash::<T>::from_raw_32_and_type(hash, content.hash_type())
         }
-        HashableContentBytes::Prehashed39(bytes) => HoloHash::from_raw_39_panicky(bytes),
+        HashableContentBytes::Prehashed39(bytes) => HoloHash::from_raw_39(bytes),
     }
 }
 

--- a/crates/holo_hash/src/ser.rs
+++ b/crates/holo_hash/src/ser.rs
@@ -42,7 +42,7 @@ impl<'de, T: HashType> serde::de::Visitor<'de> for HoloHashVisitor<T> {
                 "HoloHash serialized representation must be exactly 39 bytes",
             ))
         } else {
-            HoloHash::from_raw_39(h.to_vec())
+            HoloHash::try_from_raw_39(h.to_vec())
                 .map_err(|e| serde::de::Error::custom(format!("HoloHash error: {:?}", e)))
         }
     }
@@ -72,7 +72,7 @@ impl<'de, T: HashType> serde::de::Visitor<'de> for HoloHashVisitor<T> {
                 "HoloHash serialized representation must be exactly 39 bytes",
             ))
         } else {
-            HoloHash::from_raw_39(h.to_vec())
+            HoloHash::try_from_raw_39(h.to_vec())
                 .map_err(|e| serde::de::Error::custom(format!("HoloHash error: {:?}", e)))
         }
     }

--- a/crates/holochain_state/src/query/tests/links_test.rs
+++ b/crates/holochain_state/src/query/tests/links_test.rs
@@ -116,7 +116,7 @@ impl TestData {
 
                 move |txn| -> DatabaseResult<bool> {
                     Ok(query
-                        .run(DbScratch::new(&[&txn], &scratch))
+                        .run(DbScratch::new(&[txn], &scratch))
                         .unwrap()
                         .is_empty())
                 }
@@ -134,7 +134,7 @@ impl TestData {
                 let scratch = self.scratch.clone();
 
                 move |txn| -> StateQueryResult<Vec<Link>> {
-                    query.run(DbScratch::new(&[&txn], &scratch))
+                    query.run(DbScratch::new(&[txn], &scratch))
                 }
             })
             .await
@@ -150,7 +150,7 @@ impl TestData {
                 let scratch = self.scratch.clone();
 
                 move |txn| -> StateQueryResult<Vec<Link>> {
-                    query.run(DbScratch::new(&[&txn], &scratch))
+                    query.run(DbScratch::new(&[txn], &scratch))
                 }
             })
             .await
@@ -171,7 +171,7 @@ impl TestData {
                 let scratch = self.scratch.clone();
 
                 move |txn| -> StateQueryResult<Vec<Link>> {
-                    query_no_tag.run(DbScratch::new(&[&txn], &scratch))
+                    query_no_tag.run(DbScratch::new(&[txn], &scratch))
                 }
             })
             .await
@@ -193,7 +193,7 @@ impl TestData {
                 let scratch = self.scratch.clone();
 
                 move |txn| -> StateQueryResult<Vec<Link>> {
-                    query.run(DbScratch::new(&[&txn], &scratch))
+                    query.run(DbScratch::new(&[txn], &scratch))
                 }
             })
             .await
@@ -220,7 +220,7 @@ impl TestData {
                 let scratch = self.scratch.clone();
 
                 move |txn| -> StateQueryResult<Vec<Link>> {
-                    query.run(DbScratch::new(&[&txn], &scratch))
+                    query.run(DbScratch::new(&[txn], &scratch))
                 }
             })
             .await
@@ -251,7 +251,7 @@ impl TestData {
                 let scratch = self.scratch.clone();
 
                 move |txn| -> StateQueryResult<Vec<Link>> {
-                    query.run(DbScratch::new(&[&txn], &scratch))
+                    query.run(DbScratch::new(&[txn], &scratch))
                 }
             })
             .await
@@ -277,7 +277,7 @@ impl TestData {
                 let scratch = self.scratch.clone();
 
                 move |txn| -> StateQueryResult<Vec<Link>> {
-                    query.run(DbScratch::new(&[&txn], &scratch))
+                    query.run(DbScratch::new(&[txn], &scratch))
                 }
             })
             .await
@@ -369,7 +369,7 @@ impl TestData {
 
                         move |txn| -> DatabaseResult<IntoIter<Link>> {
                             Ok(query
-                                .run(DbScratch::new(&[&txn], &scratch))
+                                .run(DbScratch::new(&[txn], &scratch))
                                 .unwrap()
                                 .into_iter())
                         }
@@ -411,7 +411,7 @@ impl TestData {
 
                 move |txn| -> DatabaseResult<IntoIter<Link>> {
                     Ok(query
-                        .run(DbScratch::new(&[&txn], &scratch))
+                        .run(DbScratch::new(&[txn], &scratch))
                         .unwrap()
                         .into_iter())
                 }
@@ -452,7 +452,7 @@ impl TestData {
 
                         move |txn| -> DatabaseResult<IntoIter<Link>> {
                             Ok(my_query
-                                .run(DbScratch::new(&[&txn], &scratch))
+                                .run(DbScratch::new(&[txn], &scratch))
                                 .unwrap()
                                 .into_iter())
                         }
@@ -497,7 +497,7 @@ impl TestData {
 
                         move |txn| -> DatabaseResult<IntoIter<Link>> {
                             Ok(my_query
-                                .run(DbScratch::new(&[&txn], &scratch))
+                                .run(DbScratch::new(&[txn], &scratch))
                                 .unwrap()
                                 .into_iter())
                         }


### PR DESCRIPTION
### Summary
Partially addresses #3313 

- **BREAKING** Renamed `from_raw_39_panicky` to `from_raw_39`.
- Added function `try_from_raw_39` which returns an Err instead of panicking.
- Added function `try_from_raw_36_and_type` which returns an Err instead of panicking.
- Happy and error tests for all 4 functions.


Not sure if I should avoid the breaking change and keep `from_raw_39_panicky` as an alias to `from_raw_39`

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs