### PR TITLE
Add app agent info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,6 +2742,7 @@ dependencies = [
  "kitsune2_api",
  "kitsune2_bootstrap_srv",
  "kitsune2_core",
+ "kitsune2_test_utils",
  "lair_keystore",
  "lair_keystore_api",
  "maplit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2914,6 +2914,7 @@ dependencies = [
  "holochain_websocket",
  "kitsune2_api",
  "kitsune2_core",
+ "kitsune2_test_utils",
  "nanoid",
  "nix 0.29.0",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1092,9 +1092,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2947,6 +2947,7 @@ dependencies = [
  "holochain_zome_types",
  "kitsune2_api",
  "kitsune2_core",
+ "kitsune2_test_utils",
  "lair_keystore_api",
  "mr_bundle",
  "parking_lot",
@@ -3661,12 +3662,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
+checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
 dependencies = [
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -4326,6 +4328,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitsune2_test_utils"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac9b5dda78d73097e2e343e00c5b4f7ce0f633ebd5a0ab533198f24fdc6c708"
+dependencies = [
+ "axum 0.7.9",
+ "bytes",
+ "futures",
+ "kitsune2_api",
+ "rand 0.8.5",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kitsune2_transport_tx5"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4440,9 +4458,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.0",
@@ -6610,7 +6628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6929,9 +6947,9 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",

--- a/crates/client/CHANGELOG.md
+++ b/crates/client/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- `AppWebsocket::AgentInfo` call for apps to be able to inspect the connection status of agents in their various DNAs.
+
 ### Changed
 
 ### Fixed

--- a/crates/client/CHANGELOG.md
+++ b/crates/client/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- `AppWebsocket::AgentInfo` call for apps to be able to inspect the connection status of agents in their various DNAs.
+- `AppWebsocket::AgentInfo` call for apps to be able to list the discovered agents in their various DNAs.
 
 ### Changed
 

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -28,7 +28,6 @@ holochain_types = { version = "^0.6.0-dev.6", path = "../holochain_types" }
 holochain_websocket = { version = "^0.6.0-dev.6", path = "../holochain_websocket" }
 holochain_zome_types = { version = "^0.6.0-dev.5", path = "../holochain_zome_types" }
 kitsune2_api = "0.2.7"
-kitsune2_test_utils = "0.2.7"
 lair_keystore_api = { version = "0.6.1", optional = true }
 parking_lot = "0.12.1"
 rand = { version = "0.8" }
@@ -47,6 +46,7 @@ holochain = { version = "^0.6.0-dev.6", path = "../holochain", default-features 
 holochain_wasm_test_utils = { version = "^0.6.0-dev.6", path = "../test_utils/wasm" }
 
 kitsune2_core = "0.2.7"
+kitsune2_test_utils = "0.2.7"
 serde_yaml = "0.9"
 
 [features]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -28,6 +28,7 @@ holochain_types = { version = "^0.6.0-dev.6", path = "../holochain_types" }
 holochain_websocket = { version = "^0.6.0-dev.6", path = "../holochain_websocket" }
 holochain_zome_types = { version = "^0.6.0-dev.5", path = "../holochain_zome_types" }
 kitsune2_api = "0.2.7"
+kitsune2_test_utils = "0.2.7"
 lair_keystore_api = { version = "0.6.1", optional = true }
 parking_lot = "0.12.1"
 rand = { version = "0.8" }

--- a/crates/client/src/admin_websocket.rs
+++ b/crates/client/src/admin_websocket.rs
@@ -524,8 +524,11 @@ impl AdminWebsocket {
         }
     }
 
-    pub async fn agent_info(&self, cell_id: Option<CellId>) -> ConductorApiResult<Vec<String>> {
-        let msg = AdminRequest::AgentInfo { cell_id };
+    pub async fn agent_info(
+        &self,
+        dna_hashes: Option<Vec<DnaHash>>,
+    ) -> ConductorApiResult<Vec<String>> {
+        let msg = AdminRequest::AgentInfo { dna_hashes };
         let response = self.send(msg).await?;
         match response {
             AdminResponse::AgentInfo(agent_info) => Ok(agent_info),

--- a/crates/client/src/app_websocket.rs
+++ b/crates/client/src/app_websocket.rs
@@ -2,7 +2,7 @@ use crate::app_websocket_inner::AppWebsocketInner;
 use crate::signing::DynAgentSigner;
 use crate::{signing::sign_zome_call, ConductorApiError, ConductorApiResult};
 use anyhow::{anyhow, Result};
-use holo_hash::AgentPubKey;
+use holo_hash::{AgentPubKey, DnaHash};
 use holochain_conductor_api::{
     AppAuthenticationToken, AppInfo, AppRequest, AppResponse, CellInfo, ProvisionedCell,
     ZomeCallParamsSigned,
@@ -426,11 +426,17 @@ impl AppWebsocket {
         }
     }
 
+    /// Returns a list of connected peer `AgentInfo`s for the app's DNAs
+    ///
+    /// `dna_hashes` is an optional list of Dna Hashes to filter by, if `None` returns peers for all
+    /// of the app's DNAs.
+    ///
+    /// The return value is a JSON encoded list
     pub async fn agent_info(
         &self,
-        dna_hash: Option<holo_hash::DnaHash>,
+        dna_hashes: Option<Vec<DnaHash>>,
     ) -> ConductorApiResult<Vec<String>> {
-        let msg = AppRequest::AgentInfo { dna_hash };
+        let msg = AppRequest::AgentInfo { dna_hashes };
         let response = self.inner.send(msg).await?;
         match response {
             AppResponse::AgentInfo(infos) => Ok(infos),

--- a/crates/client/src/app_websocket.rs
+++ b/crates/client/src/app_websocket.rs
@@ -425,6 +425,18 @@ impl AppWebsocket {
             _ => unreachable!("Unexpected response {:?}", response),
         }
     }
+
+    pub async fn agent_info(
+        &self,
+        dna_hash: Option<holo_hash::DnaHash>,
+    ) -> ConductorApiResult<Vec<String>> {
+        let msg = AppRequest::AgentInfo { dna_hash };
+        let response = self.inner.send(msg).await?;
+        match response {
+            AppResponse::AgentInfo(infos) => Ok(infos),
+            _ => unreachable!("Unexpected response {:?}", response),
+        }
+    }
 }
 
 pub enum ZomeCallTarget {

--- a/crates/client/tests/admin.rs
+++ b/crates/client/tests/admin.rs
@@ -15,6 +15,24 @@ mod fixture;
 
 const ROLE_NAME: &str = "foo";
 
+fn make_agent(space: kitsune2_api::SpaceId) -> String {
+    let local = kitsune2_core::Ed25519LocalAgent::default();
+    let created_at = kitsune2_api::Timestamp::now();
+    let expires_at = created_at + std::time::Duration::from_secs(60 * 20);
+    let info = kitsune2_api::AgentInfo {
+        agent: kitsune2_api::LocalAgent::agent(&local).clone(),
+        space,
+        created_at,
+        expires_at,
+        is_tombstone: false,
+        url: None,
+        storage_arc: kitsune2_api::DhtArc::FULL,
+    };
+    let info =
+        futures::executor::block_on(kitsune2_api::AgentInfoSigned::sign(&local, info)).unwrap();
+    info.encode().unwrap()
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn app_interfaces() {
     let conductor = SweetConductor::from_standard_config().await;
@@ -203,7 +221,7 @@ async fn agent_info() {
     .space
     .clone();
 
-    let other_agent = fixture::make_agent(space);
+    let other_agent = make_agent(space);
 
     admin_ws
         .add_agent_info(vec![other_agent.clone()])

--- a/crates/client/tests/admin.rs
+++ b/crates/client/tests/admin.rs
@@ -170,24 +170,6 @@ async fn dump_network_stats() {
     assert_eq!("kitsune2-core-mem", network_stats.backend);
 }
 
-fn make_agent(space: kitsune2_api::SpaceId) -> String {
-    let local = kitsune2_core::Ed25519LocalAgent::default();
-    let created_at = kitsune2_api::Timestamp::now();
-    let expires_at = created_at + std::time::Duration::from_secs(60 * 20);
-    let info = kitsune2_api::AgentInfo {
-        agent: kitsune2_api::LocalAgent::agent(&local).clone(),
-        space,
-        created_at,
-        expires_at,
-        is_tombstone: false,
-        url: None,
-        storage_arc: kitsune2_api::DhtArc::FULL,
-    };
-    let info =
-        futures::executor::block_on(kitsune2_api::AgentInfoSigned::sign(&local, info)).unwrap();
-    info.encode().unwrap()
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn agent_info() {
     let conductor = SweetConductor::from_standard_config().await;
@@ -221,7 +203,7 @@ async fn agent_info() {
     .space
     .clone();
 
-    let other_agent = make_agent(space);
+    let other_agent = fixture::make_agent(space);
 
     admin_ws
         .add_agent_info(vec![other_agent.clone()])

--- a/crates/client/tests/admin.rs
+++ b/crates/client/tests/admin.rs
@@ -1,3 +1,4 @@
+use common::make_agent;
 use holochain::prelude::{DnaModifiersOpt, RoleSettings, YamlProperties};
 use holochain::test_utils::itertools::Itertools;
 use holochain::{prelude::AppBundleSource, sweettest::SweetConductor};
@@ -11,27 +12,10 @@ use holochain_zome_types::prelude::ExternIO;
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr};
 
+mod common;
 mod fixture;
 
 const ROLE_NAME: &str = "foo";
-
-fn make_agent(space: kitsune2_api::SpaceId) -> String {
-    let local = kitsune2_core::Ed25519LocalAgent::default();
-    let created_at = kitsune2_api::Timestamp::now();
-    let expires_at = created_at + std::time::Duration::from_secs(60 * 20);
-    let info = kitsune2_api::AgentInfo {
-        agent: kitsune2_api::LocalAgent::agent(&local).clone(),
-        space,
-        created_at,
-        expires_at,
-        is_tombstone: false,
-        url: None,
-        storage_arc: kitsune2_api::DhtArc::FULL,
-    };
-    let info =
-        futures::executor::block_on(kitsune2_api::AgentInfoSigned::sign(&local, info)).unwrap();
-    info.encode().unwrap()
-}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn app_interfaces() {
@@ -221,7 +205,7 @@ async fn agent_info() {
     .space
     .clone();
 
-    let other_agent = make_agent(space);
+    let other_agent = make_agent(&space);
 
     admin_ws
         .add_agent_info(vec![other_agent.clone()])

--- a/crates/client/tests/app.rs
+++ b/crates/client/tests/app.rs
@@ -23,6 +23,24 @@ use std::{
 
 mod fixture;
 
+fn make_agent(space: kitsune2_api::SpaceId) -> String {
+    let local = kitsune2_core::Ed25519LocalAgent::default();
+    let created_at = kitsune2_api::Timestamp::now();
+    let expires_at = created_at + std::time::Duration::from_secs(60 * 20);
+    let info = kitsune2_api::AgentInfo {
+        agent: kitsune2_api::LocalAgent::agent(&local).clone(),
+        space,
+        created_at,
+        expires_at,
+        is_tombstone: false,
+        url: None,
+        storage_arc: kitsune2_api::DhtArc::FULL,
+    };
+    let info =
+        futures::executor::block_on(kitsune2_api::AgentInfoSigned::sign(&local, info)).unwrap();
+    info.encode().unwrap()
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn handle_signal() {
     let conductor = SweetConductor::from_standard_config().await;
@@ -547,7 +565,7 @@ async fn agent_info() {
     .space
     .clone();
 
-    let other_agent = fixture::make_agent(space.clone());
+    let other_agent = make_agent(space.clone());
 
     admin_ws
         .add_agent_info(vec![other_agent.clone()])

--- a/crates/client/tests/app.rs
+++ b/crates/client/tests/app.rs
@@ -572,7 +572,7 @@ async fn agent_info() {
         .await
         .unwrap();
     let dna = DnaHash::from_k2_space(&space);
-    let agent_infos = app_ws.agent_info(Some(dna)).await.unwrap();
+    let agent_infos = app_ws.agent_info(Some(vec![dna])).await.unwrap();
     assert_eq!(agent_infos.len(), 2);
     assert!(agent_infos.contains(&other_agent));
 }

--- a/crates/client/tests/common/mod.rs
+++ b/crates/client/tests/common/mod.rs
@@ -4,9 +4,11 @@ use kitsune2_test_utils::agent::AgentBuilder;
 use std::sync::Arc;
 
 pub fn make_agent(space: &SpaceId) -> String {
-    let mut builder = AgentBuilder::default();
-    let local_agent: DynLocalAgent = Arc::new(Ed25519LocalAgent::default());
-    builder.space = Some(space.clone());
-    let info = builder.build(local_agent);
-    info.encode().unwrap()
+    AgentBuilder {
+        space: Some(space.clone()),
+        ..Default::default()
+    }
+    .build(Arc::new(Ed25519LocalAgent::default()) as DynLocalAgent)
+    .encode()
+    .unwrap()
 }

--- a/crates/client/tests/common/mod.rs
+++ b/crates/client/tests/common/mod.rs
@@ -1,0 +1,12 @@
+use kitsune2_api::{DynLocalAgent, SpaceId};
+use kitsune2_core::Ed25519LocalAgent;
+use kitsune2_test_utils::agent::AgentBuilder;
+use std::sync::Arc;
+
+pub fn make_agent(space: &SpaceId) -> String {
+    let mut builder = AgentBuilder::default();
+    let local_agent: DynLocalAgent = Arc::new(Ed25519LocalAgent::default());
+    builder.space = Some(space.clone());
+    let info = builder.build(local_agent);
+    info.encode().unwrap()
+}

--- a/crates/client/tests/fixture/mod.rs
+++ b/crates/client/tests/fixture/mod.rs
@@ -90,3 +90,21 @@ fn get_test_wasm_pair(wasm: TestWasm) -> (ResourceBytes, ResourceBytes) {
 
     (integrity.into(), coordinator.into())
 }
+
+pub fn make_agent(space: kitsune2_api::SpaceId) -> String {
+    let local = kitsune2_core::Ed25519LocalAgent::default();
+    let created_at = kitsune2_api::Timestamp::now();
+    let expires_at = created_at + std::time::Duration::from_secs(60 * 20);
+    let info = kitsune2_api::AgentInfo {
+        agent: kitsune2_api::LocalAgent::agent(&local).clone(),
+        space,
+        created_at,
+        expires_at,
+        is_tombstone: false,
+        url: None,
+        storage_arc: kitsune2_api::DhtArc::FULL,
+    };
+    let info =
+        futures::executor::block_on(kitsune2_api::AgentInfoSigned::sign(&local, info)).unwrap();
+    info.encode().unwrap()
+}

--- a/crates/client/tests/fixture/mod.rs
+++ b/crates/client/tests/fixture/mod.rs
@@ -90,21 +90,3 @@ fn get_test_wasm_pair(wasm: TestWasm) -> (ResourceBytes, ResourceBytes) {
 
     (integrity.into(), coordinator.into())
 }
-
-pub fn make_agent(space: kitsune2_api::SpaceId) -> String {
-    let local = kitsune2_core::Ed25519LocalAgent::default();
-    let created_at = kitsune2_api::Timestamp::now();
-    let expires_at = created_at + std::time::Duration::from_secs(60 * 20);
-    let info = kitsune2_api::AgentInfo {
-        agent: kitsune2_api::LocalAgent::agent(&local).clone(),
-        space,
-        created_at,
-        expires_at,
-        is_tombstone: false,
-        url: None,
-        storage_arc: kitsune2_api::DhtArc::FULL,
-    };
-    let info =
-        futures::executor::block_on(kitsune2_api::AgentInfoSigned::sign(&local, info)).unwrap();
-    info.encode().unwrap()
-}

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -50,6 +50,7 @@ holochain_nonce = { version = "^0.6.0-dev.0", path = "../holochain_nonce" }
 holochain_trace = { version = "^0.6.0-dev.0", path = "../holochain_trace" }
 kitsune2_api = "0.2.7"
 kitsune2_core = "0.2.7"
+kitsune2_test_utils = "0.2.7"
 nanoid = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -49,6 +49,7 @@ holochain_util = { version = "^0.6.0-dev.0", path = "../holochain_util", feature
 holochain_nonce = { version = "^0.6.0-dev.0", path = "../holochain_nonce" }
 holochain_trace = { version = "^0.6.0-dev.0", path = "../holochain_trace" }
 kitsune2_api = "0.2.7"
+kitsune2_core = "0.2.7"
 nanoid = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
@@ -62,7 +63,6 @@ ed25519-dalek = "2.1"
 
 [dev-dependencies]
 kitsune2_test_utils = "0.2.7"
-kitsune2_core = "0.2.7"
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = { version = "0.29", features = ["process", "signal"] }

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -49,8 +49,6 @@ holochain_util = { version = "^0.6.0-dev.0", path = "../holochain_util", feature
 holochain_nonce = { version = "^0.6.0-dev.0", path = "../holochain_nonce" }
 holochain_trace = { version = "^0.6.0-dev.0", path = "../holochain_trace" }
 kitsune2_api = "0.2.7"
-kitsune2_core = "0.2.7"
-kitsune2_test_utils = "0.2.7"
 nanoid = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
@@ -61,6 +59,10 @@ tracing = "0.1"
 url2 = "0.0.6"
 walkdir = "2"
 ed25519-dalek = "2.1"
+
+[dev-dependencies]
+kitsune2_test_utils = "0.2.7"
+kitsune2_core = "0.2.7"
 
 [target.'cfg(unix)'.dev-dependencies]
 nix = { version = "0.29", features = ["process", "signal"] }

--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -633,7 +633,7 @@ async fn request_agent_info(
     client: &mut AdminWebsocket,
     args: ListAgents,
 ) -> anyhow::Result<Vec<Arc<AgentInfoSigned>>> {
-    let resp = client.agent_info(args.into()).await?;
+    let resp = client.agent_info(args.dna.map(|dna| vec![dna])).await?;
     let mut out = Vec::new();
     for info in resp {
         out.push(AgentInfoSigned::decode(

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -12,7 +12,7 @@ use holochain_websocket::{
     self as ws, ConnectRequest, WebsocketConfig, WebsocketReceiver, WebsocketResult,
     WebsocketSender,
 };
-use kitsune2_api::{DynLocalAgent, SpaceId};
+use kitsune2_api::DynLocalAgent;
 use kitsune2_core::Ed25519LocalAgent;
 use kitsune2_test_utils::agent::AgentBuilder;
 use std::future::Future;

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -13,6 +13,7 @@ use holochain_websocket::{
     WebsocketSender,
 };
 use kitsune2_api::{DynLocalAgent, SpaceId};
+use kitsune2_core::Ed25519LocalAgent;
 use kitsune2_test_utils::agent::AgentBuilder;
 use std::future::Future;
 use std::net::ToSocketAddrs;

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -639,7 +639,14 @@ async fn generate_sandbox_and_add_and_list_agent() {
     .space
     .clone();
 
-    let other_agent = make_agent(space);
+    let other_agent = AgentBuilder {
+        space: Some(space.clone()),
+        ..Default::default()
+    }
+    .build(Arc::new(Ed25519LocalAgent::default()) as DynLocalAgent)
+    .encode()
+    .unwrap();
+
     let agent_infos_to_add = format!("[{}]", other_agent); // add-agents expects a JSON array
 
     let mut cmd = get_sandbox_command();
@@ -939,14 +946,6 @@ async fn shutdown_sandbox(mut child: Child) {
         // simple way.
         child.kill().await.unwrap();
     }
-}
-
-fn make_agent(space: SpaceId) -> String {
-    let mut builder = AgentBuilder::default();
-    let local_agent: DynLocalAgent = Arc::new(Ed25519LocalAgent::default());
-    builder.space = Some(space.clone());
-    let info = builder.build(local_agent);
-    info.encode().unwrap()
 }
 
 struct WsPoll(tokio::task::JoinHandle<()>);

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -6,6 +6,7 @@ default_semver_increment_mode: !pre_minor dev
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Add `AgentInfo` call to the conductor's app interface so that application developers can correlate connected kitsune nodes with app agents.
 
 ## 0.6.0-dev.6
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -6,7 +6,7 @@ default_semver_increment_mode: !pre_minor dev
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Add `AgentInfo` call to the conductor's app interface so that application developers can correlate connected kitsune nodes with app agents.
+- Add `AgentInfo` call to the conductor's app interface to retrieve the discovered peers of the app's various DNAs.
 
 ## 0.6.0-dev.6
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 - Add `AgentInfo` call to the conductor's app interface to retrieve the discovered peers of the app's various DNAs.
+- **Breaking**: admin interface `AgentInfo` call now takes an optional list of DNA hashes to filter by instead of a `CellId`.
 
 ## 0.6.0-dev.6
 

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -153,7 +153,7 @@ tokio = { version = "1.36.0", features = ["full", "test-util"] }
 tokio-tungstenite = "0.21"
 predicates = "3.1"
 assert2 = "0.3.15"
-kitsune2_test_utils = "0.2.6"
+kitsune2_test_utils = "0.2.7"
 
 [build-dependencies]
 hdk = { version = "^0.6.0-dev.5", path = "../hdk" }

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -153,6 +153,7 @@ tokio = { version = "1.36.0", features = ["full", "test-util"] }
 tokio-tungstenite = "0.21"
 predicates = "3.1"
 assert2 = "0.3.15"
+kitsune2_test_utils = "0.2.6"
 
 [build-dependencies]
 hdk = { version = "^0.6.0-dev.5", path = "../hdk" }

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -282,8 +282,8 @@ impl AdminInterfaceApi {
                 self.conductor_handle.add_agent_infos(agent_infos).await?;
                 Ok(AdminResponse::AgentInfoAdded)
             }
-            AgentInfo { cell_id } => {
-                let r = self.conductor_handle.get_agent_infos(cell_id).await?;
+            AgentInfo { dna_hashes } => {
+                let r = self.conductor_handle.get_agent_infos(dna_hashes).await?;
                 let mut encoded = Vec::with_capacity(r.len());
                 for info in r {
                     encoded.push(info.encode()?);

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use crate::conductor::api::error::ConductorApiError;
 use crate::conductor::api::error::ConductorApiResult;
 use crate::conductor::api::error::SerializationError;
@@ -10,6 +12,7 @@ use holochain_serialized_bytes::prelude::*;
 use holochain_types::prelude::*;
 
 pub use holochain_conductor_api::*;
+use kitsune2_api::AgentInfoSigned;
 
 /// The Conductor lives inside an Arc<RwLock<_>> which is shared with all
 /// other Api references
@@ -79,6 +82,59 @@ impl AppInterfaceApi {
                     .get_app_info(&installed_app_id)
                     .await?,
             )),
+            AppRequest::AgentInfo { dna_hash } => {
+                // Get app info to know which DNAs belong to this app
+                let app_info = self
+                    .conductor_handle
+                    .get_app_info(&installed_app_id)
+                    .await?
+                    .ok_or_else(|| {
+                        ConductorApiError::other(format!("App not installed: {}", installed_app_id))
+                    })?;
+
+                // Get all agent infos
+                let all_infos = self.conductor_handle.get_agent_infos(None).await?;
+
+                // 1. Create HashMap mapping DNAs to agent infos
+                let mut dna_to_infos: HashMap<DnaHash, Vec<&AgentInfoSigned>> = HashMap::new();
+                for info in &all_infos {
+                    let dna = DnaHash::from_k2_space(&info.space);
+                    dna_to_infos.entry(dna).or_default().push(info);
+                }
+
+                // 2. Collect all DNAs for this app
+                let mut app_dnas = Vec::new();
+                for cell_info in app_info.cell_info.values().flatten() {
+                    match cell_info {
+                        CellInfo::Provisioned(cell) => {
+                            app_dnas.push(cell.cell_id.dna_hash().clone())
+                        }
+                        CellInfo::Cloned(cell) => app_dnas.push(cell.cell_id.dna_hash().clone()),
+                        _ => continue,
+                    }
+                }
+
+                // If dna_hash is specified, filter to only that DNA
+                if let Some(dna_hash) = &dna_hash {
+                    if !app_dnas.contains(dna_hash) {
+                        return Ok(AppResponse::AgentInfo(Vec::new()));
+                    }
+                    app_dnas.clear();
+                    app_dnas.push(dna_hash.clone());
+                }
+
+                // 3. Collect agent infos for app's DNAs
+                let mut agent_infos = Vec::new();
+                for dna in app_dnas {
+                    if let Some(infos) = dna_to_infos.get(&dna) {
+                        for info in infos {
+                            agent_infos.push(info.encode()?);
+                        }
+                    }
+                }
+
+                Ok(AppResponse::AgentInfo(agent_infos))
+            }
             AppRequest::CallZome(zome_call_params_signed) => {
                 match self.conductor_handle.handle_external_zome_call(*zome_call_params_signed).await? {
                     Ok(ZomeCallResponse::Ok(output)) => Ok(AppResponse::ZomeCalled(Box::new(output))),

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -79,10 +79,10 @@ impl AppInterfaceApi {
                     .get_app_info(&installed_app_id)
                     .await?,
             )),
-            AppRequest::AgentInfo { dna_hash } => {
+            AppRequest::AgentInfo { dna_hashes } => {
                 let agent_infos = self
                     .conductor_handle
-                    .get_app_agent_infos(&installed_app_id, dna_hash)
+                    .get_app_agent_infos(&installed_app_id, dna_hashes)
                     .await?;
                 let items: Result<Vec<_>, _> =
                     agent_infos.into_iter().map(|info| info.encode()).collect();

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -896,7 +896,7 @@ mod network_impls {
             let hashes = match maybe_dna_hashes {
                 Some(dna_hashes) => {
                     for dna_hash in &dna_hashes {
-                        if !app_dnas.contains(&dna_hash) {
+                        if !app_dnas.contains(dna_hash) {
                             return Err(ConductorApiError::other(format!(
                                 "Dna {} not part of app: {}",
                                 dna_hash, installed_app_id

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -885,15 +885,8 @@ mod network_impls {
             }
 
             let hashes = match maybe_dna_hashes {
-                Some(dna_hashes) => {
-                    for dna_hash in &dna_hashes {
-                        if !app_dnas.contains(dna_hash) {
-                            return Err(ConductorApiError::other(format!(
-                                "Dna {} not part of app: {}",
-                                dna_hash, installed_app_id
-                            )));
-                        }
-                    }
+                Some(mut dna_hashes) => {
+                    dna_hashes.retain(|h| app_dnas.contains(h));
                     dna_hashes
                 }
                 None => app_dnas.into_iter().collect(),

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -881,7 +881,7 @@ mod network_impls {
             dna_hash: Option<DnaHash>,
         ) -> ConductorApiResult<Vec<Arc<AgentInfoSigned>>> {
             // Get app info to know which DNAs belong to this app
-            let app_info = self.get_app_info(&installed_app_id).await?.ok_or_else(|| {
+            let app_info = self.get_app_info(installed_app_id).await?.ok_or_else(|| {
                 ConductorApiError::other(format!("App not installed: {}", installed_app_id))
             })?;
 

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -859,7 +859,7 @@ mod network_impls {
                     let dna_hashes = self
                         .spaces
                         .get_from_spaces(|space| (*space.dna_hash).clone());
-                    let mut out = Vec::new();
+                    let mut out = HashSet::new();
                     for dna_hash in dna_hashes {
                         let peer_store = self
                             .holochain_p2p
@@ -869,7 +869,7 @@ mod network_impls {
                         let all_peers = peer_store.get_all().await?;
                         out.extend(all_peers);
                     }
-                    Ok(out)
+                    Ok(out.into_iter().collect())
                 }
             }
         }

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -836,15 +836,6 @@ mod network_impls {
     use zome_call_signature_verification::is_valid_signature;
 
     impl Conductor {
-        /// Get signed agent infos from the conductor for a given cell
-        pub async fn get_agent_infos_by_cell(
-            &self,
-            maybe_cell_id: Option<CellId>,
-        ) -> ConductorApiResult<Vec<Arc<AgentInfoSigned>>> {
-            let maybe_dna_hashes = maybe_cell_id.map(|cell_id| vec![cell_id.dna_hash().clone()]);
-            self.get_agent_infos(maybe_dna_hashes).await
-        }
-
         /// Get signed agent info from the conductor
         pub async fn get_agent_infos(
             &self,

--- a/crates/holochain/src/conductor/conductor/tests/add_agent_infos.rs
+++ b/crates/holochain/src/conductor/conductor/tests/add_agent_infos.rs
@@ -47,7 +47,7 @@ async fn add_agent_infos_to_peer_store() {
         .unwrap()
         .unwrap();
     let agent_infos = conductor
-        .get_agent_infos(Some(cell_id.clone()))
+        .get_agent_infos_by_cell(Some(cell_id.clone()))
         .await
         .unwrap();
     assert_eq!(agent_infos, vec![expected_agent_info.clone()]);

--- a/crates/holochain/src/conductor/conductor/tests/add_agent_infos.rs
+++ b/crates/holochain/src/conductor/conductor/tests/add_agent_infos.rs
@@ -47,7 +47,7 @@ async fn add_agent_infos_to_peer_store() {
         .unwrap()
         .unwrap();
     let agent_infos = conductor
-        .get_agent_infos_by_cell(Some(cell_id.clone()))
+        .get_agent_infos(Some(vec![cell_id.dna_hash().clone()]))
         .await
         .unwrap();
     assert_eq!(agent_infos, vec![expected_agent_info.clone()]);

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -494,9 +494,7 @@ mod test {
     use crate::conductor::Conductor;
     use crate::conductor::ConductorHandle;
     use crate::fixt::RealRibosomeFixturator;
-    use crate::retry_until_timeout;
     use crate::sweettest::websocket_client_by_port;
-    use crate::sweettest::SweetConductor;
     use crate::sweettest::SweetDnaFile;
     use crate::sweettest::WsPollRecv;
     use crate::sweettest::{app_bundle_from_dnas, authenticate_app_ws_client};
@@ -513,8 +511,6 @@ mod test {
     use holochain_types::test_utils::fake_dna_zomes;
     use holochain_wasm_test_utils::TestWasm;
     use holochain_zome_types::test_utils::fake_agent_pubkey_2;
-    use kitsune2_api::AgentInfoSigned;
-    use kitsune2_api::{AgentId, SpaceId};
     use matches::assert_matches;
     use pretty_assertions::assert_eq;
     use std::collections::HashSet;
@@ -1216,35 +1212,6 @@ mod test {
             .await
             .unwrap();
         conductor_handle.shutdown().await.unwrap().unwrap();
-    }
-
-    async fn make_req(
-        admin_api: AdminInterfaceApi,
-        req: AdminRequest,
-    ) -> tokio::sync::oneshot::Receiver<AdminResponse> {
-        let (tx, rx) = tokio::sync::oneshot::channel();
-
-        let respond = move |response: AdminResponse| {
-            tx.send(response).unwrap();
-        };
-
-        test_handle_incoming_admin_message(req, respond, admin_api)
-            .await
-            .unwrap();
-        rx
-    }
-
-    fn to_key(r: Vec<String>) -> Vec<(SpaceId, AgentId)> {
-        let mut results = r
-            .into_iter()
-            .map(|a| {
-                let parsed_info =
-                    AgentInfoSigned::decode(&kitsune2_core::Ed25519Verifier, a.as_bytes()).unwrap();
-                (parsed_info.space.clone(), parsed_info.agent.clone())
-            })
-            .collect::<Vec<_>>();
-        results.sort();
-        results
     }
 
     fn get_app_data_storage_info(

--- a/crates/holochain/src/conductor/tests/agent_info.rs
+++ b/crates/holochain/src/conductor/tests/agent_info.rs
@@ -1,0 +1,158 @@
+use crate::sweettest::*;
+use holochain_conductor_api::{AdminRequest, AdminResponse, AppRequest, AppResponse};
+use holochain_types::prelude::*;
+use holochain_wasm_test_utils::TestWasm;
+use kitsune2_api::AgentInfoSigned;
+use kitsune2_core::Ed25519Verifier;
+
+// in these tests we set up a mix of apps and including clone cells so we can test
+// different varieties of combinations in the app_agent_info case, and we use the same setup in the admin_agent_info
+// for parity.
+async fn setup_tests() -> (
+    DnaHash,
+    DnaHash,
+    DnaHash,
+    String,
+    String,
+    ClonedCell,
+    SweetConductor,
+) {
+    // Create three different DNAs
+    let dna1 = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+    let dna2 = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+    let dna3 = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+
+    // Install two different apps on a conductor: app1 (dna1, dna2) and app2 (dna3)
+    let config = SweetConductorConfig::standard();
+    let mut conductor = SweetConductor::from_config(config.clone()).await;
+
+    let app1_id: InstalledAppId = "app1".into();
+    let app2_id: InstalledAppId = "app2".into();
+
+    let installed_app1_id = conductor
+        .setup_app(&app1_id, &[dna1.0.clone(), dna2.0.clone()])
+        .await
+        .unwrap()
+        .installed_app_id()
+        .clone();
+
+    // Install app2 on conductors 1 and 2
+    let installed_app2_id = conductor
+        .setup_app(&app2_id, &[dna3.0.clone()])
+        .await
+        .unwrap()
+        .installed_app_id()
+        .clone();
+
+    // Create a disabled clone cell for app1 on conductor[0]
+    let clone_cell_r = conductor
+        .create_clone_cell(
+            &installed_app1_id,
+            CreateCloneCellPayload {
+                role_name: dna1.0.dna_hash().to_string(),
+                modifiers: DnaModifiersOpt::none().with_network_seed("test_seed".to_string()),
+                membrane_proof: None,
+                name: Some("disabled_clone".into()),
+            },
+        )
+        .await;
+    let clone_cell = clone_cell_r.unwrap();
+
+    (
+        dna1.0.dna_hash().clone(),
+        dna2.0.dna_hash().clone(),
+        dna3.0.dna_hash().clone(),
+        installed_app1_id,
+        installed_app2_id,
+        clone_cell,
+        conductor,
+    )
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn admin_agent_info() {
+    holochain_trace::test_run();
+
+    let (
+        dna1_hash,
+        dna2_hash,
+        dna3_hash,
+        _installed_app1_id,
+        _installed_app2_id,
+        clone_cell,
+        conductor,
+    ) = setup_tests().await;
+
+    // Get admin interface for conductor[0]
+    let (admin_sender, _admin_receiver) = conductor.admin_ws_client::<AdminResponse>().await;
+
+    // Get all agent infos via admin interface
+    let response = admin_sender
+        .request(AdminRequest::AgentInfo { cell_id: None })
+        .await
+        .unwrap();
+    let agent_infos = match response {
+        AdminResponse::AgentInfo(infos) => infos,
+        _ => panic!("Expected AgentInfo response"),
+    };
+
+    assert_eq!(
+        agent_infos.len(),
+        4,
+        "Should have agent_info for each dna on each conductor"
+    );
+
+    let mut seen_spaces = std::collections::HashSet::new();
+    let mut seen_agents = std::collections::HashSet::new();
+    for info in &agent_infos {
+        let decoded = AgentInfoSigned::decode(&Ed25519Verifier, info.as_bytes()).unwrap();
+        seen_spaces.insert(decoded.space.clone());
+        seen_agents.insert(decoded.agent.clone());
+    }
+
+    // Should have seen all DNA spaces
+    assert_eq!(
+        seen_spaces.len(),
+        4,
+        "The agent_infos should cover the 4 dnas"
+    );
+    assert!(seen_spaces.contains(&dna1_hash.to_k2_space()));
+    assert!(seen_spaces.contains(&dna2_hash.to_k2_space()));
+    assert!(seen_spaces.contains(&dna3_hash.to_k2_space()));
+    assert!(seen_spaces.contains(&clone_cell.cell_id.dna_hash().to_k2_space()));
+
+    assert_eq!(
+        seen_agents.len(),
+        2,
+        "The agent_infos should cover the two agents (one for each app)"
+    );
+
+    // Test getting agent info for the clone cell
+    let response = admin_sender
+        .request(AdminRequest::AgentInfo {
+            cell_id: Some(clone_cell.cell_id.clone()),
+        })
+        .await
+        .unwrap();
+    let clone_agent_infos = match response {
+        AdminResponse::AgentInfo(infos) => infos,
+        _ => panic!("Expected AgentInfo response"),
+    };
+
+    // Should have agent info for each conductor that has the clone cell (1 peers)
+    assert_eq!(
+        clone_agent_infos.len(),
+        1,
+        "Should have agent info for the clone cell on both conductors that have it"
+    );
+
+    // Verify all agent infos are for the clone cell's DNA
+    for info in &clone_agent_infos {
+        let decoded = AgentInfoSigned::decode(&Ed25519Verifier, info.as_bytes()).unwrap();
+        assert_eq!(
+            decoded.space,
+            clone_cell.cell_id.dna_hash().to_k2_space(),
+            "Agent info should be for the clone cell's DNA"
+        );
+    }
+}

--- a/crates/holochain/src/conductor/tests/agent_info.rs
+++ b/crates/holochain/src/conductor/tests/agent_info.rs
@@ -70,21 +70,11 @@ async fn setup_tests() -> (
     )
 }
 
-fn make_agent(space: kitsune2_api::SpaceId) -> String {
-    let local = kitsune2_core::Ed25519LocalAgent::default();
-    let created_at = kitsune2_api::Timestamp::now();
-    let expires_at = created_at + std::time::Duration::from_secs(60 * 20);
-    let info = kitsune2_api::AgentInfo {
-        agent: kitsune2_api::LocalAgent::agent(&local).clone(),
-        space,
-        created_at,
-        expires_at,
-        is_tombstone: false,
-        url: None,
-        storage_arc: kitsune2_api::DhtArc::FULL,
-    };
-    let info =
-        futures::executor::block_on(kitsune2_api::AgentInfoSigned::sign(&local, info)).unwrap();
+fn make_agent(space: SpaceId) -> String {
+    let mut builder = AgentBuilder::default();
+    let local_agent: DynLocalAgent = Arc::new(Ed25519LocalAgent::default());
+    builder.space = Some(space.clone());
+    let info = builder.build(local_agent);
     info.encode().unwrap()
 }
 

--- a/crates/holochain/src/conductor/tests/agent_info.rs
+++ b/crates/holochain/src/conductor/tests/agent_info.rs
@@ -4,7 +4,7 @@ use crate::sweettest::*;
 use holochain_conductor_api::{AdminRequest, AdminResponse, AppRequest, AppResponse};
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
-use kitsune2_api::{AgentInfoSigned, DynLocalAgent, SpaceId};
+use kitsune2_api::{AgentInfoSigned, DynLocalAgent};
 use kitsune2_core::{Ed25519LocalAgent, Ed25519Verifier};
 use kitsune2_test_utils::agent::AgentBuilder;
 

--- a/crates/holochain/src/conductor/tests/agent_info.rs
+++ b/crates/holochain/src/conductor/tests/agent_info.rs
@@ -147,9 +147,7 @@ async fn admin_agent_info() {
     );
 
     let clone_cell_dna = clone_cell.cell_id.dna_hash();
-println!(
-    "TESTING CLONE CELL"
-);
+
     // Test getting agent info for the clone cell
     let response = admin_sender
         .request(AdminRequest::AgentInfo {
@@ -162,9 +160,7 @@ println!(
         _ => panic!("Expected AgentInfo response"),
     };
 
-    println!("AGENT INFOS: {:?}", clone_agent_infos);
-
-    // Should have agent info for each conductor that has the clone cell (1 peers)
+    // Should have a single agent info
     assert_eq!(
         clone_agent_infos.len(),
         1,
@@ -203,7 +199,7 @@ async fn app_agent_info() {
 
     // Test getting agent info for all cells in app1
     let response = app1_sender
-        .request(AppRequest::AgentInfo { dna_hash: None })
+        .request(AppRequest::AgentInfo { dna_hashes: None })
         .await
         .unwrap();
     let agent_infos = match response {
@@ -228,7 +224,7 @@ async fn app_agent_info() {
     // Test getting agent info for dna1 in app1
     let response = app1_sender
         .request(AppRequest::AgentInfo {
-            dna_hash: Some(dna1_hash.clone()),
+            dna_hashes: Some(vec![dna1_hash.clone()]),
         })
         .await
         .unwrap();
@@ -255,7 +251,7 @@ async fn app_agent_info() {
 
     // Test getting agent info for all cells in app2
     let response = app2_sender
-        .request(AppRequest::AgentInfo { dna_hash: None })
+        .request(AppRequest::AgentInfo { dna_hashes: None })
         .await
         .unwrap();
     let agent_infos_app2 = match response {
@@ -280,7 +276,7 @@ async fn app_agent_info() {
     let non_existent_dna = DnaHash::from_raw_32(vec![0; 32]);
     let response = app1_sender
         .request(AppRequest::AgentInfo {
-            dna_hash: Some(non_existent_dna),
+            dna_hashes: Some(vec![non_existent_dna]),
         })
         .await
         .unwrap();
@@ -296,7 +292,7 @@ async fn app_agent_info() {
     // This should return no results even though dna3 exists on the conductor in a different app
     let response = app1_sender
         .request(AppRequest::AgentInfo {
-            dna_hash: Some(dna3_hash.clone()),
+            dna_hashes: Some(vec![dna3_hash.clone()]),
         })
         .await
         .unwrap();
@@ -322,7 +318,7 @@ async fn app_agent_info() {
     // get the agent infos for app1 again.
     let response = app1_sender
         .request(AppRequest::AgentInfo {
-            dna_hash: Some(dna1_hash.clone()),
+            dna_hashes: Some(vec![dna1_hash.clone()]),
         })
         .await
         .unwrap();

--- a/crates/holochain/src/conductor/tests/agent_info.rs
+++ b/crates/holochain/src/conductor/tests/agent_info.rs
@@ -24,7 +24,8 @@ async fn setup_tests() -> (
 
     // Install two different apps on a conductor: app1 (dna1, dna2) and app2 (dna3)
     let config = SweetConductorConfig::standard();
-    let mut conductor = SweetConductor::from_config(config.clone()).await;
+    let mut conductor =
+        SweetConductor::from_config_rendezvous(config, SweetLocalRendezvous::new().await).await;
 
     let app1_id: InstalledAppId = "app1".into();
     let app2_id: InstalledAppId = "app2".into();
@@ -45,7 +46,7 @@ async fn setup_tests() -> (
         .clone();
 
     // Create a disabled clone cell for app1 on conductor[0]
-    let clone_cell_r = conductor
+    let clone_cell = conductor
         .create_clone_cell(
             &installed_app1_id,
             CreateCloneCellPayload {
@@ -55,8 +56,8 @@ async fn setup_tests() -> (
                 name: Some("disabled_clone".into()),
             },
         )
-        .await;
-    let clone_cell = clone_cell_r.unwrap();
+        .await
+        .unwrap();
 
     (
         dna1.0.dna_hash().clone(),

--- a/crates/holochain/src/conductor/tests/agent_info.rs
+++ b/crates/holochain/src/conductor/tests/agent_info.rs
@@ -1,9 +1,12 @@
+use std::sync::Arc;
+
 use crate::sweettest::*;
 use holochain_conductor_api::{AdminRequest, AdminResponse, AppRequest, AppResponse};
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasm;
-use kitsune2_api::AgentInfoSigned;
-use kitsune2_core::Ed25519Verifier;
+use kitsune2_api::{AgentInfoSigned, DynLocalAgent, SpaceId};
+use kitsune2_core::{Ed25519LocalAgent, Ed25519Verifier};
+use kitsune2_test_utils::agent::AgentBuilder;
 
 // in these tests we set up a mix of apps and including clone cells so we can test
 // different varieties of combinations in the app_agent_info case, and we use the same setup in the admin_agent_info

--- a/crates/holochain/src/conductor/tests/mod.rs
+++ b/crates/holochain/src/conductor/tests/mod.rs
@@ -1,3 +1,4 @@
+mod agent_info;
 mod app_info;
 mod cell_cloning;
 mod install_app_bundle;

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -827,7 +827,11 @@ impl SweetConductor {
         tokio::time::timeout(max_wait, async move {
             loop {
                 let infos = handle
-                    .get_agent_infos_by_cell(cell_id.clone())
+                    .get_agent_infos(
+                        cell_id
+                            .clone()
+                            .map(|cell_id| vec![cell_id.dna_hash().clone()]),
+                    )
                     .await?
                     .into_iter()
                     .map(|p| AgentPubKey::from_k2_agent(&p.agent))

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -827,7 +827,7 @@ impl SweetConductor {
         tokio::time::timeout(max_wait, async move {
             loop {
                 let infos = handle
-                    .get_agent_infos(cell_id.clone())
+                    .get_agent_infos_by_cell(cell_id.clone())
                     .await?
                     .into_iter()
                     .map(|p| AgentPubKey::from_k2_agent(&p.agent))

--- a/crates/holochain/tests/tests/countersigning/session_interaction_over_websocket.rs
+++ b/crates/holochain/tests/tests/countersigning/session_interaction_over_websocket.rs
@@ -566,18 +566,18 @@ async fn countersigning_session_interaction_calls() {
     assert_matches!(get_session_state(&alice.cell_id, &alice_app_tx).await, None);
 
     let resp =
-        request::<_, AdminResponse>(AdminRequest::AgentInfo { cell_id: None }, &alice.admin_tx)
+        request::<_, AdminResponse>(AdminRequest::AgentInfo { dna_hashes: None }, &alice.admin_tx)
             .await;
     tracing::info!("Alice agent info: {:?}", resp);
 
     let resp =
-        request::<_, AdminResponse>(AdminRequest::AgentInfo { cell_id: None }, &bob.admin_tx).await;
+        request::<_, AdminResponse>(AdminRequest::AgentInfo { dna_hashes: None }, &bob.admin_tx).await;
     tracing::info!("Bob agent info: {:?}", resp);
 
     tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
     let resp =
-        request::<_, AdminResponse>(AdminRequest::AgentInfo { cell_id: None }, &bob.admin_tx).await;
+        request::<_, AdminResponse>(AdminRequest::AgentInfo { dna_hashes: None }, &bob.admin_tx).await;
     tracing::info!("Bob agent info: {:?}", resp);
 
     tracing::info!("Alice published session.\n");
@@ -803,7 +803,7 @@ impl Agent {
 async fn expect_bootstrapping_completed(agents: &[&Agent]) {
     loop {
         let agent_requests = agents.iter().map(|agent| async {
-            match request(AdminRequest::AgentInfo { cell_id: None }, &agent.admin_tx).await {
+            match request(AdminRequest::AgentInfo { dna_hashes: None }, &agent.admin_tx).await {
                 AdminResponse::AgentInfo(agent_infos) => agent_infos.len() == agents.len(),
                 _ => unreachable!(),
             }
@@ -910,7 +910,7 @@ async fn wait_for_full_arc_for_agent(
     tokio::time::timeout(Duration::from_secs(30), async move {
         loop {
             let resp =
-                request::<_, AdminResponse>(AdminRequest::AgentInfo { cell_id: None }, &admin_tx)
+                request::<_, AdminResponse>(AdminRequest::AgentInfo { dna_hashes: None }, &admin_tx)
                     .await;
             match resp {
                 AdminResponse::AgentInfo(infos) => {

--- a/crates/holochain/tests/tests/countersigning/session_interaction_over_websocket.rs
+++ b/crates/holochain/tests/tests/countersigning/session_interaction_over_websocket.rs
@@ -565,19 +565,23 @@ async fn countersigning_session_interaction_calls() {
     // Alice's session should be gone from memory.
     assert_matches!(get_session_state(&alice.cell_id, &alice_app_tx).await, None);
 
-    let resp =
-        request::<_, AdminResponse>(AdminRequest::AgentInfo { dna_hashes: None }, &alice.admin_tx)
-            .await;
+    let resp = request::<_, AdminResponse>(
+        AdminRequest::AgentInfo { dna_hashes: None },
+        &alice.admin_tx,
+    )
+    .await;
     tracing::info!("Alice agent info: {:?}", resp);
 
     let resp =
-        request::<_, AdminResponse>(AdminRequest::AgentInfo { dna_hashes: None }, &bob.admin_tx).await;
+        request::<_, AdminResponse>(AdminRequest::AgentInfo { dna_hashes: None }, &bob.admin_tx)
+            .await;
     tracing::info!("Bob agent info: {:?}", resp);
 
     tokio::time::sleep(std::time::Duration::from_secs(10)).await;
 
     let resp =
-        request::<_, AdminResponse>(AdminRequest::AgentInfo { dna_hashes: None }, &bob.admin_tx).await;
+        request::<_, AdminResponse>(AdminRequest::AgentInfo { dna_hashes: None }, &bob.admin_tx)
+            .await;
     tracing::info!("Bob agent info: {:?}", resp);
 
     tracing::info!("Alice published session.\n");
@@ -803,7 +807,12 @@ impl Agent {
 async fn expect_bootstrapping_completed(agents: &[&Agent]) {
     loop {
         let agent_requests = agents.iter().map(|agent| async {
-            match request(AdminRequest::AgentInfo { dna_hashes: None }, &agent.admin_tx).await {
+            match request(
+                AdminRequest::AgentInfo { dna_hashes: None },
+                &agent.admin_tx,
+            )
+            .await
+            {
                 AdminResponse::AgentInfo(agent_infos) => agent_infos.len() == agents.len(),
                 _ => unreachable!(),
             }
@@ -909,9 +918,11 @@ async fn wait_for_full_arc_for_agent(
 
     tokio::time::timeout(Duration::from_secs(30), async move {
         loop {
-            let resp =
-                request::<_, AdminResponse>(AdminRequest::AgentInfo { dna_hashes: None }, &admin_tx)
-                    .await;
+            let resp = request::<_, AdminResponse>(
+                AdminRequest::AgentInfo { dna_hashes: None },
+                &admin_tx,
+            )
+            .await;
             match resp {
                 AdminResponse::AgentInfo(infos) => {
                     let mut agent_infos = Vec::with_capacity(infos.len());

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -308,8 +308,8 @@ pub enum AdminRequest {
     ///
     /// [`AdminResponse::AgentInfo`]
     AgentInfo {
-        /// Optionally choose the agent info of a specific cell.
-        cell_id: Option<CellId>,
+        /// Optionally choose the agent infos of a set of Dnas.
+        dna_hashes: Option<Vec<DnaHash>>,
     },
 
     /// "Graft" [`Record`]s onto the source chain of the specified [`CellId`].

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -25,7 +25,7 @@ pub enum AppRequest {
     AppInfo,
 
     /// Request information about the agents in this Conductor's peer store.
-    /// 
+    ///
     /// This is limited to cells of the app you are connected to.
     ///
     /// # Returns

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -25,6 +25,7 @@ pub enum AppRequest {
     AppInfo,
 
     /// Request information about the agents in this Conductor's peer store.
+    /// 
     /// This is limited to cells of the app you are connected to.
     ///
     /// # Returns

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -24,6 +24,17 @@ pub enum AppRequest {
     /// [`AppResponse::AppInfo`]
     AppInfo,
 
+    /// Request information about the agents in this Conductor's peer store.
+    /// This is limited to cells of the app you are connected to.
+    ///
+    /// # Returns
+    ///
+    /// [`AppResponse::AgentInfo`]
+    AgentInfo {
+        /// Optionally limit the results to a specific DNA hash
+        dna_hash: Option<DnaHash>,
+    },
+
     /// Call a zome function.
     ///
     /// The payload to this call is composed of the serialized [`ZomeCallParams`] as bytes
@@ -238,6 +249,9 @@ pub enum AppResponse {
     ///
     /// Option will be `None` if there is no installed app with the given `installed_app_id`.
     AppInfo(Option<AppInfo>),
+
+    /// The successful response to an [`AppRequest::AgentInfo`].
+    AgentInfo(Vec<String>),
 
     /// The successful response to an [`AppRequest::CallZome`].
     ///

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -31,8 +31,8 @@ pub enum AppRequest {
     ///
     /// [`AppResponse::AgentInfo`]
     AgentInfo {
-        /// Optionally limit the results to a specific DNA hash
-        dna_hash: Option<DnaHash>,
+        /// Optionally limit the results to specific DNA hashes
+        dna_hashes: Option<Vec<DnaHash>>,
     },
 
     /// Call a zome function.


### PR DESCRIPTION
### Summary

Fixes a bug in `conductor.get_agent_infos()` where duplicate agent infos could be returned.

Adds and AgentInfo request to the app API interface and tests it with a sweetest that includes  multiple apps, one with multiple DNAs, and clone cells to confirm various possible cases.

Adds a test for the admin interface AgentInfo call in the conductor crate because there wasn't one before.

Changes the admin AgentInfo call to use `Vec<DnaHash>` for filtering instead of `CellId`

Implements the following AC from #4923:
- Limited to cells of that app
- Optionally limited by DNA hash
- Sweetests checking that this works
- Updates rust client to use this interface

Updates to JS clients in a separate PR.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs