### PR TITLE
fix: flaky `unlock_timeout_session` test

### DIFF
--- a/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
@@ -229,7 +229,61 @@ pub mod wasm_test {
                 vec![alice_response.clone(), bob_response.clone()],
             )
             .await;
+
         expect_error_for_write_without_lock(bob_result);
+
+        // @TODO - the following three zome calls all pass but perhaps we do NOT want them to?
+        // @TODO updated: You can no longer get these entries after the session has expired but
+        //       this comment is still relevant during the session, once a commit has been done
+        //       and before the session has timed out.
+        // It's not immediately clear what direct requests by hash should do in all cases here.
+        //
+        // If an author does a must_get during a zome call like we do in this test, should it
+        // be returned (it's in the scratch ready to be flushed so it does atm) even though it
+        // hasn't been countersigned and so may never be included in a source chain?
+        //
+        // Should it be returned in subsequent zome calls by an author who has signed it but it
+        // hasn't been coauthored yet, but the session is still active? (c.f. private entries being visible to author)
+        // What about after the session?
+        //
+        // What about returned by/for coauthors who do NOT sign during and after the session?
+        //
+        // What about everyone else during and after the session?
+        //
+        // The answer to the above may be different per call, idk at this point.
+        // Seems intuitive that an action that is in nobody's agent activity should never be visible
+        // but then how can you get the entry hash and entry data during the session, like we do in this test?
+        //
+        // Maybe it also seems intuitive that must_get_entry should return the entry as we know its
+        // hash and normally must_get ignores validity or even which headers created it, but what if NO
+        // headers created it?
+        //
+        // etc. etc. I'm just leaving this commentary here to germinate future headaches and self doubt.
+        conductor
+            .call_fallible::<_, SignedActionHashed>(
+                &alice,
+                "must_get_action",
+                countersigned_action_hash_alice.clone(),
+            )
+            .await
+            .unwrap();
+
+        conductor
+            .call_fallible::<_, Record>(
+                &alice,
+                "must_get_valid_record",
+                countersigned_action_hash_alice.clone(),
+            )
+            .await
+            .unwrap();
+        conductor
+            .call_fallible::<_, EntryHashed>(
+                &alice,
+                "must_get_entry",
+                countersigned_entry_hash_alice.clone(),
+            )
+            .await
+            .unwrap();
 
         // At this point Alice's session entry is a liability so can't exist.
         let alice_agent_activity_alice_observed_after: AgentActivity = conductor
@@ -293,59 +347,6 @@ pub mod wasm_test {
             bob_agent_activity_bob_observed_before,
             bob_agent_activity_bob_observed_after
         );
-
-        // @TODO - the following all pass but perhaps we do NOT want them to?
-        // @TODO updated: You can no longer get these entries after the session has expired but
-        //       this comment is still relevant during the session, once a commit has been done
-        //       and before the session has timed out.
-        // It's not immediately clear what direct requests by hash should do in all cases here.
-        //
-        // If an author does a must_get during a zome call like we do in this test, should it
-        // be returned (it's in the scratch ready to be flushed so it does atm) even though it
-        // hasn't been countersigned and so may never be included in a source chain?
-        //
-        // Should it be returned in subsequent zome calls by an author who has signed it but it
-        // hasn't been coauthored yet, but the session is still active? (c.f. private entries being visible to author)
-        // What about after the session?
-        //
-        // What about returned by/for coauthors who do NOT sign during and after the session?
-        //
-        // What about everyone else during and after the session?
-        //
-        // The answer to the above may be different per call, idk at this point.
-        // Seems intuitive that an action that is in nobody's agent activity should never be visible
-        // but then how can you get the entry hash and entry data during the session, like we do in this test?
-        //
-        // Maybe it also seems intuitive that must_get_entry should return the entry as we know its
-        // hash and normally must_get ignores validity or even which headers created it, but what if NO
-        // headers created it?
-        //
-        // etc. etc. I'm just leaving this commentary here to germinate future headaches and self doubt.
-        conductor
-            .call_fallible::<_, SignedActionHashed>(
-                &alice,
-                "must_get_action",
-                countersigned_action_hash_alice.clone(),
-            )
-            .await
-            .unwrap();
-
-        conductor
-            .call_fallible::<_, Record>(
-                &alice,
-                "must_get_valid_record",
-                countersigned_action_hash_alice.clone(),
-            )
-            .await
-            .unwrap();
-        conductor
-            .call_fallible::<_, EntryHashed>(
-                &alice,
-                "must_get_entry",
-                countersigned_entry_hash_alice.clone(),
-            )
-            .await
-            .unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
### Summary

Moves the `must_get_*` zome calls to before the timeout has passed to test that they can be retrieved as long as the session id active.


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs