### PR TITLE
test: Fix `sys_validation_workflow_test`

### DIFF
--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -18,7 +18,6 @@ use {
 };
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg_attr(target_os = "macos", ignore = "flaky")]
 async fn sys_validation_workflow_test() {
     holochain_trace::test_run();
 
@@ -395,6 +394,8 @@ async fn bob_links_in_a_legit_way(
     triggers
         .publish_dht_ops
         .trigger(&"bob_links_in_a_legit_way");
+    triggers.integrate_dht_ops
+        .trigger(&"bob_links_in_a_legit_way");
     link_add_address
 }
 
@@ -460,6 +461,7 @@ async fn bob_makes_a_large_link(
     // Produce and publish these commits
     let triggers = handle.get_cell_triggers(bob_cell_id).await.unwrap();
     triggers.publish_dht_ops.trigger(&"bob_makes_a_large_link");
+    triggers.integrate_dht_ops.trigger(&"bob_makes_a_large_link");
     (bad_update_action, bad_update_entry_hash, link_add_address)
 }
 


### PR DESCRIPTION
### Summary

The test wasn't triggering integration. It was relying on previous behavior where we'd gossip any old op. The conductor would do this, so the test wasn't an accurate simulation. 

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs