### PR TITLE
Add `--origin` option to hc s call

### DIFF
--- a/crates/client/CHANGELOG.md
+++ b/crates/client/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
-- Add `origin` argument to `AdminWebsocket::connect()`.
+- Add `origin` argument to `AdminWebsocket::connect()` and `AppWebsocket::connect()`.
 
 ## 0.8.0-dev.1
 

--- a/crates/client/CHANGELOG.md
+++ b/crates/client/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Add `origin` argument to `AdminWebsocket::connect()`.
+
 ## 0.8.0-dev.1
 
 ## 0.8.0-dev.0

--- a/crates/client/src/admin_websocket.rs
+++ b/crates/client/src/admin_websocket.rs
@@ -110,7 +110,7 @@ impl AdminWebsocket {
     ) -> ConductorApiResult<Self> {
         let mut last_err = None;
         for addr in socket_addr.to_socket_addrs()? {
-            let request: ConnectRequest = if let Some(o) = origin.clone() {
+            let request: ConnectRequest = if let Some(o) = &origin {
                 Into::<ConnectRequest>::into(addr).try_set_header("Origin", o.as_str())?
             } else {
                 addr.into()

--- a/crates/client/src/app_websocket.rs
+++ b/crates/client/src/app_websocket.rs
@@ -61,7 +61,7 @@ impl AppWebsocket {
     /// let app_id = "test-app".to_string();
     /// let issued = admin_ws.issue_app_auth_token(app_id.clone().into()).await.unwrap();
     /// let signer = ClientAgentSigner::default();
-    /// let app_ws = AppWebsocket::connect((Ipv4Addr::LOCALHOST, 30_001), issued.token, signer.into()).await.unwrap();
+    /// let app_ws = AppWebsocket::connect((Ipv4Addr::LOCALHOST, 30_001), issued.token, signer.into(), None).await.unwrap();
     /// # }
     /// ```
     ///
@@ -72,8 +72,9 @@ impl AppWebsocket {
         socket_addr: impl ToSocketAddrs,
         token: AppAuthenticationToken,
         signer: DynAgentSigner,
+        origin: Option<String>,
     ) -> ConductorApiResult<Self> {
-        let app_ws = AppWebsocketInner::connect(socket_addr).await?;
+        let app_ws = AppWebsocketInner::connect(socket_addr, origin).await?;
         Self::post_connect(app_ws, token, signer).await
     }
 
@@ -103,7 +104,7 @@ impl AppWebsocket {
     /// let client_config = Arc::new(client_config);
     ///
     /// let signer = ClientAgentSigner::default();
-    /// let app_ws = AppWebsocket::connect_with_config((Ipv4Addr::LOCALHOST, 30_001), client_config, issued.token, signer.into()).await.unwrap();
+    /// let app_ws = AppWebsocket::connect_with_config((Ipv4Addr::LOCALHOST, 30_001), client_config, issued.token, signer.into(), None).await.unwrap();
     /// # }
     /// ```
     pub async fn connect_with_config(
@@ -111,8 +112,10 @@ impl AppWebsocket {
         websocket_config: Arc<WebsocketConfig>,
         token: AppAuthenticationToken,
         signer: DynAgentSigner,
+        origin: Option<String>,
     ) -> ConductorApiResult<Self> {
-        let app_ws = AppWebsocketInner::connect_with_config(socket_addr, websocket_config).await?;
+        let app_ws =
+            AppWebsocketInner::connect_with_config(socket_addr, websocket_config, origin).await?;
         Self::post_connect(app_ws, token, signer).await
     }
 
@@ -150,13 +153,7 @@ impl AppWebsocket {
     ///     SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 30_001),
     /// ];
     /// for addr in connect_to {
-    ///     // Send a request with a custom origin header to identify the client
-    ///     let mut request: ConnectRequest = addr.into();
-    ///     let request = request
-    ///         .try_set_header("Origin", "my_cli_app")
-    ///         .unwrap();
-    ///
-    ///     match AppWebsocket::connect_with_request_and_config(request, client_config.clone(), issued.token.clone(), signer.clone()).await {
+    ///     match AppWebsocket::connect_with_request_and_config(request, client_config.clone(), issued.token.clone(), signer.clone(), None).await {
     ///         Ok(admin_ws) => {
     ///             println!("Connected to {:?}", addr);
     ///             break;

--- a/crates/client/tests/admin.rs
+++ b/crates/client/tests/admin.rs
@@ -21,7 +21,7 @@ async fn app_interfaces() {
 
     // Connect admin client
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
-    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port))
+    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port), None)
         .await
         .unwrap();
 
@@ -36,7 +36,7 @@ async fn signed_zome_call() {
 
     // Connect admin client
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
-    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port))
+    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port), None)
         .await
         .unwrap();
 
@@ -112,7 +112,7 @@ async fn signed_zome_call() {
 async fn storage_info() {
     let conductor = SweetConductor::from_standard_config().await;
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
-    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port))
+    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port), None)
         .await
         .unwrap();
     let app_id: InstalledAppId = "test-app".into();
@@ -146,7 +146,7 @@ async fn storage_info() {
 async fn dump_network_stats() {
     let conductor = SweetConductor::from_standard_config().await;
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
-    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port))
+    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port), None)
         .await
         .unwrap();
     let app_id: InstalledAppId = "test-app".into();
@@ -191,7 +191,7 @@ fn make_agent(space: kitsune2_api::SpaceId) -> String {
 async fn agent_info() {
     let conductor = SweetConductor::from_standard_config().await;
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
-    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port))
+    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port), None)
         .await
         .unwrap();
     let app_id: InstalledAppId = "test-app".into();
@@ -236,7 +236,7 @@ async fn agent_info() {
 async fn list_cell_ids() {
     let conductor = SweetConductor::from_standard_config().await;
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
-    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port))
+    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port), None)
         .await
         .unwrap();
     let app_id: InstalledAppId = "test-app".into();
@@ -270,7 +270,7 @@ async fn list_cell_ids() {
 async fn install_app_with_roles_settings() {
     let conductor = SweetConductor::from_standard_config().await;
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
-    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port))
+    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port), None)
         .await
         .unwrap();
     let app_id: InstalledAppId = "test-app".into();
@@ -341,6 +341,7 @@ async fn connect_multiple_addresses() {
             // Should then move on and try this one
             SocketAddr::new(Ipv4Addr::LOCALHOST.into(), admin_port),
         ][..],
+        None,
     )
     .await
     .unwrap();

--- a/crates/client/tests/admin.rs
+++ b/crates/client/tests/admin.rs
@@ -69,6 +69,7 @@ async fn signed_zome_call() {
         (Ipv4Addr::LOCALHOST, app_ws_port),
         issued_token.token,
         signer.clone().into(),
+        None,
     )
     .await
     .unwrap();

--- a/crates/client/tests/app.rs
+++ b/crates/client/tests/app.rs
@@ -28,7 +28,7 @@ async fn handle_signal() {
 
     // Connect admin client
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
-    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port))
+    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port), None)
         .await
         .unwrap();
 
@@ -123,7 +123,7 @@ async fn close_on_drop_is_clone_safe() {
 
     // Connect admin client
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
-    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port))
+    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port), None)
         .await
         .unwrap();
 
@@ -175,7 +175,7 @@ async fn close_on_drop_is_clone_safe() {
 async fn deferred_memproof_installation() {
     let conductor = SweetConductor::from_standard_config().await;
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
-    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port))
+    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port), None)
         .await
         .unwrap();
     let app_id: InstalledAppId = "test-app".into();
@@ -268,7 +268,7 @@ async fn connect_multiple_addresses() {
     let conductor = SweetConductor::from_standard_config().await;
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
 
-    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port))
+    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port), None)
         .await
         .unwrap();
     let app_port = admin_ws
@@ -323,7 +323,7 @@ async fn connect_with_custom_origin() {
     let conductor = SweetConductor::from_standard_config().await;
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
 
-    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port))
+    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port), None)
         .await
         .unwrap();
     let app_port = admin_ws
@@ -376,7 +376,7 @@ async fn connect_with_custom_origin() {
 async fn dump_network_stats() {
     let conductor = SweetConductor::from_standard_config().await;
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
-    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port))
+    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port), None)
         .await
         .unwrap();
     let app_port = admin_ws
@@ -429,7 +429,7 @@ async fn dump_network_stats() {
 async fn dump_network_metrics() {
     let conductor = SweetConductor::from_standard_config().await;
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
-    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port))
+    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{}", admin_port), None)
         .await
         .unwrap();
     let app_port = admin_ws

--- a/crates/client/tests/clone_cell.rs
+++ b/crates/client/tests/clone_cell.rs
@@ -21,7 +21,7 @@ async fn clone_cell_management() {
 
     // Connect admin client
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
-    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port))
+    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port), None)
         .await
         .unwrap();
 
@@ -171,7 +171,7 @@ pub async fn app_info_refresh() {
 
     // Connect admin client
     let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
-    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port))
+    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port), None)
         .await
         .unwrap();
 

--- a/crates/client/tests/clone_cell.rs
+++ b/crates/client/tests/clone_cell.rs
@@ -55,6 +55,7 @@ async fn clone_cell_management() {
         format!("127.0.0.1:{}", app_api_port),
         issued_token.token,
         signer.clone().into(),
+        None,
     )
     .await
     .unwrap();
@@ -208,6 +209,7 @@ pub async fn app_info_refresh() {
         (Ipv4Addr::LOCALHOST, app_api_port),
         token_issued.token,
         signer.clone().into(),
+        None,
     )
     .await
     .unwrap();

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+- Add `--origin` option to `hc sandbox call` command
+
 ## 0.6.0-dev.4
 
 ## 0.6.0-dev.3

--- a/crates/hc_sandbox/examples/setup_5.rs
+++ b/crates/hc_sandbox/examples/setup_5.rs
@@ -42,7 +42,7 @@ async fn main() -> anyhow::Result<()> {
         // Run a conductor and connect to the admin websocket
         let (admin_port, _, _) =
             run::run_async(&input.holochain_path, path.clone(), None, Output::Log).await?;
-        let admin_ws = AdminWebsocket::connect(format!("localhost:{admin_port}")).await?;
+        let admin_ws = AdminWebsocket::connect(format!("localhost:{admin_port}"), None).await?;
 
         let bundle = AppBundleSource::Path(happ.clone()).resolve().await?;
         let bytes = bundle.pack()?;

--- a/crates/hc_sandbox/src/run.rs
+++ b/crates/hc_sandbox/src/run.rs
@@ -53,7 +53,7 @@ pub async fn run(
     .await?;
     let mut launch_info = LaunchInfo::from_admin_port(admin_port);
     for app_port in app_ports {
-        let admin_ws = AdminWebsocket::connect(format!("localhost:{admin_port}")).await?;
+        let admin_ws = AdminWebsocket::connect(format!("localhost:{admin_port}"), None).await?;
         let port = admin_ws
             .attach_app_interface(app_port, AllowedOrigins::Any, None)
             .await?;

--- a/crates/hc_sandbox/src/sandbox.rs
+++ b/crates/hc_sandbox/src/sandbox.rs
@@ -45,7 +45,7 @@ pub async fn default_with_network(
         chc_url,
     )?;
     let conductor = run_async(holochain_path, config_path.clone(), None, structured).await?;
-    let mut client = AdminWebsocket::connect(format!("localhost:{}", conductor.0)).await?;
+    let mut client = AdminWebsocket::connect(format!("localhost:{}", conductor.0), None).await?;
     let install_bundle = InstallApp {
         app_id: Some(app_id),
         agent_key: None,

--- a/crates/hc_sandbox/src/zome_call.rs
+++ b/crates/hc_sandbox/src/zome_call.rs
@@ -401,6 +401,7 @@ async fn get_app_client(
         format!("localhost:{}", port),
         token.token,
         DynAgentSigner::from(signer),
+        Some(String::from("sandbox")),
     )
     .await?)
 }

--- a/crates/hc_sandbox/src/zome_call.rs
+++ b/crates/hc_sandbox/src/zome_call.rs
@@ -151,7 +151,7 @@ pub async fn zome_call_auth(
 ) -> anyhow::Result<()> {
     let admin_port = admin_port_from_connect_args(zome_call_auth.connect_args, admin_port).await?;
 
-    let admin_client = AdminWebsocket::connect(format!("localhost:{admin_port}")).await?;
+    let admin_client = AdminWebsocket::connect(format!("localhost:{admin_port}"), None).await?;
     let app_client = get_app_client(&admin_client, zome_call_auth.app_id.clone(), None).await?;
     let app_info = app_client.app_info().await?;
     let info = match app_info {
@@ -169,7 +169,7 @@ pub async fn zome_call_auth(
         })
         .collect::<HashSet<_>>();
 
-    let admin_client = AdminWebsocket::connect(format!("localhost:{admin_port}")).await?;
+    let admin_client = AdminWebsocket::connect(format!("localhost:{admin_port}"), None).await?;
 
     holochain_util::pw::pw_set_piped(zome_call_auth.piped);
     if !zome_call_auth.piped {
@@ -204,7 +204,7 @@ pub async fn zome_call_auth(
 pub async fn zome_call(zome_call: ZomeCall, admin_port: Option<u16>) -> anyhow::Result<()> {
     let admin_port = admin_port_from_connect_args(zome_call.connect_args, admin_port).await?;
 
-    let admin_client = AdminWebsocket::connect(format!("localhost:{admin_port}")).await?;
+    let admin_client = AdminWebsocket::connect(format!("localhost:{admin_port}"), None).await?;
 
     let app_client = get_app_client(&admin_client, zome_call.app_id.clone(), None).await?;
 

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -873,7 +873,7 @@ async fn get_config_root_path(child: &mut Child) -> PathBuf {
 
     while let Ok(Some(line)) = lines.next_line().await {
         println!("@@@-{line}-@@@");
-        if line.find("Created [ConfigRootPath(\"").is_some() {
+        if line.contains("Created [ConfigRootPath(\"") {
             let start = line
                 .find("(\"")
                 .expect("Unexpected config root path line format.");

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -419,7 +419,7 @@ async fn generate_sandbox_and_call_list_dna_with_origin() {
 
     let mut hc_call = input_piped_password(&mut cmd).await;
     let exit_code = hc_call.wait().await.unwrap();
-    assert!(exit_code.code() == Some(1)); // Should fail
+    assert!(exit_code.success() == false); // Should fail
 
     // Verify that admin call succeeds the correct origin
     let mut cmd = get_sandbox_command();

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -419,7 +419,7 @@ async fn generate_sandbox_and_call_list_dna_with_origin() {
 
     let mut hc_call = input_piped_password(&mut cmd).await;
     let exit_code = hc_call.wait().await.unwrap();
-    assert!(exit_code.success() == false); // Should fail
+    assert!(!exit_code.success()); // Should fail
 
     // Verify that admin call succeeds the correct origin
     let mut cmd = get_sandbox_command();

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -521,10 +521,12 @@ async fn generate_sandbox_and_add_and_list_agent() {
 
     let launch_info: LaunchInfo = get_launch_info(&mut hc_admin).await;
 
-    let admin_ws =
-        AdminWebsocket::connect(format!("localhost:{}", launch_info.admin_port).as_str())
-            .await
-            .unwrap();
+    let admin_ws = AdminWebsocket::connect(
+        format!("localhost:{}", launch_info.admin_port).as_str(),
+        None,
+    )
+    .await
+    .unwrap();
 
     let agent_infos = admin_ws.agent_info(None).await.unwrap();
     assert_eq!(agent_infos.len(), 2);

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -873,7 +873,7 @@ async fn get_config_root_path(child: &mut Child) -> PathBuf {
 
     while let Ok(Some(line)) = lines.next_line().await {
         println!("@@@-{line}-@@@");
-        if let Some(_) = line.find("Created [ConfigRootPath(\"") {
+        if line.find("Created [ConfigRootPath(\"").is_some() {
             let start = line
                 .find("(\"")
                 .expect("Unexpected config root path line format.");

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Add `--origin` option to `hc sandbox call` command
+
 ## 0.6.0-dev.4
 
 - Change `hc-sandbox` to use admin and app clients from the `holochain_client` crate
@@ -474,7 +476,7 @@ Now it serializes to
 - Fix: Countersigning test `lock_chain` which ensures that source chain is locked while in a countersigning session.
 
 - Major refactor of the sys validation workflow to improve reliability and performance:
-  
+
   - Reliability: The workflow will now prioritise validating ops that have their dependencies available locally. As soon as it has finished with those it will trigger app validation before dealing with missing dependencies.
   - Reliability: For ops which have dependencies we aren’t holding locally, the network get will now be retried. This was a cause of undesirable behaviour for validation where a failed get would result in validation for ops with missing dependencies not being retried until new ops arrived. The workflow now retries the get on an interval until it finds dependencies and can proceed with validation.
   - Performance and correctness: A feature which captured and processed ops that were discovered during validation has been removed. This had been added as an attempt to avoid deadlocks within validation but if that happens there’s a bug somewhere else. Sys validation needs to trust that Holochain will correctly manage its current arc and that we will get that data eventually through publishing or gossip. This probably wasn’t doing a lot of harm but it was uneccessary and doing database queries so it should be good to have that gone.
@@ -711,7 +713,7 @@ Now it serializes to
 ## 0.0.154
 
 - Revert: “Add the `hdi_version_req` key:value field to the output of the `--build-info` argument” because it broke. [\#1521](https://github.com/holochain/holochain/pull/1521)
-  
+
   Reason: it causes a build failure of the *holochain*  crate on crates.io
 
 ## 0.0.153
@@ -877,7 +879,7 @@ network:
 - **BREAKING CHANGE** `entry_defs` added to `zome_info` and referenced by macros [PR1055](https://github.com/holochain/holochain/pull/1055)
 
 - **BREAKING CHANGE**: The notion of “cell nicknames” (“nicks”) and “app slots” has been unified into the notion of “app roles”. This introduces several breaking changes. In general, you will need to rebuild any app bundles you are using, and potentially update some usages of the admin interface. In particular:
-  
+
   - The `slots` field in App manifests is now called `roles`
   - The `InstallApp` admin method now takes a `role_id` field instead of a `nick` field
   - In the return value for any admin method which lists installed apps, e.g. `ListEnabledApps`, any reference to `"slots"` is now named `"roles"`
@@ -907,7 +909,7 @@ network:
 - `call_info` is now implemented [1047](https://github.com/holochain/holochain/pull/1047)
 
 - `dna_info` now returns `DnaInfo` correctly [\#1044](https://github.com/holochain/holochain/pull/1044)
-  
+
   - `ZomeInfo` no longer includes what is now on `DnaInfo`
   - `ZomeInfo` renames `zome_name` and `zome_id` to `name` and `id`
   - `DnaInfo` includes `name`, `hash`, `properties`

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Add `--origin` option to `hc sandbox call` command
+- Adds the `--origin` option to the `hc sandbox call` command in order to allow making admin calls to deployed conductors with restricted `allowed_origins`.
 
 ## 0.6.0-dev.4
 

--- a/crates/holochain_conductor_config/src/ports.rs
+++ b/crates/holochain_conductor_config/src/ports.rs
@@ -9,7 +9,7 @@ use crate::msg;
 
 pub fn set_admin_port(config: &mut ConductorConfig, port: u16) {
     let p = port;
-    let port = AdminInterfaceConfig {
+    let default_interface = AdminInterfaceConfig {
         driver: InterfaceDriver::Websocket {
             port,
             allowed_origins: AllowedOrigins::Any,
@@ -21,9 +21,14 @@ pub fn set_admin_port(config: &mut ConductorConfig, port: u16) {
         .and_then(|ai| ai.get_mut(0))
     {
         Some(admin_interface) => {
-            *admin_interface = port;
+            *admin_interface = AdminInterfaceConfig {
+                driver: InterfaceDriver::Websocket {
+                    port,
+                    allowed_origins: admin_interface.driver.allowed_origins().to_owned(),
+                },
+            };
         }
-        None => config.admin_interfaces = Some(vec![port]),
+        None => config.admin_interfaces = Some(vec![default_interface]),
     }
     msg!("Admin port set to: {}", p);
 }

--- a/crates/holochain_conductor_config/src/ports.rs
+++ b/crates/holochain_conductor_config/src/ports.rs
@@ -8,13 +8,6 @@ use holochain_types::websocket::AllowedOrigins;
 use crate::msg;
 
 pub fn set_admin_port(config: &mut ConductorConfig, port: u16) {
-    let p = port;
-    let default_interface = AdminInterfaceConfig {
-        driver: InterfaceDriver::Websocket {
-            port,
-            allowed_origins: AllowedOrigins::Any,
-        },
-    };
     match config
         .admin_interfaces
         .as_mut()
@@ -28,7 +21,14 @@ pub fn set_admin_port(config: &mut ConductorConfig, port: u16) {
                 },
             };
         }
-        None => config.admin_interfaces = Some(vec![default_interface]),
+        None => {
+            config.admin_interfaces = Some(vec![AdminInterfaceConfig {
+                driver: InterfaceDriver::Websocket {
+                    port,
+                    allowed_origins: AllowedOrigins::Any,
+                },
+            }])
+        }
     }
-    msg!("Admin port set to: {}", p);
+    msg!("Admin port set to: {}", port);
 }

--- a/crates/holochain_terminal/src/client.rs
+++ b/crates/holochain_terminal/src/client.rs
@@ -67,7 +67,7 @@ pub struct AdminClient {
 impl AdminClient {
     /// Creates an Admin websocket client which can send messages but ignores any incoming messages
     pub async fn connect(addr: std::net::SocketAddr) -> anyhow::Result<Self> {
-        let client = AdminWebsocket::connect(addr).await?;
+        let client = AdminWebsocket::connect(addr, None).await?;
         Ok(AdminClient { client, addr })
     }
 

--- a/crates/holochain_terminal/src/client.rs
+++ b/crates/holochain_terminal/src/client.rs
@@ -19,9 +19,13 @@ impl AppClient {
         addr: std::net::SocketAddr,
         token: AppAuthenticationToken,
     ) -> anyhow::Result<Self> {
-        let client =
-            AppWebsocket::connect(addr, token, DynAgentSigner::from(ClientAgentSigner::new()))
-                .await?;
+        let client = AppWebsocket::connect(
+            addr,
+            token,
+            DynAgentSigner::from(ClientAgentSigner::new()),
+            None,
+        )
+        .await?;
         Ok(AppClient { client })
     }
 


### PR DESCRIPTION
### Summary

Adresses https://github.com/holochain/holochain/issues/4954

- Adds an origin argument to `AdminWebsocket::connect()`
- Adds an `--origin` option to `hc s call`

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs