### PR TITLE
fix: return error from must_get_valid_record when record is invalid

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **BREAKING CHANGE**: Deprecate `AppManifest::UseExisting`. For late binding, update the coordinators of a DNA. For calling cells of other apps, bridge calls can be used.
 - Fix: Unschedule already scheduled persisted functions on error or when the schedule is set to `None`.
 - Refactor: When representative agent is missing, skip app validation workflow instead of panicking.
+- Fix: Return an error with an `Invalid` result from `must_get_valid_record` when a record that is invalid is found. Previously the error returned indicated `UnresolvedDependencies`.
 
 ## 0.6.0-dev.18
 

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_valid_record.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_valid_record.rs
@@ -60,6 +60,22 @@ pub fn must_get_valid_record(
                     .map_err(|cascade_error| -> RuntimeError {
                         wasm_error!(WasmErrorInner::Host(cascade_error.to_string())).into()
                     })? {
+                    // Only short-circuit as Invalid when running inside the Validate host context.
+                    Some(RecordDetails {
+                        validation_status: ValidationStatus::Rejected,
+                        ..
+                    }) if matches!((call_context).host_context, HostContext::Validate(_)) => {
+                        Err(wasm_error!(WasmErrorInner::HostShortCircuit(
+                            holochain_serialized_bytes::encode(
+                                &ExternIO::encode(ValidateCallbackResult::Invalid(
+                                    "Found a record, but it is invalid".to_string()
+                                ))
+                                .map_err(|e| -> RuntimeError { wasm_error!(e).into() })?,
+                            )
+                            .map_err(|e| -> RuntimeError { wasm_error!(e).into() })?
+                        ))
+                        .into())
+                    }
                     Some(RecordDetails {
                         record,
                         validation_status: ValidationStatus::Valid,
@@ -116,4 +132,109 @@ pub fn must_get_valid_record(
     };
     tracing::debug!(?ret);
     ret
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        core::ribosome::{guest_callback::validate::ValidateHostAccess, InvocationAuth},
+        test_utils::RibosomeTestFixture,
+    };
+    use ::fixt::prelude::*;
+    use holochain_state::{
+        host_fn_workspace::HostFnWorkspaceRead,
+        prelude::{insert_op_cache, set_validation_status, set_when_integrated},
+    };
+    use holochain_timestamp::Timestamp;
+    use holochain_types::dht_op::{ChainOp, DhtOp, DhtOpHashed};
+    use holochain_wasm_test_utils::TestWasm;
+    use holochain_zome_types::validate::ValidationStatus;
+
+    // This test ensures the ValidationStatus::Rejected arm is hit and returns a
+    // HostShortCircuit carrying ValidateCallbackResult::Invalid with the expected message.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn must_get_valid_record_short_circuit_when_invalid_record_found() {
+        holochain_trace::test_run();
+
+        let RibosomeTestFixture {
+            alice_host_fn_caller,
+            alice_cell,
+            ..
+        } = RibosomeTestFixture::new(TestWasm::Validate).await;
+
+        // Populate the cache with a StoreRecord op for a Create action and mark it Rejected.
+        let mut create = fixt!(Create);
+        // Set author to the cell's agent to keep data coherent.
+        create.author = alice_cell.agent_pubkey().clone();
+        let create_action = Action::Create(create.clone());
+        let create_action_op =
+            DhtOpHashed::from_content_sync(DhtOp::ChainOp(Box::new(ChainOp::StoreRecord(
+                fixt!(Signature),
+                create_action.clone(),
+                RecordEntry::Present(fixt!(Entry)),
+            ))));
+
+        // Insert the StoreRecord op into the cache and mark it Rejected.
+        alice_host_fn_caller.cache.test_write(move |txn| {
+            insert_op_cache(txn, &create_action_op).unwrap();
+            set_validation_status(txn, &create_action_op.hash, ValidationStatus::Rejected).unwrap();
+            set_when_integrated(txn, &create_action_op.hash, Timestamp::now()).unwrap();
+        });
+
+        // Call must_get_valid_record directly through the host function using the `Validate` host context.
+        let cell_id = alice_host_fn_caller.zome_path.cell_id().clone();
+        let zome_name = alice_host_fn_caller.zome_path.zome_name().clone();
+        let workspace = HostFnWorkspaceRead::new(
+            alice_host_fn_caller.authored_db.clone().into(),
+            alice_host_fn_caller.dht_db.clone().into(),
+            alice_host_fn_caller.cache.clone(),
+            alice_host_fn_caller.keystore.clone(),
+            Some(cell_id.agent_pubkey().clone()),
+        )
+        .await
+        .unwrap();
+        let call_context = Arc::new(CallContext::new(
+            alice_host_fn_caller
+                .ribosome
+                .dna_def_hashed()
+                .get_zome(&zome_name)
+                .unwrap(),
+            "".into(),
+            HostContext::Validate(ValidateHostAccess::new(
+                workspace,
+                Arc::new(alice_host_fn_caller.network.clone()),
+                false,
+            )),
+            InvocationAuth::Cap(cell_id.agent_pubkey().clone(), None),
+        ));
+        let err = must_get_valid_record(
+            Arc::new(alice_host_fn_caller.ribosome.clone()),
+            call_context,
+            MustGetValidRecordInput::new(create_action.to_hash()),
+        )
+        .unwrap_err();
+
+        // Extract the HostShortCircuit payload and assert encoded Invalid message is exact.
+        let wasm_error: WasmError = err.downcast().unwrap();
+        if let WasmError {
+            error: WasmErrorInner::HostShortCircuit(bytes),
+            ..
+        } = wasm_error
+        {
+            let extern_io: ExternIO =
+                decode(&bytes).expect("decode HostShortCircuit into ExternIO");
+            let vcr: ValidateCallbackResult = extern_io
+                .decode()
+                .expect("ExternIO -> ValidateCallbackResult");
+            match vcr {
+                ValidateCallbackResult::Invalid(msg) => {
+                    assert_eq!(msg, "Found a record, but it is invalid".to_string());
+                }
+                other => panic!("Expected ValidateCallbackResult::Invalid, got {:?}", other),
+            }
+        } else {
+            panic!("Expected WasmErrorInner::HostShortCircuit");
+        }
+    }
 }


### PR DESCRIPTION
### Summary

resolves #4669 

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid records now return a clear "Invalid" validation error instead of a misleading unresolved-dependencies error, improving observed validation behavior.

* **Tests**
  * Added tests confirming validation callbacks reject when depending on invalid records; note: duplicated test instances included.

* **Documentation**
  * Changelog updated to reflect the revised error handling and validation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->