### PR TITLE
Add empty 0.4 version and deprecation messages

### DIFF
--- a/nix/modules/devShells.nix
+++ b/nix/modules/devShells.nix
@@ -32,7 +32,7 @@
                 echo "Alternatively, you can use the quickstart guide provided with the updated Holonix: https://github.com/holochain/holonix"
                 exit 1;
             '';
-          } else pkgs.mkShell {
+          } else lib.warn "\n\nThis version of Holonix is being deprecated, please consider migrating: https://developer.holochain.org/resources/upgrade/upgrade-new-holonix/" pkgs.mkShell {
             inputsFrom = [ self'.devShells.rustDev ];
             packages = (holonixPackages { inherit holochainOverrides; }) ++ [ hn-introspect ];
             shellHook = ''

--- a/versions/0_4/flake.lock
+++ b/versions/0_4/flake.lock
@@ -1,0 +1,7 @@
+{
+  "nodes": {
+    "root": {}
+  },
+  "root": "root",
+  "version": 7
+}

--- a/versions/0_4/flake.nix
+++ b/versions/0_4/flake.nix
@@ -1,0 +1,31 @@
+{
+  inputs =
+    {
+      holochain = {
+        url = "github:holochain/holochain/holochain-0.4.0-rc.2";
+        flake = false;
+      };
+
+      lair = {
+        url = "github:holochain/lair/lair_keystore-v0.5.3";
+        flake = false;
+      };
+
+      # holochain_cli_launch
+      launcher = {
+        url = "github:holochain/hc-launch/holochain-0.4";
+        flake = false;
+      };
+
+      # holochain_scaffolding_cli
+      scaffolding = {
+        url = "github:holochain/scaffolding/holochain-0.4";
+        flake = false;
+      };
+    };
+
+  outputs = { ... }: {
+    stub = true;
+    rustVersion = "1.80.1";
+  };
+}


### PR DESCRIPTION
### Summary

Using an existing version 

```terminal
$ nix develop --override-input versions ./versions/0_3 .#holonix
warning: not writing modified lock file of flake 'git+file:///Users/thetasinner/source/holochain':
• Updated input 'versions':
    'github:holochain/holochain/5c4dbe1828d0ebd67afda3f17e16192a91f321a2?dir=versions/0_3&narHash=sha256-6458g33e72eCkupEyU3pkFlaaoRICGn%2BKu7W9a07N%2B0%3D' (2024-12-06)
  → 'git+file:///Users/thetasinner/source/holochain?dir=versions/0_3&ref=refs/heads/provide-empty-0.4-version&rev=77c117b33f4fcecc17f211cecd6bff5f63ffde92' (2024-12-23)
evaluation warning:

                    This version of Holonix is being deprecated, please consider migrating: https://developer.holochain.org/resources/upgrade/upgrade-new-holonix/
Rust development shell spawned. Type exit to leave.
Holochain development shell spawned. Type exit to leave.

[holonix:~/source/holochain]$
```

and then trying to use 0.4

```terminal
$ nix develop --override-input versions ./versions/0_4 .#holonix
warning: not writing modified lock file of flake 'git+file:///Users/thetasinner/source/holochain':
• Updated input 'versions':
    'github:holochain/holochain/5c4dbe1828d0ebd67afda3f17e16192a91f321a2?dir=versions/0_3&narHash=sha256-6458g33e72eCkupEyU3pkFlaaoRICGn%2BKu7W9a07N%2B0%3D' (2024-12-06)
  → 'git+file:///Users/thetasinner/source/holochain?dir=versions/0_4&ref=refs/heads/provide-empty-0.4-version&rev=6e2319d017aa3fc81304758ccc9d7cf2c60c371a' (2024-12-23)
• Updated input 'versions/holochain':
    'github:holochain/holochain/eba9927d03edd8f27a827f8cc0026916b493c9ea?narHash=sha256-fDDdYFkkN1kJA32vVF%2BHKIbLCZTaMBPmZYah9iqB18E%3D' (2024-12-02)
  → 'github:holochain/holochain/662cbcc45a685425355f5e3682c080a101271dfa?narHash=sha256-p123iaQbIY7bkJWnRab3saVNTOBWwl4N6Sz1sYMPAWQ%3D' (2024-11-28)
• Updated input 'versions/lair':
    'github:holochain/lair/6e8938a1d574bd2f8d2f66d1983b58951d700774?narHash=sha256-kpMkLPHEAarG6MPFdJMQQnTk7YkXk9mFcWLyvbBEUVo%3D' (2024-11-27)
  → 'github:holochain/lair/e82937521ae9b7bdb30c8b0736c13cd4220a0223?narHash=sha256-D8sXIpOptaXib5bc6zS7KsGzu4D08jaL8Fx1W/mlADE%3D' (2024-11-27)
• Updated input 'versions/launcher':
    'github:holochain/hc-launch/f6f980801f820f036ef133b6dc31efbef6dd0f99?narHash=sha256-/UpB%2BzK5Yqhpoo%2B6I%2B4yl7D0DPTmh5gOOzipakjpJAA%3D' (2024-12-03)
  → 'github:holochain/hc-launch/ca598033225d8ee3df7911c1cbde6004182e84eb?narHash=sha256-OtXwvb97Qt%2Bxh/K4%2Bvoy60kMnpPZvEoqoe2Bgkn%2BNro%3D' (2024-12-17)
• Updated input 'versions/scaffolding':
    'github:holochain/scaffolding/4d97985a8a93db93c25326a4d75aac0a3ea40a06?narHash=sha256-X7MUZ6wXPcsF6cFC4AK27UiUWpVzhdlrnL%2B1znfzVfM%3D' (2024-12-05)
  → 'github:holochain/scaffolding/13c57210109e4df44b3ea9ae88013d95dc6c399d?narHash=sha256-nJkYMXTM6tDXuPEjnlT/z8mRM3S9i1latFSZ4ABhy0M%3D' (2024-12-20)
This Holochain version is not supported on the current Holonix version. Please migrate to the new Holonix
See the instructions here: https://developer.holochain.org/resources/upgrade/upgrade-new-holonix/
Alternatively, you can use the quickstart guide provided with the updated Holonix: https://github.com/holochain/holonix

$
```

So you get some messages with links and then are dropped back to the shell you started the `nix develop` command from. It does pull the source code for our projects but it doesn't attempt to build anything. That's to do with the source cleaning and I don't fancy fixing that. It is pretty quick to get the message back though so I think that's okay even if there is some waste going on behind the scenes.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs