### PR TITLE
chore: remove unnecessary use of DnaFile in the genesis workflow

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove app status transition functions and `AppInfoStatus`.
 - **BREAKING CHANGE**: Remove types `EnabledApp` and `DisabledApp` in favor of `InstalledApp` to reduce app handling complexity.
 - **BREAKING CHANGE**: Replace and remove legacy constructor for `InstalledAppCommon`.
+- Remove an unnecessary use of `DnaFile` in the genesis workflow ([#5150](https://github.com/holochain/holochain/pull/5150)).
 
 ## 0.6.0-dev.13
 

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -173,11 +173,6 @@ impl Cell {
     where
         Ribosome: RibosomeT + 'static,
     {
-        // get the dna
-        let dna_file = conductor_handle
-            .get_dna_file(cell_id.dna_hash())
-            .ok_or_else(|| DnaError::DnaMissing(cell_id.dna_hash().to_owned()))?;
-
         let conductor_api = CellConductorApi::new(conductor_handle.clone(), cell_id.clone());
 
         // run genesis
@@ -191,13 +186,7 @@ impl Cell {
             return Ok(());
         }
 
-        let args = GenesisWorkflowArgs::new(
-            dna_file,
-            cell_id.agent_pubkey().clone(),
-            membrane_proof,
-            ribosome,
-            chc,
-        );
+        let args = GenesisWorkflowArgs::new(cell_id.clone(), membrane_proof, ribosome, chc);
 
         genesis_workflow(workspace, conductor_api, args)
             .await


### PR DESCRIPTION
### Summary
Removes another unnecessary use of `DnaFile`, this time in the genesis workflow.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs