### PR TITLE
fix: Inconsistent DHT locations reported to Kitsune2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b5d4e069cbc868041a64bd68dc8cb39a0d79585cd6c5a24caa8c2d622121be"
+checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1781,9 +1781,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
@@ -2962,7 +2962,7 @@ dependencies = [
  "holochain_timestamp",
  "holochain_util",
  "proptest",
- "proptest-derive 0.5.1",
+ "proptest-derive 0.6.0",
  "schemars 0.9.0",
  "serde",
  "serde_bytes",
@@ -3265,7 +3265,7 @@ dependencies = [
  "parking_lot",
  "pretty_assertions",
  "proptest",
- "proptest-derive 0.5.1",
+ "proptest-derive 0.6.0",
  "rand 0.9.2",
  "regex",
  "rusqlite",
@@ -3395,7 +3395,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "proptest",
- "proptest-derive 0.5.1",
+ "proptest-derive 0.6.0",
  "rand 0.9.2",
  "rusqlite",
  "schemars 0.9.0",
@@ -3511,7 +3511,7 @@ dependencies = [
  "os_info",
  "serde",
  "serde_derive",
- "toml 0.9.2",
+ "toml 0.9.3",
  "uuid 1.17.0",
 ]
 
@@ -3532,7 +3532,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3593,9 +3593,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3609,7 +3609,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -3961,9 +3961,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -4124,9 +4124,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982c5f6f12f2e8314837563fcf014fae5869619f924c75e6c23688c9f1725bcf"
+checksum = "933950efece8f58e8ddb7bb7bf07be738d5bc28080b43a1765aaa3b9e6076e84"
 dependencies = [
  "bytes",
  "kitsune2_api",
@@ -4138,9 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_api"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f80ba9d8963e6164f125e85be1218a98c6c29804133eda5e1936a7ca01c215c"
+checksum = "08d8fc31f930e7dce8dd882b905182a0b115049bbd5f40cdbf77dd5b9eb91a02"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4155,9 +4155,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_client"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622cb1adf60746dbd569850c8908d3e9d7b3107ce57b114ac4896b0adaa05f3c"
+checksum = "edad9f7dd1d17edb09926d428c552fc2f5cda9a17692d0e51270a07128a910a3"
 dependencies = [
  "base64 0.22.1",
  "kitsune2_api",
@@ -4170,9 +4170,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_srv"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ec825d5c902433d4c7670e8724b5cb7faa2e34ba0e5b23fc1d3c9864aa736b"
+checksum = "8a6c1e8259dce40115db343b20b3ae30339852f49e8504ee7806236526ac6d6b"
 dependencies = [
  "async-channel",
  "axum",
@@ -4196,9 +4196,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_core"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f039403ace5997b9df3a88f0f00c83c74c626e0a7fddd8a6de2d47d259c6f91"
+checksum = "07350c37a4cdd4bd11ff6168c6f7316d6f48706ba5619888a15a6d3a391681f4"
 dependencies = [
  "bytes",
  "ed25519-dalek",
@@ -4217,9 +4217,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_dht"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf4f48b61c2b29260c62093f69c26ce6e59a095ec765c761bea7eae699f59a9"
+checksum = "e70bae42b348fa7f805e992e66ab2a6841550f2d63e34f702984bb404a7fb44e"
 dependencies = [
  "bytes",
  "kitsune2_api",
@@ -4228,9 +4228,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_gossip"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dda3f457834a149b9e8dcf6adf4d71e0ed41b2ecf6d490da4aba8716cb68266"
+checksum = "72cf3754ef95b5c436a4dfe8dc7d59daa47a58b482ee7acfd303f785f3825c49"
 dependencies = [
  "bytes",
  "futures",
@@ -4249,9 +4249,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_test_utils"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a7e19e228c87b9ea4700508d12a395ee496d65146c86e03ef2b6d8ec32a6bf"
+checksum = "ea35752c1ec145e57cf014ef05455930922f56b06cdaab03aa810b653583096c"
 dependencies = [
  "axum",
  "bytes",
@@ -4265,9 +4265,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_tx5"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edacf93691903152c10489296853718149d2c7982708dba4d639b7a28640e472"
+checksum = "e67f3b2236ce8fc4e2640873eb77dc2e920473a92d22b09c85306e10998c7c92"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4383,14 +4383,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
 name = "libredox"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -4461,9 +4461,9 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litrs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lock_api"
@@ -4704,18 +4704,18 @@ dependencies = [
 
 [[package]]
 name = "munge"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cce144fab80fbb74ec5b89d1ca9d41ddf6b644ab7e986f7d3ed0aab31625cb1"
+checksum = "d7feb0b48aa0a25f9fe0899482c6e1379ee7a11b24a53073eacdecb9adb6dc60"
 dependencies = [
  "munge_macro",
 ]
 
 [[package]]
 name = "munge_macro"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "574af9cd5b9971cbfdf535d6a8d533778481b241c447826d976101e0149392a1"
+checksum = "f2e3795a5d2da581a8b252fec6022eee01aea10161a4d1bf237d4cbe47f7e988"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5285,9 +5285,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
  "syn 2.0.104",
@@ -5509,7 +5509,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.29",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -5546,7 +5546,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5900,9 +5900,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.14"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3a5d9f0aba1dbcec1cc47f0ff94a4b778fe55bca98a6dfa92e4e094e57b1c4"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -6252,9 +6252,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -6925,6 +6925,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "sodoken"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7414,9 +7424,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7427,9 +7437,9 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7529,9 +7539,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+checksum = "e06723639aaded957e5a80be250c1f82f274b9d23ebb4d94163668470623461c"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
@@ -7743,7 +7753,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 0.9.2",
+ "toml 0.9.3",
 ]
 
 [[package]]
@@ -8232,12 +8242,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.235.0"
+version = "0.236.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
+checksum = "3108979166ab0d3c7262d2e16a2190ffe784b2a5beb963edef154b5e8e07680b"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.235.0",
+ "wasmparser 0.236.0",
 ]
 
 [[package]]
@@ -8463,9 +8473,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.235.0"
+version = "0.236.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
+checksum = "16d1eee846a705f6f3cb9d7b9f79b54583810f1fb57a1e3aea76d1742db2e3d2"
 dependencies = [
  "bitflags 2.9.1",
  "indexmap 2.10.0",
@@ -8474,9 +8484,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "235.0.0"
+version = "236.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eda4293f626c99021bb3a6fbe4fbbe90c0e31a5ace89b5f620af8925de72e13"
+checksum = "11d6b6faeab519ba6fbf9b26add41617ca6f5553f99ebc33d876e591d2f4f3c6"
 dependencies = [
  "bumpalo",
  "leb128fmt",
@@ -8487,9 +8497,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.235.0"
+version = "1.236.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e777e0327115793cb96ab220b98f85327ec3d11f34ec9e8d723264522ef206aa"
+checksum = "cc31704322400f461f7f31a5f9190d5488aaeafb63ae69ad2b5888d2704dcb08"
 dependencies = [
  "wast",
 ]
@@ -8753,7 +8763,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -8804,10 +8814,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -26,7 +26,7 @@ holochain_nonce = { version = "^0.6.0-dev.2", path = "../holochain_nonce" }
 holochain_types = { version = "^0.6.0-dev.15", path = "../holochain_types" }
 holochain_websocket = { version = "^0.6.0-dev.15", path = "../holochain_websocket" }
 holochain_zome_types = { version = "^0.6.0-dev.11", path = "../holochain_zome_types" }
-kitsune2_api = "0.2.9"
+kitsune2_api = "0.2.12"
 lair_keystore_api = { version = "0.6.1", optional = true }
 parking_lot = "0.12.1"
 rand = { version = "0.8" }
@@ -42,8 +42,8 @@ holochain = { version = "^0.6.0-dev.15", path = "../holochain", default-features
 ] }
 holochain_wasm_test_utils = { version = "^0.6.0-dev.15", path = "../test_utils/wasm" }
 
-kitsune2_core = "0.2.9"
-kitsune2_test_utils = "0.2.9"
+kitsune2_core = "0.2.12"
+kitsune2_test_utils = "0.2.12"
 serde_yaml = "0.9"
 
 [features]

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -48,8 +48,8 @@ holochain_trace = { version = "^0.6.0-dev.1", path = "../holochain_trace" }
 holo_hash = { version = "^0.6.0-dev.8", path = "../holo_hash", features = [
   "kitsune2",
 ] }
-kitsune2_api = "0.2.9"
-kitsune2_core = "0.2.9"
+kitsune2_api = "0.2.12"
+kitsune2_core = "0.2.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
@@ -62,7 +62,7 @@ walkdir = "2"
 ed25519-dalek = "2.1"
 
 [dev-dependencies]
-kitsune2_test_utils = "0.2.9"
+kitsune2_test_utils = "0.2.12"
 fixt = { version = "^0.6.0-dev.2", path = "../fixt" }
 indexmap = { version = "2.6.0", features = ["serde"] }
 

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -30,7 +30,7 @@ fixt = { version = "^0.6.0-dev.2", path = "../fixt", optional = true }
 futures = { version = "0.3", optional = true }
 holochain_serialized_bytes = { version = "=0.0.56", optional = true }
 holochain_util = { version = "^0.6.0-dev.3", path = "../holochain_util", default-features = false }
-kitsune2_api = { version = "0.2.9", optional = true }
+kitsune2_api = { version = "0.2.12", optional = true }
 must_future = { version = "0.1", optional = true }
 proptest = { version = "1", optional = true }
 proptest-derive = { version = "0", optional = true }

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -189,7 +189,7 @@ impl crate::AgentPubKey {
 #[cfg(feature = "kitsune2")]
 impl crate::DhtOpHash {
     /// Convert this holo hash into a kitsune2 OpId.
-    #[deprecated(since = "0.5.5", note = "Use `to_located_k2_op` instead")]
+    #[deprecated(since = "0.5.5", note = "Use `to_located_k2_op_id` instead")]
     pub fn to_k2_op(&self) -> kitsune2_api::OpId {
         kitsune2_api::OpId::from(bytes::Bytes::copy_from_slice(self.get_raw_36()))
     }
@@ -198,13 +198,13 @@ impl crate::DhtOpHash {
     /// with appended location bytes.
     ///
     /// The location that is reported by a [`DhtOpHash`](crate::DhtOpHash) is the location of the
-    /// op itself but that is not the location of the op in the DHT. That is given by the
+    /// op itself but that is not the location of the op in the DHT. The latter is given by the
     /// [`OpBasis`](crate::OpBasis).
     ///
     /// The resulting [`OpId`](kitsune2_api::OpId) will have the first 32 bytes as the core hash of
     /// the op, and the last 4 bytes as the location bytes taken from the
     /// [`OpBasis`](crate::OpBasis).
-    pub fn to_located_k2_op(&self, op_basis: &crate::OpBasis) -> kitsune2_api::OpId {
+    pub fn to_located_k2_op_id(&self, op_basis: &crate::OpBasis) -> kitsune2_api::OpId {
         let mut inner = bytes::BytesMut::with_capacity(HOLO_HASH_UNTYPED_LEN);
         inner.extend_from_slice(self.get_raw_32());
         inner.extend_from_slice(&op_basis.get_raw_36()[HOLO_HASH_CORE_LEN..]);

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -189,14 +189,32 @@ impl crate::AgentPubKey {
 #[cfg(feature = "kitsune2")]
 impl crate::DhtOpHash {
     /// Convert this holo hash into a kitsune2 OpId.
+    #[deprecated(since = "0.5.5", note = "Use `to_located_k2_op` instead")]
     pub fn to_k2_op(&self) -> kitsune2_api::OpId {
-        kitsune2_api::OpId::from(bytes::Bytes::copy_from_slice(self.get_raw_32()))
+        kitsune2_api::OpId::from(bytes::Bytes::copy_from_slice(self.get_raw_36()))
+    }
+
+    /// Convert this [`DhtOpHash`](crate::DhtOpHash) into a kitsune2 [`OpId`](kitsune2_api::OpId),
+    /// with appended location bytes.
+    ///
+    /// The location that is reported by a [`DhtOpHash`](crate::DhtOpHash) is the location of the
+    /// op itself but that is not the location of the op in the DHT. That is given by the
+    /// [`OpBasis`](crate::OpBasis).
+    ///
+    /// The resulting [`OpId`](kitsune2_api::OpId) will have the first 32 bytes as the core hash of
+    /// the op, and the last 4 bytes as the location bytes taken from the
+    /// [`OpBasis`](crate::OpBasis).
+    pub fn to_located_k2_op(&self, op_basis: &crate::OpBasis) -> kitsune2_api::OpId {
+        let mut inner = bytes::BytesMut::with_capacity(HOLO_HASH_UNTYPED_LEN);
+        inner.extend_from_slice(self.get_raw_32());
+        inner.extend_from_slice(&op_basis.get_raw_36()[HOLO_HASH_CORE_LEN..]);
+        kitsune2_api::OpId::from(inner.freeze())
     }
 
     /// Convert a kitsune2 OpId into a DhtOpHash.
     #[cfg(feature = "hashing")]
     pub fn from_k2_op(op: &kitsune2_api::OpId) -> Self {
-        Self::from_raw_32(op.to_vec())
+        Self::from_raw_32(op[..HOLO_HASH_CORE_LEN].to_vec())
     }
 }
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fixes a bug where the wrong DhtOp location was reported to Kitsune2. This resulted in conductors not being able to sync
+  with each other. This change can upgrade existing conductors and new data should sync correctly. However, part of the
+  DHT model gets persisted and to fix bad data in the persisted model, the model has to be wiped and rebuilt. This will
+  result in a short startup delay when upgrading to this version. After the first startup, the startup time should be
+  back to normal.
+
 ## 0.6.0-dev.15
 
 - Replace `Conductor::remove_dangling_cells` method with methods that remove the cells specific to the app and delete their databases.

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- As part of the fix below, the Holo hash method `to_k2_op` on a DhtOpHash` has been deprecated and replaced with 
+  `to_located_k2_op_id`.
 - Fixes a bug where the wrong DhtOp location was reported to Kitsune2. This resulted in conductors not being able to sync
   with each other. This change can upgrade existing conductors and new data should sync correctly. However, part of the
   DHT model gets persisted and to fix bad data in the persisted model, the model has to be wiped and rebuilt. This will

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -50,8 +50,8 @@ holochain_conductor_config = { version = "^0.6.0-dev.15", path = "../holochain_c
 holochain_timestamp = { version = "^0.6.0-dev.2", path = "../timestamp" }
 human-panic = "2.0"
 itertools = { version = "0.14" }
-kitsune2_api = "0.2.9"
-kitsune2_core = "0.2.9"
+kitsune2_api = "0.2.12"
+kitsune2_core = "0.2.12"
 mockall = "0.13"
 mr_bundle = { version = "^0.6.0-dev.5", path = "../mr_bundle", features = [
   "fs",
@@ -104,7 +104,7 @@ matches = { version = "0.1.8", optional = true }
 holochain_wasm_test_utils = { version = "^0.6.0-dev.15", path = "../test_utils/wasm", optional = true }
 holochain_test_wasm_common = { version = "^0.6.0-dev.11", path = "../test_utils/wasm_common", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
-kitsune2_bootstrap_srv = { version = "0.2.9", optional = true }
+kitsune2_bootstrap_srv = { version = "0.2.12", optional = true }
 async-once-cell = { version = "0.5", optional = true }
 get_if_addrs = { version = "0.5.3", optional = true }
 schemars = "0.9"
@@ -145,7 +145,7 @@ tokio = { version = "1.36.0", features = ["full", "test-util"] }
 tokio-tungstenite = "0.27"
 predicates = "3.1"
 assert2 = "0.3.15"
-kitsune2_test_utils = "0.2.9"
+kitsune2_test_utils = "0.2.12"
 rand_dalek = { version = "0.8", package = "rand" }
 
 [build-dependencies]

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -53,10 +53,11 @@ pub async fn integrate_dht_ops_workflow(
 
 fn to_stored_op(row: &Row<'_>) -> rusqlite::Result<StoredOp> {
     let op_hash = row.get::<_, DhtOpHash>(0)?;
-    let created_at = row.get::<_, Timestamp>(1)?;
+    let op_basis = row.get::<_, OpBasis>(1)?;
+    let created_at = row.get::<_, Timestamp>(2)?;
     let op = StoredOp {
         created_at: kitsune2_api::Timestamp::from_micros(created_at.as_micros()),
-        op_id: op_hash.to_k2_op(),
+        op_id: op_hash.to_located_k2_op(&op_basis),
     };
     Ok(op)
 }

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -57,7 +57,7 @@ fn to_stored_op(row: &Row<'_>) -> rusqlite::Result<StoredOp> {
     let created_at = row.get::<_, Timestamp>(2)?;
     let op = StoredOp {
         created_at: kitsune2_api::Timestamp::from_micros(created_at.as_micros()),
-        op_id: op_hash.to_located_k2_op(&op_basis),
+        op_id: op_hash.to_located_k2_op_id(&op_basis),
     };
     Ok(op)
 }

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
@@ -917,7 +917,7 @@ async fn inform_kitsune_about_integrated_ops() {
             .return_once(move |space_id, ops| {
                 assert_eq!(space_id, dna_hash2.to_k2_space());
                 let expected_op = StoredOp {
-                    op_id: op.to_hash().to_located_k2_op(&op.dht_basis()),
+                    op_id: op.to_hash().to_located_k2_op_id(&op.dht_basis()),
                     created_at: kitsune2_api::Timestamp::from_micros(op.timestamp().as_micros()),
                 };
                 assert_eq!(ops, vec![expected_op]);

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
@@ -917,7 +917,7 @@ async fn inform_kitsune_about_integrated_ops() {
             .return_once(move |space_id, ops| {
                 assert_eq!(space_id, dna_hash2.to_k2_space());
                 let expected_op = StoredOp {
-                    op_id: op.to_hash().to_k2_op(),
+                    op_id: op.to_hash().to_located_k2_op(&op.dht_basis()),
                     created_at: kitsune2_api::Timestamp::from_micros(op.timestamp().as_micros()),
                 };
                 assert_eq!(ops, vec![expected_op]);

--- a/crates/holochain/src/test_utils/consistency.rs
+++ b/crates/holochain/src/test_utils/consistency.rs
@@ -19,6 +19,7 @@ where
         let sql_common = "
         SELECT
         DhtOp.hash as dht_op_hash,
+        DhtOp.basis_hash as dht_op_basis,
         DhtOp.storage_center_loc as loc,
         DhtOp.type as dht_type,
         Action.blob as action_blob,
@@ -49,10 +50,11 @@ where
                 },
                 |row| {
                     let h: DhtOpHash = row.get("dht_op_hash")?;
+                    let op_basis = row.get::<_, OpBasis>("dht_op_basis")?;
                     let loc: u32 = row.get("loc")?;
                     let op = holochain_state::query::map_sql_dht_op(false, "dht_type", row)?;
 
-                    Ok((loc, h.to_k2_op(), op))
+                    Ok((loc, h.to_located_k2_op(&op_basis), op))
                 },
             )?
             .collect::<StateQueryResult<_>>()?
@@ -64,9 +66,10 @@ where
                     },
                     |row| {
                         let h: DhtOpHash = row.get("dht_op_hash")?;
+                        let op_basis = row.get::<_, OpBasis>("dht_op_basis")?;
                         let loc: u32 = row.get("loc")?;
                         let op = holochain_state::query::map_sql_dht_op(false, "dht_type", row)?;
-                        StateQueryResult::Ok((loc, h.to_k2_op(), op))
+                        StateQueryResult::Ok((loc, h.to_located_k2_op(&op_basis), op))
                     },
                 )?
                 .collect::<StateQueryResult<_>>()?

--- a/crates/holochain/src/test_utils/consistency.rs
+++ b/crates/holochain/src/test_utils/consistency.rs
@@ -54,7 +54,7 @@ where
                     let loc: u32 = row.get("loc")?;
                     let op = holochain_state::query::map_sql_dht_op(false, "dht_type", row)?;
 
-                    Ok((loc, h.to_located_k2_op(&op_basis), op))
+                    Ok((loc, h.to_located_k2_op_id(&op_basis), op))
                 },
             )?
             .collect::<StateQueryResult<_>>()?
@@ -69,7 +69,7 @@ where
                         let op_basis = row.get::<_, OpBasis>("dht_op_basis")?;
                         let loc: u32 = row.get("loc")?;
                         let op = holochain_state::query::map_sql_dht_op(false, "dht_type", row)?;
-                        StateQueryResult::Ok((loc, h.to_located_k2_op(&op_basis), op))
+                        StateQueryResult::Ok((loc, h.to_located_k2_op_id(&op_basis), op))
                     },
                 )?
                 .collect::<StateQueryResult<_>>()?

--- a/crates/holochain/tests/tests/regression/dht_location.rs
+++ b/crates/holochain/tests/tests/regression/dht_location.rs
@@ -1,0 +1,109 @@
+use holo_hash::{ActionHash, DhtOpHash, DnaHash, OpBasis};
+use holochain::sweettest::{
+    await_consistency, SweetConductor, SweetConductorBatch, SweetDnaFile, SweetInlineZomes,
+};
+use holochain::test_utils::inline_zomes::simple_crud_zome;
+use holochain_state::prelude::StateQueryResult;
+use std::collections::HashSet;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct FoundLocationInfo {
+    dht_op_hash: DhtOpHash,
+    op_basis: OpBasis,
+    storage_center_loc: u32,
+    op_id: kitsune2_api::OpId,
+}
+
+/// Check that the location of the op_basis always matches the storage center location and that the
+/// location that will be reported to Kitsune2 is consistent with both.
+///
+/// Because we can't create data over time in a unit test (at least not without writing directly
+/// to the database and risking making mistakes there), this is about as close as we can get to
+/// checking that peers who author or sync data will always agree on the location of that data.
+///
+/// If the locations and ids are consistent, then we can rely on the tests in Kitsune2 for syncing
+/// the DHT model.
+#[tokio::test(flavor = "multi_thread")]
+async fn dht_location_consistency() {
+    holochain_trace::test_run();
+
+    // Set up two conductors with standard configuration
+    let mut conductors = SweetConductorBatch::from_standard_config(2).await;
+
+    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
+    let apps = conductors.setup_app("app", [&dna_file]).await.unwrap();
+    let ((alice,), (bob,)) = apps.into_tuples();
+
+    conductors.exchange_peer_info().await;
+
+    // Create some op data
+    let alice_zome = alice.zome(SweetInlineZomes::COORDINATOR);
+    conductors[0]
+        .call::<_, ActionHash>(&alice_zome, "create_string", "hi".to_string())
+        .await;
+    conductors[0]
+        .call::<_, ActionHash>(&alice_zome, "create_string", "hello".to_string())
+        .await;
+    conductors[0]
+        .call::<_, ActionHash>(&alice_zome, "create_string", "alright guv'nor".to_string())
+        .await;
+
+    await_consistency(30, &[alice.clone(), bob.clone()])
+        .await
+        .unwrap();
+
+    let alice_info = get_location_info_from(&conductors[0], alice.dna_hash().clone());
+    let bob_info = get_location_info_from(&conductors[1], bob.dna_hash().clone());
+
+    // Demonstrates that the hash/location calculations are consistent between authoring data
+    // locally and reconstructing it after syncing over the network.
+    assert_eq!(
+        alice_info, bob_info,
+        "DHT location info should match across conductors"
+    );
+
+    // Now we need to check that the locations are internally consistent with themselves.
+    for info in &alice_info {
+        assert_eq!(info.storage_center_loc, info.op_basis.get_loc());
+        assert_eq!(info.op_id.loc(), info.storage_center_loc);
+    }
+}
+
+fn get_location_info_from(
+    conductor: &SweetConductor,
+    dna_hash: DnaHash,
+) -> HashSet<FoundLocationInfo> {
+    let dht = conductor.get_dht_db(&dna_hash).unwrap();
+    dht.test_read(|txn| -> StateQueryResult<HashSet<FoundLocationInfo>> {
+        let mut stmt = txn.prepare(
+            r#"
+        SELECT
+          hash,
+          basis_hash,
+          storage_center_loc
+        FROM
+          DhtOp
+        "#,
+        )?;
+
+        let mut out = HashSet::new();
+        let mut rows = stmt.query([])?;
+        while let Some(row) = rows.next()? {
+            let dht_op_hash = row.get::<_, DhtOpHash>(0)?;
+            let op_basis = row.get::<_, OpBasis>(1)?;
+            let storage_center_loc = row.get::<_, u32>(2)?;
+
+            let op_id = dht_op_hash.to_located_k2_op(&op_basis);
+
+            out.insert(FoundLocationInfo {
+                dht_op_hash,
+                op_basis,
+                storage_center_loc,
+                op_id,
+            });
+        }
+
+        Ok(out)
+    })
+    .unwrap()
+}

--- a/crates/holochain/tests/tests/regression/dht_location.rs
+++ b/crates/holochain/tests/tests/regression/dht_location.rs
@@ -93,7 +93,7 @@ fn get_location_info_from(
             let op_basis = row.get::<_, OpBasis>(1)?;
             let storage_center_loc = row.get::<_, u32>(2)?;
 
-            let op_id = dht_op_hash.to_located_k2_op(&op_basis);
+            let op_id = dht_op_hash.to_located_k2_op_id(&op_basis);
 
             out.insert(FoundLocationInfo {
                 dht_op_hash,

--- a/crates/holochain/tests/tests/regression/mod.rs
+++ b/crates/holochain/tests/tests/regression/mod.rs
@@ -291,5 +291,6 @@ async fn zero_arc_can_delete_link() {
         .await;
 }
 
+mod dht_location;
 pub mod must_get_agent_activity_saturation;
 mod zome_call_atomic;

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -30,7 +30,7 @@ thiserror = "2.0"
 tracing = "0.1"
 opentelemetry_api = { version = "=0.20.0", features = ["metrics"] }
 
-kitsune2_api = "0.2.9"
+kitsune2_api = "0.2.12"
 
 async-trait = "0.1"
 mockall = { version = "0.13", optional = true }

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-kitsune2_transport_tx5 = { version = "0.2.9", optional = true }
+kitsune2_transport_tx5 = { version = "0.2.12", optional = true }
 derive_more = { version = "2.0", features = ["from"] }
 holo_hash = { version = "^0.6.0-dev.8", path = "../holo_hash", features = [
   "full",
@@ -22,9 +22,9 @@ holochain_zome_types = { version = "^0.6.0-dev.11", path = "../holochain_zome_ty
 holochain_util = { version = "^0.6.0-dev.3", default-features = false, path = "../holochain_util", features = [
   "jsonschema",
 ] }
-kitsune2_api = "0.2.9"
-kitsune2_core = { version = "0.2.9" }
-kitsune2_gossip = { version = "0.2.9", optional = true }
+kitsune2_api = "0.2.12"
+kitsune2_core = { version = "0.2.12" }
+kitsune2_gossip = { version = "0.2.12", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -38,10 +38,10 @@ tokio = { version = "1.27", features = ["full"] }
 tracing = "0.1"
 opentelemetry_api = { version = "=0.20.0", features = ["metrics"] }
 
-kitsune2 = "0.2.9"
-kitsune2_api = "0.2.9"
-kitsune2_core = "0.2.9"
-kitsune2_gossip = "0.2.9"
+kitsune2 = "0.2.12"
+kitsune2_api = "0.2.12"
+kitsune2_core = "0.2.12"
+kitsune2_gossip = "0.2.12"
 bytes = "1.10"
 holochain_sqlite = { version = "^0.6.0-dev.14", path = "../holochain_sqlite" }
 lair_keystore_api = "=0.6.2"

--- a/crates/holochain_p2p/src/op_store.rs
+++ b/crates/holochain_p2p/src/op_store.rs
@@ -99,7 +99,7 @@ impl OpStore for HolochainOpStore {
                 let op = decode::<_, DhtOp>(&op_bytes)
                     .map_err(|e| K2Error::other_src("Could not decode op", e))?;
                 let op_hashed = DhtOpHashed::from_content_sync(op.clone());
-                ids.push(op_hashed.hash.to_located_k2_op(&op.dht_basis()));
+                ids.push(op_hashed.hash.to_located_k2_op_id(&op.dht_basis()));
                 dht_ops.push(op);
             }
 
@@ -149,7 +149,7 @@ impl OpStore for HolochainOpStore {
                         let op_basis: OpBasis = row.get(1)?;
                         let serialized_size: u32 = row.get(2)?;
 
-                        let op_id = hash.to_located_k2_op(&op_basis);
+                        let op_id = hash.to_located_k2_op_id(&op_basis);
                         out.push(op_id);
                         out_size += serialized_size;
                     }
@@ -191,7 +191,7 @@ impl OpStore for HolochainOpStore {
                         let dht_op = holochain_state::query::map_sql_dht_op(false, "type", row)?;
 
                         out.push(MetaOp {
-                            op_id: hash.to_located_k2_op(&op_basis),
+                            op_id: hash.to_located_k2_op_id(&op_basis),
                             op_data: holochain_serialized_bytes::prelude::encode(&dht_op)?.into(),
                         });
                     }
@@ -227,7 +227,7 @@ impl OpStore for HolochainOpStore {
                     while let Some(row) = rows.next()? {
                         let op_hash: DhtOpHash = row.get(0)?;
                         let op_basis: OpBasis = row.get(1)?;
-                        out.remove(&op_hash.to_located_k2_op(&op_basis));
+                        out.remove(&op_hash.to_located_k2_op_id(&op_basis));
                     }
 
                     Ok(out.into_iter().collect())
@@ -291,7 +291,7 @@ impl OpStore for HolochainOpStore {
                                     break 'outer;
                                 }
 
-                                let op_id = hash.to_located_k2_op(&op_basis);
+                                let op_id = hash.to_located_k2_op_id(&op_basis);
                                 if out.insert(op_id) {
                                     latest_timestamp = timestamp;
                                     used_bytes += serialized_size;

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -1468,7 +1468,7 @@ impl actor::HcP2p for HolochainP2pActor {
 
             let op_hash_list: Vec<OpId> = op_hash_list
                 .into_iter()
-                .map(|h| h.to_located_k2_op(&basis_hash))
+                .map(|h| h.to_located_k2_op_id(&basis_hash))
                 .collect();
 
             let urls: std::collections::HashSet<Url> = get_responsive_remote_agents_near_location(
@@ -2187,7 +2187,7 @@ mod tests {
 
         let h_op = DhtOpHash::from_raw_32(vec![0xdd; 32]);
         let op_basis = OpBasis::from_raw_32_and_type(vec![0xde; 32], hash_type::AnyLinkable::Entry);
-        let k_op = h_op.to_located_k2_op(&op_basis);
+        let k_op = h_op.to_located_k2_op_id(&op_basis);
 
         assert_eq!(op_basis.get_loc(), k_op.loc());
     }
@@ -2209,7 +2209,7 @@ mod tests {
         assert_eq!(h_agent.to_string(), k_agent.to_string());
 
         let h_op = DhtOpHash::from_raw_32(vec![0xdd; 32]);
-        let k_op = h_op.to_located_k2_op(&OpBasis::from_raw_32_and_type(
+        let k_op = h_op.to_located_k2_op_id(&OpBasis::from_raw_32_and_type(
             vec![0xde; 32],
             hash_type::AnyLinkable::Entry,
         ));

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -779,6 +779,14 @@ impl HolochainP2pActor {
         K2_CONFIG.call_once(|| {
             // Set up some kitsune2 specializations specific to holochain.
 
+            kitsune2_api::OpId::set_loc_callback(|bytes| {
+                u32::from_le_bytes(
+                    bytes[HOLO_HASH_CORE_LEN..HOLO_HASH_UNTYPED_LEN]
+                        .try_into()
+                        .unwrap(),
+                )
+            });
+
             // Kitsune2 by default just xors subsequent bytes of the hash
             // itself and treats that result as a LE u32.
             // Holochain, instead, first does a blake2b hash, and
@@ -805,7 +813,7 @@ impl HolochainP2pActor {
                 write!(f, "{}", AgentPubKey::from_raw_32(bytes.to_vec()))
             });
             kitsune2_api::OpId::set_global_display_callback(|bytes, f| {
-                write!(f, "{}", DhtOpHash::from_raw_32(bytes.to_vec()))
+                write!(f, "{}", DhtOpHash::from_raw_32(bytes[0..32].to_vec()))
             });
         });
 
@@ -1458,7 +1466,10 @@ impl actor::HcP2p for HolochainP2pActor {
 
             // -- actually publish the op hashes -- //
 
-            let op_hash_list: Vec<OpId> = op_hash_list.into_iter().map(|h| h.to_k2_op()).collect();
+            let op_hash_list: Vec<OpId> = op_hash_list
+                .into_iter()
+                .map(|h| h.to_located_k2_op(&basis_hash))
+                .collect();
 
             let urls: std::collections::HashSet<Url> = get_responsive_remote_agents_near_location(
                 space.peer_store().clone(),
@@ -2175,9 +2186,10 @@ mod tests {
         assert_eq!(h_agent.get_loc(), k_agent.loc());
 
         let h_op = DhtOpHash::from_raw_32(vec![0xdd; 32]);
-        let k_op = h_op.to_k2_op();
+        let op_basis = OpBasis::from_raw_32_and_type(vec![0xde; 32], hash_type::AnyLinkable::Entry);
+        let k_op = h_op.to_located_k2_op(&op_basis);
 
-        assert_eq!(h_op.get_loc(), k_op.loc());
+        assert_eq!(op_basis.get_loc(), k_op.loc());
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -2197,7 +2209,10 @@ mod tests {
         assert_eq!(h_agent.to_string(), k_agent.to_string());
 
         let h_op = DhtOpHash::from_raw_32(vec![0xdd; 32]);
-        let k_op = h_op.to_k2_op();
+        let k_op = h_op.to_located_k2_op(&OpBasis::from_raw_32_and_type(
+            vec![0xde; 32],
+            hash_type::AnyLinkable::Entry,
+        ));
 
         assert_eq!(h_op.to_string(), k_op.to_string());
     }

--- a/crates/holochain_p2p/tests/tests/op_store.rs
+++ b/crates/holochain_p2p/tests/tests/op_store.rs
@@ -182,7 +182,10 @@ async fn process_incoming_ops_and_retrieve() {
         .await
         .unwrap();
 
-    let to_retrieve = vec![dht_op_1.as_hash().to_k2_op(), dht_op_2.as_hash().to_k2_op()];
+    let to_retrieve = vec![
+        dht_op_1.as_hash().to_located_k2_op(&dht_op_1.dht_basis()),
+        dht_op_2.as_hash().to_located_k2_op(&dht_op_2.dht_basis()),
+    ];
 
     // Ops are not integrated, we shouldn't be able to retrieve them
     let retrieved = op_store.retrieve_ops(to_retrieve.clone()).await.unwrap();
@@ -211,13 +214,19 @@ async fn filter_out_existing_ops() {
         .await
         .unwrap();
 
-    let to_check = vec![dht_op_1.as_hash().to_k2_op(), dht_op_2.as_hash().to_k2_op()];
+    let to_check = vec![
+        dht_op_1.as_hash().to_located_k2_op(&dht_op_1.dht_basis()),
+        dht_op_2.as_hash().to_located_k2_op(&dht_op_2.dht_basis()),
+    ];
     let all_exist_filtered = op_store.filter_out_existing_ops(to_check).await.unwrap();
 
     assert!(all_exist_filtered.is_empty());
 
     let non_existent_op_id = OpId::from(Bytes::from_static(&[5; 32]));
-    let to_check = vec![dht_op_1.as_hash().to_k2_op(), non_existent_op_id.clone()];
+    let to_check = vec![
+        dht_op_1.as_hash().to_located_k2_op(&dht_op_1.dht_basis()),
+        non_existent_op_id.clone(),
+    ];
     let some_exists_filtered = op_store.filter_out_existing_ops(to_check).await.unwrap();
 
     assert_eq!(1, some_exists_filtered.len());

--- a/crates/holochain_p2p/tests/tests/op_store.rs
+++ b/crates/holochain_p2p/tests/tests/op_store.rs
@@ -183,8 +183,12 @@ async fn process_incoming_ops_and_retrieve() {
         .unwrap();
 
     let to_retrieve = vec![
-        dht_op_1.as_hash().to_located_k2_op(&dht_op_1.dht_basis()),
-        dht_op_2.as_hash().to_located_k2_op(&dht_op_2.dht_basis()),
+        dht_op_1
+            .as_hash()
+            .to_located_k2_op_id(&dht_op_1.dht_basis()),
+        dht_op_2
+            .as_hash()
+            .to_located_k2_op_id(&dht_op_2.dht_basis()),
     ];
 
     // Ops are not integrated, we shouldn't be able to retrieve them
@@ -215,8 +219,12 @@ async fn filter_out_existing_ops() {
         .unwrap();
 
     let to_check = vec![
-        dht_op_1.as_hash().to_located_k2_op(&dht_op_1.dht_basis()),
-        dht_op_2.as_hash().to_located_k2_op(&dht_op_2.dht_basis()),
+        dht_op_1
+            .as_hash()
+            .to_located_k2_op_id(&dht_op_1.dht_basis()),
+        dht_op_2
+            .as_hash()
+            .to_located_k2_op_id(&dht_op_2.dht_basis()),
     ];
     let all_exist_filtered = op_store.filter_out_existing_ops(to_check).await.unwrap();
 
@@ -224,7 +232,9 @@ async fn filter_out_existing_ops() {
 
     let non_existent_op_id = OpId::from(Bytes::from_static(&[5; 32]));
     let to_check = vec![
-        dht_op_1.as_hash().to_located_k2_op(&dht_op_1.dht_basis()),
+        dht_op_1
+            .as_hash()
+            .to_located_k2_op_id(&dht_op_1.dht_basis()),
         non_existent_op_id.clone(),
     ];
     let some_exists_filtered = op_store.filter_out_existing_ops(to_check).await.unwrap();

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -56,7 +56,7 @@ getrandom = "0.3"
 opentelemetry_api = { version = "=0.20.0", features = ["metrics"] }
 schemars = "0.9"
 
-kitsune2_api = "0.2.9"
+kitsune2_api = "0.2.12"
 
 rusqlite = { version = "0.36", features = [
   "blob",      # better integration with blob types (Read, Write, etc)

--- a/crates/holochain_sqlite/src/schema.rs
+++ b/crates/holochain_sqlite/src/schema.rs
@@ -42,6 +42,9 @@ pub static SCHEMA_CELL: Lazy<Schema> = Lazy::new(|| Schema {
         M {
             forward: include_str!("sql/cell/schema/7-up.sql").into(),
         },
+        M {
+            forward: include_str!("sql/cell/schema/8-up.sql").into(),
+        },
     ],
 });
 

--- a/crates/holochain_sqlite/src/sql/cell/schema/8-up.sql
+++ b/crates/holochain_sqlite/src/sql/cell/schema/8-up.sql
@@ -1,0 +1,5 @@
+-- All the content in this table will be rebuilt by Kitsune2 if it is missing.
+-- Because we are fixing a logic issue with how ops are located in the DHT, clearing this table is the simplest way to
+-- ensure that when nodes upgrade, they will rebuild the SliceHash table with the correct data.
+DELETE FROM
+  SliceHash;

--- a/crates/holochain_sqlite/src/sql/cell/set_validated_ops_to_integrated.sql
+++ b/crates/holochain_sqlite/src/sql/cell/set_validated_ops_to_integrated.sql
@@ -8,4 +8,5 @@ WHERE
   AND validation_status IS NOT NULL
 RETURNING
   hash,
+  basis_hash,
   authored_timestamp

--- a/crates/holochain_sqlite/src/sql/dht/check_op_ids_present.sql
+++ b/crates/holochain_sqlite/src/sql/dht/check_op_ids_present.sql
@@ -1,5 +1,6 @@
 SELECT
-  DhtOp.hash
+  DhtOp.hash,
+  DhtOp.basis_hash
 FROM
   DhtOp
 WHERE

--- a/crates/holochain_sqlite/src/sql/dht/op_hashes_in_time_slice.sql
+++ b/crates/holochain_sqlite/src/sql/dht/op_hashes_in_time_slice.sql
@@ -1,5 +1,6 @@
 SELECT
   hash,
+  basis_hash,
   serialized_size
 FROM
   DhtOp

--- a/crates/holochain_sqlite/src/sql/dht/op_hashes_since_time_batch.sql
+++ b/crates/holochain_sqlite/src/sql/dht/op_hashes_since_time_batch.sql
@@ -1,5 +1,6 @@
 SELECT
   hash,
+  basis_hash,
   when_integrated,
   serialized_size
 FROM

--- a/crates/holochain_sqlite/src/sql/dht/ops_by_id.sql
+++ b/crates/holochain_sqlite/src/sql/dht/ops_by_id.sql
@@ -1,5 +1,6 @@
 SELECT
   DhtOp.hash,
+  DhtOp.basis_hash,
   DhtOp.type,
   Action.blob AS action_blob,
   Action.author AS author,

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -41,7 +41,7 @@ tracing = "0.1.26"
 cron = "0.15"
 async-recursion = "1.1"
 
-kitsune2_api = "0.2.9"
+kitsune2_api = "0.2.12"
 
 tempfile = { version = "3.3", optional = true }
 base64 = { version = "0.22", optional = true }

--- a/crates/holochain_terminal/Cargo.toml
+++ b/crates/holochain_terminal/Cargo.toml
@@ -31,9 +31,9 @@ holochain_util = { version = "^0.6.0-dev.3", path = "../holochain_util" }
 holochain_conductor_api = { version = "^0.6.0-dev.15", path = "../holochain_conductor_api" }
 holochain_types = { version = "^0.6.0-dev.15", path = "../holochain_types" }
 tokio = { version = "1.36.0", features = ["full"] }
-kitsune2_api = "0.2.9"
-kitsune2_core = "0.2.9"
-kitsune2_bootstrap_client = "0.2.9"
+kitsune2_api = "0.2.12"
+kitsune2_core = "0.2.12"
+kitsune2_bootstrap_client = "0.2.12"
 
 [lints]
 workspace = true

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -33,7 +33,7 @@ holochain_zome_types = { path = "../holochain_zome_types", version = "^0.6.0-dev
   "full",
 ] }
 holochain_timestamp = { version = "^0.6.0-dev.2", path = "../timestamp" }
-kitsune2_api = "0.2.9"
+kitsune2_api = "0.2.12"
 itertools = { version = "0.14" }
 mr_bundle = { path = "../mr_bundle", features = [
   "fs",

--- a/crates/holochain_types/src/dht_op.rs
+++ b/crates/holochain_types/src/dht_op.rs
@@ -382,7 +382,7 @@ impl DhtOp {
         }
     }
 
-    /// Convert a [DhtOp] to a [DhtOpLite] and basis
+    /// Convert a [DhtOp] to a [DhtOpLite].
     pub fn to_lite(&self) -> DhtOpLite {
         match self {
             Self::ChainOp(op) => DhtOpLite::Chain(op.to_lite().into()),
@@ -468,7 +468,7 @@ impl ChainOp {
         }
     }
 
-    /// Convert a [ChainOp] to a [ChainOpLite] and basis
+    /// Convert a [ChainOp] to a [ChainOpLite].
     pub fn to_lite(&self) -> ChainOpLite {
         let basis = self.dht_basis();
         match self {


### PR DESCRIPTION
### Summary

Closes #5163

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and accuracy of DHT operation location data across peers, ensuring correct syncing and operation identification.
  * Fixed logic for rebuilding DHT operation location tables during upgrades to prevent inconsistencies.
  * Deprecated the previous method for converting operation hashes to IDs, replacing it with a new method that includes location context.

* **New Features**
  * Added a new regression test to verify DHT location consistency between nodes.

* **Documentation**
  * Clarified documentation for methods converting operations to their "lite" versions.
  * Added deprecation notice for the old operation ID conversion method.

* **Chores**
  * Updated multiple dependencies to newer versions for improved compatibility and stability.
  * Added database migration to clear and rebuild operation location data for upgrade correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->