### PR TITLE
Publish and gossip warrants

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix: Unschedule already scheduled persisted functions on error or when the schedule is set to `None`.
 - Refactor: When representative agent is missing, skip app validation workflow instead of panicking.
 - Fix: Return an error with an `Invalid` result from `must_get_valid_record` when a record that is invalid is found. Previously the error returned indicated `UnresolvedDependencies`.
+- Feat: Include warrants in publish and gossip and enable them to be fetched.
 
 ## 0.6.0-dev.18
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -210,7 +210,9 @@ async fn app_validation_workflow_inner(
     let rejected_ops = Arc::new(AtomicUsize::new(0));
     let failed_ops = Arc::new(Mutex::new(HashSet::new()));
     let mut agent_activity_ops = vec![];
-    let mut warrant_op_hashes = vec![];
+    let warrant_op_hashes: Vec<(DhtOpHash, OpBasis)> = vec![];
+    #[cfg(feature = "unstable-warrants")]
+    let mut warrant_op_hashes = warrant_op_hashes;
 
     #[cfg(all(feature = "unstable-warrants", feature = "test_utils"))]
     let disable_warrant_issuance = conductor

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -208,10 +208,8 @@ async fn app_validation_workflow_inner(
     let accepted_ops = Arc::new(AtomicUsize::new(0));
     let awaiting_ops = Arc::new(AtomicUsize::new(0));
     let rejected_ops = Arc::new(AtomicUsize::new(0));
-    let warranted_ops = Arc::new(AtomicUsize::new(0));
     let failed_ops = Arc::new(Mutex::new(HashSet::new()));
     let mut agent_activity_ops = vec![];
-    #[cfg(feature = "unstable-warrants")]
     let mut warrant_op_hashes = vec![];
 
     #[cfg(all(feature = "unstable-warrants", feature = "test_utils"))]
@@ -305,8 +303,6 @@ async fn app_validation_workflow_inner(
                         {
                             tracing::warn!("Error writing warrant op: {err}");
                         }
-
-                        warranted_ops.fetch_add(1, Ordering::SeqCst);
                     }
                 }
 
@@ -350,7 +346,7 @@ async fn app_validation_workflow_inner(
     let accepted_ops = accepted_ops.load(Ordering::SeqCst);
     let awaiting_ops = awaiting_ops.load(Ordering::SeqCst);
     let rejected_ops = rejected_ops.load(Ordering::SeqCst);
-    let warranted_ops = warranted_ops.load(Ordering::SeqCst);
+    let warranted_ops = warrant_op_hashes.len();
     let ops_validated = accepted_ops + rejected_ops;
     let failed_ops = Arc::try_unwrap(failed_ops)
         .expect("must be only reference")

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -278,10 +278,9 @@ async fn app_validation_workflow_inner(
                 let rejected_ops = rejected_ops.clone();
 
                 #[cfg(feature = "unstable-warrants")]
-                if !disable_warrant_issuance {
-                    if let Outcome::Rejected(_) = &outcome {
-                        let keystore = conductor.keystore();
-                        let warrant_op =
+                if let Outcome::Rejected(_) = &outcome {
+                    let keystore = conductor.keystore();
+                    let warrant_op =
                         crate::core::workflow::sys_validation_workflow::make_invalid_chain_warrant_op(
                             keystore,
                             _representative_agent.clone(),
@@ -290,6 +289,9 @@ async fn app_validation_workflow_inner(
                         )
                         .await?;
 
+                    if disable_warrant_issuance {
+                        tracing::warn!("Warrant issuance disabled - skipping issuing a warrant");
+                    } else {
                         warrant_op_hashes
                             .push((warrant_op.to_hash(), warrant_op.dht_basis().clone()));
 

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
@@ -79,11 +79,7 @@ where
             WHERE
             Warrant.author = :author
             AND
-            DhtOp.withhold_publish IS NULL
-            AND
             (DhtOp.last_publish_time IS NULL OR DhtOp.last_publish_time <= :recency_threshold)
-            AND
-            DhtOp.receipts_complete IS NULL
 
             ORDER BY op_order
             ",
@@ -128,8 +124,6 @@ pub fn num_still_needing_publish(txn: &Transaction, agent: AgentPubKey) -> Workf
           JOIN DhtOp ON DhtOp.action_hash = Warrant.hash
           WHERE
             Warrant.author = :author
-            AND DhtOp.withhold_publish IS NULL
-            AND DhtOp.receipts_complete IS NULL
         )
         AS num_ops
         ",
@@ -283,7 +277,6 @@ mod tests {
                         - ConductorTuningParams::default().min_publish_interval(),
                 )
                 .unwrap();
-                set_receipts_complete(txn, &invalid_op_warrant.hash, false).unwrap();
             }
         });
         warrant_op

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
@@ -43,7 +43,8 @@ where
             END AS entry_size,
             Entry.blob as entry_blob,
             DhtOp.type as dht_type,
-            DhtOp.hash as dht_hash
+            DhtOp.hash as dht_hash,
+            DhtOp.op_order as op_order
             FROM Action
             JOIN
             DhtOp ON DhtOp.action_hash = Action.hash
@@ -70,7 +71,8 @@ where
             0 AS entry_size,
             NULL as entry_blob,
             DhtOp.type as dht_type,
-            DhtOp.hash as dht_hash
+            DhtOp.hash as dht_hash,
+            DhtOp.op_order as op_order
             FROM Warrant
             JOIN
             DhtOp ON DhtOp.action_hash = Warrant.hash
@@ -82,6 +84,8 @@ where
             (DhtOp.last_publish_time IS NULL OR DhtOp.last_publish_time <= :recency_threshold)
             AND
             DhtOp.receipts_complete IS NULL
+
+            ORDER BY op_order
             ",
         )?;
         let r = stmt.query_and_then(

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
@@ -141,7 +141,9 @@ pub fn num_still_needing_publish(txn: &Transaction, agent: AgentPubKey) -> Workf
 mod tests {
     use super::*;
     use ::fixt::prelude::*;
-    use holo_hash::fixt::{ActionHashFixturator, AgentPubKeyFixturator};
+    #[cfg(feature = "unstable-warrants")]
+    use holo_hash::fixt::ActionHashFixturator;
+    use holo_hash::fixt::AgentPubKeyFixturator;
     use holo_hash::EntryHash;
     use holo_hash::HasHash;
     use holochain_conductor_api::conductor::ConductorTuningParams;
@@ -202,6 +204,7 @@ mod tests {
         assert_eq!(expected.results.len() + 1, num_to_publish);
     }
 
+    #[cfg(feature = "unstable-warrants")]
     #[tokio::test(flavor = "multi_thread")]
     async fn publish_query_includes_warrants() {
         holochain_trace::test_run();
@@ -246,6 +249,7 @@ mod tests {
         assert_eq!(num_to_publish, 2);
     }
 
+    #[cfg(feature = "unstable-warrants")]
     fn insert_invalid_chain_op_warrant_op(
         db: &DbWrite<DbKindAuthored>,
         agent: &AgentPubKey,

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
@@ -81,7 +81,7 @@ where
             AND
             DhtOp.last_publish_time IS NULL
 
-            ORDER BY op_order
+            ORDER BY op_order, dht_hash
             ",
         )?;
         let r = stmt.query_and_then(

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
@@ -251,7 +251,7 @@ mod tests {
         assert_eq!(num_to_publish, 2);
     }
 
-    fn insert_invalid_op_warrant_op(
+    fn insert_invalid_chain_op_warrant_op(
         db: &DbWrite<DbKindAuthored>,
         agent: &AgentPubKey,
     ) -> DhtOpHashed {

--- a/crates/holochain/src/sweettest/sweet_conductor_config.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor_config.rs
@@ -45,6 +45,7 @@ impl From<NetworkConfig> for SweetConductorConfig {
                 countersigning_resolution_retry_limit: None,
                 publish_trigger_interval: None,
                 min_publish_interval: None,
+                disable_warrant_issuance: false,
             }),
             ..Default::default()
         }

--- a/crates/holochain/tests/tests/gossip/mod.rs
+++ b/crates/holochain/tests/tests/gossip/mod.rs
@@ -13,6 +13,15 @@ use holochain_conductor_api::conductor::ConductorConfig;
 use holochain_conductor_api::conductor::NetworkConfig;
 use holochain_zome_types::record::Record;
 
+#[cfg(feature = "unstable-warrants")]
+use {
+    holochain::prelude::InlineZomeSet,
+    holochain_state::query::CascadeTxnWrapper,
+    holochain_state::query::Store,
+    serde::{Deserialize, Serialize},
+    std::time::Duration,
+};
+
 /// Test that conductors with arcs clamped to zero do not gossip.
 #[tokio::test(flavor = "multi_thread")]
 async fn get_with_zero_arc_2_way() {
@@ -131,4 +140,157 @@ async fn new_conductor_reaches_consistency_with_existing_conductor() {
     await_consistency(30, [&cell0, &cell1]).await.unwrap();
     let record: Option<Record> = conductor1.call(&zome1, "read", hash.clone()).await;
     assert_eq!(record.unwrap().action_address(), &hash);
+}
+
+// Test that warrants are gossiped and received.
+// Alice, Bob and Carol start a network and sync. Carol goes offline.
+// Alice creates an invalid op, Bob receives it and issues a warrant.
+// Carol has warrant issuance disabled and receives the warrant from Bob
+// via gossip after she comes back online.
+// Publish is disabled for this test.
+#[cfg(feature = "unstable-warrants")]
+#[tokio::test(flavor = "multi_thread")]
+async fn warrant_is_gossiped() {
+    holochain_trace::test_run();
+
+    #[derive(Serialize, Deserialize, SerializedBytes, Debug)]
+    struct AppString(String);
+
+    let string_entry_def = EntryDef::default_from_id("string");
+    let zome_common = SweetInlineZomes::new(vec![string_entry_def], 0).function(
+        "create_string",
+        move |api, s: AppString| {
+            let entry = Entry::app(s.try_into().unwrap()).unwrap();
+            let hash = api.create(CreateInput::new(
+                InlineZomeSet::get_entry_location(&api, EntryDefIndex(0)),
+                EntryVisibility::Public,
+                entry,
+                ChainTopOrdering::default(),
+            ))?;
+            Ok(hash)
+        },
+    );
+
+    let zome_without_validation = zome_common
+        .clone()
+        .integrity_function("validate", move |_api, _op: Op| {
+            Ok(ValidateCallbackResult::Valid)
+        });
+    // Any action after the genesis actions is invalid.
+    let zome_with_validation =
+        zome_common
+            .clone()
+            .integrity_function("validate", move |_api, op: Op| {
+                if op.action_seq() > 3 {
+                    Ok(ValidateCallbackResult::Invalid("nope".to_string()))
+                } else {
+                    Ok(ValidateCallbackResult::Valid)
+                }
+            });
+
+    let network_seed = "seed".to_string();
+
+    let (dna_without_validation, _, _) =
+        SweetDnaFile::from_inline_zomes(network_seed.clone(), zome_without_validation).await;
+    let (dna_with_validation, _, _) =
+        SweetDnaFile::from_inline_zomes(network_seed.clone(), zome_with_validation).await;
+    assert_eq!(
+        dna_without_validation.dna_hash(),
+        dna_with_validation.dna_hash()
+    );
+    let dna_hash = dna_without_validation.dna_hash();
+
+    let config =
+        SweetConductorConfig::rendezvous(true).tune_network_config(|nc| nc.disable_publish = true);
+    // Disable warrants on Carol's conductor, so that she doesn't issue warrants herself
+    // but receives them from Bob.
+    let config_no_warranting = SweetConductorConfig::rendezvous(true)
+        .tune_conductor(|tc| tc.disable_warrant_issuance = true)
+        .tune_network_config(|nc| nc.disable_publish = true);
+    let mut conductors = SweetConductorBatch::from_configs_rendezvous([
+        config.clone(),
+        config,
+        config_no_warranting,
+    ])
+    .await;
+    let (alice,) = conductors[0]
+        .setup_app("test_app", [&dna_without_validation])
+        .await
+        .unwrap()
+        .into_tuple();
+    let (bob,) = conductors[1]
+        .setup_app("test_app", [&dna_with_validation])
+        .await
+        .unwrap()
+        .into_tuple();
+    let (carol,) = conductors[2]
+        .setup_app("test_app", [&dna_with_validation])
+        .await
+        .unwrap()
+        .into_tuple();
+
+    println!("AGENTS");
+    println!(
+        "0 alice {} url {:?}",
+        alice.agent_pubkey(),
+        conductors[0].dump_network_stats().await.unwrap().peer_urls[0]
+    );
+    println!(
+        "1 bob   {} url {:?}",
+        bob.agent_pubkey(),
+        conductors[1].dump_network_stats().await.unwrap().peer_urls[0]
+    );
+    println!(
+        "2 carol {} url {:?}",
+        carol.agent_pubkey(),
+        conductors[2].dump_network_stats().await.unwrap().peer_urls[0]
+    );
+
+    await_consistency(10, [&alice, &bob, &carol]).await.unwrap();
+
+    // Shutdown Carol's conductor.
+    conductors[2].shutdown().await;
+
+    // Alice creates an invalid action.
+    let _: ActionHash = conductors[0]
+        .call(
+            &alice.zome(SweetInlineZomes::COORDINATOR),
+            "create_string",
+            AppString("entry1".into()),
+        )
+        .await;
+
+    await_consistency(10, [&alice, &bob]).await.unwrap();
+
+    // Bob should have issued a warrant against Alice.
+
+    // Shutdown Alice and startup Carol.
+    conductors[0].shutdown().await;
+    conductors[2].startup(false).await;
+
+    // Carol should receive the warrant against Alice.
+    // The warrant and the warrant op should have been written to the authored databases.
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let alice_pubkey = alice.agent_pubkey().clone();
+            let warrants = conductors[2]
+                .get_spaces()
+                .dht_db(dna_hash)
+                .unwrap()
+                .test_read(move |txn| {
+                    let store = CascadeTxnWrapper::from(txn);
+                    // TODO: check_valid here should be removed once warrants are validated.
+                    store.get_warrants_for_agent(&alice_pubkey, false).unwrap()
+                });
+            if warrants.len() == 1 {
+                assert_eq!(warrants[0].warrant().warrantee, *alice.agent_pubkey());
+                // Make sure that Bob authored the warrant and it's not been authored by Carol.
+                assert_eq!(warrants[0].warrant().author, *bob.agent_pubkey());
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .unwrap();
 }

--- a/crates/holochain/tests/tests/mod.rs
+++ b/crates/holochain/tests/tests/mod.rs
@@ -29,5 +29,7 @@ mod signals;
 mod test_cli;
 mod test_utils;
 mod validate;
+#[cfg(feature = "unstable-warrants")]
+mod warrant_issuance;
 mod websocket;
 mod websocket_stress;

--- a/crates/holochain/tests/tests/publish/mod.rs
+++ b/crates/holochain/tests/tests/publish/mod.rs
@@ -4,6 +4,19 @@ use holochain_wasm_test_utils::TestWasm;
 use holochain_zome_types::prelude::GetValidationReceiptsInput;
 use holochain_zome_types::validate::ValidationReceiptSet;
 
+#[cfg(feature = "unstable-warrants")]
+use {
+    hdk::prelude::{
+        ChainTopOrdering, CreateInput, EntryDef, EntryDefIndex, EntryVisibility, Op,
+        SerializedBytes, ValidateCallbackResult,
+    },
+    holochain::prelude::InlineZomeSet,
+    holochain_state::query::{CascadeTxnWrapper, Store},
+    holochain_zome_types::Entry,
+    serde::{Deserialize, Serialize},
+    std::time::Duration,
+};
+
 /// Verifies that publishing terminates naturally when enough validation receipts are received.
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
@@ -78,6 +91,149 @@ async fn publish_terminates_after_receiving_required_validation_receipts() {
             }
 
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .unwrap();
+}
+
+// Test that warrants are published and received.
+// Alice creates an invalid op, Bob receives it and issues a warrant.
+// Carol has warrant issuance disabled and receives the warrant from Bob
+// as he publishes it.
+#[cfg(feature = "unstable-warrants")]
+#[tokio::test(flavor = "multi_thread")]
+async fn warrant_is_published() {
+    holochain_trace::test_run();
+
+    #[derive(Serialize, Deserialize, SerializedBytes, Debug)]
+    struct AppString(String);
+
+    let string_entry_def = EntryDef::default_from_id("string");
+    let zome_common = SweetInlineZomes::new(vec![string_entry_def], 0).function(
+        "create_string",
+        move |api, s: AppString| {
+            let entry = Entry::app(s.try_into().unwrap()).unwrap();
+            let hash = api.create(CreateInput::new(
+                InlineZomeSet::get_entry_location(&api, EntryDefIndex(0)),
+                EntryVisibility::Public,
+                entry,
+                ChainTopOrdering::default(),
+            ))?;
+            Ok(hash)
+        },
+    );
+
+    let zome_without_validation = zome_common
+        .clone()
+        .integrity_function("validate", move |_api, _op: Op| {
+            Ok(ValidateCallbackResult::Valid)
+        });
+    // Any action after the genesis actions is invalid.
+    let zome_with_validation =
+        zome_common
+            .clone()
+            .integrity_function("validate", move |_api, op: Op| {
+                if op.action_seq() > 3 {
+                    Ok(ValidateCallbackResult::Invalid("nope".to_string()))
+                } else {
+                    Ok(ValidateCallbackResult::Valid)
+                }
+            });
+
+    let network_seed = "seed".to_string();
+
+    let (dna_without_validation, _, _) =
+        SweetDnaFile::from_inline_zomes(network_seed.clone(), zome_without_validation).await;
+    let (dna_with_validation, _, _) =
+        SweetDnaFile::from_inline_zomes(network_seed.clone(), zome_with_validation).await;
+    assert_eq!(
+        dna_without_validation.dna_hash(),
+        dna_with_validation.dna_hash()
+    );
+    let dna_hash = dna_without_validation.dna_hash();
+
+    let config = SweetConductorConfig::rendezvous(true);
+    // Disable warrants on Carol's conductor, so that she doesn't issue warrants herself
+    // but receives them from Bob.
+    let config_no_warranting = SweetConductorConfig::rendezvous(true)
+        .tune_conductor(|tc| tc.disable_warrant_issuance = true);
+    let mut conductors = SweetConductorBatch::from_configs_rendezvous([
+        config.clone(),
+        config,
+        config_no_warranting,
+    ])
+    .await;
+    let (alice,) = conductors[0]
+        .setup_app("test_app", [&dna_without_validation])
+        .await
+        .unwrap()
+        .into_tuple();
+    let (bob,) = conductors[1]
+        .setup_app("test_app", [&dna_with_validation])
+        .await
+        .unwrap()
+        .into_tuple();
+    let (carol,) = conductors[2]
+        .setup_app("test_app", [&dna_with_validation])
+        .await
+        .unwrap()
+        .into_tuple();
+
+    println!("AGENTS");
+    println!(
+        "0 alice {} url {:?}",
+        alice.agent_pubkey(),
+        conductors[0].dump_network_stats().await.unwrap().peer_urls[0]
+    );
+    println!(
+        "1 bob   {} url {:?}",
+        bob.agent_pubkey(),
+        conductors[1].dump_network_stats().await.unwrap().peer_urls[0]
+    );
+    println!(
+        "2 carol {} url {:?}",
+        carol.agent_pubkey(),
+        conductors[2].dump_network_stats().await.unwrap().peer_urls[0]
+    );
+
+    await_consistency(10, [&alice, &bob, &carol]).await.unwrap();
+
+    // Alice creates an invalid action.
+    let _: ActionHash = conductors[0]
+        .call(
+            &alice.zome(SweetInlineZomes::COORDINATOR),
+            "create_string",
+            AppString("entry1".into()),
+        )
+        .await;
+
+    await_consistency(10, [&alice, &bob]).await.unwrap();
+
+    // Bob should have issued a warrant against Alice.
+
+    // Carol should receive the warrant against Alice.
+    // The warrant and the warrant op should have been written to the authored databases.
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let alice_pubkey = alice.agent_pubkey().clone();
+            let warrants = conductors[2]
+                .get_spaces()
+                .dht_db(dna_hash)
+                .unwrap()
+                .test_read(move |txn| {
+                    let store = CascadeTxnWrapper::from(txn);
+                    // TODO: check_valid here should be removed once warrants are validated.
+                    store.get_warrants_for_agent(&alice_pubkey, false).unwrap()
+                });
+
+            if warrants.len() == 1 {
+                assert_eq!(warrants[0].warrant().warrantee, *alice.agent_pubkey());
+                // Make sure that Bob authored the warrant and it's not been authored by Carol.
+                assert_eq!(warrants[0].warrant().author, *bob.agent_pubkey());
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
     })
     .await

--- a/crates/holochain/tests/tests/warrant_issuance.rs
+++ b/crates/holochain/tests/tests/warrant_issuance.rs
@@ -1,0 +1,73 @@
+use hdk::prelude::{Op, ValidateCallbackResult};
+use holochain::sweettest::{
+    await_consistency, SweetConductorBatch, SweetConductorConfig, SweetDnaFile, SweetInlineZomes,
+};
+use holochain_state::query::{CascadeTxnWrapper, Store};
+
+// Test that warrants issuance can be disabled. This is useful for testing that
+// warrants are propagated through publish and gossip.
+//
+// Alice creates invalid ops, Bob receives them but should not issue any warrant.
+#[tokio::test(flavor = "multi_thread")]
+async fn invalid_op_warrant_issuance_can_be_disabled() {
+    holochain_trace::test_run();
+
+    let zome_common = SweetInlineZomes::new(vec![], 0);
+    let zome_without_validation = zome_common
+        .clone()
+        .integrity_function("validate", move |_api, _: Op| {
+            Ok(ValidateCallbackResult::Valid)
+        });
+    // Any action is invalid, including genesis actions.
+    let zome_with_validation = zome_common
+        .clone()
+        .integrity_function("validate", move |_api, _: Op| {
+            Ok(ValidateCallbackResult::Invalid("nope".to_string()))
+        });
+
+    let network_seed = "seed".to_string();
+    let (dna_without_validation, _, _) =
+        SweetDnaFile::from_inline_zomes(network_seed.clone(), zome_without_validation).await;
+    let (dna_with_validation, _, _) =
+        SweetDnaFile::from_inline_zomes(network_seed.clone(), zome_with_validation).await;
+    assert_eq!(
+        dna_without_validation.dna_hash(),
+        dna_with_validation.dna_hash()
+    );
+    let dna_hash = dna_without_validation.dna_hash();
+
+    let config = SweetConductorConfig::rendezvous(true);
+    // Disable warrants on Bob's conductor.
+    let config_no_warranting = SweetConductorConfig::rendezvous(true)
+        .tune_conductor(|tc| tc.disable_warrant_issuance = true);
+    let mut conductors =
+        SweetConductorBatch::from_configs_rendezvous([config, config_no_warranting]).await;
+    let (alice,) = conductors[0]
+        .setup_app("test_app", [&dna_without_validation])
+        .await
+        .unwrap()
+        .into_tuple();
+    let (bob,) = conductors[1]
+        .setup_app("test_app", [&dna_with_validation])
+        .await
+        .unwrap()
+        .into_tuple();
+
+    await_consistency(10, [&alice, &bob]).await.unwrap();
+
+    // Bob must not have issued a warrant against Alice.
+    // A warrant would have been created as part of app validating all of Alice's
+    // ops, so once consistency is reached, the authored DB can be checked
+    // for warrants.
+    let alice_pubkey = alice.agent_pubkey().clone();
+    conductors[1]
+        .get_spaces()
+        .get_all_authored_dbs(dna_hash)
+        .unwrap()[0]
+        .test_read(move |txn| {
+            let store = CascadeTxnWrapper::from(txn);
+            // TODO: check_valid here should be removed once warrants are validated.
+            let warrants = store.get_warrants_for_agent(&alice_pubkey, false).unwrap();
+            assert!(warrants.is_empty());
+        });
+}

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -508,6 +508,12 @@ pub struct ConductorTuningParams {
     ///
     /// Default: None
     pub publish_trigger_interval: Option<std::time::Duration>,
+    /// Prevent issuance of warrants. Useful for testing whether warrants are gossiped
+    /// and published.
+    ///
+    /// Default: false
+    #[cfg(feature = "test-utils")]
+    pub disable_warrant_issuance: bool,
 }
 
 impl ConductorTuningParams {
@@ -519,6 +525,8 @@ impl ConductorTuningParams {
             countersigning_resolution_retry_limit: None,
             min_publish_interval: None,
             publish_trigger_interval: None,
+            #[cfg(feature = "test-utils")]
+            disable_warrant_issuance: false,
         }
     }
 
@@ -552,6 +560,8 @@ impl Default for ConductorTuningParams {
             countersigning_resolution_retry_limit: None,
             publish_trigger_interval: None,
             min_publish_interval: None,
+            #[cfg(feature = "test-utils")]
+            disable_warrant_issuance: false,
         }
     }
 }

--- a/crates/holochain_sqlite/src/sql/cell/fetch_publishable_op.sql
+++ b/crates/holochain_sqlite/src/sql/cell/fetch_publishable_op.sql
@@ -24,4 +24,3 @@ FROM
   JOIN Warrant ON DhtOp.action_hash = Warrant.hash
 WHERE
   DhtOp.hash = :hash
-  AND DhtOp.withhold_publish IS NULL

--- a/crates/holochain_sqlite/src/sql/cell/fetch_publishable_op.sql
+++ b/crates/holochain_sqlite/src/sql/cell/fetch_publishable_op.sql
@@ -11,3 +11,17 @@ FROM
 WHERE
   DhtOp.hash = :hash
   AND DhtOp.withhold_publish IS NULL
+UNION
+ALL
+SELECT
+  DhtOp.hash,
+  DhtOp.type,
+  Warrant.blob AS action_blob,
+  Warrant.author AS author,
+  NULL AS entry_blob
+FROM
+  DhtOp
+  JOIN Warrant ON DhtOp.action_hash = Warrant.hash
+WHERE
+  DhtOp.hash = :hash
+  AND DhtOp.withhold_publish IS NULL

--- a/crates/holochain_sqlite/src/sql/dht/ops_by_id.sql
+++ b/crates/holochain_sqlite/src/sql/dht/ops_by_id.sql
@@ -12,3 +12,18 @@ FROM
 WHERE
   DhtOp.hash IN rarray(:hashes)
   AND DhtOp.when_integrated IS NOT NULL
+UNION
+ALL
+SELECT
+  DhtOp.hash,
+  DhtOp.basis_hash,
+  DhtOp.type,
+  Warrant.blob AS action_blob,
+  Warrant.author AS author,
+  NULL AS entry_blob
+FROM
+  DhtOp
+  JOIN Warrant ON DhtOp.action_hash = Warrant.hash
+WHERE
+  DhtOp.hash IN rarray(:hashes)
+  AND DhtOp.when_integrated IS NOT NULL


### PR DESCRIPTION
### Summary

Include warrants in publish and gossip and enable them to be fetched by the fetch module.

Add a test for each publish and gossip that confirm that warrants are published/gossiped and received by another peer. 

Queries for ops to publish have been extended to include warrants. There's a test for those.

For controlled testing of this, a conductor tuning param is added to disable warrant issuance. That prevents that invalid ops that were gossiped or published lead to a warrant on the other peer's end, who should receive the warrant from the issuer.
There's also a test that this new tuning param works.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental warrants are now included in publishing, gossip, and fetching when the feature is enabled, expanding ops eligible for distribution.

* **Configuration**
  * Added a tuning flag (test-only) to disable warrant issuance for testing; network-to-config translation also sets a default. Production builds unaffected.

* **Tests**
  * Feature-gated integration tests verifying warrant publishing, gossiping, fetching, and disabling issuance.

* **Documentation**
  * Changelog updated with a warrant-related entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->