### PR TITLE
Notify k2 of op integration during integration workflow

### DIFF
--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -4,7 +4,11 @@ use super::*;
 use crate::core::queue_consumer::TriggerSender;
 use crate::core::queue_consumer::WorkComplete;
 use holochain_p2p::HolochainP2pDna;
+use holochain_p2p::HolochainP2pDnaT;
+use holochain_sqlite::sql::sql_cell::*;
 use holochain_state::prelude::*;
+use kitsune2_api::StoredOp;
+use rusqlite::Params;
 
 #[cfg(test)]
 mod tests;
@@ -17,90 +21,114 @@ pub async fn integrate_dht_ops_workflow(
     vault: DbWrite<DbKindDht>,
     dht_query_cache: DhtDbQueryCache,
     trigger_receipt: TriggerSender,
-    _network: HolochainP2pDna,
+    network: HolochainP2pDna,
 ) -> WorkflowResult<WorkComplete> {
     let start = std::time::Instant::now();
     let time = holochain_zome_types::prelude::Timestamp::now();
     // Get any activity from the cache that is ready to be integrated.
     let activity_to_integrate = dht_query_cache.get_activity_to_integrate().await?;
-    let (changed, activity_integrated) = vault
+    let (activity_integrated, stored_ops) = vault
         .write_async(move |txn| {
-            let mut total = 0;
+            let mut stored_ops = Vec::new();
             if !activity_to_integrate.is_empty() {
-                let mut stmt = txn.prepare_cached(
-                    holochain_sqlite::sql::sql_cell::UPDATE_INTEGRATE_DEP_ACTIVITY,
-                )?;
+                let mut stmt = txn.prepare_cached(UPDATE_INTEGRATE_DEP_ACTIVITY)?;
                 for (author, seq_range) in &activity_to_integrate {
                     let start = seq_range.start();
                     let end = seq_range.end();
-
-                    total += stmt.execute(named_params! {
-                        ":when_integrated": time,
-                        ":register_activity": ChainOpType::RegisterAgentActivity,
-                        ":seq_start": start,
-                        ":seq_end": end,
-                        ":author": author,
-                    })?;
+                    let integrated_ops = stmt.query_map(
+                        named_params! {
+                            ":when_integrated": time,
+                            ":register_activity": ChainOpType::RegisterAgentActivity,
+                            ":seq_start": start,
+                            ":seq_end": end,
+                            ":author": author,
+                        },
+                        to_stored_op,
+                    )?;
+                    for integrated_op in integrated_ops {
+                        stored_ops.push(integrated_op?);
+                    }
                 }
             }
-            let changed = txn
-                .prepare_cached(holochain_sqlite::sql::sql_cell::UPDATE_INTEGRATE_STORE_RECORD)?
-                .execute(named_params! {
+            // Set all kinds of op types to integrated in DHT database and add op hashes to
+            // list of stored ops.
+            set_ops_to_integrated(
+                txn,
+                UPDATE_INTEGRATE_STORE_RECORD,
+                named_params! {
                     ":when_integrated": time,
                     ":store_record": ChainOpType::StoreRecord,
-                })?;
-            total += changed;
-            let changed = txn
-                .prepare_cached(holochain_sqlite::sql::sql_cell::UPDATE_INTEGRATE_STORE_ENTRY)?
-                .execute(named_params! {
+                },
+                &mut stored_ops,
+            )?;
+
+            set_ops_to_integrated(
+                txn,
+                UPDATE_INTEGRATE_STORE_ENTRY,
+                named_params! {
                     ":when_integrated": time,
                     ":store_entry": ChainOpType::StoreEntry,
-                })?;
-            total += changed;
-            let changed = txn
-                .prepare_cached(holochain_sqlite::sql::sql_cell::UPDATE_INTEGRATE_DEP_STORE_ENTRY)?
-                .execute(named_params! {
+                },
+                &mut stored_ops,
+            )?;
+
+            set_ops_to_integrated(
+                txn,
+                UPDATE_INTEGRATE_DEP_STORE_ENTRY,
+                named_params! {
                     ":when_integrated": time,
                     ":updated_content": ChainOpType::RegisterUpdatedContent,
                     ":deleted_entry_action": ChainOpType::RegisterDeletedEntryAction,
                     ":store_entry": ChainOpType::StoreEntry,
-                })?;
-            total += changed;
-            let changed = txn
-                .prepare_cached(holochain_sqlite::sql::sql_cell::SET_ADD_LINK_OPS_TO_INTEGRATED)?
-                .execute(named_params! {
+                },
+                &mut stored_ops,
+            )?;
+
+            set_ops_to_integrated(
+                txn,
+                SET_ADD_LINK_OPS_TO_INTEGRATED,
+                named_params! {
                     ":when_integrated": time,
                     ":create_link": ChainOpType::RegisterAddLink,
-                })?;
-            total += changed;
-            let changed = txn
-                .prepare_cached(holochain_sqlite::sql::sql_cell::UPDATE_INTEGRATE_DEP_STORE_RECORD)?
-                .execute(named_params! {
+                },
+                &mut stored_ops,
+            )?;
+
+            set_ops_to_integrated(
+                txn,
+                UPDATE_INTEGRATE_DEP_STORE_RECORD,
+                named_params! {
                     ":when_integrated": time,
                     ":store_record": ChainOpType::StoreRecord,
                     ":updated_record": ChainOpType::RegisterUpdatedRecord,
                     ":deleted_by": ChainOpType::RegisterDeletedBy,
-                })?;
-            total += changed;
-            let changed = txn
-                .prepare_cached(holochain_sqlite::sql::sql_cell::SET_DELETE_LINK_OPS_TO_INTEGRATED)?
-                .execute(named_params! {
+                },
+                &mut stored_ops,
+            )?;
+
+            set_ops_to_integrated(
+                txn,
+                SET_DELETE_LINK_OPS_TO_INTEGRATED,
+                named_params! {
                     ":when_integrated": time,
                     ":create_link": ChainOpType::RegisterAddLink,
                     ":delete_link": ChainOpType::RegisterRemoveLink,
 
-                })?;
-            total += changed;
-            let changed = txn
-                .prepare_cached(
-                    holochain_sqlite::sql::sql_cell::SET_CHAIN_INTEGRITY_WARRANT_OPS_TO_INTEGRATED,
-                )?
-                .execute(named_params! {
+                },
+                &mut stored_ops,
+            )?;
+
+            set_ops_to_integrated(
+                txn,
+                SET_CHAIN_INTEGRITY_WARRANT_OPS_TO_INTEGRATED,
+                named_params! {
                     ":when_integrated": time,
                     ":chain_integrity_warrant": WarrantOpType::ChainIntegrityWarrant,
-                })?;
-            total += changed;
-            WorkflowResult::Ok((total, activity_to_integrate))
+                },
+                &mut stored_ops,
+            )?;
+
+            WorkflowResult::Ok((activity_to_integrate, stored_ops))
         })
         .await?;
     // Once the database transaction is committed, update the cache with the
@@ -108,12 +136,38 @@ pub async fn integrate_dht_ops_workflow(
     dht_query_cache
         .set_all_activity_to_integrated(activity_integrated)
         .await?;
+    let changed = stored_ops.len();
     let ops_ps = changed as f64 / start.elapsed().as_micros() as f64 * 1_000_000.0;
     tracing::debug!(?changed, %ops_ps);
     if changed > 0 {
+        network.new_integrated_data(stored_ops).await?;
         trigger_receipt.trigger(&"integrate_dht_ops_workflow");
         Ok(WorkComplete::Incomplete(None))
     } else {
         Ok(WorkComplete::Complete)
     }
+}
+
+fn to_stored_op(row: &Row<'_>) -> rusqlite::Result<StoredOp> {
+    let op_hash = row.get::<_, DhtOpHash>(0)?;
+    let created_at = row.get::<_, Timestamp>(1)?;
+    let op = StoredOp {
+        created_at: kitsune2_api::Timestamp::from_micros(created_at.as_micros()),
+        op_id: op_hash.to_k2_op(),
+    };
+    Ok(op)
+}
+
+fn set_ops_to_integrated(
+    txn: &mut Txn<'_, '_, DbKindDht>,
+    sql: &str,
+    params: impl Params,
+    stored_ops: &mut Vec<StoredOp>,
+) -> WorkflowResult<()> {
+    let mut stmt = txn.prepare(sql)?;
+    let integrated_ops = stmt.query_map(params, to_stored_op)?;
+    for op_hash in integrated_ops {
+        stored_ops.push(op_hash?);
+    }
+    Ok(())
 }

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use super::*;
 use crate::core::queue_consumer::TriggerSender;
 use ::fixt::prelude::*;
@@ -7,6 +5,7 @@ use holo_hash::fixt::DnaHashFixturator;
 use holochain_p2p::actor::MockHcP2p;
 use holochain_state::mutations;
 use holochain_state::query::link::{GetLinksFilter, GetLinksQuery};
+use std::sync::Arc;
 
 #[derive(Clone)]
 struct TestData {
@@ -24,7 +23,7 @@ struct TestData {
 }
 
 impl TestData {
-    async fn new() -> Self {
+    fn new() -> Self {
         // original entry
         let original_entry = EntryFixturator::new(AppEntry).next().unwrap();
         // New entry
@@ -350,7 +349,6 @@ impl Db {
     }
 }
 
-#[allow(unused)]
 async fn call_workflow<'env>(env: DbWrite<DbKindDht>) {
     let (qt, _rx) = TriggerSender::new();
     let mock_network = HolochainP2pDna::new(Arc::new(MockHcP2p::new()), fixt!(DnaHash), None);
@@ -360,7 +358,6 @@ async fn call_workflow<'env>(env: DbWrite<DbKindDht>) {
 }
 
 // Need to clear the data from the previous test
-#[allow(unused)]
 async fn clear_dbs(env: DbWrite<DbKindDht>) {
     env.write_async(move |txn| -> StateMutationResult<()> {
         txn.execute("DELETE FROM DhtOp", []).unwrap();
@@ -377,8 +374,7 @@ async fn clear_dbs(env: DbWrite<DbKindDht>) {
 // with a desired pre-state that you want the database in
 // and the expected state of the database after the workflow is run
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_store_record(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+fn register_store_record(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     let op: DhtOp = ChainOp::StoreRecord(
         a.signature.clone(),
         a.original_action.clone().into(),
@@ -387,11 +383,10 @@ fn register_store_record(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
     .into();
     let pre_state = vec![Db::IntQueue(op.clone())];
     let expect = vec![Db::Integrated(op.clone())];
-    (pre_state, expect, "store record")
+    (pre_state, expect, "store record", op)
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_store_entry(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+fn register_store_entry(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     let op: DhtOp = ChainOp::StoreEntry(
         a.signature.clone(),
         a.original_action.clone(),
@@ -400,22 +395,26 @@ fn register_store_entry(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
     .into();
     let pre_state = vec![Db::IntQueue(op.clone())];
     let expect = vec![Db::Integrated(op.clone())];
-    (pre_state, expect, "store entry")
+    (pre_state, expect, "store entry", op)
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_agent_activity_dna(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
-    let mut new_action = fixt!(Dna);
+fn register_agent_activity_dna(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
+    let new_action = fixt!(Dna);
     let op: DhtOp = ChainOp::RegisterAgentActivity(a.signature.clone(), new_action.into()).into();
     let pre_state = vec![Db::IntQueue(op.clone())];
     let expect = vec![Db::Integrated(op.clone())];
-    (pre_state, expect, "register agent activity for dna action")
+    (
+        pre_state,
+        expect,
+        "register agent activity for dna action",
+        op,
+    )
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
+#[allow(unused)] // Due to unusual calling pattern
 fn register_agent_activity_agent_validation_pkg(
-    mut a: TestData,
-) -> (Vec<Db>, Vec<Db>, &'static str) {
+    a: TestData,
+) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     // Previous op to depend on
     let mut prev_create_action = fixt!(Create);
     prev_create_action.action_seq = 10;
@@ -445,13 +444,14 @@ fn register_agent_activity_agent_validation_pkg(
         pre_state,
         expect,
         "register agent activity for agent validation pkg",
+        new_dht_op,
     )
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
+#[allow(unused)] // Due to unusual calling pattern
 fn register_agent_activity_init_zomes_complete(
-    mut a: TestData,
-) -> (Vec<Db>, Vec<Db>, &'static str) {
+    a: TestData,
+) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     // Previous op to depend on
     let mut prev_create_action = fixt!(Create);
     prev_create_action.action_seq = 10;
@@ -481,11 +481,11 @@ fn register_agent_activity_init_zomes_complete(
         pre_state,
         expect,
         "register agent activity for init zomes complete action",
+        new_dht_op,
     )
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_agent_activity_create_link(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+fn register_agent_activity_create_link(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     a.link_add.action_seq = 5;
     let previous_op: DhtOp =
         ChainOp::RegisterAgentActivity(a.signature.clone(), a.link_add.clone().into()).into();
@@ -507,14 +507,16 @@ fn register_agent_activity_create_link(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'
         pre_state,
         expect,
         "register agent activity for create link action",
+        op,
     )
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_agent_activity_delete_link(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+fn register_agent_activity_delete_link(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
+    a.link_remove.action_seq = 5;
     let previous_op: DhtOp =
         ChainOp::RegisterAgentActivity(a.signature.clone(), a.link_remove.clone().into()).into();
     let mut new_action = a.link_remove.clone();
+    new_action.action_seq += 1;
     let new_op: DhtOp =
         ChainOp::RegisterAgentActivity(a.signature.clone(), new_action.clone().into()).into();
     let pre_state = vec![
@@ -531,11 +533,12 @@ fn register_agent_activity_delete_link(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'
         pre_state,
         expect,
         "register agent activity for delete link action",
+        new_op,
     )
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_agent_activity_close_chain(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+#[allow(unused)] // Due to unusual calling pattern
+fn register_agent_activity_close_chain(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     // Previous op to depend on
     let mut prev_create_action = fixt!(Create);
     prev_create_action.action_seq = 10;
@@ -563,11 +566,12 @@ fn register_agent_activity_close_chain(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'
         pre_state,
         expect,
         "register agent activity for close chain action",
+        new_dht_op,
     )
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_agent_activity_open_chain(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+#[allow(unused)] // Due to unusual calling pattern
+fn register_agent_activity_open_chain(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     // Previous op to depend on
     let mut prev_create_action = fixt!(Create);
     prev_create_action.action_seq = 10;
@@ -595,11 +599,12 @@ fn register_agent_activity_open_chain(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'s
         pre_state,
         expect,
         "register agent activity for open chain action",
+        new_dht_op,
     )
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_agent_activity_create(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+#[allow(unused)] // Due to unusual calling pattern
+fn register_agent_activity_create(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     // Previous op to depend on
     let mut prev_create_action = fixt!(Create);
     prev_create_action.action_seq = 10;
@@ -626,11 +631,12 @@ fn register_agent_activity_create(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'stati
         pre_state,
         expect,
         "register agent activity for create action",
+        new_dht_op,
     )
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_agent_activity_update(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+#[allow(unused)] // Due to unusual calling pattern
+fn register_agent_activity_update(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     // Previous op to depend on
     let mut prev_create_action = fixt!(Create);
     prev_create_action.action_seq = 10;
@@ -657,11 +663,12 @@ fn register_agent_activity_update(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'stati
         pre_state,
         expect,
         "register agent activity for update action",
+        new_dht_op,
     )
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_agent_activity_delete(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+#[allow(unused)] // Due to unusual calling pattern
+fn register_agent_activity_delete(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     // Previous op to depend on
     let mut prev_create_action = fixt!(Create);
     prev_create_action.action_seq = 10;
@@ -688,11 +695,11 @@ fn register_agent_activity_delete(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'stati
         pre_state,
         expect,
         "register agent activity for delete action",
+        new_dht_op,
     )
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_updated_record(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+fn register_updated_record(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     let original_op = ChainOp::StoreRecord(
         a.signature.clone(),
         a.original_action.clone().into(),
@@ -713,12 +720,11 @@ fn register_updated_record(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
             a.entry_update_action.clone().into(),
         ),
     ];
-    (pre_state, expect, "register updated record")
+    (pre_state, expect, "register updated record", op)
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_replaced_by_for_entry(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
-    let original_op = ChainOp::StoreEntry(
+fn register_replaced_by_for_entry(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
+    let original_op: DhtOp = ChainOp::StoreEntry(
         a.signature.clone(),
         a.original_action.clone(),
         a.original_entry.clone(),
@@ -738,11 +744,10 @@ fn register_replaced_by_for_entry(a: TestData) -> (Vec<Db>, Vec<Db>, &'static st
             a.entry_update_entry.clone().into(),
         ),
     ];
-    (pre_state, expect, "register replaced by for entry")
+    (pre_state, expect, "register replaced by for entry", op)
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_deleted_by(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+fn register_deleted_by(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     let original_op = ChainOp::StoreEntry(
         a.signature.clone(),
         a.original_action.clone(),
@@ -760,11 +765,10 @@ fn register_deleted_by(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
             a.entry_delete.clone().into(),
         ),
     ];
-    (pre_state, expect, "register deleted by")
+    (pre_state, expect, "register deleted by", op)
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_deleted_action_by(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+fn register_deleted_action_by(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     let original_op = ChainOp::StoreRecord(
         a.signature.clone(),
         a.original_action.clone().into(),
@@ -780,19 +784,17 @@ fn register_deleted_action_by(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
             a.entry_delete.clone().into(),
         ),
     ];
-    (pre_state, expect, "register deleted action by")
+    (pre_state, expect, "register deleted action by", op)
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_create_link(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+fn register_create_link(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     let op: DhtOp = ChainOp::RegisterAddLink(a.signature.clone(), a.link_add.clone()).into();
     let pre_state = vec![Db::IntQueue(op.clone())];
     let expect = vec![Db::Integrated(op.clone())];
-    (pre_state, expect, "register link create")
+    (pre_state, expect, "register link create", op)
 }
 
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_delete_link(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+fn register_delete_link(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     let original_op = ChainOp::StoreEntry(
         a.signature.clone(),
         a.original_action.clone(),
@@ -810,12 +812,11 @@ fn register_delete_link(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
         Db::Integrated(op.clone()),
         Db::MetaLinkEmpty(a.link_add.clone()),
     ];
-    (pre_state, expect, "register link remove")
+    (pre_state, expect, "register link remove", op)
 }
 
 // Link remove when not an author
-#[allow(unused)] // Wrong detection by Clippy, due to unusual calling pattern
-fn register_delete_link_missing_base(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str) {
+fn register_delete_link_missing_base(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
     let op: DhtOp = ChainOp::RegisterRemoveLink(a.signature.clone(), a.link_remove.clone()).into();
     let pre_state = vec![Db::IntQueue(op.clone())];
     let expect = vec![Db::IntegratedEmpty, Db::IntQueue(op.clone()), Db::MetaEmpty];
@@ -823,6 +824,7 @@ fn register_delete_link_missing_base(a: TestData) -> (Vec<Db>, Vec<Db>, &'static
         pre_state,
         expect,
         "register remove link remove missing base",
+        op,
     )
 }
 
@@ -830,8 +832,7 @@ fn register_delete_link_missing_base(a: TestData) -> (Vec<Db>, Vec<Db>, &'static
 #[tokio::test(flavor = "multi_thread")]
 async fn test_ops_state() {
     holochain_trace::test_run();
-    let test_db = test_dht_db();
-    let env = test_db.to_db();
+    let env = test_dht_db().to_db();
 
     let tests = [
         register_store_record,
@@ -857,9 +858,9 @@ async fn test_ops_state() {
 
     for t in tests.iter() {
         clear_dbs(env.clone()).await;
-        println!("test_ops_state on function {:?}", t);
-        let td = TestData::new().await;
-        let (pre_state, expect, name) = t(td);
+        let td = TestData::new();
+        let (pre_state, expect, name, _) = t(td);
+        println!("test_ops_state on function {name}");
         Db::set(pre_state, env.clone()).await;
         call_workflow(env.clone()).await;
         Db::check(
@@ -869,4 +870,79 @@ async fn test_ops_state() {
         )
         .await;
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn inform_kitsune_about_integrated_ops() {
+    let tests = [
+        register_store_entry,
+        register_store_record,
+        // These are not distinct cases, because all agent activity is treated equally,
+        // but they're cheap to run and were already written.
+        register_agent_activity_dna,
+        register_agent_activity_agent_validation_pkg,
+        register_agent_activity_init_zomes_complete,
+        register_agent_activity_create_link,
+        register_agent_activity_delete_link,
+        register_agent_activity_close_chain,
+        register_agent_activity_open_chain,
+        register_agent_activity_create,
+        register_agent_activity_update,
+        register_agent_activity_delete,
+        register_replaced_by_for_entry,
+        register_updated_record,
+        register_deleted_by,
+        register_deleted_action_by,
+        register_create_link,
+        register_delete_link,
+        // Not including register_delete_link_missing_base because it does not integrate ops,
+        // only tests the query cache state.
+    ];
+    for test in tests.iter() {
+        let env = test_dht_db().to_db();
+        let test_data = TestData::new();
+        let (pre_state, _, test_name, op) = test(test_data);
+        println!("inform_kitsune_about {test_name}");
+        Db::set(pre_state, env.clone()).await;
+
+        let (tx, _rx) = TriggerSender::new();
+        let dna_hash = fixt!(DnaHash);
+        let dna_hash2 = dna_hash.clone();
+        let mut hc_p2p = MockHcP2p::new();
+        hc_p2p
+            .expect_new_integrated_data()
+            .times(1)
+            .return_once(move |space_id, ops| {
+                assert_eq!(space_id, dna_hash2.to_k2_space());
+                let expected_op = StoredOp {
+                    op_id: op.to_hash().to_k2_op(),
+                    created_at: kitsune2_api::Timestamp::from_micros(op.timestamp().as_micros()),
+                };
+                assert_eq!(ops, vec![expected_op]);
+                Box::pin(async { Ok(()) })
+            });
+        let hc_p2p = Arc::new(hc_p2p);
+        let p2p_dna = HolochainP2pDna::new(hc_p2p, dna_hash, None);
+        integrate_dht_ops_workflow(env.clone(), env.into(), tx, p2p_dna)
+            .await
+            .unwrap();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn kitsune_not_informed_when_no_ops_integrated() {
+    let env = test_dht_db().to_db();
+    let test_data = TestData::new();
+    let (pre_state, _, _, _) = register_delete_link_missing_base(test_data);
+    Db::set(pre_state, env.clone()).await;
+
+    let (tx, _rx) = TriggerSender::new();
+    let dna_hash = fixt!(DnaHash);
+    let mut hc_p2p = MockHcP2p::new();
+    hc_p2p.expect_new_integrated_data().never();
+    let hc_p2p = Arc::new(hc_p2p);
+    let p2p_dna = HolochainP2pDna::new(hc_p2p, dna_hash, None);
+    integrate_dht_ops_workflow(env.clone(), env.into(), tx, p2p_dna)
+        .await
+        .unwrap();
 }

--- a/crates/holochain/tests/tests/inline_zome_spec/mod.rs
+++ b/crates/holochain/tests/tests/inline_zome_spec/mod.rs
@@ -2,13 +2,13 @@
 
 use hdk::prelude::*;
 use holochain::core::ribosome::guest_callback::validate::ValidateResult;
+use holochain::core::SourceChainError;
 use holochain::test_utils::inline_zomes::{simple_crud_zome, AppString};
 use holochain::{conductor::api::error::ConductorApiResult, sweettest::*};
 use holochain::{
     conductor::{api::error::ConductorApiError, CellError},
     core::workflow::WorkflowError,
 };
-use holochain::{core::SourceChainError, test_utils::display_agent_infos};
 use holochain_types::{inline_zome::InlineZomeSet, prelude::*};
 use holochain_wasm_test_utils::TestWasm;
 use holochain_zome_types::{op::Op, record::RecordEntry};
@@ -139,36 +139,6 @@ async fn inline_zome_3_agents_2_dnas() -> anyhow::Result<()> {
         *record.entry(),
         RecordEntry::Present(Entry::app(().try_into().unwrap()).unwrap())
     );
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread")]
-#[cfg(feature = "test_utils")]
-// I can't remember what this test was for? Should we just delete?
-#[ignore = "Needs to be completed when HolochainP2pEvents is accessible"]
-async fn invalid_cell() -> anyhow::Result<()> {
-    holochain_trace::test_run();
-    let mut conductor = SweetConductor::from_standard_config().await;
-
-    let (dna_foo, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
-    let (dna_bar, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
-
-    let _app_foo = conductor.setup_app("foo", &[dna_foo]).await;
-
-    let _app_bar = conductor.setup_app("bar", &[dna_bar]).await;
-
-    // Give small amount of time for cells to join the network
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
-    tracing::debug!(dnas = ?conductor.list_dnas());
-    tracing::debug!(cell_ids = ?conductor.running_cell_ids());
-    tracing::debug!(apps = ?conductor.list_running_apps().await.unwrap());
-
-    display_agent_infos(&conductor).await;
-
-    // Can't finish this test because there's no way to construct HolochainP2pEvents
-    // and I can't directly call query on the conductor because it's private.
 
     Ok(())
 }

--- a/crates/holochain_cascade/src/test_utils.rs
+++ b/crates/holochain_cascade/src/test_utils.rs
@@ -19,6 +19,7 @@ use holochain_types::test_utils::chain::chain_to_ops;
 use holochain_types::test_utils::chain::entry_hash;
 use holochain_types::test_utils::chain::TestChainItem;
 use kitsune2_api::AgentInfoSigned;
+use kitsune2_api::StoredOp;
 use std::collections::HashSet;
 use std::sync::Arc;
 use QueryFilter;
@@ -235,6 +236,10 @@ impl HolochainP2pDnaT for PassThroughNetwork {
     }
 
     async fn leave(&self, _agent: AgentPubKey) -> HolochainP2pResult<()> {
+        todo!()
+    }
+
+    async fn new_integrated_data(&self, _ops: Vec<StoredOp>) -> HolochainP2pResult<()> {
         todo!()
     }
 

--- a/crates/holochain_p2p/src/lib.rs
+++ b/crates/holochain_p2p/src/lib.rs
@@ -6,6 +6,7 @@ use holochain_chc::ChcImpl;
 use holochain_serialized_bytes::prelude::*;
 use holochain_types::prelude::*;
 use kitsune2_api::{AgentInfoSigned, BoxFut};
+use kitsune2_api::{SpaceId, StoredOp};
 use mockall::automock;
 use std::sync::Arc;
 use tracing::Instrument;
@@ -47,6 +48,10 @@ pub trait HolochainP2pDnaT: Send + Sync + 'static {
 
     /// If a cell is disabled, we'll need to \"leave\" the network module as well.
     async fn leave(&self, agent: AgentPubKey) -> HolochainP2pResult<()>;
+
+    /// Inform p2p module when ops have been integrated into the store, so that it can start
+    /// gossiping them.
+    async fn new_integrated_data(&self, ops: Vec<StoredOp>) -> HolochainP2pResult<()>;
 
     /// Invoke a zome function on a remote node (if you have been granted the capability).
     #[allow(clippy::too_many_arguments)]
@@ -197,6 +202,14 @@ impl HolochainP2pDnaT for HolochainP2pDna {
     /// If a cell is disabled, we'll need to \"leave\" the network module as well.
     async fn leave(&self, agent: AgentPubKey) -> HolochainP2pResult<()> {
         self.sender.leave((*self.dna_hash).clone(), agent).await
+    }
+
+    /// Inform p2p module when ops have been integrated into the store, so that it can start
+    /// gossiping them.
+    async fn new_integrated_data(&self, ops: Vec<StoredOp>) -> HolochainP2pResult<()> {
+        self.sender
+            .new_integrated_data(self.dna_hash.to_k2_space(), ops)
+            .await
     }
 
     /// Invoke a zome function on a remote node (if you have been granted the capability).

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -887,6 +887,19 @@ impl HolochainP2pActor {
         }
     }
 
+    async fn inform_ops_stored(
+        &self,
+        space_id: SpaceId,
+        ops: Vec<StoredOp>,
+    ) -> HolochainP2pResult<()> {
+        self.kitsune
+            .space(space_id)
+            .await?
+            .inform_ops_stored(ops)
+            .await
+            .map_err(HolochainP2pError::K2Error)
+    }
+
     /* -----------------
      * saving so we can implement similiar stuff later
 
@@ -1029,6 +1042,14 @@ impl actor::HcP2p for HolochainP2pActor {
             space.local_agent_leave(agent_pub_key.to_k2_agent()).await;
             Ok(())
         })
+    }
+
+    fn new_integrated_data(
+        &self,
+        space_id: SpaceId,
+        ops: Vec<StoredOp>,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        Box::pin(async move { self.inform_ops_stored(space_id, ops).await })
     }
 
     fn call_remote(

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -53,6 +53,14 @@ impl HcP2p for StubNetwork {
         Box::pin(async { Err("stub".into()) })
     }
 
+    fn new_integrated_data(
+        &self,
+        space_id: kitsune2_api::SpaceId,
+        ops: Vec<kitsune2_api::StoredOp>,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        Box::pin(async { Err("stub".into()) })
+    }
+
     fn call_remote(
         &self,
         dna_hash: DnaHash,

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -5,6 +5,8 @@ use crate::event::GetRequest;
 use crate::*;
 use holochain_types::activity::AgentActivityResponse;
 use holochain_types::prelude::ValidationReceiptBundle;
+use kitsune2_api::{SpaceId, StoredOp};
+use mockall::automock;
 
 #[derive(Clone, Debug)]
 /// Get options help control how the get is processed at various levels.
@@ -255,6 +257,14 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug {
         &self,
         dna_hash: DnaHash,
         agent_pub_key: AgentPubKey,
+    ) -> BoxFut<'_, HolochainP2pResult<()>>;
+
+    /// Inform p2p module when ops have been integrated into the store, so that it can start
+    /// gossiping them.
+    fn new_integrated_data(
+        &self,
+        space_id: SpaceId,
+        ops: Vec<StoredOp>,
     ) -> BoxFut<'_, HolochainP2pResult<()>>;
 
     /// Invoke a zome function on a remote node (if you have been granted the capability).

--- a/crates/holochain_sqlite/src/sql.rs
+++ b/crates/holochain_sqlite/src/sql.rs
@@ -1,6 +1,21 @@
 pub mod sql_cell {
+    // UPDATE queries to set ops to integrated.
     pub const UPDATE_INTEGRATE_DEP_ACTIVITY: &str =
         include_str!("sql/cell/update_dep_activity.sql");
+    pub const UPDATE_INTEGRATE_STORE_RECORD: &str =
+        include_str!("sql/cell/update_store_record.sql");
+    pub const UPDATE_INTEGRATE_STORE_ENTRY: &str = include_str!("sql/cell/update_store_entry.sql");
+    pub const UPDATE_INTEGRATE_DEP_STORE_ENTRY: &str =
+        include_str!("sql/cell/update_dep_store_entry.sql");
+    pub const SET_ADD_LINK_OPS_TO_INTEGRATED: &str =
+        include_str!("sql/cell/set_add_link_ops_to_integrated.sql");
+    pub const UPDATE_INTEGRATE_DEP_STORE_RECORD: &str =
+        include_str!("sql/cell/update_dep_store_record.sql");
+    pub const SET_DELETE_LINK_OPS_TO_INTEGRATED: &str =
+        include_str!("sql/cell/set_delete_link_ops_to_integrated.sql");
+    pub const SET_CHAIN_INTEGRITY_WARRANT_OPS_TO_INTEGRATED: &str =
+        include_str!("sql/cell/set_chain_integrity_warrant_ops_to_integrated.sql");
+
     pub const ACTIVITY_INTEGRATED_UPPER_BOUND: &str =
         include_str!("sql/cell/activity_integrated_upper_bound.sql");
     pub const ACTION_HASH_BY_PREV: &str = include_str!("sql/cell/action_hash_by_prev.sql");
@@ -8,20 +23,6 @@ pub mod sql_cell {
     pub const ALL_READY_ACTIVITY: &str = include_str!("sql/cell/all_ready_activity.sql");
     pub const DELETE_ACTIONS_AFTER_SEQ: &str =
         include_str!("sql/cell/delete_actions_after_seq.sql");
-    pub const UPDATE_INTEGRATE_DEP_STORE_RECORD: &str =
-        include_str!("sql/cell/update_dep_store_record.sql");
-    pub const UPDATE_INTEGRATE_DEP_STORE_ENTRY: &str =
-        include_str!("sql/cell/update_dep_store_entry.sql");
-    pub const SET_ADD_LINK_OPS_TO_INTEGRATED: &str =
-        include_str!("sql/cell/set_add_link_ops_to_integrated.sql");
-    pub const SET_DELETE_LINK_OPS_TO_INTEGRATED: &str =
-        include_str!("sql/cell/set_delete_link_ops_to_integrated.sql");
-    pub const SET_CHAIN_INTEGRITY_WARRANT_OPS_TO_INTEGRATED: &str =
-        include_str!("sql/cell/set_chain_integrity_warrant_ops_to_integrated.sql");
-
-    pub const UPDATE_INTEGRATE_STORE_RECORD: &str =
-        include_str!("sql/cell/update_store_record.sql");
-    pub const UPDATE_INTEGRATE_STORE_ENTRY: &str = include_str!("sql/cell/update_store_entry.sql");
 
     pub const SELECT_VALID_AGENT_PUB_KEY: &str =
         include_str!("sql/cell/select_valid_agent_pub_key.sql");

--- a/crates/holochain_sqlite/src/sql/cell/set_add_link_ops_to_integrated.sql
+++ b/crates/holochain_sqlite/src/sql/cell/set_add_link_ops_to_integrated.sql
@@ -7,3 +7,4 @@ WHERE
   validation_stage = 3
   AND validation_status IS NOT NULL
   AND DhtOp.type = :create_link
+RETURNING hash, authored_timestamp

--- a/crates/holochain_sqlite/src/sql/cell/set_chain_integrity_warrant_ops_to_integrated.sql
+++ b/crates/holochain_sqlite/src/sql/cell/set_chain_integrity_warrant_ops_to_integrated.sql
@@ -7,3 +7,4 @@ WHERE
   validation_stage = 3
   AND validation_status IS NOT NULL
   AND DhtOp.type = :chain_integrity_warrant
+RETURNING hash, authored_timestamp

--- a/crates/holochain_sqlite/src/sql/cell/set_delete_link_ops_to_integrated.sql
+++ b/crates/holochain_sqlite/src/sql/cell/set_delete_link_ops_to_integrated.sql
@@ -19,3 +19,4 @@ WHERE
     LIMIT
       1
   )
+RETURNING hash, authored_timestamp

--- a/crates/holochain_sqlite/src/sql/cell/update_dep_activity.sql
+++ b/crates/holochain_sqlite/src/sql/cell/update_dep_activity.sql
@@ -17,3 +17,4 @@ WHERE
       AND seq <= :seq_end
       AND author = :author
   )
+RETURNING hash, authored_timestamp

--- a/crates/holochain_sqlite/src/sql/cell/update_dep_store_entry.sql
+++ b/crates/holochain_sqlite/src/sql/cell/update_dep_store_entry.sql
@@ -19,3 +19,4 @@ WHERE
     LIMIT
       1
   )
+RETURNING hash, authored_timestamp

--- a/crates/holochain_sqlite/src/sql/cell/update_dep_store_record.sql
+++ b/crates/holochain_sqlite/src/sql/cell/update_dep_store_record.sql
@@ -19,3 +19,4 @@ WHERE
     LIMIT
       1
   )
+RETURNING hash, authored_timestamp

--- a/crates/holochain_sqlite/src/sql/cell/update_store_entry.sql
+++ b/crates/holochain_sqlite/src/sql/cell/update_store_entry.sql
@@ -7,3 +7,4 @@ WHERE
   validation_stage = 3
   AND validation_status IS NOT NULL
   AND DhtOp.type = :store_entry
+RETURNING hash, authored_timestamp

--- a/crates/holochain_sqlite/src/sql/cell/update_store_record.sql
+++ b/crates/holochain_sqlite/src/sql/cell/update_store_record.sql
@@ -7,3 +7,4 @@ WHERE
   validation_stage = 3
   AND validation_status IS NOT NULL
   AND DhtOp.type = :store_record
+RETURNING hash, authored_timestamp


### PR DESCRIPTION
### Summary
After integrating ops in the integration workflow, inform Kitsune2 about them.

Previous integration workflow still fail. Fix will be on a separate PR.

Partly implements #4675. The part after authoring ops will also be on a separate PR.


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs