### PR TITLE
Remove intel mac from Holonix

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Remove support for x86_64-darwin in Holonix. This is becoming hard to support in this version of Holonix. If you are
+  relying on support for a mac with an Intel chip then please migrate to the new [Holonix](https://github.com/holochain/holonix?tab=readme-ov-file#holonix) 
 - Add two new commands to the `hc sandbox` for authenticating and making zome calls to a running conductor. See the sandbox documentation for usage instructions. #4587
 - Update `holochain_wasmer_host`, remove temporary fork of wasmer and update wasmer to 5.x.
 - Disable wasmer module caching when using the feature flag `wasmer_wamr`, as caching is not relevevant when wasms are interpreted.

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,7 @@
   outputs = inputs @ { self, nixpkgs, flake-parts, ... }:
     # all possible parameters for a module: https://flake.parts/module-arguments.html#top-level-module-arguments
     flake-parts.lib.mkFlake { inherit inputs; } {
-      systems = [ "aarch64-darwin" "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
+      systems = [ "aarch64-darwin" "x86_64-linux" "aarch64-linux" ];
 
       imports =
         # auto import all nix code from `./modules`, treat each one as a flake and merge them


### PR DESCRIPTION
### Summary

This is currently broken, we can't figure out how to fix it, and we have a working solution which is just to use the new Holonix. This will make it more obvious to anyone on an Intel mac that Holonix isn't supported. Rather than spending hours trying to enter a shell and then getting a build failure that they might try to investigate, they will just be told they're on an unsupported platform right away.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs