### PR TITLE
chore: Remove unused `dna_def` field in HostFnWorkspace

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   enabled when the `NETAUDIT` tracing target is enabled at `WARN` level or lower.
 - Test app operations (install/enable/disable/uninstall) with regards to app state and cell state.
 - **BREAKING CHANGE**: Remove `start_app` from conductor. Use `enable_app` instead.
+- Remove unused field `dna_def` the `HostFnWorkspace` struct ([#5102](https://github.com/holochain/holochain/pull/5102))
 
 ## 0.6.0-dev.11
 

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -755,7 +755,6 @@ impl Cell {
         let invocation =
             ZomeCallInvocation::try_from_params(self.conductor_api.clone(), params).await?;
 
-        let dna_def = ribosome.dna_def().as_content().clone();
         // If there is no existing zome call then this is the root zome call
         let is_root_zome_call = workspace_lock.is_none();
         let workspace_lock = match workspace_lock {
@@ -767,7 +766,6 @@ impl Cell {
                     self.cache().clone(),
                     keystore.clone(),
                     self.id.agent_pubkey().clone(),
-                    Arc::new(dna_def),
                 )
                 .await?
             }
@@ -810,7 +808,6 @@ impl Cell {
 
         // get the dna
         let ribosome = self.get_ribosome()?;
-        let dna_def = ribosome.dna_def().clone();
 
         // Create the workspace
         let workspace = SourceChainWorkspace::init_as_root(
@@ -819,7 +816,6 @@ impl Cell {
             self.cache().clone(),
             keystore.clone(),
             id.agent_pubkey().clone(),
-            Arc::new(dna_def.into_content()),
         )
         .await?;
 

--- a/crates/holochain/src/conductor/conductor/graft_records_onto_source_chain.rs
+++ b/crates/holochain/src/conductor/conductor/graft_records_onto_source_chain.rs
@@ -158,7 +158,6 @@ impl Conductor {
             space.cache_db.clone(),
             self.keystore().clone(),
             cell_id.agent_pubkey().clone(),
-            Arc::new(ribosome.dna_def().as_content().clone()),
         )
         .await?;
 

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -583,7 +583,6 @@ impl Space {
         &self,
         keystore: MetaLairClient,
         author: AgentPubKey,
-        dna_def: Arc<DnaDef>,
     ) -> ConductorResult<SourceChainWorkspace> {
         Ok(SourceChainWorkspace::new(
             self.get_or_create_authored_db(author.clone())?.clone(),
@@ -591,7 +590,6 @@ impl Space {
             self.cache_db.clone(),
             keystore,
             author,
-            dna_def,
         )
         .await?)
     }

--- a/crates/holochain/src/core/queue_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer.rs
@@ -126,10 +126,6 @@ pub async fn spawn_queue_consumer_tasks(
         )
     });
 
-    let dna_def = conductor
-        .get_dna_def(&dna_hash)
-        .expect("Dna must be in store");
-
     // App validation
     // One per space.
     let tx_app = queue_consumer_map.spawn_once_app_validation(dna_hash.clone(), || {
@@ -140,7 +136,6 @@ pub async fn spawn_queue_consumer_tasks(
                 dht_db.clone(),
                 cache.clone(),
                 keystore.clone(),
-                Arc::new(dna_def),
             ),
             conductor.clone(),
             tx_integration.clone(),

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -807,7 +807,6 @@ pub struct AppValidationWorkspace {
     dht_db: DbWrite<DbKindDht>,
     cache: DbWrite<DbKindCache>,
     keystore: MetaLairClient,
-    dna_def: Arc<DnaDef>,
 }
 
 impl AppValidationWorkspace {
@@ -817,14 +816,12 @@ impl AppValidationWorkspace {
         dht_db: DbWrite<DbKindDht>,
         cache: DbWrite<DbKindCache>,
         keystore: MetaLairClient,
-        dna_def: Arc<DnaDef>,
     ) -> Self {
         Self {
             authored_db,
             dht_db,
             cache,
             keystore,
-            dna_def,
         }
     }
 
@@ -835,7 +832,6 @@ impl AppValidationWorkspace {
             self.cache.clone(),
             self.keystore.clone(),
             None,
-            self.dna_def.clone(),
         )
         .await?)
     }

--- a/crates/holochain/src/core/workflow/app_validation_workflow/get_zomes_to_invoke_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/get_zomes_to_invoke_tests.rs
@@ -54,7 +54,6 @@ async fn register_agent_activity() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -113,7 +112,6 @@ async fn store_entry_create_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -168,7 +166,6 @@ async fn store_entry_create_non_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -229,7 +226,6 @@ async fn store_entry_update_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -286,7 +282,6 @@ async fn store_entry_update_non_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -342,7 +337,6 @@ async fn store_record_create_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -384,7 +378,6 @@ async fn store_record_create_non_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -439,7 +432,6 @@ async fn store_record_create_wrong_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -485,7 +477,6 @@ async fn store_record_create_link() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -548,7 +539,6 @@ async fn store_record_update_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -594,7 +584,6 @@ async fn store_record_update_non_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -672,7 +661,6 @@ async fn store_record_update_of_update_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -730,7 +718,6 @@ async fn store_record_delete_without_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -786,7 +773,6 @@ async fn store_record_delete_non_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -845,7 +831,6 @@ async fn store_record_delete_link() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -916,7 +901,6 @@ async fn register_update_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -963,7 +947,6 @@ async fn register_update_non_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -1022,7 +1005,6 @@ async fn register_delete_create_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -1088,7 +1070,6 @@ async fn register_delete_create_non_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -1158,7 +1139,6 @@ async fn register_delete_update_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -1224,7 +1204,6 @@ async fn register_delete_update_non_app_entry() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -1280,7 +1259,6 @@ async fn register_create_link() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();
@@ -1326,7 +1304,6 @@ async fn register_delete_link() {
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
-        Arc::new(dna_file.dna_def().clone()),
     )
     .await
     .unwrap();

--- a/crates/holochain/src/core/workflow/app_validation_workflow/run_validation_callback_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/run_validation_callback_tests.rs
@@ -377,7 +377,6 @@ impl TestCase {
             test_space.space.cache_db.clone(),
             fixt!(MetaLairClient),
             None,
-            Arc::new(dna_file.dna_def().clone()),
         )
         .await
         .unwrap();

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -85,7 +85,6 @@ async fn main_workflow() {
         conductor.get_dht_db(&dna_hash).unwrap(),
         conductor.get_cache_db(&cell_id).await.unwrap(),
         conductor.keystore(),
-        Arc::new(dna_file.dna_def().clone()),
     ));
 
     // check there are no ops to app validate
@@ -299,7 +298,6 @@ async fn validate_ops_in_sequence_must_get_agent_activity() {
         conductor.get_dht_db(&dna_hash).unwrap(),
         conductor.get_cache_db(&cell_id).await.unwrap(),
         conductor.keystore(),
-        Arc::new(dna_file.dna_def().clone()),
     ));
 
     // check there are no ops to app validate
@@ -417,7 +415,6 @@ async fn validate_ops_in_sequence_must_get_action() {
         conductor.get_dht_db(&dna_hash).unwrap(),
         conductor.get_cache_db(&cell_id).await.unwrap(),
         conductor.keystore(),
-        Arc::new(dna_file.dna_def().clone()),
     ));
 
     // check there are no ops to app validate
@@ -583,7 +580,6 @@ async fn handle_error_in_op_validation() {
         conductor.get_dht_db(&dna_hash).unwrap(),
         conductor.get_cache_db(&cell_id).await.unwrap(),
         conductor.keystore(),
-        Arc::new(dna_file.dna_def().clone()),
     ));
 
     // create register agent activity op that will return an error during validation
@@ -957,7 +953,6 @@ async fn app_validation_workflow_correctly_sets_state_and_status() {
         conductor.get_dht_db(&dna_hash).unwrap(),
         conductor.get_cache_db(&cell_id).await.unwrap(),
         conductor.keystore(),
-        Arc::new(dna_file.dna_def().clone()),
     ));
 
     // Check there are no ops to app validate as genesis entries should have already been validated

--- a/crates/holochain/src/core/workflow/call_zome_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow/unit_tests.rs
@@ -103,7 +103,6 @@ impl TestCase {
     {
         let mut conductor = SweetConductor::from_standard_config().await;
         let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Crd]).await;
-        let dna_def = Arc::new(dna_file.dna_def().clone());
         let app = conductor.setup_app("", &[dna_file]).await.unwrap();
         let dna_hash = app.cells()[0].dna_hash().clone();
         let agent = app.agent().clone();
@@ -116,7 +115,6 @@ impl TestCase {
             conductor.get_cache_db(&cell_id).await.unwrap(),
             conductor.keystore(),
             agent.clone(),
-            dna_def,
         )
         .await
         .unwrap();

--- a/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
+++ b/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
@@ -186,7 +186,6 @@ mod tests {
             test_cache.to_db(),
             keystore,
             author.clone(),
-            Arc::new(dna_def),
         )
         .await
         .unwrap();

--- a/crates/holochain/src/fixt.rs
+++ b/crates/holochain/src/fixt.rs
@@ -221,7 +221,6 @@ fixturator!(
                 cache.to_db(),
                 keystore,
                 Some(fixt!(AgentPubKey, Predictable, get_fixt_index!())),
-                Arc::new(fixt!(DnaDef))
             ).await.unwrap()
         })
     };
@@ -238,7 +237,6 @@ fixturator!(
                 cache.to_db(),
                 keystore,
                 Some(fixt!(AgentPubKey, Predictable, get_fixt_index!())),
-                Arc::new(fixt!(DnaDef))
             ).await.unwrap()
         })
     };
@@ -256,7 +254,6 @@ fixturator!(
                 cache.to_db(),
                 keystore,
                 Some(agent),
-                Arc::new(fixt!(DnaDef))
             ).await.unwrap()
         })
     };
@@ -277,7 +274,6 @@ fixturator!(
                 cache.to_db(),
                 keystore,
                 Some(fixt!(AgentPubKey, Predictable, get_fixt_index!())),
-                Arc::new(fixt!(DnaDef))
             ).await.unwrap()
         })
     };
@@ -294,7 +290,6 @@ fixturator!(
                 cache.to_db(),
                 keystore,
                 Some(fixt!(AgentPubKey, Predictable, get_fixt_index!())),
-                Arc::new(fixt!(DnaDef)),
             ).await.unwrap()
         })
     };
@@ -312,7 +307,6 @@ fixturator!(
                 cache.to_db(),
                 keystore,
                 Some(agent),
-                Arc::new(fixt!(DnaDef))
             ).await.unwrap()
         })
     };

--- a/crates/holochain/src/test_utils/host_fn_caller.rs
+++ b/crates/holochain/src/test_utils/host_fn_caller.rs
@@ -182,7 +182,6 @@ impl HostFnCaller {
             cache,
             keystore.clone(),
             cell_id.agent_pubkey().clone(),
-            Arc::new(ribosome.dna_def().as_content().clone()),
         )
         .await
         .unwrap();

--- a/crates/holochain_state/src/host_fn_workspace.rs
+++ b/crates/holochain_state/src/host_fn_workspace.rs
@@ -38,13 +38,6 @@ pub struct HostFnStores {
 
 pub type HostFnWorkspaceRead = HostFnWorkspace<DbRead<DbKindAuthored>, DbRead<DbKindDht>>;
 
-impl HostFnWorkspace {
-    /// Get a reference to the host fn workspace's dna def.
-    pub fn dna_def(&self) -> Arc<DnaDef> {
-        self.dna_def.clone()
-    }
-}
-
 impl SourceChainWorkspace {
     pub async fn new(
         authored: DbWrite<DbKindAuthored>,

--- a/crates/holochain_state/src/host_fn_workspace.rs
+++ b/crates/holochain_state/src/host_fn_workspace.rs
@@ -14,7 +14,6 @@ pub struct HostFnWorkspace<
     authored: DbRead<DbKindAuthored>,
     dht: DbRead<DbKindDht>,
     cache: DbWrite<DbKindCache>,
-    dna_def: Arc<DnaDef>,
     /// Did the root call that started this call chain
     /// come from an init callback.
     /// This is needed so that we don't run init recursively inside
@@ -45,11 +44,10 @@ impl SourceChainWorkspace {
         cache: DbWrite<DbKindCache>,
         keystore: MetaLairClient,
         author: AgentPubKey,
-        dna_def: Arc<DnaDef>,
     ) -> SourceChainResult<Self> {
         let source_chain =
             SourceChain::new(authored.clone(), dht.clone(), keystore, author).await?;
-        Self::new_inner(authored, dht, cache, source_chain, dna_def, false)
+        Self::new_inner(authored, dht, cache, source_chain, false)
     }
 
     /// Create a source chain workspace where the root caller is the init callback.
@@ -59,11 +57,10 @@ impl SourceChainWorkspace {
         cache: DbWrite<DbKindCache>,
         keystore: MetaLairClient,
         author: AgentPubKey,
-        dna_def: Arc<DnaDef>,
     ) -> SourceChainResult<Self> {
         let source_chain =
             SourceChain::new(authored.clone(), dht.clone(), keystore, author).await?;
-        Self::new_inner(authored, dht, cache, source_chain, dna_def, true)
+        Self::new_inner(authored, dht, cache, source_chain, true)
     }
 
     /// Create a source chain with a blank chain head.
@@ -76,11 +73,10 @@ impl SourceChainWorkspace {
         cache: DbWrite<DbKindCache>,
         keystore: MetaLairClient,
         author: AgentPubKey,
-        dna_def: Arc<DnaDef>,
     ) -> SourceChainResult<Self> {
         let source_chain =
             SourceChain::raw_empty(authored.clone(), dht.clone(), keystore, author).await?;
-        Self::new_inner(authored, dht, cache, source_chain, dna_def, false)
+        Self::new_inner(authored, dht, cache, source_chain, false)
     }
 
     fn new_inner(
@@ -88,7 +84,6 @@ impl SourceChainWorkspace {
         dht: DbWrite<DbKindDht>,
         cache: DbWrite<DbKindCache>,
         source_chain: SourceChain,
-        dna_def: Arc<DnaDef>,
         init_is_root: bool,
     ) -> SourceChainResult<Self> {
         Ok(Self {
@@ -96,7 +91,6 @@ impl SourceChainWorkspace {
                 source_chain: Some(source_chain.clone()),
                 authored: authored.into(),
                 dht: dht.into(),
-                dna_def,
                 cache,
                 init_is_root,
             },
@@ -122,7 +116,6 @@ where
         cache: DbWrite<DbKindCache>,
         keystore: MetaLairClient,
         author: Option<AgentPubKey>,
-        dna_def: Arc<DnaDef>,
     ) -> SourceChainResult<Self> {
         let source_chain = match author {
             Some(author) => {
@@ -135,7 +128,6 @@ where
             authored: authored.into(),
             dht: dht.into(),
             cache,
-            dna_def,
             init_is_root: false,
         })
     }
@@ -181,7 +173,6 @@ impl From<HostFnWorkspace> for HostFnWorkspaceRead {
             authored: workspace.authored,
             dht: workspace.dht,
             cache: workspace.cache,
-            dna_def: workspace.dna_def,
             init_is_root: workspace.init_is_root,
         }
     }
@@ -200,7 +191,6 @@ impl From<SourceChainWorkspace> for HostFnWorkspaceRead {
             authored: workspace.inner.authored,
             dht: workspace.inner.dht,
             cache: workspace.inner.cache,
-            dna_def: workspace.inner.dna_def,
             init_is_root: workspace.inner.init_is_root,
         }
     }


### PR DESCRIPTION
### Summary
Removes an unused `dna_def` field in the `HostFnWorkspace` struct.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs