### PR TITLE
chore: `hc` should not depend on tx5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,7 +1512,8 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 [[package]]
 name = "datachannel"
 version = "0.14.0"
-source = "git+https://github.com/ThetaSinner/datachannel-rs.git?branch=find-libs-on-windows-not-just-msvc#f170739eaf418adc4f2d08609714b3b981bee9c8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9104be65808f5ba4cae77831aa5b1874a64de31ceed449db37897910d0d72e"
 dependencies = [
  "datachannel-sys",
  "derivative",
@@ -1525,7 +1526,8 @@ dependencies = [
 [[package]]
 name = "datachannel-sys"
 version = "0.22.2"
-source = "git+https://github.com/ThetaSinner/datachannel-rs.git?branch=find-libs-on-windows-not-just-msvc#f170739eaf418adc4f2d08609714b3b981bee9c8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ead19df10c4e46d8d4b33de06c6224dcafc98bad666ac62629d363675866cae"
 dependencies = [
  "bindgen 0.69.5",
  "cmake",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.155"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76751bca18309cbce06f9821698d6c05b3af5c3fde8af5caf57f11611729397b"
+checksum = "aa3a202fc4f3dd6d2ce5a2f87b04fb2becc00f5643ee9c4743ba10777efb314f"
 dependencies = [
  "cc",
  "cxxbridge-cmd",
@@ -1370,9 +1370,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.155"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3309df6a3cbbfc900c1b7665f4a4109da2b90ce5fd9b0c9f51e3687f51c970"
+checksum = "644bdf46f34f6325783f76a8ad8e737ab995a302d7868b5236a1ba55008883e0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -1384,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.155"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ce717e582fc3b56bd2f1eb3cda9916e9b4629721e4c2ce637ac5e7d4beef11"
+checksum = "8e8cefbebcb74ed0b4a08b76139e6c29d8884a0bb94d02c6f35de821a14a6e39"
 dependencies = [
  "clap 4.5.35",
  "codespan-reporting",
@@ -1397,15 +1397,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.155"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7fdd4b264a3335a8b21221092bd2fbfba35c3606bd50feb28d22ba3fb0a6e5"
+checksum = "604e3eff62e2f27289d618f621491a068330c3c9f8eb06555dabc292c123596e"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.155"
+version = "1.0.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36a0a2b78ff9232a3dc584340471d4fa1751a81026cf62f3661a06d5a8bae17"
+checksum = "130c3a05501d9c15dedbf08f2ff9af60f8e78422e3dffac1f43e2d83c5b489a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1512,8 +1512,7 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 [[package]]
 name = "datachannel"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9104be65808f5ba4cae77831aa5b1874a64de31ceed449db37897910d0d72e"
+source = "git+https://github.com/ThetaSinner/datachannel-rs.git?branch=find-libs-on-windows-not-just-msvc#f170739eaf418adc4f2d08609714b3b981bee9c8"
 dependencies = [
  "datachannel-sys",
  "derivative",
@@ -1526,8 +1525,7 @@ dependencies = [
 [[package]]
 name = "datachannel-sys"
 version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ead19df10c4e46d8d4b33de06c6224dcafc98bad666ac62629d363675866cae"
+source = "git+https://github.com/ThetaSinner/datachannel-rs.git?branch=find-libs-on-windows-not-just-msvc#f170739eaf418adc4f2d08609714b3b981bee9c8"
 dependencies = [
  "bindgen 0.69.5",
  "cmake",
@@ -2268,9 +2266,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if 1.0.0",
  "crunchy",
@@ -2797,11 +2795,11 @@ dependencies = [
  "clap 4.5.35",
  "ed25519-dalek",
  "futures",
+ "holo_hash",
  "holochain_chc",
  "holochain_conductor_api",
  "holochain_conductor_config",
  "holochain_nonce",
- "holochain_p2p",
  "holochain_trace",
  "holochain_types",
  "holochain_util",
@@ -3388,13 +3386,13 @@ dependencies = [
 
 [[package]]
 name = "hostname"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
+checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "windows 0.52.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -8405,16 +8403,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
@@ -8430,15 +8418,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
  "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -8832,9 +8811,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,3 +110,5 @@ lto = true
 # lair_keystore_api = { path = "../lair/crates/lair_keystore_api" }
 # lair_keystore = { path = "../lair/crates/lair_keystore" }
 # r2d2_sqlite = { path = "../r2d2-sqlite" }
+
+datachannel = { git = "https://github.com/ThetaSinner/datachannel-rs.git", branch = "find-libs-on-windows-not-just-msvc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,5 +110,3 @@ lto = true
 # lair_keystore_api = { path = "../lair/crates/lair_keystore_api" }
 # lair_keystore = { path = "../lair/crates/lair_keystore" }
 # r2d2_sqlite = { path = "../r2d2-sqlite" }
-
-datachannel = { git = "https://github.com/ThetaSinner/datachannel-rs.git", branch = "find-libs-on-windows-not-just-msvc" }

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -30,6 +30,7 @@ chrono = { version = "0.4.22", default-features = false, features = [
 ] }
 clap = { version = "4.0", features = ["derive", "env"] }
 futures = "0.3"
+holo_hash = { version = "^0.5.0-rc.0", path = "../holo_hash", features = ["kitsune2"] }
 holochain_chc = { version = "^0.2.0-rc.0", path = "../holochain_chc", optional = true }
 holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.5.0-rc.0", features = [
   "sqlite",
@@ -39,9 +40,6 @@ holochain_types = { path = "../holochain_types", version = "^0.5.0-rc.0", featur
 ] }
 holochain_conductor_config = { version = "^0.5.0-rc.0", path = "../holochain_conductor_config" }
 holochain_websocket = { path = "../holochain_websocket", version = "^0.5.0-rc.0" }
-holochain_p2p = { path = "../holochain_p2p", version = "^0.5.0-rc.0", features = [
-  "sqlite",
-] }
 holochain_util = { version = "^0.5.0-rc.0", path = "../holochain_util", features = [
   "pw",
 ] }

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -30,7 +30,9 @@ chrono = { version = "0.4.22", default-features = false, features = [
 ] }
 clap = { version = "4.0", features = ["derive", "env"] }
 futures = "0.3"
-holo_hash = { version = "^0.5.0-rc.0", path = "../holo_hash", features = ["kitsune2"] }
+holo_hash = { version = "^0.5.0-rc.0", path = "../holo_hash", features = [
+  "kitsune2",
+] }
 holochain_chc = { version = "^0.2.0-rc.0", path = "../holochain_chc", optional = true }
 holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.5.0-rc.0", features = [
   "sqlite",


### PR DESCRIPTION
### Summary

This dependency was not needed and was ending up forcing `hc` to depend on libdatachannel. We do need the effect it was having, of turning on the `kitsune2` feature flag for `holo_hash`

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs