### PR TITLE
Fix broken macro links in HDK README

### DIFF
--- a/crates/hdk/README.md
+++ b/crates/hdk/README.md
@@ -65,7 +65,7 @@ HDK implements several key features:
 - Ed25519 signing and verification of data: [`ed25519`] module
 - Exposing information about the current execution context such as zome name: [`info`] module
 - Other utility functions provided by the host such as generating randomness and timestamps that are impossible in WASM: utility module
-- Exposing functions to external processes and callbacks to the host: [`hdk_extern!`](macro@crate::prelude::hdk_extern) and [`map_extern!`](macro@crate::prelude::map_extern) macros
+- Exposing functions to external processes and callbacks to the host: [`hdk_extern`](https://github.com/holochain/holochain/blob/develop/crates/hdk_derive/src/lib.rs) and [`map_extern`](https://github.com/holochain/holochain/blob/develop/crates/hdk/src/map_extern.rs) macros
 - Integration with the Rust [tracing](https://docs.rs/tracing/0.1.23/tracing/) crate
 - Exposing a [`prelude`] of common types and functions for convenience
 
@@ -99,7 +99,7 @@ Using the HDK, hApp developers can focus on their application's logic. [Learn mo
 
 ### External callbacks = Zome functions
 
-To extend a Rust function so that it can be called by the host, add the [`hdk_extern!`](macro@crate::prelude::hdk_extern) attribute.
+To extend a Rust function so that it can be called by the host, add the [`hdk_extern`](https://github.com/holochain/holochain/blob/develop/crates/hdk_derive/src/lib.rs) attribute.
 
 - The function may take _none_ or _one_ argument that, if provided, must implement `serde::Serialize + std::fmt::Debug`.
 - The function must return an `ExternResult` where the success value implements `serde::Serialize + std::fmt::Debug`
@@ -184,7 +184,7 @@ HDK is designed in layers so that there is some kind of 80/20 rule.
 The code is not strictly organised this way but you'll get a feel for it as you write your own hApps.
 
 Roughly speaking, 80% of your apps can be production ready using just 20% of the HDK features and code.
-These are the 'high level' functions such as [`crate::entry::create_entry`] and macros like [`hdk_extern!`](macro@crate::prelude::hdk_extern).
+These are the 'high level' functions such as [`crate::entry::create_entry`] and macros like [`hdk_extern`](https://github.com/holochain/holochain/blob/develop/crates/hdk_derive/src/lib.rs).
 Every Holochain function is available with a typed and documented wrapper and there is a set of macros for exposing functions and defining entries.
 
 The 20% of the time that you need to go deeper there is another layer followng its own 80/20 rule.
@@ -240,7 +240,7 @@ You do _not_ need to pin _all_ your Rust dependencies, just those that take part
 
 ## HDK is integrated with rust tracing for better debugging 🐛
 
-Every extern defined with the [`hdk_extern!`](macro@crate::prelude::hdk_extern) attribute registers a [tracing subscriber](https://crates.io/crates/tracing-subscriber) that works in WASM.
+Every extern defined with the [`hdk_extern`](https://github.com/holochain/holochain/blob/develop/crates/hdk_derive/src/lib.rs) attribute registers a [tracing subscriber](https://crates.io/crates/tracing-subscriber) that works in WASM.
 
 All the basic tracing macros `trace!`, `debug!`, `warn!`, `error!` are implemented.
 


### PR DESCRIPTION
Replaced outdated intra-doc links to `hdk_extern!` and `map_extern!` macros with direct GitHub source links. This ensures the documentation renders correctly on GitHub and avoids broken references, improving the developer experience and documentation reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated references in the README to link directly to the source code locations for relevant macros and adjusted macro notation for clarity. No changes to functional descriptions or usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->