### PR TITLE
refactor!: deprecate UseExisting in app manifest

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -6,6 +6,7 @@ default_semver_increment_mode: !pre_minor dev
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- **BREAKING CHANGE**: Deprecate `AppManifest::UseExisting`. For late binding, update the coordinators of a DNA. For calling cells of other apps, bridge calls can be used.
 
 ## 0.6.0-dev.18
 

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -3317,6 +3317,7 @@ fn get_modifiers_map_from_role_settings(roles_settings: &Option<RoleSettingsMap>
         Some(role_settings_map) => role_settings_map
             .iter()
             .filter_map(|(role_name, role_settings)| match role_settings {
+                #[allow(deprecated)]
                 RoleSettings::UseExisting { .. } => None,
                 RoleSettings::Provisioned { modifiers, .. } => {
                     modifiers.as_ref().map(|m| (role_name.clone(), m.clone()))
@@ -3333,6 +3334,7 @@ fn get_memproof_map_from_role_settings(role_settings: &Option<RoleSettingsMap>) 
         Some(role_settings_map) => role_settings_map
             .iter()
             .filter_map(|(role_name, role_settings)| match role_settings {
+                #[allow(deprecated)]
                 RoleSettings::UseExisting { .. } => None,
                 RoleSettings::Provisioned { membrane_proof, .. } => membrane_proof
                     .as_ref()
@@ -3351,6 +3353,7 @@ fn get_existing_cells_map_from_role_settings(
         Some(role_settings_map) => role_settings_map
             .iter()
             .filter_map(|(role_name, role_settings)| match role_settings {
+                #[allow(deprecated)]
                 RoleSettings::UseExisting { cell_id } => Some((role_name.clone(), cell_id.clone())),
                 _ => None,
             })

--- a/crates/holochain/src/conductor/tests/install_app_bundle.rs
+++ b/crates/holochain/src/conductor/tests/install_app_bundle.rs
@@ -397,6 +397,7 @@ async fn use_existing_integration() {
                         installed_hash,
                         clone_limit: 0,
                     },
+                    #[allow(deprecated)]
                     provisioning: Some(CellProvisioning::UseExisting { protected: true }),
                 },
             ];

--- a/crates/holochain_types/src/app/app_bundle.rs
+++ b/crates/holochain_types/src/app/app_bundle.rs
@@ -122,6 +122,7 @@ impl AppBundle {
                 Ok(CellProvisioningOp::CreateFromDnaFile(dna, clone_limit))
             }
 
+            #[allow(deprecated)]
             AppRoleManifestValidated::UseExisting {
                 compatible_hash,
                 protected,

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_v0.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_v0.rs
@@ -10,6 +10,9 @@
 //! - Using existing Cells is not implemented
 //! - Specifying DNA version is not implemented (DNA migration needs to land first)
 
+// Temporarily allowing deprecation because of [`CellProvisioning::UseExisting`].
+#![allow(deprecated)]
+
 use super::{
     app_manifest_validated::{AppManifestValidated, AppRoleManifestValidated},
     error::{AppManifestError, AppManifestResult},
@@ -140,6 +143,10 @@ pub enum CellProvisioning {
     /// Always create a new Cell when installing this App
     Create { deferred: bool },
 
+    #[deprecated(
+        since = "0.6.0-dev.17",
+        note = "for late binding, bundle your own coordinators and for calling cells of other apps, use bridge calls"
+    )]
     /// Require that a Cell is already installed which has a DNA that's compatible with the
     /// `installed_hash` specified in the manifest.
     ///
@@ -243,6 +250,7 @@ impl AppManifestV0 {
                             modifiers,
                             installed_hash,
                         },
+                        #[allow(deprecated)]
                         CellProvisioning::UseExisting { protected } => {
                             AppRoleManifestValidated::UseExisting {
                                 protected,

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_validated.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_validated.rs
@@ -5,6 +5,9 @@
 //! may contain various invalid combinations of data. In contrast, these types
 //! are structured to ensure validity, and are used internally by Holochain.
 
+// Temporarily allowing deprecation because of [`AppRoleManifestValidated::UseExisting`].
+#![allow(deprecated)]
+
 use super::error::{AppManifestError, AppManifestResult};
 use crate::prelude::*;
 use holo_hash::DnaHashB64;
@@ -54,6 +57,10 @@ pub enum AppRoleManifestValidated {
         modifiers: DnaModifiersOpt,
         installed_hash: Option<DnaHashB64>,
     },
+    #[deprecated(
+        since = "0.6.0-dev.17",
+        note = "for late binding, bundle your own coordinators and for calling cells of other apps, use bridge calls"
+    )]
     /// Require that a Cell is already installed which has a DNA that's compatible with the
     /// `compatible_hash` specified in the manifest.
     UseExisting {


### PR DESCRIPTION
### Summary

Second part of deprecating `UseExisting`.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs