### PR TITLE
feat: document `chain_head` field in `AgentInfo` struct

### DIFF
--- a/crates/holochain_zome_types/src/info.rs
+++ b/crates/holochain_zome_types/src/info.rs
@@ -16,6 +16,9 @@ pub struct AgentInfo {
     /// Same as the initial pubkey if it has never been changed.
     /// The agent can revoke an old key and replace it with a new one, the latest appears here.
     pub agent_latest_pubkey: AgentPubKey,
+    /// The current source chain head, including any changes staged in the
+    /// scratch space by the current function call but not yet persisted to
+    /// the database.
     pub chain_head: (ActionHash, u32, Timestamp),
 }
 


### PR DESCRIPTION
### Summary

The `chain_head` field was undocumented, and it's important to know that it includes the scratch space.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs