### PR TITLE
Stop caching x86_64-darwin, no longer supported

### DIFF
--- a/.github/workflows/holonix-cache.yml
+++ b/.github/workflows/holonix-cache.yml
@@ -25,7 +25,6 @@ jobs:
           - "--refresh --override-input versions github:holochain/holochain?dir=versions/0_4_rc"
           - "--refresh --override-input versions github:holochain/holochain?dir=versions/weekly"
         platform:
-          - x86_64-darwin
           - aarch64-darwin
           - x86_64-linux
 
@@ -82,7 +81,6 @@ jobs:
           - "--refresh --override-input versions github:holochain/holochain?dir=versions/0_3_rc"
           - "--refresh --override-input versions github:holochain/holochain?dir=versions/weekly"
         platform:
-          - x86_64-darwin
           - aarch64-darwin
           - x86_64-linux
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary

Follow up from #4610, I meant to do both at the same time

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs