### PR TITLE
fix: backport DHT cache fix from #4464

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,6 +3338,7 @@ dependencies = [
  "serde_json",
  "shrinkwraprs",
  "tempfile",
+ "test-case",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -6,6 +6,7 @@ default_semver_increment_mode: !pre_patch rc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Fix issue where genesis actions weren't integrated when others were ready to integrate. When nothing had been integrated yet then we started integration at the value of how many ops were `ready_to_integrate` so if we had other ops that were ready then the range started at them instead of at genesis (index 0).
 
 ## 0.4.1-rc.1
 

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -70,6 +70,7 @@ matches = "0.1.8"
 pretty_assertions = "1.4"
 
 tempfile = "3.3"
+test-case = "3.3.1"
 
 [lints]
 workspace = true

--- a/crates/holochain_types/src/db_cache.rs
+++ b/crates/holochain_types/src/db_cache.rs
@@ -184,13 +184,14 @@ impl DhtDbQueryCache {
                     let ready_to_integrate = bounds.ready_to_integrate?;
 
                     // The start of the range will be one more then the last integrated item or
-                    // if there is nothing integrated then the start will be also the ready_to_integrate.
-                    // This is why we use an inclusive range.
+                    // if there is nothing integrated then the start will be `0`.
+                    // We use an inclusive range in case there is only one item to be integrated
+                    // and so the start and end indices are the same.
                     let start = bounds
                         .integrated
                         .and_then(|i| i.checked_add(1))
                         .filter(|i_prime| *i_prime <= ready_to_integrate)
-                        .unwrap_or(ready_to_integrate);
+                        .unwrap_or_default();
                     Some((agent.clone(), start..=ready_to_integrate))
                 })
                 .collect()


### PR DESCRIPTION
### Summary

Backport of the DHT cache fix where genesis operations were missed if other ops were read to integrate before genesis ops were integrated.

Original fix in #4464.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs