### PR TITLE
refactor(holochain): pass hash instead of byte array through to zome …

### DIFF
--- a/crates/holochain/benches/bench.rs
+++ b/crates/holochain/benches/bench.rs
@@ -6,7 +6,6 @@ use criterion::Throughput;
 use hdk::prelude::*;
 use holo_hash::fixt::AgentPubKeyFixturator;
 use holochain::core::ribosome::ZomeCallInvocation;
-use holochain_conductor_api::ZomeCallParamsSigned;
 use holochain_wasm_test_utils::TestWasm;
 use holochain_wasm_test_utils::TestZomes;
 use once_cell::sync::Lazy;
@@ -75,10 +74,8 @@ pub fn wasm_call_n(c: &mut Criterion) {
             b.iter(|| {
                 let zome: Zome = TestZomes::from(TestWasm::Bench).coordinator.erase_type();
                 let i = ZomeCallInvocation {
-                    signed_params: ZomeCallParamsSigned {
-                        bytes: ExternIO(vec![]),
-                        signature: [0; 64].into(),
-                    },
+                    bytes_hash: vec![],
+                    signature: [0; 64].into(),
                     cell_id: CELL_ID.lock().unwrap().clone(),
                     zome: zome.clone(),
                     cap_secret: Some(*CAP.lock().unwrap()),

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -747,12 +747,12 @@ pub mod test {
             .into();
         zome_call.params.cell_id = cell_id;
         zome_call.params.provenance = fixt!(AgentPubKey, Predictable, 0);
-        zome_call.signed =
+        let zome_call_params_signed =
             ZomeCallParamsSigned::try_from_params(&test_keystore(), zome_call.params)
                 .await
                 .unwrap();
 
-        let msg = AppRequest::CallZome(Box::new(zome_call.signed));
+        let msg = AppRequest::CallZome(Box::new(zome_call_params_signed));
         test_handle_incoming_app_message(
             "".to_string(),
             msg,

--- a/crates/holochain/src/core/ribosome/host_fn/call.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call.rs
@@ -221,7 +221,6 @@ pub mod wasm_test {
 
     use crate::core::ribosome::wasm_test::RibosomeTestFixture;
     use crate::test_utils::new_zome_call_unsigned;
-    use holochain_conductor_api::ZomeCallParamsSigned;
     use holochain_sqlite::prelude::DatabaseResult;
 
     #[tokio::test(flavor = "multi_thread")]
@@ -291,15 +290,10 @@ pub mod wasm_test {
         let zome_call_unsigned =
             new_zome_call_unsigned(alice.cell_id(), "call_create_entry", (), TestWasm::Create)
                 .unwrap();
-        let zome_call =
-            ZomeCallParamsSigned::try_from_params(handle.keystore(), zome_call_unsigned.clone())
-                .await
-                .unwrap();
-        let call = ZomeCall {
-            signed: zome_call,
-            params: zome_call_unsigned,
-        };
-        let result = handle.call_zome(call).await;
+        let zome_call = ZomeCall::try_from_params(handle.keystore(), zome_call_unsigned.clone())
+            .await
+            .unwrap();
+        let result = handle.call_zome(zome_call).await;
         assert_matches!(result, Ok(Ok(ZomeCallResponse::Ok(_))));
 
         // Get the action hash of that entry

--- a/crates/holochain/src/fixt.rs
+++ b/crates/holochain/src/fixt.rs
@@ -24,7 +24,6 @@ use crate::test_utils::fake_genesis;
 use ::fixt::prelude::*;
 pub use holo_hash::fixt::*;
 use holo_hash::WasmHash;
-use holochain_conductor_api::ZomeCallParamsSigned;
 use holochain_keystore::test_keystore;
 use holochain_keystore::MetaLairClient;
 use holochain_p2p::HolochainP2pDnaFixturator;
@@ -514,10 +513,8 @@ fixturator!(
 fixturator!(
     ZomeCallInvocation;
     curve Empty ZomeCallInvocation {
-        signed_params: ZomeCallParamsSigned {
-            bytes: ExternIoFixturator::new(Empty).next().unwrap(),
-            signature: SignatureFixturator::new(Empty).next().unwrap(),
-        },
+        bytes_hash: ExternIoFixturator::new(Empty).next().unwrap().into_vec(),
+        signature: SignatureFixturator::new(Empty).next().unwrap(),
         cell_id: CellIdFixturator::new(Empty).next().unwrap(),
         zome: ZomeFixturator::new(Empty).next().unwrap(),
         cap_secret: Some(CapSecretFixturator::new(Empty).next().unwrap()),
@@ -528,10 +525,8 @@ fixturator!(
         expires_at: TimestampFixturator::new(Empty).next().unwrap(),
     };
     curve Unpredictable ZomeCallInvocation {
-        signed_params: ZomeCallParamsSigned {
-            bytes: ExternIoFixturator::new(Unpredictable).next().unwrap(),
-            signature: SignatureFixturator::new(Unpredictable).next().unwrap(),
-        },
+        bytes_hash: ExternIoFixturator::new(Unpredictable).next().unwrap().into_vec(),
+        signature: SignatureFixturator::new(Unpredictable).next().unwrap(),
         cell_id: CellIdFixturator::new(Unpredictable).next().unwrap(),
         zome: ZomeFixturator::new(Unpredictable).next().unwrap(),
         cap_secret: Some(CapSecretFixturator::new(Unpredictable).next().unwrap()),
@@ -543,10 +538,8 @@ fixturator!(
         expires_at: (Timestamp::now() + std::time::Duration::from_secs(30)).unwrap(),
     };
     curve Predictable ZomeCallInvocation {
-        signed_params: ZomeCallParamsSigned {
-            bytes: ExternIoFixturator::new_indexed(Predictable, get_fixt_index!()).next().unwrap(),
-            signature: SignatureFixturator::new_indexed(Predictable, get_fixt_index!()).next().unwrap(),
-        },
+        bytes_hash: ExternIoFixturator::new_indexed(Predictable, get_fixt_index!()).next().unwrap().into_vec(),
+        signature: SignatureFixturator::new_indexed(Predictable, get_fixt_index!()).next().unwrap(),
         cell_id: CellIdFixturator::new_indexed(Predictable, get_fixt_index!())
             .next()
             .unwrap(),

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -945,7 +945,8 @@ where
     P: serde::Serialize + std::fmt::Debug,
 {
     let ZomeCall {
-        signed,
+        bytes_hash,
+        signature,
         params:
             ZomeCallParams {
                 cell_id,
@@ -959,7 +960,8 @@ where
             },
     } = new_zome_call(keystore, cell_id, func, payload, zome.clone().into()).await?;
     Ok(ZomeCallInvocation {
-        signed_params: signed,
+        bytes_hash,
+        signature,
         cell_id,
         zome: zome.into(),
         cap_secret,


### PR DESCRIPTION
### Summary
After the conductor API, hash serialized zome call params and pass on hash instead of serialized bytes.


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs