### PR TITLE
bump k2 to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
+name = "app_dirs2"
+version = "2.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e7b35733e3a8c1ccb90385088dd5b6eaa61325cb4d1ad56e683b5224ff352e"
+dependencies = [
+ "jni",
+ "ndk-context",
+ "winapi 0.3.9",
+ "xdg",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +739,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +927,16 @@ checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -4006,6 +4034,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4066,9 +4116,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e02f0a8c6e494ea8ac180daab1daa4b0a3e8b30e21ec6545085dc891b306aad"
+checksum = "20abbce6df4fe81f1d4ad6d6c02a3b731a42160921036d31b36477303bc59468"
 dependencies = [
  "bytes",
  "kitsune2_api",
@@ -4080,9 +4130,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_api"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c23a9357eda3bff9232ceebb20018b9cf3b1a4e0ffbe7eeba9e2495df1c70d7e"
+checksum = "94fe096ea6f0ae356031dfe6df4ed6b0f83076cdc78fe1b420451ab3c152a012"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4097,9 +4147,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_client"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2498d7864dd5bab86a2914fca2b7554652b2a0cffdedd52e14578e1de6c38db1"
+checksum = "c4815ccaa0879e6324d98713cd6e636510e1ef4a71a33fc986b56d20eda4165c"
 dependencies = [
  "base64 0.22.1",
  "kitsune2_api",
@@ -4110,9 +4160,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_srv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093d253286f39e2fc131ebc79ba4a17ab5b678b8320190191bf84f7b2820bdca"
+checksum = "d6bd822c1e5505a3c213b50f60c1415454005c7c69c4dc865b9fbe366d348d2d"
 dependencies = [
  "async-channel",
  "axum",
@@ -4137,9 +4187,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_core"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fbf84fcd26c7abad2d4065f2823ba9f77c4bca86c7046ebacc3b35a3fa4bdd"
+checksum = "90b1a591b76f38d9169824b80fd59d1875c23245d0c69055c40ddb5fd10092c5"
 dependencies = [
  "backon",
  "bytes",
@@ -4159,9 +4209,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_dht"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4d238d7a040f84a2f763b85a06c5ce6fe8d97c3c2a493901da9acf6aeb523e"
+checksum = "5ab15e5fe2e5d8a56f1497e04112922ac160498fac1f4c968b9791454a9b09a6"
 dependencies = [
  "bytes",
  "kitsune2_api",
@@ -4170,9 +4220,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_gossip"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8741f78915c9f62d6ea8bd224a602e61a0fd67229d074b4624623eca93ff7395"
+checksum = "406615dd73489b511c1acdd5ca1c64d704e6b719f2793ef7613d0727eaf82ab5"
 dependencies = [
  "backon",
  "bytes",
@@ -4191,9 +4241,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_tx5"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d855950caa4b3c1156c6ab7650129ae4ee6a1e3dfa9ef770361947e999655b0"
+checksum = "0cdc4e68f3aae7a3eaf6edf2c0b7ef0a0e705618b73ecffdc3acae5be9a106a6"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4203,6 +4253,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tx5",
+ "tx5-core 0.4.0",
  "url",
 ]
 
@@ -4643,6 +4694,12 @@ checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
  "rand 0.8.5",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -7652,11 +7709,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89c76968f7b5c6d26f36f9067044e3b3be0c45b49cd3ce58e4ca55a9fe61576"
 dependencies = [
+ "app_dirs2",
  "base64 0.22.1",
  "once_cell",
  "rand 0.8.5",
  "serde",
  "serde_json",
+ "sha2",
+ "tempfile",
  "tokio",
  "tracing",
 ]
@@ -8592,6 +8652,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -8615,6 +8684,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -8666,6 +8750,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -8684,6 +8774,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -8699,6 +8795,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8732,6 +8834,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -8747,6 +8855,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -8768,6 +8882,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -8783,6 +8903,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -8860,6 +8986,12 @@ dependencies = [
  "libc",
  "rustix 1.0.5",
 ]
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "xxhash-rust"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -27,7 +27,7 @@ holochain_nonce = { version = "^0.6.0-dev.0", path = "../holochain_nonce" }
 holochain_types = { version = "^0.6.0-dev.1", path = "../holochain_types" }
 holochain_websocket = { version = "^0.6.0-dev.1", path = "../holochain_websocket" }
 holochain_zome_types = { version = "^0.6.0-dev.1", path = "../holochain_zome_types" }
-kitsune2_api = "0.2.1"
+kitsune2_api = "0.2.2"
 lair_keystore_api = { version = "0.6.1", optional = true }
 parking_lot = "0.12.1"
 rand = { version = "0.8" }
@@ -45,7 +45,7 @@ holochain = { version = "^0.6.0-dev.1", path = "../holochain", default-features 
 ] }
 holochain_wasm_test_utils = { version = "^0.6.0-dev.1", path = "../test_utils/wasm" }
 
-kitsune2_core = "0.2.1"
+kitsune2_core = "0.2.2"
 serde_yaml = "0.9"
 
 [features]

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -47,8 +47,8 @@ holochain_util = { version = "^0.6.0-dev.0", path = "../holochain_util", feature
 ] }
 holochain_nonce = { version = "^0.6.0-dev.0", path = "../holochain_nonce" }
 holochain_trace = { version = "^0.6.0-dev.0", path = "../holochain_trace" }
-kitsune2_api = "0.2.1"
-kitsune2_core = "0.2.1"
+kitsune2_api = "0.2.2"
+kitsune2_core = "0.2.2"
 nanoid = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -25,7 +25,7 @@ fixt = { version = "^0.6.0-dev.0", path = "../fixt", optional = true }
 futures = { version = "0.3", optional = true }
 holochain_serialized_bytes = { version = "=0.0.55", optional = true }
 holochain_util = { version = "^0.6.0-dev.0", path = "../holochain_util", default-features = false }
-kitsune2_api = { version = "0.2.1", optional = true }
+kitsune2_api = { version = "0.2.2", optional = true }
 must_future = { version = "0.1", optional = true }
 proptest = { version = "1", optional = true }
 proptest-derive = { version = "0", optional = true }

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -51,8 +51,8 @@ holochain_conductor_config = { version = "^0.6.0-dev.1", path = "../holochain_co
 holochain_timestamp = { version = "^0.6.0-dev.0", path = "../timestamp" }
 human-panic = "2.0"
 itertools = { version = "0.12" }
-kitsune2_api = "0.2.1"
-kitsune2_core = "0.2.1"
+kitsune2_api = "0.2.2"
+kitsune2_core = "0.2.2"
 mockall = "0.11.3"
 mr_bundle = { version = "^0.6.0-dev.1", path = "../mr_bundle", features = [
   "fs",
@@ -107,7 +107,7 @@ matches = { version = "0.1.8", optional = true }
 holochain_wasm_test_utils = { version = "^0.6.0-dev.1", path = "../test_utils/wasm", optional = true }
 holochain_test_wasm_common = { version = "^0.6.0-dev.1", path = "../test_utils/wasm_common", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
-kitsune2_bootstrap_srv = { version = "0.2.1", optional = true }
+kitsune2_bootstrap_srv = { version = "0.2.2", optional = true }
 async-once-cell = { version = "0.5", optional = true }
 get_if_addrs = { version = "0.5.3", optional = true }
 schemars = "0.8.21"

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = "1.0"
 tracing = "0.1"
 opentelemetry_api = { version = "=0.20.0", features = ["metrics"] }
 
-kitsune2_api = "0.2.1"
+kitsune2_api = "0.2.2"
 
 async-trait = "0.1"
 mockall = { version = "0.11.3", optional = true }

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -22,10 +22,10 @@ holochain_zome_types = { version = "^0.6.0-dev.1", path = "../holochain_zome_typ
 holochain_util = { version = "^0.6.0-dev.0", default-features = false, path = "../holochain_util", features = [
   "jsonschema",
 ] }
-kitsune2_api = "0.2.1"
-kitsune2_core = { version = "0.2.1", features = ["schema"] }
-kitsune2_gossip = { version = "0.2.1", features = ["schema"] }
-kitsune2_transport_tx5 = { version = "0.2.1", features = ["schema"] }
+kitsune2_api = "0.2.2"
+kitsune2_core = { version = "0.2.2", features = ["schema"] }
+kitsune2_gossip = { version = "0.2.2", features = ["schema"] }
+kitsune2_transport_tx5 = { version = "0.2.2", features = ["schema"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -40,10 +40,10 @@ tokio-stream = "0.1"
 tracing = "0.1"
 opentelemetry_api = { version = "=0.20.0", features = ["metrics"] }
 
-kitsune2 = "0.2.1"
-kitsune2_api = "0.2.1"
-kitsune2_core = "0.2.1"
-kitsune2_gossip = "0.2.1"
+kitsune2 = "0.2.2"
+kitsune2_api = "0.2.2"
+kitsune2_core = "0.2.2"
+kitsune2_gossip = "0.2.2"
 bytes = "1.10"
 holochain_sqlite = { version = "^0.6.0-dev.1", path = "../holochain_sqlite" }
 lair_keystore_api = "=0.6.1"

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -51,7 +51,7 @@ getrandom = "0.2.7"
 opentelemetry_api = { version = "=0.20.0", features = ["metrics"] }
 schemars = "0.8.21"
 
-kitsune2_api = "0.2.1"
+kitsune2_api = "0.2.2"
 bytes = "1.10"
 
 rusqlite = { version = "0.32.1", features = [

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -41,7 +41,7 @@ tracing = "0.1.26"
 cron = "0.15"
 async-recursion = "1.1"
 
-kitsune2_api = "0.2.1"
+kitsune2_api = "0.2.2"
 
 tempfile = { version = "3.3", optional = true }
 base64 = { version = "0.22", optional = true }

--- a/crates/holochain_terminal/Cargo.toml
+++ b/crates/holochain_terminal/Cargo.toml
@@ -31,9 +31,9 @@ holochain_conductor_api = { version = "^0.6.0-dev.1", path = "../holochain_condu
 holochain_websocket = { version = "^0.6.0-dev.1", path = "../holochain_websocket" }
 holochain_types = { version = "^0.6.0-dev.1", path = "../holochain_types" }
 tokio = { version = "1.36.0", features = ["full"] }
-kitsune2_api = "0.2.1"
-kitsune2_core = "0.2.1"
-kitsune2_bootstrap_client = "0.2.1"
+kitsune2_api = "0.2.2"
+kitsune2_core = "0.2.2"
+kitsune2_bootstrap_client = "0.2.2"
 
 [lints]
 workspace = true

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -33,7 +33,7 @@ holochain_zome_types = { path = "../holochain_zome_types", version = "^0.6.0-dev
   "full",
 ] }
 holochain_timestamp = { version = "^0.6.0-dev.0", path = "../timestamp" }
-kitsune2_api = "0.2.1"
+kitsune2_api = "0.2.2"
 itertools = { version = "0.12" }
 mr_bundle = { path = "../mr_bundle", features = [
   "fs",


### PR DESCRIPTION
Includes additional tx5 configs for enabling backend tracing and setting min/max ports to use.