### PR TITLE
fix: backport network_metrics clone-cell fix

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -9,7 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Remove network joining timeout ([#5238](https://github.com/holochain/holochain/pull/5238)). This used to work with the previous version of kitsune, but now all the `join` call does is to join the local peer store which is a matter of acquiring a write lock on a mutex and doesn't indicate whether publishing the agent info to the peer store and the bootstrap has been successful.
 - Add support for writing metrics to InfluxDB file on disk.
-
+- Fix: Correctly return metrics when calling `dump_network_metrics_for_app` with apps that have clone cells.
+  
 ## 0.5.5
 
 ## 0.5.5-rc.3

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -2931,7 +2931,9 @@ mod misc_impls {
                     .values()
                     .flat_map(|r| match r {
                         AppRoleAssignment::Primary(p) if p.is_provisioned => {
-                            vec![p.base_dna_hash.clone()]
+                            let mut hashes = vec![p.base_dna_hash.clone()];
+                            hashes.extend(p.clones.values().cloned().collect::<Vec<_>>());
+                            hashes
                         }
                         AppRoleAssignment::Primary(p) => {
                             p.clones.values().cloned().collect::<Vec<_>>()
@@ -2997,7 +2999,9 @@ mod misc_impls {
                     .values()
                     .flat_map(|r| match r {
                         AppRoleAssignment::Primary(p) if p.is_provisioned => {
-                            vec![p.base_dna_hash.clone()]
+                            let mut hashes = vec![p.base_dna_hash.clone()];
+                            hashes.extend(p.clones.values().cloned().collect::<Vec<_>>());
+                            hashes
                         }
                         AppRoleAssignment::Primary(p) => {
                             p.clones.values().cloned().collect::<Vec<_>>()

--- a/crates/holochain/src/conductor/tests/network_info.rs
+++ b/crates/holochain/src/conductor/tests/network_info.rs
@@ -1,8 +1,11 @@
+use crate::prelude::fake_dna_hash;
+use crate::sweettest::*;
+use hdk::prelude::CloneCellId;
+use hdk::prelude::DnaModifiersOpt;
+use holochain_types::app::{CreateCloneCellPayload, EnableCloneCellPayload};
 use holochain_types::network::Kitsune2NetworkMetricsRequest;
 use holochain_types::prelude::InstalledAppId;
 use holochain_wasm_test_utils::TestWasm;
-
-use crate::sweettest::*;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn network_metrics() {
@@ -10,7 +13,7 @@ async fn network_metrics() {
 
     let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
     let number_of_peers = 3;
-    let config = SweetConductorConfig::standard().no_dpki();
+    let config = SweetConductorConfig::standard();
     let mut conductors = SweetConductorBatch::from_config(number_of_peers, config).await;
     let app_id: InstalledAppId = "app".into();
     conductors.setup_app(&app_id, &[dna.clone()]).await.unwrap();
@@ -32,4 +35,50 @@ async fn network_metrics() {
 
     let network_metrics = &network_metrics[dna.dna_hash()];
     assert_eq!(network_metrics.gossip_state_summary.peer_meta.len(), 2);
+
+    let fake_dna = fake_dna_hash(1);
+    let response = conductors[0]
+        .dump_network_metrics_for_app(
+            &app_id,
+            Kitsune2NetworkMetricsRequest {
+                dna_hash: Some(fake_dna),
+                include_dht_summary: false,
+            },
+        )
+        .await;
+    assert!(response.is_err());
+
+    // Create a disabled clone cell for app1
+    let clone_cell = conductors[0]
+        .create_clone_cell(
+            &app_id,
+            CreateCloneCellPayload {
+                role_name: dna.dna_hash().to_string(),
+                modifiers: DnaModifiersOpt::none().with_network_seed("test_seed".to_string()),
+                membrane_proof: None,
+                name: Some("disabled_clone".into()),
+            },
+        )
+        .await
+        .unwrap();
+
+    let clone_cell_id = CloneCellId::CloneId(clone_cell.clone_id);
+    let response = conductors[0]
+        .clone()
+        .enable_clone_cell(&app_id, &EnableCloneCellPayload { clone_cell_id })
+        .await;
+    assert!(response.is_ok());
+
+    let response = conductors[0]
+        .dump_network_metrics_for_app(
+            &app_id,
+            Kitsune2NetworkMetricsRequest {
+                dna_hash: Some(clone_cell.cell_id.dna_hash().clone()),
+                include_dht_summary: false,
+            },
+        )
+        .await;
+    assert!(response
+        .unwrap()
+        .contains_key(clone_cell.cell_id.dna_hash()));
 }


### PR DESCRIPTION
### Summary

backport of fix where calls to dump_network_metrics/cells_for_app would fail with DNA not found in app.

https://github.com/holochain/holochain/pull/5247


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs