### PR TITLE
feat: add schema feature

### DIFF
--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -179,7 +179,7 @@ path = "src/bin/holochain/main.rs"
 workspace = true
 
 [features]
-default = ["sqlite-encrypted", "metrics_influxive", "wasmer_sys"]
+default = ["sqlite-encrypted", "metrics_influxive", "schema", "wasmer_sys"]
 
 # Use the "Influxive" opentelemetry metrics binding to write metrics
 # to an InfluxDB time series database.
@@ -221,6 +221,9 @@ glacial_tests = []
 # Includes the wasm build script, which we don't need when not building wasms
 build_wasms = ["holochain_wasm_test_utils/build"]
 only_check_wasms = ["holochain_wasm_test_utils/only_check"]
+
+# Enable schema generation for kitsune2 related types in the conductor config
+schema = ["holochain_conductor_api/schema"]
 
 # Enables at-rest encryption of the SQLite database.
 # Incompatible with "sqlite".

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
+kitsune2_transport_tx5 = { version = "0.2.9", optional = true }
 derive_more = { version = "2.0", features = ["from"] }
 holo_hash = { version = "^0.6.0-dev.7", path = "../holo_hash", features = [
   "full",
@@ -22,9 +23,8 @@ holochain_util = { version = "^0.6.0-dev.3", default-features = false, path = ".
   "jsonschema",
 ] }
 kitsune2_api = "0.2.9"
-kitsune2_core = { version = "0.2.9", features = ["schema"] }
-kitsune2_gossip = { version = "0.2.9", features = ["schema"] }
-kitsune2_transport_tx5 = { version = "0.2.9", features = ["schema"] }
+kitsune2_core = { version = "0.2.9" }
+kitsune2_gossip = { version = "0.2.9", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
@@ -58,6 +58,11 @@ sqlite-encrypted = [
   "holochain_types/sqlite-encrypted",
   "holochain_zome_types/sqlite-encrypted",
   "holochain_keystore/sqlite-encrypted",
+]
+schema = [
+  "kitsune2_gossip/schema",
+  "kitsune2_transport_tx5/schema",
+  "kitsune2_core/schema",
 ]
 sqlite = [
   "holo_hash/sqlite",

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -46,8 +46,11 @@
 use crate::conductor::process::ERROR_CODE;
 use crate::config::conductor::paths::DataRootPath;
 use holochain_types::prelude::DbSyncStrategy;
+#[cfg(feature = "schema")]
 use kitsune2_transport_tx5::WebRtcConfig;
-use schemars::{JsonSchema, Schema};
+use schemars::JsonSchema;
+#[cfg(feature = "schema")]
+use schemars::Schema;
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde::Serialize;
@@ -224,7 +227,7 @@ pub struct NetworkConfig {
     pub signal_url: url2::Url2,
 
     /// The Kitsune2 webrtc_config to use for connecting to peers.
-    #[schemars(schema_with = "webrtc_config_schema")]
+    #[cfg_attr(feature = "schema", schemars(schema_with = "webrtc_config_schema"))]
     pub webrtc_config: Option<serde_json::Value>,
 
     /// The target arc factor to apply when receiving hints from kitsune2.
@@ -238,7 +241,7 @@ pub struct NetworkConfig {
     ///
     /// The above options actually just set specific values in this config.
     /// Use only if you know what you are doing!
-    #[schemars(schema_with = "kitsune2_config_schema")]
+    #[cfg_attr(feature = "schema", schemars(schema_with = "kitsune2_config_schema"))]
     pub advanced: Option<serde_json::Value>,
 
     /// Disable the bootstrap module.
@@ -541,6 +544,7 @@ impl Default for ConductorTuningParams {
     }
 }
 
+#[cfg(feature = "schema")]
 fn webrtc_config_schema(_: &mut schemars::SchemaGenerator) -> Schema {
     let schema = schemars::schema_for!(Option<WebRtcConfig>);
 
@@ -551,6 +555,7 @@ fn webrtc_config_schema(_: &mut schemars::SchemaGenerator) -> Schema {
         .expect("Failed to convert schema")
 }
 
+#[cfg(feature = "schema")]
 fn kitsune2_config_schema(generator: &mut schemars::SchemaGenerator) -> Schema {
     #[allow(dead_code)]
     #[derive(JsonSchema)]


### PR DESCRIPTION
### Summary

Adds the `schema` feature to `holochain` and `holochain_conductor_api` to enable the `schema` features in kitsune dependencies where necessary. Enabled by default in the `holochain` crate but not in `holochain_conductor_api`.


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs