### PR TITLE
Chore: Rustdoc formatting fixes

### DIFF
--- a/crates/fixt/src/lib.rs
+++ b/crates/fixt/src/lib.rs
@@ -30,7 +30,7 @@ pub use rng::rng;
 /// their inner types by constructing an inner Fixturator directly with the outer index passed in.
 /// If we can always assume the inner fixturators can be efficiently constructed at any index this
 /// allows us to efficiently compose fixturators.
-/// See [ `newtype_fixturator!` ](newtype_fixturator) macro defined below for an example of this.
+/// See [`newtype_fixturator!`](newtype_fixturator) macro defined below for an example of this.
 ///
 /// Fixturator implements Clone for convenience but note that this will clone the current index.
 ///
@@ -515,7 +515,6 @@ macro_rules! get_fixt_curve {
     }};
 }
 
-#[macro_export]
 /// implement Iterator for a FooFixturator for a given curve
 ///
 /// curve!(Foo, Unpredictable, /* make an Unpredictable Foo here */ );
@@ -525,6 +524,7 @@ macro_rules! get_fixt_curve {
 /// ability to return an Option - i.e. return a value of type Foo _not_ `Option<Foo>`
 /// if the body of the expression changes the index it will be respected, if not then it will be
 /// incremented by 1 automatically by the macro
+#[macro_export]
 macro_rules! curve {
     ( $type:ident, $curve:ident, $e:expr ) => {
         $crate::prelude::paste! {
@@ -550,10 +550,10 @@ macro_rules! curve {
     };
 }
 
-#[macro_export]
 /// tiny convenience macro to make it easy to get the first Foo from its fixturator without using
 /// the iterator interface to save a little typing
 /// c.f. fixt!(Foo) vs. FooFixturator::new(Unpredictable).next().unwrap();
+#[macro_export]
 macro_rules! fixt {
     ( $name:tt ) => {
         $crate::fixt!($name, $crate::prelude::Unpredictable)
@@ -618,8 +618,8 @@ pub struct Predictable;
 #[derive(Clone, Copy)]
 pub struct Empty;
 
-#[macro_export]
 /// a direct delegation of fixtures to the inner type for new types
+#[macro_export]
 macro_rules! newtype_fixturator {
     ( $outer:ident<Vec<$inner:ty>> ) => {
         fixturator!(
@@ -682,9 +682,9 @@ macro_rules! newtype_fixturator {
     };
 }
 
-#[macro_export]
 /// a direct delegation of fixtures to the inner type for wasm io types
 /// See zome types crate
+#[macro_export]
 macro_rules! wasm_io_fixturator {
     ( $outer:ident<$inner:ty> ) => {
         fixturator!(
@@ -711,11 +711,11 @@ macro_rules! wasm_io_fixturator {
     };
 }
 
-#[macro_export]
 /// Creates a simple way to generate enums that use the strum way of iterating
 /// <https://docs.rs/strum/0.27.0/strum/>
 /// iterates over all the variants (Predictable) or selects random variants (Unpredictable)
 /// You do still need to BYO "empty" variant as the macro doesn't know what to use there
+#[macro_export]
 macro_rules! enum_fixturator {
     ( $enum:ident, $empty:expr ) => {
         use rand::seq::IteratorRandom;

--- a/crates/fixt/src/serialized_bytes.rs
+++ b/crates/fixt/src/serialized_bytes.rs
@@ -2,9 +2,9 @@
 use crate::prelude::*;
 use holochain_serialized_bytes::prelude::*;
 
-#[derive(Clone, Copy)]
 /// there are many different types of things that we could reasonably serialize in our examples
 /// a list of things that we serialize iteratively (Predictable) or randomly (Unpredictable)
+#[derive(Clone, Copy)]
 pub enum ThingsToSerialize {
     Unit,
     Bool,

--- a/crates/hc_bundle/tests/test_cli.rs
+++ b/crates/hc_bundle/tests/test_cli.rs
@@ -268,11 +268,11 @@ async fn test_multi_integrity() {
     assert_eq!(*dna.dna_def(), expected);
 }
 
+/// Test that a manifest with multiple integrity zomes and dependencies parses
+/// to the correct dna file.
 #[tokio::test]
 #[cfg_attr(target_os = "windows", ignore = "theres a hash mismatch - check crlf?")]
 #[cfg(feature = "unstable-migration")]
-/// Test that a manifest with multiple integrity zomes and dependencies parses
-/// to the correct dna file.
 async fn test_multi_integrity() {
     let pack_dna = |path| async move {
         let mut cmd = Command::cargo_bin("hc-dna").unwrap();

--- a/crates/hdi/src/flat_op.rs
+++ b/crates/hdi/src/flat_op.rs
@@ -14,8 +14,8 @@ pub use flat_op_activity::*;
 pub use flat_op_entry::*;
 pub use flat_op_record::*;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 /// A convenience type for validation [`Op`](holochain_integrity_types::op::Op)s.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FlatOp<ET, LT>
 where
     ET: UnitEnum,

--- a/crates/hdi/src/flat_op/flat_op_activity.rs
+++ b/crates/hdi/src/flat_op/flat_op_activity.rs
@@ -1,10 +1,10 @@
 use super::*;
 use holochain_integrity_types::MigrationTarget;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 /// Data specific to the
 /// [`Op::RegisterAgentActivity`](holochain_integrity_types::op::Op::RegisterAgentActivity)
 /// operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OpActivity<UnitType, LT> {
     /// This operation registers the [`Action`](holochain_integrity_types::action::Action) for an
     /// app defined entry type to the author's chain.

--- a/crates/hdi/src/flat_op/flat_op_entry.rs
+++ b/crates/hdi/src/flat_op/flat_op_entry.rs
@@ -1,9 +1,9 @@
 use super::*;
 use holochain_integrity_types::{CapClaimEntry, CapGrantEntry};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 /// Data specific to the [`Op::StoreEntry`](holochain_integrity_types::op::Op::StoreEntry)
 /// operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OpEntry<ET>
 where
     ET: UnitEnum,
@@ -97,9 +97,9 @@ where
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 /// Data specific to the [`Op::RegisterUpdate`](holochain_integrity_types::op::Op::RegisterUpdate)
 /// operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OpUpdate<ET>
 where
     ET: UnitEnum,
@@ -156,9 +156,9 @@ where
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 /// Data specific to the [`Op::RegisterDelete`](holochain_integrity_types::op::Op::RegisterDelete)
 /// operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OpDelete {
     /// The [`Delete`] action that deletes this entry
     pub action: Delete,

--- a/crates/hdi/src/flat_op/flat_op_record.rs
+++ b/crates/hdi/src/flat_op/flat_op_record.rs
@@ -1,9 +1,9 @@
 use super::*;
 use holochain_integrity_types::MigrationTarget;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 /// Data specific to the [`Op::StoreRecord`](holochain_integrity_types::op::Op::StoreRecord)
 /// operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum OpRecord<ET: UnitEnum, LT> {
     /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an app
     /// defined entry type.

--- a/crates/hdi/src/hash_path/path.rs
+++ b/crates/hdi/src/hash_path/path.rs
@@ -159,7 +159,6 @@ impl TryFrom<&Component> for String {
 #[repr(transparent)]
 pub struct Path(pub Vec<Component>);
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize, SerializedBytes)]
 /// A [`LinkType`] applied to a [`Path`].
 ///
 /// All links committed from this path will have this link type.
@@ -168,6 +167,7 @@ pub struct Path(pub Vec<Component>);
 /// ```ignore
 /// let typed_path = path.typed(LinkTypes::MyLink)?;
 /// ```
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize, SerializedBytes)]
 pub struct TypedPath {
     /// The [`LinkType`] within the scope of the zome where it's defined.
     pub link_type: ScopedLinkType,

--- a/crates/hdi/src/hash_path/shard.rs
+++ b/crates/hdi/src/hash_path/shard.rs
@@ -14,12 +14,12 @@ pub type ShardWidth = u32;
 /// e.g. abcdef with a depth of 1 and width 1 shards to a.abcdef and depth 2 shards to a.b.abcdef.
 pub type ShardDepth = u32;
 
-#[derive(Debug)]
 /// A valid strategy for sharding requires both a width and a depth.
 /// At the moment sharding only works well for data that is reliably longer than width/depth.
 /// For example, sharding the username foo with width 4 doesn't make sense.
 /// There is no magic padding or extending of the provided data to make up undersized shards.
 // @todo stretch short shards out in a nice balanced way (append some bytes from the hash?)
+#[derive(Debug)]
 pub struct ShardStrategy(ShardWidth, ShardDepth);
 
 /// impl [`ShardStrategy`] as an immutable/read-only thingy.

--- a/crates/hdi/src/lib.rs
+++ b/crates/hdi/src/lib.rs
@@ -312,7 +312,6 @@ pub mod ed25519;
 /// - The function call itself
 pub mod info;
 
-#[cfg(feature = "trace")]
 /// Integrates HDI with the Rust tracing crate.
 ///
 /// The functions and structs in this module do _not_ need to be used directly.
@@ -323,6 +322,7 @@ pub mod info;
 /// another subscriber on the host.
 /// The logging level can be changed for the host at runtime using the `WASM_LOG` environment
 /// variable that works exactly as `RUST_LOG` for other tracing.
+#[cfg(feature = "trace")]
 pub mod trace;
 
 /// The interface between the host and guest is implemented as an [`hdi::HdiT`] trait.

--- a/crates/hdi/src/link/examples.rs
+++ b/crates/hdi/src/link/examples.rs
@@ -13,8 +13,8 @@
 //! ```
 use crate::prelude::*;
 
-#[hdk_link_types]
 /// This is an example of declaring your link types.
+#[hdk_link_types]
 pub enum SomeLinkTypes {
     SomeLinkType,
     SomeOtherLinkType,

--- a/crates/hdi/src/map_extern.rs
+++ b/crates/hdi/src/map_extern.rs
@@ -6,9 +6,9 @@ pub fn make_subscriber() -> impl Drop {
     crate::prelude::tracing::subscriber::set_default(crate::trace::WasmSubscriber::default())
 }
 
+/// Needed as a noop for map_extern! when trace is off.
 #[cfg(not(feature = "trace"))]
 #[doc(hidden)]
-/// Needed as a noop for map_extern! when trace is off.
 pub fn make_subscriber() -> impl Drop {
     struct Noop;
     impl Drop for Noop {

--- a/crates/hdi/src/prelude.rs
+++ b/crates/hdi/src/prelude.rs
@@ -6,8 +6,8 @@ pub use crate::entry::must_get_action;
 pub use crate::entry::must_get_entry;
 pub use crate::entry::must_get_valid_record;
 pub use crate::entry_types;
-#[cfg(not(feature = "trace"))]
 /// Needed as a noop for map_extern! when trace is off.
+#[cfg(not(feature = "trace"))]
 pub use crate::error;
 pub use crate::flat_op::*;
 pub use crate::hash::*;
@@ -61,10 +61,10 @@ pub use tracing;
 #[cfg(feature = "trace")]
 pub use tracing::{debug, error, info, instrument, trace, warn};
 
+/// Needed as a noop for map_extern! when trace is off.
 #[doc(hidden)]
 #[cfg(not(feature = "trace"))]
 #[macro_export]
-/// Needed as a noop for map_extern! when trace is off.
 macro_rules! error {
     ($($field:tt)*) => {};
 }

--- a/crates/hdi/tests/integration.rs
+++ b/crates/hdi/tests/integration.rs
@@ -51,8 +51,8 @@ fn to_local_types_test_unit() {
     assert_eq!(to_coords(Unit::C), (0, 2));
 }
 
-#[test]
 /// Setting the discriminant explicitly should have no effect.
+#[test]
 fn to_local_types_test_discriminant() {
     #[hdk_to_coordinates]
     enum Unit {

--- a/crates/hdk/src/chain.rs
+++ b/crates/hdk/src/chain.rs
@@ -6,7 +6,7 @@ pub use hdi::chain::*;
 /// The agent activity is only the actions of their source chain.
 /// The agent activity is held by the neighbourhood of the agent's public key, rather than a content hash like the rest of the DHT.
 ///
-/// The agent activity can be filtered with [ `ChainQueryFilter` ] like a local chain query.
+/// The agent activity can be filtered with [`ChainQueryFilter`] like a local chain query.
 pub fn get_agent_activity(
     agent: AgentPubKey,
     query: ChainQueryFilter,
@@ -20,7 +20,7 @@ pub fn get_agent_activity(
 
 /// Walks the source chain in ascending order (oldest to latest) filtering by action and/or entry type
 ///
-/// Given an action and entry type, returns an [ `Vec<Record>` ]
+/// Given an action and entry type, returns an [`Vec<Record>`]
 ///
 // @todo document this better with examples after we make query do all the things we want.
 // @todo implement cap grant/claim usage in terms of query

--- a/crates/hdk/src/ed25519.rs
+++ b/crates/hdk/src/ed25519.rs
@@ -20,7 +20,7 @@ where
 /// Assuming the private key for the provided pubkey exists in lair this will work.
 /// If we don't have the private key for the public key then we can't sign anything!
 ///
-/// See [ `sign` ]
+/// See [`sign`]
 pub fn sign_raw<K>(key: K, data: Vec<u8>) -> ExternResult<Signature>
 where
     K: Into<AgentPubKey>,
@@ -30,7 +30,7 @@ where
 
 /// Sign N serializable things using an ephemeral private key.
 ///
-/// Serde convenience for [ `sign_ephemeral_raw` ].
+/// Serde convenience for [`sign_ephemeral_raw`].
 pub fn sign_ephemeral<D>(datas: Vec<D>) -> ExternResult<EphemeralSignatures>
 where
     D: serde::Serialize + std::fmt::Debug,
@@ -43,7 +43,7 @@ where
 
 /// Sign N data using an ephemeral private key.
 ///
-/// This is a complement to [ `sign_raw` ] in case we don't have a meaningful key for the input.
+/// This is a complement to [`sign_raw`] in case we don't have a meaningful key for the input.
 /// __The generated private half of the key is discarded immediately upon signing__.
 ///
 /// The signatures output are pairwise ordered the same as the input data.

--- a/crates/hdk/src/lib.rs
+++ b/crates/hdk/src/lib.rs
@@ -532,7 +532,7 @@ pub mod info;
 /// - Many links can point from/to the same hash
 /// - Links reference entry hashes not actions
 ///
-/// Links are retrived from the DHT by performing [ `link::get_links` ] or [ `link::get_links_details` ] against the _base_ of a link.
+/// Links are retrived from the DHT by performing [`link::get_links`] or [`link::get_links_details`] against the _base_ of a link.
 ///
 /// Links also support short (about 500 bytes) binary data to encode contextual data on a domain specific basis.
 ///
@@ -557,7 +557,7 @@ pub mod p2p;
 /// The functions and structs in this module do _not_ need to be used directly.
 /// The [`hdk_extern!`] attribute on functions exposed externally all set the `WasmSubscriber` as the global default.
 ///
-/// This module defines a [ `trace::WasmSubscriber` ] that forwards all tracing macro calls to another subscriber on the host.
+/// This module defines a [`trace::WasmSubscriber`] that forwards all tracing macro calls to another subscriber on the host.
 /// The logging level can be changed for the host at runtime using the `WASM_LOG` environment variable that works exactly as `RUST_LOG` for other tracing.
 ///
 /// [`hdk_extern!`]: hdk_derive::hdk_extern

--- a/crates/hdk/src/link.rs
+++ b/crates/hdk/src/link.rs
@@ -110,7 +110,7 @@ where
 ///   former leads to flakiness as above and the latter means it would be impossible to create a
 ///   link after any previous delete of any link.
 ///
-/// All of this is bad so link creates point to entries (See [ `create_link` ]) and deletes point to
+/// All of this is bad so link creates point to entries (See [`create_link`]) and deletes point to
 /// creates.
 pub fn delete_link(address: ActionHash, get_options: GetOptions) -> ExternResult<ActionHash> {
     HDK.with(|h| {

--- a/crates/hdk/src/p2p.rs
+++ b/crates/hdk/src/p2p.rs
@@ -56,13 +56,13 @@ where
 /// - cap_secret: Optional cap claim secret to allow access to the remote call.
 /// - payload: The payload to send to the remote function; receiver needs to deserialize cleanly.
 ///
-/// Response is [ `ExternResult` ] which returns [ `ZomeCallResponse` ] of the function call.
-/// [ `ZomeCallResponse::NetworkError` ] if there was a network error.
-/// [ `ZomeCallResponse::Unauthorized` ] if the provided cap grant is invalid.
+/// Response is [`ExternResult`] which returns [`ZomeCallResponse`] of the function call.
+/// [`ZomeCallResponse::NetworkError`] if there was a network error.
+/// [`ZomeCallResponse::Unauthorized`] if the provided cap grant is invalid.
 /// The unauthorized case should always be handled gracefully because gap grants can be revoked at
 /// any time and the claim holder has no way of knowing until they provide a secret for a call.
 ///
-/// An Ok response already includes an [ `ExternIO` ] to be deserialized with `extern_io.decode()?`.
+/// An Ok response already includes an [`ExternIO`] to be deserialized with `extern_io.decode()?`.
 ///
 /// ```ignore
 /// ...
@@ -120,7 +120,7 @@ where
 
 /// ## Remote Signal
 /// Send a signal to a list of other agents.
-/// This will send the data as an [ `AppSignal` ] to
+/// This will send the data as an [`AppSignal`] to
 /// this zome for all the agents supplied.
 ///
 /// ### Non-blocking

--- a/crates/hdk_derive/src/link_types.rs
+++ b/crates/hdk_derive/src/link_types.rs
@@ -5,10 +5,10 @@ use syn::Item;
 use syn::ItemEnum;
 use syn::{parse, parse_macro_input};
 
-#[derive(Debug, FromMeta)]
-#[darling(derive_syn_parse)]
 /// Optional attribute for skipping `#[no_mangle]`.
 /// Useful for testing.
+#[derive(Debug, FromMeta)]
+#[darling(derive_syn_parse)]
 struct MacroArgs {
     #[darling(default)]
     skip_no_mangle: bool,

--- a/crates/hdk_derive/src/to_coordinates.rs
+++ b/crates/hdk_derive/src/to_coordinates.rs
@@ -10,10 +10,10 @@ use syn::ItemEnum;
 use syn::Variant;
 use syn::{parse, parse_macro_input};
 
-#[derive(Debug, FromMeta)]
-#[darling(derive_syn_parse)]
 /// Type for parsing the `#[hdk_to_coordinates(nested = true)]`
 /// attribute into. Defaults to false.
+#[derive(Debug, FromMeta)]
+#[darling(derive_syn_parse)]
 struct MacroArgs {
     #[darling(default)]
     nested: bool,

--- a/crates/hdk_derive/src/unit_enum.rs
+++ b/crates/hdk_derive/src/unit_enum.rs
@@ -8,17 +8,17 @@ use syn::parse::Parser;
 use syn::punctuated::Punctuated;
 use syn::{parse_macro_input, Token};
 
-#[derive(FromVariant)]
 /// Type for gathering each variants ident and fields.
+#[derive(FromVariant)]
 struct VarOpts {
     ident: syn::Ident,
     fields: darling::ast::Fields<darling::util::Ignored>,
 }
 
-#[derive(FromDeriveInput)]
-#[darling(attributes(unit_attrs), forward_attrs(unit_enum))]
 /// Type for parsing the input and extracting the
 /// unit_name attribute like: `#[unit_enum(UnitFoo)]`.
+#[derive(FromDeriveInput)]
+#[darling(attributes(unit_attrs), forward_attrs(unit_enum))]
 struct Opts {
     ident: syn::Ident,
     attrs: Vec<syn::Attribute>,

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -238,9 +238,9 @@ impl<P: PrimitiveHashType> HoloHash<P> {
         Self::from_raw_36_and_type(hash, P::new())
     }
 
-    #[cfg(feature = "hashing")]
     /// Construct a HoloHash from a prehashed raw 32-byte slice.
     /// The location bytes will be calculated.
+    #[cfg(feature = "hashing")]
     pub fn from_raw_32(hash: Vec<u8>) -> Self {
         Self::from_raw_32_and_type(hash, P::new())
     }

--- a/crates/holo_hash/src/lib.rs
+++ b/crates/holo_hash/src/lib.rs
@@ -31,9 +31,9 @@ pub use hashable_content::*;
 #[cfg(feature = "serialization")]
 mod ser;
 
-#[cfg(feature = "serialization")]
 /// A convenience type, for specifying a hash by HashableContent rather than
 /// by its HashType
+#[cfg(feature = "serialization")]
 pub type HoloHashOf<C> = HoloHash<<C as HashableContent>::HashType>;
 
 // feature: encoding

--- a/crates/holochain/src/conductor/api/api_cell.rs
+++ b/crates/holochain/src/conductor/api/api_cell.rs
@@ -113,10 +113,10 @@ pub trait CellConductorApiT: Send + Sync {
     async fn post_commit_permit(&self) -> Result<OwnedPermit<PostCommitArgs>, SendError<()>>;
 }
 
-#[async_trait]
-#[cfg_attr(feature = "test_utils", mockall::automock)]
 /// A minimal set of functionality needed from the conductor by
 /// host functions.
+#[async_trait]
+#[cfg_attr(feature = "test_utils", mockall::automock)]
 pub trait CellConductorReadHandleT: Send + Sync {
     /// Get this cell id
     fn cell_id(&self) -> &CellId;
@@ -193,8 +193,8 @@ pub trait CellConductorReadHandleT: Send + Sync {
     /// Expose delete_clone_cell functionality to zomes.
     async fn delete_clone_cell(&self, payload: DeleteCloneCellPayload) -> ConductorResult<()>;
 
-    #[cfg(feature = "unstable-countersigning")]
     /// Accept a countersigning session.
+    #[cfg(feature = "unstable-countersigning")]
     async fn accept_countersigning_session(
         &self,
         cell_id: CellId,

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -2739,8 +2739,8 @@ mod authenticate_token_impls {
     }
 }
 
-#[cfg(feature = "unstable-countersigning")]
 /// Methods for bridging from host calls to workflows for countersigning
+#[cfg(feature = "unstable-countersigning")]
 mod countersigning_impls {
     use super::*;
     use crate::core::workflow::{self, countersigning_workflow::CountersigningWorkspace};

--- a/crates/holochain/src/conductor/entry_def_store.rs
+++ b/crates/holochain/src/conductor/entry_def_store.rs
@@ -49,8 +49,8 @@ pub(crate) async fn get_entry_def(
     }
 }
 
-#[cfg_attr(feature = "instrument", tracing::instrument(skip(ribosome)))]
 /// Get all the [EntryDef] for this dna
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(ribosome)))]
 pub(crate) async fn get_entry_defs(
     ribosome: RealRibosome,
 ) -> EntryDefStoreResult<Vec<(EntryDefBufferKey, EntryDef)>> {

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -34,10 +34,10 @@ use std::{
     sync::Arc,
 };
 
-#[derive(Clone)]
 /// This is the set of all current
 /// [`DnaHash`] spaces for all cells
 /// installed on this conductor.
+#[derive(Clone)]
 pub struct Spaces {
     map: RwShare<HashMap<DnaHash, Space>>,
     pub(crate) db_dir: Arc<DatabasesRootPath>,
@@ -49,11 +49,11 @@ pub struct Spaces {
     db_key: DbKey,
 }
 
-#[derive(Clone)]
 /// This is the set of data required at the
 /// [`DnaHash`] space level.
 /// All cells in the same [`DnaHash`] space
 /// will share these.
+#[derive(Clone)]
 pub struct Space {
     /// The dna hash for this space.
     pub dna_hash: Arc<DnaHash>,

--- a/crates/holochain/src/core/queue_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer.rs
@@ -222,8 +222,8 @@ pub async fn spawn_queue_consumer_tasks(
     ))
 }
 
-#[derive(Clone)]
 /// Map of running queue consumers workflows per dna space.
+#[derive(Clone)]
 pub struct QueueConsumerMap {
     map: RwShare<HashMap<QueueEntry, TriggerSender>>,
 }

--- a/crates/holochain/src/core/ribosome.rs
+++ b/crates/holochain/src/core/ribosome.rs
@@ -354,7 +354,7 @@ pub trait Invocation: Clone + Send + Sync {
     /// For example, if FnComponents was vec!["foo", "bar", "baz"] it would loop as "foo_bar_baz"
     /// then "foo_bar" then "foo". All of those three callbacks that are defined will be called
     /// _unless a definitive callback result is returned_.
-    /// See [ `CallbackResult::is_definitive` ] in zome_types.
+    /// See [`CallbackResult::is_definitive`] in zome_types.
     /// All of the individual callback results are then folded into a single overall result value
     /// as a From implementation on the invocation results structs (e.g. zome results vs. ribosome
     /// results).

--- a/crates/holochain/src/core/ribosome/guest_callback/entry_defs.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/entry_defs.rs
@@ -92,8 +92,8 @@ mod test {
     use holochain_types::prelude::*;
     use std::collections::BTreeMap;
 
-    #[test]
     /// this is a non-standard fold test because the result is not so simple
+    #[test]
     fn entry_defs_callback_result_fold() {
         let mut zome_name_fixturator = ZomeNameFixturator::new(::fixt::Unpredictable);
         let mut entry_defs_fixturator = EntryDefsFixturator::new(::fixt::Unpredictable);

--- a/crates/holochain/src/core/ribosome/guest_callback/validate.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/validate.rs
@@ -11,8 +11,8 @@ use holochain_types::prelude::*;
 use holochain_zome_types::op::Op;
 use std::sync::Arc;
 
-#[derive(Clone, Debug)]
 /// An invocation of the validate callback function.
+#[derive(Clone, Debug)]
 pub struct ValidateInvocation {
     /// The zomes this invocation will invoke.
     zomes_to_invoke: ZomesToInvoke,

--- a/crates/holochain/src/core/ribosome/host_fn/create.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/create.rs
@@ -120,8 +120,8 @@ pub mod wasm_test {
     use holochain_wasm_test_utils::TestWasmPair;
     use std::sync::Arc;
 
-    #[tokio::test(flavor = "multi_thread")]
     /// we can get an entry hash out of the fn directly
+    #[tokio::test(flavor = "multi_thread")]
     async fn create_entry_test() {
         let ribosome =
             RealRibosomeFixturator::new(crate::fixt::Zomes(vec![TestWasm::Create]))

--- a/crates/holochain/src/core/ribosome/host_fn/random_bytes.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/random_bytes.rs
@@ -52,8 +52,8 @@ pub mod wasm_test {
     use holochain_wasm_test_utils::TestWasm;
     use std::sync::Arc;
 
-    #[tokio::test(flavor = "multi_thread")]
     /// we can get some random data out of the fn directly
+    #[tokio::test(flavor = "multi_thread")]
     async fn random_bytes_test() {
         let ribosome = RealRibosomeFixturator::new(crate::fixt::Zomes(vec![]))
             .next()
@@ -72,8 +72,8 @@ pub mod wasm_test {
         assert_ne!(&[0; LEN as usize], output.as_ref(),);
     }
 
-    #[tokio::test(flavor = "multi_thread")]
     /// we can get some random data out of the fn via. a wasm call
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_random_bytes_test() {
         holochain_trace::test_run();
         let RibosomeTestFixture {
@@ -85,8 +85,8 @@ pub mod wasm_test {
         assert_ne!(&vec![0; LEN as usize], &output.to_vec());
     }
 
-    #[tokio::test(flavor = "multi_thread")]
     /// we can get some random data out of the fn via. a wasm call
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_rand_random_bytes_test() {
         holochain_trace::test_run();
         let RibosomeTestFixture {

--- a/crates/holochain/src/core/ribosome/real_ribosome.rs
+++ b/crates/holochain/src/core/ribosome/real_ribosome.rs
@@ -1249,9 +1249,9 @@ pub mod wasm_test {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread")]
     /// Basic checks that we can call externs internally and externally the way we want using the
     /// hdk macros rather than low level rust extern syntax.
+    #[tokio::test(flavor = "multi_thread")]
     async fn ribosome_extern_test() {
         holochain_trace::test_run();
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow/types.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/types.rs
@@ -2,8 +2,8 @@ use crate::core::validation::OutcomeOrError;
 use holo_hash::AnyDhtHash;
 use std::convert::TryFrom;
 
-#[derive(Debug)]
 /// The outcome of app validation
+#[derive(Debug)]
 pub enum Outcome {
     /// Moves to integration
     Accepted,

--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
@@ -163,9 +163,9 @@ impl Expected {
     }
 }
 
-#[tokio::test(flavor = "multi_thread")]
 /// Test that all ops are created and the correct zomes
 /// are called for each op.
+#[tokio::test(flavor = "multi_thread")]
 async fn app_validation_ops() {
     holochain_trace::test_run();
     let entry_def_a = EntryDef::default_from_id("a");

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -17,24 +17,24 @@ use {
     tokio::task::AbortHandle,
 };
 
-#[cfg(feature = "unstable-countersigning")]
 /// Accept handler for starting countersigning sessions.
+#[cfg(feature = "unstable-countersigning")]
 mod accept;
 
-#[cfg(feature = "unstable-countersigning")]
 /// Inner workflow for resolving an incomplete countersigning session.
+#[cfg(feature = "unstable-countersigning")]
 mod incomplete;
 
-#[cfg(feature = "unstable-countersigning")]
 /// Inner workflow for completing a countersigning session based on received signatures.
+#[cfg(feature = "unstable-countersigning")]
 mod complete;
 
-#[cfg(feature = "unstable-countersigning")]
 /// State integrity function to ensure that the database and the workspace are in sync.
+#[cfg(feature = "unstable-countersigning")]
 mod refresh;
 
-#[cfg(feature = "unstable-countersigning")]
 /// Success handler for receiving signature bundles from the network.
+#[cfg(feature = "unstable-countersigning")]
 mod success;
 
 #[cfg(feature = "unstable-countersigning")]
@@ -806,8 +806,8 @@ pub async fn countersigning_publish(
     Ok(())
 }
 
-#[cfg(feature = "unstable-countersigning")]
 /// Abandon a countersigning session.
+#[cfg(feature = "unstable-countersigning")]
 async fn abandon_session(
     authored_db: DbWrite<DbKindAuthored>,
     author: AgentPubKey,

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
@@ -197,8 +197,8 @@ pub async fn incoming_dht_ops_workflow(
         .map_err(|_| super::error::WorkflowError::RecvError)?
 }
 
-#[cfg_attr(feature = "instrument", tracing::instrument(skip(op)))]
 /// If this op fails the counterfeit check it should be dropped
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(op)))]
 async fn should_keep(op: &DhtOp) -> WorkflowResult<()> {
     match op {
         DhtOp::ChainOp(op) => {

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/types.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/types.rs
@@ -1,5 +1,5 @@
-#[derive(Debug, PartialEq, Eq)]
 /// The outcome of sys validation
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum Outcome {
     /// Moves to app validation
     Accepted,

--- a/crates/holochain/src/sweettest/sweet_zome.rs
+++ b/crates/holochain/src/sweettest/sweet_zome.rs
@@ -22,9 +22,9 @@ impl SweetZome {
     }
 }
 
-#[derive(Default, Clone)]
 /// A helper for creating an [`InlineZomeSet`] consisting of a single
 /// integrity zome and a single coordinator zome.
+#[derive(Default, Clone)]
 pub struct SweetInlineZomes(pub InlineZomeSet);
 
 impl SweetInlineZomes {

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -296,8 +296,8 @@ pub async fn wait_for_integration<Db: ReadAccess<DbKindDht>>(
     ))
 }
 
-#[cfg_attr(feature = "instrument", tracing::instrument(skip(envs)))]
 /// Show authored data for each cell environment
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(envs)))]
 pub async fn show_authored<Db: ReadAccess<DbKindAuthored>>(envs: &[&Db]) {
     for (i, &db) in envs.iter().enumerate() {
         db.read_async(move |txn| -> DatabaseResult<()> {

--- a/crates/holochain/src/test_utils/conditional_consistency.rs
+++ b/crates/holochain/src/test_utils/conditional_consistency.rs
@@ -378,8 +378,8 @@ pub async fn wait_for_integration<Db: ReadAccess<DbKindDht>>(
     ))
 }
 
-#[cfg_attr(feature = "instrument", tracing::instrument(skip(envs)))]
 /// Show authored data for each cell environment
+#[cfg_attr(feature = "instrument", tracing::instrument(skip(envs)))]
 pub async fn show_authored<Db: ReadAccess<DbKindAuthored>>(envs: &[&Db]) {
     for (i, &db) in envs.iter().enumerate() {
         db.read_async(move |txn| -> DatabaseResult<()> {

--- a/crates/holochain/src/test_utils/inline_zomes.rs
+++ b/crates/holochain/src/test_utils/inline_zomes.rs
@@ -67,6 +67,7 @@ pub fn batch_create_zome() -> InlineIntegrityZome {
         })
 }
 
+/// Newtype for simple_crud_zome entry type
 #[derive(
     Debug,
     Clone,
@@ -81,7 +82,6 @@ pub fn batch_create_zome() -> InlineIntegrityZome {
 )]
 #[serde(transparent)]
 #[repr(transparent)]
-/// Newtype for simple_crud_zome entry type
 pub struct AppString(pub String);
 
 impl AppString {

--- a/crates/holochain/src/test_utils/wait_for.rs
+++ b/crates/holochain/src/test_utils/wait_for.rs
@@ -87,11 +87,11 @@ macro_rules! assert_eq_retry_5m {
     };
 }
 
-#[derive(Debug, Clone)]
 /// Generic waiting for some test property to
 /// be true. This allows early exit from waiting when
 /// the condition becomes true but will wait up to a
 /// maximum if the condition is not true.
+#[derive(Debug, Clone)]
 pub struct WaitFor {
     num_attempts: u32,
     attempt: u32,

--- a/crates/holochain/tests/tests/ser_regression/mod.rs
+++ b/crates/holochain/tests/tests/ser_regression/mod.rs
@@ -32,8 +32,8 @@ async fn ser_entry_hash_test() {
     let _eh: EntryHash = extern_io.decode().unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread")]
 /// we can call a fn on a remote
+#[tokio::test(flavor = "multi_thread")]
 async fn ser_regression_test() {
     holochain_trace::test_run();
     // ////////////

--- a/crates/holochain_cascade/src/authority/get_agent_activity_query/must_get_agent_activity/test.rs
+++ b/crates/holochain_cascade/src/authority/get_agent_activity_query/must_get_agent_activity/test.rs
@@ -86,9 +86,9 @@ use test_case::test_case;
     agent_chain(&[(0, 0..10)]), agent_hash(&[0]),
     ChainFilter::new(action_hash(&[8])).until_hash(action_hash(&[3])).until_timestamp(Timestamp::from_micros(4000)).take(8)
     => agent_chain(&[(0, 4..9)]) ; "Until 3 Until timestamp 4 take 8")]
-#[tokio::test(flavor = "multi_thread")]
 /// Extracts the smallest range from the chain filter
 /// and then returns all actions within that range
+#[tokio::test(flavor = "multi_thread")]
 async fn returns_full_sequence_from_filter(
     chain: Vec<(AgentPubKey, Vec<TestChainItem>)>,
     agent: AgentPubKey,
@@ -146,8 +146,8 @@ async fn returns_full_sequence_from_filter(
 #[test_case(
     agent_chain(&[(0, 0..2)]), agent_hash(&[0]), ChainFilter::new(action_hash(&[1])).take(0)
     => MustGetAgentActivityResponse::EmptyRange; "Take nothing produces an empty range")]
-#[tokio::test(flavor = "multi_thread")]
 /// Check the query returns the appropriate responses.
+#[tokio::test(flavor = "multi_thread")]
 async fn test_responses(
     chain: Vec<(AgentPubKey, Vec<TestChainItem>)>,
     agent: AgentPubKey,

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -462,8 +462,8 @@ impl CascadeImpl {
         Ok(results)
     }
 
-    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     /// Fetch hash bounded agent activity from the network.
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     async fn fetch_must_get_agent_activity(
         &self,
         author: AgentPubKey,
@@ -728,11 +728,11 @@ impl CascadeImpl {
             .await
     }
 
-    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     /// Updates the cache with the latest network authority data
     /// and returns what is in the cache.
     /// This gives you the latest possible picture of the current dht state.
     /// Data from your zome call is also added to the cache.
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     pub async fn dht_get(
         &self,
         hash: AnyDhtHash,

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -649,11 +649,11 @@ impl ExternalApiWireError {
     }
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, SerializedBytes, Clone)]
-#[serde(rename_all = "snake_case")]
 /// Filter for [`AdminRequest::ListApps`].
 ///
 /// Apps can be either enabled or disabled, set by the user via the conductor interface.
+#[derive(Debug, serde::Serialize, serde::Deserialize, SerializedBytes, Clone)]
+#[serde(rename_all = "snake_case")]
 pub enum AppStatusFilter {
     /// Filter on apps which are Enabled.
     Enabled,

--- a/crates/holochain_conductor_api/src/state_dump.rs
+++ b/crates/holochain_conductor_api/src/state_dump.rs
@@ -20,16 +20,16 @@ pub struct FullStateDump {
     pub integration_dump: FullIntegrationStateDump,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
 /// A collection of many cells dumps for easy viewing.
 /// Use display to see a nice printout.
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IntegrationStateDumps(pub Vec<IntegrationStateDump>);
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
 /// A high level view of the incoming ops and where
 /// they are currently.
 /// Ops start in the validation limbo then proceed
 /// to the integration limbo then finally are integrated.
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct IntegrationStateDump {
     /// Ops in validation limbo awaiting sys
     /// or app validation.
@@ -41,10 +41,10 @@ pub struct IntegrationStateDump {
     pub integrated: usize,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 /// A full view of the DHT shard of the Cell.
 /// Ops start in the validation limbo then proceed
 /// to the integration limbo then finally are integrated.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct FullIntegrationStateDump {
     /// Ops in validation limbo awaiting sys
     /// or app validation.
@@ -63,8 +63,8 @@ pub struct FullIntegrationStateDump {
     pub dht_ops_cursor: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 /// State dump of all the peer info
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct P2pAgentsDump {
     /// The info of this agents cell.
     pub this_agent_info: Option<AgentInfoDump>,
@@ -76,10 +76,10 @@ pub struct P2pAgentsDump {
     pub peers: Vec<AgentInfoDump>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 /// Agent info dump with the agent,
 /// space, signed time, expires in and
 /// urls printed in a pretty way.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct AgentInfoDump {
     pub kitsune_agent: Arc<kitsune2_api::AgentId>,
     pub kitsune_space: Arc<kitsune2_api::SpaceId>,

--- a/crates/holochain_integrity_types/src/action.rs
+++ b/crates/holochain_integrity_types/src/action.rs
@@ -88,11 +88,11 @@ impl Display for Action {
     }
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq, Eq, Hash)]
-#[serde(tag = "type")]
 /// This allows action types to be serialized to bytes without requiring
 /// an owned value. This produces the same bytes as if they were
 /// serialized with the [`Action`] type.
+#[derive(Clone, Debug, Serialize, PartialEq, Eq, Hash)]
+#[serde(tag = "type")]
 pub(crate) enum ActionRef<'a> {
     Dna(&'a Dna),
     AgentValidationPkg(&'a AgentValidationPkg),

--- a/crates/holochain_integrity_types/src/capability/grant.rs
+++ b/crates/holochain_integrity_types/src/capability/grant.rs
@@ -223,8 +223,8 @@ pub struct CapAccessInfo {
 
 /// a single zome/function pair
 pub type GrantedFunction = (ZomeName, FunctionName);
-/// A collection of zome/function pairs
 
+/// A collection of zome/function pairs
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
 pub enum GrantedFunctions {

--- a/crates/holochain_integrity_types/src/chain.rs
+++ b/crates/holochain_integrity_types/src/chain.rs
@@ -11,7 +11,6 @@ use std::collections::HashSet;
 #[cfg(test)]
 mod test;
 
-#[derive(Serialize, Deserialize, SerializedBytes, Debug, PartialEq, Eq, Hash, Clone)]
 /// Filter source chain items.
 /// Starting from some chain position given as an [`ActionHash`]
 /// the chain is walked backwards to genesis.
@@ -23,6 +22,7 @@ mod test;
 /// Timestamp newer than the provided one. In the case of multiple actions having the same
 /// Timestamp as the limit condition, the filter will stop at the action with the lowest sequence.
 /// Multiple limit conditions can be set. Whichever is the smaller set will be kept.
+#[derive(Serialize, Deserialize, SerializedBytes, Debug, PartialEq, Eq, Hash, Clone)]
 pub struct ChainFilter<H: Eq + Ord + std::hash::Hash = ActionHash> {
     /// The starting position of the filter.
     pub chain_top: H,
@@ -34,8 +34,8 @@ pub struct ChainFilter<H: Eq + Ord + std::hash::Hash = ActionHash> {
     pub include_cached_entries: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, Clone)]
 /// Specify when to stop walking down the chain.
+#[derive(Serialize, Deserialize, Debug, Eq, Clone)]
 pub enum LimitConditions<H: Eq + Ord + std::hash::Hash = ActionHash> {
     /// Allow all up to genesis.
     ToGenesis,
@@ -98,8 +98,8 @@ impl<H: Eq + Ord + std::hash::Hash> core::cmp::PartialEq for LimitConditions<H> 
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 /// Input to the `must_get_agent_activity` call.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MustGetAgentActivityInput {
     /// The author of the chain that you are requesting
     /// activity from.

--- a/crates/holochain_integrity_types/src/entry_def.rs
+++ b/crates/holochain_integrity_types/src/entry_def.rs
@@ -56,8 +56,8 @@ pub struct EntryDef {
     pub cache_at_agent_activity: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 /// All definitions for all entry types in an integrity zome.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct EntryDefs(pub Vec<EntryDef>);
 
 #[derive(

--- a/crates/holochain_integrity_types/src/info.rs
+++ b/crates/holochain_integrity_types/src/info.rs
@@ -51,8 +51,8 @@ impl ZomeInfo {
 /// Placeholder for a real network seed type. See [`DnaModifiers`].
 pub type NetworkSeed = String;
 
-#[derive(Debug, Serialize, Deserialize)]
 /// Information about the current DNA.
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DnaInfoV1 {
     /// The name of this DNA.
     pub name: String,
@@ -65,8 +65,8 @@ pub struct DnaInfoV1 {
     pub zome_names: Vec<ZomeName>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
 /// Information about the current DNA.
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DnaInfoV2 {
     /// The name of this DNA.
     pub name: String,
@@ -82,8 +82,8 @@ pub struct DnaInfoV2 {
 /// Convenience alias to the latest `DnaInfoN`.
 pub type DnaInfo = DnaInfoV2;
 
-#[derive(Clone, Debug, Serialize, Deserialize, SerializedBytes, PartialEq, Default)]
 /// The set of [`EntryDefIndex`] and [`LinkType`]s in scope for the calling zome.
+#[derive(Clone, Debug, Serialize, Deserialize, SerializedBytes, PartialEq, Default)]
 pub struct ScopedZomeTypesSet {
     /// All the entry [`EntryDefIndex`]s in scope for this zome.
     pub entries: ScopedZomeTypes<EntryDefIndex>,
@@ -91,8 +91,8 @@ pub struct ScopedZomeTypesSet {
     pub links: ScopedZomeTypes<LinkType>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 /// zome types that are in scope for the calling zome.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ScopedZomeTypes<T>(pub Vec<(ZomeIndex, Vec<T>)>);
 
 impl<T> Default for ScopedZomeTypes<T> {
@@ -101,8 +101,8 @@ impl<T> Default for ScopedZomeTypes<T> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// A key to the [`ScopedZomeTypes`] container.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ZomeTypesKey<T>
 where
     T: U8Index + Copy,
@@ -118,12 +118,12 @@ pub type ZomeEntryTypesKey = ZomeTypesKey<EntryDefIndex>;
 /// A key to the [`ScopedZomeTypes<LinkType>`] container.
 pub type ZomeLinkTypesKey = ZomeTypesKey<LinkType>;
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// The index into the [`ZomeIndex`] vec.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ZomeDependencyIndex(pub u8);
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// A type with the zome that it is defined in.
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ScopedZomeType<T> {
     /// The zome that defines this type.
     pub zome_index: ZomeIndex,
@@ -218,23 +218,23 @@ impl From<LinkType> for ZomeLinkTypesKey {
     }
 }
 
-#[doc(hidden)]
 /// This is an internally used trait for checking
 /// enum lengths at compile time.
 /// This is used by proc macros in the
 /// `hdk_derive` crate and should not be used directly.
+#[doc(hidden)]
 pub trait EnumLen {
     /// The total length of an enum (possibly recusively)
     /// known at compile time.
     const ENUM_LEN: u8;
 }
 
-#[doc(hidden)]
 /// This is an internally used trait for checking
 /// enum variant lengths at compile time.
 /// This is used by proc macros in the
 /// `hdk_derive` crate and should not be used directly.
 /// `V` is the variant index.
+#[doc(hidden)]
 pub trait EnumVariantLen<const V: u8> {
     /// The starting point of this enum variant.
     const ENUM_VARIANT_START: u8;

--- a/crates/holochain_integrity_types/src/link.rs
+++ b/crates/holochain_integrity_types/src/link.rs
@@ -45,8 +45,8 @@ impl LinkTag {
     }
 }
 
-#[derive(PartialEq, Eq, Hash, Clone, Debug, Serialize, Deserialize)]
 /// Filter on a set of [`LinkType`]s.
+#[derive(PartialEq, Eq, Hash, Clone, Debug, Serialize, Deserialize)]
 pub enum LinkTypeFilter {
     /// Return links that match any of these types.
     Types(Vec<(ZomeIndex, Vec<LinkType>)>),

--- a/crates/holochain_integrity_types/src/op.rs
+++ b/crates/holochain_integrity_types/src/op.rs
@@ -127,11 +127,11 @@ pub struct StoreRecord {
     pub record: Record,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
 /// Stores a new [`Entry`] in the DHT.
 /// This is the act of creating a either a [`Action::Create`] or
 /// a [`Action::Update`] and publishing it to the DHT.
 /// These actions create a new instance of an [`Entry`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
 pub struct StoreEntry {
     /// The signed and hashed [`EntryCreationAction`] that creates
     /// a new instance of the [`Entry`].
@@ -334,9 +334,9 @@ impl Op {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes, Eq)]
 /// Either a [`Action::Create`] or a [`Action::Update`].
 /// These actions both create a new instance of an [`Entry`].
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes, Eq)]
 pub enum EntryCreationAction {
     /// A [`Action::Create`] that creates a new instance of an [`Entry`].
     Create(Create),

--- a/crates/holochain_integrity_types/src/record.rs
+++ b/crates/holochain_integrity_types/src/record.rs
@@ -185,8 +185,8 @@ impl AsRef<SignedActionHashed> for SignedActionHashed {
     }
 }
 
-#[derive(Clone, Debug, Eq, Serialize, Deserialize)]
 /// Any content that has been hashed and signed.
+#[derive(Clone, Debug, Eq, Serialize, Deserialize)]
 pub struct SignedHashed<T>
 where
     T: HashableContent,

--- a/crates/holochain_integrity_types/src/validate.rs
+++ b/crates/holochain_integrity_types/src/validate.rs
@@ -12,9 +12,9 @@ pub enum ValidateCallbackResult {
     UnresolvedDependencies(UnresolvedDependencies),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// Unresolved dependencies that are either a set of hashes
 /// or an agent activity query.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum UnresolvedDependencies {
     Hashes(Vec<AnyDhtHash>),
     AgentActivity(AgentPubKey, ChainFilter),

--- a/crates/holochain_metrics/src/lib.rs
+++ b/crates/holochain_metrics/src/lib.rs
@@ -205,9 +205,9 @@ pub enum HolochainMetricsConfig {
         otel_config: influxive::InfluxiveMeterProviderConfig,
     },
 
-    #[cfg(feature = "influxive")]
     /// Use influxive to connect to an already running InfluxDB instance.
     /// NOTE: this means we cannot initialize any dashboards.
+    #[cfg(feature = "influxive")]
     InfluxiveExternal {
         /// The writer config for connecting to the external influxdb instance.
         writer_config: influxive::InfluxiveWriterConfig,
@@ -226,8 +226,8 @@ pub enum HolochainMetricsConfig {
         token: String,
     },
 
-    #[cfg(feature = "influxive")]
     /// Use influxive as a child service to write metrics.
+    #[cfg(feature = "influxive")]
     InfluxiveChildSvc {
         /// The child service config for running the influxd server.
         child_svc_config: Box<influxive::InfluxiveChildSvcConfig>,

--- a/crates/holochain_p2p/src/lib.rs
+++ b/crates/holochain_p2p/src/lib.rs
@@ -77,11 +77,11 @@ fn check_k2_init() {
     });
 }
 
+/// A wrapper around HolochainP2pSender that partially applies the dna_hash / agent_pub_key.
+/// I.e. a sender that is tied to a specific cell.
 #[automock]
 #[allow(clippy::too_many_arguments)]
 #[async_trait::async_trait]
-/// A wrapper around HolochainP2pSender that partially applies the dna_hash / agent_pub_key.
-/// I.e. a sender that is tied to a specific cell.
 pub trait HolochainP2pDnaT: Send + Sync + 'static {
     /// owned getter
     fn dna_hash(&self) -> DnaHash;

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -7,11 +7,11 @@ use holochain_types::prelude::ValidationReceiptBundle;
 use kitsune2_api::{SpaceId, StoredOp};
 use std::collections::HashMap;
 
-#[derive(Clone, Debug)]
 /// Get options help control how the get is processed at various levels.
 /// Fields tagged with `[Network]` are network-level controls.
 /// Fields tagged with `[Remote]` are controls that will be forwarded to the
 /// remote agent processing this `Get` request.
+#[derive(Clone, Debug)]
 pub struct GetOptions {
     /// `[Network]`
     /// How many remote nodes should we make requests of / aggregate.
@@ -115,11 +115,11 @@ impl Default for GetMetaOptions {
     }
 }
 
-#[derive(Debug, Clone, Default)]
 /// Get links from the DHT.
 /// Fields tagged with `[Network]` are network-level controls.
 /// Fields tagged with `[Remote]` are controls that will be forwarded to the
 /// remote agent processing this `GetLinks` request.
+#[derive(Debug, Clone, Default)]
 pub struct GetLinksOptions {
     /// `[Network]`
     /// Timeout to await responses for aggregation.
@@ -132,11 +132,11 @@ pub struct GetLinksOptions {
     pub get_options: holochain_zome_types::entry::GetOptions,
 }
 
-#[derive(Debug, Clone)]
 /// Get agent activity from the DHT.
 /// Fields tagged with `[Network]` are network-level controls.
 /// Fields tagged with `[Remote]` are controls that will be forwarded to the
 /// remote agent processing this `GetLinks` request.
+#[derive(Debug, Clone)]
 pub struct GetActivityOptions {
     /// `[Network]`
     /// Timeout to await responses for aggregation.

--- a/crates/holochain_p2p/src/types/wire.rs
+++ b/crates/holochain_p2p/src/types/wire.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// Struct for encoding DhtOp as bytes.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct WireDhtOpData {
     /// The dht op.
     pub op_data: holochain_types::dht_op::DhtOp,

--- a/crates/holochain_secure_primitive/src/lib.rs
+++ b/crates/holochain_secure_primitive/src/lib.rs
@@ -5,10 +5,10 @@ pub use subtle;
 mod types;
 pub use types::*;
 
-#[macro_export]
 /// Serialization for fixed arrays is generally not available in a way that can be derived.
 /// Being able to wrap fixed size arrays is important e.g. for crypto safety etc. so this is a
 /// simple way to implement serialization so that we can send these types between the host/guest.
+#[macro_export]
 macro_rules! fixed_array_serialization {
     ($t:ty, $len:expr) => {
         $crate::paste::paste! {
@@ -74,7 +74,6 @@ macro_rules! fixed_array_serialization {
     };
 }
 
-#[macro_export]
 /// Cryptographic secrets are fiddly at the best of times.
 ///
 /// In wasm it is somewhat impossible to have true secrets because wasm memory is not secure.
@@ -105,6 +104,7 @@ macro_rules! fixed_array_serialization {
 //
 // @todo implement explicit zeroing, moving and copying of memory for sensitive data.
 //       - e.g. the secrecy crate <https://crates.io/crates/secrecy>
+#[macro_export]
 macro_rules! secure_primitive {
     ($t:ty, $len:expr) => {
         $crate::fixed_array_serialization!($t, $len);

--- a/crates/holochain_sqlite/src/db/access.rs
+++ b/crates/holochain_sqlite/src/db/access.rs
@@ -47,9 +47,9 @@ impl<'a, 'txn, D: DbKindT> From<&'a mut Transaction<'txn>> for Txn<'a, 'txn, D> 
     }
 }
 
-#[async_trait::async_trait]
 /// A trait for being generic over [`DbWrite`] and [`DbRead`] that
 /// both implement read access.
+#[async_trait::async_trait]
 pub trait ReadAccess<Kind: DbKindT>: Clone + Into<DbRead<Kind>> {
     /// Run an async read transaction on a background thread.
     async fn read_async<E, R, F>(&self, f: F) -> Result<R, E>

--- a/crates/holochain_sqlite/src/db/kind.rs
+++ b/crates/holochain_sqlite/src/db/kind.rs
@@ -46,24 +46,24 @@ pub trait DbKindT: Clone + std::fmt::Debug + Send + Sync + 'static {
 
 pub trait DbKindOp {}
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::Display)]
 /// Specifies the environment used for authoring data by all cells on the same [`DnaHash`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::Display)]
 pub struct DbKindAuthored(pub Arc<CellId>);
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::Display)]
 /// Specifies the environment used for dht data by all cells on the same [`DnaHash`].
+#[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::Display)]
 pub struct DbKindDht(pub Arc<DnaHash>);
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::Display)]
 /// Specifies the environment used by each Cache (one per dna).
+#[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::Display)]
 pub struct DbKindCache(pub Arc<DnaHash>);
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::Display)]
 /// Specifies the environment used by a Conductor
+#[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::Display)]
 pub struct DbKindConductor;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::Display)]
 /// Specifies the environment used to save wasm
+#[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::Display)]
 pub struct DbKindWasm;
 
 /// Database kind for [DbKind::PeerMetaStore]

--- a/crates/holochain_state/src/mutations.rs
+++ b/crates/holochain_state/src/mutations.rs
@@ -735,8 +735,8 @@ pub fn set_receipts_complete_redundantly_in_dht_db(
     Ok(())
 }
 
-#[cfg(feature = "unstable-warrants")]
 /// Insert a [`Warrant`] into the Warrant table.
+#[cfg(feature = "unstable-warrants")]
 pub fn insert_warrant(txn: &mut Transaction, warrant: SignedWarrant) -> StateMutationResult<usize> {
     let warrant_type = warrant.get_type();
     let hash = warrant.to_hash();

--- a/crates/holochain_state/src/test_utils.rs
+++ b/crates/holochain_state/src/test_utils.rs
@@ -104,8 +104,8 @@ pub fn test_dbs_in(path: impl AsRef<Path>) -> TestDbs {
 /// A test database in a temp directory
 #[derive(Shrinkwrap)]
 pub struct TestDb<Kind: DbKindT> {
-    #[shrinkwrap(main_field)]
     /// sqlite database
+    #[shrinkwrap(main_field)]
     db: DbWrite<Kind>,
     /// temp directory for this environment
     dir: TestDir,

--- a/crates/holochain_state/tests/corrupt_db/mod.rs
+++ b/crates/holochain_state/tests/corrupt_db/mod.rs
@@ -6,8 +6,8 @@ use holochain_state::prelude::{mutations_helpers, *};
 use std::{path::Path, sync::Arc};
 use tempfile::TempDir;
 
-#[tokio::test(flavor = "multi_thread")]
 /// Checks a corrupt cache will be wiped on load.
+#[tokio::test(flavor = "multi_thread")]
 async fn corrupt_cache_creates_new_db() {
     holochain_trace::test_run();
 

--- a/crates/holochain_trace/src/lib.rs
+++ b/crates/holochain_trace/src/lib.rs
@@ -103,8 +103,8 @@ pub use open::{Config, Context, MsgWrap, OpenSpanExt};
 pub use tracing;
 use tracing_subscriber::fmt::MakeWriter;
 
-#[derive(Debug, Clone, Display)]
 /// Sets the kind of structured logging output you want
+#[derive(Debug, Clone, Display)]
 pub enum Output {
     /// More compact version of above
     Compact,

--- a/crates/holochain_types/src/access.rs
+++ b/crates/holochain_types/src/access.rs
@@ -25,8 +25,8 @@ pub struct HostFnAccess {
     pub keystore_deterministic: Permission,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
 /// Permission granted to a call
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum Permission {
     /// Host functions with this access will be included
     Allow,
@@ -35,8 +35,8 @@ pub enum Permission {
 }
 
 impl HostFnAccess {
-    #[allow(clippy::too_many_arguments)]
     /// Constructor.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         agent_info: Permission,
         read_workspace: Permission,

--- a/crates/holochain_types/src/action.rs
+++ b/crates/holochain_types/src/action.rs
@@ -14,10 +14,10 @@ use derive_more::From;
 use holo_hash::EntryHash;
 use holochain_zome_types::op::EntryCreationAction;
 
+/// A action of one of the two types that create a new entry.
 #[derive(
     Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Hash, derive_more::From,
 )]
-/// A action of one of the two types that create a new entry.
 pub enum NewEntryAction {
     /// A action which simply creates a new entry
     Create(Create),
@@ -26,25 +26,25 @@ pub enum NewEntryAction {
     Update(Update),
 }
 
+/// Same as NewEntryAction but takes actions as reference
 #[allow(missing_docs)]
 #[derive(Debug, From)]
-/// Same as NewEntryAction but takes actions as reference
 pub enum NewEntryActionRef<'a> {
     Create(&'a Create),
     Update(&'a Update),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Ord, PartialOrd)]
 /// A action of one of the two types that create a new entry.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, SerializedBytes, Ord, PartialOrd)]
 pub enum WireNewEntryAction {
     Create(WireCreate),
     Update(WireUpdate),
 }
 
+/// A action of one of the two types that create a new entry.
 #[derive(
     Debug, Clone, derive_more::Constructor, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd,
 )]
-/// A action of one of the two types that create a new entry.
 pub struct WireActionStatus<W> {
     /// Skinny action for sending over the wire.
     pub action: W,

--- a/crates/holochain_types/src/activity.rs
+++ b/crates/holochain_types/src/activity.rs
@@ -5,8 +5,8 @@ use holo_hash::AgentPubKey;
 use holochain_serialized_bytes::prelude::*;
 use holochain_zome_types::prelude::*;
 
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, SerializedBytes)]
 /// An agents chain records returned from a agent_activity_query
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, SerializedBytes)]
 pub struct AgentActivityResponse {
     /// The agent this activity is for
     pub agent: AgentPubKey,
@@ -77,8 +77,8 @@ impl AgentActivityResponse {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, SerializedBytes)]
 /// The type of agent activity returned in this request
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize, SerializedBytes)]
 pub enum ChainItems {
     /// The full records
     Full(Vec<Record>),

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -55,8 +55,8 @@ pub enum CoordinatorSource {
     Bundle(Box<CoordinatorBundle>),
 }
 
-#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 /// The instructions on how to update coordinators for a cell.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct UpdateCoordinatorsPayload {
     /// The cell id of the cell to swap coordinators for.
     pub cell_id: CellId,

--- a/crates/holochain_types/src/app/app_manifest.rs
+++ b/crates/holochain_types/src/app/app_manifest.rs
@@ -150,8 +150,8 @@ mod tests {
     use crate::app::app_manifest::{AppManifest, AppManifestV0Builder, AppRoleManifest};
     use mr_bundle::{resource_id_for_path, Manifest};
 
-    #[test]
     /// Replicate this test for any new version of the manifest that gets created
+    #[test]
     fn app_manifest_v0_helper_functions() {
         let app_name = String::from("sample-app");
 

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_validated.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_validated.rs
@@ -57,12 +57,12 @@ pub enum AppRoleManifestValidated {
         modifiers: DnaModifiersOpt,
         installed_hash: Option<DnaHashB64>,
     },
+    /// Require that a Cell is already installed which has a DNA that's compatible with the
+    /// `compatible_hash` specified in the manifest.
     #[deprecated(
         since = "0.6.0-dev.17",
         note = "For late binding, update the coordinators of a DNA. For calling cells of other apps, use bridge calls."
     )]
-    /// Require that a Cell is already installed which has a DNA that's compatible with the
-    /// `compatible_hash` specified in the manifest.
     UseExisting {
         compatible_hash: DnaHashB64,
         protected: bool,

--- a/crates/holochain_types/src/chain.rs
+++ b/crates/holochain_types/src/chain.rs
@@ -34,8 +34,6 @@ pub trait AgentActivityExt {
 
 impl AgentActivityExt for AgentActivityResponse {}
 
-#[must_use = "Iterator doesn't do anything unless consumed."]
-#[derive(Debug)]
 /// Iterate over a source chain and apply the [`ChainFilter`] to each element.
 /// This iterator will:
 /// - Ignore any ops that are not a direct ancestor to the starting position.
@@ -47,15 +45,17 @@ impl AgentActivityExt for AgentActivityResponse {}
 /// [`take`]: ChainFilter::take
 /// [`until_timestamp`]: ChainFilter::until_timestamp
 /// [`until_hash`]: ChainFilter::until_hash
+#[must_use = "Iterator doesn't do anything unless consumed."]
+#[derive(Debug)]
 pub struct ChainFilterIter<I: AsRef<A>, A: ChainItem = SignedActionHashed> {
     filter: ChainFilter<A::Hash>,
     iter: Peekable<std::vec::IntoIter<I>>,
     end: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 /// A [`ChainFilter`] with the action sequences for the
 /// starting position and any `until` hashes.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChainFilterRange {
     /// The filter for this chain.
     filter: ChainFilter,
@@ -68,8 +68,8 @@ pub struct ChainFilterRange {
     chain_bottom_type: ChainBottomType,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 /// The type of chain item that forms the bottom of the chain.
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum ChainBottomType {
     /// The bottom of the chain is genesis.
     Genesis,
@@ -84,8 +84,8 @@ enum ChainBottomType {
     UntilHash,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
 /// Outcome of trying to find the action sequences in a filter.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Sequences {
     /// Found all action sequences
     Found(ChainFilterRange),
@@ -95,9 +95,9 @@ pub enum Sequences {
     EmptyRange,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, SerializedBytes, Serialize, Deserialize)]
 /// Intermediate data structure used during a `must_get_agent_activity` call.
 /// Note that this is not the final return value of `must_get_agent_activity`.
+#[derive(Debug, Clone, PartialEq, Eq, SerializedBytes, Serialize, Deserialize)]
 pub enum MustGetAgentActivityResponse {
     /// The activity was found.
     Activity {

--- a/crates/holochain_types/src/chain/test.rs
+++ b/crates/holochain_types/src/chain/test.rs
@@ -25,29 +25,30 @@ fn build_chain(c: Vec<TestChainItem>, filter: TestFilter) -> Vec<TestChainItem> 
 fn pretty(expected: Vec<TestChainItem>) -> impl Fn(Vec<TestChainItem>) {
     move |actual: Vec<TestChainItem>| pretty_assertions::assert_eq!(actual, expected)
 }
+/// Check taking n items works.
 #[test_case(1, 0, 0 => chain(0..0))]
 #[test_case(1, 0, 1 => chain(0..1))]
 #[test_case(1, 0, 10 => chain(0..1))]
 #[test_case(2, 0, 10 => chain(0..1))]
 #[test_case(2, 1, 10 => chain(0..2))]
 #[test_case(10, 9, 10 => chain(0..10))]
-/// Check taking n items works.
 fn can_take_n(len: u32, chain_top: u32, take: u32) -> Vec<TestChainItem> {
     let filter = TestFilter::new(hash(chain_top)).take(take);
     build_chain(chain(0..len), filter)
 }
 
+/// Check taking until some hash works.
 #[test_case(1, 0, hash(0) => chain(0..1))]
 #[test_case(1, 0, hash(1) => chain(0..1))]
 #[test_case(2, 1, hash(1) => chain(1..2))]
 #[test_case(10, 5, hash(1) => using pretty(chain(1..6)))]
 #[test_case(10, 9, hash(0) => using pretty(chain(0..10)))]
-/// Check taking until some hash works.
 fn can_until_hash(len: u32, chain_top: u32, until: TestHash) -> Vec<TestChainItem> {
     let filter = TestFilter::new(hash(chain_top)).until_hash(until);
     build_chain(chain(0..len), filter)
 }
 
+/// Check taking until some timestamp is passed works.
 #[test_case(1, 0, 0 => chain(0..1))]
 #[test_case(1, 0, 1000 => chain(0..0))]
 #[test_case(2, 1, 1000 => chain(1..2))]
@@ -56,12 +57,12 @@ fn can_until_hash(len: u32, chain_top: u32, until: TestHash) -> Vec<TestChainIte
 #[test_case(10, 5, 999 => using pretty(chain(1..6)))]
 #[test_case(10, 5, 1200 => using pretty(chain(2..6)))]
 #[test_case(10, 9, 0 => using pretty(chain(0..10)))]
-/// Check taking until some timestamp is passed works.
 fn can_until_timestamp(len: u32, chain_top: u32, until_us: i64) -> Vec<TestChainItem> {
     let filter = TestFilter::new(hash(chain_top)).until_timestamp(Timestamp::from_micros(until_us));
     build_chain(chain(0..len), filter)
 }
 
+/// Check taking until some timestamp is passed works, even when multiple items share the same timestamp
 #[test_case(1, 0, 0 => doubled_chain(0..1))]
 #[test_case(1, 0, 1000 => doubled_chain(0..0))]
 #[test_case(2, 1, 1000 => using pretty(doubled_chain(1..1)))]
@@ -69,12 +70,13 @@ fn can_until_timestamp(len: u32, chain_top: u32, until_us: i64) -> Vec<TestChain
 #[test_case(10, 5, 1000 => using pretty(doubled_chain(2..6)))]
 #[test_case(10, 5, 1001 => using pretty(doubled_chain(4..6)))]
 #[test_case(10, 9, 0 => using pretty(doubled_chain(0..10)))]
-/// Check taking until some timestamp is passed works, even when multiple items share the same timestamp
 fn can_until_timestamp_doubled(len: u32, chain_top: u32, until_us: i64) -> Vec<TestChainItem> {
     let filter = TestFilter::new(hash(chain_top)).until_timestamp(Timestamp::from_micros(until_us));
     build_chain(doubled_chain(0..len), filter)
 }
 
+/// Check take and until can be combined and the first to be
+/// reached ends the iterator.
 #[test_case(10, TestFilter::new(hash(9)).take(10).until_hash(hash(4)) => chain(4..10))]
 #[test_case(10, TestFilter::new(hash(9)).take(2).until_hash(hash(4)) => chain(8..10))]
 #[test_case(10, TestFilter::new(hash(9)).take(20).take(2).until_hash(hash(4)) => chain(8..10))]
@@ -84,25 +86,23 @@ fn can_until_timestamp_doubled(len: u32, chain_top: u32, until_us: i64) -> Vec<T
 #[test_case(10, TestFilter::new(hash(9)).take(20).take(2).until_hash(hash(4)).until_timestamp(Timestamp::from_micros(9000)) => chain(9..10))]
 #[test_case(10, TestFilter::new(hash(9)).take(20).take(2).until_hash(hash(4)).until_timestamp(Timestamp::from_micros(4000)) => chain(8..10))]
 #[test_case(10, TestFilter::new(hash(9)).take(20).until_hash(hash(9)).until_timestamp(Timestamp::from_micros(4000)) => chain(9..10))]
-/// Check take and until can be combined and the first to be
-/// reached ends the iterator.
 fn can_combine(len: u32, filter: TestFilter) -> Vec<TestChainItem> {
     build_chain(chain(0..len), filter)
 }
 
+/// Check that forked chains are ignored.
 #[test_case(&[0..10], TestFilter::new(hash(9)).take(10).until_hash(hash(4)) => chain(4..10))]
 #[test_case(&[0..10, 7..10], TestFilter::new(hash(9)).take(10).until_hash(hash(4)) => chain(4..10))]
 #[test_case(&[0..10, 7..10, 5..8, 3..7], TestFilter::new(hash(9)).take(10).until_hash(hash(4)) => chain(4..10))]
-/// Check that forked chains are ignored.
 fn can_ignore_forks(ranges: &[Range<u8>], filter: TestFilter) -> Vec<TestChainItem> {
     build_chain(forked_chain(ranges), filter)
 }
 
+/// Check the iterator will stop at a gap in the chain.
 #[test_case(&[0..10], TestFilter::new(hash(9)).take(10).until_hash(hash(4)) => chain(4..10))]
 #[test_case(&[0..5, 6..10], TestFilter::new(hash(9)).take(10).until_hash(hash(4)) => chain(6..10))]
 #[test_case(&[0..5, 6..7, 8..10], TestFilter::new(hash(9)).take(10).until_hash(hash(4)) => chain(8..10))]
 #[test_case(&[0..5, 6..7, 8..10], TestFilter::new(hash(9)).take(3).until_hash(hash(4)) => chain(8..10))]
-/// Check the iterator will stop at a gap in the chain.
 fn stop_at_gap(ranges: &[Range<u32>], filter: TestFilter) -> Vec<TestChainItem> {
     build_chain(gap_chain(ranges), filter)
 }

--- a/crates/holochain_types/src/countersigning.rs
+++ b/crates/holochain_types/src/countersigning.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// State and data of an ongoing countersigning session.
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum CountersigningSessionState {
     /// This is the entry state. Accepting a countersigning session through the HDK will immediately

--- a/crates/holochain_types/src/dht_op.rs
+++ b/crates/holochain_types/src/dht_op.rs
@@ -40,7 +40,6 @@ pub enum DhtOp {
     Clone, Debug, Serialize, Deserialize, SerializedBytes, Eq, PartialEq, Hash, derive_more::Display,
 )]
 pub enum ChainOp {
-    #[display("StoreRecord")]
     /// Used to notify the authority for an action that it has been created.
     ///
     /// Conceptually, authorities receiving this `ChainOp` do three things:
@@ -50,9 +49,9 @@ pub enum ChainOp {
     /// - Store the entry into their CAS.
     ///   - Note: they do not become responsible for keeping the set of
     ///     references from that entry up-to-date.
+    #[display("StoreRecord")]
     StoreRecord(Signature, Action, RecordEntry),
 
-    #[display("StoreEntry")]
     /// Used to notify the authority for an entry that it has been created
     /// anew. (The same entry can be created more than once.)
     ///
@@ -67,9 +66,9 @@ pub enum ChainOp {
     ///
     // TODO: document how those "created-by" references are stored in
     // reality.
+    #[display("StoreEntry")]
     StoreEntry(Signature, NewEntryAction, Entry),
 
-    #[display("RegisterAgentActivity")]
     /// Used to notify the authority for an agent's public key that that agent
     /// has committed a new action.
     ///
@@ -83,36 +82,37 @@ pub enum ChainOp {
     ///
     // TODO: document how those "agent-activity" references are stored in
     // reality.
+    #[display("RegisterAgentActivity")]
     RegisterAgentActivity(Signature, Action),
 
-    #[display("RegisterUpdatedContent")]
     /// Op for updating an entry.
     /// This is sent to the entry authority.
     // TODO: This entry is here for validation by the entry update action holder
     // link's don't do this. The entry is validated by store entry. Maybe we either
     // need to remove the Entry here or add it to link.
+    #[display("RegisterUpdatedContent")]
     RegisterUpdatedContent(Signature, action::Update, RecordEntry),
 
-    #[display("RegisterUpdatedRecord")]
     /// Op for updating a record.
     /// This is sent to the record authority.
+    #[display("RegisterUpdatedRecord")]
     RegisterUpdatedRecord(Signature, action::Update, RecordEntry),
 
-    #[display("RegisterDeletedBy")]
     /// Op for registering an action deletion with the Action authority
+    #[display("RegisterDeletedBy")]
     RegisterDeletedBy(Signature, action::Delete),
 
-    #[display("RegisterDeletedEntryAction")]
     /// Op for registering an action deletion with the Entry authority, so that
     /// the Entry can be marked Dead if all of its Actions have been deleted
+    #[display("RegisterDeletedEntryAction")]
     RegisterDeletedEntryAction(Signature, action::Delete),
 
-    #[display("RegisterAddLink")]
     /// Op for adding a link
+    #[display("RegisterAddLink")]
     RegisterAddLink(Signature, action::CreateLink),
 
-    #[display("RegisterRemoveLink")]
     /// Op for removing a link
+    #[display("RegisterRemoveLink")]
     RegisterRemoveLink(Signature, action::DeleteLink),
 }
 
@@ -1202,8 +1202,8 @@ impl HashableContent for ChainOpUniqueForm<'_> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
 /// Condensed version of ops for sending across the wire.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
 pub enum WireOps {
     /// Response for get entry.
     Entry(WireEntryOps),
@@ -1229,8 +1229,8 @@ impl WireOps {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
 /// The data rendered from a wire op to place in the database.
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RenderedOp {
     /// The action to insert into the database.
     pub action: SignedActionHashed,
@@ -1267,10 +1267,10 @@ impl RenderedOp {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Default)]
 /// The full data for insertion into the database.
 /// The reason we don't use [`DhtOp`] is because we don't
 /// want to clone the entry for every action.
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct RenderedOps {
     /// Entry for the ops if there is one.
     pub entry: Option<EntryHashed>,

--- a/crates/holochain_types/src/dna/dna_manifest.rs
+++ b/crates/holochain_types/src/dna/dna_manifest.rs
@@ -26,11 +26,11 @@ pub enum DnaManifest {
     V0(DnaManifestV0),
 }
 
+/// A dna manifest that has been successfully validated.
 #[derive(
     Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, shrinkwraprs::Shrinkwrap,
 )]
 #[serde(try_from = "DnaManifest")]
-/// A dna manifest that has been successfully validated.
 pub struct ValidatedDnaManifest(pub DnaManifest);
 
 impl mr_bundle::Manifest for ValidatedDnaManifest {

--- a/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v0.rs
+++ b/crates/holochain_types/src/dna/dna_manifest/dna_manifest_v0.rs
@@ -127,6 +127,7 @@ impl DnaManifestV0 {
     }
 }
 
+/// Manifest for all items that will change the [`DnaHash`].
 #[serde_as]
 #[derive(
     Serialize,
@@ -140,7 +141,6 @@ impl DnaManifestV0 {
     derive_builder::Builder,
 )]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
-/// Manifest for all items that will change the [`DnaHash`].
 pub struct IntegrityManifest {
     /// A network seed for uniquifying this DNA. See [`DnaDef`].
     pub network_seed: Option<String>,
@@ -154,9 +154,9 @@ pub struct IntegrityManifest {
     pub zomes: Vec<ZomeManifest>,
 }
 
+/// Coordinator zomes.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
-/// Coordinator zomes.
 pub struct CoordinatorManifest {
     /// Coordinator zomes to install with this dna.
     pub zomes: Vec<ZomeManifest>,

--- a/crates/holochain_types/src/entry.rs
+++ b/crates/holochain_types/src/entry.rs
@@ -24,9 +24,9 @@ pub fn option_entry_hashed(entry: RecordEntry) -> Option<EntryHashed> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes, Default)]
 /// Condensed data needed for a get entry request.
 // TODO: Could use actual compression to get even smaller.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes, Default)]
 pub struct WireEntryOps {
     /// Any actions that created this entry.
     pub creates: Vec<Judged<WireNewEntryAction>>,
@@ -40,8 +40,8 @@ pub struct WireEntryOps {
     pub entry: Option<EntryData>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
 /// All entry data common to an get entry request.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes)]
 pub struct EntryData {
     /// The entry shared across all actions.
     pub entry: Entry,

--- a/crates/holochain_types/src/inline_zome.rs
+++ b/crates/holochain_types/src/inline_zome.rs
@@ -3,8 +3,8 @@ use holochain_zome_types::prelude::*;
 use serde::de::DeserializeOwned;
 use std::collections::HashMap;
 
-#[derive(Default, Clone)]
 /// A set of inline integrity and coordinator zomes.
+#[derive(Default, Clone)]
 pub struct InlineZomeSet {
     /// The set of inline zomes that will be installed as the integrity zomes.
     /// Only these affect the [`DnaHash`].
@@ -18,8 +18,8 @@ pub struct InlineZomeSet {
     pub dependencies: HashMap<ZomeName, ZomeName>,
 }
 
-#[allow(missing_docs)]
 /// Some blank entry types to use for testing.
+#[allow(missing_docs)]
 pub enum InlineEntryTypes {
     A,
     B,

--- a/crates/holochain_types/src/link.rs
+++ b/crates/holochain_types/src/link.rs
@@ -12,8 +12,8 @@ use holochain_zome_types::op::ChainOpType;
 use holochain_zome_types::prelude::*;
 use regex::Regex;
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes)]
 /// Link key for sending across the wire for get links requests.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes)]
 pub struct WireLinkKey {
     /// Base the links are on.
     pub base: AnyLinkableHash,
@@ -29,8 +29,8 @@ pub struct WireLinkKey {
     pub author: Option<AgentPubKey>,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes, Default)]
 /// Condensed link ops for sending across the wire in response to get links.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes, Default)]
 pub struct WireLinkOps {
     /// create links that match this query.
     pub creates: Vec<WireCreateLink>,
@@ -57,9 +57,9 @@ impl WireLinkOps {
     }
 }
 
+/// Condensed version of a [`CreateLink`]
 #[allow(missing_docs)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes)]
-/// Condensed version of a [`CreateLink`]
 pub struct WireCreateLink {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,
@@ -75,9 +75,9 @@ pub struct WireCreateLink {
     pub weight: RateWeight,
 }
 
+/// Condensed version of a [`DeleteLink`]
 #[allow(missing_docs)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes)]
-/// Condensed version of a [`DeleteLink`]
 pub struct WireDeleteLink {
     pub author: AgentPubKey,
     pub timestamp: Timestamp,

--- a/crates/holochain_types/src/record.rs
+++ b/crates/holochain_types/src/record.rs
@@ -16,9 +16,9 @@ use std::collections::BTreeSet;
 mod error;
 pub use error::*;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes, Default)]
 /// A condensed version of get record request.
 /// This saves bandwidth by removing duplicated and implied data.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, SerializedBytes, Default)]
 pub struct WireRecordOps {
     /// The action this request was for.
     pub action: Option<Judged<SignedAction>>,
@@ -92,9 +92,9 @@ impl WireRecordOps {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes)]
 /// Record without the hashes for sending across the network
 /// TODO: Remove this as it's no longer needed.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, SerializedBytes)]
 pub struct WireRecord {
     /// The signed action for this record
     signed_action: SignedAction,

--- a/crates/holochain_types/src/sql.rs
+++ b/crates/holochain_types/src/sql.rs
@@ -23,10 +23,10 @@ pub trait ToSqlStatement {
     fn to_sql_statement(&self) -> String;
 }
 
-#[derive(Clone, Debug, PartialEq)]
 /// A wrapper around [`rusqlite::types::ToSqlOutput`].
 /// This allows implementing `From<Foo> for SqlOutput`
 /// for types defined outside this crate.
+#[derive(Clone, Debug, PartialEq)]
 pub struct SqlOutput<'a>(pub ToSqlOutput<'a>);
 
 impl rusqlite::ToSql for SqlOutput<'_> {

--- a/crates/holochain_types/src/web_app/web_app_manifest.rs
+++ b/crates/holochain_types/src/web_app/web_app_manifest.rs
@@ -111,8 +111,8 @@ mod tests {
     };
     use mr_bundle::Manifest;
 
-    #[test]
     /// Replicate this test for any new version of the manifest that gets created
+    #[test]
     fn web_app_manifest_v0_helper_functions() {
         let ui_location = "./path/to/my/ui.zip".to_string();
         let happ_location = "./path/to/my/happ-bundle.happ".to_string();

--- a/crates/holochain_websocket/src/lib.rs
+++ b/crates/holochain_websocket/src/lib.rs
@@ -17,23 +17,23 @@ use tokio_tungstenite::tungstenite::handshake::server::{Callback, ErrorResponse,
 use tokio_tungstenite::tungstenite::http::{HeaderMap, HeaderValue, StatusCode};
 use tokio_tungstenite::tungstenite::protocol::Message;
 
-#[derive(Debug, serde::Serialize, serde::Deserialize, SerializedBytes)]
-#[serde(rename_all = "snake_case", tag = "type")]
 /// The messages actually sent over the wire by this library.
 /// If you want to implement your own server or client you
 /// will need this type or be able to serialize / deserialize it.
+#[derive(Debug, serde::Serialize, serde::Deserialize, SerializedBytes)]
+#[serde(rename_all = "snake_case", tag = "type")]
 pub enum WireMessage {
     /// A message without a response.
     Signal {
-        #[serde(with = "serde_bytes")]
         /// Actual bytes of the message serialized as [message pack](https://msgpack.org/).
+        #[serde(with = "serde_bytes")]
         data: Vec<u8>,
     },
 
     /// An authentication message, sent by the client if the server requires it.
     Authenticate {
-        #[serde(with = "serde_bytes")]
         /// Actual bytes of the message serialized as [message pack](https://msgpack.org/).
+        #[serde(with = "serde_bytes")]
         data: Vec<u8>,
     },
 
@@ -41,8 +41,8 @@ pub enum WireMessage {
     Request {
         /// The id of this request.
         id: u64,
-        #[serde(with = "serde_bytes")]
         /// Actual bytes of the message serialized as [message pack](https://msgpack.org/).
+        #[serde(with = "serde_bytes")]
         data: Vec<u8>,
     },
 
@@ -50,8 +50,8 @@ pub enum WireMessage {
     Response {
         /// The id of the request that this response is for.
         id: u64,
-        #[serde(with = "serde_bytes")]
         /// Actual bytes of the message serialized as [message pack](https://msgpack.org/).
+        #[serde(with = "serde_bytes")]
         data: Option<Vec<u8>>,
     },
 }

--- a/crates/holochain_zome_types/src/dna_def.rs
+++ b/crates/holochain_zome_types/src/dna_def.rs
@@ -69,9 +69,9 @@ pub struct DnaDef {
     pub lineage: HashSet<DnaHash>,
 }
 
+/// A reference to for creating the hash for [`DnaDef`].
 #[cfg(feature = "full-dna-def")]
 #[derive(Serialize, Debug, PartialEq, Eq)]
-/// A reference to for creating the hash for [`DnaDef`].
 struct DnaDefHash<'a> {
     modifiers: &'a DnaModifiers,
     integrity_zomes: &'a IntegrityZomes,

--- a/crates/holochain_zome_types/src/entry.rs
+++ b/crates/holochain_zome_types/src/entry.rs
@@ -17,14 +17,14 @@ mod app_entry_bytes;
 pub use app_entry_bytes::*;
 pub use holochain_integrity_types::entry::*;
 
-#[derive(
-    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
-)]
 /// Either an [`EntryDefIndex`] or one of:
 /// - [EntryType::CapGrant]
 /// - [EntryType::CapClaim]
 ///
 /// Which don't have an index.
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
 pub enum EntryDefLocation {
     /// App defined entries always have a unique [`u8`] index
     /// within the Dna.
@@ -37,10 +37,10 @@ pub enum EntryDefLocation {
     CapGrant,
 }
 
+/// The location of an app entry definition.
 #[derive(
     Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
-/// The location of an app entry definition.
 pub struct AppEntryDefLocation {
     /// The zome that defines this entry type.
     pub zome_index: ZomeIndex,
@@ -48,8 +48,8 @@ pub struct AppEntryDefLocation {
     pub entry_def_index: EntryDefIndex,
 }
 
-#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 /// Options for controlling how get is executed.
+#[derive(PartialEq, Debug, Clone, Serialize, Deserialize)]
 pub struct GetOptions {
     /// Configure whether data should be fetched from the network or only from the local
     /// databases.

--- a/crates/holochain_zome_types/src/judged.rs
+++ b/crates/holochain_zome_types/src/judged.rs
@@ -12,8 +12,8 @@
 
 use crate::prelude::*;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 /// Data with an optional validation status.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Judged<T> {
     /// The data that the status applies to.
     pub data: T,

--- a/crates/holochain_zome_types/src/link.rs
+++ b/crates/holochain_zome_types/src/link.rs
@@ -133,9 +133,9 @@ impl GetLinksInput {
 }
 
 type CreateLinkWithDeleteLinks = Vec<(SignedActionHashed, Vec<SignedActionHashed>)>;
-#[derive(Clone, PartialEq, Debug, serde::Serialize, serde::Deserialize, SerializedBytes)]
 /// CreateLinks with and DeleteLinks on them
 /// `[CreateLink, [DeleteLink]]`
+#[derive(Clone, PartialEq, Debug, serde::Serialize, serde::Deserialize, SerializedBytes)]
 pub struct LinkDetails(CreateLinkWithDeleteLinks);
 
 impl From<CreateLinkWithDeleteLinks> for LinkDetails {

--- a/crates/holochain_zome_types/src/metadata.rs
+++ b/crates/holochain_zome_types/src/metadata.rs
@@ -5,11 +5,11 @@ use crate::validate::ValidationStatus;
 use crate::Entry;
 use holochain_serialized_bytes::prelude::*;
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, SerializedBytes)]
-#[serde(tag = "type", content = "content")]
 /// Return type for get_details calls.
 /// ActionHash returns a Record.
 /// EntryHash returns an Entry.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, SerializedBytes)]
+#[serde(tag = "type", content = "content")]
 pub enum Details {
     /// Variant holding a specific record. Returned when an action hash was passed.
     Record(RecordDetails),
@@ -17,9 +17,9 @@ pub enum Details {
     Entry(EntryDetails),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, SerializedBytes)]
 /// A specific Record with any updates and deletes.
 /// This is all the metadata available for a record.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, SerializedBytes)]
 pub struct RecordDetails {
     /// The specific record.
     /// Either a Create or an Update.
@@ -32,8 +32,8 @@ pub struct RecordDetails {
     pub updates: Vec<SignedActionHashed>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, SerializedBytes)]
 /// An Entry with all its metadata.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, SerializedBytes)]
 pub struct EntryDetails {
     /// The data
     pub entry: Entry,

--- a/crates/holochain_zome_types/src/query.rs
+++ b/crates/holochain_zome_types/src/query.rs
@@ -122,8 +122,8 @@ pub struct AgentActivity {
     pub warrants: Vec<SignedWarrant>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize, SerializedBytes)]
 /// Get either the full activity or just the status of the chain
+#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize, SerializedBytes)]
 pub enum ActivityRequest {
     /// Just request the status of the chain
     Status,
@@ -131,7 +131,6 @@ pub enum ActivityRequest {
     Full,
 }
 
-#[derive(Clone, Debug, PartialEq, Hash, Eq, serde::Serialize, serde::Deserialize)]
 /// The highest action sequence observed by this authority.
 /// This also includes the actions at this sequence.
 /// If there is more then one then there is a fork.
@@ -141,6 +140,7 @@ pub enum ActivityRequest {
 ///
 /// The information is tracked at the edge of holochain before
 /// validation (but after drop checks).
+#[derive(Clone, Debug, PartialEq, Hash, Eq, serde::Serialize, serde::Deserialize)]
 pub struct HighestObserved {
     /// The highest sequence number observed.
     pub action_seq: u32,
@@ -149,12 +149,11 @@ pub struct HighestObserved {
     pub hash: Vec<ActionHash>,
 }
 
-#[derive(Clone, Debug, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 /// Status of the agent activity chain
 // TODO: In the future we will most likely be replaced
 // by warrants instead of Forked / Invalid so we can provide
 // evidence of why the chain has a status.
-#[derive(Default)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize, Default)]
 pub enum ChainStatus {
     /// This authority has no information on the chain.
     #[default]
@@ -167,10 +166,10 @@ pub enum ChainStatus {
     Invalid(ChainHead),
 }
 
-#[derive(Clone, Debug, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 /// The action at the head of the complete chain.
 /// This is as far as this authority can see a
 /// chain with no gaps.
+#[derive(Clone, Debug, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ChainHead {
     /// Sequence number of this chain head.
     pub action_seq: u32,
@@ -178,8 +177,8 @@ pub struct ChainHead {
     pub hash: ActionHash,
 }
 
-#[derive(Clone, Debug, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 /// The chain has been forked by these two actions
+#[derive(Clone, Debug, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ChainFork {
     /// The point where the chain has forked.
     pub fork_seq: u32,

--- a/crates/holochain_zome_types/src/request.rs
+++ b/crates/holochain_zome_types/src/request.rs
@@ -2,8 +2,8 @@
 
 use holochain_serialized_bytes::prelude::*;
 
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Serialize, Deserialize)]
 /// Metadata that can be requested on a basis
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct MetadataRequest {
     /// Get all the actions on an entry.
     /// Invalid request on an action.

--- a/crates/holochain_zome_types/src/zome/inline_zome.rs
+++ b/crates/holochain_zome_types/src/zome/inline_zome.rs
@@ -17,11 +17,11 @@ mod error;
 
 pub type BoxApi = Box<dyn HostFnApiT>;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// A type marker for an integrity [`InlineZome`].
-pub struct IntegrityZomeMarker;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct IntegrityZomeMarker;
 /// A type marker for a coordinator [`InlineZome`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CoordinatorZomeMarker;
 
 pub type InlineIntegrityZome = InlineZome<IntegrityZomeMarker>;
@@ -141,8 +141,8 @@ impl InlineCoordinatorZome {
     }
 }
 
-#[derive(Debug, Clone)]
 /// An inline zome clonable type object.
+#[derive(Debug, Clone)]
 pub struct DynInlineZome(pub Arc<dyn InlineZomeT + Send + Sync>);
 
 pub trait InlineZomeT: std::fmt::Debug {

--- a/crates/test_utils/wasm/wasm_workspace/crud/src/coordinator/countree.rs
+++ b/crates/test_utils/wasm/wasm_workspace/crud/src/coordinator/countree.rs
@@ -12,8 +12,8 @@ impl std::ops::Add for CounTree {
 }
 
 impl CounTree {
-    #[allow(clippy::new_ret_no_self)]
     /// ensures that a default countree exists and returns the action
+    #[allow(clippy::new_ret_no_self)]
     pub fn new() -> ExternResult<ActionHash> {
         Self::ensure(Self::default())
     }

--- a/crates/test_utils/wasm/wasm_workspace/update_entry/src/coordinator.rs
+++ b/crates/test_utils/wasm/wasm_workspace/update_entry/src/coordinator.rs
@@ -29,8 +29,8 @@ fn update_private_entry(_: ()) -> ExternResult<ActionHash> {
     hdk::prelude::update_entry(action_hash, &msg_private())
 }
 
-#[hdk_extern]
 /// Updates to a different entry, this will fail
+#[hdk_extern]
 fn invalid_update_entry(_: ()) -> ExternResult<ActionHash> {
     let action_hash = hdk::prelude::create_entry(&IntegrityUpdateEntry(post()))?;
     hdk::prelude::update_entry(action_hash, &msg())


### PR DESCRIPTION
### Summary

Fix inconsistencies with docs comments:

* link labels shouldn't have space, e.g.,
   ```
   Please see [ `Foo` ]
   ```

   becomes

   ```
   Please see [`Foo`]
   ```
* proc macros should come after docs comment block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Richer agent-activity queries with explicit request parameter and new stop conditions.
  - New public convenience type for serialized hashes; WebSocket messages now public and consistently handle binary payloads.
  - App listing can show Disabled apps; entry location/type exposed.
  - Wire-level data expanded for richer record, entry and metadata details; entry data now includes type.

- Bug Fixes/Stability
  - Safe no-op tracing subscriber when tracing is disabled.

- Tests
  - Added extensive chain-filtering tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->