### PR TITLE
Demonstrate consistency awaiting problem in `three_way_gossip_recent`

### DIFF
--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -3072,7 +3072,6 @@ mod misc_impls {
                 .map(|op| match op {
                     DhtOp::ChainOp(op) => {
                         let a = op.action();
-                        let ah = a.to_hash();
                         format!("{:>3} {} {}", a.action_seq(), a.author(), op.to_hash())
                     }
                     DhtOp::WarrantOp(op) => format!("warrant {}", op.to_hash()),

--- a/crates/holochain/tests/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/tests/sharded_gossip/mod.rs
@@ -777,7 +777,7 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
     );
 
     await_consistency_advanced(
-        20,
+        10,
         (),
         [(&cells[0], false), (&cells[1], true), (&cell, true)],
     )

--- a/crates/holochain/tests/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/tests/sharded_gossip/mod.rs
@@ -802,6 +802,9 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
     );
     assert_eq!(records_2, records_1);
 
+    // uncomment this and the test passes (locally)
+    // tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
     let dump1 = conductors[1]
         .dump_all_integrated_op_hashes(cells[1].cell_id().dna_hash())
         .await

--- a/crates/holochain/tests/tests/sharded_gossip/mod.rs
+++ b/crates/holochain/tests/tests/sharded_gossip/mod.rs
@@ -698,7 +698,7 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
         .collect();
 
     let size = 3_000_000;
-    let num = 2;
+    let num = 3;
 
     let mut hashes = vec![];
     for i in 0..num {
@@ -708,6 +708,16 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
     }
 
     await_consistency(10, [&cells[0], &cells[1]]).await.unwrap();
+
+    let dump0 = conductors[0]
+        .dump_all_integrated_op_hashes(cells[0].cell_id().dna_hash())
+        .await
+        .unwrap();
+    let dump1 = conductors[1]
+        .dump_all_integrated_op_hashes(cells[1].cell_id().dna_hash())
+        .await
+        .unwrap();
+    pretty_assertions::assert_eq!(dump0, dump1);
 
     println!(
         "Done waiting for consistency between first two nodes. Elapsed: {:?}",
@@ -767,7 +777,7 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
     );
 
     await_consistency_advanced(
-        10,
+        20,
         (),
         [(&cells[0], false), (&cells[1], true), (&cell, true)],
     )
@@ -791,6 +801,17 @@ async fn three_way_gossip(config: holochain::sweettest::SweetConductorConfig) {
             .collect::<Vec<_>>()
     );
     assert_eq!(records_2, records_1);
+
+    let dump1 = conductors[1]
+        .dump_all_integrated_op_hashes(cells[1].cell_id().dna_hash())
+        .await
+        .unwrap();
+    let dump2 = conductors[2]
+        .dump_all_integrated_op_hashes(cell.cell_id().dna_hash())
+        .await
+        .unwrap();
+
+    pretty_assertions::assert_eq!(dump1, dump2);
 }
 
 #[cfg(feature = "test_utils")]


### PR DESCRIPTION
### Summary

While doing some [model checking](https://en.wikipedia.org/wiki/Model_checking) on Holochain, I discovered a case where await_consistency seems to not await full consistency, i.e. it returns early. For me, locally, this test fails with two ops not integrated by node 1. Simply waiting longer makes this test pass (the last op gets integrated). This means that any test which uses await_consistency could potentially be a false positive by passing before all ops are accounted for.

The way to really understand what's going on would involve digging into why the ["published ops" request](https://github.com/maackle/holochain/blob/a999f5041bd16926cddb655cf1ca113bac7c5610/crates/holochain/src/test_utils.rs#L593) returns an incomplete set, but that's beyond my pay grade

(The one failing test in this PR is intentional.)

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs