### PR TITLE
fix: unschedule scheduled persisted fns

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix: Unschedule scheduled persisted functions on error or `None` schedule.
 - Add tests for the `schedule` host fn
 - Fix: `hc-sandbox run` dedupes indices before proceeding.
 - Update Kitsune2 to 0.2.15 and tx5 to 0.7.1 to get various bugfixes.

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- Fix: Unschedule scheduled persisted functions on error or `None` schedule.
+- Fix: Unschedule already scheduled persisted functions on error or when the schedule is set to `None`.
 - Add tests for the `schedule` host fn
 - Fix: `hc-sandbox run` dedupes indices before proceeding.
 - Update Kitsune2 to 0.2.15 and tx5 to 0.7.1 to get various bugfixes.

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -256,7 +256,8 @@ impl Cell {
             }
             Ok(live_fns) => {
                 let mut tasks = vec![];
-                for (scheduled_fn, schedule) in &live_fns {
+                let mut dispatched: Vec<(ScheduledFn, bool)> = Vec::with_capacity(live_fns.len());
+                for (scheduled_fn, schedule, ephemeral) in &live_fns {
                     // Failing to encode a schedule should never happen.
                     // If it does log the error and bail.
                     let payload = match ExternIO::encode(schedule) {
@@ -292,30 +293,37 @@ impl Cell {
                     };
 
                     tasks.push(self.call_zome(zome_call_params, None));
+                    // keep track of fns that actually dispatched.
+                    dispatched.push((scheduled_fn.clone(), *ephemeral));
                 }
                 let results: Vec<CellResult<ZomeCallResult>> =
                     futures::future::join_all(tasks).await;
 
                 let author = self.id.agent_pubkey().clone();
-                // We don't do anything with errors in here.
+                // In case of an error, a persisted fn needs to be unscheduled.
+                // If unscheduling fails, don't do anything.
                 let _ = authored_db
                     .write_async(move |txn| {
-                        for ((scheduled_fn, _), result) in live_fns.iter().zip(results.iter()) {
+                        for ((scheduled_fn, ephemeral), result) in dispatched.into_iter().zip(results.iter()) {
                             match result {
                                 Ok(Ok(ZomeCallResponse::Ok(extern_io))) => {
                                     let next_schedule: Schedule = match extern_io.decode() {
                                         Ok(Some(v)) => v,
                                         Ok(None) => {
+                                            // If the schedule of a persisted fn is `None` then it should be unscheduled.
+                                            if !ephemeral {
+                                                let _ = unschedule_fn(txn, &author, &scheduled_fn);
+                                            }
                                             continue;
                                         }
                                         Err(e) => {
                                             error!("scheduled zome call error in ExternIO::decode: {:?}", e);
+                                            if !ephemeral {
+                                                let _ = unschedule_fn(txn, &author, &scheduled_fn);
+                                            }
                                             continue;
                                         }
                                     };
-                                    // Ignore errors so that failing to schedule
-                                    // one function doesn't error others.
-                                    // For example if a zome returns a bad cron.
                                     if let Err(e) = schedule_fn(
                                         txn,
                                         &author,
@@ -324,10 +332,18 @@ impl Cell {
                                         now,
                                     ) {
                                         error!("scheduled zome call error in schedule_fn: {:?}", e);
+                                        if !ephemeral {
+                                            let _ = unschedule_fn(txn, &author, &scheduled_fn);
+                                        }
                                         continue;
                                     }
                                 }
-                                errorish => error!("scheduled zome call error: {:?}", errorish),
+                                errorish => {
+                                    error!("scheduled zome call error: {:?}", errorish);
+                                    if !ephemeral {
+                                        let _ = unschedule_fn(txn, &author, &scheduled_fn);
+                                    }
+                                },
                             }
                         }
                         Result::<(), DatabaseError>::Ok(())

--- a/crates/holochain/src/core/ribosome/host_fn/schedule.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/schedule.rs
@@ -175,14 +175,19 @@ mod tests {
                 assert_eq!(
                     vec![(
                         persisted_scheduled_fn.clone(),
-                        Some(persisted_schedule.clone())
+                        Some(persisted_schedule.clone()),
+                        false,
                     )],
                     live_scheduled_fns(txn, the_future, &alice_pubkey,).unwrap(),
                 );
                 assert_eq!(
                     vec![
-                        (persisted_scheduled_fn, Some(persisted_schedule)),
-                        (ephemeral_scheduled_fn, Some(ephemeral_future_schedule)),
+                        (persisted_scheduled_fn, Some(persisted_schedule), false),
+                        (
+                            ephemeral_scheduled_fn,
+                            Some(ephemeral_future_schedule),
+                            true
+                        ),
                     ],
                     live_scheduled_fns(txn, the_distant_future, &alice_pubkey,).unwrap(),
                 );

--- a/crates/holochain/tests/tests/schedule.rs
+++ b/crates/holochain/tests/tests/schedule.rs
@@ -113,7 +113,6 @@ async fn schedule_ephemeral_error() {
 /// before unscheduling.
 /// Assuming a scheduler interval of 100ms
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Test not passing ; awaiting bug fix"]
 async fn schedule_persisted_fn_then_unschedule() {
     holochain_trace::test_run();
 
@@ -169,7 +168,6 @@ async fn schedule_persisted_fn_then_unschedule() {
 /// Test persisted schedule with invalid crontab output which should unschedule the function.
 /// Assuming a scheduler interval of 100ms
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Test not passing ; awaiting bug fix"]
 async fn schedule_persisted_fn_with_bad_crontab() {
     holochain_trace::test_run();
 
@@ -208,7 +206,6 @@ async fn schedule_persisted_fn_with_bad_crontab() {
 /// Test schedule persisted function which gives an error, which should unschedule the function.
 /// Assuming a scheduler interval of 100ms
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Test not passing ; awaiting bug fix"]
 async fn schedule_persisted_fn_that_errors() {
     holochain_trace::test_run();
 

--- a/crates/holochain_state/src/schedule.rs
+++ b/crates/holochain_state/src/schedule.rs
@@ -30,7 +30,12 @@ pub fn fn_is_scheduled(
         .is_some())
 }
 
-/// A scheduled function is "live" if it is in the database with now between its start and end times.
+/// Get a list of "live" scheduled functions.
+///
+/// A scheduled function is "live" if it is in the database with `now` between its start and end times.
+///
+/// Returns the list of scheduled functions with their next schedule and a bool indicating
+/// if the schedule is ephemeral or not.
 pub fn live_scheduled_fns(
     txn: &Transaction,
     now: Timestamp,

--- a/crates/holochain_state/src/schedule.rs
+++ b/crates/holochain_state/src/schedule.rs
@@ -30,17 +30,19 @@ pub fn fn_is_scheduled(
         .is_some())
 }
 
+/// A scheduled function is "live" if it is in the database with now between its start and end times.
 pub fn live_scheduled_fns(
     txn: &Transaction,
     now: Timestamp,
     author: &AgentPubKey,
-) -> StateMutationResult<Vec<(ScheduledFn, Option<Schedule>)>> {
+) -> StateMutationResult<Vec<(ScheduledFn, Option<Schedule>, bool)>> {
     let mut stmt = txn.prepare(
         "
         SELECT
         zome_name,
         scheduled_fn,
-        maybe_schedule
+        maybe_schedule,
+        ephemeral
         FROM ScheduledFunctions
         WHERE
         start <= :now
@@ -60,13 +62,18 @@ pub fn live_scheduled_fns(
                     FunctionName(row.get(1)?),
                 ),
                 row.get(2)?,
+                row.get(3)?,
             ))
         },
     )?;
     let mut ret = vec![];
     for row in rows {
-        let (scheduled_fn, maybe_schedule_serialized) = row?;
-        ret.push((scheduled_fn, from_blob(maybe_schedule_serialized)?));
+        let (scheduled_fn, maybe_schedule_serialized, ephemeral) = row?;
+        ret.push((
+            scheduled_fn,
+            from_blob(maybe_schedule_serialized)?,
+            ephemeral,
+        ));
     }
     Ok(ret)
 }


### PR DESCRIPTION
https://github.com/holochain/holochain/issues/5140

Correctly unschedule a persisted fn when schedule is None or some error happened.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Persisted scheduled functions are now automatically unscheduled on errors or when their schedule becomes invalid, reducing repeated failures and improving reliability.
  * Clearer handling between ephemeral and persisted schedules prevents unintended removals.

* **Tests**
  * Previously-skipped schedule tests are enabled to validate scheduling behavior.

* **Documentation**
  * Changelog updated to reflect the unscheduling fix.

* **API**
  * Schedule listings now surface an explicit ephemeral vs persisted marker for each entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->