### PR TITLE
fix: Fix storage info for empty databases

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Handle empty databases in `StorageInfo` request. Previously, if the database was empty, the request would return an error. #4756
 - Add `DnaHash` to the `DnaStorageInfo` which is part of the `StorageInfo` response.
 
 ## 0.5.0-dev.21

--- a/crates/holochain_sqlite/src/stats.rs
+++ b/crates/holochain_sqlite/src/stats.rs
@@ -1,8 +1,8 @@
-use rusqlite::OptionalExtension;
 use crate::{
     db::{DbKindT, Txn},
     error::DatabaseError,
 };
+use rusqlite::OptionalExtension;
 
 pub fn get_size_on_disk<K: DbKindT>(txn: &Txn<K>) -> Result<usize, DatabaseError> {
     Ok(txn

--- a/crates/holochain_sqlite/src/stats.rs
+++ b/crates/holochain_sqlite/src/stats.rs
@@ -1,3 +1,4 @@
+use rusqlite::OptionalExtension;
 use crate::{
     db::{DbKindT, Txn},
     error::DatabaseError,
@@ -5,18 +6,16 @@ use crate::{
 
 pub fn get_size_on_disk<K: DbKindT>(txn: &Txn<K>) -> Result<usize, DatabaseError> {
     Ok(txn
-        .query_row("select sum(pgsize) from dbstat", (), |r| {
-            r.get::<_, Option<usize>>(0)
-        })
+        .query_row("select sum(pgsize) from dbstat", (), |r| r.get(0))
+        .optional()
         .map_err(DatabaseError::SqliteError)?
         .unwrap_or_default())
 }
 
 pub fn get_used_size<K: DbKindT>(txn: &Txn<K>) -> Result<usize, DatabaseError> {
     Ok(txn
-        .query_row("select sum(pgsize - unused) from dbstat", (), |r| {
-            r.get::<_, Option<usize>>(0)
-        })
+        .query_row("select sum(pgsize - unused) from dbstat", (), |r| r.get(0))
+        .optional()
         .map_err(DatabaseError::SqliteError)?
         .unwrap_or_default())
 }

--- a/crates/holochain_sqlite/src/stats.rs
+++ b/crates/holochain_sqlite/src/stats.rs
@@ -4,11 +4,19 @@ use crate::{
 };
 
 pub fn get_size_on_disk<K: DbKindT>(txn: &Txn<K>) -> Result<usize, DatabaseError> {
-    txn.query_row("select sum(pgsize) from dbstat", (), |r| r.get(0))
-        .map_err(DatabaseError::SqliteError)
+    Ok(txn
+        .query_row("select sum(pgsize) from dbstat", (), |r| {
+            r.get::<_, Option<usize>>(0)
+        })
+        .map_err(DatabaseError::SqliteError)?
+        .unwrap_or_default())
 }
 
 pub fn get_used_size<K: DbKindT>(txn: &Txn<K>) -> Result<usize, DatabaseError> {
-    txn.query_row("select sum(pgsize - unused) from dbstat", (), |r| r.get(0))
-        .map_err(DatabaseError::SqliteError)
+    Ok(txn
+        .query_row("select sum(pgsize - unused) from dbstat", (), |r| {
+            r.get::<_, Option<usize>>(0)
+        })
+        .map_err(DatabaseError::SqliteError)?
+        .unwrap_or_default())
 }


### PR DESCRIPTION
### Summary

The SQL function `sum` returns NULL when there are no non-null rows. So a single empty database prevents the storage info response for all cells.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs