### PR TITLE
feat: add `Bytes` variant to `AppBundleSource` and deprecate `Bundle` variant

### DIFF
--- a/crates/hc_sandbox/examples/setup_5.rs
+++ b/crates/hc_sandbox/examples/setup_5.rs
@@ -55,12 +55,13 @@ async fn main() -> anyhow::Result<()> {
             CmdRunner::from_sandbox_with_bin_path(&input.holochain_path, path.clone()).await?;
 
         let bundle = AppBundleSource::Path(happ.clone()).resolve().await?;
+        let bundle_bytes = bundle.encode()?;
 
         // Create the raw InstallAppPayload request.
         let payload = InstallAppPayload {
             installed_app_id: Some(app_id),
             agent_key: None,
-            source: AppBundleSource::Bundle(bundle),
+            source: AppBundleSource::Bytes(bundle_bytes),
             roles_settings: Default::default(),
             network_seed: None,
             ignore_genesis_failure: false,

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -1210,12 +1210,13 @@ async fn test_deferred_memproof_provisioning() {
     let app_id = "app-id".to_string();
     let role_name = "role".to_string();
     let bundle = app_bundle_from_dnas(&[(role_name.clone(), dna)], true, None).await;
+    let bundle_bytes = bundle.encode().unwrap();
 
     //- Install with deferred memproofs
     let app = conductor
         .clone()
         .install_app_bundle(InstallAppPayload {
-            source: AppBundleSource::Bundle(bundle),
+            source: AppBundleSource::Bytes(bundle_bytes),
             agent_key: None,
             installed_app_id: Some(app_id.clone()),
             roles_settings: Default::default(),
@@ -1338,12 +1339,13 @@ async fn test_deferred_memproof_provisioning_uninstall() {
     let app_id = "app-id".to_string();
     let role_name = "role".to_string();
     let bundle = app_bundle_from_dnas(&[(role_name.clone(), dna)], true, None).await;
+    let bundle_bytes = bundle.encode().unwrap();
 
     //- Install with deferred memproofs
     conductor
         .clone()
         .install_app_bundle(InstallAppPayload {
-            source: AppBundleSource::Bundle(bundle),
+            source: AppBundleSource::Bytes(bundle_bytes),
             agent_key: None,
             installed_app_id: Some(app_id.clone()),
             roles_settings: Default::default(),

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -571,9 +571,12 @@ pub mod test {
 
         let (dna_file, _, _) =
             SweetDnaFile::unique_from_test_wasms(vec![TestWasm::PostCommitSignal]).await;
-        let app_bundle = app_bundle_from_dnas(&[dna_file.clone()], false, None).await;
+        let app_bundle = app_bundle_from_dnas(&[dna_file.clone()], false, None)
+            .await
+            .encode()
+            .expect("failed to encode app bundle as bytes");
         let request = AdminRequest::InstallApp(Box::new(InstallAppPayload {
-            source: AppBundleSource::Bundle(app_bundle),
+            source: AppBundleSource::Bytes(app_bundle),
             agent_key: None,
             installed_app_id: None,
             roles_settings: Default::default(),

--- a/crates/holochain/src/conductor/tests/install_app_bundle.rs
+++ b/crates/holochain/src/conductor/tests/install_app_bundle.rs
@@ -47,9 +47,10 @@ async fn clone_only_provisioning_creates_no_cell_and_allows_cloning() {
             .await
             .unwrap();
 
+        let bundle_bytes = bundle.encode().unwrap();
         InstallAppPayload {
             agent_key: None,
-            source: AppBundleSource::Bundle(bundle),
+            source: AppBundleSource::Bytes(bundle_bytes),
             installed_app_id: Some("app_1".into()),
             network_seed: None,
             roles_settings: Default::default(),
@@ -166,11 +167,12 @@ async fn reject_duplicate_app_for_same_agent() {
         .await
         .unwrap();
 
+    let bundle_bytes = bundle.encode().unwrap();
     let app = conductor
         .clone()
         .install_app_bundle(InstallAppPayload {
             agent_key: None,
-            source: AppBundleSource::Bundle(bundle),
+            source: AppBundleSource::Bytes(bundle_bytes),
             installed_app_id: Some("app_1".into()),
             network_seed: None,
             roles_settings: Default::default(),
@@ -187,10 +189,11 @@ async fn reject_duplicate_app_for_same_agent() {
     let bundle = AppBundle::new(manifest.clone().into(), resources, PathBuf::from("."))
         .await
         .unwrap();
+    let bundle_bytes = bundle.encode().unwrap();
     let duplicate_install_with_app_disabled = conductor
         .clone()
         .install_app_bundle(InstallAppPayload {
-            source: AppBundleSource::Bundle(bundle),
+            source: AppBundleSource::Bytes(bundle_bytes),
             agent_key: Some(alice.clone()),
             installed_app_id: Some("app_2".into()),
             roles_settings: Default::default(),
@@ -211,10 +214,11 @@ async fn reject_duplicate_app_for_same_agent() {
     let bundle = AppBundle::new(manifest.clone().into(), resources, PathBuf::from("."))
         .await
         .unwrap();
+    let bundle_bytes = bundle.encode().unwrap();
     let duplicate_install_with_app_enabled = conductor
         .clone()
         .install_app_bundle(InstallAppPayload {
-            source: AppBundleSource::Bundle(bundle),
+            source: AppBundleSource::Bytes(bundle_bytes),
             agent_key: Some(alice.clone()),
             installed_app_id: Some("app_2".into()),
             roles_settings: Default::default(),
@@ -232,10 +236,11 @@ async fn reject_duplicate_app_for_same_agent() {
     let bundle = AppBundle::new(manifest.into(), resources, PathBuf::from("."))
         .await
         .unwrap();
+    let bundle_bytes = bundle.encode().unwrap();
     let valid_install_of_second_app = conductor
         .clone()
         .install_app_bundle(InstallAppPayload {
-            source: AppBundleSource::Bundle(bundle),
+            source: AppBundleSource::Bytes(bundle_bytes),
             agent_key: Some(alice.clone()),
             installed_app_id: Some("app_2".into()),
             roles_settings: Default::default(),
@@ -282,11 +287,12 @@ async fn can_install_app_a_second_time_using_nothing_but_the_manifest_from_app_i
         .await
         .unwrap();
 
+    let bundle_bytes = bundle.encode().unwrap();
     conductor
         .clone()
         .install_app_bundle(InstallAppPayload {
             agent_key: None,
-            source: AppBundleSource::Bundle(bundle),
+            source: AppBundleSource::Bytes(bundle_bytes),
             installed_app_id: Some("app_1".into()),
             network_seed: Some("final seed".into()),
             roles_settings: Default::default(),
@@ -326,11 +332,12 @@ async fn can_install_app_a_second_time_using_nothing_but_the_manifest_from_app_i
         .await
         .unwrap();
 
+    let bundle_bytes = bundle.encode().unwrap();
     conductor
         .clone()
         .install_app_bundle(InstallAppPayload {
             agent_key: None,
-            source: AppBundleSource::Bundle(bundle),
+            source: AppBundleSource::Bytes(bundle_bytes),
             installed_app_id: Some("app_2".into()),
             network_seed: None,
             roles_settings: Default::default(),
@@ -440,7 +447,7 @@ async fn use_existing_integration() {
     let (dna1, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::WhoAmI]).await;
     let (dna2, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::WhoAmI]).await;
 
-    let bundle1 = {
+    let bundle1_bytes = {
         let path = PathBuf::from(format!("{}", dna1.dna_hash()));
 
         let roles = vec![AppRoleManifest {
@@ -468,9 +475,11 @@ async fn use_existing_integration() {
         AppBundle::new(manifest.clone().into(), resources, PathBuf::from("."))
             .await
             .unwrap()
+            .encode()
+            .unwrap()
     };
 
-    let bundle2 = |correct: bool| {
+    let bundle2_bytes = |correct: bool| {
         let dna2 = dna2.clone();
         async move {
             let path = PathBuf::from(format!("{}", dna2.dna_hash()));
@@ -517,6 +526,8 @@ async fn use_existing_integration() {
             AppBundle::new(manifest.clone().into(), resources, PathBuf::from("."))
                 .await
                 .unwrap()
+                .encode()
+                .unwrap()
         }
     };
 
@@ -525,7 +536,7 @@ async fn use_existing_integration() {
         .clone()
         .install_app_bundle(InstallAppPayload {
             agent_key: None,
-            source: AppBundleSource::Bundle(bundle1),
+            source: AppBundleSource::Bytes(bundle1_bytes),
             installed_app_id: Some("app_1".into()),
             network_seed: None,
             roles_settings: Default::default(),
@@ -541,7 +552,7 @@ async fn use_existing_integration() {
             .clone()
             .install_app_bundle(InstallAppPayload {
                 agent_key: None,
-                source: AppBundleSource::Bundle(bundle2(false).await),
+                source: AppBundleSource::Bytes(bundle2_bytes(false).await),
                 installed_app_id: Some("app_2".into()),
                 network_seed: None,
                 roles_settings: Default::default(),
@@ -562,7 +573,7 @@ async fn use_existing_integration() {
             .clone()
             .install_app_bundle(InstallAppPayload {
                 agent_key: None,
-                source: AppBundleSource::Bundle(bundle2(true).await),
+                source: AppBundleSource::Bytes(bundle2_bytes(true).await),
                 installed_app_id: Some("app_2".into()),
                 network_seed: None,
                 roles_settings: Default::default(),
@@ -595,7 +606,7 @@ async fn use_existing_integration() {
         .clone()
         .install_app_bundle(InstallAppPayload {
             agent_key: None,
-            source: AppBundleSource::Bundle(bundle2(true).await),
+            source: AppBundleSource::Bytes(bundle2_bytes(true).await),
             installed_app_id: Some("app_2".into()),
             network_seed: None,
             roles_settings: Some(HashMap::from([role_settings])),

--- a/crates/holochain/src/conductor/tests/network_seed_regression.rs
+++ b/crates/holochain/src/conductor/tests/network_seed_regression.rs
@@ -47,11 +47,15 @@ async fn network_seed_regression() {
             .unwrap()
     };
 
-    let bundle1 = AppBundle::new(manifest.clone().into(), vec![], PathBuf::from("."))
+    let bundle1_bytes = AppBundle::new(manifest.clone().into(), vec![], PathBuf::from("."))
         .await
+        .unwrap()
+        .encode()
         .unwrap();
-    let bundle2 = AppBundle::new(manifest.into(), vec![], PathBuf::from("."))
+    let bundle2_bytes = AppBundle::new(manifest.into(), vec![], PathBuf::from("."))
         .await
+        .unwrap()
+        .encode()
         .unwrap();
 
     // if both of these apps can be installed under the same agent, the
@@ -62,7 +66,7 @@ async fn network_seed_regression() {
         .clone()
         .install_app_bundle(InstallAppPayload {
             agent_key: None,
-            source: AppBundleSource::Bundle(bundle1),
+            source: AppBundleSource::Bytes(bundle1_bytes),
             installed_app_id: Some("no-seed".into()),
             network_seed: None,
             roles_settings: Default::default(),
@@ -76,7 +80,7 @@ async fn network_seed_regression() {
         .clone()
         .install_app_bundle(InstallAppPayload {
             agent_key: None,
-            source: AppBundleSource::Bundle(bundle2),
+            source: AppBundleSource::Bytes(bundle2_bytes),
             installed_app_id: Some("yes-seed".into()),
             network_seed: Some("seed".into()),
             roles_settings: Default::default(),
@@ -302,7 +306,10 @@ impl TestCase {
                 bundle.write_to_file(&happ_path).await.unwrap();
                 AppBundleSource::Path(happ_path)
             }
-            Location::Bundle => AppBundleSource::Bundle(bundle),
+            Location::Bundle => {
+                let bundle_bytes = bundle.encode().unwrap();
+                AppBundleSource::Bytes(bundle_bytes)
+            }
         };
 
         let app = common

--- a/crates/holochain/src/sweettest/sweet_app_installation.rs
+++ b/crates/holochain/src/sweettest/sweet_app_installation.rs
@@ -81,9 +81,12 @@ pub async fn get_install_app_payload_from_dnas(
             .collect(),
     );
 
+    let bundle_bytes = bundle
+        .encode()
+        .expect("failed to encode app bundle as bytes");
     InstallAppPayload {
         agent_key,
-        source: AppBundleSource::Bundle(bundle),
+        source: AppBundleSource::Bytes(bundle_bytes),
         installed_app_id: Some(installed_app_id.into()),
         network_seed: None,
         roles_settings,

--- a/crates/holochain/tests/tests/app_installation/mod.rs
+++ b/crates/holochain/tests/tests/app_installation/mod.rs
@@ -93,11 +93,12 @@ async fn can_install_app_with_custom_modifiers_overridden_correctly() {
 
     let network_seed_override = "overridden by network_seed field";
 
+    let bundle_bytes = bundle.encode().unwrap();
     conductor
         .clone()
         .install_app_bundle(InstallAppPayload {
             agent_key: None,
-            source: AppBundleSource::Bundle(bundle.clone()),
+            source: AppBundleSource::Bytes(bundle_bytes.clone()),
             installed_app_id: Some("app_0".into()),
             network_seed: Some(network_seed_override.into()),
             roles_settings: None,
@@ -111,7 +112,7 @@ async fn can_install_app_with_custom_modifiers_overridden_correctly() {
         .clone()
         .install_app_bundle(InstallAppPayload {
             agent_key: None,
-            source: AppBundleSource::Bundle(bundle.clone()),
+            source: AppBundleSource::Bytes(bundle_bytes),
             installed_app_id: Some("app_1".into()),
             network_seed: Some(network_seed_override.into()),
             roles_settings: Some(HashMap::from([role_settings])),
@@ -271,11 +272,12 @@ async fn install_app_with_custom_modifier_fields_none_does_not_override_existing
         },
     );
 
+    let bundle_bytes = bundle.encode().unwrap();
     conductor
         .clone()
         .install_app_bundle(InstallAppPayload {
             agent_key: None,
-            source: AppBundleSource::Bundle(bundle.clone()),
+            source: AppBundleSource::Bytes(bundle_bytes),
             installed_app_id: Some("app".into()),
             network_seed: None,
             roles_settings: Some(HashMap::from([role_settings])),
@@ -332,11 +334,12 @@ async fn installing_with_modifiers_for_non_existing_role_fails() {
         },
     );
 
+    let bundle_bytes = bundle.encode().unwrap();
     let result = conductor
         .clone()
         .install_app_bundle(InstallAppPayload {
             agent_key: None,
-            source: AppBundleSource::Bundle(bundle.clone()),
+            source: AppBundleSource::Bytes(bundle_bytes),
             installed_app_id: Some("app_3".into()),
             network_seed: Some("final seed".into()),
             roles_settings: Some(HashMap::from([role_settings])),
@@ -367,11 +370,12 @@ async fn providing_membrane_proof_overrides_deferred_provisioning() {
         },
     );
 
+    let bundle_bytes = bundle.encode().unwrap();
     //- Install with a membrane proof provided in the roles_settings
     let app = conductor
         .clone()
         .install_app_bundle(InstallAppPayload {
-            source: AppBundleSource::Bundle(bundle),
+            source: AppBundleSource::Bytes(bundle_bytes),
             agent_key: None,
             installed_app_id: Some(app_id.clone()),
             roles_settings: Some(HashMap::from([role_settings])),

--- a/crates/holochain/tests/tests/test_utils/mod.rs
+++ b/crates/holochain/tests/tests/test_utils/mod.rs
@@ -271,13 +271,15 @@ pub async fn register_and_install_dna_named(
 
     let resources = vec![(dna_path.clone(), dna_bundle)];
 
-    let bundle = AppBundle::new(manifest.clone().into(), resources, dna_path.clone())
+    let bundle_bytes = AppBundle::new(manifest.clone().into(), resources, dna_path.clone())
         .await
-        .unwrap();
+        .unwrap()
+        .encode()
+        .expect("failed to encode AppBundle to bytes");
 
     let payload = InstallAppPayload {
         agent_key: None,
-        source: AppBundleSource::Bundle(bundle),
+        source: AppBundleSource::Bytes(bundle_bytes),
         installed_app_id: Some(name),
         network_seed: None,
         roles_settings: Default::default(),

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 - Prevent "TODO" comments from being rendered in cargo docs.
+- Add `Bytes(Vec<u8>)` variant in `AppBundleSource`.
 
 ## 0.4.1
 

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## \[Unreleased\]
 - Prevent "TODO" comments from being rendered in cargo docs.
 - Add `Bytes(Vec<u8>)` variant in `AppBundleSource`.
+- Deprecated `Bundle` variant in `AppBundleSource`, to be replaced by `Bytes` variant.
 
 ## 0.4.1
 

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -7,6 +7,8 @@
 //! Each Cell maintains its own identity separate from any App.
 //! Access to Cells can be shared between different Apps.
 
+#![allow(deprecated)] // Remove warnings created by using serde on deprecated AppBundleSource::Bundle variant
+
 mod app_bundle;
 mod app_manifest;
 mod error;
@@ -236,6 +238,10 @@ impl Default for RoleSettings {
 #[serde(rename_all = "snake_case")]
 pub enum AppBundleSource {
     /// A bundle of an AppManifest and collection of DNAs
+    #[deprecated(
+        since = "0.4.2",
+        note = "Unsupported variant. Instead, encode an AppBundle to Vec<u8> and use Bytes variant."
+    )]
     Bundle(AppBundle),
     /// The raw bytes of an app bundle
     #[serde(with = "serde_bytes")]

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -237,6 +237,9 @@ impl Default for RoleSettings {
 pub enum AppBundleSource {
     /// A bundle of an AppManifest and collection of DNAs
     Bundle(AppBundle),
+    /// The raw bytes of an app bundle
+    #[serde(with = "serde_bytes")]
+    Bytes(Vec<u8>),
     /// A local file path
     Path(PathBuf),
     // /// A URL
@@ -248,6 +251,7 @@ impl AppBundleSource {
     pub async fn resolve(self) -> Result<AppBundle, AppBundleError> {
         Ok(match self {
             Self::Bundle(bundle) => bundle,
+            Self::Bytes(bytes) => AppBundle::decode(&bytes)?,
             Self::Path(path) => AppBundle::decode(&ffs::read(&path).await?)?,
             // Self::Url(url) => todo!("reqwest::get"),
         })

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -235,7 +235,7 @@ impl Default for RoleSettings {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AppBundleSource {
-    /// The actual serialized bytes of a bundle
+    /// A bundle of an AppManifest and collection of DNAs
     Bundle(AppBundle),
     /// A local file path
     Path(PathBuf),


### PR DESCRIPTION
### Summary

Backport of #4745 as part of #4651.
This adds `Bytes` as a variant to `AppBundleSource` and deprecates the `Bundle` variant.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs