### PR TITLE
chore!: remove unused field ConductorBuilder::state

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Replace `Conductor::remove_dangling_cells` method with methods that remove the cells specific to the app and delete their databases.
+- **BREAKING CHANGE**: Remove unused field `ConductorBuilder::state`.
 
 ## 0.6.0-dev.14
 

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -24,10 +24,6 @@ pub struct ConductorBuilder {
     /// Optional keystore override
     pub keystore: Option<MetaLairClient>,
 
-    /// Optional state override (for testing)
-    #[cfg(any(test, feature = "test_utils"))]
-    pub state: Option<ConductorState>,
-
     /// Skip printing setup info to stdout
     pub no_print_setup: bool,
 
@@ -244,9 +240,6 @@ impl ConductorBuilder {
             outcome_tx,
         );
 
-        #[cfg(any(test, feature = "test_utils"))]
-        let conductor = Self::update_fake_state(builder.state, conductor).await?;
-
         // Create handle
         let handle: ConductorHandle = Arc::new(conductor);
 
@@ -358,18 +351,6 @@ impl ConductorBuilder {
         self
     }
 
-    #[cfg(any(test, feature = "test_utils"))]
-    #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
-    pub(crate) async fn update_fake_state(
-        state: Option<ConductorState>,
-        conductor: Conductor,
-    ) -> ConductorResult<Conductor> {
-        if let Some(state) = state {
-            conductor.update_state(move |_| Ok(state)).await?;
-        }
-        Ok(conductor)
-    }
-
     /// Build a Conductor with a test environment
     #[cfg(any(test, feature = "test_utils"))]
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all, fields(scope = self.config.network.tracing_scope)))]
@@ -454,8 +435,6 @@ impl ConductorBuilder {
             post_commit_sender,
             outcome_tx,
         );
-
-        let conductor = Self::update_fake_state(builder.state, conductor).await?;
 
         // Create handle
         let handle: ConductorHandle = Arc::new(conductor);


### PR DESCRIPTION
### Summary

This facility to set a fake state had no application.


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs