### PR TITLE
refactor(holochain_state): simplify GetLinksQuery

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Slightly simplify `GetLinksQuery` by removing a sub query. The sub query filtered `RegisterRemoveLink` ops by those that reference a `RegisterAddLink` op. That filter is not needed, because the logic then only filters out removed links from the result set if they reference a created link in the result set. Also it is very unlikely if not impossible that there are remove link actions in the database without the corresponding create link actions.
+
 ## 0.6.0-dev.4
 
 - Change `hc-sandbox` to use admin and app clients from the `holochain_client` crate

--- a/crates/holochain_state/src/query/link.rs
+++ b/crates/holochain_state/src/query/link.rs
@@ -37,7 +37,7 @@ impl LinksQuery {
     ) -> Self {
         let tag = tag.map(|tag| Self::tag_to_hex(&tag));
         let create_string = Self::create_query_string(&type_query, tag.clone(), &filter);
-        let delete_string = Self::delete_query_string(&type_query, tag.clone());
+        let delete_string = Self::delete_query_string();
         Self {
             base: Arc::new(base),
             type_query,
@@ -145,31 +145,17 @@ impl LinksQuery {
         }
     }
 
-    fn delete_query_string(type_query: &LinkTypeFilter, tag: Option<String>) -> String {
-        let mut sub_create_query = format!(
-            "
-            SELECT Action.hash FROM DhtOp
-            {}
-            ",
-            Self::common_query_string()
-        );
-        sub_create_query = Self::add_type_query(sub_create_query, type_query);
-        sub_create_query = Self::add_tag(sub_create_query, tag);
-        let delete_query = format!(
-            "
+    fn delete_query_string() -> String {
+        "
             SELECT Action.blob AS action_blob FROM DhtOp
             JOIN Action On DhtOp.action_hash = Action.hash
             WHERE DhtOp.type = :delete
             AND
-            Action.create_link_hash IN ({})
-            AND
             DhtOp.validation_status = :status
             AND
             DhtOp.when_integrated IS NOT NULL
-            ",
-            sub_create_query
-        );
-        delete_query
+        "
+        .to_string()
     }
 
     pub fn params(&self) -> Vec<Params> {


### PR DESCRIPTION
### Summary
see changelog

changing from this
```sql
SELECT Action.blob AS action_blob
FROM DhtOp
JOIN Action On DhtOp.action_hash = Action.hash
WHERE DhtOp.type = :create
AND Action.base_hash = :base_hash
AND DhtOp.validation_status = :status
AND DhtOp.when_integrated IS NOT NULL
AND :after IS NULL AND :before IS NULL AND :author IS NULL
UNION ALL 
SELECT Action.blob AS action_blob
FROM DhtOp
JOIN Action On DhtOp.action_hash = Action.hash
WHERE DhtOp.type = :delete
AND Action.create_link_hash IN (
  SELECT Action.hash FROM DhtOp
  JOIN Action On DhtOp.action_hash = Action.hash
  WHERE DhtOp.type = :create
  AND Action.base_hash = :base_hash
  AND DhtOp.validation_status = :status
  AND DhtOp.when_integrated IS NOT NULL
)
AND DhtOp.validation_status = :status
AND DhtOp.when_integrated IS NOT NULL
```

to this
```sql
SELECT Action.blob AS action_blob
FROM DhtOp
JOIN Action On DhtOp.action_hash = Action.hash
WHERE DhtOp.type = :create
AND Action.base_hash = :base_hash
AND DhtOp.validation_status = :status
AND DhtOp.when_integrated IS NOT NULL
AND :after IS NULL AND :before IS NULL AND :author IS NULL
UNION ALL 
SELECT Action.blob AS action_blob
FROM DhtOp
JOIN Action On DhtOp.action_hash = Action.hash
WHERE DhtOp.type = :delete
AND DhtOp.validation_status = :status
AND DhtOp.when_integrated IS NOT NULL
```


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs