### PR TITLE
docs(hdi): fix doc-comment warnings in HDI crate

### DIFF
--- a/crates/hdi/src/ed25519.rs
+++ b/crates/hdi/src/ed25519.rs
@@ -7,7 +7,7 @@ use crate::prelude::*;
 /// be passed through the canonical serialization process, guaranteeing consistent behaviour.
 /// If you pass in a `Vec<u8>` expecting it to be verified literally the signature won't verify correctly.
 ///
-/// See [ `verify_signature_raw` ]
+/// See [`verify_signature_raw`]
 pub fn verify_signature<K, S, D>(key: K, signature: S, data: D) -> ExternResult<bool>
 where
     K: Into<AgentPubKey>,
@@ -27,7 +27,7 @@ where
 /// This is best to use if you have literal bytes from somewhere.
 /// If you pass in a` Vec<u8>` expecting it to be serialized here, the signature won't verify correctly.
 ///
-/// See [ `verify_signature` ]
+/// See [`verify_signature`]
 pub fn verify_signature_raw<K, S>(key: K, signature: S, data: Vec<u8>) -> ExternResult<bool>
 where
     K: Into<AgentPubKey>,

--- a/crates/hdi/src/entry.rs
+++ b/crates/hdi/src/entry.rs
@@ -9,15 +9,15 @@ pub mod examples;
 /// MUST get an EntryHashed at a given EntryHash.
 ///
 /// The EntryHashed is NOT guaranteed to be associated with a valid (or even validated) Action/Record.
-/// For example, an invalid Record could be published and `must_get_entry` would return the EntryHashed.
+/// For example, an invalid [`Record`] could be published and [`must_get_entry`] would return the EntryHashed.
 ///
 /// This may be useful during validation callbacks where the validity and relevance of some content can be
 /// asserted by the CURRENT validation callback independent of a Record. This behaviour avoids the potential for
 /// eclipse attacks to lie about the validity of some data and cause problems for a hApp.
 /// If you NEED to know that a dependency is valid in order for the current validation logic
-/// (e.g. inductive validation of a tree) then `must_get_valid_record` is likely what you need.
+/// (e.g. inductive validation of a tree) then [`must_get_valid_record`] is likely what you need.
 ///
-/// `must_get_entry` is available in contexts such as validation where both determinism and network access is desirable.
+/// [`must_get_entry`] is available in contexts such as validation where both determinism and network access is desirable.
 ///
 /// An EntryHashed will NOT be returned if:
 /// - @TODO It is PURGED (community redacted entry)
@@ -27,8 +27,8 @@ pub mod examples;
 ///
 /// If an EntryHashed fails to be returned:
 ///
-/// - Callbacks will return early with `UnresolvedDependencies`
-/// - Zome calls will receive a `WasmError` from the host
+/// - Callbacks will return early with [`UnresolvedDependencies`]
+/// - Zome calls will receive a [`WasmError`] from the host
 pub fn must_get_entry(entry_hash: EntryHash) -> ExternResult<EntryHashed> {
     HDI.with(|h| {
         h.borrow()
@@ -39,23 +39,23 @@ pub fn must_get_entry(entry_hash: EntryHash) -> ExternResult<EntryHashed> {
 /// MUST get a SignedActionHashed at a given ActionHash.
 ///
 /// The SignedActionHashed is NOT guaranteed to be a valid (or even validated) Record.
-/// For example, an invalid Action could be published and `must_get_action` would return the `SignedActionHashed`.
+/// For example, an invalid [`Action`] could be published and [`must_get_action`] would return the [`SignedActionHashed`].
 ///
 /// This may be useful during validation callbacks where the validity depends on an action existing regardless of its associated Entry.
 /// For example, we may simply need to check that the author is the same for two referenced Actions.
 ///
-/// `must_get_action` is available in contexts such as validation where both determinism and network access is desirable.
+/// [`must_get_action`] is available in contexts such as validation where both determinism and network access is desirable.
 ///
-/// A `SignedActionHashed` will NOT be returned if:
+/// A [`SignedActionHashed`] will NOT be returned if:
 ///
 /// - @TODO The action is WITHDRAWN by the author
 /// - @TODO The action is ABANDONED by ALL authorities
 /// - Nobody knows about it on the currently visible network
 ///
-/// If a `SignedActionHashed` fails to be returned:
+/// If a [`SignedActionHashed`] fails to be returned:
 ///
-/// - Callbacks will return early with `UnresolvedDependencies`
-/// - Zome calls will receive a `WasmError` from the host
+/// - Callbacks will return early with [`UnresolvedDependencies`]
+/// - Zome calls will receive a [`WasmError`] from the host
 pub fn must_get_action(action_hash: ActionHash) -> ExternResult<SignedActionHashed> {
     HDI.with(|h| {
         h.borrow()
@@ -63,34 +63,34 @@ pub fn must_get_action(action_hash: ActionHash) -> ExternResult<SignedActionHash
     })
 }
 
-/// MUST get a VALID Record at a given ActionHash.
+/// MUST get a VALID [`Record`] at a given ActionHash.
 ///
-/// The Record is guaranteed to be valid.
-/// More accurately the Record is guarantee to be consistently reported as valid by the visible network.
+/// The [`Record`] is guaranteed to be valid.
+/// More accurately the [`Record`] is guarantee to be consistently reported as valid by the visible network.
 ///
 /// The validity requirement makes this more complex but notably enables inductive validation of arbitrary graph structures.
-/// For example "If this Record is valid, and its parent is valid, up to the root, then the whole tree of Records is valid".
+/// For example "If this [`Record`] is valid, and its parent is valid, up to the root, then the whole tree of Records is valid".
 ///
-/// If at least one authority (1 of N trust) claims the Record is invalid then a conflict resolution/warranting round will be triggered.
+/// If at least one authority (1 of N trust) claims the [`Record`] is invalid then a conflict resolution/warranting round will be triggered.
 ///
 /// In the case of a total eclipse (every visible authority is lying) then we cannot immediately detect an invalid Record.
-/// Unlike `must_get_entry` and `must_get_action` we cannot simply inspect the cryptographic integrity to know this.
+/// Unlike [`must_get_entry`] and [`must_get_action`] we cannot simply inspect the cryptographic integrity to know this.
 ///
-/// In theory we can run validation of the returned Record ourselves, which itself may be based on `must_get_X` calls.
-/// If there is a large nested graph of `must_get_valid_record` calls this could be extremely heavy.
+/// In theory we can run validation of the returned [`Record`] ourselves, which itself may be based on `must_get_X` calls.
+/// If there is a large nested graph of [`must_get_valid_record`] calls this could be extremely heavy.
 /// Note though that each "hop" in recursive validation is routed to a completely different set of authorities.
-/// It does not take many hops to reach the point where an attacker needs to eclipse the entire network to lie about Record validity.
+/// It does not take many hops to reach the point where an attacker needs to eclipse the entire network to lie about [`Record`] validity.
 ///
 /// @TODO We keep signed receipts from authorities serving up "valid records".
 /// - If we ever discover a record we were told is valid is invalid we can retroactively look to warrant authorities
-/// - We can async (e.g. in a background task) be recursively validating Record dependencies ourselves, following hops until there is no room for lies
+/// - We can async (e.g. in a background task) be recursively validating [`Record`] dependencies ourselves, following hops until there is no room for lies
 /// - We can with small probability recursively validate to several hops inline to discourage potential eclipse attacks with a credible immediate threat
 ///
-/// If you do not care about validity and simply want a pair of Action+Entry data, then use both `must_get_action` and `must_get_entry` together.
+/// If you do not care about validity and simply want a pair of Action+Entry data, then use both [`must_get_action`] and [`must_get_entry`] together.
 ///
-/// `must_get_valid_record` is available in contexts such as validation where both determinism and network access is desirable.
+/// [`must_get_valid_record`] is available in contexts such as validation where both determinism and network access is desirable.
 ///
-/// An `Record` will not be returned if:
+/// An [`Record`] will not be returned if:
 ///
 /// - @TODO It is WITHDRAWN by the author
 /// - @TODO The Entry is PURGED by the community
@@ -98,10 +98,10 @@ pub fn must_get_action(action_hash: ActionHash) -> ExternResult<SignedActionHash
 /// - If ANY authority (1 of N trust) OR ourselves (0 of N trust) believes it INVALID
 /// - Nobody knows about it on the visible network
 ///
-/// If an `Record` fails to be returned:
+/// If an [`Record`] fails to be returned:
 ///
-/// - Callbacks will return early with `UnresolvedDependencies`
-/// - Zome calls will receive a `WasmError` from the host
+/// - Callbacks will return early with [`UnresolvedDependencies`]
+/// - Zome calls will receive a [`WasmError`] from the host
 pub fn must_get_valid_record(action_hash: ActionHash) -> ExternResult<Record> {
     HDI.with(|h| {
         h.borrow()

--- a/crates/hdi/src/entry.rs
+++ b/crates/hdi/src/entry.rs
@@ -25,7 +25,7 @@ pub mod examples;
 /// - ALL actions pointing to it are ABANDONED by ALL authorities due to validation failure
 /// - Nobody knows about it on the currently visible network
 ///
-/// If an EntryHashed fails to be returned:
+/// If an [`EntryHashed`] fails to be returned:
 ///
 /// - Callbacks will return early with [`UnresolvedDependencies`]
 /// - Zome calls will receive a [`WasmError`] from the host
@@ -36,13 +36,14 @@ pub fn must_get_entry(entry_hash: EntryHash) -> ExternResult<EntryHashed> {
     })
 }
 
-/// MUST get a SignedActionHashed at a given ActionHash.
+/// MUST get a [`SignedActionHashed`] at a given [`ActionHash`].
 ///
-/// The SignedActionHashed is NOT guaranteed to be a valid (or even validated) Record.
+/// The [`SignedActionHashed`] is NOT guaranteed to be a valid (or even validated) Record.
 /// For example, an invalid [`Action`] could be published and [`must_get_action`] would return the [`SignedActionHashed`].
 ///
-/// This may be useful during validation callbacks where the validity depends on an action existing regardless of its associated Entry.
-/// For example, we may simply need to check that the author is the same for two referenced Actions.
+/// This may be useful during validation callbacks where the validity depends on an action existing
+/// regardless of its associated [`Entry`].
+/// For example, we may simply need to check that the author is the same for two referenced [`Action`]'s.
 ///
 /// [`must_get_action`] is available in contexts such as validation where both determinism and network access is desirable.
 ///
@@ -63,7 +64,7 @@ pub fn must_get_action(action_hash: ActionHash) -> ExternResult<SignedActionHash
     })
 }
 
-/// MUST get a VALID [`Record`] at a given ActionHash.
+/// MUST get a VALID [`Record`] at a given [`ActionHash`].
 ///
 /// The [`Record`] is guaranteed to be valid.
 /// More accurately the [`Record`] is guarantee to be consistently reported as valid by the visible network.
@@ -86,7 +87,7 @@ pub fn must_get_action(action_hash: ActionHash) -> ExternResult<SignedActionHash
 /// - We can async (e.g. in a background task) be recursively validating [`Record`] dependencies ourselves, following hops until there is no room for lies
 /// - We can with small probability recursively validate to several hops inline to discourage potential eclipse attacks with a credible immediate threat
 ///
-/// If you do not care about validity and simply want a pair of Action+Entry data, then use both [`must_get_action`] and [`must_get_entry`] together.
+/// If you do not care about validity and simply want a pair of [`Action`]+[`Entry`] data, then use both [`must_get_action`] and [`must_get_entry`] together.
 ///
 /// [`must_get_valid_record`] is available in contexts such as validation where both determinism and network access is desirable.
 ///
@@ -113,8 +114,9 @@ pub fn must_get_valid_record(action_hash: ActionHash) -> ExternResult<Record> {
 /// If you have some need to implement custom serialization logic or metadata injection
 /// you can do so by implementing these traits manually instead.
 ///
-/// This requires that TryFrom and TryInto [`derive@SerializedBytes`] is implemented for the entry type,
-/// which implies that [`serde::Serialize`] and [`serde::Deserialize`] is also implemented.
+/// This requires that [`TryFrom<SerializedBytes>`] and [`TryInto<SerializedBytes>`]
+/// [`derive@SerializedBytes`] is implemented for the entry type, which implies that
+/// [`serde::Serialize`] and [`serde::Deserialize`] is also implemented.
 /// These can all be derived and there is an attribute macro that both does the default defines.
 #[macro_export]
 macro_rules! app_entry {

--- a/crates/hdi/src/flat_op.rs
+++ b/crates/hdi/src/flat_op.rs
@@ -1,5 +1,5 @@
-//! An alternative to [`Op`] using a flatter structure, and user-defined deserialized
-//! entry included where appropriate
+//! An alternative to [`Op`](holochain_integrity_types::op::Op) using a flatter structure, and
+//! user-defined deserialized entry included where appropriate
 
 use holo_hash::{ActionHash, AgentPubKey, AnyLinkableHash, DnaHash, EntryHash};
 use holochain_integrity_types::{
@@ -15,42 +15,41 @@ pub use flat_op_entry::*;
 pub use flat_op_record::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-/// A convenience type for validation [`Op`]s.
+/// A convenience type for validation [`Op`](holochain_integrity_types::op::Op)s.
 pub enum FlatOp<ET, LT>
 where
     ET: UnitEnum,
 {
-    /// The [`Op::StoreRecord`] which is validated by the authority
-    /// for the [`ActionHash`] of this record.
+    /// The [`Op::StoreRecord`](holochain_integrity_types::op::Op::StoreRecord) which is validated
+    /// by the authority for the [`ActionHash`] of this record.
     ///
-    /// This operation stores a [`Record`] on the DHT and is
-    /// returned when the authority receives a request
-    /// on the [`ActionHash`].
+    /// This operation stores a [`Record`](holochain_integrity_types::record::Record) on the
+    /// DHT and is returned when the authority receives a request on the [`ActionHash`].
     StoreRecord(OpRecord<ET, LT>),
-    /// The [`Op::StoreEntry`] which is validated by the authority
-    /// for the [`EntryHash`] of this entry.
+    /// The [`Op::StoreEntry`](holochain_integrity_types::op::Op::StoreEntry) which is validated by
+    /// the authority for the [`EntryHash`] of this entry.
     ///
-    /// This operation stores an [`Entry`] on the DHT and is
-    /// returned when the authority receives a request
-    /// on the [`EntryHash`].
+    /// This operation stores an [`Entry`](holochain_integrity_types::entry::Entry) on the DHT
+    /// and is returned when the authority receives a request on the [`EntryHash`].
     StoreEntry(OpEntry<ET>),
-    /// The [`Op::RegisterAgentActivity`] which is validated by
-    /// the authority for the [`AgentPubKey`] for the author of this [`Action`].
+    /// The [`Op::RegisterAgentActivity`](holochain_integrity_types::op::Op::RegisterAgentActivity)
+    /// which is validated by the authority for the [`AgentPubKey`] for the author of this
+    /// [`Action`](holochain_integrity_types::action::Action).
     ///
-    /// This operation registers an [`Action`] to an agent's chain
-    /// on the DHT and is returned when the authority receives a request
-    /// on the [`AgentPubKey`] for chain data.
+    /// This operation registers an [`Action`](holochain_integrity_types::action::Action) to an
+    /// agent's chain on the DHT and is returned when the authority receives a request on the
+    /// [`AgentPubKey`] for chain data.
     ///
-    /// Note that [`Op::RegisterAgentActivity`] is the only operation
-    /// that is validated by all zomes regardless of entry or link types.
+    /// Note that
+    /// [`Op::RegisterAgentActivity`](holochain_integrity_types::op::Op::RegisterAgentActivity)
+    /// is the only operation that is validated by all zomes regardless of entry or link types.
     RegisterAgentActivity(OpActivity<<ET as UnitEnum>::Unit, LT>),
-    /// The [`Op::RegisterCreateLink`] which is validated by
-    /// the authority for the [`AnyLinkableHash`] in the base address
-    /// of this link.
+    /// The [`Op::RegisterCreateLink`](holochain_integrity_types::op::Op::RegisterCreateLink) which
+    /// is validated by the authority for the [`AnyLinkableHash`] in the base address of this
+    /// link.
     ///
-    /// This operation register's a link to the base address
-    /// on the DHT and is returned when the authority receives a request
-    /// on the base [`AnyLinkableHash`] for links.
+    /// This operation register's a link to the base address on the DHT and is returned when
+    /// the authority receives a request on the base [`AnyLinkableHash`] for links.
     RegisterCreateLink {
         /// The base address where this link is stored.
         base_address: AnyLinkableHash,
@@ -63,15 +62,16 @@ where
         /// The [`CreateLink`] action that creates the link
         action: CreateLink,
     },
-    /// The [`Op::RegisterDeleteLink`] which is validated by
-    /// the authority for the [`AnyLinkableHash`] in the base address
-    /// of the link that is being deleted.
+    /// The [`Op::RegisterDeleteLink`](holochain_integrity_types::op::Op::RegisterDeleteLink) which
+    /// is validated by the authority for the [`AnyLinkableHash`] in the base address of the
+    /// link that is being deleted.
     ///
-    /// This operation registers a deletion of a link to the base address
-    /// on the DHT and is returned when the authority receives a request
-    /// on the base [`AnyLinkableHash`] for the link that is being deleted.
+    /// This operation registers a deletion of a link to the base address on the DHT and is
+    /// returned when the authority receives a request on the base [`AnyLinkableHash`] for the
+    /// link that is being deleted.
     RegisterDeleteLink {
-        /// The original [`CreateLink`] [`Action`] that created the link.
+        /// The original [`CreateLink`] [`Action`](holochain_integrity_types::action::Action) that
+        /// created the link.
         original_action: CreateLink,
         /// The base address where this link is stored.
         /// This is the base address of the link that is being deleted.
@@ -85,22 +85,22 @@ where
         /// The [`DeleteLink`] action that deletes the link
         action: DeleteLink,
     },
-    /// The [`Op::RegisterUpdate`] which is validated by
-    /// the authority for the [`ActionHash`] of the original entry
-    /// and the authority for the [`EntryHash`] of the original entry.
+    /// The [`Op::RegisterUpdate`](holochain_integrity_types::op::Op::RegisterUpdate) which is
+    /// validated by the authority for the [`ActionHash`] of the original entry and the
+    /// authority for the [`EntryHash`] of the original entry.
     ///
-    /// This operation registers an update from the original entry on
-    /// the DHT and is returned when the authority receives a request
-    /// for the [`ActionHash`] of the original entry [`Action`] or the
-    /// [`EntryHash`] of the original entry.
+    /// This operation registers an update from the original entry on the DHT and is returned
+    /// when the authority receives a request for the [`ActionHash`] of the original entry
+    /// [`Action`](holochain_integrity_types::action::Action) or the [`EntryHash`] of the
+    /// original entry.
     RegisterUpdate(OpUpdate<ET>),
-    /// The [`Op::RegisterDelete`] which is validated by
-    /// the authority for the [`ActionHash`] of the deleted entry
-    /// and the authority for the [`EntryHash`] of the deleted entry.
+    /// The [`Op::RegisterDelete`](holochain_integrity_types::op::Op::RegisterDelete) which is
+    /// validated by the authority for the [`ActionHash`] of the deleted entry and the
+    /// authority for the [`EntryHash`] of the deleted entry.
     ///
-    /// This operation registers a deletion to the original entry on
-    /// the DHT and is returned when the authority receives a request
-    /// for the [`ActionHash`] of the deleted entry [`Action`] or the
-    /// [`EntryHash`] of the deleted entry.
+    /// This operation registers a deletion to the original entry on the DHT and is returned
+    /// when the authority receives a request for the [`ActionHash`] of the deleted entry
+    /// [`Action`](holochain_integrity_types::action::Action) or the [`EntryHash`] of the
+    /// deleted entry.
     RegisterDelete(OpDelete),
 }

--- a/crates/hdi/src/flat_op/flat_op_activity.rs
+++ b/crates/hdi/src/flat_op/flat_op_activity.rs
@@ -3,29 +3,29 @@ use holochain_integrity_types::MigrationTarget;
 use super::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-/// Data specific to the [`Op::RegisterAgentActivity`] operation.
+/// Data specific to the
+/// [`Op::RegisterAgentActivity`](holochain_integrity_types::op::Op::RegisterAgentActivity)
+/// operation.
 pub enum OpActivity<UnitType, LT> {
-    /// This operation registers the [`Action`] for an
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for an
     /// app defined entry type to the author's chain.
     CreateEntry {
-        /// The unit version of the app defined entry type.
-        /// If this is [`None`] then the entry type is defined
-        /// in a different zome.
+        /// The unit version of the app defined entry type. If this is [`None`] then the entry type
+        /// is defined in a different zome.
         app_entry_type: Option<UnitType>,
         /// The [`Create`] action that creates the entry
         action: Create,
     },
-    /// This operation registers the [`Action`] for an
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for an
     /// app defined private entry type to the author's chain.
     CreatePrivateEntry {
-        /// The unit version of the app defined entry type.
-        /// If this is [`None`] then the entry type is defined
-        /// in a different zome.
+        /// The unit version of the app defined entry type. If this is [`None`] then the entry type
+        /// is defined in a different zome.
         app_entry_type: Option<UnitType>,
         /// The [`Create`] action that creates the entry
         action: Create,
     },
-    /// This operation registers the [`Action`] for an
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for an
     /// [`AgentPubKey`] to the author's chain.
     CreateAgent {
         /// The agent that was created
@@ -33,89 +33,99 @@ pub enum OpActivity<UnitType, LT> {
         /// The [`Create`] action that creates the entry
         action: Create,
     },
-    /// This operation registers the [`Action`] for a
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for a
     /// Capability Claim to the author's chain.
     CreateCapClaim {
-        /// The [`Create`] action that creates the [`crate::CapClaim`]
+        /// The [`Create`] action that creates the
+        /// [`CapClaim`](holochain_integrity_types::action::EntryType::CapClaim)
         action: Create,
     },
-    /// This operation registers the [`Action`] for a
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for a
     /// Capability Grant to the author's chain.
     CreateCapGrant {
-        /// The [`Create`] action that creates the [`crate::CapGrant`]
+        /// The [`Create`] action that creates the
+        /// [`CapGrant`](holochain_integrity_types::action::EntryType::CapGrant)
         action: Create,
     },
-    /// This operation registers the [`Action`] for an
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for an
     /// updated app defined entry type to the author's chain.
     UpdateEntry {
-        /// The hash of the [`Action`] that created the original entry
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original entry
         original_action_hash: ActionHash,
         /// The hash of the original entry
         original_entry_hash: EntryHash,
-        /// The unit version of the app defined entry type.
-        /// If this is [`None`] then the entry type is defined
-        /// in a different zome.
+        /// The unit version of the app defined entry type. If this is [`None`] then the entry type
+        /// is defined in a different zome.
         app_entry_type: Option<UnitType>,
         /// The [`Update`] action that updates the entry
         action: Update,
     },
-    /// This operation registers the [`Action`] for an
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for an
     /// updated app defined private entry type to the author's chain.
     UpdatePrivateEntry {
-        /// The hash of the [`Action`] that created the original entry
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original entry
         original_action_hash: ActionHash,
         /// The hash of the original entry
         original_entry_hash: EntryHash,
         /// The unit version of the app defined entry type.
-        /// If this is [`None`] then the entry type is defined
-        /// in a different zome.
+        /// If this is [`None`] then the entry type is defined in a different zome.
         app_entry_type: Option<UnitType>,
         /// The [`Update`] action that updates the entry
         action: Update,
     },
-    /// This operation registers the [`Action`] for an
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for an
     /// updated [`AgentPubKey`] to the author's chain.
     UpdateAgent {
         /// The new [`AgentPubKey`].
         new_key: AgentPubKey,
         /// The original [`AgentPubKey`].
         original_key: AgentPubKey,
-        /// The hash of the [`Action`] that created the original entry
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original entry
         original_action_hash: ActionHash,
         /// The [`Update`] action that updates the agent's key
         action: Update,
     },
-    /// This operation registers the [`Action`] for an
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for an
     /// updated Capability Claim to the author's chain.
     UpdateCapClaim {
-        /// The hash of the [`Action`] that created the original [`crate::CapClaim`]
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original [`CapClaim`](holochain_integrity_types::action::EntryType::CapClaim)
         original_action_hash: ActionHash,
-        /// The hash of the original [`crate::CapClaim`]
+        /// The hash of the original
+        /// [`CapClaim`](holochain_integrity_types::action::EntryType::CapClaim)
         original_entry_hash: EntryHash,
-        /// The [`Update`] action that updates the [`crate::CapClaim`]
+        /// The [`Update`] action that updates the
+        /// [`CapClaim`](holochain_integrity_types::action::EntryType::CapClaim)
         action: Update,
     },
-    /// This operation registers the [`Action`] for an
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for an
     /// updated Capability Grant to the author's chain.
     UpdateCapGrant {
-        /// The hash of the [`Action`] that created the original [`crate::CapGrant`]
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original [`CapGrant`](holochain_integrity_types::action::EntryType::CapGrant)
         original_action_hash: ActionHash,
-        /// The hash of the original [`crate::CapGrant`]
+        /// The hash of the original
+        /// [`CapGrant`](holochain_integrity_types::action::EntryType::CapGrant)
         original_entry_hash: EntryHash,
-        /// The [`Update`] action that updates the [`crate::CapGrant`]
+        /// The [`Update`] action that updates the
+        /// [`CapGrant`](holochain_integrity_types::action::EntryType::CapGrant)
         action: Update,
     },
-    /// This operation registers the [`Action`] for a
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for a
     /// deleted app defined entry type to the author's chain.
     DeleteEntry {
-        /// The hash of the [`Action`] that created the original entry
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original entry
         original_action_hash: ActionHash,
         /// The hash of the original entry
         original_entry_hash: EntryHash,
         /// The action that deletes the original entry
         action: Delete,
     },
-    /// This operation registers the [`Action`] for a
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for a
     /// new link to the author's chain.
     CreateLink {
         /// The base address of the link.
@@ -125,17 +135,16 @@ pub enum OpActivity<UnitType, LT> {
         /// The link's tag.
         tag: LinkTag,
         /// The app defined link type of this link.
-        /// If this is [`None`] then the link type is defined
-        /// in a different zome.
+        /// If this is [`None`] then the link type is defined in a different zome.
         link_type: Option<LT>,
         /// The action that creates this link
         action: CreateLink,
     },
-    /// This operation registers the [`Action`] for a
-    /// deleted link to the author's chain and contains
-    /// the original link's [`Action`] hash.
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for a
+    /// deleted link to the author's chain and contains the original link's
+    /// [`Action`](holochain_integrity_types::action::Action) hash.
     DeleteLink {
-        /// The deleted links [`CreateLink`] [`Action`].
+        /// The deleted links [`CreateLink`] [`Action`](holochain_integrity_types::action::Action).
         original_action_hash: ActionHash,
         /// The base address where this link is stored.
         /// This is the base address of the link that is being deleted.
@@ -143,17 +152,17 @@ pub enum OpActivity<UnitType, LT> {
         /// The [`DeleteLink`] action that deletes the link
         action: DeleteLink,
     },
-    /// This operation registers the [`Action`] for an
-    /// [`Action::Dna`] to the author's chain.
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for an
+    /// [`Action::Dna`](holochain_integrity_types::action::Action::Dna) to the author's chain.
     Dna {
         /// The hash of the DNA
         dna_hash: DnaHash,
         /// The [`Dna`] action
         action: Dna,
     },
-    /// This operation registers the [`Action`] for an
-    /// [`Action::OpenChain`] to the author's chain
-    /// and contains the previous chains's [`MigrationTarget`].
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for an
+    /// [`Action::OpenChain`](holochain_integrity_types::action::Action::OpenChain) to the author's
+    /// chain and contains the previous chains's [`MigrationTarget`].
     OpenChain {
         /// Target for the previous chain that we are migrating from
         previous_target: MigrationTarget,
@@ -162,27 +171,27 @@ pub enum OpActivity<UnitType, LT> {
         /// The [`OpenChain`] action
         action: OpenChain,
     },
-    /// This operation registers the [`Action`] for an
-    /// [`Action::CloseChain`] to the author's chain
-    /// and contains the new chains's [`MigrationTarget`]
-    /// if applicable.
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for an
+    /// [`Action::CloseChain`](holochain_integrity_types::action::Action::CloseChain) to the
+    /// author's chain and contains the new chains's [`MigrationTarget`] if applicable.
     CloseChain {
         /// Target for the new chain that we are migrating to
         new_target: Option<MigrationTarget>,
         /// The [`CloseChain`] action
         action: CloseChain,
     },
-    /// This operation registers the [`Action`] for an
-    /// [`Action::AgentValidationPkg`] to the author's chain
-    /// and contains the membrane proof if there is one.
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for an
+    /// [`Action::AgentValidationPkg`](holochain_integrity_types::action::Action::AgentValidationPkg)
+    /// to the author's chain and contains the membrane proof if there is one.
     AgentValidationPkg {
         /// The membrane proof proving that the agent is allowed to participate in this DNA
         membrane_proof: Option<MembraneProof>,
         /// The [`AgentValidationPkg`] action
         action: AgentValidationPkg,
     },
-    /// This operation registers the [`Action`] for an
-    /// [`Action::InitZomesComplete`] to the author's chain.
+    /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for an
+    /// [`Action::InitZomesComplete`](holochain_integrity_types::action::Action::InitZomesComplete)
+    /// to the author's chain.
     InitZomesComplete {
         /// The [`InitZomesComplete`] action
         action: InitZomesComplete,

--- a/crates/hdi/src/flat_op/flat_op_entry.rs
+++ b/crates/hdi/src/flat_op/flat_op_entry.rs
@@ -3,21 +3,22 @@ use holochain_integrity_types::{CapClaimEntry, CapGrantEntry};
 use super::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-/// Data specific to the [`Op::StoreEntry`] operation.
+/// Data specific to the [`Op::StoreEntry`](holochain_integrity_types::op::Op::StoreEntry)
+/// operation.
 pub enum OpEntry<ET>
 where
     ET: UnitEnum,
 {
-    /// This operation stores the [`Entry`] for an
-    /// app defined entry type.
+    /// This operation stores the [`Entry`](holochain_integrity_types::entry::Entry) for an app
+    /// defined entry type.
     CreateEntry {
         /// The app defined entry with the deserialized
-        /// [`Entry`] data.
+        /// [`Entry`](holochain_integrity_types::entry::Entry) data.
         app_entry: ET,
         /// The [`Create`] action that creates this entry
         action: Create,
     },
-    /// This operation stores the [`Entry`] for an
+    /// This operation stores the [`Entry`](holochain_integrity_types::entry::Entry) for an
     /// [`AgentPubKey`].
     CreateAgent {
         /// The agent that was created
@@ -25,63 +26,72 @@ where
         /// The [`Create`] action that creates this agent's key
         action: Create,
     },
-    /// This operation stores the [`Entry`] for the
-    /// newly created entry in an update.
+    /// This operation stores the [`Entry`](holochain_integrity_types::entry::Entry) for the newly
+    /// created entry in an update.
     UpdateEntry {
-        /// The hash of the [`Action`] that created the original entry
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original entry
         original_action_hash: ActionHash,
         /// The hash of the original entry
         original_entry_hash: EntryHash,
         /// The app defined entry with the deserialized
-        /// [`Entry`] data of the new entry.
+        /// [`Entry`](holochain_integrity_types::entry::Entry) data of the new entry.
         app_entry: ET,
         /// The [`Update`] action that updates this entry
         action: Update,
     },
-    /// This operation stores the [`Entry`] for an
-    /// updated [`AgentPubKey`].
+    /// This operation stores the [`Entry`](holochain_integrity_types::entry::Entry) for an updated
+    /// [`AgentPubKey`].
     UpdateAgent {
         /// The new [`AgentPubKey`].
         new_key: AgentPubKey,
         /// The original [`AgentPubKey`].
         original_key: AgentPubKey,
-        /// The hash of the original keys [`Action`].
+        /// The hash of the original keys [`Action`](holochain_integrity_types::action::Action).
         original_action_hash: ActionHash,
         /// The [`Update`] action that updates this entry
         action: Update,
     },
-    /// This operation stores the [`Entry`] for a CapGrant
+    /// This operation stores the [`Entry`](holochain_integrity_types::entry::Entry) for a CapGrant
     CreateCapGrant {
         /// The cap grant entry data.
         entry: CapGrantEntry,
         /// The [`Create`] action that creates this cap grant
         action: Create,
     },
-    /// This operation stores the [`Entry`] for a CapClaim
+    /// This operation stores the [`Entry`](holochain_integrity_types::entry::Entry) for a CapClaim
     CreateCapClaim {
         /// The cap claim entry data.
         entry: CapClaimEntry,
         /// The [`Create`] action that creates this cap claim
         action: Create,
     },
-    /// This operation updates the [`Entry`] for a CapGrant
+    /// This operation updates the [`Entry`](holochain_integrity_types::entry::Entry) for a
+    /// CapGrant
     UpdateCapGrant {
-        /// The hash of the [`Action`] that created the original [`crate::CapGrant`]
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original [`CapGrant`](holochain_integrity_types::action::EntryType::CapGrant)
         original_action_hash: ActionHash,
-        /// The hash of the original [`crate::CapGrant`]
+        /// The hash of the original
+        /// [`CapGrant`](holochain_integrity_types::action::EntryType::CapGrant)
         original_entry_hash: EntryHash,
-        /// The [`Update`] action that updates the [`crate::CapGrant`]
+        /// The [`Update`] action that updates the
+        /// [`CapGrant`](holochain_integrity_types::action::EntryType::CapGrant)
         action: Update,
         /// The new entry to store
         entry: CapGrantEntry,
     },
-    /// This operation updates the [`Entry`] for a CapClaim
+    /// This operation updates the [`Entry`](holochain_integrity_types::entry::Entry) for a
+    /// CapClaim
     UpdateCapClaim {
-        /// The hash of the [`Action`] that created the original [`crate::CapClaim`]
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original [`CapClaim`](holochain_integrity_types::action::EntryType::CapClaim)
         original_action_hash: ActionHash,
-        /// The hash of the original [`crate::CapClaim`]
+        /// The hash of the original
+        /// [`CapClaim`](holochain_integrity_types::action::EntryType::CapClaim)
         original_entry_hash: EntryHash,
-        /// The [`Update`] action that updates the [`crate::CapClaim`]
+        /// The [`Update`] action that updates the
+        /// [`CapClaim`](holochain_integrity_types::action::EntryType::CapClaim)
         action: Update,
         /// The new entry to store
         entry: CapClaimEntry,
@@ -89,63 +99,67 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-/// Data specific to the [`Op::RegisterUpdate`] operation.
+/// Data specific to the [`Op::RegisterUpdate`](holochain_integrity_types::op::Op::RegisterUpdate)
+/// operation.
 pub enum OpUpdate<ET>
 where
     ET: UnitEnum,
 {
-    /// This operation registers an update from
-    /// the original [`Entry`].
+    /// This operation registers an update from the original
+    /// [`Entry`](holochain_integrity_types::entry::Entry).
     Entry {
         /// The app defined entry type with the deserialized
-        /// [`Entry`] data of the new entry.
+        /// [`Entry`](holochain_integrity_types::entry::Entry) data of the new entry.
         app_entry: ET,
         /// The action that updates this entry
         action: Update,
     },
-    /// This operation registers an update from
-    /// the original private [`Entry`].
+    /// This operation registers an update from the original private
+    /// [`Entry`](holochain_integrity_types::entry::Entry).
     PrivateEntry {
-        /// The hash of the original original [`Action`].
+        /// The hash of the original original
+        /// [`Action`](holochain_integrity_types::action::Action).
         original_action_hash: ActionHash,
-        /// The unit version of the app defined entry type
-        /// for the new entry.
+        /// The unit version of the app defined entry type for the new entry.
         app_entry_type: <ET as UnitEnum>::Unit,
         /// The action that updates this entry
         action: Update,
     },
-    /// This operation registers an update from
-    /// the original [`AgentPubKey`].
+    /// This operation registers an update from the original [`AgentPubKey`].
     Agent {
         /// The new [`AgentPubKey`].
         new_key: AgentPubKey,
         /// The original [`AgentPubKey`].
         original_key: AgentPubKey,
-        /// The hash of the original original [`Action`].
+        /// The hash of the original original
+        /// [`Action`](holochain_integrity_types::action::Action).
         original_action_hash: ActionHash,
         /// The [`Update`] action that updates the agent's key
         action: Update,
     },
-    /// This operation registers an update from
-    /// a Capability Claim.
+    /// This operation registers an update from a Capability Claim.
     CapClaim {
-        /// The hash of the original original [`Action`].
+        /// The hash of the original original
+        /// [`Action`](holochain_integrity_types::action::Action).
         original_action_hash: ActionHash,
-        /// The [`Update`] action that updates the [`crate::CapClaim`]
+        /// The [`Update`] action that updates the
+        /// [`CapClaim`](holochain_integrity_types::action::EntryType::CapClaim)
         action: Update,
     },
-    /// This operation registers an update from
-    /// a Capability Grant.
+    /// This operation registers an update from a Capability Grant.
     CapGrant {
-        /// The hash of the original original [`Action`].
+        /// The hash of the original original
+        /// [`Action`](holochain_integrity_types::action::Action).
         original_action_hash: ActionHash,
-        /// The [`Update`] action that updates the [`crate::CapGrant`]
+        /// The [`Update`] action that updates the
+        /// [`CapGrant`](holochain_integrity_types::action::EntryType::CapGrant)
         action: Update,
     },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-/// Data specific to the [`Op::RegisterDelete`] operation.
+/// Data specific to the [`Op::RegisterDelete`](holochain_integrity_types::op::Op::RegisterDelete)
+/// operation.
 pub struct OpDelete {
     /// The [`Delete`] action that deletes this entry
     pub action: Delete,

--- a/crates/hdi/src/flat_op/flat_op_record.rs
+++ b/crates/hdi/src/flat_op/flat_op_record.rs
@@ -3,28 +3,29 @@ use holochain_integrity_types::MigrationTarget;
 use super::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-/// Data specific to the [`Op::StoreRecord`] operation.
+/// Data specific to the [`Op::StoreRecord`](holochain_integrity_types::op::Op::StoreRecord)
+/// operation.
 pub enum OpRecord<ET: UnitEnum, LT> {
-    /// This operation stores the [`Record`] for an
-    /// app defined entry type.
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an app
+    /// defined entry type.
     CreateEntry {
         /// The app defined entry type with the deserialized
-        /// [`Entry`] data.
+        /// [`Entry`](holochain_integrity_types::entry::Entry) data.
         app_entry: ET,
         /// The [`Create`] action that creates the entry
         action: Create,
     },
-    /// This operation stores the [`Record`] for an
-    /// app defined private entry type.
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an app
+    /// defined private entry type.
     CreatePrivateEntry {
-        /// The unit version of the app defined entry type.
-        /// Note it is not possible to deserialize the full
-        /// entry type here because we don't have the [`Entry`] data.
+        /// The unit version of the app defined entry type. Note it is not possible to deserialize
+        /// the full entry type here because we don't have the
+        /// [`Entry`](holochain_integrity_types::entry::Entry) data.
         app_entry_type: <ET as UnitEnum>::Unit,
         /// The [`Create`] action that creates the entry
         action: Create,
     },
-    /// This operation stores the [`Record`] for an
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an
     /// [`AgentPubKey`] that has been created.
     CreateAgent {
         /// The agent that was created
@@ -32,91 +33,102 @@ pub enum OpRecord<ET: UnitEnum, LT> {
         /// The [`Create`] action that creates the entry
         action: Create,
     },
-    /// This operation stores the [`Record`] for a
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for a
     /// Capability Claim that has been created.
     CreateCapClaim {
-        /// The [`Create`] action that creates the [`crate::CapClaim`]
+        /// The [`Create`] action that creates the
+        /// [`CapClaim`](holochain_integrity_types::action::EntryType::CapClaim)
         action: Create,
     },
-    /// This operation stores the [`Record`] for a
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for a
     /// Capability Grant that has been created.
     CreateCapGrant {
-        /// The [`Create`] action that creates the [`crate::CapGrant`]
+        /// The [`Create`] action that creates the
+        /// [`CapGrant`](holochain_integrity_types::action::EntryType::CapGrant)
         action: Create,
     },
-    /// This operation stores the [`Record`] for an
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an
     /// updated app defined entry type.
     UpdateEntry {
-        /// The hash of the [`Action`] that created the original entry
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original entry
         original_action_hash: ActionHash,
         /// The hash of the original entry
         original_entry_hash: EntryHash,
         /// The app defined entry type with the deserialized
-        /// [`Entry`] data from the new entry.
-        /// Note the new entry type is always the same as the
-        /// original entry type however the data may have changed.
+        /// [`Entry`](holochain_integrity_types::entry::Entry) data from the new entry. Note the
+        /// new entry type is always the same as the original entry type however the data may have
+        /// changed.
         app_entry: ET,
         /// The [`Update`] action that updates the entry
         action: Update,
     },
-    /// This operation stores the [`Record`] for an
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an
     /// updated app defined private entry type.
     UpdatePrivateEntry {
-        /// The hash of the [`Action`] that created the original entry
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original entry
         original_action_hash: ActionHash,
         /// The hash of the original entry
         original_entry_hash: EntryHash,
-        /// The unit version of the app defined entry type.
-        /// Note the new entry type is always the same as the
-        /// original entry type however the data may have changed.
+        /// The unit version of the app defined entry type. Note the new entry type is always the
+        /// same as the original entry type however the data may have changed.
         app_entry_type: <ET as UnitEnum>::Unit,
         /// The [`Update`] action that updates the entry
         action: Update,
     },
-    /// This operation stores the [`Record`] for an
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an
     /// updated [`AgentPubKey`].
     UpdateAgent {
         /// The original [`AgentPubKey`].
         original_key: AgentPubKey,
         /// The new [`AgentPubKey`].
         new_key: AgentPubKey,
-        /// The hash of the [`Action`] that created the original key
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original key
         original_action_hash: ActionHash,
         /// The [`Update`] action that updates the entry
         action: Update,
     },
-    /// This operation stores the [`Record`] for an
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an
     /// updated Capability Claim.
     UpdateCapClaim {
-        /// The hash of the [`Action`] that created the original [`crate::CapClaim`]
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original [`CapClaim`](holochain_integrity_types::action::EntryType::CapClaim)
         original_action_hash: ActionHash,
-        /// The hash of the original [`crate::CapClaim`]
+        /// The hash of the original
+        /// [`CapClaim`](holochain_integrity_types::action::EntryType::CapClaim)
         original_entry_hash: EntryHash,
-        /// The [`Update`] action that updates the [`crate::CapClaim`]
+        /// The [`Update`] action that updates the
+        /// [`CapClaim`](holochain_integrity_types::action::EntryType::CapClaim)
         action: Update,
     },
-    /// This operation stores the [`Record`] for an
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an
     /// updated Capability Grant.
     UpdateCapGrant {
-        /// The hash of the [`Action`] that created the original [`crate::CapGrant`]
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original [`CapGrant`](holochain_integrity_types::action::EntryType::CapGrant)
         original_action_hash: ActionHash,
-        /// The hash of the original [`crate::CapGrant`]
+        /// The hash of the original
+        /// [`CapGrant`](holochain_integrity_types::action::EntryType::CapGrant)
         original_entry_hash: EntryHash,
-        /// The [`Update`] action that updates the [`crate::CapGrant`]
+        /// The [`Update`] action that updates the
+        /// [`CapGrant`](holochain_integrity_types::action::EntryType::CapGrant)
         action: Update,
     },
-    /// This operation stores the [`Record`] for a
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for a
     /// deleted app defined entry type.
     DeleteEntry {
-        /// The hash of the [`Action`] that created the original entry
+        /// The hash of the [`Action`](holochain_integrity_types::action::Action) that created the
+        /// original entry
         original_action_hash: ActionHash,
         /// The hash of the original entry
         original_entry_hash: EntryHash,
         /// The [`Delete`] action that creates the entry
         action: Delete,
     },
-    /// This operation stores the [`Record`] for a
-    /// new link.
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for a new
+    /// link.
     CreateLink {
         /// The base address of the link.
         base_address: AnyLinkableHash,
@@ -129,11 +141,11 @@ pub enum OpRecord<ET: UnitEnum, LT> {
         /// The [`CreateLink`] action that creates this link
         action: CreateLink,
     },
-    /// This operation stores the [`Record`] for a
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for a
     /// deleted link and contains the original link's
-    /// [`Action`] hash.
+    /// [`Action`](holochain_integrity_types::action::Action) hash.
     DeleteLink {
-        /// The deleted links [`CreateLink`] [`Action`].
+        /// The deleted links [`CreateLink`] [`Action`](holochain_integrity_types::action::Action).
         original_action_hash: ActionHash,
         /// The base address where this link is stored.
         /// This is the base address of the link that is being deleted.
@@ -141,17 +153,17 @@ pub enum OpRecord<ET: UnitEnum, LT> {
         /// The [`DeleteLink`] action that deletes the link
         action: DeleteLink,
     },
-    /// This operation stores the [`Record`] for an
-    /// [`Action::Dna`].
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an
+    /// [`Action::Dna`](holochain_integrity_types::action::Action::Dna).
     Dna {
         /// The hash of the DNA
         dna_hash: DnaHash,
         /// The [`Dna`] action
         action: Dna,
     },
-    /// This operation stores the [`Record`] for an
-    /// [`Action::OpenChain`] and contains the previous
-    /// chains's [`MigrationTarget`].
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an
+    /// [`Action::OpenChain`](holochain_integrity_types::action::Action::OpenChain) and contains
+    /// the previous chains's [`MigrationTarget`].
     OpenChain {
         /// Specifier for the previous chain that we are migrating from
         previous_target: MigrationTarget,
@@ -160,26 +172,26 @@ pub enum OpRecord<ET: UnitEnum, LT> {
         /// The [`OpenChain`] action
         action: OpenChain,
     },
-    /// This operation stores the [`Record`] for an
-    /// [`Action::CloseChain`] and contains the new
-    /// chains's [`MigrationTarget`], if applicable.
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an
+    /// [`Action::CloseChain`](holochain_integrity_types::action::Action::CloseChain) and contains
+    /// the new chains's [`MigrationTarget`], if applicable.
     CloseChain {
         /// Specifier for the new chain that we are migrating to
         new_target: Option<MigrationTarget>,
         /// The [`CloseChain`] action
         action: CloseChain,
     },
-    /// This operation stores the [`Record`] for an
-    /// [`Action::AgentValidationPkg`] and contains
-    /// the membrane proof if there is one.
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an
+    /// [`Action::AgentValidationPkg`](holochain_integrity_types::action::Action::AgentValidationPkg)
+    /// and contains the membrane proof if there is one.
     AgentValidationPkg {
         /// The membrane proof proving that the agent is allowed to participate in this DNA
         membrane_proof: Option<MembraneProof>,
         /// The [`AgentValidationPkg`] action
         action: AgentValidationPkg,
     },
-    /// This operation stores the [`Record`] for an
-    /// [`Action::InitZomesComplete`].
+    /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an
+    /// [`Action::InitZomesComplete`](holochain_integrity_types::action::Action::InitZomesComplete).
     InitZomesComplete {
         /// The [`InitZomesComplete`] action
         action: InitZomesComplete,

--- a/crates/hdi/src/hash.rs
+++ b/crates/hdi/src/hash.rs
@@ -204,16 +204,18 @@ where
     }
 }
 
-/// Hash an `Action` into an `ActionHash`.
+/// Hash an [`Action`] into an [`ActionHash`].
 ///
-/// [`hash_entry`] has more of a discussion around different hash types and how
-/// they are used within the HDI.
+/// [`hash_entry`] has more of a discussion around different hash types and how they are used
+/// within the HDI.
 ///
-/// It is strongly recommended to use [`hash_action`] to calculate the hash rather than hand rolling an in-wasm solution.
-/// Any inconsistencies in serialization or hash handling will result in dangling references to things due to a "corrupt" hash.
+/// It is strongly recommended to use [`hash_action`] to calculate the hash rather than hand
+/// rolling an in-wasm solution. Any inconsistencies in serialization or hash handling will result
+/// in dangling references to things due to a "corrupt" hash.
 ///
-/// Note that usually relevant HDI functions return a [`ActionHashed`] or [`SignedActionHashed`] which already has associated methods to access the `ActionHash` of the inner `Action`.
-/// In normal usage it is unlikely to be required to separately hash a [`Action`] like this.
+/// Note that usually relevant HDI functions return a [`ActionHashed`] or [`SignedActionHashed`]
+/// which already has associated methods to access the [`ActionHash`] of the inner [`Action`]. In
+/// normal usage it is unlikely to be required to separately hash a [`Action`] like this.
 pub fn hash_action(input: Action) -> ExternResult<ActionHash> {
     match HDI.with(|h| h.borrow().hash(HashInput::Action(input)))? {
         HashOutput::Action(action_hash) => Ok(action_hash),

--- a/crates/hdi/src/hash_path.rs
+++ b/crates/hdi/src/hash_path.rs
@@ -7,7 +7,7 @@
 /// - A two level Path tree
 /// - Each level of the path is defined as strings not binary data
 /// - The top level is the "type" and the second level is the "text"
-/// - The second level is optional as `Option<String>`
+/// - The second level is optional as [`Option<String>`]
 pub mod anchor;
 
 /// The generic [`path::Path`] pattern.

--- a/crates/hdi/src/hash_path.rs
+++ b/crates/hdi/src/hash_path.rs
@@ -1,4 +1,4 @@
-/// The anchor pattern implemented in terms of [ `path::Path` ]
+/// The anchor pattern implemented in terms of [`path::Path`]
 ///
 /// The anchor pattern predates the path crate.
 ///
@@ -10,9 +10,9 @@
 /// - The second level is optional as `Option<String>`
 pub mod anchor;
 
-/// The generic [ `path::Path` ] pattern.
+/// The generic [`path::Path`] pattern.
 ///
-/// As explained in the parent module documentation the [ `path::Path` ] defines a tree structure.
+/// As explained in the parent module documentation the [`path::Path`] defines a tree structure.
 ///
 /// The path is _not_ an entire tree but simply one path from the root to the current depth of the tree.
 ///
@@ -30,9 +30,9 @@ pub mod anchor;
 /// Note:
 ///
 /// - The path must always start at the root
-/// - [ `path::Path` ] are sequential and contigious
-/// - [ `path::Path` ] may be empty
-/// - [ `path::Path` ] only track one branch
+/// - [`path::Path`] are sequential and contigious
+/// - [`path::Path`] may be empty
+/// - [`path::Path`] only track one branch
 ///
 /// Applications can discover all links from a path to all children by constructing the known path components.
 ///
@@ -41,7 +41,7 @@ pub mod anchor;
 /// If an application knows `[ A B ]` then a link to `C` will be discoverable.
 pub mod path;
 
-/// A [ `String` ] based DSL for [ `path::Path` ] that builds trees based on lexical granularity.
+/// A [`String`] based DSL for [`path::Path`] that builds trees based on lexical granularity.
 ///
 /// The basic form is `width:depth#` in the string with `.` separators for each component.
 ///

--- a/crates/hdi/src/hash_path.rs
+++ b/crates/hdi/src/hash_path.rs
@@ -30,7 +30,7 @@ pub mod anchor;
 /// Note:
 ///
 /// - The path must always start at the root
-/// - [`path::Path`] are sequential and contigious
+/// - [`path::Path`] are sequential and contiguous
 /// - [`path::Path`] may be empty
 /// - [`path::Path`] only track one branch
 ///

--- a/crates/hdi/src/hash_path/path.rs
+++ b/crates/hdi/src/hash_path/path.rs
@@ -93,7 +93,7 @@ impl From<String> for Component {
     }
 }
 
-/// Restoring a [ `String` ] from a [ `Component` ] requires [ `Vec<u8>` ] to [ `u32` ] to utf8 handling.
+/// Restoring a [`String`] from a [`Component`] requires [`Vec<u8>`] to [`u32`] to utf8 handling.
 impl TryFrom<&Component> for String {
     type Error = SerializedBytesError;
     fn try_from(component: &Component) -> Result<Self, Self::Error> {
@@ -273,14 +273,12 @@ impl TryInto<String> for Path {
 }
 
 impl Path {
-    /// Attach a [`LinkType`] to this path
-    /// so its type is known for [`create_link`] and [`get_links`].
+    /// Attach a [`LinkType`] to this path so its type is known for test utility functions.
     pub fn into_typed(self, link_type: impl Into<ScopedLinkType>) -> TypedPath {
         TypedPath::new(link_type, self)
     }
 
-    /// Try attaching a [`LinkType`] to this path
-    /// so its type is known for [`create_link`] and [`get_links`].
+    /// Try attaching a [`LinkType`] to this path so its type is known for test utility functions.
     pub fn typed<TY, E>(self, link_type: TY) -> Result<TypedPath, WasmError>
     where
         ScopedLinkType: TryFrom<TY, Error = E>,
@@ -288,7 +286,7 @@ impl Path {
     {
         Ok(TypedPath::new(ScopedLinkType::try_from(link_type)?, self))
     }
-    /// What is the hash for the current [ `Path` ]?
+    /// What is the hash for the current [`Path`]?
     pub fn path_entry_hash(&self) -> ExternResult<holo_hash::EntryHash> {
         hash_entry(Entry::App(AppEntryBytes(
             SerializedBytes::try_from(self).map_err(|e| wasm_error!(e))?,

--- a/crates/hdi/src/hash_path/path.rs
+++ b/crates/hdi/src/hash_path/path.rs
@@ -66,9 +66,9 @@ impl From<Component> for Vec<u8> {
 /// sharding based on strings by iterating over u32s rather than deciding what to do with variable
 /// width u8 or u16 characters.
 ///
-/// IMPORTANT: if you are not using sharding and make heavy use of `Path` then
-/// consider building your `Component` directly from `my_string.as_bytes()` to
-/// achieve much more compact utf8 representations of each `Component`.
+/// IMPORTANT: if you are not using sharding and make heavy use of [`Path`] then
+/// consider building your [`Component`] directly from `my_string.as_bytes()` to
+/// achieve much more compact utf8 representations of each [`Component`].
 impl From<&str> for Component {
     fn from(s: &str) -> Self {
         let bytes: Vec<u8> = s
@@ -293,14 +293,14 @@ impl Path {
         )))
     }
 
-    /// Mutate this `Path` into a child of itself by appending a `Component`.
+    /// Mutate this [`Path`] into a child of itself by appending a [`Component`].
     pub fn append_component(&mut self, component: Component) {
         self.0.push(component);
     }
 
-    /// Accessor for the last `Component` of this `Path`.
+    /// Accessor for the last [`Component`] of this [`Path`].
     /// This can be thought of as the leaf of the implied tree structure of
-    /// which this `Path` is one branch of.
+    /// which this [`Path`] is one branch of.
     pub fn leaf(&self) -> Option<&Component> {
         self.0.last()
     }

--- a/crates/hdi/src/hash_path/shard.rs
+++ b/crates/hdi/src/hash_path/shard.rs
@@ -22,7 +22,7 @@ pub type ShardDepth = u32;
 /// @todo stretch short shards out in a nice balanced way (append some bytes from the hash?)
 pub struct ShardStrategy(ShardWidth, ShardDepth);
 
-/// impl [ `ShardStrategy` ] as an immutable/read-only thingy.
+/// impl [`ShardStrategy`] as an immutable/read-only thingy.
 impl ShardStrategy {
     fn width(&self) -> ShardWidth {
         self.0
@@ -104,7 +104,7 @@ impl From<(&ShardStrategy, &[u8])> for Path {
     fn from((strategy, bytes): (&ShardStrategy, &[u8])) -> Path {
         let full_length = strategy.width() * strategy.depth();
         // Fold a flat slice of bytes into `strategy.depth` number of `strategy.width` length byte
-        // [ `Component` ]s.
+        // [`Component`]s.
         let sharded: Vec<Component> = bytes
             .iter()
             .take(full_length as _)
@@ -141,7 +141,7 @@ impl From<(&ShardStrategy, Vec<u8>)> for Path {
         Path::from((strategy, bytes))
     }
 }
-/// Create [ `Path` ] from [ `String` ].
+/// Create [`Path`] from [`String`].
 /// To ensure that this works for all utf8, which can have anywhere from 1-4 bytes for a single
 /// character, we first represent each character as a utf32 so it gets padded out with 0 bytes.
 /// This means the width is 4x what it would be for raw bytes with the same strategy.

--- a/crates/hdi/src/info.rs
+++ b/crates/hdi/src/info.rs
@@ -1,7 +1,7 @@
 use crate::prelude::*;
 
 /// Get the DNA information.
-/// There are no inputs to [ `dna_info` ].
+/// There are no inputs to [`dna_info`].
 ///
 /// DNA information includes dna name, hash, properties, and zome names.
 pub fn dna_info() -> ExternResult<DnaInfo> {
@@ -9,7 +9,7 @@ pub fn dna_info() -> ExternResult<DnaInfo> {
 }
 
 /// Get the zome information.
-/// There are no inputs to [ `zome_info` ].
+/// There are no inputs to [`zome_info`].
 ///
 /// Zome information includes zome name, id and properties.
 ///

--- a/crates/hdi/src/lib.rs
+++ b/crates/hdi/src/lib.rs
@@ -315,7 +315,7 @@ pub mod info;
 /// The functions and structs in this module do _not_ need to be used directly.
 /// The `#[hdk_extern]` attribute on functions exposed externally all set the `WasmSubscriber` as the global default.
 ///
-/// This module defines a [ `trace::WasmSubscriber` ] that forwards all tracing macro calls to another subscriber on the host.
+/// This module defines a [`trace::WasmSubscriber`] that forwards all tracing macro calls to another subscriber on the host.
 /// The logging level can be changed for the host at runtime using the `WASM_LOG` environment variable that works exactly as `RUST_LOG` for other tracing.
 pub mod trace;
 

--- a/crates/hdi/src/lib.rs
+++ b/crates/hdi/src/lib.rs
@@ -54,11 +54,13 @@
 //! All of these validation rules are declared in the `validate` callback. It
 //! is executed for a new action by each validation authority.
 //!
-//! There's a helper type called [`FlatOp`](crate::flat_op::FlatOp) available for easy
-//! access to all link and entry variants when validating an operation. In many cases, this type can
-//! be easier to work with than the bare [`Op`](crate::prelude::holochain_integrity_types::Op).
-//! `FlatOp` contains the same information as `Op` but with a flatter, more accessible data structure
-//! than `Op`'s deeply nested and concise structure.
+//! There's a helper type called [`FlatOp`](crate::flat_op::FlatOp) available for easy access to
+//! all link and entry variants when validating an operation. In many cases, this type can be
+//! easier to work with than the bare [`Op`](crate::prelude::holochain_integrity_types::Op).
+//! [`FlatOp`](crate::flat_op::FlatOp) contains the same information as
+//! [`Op`](crate::prelude::holochain_integrity_types::Op) but with a flatter, more accessible data
+//! structure than [`Op`](crate::prelude::holochain_integrity_types::Op)'s deeply nested and
+//! concise structure.
 //!
 //! ```
 //! # #[cfg(not(feature = "test_utils"))]
@@ -236,7 +238,7 @@ pub mod hash_path;
 ///
 /// - Have a globally unique name
 /// - Accept `serde::Serialize + std::fmt::Debug` input
-/// - Return `Result<O, WasmError>` (`ExternResult`) output where `O: serde::Serialize + std::fmt::Debug`
+/// - Return [`Result<O, WasmError>`] ([`map_extern::ExternResult`]) output where `O: serde::Serialize + std::fmt::Debug`
 ///
 /// This module only defines macros so check the HDI crate root to see more documentation.
 ///
@@ -313,15 +315,18 @@ pub mod info;
 /// Integrates HDI with the Rust tracing crate.
 ///
 /// The functions and structs in this module do _not_ need to be used directly.
-/// The `#[hdk_extern]` attribute on functions exposed externally all set the `WasmSubscriber` as the global default.
+/// The `#[hdk_extern]` attribute on functions exposed externally all set the
+/// [`trace::WasmSubscriber`] as the global default.
 ///
-/// This module defines a [`trace::WasmSubscriber`] that forwards all tracing macro calls to another subscriber on the host.
-/// The logging level can be changed for the host at runtime using the `WASM_LOG` environment variable that works exactly as `RUST_LOG` for other tracing.
+/// This module defines a [`trace::WasmSubscriber`] that forwards all tracing macro calls to
+/// another subscriber on the host.
+/// The logging level can be changed for the host at runtime using the `WASM_LOG` environment
+/// variable that works exactly as `RUST_LOG` for other tracing.
 pub mod trace;
 
-/// The interface between the host and guest is implemented as an `HdiT` trait.
+/// The interface between the host and guest is implemented as an [`hdi::HdiT`] trait.
 ///
-/// The `set_hdi` function globally sets a `RefCell` to track the current HDI implementation.
+/// The [`hdi::set_hdi`] function globally sets a [`std::cell::RefCell`] to track the current HDI implementation.
 /// When the `mock` feature is set then this will default to an HDI that always errors, else a WASM host is assumed to exist.
 /// The `mockall` crate (in prelude with `mock` feature) can be used to generate compatible mocks for unit testing.
 /// See mocking examples in the test WASMs crate, such as `agent_info`.

--- a/crates/hdi/src/map_extern.rs
+++ b/crates/hdi/src/map_extern.rs
@@ -110,5 +110,5 @@ macro_rules! map_extern_infallible {
     }
 }
 
-/// Every extern _must_ return a `WasmError` in the case of failure.
+/// Every extern _must_ return a [`WasmError`] in the case of failure.
 pub type ExternResult<T> = Result<T, WasmError>;

--- a/crates/hdi/src/x_salsa20_poly1305.rs
+++ b/crates/hdi/src/x_salsa20_poly1305.rs
@@ -24,7 +24,7 @@ pub fn x_salsa20_poly1305_decrypt(
 ///
 /// Opens encrypted data created by box.
 ///
-/// If the encrypted data fails authentication and cannot be decrypted this function returns [ `None` ].
+/// If the encrypted data fails authentication and cannot be decrypted this function returns [`None`].
 ///
 /// This means that if any decrypted data is returned by this function it was created by _either_
 /// keypair and has not been tampered with.


### PR DESCRIPTION
### Summary
This is part of #3554 and serves to fix broken and malformed links as well as add missing links to known types in the HDI crate.

I also formatted the comments where I was fixing the links.

Closes #4539


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs