### PR TITLE
chore: remove obsolete kitsune_p2p_block types

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 - Support binding admin and app websocket interfaces on designated listen addresses. #5271
+- Remove obsolete kitsune_p2p types that were used with the previous version of kitsune.
 
 ## 0.6.0-dev.22
 

--- a/crates/holochain_zome_types/src/block.rs
+++ b/crates/holochain_zome_types/src/block.rs
@@ -7,115 +7,10 @@ use holo_hash::DhtOpHash;
 use holo_hash::DnaHash;
 use holochain_integrity_types::Timestamp;
 use holochain_timestamp::InclusiveTimestampInterval;
-use kitsune_p2p_block::NodeSpaceBlockReason;
 #[cfg(feature = "rusqlite")]
 use rusqlite::types::ToSqlOutput;
 #[cfg(feature = "rusqlite")]
 use rusqlite::ToSql;
-
-mod kitsune_p2p_block {
-    use super::*;
-
-    /// Reason for an Agent/Space Block.
-    #[derive(Clone)]
-    pub enum AgentSpaceBlockReason {
-        /// Cryptography violation.
-        BadCrypto,
-    }
-
-    /// Reason for a Node Block.
-    #[deprecated(since = "0.6.0")]
-    #[derive(Clone, serde::Serialize, Debug, Eq, PartialEq, Hash)]
-    pub enum NodeBlockReason {
-        /// The node did some bad cryptography.
-        BadCrypto,
-        /// Dos attack.
-        DoS,
-    }
-
-    /// Reason for a Node/Space Block.
-    #[deprecated(since = "0.6.0")]
-    #[derive(Clone, serde::Serialize, Debug, Eq, PartialEq, Hash)]
-    pub enum NodeSpaceBlockReason {
-        /// Bad message encoding.
-        BadWire,
-    }
-
-    /// Reason for an Ip Block.
-    #[derive(Clone, serde::Serialize, Debug, Eq, PartialEq, Hash)]
-    pub enum IpBlockReason {
-        /// Classic DoS.
-        DoS,
-    }
-
-    /// kitsune2::Url returns a peer id as a &str
-    pub type NodeId = String;
-
-    /// Block Target.
-    #[derive(Clone, Eq, PartialEq, Hash)]
-    pub enum BlockTarget {
-        Node(NodeId, NodeBlockReason),
-        NodeSpace(NodeId, DnaHash, NodeSpaceBlockReason),
-        Ip(std::net::Ipv4Addr, IpBlockReason),
-    }
-
-    /// Block Target Id.
-    #[derive(Eq, PartialEq)]
-    pub enum BlockTargetId {
-        Node(NodeId),
-        NodeSpace(NodeId, DnaHash),
-        Ip(std::net::Ipv4Addr),
-    }
-
-    impl From<BlockTarget> for BlockTargetId {
-        fn from(block_target: BlockTarget) -> Self {
-            match block_target {
-                BlockTarget::NodeSpace(node_id, space, _) => Self::NodeSpace(node_id, space),
-                BlockTarget::Node(node_id, _) => Self::Node(node_id),
-                BlockTarget::Ip(ip_addr, _) => Self::Ip(ip_addr),
-            }
-        }
-    }
-
-    /// Basic block struct.
-    #[derive(Clone, Eq, PartialEq, Hash)]
-    pub struct Block {
-        target: BlockTarget,
-        interval: InclusiveTimestampInterval,
-    }
-
-    impl Block {
-        /// Create a new block.
-        pub fn new(target: BlockTarget, interval: InclusiveTimestampInterval) -> Self {
-            Self { target, interval }
-        }
-
-        /// Access the block target.
-        pub fn target(&self) -> &BlockTarget {
-            &self.target
-        }
-
-        /// Convert into a block target.
-        pub fn into_target(self) -> BlockTarget {
-            self.target
-        }
-
-        /// Convert into an interval.
-        pub fn into_interval(self) -> InclusiveTimestampInterval {
-            self.interval
-        }
-
-        /// Get the block start timestamp.
-        pub fn start(&self) -> Timestamp {
-            self.interval.start()
-        }
-
-        /// Get the block end timestamp.
-        pub fn end(&self) -> Timestamp {
-            self.interval.end()
-        }
-    }
-}
 
 /// Everything required for a coordinator to block some agent on the same DNA.
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
@@ -140,40 +35,37 @@ pub enum CellBlockReason {
     BadCrypto,
 }
 
-impl From<kitsune_p2p_block::AgentSpaceBlockReason> for CellBlockReason {
-    fn from(agent_space_block_reason: kitsune_p2p_block::AgentSpaceBlockReason) -> Self {
-        match agent_space_block_reason {
-            kitsune_p2p_block::AgentSpaceBlockReason::BadCrypto => CellBlockReason::BadCrypto,
-        }
-    }
-}
-
 /// Reason why we might want to block a node.
+#[deprecated(since = "0.6.0")]
 #[derive(Clone, serde::Serialize, Debug)]
 pub enum NodeBlockReason {
-    Kitsune(kitsune_p2p_block::NodeBlockReason),
+    /// The node did some bad cryptography.
+    BadCrypto,
+    /// Dos attack.
+    DoS,
 }
 
-impl From<kitsune_p2p_block::NodeBlockReason> for NodeBlockReason {
-    fn from(kitsune_node_block_reason: kitsune_p2p_block::NodeBlockReason) -> Self {
-        Self::Kitsune(kitsune_node_block_reason)
-    }
+/// Reason for a Node/Space Block.
+#[deprecated(since = "0.6.0")]
+#[derive(Clone, serde::Serialize, Debug, Eq, PartialEq, Hash)]
+pub enum NodeSpaceBlockReason {
+    /// Bad message encoding.
+    BadWire,
 }
 
 /// Reason why we might want to block an IP.
 #[derive(Clone, serde::Serialize, Debug)]
 pub enum IpBlockReason {
-    Kitsune(kitsune_p2p_block::IpBlockReason),
-}
-
-impl From<kitsune_p2p_block::IpBlockReason> for IpBlockReason {
-    fn from(kitsune_ip_block_reason: kitsune_p2p_block::IpBlockReason) -> Self {
-        Self::Kitsune(kitsune_ip_block_reason)
-    }
+    /// Classic DoS.
+    DoS,
 }
 
 /// The type to use for identifying blocking ipv4 addresses.
 type IpV4 = std::net::Ipv4Addr;
+
+/// An ID to identify a Node by.
+#[deprecated(since = "0.6.0")]
+pub type NodeId = String;
 
 /// Target of a block.
 /// Each target type has an ID and associated reason.
@@ -182,26 +74,12 @@ pub enum BlockTarget {
     /// Block an agent for a DNA, encoded in a cell ID.
     Cell(CellId, CellBlockReason),
     #[deprecated(since = "0.6.0", note = "not respected, use cell instead")]
-    NodeDna(kitsune_p2p_block::NodeId, DnaHash, NodeSpaceBlockReason),
+    NodeDna(NodeId, DnaHash, NodeSpaceBlockReason),
     /// Some node is playing silly buggers.
     #[deprecated(since = "0.6.0", note = "not respected")]
-    Node(kitsune_p2p_block::NodeId, NodeBlockReason),
+    Node(NodeId, NodeBlockReason),
     /// Currently not supported
     Ip(IpV4, IpBlockReason),
-}
-
-impl From<kitsune_p2p_block::BlockTarget> for BlockTarget {
-    fn from(kblock_target: kitsune_p2p_block::BlockTarget) -> Self {
-        match kblock_target {
-            kitsune_p2p_block::BlockTarget::NodeSpace(node_id, space, reason) => {
-                Self::NodeDna(node_id, space.clone(), reason)
-            }
-            kitsune_p2p_block::BlockTarget::Node(node_id, reason) => {
-                Self::Node(node_id, reason.into())
-            }
-            kitsune_p2p_block::BlockTarget::Ip(ip_addr, reason) => Self::Ip(ip_addr, reason.into()),
-        }
-    }
 }
 
 #[derive(
@@ -210,22 +88,10 @@ impl From<kitsune_p2p_block::BlockTarget> for BlockTarget {
 pub enum BlockTargetId {
     Cell(CellId),
     #[deprecated(since = "0.6.0", note = "not respected, use cell instead")]
-    NodeDna(kitsune_p2p_block::NodeId, DnaHash),
+    NodeDna(NodeId, DnaHash),
     #[deprecated(since = "0.6.0", note = "not respected")]
-    Node(kitsune_p2p_block::NodeId),
+    Node(NodeId),
     Ip(IpV4),
-}
-
-impl From<kitsune_p2p_block::BlockTargetId> for BlockTargetId {
-    fn from(kblock_target_id: kitsune_p2p_block::BlockTargetId) -> Self {
-        match kblock_target_id {
-            kitsune_p2p_block::BlockTargetId::NodeSpace(node_id, space) => {
-                Self::NodeDna(node_id, space.clone())
-            }
-            kitsune_p2p_block::BlockTargetId::Node(node_id) => Self::Node(node_id),
-            kitsune_p2p_block::BlockTargetId::Ip(ip_addr) => Self::Ip(ip_addr),
-        }
-    }
 }
 
 impl From<BlockTarget> for BlockTargetId {
@@ -293,19 +159,6 @@ pub struct Block {
     /// Target of the block.
     target: BlockTarget,
     interval: InclusiveTimestampInterval,
-}
-
-impl From<kitsune_p2p_block::Block> for Block {
-    fn from(kblock: kitsune_p2p_block::Block) -> Self {
-        Self {
-            target: kblock.clone().into_target().into(),
-            interval: InclusiveTimestampInterval::try_new(
-                Timestamp::from_micros(kblock.start().0),
-                Timestamp::from_micros(kblock.end().0),
-            )
-            .unwrap(),
-        }
-    }
 }
 
 impl Block {


### PR DESCRIPTION
### Summary

These types were used with kitsune1, but are no longer required now.


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Exposed block/ban reason types at the top level for clearer use in apps.

- **Refactor**
  - Consolidated and simplified blocking targets; node-based variants deprecated in favor of cell/IP-focused blocking.
  - Streamlined public enums/IDs for blocking targets to be more consistent.

- **Chores**
  - Removed obsolete networking types from an older stack.

- **Documentation**
  - Updated Unreleased notes to reflect removals and interface binding updates.

- **Tests**
  - No changes required for most users; deprecations remain backward-compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->