### PR TITLE
Reject deletes of deletes

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 - **BREAKING**: As the DPKI feature is unstable and incomplete, it is disabled with default cargo features and put behind a feature called `unstable-dpki`. If this feature is specified at compile time, DPKI is enabled by default.
 - **BREAKING**: Issuing and persisting warrants is behind a feature `unstable-warrants` now. Warrants have not been tested extensively and there is no way to recover from a warrant. Hence the feature is considered unstable and must be explicitly enabled. Note that once warrants are issued some functions or calls may not work correctly.
-
+- **BREAKING**: Conductor::get_dna_definitions now returns an `IndexMap` to ensure consistent ordering.
+- Add test to make sure sys validation rejects deleting a delete. Unit tests to get zomes to invoke for app validation were removed for these cases of deleting a delete, because the code path cannot be reached by the system.
 - Added a new feature "unstable-sharding" which puts the network sharding behind a feature flag. It will not be possible
   to configure network sharding unless Holochain is built with this feature enabled. By default, the network tuning 
   parameter `gossip_dynamic_arcs` is ignored, and the parameter `gossip_arc_clamping` must be set to either `"full"`

--- a/crates/holochain/src/core/workflow/app_validation_workflow/get_zomes_to_invoke_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/get_zomes_to_invoke_tests.rs
@@ -17,8 +17,8 @@ use holochain_types::rate_limit::{EntryRateWeight, RateWeight};
 use holochain_zome_types::action::{AppEntryDef, Create, Delete, EntryType, Update, ZomeIndex};
 use holochain_zome_types::fixt::{
     ActionFixturator, ActionHashFixturator, AgentPubKeyFixturator, CreateFixturator,
-    CreateLinkFixturator, DeleteFixturator, DeleteLinkFixturator, EntryFixturator,
-    EntryHashFixturator, SignatureFixturator, UpdateFixturator,
+    CreateLinkFixturator, DeleteLinkFixturator, EntryFixturator, EntryHashFixturator,
+    SignatureFixturator, UpdateFixturator,
 };
 use holochain_zome_types::op::{
     EntryCreationAction, Op, RegisterAgentActivity, RegisterCreateLink, RegisterDelete,
@@ -29,6 +29,8 @@ use holochain_zome_types::timestamp::Timestamp;
 use holochain_zome_types::Action;
 use matches::assert_matches;
 use std::sync::Arc;
+
+// Deletes of deletes are not tested, as they are rejected by sys validation.
 
 #[tokio::test(flavor = "multi_thread")]
 async fn register_agent_activity() {
@@ -883,166 +885,6 @@ async fn store_record_delete_link() {
     assert_matches!(zomes_to_invoke, ZomesToInvoke::OneIntegrity(z) if z.name == zome.name);
 }
 
-// not a logical case that a delete is deleted, but valid nonetheless
-#[tokio::test(flavor = "multi_thread")]
-async fn store_record_delete_of_delete_entry() {
-    let zomes = SweetInlineZomes::new(vec![], 0);
-    let (dna_file, integrity_zomes, _) = SweetDnaFile::unique_from_inline_zomes(zomes).await;
-    let zome = &integrity_zomes[0];
-    let zome_index = ZomeIndex(0);
-    let mut ribosome = MockRibosomeT::new();
-    ribosome.expect_get_integrity_zome().return_once({
-        let zome = zome.clone();
-        move |index| {
-            assert_eq!(index, &zome_index, "expected zome index {zome_index:?}");
-            Some(zome)
-        }
-    });
-
-    let mut create = fixt!(Create);
-    create.entry_type = EntryType::App(AppEntryDef {
-        zome_index,
-        entry_index: 0.into(),
-        visibility: Default::default(),
-    });
-    let delete = Delete {
-        action_seq: 0,
-        author: fixt!(AgentPubKey),
-        deletes_address: create.to_hash(),
-        deletes_entry_address: create.entry_hash.clone(),
-        prev_action: fixt!(ActionHash),
-        timestamp: Timestamp::now(),
-        weight: RateWeight::default(),
-    };
-    let delete_action = Action::Delete(delete.clone());
-    let delete_action = SignedActionHashed::new_unchecked(delete_action, fixt!(Signature));
-    let action = Action::Delete(Delete {
-        action_seq: 1,
-        author: fixt!(AgentPubKey),
-        deletes_address: delete_action.as_hash().clone(),
-        deletes_entry_address: fixt!(EntryHash),
-        prev_action: fixt!(ActionHash),
-        timestamp: Timestamp::now(),
-        weight: RateWeight::default(),
-    });
-    let action = SignedActionHashed::new_unchecked(action, fixt!(Signature));
-    let record = Record::new(action.clone(), None);
-    let op = Op::StoreRecord(StoreRecord { record });
-
-    let test_space = TestSpace::new(dna_file.dna_hash().clone());
-    let workspace = HostFnWorkspaceRead::new(
-        test_space
-            .space
-            .get_or_create_authored_db(fixt!(AgentPubKey))
-            .unwrap()
-            .into(),
-        test_space.space.dht_db.clone().into(),
-        test_space.space.dht_query_cache.clone(),
-        test_space.space.cache_db.clone(),
-        fixt!(MetaLairClient),
-        None,
-        Arc::new(dna_file.dna_def().clone()),
-    )
-    .await
-    .unwrap();
-    let network = Arc::new(MockHolochainP2pDnaT::new());
-
-    // write original action to dht db
-    let dht_op = DhtOpHashed::from_content_sync(ChainOp::RegisterDeletedEntryAction(
-        fixt!(Signature),
-        delete,
-    ));
-    test_space.space.dht_db.test_write(move |txn| {
-        insert_op_dht(txn, &dht_op, None).unwrap();
-        put_validation_limbo(txn, dht_op.as_hash(), ValidationStage::SysValidated).unwrap();
-    });
-
-    let zomes_to_invoke = get_zomes_to_invoke(&op, &workspace, network, &ribosome)
-        .await
-        .unwrap();
-    assert_matches!(zomes_to_invoke, ZomesToInvoke::AllIntegrity);
-}
-
-// not a logical case that a delete is deleted, but valid nonetheless
-#[tokio::test(flavor = "multi_thread")]
-async fn store_record_delete_of_delete_without_entry() {
-    let zomes = SweetInlineZomes::new(vec![], 0);
-    let (dna_file, integrity_zomes, _) = SweetDnaFile::unique_from_inline_zomes(zomes).await;
-    let zome = &integrity_zomes[0];
-    let zome_index = ZomeIndex(0);
-    let mut ribosome = MockRibosomeT::new();
-    ribosome.expect_get_integrity_zome().return_once({
-        let zome = zome.clone();
-        move |index| {
-            assert_eq!(index, &zome_index, "expected zome index {zome_index:?}");
-            Some(zome)
-        }
-    });
-
-    let mut create = fixt!(Create);
-    create.entry_type = EntryType::App(AppEntryDef {
-        zome_index,
-        entry_index: 0.into(),
-        visibility: Default::default(),
-    });
-    let delete = Delete {
-        action_seq: 0,
-        author: fixt!(AgentPubKey),
-        deletes_address: create.to_hash(),
-        deletes_entry_address: create.entry_hash.clone(),
-        prev_action: fixt!(ActionHash),
-        timestamp: Timestamp::now(),
-        weight: RateWeight::default(),
-    };
-    let delete_action = Action::Delete(delete.clone());
-    let delete_action = SignedActionHashed::new_unchecked(delete_action, fixt!(Signature));
-    let action = Action::Delete(Delete {
-        action_seq: 1,
-        author: fixt!(AgentPubKey),
-        deletes_address: delete_action.as_hash().clone(),
-        deletes_entry_address: fixt!(EntryHash),
-        prev_action: fixt!(ActionHash),
-        timestamp: Timestamp::now(),
-        weight: RateWeight::default(),
-    });
-    let action = SignedActionHashed::new_unchecked(action, fixt!(Signature));
-    let record = Record::new(action.clone(), None);
-    let op = Op::StoreRecord(StoreRecord { record });
-
-    let test_space = TestSpace::new(dna_file.dna_hash().clone());
-    let workspace = HostFnWorkspaceRead::new(
-        test_space
-            .space
-            .get_or_create_authored_db(fixt!(AgentPubKey))
-            .unwrap()
-            .into(),
-        test_space.space.dht_db.clone().into(),
-        test_space.space.dht_query_cache.clone(),
-        test_space.space.cache_db.clone(),
-        fixt!(MetaLairClient),
-        None,
-        Arc::new(dna_file.dna_def().clone()),
-    )
-    .await
-    .unwrap();
-    let network = Arc::new(MockHolochainP2pDnaT::new());
-
-    // write original action to dht db
-    let dht_op = DhtOpHashed::from_content_sync(ChainOp::RegisterDeletedEntryAction(
-        fixt!(Signature),
-        delete,
-    ));
-    test_space.space.dht_db.test_write(move |txn| {
-        insert_op_dht(txn, &dht_op, None).unwrap();
-        put_validation_limbo(txn, dht_op.as_hash(), ValidationStage::SysValidated).unwrap();
-    });
-
-    let zomes_to_invoke = get_zomes_to_invoke(&op, &workspace, network, &ribosome)
-        .await
-        .unwrap();
-    assert_matches!(zomes_to_invoke, ZomesToInvoke::AllIntegrity);
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn register_update_app_entry() {
     let zomes = SweetInlineZomes::new(vec![], 0);
@@ -1425,65 +1267,6 @@ async fn register_delete_update_non_app_entry() {
     let zomes_to_invoke = get_zomes_to_invoke(&op, &workspace, network, &ribosome)
         .await
         .unwrap();
-    assert_matches!(zomes_to_invoke, ZomesToInvoke::AllIntegrity);
-}
-
-// not a logical case that a delete is deleted, but valid nonetheless
-#[tokio::test(flavor = "multi_thread")]
-async fn register_delete_of_delete() {
-    let zomes = SweetInlineZomes::new(vec![], 0);
-    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(zomes).await;
-    let ribosome = MockRibosomeT::new();
-
-    let original_action = Action::Delete(fixt!(Delete));
-    let delete = Delete {
-        action_seq: 1,
-        author: fixt!(AgentPubKey),
-        deletes_address: original_action.to_hash(),
-        deletes_entry_address: fixt!(EntryHash),
-        prev_action: fixt!(ActionHash),
-        timestamp: Timestamp::now(),
-        weight: RateWeight::default(),
-    };
-    let delete = SignedHashed::new_unchecked(delete, fixt!(Signature));
-    let op = Op::RegisterDelete(RegisterDelete {
-        delete: delete.clone(),
-    });
-
-    let test_space = TestSpace::new(dna_file.dna_hash().clone());
-    let workspace = HostFnWorkspaceRead::new(
-        test_space
-            .space
-            .get_or_create_authored_db(fixt!(AgentPubKey))
-            .unwrap()
-            .into(),
-        test_space.space.dht_db.clone().into(),
-        test_space.space.dht_query_cache.clone(),
-        test_space.space.cache_db.clone(),
-        fixt!(MetaLairClient),
-        None,
-        Arc::new(dna_file.dna_def().clone()),
-    )
-    .await
-    .unwrap();
-    let network = Arc::new(MockHolochainP2pDnaT::new());
-
-    // write original action to dht db
-    let dht_op = DhtOpHashed::from_content_sync(ChainOp::StoreRecord(
-        fixt!(Signature),
-        original_action,
-        RecordEntry::NA,
-    ));
-    test_space.space.dht_db.test_write(move |txn| {
-        insert_op_dht(txn, &dht_op, None).unwrap();
-        put_validation_limbo(txn, dht_op.as_hash(), ValidationStage::SysValidated).unwrap();
-    });
-
-    let zomes_to_invoke = get_zomes_to_invoke(&op, &workspace, network, &ribosome)
-        .await
-        .unwrap();
-    // there is no app entry def in a delete which would indicate the zome index,
-    // therefore all integrity zomes are invoked for validation
     assert_matches!(zomes_to_invoke, ZomesToInvoke::AllIntegrity);
 }
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow/get_zomes_to_invoke_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/get_zomes_to_invoke_tests.rs
@@ -30,8 +30,6 @@ use holochain_zome_types::Action;
 use matches::assert_matches;
 use std::sync::Arc;
 
-// Deletes of deletes are not tested, as they are rejected by sys validation.
-
 #[tokio::test(flavor = "multi_thread")]
 async fn register_agent_activity() {
     let zomes = SweetInlineZomes::new(vec![], 0);


### PR DESCRIPTION
### Summary
It turns out that sys validation already [rejects deletes of anything other than create or update](https://github.com/holochain/holochain/blob/develop/crates/holochain/src/core/workflow/sys_validation_workflow.rs#L1162-L1180) ([check_new_entry](https://github.com/holochain/holochain/blob/develop/crates/holochain/src/core/sys_validate.rs#L462-L463)).

I've added a test that confirms that. In tests to get zomes to invoke for app validation a delete of a delete is still a test scenario possiblity. As this cannot happen in practice, I deleted those tests.

resolves #3754 

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs