### PR TITLE
[fix] Don't recommend multiple dependencies in DNA manifest

### DIFF
--- a/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
+++ b/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
@@ -34,12 +34,14 @@ use serde_with::serde_as;
 ///     - name: zome4
 ///       bundled: ../dna2/zomes/zome2.wasm
 ///       dependencies:
-///         - name: zome1
 ///         - name: zome2
 /// ```
 ///
 /// When there's only one integrity zome, it will automatically be a dependency
 /// of the coordinator zomes. It doesn't need to be specified explicitly.
+///
+/// Note that while the `dependencies` field is a list, right now there should
+/// be **at most one item in this list**.
 ///
 /// ```yaml
 /// manifest_version: "1"
@@ -172,9 +174,8 @@ pub struct ZomeManifest {
     #[serde(flatten)]
     pub location: ZomeLocation,
 
-    /// The integrity zomes this zome depends on.
-    /// The order of these must match the order the types
-    /// are used in the zome.
+    /// The integrity zomes this zome depends on, if it's a coordinator zome.
+    /// Currently a coordinator zome should have **at most one dependency**.
     pub dependencies: Option<Vec<ZomeDependency>>,
 
     /// DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.

--- a/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
+++ b/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v1.rs
@@ -174,7 +174,9 @@ pub struct ZomeManifest {
     #[serde(flatten)]
     pub location: ZomeLocation,
 
-    /// The integrity zomes this zome depends on, if it's a coordinator zome.
+    /// The integrity zomes this zome depends on.
+    /// Integrity zomes should have no dependencies; leave this field `null`.
+    /// Coordinator zomes may depend on zero or exactly 1 integrity zome.
     /// Currently a coordinator zome should have **at most one dependency**.
     pub dependencies: Option<Vec<ZomeDependency>>,
 


### PR DESCRIPTION
### Summary

The documentation for `DnaManifestV1` demonstrates that a coordinator zome can have multiple integrity dependencies, yet this doesn't work ( #4660 ) for dependency 2 and onwards. This tiny PR removes the second dep in the example YAML and warns people against trying to list more than one dep.

### TODO:

- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs