### PR TITLE
hc-sandbox: Add default network config if not provided

### DIFF
--- a/crates/hc_sandbox/src/cmds.rs
+++ b/crates/hc_sandbox/src/cmds.rs
@@ -176,7 +176,18 @@ impl Network {
             transport,
             bootstrap,
         } = match this {
-            None => return None,
+            None => {
+                return Some(NetworkConfig {
+                    advanced: Some(serde_json::json!({
+                        // Allow plaintext signal for hc sandbox to have it work with local
+                        // signaling servers spawned by kitsune2-bootstrap-srv
+                        "tx5Transport": {
+                            "signalAllowPlainText": true,
+                        }
+                    })),
+                    ..NetworkConfig::default()
+                });
+            }
             Some(n) => (*n).clone(),
         };
 


### PR DESCRIPTION
### Summary

Follow-up on #4933 to cover the case where no NetworkConfig is provided.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs