### PR TITLE
refactor(holochain_state): optimize chain head query

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Change `hcterm` to use the admin and app websocket clients from `holochain_client` internally
+- Reinstate indexes on `DhtOp` tables. With the latest migration script, the indexes were not carried over. #4970
+- Optimize `ChainHeadQuery` for performance. A flame graph analysis revealed that a significant proportion of the CPU time was spent on this query in a test with a high number of entry creates and reads. The query now runs about 30 % faster. #4971
 
 ## 0.6.0-dev.3
 

--- a/crates/holochain_state/src/query/chain_head.rs
+++ b/crates/holochain_state/src/query/chain_head.rs
@@ -26,8 +26,7 @@ impl Query for ChainHeadQuery {
         "
         SELECT Action.blob, Action.hash
         FROM Action
-        JOIN DhtOp ON DhtOp.action_hash = Action.hash
-        WHERE Action.author = :author AND Action.hash IS NOT NULL
+        WHERE Action.author = :author
         ORDER BY Action.seq DESC LIMIT 1
         "
         .into()


### PR DESCRIPTION
### Summary

The `ChainHeadQuery` is run every time an action is created in the source chain. A flamegraph uncovered that it was taking up a significant portion of the CPU time. This is a proposal to optimize it.

Here's a test run that exercises this query heavily, creating 5000 entries and reading them back.

Query before
```sh
running 1 test
The last 100 calls took on average 5 ms
The last 100 calls took on average 5 ms
The last 100 calls took on average 5 ms
The last 100 calls took on average 6 ms
The last 100 calls took on average 6 ms
The last 100 calls took on average 6 ms
The last 100 calls took on average 7 ms
The last 100 calls took on average 7 ms
The last 100 calls took on average 8 ms
The last 100 calls took on average 8 ms
The last 100 calls took on average 8 ms
The last 100 calls took on average 9 ms
The last 100 calls took on average 9 ms
The last 100 calls took on average 10 ms
The last 100 calls took on average 11 ms
The last 100 calls took on average 11 ms
The last 100 calls took on average 11 ms
The last 100 calls took on average 12 ms
The last 100 calls took on average 12 ms
The last 100 calls took on average 13 ms
The last 100 calls took on average 13 ms
The last 100 calls took on average 15 ms
The last 100 calls took on average 16 ms
The last 100 calls took on average 16 ms
The last 100 calls took on average 16 ms
The last 100 calls took on average 18 ms
The last 100 calls took on average 18 ms
The last 100 calls took on average 19 ms
The last 100 calls took on average 20 ms
The last 100 calls took on average 21 ms
The last 100 calls took on average 21 ms
The last 100 calls took on average 21 ms
The last 100 calls took on average 23 ms
The last 100 calls took on average 25 ms
The last 100 calls took on average 25 ms
The last 100 calls took on average 25 ms
The last 100 calls took on average 25 ms
The last 100 calls took on average 28 ms
The last 100 calls took on average 27 ms
The last 100 calls took on average 28 ms
The last 100 calls took on average 28 ms
The last 100 calls took on average 28 ms
The last 100 calls took on average 28 ms
The last 100 calls took on average 32 ms
The last 100 calls took on average 32 ms
The last 100 calls took on average 32 ms
The last 100 calls took on average 34 ms
The last 100 calls took on average 33 ms
The last 100 calls took on average 35 ms
The last 100 calls took on average 37 ms
Made 5000 calls in total over 152.306901917s.
```

Query after
```sh
running 1 test
The last 100 calls took on average 4 ms
The last 100 calls took on average 4 ms
The last 100 calls took on average 4 ms
The last 100 calls took on average 5 ms
The last 100 calls took on average 5 ms
The last 100 calls took on average 5 ms
The last 100 calls took on average 5 ms
The last 100 calls took on average 6 ms
The last 100 calls took on average 6 ms
The last 100 calls took on average 6 ms
The last 100 calls took on average 6 ms
The last 100 calls took on average 7 ms
The last 100 calls took on average 7 ms
The last 100 calls took on average 7 ms
The last 100 calls took on average 7 ms
The last 100 calls took on average 8 ms
The last 100 calls took on average 8 ms
The last 100 calls took on average 8 ms
The last 100 calls took on average 8 ms
The last 100 calls took on average 9 ms
The last 100 calls took on average 9 ms
The last 100 calls took on average 9 ms
The last 100 calls took on average 9 ms
The last 100 calls took on average 10 ms
The last 100 calls took on average 10 ms
The last 100 calls took on average 10 ms
The last 100 calls took on average 11 ms
The last 100 calls took on average 11 ms
The last 100 calls took on average 12 ms
The last 100 calls took on average 13 ms
The last 100 calls took on average 13 ms
The last 100 calls took on average 13 ms
The last 100 calls took on average 13 ms
The last 100 calls took on average 14 ms
The last 100 calls took on average 14 ms
The last 100 calls took on average 14 ms
The last 100 calls took on average 14 ms
The last 100 calls took on average 14 ms
The last 100 calls took on average 15 ms
The last 100 calls took on average 15 ms
The last 100 calls took on average 15 ms
The last 100 calls took on average 16 ms
The last 100 calls took on average 16 ms
The last 100 calls took on average 16 ms
The last 100 calls took on average 17 ms
The last 100 calls took on average 17 ms
The last 100 calls took on average 17 ms
The last 100 calls took on average 17 ms
The last 100 calls took on average 18 ms
The last 100 calls took on average 19 ms
Made 5000 calls in total over 115.961880667s.
```

see also #4079 

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs