### PR TITLE
Add function counterpart to retry_until_timeout macro to test_utils

### DIFF
--- a/crates/holochain/tests/tests/regression/mod.rs
+++ b/crates/holochain/tests/tests/regression/mod.rs
@@ -1,7 +1,7 @@
 use holo_hash::ActionHash;
 #[cfg(not(feature = "wasmer_wamr"))]
 use holochain::conductor::conductor::WASM_CACHE;
-use holochain::{retry_until_timeout, sweettest::*};
+use holochain::{sweettest::*, test_utils::retry_fn_until_timeout};
 use holochain_wasm_test_utils::TestWasm;
 
 // Make sure the wasm cache at least creates files.
@@ -207,14 +207,17 @@ async fn zero_arc_can_link_to_uncached_base() {
         )
         .await;
 
-    retry_until_timeout!(5000, 500, {
-        if conductors[0]
-            .all_ops_of_author_integrated(dna_file.dna_hash(), alice.agent_pubkey())
-            .unwrap()
-        {
-            break;
-        }
-    });
+    retry_fn_until_timeout(
+        || async {
+            conductors[0]
+                .all_ops_of_author_integrated(dna_file.dna_hash(), alice.agent_pubkey())
+                .unwrap()
+        },
+        None,
+        None,
+    )
+    .await
+    .unwrap();
 
     println!("@!@!@ -- must_get_agent_activity --");
     println!("@!@!@ action_hash: {action_hash:?}");


### PR DESCRIPTION
### Summary

There's the macro `retry_until_timeout` to abbreviate the much used pattern of performing a check repeatedly until it is valid or a timeout has elapsed. This PR adds an almost drop-in replacement as a function. Two occurrences where the macro is used are replaced with the function to illustrate what it looks like.

Let me know if you find this useful.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs