### PR TITLE
fix!: convert expires_at field in PeerMetaInfo to Option<Timestamp>

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fixes the type of the `expires_at` field in `PeerMetaInfo` returned by the admin API from `Timestamp` to `Option<Timestamp>` ([#5183](https://github.com/holochain/holochain/pull/5183)).
 - **BREAKING CHANGE**: The admin call `RegisterDna` has been removed ([#5175](https://github.com/holochain/holochain/pull/5175))
 - As part of the fix below, the Holo hash method `to_k2_op` on a DhtOpHash` has been deprecated and replaced with 
   `to_located_k2_op_id`.

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -882,11 +882,11 @@ mod network_impls {
                                                 e.into(),
                                             )
                                         })?;
-                                let expires_at = row.get::<_, i64>(2)?;
+                                let expires_at = row.get::<_, Option<i64>>(2)?;
 
                                 let peer_meta_info = PeerMetaInfo {
                                     meta_value,
-                                    expires_at: Timestamp(expires_at),
+                                    expires_at: expires_at.map(Timestamp),
                                 };
 
                                 infos.insert(meta_key, peer_meta_info);

--- a/crates/holochain/src/conductor/tests/peer_meta_info.rs
+++ b/crates/holochain/src/conductor/tests/peer_meta_info.rs
@@ -94,14 +94,14 @@ async fn peer_meta_info() {
 
     let peer_meta_info11 = meta_infos1.get("root:unresponsive").unwrap();
     assert_eq!(peer_meta_info11.meta_value, ktimestamp.as_micros());
-    assert_eq!(peer_meta_info11.expires_at, htimestamp);
+    assert_eq!(peer_meta_info11.expires_at, Some(htimestamp));
 
     let peer_meta_info12 = meta_infos1.get("test:meta").unwrap();
     assert_eq!(
         peer_meta_info12.meta_value,
         serde_json::Value::String("hello".into())
     );
-    assert_eq!(peer_meta_info12.expires_at, htimestamp);
+    assert_eq!(peer_meta_info12.expires_at, Some(htimestamp));
 
     let meta_infos2 = response
         .get(dna2.dna_hash())
@@ -114,7 +114,7 @@ async fn peer_meta_info() {
         peer_meta_info2.meta_value,
         serde_json::Value::String("hello2".into())
     );
-    assert_eq!(peer_meta_info2.expires_at, htimestamp);
+    assert_eq!(peer_meta_info2.expires_at, Some(htimestamp));
 
     // Get the agent meta info for a selected space only
     let response2 = conductor
@@ -135,7 +135,7 @@ async fn peer_meta_info() {
         peer_meta_info2.meta_value,
         serde_json::Value::String("hello2".into())
     );
-    assert_eq!(peer_meta_info2.expires_at, htimestamp);
+    assert_eq!(peer_meta_info2.expires_at, Some(htimestamp));
 
     // Try to get agent meta info for a non-existent space. Should
     // throw an error.
@@ -205,5 +205,5 @@ async fn app_peer_meta_info() {
         peer_meta_info.meta_value,
         serde_json::Value::String("hello".into())
     );
-    assert_eq!(peer_meta_info.expires_at, htimestamp);
+    assert_eq!(peer_meta_info.expires_at, Some(htimestamp));
 }

--- a/crates/holochain_conductor_api/src/peer_meta.rs
+++ b/crates/holochain_conductor_api/src/peer_meta.rs
@@ -6,5 +6,5 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct PeerMetaInfo {
     pub meta_value: serde_json::Value,
-    pub expires_at: Timestamp,
+    pub expires_at: Option<Timestamp>,
 }


### PR DESCRIPTION
### Summary

The `expires_at` field in the peer meta store is optional ([kitsune](https://github.com/holochain/kitsune2/blob/5510376618428ea7f73bf58e5194a43bbd994021/crates/api/src/peer_meta_store.rs#L22), [holochain](https://github.com/holochain/holochain/blob/1c2f8f682304c725569a2fa0dd1cf6c49829c027/crates/holochain_sqlite/src/sql/peer_meta_store/schema/0.sql#L5)) and it should be exposed correspondingly in the `PeerMetaInfo` returned via the admin API.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the `expires_at` field in peer metadata returned by the admin API to support optional expiration timestamps.

* **Documentation**
  * Updated changelog to document the fix for the `expires_at` field handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->