### PR TITLE
refactor: rename AgentMetaInfo to PeerMetaInfo

### DIFF
--- a/crates/client/src/admin_websocket.rs
+++ b/crates/client/src/admin_websocket.rs
@@ -2,9 +2,9 @@ use crate::error::{ConductorApiError, ConductorApiResult};
 use crate::util::AbortOnDropHandle;
 use holo_hash::{ActionHash, DnaHash};
 use holochain_conductor_api::{
-    AdminInterfaceConfig, AdminRequest, AdminResponse, AgentMetaInfo, AppAuthenticationToken,
+    AdminInterfaceConfig, AdminRequest, AdminResponse, AppAuthenticationToken,
     AppAuthenticationTokenIssued, AppInfo, AppInterfaceInfo, AppStatusFilter, FullStateDump,
-    IssueAppAuthenticationTokenPayload, StorageInfo,
+    IssueAppAuthenticationTokenPayload, PeerMetaInfo, StorageInfo,
 };
 use holochain_types::websocket::AllowedOrigins;
 use holochain_types::{
@@ -566,15 +566,15 @@ impl AdminWebsocket {
     ///
     /// If `dna_hashes` is set to `None` it returns the contents
     /// for all dnas that the agent is part of.
-    pub async fn agent_meta_info(
+    pub async fn peer_meta_info(
         &self,
         url: Url,
         dna_hashes: Option<Vec<DnaHash>>,
-    ) -> ConductorApiResult<BTreeMap<DnaHash, BTreeMap<String, AgentMetaInfo>>> {
-        let msg = AdminRequest::AgentMetaInfo { url, dna_hashes };
+    ) -> ConductorApiResult<BTreeMap<DnaHash, BTreeMap<String, PeerMetaInfo>>> {
+        let msg = AdminRequest::PeerMetaInfo { url, dna_hashes };
         let response = self.send(msg).await?;
         match response {
-            AdminResponse::AgentMetaInfo(info) => Ok(info),
+            AdminResponse::PeerMetaInfo(info) => Ok(info),
             _ => unreachable!("Unexpected response {:?}", response),
         }
     }

--- a/crates/client/src/app_websocket.rs
+++ b/crates/client/src/app_websocket.rs
@@ -4,7 +4,7 @@ use crate::{signing::sign_zome_call, ConductorApiError, ConductorApiResult};
 use anyhow::{anyhow, Result};
 use holo_hash::{AgentPubKey, DnaHash};
 use holochain_conductor_api::{
-    AgentMetaInfo, AppAuthenticationToken, AppInfo, AppRequest, AppResponse, CellInfo,
+    AppAuthenticationToken, AppInfo, AppRequest, AppResponse, CellInfo, PeerMetaInfo,
     ProvisionedCell, ZomeCallParamsSigned,
 };
 use holochain_nonce::fresh_nonce;
@@ -451,15 +451,15 @@ impl AppWebsocket {
     ///
     /// If `dna_hashes` is set to `None` it returns the contents
     /// for all dnas of the app.
-    pub async fn agent_meta_info(
+    pub async fn peer_meta_info(
         &self,
         url: Url,
         dna_hashes: Option<Vec<DnaHash>>,
-    ) -> ConductorApiResult<BTreeMap<DnaHash, BTreeMap<String, AgentMetaInfo>>> {
-        let msg = AppRequest::AgentMetaInfo { url, dna_hashes };
+    ) -> ConductorApiResult<BTreeMap<DnaHash, BTreeMap<String, PeerMetaInfo>>> {
+        let msg = AppRequest::PeerMetaInfo { url, dna_hashes };
         let response = self.inner.send(msg).await?;
         match response {
-            AppResponse::AgentMetaInfo(info) => Ok(info),
+            AppResponse::PeerMetaInfo(info) => Ok(info),
             _ => unreachable!("Unexpected response {:?}", response),
         }
     }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -9,9 +9,9 @@ pub use admin_websocket::{AdminWebsocket, AuthorizeSigningCredentialsPayload, En
 pub use app_websocket::{AppWebsocket, ZomeCallTarget};
 pub use error::{ConductorApiError, ConductorApiResult};
 pub use holochain_conductor_api::{
-    AdminRequest, AdminResponse, AgentMetaInfo, AppAuthenticationRequest, AppAuthenticationToken,
+    AdminRequest, AdminResponse, AppAuthenticationRequest, AppAuthenticationToken,
     AppAuthenticationTokenIssued, AppInfo, AppRequest, AppResponse, AppStatusFilter, CellInfo,
-    IssueAppAuthenticationTokenPayload, ProvisionedCell,
+    IssueAppAuthenticationTokenPayload, PeerMetaInfo, ProvisionedCell,
 };
 pub use holochain_types::{
     app::{InstallAppPayload, InstalledAppId},

--- a/crates/client/tests/admin.rs
+++ b/crates/client/tests/admin.rs
@@ -219,7 +219,7 @@ async fn agent_info() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn agent_meta_info() {
+async fn peer_meta_info() {
     // This is just a rudimentary test. More detailed functionality is tested in
     // conductor tests in the holochain crate where the peer meta store is
     // accessible on the SweetConductor.
@@ -260,7 +260,7 @@ async fn agent_meta_info() {
     let url = Url::from_str("ws://test.com:80/test-url").unwrap();
 
     // Get the agent meta info for all spaces
-    let response = admin_ws.agent_meta_info(url.clone(), None).await.unwrap();
+    let response = admin_ws.peer_meta_info(url.clone(), None).await.unwrap();
     assert_eq!(response.len(), 1);
 
     let meta_infos = response

--- a/crates/client/tests/app.rs
+++ b/crates/client/tests/app.rs
@@ -555,7 +555,7 @@ async fn agent_info() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn agent_meta_info() {
+async fn peer_meta_info() {
     // This is just a rudimentary test. More detailed functionality is tested in
     // conductor tests in the holochain crate where the peer meta store is
     // accessible on the SweetConductor.
@@ -601,7 +601,7 @@ async fn agent_meta_info() {
 
     // Get the agent meta info for all spaces
     let url = Url::from_str("ws://test.com:80/test-url").unwrap();
-    let response = app_ws.agent_meta_info(url.clone(), None).await.unwrap();
+    let response = app_ws.peer_meta_info(url.clone(), None).await.unwrap();
 
     let app_info = admin_ws
         .list_apps(None)

--- a/crates/hc_sandbox/src/calls.rs
+++ b/crates/hc_sandbox/src/calls.rs
@@ -15,9 +15,9 @@ use holo_hash::ActionHash;
 use holo_hash::DnaHashB64;
 use holochain_client::AdminWebsocket;
 use holochain_conductor_api::conductor::paths::ConfigRootPath;
-use holochain_conductor_api::AgentMetaInfo;
 use holochain_conductor_api::AppStatusFilter;
 use holochain_conductor_api::InterfaceDriver;
+use holochain_conductor_api::PeerMetaInfo;
 use holochain_conductor_api::{AdminInterfaceConfig, AppInfo};
 use holochain_types::app::AppManifest;
 use holochain_types::app::RoleSettingsMap;
@@ -105,8 +105,8 @@ pub enum AdminRequestCli {
     AddAgents(AgentInfos),
     /// Calls [`AdminWebsocket::agent_info`].
     ListAgents(ListAgents),
-    /// Calls [`AdminWebsocket::agent_meta_info`].
-    AgentMetaInfo(AgentMetaInfoArgs),
+    /// Calls [`AdminWebsocket::peer_meta_info`].
+    PeerMetaInfo(PeerMetaInfoArgs),
 }
 
 /// Calls [`AdminWebsocket::add_admin_interfaces`]
@@ -310,10 +310,10 @@ pub struct ListApps {
     pub status: Option<AppStatusFilter>,
 }
 
-/// Calls [`AdminWebsocket::agent_meta_info`]
+/// Calls [`AdminWebsocket::peer_meta_info`]
 /// and prints the agent meta info related to the specified Url
 #[derive(Debug, Args, Clone)]
-pub struct AgentMetaInfoArgs {
+pub struct PeerMetaInfoArgs {
     /// The kitsune Url of the agent to get meta info about.
     #[arg(long)]
     pub url: Url,
@@ -585,12 +585,12 @@ async fn call_inner(client: &mut AdminWebsocket, call: AdminRequestCli) -> anyho
                 msg!("{}\n", out);
             }
         }
-        AdminRequestCli::AgentMetaInfo(args) => {
-            let info = client.agent_meta_info(args.url, args.dna).await?;
+        AdminRequestCli::PeerMetaInfo(args) => {
+            let info = client.peer_meta_info(args.url, args.dna).await?;
             let string_key_info = info
                 .into_iter()
                 .map(|(k, v)| (DnaHashB64::from(k).to_string(), v))
-                .collect::<BTreeMap<String, BTreeMap<String, AgentMetaInfo>>>();
+                .collect::<BTreeMap<String, BTreeMap<String, PeerMetaInfo>>>();
 
             let info_json = serde_json::to_string_pretty(&string_key_info)?;
             println!("{}", info_json);

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -750,9 +750,9 @@ async fn generate_sandbox_and_add_and_list_agent() {
     shutdown_sandbox(hc_admin).await;
 }
 
-/// Tests retrieval of agent meta info via `hc sandbox call agent-meta-info`
+/// Tests retrieval of agent meta info via `hc sandbox call peer-meta-info`
 #[tokio::test(flavor = "multi_thread")]
-async fn generate_sandbox_and_call_agent_meta_info() {
+async fn generate_sandbox_and_call_peer_meta_info() {
     clean_sandboxes().await;
     package_fixture_if_not_packaged().await;
 
@@ -817,7 +817,7 @@ async fn generate_sandbox_and_call_agent_meta_info() {
     };
 
     // Needs to get converted to a String (not DnaHashB64) so that the sorting will
-    // match the sorting of the JSON output from the `hc sandbox agent-meta-info` call
+    // match the sorting of the JSON output from the `hc sandbox peer-meta-info` call
     let mut dna_hashes_b64: Vec<String> = dna_hashes
         .into_iter()
         .map(|h| DnaHashB64::from(h).to_string())
@@ -835,7 +835,7 @@ async fn generate_sandbox_and_call_agent_meta_info() {
             get_holochain_bin_path().to_str().unwrap()
         ))
         .arg("call")
-        .arg("agent-meta-info")
+        .arg("peer-meta-info")
         .arg("--url")
         .arg("wss://someurl:443")
         .stdin(Stdio::piped())
@@ -876,7 +876,7 @@ async fn generate_sandbox_and_call_agent_meta_info() {
             get_holochain_bin_path().to_str().unwrap()
         ))
         .arg("call")
-        .arg("agent-meta-info")
+        .arg("peer-meta-info")
         .arg("--url")
         .arg("wss://someurl:443")
         .arg("--dna")

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **BREAKING CHANGE**: Remove unused field `ConductorBuilder::state`.
 - Remove network joining timeout. This used to work with the previous version of kitsune, but now all the `join` call does is to join the local peer store which is a matter of acquiring a write lock on a mutex and doesn't indicate whether publishing the agent info to the peer store and the bootstrap has been successful.
 - **BREAKING CHANGE**: Remove unused function `get_dependency_apps`.
+- **BREAKING CHANGE**: Rename `AgentMetaInfo` to `PeerMetaInfo` since the info returns meta data for potentially multiple agents at a given peer URL ([#5164](https://github.com/holochain/holochain/pull/5164)).
 
 ## 0.6.0-dev.14
 

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -277,12 +277,12 @@ impl AdminInterfaceApi {
                 }
                 Ok(AdminResponse::AgentInfo(encoded))
             }
-            AgentMetaInfo { url, dna_hashes } => {
+            PeerMetaInfo { url, dna_hashes } => {
                 let r = self
                     .conductor_handle
-                    .agent_meta_info(url, dna_hashes)
+                    .peer_meta_info(url, dna_hashes)
                     .await?;
-                Ok(AdminResponse::AgentMetaInfo(r))
+                Ok(AdminResponse::PeerMetaInfo(r))
             }
             GraftRecords {
                 cell_id,

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -88,12 +88,12 @@ impl AppInterfaceApi {
                     agent_infos.into_iter().map(|info| info.encode()).collect();
                 Ok(AppResponse::AgentInfo(items?))
             }
-            AppRequest::AgentMetaInfo { url, dna_hashes } => {
+            AppRequest::PeerMetaInfo { url, dna_hashes } => {
                 let r = self
                     .conductor_handle
-                    .app_agent_meta_info(&installed_app_id, url, dna_hashes)
+                    .app_peer_meta_info(&installed_app_id, url, dna_hashes)
                     .await?;
-                Ok(AppResponse::AgentMetaInfo(r))
+                Ok(AppResponse::PeerMetaInfo(r))
             }
             AppRequest::CallZome(zome_call_params_signed) => {
                 match self.conductor_handle.handle_external_zome_call(*zome_call_params_signed).await? {

--- a/crates/holochain/src/conductor/tests/mod.rs
+++ b/crates/holochain/src/conductor/tests/mod.rs
@@ -1,9 +1,9 @@
 mod agent_info;
-mod agent_meta_info;
 mod app_info;
 mod cell_cloning;
 mod install_app_bundle;
 mod network_info;
 mod network_seed_regression;
+mod peer_meta_info;
 mod request_dna_def;
 mod signed_zome_call;

--- a/crates/holochain/src/conductor/tests/peer_meta_info.rs
+++ b/crates/holochain/src/conductor/tests/peer_meta_info.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use crate::sweettest::*;
 
 #[tokio::test(flavor = "multi_thread")]
-async fn agent_meta_info() {
+async fn peer_meta_info() {
     holochain_trace::test_run();
 
     // We want deterministic dna hashes to get the JSON output in a deterministic
@@ -82,7 +82,7 @@ async fn agent_meta_info() {
         .unwrap();
 
     // Get the agent meta info for all spaces
-    let response = conductor.agent_meta_info(url.clone(), None).await.unwrap();
+    let response = conductor.peer_meta_info(url.clone(), None).await.unwrap();
 
     assert_eq!(response.len(), 2);
 
@@ -92,16 +92,16 @@ async fn agent_meta_info() {
 
     assert_eq!(meta_infos1.len(), 2);
 
-    let agent_meta_info11 = meta_infos1.get("root:unresponsive").unwrap();
-    assert_eq!(agent_meta_info11.meta_value, ktimestamp.as_micros());
-    assert_eq!(agent_meta_info11.expires_at, htimestamp);
+    let peer_meta_info11 = meta_infos1.get("root:unresponsive").unwrap();
+    assert_eq!(peer_meta_info11.meta_value, ktimestamp.as_micros());
+    assert_eq!(peer_meta_info11.expires_at, htimestamp);
 
-    let agent_meta_info12 = meta_infos1.get("test:meta").unwrap();
+    let peer_meta_info12 = meta_infos1.get("test:meta").unwrap();
     assert_eq!(
-        agent_meta_info12.meta_value,
+        peer_meta_info12.meta_value,
         serde_json::Value::String("hello".into())
     );
-    assert_eq!(agent_meta_info12.expires_at, htimestamp);
+    assert_eq!(peer_meta_info12.expires_at, htimestamp);
 
     let meta_infos2 = response
         .get(dna2.dna_hash())
@@ -109,16 +109,16 @@ async fn agent_meta_info() {
 
     assert_eq!(meta_infos2.len(), 1);
 
-    let agent_meta_info2 = meta_infos2.get("test:meta").unwrap();
+    let peer_meta_info2 = meta_infos2.get("test:meta").unwrap();
     assert_eq!(
-        agent_meta_info2.meta_value,
+        peer_meta_info2.meta_value,
         serde_json::Value::String("hello2".into())
     );
-    assert_eq!(agent_meta_info2.expires_at, htimestamp);
+    assert_eq!(peer_meta_info2.expires_at, htimestamp);
 
     // Get the agent meta info for a selected space only
     let response2 = conductor
-        .agent_meta_info(url.clone(), Some(vec![dna2.dna_hash().clone()]))
+        .peer_meta_info(url.clone(), Some(vec![dna2.dna_hash().clone()]))
         .await
         .unwrap();
 
@@ -130,24 +130,24 @@ async fn agent_meta_info() {
 
     assert_eq!(meta_infos2.len(), 1);
 
-    let agent_meta_info2 = meta_infos2.get("test:meta").unwrap();
+    let peer_meta_info2 = meta_infos2.get("test:meta").unwrap();
     assert_eq!(
-        agent_meta_info2.meta_value,
+        peer_meta_info2.meta_value,
         serde_json::Value::String("hello2".into())
     );
-    assert_eq!(agent_meta_info2.expires_at, htimestamp);
+    assert_eq!(peer_meta_info2.expires_at, htimestamp);
 
     // Try to get agent meta info for a non-existent space. Should
     // throw an error.
     let res = conductor
-        .agent_meta_info(url.clone(), Some(vec![fixt!(DnaHash)]))
+        .peer_meta_info(url.clone(), Some(vec![fixt!(DnaHash)]))
         .await;
 
     assert!(res.is_err());
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn app_agent_meta_info() {
+async fn app_peer_meta_info() {
     holochain_trace::test_run();
 
     let (dna1, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
@@ -190,7 +190,7 @@ async fn app_agent_meta_info() {
     // Get the agent meta info for all spaces of app1. Should only return
     // info for the space of app1
     let response = conductor
-        .app_agent_meta_info(&app_id1, url.clone(), None)
+        .app_peer_meta_info(&app_id1, url.clone(), None)
         .await
         .unwrap();
     assert_eq!(response.len(), 1);
@@ -200,10 +200,10 @@ async fn app_agent_meta_info() {
         .expect("No value found for dna");
     assert_eq!(meta_infos.len(), 1);
 
-    let agent_meta_info = meta_infos.get("test:meta").unwrap();
+    let peer_meta_info = meta_infos.get("test:meta").unwrap();
     assert_eq!(
-        agent_meta_info.meta_value,
+        peer_meta_info.meta_value,
         serde_json::Value::String("hello".into())
     );
-    assert_eq!(agent_meta_info.expires_at, htimestamp);
+    assert_eq!(peer_meta_info.expires_at, htimestamp);
 }

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -1,4 +1,4 @@
-use crate::peer_meta::AgentMetaInfo;
+use crate::peer_meta::PeerMetaInfo;
 use crate::{AppInfo, FullStateDump, StorageInfo};
 use holo_hash::*;
 use holochain_types::prelude::*;
@@ -328,8 +328,8 @@ pub enum AdminRequest {
     ///
     /// # Returns
     ///
-    /// [`AdminResponse::AgentMetaInfo`]
-    AgentMetaInfo {
+    /// [`AdminResponse::PeerMetaInfo`]
+    PeerMetaInfo {
         url: Url,
         dna_hashes: Option<Vec<DnaHash>>,
     },
@@ -573,10 +573,10 @@ pub enum AdminResponse {
     /// This is all the agent info that was found for the request.
     AgentInfo(Vec<String>),
 
-    /// The successful response to an [`AdminRequest::AgentMetaInfo`].
+    /// The successful response to an [`AdminRequest::PeerMetaInfo`].
     ///
     /// A JSON formatted string.
-    AgentMetaInfo(BTreeMap<DnaHash, BTreeMap<String, AgentMetaInfo>>),
+    PeerMetaInfo(BTreeMap<DnaHash, BTreeMap<String, PeerMetaInfo>>),
 
     /// The successful response to an [`AdminRequest::GraftRecords`].
     RecordsGrafted,

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -1,4 +1,4 @@
-use crate::peer_meta::AgentMetaInfo;
+use crate::peer_meta::PeerMetaInfo;
 use crate::{AppAuthenticationToken, ExternalApiWireError};
 use holo_hash::AgentPubKey;
 use holochain_keystore::LairResult;
@@ -46,8 +46,8 @@ pub enum AppRequest {
     ///
     /// # Returns
     ///
-    /// [`AppResponse::AgentMetaInfo`]
-    AgentMetaInfo {
+    /// [`AppResponse::PeerMetaInfo`]
+    PeerMetaInfo {
         url: Url,
         dna_hashes: Option<Vec<DnaHash>>,
     },
@@ -270,10 +270,10 @@ pub enum AppResponse {
     /// The successful response to an [`AppRequest::AgentInfo`].
     AgentInfo(Vec<String>),
 
-    /// The successful response to an [`AppRequest::AgentMetaInfo`].
+    /// The successful response to an [`AppRequest::PeerMetaInfo`].
     ///
     /// A JSON formatted string.
-    AgentMetaInfo(BTreeMap<DnaHash, BTreeMap<String, AgentMetaInfo>>),
+    PeerMetaInfo(BTreeMap<DnaHash, BTreeMap<String, PeerMetaInfo>>),
 
     /// The successful response to an [`AppRequest::CallZome`].
     ///

--- a/crates/holochain_conductor_api/src/peer_meta.rs
+++ b/crates/holochain_conductor_api/src/peer_meta.rs
@@ -1,10 +1,10 @@
 use holochain_types::prelude::Timestamp;
 use serde::{Deserialize, Serialize};
 
-/// Agent meta info as stored in the peer meta store for a given
+/// Peer meta info as stored in the peer meta store for a given
 /// (peer_url, meta_key) pair
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct AgentMetaInfo {
+pub struct PeerMetaInfo {
     pub meta_value: serde_json::Value,
     pub expires_at: Timestamp,
 }


### PR DESCRIPTION
### Summary
Renames `AgentMetaInfo` to `PeerMetaInfo` since the info returns meta data for potentially multiple agents at a given peer URL.


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed all references of "AgentMetaInfo" to "PeerMetaInfo" across APIs, CLI, and responses, including method names, enum variants, struct names, and command-line arguments.
  * Updated all user-facing commands and API calls to use "peer-meta-info" instead of "agent-meta-info".

* **Documentation**
  * Updated documentation and changelog to clarify that metadata pertains to peers rather than individual agents.

* **Tests**
  * Updated test names and logic to align with the new "PeerMetaInfo" terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->