### PR TITLE
chore: 0.5 dependency updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.31.x'
+          cmake-version: "3.31.x"
 
       - name: static-fmt
         run: make static-fmt
@@ -84,12 +84,13 @@ jobs:
       - name: cmake
         uses: jwlawson/actions-setup-cmake@v2
         with:
-          cmake-version: '3.31.x'
+          cmake-version: "3.31.x"
 
       - name: install build dependencies (macos-latest, wasmer_wamr)
         if: matrix.os == 'macos-latest' && matrix.target == 'wasmer_wamr'
-        shell: bash
-        run: brew install cmake ninja
+        run: |
+          brew install llvm
+          echo "PATH=/opt/homebrew/opt/llvm/bin:$PATH" >> "$GITHUB_ENV"
 
       - name: build (windows-latest)
         if: matrix.os == 'windows-latest'
@@ -99,7 +100,8 @@ jobs:
 
       - name: build
         if: matrix.os != 'windows-latest'
-        run: make build-workspace-${{ matrix.target }}
+        run: |
+          make build-workspace-${{ matrix.target }}
 
       - name: install nextest
         uses: taiki-e/install-action@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adler32"
@@ -29,23 +29,23 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cipher",
  "cpufeatures",
 ]
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
- "cfg-if 1.0.0",
- "getrandom 0.2.16",
+ "cfg-if 1.0.1",
+ "getrandom 0.3.3",
  "once_cell",
  "serde",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -110,36 +110,36 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -209,7 +209,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -254,7 +254,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -265,7 +265,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -291,14 +291,14 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "automap"
@@ -306,7 +306,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b99d887f4066f8a1b4a713a8121fab07ff543863ac86177ebdee6b5cb18acf12"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "derive_more 0.99.20",
  "serde",
  "shrinkwraprs",
@@ -314,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878"
+checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa9b6986f250236c27e5a204062434a773a13243d2ffc2955f37bdba4c5c6a1"
+checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
 dependencies = [
  "bindgen 0.69.5",
  "cc",
@@ -402,7 +402,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.26",
+ "rustls 0.23.28",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "tokio",
@@ -412,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "backon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0b50b1b78dbadd44ab18b3c794e496f3a139abb9fbc27d9c94c4eebbb96496"
+checksum = "302eaff5357a264a2c42f127ecb8bac761cf99749fc3dc95677e2743991f99e7"
 dependencies = [
  "fastrand",
 ]
@@ -426,7 +426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "miniz_oxide",
  "object 0.36.7",
@@ -454,9 +454,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.7.3"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bimap"
@@ -470,7 +470,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -483,8 +483,8 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.101",
- "which",
+ "syn 2.0.104",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -493,7 +493,7 @@ version = "0.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -504,7 +504,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -513,7 +513,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -524,7 +524,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -571,9 +571,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "blake2b_simd"
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytecheck"
@@ -654,20 +654,20 @@ checksum = "efb7846e0cb180355c2dec69e721edafa36919850f1a9f52ffba4ebc0393cb71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "bytecount"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 
 [[package]]
 name = "byteorder"
@@ -732,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -764,9 +764,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -854,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -864,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -877,21 +877,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "cloudabi"
@@ -924,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
@@ -955,7 +955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
 dependencies = [
  "castaway",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "itoa",
  "rustversion",
  "ryu",
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1071,12 +1071,12 @@ dependencies = [
 
 [[package]]
 name = "corosensei"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad067b451c08956709f8762dba86e049c124ea52858e3ab8d076ba2892caa437"
+checksum = "5d1ea1c2a2f898d2a6ff149587b8a04f41ee708d248c723f01ac2f0f01edc0b3"
 dependencies = [
- "autocfg 1.4.0",
- "cfg-if 1.0.0",
+ "autocfg 1.5.0",
+ "cfg-if 1.0.1",
  "libc",
  "scopeguard",
  "windows-sys 0.59.0",
@@ -1093,7 +1093,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "regex",
- "syn 2.0.101",
+ "syn 2.0.104",
  "unicode-xid",
 ]
 
@@ -1105,7 +1105,7 @@ checksum = "25fcfea2ee05889597d35e986c2ad0169694320ae5cc8f6d2640a4bb8a884560"
 dependencies = [
  "lazy_static",
  "proc-macro2",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1208,9 +1208,9 @@ checksum = "56b08621c00321efcfa3eee6a3179adc009e21ea8d24ca7adc3c326184bc3f48"
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -1227,7 +1227,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
 ]
 
 [[package]]
@@ -1239,7 +1239,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.5.37",
+ "clap 4.5.40",
  "criterion-plot",
  "futures",
  "is-terminal",
@@ -1328,7 +1328,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -1365,11 +1365,11 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.6"
+version = "3.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697b5419f348fd5ae2478e8018cb016c00a5881c7f46c717de98ffd135a5651c"
+checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
 dependencies = [
- "nix",
+ "nix 0.30.1",
  "windows-sys 0.59.0",
 ]
 
@@ -1379,7 +1379,7 @@ version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
@@ -1397,7 +1397,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1425,7 +1425,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1434,11 +1434,11 @@ version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f44296c8693e9ea226a48f6a122727f77aa9e9e338380cb021accaeeb7ee279"
 dependencies = [
- "clap 4.5.37",
+ "clap 4.5.40",
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1456,7 +1456,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1504,7 +1504,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1526,7 +1526,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1541,7 +1541,7 @@ version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
@@ -1616,7 +1616,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1637,7 +1637,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1647,7 +1647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1660,7 +1660,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.101",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
 ]
 
 [[package]]
@@ -1669,7 +1678,19 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 2.0.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1680,7 +1701,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "unicode-xid",
 ]
 
@@ -1725,7 +1746,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1736,7 +1757,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1809,7 +1830,7 @@ version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
 ]
 
 [[package]]
@@ -1834,23 +1855,23 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a4b049558765cef5f0c1a273c3fc57084d768b44d2f98127aef4cceb17293"
+checksum = "11a6b7c3d347de0a9f7bfd2f853be43fe32fa6fac30c70f6d6d67a1e936b87ee"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c3b24c345d8c314966bdc1832f6c2635bfcce8e7cf363bd115987bba2ee242"
+checksum = "6da3ea9e1d1a3b1593e15781f930120e72aa7501610b2f82e5b6739c72e8eac5"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1861,6 +1882,12 @@ checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
@@ -1880,12 +1907,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1949,7 +1976,7 @@ version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "libredox",
  "windows-sys 0.59.0",
@@ -1986,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2051,11 +2078,11 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "fs-err"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
+checksum = "88d7be93788013f265201256d58f04936a8079ad5dc898743aa20525f503b683"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "tokio",
 ]
 
@@ -2127,7 +2154,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2168,15 +2195,16 @@ checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generator"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bd114ceda131d3b1d665eba35788690ad37f5916457286b32ab6fd3c438dd"
+checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
 dependencies = [
- "cfg-if 1.0.0",
+ "cc",
+ "cfg-if 1.0.1",
  "libc",
  "log",
  "rustversion",
- "windows 0.58.0",
+ "windows",
 ]
 
 [[package]]
@@ -2217,7 +2245,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -2228,20 +2256,20 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "js-sys",
  "libc",
  "r-efi",
@@ -2293,9 +2321,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2316,7 +2344,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "crunchy",
 ]
 
@@ -2347,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2358,11 +2386,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
@@ -2371,6 +2399,7 @@ version = "0.8.2"
 dependencies = [
  "hc_deepkey_types",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
  "serde_bytes",
 ]
@@ -2382,6 +2411,7 @@ dependencies = [
  "hdi",
  "holo_hash",
  "holochain_integrity_types",
+ "holochain_serialized_bytes",
  "rmpv",
  "serde",
 ]
@@ -2390,18 +2420,19 @@ dependencies = [
 name = "hc_demo_cli"
 version = "0.2.0-beta-rc.0"
 dependencies = [
- "cfg-if 1.0.0",
- "clap 4.5.37",
+ "cfg-if 1.0.1",
+ "clap 4.5.40",
  "flate2",
  "getrandom 0.2.16",
  "hdi",
  "hdk",
  "holochain",
  "holochain_keystore",
+ "holochain_serialized_bytes",
  "holochain_types",
  "rand 0.8.5",
  "rand-utf8",
- "rustls 0.23.26",
+ "rustls 0.23.28",
  "serde",
  "tempfile",
  "tokio",
@@ -2411,21 +2442,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hc_r2d2_sqlite"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4044c2cadf3d960fa91a7ef91590da202797fe82cf687b029235f98be5ff49"
-dependencies = [
- "r2d2",
- "rusqlite",
- "uuid",
-]
-
-[[package]]
 name = "hc_seed_bundle"
-version = "0.3.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7dccfe4fef9db0bfc6ae68488e7517f1790bc62262d05beefa2377218978c3"
+checksum = "b68ff0840d162ef4e81e2349aac1be3accb4fdd841bf7557712d6bb96831f4f1"
 dependencies = [
  "futures",
  "one_err",
@@ -2441,10 +2461,10 @@ dependencies = [
 name = "hc_service_check"
 version = "0.2.2"
 dependencies = [
- "clap 4.5.37",
+ "clap 4.5.40",
  "tokio",
  "tx5-signal",
- "ureq 3.0.11",
+ "ureq 3.0.12",
  "url2",
 ]
 
@@ -2454,7 +2474,7 @@ version = "0.5.2"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.5.37",
+ "clap 4.5.40",
  "crossterm",
  "holo_hash",
  "holochain_conductor_api",
@@ -2480,6 +2500,7 @@ dependencies = [
  "hdk_derive",
  "holo_hash",
  "holochain_integrity_types",
+ "holochain_serialized_bytes",
  "holochain_wasmer_guest",
  "mockall",
  "paste",
@@ -2559,15 +2580,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2606,7 +2621,7 @@ dependencies = [
  "kitsune2_api",
  "must_future",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.6.0",
  "rand 0.8.5",
  "rusqlite",
  "serde",
@@ -2629,9 +2644,9 @@ dependencies = [
  "backtrace",
  "base64 0.22.1",
  "bytes",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "chrono",
- "clap 4.5.37",
+ "clap 4.5.40",
  "contrafact",
  "criterion",
  "derive_more 0.99.20",
@@ -2697,10 +2712,10 @@ dependencies = [
  "rand-utf8",
  "rand_chacha 0.3.1",
  "regex",
- "reqwest 0.12.15",
+ "reqwest 0.12.20",
  "rusqlite",
- "rustls 0.23.26",
- "schemars",
+ "rustls 0.23.28",
+ "schemars 0.8.22",
  "sd-notify",
  "serde",
  "serde_bytes",
@@ -2783,7 +2798,7 @@ dependencies = [
  "one_err",
  "parking_lot",
  "pretty_assertions",
- "reqwest 0.12.15",
+ "reqwest 0.12.20",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -2798,7 +2813,7 @@ name = "holochain_cli"
 version = "0.5.2"
 dependencies = [
  "anyhow",
- "clap 4.5.37",
+ "clap 4.5.40",
  "holochain_cli_bundle",
  "holochain_cli_sandbox",
  "holochain_trace",
@@ -2812,7 +2827,7 @@ version = "0.5.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
- "clap 4.5.37",
+ "clap 4.5.40",
  "futures",
  "holochain_serialized_bytes",
  "holochain_types",
@@ -2839,7 +2854,7 @@ dependencies = [
  "ansi_term",
  "anyhow",
  "chrono",
- "clap 4.5.37",
+ "clap 4.5.40",
  "ed25519-dalek",
  "futures",
  "holo_hash",
@@ -2854,7 +2869,7 @@ dependencies = [
  "kitsune2_api",
  "kitsune2_core",
  "nanoid",
- "nix",
+ "nix 0.29.0",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2869,7 +2884,7 @@ dependencies = [
 name = "holochain_conductor_api"
 version = "0.5.2"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "derive_more 0.99.20",
  "holo_hash",
  "holochain_conductor_api",
@@ -2886,7 +2901,7 @@ dependencies = [
  "matches",
  "pretty_assertions",
  "rmp-serde",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -2924,6 +2939,7 @@ dependencies = [
  "hc_deepkey_sdk",
  "hdk",
  "holochain_keystore",
+ "holochain_serialized_bytes",
  "holochain_types",
  "holochain_util",
  "mockall",
@@ -2955,7 +2971,7 @@ dependencies = [
  "holochain_timestamp",
  "holochain_util",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.6.0",
  "serde",
  "serde_bytes",
  "serde_json",
@@ -2982,7 +2998,7 @@ dependencies = [
  "nanoid",
  "one_err",
  "parking_lot",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_bytes",
  "serde_yaml",
@@ -3072,30 +3088,30 @@ dependencies = [
 
 [[package]]
 name = "holochain_serialized_bytes"
-version = "0.0.55"
+version = "0.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719fa847cf9f772f7e8e1a6f11d801e1383cc5af043292042665da9a6ce5c742"
+checksum = "ad33bcab89bdceca5498f1b2fd5c4d1c07d35749deba965c2911494001845ac8"
 dependencies = [
  "arbitrary",
  "holochain_serialized_bytes_derive",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.5.1",
  "rmp-serde",
  "serde",
  "serde-transcode",
  "serde_bytes",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "holochain_serialized_bytes_derive"
-version = "0.0.55"
+version = "0.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6a221b5650251e09ef0b9223cf39e72b5222492cffc6bb4bdf36b2a6bc91aa"
+checksum = "01865625f72d8b6a05487440dfce3c03b0fc83ae03bba7ed6bfbc2f6f8143d14"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3110,7 +3126,6 @@ dependencies = [
  "fallible-iterator",
  "futures",
  "getrandom 0.2.16",
- "hc_r2d2_sqlite",
  "holo_hash",
  "holochain_nonce",
  "holochain_serialized_bytes",
@@ -3128,16 +3143,17 @@ dependencies = [
  "parking_lot",
  "pretty_assertions",
  "r2d2",
+ "r2d2_sqlite",
  "rand 0.8.5",
  "rmp-serde",
  "rusqlite",
  "scheduled-thread-pool",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "shrinkwraprs",
  "sodoken",
- "sqlformat",
+ "sqlformat 0.2.6",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -3201,6 +3217,7 @@ name = "holochain_test_wasm_common"
 version = "0.5.2"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -3276,11 +3293,11 @@ dependencies = [
  "parking_lot",
  "pretty_assertions",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.6.0",
  "rand 0.8.5",
  "regex",
  "rusqlite",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_bytes",
  "serde_derive",
@@ -3302,13 +3319,13 @@ name = "holochain_util"
 version = "0.5.2"
 dependencies = [
  "backtrace",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "colored",
  "dunce",
  "futures",
  "once_cell",
  "rpassword",
- "schemars",
+ "schemars 0.8.22",
  "sodoken",
  "tokio",
  "tracing",
@@ -3329,9 +3346,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_common"
-version = "0.0.99"
+version = "0.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c826653a839b4cd5ac5728c52daab4cd27e1bcc23bdd5121ef64977f7a25196"
+checksum = "2246138152bef3637f773399fb7118527715f3d03bea85c442d299a518f2bfd1"
 dependencies = [
  "holochain_serialized_bytes",
  "serde",
@@ -3341,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_guest"
-version = "0.0.99"
+version = "0.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe3e79d77552986719fd47a1134bbb46f67c16a09b96ca0b6ef90af03d4f34d"
+checksum = "b408ee73bd97b4daeae9a420fe3c321063d0aeaeee08bbbb3f7d9ae25d6f87a4"
 dependencies = [
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
@@ -3354,9 +3371,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_host"
-version = "0.0.99"
+version = "0.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c80387609411f8d4864e518fbe9c6602a2a761d4f956955438fe1ff0ddaa7"
+checksum = "eac72ce40830ece92bcd841fe5458c579ee2ed3c36c32868114ee70dbf11e590"
 dependencies = [
  "bimap",
  "bytes",
@@ -3409,7 +3426,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.6.0",
  "rand 0.8.5",
  "rusqlite",
  "serde",
@@ -3437,7 +3454,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "windows-link",
 ]
@@ -3559,7 +3576,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.9",
+ "h2 0.4.10",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -3587,35 +3604,38 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.26",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 0.26.9",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3635,7 +3655,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.0",
+ "windows-core",
 ]
 
 [[package]]
@@ -3762,7 +3782,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3798,7 +3818,7 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "hashbrown 0.12.3",
  "serde",
 ]
@@ -3810,7 +3830,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -3827,7 +3847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash",
- "clap 4.5.37",
+ "clap 4.5.40",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap",
@@ -3838,7 +3858,7 @@ dependencies = [
  "log",
  "num-format",
  "once_cell",
- "quick-xml",
+ "quick-xml 0.26.0",
  "rgb",
  "str_stack",
 ]
@@ -3906,7 +3926,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "influxive-core",
- "reqwest 0.12.15",
+ "reqwest 0.12.20",
  "sha2",
  "tar",
  "tempfile",
@@ -3965,7 +3985,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3975,12 +3995,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.5.0",
+ "hermit-abi 0.5.2",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -3993,9 +4023,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "iso8601"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c177cff824ab21a6f41079a4c401241c4e8be14f316c4c6b07d5fca351c98d"
+checksum = "e1082f0c48f143442a1ac6122f67e360ceee130b967af4d50996e5154a45df46"
 dependencies = [
  "nom 8.0.0",
 ]
@@ -4068,7 +4098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
 dependencies = [
  "cesu8",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "combine",
  "jni-sys",
  "log",
@@ -4089,7 +4119,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -4113,7 +4143,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.7",
  "bytecount",
- "clap 4.5.37",
+ "clap 4.5.40",
  "fancy-regex",
  "fraction",
  "getrandom 0.2.16",
@@ -4187,21 +4217,21 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_srv"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf95a5f30abe26c056ce118fc212cab6934b847cf99b28b791f99c73c8c13526"
+checksum = "478041cd70366d264d9df1729d92f830406c00b04be52c062f6c1e93bf027c3b"
 dependencies = [
  "async-channel",
  "axum",
  "axum-server",
  "base64 0.22.1",
  "bytes",
- "clap 4.5.37",
+ "clap 4.5.40",
  "ctrlc",
  "ed25519-dalek",
  "futures",
  "num_cpus",
- "rustls 0.23.26",
+ "rustls 0.23.28",
  "sbd-server",
  "serde",
  "serde_json",
@@ -4285,15 +4315,15 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b8d47b9d650eb27ff3fdeebe41b667b5f70662f1c31da3dab029dde61bd3e1"
+checksum = "d618eaeba255c4f1853543098fa8e460fa65a9487a66eb94e6c8b326a5299e51"
 dependencies = [
  "lair_keystore_api",
  "pretty_assertions",
  "rpassword",
  "rusqlite",
- "sqlformat",
+ "sqlformat 0.3.5",
  "structopt",
  "sysinfo",
  "tracing-subscriber",
@@ -4301,14 +4331,14 @@ dependencies = [
 
 [[package]]
 name = "lair_keystore_api"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee05a24db1c24d9b5e8f97c9b9d18fbddc9fb4adb505f097fd19f1f8396fdc1"
+checksum = "18e435134898d2239e85569729824db4a45655f74818bb2f8a69d27c11467059"
 dependencies = [
  "base64 0.22.1",
  "dunce",
  "hc_seed_bundle",
- "lru 0.13.0",
+ "lru 0.14.0",
  "nanoid",
  "once_cell",
  "one_err",
@@ -4350,9 +4380,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libflate"
@@ -4380,12 +4410,12 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
- "cfg-if 1.0.0",
- "windows-targets 0.52.6",
+ "cfg-if 1.0.1",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -4394,7 +4424,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
  "redox_syscall",
 ]
@@ -4418,15 +4448,21 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "91632f3b4fb6bd1d72aa3d78f41ffecfcf2b1a6648d8c241dbe7dbfaf4875e15"
 dependencies = [
  "cc",
  "openssl-sys",
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "libunwind"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6639b70a7ce854b79c70d7e83f16b5dc0137cc914f3d7d03803b513ecc67ac"
 
 [[package]]
 name = "link-cplusplus"
@@ -4463,11 +4499,11 @@ checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "scopeguard",
 ]
 
@@ -4483,7 +4519,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "generator",
  "pin-utils",
  "scoped-tls",
@@ -4499,17 +4535,23 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
 ]
 
 [[package]]
 name = "lru"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rs"
@@ -4534,11 +4576,22 @@ dependencies = [
 
 [[package]]
 name = "mach2"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "macho-unwind-info"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4bdc8b0ce69932332cf76d24af69c3a155242af95c226b2ab6c2e371ed1149"
+dependencies = [
+ "thiserror 2.0.12",
+ "zerocopy",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -4570,9 +4623,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
@@ -4589,7 +4642,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
 ]
 
 [[package]]
@@ -4606,29 +4659,29 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minisign-verify"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6367d84fb54d4242af283086402907277715b8fe46976963af5ebf173f8efba3"
+checksum = "e856fdd13623a2f5f2f54676a4ee49502a96a80ef4a62bcedd23d52427c44d43"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4637,7 +4690,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c84490118f2ee2d74570d114f3d0493cbf02790df303d2707606c3e14e07c96"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "downcast",
  "fragile",
  "lazy_static",
@@ -4652,7 +4705,7 @@ version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ce75669015c4f47b289fd4d4f56e894e4c96003ffdf3ac51313126f94c6cbb"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -4676,8 +4729,8 @@ dependencies = [
  "maplit",
  "matches",
  "proptest",
- "proptest-derive",
- "reqwest 0.12.15",
+ "proptest-derive 0.6.0",
+ "reqwest 0.12.20",
  "rmp-serde",
  "serde",
  "serde_bytes",
@@ -4690,22 +4743,22 @@ dependencies = [
 
 [[package]]
 name = "munge"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e22e7961c873e8b305b176d2a4e1d41ce7ba31bc1c52d2a107a89568ec74c55"
+checksum = "9cce144fab80fbb74ec5b89d1ca9d41ddf6b644ab7e986f7d3ed0aab31625cb1"
 dependencies = [
  "munge_macro",
 ]
 
 [[package]]
 name = "munge_macro"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac7d860b767c6398e88fe93db73ce53eb496057aa6895ffa4d60cb02e1d1c6b"
+checksum = "574af9cd5b9971cbfdf535d6a8d533778481b241c447826d976101e0149392a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4739,8 +4792,20 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.0",
- "cfg-if 1.0.0",
+ "bitflags 2.9.1",
+ "cfg-if 1.0.1",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if 1.0.1",
  "cfg_aliases",
  "libc",
 ]
@@ -4859,7 +4924,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
  "num-integer",
  "num-traits",
 ]
@@ -4881,38 +4946,39 @@ version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
- "autocfg 1.4.0",
+ "autocfg 1.5.0",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4921,7 +4987,17 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -4952,6 +5028,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "one_err"
@@ -4988,9 +5070,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -5023,11 +5105,12 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_info"
-version = "3.10.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a604e53c24761286860eba4e2c8b23a0161526476b1de520139d69cdb85a6b5"
+checksum = "d0e1ac5fde8d43c34139135df8ea9ee9465394b2d8d20f032d38998f64afffc3"
 dependencies = [
  "log",
+ "plist",
  "serde",
  "windows-sys 0.52.0",
 ]
@@ -5046,9 +5129,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -5056,11 +5139,11 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -5085,11 +5168,12 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
+ "serde",
 ]
 
 [[package]]
@@ -5126,7 +5210,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5156,6 +5240,19 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plist"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d77244ce2d584cd84f6a15f86195b8c9b2a0dfbfd817c09e0464244091a58ed"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.9.0",
+ "quick-xml 0.37.5",
+ "serde",
+ "time",
+]
 
 [[package]]
 name = "plotters"
@@ -5197,7 +5294,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5256,12 +5353,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5316,7 +5413,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5330,18 +5427,18 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "rand_xorshift 0.3.0",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
+ "rand_xorshift 0.4.0",
  "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
@@ -5350,13 +5447,24 @@ dependencies = [
 
 [[package]]
 name = "proptest-derive"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
+checksum = "4ee1c9ac207483d5e7db4940700de86a9aae46ef90c48b57f99fe7edb8345e49"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "proptest-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "095a99f75c69734802359b682be8daaf8980296731f6470434ea2c652af1dd30"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5379,7 +5487,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5419,7 +5527,7 @@ checksum = "ca414edb151b4c8d125c12566ab0d74dc9cdba36fb80eb7b848c15f495fd32d1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5438,6 +5546,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quickcheck"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5449,9 +5566,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -5459,7 +5576,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.26",
+ "rustls 0.23.28",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -5469,16 +5586,17 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
+ "lru-slab",
  "rand 0.9.1",
- "ring 0.17.14",
+ "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.26",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -5489,9 +5607,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -5512,9 +5630,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r2d2"
@@ -5525,6 +5643,17 @@ dependencies = [
  "log",
  "parking_lot",
  "scheduled-thread-pool",
+]
+
+[[package]]
+name = "r2d2_sqlite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06cc23a61faf4643d8b59ed52c27ed434476dd7aa6f39e1eff7d6bbd35985093"
+dependencies = [
+ "r2d2",
+ "rusqlite",
+ "uuid",
 ]
 
 [[package]]
@@ -5690,7 +5819,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -5766,11 +5895,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5779,7 +5908,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -5816,12 +5945,13 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.10.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
  "pem",
- "ring 0.16.20",
+ "ring",
+ "rustls-pki-types",
  "time",
  "yasna",
  "zeroize",
@@ -5838,11 +5968,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -5854,6 +5984,26 @@ dependencies = [
  "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.12",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5986,9 +6136,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5998,18 +6148,14 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.7",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
- "mime",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.26",
- "rustls-pemfile 2.2.0",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -6019,14 +6165,14 @@ dependencies = [
  "tokio-rustls 0.26.2",
  "tokio-util",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.9",
- "windows-registry",
+ "webpki-roots 1.0.1",
 ]
 
 [[package]]
@@ -6040,30 +6186,15 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted 0.7.1",
- "web-sys",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "getrandom 0.2.16",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -6075,7 +6206,7 @@ checksum = "1e147371c75553e1e2fcdb483944a8540b8438c31426279553b9a8182a9b7b65"
 dependencies = [
  "bytecheck 0.8.1",
  "bytes",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "indexmap 2.9.0",
  "munge",
  "ptr_meta 0.3.0",
@@ -6094,7 +6225,7 @@ checksum = "246b40ac189af6c675d124b802e8ef6d5246c53e17367ce9501f8f66a81abb7a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6160,11 +6291,11 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "3de23c3319433716cf134eed225fe9986bc24f63bed9be9f20c329029e672dc7"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -6174,9 +6305,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -6205,7 +6336,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6214,11 +6345,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -6232,23 +6363,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
- "ring 0.17.14",
+ "ring",
  "rustls-webpki 0.101.7",
  "sct",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.1",
+ "rustls-webpki 0.103.3",
  "subtle",
  "zeroize",
 ]
@@ -6285,11 +6416,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
@@ -6298,27 +6430,27 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "aws-lc-rs",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rusty-fork"
@@ -6368,13 +6500,13 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "rand 0.8.5",
- "rustls 0.23.26",
+ "rustls 0.23.28",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.26.2",
  "tokio-tungstenite 0.23.1",
  "tracing",
- "webpki-roots 0.26.9",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -6399,11 +6531,11 @@ dependencies = [
  "anstyle",
  "base64 0.22.1",
  "bytes",
- "clap 4.5.37",
+ "clap 4.5.40",
  "ed25519-dalek",
  "futures",
  "rand 0.8.5",
- "rustls 0.23.26",
+ "rustls 0.23.28",
  "rustls-pemfile 2.2.0",
  "slab",
  "tokio",
@@ -6442,6 +6574,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6450,7 +6594,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6477,8 +6621,8 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -6496,8 +6640,8 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.0",
- "core-foundation 0.10.0",
+ "bitflags 2.9.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -6527,9 +6671,9 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -6545,9 +6689,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.4.5"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
 dependencies = [
  "js-sys",
  "serde",
@@ -6565,13 +6709,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6582,7 +6726,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6600,9 +6744,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -6621,15 +6765,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.9.0",
+ "schemars 0.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -6639,14 +6784,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
 dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6668,18 +6813,18 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cpufeatures",
  "digest",
 ]
@@ -6734,9 +6879,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -6785,12 +6930,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg 1.4.0",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "slice-group-by"
@@ -6800,15 +6942,15 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -6824,12 +6966,6 @@ dependencies = [
  "libsodium-sys-stable",
  "zeroize",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
@@ -6849,6 +6985,16 @@ checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
 dependencies = [
  "nom 7.1.3",
  "unicode_categories",
+]
+
+[[package]]
+name = "sqlformat"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d7b3e8a3b6f2ee93ac391a0f757c13790caa0147892e3545cd549dd5b54bc0"
+dependencies = [
+ "unicode_categories",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -6896,7 +7042,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta-derive",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6907,7 +7053,7 @@ checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6990,7 +7136,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7021,9 +7167,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7047,26 +7193,27 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.34.2"
+version = "0.35.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
+checksum = "3c3ffa3e4ff2b324a57f7aeb3c349656c7b127c3c189520251a648102a92496e"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
- "windows 0.57.0",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -7137,14 +7284,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -7163,7 +7310,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -7188,10 +7335,10 @@ version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7202,7 +7349,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "test-case-core",
 ]
 
@@ -7215,7 +7362,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "structmeta",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7253,7 +7400,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7264,17 +7411,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if 1.0.0",
- "once_cell",
+ "cfg-if 1.0.1",
 ]
 
 [[package]]
@@ -7345,9 +7491,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7369,7 +7515,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7388,7 +7534,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.26",
+ "rustls 0.23.28",
  "tokio",
 ]
 
@@ -7424,7 +7570,7 @@ checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.26",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -7458,9 +7604,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -7470,32 +7616,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "toml_write",
- "winnow",
+ "winnow 0.7.11",
 ]
 
 [[package]]
 name = "toml_write"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -7508,6 +7654,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -7537,20 +7701,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
  "valuable",
@@ -7627,9 +7791,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae08be68c056db96f0e6c6dd820727cca756ced9e1f4cc7fdd20e2a55e23898"
+checksum = "1c9bf9513a2f4aeef5fdac8677d7d349c79fdbcc03b9c86da6e9d254f1e43be2"
 dependencies = [
  "glob",
  "serde",
@@ -7672,7 +7836,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "rustls 0.23.26",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
@@ -7703,7 +7867,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "static_assertions",
 ]
 
@@ -7840,12 +8004,6 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -7866,38 +8024,38 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls 0.23.26",
+ "rustls 0.23.28",
  "rustls-pki-types",
  "url",
- "webpki-roots 0.26.9",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "ureq"
-version = "3.0.11"
+version = "3.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a3e9af6113ecd57b8c63d3cd76a385b2e3881365f1f489e54f49801d0c83ea"
+checksum = "9f0fde9bc91026e381155f8c67cb354bcd35260b2f4a29bcc84639f762760c39"
 dependencies = [
  "base64 0.22.1",
  "cookie_store",
  "flate2",
  "log",
  "percent-encoding",
- "rustls 0.23.26",
+ "rustls 0.23.28",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "ureq-proto",
  "utf-8",
- "webpki-roots 0.26.9",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadf18427d33828c311234884b7ba2afb57143e6e7e69fda7ee883b624661e36"
+checksum = "59db78ad1923f2b1be62b6da81fe80b173605ca0d57f85da2e005382adf693f7"
 dependencies = [
  "base64 0.22.1",
  "http 1.3.1",
@@ -7959,13 +8117,15 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
+ "js-sys",
  "rand 0.9.1",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -8028,9 +8188,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -8047,7 +8207,7 @@ version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -8063,7 +8223,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -8073,7 +8233,7 @@ version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -8098,7 +8258,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8114,12 +8274,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.229.0"
+version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ba1d491ecacb085a2552025c10a675a6fddcbd03b1fc9b36c536010ce265d2"
+checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.229.0",
+ "wasmparser 0.235.0",
 ]
 
 [[package]]
@@ -8177,17 +8337,20 @@ dependencies = [
 
 [[package]]
 name = "wasmer"
-version = "5.0.4"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998dea47d6bb6a8fc7dd8a17b13bf8de277e007229f270c67105cb67fc2d9657"
+checksum = "f25dccc6251837449135914ee1978731c2c3df9fc727088eb7e098736c0f15d1"
 dependencies = [
  "bindgen 0.70.1",
  "bytes",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "cmake",
- "indexmap 1.9.3",
+ "derive_more 1.0.0",
+ "idna_adapter",
+ "indexmap 2.9.0",
  "js-sys",
  "more-asserts",
+ "paste",
  "rustc-demangle",
  "serde",
  "serde-wasm-bindgen",
@@ -8203,27 +8366,27 @@ dependencies = [
  "wasmer-derive",
  "wasmer-types",
  "wasmer-vm",
- "wasmparser 0.216.1",
+ "wasmparser 0.224.1",
  "wat",
+ "which 7.0.3",
  "windows-sys 0.59.0",
- "xz",
  "zip",
 ]
 
 [[package]]
 name = "wasmer-compiler"
-version = "5.0.4"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082f48ba006cce2358f6c63d8dba732c9d12ba5833008c9ff2944290eb72c3dc"
+checksum = "6f35baeb0d5b20710b5b9c59477dbf813b1ac53da33ee46cb22f8c4190e3986e"
 dependencies = [
  "backtrace",
  "bytes",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "enum-iterator",
  "enumset",
- "lazy_static",
  "leb128",
  "libc",
+ "macho-unwind-info",
  "memmap2",
  "more-asserts",
  "object 0.32.2",
@@ -8236,16 +8399,16 @@ dependencies = [
  "thiserror 1.0.69",
  "wasmer-types",
  "wasmer-vm",
- "wasmparser 0.216.1",
+ "wasmparser 0.224.1",
  "windows-sys 0.59.0",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "5.0.4"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0272ad7daf59d43419cda9ae58b9cf8df6a115c8632fbb91c600892dff52f7a8"
+checksum = "6d657a96003ce3f54a3cbbf681fcd782b983f9362c97cfbbe243cbf66790e004"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -8263,9 +8426,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "5.0.4"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87b16fa0b2199083143705698ea9fc2ffd0328d7061f54e0e20ccd0ec2020466"
+checksum = "62b57be80a67de03c2a02d697bfd763e097546b11f0020cf9930ebaa4f8cf965"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -8275,9 +8438,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-middlewares"
-version = "5.0.4"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "371b38abbba1a0fb747bee025d3a40c776842be4a2052b7a3ca18bd2db80669d"
+checksum = "e61dce6fcf320ab506a9cbf6f12255ccc894e93c5d7a530f14cc7717e81a3c94"
 dependencies = [
  "wasmer",
  "wasmer-types",
@@ -8286,9 +8449,9 @@ dependencies = [
 
 [[package]]
 name = "wasmer-types"
-version = "5.0.4"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41b0b9b3242c1a6269e544401b1741a56502a5f79db8e1b318cacf1b34b2690d"
+checksum = "1b8424d15f5c19a8df972fc9367d75ba3b87af63b279208d50a32e9a298d944b"
 dependencies = [
  "bytecheck 0.6.12",
  "enum-iterator",
@@ -8306,21 +8469,21 @@ dependencies = [
 
 [[package]]
 name = "wasmer-vm"
-version = "5.0.4"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92c7f8dbaceb0ab7901702e3c2bb43b09d2635aaa5ad39679c6560bcb9acde7c"
+checksum = "faabfffefc6fc350bb5b07301f05ba604a18c3d2d97c6354183f15792577056d"
 dependencies = [
  "backtrace",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "corosensei",
  "crossbeam-queue",
  "dashmap",
  "enum-iterator",
  "fnv",
  "indexmap 2.9.0",
- "lazy_static",
  "libc",
+ "libunwind",
  "mach2",
  "memoffset",
  "more-asserts",
@@ -8333,33 +8496,29 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.216.1"
+version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc7c63191ae61c70befbe6045b9be65ef2082fa89421a386ae172cb1e08e92d"
+checksum = "04f17a5917c2ddd3819e84c661fae0d6ba29d7b9c1f0e96c708c65a9c4188e11"
 dependencies = [
- "ahash",
- "bitflags 2.9.0",
- "hashbrown 0.14.5",
- "indexmap 2.9.0",
- "semver",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.229.0"
+version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3b1f053f5d41aa55640a1fa9b6d1b8a9e4418d118ce308d20e24ff3575a8c"
+checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "indexmap 2.9.0",
  "semver",
 ]
 
 [[package]]
 name = "wast"
-version = "229.0.0"
+version = "235.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63fcaff613c12225696bb163f79ca38ffb40e9300eff0ff4b8aa8b2f7eadf0d9"
+checksum = "1eda4293f626c99021bb3a6fbe4fbbe90c0e31a5ace89b5f620af8925de72e13"
 dependencies = [
  "bumpalo",
  "leb128fmt",
@@ -8370,9 +8529,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.229.0"
+version = "1.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4189bad08b70455a9e9e67dc126d2dcf91fac143a80f1046747a5dde6d4c33e0"
+checksum = "e777e0327115793cb96ab220b98f85327ec3d11f34ec9e8d723264522ef206aa"
 dependencies = [
  "wast",
 ]
@@ -8405,9 +8564,18 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.9"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.1",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8432,6 +8600,18 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix 1.0.7",
+ "winsafe",
 ]
 
 [[package]]
@@ -8473,82 +8653,48 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
-dependencies = [
- "windows-core 0.58.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
-dependencies = [
- "windows-implement 0.57.0",
- "windows-interface 0.57.0",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
-dependencies = [
- "windows-implement 0.58.0",
- "windows-interface 0.58.0",
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
-dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
  "windows-link",
- "windows-result 0.3.2",
- "windows-strings 0.4.0",
+ "windows-numerics",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.57.0"
+name = "windows-collections"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "windows-core",
 ]
 
 [[package]]
-name = "windows-implement"
-version = "0.58.0"
+name = "windows-core"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -8559,29 +8705,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8592,77 +8716,39 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
-name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result 0.3.2",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
+name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]
@@ -8701,6 +8787,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -8751,9 +8846,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.0"
+version = "0.53.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
 dependencies = [
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
@@ -8763,6 +8858,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.0",
  "windows_x86_64_gnullvm 0.53.0",
  "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -8947,9 +9051,18 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.7"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -8960,9 +9073,15 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.1",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"
@@ -8970,7 +9089,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -8992,7 +9111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix 1.0.5",
+ "rustix 1.0.7",
 ]
 
 [[package]]
@@ -9006,15 +9125,6 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
-
-[[package]]
-name = "xz"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c887690ff2a2e233e8e49633461521f98ec57fbff9d59a884c9a4f04ec1da34"
-dependencies = [
- "xz2",
-]
 
 [[package]]
 name = "xz2"
@@ -9060,48 +9170,28 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
-dependencies = [
- "zerocopy-derive 0.8.25",
+ "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9121,7 +9211,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -9142,7 +9232,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9164,14 +9254,14 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "zip"
-version = "2.6.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
 dependencies = [
  "aes",
  "arbitrary",
@@ -9180,14 +9270,16 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "deflate64",
+ "displaydoc",
  "flate2",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "hmac",
  "indexmap 2.9.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",
  "sha1",
+ "thiserror 2.0.12",
  "time",
  "xz2",
  "zeroize",

--- a/crates/fixt/Cargo.toml
+++ b/crates/fixt/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-holochain_serialized_bytes = "=0.0.55"
+holochain_serialized_bytes = "=0.0.56"
 lazy_static = "1.4"
 parking_lot = "0.12"
 paste = "1.0.12"

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -24,21 +24,21 @@ path = "src/bin/hc-dna.rs"
 
 # reminder - do not use workspace deps
 [dependencies]
-holochain_wasmer_host = { version = "=0.0.99", default-features = false }
+holochain_wasmer_host = { version = "=0.0.101", default-features = false }
 futures = "0.3"
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 holochain_util = { version = "^0.5.2", path = "../holochain_util", features = [
   "backtrace",
 ] }
-holochain_serialized_bytes = "=0.0.55"
+holochain_serialized_bytes = "=0.0.56"
 holochain_types = { version = "^0.5.2", path = "../holochain_types" }
 mr_bundle = { version = "^0.5.2", path = "../mr_bundle" }
 serde_yaml = "0.9"
 thiserror = "1.0.22"
 tracing = "0.1"
 tokio = { version = "1.27", features = ["full"] }
-wasmer = { version = "5.0.2", default-features = false }
+wasmer = { version = "6.0", default-features = false }
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/crates/hc_bundle/src/packing/wasmer_sys.rs
+++ b/crates/hc_bundle/src/packing/wasmer_sys.rs
@@ -1,6 +1,6 @@
 use crate::error::HcBundleError;
 use holochain_util::ffs;
-use holochain_wasmer_host::module::build_ios_module;
+use holochain_wasmer_host::module::build_module;
 use mr_bundle::{Bundle, Manifest};
 use std::path::Path;
 use tracing::info;
@@ -30,7 +30,7 @@ pub(super) async fn build_preserialized_wasm<M: Manifest>(
                     ffs::create_dir_all(ios_folder_path).await?;
                     ffs::write(&resource_path_adjoined, vec![].as_slice()).await?;
                     let resource_path = ffs::canonicalize(resource_path_adjoined).await?;
-                    match build_ios_module(bytes.as_slice()) {
+                    match build_module(bytes.as_slice()) {
                         Ok(module) => match module.serialize_to_file(resource_path.clone()) {
                             Ok(()) => {
                                 info!("wrote ios dylib to {:?}", resource_path);
@@ -38,7 +38,7 @@ pub(super) async fn build_preserialized_wasm<M: Manifest>(
                             }
                             Err(e) => Err(HcBundleError::SerializedModuleError(e)),
                         },
-                        Err(e) => Err(HcBundleError::ModuleCompileError(e)),
+                        Err(e) => Err(HcBundleError::MiscError(Box::new(e))),
                     }
                 } else {
                     Ok(())

--- a/crates/hc_deepkey_sdk/Cargo.toml
+++ b/crates/hc_deepkey_sdk/Cargo.toml
@@ -17,6 +17,7 @@ hc_deepkey_types = { version = "^0.9.2", path = "../hc_deepkey_types" }
 hdk = { version = "^0.5.2", path = "../hdk" }
 serde = "1"
 serde_bytes = "0.11"
+holochain_serialized_bytes = "=0.0.56"
 
 [features]
 fuzzing = ["hc_deepkey_types/fuzzing", "hdk/fuzzing"]

--- a/crates/hc_deepkey_types/Cargo.toml
+++ b/crates/hc_deepkey_types/Cargo.toml
@@ -19,6 +19,7 @@ holo_hash = { version = "^0.5.2", path = "../holo_hash", features = [
 holochain_integrity_types = { version = "^0.5.2", path = "../holochain_integrity_types" }
 rmpv = { version = "1", features = ["with-serde"] }
 serde = "1"
+holochain_serialized_bytes = "=0.0.56"
 
 [features]
 fuzzing = [

--- a/crates/hc_demo_cli/Cargo.toml
+++ b/crates/hc_demo_cli/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1", optional = true }
 tokio = { version = "1.27", features = ["full"], optional = true }
 tracing = { version = "0.1.37", optional = true }
 tracing-subscriber = { version = "0.3.16", optional = true }
+holochain_serialized_bytes = "=0.0.56"
 
 [dev-dependencies]
 tempfile = "3.5.0"

--- a/crates/hdi/Cargo.toml
+++ b/crates/hdi/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 hdk_derive = { version = "^0.5.2", path = "../hdk_derive" }
 holo_hash = { version = "^0.5.2", path = "../holo_hash" }
-holochain_wasmer_guest = "=0.0.99"
+holochain_wasmer_guest = "=0.0.101"
 # it's important that we depend on holochain_integrity_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
 holochain_integrity_types = { version = "^0.5.2", path = "../holochain_integrity_types", default-features = false }
@@ -25,6 +25,7 @@ serde_bytes = "0.11"
 tracing = { version = "0.1", optional = true }
 tracing-core = { version = "0.1", optional = true }
 mockall = { version = "0.11.3", optional = true }
+holochain_serialized_bytes = "=0.0.56"
 
 # When building for the WASM target, we need to configure getrandom
 # to use the host system for the source of crypto-secure randomness.

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 hdi = { version = "=0.6.2", path = "../hdi", features = ["trace"] }
 hdk_derive = { version = "^0.5.2", path = "../hdk_derive" }
 holo_hash = { version = "^0.5.2", path = "../holo_hash" }
-holochain_wasmer_guest = "=0.0.99"
+holochain_wasmer_guest = "=0.0.101"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
 holochain_zome_types = { version = "^0.5.2", path = "../holochain_zome_types", default-features = false }

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -23,19 +23,19 @@ bytes = { version = "1", optional = true }
 derive_more = { version = "0.99", optional = true }
 fixt = { version = "^0.5.2", path = "../fixt", optional = true }
 futures = { version = "0.3", optional = true }
-holochain_serialized_bytes = { version = "=0.0.55", optional = true }
+holochain_serialized_bytes = { version = "=0.0.56", optional = true }
 holochain_util = { version = "^0.5.2", path = "../holochain_util", default-features = false }
 kitsune2_api = { version = "0.1.8", optional = true }
 must_future = { version = "0.1", optional = true }
 proptest = { version = "1", optional = true }
 proptest-derive = { version = "0", optional = true }
 rand = { version = "0.8.5", optional = true }
-rusqlite = { version = "0.32.1", optional = true }
+rusqlite = { version = "0.36", optional = true }
 serde = { version = "1", optional = true }
 serde_bytes = { version = "0.11", optional = true }
 sha2 = { version = "0.10", optional = true }
 tracing = { version = "0.1", optional = true }
-holochain_wasmer_common = { version = "=0.0.99", optional = true }
+holochain_wasmer_common = { version = "=0.0.101", optional = true }
 
 [dev-dependencies]
 serde_json = { version = "1.0.51", features = ["preserve_order"] }

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -6,6 +6,11 @@ default_semver_increment_mode: !pre_patch rc
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Updates rusqlite to 0.36.
+- Updates holochain_serialized_bytes to 0.0.56 which updates serde to 1.0.219, now requires projects using serialized 
+  bytes to have a direct dependency on it similarly to serde itself.
+- Updates holochain-wasmer to 0.0.101, which updates to wasmer to v6 and drops support for precompiled iOS modules 
+  which was deprecated at 0.4.
 - Filter out unresponsive agents when publishing ops. Any URL that is set as unresponsive in the peer meta store will be filtered out when determining the agents
   near a location to publish to.
 - Integrate all app validated ops, regardless of type and order

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -34,11 +34,11 @@ holochain_deepkey_dna = "0.0.8-dev.2"
 holochain_keystore = { version = "^0.5.2", path = "../holochain_keystore", default-features = false }
 holochain_p2p = { version = "^0.5.2", path = "../holochain_p2p" }
 holochain_sqlite = { version = "^0.5.2", path = "../holochain_sqlite" }
-holochain_serialized_bytes = "=0.0.55"
+holochain_serialized_bytes = "=0.0.56"
 holochain_state = { version = "^0.5.2", path = "../holochain_state" }
 holochain_types = { version = "^0.5.2", path = "../holochain_types" }
 holochain_util = { version = "^0.5.2", path = "../holochain_util" }
-holochain_wasmer_host = { version = "=0.0.99", default-features = false, features = [
+holochain_wasmer_host = { version = "=0.0.101", default-features = false, features = [
   "error_as_host",
 ] }
 holochain_websocket = { version = "^0.5.2", path = "../holochain_websocket" }
@@ -60,14 +60,14 @@ must_future = "0.1.1"
 nanoid = "0.4"
 holochain_trace = { version = "^0.5.2", path = "../holochain_trace" }
 holochain_metrics = { version = "^0.5.2", path = "../holochain_metrics", default-features = false }
-lair_keystore_api = "=0.6.1"
+lair_keystore_api = "=0.6.2"
 once_cell = "1.4.1"
 one_err = "0.0.8"
 parking_lot = "0.12"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rand-utf8 = "0.0.1"
-rusqlite = { version = "0.32.1" }
+rusqlite = { version = "0.36" }
 # Used to set a crypto provider for TLS connections.
 rustls = "0.23.25"
 serde = { version = "1.0", features = ["derive"] }
@@ -94,8 +94,8 @@ uuid = { version = "1.8", features = ["serde", "v4"] }
 sha3 = "0.10"
 opentelemetry_api = { version = "=0.20.0", features = ["metrics"] }
 indexmap = { version = "2.6.0", features = ["serde"] }
-wasmer = { version = "5.0.2", default-features = false }
-wasmer-middlewares = { version = "5.0.2", optional = true, default-features = false }
+wasmer = { version = "6.0", default-features = false }
+wasmer-middlewares = { version = "6.0", optional = true, default-features = false }
 
 # Dependencies for test_utils / other optional deps
 fixt = { version = "^0.5.2", path = "../fixt", optional = true }
@@ -143,7 +143,7 @@ contrafact = "0.2.0-rc.1"
 criterion = { version = "0.5", features = ["async_tokio"] }
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 isotest = "0"
-lair_keystore = "0.6.1"
+lair_keystore = "0.6.2"
 maplit = "1"
 pretty_assertions = "1.4"
 regex = "1.5"
@@ -161,7 +161,7 @@ serde_json = { version = "1.0.51" }
 toml = "0.8"
 chrono = { version = "0.4.6", features = ["serde"] }
 hostname = "0.4"
-lair_keystore = { version = "0.6.1", default-features = false, features = [
+lair_keystore = { version = "0.6.2", default-features = false, features = [
   "rusqlite-bundled-sqlcipher-vendored-openssl",
 ] }
 

--- a/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome/wasmer_sys.rs
@@ -30,10 +30,9 @@ pub fn get_used_metering_points(instance_with_store: Arc<InstanceWithStore>) -> 
 /// DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.
 pub fn get_prebuilt_module(wasm_zome: &WasmZome) -> RibosomeResult<Option<Arc<Module>>> {
     match &wasm_zome.preserialized_path {
-        Some(path) => {
-            eprintln!("DEPRECATED: Bundling precompiled and preserialized wasm for iOS is deprecated. Please use the wasm interpreter instead.");
-            let module = holochain_wasmer_host::module::get_ios_module_from_file(path.as_path())?;
-            Ok(Some(Arc::new(module)))
+        Some(_) => {
+            eprintln!("DEPRECATED: Bundling precompiled and preserialized wasm for iOS is no longer supported. Please use the wasm interpreter instead.");
+            Ok(None)
         }
         None => Ok(None),
     }

--- a/crates/holochain/tests/tests/countersigning/session_interaction_over_websocket.rs
+++ b/crates/holochain/tests/tests/countersigning/session_interaction_over_websocket.rs
@@ -615,7 +615,7 @@ impl Agent {
     async fn setup(bootstrap_url: String, signal_url: String, network_seed: String) -> Agent {
         let admin_port = 0;
         let tmp_dir = TempDir::new().unwrap();
-        let path = tmp_dir.into_path();
+        let path = tmp_dir.keep();
         let environment_path = path.clone();
         let mut config = create_config(admin_port, environment_path.into());
         config.network.advanced = Some(serde_json::json!({

--- a/crates/holochain/tests/tests/websocket/mod.rs
+++ b/crates/holochain/tests/tests/websocket/mod.rs
@@ -1172,7 +1172,7 @@ impl TestCase {
         let admin_port = 0;
 
         let tmp_dir = TempDir::new().unwrap();
-        let path = tmp_dir.into_path();
+        let path = tmp_dir.keep();
         let environment_path = path.clone();
         let config = create_config(admin_port, environment_path.into());
         let config_path = write_config(path, &config);

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -16,7 +16,7 @@ holo_hash = { version = "^0.5.2", path = "../holo_hash", features = ["full"] }
 holochain_chc = { version = "^0.2.2", path = "../holochain_chc" }
 holochain_sqlite = { version = "^0.5.2", path = "../holochain_sqlite" }
 holochain_p2p = { version = "^0.5.2", path = "../holochain_p2p" }
-holochain_serialized_bytes = "=0.0.55"
+holochain_serialized_bytes = "=0.0.56"
 holochain_state = { version = "^0.5.2", path = "../holochain_state" }
 holochain_types = { version = "^0.5.2", path = "../holochain_types" }
 holochain_trace = { version = "^0.5.2", path = "../holochain_trace" }

--- a/crates/holochain_chc/Cargo.toml
+++ b/crates/holochain_chc/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "1.0.22"
 tracing = "0.1"
 url = "2.4"
 
-holochain_serialized_bytes = { version = "=0.0.55", optional = true }
+holochain_serialized_bytes = { version = "=0.0.56", optional = true }
 holo_hash = { version = "^0.5.2", path = "../holo_hash", optional = true }
 reqwest = { version = "0.12", default-features = false, features = [
   "json",

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -14,7 +14,7 @@ cfg-if = "1.0"
 derive_more = "0.99"
 holo_hash = { version = "^0.5.2", path = "../holo_hash", features = ["full"] }
 holochain_state_types = { version = "^0.5.2", path = "../holochain_state_types" }
-holochain_serialized_bytes = "=0.0.55"
+holochain_serialized_bytes = "=0.0.56"
 holochain_types = { version = "^0.5.2", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.5.2", path = "../holochain_zome_types" }
 holochain_util = { version = "^0.5.2", default-features = false, path = "../holochain_util", features = [

--- a/crates/holochain_conductor_services/Cargo.toml
+++ b/crates/holochain_conductor_services/Cargo.toml
@@ -30,6 +30,7 @@ holochain_types = { version = "^0.5.2", path = "../holochain_types" }
 holochain_util = { version = "^0.5.2", path = "../holochain_util", features = [
   "time",
 ] }
+holochain_serialized_bytes = "=0.0.56"
 
 [dev-dependencies]
 hdk = { version = "^0.5.2", path = "../hdk" }

--- a/crates/holochain_integrity_types/Cargo.toml
+++ b/crates/holochain_integrity_types/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 holo_hash = { version = "^0.5.2", path = "../holo_hash", features = [
   "encoding",
 ] }
-holochain_serialized_bytes = "=0.0.55"
+holochain_serialized_bytes = "=0.0.56"
 holochain_util = { version = "^0.5.2", path = "../holochain_util", default-features = false }
 holochain_secure_primitive = { version = "^0.5.2", path = "../holochain_secure_primitive" }
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -16,11 +16,11 @@ base64 = "0.22"
 derive_more = "0.99"
 futures = "0.3"
 holo_hash = { version = "^0.5.2", path = "../holo_hash", features = ["full"] }
-holochain_serialized_bytes = "=0.0.55"
+holochain_serialized_bytes = "=0.0.56"
 holochain_zome_types = { path = "../holochain_zome_types", version = "^0.5.2" }
 holochain_secure_primitive = { version = "^0.5.2", path = "../holochain_secure_primitive" }
 holochain_util = { version = "^0.5.2", path = "../holochain_util" }
-lair_keystore = { version = "0.6.1", default-features = false }
+lair_keystore = { version = "0.6.2", default-features = false }
 must_future = "0.1.2"
 nanoid = "0.4"
 one_err = "0.0.8"

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -24,7 +24,7 @@ holo_hash = { version = "^0.5.2", path = "../holo_hash", features = [
 ] }
 holochain_chc = { version = "^0.2.2", path = "../holochain_chc" }
 holochain_keystore = { version = "^0.5.2", path = "../holochain_keystore" }
-holochain_serialized_bytes = "=0.0.55"
+holochain_serialized_bytes = "=0.0.56"
 holochain_types = { version = "^0.5.2", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.5.2", path = "../holochain_zome_types" }
 holochain_nonce = { version = "^0.5.2", path = "../holochain_nonce" }
@@ -46,7 +46,7 @@ kitsune2_core = "0.1.9"
 kitsune2_gossip = "0.1.9"
 bytes = "1.10"
 holochain_sqlite = { version = "^0.5.2", path = "../holochain_sqlite" }
-lair_keystore_api = "=0.6.1"
+lair_keystore_api = "=0.6.2"
 parking_lot = "0.12.3"
 holochain_state = { version = "^0.5.2", path = "../holochain_state" }
 holochain_timestamp = { version = "^0.5.2", path = "../timestamp" }

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -17,7 +17,7 @@ derive_more = "0.99"
 fallible-iterator = "0.3.0"
 futures = "0.3"
 holo_hash = { path = "../holo_hash", version = "^0.5.2" }
-holochain_serialized_bytes = "=0.0.55"
+holochain_serialized_bytes = "=0.0.56"
 holochain_util = { version = "^0.5.2", path = "../holochain_util", features = [
   "backtrace",
   "time",
@@ -30,7 +30,7 @@ once_cell = "1.4.1"
 num_cpus = "1.13.0"
 parking_lot = "0.12"
 r2d2 = "0.8"
-r2d2_sqlite = { version = "0.25.0", package = "hc_r2d2_sqlite" }
+r2d2_sqlite = { version = "0.30" }
 rmp-serde = "=1.3.0"
 scheduled-thread-pool = "0.2"
 serde = "1.0"
@@ -54,7 +54,7 @@ schemars = "0.8.21"
 kitsune2_api = "0.1.8"
 bytes = "1.10"
 
-rusqlite = { version = "0.32.1", features = [
+rusqlite = { version = "0.36", features = [
   "blob",      # better integration with blob types (Read, Write, etc)
   "backup",
   "trace",

--- a/crates/holochain_sqlite/src/db/access.rs
+++ b/crates/holochain_sqlite/src/db/access.rs
@@ -203,6 +203,7 @@ impl<Kind: DbKindT> DbRead<Kind> {
 
         let mut conn = self.get_connection_from_pool()?;
         if self.statement_trace_fn.is_some() {
+            #[allow(deprecated)]
             conn.trace(self.statement_trace_fn);
         }
 

--- a/crates/holochain_sqlite/tests/tests/db_wrapper.rs
+++ b/crates/holochain_sqlite/tests/tests/db_wrapper.rs
@@ -16,7 +16,7 @@ async fn async_read_respects_reader_permit_limits() {
     set_connection_timeout(300);
 
     let tmp_dir = tempfile::TempDir::new().unwrap();
-    let db_handle = DbWrite::test(&tmp_dir.into_path(), TestDatabaseKind::new()).unwrap();
+    let db_handle = DbWrite::test(&tmp_dir.keep(), TestDatabaseKind::new()).unwrap();
 
     let num_readers = num_read_threads();
 
@@ -88,7 +88,7 @@ async fn get_read_txn_respects_reader_permit_limits() {
     set_connection_timeout(300);
 
     let tmp_dir = tempfile::TempDir::new().unwrap();
-    let db_handle = DbWrite::test(&tmp_dir.into_path(), TestDatabaseKind::new()).unwrap();
+    let db_handle = DbWrite::test(&tmp_dir.keep(), TestDatabaseKind::new()).unwrap();
 
     let num_readers = num_read_threads();
 
@@ -159,7 +159,7 @@ async fn read_async_releases_permits() {
     set_connection_timeout(300);
 
     let tmp_dir = tempfile::TempDir::new().unwrap();
-    let db_handle = DbWrite::test(&tmp_dir.into_path(), TestDatabaseKind::new()).unwrap();
+    let db_handle = DbWrite::test(&tmp_dir.keep(), TestDatabaseKind::new()).unwrap();
 
     let num_readers = num_read_threads();
 
@@ -190,7 +190,7 @@ async fn write_permits_can_be_released() {
     set_connection_timeout(300);
 
     let tmp_dir = tempfile::TempDir::new().unwrap();
-    let db_handle = DbWrite::test(&tmp_dir.into_path(), TestDatabaseKind::new()).unwrap();
+    let db_handle = DbWrite::test(&tmp_dir.keep(), TestDatabaseKind::new()).unwrap();
 
     let ran_count = Arc::new(AtomicUsize::new(0));
     for _ in 0..3 {

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -22,7 +22,7 @@ holo_hash = { version = "^0.5.2", path = "../holo_hash", features = ["full"] }
 fallible-iterator = "0.3.0"
 holochain_chc = { version = "^0.2.2", path = "../holochain_chc" }
 holochain_keystore = { version = "^0.5.2", path = "../holochain_keystore" }
-holochain_serialized_bytes = "=0.0.55"
+holochain_serialized_bytes = "=0.0.56"
 holochain_types = { version = "^0.5.2", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.5.2", path = "../holochain_zome_types", features = [
   "full",

--- a/crates/holochain_state/src/test_utils.rs
+++ b/crates/holochain_state/src/test_utils.rs
@@ -275,7 +275,7 @@ impl TestDir {
             Self::Temp(d) => {
                 println!("Made temp dir permanent at {:?}", d);
                 tracing::info!("Made temp dir permanent at {:?}", d);
-                *self = Self::Perm(d.into_path());
+                *self = Self::Perm(d.keep());
             }
             old => *self = old,
         }

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -34,7 +34,7 @@ holo_hash = { version = "^0.5.2", path = "../holo_hash", features = [
 ] }
 holochain_keystore = { version = "^0.5.2", path = "../holochain_keystore" }
 holochain_nonce = { version = "^0.5.2", path = "../holochain_nonce" }
-holochain_serialized_bytes = "=0.0.55"
+holochain_serialized_bytes = "=0.0.56"
 holochain_sqlite = { path = "../holochain_sqlite", version = "^0.5.2" }
 holochain_trace = { version = "^0.5.2", path = "../holochain_trace" }
 holochain_util = { version = "^0.5.2", path = "../holochain_util", features = [
@@ -54,7 +54,7 @@ nanoid = "0.4"
 parking_lot = "0.12"
 rand = "0.8.5"
 regex = "1.4"
-rusqlite = { version = "0.32.1" }
+rusqlite = { version = "0.36" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 serde_derive = "1.0"

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 # reminder - do not use workspace deps
 [dependencies]
 futures = "0.3"
-holochain_serialized_bytes = "=0.0.55"
+holochain_serialized_bytes = "=0.0.56"
 holochain_types = { version = "^0.5.2", path = "../holochain_types" }
 serde = "1.0"
 serde_bytes = "0.11.14"

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -19,14 +19,14 @@ holochain_integrity_types = { version = "^0.5.2", path = "../holochain_integrity
   "tracing",
 ] }
 holochain_nonce = { version = "^0.5.2", path = "../holochain_nonce" }
-holochain_serialized_bytes = "=0.0.55"
+holochain_serialized_bytes = "=0.0.56"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 serde_yaml = { version = "0.9", optional = true }
 subtle = "2"
 thiserror = "1.0.22"
 tracing = "0.1"
-holochain_wasmer_common = "=0.0.99"
+holochain_wasmer_common = "=0.0.101"
 derive_more = "0.99"
 
 # fixturator dependencies
@@ -35,7 +35,7 @@ strum = { version = "0.18.0", optional = true }
 rand = { version = "0.8.5", optional = true }
 
 # sqlite dependencies
-rusqlite = { version = "0.32.1", optional = true }
+rusqlite = { version = "0.36", optional = true }
 num_enum = { version = "0.7", optional = true }
 
 # full-dna-def dependencies

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -338,6 +339,7 @@ version = "0.0.1"
 dependencies = [
  "files_integrity",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -346,6 +348,7 @@ name = "files_integrity"
 version = "0.0.1"
 dependencies = [
  "hdi",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -509,6 +512,7 @@ dependencies = [
  "hdk_derive",
  "holo_hash",
  "holochain_integrity_types",
+ "holochain_serialized_bytes",
  "holochain_wasmer_guest",
  "paste",
  "serde",
@@ -630,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_serialized_bytes"
-version = "0.0.55"
+version = "0.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719fa847cf9f772f7e8e1a6f11d801e1383cc5af043292042665da9a6ce5c742"
+checksum = "ad33bcab89bdceca5498f1b2fd5c4d1c07d35749deba965c2911494001845ac8"
 dependencies = [
  "holochain_serialized_bytes_derive",
  "rmp-serde",
@@ -640,17 +644,17 @@ dependencies = [
  "serde-transcode",
  "serde_bytes",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "holochain_serialized_bytes_derive"
-version = "0.0.55"
+version = "0.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6a221b5650251e09ef0b9223cf39e72b5222492cffc6bb4bdf36b2a6bc91aa"
+checksum = "01865625f72d8b6a05487440dfce3c03b0fc83ae03bba7ed6bfbc2f6f8143d14"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -658,6 +662,7 @@ name = "holochain_test_wasm_common"
 version = "0.5.2"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -682,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_common"
-version = "0.0.99"
+version = "0.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c826653a839b4cd5ac5728c52daab4cd27e1bcc23bdd5121ef64977f7a25196"
+checksum = "2246138152bef3637f773399fb7118527715f3d03bea85c442d299a518f2bfd1"
 dependencies = [
  "holochain_serialized_bytes",
  "serde",
@@ -694,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasmer_guest"
-version = "0.0.99"
+version = "0.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe3e79d77552986719fd47a1134bbb46f67c16a09b96ca0b6ef90af03d4f34d"
+checksum = "b408ee73bd97b4daeae9a420fe3c321063d0aeaeee08bbbb3f7d9ae25d6f87a4"
 dependencies = [
  "holochain_serialized_bytes",
  "holochain_wasmer_common",
@@ -1152,9 +1157,9 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.203"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -1179,9 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.203"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1339,6 +1344,7 @@ dependencies = [
  "fixt",
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1348,6 +1354,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1358,6 +1365,7 @@ version = "0.1.0"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1368,6 +1376,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1376,6 +1385,7 @@ name = "test_wasm_capability"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1385,6 +1395,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1393,6 +1404,7 @@ name = "test_wasm_coordinator_zome"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
  "test_wasm_integrity_zome",
@@ -1403,6 +1415,7 @@ name = "test_wasm_coordinator_zome_update"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
  "test_wasm_integrity_zome",
@@ -1414,6 +1427,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1425,6 +1439,7 @@ dependencies = [
  "fixt",
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1435,6 +1450,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1445,6 +1461,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1455,6 +1472,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
  "tracing",
  "tracing-core",
@@ -1467,6 +1485,7 @@ dependencies = [
  "fixt",
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1476,6 +1495,7 @@ name = "test_wasm_emit_signal"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1486,6 +1506,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1494,6 +1515,7 @@ name = "test_wasm_foo"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1504,6 +1526,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1513,6 +1536,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1522,6 +1546,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1531,6 +1556,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
  "serde_yaml",
 ]
@@ -1541,6 +1567,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1551,6 +1578,7 @@ dependencies = [
  "fixt",
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1559,6 +1587,7 @@ name = "test_wasm_hash_path"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1568,6 +1597,7 @@ name = "test_wasm_hdk_extern"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1577,6 +1607,7 @@ name = "test_wasm_init_fail"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1585,6 +1616,7 @@ name = "test_wasm_init_invalid_params"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1593,6 +1625,7 @@ name = "test_wasm_init_pass"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1602,6 +1635,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1611,6 +1645,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "holochain_mock_hdi",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1620,6 +1655,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1630,6 +1666,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1640,6 +1677,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1650,6 +1688,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1660,6 +1699,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
  "thiserror 1.0.69",
@@ -1671,6 +1711,7 @@ version = "0.1.0"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1679,6 +1720,7 @@ name = "test_wasm_post_commit_signal"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1688,6 +1730,7 @@ name = "test_wasm_post_commit_success"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1697,6 +1740,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1705,6 +1749,7 @@ name = "test_wasm_query"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1715,6 +1760,7 @@ version = "0.0.1"
 dependencies = [
  "fixt",
  "hdk",
+ "holochain_serialized_bytes",
  "rand",
  "serde",
 ]
@@ -1726,6 +1772,7 @@ dependencies = [
  "fixt",
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1736,6 +1783,7 @@ dependencies = [
  "derive_more",
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1745,6 +1793,7 @@ version = "0.0.1"
 dependencies = [
  "fixt",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1753,6 +1802,7 @@ name = "test_wasm_sys_time"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1762,6 +1812,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1771,6 +1822,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1781,6 +1833,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1790,6 +1843,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1798,6 +1852,7 @@ name = "test_wasm_validate_invalid_params"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1807,6 +1862,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1816,6 +1872,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1825,6 +1882,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1834,6 +1892,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1843,6 +1902,7 @@ version = "0.0.1"
 dependencies = [
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1851,6 +1911,7 @@ name = "test_wasm_whoami"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "holochain_test_wasm_common",
  "serde",
 ]
@@ -1860,6 +1921,7 @@ name = "test_wasm_x_salsa20_poly1305"
 version = "0.0.1"
 dependencies = [
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
 ]
 
@@ -1870,6 +1932,7 @@ dependencies = [
  "fixt",
  "hdi",
  "hdk",
+ "holochain_serialized_bytes",
  "serde",
  "serde_yaml",
 ]

--- a/crates/test_utils/wasm/wasm_workspace/agent_info/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/agent_info/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk", optional = true }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdi = { path = "../../../../hdi" }
 
 [dev-dependencies]

--- a/crates/test_utils/wasm/wasm_workspace/agent_key_lineage/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/agent_key_lineage/Cargo.toml
@@ -16,4 +16,5 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk", features = ["unstable-functions"] }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdi = { path = "../../../../hdi", features = ["unstable-functions"] }

--- a/crates/test_utils/wasm/wasm_workspace/anchor/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/anchor/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk", optional = true }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdi = { path = "../../../../hdi" }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 

--- a/crates/test_utils/wasm/wasm_workspace/app_validation/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/app_validation/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common", optional = true }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/bench/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/bench/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk", optional = true }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdi = { path = "../../../../hdi" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/capability/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/capability/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk", optional = true }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/clone/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/clone/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk", optional = true, features = ["properties"] }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/coordinator_zome/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/coordinator_zome/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk" }
 test_wasm_integrity_zome = { path = "../integrity_zome" }

--- a/crates/test_utils/wasm/wasm_workspace/coordinator_zome_update/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/coordinator_zome_update/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk" }
 test_wasm_integrity_zome = { path = "../integrity_zome" }

--- a/crates/test_utils/wasm/wasm_workspace/countersigning/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/countersigning/Cargo.toml
@@ -20,6 +20,7 @@ hdk = { path = "../../../../hdk", optional = true, features = [
     "unstable-countersigning",
 ] }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/crd/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/crd/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk", optional = true }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/create_entry/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/create_entry/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common", optional = true }
 hdk = { path = "../../../../hdk", optional = true }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/crud/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/crud/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk", optional = true }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/debug/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/debug/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 tracing = "0.1"
 tracing-core = "0.1"
 hdi = { path = "../../../../hdi", features = ["trace"] }

--- a/crates/test_utils/wasm/wasm_workspace/dna_properties/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/dna_properties/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk", optional = true }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdi = { path = "../../../../hdi" }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 

--- a/crates/test_utils/wasm/wasm_workspace/emit_signal/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/emit_signal/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk" }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/entry_defs/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/entry_defs/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk", optional = true }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/foo/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/foo/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk" }
 

--- a/crates/test_utils/wasm/wasm_workspace/genesis_self_check_1/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/genesis_self_check_1/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/genesis_self_check_invalid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/genesis_self_check_invalid/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/genesis_self_check_legacy/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/genesis_self_check_legacy/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/genesis_self_check_requires_properties/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/genesis_self_check_requires_properties/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 serde_yaml = "0.9"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/genesis_self_check_valid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/genesis_self_check_valid/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/hash_entry/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/hash_entry/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk", optional = true }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/hash_path/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/hash_path/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk" }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/hc-stress-test-coordinator/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/hc-stress-test-coordinator/Cargo.toml
@@ -12,6 +12,7 @@ name = "files"
 hdk = { path = "../../../../hdk" }
 
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 
 # workaround to make it slightly easier to import hc-scress-test zomes
 files_integrity = { path = "../hc-stress-test-integrity" }

--- a/crates/test_utils/wasm/wasm_workspace/hc-stress-test-integrity/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/hc-stress-test-integrity/Cargo.toml
@@ -12,3 +12,4 @@ name = "files_integrity"
 hdi = { path = "../../../../hdi" }
 
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"

--- a/crates/test_utils/wasm/wasm_workspace/hdk_extern/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/hdk_extern/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk" }
 

--- a/crates/test_utils/wasm/wasm_workspace/init_fail/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/init_fail/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/init_invalid_params/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/init_invalid_params/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/init_pass/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/init_pass/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/init_single/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/init_single/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdi = { path = "../../../../hdi"}
 hdk = { path = "../../../../hdk" }
 

--- a/crates/test_utils/wasm/wasm_workspace/integrity_zome/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/integrity_zome/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdi = { path = "../../../../hdi" }
 holochain_mock_hdi = { path = "../../../../mock_hdi", optional = true }
 

--- a/crates/test_utils/wasm/wasm_workspace/link/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/link/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk", optional = true }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/migrate_initial/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/migrate_initial/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk", optional = true }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/migrate_new/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/migrate_new/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk", optional = true }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/multiple_calls/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/multiple_calls/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/must_get/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/must_get/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk" }
 thiserror = "1"

--- a/crates/test_utils/wasm/wasm_workspace/must_get_agent_activity/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/must_get_agent_activity/Cargo.toml
@@ -15,5 +15,6 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/post_commit_signal/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/post_commit_signal/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk" }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/post_commit_success/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/post_commit_success/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/post_commit_volley/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/post_commit_volley/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/query/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/query/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk" }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/random_bytes/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/random_bytes/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk" }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 rand = "0.8.5"
 
 [dev-dependencies]

--- a/crates/test_utils/wasm/wasm_workspace/schedule/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/schedule/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk", features = ["unstable-functions"] }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdi = { path = "../../../../hdi" }
 
 [dev-dependencies]

--- a/crates/test_utils/wasm/wasm_workspace/ser_regression/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/ser_regression/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 derive_more = "0.99"
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/sign/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/sign/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk" }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 
 [dev-dependencies]
 hdk = { path = "../../../../hdk", features = ["fixturators"] }

--- a/crates/test_utils/wasm/wasm_workspace/sys_time/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/sys_time/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk" }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 
 [dev-dependencies]
 hdk = { path = "../../../../hdk", features = ["fixturators"] }

--- a/crates/test_utils/wasm/wasm_workspace/the_incredible_halt/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/the_incredible_halt/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/update_entry/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/update_entry/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }

--- a/crates/test_utils/wasm/wasm_workspace/validate/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/validate_invalid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_invalid/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/validate_invalid_params/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_invalid_params/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/validate_link/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_link/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/validate_link_add_invalid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_link_add_invalid/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/validate_link_add_valid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_link_add_valid/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/validate_reject_app_types/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_reject_app_types/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/validate_valid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_valid/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["cdylib", "rlib"]
 # reminder - do not use workspace deps
 [dependencies]
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm/wasm_workspace/whoami/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/whoami/Cargo.toml
@@ -18,6 +18,7 @@ crate-type = ["cdylib", "rlib"]
 hdk = { path = "../../../../hdk" }
 holochain_test_wasm_common = { path = "../../../wasm_common" }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 
 [features]
 default = []

--- a/crates/test_utils/wasm/wasm_workspace/x_salsa20_poly1305/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/x_salsa20_poly1305/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk" }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 
 [features]
 default = []

--- a/crates/test_utils/wasm/wasm_workspace/zome_info/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/zome_info/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk", features = ["properties"] }
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"
 serde_yaml = "0.9"
 hdi = { path = "../../../../hdi" }
 

--- a/crates/test_utils/wasm_common/Cargo.toml
+++ b/crates/test_utils/wasm_common/Cargo.toml
@@ -16,3 +16,4 @@ path = "src/lib.rs"
 [dependencies]
 hdk = { path = "../../hdk", version = "^0.5.2"}
 serde = "1.0"
+holochain_serialized_bytes = "=0.0.56"

--- a/crates/timestamp/Cargo.toml
+++ b/crates/timestamp/Cargo.toml
@@ -23,10 +23,10 @@ chrono = { version = "0.4.22", default-features = false, features = [
 ], optional = true }
 
 # Dependencies only needed for full.
-rusqlite = { version = "0.32.1", optional = true }
+rusqlite = { version = "0.36", optional = true }
 
 [dev-dependencies]
-holochain_serialized_bytes = "=0.0.55"
+holochain_serialized_bytes = "=0.0.56"
 
 [lints]
 workspace = true


### PR DESCRIPTION
- Updates rusqlite to 0.36.
- Updates holochain_serialized_bytes to 0.0.56 which updates serde to 1.0.219, now requires projects using serialized bytes to have a direct dependency on it similarly to serde itself.
- Updates holochain-wasmer to 0.0.101, which updates to wasmer to v6 and drops support for precompiled iOS modules which was deprecated at 0.4

### Summary



### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs