### PR TITLE
Test/fix unit tests

### DIFF
--- a/crates/holochain/src/core/ribosome/real_ribosome.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome.rs
@@ -1269,7 +1269,7 @@ pub mod wasm_test {
             let maximum_response_time_ms = Duration::from_millis(150);
 
             #[cfg(not(feature = "wasmer_wamr"))]
-            let maximum_response_time_ms = Duration::from_millis(15);
+            let maximum_response_time_ms = Duration::from_millis(50);
 
             assert!(
                 results[0] <= maximum_response_time_ms,


### PR DESCRIPTION
### Summary
* In relation to #4800, fix other fetch requests that respond with an error when no peers are online to fetch from.
* Replace one more `test_network` by the mock network.
* Replace real network in app validation by mock network.

After this PR is merged, all remaining failing unit tests depend on `network_info`.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs