### PR TITLE
Fix: expand/correct documentation around `get_agent_activity` and `ChainQueryFilter`

### DIFF
--- a/crates/hdk/src/chain.rs
+++ b/crates/hdk/src/chain.rs
@@ -1,12 +1,31 @@
 use crate::prelude::*;
 pub use hdi::chain::*;
 
-/// Query the _actions_ of a remote agent's chain.
+/// Query the current state of an agent's chain, including:
 ///
-/// The agent activity is only the actions of their source chain.
-/// The agent activity is held by the neighbourhood of the agent's public key, rather than a content hash like the rest of the DHT.
+/// * The highest observed chain item (or items, in the case of a chain fork),
+/// * A summary of whether the chain contains only valid items, contains at
+/// least one invalid item, is forked, or is empty,
+/// * Any warrants collected for invalid actions committed by the agent,
+/// * Sequence indices and action hashes of valid and rejected actions if
+/// desired (see [ `ActivityRequest::Full` ]).
 ///
-/// The agent activity can be filtered with [`ChainQueryFilter`] like a local chain query.
+/// The agent activity is held by the neighborhood of the agent's public key,
+/// rather than a content hash like the rest of the DHT.
+///
+/// If retrieving chain items along with the current state using
+/// [ `ActivityRequest::Full` ], the chain items can be filtered with
+/// [ `ChainQueryFilter` ] like a local chain query. This filtering happens at
+/// the source before it sends the data to the receiver.
+///
+/// Parameters:
+///
+/// * `agent`: The agent to retrieve the status of.
+/// * `query`: An optional filter for the resulting [ `AgentActivity::valid_activity` ]
+///   and [ `AgentActivity::rejected_activity` ] values. This is only used when
+///   the `request` argument is [ `ActivityRequest::Full` ].
+/// * `request`: The type of data to retrieve -- a summary of current state, or
+/// the summary plus hashes of chain actions matching the filter.
 pub fn get_agent_activity(
     agent: AgentPubKey,
     query: ChainQueryFilter,

--- a/crates/hdk/src/chain.rs
+++ b/crates/hdk/src/chain.rs
@@ -5,7 +5,7 @@ pub use hdi::chain::*;
 ///
 /// * The highest observed chain item (or items, in the case of a chain fork),
 /// * A summary of whether the chain contains only valid items, contains at
-/// least one invalid item, is forked, or is empty,
+///   least one invalid item, is forked, or is empty,
 /// * Any warrants collected for invalid actions committed by the agent, and
 /// * Action sequences and hashes of valid and rejected actions if desired (see
 ///   [`ActivityRequest::Full`]).
@@ -25,7 +25,7 @@ pub use hdi::chain::*;
 ///   and [`AgentActivity::rejected_activity`] values. This is only used when
 ///   the `request` argument is [`ActivityRequest::Full`].
 /// * `request`: The type of data to retrieve -- a summary of current state, or
-/// the summary plus hashes of chain actions matching the filter.
+///   the summary plus hashes of chain actions matching the filter.
 pub fn get_agent_activity(
     agent: AgentPubKey,
     query: ChainQueryFilter,

--- a/crates/hdk/src/chain.rs
+++ b/crates/hdk/src/chain.rs
@@ -6,9 +6,9 @@ pub use hdi::chain::*;
 /// * The highest observed chain item (or items, in the case of a chain fork),
 /// * A summary of whether the chain contains only valid items, contains at
 /// least one invalid item, is forked, or is empty,
-/// * Any warrants collected for invalid actions committed by the agent,
-/// * Sequence indices and action hashes of valid and rejected actions if
-/// desired (see [`ActivityRequest::Full`]).
+/// * Any warrants collected for invalid actions committed by the agent, and
+/// * Action sequences and hashes of valid and rejected actions if desired (see
+///   [`ActivityRequest::Full`]).
 ///
 /// The agent activity is held by the neighborhood of the agent's public key.
 ///

--- a/crates/hdk/src/chain.rs
+++ b/crates/hdk/src/chain.rs
@@ -8,22 +8,22 @@ pub use hdi::chain::*;
 /// least one invalid item, is forked, or is empty,
 /// * Any warrants collected for invalid actions committed by the agent,
 /// * Sequence indices and action hashes of valid and rejected actions if
-/// desired (see [ `ActivityRequest::Full` ]).
+/// desired (see [`ActivityRequest::Full`]).
 ///
-/// The agent activity is held by the neighborhood of the agent's public key,
-/// rather than a content hash like the rest of the DHT.
+/// The agent activity is held by the neighborhood of the agent's public key.
 ///
 /// If retrieving chain items along with the current state using
-/// [ `ActivityRequest::Full` ], the chain items can be filtered with
-/// [ `ChainQueryFilter` ] like a local chain query. This filtering happens at
-/// the source before it sends the data to the receiver.
+/// [`ActivityRequest::Full`], the chain items in
+/// [`AgentActivity::valid_activity`] and [`AgentActivity::rejected_activity`]
+/// can be filtered with [`ChainQueryFilter`] like a local chain query. This
+/// filtering happens at the source before it sends the data to the receiver.
 ///
 /// Parameters:
 ///
 /// * `agent`: The agent to retrieve the status of.
-/// * `query`: An optional filter for the resulting [ `AgentActivity::valid_activity` ]
-///   and [ `AgentActivity::rejected_activity` ] values. This is only used when
-///   the `request` argument is [ `ActivityRequest::Full` ].
+/// * `query`: An optional filter for the resulting [`AgentActivity::valid_activity`]
+///   and [`AgentActivity::rejected_activity`] values. This is only used when
+///   the `request` argument is [`ActivityRequest::Full`].
 /// * `request`: The type of data to retrieve -- a summary of current state, or
 /// the summary plus hashes of chain actions matching the filter.
 pub fn get_agent_activity(

--- a/crates/holochain_zome_types/src/query.rs
+++ b/crates/holochain_zome_types/src/query.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 /// Defines several ways that queries can be restricted to a range.
-/// Notably hash bounded ranges disambiguate forks whereas sequence indexes do
+/// Notably hash bounded ranges disambiguate forks whereas action sequences do
 /// not as the same position can be found in many forks.
 /// The reason that this does NOT use native rust range traits is that the hash
 /// bounded queries MUST be inclusive otherwise the integrity and fork
@@ -20,7 +20,7 @@ use std::collections::HashSet;
 /// between N forks of equal length that proceed it. With an inclusive hash
 /// bounded range the final action always points unambiguously at the "correct"
 /// fork that the range is over. Start hashes are not needed to provide this
-/// property so ranges can be hash terminated with a length of preceeding
+/// property so ranges can be hash terminated with a length of preceding
 /// records to return only. Technically the seq bounded ranges do not imply
 /// any fork disambiguation and so could be a range but for simplicity we left
 /// the API symmetrical in boundedness across all enum variants.
@@ -115,17 +115,18 @@ pub struct LinkQuery {
 /// query.
 #[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, SerializedBytes)]
 pub struct AgentActivity {
-    /// Valid actions on this chain matching the filters passed to the query,
-    /// as a vector of `(sequence_index, action_hash)` tuples. **Note**:
-    /// Warrants received from other sources are not reflected in this field;
-    /// it simply contains actions whose [`RegisterAgentActivity`] operations
-    /// are valid.
+    /// Actions on this chain seen as valid by this authority, matching the
+    /// filters passed to the query, as a vector of
+    /// `(action_sequence, action_hash)` tuples.
+    ///
+    /// **Note**: This may include actions seen as _invalid_ by authorities
+    /// who have validated _other_ DHT operations for the actions. Check the
+    /// [`AgentActivity::warrants`] field for warrants against any of these
+    /// actions for a full picture of their validity.
     pub valid_activity: Vec<(u32, ActionHash)>,
-    /// Rejected actions on this chain matching the filters passed to the
-    /// query, as a vector of `(sequence_index, action_hash)` tuples.  **Note**:
-    /// Warrants received from other sources are not reflected in this field;
-    /// it simply contains actions whose [`RegisterAgentActivity`] operations
-    /// are invalid.
+    /// Actions on this chain seen as invalid by this authority, matching the
+    /// filters passed to the query, as a vector of
+    /// `(action_sequence, action_hash)` tuples.
     pub rejected_activity: Vec<(u32, ActionHash)>,
     /// The current status of this chain including details about the current
     /// chain head, last valid action, and any forks, irrespective of
@@ -147,8 +148,8 @@ pub struct AgentActivity {
 
 /// When calling `hdk::chain::get_agent_activity`, specify whether to get either a
 /// summary of the chain's status, or a summary plus the hashes of the chain
-/// actions that match the given [`ChainQueryFilter`]. **Note**: See the notes
-/// on [`AgentActivity`] about the perspective-dependent nature of the agent's
+/// actions that match the given [`ChainQueryFilter`]. See the notes on
+/// [`AgentActivity`] about the perspective-dependent nature of the agent's
 /// status and valid/rejected activity.
 #[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize, SerializedBytes)]
 pub enum ActivityRequest {
@@ -161,25 +162,21 @@ pub enum ActivityRequest {
     Full,
 }
 
-/// The highest action sequence index for an agent's chain that has been
+/// The highest action sequence for an agent's chain that has been
 /// _observed_, but not necessarily validated and integrated, by this
 /// authority. This struct is seen in the [`AgentActivity`] response from
-/// the `hdk::chain::get_agent_activity` query.
-///
-/// This struct also includes the hash(es) of the action(s) at this sequence
-/// index. If there is more than one, then there is a fork.
+/// the `hdk::chain::get_agent_activity` query. It also includes the hash(es) of
+/// the action(s) at this action sequence.
 ///
 /// Because it may come from an unintegrated DHT operation, the given hash
 /// shouldn't be used as a dependency when constructing another action that
 /// depends on its validity. Instead, check that value of
-/// [`AgentActivity::status`] is [`ChainStatus::Valid`], an enum variant
-/// which will contain the highest sequence index and action hash for a locally
+/// [`AgentActivity::status`] is [`ChainStatus::Valid`], an enum variant which
+/// will contain the highest action sequence and action hash for a locally
 /// validated action; and the [`AgentActivity::warrants`] field, which may
 /// contain warrants from other DHT authorities that have found the action to be
 /// invalid from the perspective of the DHT operations they've validated.
-
-// The information is tracked at the edge of holochain before
-// validation (but after drop checks).
+#[derive(Clone, Debug, PartialEq, Hash, Eq, serde::Serialize, serde::Deserialize)]
 pub struct HighestObserved {
     /// The highest sequence number observed.
     pub action_seq: u32,
@@ -189,8 +186,7 @@ pub struct HighestObserved {
 }
 
 /// Status of the agent activity chain, as part of the return value from
-/// `hdk::chain::get_agent_activity`. If the chain is both forked and invalid, the
-/// [`ChainStatus::Forked`] variant will be used.
+/// `hdk::chain::get_agent_activity`.
 // TODO: In the future we will most likely be replaced
 // by warrants instead of Forked / Invalid so we can provide
 // evidence of why the chain has a status.
@@ -200,23 +196,25 @@ pub enum ChainStatus {
     #[default]
     Empty,
     /// The chain is valid from the perspective of this authority, and the
-    /// highest integrated action is at the given sequence index and action
+    /// highest integrated action is at the given action sequence and action
     /// hash. This does not indicate that the chain is valid from the
     /// perspective of _all_ authorities; check the contents of
     /// [`AgentActivity::warrants`] for notices of invalidity found by
     /// other authorities.
     Valid(ChainHead),
-    /// The chain is forked at the given sequence index by at least two
+    /// The chain is forked at the given action sequence by at least two
     /// conflicting actions, indicated by the two given action hashes. See
     /// the note about the action hashes on [`ChainFork`].
     ///
     /// The chain may also have invalid records in addition to being forked;
     /// in this case, `Forked` is still used. To check for invalid records,
     /// look at the value of [`AgentActivity::warrants`] and/or call
-    /// `hdk::chain::get_agent_activity` with [`ActivityRequest::Full`] and look at
-    /// the values in [`AgentActivity::reje cted_activity`].
+    /// `hdk::chain::get_agent_activity` with [`ActivityRequest::Full`] and look
+    /// at the values in [`AgentActivity::rejected_activity`].
+    ///
+    /// **NOTE**: Chain fork detection is not considered stable at this time.
     Forked(ChainFork),
-    /// The chain is not forked, but is invalid from the given sequence index
+    /// The chain is not forked, but is invalid from the given action sequence
     /// and action hash forward, by virtue of this authority finding a
     /// [`RegisterAgentActivity`] DHT operation for that action to be
     /// invalid. There may be other types of operations for the chain's
@@ -226,7 +224,7 @@ pub enum ChainStatus {
     Invalid(ChainHead),
 }
 
-/// A pairing of a sequence index and its corresponding action hash in a chain.
+/// A pairing of an action sequence and its corresponding action hash in a chain.
 /// This is used for both [`ChainStatus::Valid`], where the given value is the
 /// most recent item in a valid and contiguous chain, and
 /// [`ChainStatus::Invalid`], where the value is the first invalid item in a
@@ -240,11 +238,11 @@ pub struct ChainHead {
 }
 
 /// The chain has been forked by these two actions at this point. The ordering
-/// of the values in `first_action` and `second_action` is not guaranteed to be
-/// identical across peers; and, in cases of three or more actions (A, B, C)
-/// causing a fork at the same spot, the values are not guaranteed to be
-/// identical either (some authorities may report A and B, others may report C
-/// and A, and so on).
+/// of the values in `first_action` and `second_action` is undefined, and in
+/// cases of three or more actions causing a fork, different peers may report
+/// different hash pairs.
+///
+/// **NOTE**: Chain fork detection is not considered stable at this time.
 #[derive(Clone, Debug, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ChainFork {
     /// The point where the chain has forked.

--- a/crates/holochain_zome_types/src/query.rs
+++ b/crates/holochain_zome_types/src/query.rs
@@ -143,7 +143,7 @@ pub struct AgentActivity {
     /// operations produced by the agent; they have been published to this
     /// authority as part of their responsibility to keep track of the
     /// agent's status.
-    pub warrants: Vec<Warrant>,
+    pub warrants: Vec<SignedWarrant>,
 }
 
 /// When calling `hdk::chain::get_agent_activity`, specify whether to get either a

--- a/crates/holochain_zome_types/src/query.rs
+++ b/crates/holochain_zome_types/src/query.rs
@@ -168,7 +168,7 @@ pub enum ActivityRequest {
 /// the `hdk::chain::get_agent_activity` query. It also includes the hash(es) of
 /// the action(s) at this action sequence.
 ///
-/// Because it may come from an unintegrated DHT operation, the given hash
+/// Because they may come from unintegrated DHT operations, the given hashes
 /// shouldn't be used as a dependency when constructing another action that
 /// depends on its validity. Instead, check that value of
 /// [`AgentActivity::status`] is [`ChainStatus::Valid`], an enum variant which
@@ -180,8 +180,9 @@ pub enum ActivityRequest {
 pub struct HighestObserved {
     /// The highest sequence number observed.
     pub action_seq: u32,
-    /// Hashes of any actions claiming to be at this
-    /// action sequence.
+    /// Hashes of any actions claiming to be at this action sequence. Note that
+    /// this is a vector and may contain more than one hash in the case of a
+    /// chain fork.
     pub hash: Vec<ActionHash>,
 }
 
@@ -220,7 +221,7 @@ pub enum ChainStatus {
     /// invalid. There may be other types of operations for the chain's
     /// actions which other authorities have found to be invalid; this
     /// information is not reflected here but is instead found in the
-    //// [`AgentActivity::warrants`] field.
+    /// [`AgentActivity::warrants`] field.
     Invalid(ChainHead),
 }
 

--- a/crates/holochain_zome_types/src/query.rs
+++ b/crates/holochain_zome_types/src/query.rs
@@ -168,14 +168,13 @@ pub enum ActivityRequest {
 /// the `hdk::chain::get_agent_activity` query. It also includes the hash(es) of
 /// the action(s) at this action sequence.
 ///
-/// Because they may come from unintegrated DHT operations, the given hashes
+/// Because it may come from an unintegrated DHT operation, a given hash
 /// shouldn't be used as a dependency when constructing another action that
-/// depends on its validity. Instead, check that value of
-/// [`AgentActivity::status`] is [`ChainStatus::Valid`], an enum variant which
-/// will contain the highest action sequence and action hash for a locally
-/// validated action; and the [`AgentActivity::warrants`] field, which may
-/// contain warrants from other DHT authorities that have found the action to be
-/// invalid from the perspective of the DHT operations they've validated.
+/// depends on its validity. Instead, check that the hash exists in
+/// [`AgentActivity::valid_activity`] and does not exist in
+/// [`AgentActivity::warrants`]; this will tell you that the action has been
+/// integrated and presumably found valid by all validators. It's also
+/// recommended to check that [`AgentActivity::status`] is [`ChainStatus::Valid`].
 #[derive(Clone, Debug, PartialEq, Hash, Eq, serde::Serialize, serde::Deserialize)]
 pub struct HighestObserved {
     /// The highest sequence number observed.

--- a/docs/specs/src/hwp_2_overview.md
+++ b/docs/specs/src/hwp_2_overview.md
@@ -116,7 +116,7 @@ A Record consists of an Action which holds context and points to an Entry which 
 
 3. The hash of the previous Action (to create the chain)
 
-4. The sequence index of the Action in the chain
+4. The action sequence of the Action in the chain
 
 5. The hash of the Entry
 


### PR DESCRIPTION
Closes #5235 .

### Summary

Corrects and expands on the RustDoc for `get_agent_activity` and all the other types that touch it.

### TODO:
- [ ] CHANGELOGs updated with appropriate info


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent activity queries gain a request mode (Status or Full) and return richer details: chain status (Empty/Valid/Forked/Invalid), highest‑observed items, warrants, and matching action hashes when Full is requested.
  * Query filtering can toggle inclusion of entry data for matching actions.

* **Refactor**
  * Agent activity API now accepts an explicit request parameter to control returned data.

* **Documentation**
  * Clarified terminology (e.g., “action sequence”) and expanded guidance on status, warrants, and filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->