### PR TITLE
Countersigning should always progress from an unknown state

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,14 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-## 0.5.0-dev.4
-
-- **BREAKING**: As the DPKI feature is unstable and incomplete, it is disabled with default cargo features and put behind a feature called `unstable-dpki`. If this feature is specified at compile time, DPKI is enabled by default.
-- **BREAKING**: Issuing and persisting warrants is behind a feature `unstable-warrants` now. Warrants have not been tested extensively and there is no way to recover from a warrant. Hence the feature is considered unstable and must be explicitly enabled. Note that once warrants are issued some functions or calls may not work correctly.
-- **BREAKING**: Conductor::get\_dna\_definitions now returns an `IndexMap` to ensure consistent ordering.
-- Add test to make sure sys validation rejects deleting a delete. Unit tests to get zomes to invoke for app validation were removed for these cases of deleting a delete, because the code path cannot be reached by the system.
-- Added a new feature “unstable-sharding” which puts the network sharding behind a feature flag. It will not be possible to configure network sharding unless Holochain is built with this feature enabled. By default, the network tuning parameter `gossip_dynamic_arcs` is ignored, and the parameter `gossip_arc_clamping` must be set to either `"full"` or `"empty"`, the previous default value of `"none"` will prevent the conductor from starting. We intend to stabilise this feature in the future, and it will return to being available without a feature flag. \#4344
-
 - **BREAKING** The following HDK functions have been temporarily removed as "unstable". They can be re-enabled by building Holochain with the "unstable-functions" feature flag:
   - `accept_countersigning_preflight_request`
   - `block_agent`
@@ -24,10 +16,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - `schedule`
   - the function `sleep` has been removed entirely because it wasn't implemented
   - and the HDI function `is_same_agent`
-  Note that installing apps that have been built with an HDK from before this change will not be possible to install on
-  a conductor that has been built without the `unstable-functions` feature. You will get import errors when Holochain tries
-  to compile the WASM. It is valid to install an app that has been compiled without the `unstable-functions` feature onto
-  a conductor which has been compiled with `unstable-functions` but the reverse is not true. #4371
+    Note that installing apps that have been built with an HDK from before this change will not be possible to install on
+    a conductor that has been built without the `unstable-functions` feature. You will get import errors when Holochain tries
+    to compile the WASM. It is valid to install an app that has been compiled without the `unstable-functions` feature onto
+    a conductor which has been compiled with `unstable-functions` but the reverse is not true. #4371
+- Fix a problem with countersigning where it would stay in resolution when entering an unknown state from a restart. This 
+  was intended behaviour previously to ensure the agent got a change to get online before giving up on countersigning but 
+  it is not necessary now that we consider network errors to be a failed resolution and always retry.
+
+## 0.5.0-dev.4
+
+- **BREAKING**: As the DPKI feature is unstable and incomplete, it is disabled with default cargo features and put behind a feature called `unstable-dpki`. If this feature is specified at compile time, DPKI is enabled by default.
+- **BREAKING**: Issuing and persisting warrants is behind a feature `unstable-warrants` now. Warrants have not been tested extensively and there is no way to recover from a warrant. Hence the feature is considered unstable and must be explicitly enabled. Note that once warrants are issued some functions or calls may not work correctly.
+- **BREAKING**: Conductor::get\_dna\_definitions now returns an `IndexMap` to ensure consistent ordering.
+- Add test to make sure sys validation rejects deleting a delete. Unit tests to get zomes to invoke for app validation were removed for these cases of deleting a delete, because the code path cannot be reached by the system.
+- Added a new feature “unstable-sharding” which puts the network sharding behind a feature flag. It will not be possible to configure network sharding unless Holochain is built with this feature enabled. By default, the network tuning parameter `gossip_dynamic_arcs` is ignored, and the parameter `gossip_arc_clamping` must be set to either `"full"` or `"empty"`, the previous default value of `"none"` will prevent the conductor from starting. We intend to stabilise this feature in the future, and it will return to being available without a feature flag. \#4344
 
 ## 0.5.0-dev.3
 

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -442,12 +442,7 @@ async fn try_recover_failed_session(
                 update_last_attempted(workspace.clone(), true, outcomes, cell_id);
 
                 let resolution = get_resolution(workspace.clone());
-                if let Some(SessionResolutionSummary {
-                    required_reason: ResolutionRequiredReason::Timeout,
-                    attempts,
-                    ..
-                }) = resolution
-                {
+                if let Some(SessionResolutionSummary { attempts, .. }) = resolution {
                     let limit = workspace.countersigning_resolution_retry_limit.unwrap_or(0);
 
                     // If we have reached the limit of attempts, then abandon the session.

--- a/crates/holochain/tests/tests/countersigning.rs
+++ b/crates/holochain/tests/tests/countersigning.rs
@@ -390,6 +390,7 @@ async fn alice_can_recover_from_a_session_timeout() {
     let config = SweetConductorConfig::rendezvous(true)
         .no_dpki()
         .tune_conductor(|c| {
+            c.countersigning_resolution_retry_limit = Some(3);
             c.countersigning_resolution_retry_delay = Some(Duration::from_secs(3));
         });
     let mut conductors = SweetConductorBatch::from_config_rendezvous(3, config).await;
@@ -1214,6 +1215,7 @@ async fn alice_can_force_abandon_session_when_automatic_resolution_has_failed_af
 
     let config = SweetConductorConfig::rendezvous(true)
         .tune_conductor(|c| {
+            c.countersigning_resolution_retry_limit = Some(3);
             c.countersigning_resolution_retry_delay = Some(Duration::from_secs(3));
         })
         .tune(|params| {
@@ -1363,6 +1365,7 @@ async fn alice_can_force_publish_session_when_automatic_resolution_has_failed_af
 
     let config = SweetConductorConfig::rendezvous(true)
         .tune_conductor(|c| {
+            c.countersigning_resolution_retry_limit = Some(3);
             c.countersigning_resolution_retry_delay = Some(Duration::from_secs(3));
         })
         .tune(|params| {

--- a/crates/holochain/tests/tests/countersigning/session_interaction_over_websocket.rs
+++ b/crates/holochain/tests/tests/countersigning/session_interaction_over_websocket.rs
@@ -601,6 +601,7 @@ impl Agent {
         });
         config.keystore = KeystoreConfig::LairServerInProc { lair_root: None };
         config.tuning_params = Some(ConductorTuningParams {
+            countersigning_resolution_retry_limit: Some(3),
             countersigning_resolution_retry_delay: Some(Duration::from_secs(5)),
             min_publish_interval: Some(Duration::from_secs(5)),
             ..Default::default()


### PR DESCRIPTION
### Summary

See the changelog. I'm reasonably confident that this is the only thing that could have cause the problem. We know that resolution was running returning an "Unresolved" state, so it's really only that one match arm that could have contained a bug. It would have been helpful to see the sessions state information but the clients don't expose that yet.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs