### PR TITLE
feat: Add DNA hash to StorageInfo

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Add `DnaHash` to the `DnaStorageInfo` which is part of the `StorageInfo` response.
+
 ## 0.5.0-dev.21
 
 ## 0.5.0-dev.20

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1185,6 +1185,7 @@ mod network_impls {
                     .read_async(get_used_size)
                     .map_err(ConductorError::DatabaseError)
                     .await?,
+                dna_hash: dna_hash.clone(),
                 used_by: used_by.clone(),
             }))
         }

--- a/crates/holochain_conductor_api/src/storage_info.rs
+++ b/crates/holochain_conductor_api/src/storage_info.rs
@@ -9,6 +9,7 @@ pub struct DnaStorageInfo {
     pub dht_data_size_on_disk: usize,
     pub cache_data_size: usize,
     pub cache_data_size_on_disk: usize,
+    pub dna_hash: DnaHash,
     pub used_by: Vec<InstalledAppId>,
 }
 


### PR DESCRIPTION
### Summary

I think this was left out originally because you know what app the storage is for, but when you have multiple cells in an app, it's interesting to know which DNA is which.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs