### PR TITLE
Validate warrants

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Validate warrants in the sys validation workflow. #5249
 - Upgrade `syn` to `2.0` and `darling` to `0.21.3`. #4446
 - Mark `schedule` host fn as stable in code. #5240
 - Upgrade `strum` and `strum_macros` to `0.27.x`. #4447

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
@@ -251,7 +251,7 @@ async fn validate_create_op_with_prev_from_network() {
         .current_validation_dependencies
         .lock()
         .expect("poisoned")
-        .insert(previous_action, CascadeSource::Network);
+        .insert_action(previous_action, CascadeSource::Network);
 
     // Run again to process new ops from the network
     let outcome = test_case.run().await.unwrap();

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validation_deps.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validation_deps.rs
@@ -58,6 +58,7 @@ impl ValidationDependencies {
     }
 
     /// Check whether a given dependency is currently held.
+    ///
     /// Note that we may have this dependency as a key but the state won't contain the dependency because
     /// this is how we're tracking ops we know we need to fetch from the network.
     pub fn has(&mut self, hash: &ActionHash) -> bool {
@@ -68,8 +69,10 @@ impl ValidationDependencies {
             .unwrap_or(false)
     }
 
-    /// Get the state of a given dependency. This should always return a value because we should know about the dependency
-    /// by examining the ops that are being validated. However, the dependency may not be found on the DHT yet.
+    /// Get the state of a given dependency.
+    ///
+    /// This should always return a value because we should know about the dependency by examining
+    /// the ops that are being validated. However, the dependency may not be found on the DHT yet.
     pub fn get(&self, hash: &ActionHash) -> Option<&ValidationDependencyState> {
         match self.states.get(hash) {
             Some(dep) => Some(dep),
@@ -80,23 +83,13 @@ impl ValidationDependencies {
         }
     }
 
-    pub fn get_mut(&mut self, hash: &ActionHash) -> Option<&mut ValidationDependencyState> {
-        match self.states.get_mut(hash) {
-            Some(dep) => Some(dep),
-            None => {
-                tracing::warn!(hash = ?hash, "Have not attempted to fetch requested dependency, this is a bug");
-                None
-            }
-        }
-    }
-
-    /// Get the hashes of all dependencies that are currently missing from the DHT.
-    pub fn get_missing_hashes(&self) -> Vec<ActionHash> {
+    /// Get the hashes and types of all dependencies that are currently missing from the DHT.
+    pub(super) fn get_missing_dependencies(&self) -> Vec<(ActionHash, ValidationDependencyType)> {
         self.states
             .iter()
             .filter_map(|(hash, state)| {
                 if state.dependency.is_none() {
-                    Some(hash.clone())
+                    Some((hash.clone(), state.dependency_type.clone()))
                 } else {
                     None
                 }
@@ -123,8 +116,8 @@ impl ValidationDependencies {
             .collect()
     }
 
-    /// Insert a record which was found after this set of dependencies was created.
-    pub fn insert(&mut self, action: SignedActionHashed, source: CascadeSource) -> bool {
+    /// Insert an action which was found after this set of dependencies was created.
+    pub fn insert_action(&mut self, action: SignedActionHashed, source: CascadeSource) -> bool {
         let hash = action.as_hash();
 
         // Note that `has` is checking that the dependency is actually set, not just that we have the key!
@@ -133,15 +126,54 @@ impl ValidationDependencies {
             return false;
         }
 
-        self.retained_deps.insert(hash.clone());
-
         if let Some(s) = self.states.get_mut(hash) {
-            s.set_dep(action);
+            s.set_action_dep(action);
             s.set_source(source);
             return true;
         }
 
         false
+    }
+
+    /// Insert a record which was found after this set of dependencies was created.
+    pub fn insert_pending_validation_warranted(
+        &mut self,
+        action: SignedActionHashed,
+        chain_op_type: ChainOpType,
+        source: CascadeSource,
+    ) -> bool {
+        let hash = action.as_hash();
+
+        // Note that `has` is checking that the dependency is actually set, not just that we have the key!
+        if self.has(hash) {
+            tracing::warn!(hash = ?hash, "Attempted to insert a dependency that was already present, this is not expected");
+            return false;
+        }
+
+        if let Some(s) = self.states.get_mut(hash) {
+            s.set_pending_validation_warranted(action, chain_op_type);
+            s.set_source(source);
+            return true;
+        }
+
+        false
+    }
+
+    /// Update a warranted dependency with its validation status.
+    pub fn update_warrant_dep_validated(
+        &mut self,
+        action: &ActionHash,
+        validation_status: ValidationStatus,
+    ) {
+        // Note that `has` is checking that the dependency is actually set, not just that we have the key!
+        if !self.has(action) {
+            tracing::warn!(hash = ?action, "Attempted to update a dependency that is not present, this is not expected");
+            return;
+        }
+
+        if let Some(s) = self.states.get_mut(action) {
+            s.set_validation_status_for_warranted(validation_status);
+        }
     }
 
     /// Forget which dependencies have been accessed since this method was last called.
@@ -158,7 +190,43 @@ impl ValidationDependencies {
     /// Merge the dependencies from another set into this one.
     pub fn merge(&mut self, other: Self) {
         self.retained_deps.extend(other.states.keys().cloned());
-        self.states.extend(other.states);
+
+        // When merging, prefer keeping warrant records because those contain actions too, but if
+        // an action overwrites the record then we don't have the entry anymore.
+        for (hash, other_state) in other.states {
+            match self.states.entry(hash.clone()) {
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert(other_state);
+                }
+                std::collections::hash_map::Entry::Occupied(mut e) => {
+                    let existing = e.get_mut();
+                    match (&existing.dependency, &other_state.dependency) {
+                        (None, Some(_)) => {
+                            // If we don't have it but the other does, take it.
+                            *existing = other_state;
+                        }
+                        (Some(_), None) => {
+                            // If we have it but the other doesn't, keep what we have.
+                        }
+                        (Some(_), Some(_)) => {
+                            // If we both have it, prefer keeping a record dependency over an action
+                            // dependency.
+                            if existing.dependency_type == ValidationDependencyType::Action
+                                && matches!(
+                                    other_state.dependency_type,
+                                    ValidationDependencyType::Warranted(_)
+                                )
+                            {
+                                *existing = other_state;
+                            }
+                        }
+                        (None, None) => {
+                            // If neither side has a value, don't make changes.
+                        }
+                    }
+                }
+            }
+        }
     }
 
     pub fn new_from_iter<I: IntoIterator<Item = (ActionHash, ValidationDependencyState)>>(
@@ -169,43 +237,142 @@ impl ValidationDependencies {
             retained_deps: HashSet::new(),
         }
     }
+
+    /// Get the list of warranted dependencies that are pending validation.
+    pub fn get_pending_warrant_dependencies(&self) -> Vec<(ActionHash, ChainOpType)> {
+        self.states
+            .values()
+            .filter_map(|state| match (&state.dependency_type, &state.dependency) {
+                (ValidationDependencyType::Warranted(_), Some(v)) => match &v.value {
+                    ValidationDependencyValue::Warranted(WarrantedDep::Pending(r, t)) => {
+                        Some((r.action_address().clone(), *t))
+                    }
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect()
+    }
 }
 
 #[derive(Clone, Debug)]
 pub struct ValidationDependencyState {
+    /// The type of dependency this is, either an Action or a Record.
+    dependency_type: ValidationDependencyType,
     /// The dependency if we've been able to fetch it, otherwise None until we manage to find it.
     dependency: Option<ValidationDependency>,
 }
 
 impl ValidationDependencyState {
-    pub fn new(dependency: Option<ValidationDependency>) -> Self {
-        Self { dependency }
-    }
-
-    pub fn single(dep: SignedActionHashed, fetched_from: CascadeSource) -> Self {
+    pub(super) fn new_present(
+        value: ValidationDependencyValue,
+        fetched_from: CascadeSource,
+    ) -> Self {
         Self {
-            dependency: Some(ValidationDependency { dep, fetched_from }),
+            dependency_type: match value {
+                ValidationDependencyValue::Action(_) => ValidationDependencyType::Action,
+                ValidationDependencyValue::Warranted(WarrantedDep::Pending(_, chain_op_type)) => {
+                    ValidationDependencyType::Warranted(chain_op_type)
+                }
+                ValidationDependencyValue::Warranted(WarrantedDep::Validated(_, _)) => {
+                    unreachable!("Cannot create a new present dependency that already has a validated dependency")
+                }
+            },
+            dependency: Some(ValidationDependency {
+                value,
+                fetched_from,
+            }),
         }
     }
 
-    pub fn set_dep(&mut self, dep: SignedActionHashed) {
+    pub(super) fn new_pending(dependency_type: ValidationDependencyType) -> Self {
+        Self {
+            dependency_type,
+            dependency: None,
+        }
+    }
+
+    /// Provide the missing [`SignedActionHashed`] for this action dependency.
+    pub(super) fn set_action_dep(&mut self, action: SignedActionHashed) {
+        if !matches!(self.dependency_type, ValidationDependencyType::Action) {
+            tracing::warn!("Attempted to set an action dependency for a validation dependency that is not expecting an action, this is a bug");
+            return;
+        }
+
         match self.dependency {
             None => {
                 self.dependency = Some(ValidationDependency {
-                    dep,
+                    value: ValidationDependencyValue::Action(action),
                     fetched_from: CascadeSource::Network,
                 });
             }
             _ => {
-                tracing::warn!("Attempted to set a record on a dependency that already has a value, this is a bug")
+                tracing::warn!(
+                    "Attempted to set an action dependency that already has a value, this is a bug"
+                )
             }
+        }
+    }
+
+    /// Provide the missing [`SignedActionHashed`] for this warranted record dependency, marking it
+    /// as pending validation.
+    pub(super) fn set_pending_validation_warranted(
+        &mut self,
+        action: SignedActionHashed,
+        op_type: ChainOpType,
+    ) {
+        if !matches!(self.dependency_type, ValidationDependencyType::Warranted(_)) {
+            tracing::warn!("Attempted to set a warranted record dependency for a validation dependency that is not expecting Warranted, this is a bug");
+            return;
+        }
+
+        match self.dependency {
+            None => {
+                self.dependency = Some(ValidationDependency {
+                    value: ValidationDependencyValue::Warranted(WarrantedDep::Pending(
+                        action, op_type,
+                    )),
+                    fetched_from: CascadeSource::Network,
+                });
+            }
+            _ => {
+                tracing::warn!("Attempted to set a warranted record dependency that already has a value, this is a bug")
+            }
+        }
+    }
+
+    /// Set the validation status for a warranted record dependency that has now been validated.
+    pub(super) fn set_validation_status_for_warranted(
+        &mut self,
+        validation_status: ValidationStatus,
+    ) {
+        if !matches!(self.dependency_type, ValidationDependencyType::Warranted(_)) {
+            tracing::warn!("Attempted to set an action on a dependency that is not of type Action, this is a bug");
+            return;
+        }
+
+        if let Some(ValidationDependency { value, .. }) = self.dependency.as_mut() {
+            match value {
+                ValidationDependencyValue::Warranted(WarrantedDep::Pending(action, _)) => {
+                    let action = action.clone();
+                    *value = ValidationDependencyValue::Warranted(WarrantedDep::Validated(
+                        action,
+                        validation_status,
+                    ));
+                }
+                _ => {
+                    tracing::warn!("Attempted to set a status for a dependency that is not pending validation, this is a bug");
+                }
+            }
+        } else {
+            tracing::warn!("Attempted to set a status for a dependency that is not pending validation, this is a bug")
         }
     }
 
     /// Set the source of the dependency.
     ///
     /// This is used to track where the dependency was found.
-    pub fn set_source(&mut self, new_source: CascadeSource) {
+    fn set_source(&mut self, new_source: CascadeSource) {
         if let Some(ValidationDependency { fetched_from, .. }) = &mut self.dependency {
             *fetched_from = new_source;
         }
@@ -214,15 +381,55 @@ impl ValidationDependencyState {
 
 impl ValidationDependencyState {
     /// Get the action from the dependency state if it is present.
-    pub fn as_action(&self) -> Option<&Action> {
-        self.dependency.as_ref().map(|d| d.dep.action())
+    pub(super) fn as_action(&self) -> Option<&Action> {
+        self.dependency.as_ref().map(|d| match &d.value {
+            ValidationDependencyValue::Action(a) => a.action(),
+            ValidationDependencyValue::Warranted(WarrantedDep::Pending(action, _)) => {
+                action.action()
+            }
+            ValidationDependencyValue::Warranted(WarrantedDep::Validated(action, _)) => {
+                action.action()
+            }
+        })
+    }
+
+    /// Get the record from the dependency state if it is for a warranted record op that has been
+    /// validated.
+    pub(super) fn as_action_and_validation_status(&self) -> Option<(&Action, ValidationStatus)> {
+        match &self.dependency {
+            Some(d) => match &d.value {
+                ValidationDependencyValue::Warranted(WarrantedDep::Validated(
+                    a,
+                    validation_status,
+                )) => Some((a.action(), *validation_status)),
+                _ => None,
+            },
+            None => None,
+        }
     }
 }
 
 /// A validation dependency which is either an Action or a Record, and the source of the dependency.
 #[derive(Clone, Debug)]
-#[allow(clippy::large_enum_variant)]
-pub struct ValidationDependency {
-    dep: SignedActionHashed,
+pub(super) struct ValidationDependency {
+    value: ValidationDependencyValue,
     fetched_from: CascadeSource,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum ValidationDependencyType {
+    Action,
+    Warranted(ChainOpType),
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum ValidationDependencyValue {
+    Action(SignedActionHashed),
+    Warranted(WarrantedDep),
+}
+
+#[derive(Clone, Debug)]
+pub(super) enum WarrantedDep {
+    Pending(SignedActionHashed, ChainOpType),
+    Validated(SignedActionHashed, ValidationStatus),
 }


### PR DESCRIPTION
### Summary

Closes #5224

The general approach here is to try to fit in with what sys validation already does but warrants are a little different so here goes:
- The database query has been updated so that warrant `DhtOp`s are also fetched
- The dependency tracking has been updated to track warrant dependencies:
  - Initially, warrant dependencies are treated as unvalidated dependencies
  - In the unvalidated state, ops may be copied from the cache to the DHT database
  - Once a validation status is observed it is captured into the dependency tracking state
- When attempting to validate a warrant, we now wait until there is a validation status for the warranted op
- If the op passed validation then the warrant is treated as invalid

There is now a test for the happy path that should already have been here but was missing. A test has also been added that checks what happens when a warrant is issued of a valid op.

Things I'm leaving out of this PR because it's already too big:
- Updating the sys validation documentation to describe how warrants are validated
- Integration tests for warrants to check that the warrant validation logic works properly when app validation is also involved.
- I'm thinking it's best that we don't try to optimize only running one kind of validation and should remove the "validation type" from the warrant. If the op fails sys validation then it's not an optimization to only run sys validation and that'd be hard to do anyway because how would app validation know? If we have to run app validation then I think it would be a mistake to skip sys validation because it breaks the assumptions made by app validation about what has already been checked.
- Test that a warrant dependency that is already validated can be loaded and used to validate the warrant.
- Extract dependency fetching stream to its own function.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - System validation now treats warrants as first-class dependencies and unifies Action+Warrant sources for consistent ordering and processing; warranted dependencies trigger re-validation when available.

- Bug Fixes / Improvements
  - Progress tracking for copied warrant dependencies added.
  - Copy-from-cache-to-DHT now reports whether an op was actually copied.

- Documentation
  - Changelog updated with an Unreleased entry for warrant validation.

- Tests
  - New feature-gated tests covering valid/invalid warrant scenarios (cached and network-fetched).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->