### PR TITLE
fix: Replace `tiny-keccak` with `sha3` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2820,6 +2820,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "sha3",
  "shrinkwraprs",
  "sodoken 0.0.11",
  "structopt",
@@ -2829,7 +2830,6 @@ dependencies = [
  "tempfile",
  "test-case",
  "thiserror 1.0.69",
- "tiny-keccak",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -3084,7 +3084,7 @@ dependencies = [
  "holochain_util",
  "kitsune_p2p_timestamp",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive 0.5.1",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -3388,7 +3388,7 @@ dependencies = [
  "parking_lot 0.12.3",
  "pretty_assertions",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive 0.5.1",
  "rand 0.8.5",
  "regex",
  "rusqlite",
@@ -3523,7 +3523,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "proptest",
- "proptest-derive 0.4.0",
+ "proptest-derive 0.5.1",
  "rand 0.8.5",
  "rusqlite",
  "serde",
@@ -4286,6 +4286,15 @@ dependencies = [
  "time",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "keccak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
+dependencies = [
+ "cpufeatures",
 ]
 
 [[package]]
@@ -7131,6 +7140,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest",
+ "keccak",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7832,15 +7851,6 @@ checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Replace `tiny-keccak` with `sha3` due to dependency on problematic `crunchy` crate
+
 ## 0.5.0-dev.17
 
 - added admin\_api capability\_grant\_info for getting a list of grants valid and revoked from the source chain

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -92,7 +92,7 @@ tracing-subscriber = "0.3.16"
 url = "2.4"
 url2 = "0.0.6"
 uuid = { version = "1.8", features = ["serde", "v4"] }
-tiny-keccak = { version = "2.0.2", features = ["keccak", "sha3"] }
+sha3 = "0.10"
 opentelemetry_api = { version = "=0.20.0", features = ["metrics"] }
 indexmap = { version = "2.6.0", features = ["serde"] }
 wasmer = { version = "5.0.2", default-features = false }

--- a/crates/holochain/src/core/ribosome/host_fn/hash.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/hash.rs
@@ -5,7 +5,7 @@ use holo_hash::HasHash;
 use holochain_wasmer_host::prelude::*;
 use holochain_zome_types::prelude::*;
 use std::sync::Arc;
-use tiny_keccak::{Hasher, Keccak, Sha3};
+use sha3::Digest;
 use wasmer::RuntimeError;
 
 pub fn hash(
@@ -26,18 +26,25 @@ pub fn hash(
             )?)
         }
         HashInput::Keccak256(data) => HashOutput::Keccak256({
-            let mut output = [0u8; 32];
-            let mut hasher = Keccak::v256();
-            hasher.update(data.as_ref());
-            hasher.finalize(&mut output);
-            output.into()
+            let mut hasher = sha3::Keccak256::new();
+            hasher.update(data);
+
+            hasher.finalize().as_slice().try_into().map_err(|e| {
+                wasm_error!(WasmErrorInner::Host(format!(
+                    "Failed to convert keccak256 output: {:?}",
+                    e
+                )))
+            })?
         }),
         HashInput::Sha3256(data) => HashOutput::Sha3256({
-            let mut output = [0u8; 32];
-            let mut hasher = Sha3::v256();
-            hasher.update(data.as_ref());
-            hasher.finalize(&mut output);
-            output.into()
+            let mut hasher = sha3::Sha3_256::new();
+            hasher.update(data);
+            hasher.finalize().as_slice().try_into().map_err(|e| {
+                wasm_error!(WasmErrorInner::Host(format!(
+                    "Failed to convert sha3-256 output: {:?}",
+                    e
+                )))
+            })?
         }),
         _ => {
             return Err(wasm_error!(WasmErrorInner::Host(format!(


### PR DESCRIPTION
### Summary

Replace `tiny-keccak` with `sha3` due to dependency on problematic `crunchy` crate.

Note that this only gets rid of `crunch` for release builds. It's still used as a dev dependency via `criterion`, but I don't think we need to cross-compile our tests :)

Related build failure -> https://github.com/holochain/binaries/actions/runs/13165372167/job/36785363299

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs