### PR TITLE
test: AdminRequest::DumpConductorState smoke test

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix issue where genesis actions weren't integrated when others were ready to integrate. When nothing had been integrated yet then we started integration at the value of how many ops were `ready_to_integrate` so if we had other ops that were ready then the range started at them instead of at genesis (index 0).
 - Update `await_consistency` test utility function so that it prints every inconsistent agent when it fails instead of just the first one.
 - Rename the SQL queries that are used to set `RegisterAddLink` and `RegisterRemoveLink` ops to integrated
+- Add smoke test for `AdminRequest::DumpConductorState`
 
 ## 0.5.0-dev.15
 


### PR DESCRIPTION
### Summary
Smoke test to exercise `AdminRequest::DumpConductorState`

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs