### PR TITLE
fix: Fix atomic zome call failure (#5083)

### DIFF
--- a/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
@@ -60,8 +60,9 @@ pub fn accept_countersigning_preflight_request<'a>(
 }
 
 #[cfg(test)]
-#[cfg(all(feature = "slow_tests", feature = "unstable-countersigning"))]
+// #[cfg(all(feature = "slow_tests", feature = "unstable-countersigning"))]
 pub mod wasm_test {
+    use assert2::let_assert;
     use crate::conductor::api::error::ConductorApiError;
     use crate::conductor::CellError;
     use crate::core::ribosome::error::RibosomeError;
@@ -484,8 +485,8 @@ pub mod wasm_test {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    #[cfg_attr(target_os = "macos", ignore = "flaky on macos")]
-    #[cfg_attr(target_os = "windows", ignore = "stack overflow on windows")]
+    // #[cfg_attr(target_os = "macos", ignore = "flaky on macos")]
+    // #[cfg_attr(target_os = "windows", ignore = "stack overflow on windows")]
     async fn lock_chain() {
         holochain_trace::test_run();
 
@@ -573,9 +574,10 @@ pub mod wasm_test {
                 expires_at,
             })
             .await;
+        let_assert!(Err(ConductorApiError::CellError(CellError::WorkflowError(err))) = preflight_acceptance_fail);
         assert_matches!(
-            preflight_acceptance_fail,
-            Ok(Err(RibosomeError::WasmRuntimeError(RuntimeError { .. })))
+            *err,
+            WorkflowError::RibosomeError(RibosomeError::WasmRuntimeError(RuntimeError { .. }))
         );
 
         // Bob can also accept the preflight request.

--- a/crates/holochain/src/core/workflow/call_zome_workflow.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow.rs
@@ -172,6 +172,9 @@ where
         call_zome_function_authorized(ribosome, host_access, invocation).await?;
     tracing::trace!("After zome call");
 
+    // If the zome call failed, don't try to validate and store any data it created.
+    let result = result?;
+
     let validation_result =
         inline_validation(workspace.clone(), network, conductor_handle, ribosome).await;
 
@@ -216,7 +219,7 @@ where
     }
 
     validation_result?;
-    Ok(result)
+    Ok(Ok(result))
 }
 
 /// First check if we are authorized to call

--- a/crates/holochain/tests/tests/init.rs
+++ b/crates/holochain/tests/tests/init.rs
@@ -228,7 +228,7 @@ async fn call_init_with_invalid_return_type_across_cells() {
         .await
         .unwrap_err();
 
-    let_assert!(ConductorApiError::Other(other_err) = err);
+    let_assert!(ConductorApiError::CellError(other_err) = err);
     // Can't downcast the `Box<dyn Error>` to a concrete type so just compare the error message.
     assert!(other_err
         .to_string()
@@ -370,7 +370,7 @@ async fn call_init_with_invalid_parameters_across_cells() {
         .await
         .unwrap_err();
 
-    let_assert!(ConductorApiError::Other(other_err) = err);
+    let_assert!(ConductorApiError::CellError(other_err) = err);
     // Can't downcast the `Box<dyn Error>` to a concrete type so just compare the error message.
     assert!(other_err
         .to_string()

--- a/crates/holochain/tests/tests/regression/mod.rs
+++ b/crates/holochain/tests/tests/regression/mod.rs
@@ -235,3 +235,4 @@ async fn zero_arc_can_link_to_uncached_base() {
 }
 
 pub mod must_get_agent_activity_saturation;
+mod zome_call_atomic;

--- a/crates/holochain/tests/tests/regression/zome_call_atomic.rs
+++ b/crates/holochain/tests/tests/regression/zome_call_atomic.rs
@@ -1,0 +1,79 @@
+use hdk::prelude::{Entry, EntryDefIndex, EntryVisibility, ExternIO};
+use holo_hash::ActionHash;
+use holochain::sweettest::{SweetConductor, SweetDnaFile};
+use holochain_types::inline_zome::InlineZomeSet;
+use holochain_types::prelude::Record;
+use holochain_types::signal::Signal;
+use holochain_zome_types::action::ChainTopOrdering;
+use holochain_zome_types::entry::{CreateInput, GetInput, GetOptions};
+use holochain_zome_types::prelude::{EntryDef, InlineZomeError};
+use holochain_zome_types::signal::AppSignal;
+
+/// When there is any error in a zome call, any data in the scratch space should not be written to
+/// the agent's source chain.
+#[tokio::test(flavor = "multi_thread")]
+async fn zome_call_error_drop_uncommited() {
+    holochain_trace::test_run();
+
+    let mut conductor = SweetConductor::from_standard_config().await;
+
+    let zome = InlineZomeSet::new_unique_single(
+        "integrity",
+        "coordinator",
+        vec![EntryDef::default_from_id("1")],
+        0,
+    )
+    .function::<_, _, ()>("coordinator", "create_with_error", move |api, ()| {
+        let entry = Entry::app(().try_into().unwrap()).unwrap();
+        let hash = api.create(CreateInput::new(
+            InlineZomeSet::get_entry_location(&api, EntryDefIndex(0)),
+            EntryVisibility::Public,
+            entry,
+            ChainTopOrdering::default(),
+        ))?;
+        api.emit_signal(AppSignal::new(ExternIO::encode(hash)?))?;
+
+        Err(InlineZomeError::TestError(
+            "Something went wrong".to_string(),
+        ))
+    })
+    .function(
+        "coordinator",
+        "get_by_hash",
+        move |api, hash: ActionHash| {
+            let entry = api.get(vec![GetInput::new(hash.into(), GetOptions::local())])?;
+            Ok(entry[0].clone())
+        },
+    );
+
+    let dna = SweetDnaFile::unique_from_inline_zomes(zome).await;
+
+    let app = conductor.setup_app("app", &[dna.0]).await.unwrap();
+    let cell = app.into_cells()[0].clone();
+
+    let mut app_signal = conductor.subscribe_to_app_signals("app".into());
+
+    let err = conductor
+        .call_fallible::<_, ()>(&cell.zome("coordinator"), "create_with_error", ())
+        .await
+        .unwrap_err();
+
+    let msg = app_signal.recv().await.unwrap();
+    let action_hash = match msg {
+        Signal::App { signal, .. } => {
+            let action_hash: ActionHash = signal.into_inner().decode().unwrap();
+            action_hash
+        }
+        _ => panic!("Expected AppSignal, got {:?}", msg),
+    };
+
+    let entry = conductor
+        .call::<_, Option<Record>>(&cell.zome("coordinator"), "get_by_hash", action_hash)
+        .await;
+
+    assert!(
+        entry.is_none(),
+        "Entry should not have been created due to error: {:?}",
+        err
+    );
+}

--- a/crates/holochain/tests/tests/validate.rs
+++ b/crates/holochain/tests/tests/validate.rs
@@ -167,7 +167,7 @@ async fn call_validate_with_invalid_return_type_across_cells() {
         .await
         .unwrap_err();
 
-    let_assert!(ConductorApiError::Other(other_err) = err);
+    let_assert!(ConductorApiError::CellError(other_err) = err);
     // Can't downcast the `Box<dyn Error>` to a concrete type so just compare the error message.
     assert!(other_err
         .to_string()
@@ -254,7 +254,7 @@ async fn call_validate_with_invalid_parameters_across_cells() {
         .await
         .unwrap_err();
 
-    let_assert!(ConductorApiError::Other(other_err) = err);
+    let_assert!(ConductorApiError::CellError(other_err) = err);
     // Can't downcast the `Box<dyn Error>` to a concrete type so just compare the error message.
     assert!(other_err
         .to_string()


### PR DESCRIPTION
### Summary

* fix: Fix atomic zome call failure

When a zome call fails, no data is supposed to be written. Only when all operations in a zome call succeed should data be created. This wasn't working and when a zome call failed, we were writing whatever data had been created.

* chore: Follow-up test fixes

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs