### PR TITLE
Handle non existing representative agent when issuing a warrant

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Changed `schedule` host fn unit tests to integration tests. 
 - **BREAKING CHANGE**: Deprecate `AppManifest::UseExisting`. For late binding, update the coordinators of a DNA. For calling cells of other apps, bridge calls can be used.
 - Fix: Unschedule already scheduled persisted functions on error or when the schedule is set to `None`.
+- Refactor: When representative agent is missing, skip app validation workflow instead of panicking.
 
 ## 0.6.0-dev.18
 

--- a/crates/holochain/src/core/queue_consumer/sys_validation_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/sys_validation_consumer.rs
@@ -46,7 +46,7 @@ pub fn spawn_sys_validation_consumer(
                     representative_agent,
                 ))
             } else {
-                tracing::warn!("No agent found for DNA, skipping sys validation");
+                tracing::warn!("No representative agent found for DNA, skipping sys validation.");
                 Either::Right(async move { Ok(WorkComplete::Complete) })
             }
         },

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -151,6 +151,7 @@ async fn main_workflow() {
         app_validation_workspace.clone(),
         conductor.raw_handle(),
         network,
+        fixt!(AgentPubKey),
     )
     .await
     .unwrap();
@@ -192,6 +193,7 @@ async fn main_workflow() {
             dna_hash.clone(),
             None,
         )),
+        fixt!(AgentPubKey),
     )
     .await
     .unwrap();
@@ -341,6 +343,7 @@ async fn validate_ops_in_sequence_must_get_agent_activity() {
             dna_hash.clone(),
             None,
         )),
+        fixt!(AgentPubKey),
     )
     .await
     .unwrap();
@@ -478,6 +481,7 @@ async fn validate_ops_in_sequence_must_get_action() {
             dna_hash.clone(),
             None,
         )),
+        fixt!(AgentPubKey),
     )
     .await
     .unwrap();
@@ -636,6 +640,7 @@ async fn handle_error_in_op_validation() {
             dna_hash.clone(),
             None,
         )),
+        fixt!(AgentPubKey),
     )
     .await
     .unwrap();
@@ -1018,6 +1023,7 @@ async fn app_validation_workflow_correctly_sets_state_and_status() {
             dna_hash.clone(),
             None,
         )),
+        fixt!(AgentPubKey),
     )
     .await
     .unwrap();

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -1227,17 +1227,6 @@ fn put_integration_limbo(
     Ok(())
 }
 
-pub async fn make_warrant_op(
-    conductor: &Conductor,
-    dna_hash: &DnaHash,
-    op: &ChainOp,
-    validation_type: ValidationType,
-) -> WorkflowResult<DhtOpHashed> {
-    let keystore = conductor.keystore();
-    let warrant_author = get_representative_agent(conductor, dna_hash).expect("TODO: handle");
-    make_invalid_chain_warrant_op_inner(keystore, warrant_author, op, validation_type).await
-}
-
 /// Gets an arbitrary agent with a cell running the given DNA, needed for processes
 /// which require an agent signature but happen at the DNA level, i.e. not bound to any
 /// particular cell.
@@ -1249,7 +1238,7 @@ pub fn get_representative_agent(conductor: &Conductor, dna_hash: &DnaHash) -> Op
         .map(|id| id.agent_pubkey().clone())
 }
 
-pub async fn make_invalid_chain_warrant_op_inner(
+pub async fn make_invalid_chain_warrant_op(
     keystore: &MetaLairClient,
     warrant_author: AgentPubKey,
     op: &ChainOp,

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -359,17 +359,16 @@ async fn sys_validation_workflow_inner(
     #[cfg(feature = "unstable-warrants")]
     {
         let mut warrants = vec![];
-        for (_, op) in _invalid_ops {
-            if let Some(chain_op) = op.as_chain_op() {
-                let warrant_op = crate::core::workflow::sys_validation_workflow::make_invalid_chain_warrant_op_inner(
-                &_keystore,
-                _representative_agent.clone(),
-                chain_op,
-                ValidationType::Sys,
-            )
-            .await?;
-                warrants.push(warrant_op);
-            }
+        for chain_op in _invalid_ops.iter().filter_map(|op| op.1.as_chain_op()) {
+            let warrant_op =
+                crate::core::workflow::sys_validation_workflow::make_invalid_chain_warrant_op(
+                    &_keystore,
+                    _representative_agent.clone(),
+                    chain_op,
+                    ValidationType::Sys,
+                )
+                .await?;
+            warrants.push(warrant_op);
         }
 
         for (author, pair) in _forked_pairs {


### PR DESCRIPTION
### Summary

by logging an error at `error` level, because in theory it's impossible for that to happen. Some cell runs the sys and app workflow, so not finding any agent for the current DNA must be impossible.

Writing a test seemed overkill in the end, because I'd need to create a conductor with a cell to run the workflows and create a warrant, but the workflow must not find a cell to use as representative agent. In fact the test tooling doesn't even exist to achieve that. Since I just replaced an `expect` with a `match`, visual inspection should be enough.

resolves #5191 

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents crashes by safely skipping app validation when no representative agent is available.
  * Improves reliability of warrant creation during rejected validations, ensuring proper authorship and persistence.

* **Refactor**
  * Streamlines validation and warrant-generation flow for clearer, more maintainable behavior.

* **Tests**
  * Updates tests to cover the representative-agent path and adjusted validation workflow.

* **Documentation**
  * Adds an Unreleased changelog entry describing the updated behavior when a representative agent is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->