### PR TITLE
fix: Remove `same_dht` field from `SysValDeps`

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Internal refactor to remove the `same_dht` field of `SysValDeps`. This field was redundant because the `SysValDeps` are always for the same DHT as the cell they are part of. #5243
 - **BREAKING CHANGE**: The agent activity response has been changed to return warrants as a `Vec<SignedWarrant>` instead of a `Vec<Warrant>`. This change ensures that warrant integrity can be checked and discovered warrants can be validated. Note that this also affects the HDK's `get_agent_activity` function which will now also return `SignedWarrant`s instead of `Warrant`s. #5237
 - **BREAKING CHANGE**: Move `ChainOpType` from `holochain_types` to `holochain_zome_types`. #5236
 - **BREAKING CHANGE**: Remove the `SysValDeps` typedef and use instead `Vec<ActionHash>` in the few places that was used. #5236

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
@@ -249,8 +249,8 @@ async fn validate_create_op_with_prev_from_network() {
     // Simulate the dep being found on the network
     test_case
         .current_validation_dependencies
-        .same_dht
         .lock()
+        .expect("poisoned")
         .insert(previous_action, CascadeSource::Network);
 
     // Run again to process new ops from the network


### PR DESCRIPTION
### Summary

The field is speculative in case we add the ability to fetch ops from other DHTs when validating but there is no plan to implement that and the type is internal. For now, it's just more effort to read than simply getting the current validation dependencies which can only come from the current DHT anyway.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined system validation dependency handling for improved consistency and resilience during validation workflows. No user-visible behavior changes expected.

* **Tests**
  * Updated validation tests to align with the new dependency handling approach.

* **Documentation**
  * Added an “Unreleased” changelog entry summarizing internal validation dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->