### PR TITLE
fix: Return signed warrants from `get_agent_activity` so that the warrants can be validated when received

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- **BREAKING CHANGE**: The agent activity response has been changed to return warrants as a `Vec<SignedWarrant>` instead of a `Vec<Warrant>`. This change ensures that warrant integrity can be checked and discovered warrants can be validated. Note that this also affects the HDK's `get_agent_activity` function which will now also return `SignedWarrant`s instead of `Warrant`s. #5237
 - **BREAKING CHANGE**: Move `ChainOpType` from `holochain_types` to `holochain_zome_types`. #5236
 - **BREAKING CHANGE**: Remove the `SysValDeps` typedef and use instead `Vec<ActionHash>` in the few places that was used. #5236
 - **BREAKING CHANGE**: Modify the fields of `ChainIntegrityWarrant::ChainIntegrityWarrant` to add a `ChainOpType` field which allows just one op type to be validated when checking the warrant. #5236

--- a/crates/holochain_cascade/src/authority.rs
+++ b/crates/holochain_cascade/src/authority.rs
@@ -72,8 +72,7 @@ pub async fn handle_get_agent_activity(
 
             if !warrants.is_empty() {
                 // TODO why did we retrieve warrants in the activity query if we're going to overwrite them here?
-                activity_response.warrants =
-                    warrants.into_iter().map(|w| w.into_warrant()).collect();
+                activity_response.warrants = warrants.into_iter().map(|w| (*w).clone()).collect();
             }
 
             Ok(activity_response)

--- a/crates/holochain_cascade/src/authority/get_agent_activity_query.rs
+++ b/crates/holochain_cascade/src/authority/get_agent_activity_query.rs
@@ -8,7 +8,7 @@ use holochain_types::prelude::{
 };
 use holochain_zome_types::prelude::{
     ChainFork, ChainHead, ChainQueryFilter, ChainStatus, HasValidationStatus, HighestObserved,
-    Judged, ValidationStatus, Warrant,
+    Judged, SignedWarrant, ValidationStatus,
 };
 
 pub mod hashes;
@@ -20,7 +20,7 @@ pub struct State<T> {
     pub(super) valid: Vec<T>,
     pub(super) rejected: Vec<T>,
     pub(super) pending: Vec<T>,
-    pub(super) warrants: Vec<Warrant>,
+    pub(super) warrants: Vec<SignedWarrant>,
     pub(super) status: Option<ChainStatus>,
 }
 
@@ -40,7 +40,7 @@ impl<T> Default for State<T> {
 pub enum Item<T> {
     Integrated(T),
     Pending(T),
-    Warrant(Warrant),
+    Warrant(SignedWarrant),
 }
 
 fn fold<T: ActionHashedContainer>(
@@ -90,7 +90,7 @@ fn fold<T: ActionHashedContainer>(
 
 /// Find the highest observed sequence number from multiple action lists.
 ///
-/// THe function searches the valid, rejected, and pending action lists for the highest sequence
+/// The function searches the valid, rejected, and pending action lists for the highest sequence
 /// number. If there are multiple actions with the same sequence number, all of their hashes are
 /// returned.
 fn compute_highest_observed<T: ActionSequenceAndHash>(state: &State<T>) -> Option<HighestObserved> {

--- a/crates/holochain_cascade/src/authority/get_agent_activity_query/hashes.rs
+++ b/crates/holochain_cascade/src/authority/get_agent_activity_query/hashes.rs
@@ -111,7 +111,7 @@ impl Query for GetAgentActivityHashesQuery {
                 DhtOpType::Warrant(_) => {
                     let _hash: WarrantHash = row.get("hash")?;
                     from_blob::<SignedWarrant>(row.get("action_blob")?).map(|warrant| {
-                        let item = Item::Warrant(warrant.into_data());
+                        let item = Item::Warrant(warrant);
                         Judged::raw(item, None)
                     })
                 }

--- a/crates/holochain_cascade/src/authority/get_agent_activity_query/records.rs
+++ b/crates/holochain_cascade/src/authority/get_agent_activity_query/records.rs
@@ -124,7 +124,7 @@ impl Query for GetAgentActivityRecordsQuery {
                 DhtOpType::Warrant(_) => {
                     let _hash: WarrantHash = row.get("hash")?;
                     from_blob::<SignedWarrant>(row.get("action_blob")?).map(|warrant| {
-                        let item = Item::Warrant(warrant.into_data());
+                        let item = Item::Warrant(warrant);
                         Judged::raw(item, None)
                     })
                 }

--- a/crates/holochain_cascade/src/authority/test.rs
+++ b/crates/holochain_cascade/src/authority/test.rs
@@ -200,16 +200,14 @@ async fn get_agent_activity() {
         fixt!(AgentPubKey),
         td.agent.clone(),
     );
-    {
-        let warrant_op_valid =
-            WarrantOp::from(SignedWarrant::new(warrant_valid.clone(), fixt!(Signature)))
-                .into_hashed();
 
-        let warrant_op_invalid = WarrantOp::from(SignedWarrant::new(
-            warrant_invalid.clone(),
-            fixt!(Signature),
-        ))
-        .into_hashed();
+    let signed_warrant_valid = SignedWarrant::new(warrant_valid.clone(), fixt!(Signature));
+    let signed_warrant_invalid = SignedWarrant::new(warrant_invalid.clone(), fixt!(Signature));
+
+    {
+        let warrant_op_valid = WarrantOp::from(signed_warrant_valid.clone()).into_hashed();
+
+        let warrant_op_invalid = WarrantOp::from(signed_warrant_invalid).into_hashed();
 
         db.write_async(move |txn| {
             {
@@ -251,7 +249,7 @@ async fn get_agent_activity() {
         agent: td.agent.clone(),
         valid_activity: td.valid_hashes.clone(),
         rejected_activity: ChainItems::NotRequested,
-        warrants: vec![warrant_valid],
+        warrants: vec![signed_warrant_valid],
         status: ChainStatus::Valid(td.chain_head.clone()),
         highest_observed: Some(td.highest_observed.clone()),
     };

--- a/crates/holochain_cascade/tests/tests/get_activity.rs
+++ b/crates/holochain_cascade/tests/tests/get_activity.rs
@@ -452,7 +452,7 @@ async fn get_activity_with_warrants() {
         .await
         .unwrap();
 
-    expected.warrants = vec![warrant.into_warrant()];
+    expected.warrants = vec![(*warrant).clone()];
 
     assert_eq!(r2, expected);
 }

--- a/crates/holochain_types/src/activity.rs
+++ b/crates/holochain_types/src/activity.rs
@@ -21,7 +21,7 @@ pub struct AgentActivityResponse {
     /// been observed by this authority.
     pub highest_observed: Option<HighestObserved>,
     /// Any warrants at the basis of this agent.
-    pub warrants: Vec<Warrant>,
+    pub warrants: Vec<SignedWarrant>,
 }
 
 impl AgentActivityResponse {

--- a/crates/holochain_types/src/warrant.rs
+++ b/crates/holochain_types/src/warrant.rs
@@ -42,11 +42,6 @@ impl WarrantOp {
     pub fn warrant(&self) -> &Warrant {
         self
     }
-
-    /// Accessor for the warrant
-    pub fn into_warrant(self) -> Warrant {
-        self.0.into_data()
-    }
 }
 
 /// Different types of warrants

--- a/crates/holochain_zome_types/src/query.rs
+++ b/crates/holochain_zome_types/src/query.rs
@@ -1,7 +1,6 @@
 //! Types for source chain queries
 
 use crate::prelude::*;
-use crate::warrant::Warrant;
 use holo_hash::EntryHash;
 use holo_hash::HasHash;
 use holo_hash::{ActionHash, AgentPubKey, AnyLinkableHash};
@@ -106,8 +105,8 @@ pub struct LinkQuery {
     pub author: Option<AgentPubKey>,
 }
 
+/// An agent's chain records, returned from an agent activity query.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, SerializedBytes)]
-/// An agents chain records returned from a agent_activity_query
 pub struct AgentActivity {
     /// Valid actions on this chain. `(sequence, action_hash)`.
     pub valid_activity: Vec<(u32, ActionHash)>,
@@ -120,7 +119,7 @@ pub struct AgentActivity {
     pub highest_observed: Option<HighestObserved>,
     /// Warrants about this AgentActivity.
     /// Placeholder for future.
-    pub warrants: Vec<Warrant>,
+    pub warrants: Vec<SignedWarrant>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize, SerializedBytes)]

--- a/docs/specs/src/hwp_A_implementation_spec.md
+++ b/docs/specs/src/hwp_A_implementation_spec.md
@@ -884,7 +884,7 @@ It is the application's responsibility to retrieve a stored capability claim usi
         rejected_activity: Vec<(u32, ActionHash)>,
         status: ChainStatus,
         highest_observed: Option<(u32, ActionHash)>,
-        warrants: Vec<Warrant>,
+        warrants: Vec<SignedWarrant>,
     }
 
     enum ChainStatus {


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Agent activity responses and related APIs now return SignedWarrant values instead of Warrant; integrations may need updates.
- Tests
  - Tests updated to use SignedWarrant fixtures and reflect the new warrant type.
- Documentation
  - Specs and changelog updated to document that agent activity responses carry SignedWarrant values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->