### PR TITLE
feat(holochain_integrity_types): Implemented `action_hash` for `Op`.

### DIFF
--- a/crates/holochain_integrity_types/CHANGELOG.md
+++ b/crates/holochain_integrity_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- [Fixed issue 3606](https://github.com/holochain/holochain/issues/3606): Implemented `action_hash` for `Op`.
+
 ## 0.6.0-dev.7
 
 ## 0.6.0-dev.6


### PR DESCRIPTION
closes #3606

### Summary

Implemented `action_hash` for `Op`

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs
