### PR TITLE
test: add tests for the use of paths in a real-ish scenario

### DIFF
--- a/crates/holochain/tests/tests/mod.rs
+++ b/crates/holochain/tests/tests/mod.rs
@@ -18,6 +18,7 @@ mod lair_in_proc_restart;
 mod migration;
 mod multi_conductor;
 mod new_lair;
+mod paths;
 mod publish;
 mod regression;
 mod send_signal;

--- a/crates/holochain/tests/tests/paths.rs
+++ b/crates/holochain/tests/tests/paths.rs
@@ -1,0 +1,100 @@
+use std::time::Duration;
+
+use holochain::sweettest::{await_consistency, SweetConductorBatch, SweetDnaFile};
+use holochain_wasm_test_utils::TestWasm;
+
+#[derive(Debug, PartialEq, Eq, serde::Deserialize)]
+pub struct BookEntry {
+    pub name: String,
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agents_can_find_entries_at_paths() {
+    holochain_trace::test_run();
+
+    let mut conductor_batch = SweetConductorBatch::from_standard_config_rendezvous(2).await;
+
+    let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Paths]).await;
+
+    let apps = conductor_batch
+        .setup_app("paths_app", [&dna])
+        .await
+        .unwrap();
+
+    let ((alice_cell,), (bob_cell,)) = apps.into_tuples();
+
+    conductor_batch[0]
+        .declare_full_storage_arcs(dna.dna_hash())
+        .await;
+    conductor_batch[1]
+        .declare_full_storage_arcs(dna.dna_hash())
+        .await;
+
+    // Wait for gossip to start
+    conductor_batch[0]
+        .require_initial_gossip_activity_for_cell(&alice_cell, 1, Duration::from_secs(30))
+        .await
+        .unwrap();
+
+    // There should be no books created yet.
+    let books: Vec<BookEntry> = conductor_batch[0]
+        .call(
+            &alice_cell.zome(TestWasm::Paths.coordinator_zome_name()),
+            "find_books_from_author",
+            "Shakespeare",
+        )
+        .await;
+    assert!(books.is_empty());
+
+    let books: Vec<BookEntry> = conductor_batch[1]
+        .call(
+            &bob_cell.zome(TestWasm::Paths.coordinator_zome_name()),
+            "find_books_from_author",
+            "Shakespeare",
+        )
+        .await;
+    assert!(books.is_empty());
+
+    // Alice adds a book entry.
+    let () = conductor_batch[0]
+        .call(
+            &alice_cell.zome(TestWasm::Paths.coordinator_zome_name()),
+            "add_book_entry",
+            ("Shakespeare", "Romeo and Juliet"),
+        )
+        .await;
+
+    // Alice should see her own entry.
+    let books: Vec<BookEntry> = conductor_batch[0]
+        .call(
+            &alice_cell.zome(TestWasm::Paths.coordinator_zome_name()),
+            "find_books_from_author",
+            "Shakespeare",
+        )
+        .await;
+    assert_eq!(
+        books,
+        [BookEntry {
+            name: "Romeo and Juliet".to_string()
+        }]
+    );
+
+    await_consistency(Duration::from_secs(60), [&alice_cell, &bob_cell])
+        .await
+        .unwrap();
+
+    // After consistency, Bob should see Alice's entry.
+    let books: Vec<BookEntry> = conductor_batch[1]
+        .call(
+            &bob_cell.zome(TestWasm::Paths.coordinator_zome_name()),
+            "find_books_from_author",
+            "Shakespeare",
+        )
+        .await;
+    assert_eq!(
+        books,
+        [BookEntry {
+            name: "Romeo and Juliet".to_string()
+        }]
+    );
+}

--- a/crates/holochain/tests/tests/paths.rs
+++ b/crates/holochain/tests/tests/paths.rs
@@ -232,6 +232,114 @@ async fn agents_can_find_multiple_entries_at_same_path() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn agents_can_find_entries_with_partial_path() {
+    holochain_trace::test_run();
+
+    let mut conductor_batch = SweetConductorBatch::from_standard_config_rendezvous(2).await;
+
+    let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Paths]).await;
+
+    let apps = conductor_batch
+        .setup_app("paths_app", [&dna])
+        .await
+        .unwrap();
+
+    let ((alice_cell,), (bob_cell,)) = apps.into_tuples();
+
+    conductor_batch[0]
+        .declare_full_storage_arcs(dna.dna_hash())
+        .await;
+    conductor_batch[1]
+        .declare_full_storage_arcs(dna.dna_hash())
+        .await;
+
+    // Wait for gossip to start
+    conductor_batch[0]
+        .require_initial_gossip_activity_for_cell(&alice_cell, 1, Duration::from_secs(30))
+        .await
+        .unwrap();
+
+    // There should be no books created yet.
+    let books: Vec<BookEntry> = conductor_batch[0]
+        .call(
+            &alice_cell.zome(TestWasm::Paths.coordinator_zome_name()),
+            "find_books_from_author",
+            "S",
+        )
+        .await;
+    assert!(books.is_empty());
+
+    let books: Vec<BookEntry> = conductor_batch[1]
+        .call(
+            &bob_cell.zome(TestWasm::Paths.coordinator_zome_name()),
+            "find_books_from_author",
+            "S",
+        )
+        .await;
+    assert!(books.is_empty());
+
+    // Alice adds a book entry.
+    let () = conductor_batch[0]
+        .call(
+            &alice_cell.zome(TestWasm::Paths.coordinator_zome_name()),
+            "add_book_entry",
+            ("Shakespeare", "Romeo and Juliet"),
+        )
+        .await;
+
+    // Bob adds a book entry.
+    let () = conductor_batch[1]
+        .call(
+            &bob_cell.zome(TestWasm::Paths.coordinator_zome_name()),
+            "add_book_entry",
+            ("Stevenson", "Strange Case of Dr Jekyll and Mr Hyde"),
+        )
+        .await;
+
+    await_consistency(Duration::from_secs(60), [&alice_cell, &bob_cell])
+        .await
+        .unwrap();
+
+    // After consistency, both should see each other's entries.
+    let books: Vec<BookEntry> = conductor_batch[0]
+        .call(
+            &alice_cell.zome(TestWasm::Paths.coordinator_zome_name()),
+            "find_books_from_author",
+            "S",
+        )
+        .await;
+    assert_eq!(
+        books,
+        [
+            BookEntry {
+                name: "Romeo and Juliet".to_string()
+            },
+            BookEntry {
+                name: "Strange Case of Dr Jekyll and Mr Hyde".to_string()
+            }
+        ]
+    );
+    let books: Vec<BookEntry> = conductor_batch[1]
+        .call(
+            &bob_cell.zome(TestWasm::Paths.coordinator_zome_name()),
+            "find_books_from_author",
+            "S",
+        )
+        .await;
+    assert_eq!(
+        books,
+        [
+            BookEntry {
+                name: "Romeo and Juliet".to_string()
+            },
+            BookEntry {
+                name: "Strange Case of Dr Jekyll and Mr Hyde".to_string()
+            }
+        ]
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn paths_are_case_sensitive() {
     holochain_trace::test_run();
 

--- a/crates/test_utils/wasm/src/lib.rs
+++ b/crates/test_utils/wasm/src/lib.rs
@@ -56,6 +56,7 @@ pub enum TestWasm {
     MultipleCalls,
     MustGet,
     MustGetAgentActivity,
+    Paths,
     PostCommitSuccess,
     PostCommitVolley,
     Query,
@@ -173,6 +174,7 @@ impl From<TestWasm> for ZomeName {
             TestWasm::MultipleCalls => "multiple_calls",
             TestWasm::MustGet => "must_get",
             TestWasm::MustGetAgentActivity => "must_get_agent_activity",
+            TestWasm::Paths => "paths",
             TestWasm::PostCommitSuccess => "post_commit_success",
             TestWasm::PostCommitVolley => "post_commit_volley",
             TestWasm::Query => "query",
@@ -267,6 +269,9 @@ impl From<TestWasm> for PathBuf {
             }
             TestWasm::MustGet => "wasm32-unknown-unknown/release/test_wasm_must_get.wasm",
             TestWasm::MustGetAgentActivity => "wasm32-unknown-unknown/release/test_wasm_must_get_agent_activity.wasm",
+            TestWasm::Paths => {
+                "wasm32-unknown-unknown/release/test_wasm_paths.wasm"
+            }
             TestWasm::PostCommitSuccess => {
                 "wasm32-unknown-unknown/release/test_wasm_post_commit_success.wasm"
             }

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -1690,6 +1690,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "test_wasm_paths"
+version = "0.0.1"
+dependencies = [
+ "hdi",
+ "hdk",
+ "holochain_serialized_bytes",
+ "serde",
+]
+
+[[package]]
 name = "test_wasm_post_commit_signal"
 version = "0.0.1"
 dependencies = [

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "debug",
   "dna_properties",
   "emit_signal",
+  "paths",
   "post_commit_signal",
   "entry_defs",
   "hash_entry",

--- a/crates/test_utils/wasm/wasm_workspace/paths/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/paths/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "test_wasm_paths"
+version = "0.0.1"
+authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
+edition = "2021"
+
+[lib]
+name = "test_wasm_paths"
+crate-type = ["cdylib", "rlib"]
+
+[[example]]
+name = "integrity_test_wasm_paths"
+path = "src/integrity.rs"
+crate-type = ["cdylib", "rlib"]
+
+# reminder - do not use workspace deps
+[dependencies]
+hdk = { path = "../../../../hdk" }
+hdi = { path = "../../../../hdi" }
+holochain_serialized_bytes = "0.0.56"
+serde = "1.0"
+
+[features]
+default = []
+mock = ["hdk/mock"]

--- a/crates/test_utils/wasm/wasm_workspace/paths/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/paths/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 hdk = { path = "../../../../hdk" }
 hdi = { path = "../../../../hdi" }
-holochain_serialized_bytes = "0.0.56"
+holochain_serialized_bytes = "*"
 serde = "1.0"
 
 [features]

--- a/crates/test_utils/wasm/wasm_workspace/paths/src/integrity.rs
+++ b/crates/test_utils/wasm/wasm_workspace/paths/src/integrity.rs
@@ -41,17 +41,8 @@ fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
                     "Link's target_address '{target_address}' was not a valid entry hash",
                 )))
             } else if let Ok(tag_components) = Component::try_from(tag_bytes) {
-                if let Ok(tag_string) = String::try_from(&tag_components) {
-                    if tag_string
-                        .chars()
-                        .all(|c| c == '-' || c.is_ascii_lowercase())
-                    {
-                        Ok(ValidateCallbackResult::Valid)
-                    } else {
-                        Ok(ValidateCallbackResult::Invalid(format!(
-                    "Link's tag of '{tag_string:?}' contained more than lower-case ASCII letters and dashes",
-                )))
-                    }
+                if String::try_from(&tag_components).is_ok() {
+                    Ok(ValidateCallbackResult::Valid)
                 } else {
                     Ok(ValidateCallbackResult::Invalid(format!(
                         "The components of the link's tag '{tag_components:?}' were not valid strings",

--- a/crates/test_utils/wasm/wasm_workspace/paths/src/integrity.rs
+++ b/crates/test_utils/wasm/wasm_workspace/paths/src/integrity.rs
@@ -1,0 +1,97 @@
+use hdi::prelude::*;
+
+#[hdk_entry_helper]
+#[derive(PartialEq, Eq)]
+pub struct BookEntry {
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[hdk_entry_types]
+#[unit_enum(UnitEntryTypes)]
+pub enum EntryTypes {
+    BookEntry(BookEntry),
+}
+
+#[hdk_link_types]
+pub enum LinkTypes {
+    AuthorPath,
+    AuthorBook,
+}
+
+#[hdk_extern]
+fn validate(op: Op) -> ExternResult<ValidateCallbackResult> {
+    match op.flattened::<EntryTypes, LinkTypes>()? {
+        FlatOp::StoreRecord(OpRecord::CreateLink {
+            link_type: LinkTypes::AuthorPath,
+            base_address,
+            target_address,
+            tag,
+            ..
+        }) => {
+            let tag_bytes = SerializedBytes::from(UnsafeBytes::from(tag.clone().into_inner()));
+
+            if base_address.clone().into_entry_hash().is_none() {
+                Ok(ValidateCallbackResult::Invalid(format!(
+                    "Link's base_address '{base_address}' was not a valid entry hash",
+                )))
+            } else if target_address.clone().into_entry_hash().is_none() {
+                Ok(ValidateCallbackResult::Invalid(format!(
+                    "Link's target_address '{target_address}' was not a valid entry hash",
+                )))
+            } else if let Ok(tag_components) = Component::try_from(tag_bytes) {
+                if let Ok(tag_string) = String::try_from(&tag_components) {
+                    if tag_string
+                        .chars()
+                        .all(|c| c == '-' || c.is_ascii_lowercase())
+                    {
+                        Ok(ValidateCallbackResult::Valid)
+                    } else {
+                        Ok(ValidateCallbackResult::Invalid(format!(
+                    "Link's tag of '{tag_string:?}' contained more than lower-case ASCII letters and dashes",
+                )))
+                    }
+                } else {
+                    Ok(ValidateCallbackResult::Invalid(format!(
+                        "The components of the link's tag '{tag_components:?}' were not valid strings",
+                    )))
+                }
+            } else {
+                Ok(ValidateCallbackResult::Invalid(format!(
+                    "Link's tag '{tag:?}' was not a path component",
+                )))
+            }
+        }
+        FlatOp::StoreRecord(OpRecord::CreateLink {
+            link_type: LinkTypes::AuthorBook,
+            base_address,
+            target_address,
+            tag,
+            ..
+        }) => {
+            if TryInto::<String>::try_into(tag.clone()).is_err() {
+                Ok(ValidateCallbackResult::Invalid(format!(
+                    "Link's tag of '{tag:?}' was not a valid string",
+                )))
+            } else if base_address.clone().into_entry_hash().is_none() {
+                Ok(ValidateCallbackResult::Invalid(format!(
+                    "Link's base_address '{base_address}' was not a valid entry hash",
+                )))
+            } else if let Some(book_entry_hash) = target_address.clone().into_entry_hash() {
+                if must_get_entry(book_entry_hash).is_ok() {
+                    Ok(ValidateCallbackResult::Valid)
+                } else {
+                    Ok(ValidateCallbackResult::Invalid(format!(
+                        "Link's target_address '{target_address}' does not point to an entry",
+                    )))
+                }
+            } else {
+                Ok(ValidateCallbackResult::Invalid(format!(
+                    "Link's target_address '{target_address}' was not a valid entry hash",
+                )))
+            }
+        }
+        _ => Ok(ValidateCallbackResult::Valid),
+    }
+}

--- a/crates/test_utils/wasm/wasm_workspace/paths/src/lib.rs
+++ b/crates/test_utils/wasm/wasm_workspace/paths/src/lib.rs
@@ -28,7 +28,8 @@ fn add_book_entry(author_and_name: (String, String)) -> ExternResult<()> {
     let book_action_hash = create_entry(EntryTypes::BookEntry(BookEntry {
         name: author_and_name.1,
     }))?;
-    let book_action = must_get_action(book_action_hash)?;
+    let book_action =
+        get(book_action_hash, GetOptions::default())?.expect("failed to get entry we just created");
     let book_entry_hash = book_action
         .action()
         .entry_hash()
@@ -89,8 +90,8 @@ fn find_books_from_author(author: String) -> ExternResult<Vec<BookEntry>> {
     let books = book_links
         .into_iter()
         .filter_map(|link| link.target.into_entry_hash())
-        .filter_map(|entry_hash| must_get_entry(entry_hash).map(|entry| entry.content).ok())
-        .filter_map(|entry_content| BookEntry::try_from(entry_content).ok())
+        .filter_map(|entry_hash| get(entry_hash, GetOptions::default()).ok().flatten())
+        .filter_map(|record| BookEntry::try_from(record).ok())
         .collect();
 
     Ok(books)
@@ -109,8 +110,8 @@ fn find_books_at_path(path_string: String) -> ExternResult<Vec<BookEntry>> {
     )?
     .into_iter()
     .filter_map(|link| link.target.into_entry_hash())
-    .filter_map(|entry_hash| must_get_entry(entry_hash).map(|entry| entry.content).ok())
-    .filter_map(|entry_content| BookEntry::try_from(entry_content).ok())
+    .filter_map(|entry_hash| get(entry_hash, GetOptions::default()).ok().flatten())
+    .filter_map(|record| BookEntry::try_from(record).ok())
     .collect();
 
     Ok(books)

--- a/crates/test_utils/wasm/wasm_workspace/paths/src/lib.rs
+++ b/crates/test_utils/wasm/wasm_workspace/paths/src/lib.rs
@@ -1,0 +1,104 @@
+use hdk::prelude::*;
+use integrity::{BookEntry, EntryTypes, LinkTypes};
+
+mod integrity;
+
+#[hdk_extern]
+fn add_book_entry(author_and_name: (String, String)) -> ExternResult<()> {
+    // Use path-sharding to split author's name into single character paths.
+    let path_string = format!(
+        "1:{}#{}",
+        author_and_name.0.len(),
+        author_and_name
+            .0
+            .to_lowercase()
+            .replace(char::is_whitespace, "-"),
+    );
+    let path = Path::from(path_string).typed(LinkTypes::AuthorPath)?;
+
+    let book_tag: LinkTag = author_and_name.1.clone().into();
+
+    if !get_links(
+        LinkQuery::new(
+            path.path_entry_hash()?,
+            LinkTypes::AuthorBook.try_into_filter()?,
+        )
+        .tag_prefix(book_tag.clone()),
+        GetStrategy::default(),
+    )?
+    .is_empty()
+    {
+        // Link to book with name as tag exists so the book should exist.
+        return Ok(());
+    }
+
+    let book_action_hash = create_entry(EntryTypes::BookEntry(BookEntry {
+        name: author_and_name.1,
+    }))?;
+    let book_action = must_get_action(book_action_hash)?;
+    let book_entry_hash = book_action
+        .action()
+        .entry_hash()
+        .expect("created book action has no entry hash");
+
+    // Create links for each component in the path.
+    path.ensure()?;
+
+    // Link the end of the path to the book itself with the book's name as the tag.
+    create_link(
+        path.path_entry_hash()?,
+        book_entry_hash.clone(),
+        LinkTypes::AuthorBook,
+        book_tag,
+    )?;
+
+    Ok(())
+}
+
+fn recursively_find_books(path: TypedPath) -> ExternResult<Vec<Link>> {
+    let mut links = Vec::new();
+
+    for child in path.children_paths()? {
+        let child_links = get_links(
+            LinkQuery::new(
+                child.path_entry_hash()?,
+                LinkTypes::AuthorBook.try_into_filter()?,
+            ),
+            GetStrategy::default(),
+        )?;
+        links.extend(child_links);
+        links.extend(recursively_find_books(child)?);
+    }
+
+    Ok(links)
+}
+
+#[hdk_extern]
+fn find_books_from_author(author: String) -> ExternResult<Vec<BookEntry>> {
+    let path_string = format!("1:{}#{}", author.len(), author.to_lowercase(),);
+    let path = Path::from(path_string).typed(LinkTypes::AuthorPath)?;
+
+    // Path-sharding appends an extra leaf to the path so remove it.
+    // Example: if trying to find authors beginning with 'ab' then the path will be "a.b.ab" which will
+    // find nothing so instead, use the parent path which is "a.b".
+    let path = path
+        .parent()
+        .ok_or(wasm_error!("Could not get path from author"))?;
+
+    // Because we start at the parent path then we never need to check ourselves and instead only
+    // our children because we are our parent's child.
+    // Example 1: Given a full author's name "bob", the path will be "b.o.b.bob" so take our parent
+    // "b.o.b" and then search its children and we find "b.o.b.bob" which is where the links are.
+    // Example 2: Given a part of an author's name "bo", the path will be "b.o.bo" which is not
+    // valid so we take the parent "b.o" and recursively search its children to find "b.o.b.bob".
+    let book_links = recursively_find_books(path)?;
+
+    let books = book_links
+        .into_iter()
+        .filter_map(|link| link.target.into_entry_hash())
+        .filter_map(|entry_hash| must_get_entry(entry_hash).map(|entry| entry.content).ok())
+        .filter_map(|entry_content| BookEntry::try_from(entry_content).ok())
+        .collect();
+
+    Ok(books)
+}

--- a/crates/test_utils/wasm/wasm_workspace/paths/src/lib.rs
+++ b/crates/test_utils/wasm/wasm_workspace/paths/src/lib.rs
@@ -6,14 +6,7 @@ mod integrity;
 #[hdk_extern]
 fn add_book_entry(author_and_name: (String, String)) -> ExternResult<()> {
     // Use path-sharding to split author's name into single character paths.
-    let path_string = format!(
-        "1:{}#{}",
-        author_and_name.0.len(),
-        author_and_name
-            .0
-            .to_lowercase()
-            .replace(char::is_whitespace, "-"),
-    );
+    let path_string = format!("1:{}#{}", author_and_name.0.len(), author_and_name.0);
     let path = Path::from(path_string).typed(LinkTypes::AuthorPath)?;
 
     let book_tag: LinkTag = author_and_name.1.clone().into();
@@ -75,7 +68,7 @@ fn recursively_find_books(path: TypedPath) -> ExternResult<Vec<Link>> {
 
 #[hdk_extern]
 fn find_books_from_author(author: String) -> ExternResult<Vec<BookEntry>> {
-    let path_string = format!("1:{}#{}", author.len(), author.to_lowercase(),);
+    let path_string = format!("1:{}#{}", author.len(), author,);
     let path = Path::from(path_string).typed(LinkTypes::AuthorPath)?;
 
     // Path-sharding appends an extra leaf to the path so remove it.


### PR DESCRIPTION
### Summary

As part of #3178.
I'm honestly still not really sure if these are valid test or if they are in the correct place as these tests are kinda testing the paths feature but also working as a demo of how to use the feature and a test of an example hApp making use of paths.

All I can think of to make the tests more valid is to reduce them further so that only the very basic functionality of paths are tested like the `ensure` method and path-sharding but this is already somewhat covered by the `get_links` tests that use the `hash_path` test WASM.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs