### PR TITLE
Test/add publish query tests

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add a new function `get_dht_op_validation_state` to `holochain_state` for checking the state of a DHT op. #5246
 - Fix a reference to a method that no longer exists in the conductor documentation `list_dnas` -> `list_dna_hashes`. #5245
 - Remove generic type parameters in `SysValDeps` and related types that are always used with the default types. #5245
+- Add tests for `publish_query` to ensure that chain ops and warrant ops pending publish are counted correctly.
 
 ## 0.6.0-dev.19
 

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
@@ -182,8 +182,7 @@ mod tests {
             within_min_period: false,
             withold_publish: false,
         };
-        let chain_op = create_and_insert_chain_op(&db.to_db(), &agent, facts);
-        db.test_write(move |txn| insert_op_authored(txn, &chain_op).unwrap());
+        let _ = create_and_insert_chain_op(&db.to_db(), &agent, facts);
 
         // Should both be 1 now.
         let agent_clone = agent.clone();
@@ -211,8 +210,7 @@ mod tests {
             withold_publish: false,
         };
         // Create chain op with different agent key.
-        let chain_op = create_and_insert_chain_op(&db.to_db(), &fixt!(AgentPubKey), facts);
-        db.test_write(move |txn| insert_op_authored(txn, &chain_op).unwrap());
+        let _ = create_and_insert_chain_op(&db.to_db(), &fixt!(AgentPubKey), facts);
 
         // num_to_publish and length of get_ops_to_publish should be 0.
         let agent_clone = agent.clone();
@@ -239,8 +237,7 @@ mod tests {
             within_min_period: false,
             withold_publish: false,
         };
-        let chain_op = create_and_insert_chain_op(&db.to_db(), &agent, facts);
-        db.test_write(move |txn| insert_op_authored(txn, &chain_op).unwrap());
+        let _ = create_and_insert_chain_op(&db.to_db(), &agent, facts);
 
         // num_to_publish and length of get_ops_to_publish should be 0.
         let agent_clone = agent.clone();
@@ -267,8 +264,7 @@ mod tests {
             within_min_period: false,
             withold_publish: false,
         };
-        let chain_op = create_and_insert_chain_op(&db.to_db(), &agent, facts);
-        db.test_write(move |txn| insert_op_authored(txn, &chain_op).unwrap());
+        let _ = create_and_insert_chain_op(&db.to_db(), &agent, facts);
 
         // num_to_publish and length of get_ops_to_publish should be 0.
         let agent_clone = agent.clone();
@@ -295,8 +291,7 @@ mod tests {
             within_min_period: false,
             withold_publish: false,
         };
-        let chain_op = create_and_insert_chain_op(&db.to_db(), &agent, facts);
-        db.test_write(move |txn| insert_op_authored(txn, &chain_op).unwrap());
+        let _ = create_and_insert_chain_op(&db.to_db(), &agent, facts);
 
         // num_to_publish and length of get_ops_to_publish should be 0.
         let agent_clone = agent.clone();
@@ -323,8 +318,7 @@ mod tests {
             within_min_period: true,
             withold_publish: false,
         };
-        let chain_op = create_and_insert_chain_op(&db.to_db(), &agent, facts);
-        db.test_write(move |txn| insert_op_authored(txn, &chain_op).unwrap());
+        let _ = create_and_insert_chain_op(&db.to_db(), &agent, facts);
 
         // num_to_publish should be 1 because the query does not consider whether the op
         // has been published recently.
@@ -353,8 +347,7 @@ mod tests {
             within_min_period: false,
             withold_publish: true,
         };
-        let chain_op = create_and_insert_chain_op(&db.to_db(), &agent, facts);
-        db.test_write(move |txn| insert_op_authored(txn, &chain_op).unwrap());
+        let _ = create_and_insert_chain_op(&db.to_db(), &agent, facts);
 
         // num_to_publish and length of get_ops_to_publish should be 0.
         let agent_clone = agent.clone();
@@ -452,8 +445,14 @@ mod tests {
         .content;
         let warrant_op = insert_invalid_chain_op_warrant_op(&db, &agent).content;
 
+        let agent_clone = agent.clone();
+        let num_to_publish = db
+            .to_db()
+            .test_read(move |txn| num_still_needing_publish(txn, agent_clone).unwrap());
+        assert_eq!(num_to_publish, 2);
+
         let ops_to_publish = get_ops_to_publish(
-            agent.clone(),
+            agent,
             &db.to_db(),
             ConductorTuningParams::default().min_publish_interval(),
         )
@@ -463,11 +462,6 @@ mod tests {
         .map(|(_, _, op)| op)
         .collect::<Vec<_>>();
         assert_eq!(ops_to_publish, vec![chain_op, warrant_op]);
-
-        let num_to_publish = db
-            .to_db()
-            .test_read(|txn| num_still_needing_publish(txn, agent).unwrap());
-        assert_eq!(num_to_publish, 2);
     }
 
     #[cfg(feature = "unstable-warrants")]


### PR DESCRIPTION
### Summary

Add tests for `publish_query::num_still_needing_publish` and simplify the test harness. Instead of the one test with all different combinations of conditions, there are multiple tests now, and each one exercises both the `get_ops_to_publish` and `num_still_needing_publish` queries.


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for publish-query with scenarios for agent matching, privacy, withhold-publish, publish-interval, and optional warrants; refactored test harness to use per-test DB inserts and new helpers.
* **Documentation**
  * Added Unreleased changelog entry noting new tests and that no public API or runtime behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->