### PR TITLE
chore: remove redundant words in comment

### DIFF
--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -12,11 +12,11 @@
 //! Checks that you can rely on sys validation having performed are:
 //! - For a [`ChainOp::StoreRecord`]
 //!    - Check that the [`Action`] is either a [`Action::Dna`] at sequence number 0, or has a previous action with sequence number strictly greater than 0.
-//!    - If the [`Entry`] is an [`Entry::CounterSign`], then the countersigning session data is mapped to a set of [`Action`]s and each of those actions must be be found locally before this op can progress.
+//!    - If the [`Entry`] is an [`Entry::CounterSign`], then the countersigning session data is mapped to a set of [`Action`]s and each of those actions must be found locally before this op can progress.
 //!    - The [`Action`] must be either a [`Action::Create`] or an [`Action::Update`].
 //!    - Run the [store entry checks](#store-entry-checks).
 //! - For a [`ChainOp::StoreEntry`]
-//!    - If the [`Entry`] is an [`Entry::CounterSign`], then the countersigning session data is mapped to a set of [`Action`]s and each of those actions must be be found locally before this op is accepted.
+//!    - If the [`Entry`] is an [`Entry::CounterSign`], then the countersigning session data is mapped to a set of [`Action`]s and each of those actions must be found locally before this op is accepted.
 //!    - Check that the [`Action`] is either a [`Action::Dna`] at sequence number 0, or has a previous action with sequence number strictly greater than 0.
 //!    - Run the [store entry checks](#store-entry-checks).
 //! - For a [`ChainOp::RegisterAgentActivity`]

--- a/crates/holochain_types/src/zome_types/error.rs
+++ b/crates/holochain_types/src/zome_types/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ZomeTypesError {
-    #[error("There is more then the maximum of 255 Zomes in in a single DNA")]
+    #[error("There is more then the maximum of 255 Zomes in a single DNA")]
     ZomeIndexOverflow,
     #[error("There is more then the maximum of 255 Entry Types in a single DNA")]
     EntryTypeIndexOverflow,

--- a/docs/specs/src/diagram-1.0.0/README.md
+++ b/docs/specs/src/diagram-1.0.0/README.md
@@ -123,7 +123,7 @@ Currently supported options:
 - `engine`: options for specific engines, e.g. `plantuml` or
   `mermaid`. The options must be nested below the engine name.
   Allowed settings are either `true` or `false` to enable or
-  disable the engine, respectively, or a a map of options.
+  disable the engine, respectively, or a map of options.
   The available settings are:
 
   + `mime-type`: the output MIME type that should be produced with


### PR DESCRIPTION
### Summary


 Remove redundant words in comment.


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs