### PR TITLE
chore: replace `dna_def` field SysValidationWorkspace with `dna_hash` field

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Test app operations (install/enable/disable/uninstall) with regards to app state and cell state.
 - **BREAKING CHANGE**: Remove `start_app` from conductor. Use `enable_app` instead.
 - Remove unused field `dna_def` the `HostFnWorkspace` struct ([#5102](https://github.com/holochain/holochain/pull/5102))
+- Replace the `dna_def` field of the `SysValidationWorkspace` with a `dna_hash` field.
 
 ## 0.6.0-dev.11
 

--- a/crates/holochain/src/core/queue_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer.rs
@@ -144,10 +144,6 @@ pub async fn spawn_queue_consumer_tasks(
         )
     });
 
-    let dna_def = conductor
-        .get_dna_def(&dna_hash)
-        .expect("Dna must be in store");
-
     // Sys validation
     // One per space.
     let tx_sys = queue_consumer_map.spawn_once_sys_validation(dna_hash.clone(), || {
@@ -156,7 +152,7 @@ pub async fn spawn_queue_consumer_tasks(
                 authored_db.clone(),
                 dht_db.clone(),
                 cache.clone(),
-                Arc::new(dna_def),
+                cell_id.dna_hash().clone(),
                 conductor
                     .get_config()
                     .conductor_tuning_params()

--- a/crates/holochain/src/core/sys_validate.rs
+++ b/crates/holochain/src/core/sys_validate.rs
@@ -184,10 +184,9 @@ pub fn check_prev_action(action: &Action) -> SysValidationResult<()> {
 }
 
 /// Check that Dna actions are only added to empty source chains
-pub fn check_valid_if_dna(action: &Action, dna_def: &DnaDefHashed) -> SysValidationResult<()> {
+pub fn check_valid_if_dna(action: &Action, dna_hash: &DnaHash) -> SysValidationResult<()> {
     match action {
         Action::Dna(a) => {
-            let dna_hash = dna_def.as_hash();
             if a.hash != *dna_hash {
                 Err(ValidationOutcome::WrongDna(a.hash.clone(), dna_hash.clone()).into())
             } else {

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -57,12 +57,12 @@ async fn sys_validation_produces_invalid_chain_op_warrant() {
         fixt!(Entry),
     )
     .into();
-    let dna_def = dna.dna_def().clone().into_hashed();
+    let dna_hash = dna.dna_hash().clone();
 
     //- Check that the op is indeed invalid
     let outcome = crate::core::workflow::sys_validation_workflow::validate_op(
         &op,
-        &dna_def,
+        &dna_hash,
         Default::default(),
     )
     .await
@@ -147,10 +147,10 @@ async fn sys_validation_produces_forked_chain_warrant() {
         ChainOp::from_type(ChainOpType::StoreRecord, action.clone(), Some(entry)).unwrap();
 
     //- Check that the op is valid
-    let dna_def = dna.dna_def().clone().into_hashed();
+    let dna_hash = dna.dna_hash().clone();
     let outcome = crate::core::workflow::sys_validation_workflow::validate_op(
         &forked_op.clone().into(),
-        &dna_def,
+        &dna_hash,
         Default::default(),
     )
     .await

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
@@ -314,7 +314,6 @@ async fn validate_op_with_wrong_sequence_number_rejected_and_not_forwarded_to_ap
 }
 
 struct TestCase {
-    dna_def: DnaDef,
     dna_hash: DnaDefHashed,
     test_space: TestSpace,
     keystore: MetaLairClient,
@@ -337,7 +336,6 @@ impl TestCase {
         let agent = keystore.new_sign_keypair_random().await.unwrap();
 
         Self {
-            dna_def,
             dna_hash,
             test_space,
             keystore,
@@ -402,7 +400,7 @@ impl TestCase {
                 .unwrap(),
             self.test_space.space.dht_db.clone(),
             self.test_space.space.cache_db.clone(),
-            Arc::new(self.dna_def.clone()),
+            self.dna_hash.hash.clone(),
             std::time::Duration::from_secs(10),
         );
 

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
@@ -2286,7 +2286,7 @@ async fn crash_case() {
             .boxed()
         });
 
-    let validation_outcome = validate_op(&op, &dna_def, SysValDeps::default())
+    let validation_outcome = validate_op(&op, &dna_def.hash, SysValDeps::default())
         .await
         .unwrap();
 
@@ -2362,7 +2362,7 @@ impl TestCase {
     }
 
     async fn run(&mut self) -> WorkflowResult<Outcome> {
-        let dna_def = self.dna_def_hash();
+        let dna_hash = self.dna_def_hash().hash;
 
         // Swap out the cascade so we can move it into the workflow
         let mut new_cascade = MockCascade::new();
@@ -2385,7 +2385,7 @@ impl TestCase {
 
         validate_op(
             self.op.as_ref().expect("No op set, invalid test case"),
-            &dna_def,
+            &dna_hash,
             self.current_validation_dependencies.clone(),
         )
         .await


### PR DESCRIPTION
### Summary
Replaces the `dna_def` field in `SysValidationWorkspace` with a `dna_hash` field since this is all that's required from the DnaDef in the sys validation workflow.


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs