### PR TITLE
Simplify app state operations (enable/disable/uninstall)

### DIFF
--- a/crates/client/src/admin_websocket.rs
+++ b/crates/client/src/admin_websocket.rs
@@ -39,10 +39,7 @@ impl std::fmt::Debug for AdminWebsocket {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct EnableAppResponse {
-    pub app: AppInfo,
-    pub errors: Vec<(CellId, String)>,
-}
+pub struct EnableAppResponse(AppInfo);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct AuthorizeSigningCredentialsPayload {
@@ -350,7 +347,7 @@ impl AdminWebsocket {
         let response = self.send(msg).await?;
 
         match response {
-            AdminResponse::AppEnabled { app, errors } => Ok(EnableAppResponse { app, errors }),
+            AdminResponse::AppEnabled(app) => Ok(EnableAppResponse(app)),
             _ => unreachable!("Unexpected response {:?}", response),
         }
     }

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,15 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- **BREAKING CHANGE**: `AdminRequest::EnableApp` fails when creating the app's cells fails and returns the first error that occurred. In case of success the enabled app info is returned.
+
 ## 0.6.0-dev.13
 
 - **BREAKING CHANGE**: Remove `pause_app` and `Paused` state from conductor. Pausing an app was used when enabling an app partially failed and could be re-attempted. Now the app is only enabled if all cells successfully started up.
 - **BREAKING CHANGE**: Removed everything related to `started` and `stopped` apps. Instead `enabled` and `disabled` remain as the only two possible states an app can be in after it has been installed.
 - **BREAKING CHANGE**: Remove `CellStatus` which used to indicate whether a cell has joined the network or not. Going forward cells that couldn’t join the network will not be kept in conductor state.
 - **BREAKING CHANGE**: Remove `generate_test_device_seed` from `ConductorBuilder`. This was a remnant from DPKI.
-- Add integration tests for the use of `path`’s and the links created by them. ([\#5114](https://github.com/holochain/holochain/pull/5114))
-- **BREAKING CHANGE** Removed an if/else clause in the `Ribosome::new()` impl that lead to inconsistent behavior depending on the number of zomes defined in the dna manifest ([\#5105](https://github.com/holochain/holochain/pull/5105)). This means that **the dependencies field for zomes in the dna manifest is now always mandatory**. Previously, if there was only one single integrity zome in the whole dna, it was implied by the conductor that a coordinator zome would depend on that integrity zome. This is no longer the case.
-- Clearer error message if `ScopeLinkedType` or `ScopedEntryDefIndex` cannot be created due to zome dependencies not being specified in the dna manifest ([\#5105](https://github.com/holochain/holochain/pull/5105)).
+- Add integration tests for the use of `path`'s and the links created by them. ([\#5114](https://github.com/holochain/holochain/pull/5114))
+- **BREAKING CHANGE** Removed an if/else clause in the `Ribosome::new()` impl that lead to inconsistent behavior depending on the number of zomes defined in the dna manifest ([#5105](https://github.com/holochain/holochain/pull/5105)). This means that **the dependencies field for zomes in the dna manifest is now always mandatory**. Previously, if there was only one single integrity zome in the whole dna, it was implied by the conductor that a coordinator zome would depend on that integrity zome. This is no longer the case.
+- Clearer error message if `ScopeLinkedType` or `ScopedEntryDefIndex` cannot be created due to zome dependencies not being specified in the dna manifest ([#5105](https://github.com/holochain/holochain/pull/5105)).
 
 ## 0.6.0-dev.12
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Refactor conductor methods `enable_app`, `disable_app`, `uninstall_app` and `initialize_conductor` to directly manage cells instead of using state machine code.
 - **BREAKING CHANGE**: `AdminRequest::EnableApp` fails when creating the app's cells fails and returns the first error that occurred. In case of success the enabled app info is returned.
 
 ## 0.6.0-dev.13

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -189,30 +189,17 @@ impl AdminInterfaceApi {
             }
             EnableApp { installed_app_id } => {
                 // Enable app
-                let (app, errors) = self
+                let _ = self
                     .conductor_handle
                     .clone()
                     .enable_app(installed_app_id.clone())
                     .await?;
-
-                let app_cells: HashSet<_> = app.required_cells().collect();
-
                 let app_info = self
                     .conductor_handle
                     .get_app_info(&installed_app_id)
                     .await?
                     .ok_or(ConductorError::AppNotInstalled(installed_app_id))?;
-
-                let errors: Vec<_> = errors
-                    .into_iter()
-                    .filter(|(cell_id, _)| app_cells.contains(cell_id))
-                    .map(|(cell_id, error)| (cell_id, error.to_string()))
-                    .collect();
-
-                Ok(AdminResponse::AppEnabled {
-                    app: app_info,
-                    errors,
-                })
+                Ok(AdminResponse::AppEnabled(app_info))
             }
             DisableApp { installed_app_id } => {
                 // Disable app

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -110,14 +110,7 @@ pub struct Cell {
 }
 
 impl Cell {
-    /// Constructor for a Cell, which ensure the Cell is fully initialized
-    /// before returning.
-    ///
-    /// If it hasn't happened already, a SourceChain will be created, and
-    /// genesis will be run. If these have already happened, those steps are
-    /// skipped.
-    ///
-    /// No Cell will be created if the SourceChain is not ready to be used.
+    /// Constructor for a Cell that has gone through genesis; fails otherwise.
     pub async fn create(
         id: CellId,
         conductor_handle: ConductorHandle,

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1833,14 +1833,14 @@ mod app_status_impls {
         pub async fn enable_app(
             self: Arc<Self>,
             app_id: InstalledAppId,
-        ) -> ConductorResult<(InstalledApp, CellStartupErrors)> {
+        ) -> ConductorResult<InstalledApp> {
             let (app, delta) = self
                 .transition_app_status(app_id.clone(), AppStatusTransition::Enable)
                 .await?;
-            let errors = self
+            let _ = self
                 .process_app_status_fx(delta, Some(vec![app_id.to_owned()].into_iter().collect()))
                 .await?;
-            Ok((app, errors))
+            Ok(app)
         }
 
         /// Disable an app
@@ -1864,13 +1864,13 @@ mod app_status_impls {
             &self,
             app: InstalledAppCommon,
         ) -> ConductorResult<DisabledApp> {
-            let (_, stopped_app) = self
+            let (_, disabled_app) = self
                 .update_state_prime(move |mut state| {
-                    let stopped_app = state.add_app(app)?;
-                    Ok((state, stopped_app))
+                    let disabled_app = state.add_app(app)?;
+                    Ok((state, disabled_app))
                 })
                 .await?;
-            Ok(stopped_app)
+            Ok(disabled_app)
         }
 
         /// Transition an app's status to a new state.

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -687,11 +687,12 @@ mod dna_impls {
                     .filter_map(|cell_id| cells.remove(cell_id).map(|c| (cell_id, c)))
                     .collect()
             });
-            for (cell_id, cell) in to_cleanup {
+            future::join_all(to_cleanup.into_iter().map(|(cell_id, cell)| async move {
                 if let Err(err) = cell.cleanup().await {
                     tracing::error!("Error cleaning up Cell: {:?}\nCellId: {}", err, cell_id);
                 }
-            }
+            }))
+            .await;
         }
 
         pub(crate) async fn put_wasm(

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1225,11 +1225,6 @@ mod app_impls {
                 self.clone().register_dna(dna).await?;
             }
 
-            let cell_ids: Vec<_> = cells_to_create
-                .iter()
-                .map(|(cell_id, _)| cell_id.clone())
-                .collect();
-
             if flags.defer_memproofs {
                 let roles = ops.role_assignments;
                 let app = InstalledAppCommon::new(
@@ -1267,8 +1262,6 @@ mod app_impls {
                     // Return the result, which be may be an error if no_rollback was specified
                     genesis_result.map(|()| stopped_app.into())
                 } else if let Err(err) = genesis_result {
-                    // Rollback created cells on error
-                    self.remove_cells(&cell_ids).await;
                     Err(err)
                 } else {
                     unreachable!()

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -342,7 +342,7 @@ mod startup_shutdown_impls {
             self: Arc<Self>,
             outcome_rx: OutcomeReceiver,
             admin_configs: Vec<AdminInterfaceConfig>,
-        ) -> ConductorResult<CellStartupErrors> {
+        ) -> ConductorResult<()> {
             self.load_dnas().await?;
 
             info!("Conductor startup: DNAs loaded.");
@@ -364,11 +364,11 @@ mod startup_shutdown_impls {
 
             info!("Conductor startup: app interfaces started.");
 
-            let res = self.process_app_status_fx(AppStatusFx::SpinUp, None).await;
+            let _ = self.process_app_status_fx(AppStatusFx::SpinUp, None).await;
 
             info!("Conductor startup: apps enabled.");
 
-            res
+            Ok(())
         }
     }
 }

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1995,23 +1995,6 @@ mod app_status_impls {
             Ok(disabled_app)
         }
 
-        /// Transition an app's status to a new state.
-        #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
-        pub(crate) async fn transition_app_status(
-            &self,
-            app_id: InstalledAppId,
-            transition: AppStatusTransition,
-        ) -> ConductorResult<(InstalledApp, AppStatusFx)> {
-            Ok(self
-                .update_state_prime(move |mut state| {
-                    let (app, delta) = state.transition_app_status(&app_id, transition)?.clone();
-                    let app = app.clone();
-                    Ok((state, (app, delta)))
-                })
-                .await?
-                .1)
-        }
-
         /// Create any Cells which are missing for any running apps, then initialize
         /// and join them. (Joining could take a while.)
         #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -339,18 +339,10 @@ impl ConductorBuilder {
         });
 
         let configs = config.admin_interfaces.clone().unwrap_or_default();
-        let cell_startup_errors = conductor
+        conductor
             .clone()
             .initialize_conductor(outcome_receiver, configs)
             .await?;
-
-        // TODO: This should probably be emitted over the admin interface
-        if !cell_startup_errors.is_empty() {
-            error!(
-                msg = "Failed to create the following active apps",
-                ?cell_startup_errors
-            );
-        }
 
         if !no_print_setup {
             conductor.print_setup();

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -63,26 +63,14 @@ async fn app_ids_are_unique() {
     let cell_id = fake_cell_id(1);
 
     let installed_cell = InstalledCell::new(cell_id.clone(), "handle".to_string());
-    let app = InstalledAppCommon::new_legacy("id".to_string(), vec![installed_cell]).unwrap();
+    let app_id = "app_id".to_string();
+    let app = InstalledAppCommon::new_legacy(app_id.clone(), vec![installed_cell]).unwrap();
 
     conductor.add_disabled_app_to_db(app.clone()).await.unwrap();
 
     assert_matches!(
         conductor.add_disabled_app_to_db(app.clone()).await,
-        Err(ConductorError::AppAlreadyInstalled(id))
-        if id == *"id"
-    );
-
-    //- it doesn't matter whether the app is active or inactive
-    let (_, delta) = conductor
-        .transition_app_status("id".to_string(), AppStatusTransition::Enable)
-        .await
-        .unwrap();
-    assert_eq!(delta, AppStatusFx::SpinUp);
-    assert_matches!(
-        conductor.add_disabled_app_to_db(app.clone()).await,
-        Err(ConductorError::AppAlreadyInstalled(id))
-        if &id == "id"
+        Err(ConductorError::AppAlreadyInstalled(id)) if id == app_id
     );
 }
 

--- a/crates/holochain/src/conductor/conductor/tests/app_state.rs
+++ b/crates/holochain/src/conductor/conductor/tests/app_state.rs
@@ -493,12 +493,12 @@ async fn app_status_and_cell_state() {
     // Running cells should only contain the installed cell.
     conductor.running_cells.share_ref(|cells| {
         assert_eq!(cells.len(), 1);
-        let (cell_id, cell_item) = cells.get_index(0).unwrap();
+        let (cell_id, cell) = cells.get_index(0).unwrap();
         assert_eq!(
             *cell_id,
             CellId::new(dna_files_1[0].dna_hash().clone(), app_1.agent_key.clone())
         );
-        assert_eq!(cell_id, cell_item.cell.id());
+        assert_eq!(cell_id, cell.id());
     });
 
     // Disable app
@@ -532,12 +532,12 @@ async fn app_status_and_cell_state() {
     // Running cells should contain only the installed cell.
     conductor.running_cells.share_ref(|cells| {
         assert_eq!(cells.len(), 1);
-        let (cell_id, cell_item) = cells.get_index(0).unwrap();
+        let (cell_id, cell) = cells.get_index(0).unwrap();
         assert_eq!(
             *cell_id,
             CellId::new(dna_files_1[0].dna_hash().clone(), app_1.agent_key.clone())
         );
-        assert_eq!(cell_id, cell_item.cell.id());
+        assert_eq!(cell_id, cell.id());
     });
 
     // Install another app with 2 DNAs
@@ -617,18 +617,18 @@ async fn app_status_and_cell_state() {
         // Cell of app 1
         let expected_cell_id =
             CellId::new(dna_files_1[0].dna_hash().clone(), app_1.agent_key.clone());
-        let cell_item = cells.get(&expected_cell_id).unwrap();
-        assert_eq!(*cell_item.cell.id(), expected_cell_id);
+        let cell = cells.get(&expected_cell_id).unwrap();
+        assert_eq!(*cell.id(), expected_cell_id);
         // Cell 1 of app 2
         let expected_cell_id =
             CellId::new(dna_files_2[0].dna_hash().clone(), app_2.agent_key.clone());
-        let cell_item = cells.get(&expected_cell_id).unwrap();
-        assert_eq!(*cell_item.cell.id(), expected_cell_id);
+        let cell = cells.get(&expected_cell_id).unwrap();
+        assert_eq!(*cell.id(), expected_cell_id);
         // Cell 2 of app 2
         let expected_cell_id =
             CellId::new(dna_files_2[1].dna_hash().clone(), app_2.agent_key.clone());
-        let cell_item = cells.get(&expected_cell_id).unwrap();
-        assert_eq!(*cell_item.cell.id(), expected_cell_id);
+        let cell = cells.get(&expected_cell_id).unwrap();
+        assert_eq!(*cell.id(), expected_cell_id);
     });
 
     // Uninstall app 1
@@ -649,13 +649,13 @@ async fn app_status_and_cell_state() {
         // Cell 1 of app 2
         let expected_cell_id =
             CellId::new(dna_files_2[0].dna_hash().clone(), app_2.agent_key.clone());
-        let cell_item = cells.get(&expected_cell_id).unwrap();
-        assert_eq!(*cell_item.cell.id(), expected_cell_id);
+        let cell = cells.get(&expected_cell_id).unwrap();
+        assert_eq!(*cell.id(), expected_cell_id);
         // Cell 2 of app 2
         let expected_cell_id =
             CellId::new(dna_files_2[1].dna_hash().clone(), app_2.agent_key.clone());
-        let cell_item = cells.get(&expected_cell_id).unwrap();
-        assert_eq!(*cell_item.cell.id(), expected_cell_id);
+        let cell = cells.get(&expected_cell_id).unwrap();
+        assert_eq!(*cell.id(), expected_cell_id);
     });
 
     // Uninstall app 2

--- a/crates/holochain/src/conductor/conductor/tests/app_state.rs
+++ b/crates/holochain/src/conductor/conductor/tests/app_state.rs
@@ -676,6 +676,18 @@ async fn app_status_and_cell_state() {
     });
 }
 
+// #[tokio::test(flavor = "multi_thread")]
+// async fn cannot_create_cell_without_genesis() {
+//     let conductor = SweetConductor::from_standard_config().await;
+//     let cell_id = ::fixt::fixt!(CellId);
+//     let signal_tx = tokio::sync::broadcast::channel::<Signal>(1).0;
+//     assert!(conductor
+//         .raw_handle()
+//         .create_cell(&cell_id, signal_tx, None)
+//         .await
+//         .is_err());
+// }
+
 struct App {
     bundle: AppBundle,
     dna_files: Vec<DnaFile>,

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -5,8 +5,8 @@ use super::*;
 use crate::conductor::api::error::ConductorApiError;
 use crate::conductor::ConductorHandle;
 use crate::conductor::{
-    api::error::ConductorApiResult, config::ConductorConfig, error::ConductorResult, CellError,
-    Conductor, ConductorBuilder,
+    api::error::ConductorApiResult, config::ConductorConfig, error::ConductorResult, Conductor,
+    ConductorBuilder,
 };
 use crate::retry_until_timeout;
 use ::fixt::prelude::StdRng;
@@ -285,10 +285,7 @@ impl SweetConductor {
     }
 
     /// Convenience function that uses the internal handle to enable an app
-    pub async fn enable_app(
-        &self,
-        id: InstalledAppId,
-    ) -> ConductorResult<(InstalledApp, Vec<(CellId, CellError)>)> {
+    pub async fn enable_app(&self, id: InstalledAppId) -> ConductorResult<InstalledApp> {
         self.raw_handle().enable_app(id).await
     }
 

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -506,15 +506,13 @@ pub enum AdminResponse {
 
     /// The successful response to an [`AdminRequest::EnableApp`].
     ///
-    /// It means the app was enabled successfully. If it was possible to
-    /// put the app in a running state, it will be running, otherwise it will
-    /// be paused.
+    /// If anything during the process of enabling the app fails,
+    /// the error is returned and the app remains disabled.
+    /// In case of failure to join the network of any of the app's
+    /// cells, it can be re-attempted to enable the app.
     ///
-    /// Contains the app info and list of errors for cells that could not be enabled.
-    AppEnabled {
-        app: AppInfo,
-        errors: Vec<(CellId, String)>,
-    },
+    /// Contains the app info of the enabled app.
+    AppEnabled(AppInfo),
 
     /// The successful response to an [`AdminRequest::DisableApp`].
     ///

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -137,6 +137,9 @@ pub enum AdminRequest {
     /// installed app is not enabled automatically. Once the app is enabled,
     /// zomes can be immediately called and it will also be loaded and enabled automatically on any reboot of the conductor.
     ///
+    /// This call is idempotent. If the app is already enabled, the call will be a no-op
+    /// and just return the already enabled app info.
+    ///
     /// # Returns
     ///
     /// [`AdminResponse::AppEnabled`]
@@ -148,7 +151,10 @@ pub enum AdminRequest {
     /// Changes the specified app from an enabled to a disabled state in the conductor.
     ///
     /// When an app is disabled, zome calls can no longer be made, and the app will not be
-    /// loaded on a reboot of the conductor.
+    /// enabled on a reboot of the conductor.
+    ///
+    /// This call is idempotent. If the app is already disabled, the call will be a no-op
+    /// and just return the already disabled app info.
     ///
     /// # Returns
     ///


### PR DESCRIPTION
### Summary

- rewrite app operations `enable_app` and `disable_app` without state machinery
- refactor `uninstall_app` and `initialize_conductor` away from state machinery
- remove unused methods `transition_app_status` and `process_app_status_fx`
- add a test for `enable_app` and `disable_app` idempotency
- actually you can read the commit history =D

part of #5095 

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs