### PR TITLE
feat: hc sandbox create/generate displays created sandbox index and path

### DIFF
--- a/crates/hc_sandbox/src/cli.rs
+++ b/crates/hc_sandbox/src/cli.rs
@@ -269,10 +269,12 @@ impl HcSandbox {
                 chc_url,
             }) => {
                 let mut paths = Vec::with_capacity(num_sandboxes.into());
-                msg!(
-                    "Creating {} conductor sandboxes with same settings",
-                    num_sandboxes
-                );
+
+                match num_sandboxes.into() {
+                    1 => msg!("Creating 1 conductor sandbox"),
+                    _ => msg!("Creating {} conductor sandboxes with same settings", num_sandboxes)
+                }
+
                 for i in 0..num_sandboxes.into() {
                     let network = Network::to_kitsune(&NetworkCmd::as_inner(&network)).await;
                     let path = holochain_conductor_config::generate::generate(
@@ -371,6 +373,7 @@ pub async fn generate(
     structured: Output,
 ) -> anyhow::Result<Vec<ConfigRootPath>> {
     let happ = crate::bundles::parse_happ(happ)?;
+
     match create.num_sandboxes.into() {
         1 => msg!("Creating 1 conductor sandbox"),
         _ => msg!("Creating {} conductor sandboxes with same settings", create.num_sandboxes)

--- a/crates/hc_sandbox/src/cli.rs
+++ b/crates/hc_sandbox/src/cli.rs
@@ -286,8 +286,18 @@ impl HcSandbox {
                     )?;
                     paths.push(path);
                 }
+                let pre_existing = crate::save::load(std::env::current_dir()?)?;
                 crate::save::save(std::env::current_dir()?, paths.clone())?;
-                msg!("Created {:?}", paths);
+                match paths.len() {
+                    0 => msg!("No sandboxes have been created"),
+                    1 => msg!("1 sandbox has been created:\n  - {}:{}", pre_existing.len(), paths[0].display()),
+                    _ => {
+                        msg!("{} sandboxes have been created:", paths.len());
+                        for (i, path) in paths.into_iter().enumerate() {
+                            msg!("  - {}:{}", pre_existing.len() + i, path.display());
+                        }
+                    },
+                }
             }
         }
 

--- a/crates/hc_sandbox/src/cli.rs
+++ b/crates/hc_sandbox/src/cli.rs
@@ -268,12 +268,12 @@ impl HcSandbox {
                 #[cfg(feature = "chc")]
                 chc_url,
             }) => {
-                let mut paths = Vec::with_capacity(num_sandboxes);
+                let mut paths = Vec::with_capacity(num_sandboxes.into());
                 msg!(
                     "Creating {} conductor sandboxes with same settings",
                     num_sandboxes
                 );
-                for i in 0..num_sandboxes {
+                for i in 0..num_sandboxes.into() {
                     let network = Network::to_kitsune(&NetworkCmd::as_inner(&network)).await;
                     let path = holochain_conductor_config::generate::generate(
                         network,
@@ -286,18 +286,7 @@ impl HcSandbox {
                     )?;
                     paths.push(path);
                 }
-                let pre_existing = crate::save::load(std::env::current_dir()?)?;
-                crate::save::save(std::env::current_dir()?, paths.clone())?;
-                match paths.len() {
-                    0 => msg!("No sandboxes have been created"),
-                    1 => msg!("1 sandbox has been created:\n  - {}:{}", pre_existing.len(), paths[0].display()),
-                    _ => {
-                        msg!("{} sandboxes have been created:", paths.len());
-                        for (i, path) in paths.into_iter().enumerate() {
-                            msg!("  - {}:{}", pre_existing.len() + i, path.display());
-                        }
-                    },
-                }
+                save_and_print(std::env::current_dir()?, paths)?;
             }
         }
 
@@ -382,6 +371,11 @@ pub async fn generate(
     structured: Output,
 ) -> anyhow::Result<Vec<ConfigRootPath>> {
     let happ = crate::bundles::parse_happ(happ)?;
+    match create.num_sandboxes.into() {
+        1 => msg!("Creating 1 conductor sandbox"),
+        _ => msg!("Creating {} conductor sandboxes with same settings", create.num_sandboxes)
+    }
+
     let paths = crate::sandbox::default_n(
         holochain_path,
         create,
@@ -392,6 +386,25 @@ pub async fn generate(
         structured,
     )
     .await?;
-    crate::save::save(std::env::current_dir()?, paths.clone())?;
+    save_and_print(std::env::current_dir()?, paths.clone())?;
     Ok(paths)
+}
+
+fn save_and_print(hc_dir: PathBuf, paths: Vec<ConfigRootPath>) -> std::io::Result<()> {
+    let pre_existing = crate::save::load(hc_dir.clone())?;
+    crate::save::save(hc_dir, paths.clone())?;
+    match paths.len() {
+        1 => msg!(
+            "Created 1 sandbox:\n{}:{}",
+            pre_existing.len(),
+            paths[0].display()
+        ),
+        _ => {
+            msg!("Created {} sandboxes:", paths.len());
+            for (i, path) in paths.into_iter().enumerate() {
+                msg!("{}:{}", pre_existing.len() + i, path.display());
+            }
+        }
+    }
+    Ok(())
 }

--- a/crates/hc_sandbox/src/cmds.rs
+++ b/crates/hc_sandbox/src/cmds.rs
@@ -1,4 +1,5 @@
 use holochain_conductor_api::conductor::NetworkConfig;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 use clap::Parser;
@@ -13,7 +14,7 @@ use url2::Url2;
 pub struct Create {
     /// Number of conductor sandboxes to create.
     #[arg(short, long, default_value = "1")]
-    pub num_sandboxes: usize,
+    pub num_sandboxes: NonZeroUsize,
 
     /// Add an optional network config.
     #[command(subcommand)]
@@ -251,7 +252,7 @@ impl Network {
 impl Default for Create {
     fn default() -> Self {
         Self {
-            num_sandboxes: 1,
+            num_sandboxes: NonZeroUsize::new(1).unwrap(),
             network: None,
             root: None,
             directories: Vec::with_capacity(0),

--- a/crates/hc_sandbox/src/sandbox.rs
+++ b/crates/hc_sandbox/src/sandbox.rs
@@ -68,11 +68,7 @@ pub async fn default_n(
     roles_settings: Option<PathBuf>,
     structured: Output,
 ) -> anyhow::Result<Vec<ConfigRootPath>> {
-    let num_sandboxes = create.num_sandboxes;
-    msg!(
-        "Creating {} conductor sandboxes with same settings",
-        num_sandboxes
-    );
+    let num_sandboxes = create.num_sandboxes.into();
     let mut paths = Vec::with_capacity(num_sandboxes);
     for i in 0..num_sandboxes {
         let p = default_with_network(
@@ -88,6 +84,5 @@ pub async fn default_n(
         .await?;
         paths.push(p);
     }
-    msg!("Created {:?}", paths);
     Ok(paths)
 }


### PR DESCRIPTION
### Summary

Changed `num_sandboxes` option to `NonZeroUsize` since we don't want to create 0 sandbox.
Prints out the index and path of all created sandboxes at the end of the `Create` and `Generate` commands. 


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs