### PR TITLE
Fix: AdminRequest::DumpConductorState fails when there is an AppInterface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2806,6 +2806,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serde_with",
  "serde_yaml",
  "shrinkwraprs",
  "sodoken 0.0.11",

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix issue where genesis actions weren't integrated when others were ready to integrate. When nothing had been integrated yet then we started integration at the value of how many ops were `ready_to_integrate` so if we had other ops that were ready then the range started at them instead of at genesis (index 0).
 - Update `await_consistency` test utility function so that it prints every inconsistent agent when it fails instead of just the first one.
 - Rename the SQL queries that are used to set `RegisterAddLink` and `RegisterRemoveLink` ops to integrated
+- Add smoke test for `AdminRequest::DumpConductorState`
 
 ## 0.5.0-dev.15
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Update `await_consistency` test utility function so that it prints every inconsistent agent when it fails instead of just the first one.
 - Rename the SQL queries that are used to set `RegisterAddLink` and `RegisterRemoveLink` ops to integrated
 - Add smoke test for `AdminRequest::DumpConductorState`
+- Fix issue where `AdminRequest::DumpConductorState` fails when the conductor has an `AppInterface` attached.
 
 ## 0.5.0-dev.15
 

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -75,6 +75,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.12"
 serde_json = { version = "1.0.51", features = ["preserve_order"] }
 serde_yaml = "0.9"
+serde_with = { version = "3.12.0", features = ["json"] }
 shrinkwraprs = "0.3.0"
 sodoken = "=0.0.11"
 structopt = "0.3.11"

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -226,7 +226,7 @@ pub(crate) type StopReceiver = task_motel::StopListener;
 /// A Conductor is a group of [Cell]s
 pub struct Conductor {
     /// The collection of available, running cells associated with this Conductor
-    running_cells: RwShare<HashMap<CellId, CellItem>>,
+    running_cells: RwShare<IndexMap<CellId, CellItem>>,
 
     /// The config used to create this Conductor
     pub config: Arc<ConductorConfig>,
@@ -324,7 +324,7 @@ mod startup_shutdown_impls {
 
             Self {
                 spaces,
-                running_cells: RwShare::new(HashMap::new()),
+                running_cells: RwShare::new(IndexMap::new()),
                 config,
                 shutting_down: Arc::new(AtomicBool::new(false)),
                 task_manager: TaskManagerClient::new(outcome_sender, tracing_scope),

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -1228,9 +1228,6 @@ mod test {
         .await;
         let dna_hash = dna.dna_hash();
 
-        // Allow agents time to join
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-
         #[derive(Serialize, Debug)]
         pub struct ConductorSerialized {
             running_cells: Vec<(DnaHashB64, AgentPubKeyB64)>,

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -370,16 +370,8 @@ impl InstalledApp {
     }
 }
 
-impl automap::AutoMapped for InstalledApp {
-    type Key = InstalledAppId;
-
-    fn key(&self) -> &Self::Key {
-        &self.app.installed_app_id
-    }
-}
-
 /// A map from InstalledAppId -> InstalledApp
-pub type InstalledAppMap = automap::AutoHashMap<InstalledApp>;
+pub type InstalledAppMap = IndexMap<InstalledAppId, InstalledApp>;
 
 /// An active app
 #[derive(


### PR DESCRIPTION
### Summary
Resolves #4480 

(Supersedes #4646)


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs