### PR TITLE
Change UseExisting enum variant format

### DIFF
--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -4173,7 +4173,7 @@ fn get_modifiers_map_from_role_settings(roles_settings: &Option<RoleSettingsMap>
         Some(role_settings_map) => role_settings_map
             .iter()
             .filter_map(|(role_name, role_settings)| match role_settings {
-                RoleSettings::UseExisting(_) => None,
+                RoleSettings::UseExisting { .. } => None,
                 RoleSettings::Provisioned { modifiers, .. } => {
                     modifiers.as_ref().map(|m| (role_name.clone(), m.clone()))
                 }
@@ -4189,7 +4189,7 @@ fn get_memproof_map_from_role_settings(role_settings: &Option<RoleSettingsMap>) 
         Some(role_settings_map) => role_settings_map
             .iter()
             .filter_map(|(role_name, role_settings)| match role_settings {
-                RoleSettings::UseExisting(_) => None,
+                RoleSettings::UseExisting { .. } => None,
                 RoleSettings::Provisioned { membrane_proof, .. } => membrane_proof
                     .as_ref()
                     .map(|m| (role_name.clone(), m.clone())),
@@ -4207,7 +4207,7 @@ fn get_existing_cells_map_from_role_settings(
         Some(role_settings_map) => role_settings_map
             .iter()
             .filter_map(|(role_name, role_settings)| match role_settings {
-                RoleSettings::UseExisting(cell_id) => Some((role_name.clone(), cell_id.clone())),
+                RoleSettings::UseExisting { cell_id } => Some((role_name.clone(), cell_id.clone())),
                 _ => None,
             })
             .collect(),

--- a/crates/holochain/src/conductor/tests/install_app_bundle.rs
+++ b/crates/holochain/src/conductor/tests/install_app_bundle.rs
@@ -589,7 +589,7 @@ async fn use_existing_integration() {
     assert_eq!(cells.len(), 1);
     let cell_id = cells.first().unwrap().clone();
 
-    let role_settings = ("extant".into(), RoleSettings::UseExisting(cell_id));
+    let role_settings = ("extant".into(), RoleSettings::UseExisting { cell_id });
 
     let app_2 = conductor
         .clone()

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -204,7 +204,10 @@ pub type RoleSettingsMap = HashMap<RoleName, RoleSettings>;
 pub enum RoleSettings {
     /// If the role has the UseExisting strategy defined in the app manifest
     /// the cell id to use needs to be specified here.
-    UseExisting { cell_id: CellId },
+    UseExisting {
+        /// Existing cell id to use
+        cell_id: CellId,
+    },
     /// Optional settings for a normally provisioned cell
     Provisioned {
         /// When the app being installed has the `allow_deferred_memproofs` manifest flag set,

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -204,7 +204,7 @@ pub type RoleSettingsMap = HashMap<RoleName, RoleSettings>;
 pub enum RoleSettings {
     /// If the role has the UseExisting strategy defined in the app manifest
     /// the cell id to use needs to be specified here.
-    UseExisting(CellId),
+    UseExisting { cell_id: CellId },
     /// Optional settings for a normally provisioned cell
     Provisioned {
         /// When the app being installed has the `allow_deferred_memproofs` manifest flag set,


### PR DESCRIPTION
### Summary

While starting to acoomodate the types in the js-client I realized that the `RoleSettings::UseExisting` enum variant is not serializable as it was. This PR addresses this.


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs