### PR TITLE
Backport 0.4 -- Deprecate precompiled wasm bundling for ios

### DIFF
--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- The flag `--dylib-ios` in `hc bundle dna pack` has been **deprecated**. Please use the wasm interpreter instead.
+
 ## 0.4.0-rc.0
 
 ## 0.4.0-dev.27

--- a/crates/hc_bundle/src/cli.rs
+++ b/crates/hc_bundle/src/cli.rs
@@ -59,6 +59,8 @@ pub enum HcDnaBundleSubcommand {
         #[arg(short = 'o', long)]
         output: Option<PathBuf>,
 
+        /// DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
+        ///
         /// Output shared object "dylib" files
         /// that can be used to run this happ on iOS
         #[arg(long)]

--- a/crates/hc_bundle/src/packing.rs
+++ b/crates/hc_bundle/src/packing.rs
@@ -103,6 +103,7 @@ pub async fn pack<M: Manifest>(
     };
     bundle.write_to_file(&target_path).await?;
     if serialize_wasm {
+        eprintln!("DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.");
         build_preserialized_wasm(&target_path, &bundle).await?;
     }
 

--- a/crates/hc_bundle/src/packing/wasmer_sys.rs
+++ b/crates/hc_bundle/src/packing/wasmer_sys.rs
@@ -7,6 +7,7 @@ use mr_bundle::{Bundle, Manifest};
 use std::path::Path;
 use tracing::info;
 
+/// DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
 pub(super) async fn build_preserialized_wasm<M: Manifest>(
     target_path: &Path,
     bundle: &Bundle<M>,

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -6,6 +6,7 @@ default_semver_increment_mode: !pre_patch rc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Use of WasmZome preserialized_path has been **deprecated**. Please use the wasm interpreter instead.
 
 ## 0.4.0-rc.0
 

--- a/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
@@ -29,9 +29,11 @@ pub fn get_used_metering_points(instance_with_store: Arc<InstanceWithStore>) -> 
     }
 }
 
+/// DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
 pub fn get_prebuilt_module(wasm_zome: &WasmZome) -> RibosomeResult<Option<Arc<Module>>> {
     match &wasm_zome.preserialized_path {
         Some(path) => {
+            eprintln!("DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.");
             let module = holochain_wasmer_host::module::get_ios_module_from_file(path.as_path())?;
             Ok(Some(Arc::new(module)))
         }

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- ZomeManifest dylib has been **deprecated**. Please use the wasm interpreter instead.
+
 ## 0.4.0-rc.0
 
 ## 0.4.0-dev.27

--- a/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
+++ b/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
@@ -177,6 +177,8 @@ pub struct ZomeManifest {
     /// are used in the zome.
     pub dependencies: Option<Vec<ZomeDependency>>,
 
+    /// DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
+    ///
     /// The location of the wasm dylib for this zome
     /// Useful for iOS.
     #[serde(default)]

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- WasmZome preserialized_path has been **deprecated**. Please use the wasm interpreter instead.
+
 ## 0.4.0-rc.0
 
 ## 0.4.0-dev.18

--- a/crates/holochain_zome_types/src/zome.rs
+++ b/crates/holochain_zome_types/src/zome.rs
@@ -155,6 +155,8 @@ pub struct WasmZome {
     /// The zome dependencies
     pub dependencies: Vec<ZomeName>,
 
+    /// DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
+    ///
     /// The path to a preserialized wasmer module used as a "dynamic library" (dylib).
     /// Useful for iOS and other targets.
     #[serde(default)]


### PR DESCRIPTION
### Summary
Backport of #4376 to 0.4


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs