### PR TITLE
Doc/dna properties macro

### DIFF
--- a/crates/hdk_derive/src/lib.rs
+++ b/crates/hdk_derive/src/lib.rs
@@ -290,6 +290,22 @@ pub fn hdk_entry_helper(attrs: TokenStream, code: TokenStream) -> TokenStream {
     entry_helper::build(attrs, code)
 }
 
+/// Helper for decoding DNA Properties into a struct.
+///
+/// # Implements
+/// - `[holochain_integrity_types::TryFromDnaProperties]
+///
+/// # Examples
+/// ```ignore
+/// #[dna_properties]
+/// pub struct MyDnaProperties {
+///     pub progenitor: String,
+///     pub max_length: u16,
+/// }
+///
+/// let my_props = MyDnaProperties::try_from_dna_properties()?;
+/// println!("The progenitor is {}", my_props.progenitor);
+/// ```
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn dna_properties(attrs: TokenStream, code: TokenStream) -> TokenStream {

--- a/crates/hdk_derive/src/lib.rs
+++ b/crates/hdk_derive/src/lib.rs
@@ -293,7 +293,7 @@ pub fn hdk_entry_helper(attrs: TokenStream, code: TokenStream) -> TokenStream {
 /// Helper for decoding DNA Properties into a struct.
 ///
 /// # Implements
-/// - `[holochain_integrity_types::TryFromDnaProperties]
+/// - [`holochain_integrity_types::TryFromDnaProperties`]
 ///
 /// # Examples
 /// ```ignore


### PR DESCRIPTION
### Summary
I realized I never documented the macro `#[dna_properties]`
![image](https://github.com/user-attachments/assets/19465d36-0096-4055-8f95-8934c8267b6f)



### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs