### PR TITLE
chore: remove derived agent key count

### DIFF
--- a/crates/holochain/src/conductor/state.rs
+++ b/crates/holochain/src/conductor/state.rs
@@ -42,12 +42,6 @@ pub struct ConductorState {
     #[serde(default)]
     installed_apps: InstalledAppMap,
 
-    /// Number of agent keys that have ever been derived from the device seed.
-    /// Only increases, never decreases. Used for deriving reconstructible
-    /// agent keys from the lair "device seed".
-    #[serde(default)]
-    pub derived_agent_key_count: u32,
-
     /// List of interfaces any UI can use to access zome functions.
     #[serde_as(as = "Vec<(_, _)>")]
     #[serde(default)]


### PR DESCRIPTION
### Summary

A remnant from DPKI.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs