### PR TITLE
chore(nextest): Increased slow timeout abort period

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,7 +15,7 @@ status-level = "skip"
 # Treat a test that takes longer than this period as slow, and print a message.
 # Given a non-zero positive integer, shutdown the tests when the number periods
 # have passed.
-slow-timeout = { period = "30s", terminate-after = 4 }
+slow-timeout = { period = "30s", terminate-after = 10 }
 
 # * "immediate-final": output failures as soon as they happen and at the end of
 #   the test run


### PR DESCRIPTION
# Summary

Some tests using wamr are taking a long time to complete. When they are killed, they print linking errors, but it's actually just a matter of timeout.

closes #5117

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs
