### PR TITLE
doc: default stun server to reflect change in kitsune2

### DIFF
--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -33,7 +33,7 @@
 //!   ## to what you can see here:
 //!   webrtc_config: {
 //!     "iceServers": [
-//!       { "urls": ["stun:devtest-stun-1.holochain.org:443"] }
+//!       { "urls": ["stun://stun.l.google.com:19302"] }
 //!     ]
 //!   }
 //! "#;

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -33,7 +33,7 @@
 //!   ## to what you can see here:
 //!   webrtc_config: {
 //!     "iceServers": [
-//!       { "urls": ["stun://stun.l.google.com:19302"] }
+//!       { "urls": ["stun:stun.l.google.com:19302"] }
 //!     ]
 //!   }
 //! "#;


### PR DESCRIPTION
### Summary
Update doc comment to reflect new default stun server in kitsune2.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs