### PR TITLE
[0.4] Update to Rust 1.80

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,6 +4,6 @@ fi
 
 watch_file nix/**
 
-use flake .#coreDev \
-  --override-input versions ./versions/weekly \
+use flake "github:holochain/holochain#coreDev" \
+  --override-input versions "github:holochain/holochain?dir=versions/0_4_rc" \
   --override-input holochain .

--- a/.github/workflows/holochain-build-and-test.yml
+++ b/.github/workflows/holochain-build-and-test.yml
@@ -41,7 +41,7 @@ jobs:
           - cmd:
               pkgs:
                 - build-release-automation-tests-unit
-              extra_arg: "--override-input versions 'github:holochain/holochain?dir=versions/weekly' --override-input holochain ${{ inputs.repo_path }}"
+              extra_arg: "--override-input versions 'github:holochain/holochain?dir=versions/0_4_rc' --override-input holochain ${{ inputs.repo_path }}"
             platform:
               system: x86_64-linux
 
@@ -49,7 +49,7 @@ jobs:
           - cmd:
               pkgs:
                 - build-release-automation-tests-repo
-              extra_arg: "--override-input versions 'github:holochain/holochain?dir=versions/weekly' --override-input repo-git 'path:.git'"
+              extra_arg: "--override-input versions 'github:holochain/holochain?dir=versions/0_4_rc' --override-input repo-git 'path:.git'"
             platform:
               system: x86_64-linux
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,9 +761,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 dependencies = [
  "serde",
 ]
@@ -859,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -2006,12 +2006,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3647,7 +3647,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pretty_assertions",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive 0.5.0",
  "rand 0.8.5",
  "regex",
  "rusqlite",
@@ -3936,7 +3936,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -4023,7 +4023,7 @@ dependencies = [
  "http-body 1.0.1",
  "hyper 1.5.1",
  "pin-project-lite",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -4618,7 +4618,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pretty_assertions",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive 0.5.0",
  "rand 0.8.5",
  "sbd-server",
  "serde",
@@ -4767,7 +4767,7 @@ dependencies = [
  "kitsune_p2p_types",
  "pretty_assertions",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive 0.5.0",
  "rand 0.8.5",
  "serde",
  "test-case",
@@ -4843,7 +4843,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "paste",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive 0.5.0",
  "rmp-serde",
  "rustls 0.21.12",
  "serde",
@@ -4926,9 +4926,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.166"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libflate"
@@ -5047,9 +5047,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "litrs"
@@ -7601,9 +7601,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -8285,7 +8285,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.7",
+ "socket2 0.5.8",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -8773,18 +8773,21 @@ checksum = "cad414b2eed757c1b6f810f8abc814e298a9c89176b21fae092c7a87756fb839"
 
 [[package]]
 name = "ureq"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
+checksum = "b30e6f97efe1fa43535ee241ee76967d3ff6ff3953ebb430d8d55c5393029e7b"
 dependencies = [
  "base64 0.22.1",
  "flate2",
+ "litemap",
  "log",
  "once_cell",
  "rustls 0.23.19",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.7",
+ "yoke",
+ "zerofrom",
 ]
 
 [[package]]
@@ -9878,9 +9881,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -9923,9 +9926,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,10 +77,10 @@ nursery = { level = "allow", priority = -1 }
 cargo = { level = "allow", priority = -1 }
 pedantic = { level = "allow", priority = -1 }
 restriction = { level = "allow", priority = -1 }
-style = "deny"
-complexity = "deny"
-perf = "deny"
-correctness = "deny"
+style = { level = "deny", priority = -1 }
+complexity = { level = "deny", priority = -1 }
+perf = { level = "deny", priority = -1 }
+correctness = { level = "deny", priority = -1 }
 dbg_macro = "deny"
 
 [workspace.lints.rust]

--- a/crates/hc_bundle/src/packing/wasmer_sys.rs
+++ b/crates/hc_bundle/src/packing/wasmer_sys.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "wasmer_sys")]
-
 use crate::error::HcBundleError;
 use holochain_util::ffs;
 use holochain_wasmer_host::module::build_ios_module;

--- a/crates/hc_bundle/src/packing/wasmer_wamr.rs
+++ b/crates/hc_bundle/src/packing/wasmer_wamr.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "wasmer_wamr")]
-
 use crate::error::HcBundleError;
 use mr_bundle::{Bundle, Manifest};
 use std::path::Path;

--- a/crates/hdk/src/lib.rs
+++ b/crates/hdk/src/lib.rs
@@ -73,7 +73,7 @@
 //! The only way to execute logic inside WASM is by having the conductor (host) call a function that is marked as an `extern` by the zome (guest).
 //!
 //! > Note: From the perspective of hApp development in WASM, the "guest" is the WASM and the "host" is the running Holochain conductor.
-//!   The host is _not_ the "host operating system" in this context.
+//! > The host is _not_ the "host operating system" in this context.
 //!
 //! Similarly, the only way for the guest to do anything other than process data and calculations is to call functions the host provides to it at runtime.
 //!

--- a/crates/hdk_derive/src/lib.rs
+++ b/crates/hdk_derive/src/lib.rs
@@ -1,5 +1,5 @@
 #![crate_type = "proc-macro"]
-#![allow(clippy::unwrap_or_default)] // Fixing requires a `darling` upgrade
+#![allow(clippy::manual_unwrap_or_default)] // Fixing requires a `darling` upgrade
 
 use proc_macro::Span;
 use proc_macro::TokenStream;

--- a/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "wasmer_sys")]
-
 use crate::{
     core::ribosome::error::RibosomeResult, holochain_wasmer_host::module::WASM_METERING_LIMIT,
 };

--- a/crates/holochain/src/core/ribosome/real_ribosome/wasmer_wamr.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome/wasmer_wamr.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "wasmer_wamr")]
-
 use crate::core::ribosome::error::RibosomeResult;
 use holochain_wasmer_host::module::InstanceWithStore;
 use holochain_zome_types::prelude::WasmZome;

--- a/crates/holochain/tests/tests/countersigning.rs
+++ b/crates/holochain/tests/tests/countersigning.rs
@@ -372,7 +372,7 @@ async fn alice_can_recover_when_bob_abandons_a_countersigning_session() {
         .unwrap();
 
     // Everyone's DHT should sync
-    await_consistency(60, [alice, bob, &carol]).await.unwrap();
+    await_consistency(60, [alice, bob, carol]).await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -513,7 +513,7 @@ async fn alice_can_recover_from_a_session_timeout() {
         .unwrap();
 
     // Everyone's DHT should sync
-    await_consistency(60, [alice, bob, &carol]).await.unwrap();
+    await_consistency(60, [alice, bob, carol]).await.unwrap();
 }
 
 #[cfg(feature = "chc")]

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -245,7 +245,7 @@ mod tests {
 
     macro_rules! newhash {
         ($p:ident, $c:expr) => {
-            holo_hash::$p::from_raw_36([$c as u8; HOLO_HASH_UNTYPED_LEN].to_vec())
+            holo_hash::$p::from_raw_36([$c; HOLO_HASH_UNTYPED_LEN].to_vec())
         };
     }
 
@@ -257,10 +257,10 @@ mod tests {
     ) {
         holochain_trace::test_run();
         (
-            newhash!(DnaHash, 's'),
+            newhash!(DnaHash, b's'),
             fixt!(AgentPubKey, Predictable, 0),
-            newhash!(AgentPubKey, '2'),
-            newhash!(AgentPubKey, '3'),
+            newhash!(AgentPubKey, b'2'),
+            newhash!(AgentPubKey, b'3'),
         )
     }
 

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "shlex",
 ]
@@ -985,9 +985,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.166"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libm"

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "cargo-chef": {
       "flake": false,
       "locked": {
-        "lastModified": 1716357509,
-        "narHash": "sha256-7iSxwTaJnDLqaFu4ydxkx7ivhDvSQQcXWKawv/e4NHE=",
+        "lastModified": 1727084300,
+        "narHash": "sha256-ya6hQXFDWMvb265v7vktRcc/kVb833vmq8Z9ArM70F0=",
         "owner": "LukeMathWalker",
         "repo": "cargo-chef",
-        "rev": "b468537839bfc7c23d744b85d7a5090954626550",
+        "rev": "a228626f314d3aacd21723b49dd5cc4257d3f716",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1725125250,
-        "narHash": "sha256-CB20rDD5eHikF6mMTTJdwPP1qvyoiyyw1RDUzwIaIF8=",
+        "lastModified": 1732407143,
+        "narHash": "sha256-qJOGDT6PACoX+GbNH2PPx2ievlmtT1NVeTB80EkRLys=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "96fd12c7100e9e05fa1a0a5bd108525600ce282f",
+        "rev": "f2b4b472983817021d9ffb60838b2b36b9376b20",
         "type": "github"
       },
       "original": {
@@ -68,11 +68,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1732722421,
+        "narHash": "sha256-HRJ/18p+WoXpWJkcdsk9St5ZiukCqSDgbOGFa8Okehg=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9ed2ac151eada2306ca8c418ebd97807bb08f6ac",
         "type": "github"
       },
       "original": {
@@ -86,11 +86,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -101,16 +101,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1722347117,
-        "narHash": "sha256-Jv4DxaVtdbO+fOD4woFoepCCOtRN/HF94xJSwViz3ck=",
+        "lastModified": 1729163773,
+        "narHash": "sha256-5tl0Wx0GG/0804Hl0eXiS7RCTinEFKBfhFIjUjrNtbw=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "97d86050b177829b623461970db5c3b64fbd74c1",
+        "rev": "d0eb7a38619bcc226069d4a135c6c16c2017c782",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.3.2",
+        "ref": "holochain-0.3.4",
         "repo": "holochain",
         "type": "github"
       }
@@ -118,16 +118,16 @@
     "lair": {
       "flake": false,
       "locked": {
-        "lastModified": 1717684904,
-        "narHash": "sha256-vcXt67Tl1qwVUkx8CBevdQocqZXUEeoXjaYw86ljsYo=",
+        "lastModified": 1728644214,
+        "narHash": "sha256-cuYpImsJb/iPbqnAfaRsXlmJ36e9e8kyNL7Tq/+yauQ=",
         "owner": "holochain",
         "repo": "lair",
-        "rev": "6a84ed490fc7074d107e38bbb4a8d707e9b8e066",
+        "rev": "7002ef751b08a969e6002776ed3a8dfd929d7577",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "lair_keystore-v0.4.5",
+        "ref": "lair_keystore-v0.4.6",
         "repo": "lair",
         "type": "github"
       }
@@ -151,11 +151,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1710156097,
-        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
+        "lastModified": 1731533336,
+        "narHash": "sha256-oRam5PS1vcrr5UPgALW0eo1m/5/pls27Z/pabHNy2Ms=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
+        "rev": "f7653272fd234696ae94229839a99b73c9ab7de0",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727348695,
-        "narHash": "sha256-J+PeFKSDV+pHL7ukkfpVzCOO7mBSrrpJ3svwBFABbhI=",
+        "lastModified": 1732521221,
+        "narHash": "sha256-2ThgXBUXAE1oFsVATK1ZX9IjPcS4nKFOAjhPNKuiMn0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1925c603f17fc89f4c8f6bf6f631a802ad85d784",
+        "rev": "4633a7c72337ea8fd23a4f2ba3972865e3ec685d",
         "type": "github"
       },
       "original": {
@@ -181,24 +181,24 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
       }
     },
     "pre-commit-hooks-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1724857454,
-        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
+        "lastModified": 1732021966,
+        "narHash": "sha256-mnTbjpdqF0luOkou8ZFi2asa1N3AA2CchR/RqCNmsGE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
+        "rev": "3308484d1a443fc5bc92012435d79e80458fe43c",
         "type": "github"
       },
       "original": {
@@ -254,11 +254,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727577080,
-        "narHash": "sha256-2LPT76Acp6ebt7fCt90eq/M8T2+X09s/yTVgfVFrtno=",
+        "lastModified": 1732847586,
+        "narHash": "sha256-SnHHSBNZ+aj8mRzYxb6yXBl9ei3K3j5agC/D8Vjw/no=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "73a833855442ce8cee710cf4d8d054fea1c81196",
+        "rev": "97210ddff72fe139815f4c1ac5da74b5b0dde2d7",
         "type": "github"
       },
       "original": {
@@ -270,11 +270,11 @@
     "scaffolding": {
       "flake": false,
       "locked": {
-        "lastModified": 1724073530,
-        "narHash": "sha256-PUM8otA5F5s8ZHxhjupn7R+RZAjh2rueYIFwu3UkK44=",
+        "lastModified": 1727691892,
+        "narHash": "sha256-8dMLmpYp19wZhxlR1uiSeR23nGAOhHnyiZ/5CPwOoAg=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "8a6d1dab0f1668c2781a46d93a5ad638fcf25598",
+        "rev": "d0290b88ac08e6811d57acb3294a177d107d2528",
         "type": "github"
       },
       "original": {
@@ -293,11 +293,11 @@
       },
       "locked": {
         "dir": "versions/0_3",
-        "lastModified": 1725035662,
-        "narHash": "sha256-Iqilj3juOxCm51wn1r0vIsTcP/VhkaC5KqxZv0BYCsk=",
+        "lastModified": 1732887569,
+        "narHash": "sha256-tdR2bpPsRi9PKP/IFKCdtBVkNeXS2ShiuujOMqM5zbU=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "3ac784851357bb6c74a61b9ce8de8a034b9a5cf4",
+        "rev": "4bba9cf6b1d92faee6867a279599e0f321733abe",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -293,11 +293,11 @@
       },
       "locked": {
         "dir": "versions/0_3",
-        "lastModified": 1732887569,
-        "narHash": "sha256-tdR2bpPsRi9PKP/IFKCdtBVkNeXS2ShiuujOMqM5zbU=",
+        "lastModified": 1732892877,
+        "narHash": "sha256-i62ZIC7zQ283uo/9iGGxUBeRDPpSdqnu8j8QJIOwmgM=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "4bba9cf6b1d92faee6867a279599e0f321733abe",
+        "rev": "9ff3291ecf833c7627824ed3f4e8b7c8d9047cf7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -15,9 +15,7 @@
     nixpkgs.url = "nixpkgs/nixos-unstable";
 
     # lib to build nix packages from rust crates
-    crane = {
-      url = "github:ipetkov/crane";
-    };
+    crane.url = "github:ipetkov/crane";
 
     # filter out all .nix files to not affect the input hash
     # when these are changes

--- a/nix/modules/go.nix
+++ b/nix/modules/go.nix
@@ -14,7 +14,7 @@
       packages = {
         goWrapper =
           let
-            go = pkgs.go_1_23;
+            go = pkgs.go;
           in
           # there is interference only in this specific case, we assemble a go derivationt that not propagate anything but still has everything available required for our specific use-case
             #

--- a/nix/modules/go.nix
+++ b/nix/modules/go.nix
@@ -14,7 +14,7 @@
       packages = {
         goWrapper =
           let
-            go = pkgs.go_1_21;
+            go = pkgs.go_1_23;
           in
           # there is interference only in this specific case, we assemble a go derivationt that not propagate anything but still has everything available required for our specific use-case
             #

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -21,78 +21,61 @@
 
       options.rustHelper = lib.mkOption { type = lib.types.raw; };
 
-      config.rustHelper = {
-        defaultTrack = "stable";
-        defaultVersion = "1.77.2";
-
-        defaultExtensions = [
-          "rust-src"
-          "rust-analyzer"
-          "clippy"
-          "rustfmt"
-        ];
-
-        defaultTargets = [
-          "wasm32-unknown-unknown"
-        ];
-
-        defaultStdenv = pkgs:
-          if pkgs.stdenv.isLinux
-          then pkgs.stdenvAdapters.useMoldLinker pkgs.stdenv
-          else pkgs.stdenv;
-
-        mkRustPkgs =
-          { track ? config.rustHelper.defaultTrack
-          , version ? config.rustHelper.defaultVersion
-          , extensions ? config.rustHelper.defaultExtensions
-          , targets ? config.rustHelper.defaultTargets
-          }:
-          import inputs.nixpkgs {
+      config.rustHelper =
+        let
+          rustPkgs = import inputs.nixpkgs {
             inherit system;
+            overlays = [ (import inputs.rust-overlay) ];
+          };
+        in
+        {
+          defaultTrack = "stable";
+          defaultVersion = "1.77.2";
 
-            overlays = [
-              inputs.rust-overlay.overlays.default
+          defaultExtensions = [
+            "rust-src"
+            "rust-analyzer"
+            "clippy"
+            "rustfmt"
+          ];
 
-              (final: prev: { })
+          defaultTargets = [
+            "wasm32-unknown-unknown"
+          ];
 
-              (final: prev: {
-                rustToolchain =
-                  (prev.rust-bin."${track}"."${version}".minimal.override ({
-                    inherit extensions targets;
-                  }));
+          defaultStdenv = pkgs:
+            if pkgs.stdenv.isLinux
+            then pkgs.stdenvAdapters.useMoldLinker pkgs.stdenv
+            else pkgs.stdenv;
 
-                rustc = final.rustToolchain;
-                cargo = final.rustToolchain;
-              })
-            ];
+          mkRust =
+            { track ? config.rustHelper.defaultTrack
+            , version ? config.rustHelper.defaultVersion
+            , extensions ? config.rustHelper.defaultExtensions
+            , targets ? config.rustHelper.defaultTargets
+            }: (rustPkgs.rust-bin."${track}"."${version}".minimal.override ({
+              inherit extensions targets;
+            }));
+
+          customBuildRustCrateForPkgs = pkgs: pkgs.buildRustCrate.override {
+            stdenv = config.rustHelper.defaultStdenv pkgs;
+
+            defaultCrateOverrides = pkgs.lib.attrsets.recursiveUpdate pkgs.defaultCrateOverrides
+              ({
+                tx5-go-pion-sys = _: { nativeBuildInputs = with pkgs; [ go ]; };
+                tx5-go-pion-turn = _: { nativeBuildInputs = with pkgs; [ go ]; };
+              });
           };
 
-        mkRust =
-          { track ? config.rustHelper.defaultTrack
-          , version ? config.rustHelper.defaultVersion
-          , extensions ? config.rustHelper.defaultExtensions
-          , targets ? config.rustHelper.defaultTargets
-          }: (config.rustHelper.mkRustPkgs { inherit track version extensions targets; }).rustToolchain;
-
-        customBuildRustCrateForPkgs = pkgs: pkgs.buildRustCrate.override {
-          stdenv = config.rustHelper.defaultStdenv pkgs;
-
-          defaultCrateOverrides = pkgs.lib.attrsets.recursiveUpdate pkgs.defaultCrateOverrides
-            ({
-              tx5-go-pion-sys = _: { nativeBuildInputs = with pkgs; [ go ]; };
-              tx5-go-pion-turn = _: { nativeBuildInputs = with pkgs; [ go ]; };
-            });
+          # `nix flake show` is incompatible with IFD by default
+          # This works around the issue by making the name of the package
+          #   discoverable without IFD.
+          mkNoIfdPackage = name: pkg: {
+            inherit name;
+            inherit (pkg) drvPath outPath;
+            type = "derivation";
+            orig = pkg;
+          };
         };
-
-        # `nix flake show` is incompatible with IFD by default
-        # This works around the issue by making the name of the package
-        #   discoverable without IFD.
-        mkNoIfdPackage = name: pkg: {
-          inherit name;
-          inherit (pkg) drvPath outPath;
-          type = "derivation";
-          orig = pkg;
-        };
-      };
     };
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.77.2"
+channel = "1.80.1"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"


### PR DESCRIPTION
### Summary

Matching the Rust version used for 0.4 in Holonix -> https://github.com/holochain/holochain/blob/develop/versions/0_4_rc/flake.nix#L28

This just updates the toolchain used in the project to match and fixes some Clippy issues to make the build pass.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs