### PR TITLE
Remove unused get request kinds & GetOptions

### DIFF
--- a/crates/holochain/src/conductor/conductor/hc_p2p_handler_impl.rs
+++ b/crates/holochain/src/conductor/conductor/hc_p2p_handler_impl.rs
@@ -50,12 +50,11 @@ impl holochain_p2p::event::HcP2pHandler for Conductor {
         dna_hash: DnaHash,
         to_agent: AgentPubKey,
         dht_hash: holo_hash::AnyDhtHash,
-        options: holochain_p2p::event::GetOptions,
     ) -> BoxFut<'_, HolochainP2pResult<WireOps>> {
         Box::pin(async {
             self.cell_by_parts(&dna_hash, &to_agent)
                 .await?
-                .handle_get(dna_hash, to_agent, dht_hash, options)
+                .handle_get(dna_hash, to_agent, dht_hash)
                 .await
         })
     }

--- a/crates/holochain/src/core/workflow/app_validation_workflow/run_validation_callback_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/run_validation_callback_tests.rs
@@ -174,7 +174,7 @@ async fn validation_callback_awaiting_deps_hashes() {
     // mock network that returns the requested create action
     let mut network = MockHolochainP2pDnaT::new();
     let action_to_return = create_action_signed_hashed.clone();
-    network.expect_get().returning(move |hash, _| {
+    network.expect_get().returning(move |hash| {
         assert_eq!(hash, action_to_return.as_hash().clone().into());
         Ok(vec![WireOps::Record(WireRecordOps {
             action: Some(Judged::new(

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -135,7 +135,7 @@ async fn main_workflow() {
     hc_p2p
         .expect_get()
         .times(1)
-        .return_once(|_, _, _| Box::pin(async { Ok(vec![]) }));
+        .return_once(|_, _| Box::pin(async { Ok(vec![]) }));
     hc_p2p
         .expect_target_arcs()
         .returning(|_| Box::pin(async move { Ok(vec![]) }));

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
@@ -179,7 +179,7 @@ async fn validate_op_with_dependency_not_held() {
     let response = WireOps::Record(ops);
     network
         .expect_get()
-        .return_once(move |_, _| Ok(vec![response]));
+        .return_once(move |_| Ok(vec![response]));
 
     network
         .expect_target_arcs()
@@ -242,7 +242,7 @@ async fn validate_op_with_dependency_not_found_on_the_dht() {
     let response = WireOps::Record(WireRecordOps::new());
     network
         .expect_get()
-        .return_once(move |_, _| Ok(vec![response]));
+        .return_once(move |_| Ok(vec![response]));
 
     #[cfg(feature = "unstable-warrants")]
     network

--- a/crates/holochain_cascade/src/authority.rs
+++ b/crates/holochain_cascade/src/authority.rs
@@ -41,9 +41,9 @@ pub async fn handle_get_entry(
 pub async fn handle_get_record(
     env: DbRead<DbKindDht>,
     hash: ActionHash,
-    options: holochain_p2p::event::GetOptions,
+    _options: holochain_p2p::event::GetOptions,
 ) -> CascadeResult<WireRecordOps> {
-    let query = GetRecordOpsQuery::new(hash, options);
+    let query = GetRecordOpsQuery::new(hash);
     let results = env
         .read_async(move |txn| query.run(CascadeTxnWrapper::from(txn)))
         .await?;

--- a/crates/holochain_cascade/src/authority.rs
+++ b/crates/holochain_cascade/src/authority.rs
@@ -27,7 +27,6 @@ pub(crate) mod get_record_query;
 pub async fn handle_get_entry(
     db: DbRead<DbKindDht>,
     hash: EntryHash,
-    _options: holochain_p2p::event::GetOptions,
 ) -> CascadeResult<WireEntryOps> {
     let query = GetEntryOpsQuery::new(hash);
     let results = db
@@ -41,7 +40,6 @@ pub async fn handle_get_entry(
 pub async fn handle_get_record(
     env: DbRead<DbKindDht>,
     hash: ActionHash,
-    _options: holochain_p2p::event::GetOptions,
 ) -> CascadeResult<WireRecordOps> {
     let query = GetRecordOpsQuery::new(hash);
     let results = env

--- a/crates/holochain_cascade/src/authority/test.rs
+++ b/crates/holochain_cascade/src/authority/test.rs
@@ -5,7 +5,6 @@ use holo_hash::fixt::ActionHashFixturator;
 #[cfg(feature = "unstable-warrants")]
 use holo_hash::fixt::AgentPubKeyFixturator;
 use holochain_p2p::actor;
-use holochain_p2p::event::GetRequest;
 use holochain_state::prelude::test_dht_db;
 #[cfg(feature = "unstable-warrants")]
 use {crate::authority::handle_get_agent_activity, holochain_types::activity::ChainItems};
@@ -14,7 +13,6 @@ fn options() -> holochain_p2p::event::GetOptions {
     holochain_p2p::event::GetOptions {
         follow_redirects: false,
         all_live_actions_with_metadata: true,
-        request_type: Default::default(),
     }
 }
 
@@ -128,30 +126,6 @@ async fn get_record() {
         deletes: vec![],
         updates: vec![],
         entry: td.any_entry.clone(),
-    };
-    assert_eq!(result, expected);
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn retrieve_record() {
-    holochain_trace::test_run();
-    let db = test_dht_db();
-
-    let td = RecordTestData::create();
-
-    fill_db_pending(&db.to_db(), td.store_record_op.clone()).await;
-
-    let mut options = options();
-    options.request_type = GetRequest::Pending;
-
-    let result = handle_get_record(db.to_db().into(), td.create_hash.clone(), options.clone())
-        .await
-        .unwrap();
-    let expected = WireRecordOps {
-        action: Some(td.wire_create.clone()),
-        deletes: vec![],
-        updates: vec![],
-        entry: Some(td.entry.clone()),
     };
     assert_eq!(result, expected);
 }

--- a/crates/holochain_cascade/src/authority/test.rs
+++ b/crates/holochain_cascade/src/authority/test.rs
@@ -9,13 +9,6 @@ use holochain_state::prelude::test_dht_db;
 #[cfg(feature = "unstable-warrants")]
 use {crate::authority::handle_get_agent_activity, holochain_types::activity::ChainItems};
 
-fn options() -> holochain_p2p::event::GetOptions {
-    holochain_p2p::event::GetOptions {
-        follow_redirects: false,
-        all_live_actions_with_metadata: true,
-    }
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn get_entry() {
     holochain_trace::test_run();
@@ -24,9 +17,8 @@ async fn get_entry() {
     let td = EntryTestData::create();
 
     fill_db(&db.to_db(), td.store_entry_op.clone()).await;
-    let options = options();
 
-    let result = handle_get_entry(db.to_db().into(), td.hash.clone(), options.clone())
+    let result = handle_get_entry(db.to_db().into(), td.hash.clone())
         .await
         .unwrap();
     let expected = WireEntryOps {
@@ -39,7 +31,7 @@ async fn get_entry() {
 
     fill_db(&db.to_db(), td.delete_entry_action_op.clone()).await;
 
-    let result = handle_get_entry(db.to_db().into(), td.hash.clone(), options.clone())
+    let result = handle_get_entry(db.to_db().into(), td.hash.clone())
         .await
         .unwrap();
     let expected = WireEntryOps {
@@ -52,9 +44,19 @@ async fn get_entry() {
 
     fill_db(&db.to_db(), td.update_content_op.clone()).await;
 
-    let result = handle_get_entry(db.to_db().into(), td.hash.clone(), options.clone())
+    let result = handle_get_entry(db.to_db().into(), td.hash.clone())
         .await
         .unwrap();
+    let result_2 = handle_get_entry(db.to_db().into(), td.hash.clone())
+        .await
+        .unwrap();
+    let result_3 = handle_get_entry(db.to_db().into(), td.hash.clone())
+        .await
+        .unwrap();
+    println!("wire entry ops 1 {result:?}");
+    println!("wire entry ops 2 {result_2:?}");
+    println!("result == result_2 {}", result == result_2);
+    println!("result2 == result_3 {}", result_2 == result_3);
     let expected = WireEntryOps {
         creates: vec![td.wire_create.clone()],
         deletes: vec![td.wire_delete.clone()],
@@ -73,9 +75,7 @@ async fn get_record() {
 
     fill_db(&db.to_db(), td.store_record_op.clone()).await;
 
-    let options = options();
-
-    let result = handle_get_record(db.to_db().into(), td.create_hash.clone(), options.clone())
+    let result = handle_get_record(db.to_db().into(), td.create_hash.clone())
         .await
         .unwrap();
     let expected = WireRecordOps {
@@ -88,7 +88,7 @@ async fn get_record() {
 
     fill_db(&db.to_db(), td.deleted_by_op.clone()).await;
 
-    let result = handle_get_record(db.to_db().into(), td.create_hash.clone(), options.clone())
+    let result = handle_get_record(db.to_db().into(), td.create_hash.clone())
         .await
         .unwrap();
     let expected = WireRecordOps {
@@ -101,7 +101,7 @@ async fn get_record() {
 
     fill_db(&db.to_db(), td.update_record_op.clone()).await;
 
-    let result = handle_get_record(db.to_db().into(), td.create_hash.clone(), options.clone())
+    let result = handle_get_record(db.to_db().into(), td.create_hash.clone())
         .await
         .unwrap();
     let expected = WireRecordOps {
@@ -114,13 +114,9 @@ async fn get_record() {
 
     fill_db(&db.to_db(), td.any_store_record_op.clone()).await;
 
-    let result = handle_get_record(
-        db.to_db().into(),
-        td.any_action_hash.clone(),
-        options.clone(),
-    )
-    .await
-    .unwrap();
+    let result = handle_get_record(db.to_db().into(), td.any_action_hash.clone())
+        .await
+        .unwrap();
     let expected = WireRecordOps {
         action: Some(td.any_action.clone()),
         deletes: vec![],

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -536,11 +536,11 @@ impl CascadeImpl {
     pub async fn fetch_record(
         &self,
         hash: AnyDhtHash,
-        options: NetworkGetOptions,
+        _options: NetworkGetOptions,
     ) -> CascadeResult<()> {
         let network = some_or_return!(self.network.as_ref());
         let results = match network
-            .get(hash, options.clone())
+            .get(hash)
             .instrument(debug_span!("fetch_record::network_get"))
             .await
         {

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -263,7 +263,7 @@ impl Cascade for CascadeImpl {
     async fn retrieve_entry(
         &self,
         hash: EntryHash,
-        mut options: NetworkGetOptions,
+        options: NetworkGetOptions,
     ) -> CascadeResult<Option<(EntryHashed, CascadeSource)>> {
         let private_data = self.private_data.clone();
         let result = self
@@ -280,7 +280,6 @@ impl Cascade for CascadeImpl {
         if result.is_some() {
             return Ok(result.map(|e| (EntryHashed::from_content_sync(e), CascadeSource::Local)));
         }
-        options.request_type = holochain_p2p::event::GetRequest::Pending;
         self.fetch_record(hash.clone().into(), options).await?;
 
         // Check if we have the data now after the network call.
@@ -302,7 +301,7 @@ impl Cascade for CascadeImpl {
     async fn retrieve_action(
         &self,
         hash: ActionHash,
-        mut options: NetworkGetOptions,
+        options: NetworkGetOptions,
     ) -> CascadeResult<Option<(SignedActionHashed, CascadeSource)>> {
         let result = self
             .find_map({
@@ -313,7 +312,6 @@ impl Cascade for CascadeImpl {
         if result.is_some() {
             return Ok(result.map(|a| (a, CascadeSource::Local)));
         }
-        options.request_type = holochain_p2p::event::GetRequest::Pending;
         self.fetch_record(hash.clone().into(), options).await?;
 
         // Check if we have the data now after the network call.
@@ -330,7 +328,7 @@ impl Cascade for CascadeImpl {
     async fn retrieve(
         &self,
         hash: AnyDhtHash,
-        mut options: NetworkGetOptions,
+        options: NetworkGetOptions,
     ) -> CascadeResult<Option<(Record, CascadeSource)>> {
         let private_data = self.private_data.clone();
         let result = self
@@ -347,7 +345,6 @@ impl Cascade for CascadeImpl {
         if result.is_some() {
             return Ok(result.map(|r| (r, CascadeSource::Local)));
         }
-        options.request_type = holochain_p2p::event::GetRequest::Pending;
         self.fetch_record(hash.clone(), options).await?;
 
         let private_data = self.private_data.clone();

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -227,141 +227,7 @@ impl CascadeImpl {
     pub fn cache(&self) -> Option<&DbWrite<DbKindCache>> {
         self.cache.as_ref()
     }
-}
 
-/// TODO
-#[async_trait::async_trait]
-#[cfg_attr(feature = "test_utils", mockall::automock)]
-pub trait Cascade {
-    /// Retrieve [`Entry`] either locally or from an authority.
-    /// Data might not have been validated yet by the authority.
-    async fn retrieve_entry(
-        &self,
-        hash: EntryHash,
-        mut options: NetworkGetOptions,
-    ) -> CascadeResult<Option<(EntryHashed, CascadeSource)>>;
-
-    /// Retrieve [`SignedActionHashed`] from either locally or from an authority.
-    /// Data might not have been validated yet by the authority.
-    async fn retrieve_action(
-        &self,
-        hash: ActionHash,
-        mut options: NetworkGetOptions,
-    ) -> CascadeResult<Option<(SignedActionHashed, CascadeSource)>>;
-
-    /// Retrieve data from either locally or from an authority.
-    /// Data might not have been validated yet by the authority.
-    async fn retrieve(
-        &self,
-        hash: AnyDhtHash,
-        mut options: NetworkGetOptions,
-    ) -> CascadeResult<Option<(Record, CascadeSource)>>;
-}
-
-#[async_trait::async_trait]
-impl Cascade for CascadeImpl {
-    async fn retrieve_entry(
-        &self,
-        hash: EntryHash,
-        options: NetworkGetOptions,
-    ) -> CascadeResult<Option<(EntryHashed, CascadeSource)>> {
-        let private_data = self.private_data.clone();
-        let result = self
-            .find_map({
-                let hash = hash.clone();
-                move |store| {
-                    Ok(store.get_public_or_authored_entry(
-                        &hash,
-                        private_data.as_ref().map(|a| a.as_ref()),
-                    )?)
-                }
-            })
-            .await?;
-        if result.is_some() {
-            return Ok(result.map(|e| (EntryHashed::from_content_sync(e), CascadeSource::Local)));
-        }
-        self.fetch_record(hash.clone().into(), options).await?;
-
-        // Check if we have the data now after the network call.
-        let private_data = self.private_data.clone();
-        let result = self
-            .find_map({
-                let hash = hash.clone();
-                move |store| {
-                    Ok(store.get_public_or_authored_entry(
-                        &hash,
-                        private_data.as_ref().map(|a| a.as_ref()),
-                    )?)
-                }
-            })
-            .await?;
-        Ok(result.map(|e| (EntryHashed::from_content_sync(e), CascadeSource::Network)))
-    }
-
-    async fn retrieve_action(
-        &self,
-        hash: ActionHash,
-        options: NetworkGetOptions,
-    ) -> CascadeResult<Option<(SignedActionHashed, CascadeSource)>> {
-        let result = self
-            .find_map({
-                let hash = hash.clone();
-                move |store| Ok(store.get_action(&hash)?)
-            })
-            .await?;
-        if result.is_some() {
-            return Ok(result.map(|a| (a, CascadeSource::Local)));
-        }
-        self.fetch_record(hash.clone().into(), options).await?;
-
-        // Check if we have the data now after the network call.
-        let result = self
-            .find_map(move |store| {
-                Ok(store
-                    .get_action(&hash)?
-                    .map(|a| (a, CascadeSource::Network)))
-            })
-            .await?;
-        Ok(result)
-    }
-
-    async fn retrieve(
-        &self,
-        hash: AnyDhtHash,
-        options: NetworkGetOptions,
-    ) -> CascadeResult<Option<(Record, CascadeSource)>> {
-        let private_data = self.private_data.clone();
-        let result = self
-            .find_map({
-                let hash = hash.clone();
-                move |store| {
-                    Ok(store.get_public_or_authored_record(
-                        &hash,
-                        private_data.as_ref().map(|a| a.as_ref()),
-                    )?)
-                }
-            })
-            .await?;
-        if result.is_some() {
-            return Ok(result.map(|r| (r, CascadeSource::Local)));
-        }
-        self.fetch_record(hash.clone(), options).await?;
-
-        let private_data = self.private_data.clone();
-        // Check if we have the data now after the network call.
-        let result = self
-            .find_map(move |store| {
-                Ok(store.get_public_or_authored_record(
-                    &hash,
-                    private_data.as_ref().map(|a| a.as_ref()),
-                )?)
-            })
-            .await?;
-        Ok(result.map(|r| (r, CascadeSource::Network)))
-    }
-}
-
-impl CascadeImpl {
     #[allow(clippy::result_large_err)] // TODO - investigate this lint
     fn insert_rendered_op(txn: &mut Txn<DbKindCache>, op: &RenderedOp) -> CascadeResult<()> {
         let RenderedOp {
@@ -1264,6 +1130,138 @@ impl CascadeImpl {
             Some(author) => Q::with_private_data_access(hash, author),
             None => Q::without_private_data_access(hash),
         }
+    }
+}
+
+/// TODO
+#[async_trait::async_trait]
+#[cfg_attr(feature = "test_utils", mockall::automock)]
+pub trait Cascade {
+    /// Retrieve [`Entry`] either locally or from an authority.
+    /// Data might not have been validated yet by the authority.
+    async fn retrieve_entry(
+        &self,
+        hash: EntryHash,
+        mut options: NetworkGetOptions,
+    ) -> CascadeResult<Option<(EntryHashed, CascadeSource)>>;
+
+    /// Retrieve [`SignedActionHashed`] from either locally or from an authority.
+    /// Data might not have been validated yet by the authority.
+    async fn retrieve_action(
+        &self,
+        hash: ActionHash,
+        mut options: NetworkGetOptions,
+    ) -> CascadeResult<Option<(SignedActionHashed, CascadeSource)>>;
+
+    /// Retrieve data from either locally or from an authority.
+    /// Data might not have been validated yet by the authority.
+    async fn retrieve(
+        &self,
+        hash: AnyDhtHash,
+        mut options: NetworkGetOptions,
+    ) -> CascadeResult<Option<(Record, CascadeSource)>>;
+}
+
+#[async_trait::async_trait]
+impl Cascade for CascadeImpl {
+    async fn retrieve_entry(
+        &self,
+        hash: EntryHash,
+        options: NetworkGetOptions,
+    ) -> CascadeResult<Option<(EntryHashed, CascadeSource)>> {
+        let private_data = self.private_data.clone();
+        let result = self
+            .find_map({
+                let hash = hash.clone();
+                move |store| {
+                    Ok(store.get_public_or_authored_entry(
+                        &hash,
+                        private_data.as_ref().map(|a| a.as_ref()),
+                    )?)
+                }
+            })
+            .await?;
+        if result.is_some() {
+            return Ok(result.map(|e| (EntryHashed::from_content_sync(e), CascadeSource::Local)));
+        }
+        self.fetch_record(hash.clone().into(), options).await?;
+
+        // Check if we have the data now after the network call.
+        let private_data = self.private_data.clone();
+        let result = self
+            .find_map({
+                let hash = hash.clone();
+                move |store| {
+                    Ok(store.get_public_or_authored_entry(
+                        &hash,
+                        private_data.as_ref().map(|a| a.as_ref()),
+                    )?)
+                }
+            })
+            .await?;
+        Ok(result.map(|e| (EntryHashed::from_content_sync(e), CascadeSource::Network)))
+    }
+
+    async fn retrieve_action(
+        &self,
+        hash: ActionHash,
+        options: NetworkGetOptions,
+    ) -> CascadeResult<Option<(SignedActionHashed, CascadeSource)>> {
+        let result = self
+            .find_map({
+                let hash = hash.clone();
+                move |store| Ok(store.get_action(&hash)?)
+            })
+            .await?;
+        if result.is_some() {
+            return Ok(result.map(|a| (a, CascadeSource::Local)));
+        }
+        self.fetch_record(hash.clone().into(), options).await?;
+
+        // Check if we have the data now after the network call.
+        let result = self
+            .find_map(move |store| {
+                Ok(store
+                    .get_action(&hash)?
+                    .map(|a| (a, CascadeSource::Network)))
+            })
+            .await?;
+        Ok(result)
+    }
+
+    async fn retrieve(
+        &self,
+        hash: AnyDhtHash,
+        options: NetworkGetOptions,
+    ) -> CascadeResult<Option<(Record, CascadeSource)>> {
+        let private_data = self.private_data.clone();
+        let result = self
+            .find_map({
+                let hash = hash.clone();
+                move |store| {
+                    Ok(store.get_public_or_authored_record(
+                        &hash,
+                        private_data.as_ref().map(|a| a.as_ref()),
+                    )?)
+                }
+            })
+            .await?;
+        if result.is_some() {
+            return Ok(result.map(|r| (r, CascadeSource::Local)));
+        }
+        self.fetch_record(hash.clone(), options).await?;
+
+        let private_data = self.private_data.clone();
+        // Check if we have the data now after the network call.
+        let result = self
+            .find_map(move |store| {
+                Ok(store.get_public_or_authored_record(
+                    &hash,
+                    private_data.as_ref().map(|a| a.as_ref()),
+                )?)
+            })
+            .await?;
+        Ok(result.map(|r| (r, CascadeSource::Network)))
     }
 }
 

--- a/crates/holochain_cascade/src/test_utils.rs
+++ b/crates/holochain_cascade/src/test_utils.rs
@@ -321,9 +321,9 @@ pub fn handle_get_entry_txn(
 pub fn handle_get_record_txn(
     txn: &Transaction<'_>,
     hash: ActionHash,
-    options: holochain_p2p::event::GetOptions,
+    _options: holochain_p2p::event::GetOptions,
 ) -> WireRecordOps {
-    let query = GetRecordOpsQuery::new(hash, options);
+    let query = GetRecordOpsQuery::new(hash);
     query.run(CascadeTxnWrapper::from(txn)).unwrap()
 }
 

--- a/crates/holochain_cascade/src/test_utils.rs
+++ b/crates/holochain_cascade/src/test_utils.rs
@@ -65,28 +65,22 @@ impl PassThroughNetwork {
 
 #[async_trait::async_trait]
 impl HolochainP2pDnaT for PassThroughNetwork {
-    async fn get(
-        &self,
-        dht_hash: holo_hash::AnyDhtHash,
-        options: actor::GetOptions,
-    ) -> HolochainP2pResult<Vec<WireOps>> {
+    async fn get(&self, dht_hash: holo_hash::AnyDhtHash) -> HolochainP2pResult<Vec<WireOps>> {
         let mut out = Vec::new();
         match dht_hash.into_primitive() {
             AnyDhtHashPrimitive::Entry(hash) => {
                 for db in &self.envs {
-                    let r =
-                        authority::handle_get_entry(db.clone(), hash.clone(), (&options).into())
-                            .await
-                            .map_err(|e| HolochainP2pError::Other(e.into()))?;
+                    let r = authority::handle_get_entry(db.clone(), hash.clone())
+                        .await
+                        .map_err(|e| HolochainP2pError::Other(e.into()))?;
                     out.push(WireOps::Entry(r));
                 }
             }
             AnyDhtHashPrimitive::Action(hash) => {
                 for db in &self.envs {
-                    let r =
-                        authority::handle_get_record(db.clone(), hash.clone(), (&options).into())
-                            .await
-                            .map_err(|e| HolochainP2pError::Other(e.into()))?;
+                    let r = authority::handle_get_record(db.clone(), hash.clone())
+                        .await
+                        .map_err(|e| HolochainP2pError::Other(e.into()))?;
                     out.push(WireOps::Record(r));
                 }
             }
@@ -308,38 +302,22 @@ pub async fn fill_db_as_author(db: &DbWrite<DbKindAuthored>, op: ChainOpHashed) 
 }
 
 /// Utility for network simulation response to get entry.
-pub fn handle_get_entry_txn(
-    txn: &Transaction<'_>,
-    hash: EntryHash,
-    _options: holochain_p2p::event::GetOptions,
-) -> WireEntryOps {
+pub fn handle_get_entry_txn(txn: &Transaction<'_>, hash: EntryHash) -> WireEntryOps {
     let query = GetEntryOpsQuery::new(hash);
     query.run(CascadeTxnWrapper::from(txn)).unwrap()
 }
 
 /// Utility for network simulation response to get record.
-pub fn handle_get_record_txn(
-    txn: &Transaction<'_>,
-    hash: ActionHash,
-    _options: holochain_p2p::event::GetOptions,
-) -> WireRecordOps {
+pub fn handle_get_record_txn(txn: &Transaction<'_>, hash: ActionHash) -> WireRecordOps {
     let query = GetRecordOpsQuery::new(hash);
     query.run(CascadeTxnWrapper::from(txn)).unwrap()
 }
 
 /// Utility for network simulation response to get.
-pub fn handle_get_txn(
-    txn: &Transaction<'_>,
-    hash: AnyDhtHash,
-    options: holochain_p2p::event::GetOptions,
-) -> WireOps {
+pub fn handle_get_txn(txn: &Transaction<'_>, hash: AnyDhtHash) -> WireOps {
     match hash.into_primitive() {
-        AnyDhtHashPrimitive::Entry(hash) => {
-            WireOps::Entry(handle_get_entry_txn(txn, hash, options))
-        }
-        AnyDhtHashPrimitive::Action(hash) => {
-            WireOps::Record(handle_get_record_txn(txn, hash, options))
-        }
+        AnyDhtHashPrimitive::Entry(hash) => WireOps::Entry(handle_get_entry_txn(txn, hash)),
+        AnyDhtHashPrimitive::Action(hash) => WireOps::Record(handle_get_record_txn(txn, hash)),
     }
 }
 

--- a/crates/holochain_p2p/src/lib.rs
+++ b/crates/holochain_p2p/src/lib.rs
@@ -91,11 +91,7 @@ pub trait HolochainP2pDnaT: Send + Sync + 'static {
     ) -> HolochainP2pResult<()>;
 
     /// Get an entry from the DHT.
-    async fn get(
-        &self,
-        dht_hash: holo_hash::AnyDhtHash,
-        options: actor::GetOptions,
-    ) -> HolochainP2pResult<Vec<WireOps>>;
+    async fn get(&self, dht_hash: holo_hash::AnyDhtHash) -> HolochainP2pResult<Vec<WireOps>>;
 
     /// Get metadata from the DHT.
     async fn get_meta(
@@ -272,13 +268,9 @@ impl HolochainP2pDnaT for HolochainP2pDna {
     }
 
     /// Get [`ChainOp::StoreRecord`] or [`ChainOp::StoreEntry`] from the DHT.
-    async fn get(
-        &self,
-        dht_hash: holo_hash::AnyDhtHash,
-        options: actor::GetOptions,
-    ) -> HolochainP2pResult<Vec<WireOps>> {
+    async fn get(&self, dht_hash: holo_hash::AnyDhtHash) -> HolochainP2pResult<Vec<WireOps>> {
         self.sender
-            .get((*self.dna_hash).clone(), dht_hash, options)
+            .get((*self.dna_hash).clone(), dht_hash)
             .instrument(tracing::debug_span!("HolochainP2p::get"))
             .await
     }

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -82,11 +82,10 @@ impl event::HcP2pHandler for WrapEvtSender {
         dna_hash: DnaHash,
         to_agent: AgentPubKey,
         dht_hash: holo_hash::AnyDhtHash,
-        options: event::GetOptions,
     ) -> BoxFut<'_, HolochainP2pResult<WireOps>> {
         timing_trace!(
             true,
-            { self.0.handle_get(dna_hash, to_agent, dht_hash, options) },
+            { self.0.handle_get(dna_hash, to_agent, dht_hash) },
             a = "recv_get",
         )
     }
@@ -332,13 +331,12 @@ impl SpaceHandler for HolochainP2pActor {
                         msg_id,
                         to_agent,
                         dht_hash,
-                        options,
                     } => {
                         let dna_hash = DnaHash::from_k2_space(&space_id);
                         let resp = match evt_sender
                             .get()
                             .ok_or_else(|| HolochainP2pError::other(EVT_REG_ERR))?
-                            .handle_get(dna_hash, to_agent, dht_hash, options)
+                            .handle_get(dna_hash, to_agent, dht_hash)
                             .await
                         {
                             Ok(response) => GetRes { msg_id, response },
@@ -1372,7 +1370,6 @@ impl actor::HcP2p for HolochainP2pActor {
         &self,
         dna_hash: DnaHash,
         dht_hash: holo_hash::AnyDhtHash,
-        options: actor::GetOptions,
     ) -> BoxFut<'_, HolochainP2pResult<Vec<WireOps>>> {
         Box::pin(async move {
             let space_id = dna_hash.to_k2_space();
@@ -1381,9 +1378,7 @@ impl actor::HcP2p for HolochainP2pActor {
 
             let (to_agent, to_url) = self.get_peer_for_loc("get", &space, loc).await?;
 
-            let r_options: event::GetOptions = (&options).into();
-
-            let (msg_id, req) = crate::wire::WireMessage::get_req(to_agent, dht_hash, r_options);
+            let (msg_id, req) = crate::wire::WireMessage::get_req(to_agent, dht_hash);
 
             let start = std::time::Instant::now();
 

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -36,16 +36,6 @@ pub struct GetOptions {
     /// See `as_race` for details.
     /// Set to `None` for a default "best-effort" race.
     pub race_timeout_ms: Option<u64>,
-
-    /// `[Remote]`
-    /// Whether the remote-end should follow redirects or just return the
-    /// requested entry.
-    pub follow_redirects: bool,
-
-    /// `[Remote]`
-    /// Return all live actions even if there is deletes.
-    /// Useful for metadata calls.
-    pub all_live_actions_with_metadata: bool,
 }
 
 impl Default for GetOptions {
@@ -55,8 +45,6 @@ impl Default for GetOptions {
             timeout_ms: None,
             as_race: true,
             race_timeout_ms: None,
-            follow_redirects: true,
-            all_live_actions_with_metadata: false,
         }
     }
 }
@@ -70,9 +58,6 @@ impl GetOptions {
             timeout_ms: None,
             as_race: true,
             race_timeout_ms: None,
-            // Never redirect as the returned value must always match the hash.
-            follow_redirects: false,
-            all_live_actions_with_metadata: false,
         }
     }
 }
@@ -303,7 +288,6 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug {
         &self,
         dna_hash: DnaHash,
         dht_hash: holo_hash::AnyDhtHash,
-        options: GetOptions,
     ) -> BoxFut<'_, HolochainP2pResult<Vec<WireOps>>>;
 
     /// Get metadata from the DHT.

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -1,7 +1,6 @@
 //! Module containing the HolochainP2p actor definition.
 #![allow(clippy::too_many_arguments)]
 
-use crate::event::GetRequest;
 use crate::*;
 use holochain_types::activity::AgentActivityResponse;
 use holochain_types::prelude::ValidationReceiptBundle;
@@ -47,10 +46,6 @@ pub struct GetOptions {
     /// Return all live actions even if there is deletes.
     /// Useful for metadata calls.
     pub all_live_actions_with_metadata: bool,
-
-    /// `[Remote]`
-    /// The type of data this get request requires.
-    pub request_type: GetRequest,
 }
 
 impl Default for GetOptions {
@@ -62,7 +57,6 @@ impl Default for GetOptions {
             race_timeout_ms: None,
             follow_redirects: true,
             all_live_actions_with_metadata: false,
-            request_type: Default::default(),
         }
     }
 }
@@ -79,8 +73,6 @@ impl GetOptions {
             // Never redirect as the returned value must always match the hash.
             follow_redirects: false,
             all_live_actions_with_metadata: false,
-            // Redundant with retrieve_entry internals.
-            request_type: GetRequest::Pending,
         }
     }
 }

--- a/crates/holochain_p2p/src/types/event.rs
+++ b/crates/holochain_p2p/src/types/event.rs
@@ -4,26 +4,6 @@
 use crate::*;
 use holochain_zome_types::signature::Signature;
 
-/// Get options help control how the get is processed at various levels.
-#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
-pub struct GetOptions {
-    /// Whether the remote-end should follow redirects or just return the
-    /// requested entry.
-    pub follow_redirects: bool,
-    /// Return all live actions even if there is deletes.
-    /// Useful for metadata calls.
-    pub all_live_actions_with_metadata: bool,
-}
-
-impl From<&actor::GetOptions> for GetOptions {
-    fn from(a: &actor::GetOptions) -> Self {
-        Self {
-            follow_redirects: a.follow_redirects,
-            all_live_actions_with_metadata: a.all_live_actions_with_metadata,
-        }
-    }
-}
-
 /// GetMeta options help control how the get is processed at various levels.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct GetMetaOptions {}
@@ -115,7 +95,6 @@ pub trait HcP2pHandler: 'static + Send + Sync + std::fmt::Debug {
         dna_hash: DnaHash,
         to_agent: AgentPubKey,
         dht_hash: holo_hash::AnyDhtHash,
-        options: GetOptions,
     ) -> BoxFut<'_, HolochainP2pResult<WireOps>>;
 
     /// A remote node is requesting metadata from us.

--- a/crates/holochain_p2p/src/types/event.rs
+++ b/crates/holochain_p2p/src/types/event.rs
@@ -4,21 +4,6 @@
 use crate::*;
 use holochain_zome_types::signature::Signature;
 
-/// The data required for a get request.
-#[derive(Default, Debug, serde::Serialize, serde::Deserialize, Clone)]
-pub enum GetRequest {
-    /// Get all the integrated data.
-    #[default]
-    All,
-    /// Get only the integrated content.
-    Content,
-    /// Get only the metadata.
-    /// If you already have the content this is all you need.
-    Metadata,
-    /// Get the content even if it's still pending.
-    Pending,
-}
-
 /// Get options help control how the get is processed at various levels.
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub struct GetOptions {
@@ -28,8 +13,6 @@ pub struct GetOptions {
     /// Return all live actions even if there is deletes.
     /// Useful for metadata calls.
     pub all_live_actions_with_metadata: bool,
-    /// The type of data this get request requires.
-    pub request_type: GetRequest,
 }
 
 impl From<&actor::GetOptions> for GetOptions {
@@ -37,7 +20,6 @@ impl From<&actor::GetOptions> for GetOptions {
         Self {
             follow_redirects: a.follow_redirects,
             all_live_actions_with_metadata: a.all_live_actions_with_metadata,
-            request_type: a.request_type.clone(),
         }
     }
 }

--- a/crates/holochain_p2p/src/types/wire.rs
+++ b/crates/holochain_p2p/src/types/wire.rs
@@ -66,7 +66,6 @@ pub enum WireMessage {
         msg_id: u64,
         to_agent: AgentPubKey,
         dht_hash: holo_hash::AnyDhtHash,
-        options: event::GetOptions,
     },
     GetRes {
         msg_id: u64,
@@ -208,11 +207,7 @@ impl WireMessage {
     }
 
     /// Outgoing "Get" request.
-    pub fn get_req(
-        to_agent: AgentPubKey,
-        dht_hash: holo_hash::AnyDhtHash,
-        options: event::GetOptions,
-    ) -> (u64, WireMessage) {
+    pub fn get_req(to_agent: AgentPubKey, dht_hash: holo_hash::AnyDhtHash) -> (u64, WireMessage) {
         let msg_id = next_msg_id();
         (
             msg_id,
@@ -220,7 +215,6 @@ impl WireMessage {
                 msg_id,
                 to_agent,
                 dht_hash,
-                options,
             },
         )
     }

--- a/crates/holochain_p2p/tests/tests/node_messaging.rs
+++ b/crates/holochain_p2p/tests/tests/node_messaging.rs
@@ -50,7 +50,6 @@ impl HcP2pHandler for Handler {
         _dna_hash: DnaHash,
         _to_agent: AgentPubKey,
         _dht_hash: holo_hash::AnyDhtHash,
-        _options: holochain_p2p::event::GetOptions,
     ) -> BoxFut<'_, HolochainP2pResult<WireOps>> {
         Box::pin(async move {
             self.0.lock().unwrap().push("get".into());
@@ -411,7 +410,6 @@ async fn test_get() {
                         vec![1; 36],
                         holo_hash::hash_type::AnyDht::Entry,
                     ),
-                    holochain_p2p::actor::GetOptions::default(),
                 )
                 .await
                 .is_ok()

--- a/crates/holochain_p2p/tests/tests/op_store.rs
+++ b/crates/holochain_p2p/tests/tests/op_store.rs
@@ -3,7 +3,7 @@ use fixt::fixt;
 use holo_hash::{AgentPubKey, AnyDhtHash, DnaHash, HasHash};
 use holochain_p2p::event::{
     CountersigningSessionNegotiationMessage, DynHcP2pHandler, GetActivityOptions, GetLinksOptions,
-    GetMetaOptions, GetOptions, HcP2pHandler,
+    GetMetaOptions, HcP2pHandler,
 };
 use holochain_p2p::{HolochainOpStore, HolochainP2pResult};
 use holochain_serialized_bytes::SerializedBytes;
@@ -74,7 +74,6 @@ impl HcP2pHandler for StubHost {
         _dna_hash: DnaHash,
         _to_agent: AgentPubKey,
         _dht_hash: AnyDhtHash,
-        _options: GetOptions,
     ) -> BoxFut<'_, HolochainP2pResult<WireOps>> {
         unimplemented!()
     }

--- a/crates/holochain_types/src/record.rs
+++ b/crates/holochain_types/src/record.rs
@@ -244,8 +244,6 @@ pub struct RawGetEntryResponse {
     // not the delete action hash as we do now.
     pub deletes: Vec<WireActionStatus<WireDelete>>,
     /// Any updates on this entry.
-    /// Note you will need to ask for "all_live_actions_with_metadata"
-    /// to get this back
     pub updates: Vec<WireActionStatus<WireUpdateRelationship>>,
     /// The entry shared across all actions
     pub entry: Entry,

--- a/crates/holochain_zome_types/src/request.rs
+++ b/crates/holochain_zome_types/src/request.rs
@@ -15,8 +15,6 @@ pub struct MetadataRequest {
     pub all_deletes: bool,
     /// Get all the updates on an entry or action
     pub all_updates: bool,
-    /// Placeholder
-    pub follow_redirects: bool,
     /// Request the status of an entry.
     /// This is faster then getting all the actions
     /// and checking for live actions.
@@ -30,7 +28,6 @@ impl Default for MetadataRequest {
             all_invalid_actions: false,
             all_deletes: true,
             all_updates: true,
-            follow_redirects: false,
             entry_dht_status: false,
         }
     }

--- a/docs/specs/src/hwp_A_implementation_spec.md
+++ b/docs/specs/src/hwp_A_implementation_spec.md
@@ -1764,22 +1764,6 @@ publish
         ```rust
         {
             dht_hash: AnyDhtHash,
-            options: GetOptions,
-        }
-
-        struct GetOptions {
-            request_type: GetRequest,
-        }
-
-        enum GetRequest {
-            // Get integrated content and metadata.
-            All,
-            // Get only addressable content.
-            Content,
-            // Get only metadata.
-            Metadata,
-            // Get content even if it hasn't been integrated.
-            Pending,
         }
         ```
 


### PR DESCRIPTION
### Summary
I came across the request kinds in the `GetLiveRecordQuery` and noticed there was an option to query data that has not been integrated. I think that's no longer necessary that authorities serve that kind of data.

That option was part of a struct `GetOptions` that contained further options that were unused. I've removed that struct. There's more to clean up, more options that aren't used anywhere, but let me know if this is useful before I continue.


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs