### PR TITLE
Implement blocks trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3203,6 +3203,7 @@ dependencies = [
  "holochain_sqlite",
  "holochain_state",
  "holochain_state_types",
+ "holochain_timestamp",
  "holochain_trace",
  "holochain_types",
  "holochain_wasm_test_utils",

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add query `are_all_blocked`, taking a vector of `BlockTargetId`s, to `holochain_state`.
 - Upgrade to kitsune2 0.3.0.
 - Deprecate `BlockTarget::NodeDna` and `BlockTarget::Node`. These block variants are not currently respected and will be removed with the 0.6.0 minor release.
+- Add `Blocks` implementation to `holochain_p2p`, allowing for managing network blocks.
 
 ## 0.6.0-dev.21
 

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -128,6 +128,9 @@ holochain = { path = ".", default-features = false, features = [
   "slow_tests",
   "metrics_influxive",
 ] }
+holochain_state = { version = "^0.6.0-dev.23", path = "../holochain_state", features = [
+  "test_utils",
+] }
 
 anyhow = "1.0"
 assert_cmd = "2"

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -203,6 +203,7 @@ impl ConductorBuilder {
 
         let net_spaces1 = spaces.clone();
         let net_spaces2 = spaces.clone();
+        let conductor_db = spaces.conductor_db.clone();
         let p2p_config = holochain_p2p::HolochainP2pConfig {
             auth_material: config
                 .network
@@ -220,6 +221,10 @@ impl ConductorBuilder {
             get_db_op_store: Arc::new(move |dna_hash| {
                 let res = net_spaces2.dht_db(&dna_hash);
                 Box::pin(async move { res.map_err(holochain_p2p::HolochainP2pError::other) })
+            }),
+            get_conductor_db: Arc::new(move || {
+                let conductor_db = conductor_db.clone();
+                Box::pin(async move { conductor_db })
             }),
             target_arc_factor: config.network.target_arc_factor,
             network_config: Some(config.network.to_k2_config()?),
@@ -416,6 +421,7 @@ impl ConductorBuilder {
 
         let net_spaces1 = spaces.clone();
         let net_spaces2 = spaces.clone();
+        let conductor_db = spaces.conductor_db.clone();
         let p2p_config = holochain_p2p::HolochainP2pConfig {
             auth_material: config
                 .network
@@ -433,6 +439,10 @@ impl ConductorBuilder {
             get_db_op_store: Arc::new(move |dna_hash| {
                 let res = net_spaces2.dht_db(&dna_hash);
                 Box::pin(async move { res.map_err(holochain_p2p::HolochainP2pError::other) })
+            }),
+            get_conductor_db: Arc::new(move || {
+                let conductor_db = conductor_db.clone();
+                Box::pin(async move { conductor_db })
             }),
             target_arc_factor: config.network.target_arc_factor,
             network_config: Some(config.network.to_k2_config()?),

--- a/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
@@ -187,16 +187,11 @@ mod test {
         let mut conductor = SweetConductor::from_standard_config().await;
         let app = conductor.setup_app("", [&dna_file]).await.unwrap();
 
-        let blocks_count = conductor
+        let blocks = conductor
             .spaces
             .conductor_db
-            .test_read(|txn| {
-                txn.query_row("SELECT COUNT(*) FROM BlockSpan", [], |row| {
-                    row.get::<_, u32>(0)
-                })
-            })
-            .unwrap();
-        assert_eq!(blocks_count, 0);
+            .test_read(|txn| get_all_cell_blocks(txn));
+        assert!(blocks.is_empty());
 
         let agent_key = app.agent().clone();
         let cell_id = app.cells()[0].cell_id().clone();

--- a/crates/holochain_p2p/src/blocks.rs
+++ b/crates/holochain_p2p/src/blocks.rs
@@ -85,13 +85,12 @@ impl Blocks for HolochainBlocks {
     fn are_all_blocked(&self, targets: Vec<BlockTarget>) -> BoxFut<'static, K2Result<bool>> {
         let mut cell_ids = Vec::new();
         for target in targets {
-            let BlockTarget::Agent(agent_id) = target else {
-                return Box::pin(async move { Err(K2Error::other("only agents can be blocked")) });
-            };
-            cell_ids.push(BlockTargetId::Cell(CellId::new(
-                self.dna_hash.clone(),
-                AgentPubKey::from_k2_agent(&agent_id),
-            )));
+            if let BlockTarget::Agent(agent_id) = target {
+                cell_ids.push(BlockTargetId::Cell(CellId::new(
+                    self.dna_hash.clone(),
+                    AgentPubKey::from_k2_agent(&agent_id),
+                )));
+            }
         }
         let db = self.db.clone();
         Box::pin(async move {

--- a/crates/holochain_p2p/src/blocks.rs
+++ b/crates/holochain_p2p/src/blocks.rs
@@ -69,7 +69,7 @@ impl HolochainBlocks {
 impl Blocks for HolochainBlocks {
     fn is_blocked(&self, target: BlockTarget) -> BoxFut<'static, K2Result<bool>> {
         let BlockTarget::Agent(agent_id) = target else {
-            return Box::pin(async move { Err(K2Error::other("only agents can be blocked")) });
+            return Box::pin(async move { Ok(false) });
         };
         let db = self.db.clone();
         let cell_id = CellId::new(self.dna_hash.clone(), AgentPubKey::from_k2_agent(&agent_id));

--- a/crates/holochain_p2p/src/blocks.rs
+++ b/crates/holochain_p2p/src/blocks.rs
@@ -1,0 +1,110 @@
+use holo_hash::{AgentPubKey, DnaHash};
+use holochain_state::block::{query_are_all_blocked, query_is_blocked};
+use holochain_timestamp::Timestamp;
+use holochain_types::{
+    db::{DbKindConductor, DbWrite},
+    prelude::{BlockTargetId, CellId},
+};
+use kitsune2_api::{
+    BlockTarget, Blocks, BlocksFactory, BoxFut, Builder, Config, DynBlocks, K2Error, K2Result,
+    SpaceId,
+};
+use std::sync::Arc;
+
+/// Factory for constructing kitsune2_api Blocks backed by the conductor DB.
+/// Uses GetDbConductor to query and persist block state (agents, DNAs, cells, spaces),
+/// enabling enforcement of block rules across a SpaceId via the BlocksFactory trait.
+pub struct HolochainBlocksFactory {
+    /// The conductor database connection getter.
+    pub getter: crate::GetDbConductor,
+}
+
+impl std::fmt::Debug for HolochainBlocksFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HolochainBlocksFactory").finish()
+    }
+}
+
+impl BlocksFactory for HolochainBlocksFactory {
+    fn default_config(&self, _config: &mut Config) -> K2Result<()> {
+        Ok(())
+    }
+
+    fn validate_config(&self, _config: &Config) -> K2Result<()> {
+        Ok(())
+    }
+
+    fn create(
+        &self,
+        _builder: Arc<Builder>,
+        space_id: SpaceId,
+    ) -> BoxFut<'static, K2Result<DynBlocks>> {
+        let dna_hash = DnaHash::from_k2_space(&space_id);
+        let getter = self.getter.clone();
+        Box::pin(async move {
+            let blocks: DynBlocks = Arc::new(HolochainBlocks::new(dna_hash, getter().await));
+            Ok(blocks)
+        })
+    }
+}
+
+/// Block implementation in Holochain.
+///
+/// Holds the target [`DnaHash`] to construct cell IDs for target agents,
+/// and a write handle to the conductor database,
+/// enabling queries and mutations of block state for this DNA within the networking layer.
+#[derive(Debug)]
+pub struct HolochainBlocks {
+    dna_hash: DnaHash,
+    db: DbWrite<DbKindConductor>,
+}
+
+impl HolochainBlocks {
+    /// Create a new [`HolochainBlocks`].
+    pub fn new(dna_hash: DnaHash, db: DbWrite<DbKindConductor>) -> Self {
+        Self { dna_hash, db }
+    }
+}
+
+impl Blocks for HolochainBlocks {
+    fn is_blocked(&self, target: BlockTarget) -> BoxFut<'static, K2Result<bool>> {
+        let BlockTarget::Agent(agent_id) = target else {
+            return Box::pin(async move { Err(K2Error::other("only agents can be blocked")) });
+        };
+        let db = self.db.clone();
+        let cell_id = CellId::new(self.dna_hash.clone(), AgentPubKey::from_k2_agent(&agent_id));
+        Box::pin(async move {
+            db.read_async(|txn| {
+                query_is_blocked(txn, BlockTargetId::Cell(cell_id), Timestamp::now())
+            })
+            .await
+            .map_err(|err| K2Error::other_src("failed to query block for agent", err))
+        })
+    }
+
+    fn are_all_blocked(&self, targets: Vec<BlockTarget>) -> BoxFut<'static, K2Result<bool>> {
+        let mut cell_ids = Vec::new();
+        for target in targets {
+            let BlockTarget::Agent(agent_id) = target else {
+                return Box::pin(async move { Err(K2Error::other("only agents can be blocked")) });
+            };
+            cell_ids.push(BlockTargetId::Cell(CellId::new(
+                self.dna_hash.clone(),
+                AgentPubKey::from_k2_agent(&agent_id),
+            )));
+        }
+        let db = self.db.clone();
+        Box::pin(async move {
+            db.read_async(|txn| query_are_all_blocked(txn, cell_ids, Timestamp::now()))
+                .await
+                .map_err(|err| {
+                    K2Error::other_src("failed to query blocks for vector of block targets", err)
+                })
+        })
+    }
+
+    fn block(&self, _target: BlockTarget) -> BoxFut<'static, K2Result<()>> {
+        // Holochain-based blocking is implemented in the actor.
+        Box::pin(async move { Ok(()) })
+    }
+}

--- a/crates/holochain_p2p/src/blocks.rs
+++ b/crates/holochain_p2p/src/blocks.rs
@@ -104,7 +104,7 @@ impl Blocks for HolochainBlocks {
     }
 
     fn block(&self, _target: BlockTarget) -> BoxFut<'static, K2Result<()>> {
-        // Holochain-based blocking is implemented in the actor.
+        // Holochain can insert blocks directly into the conductor database. Blocks created by Kitsune2 are not yet supported
         Box::pin(async move { Ok(()) })
     }
 }

--- a/crates/holochain_p2p/src/lib.rs
+++ b/crates/holochain_p2p/src/lib.rs
@@ -31,6 +31,9 @@ pub use op_store::*;
 mod hc_report;
 pub use hc_report::*;
 
+mod blocks;
+pub use blocks::*;
+
 mod metrics;
 
 fn check_k2_init() {

--- a/crates/holochain_p2p/src/spawn.rs
+++ b/crates/holochain_p2p/src/spawn.rs
@@ -31,6 +31,10 @@ pub type GetDbOpStore = Arc<
         + Sync,
 >;
 
+/// Callback function to retrieve a conductor database.
+pub type GetDbConductor =
+    Arc<dyn Fn() -> BoxFut<'static, DbWrite<DbKindConductor>> + 'static + Send + Sync>;
+
 /// Configure reporting.
 #[derive(Default)]
 pub enum ReportConfig {
@@ -54,6 +58,9 @@ pub struct HolochainP2pConfig {
 
     /// Callback function to retrieve an op store database handle for a dna hash.
     pub get_db_op_store: GetDbOpStore,
+
+    /// Callback function to retrieve the conductor database handle.
+    pub get_conductor_db: GetDbConductor,
 
     /// The arc factor to apply to target arc hints.
     pub target_arc_factor: u32,
@@ -132,6 +139,7 @@ impl Default for HolochainP2pConfig {
             get_db_peer_meta: Arc::new(|_| unimplemented!()),
             peer_meta_pruning_interval_ms: 10_000,
             get_db_op_store: Arc::new(|_| unimplemented!()),
+            get_conductor_db: Arc::new(|| unimplemented!()),
             target_arc_factor: 1,
             auth_material: None,
             network_config: None,

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -7,7 +7,7 @@ use holochain_sqlite::helpers::BytesSql;
 use holochain_sqlite::rusqlite::types::Value;
 use holochain_sqlite::sql::sql_peer_meta_store;
 use holochain_state::prelude::named_params;
-use kitsune2_api::*;
+use kitsune2_api::{BlockTarget, *};
 use kitsune2_core::get_responsive_remote_agents_near_location;
 use rand::prelude::IndexedRandom;
 use std::collections::HashMap;
@@ -2159,7 +2159,7 @@ impl actor::HcP2p for HolochainP2pActor {
     ) -> BoxFut<'_, HolochainP2pResult<Vec<kitsune2_api::DhtArc>>> {
         Box::pin(async move {
             let space_id = dna_hash.to_k2_space();
-            let space = self.kitsune.space(space_id.clone()).await?;
+            let space = self.kitsune.space(space_id).await?;
 
             Ok(space
                 .local_agent_store()
@@ -2168,6 +2168,22 @@ impl actor::HcP2p for HolochainP2pActor {
                 .into_iter()
                 .map(|a| a.get_tgt_storage_arc())
                 .collect())
+        })
+    }
+
+    fn block(
+        &self,
+        dna_hash: DnaHash,
+        agent_pub_key: AgentPubKey,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        Box::pin(async move {
+            let space_id = dna_hash.to_k2_space();
+            let space = self.kitsune.space(space_id).await?;
+
+            Ok(space
+                .blocks()
+                .block(BlockTarget::Agent(agent_pub_key.to_k2_agent()))
+                .await?)
         })
     }
 }

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -825,6 +825,9 @@ impl HolochainP2pActor {
         if let ReportConfig::JsonLines(_) = &config.report {
             builder.report = HcReportFactory::create(lair_client.clone());
         }
+        builder.blocks = Arc::new(HolochainBlocksFactory {
+            getter: config.get_conductor_db.clone(),
+        });
         builder.peer_meta_store = Arc::new(HolochainPeerMetaStoreFactory {
             getter: config.get_db_peer_meta.clone(),
         });
@@ -1159,6 +1162,34 @@ impl HolochainP2pActor {
             .await
             .map_err(HolochainP2pError::K2Error)
     }
+
+    // async fn invalid_op_block(&self,
+    //     dna_hash: DnaHash,
+    //     agent_pub_key: AgentPubKey) -> HolochainP2pResult<()> {
+    // let BlockTarget::Agent(agent_id) = target else {
+    //         return Box::pin(async move { Err(K2Error::other("only agents can be blocked")) });
+    //     };
+    //     let db = self.db.clone();
+    //     let cell_id = CellId::new(self.dna_hash.clone(), AgentPubKey::from_k2_agent(&agent_id));
+    //     Box::pin(async move {
+    //         block(
+    //             &db,
+    //             Block::new(
+    //                 holochain_types::prelude::BlockTarget::Cell(
+    //                     cell_id,
+    //                     CellBlockReason::App(App(vec![]),
+    //                 ),
+    //                 InclusiveTimestampInterval::try_new(Timestamp::now(), Timestamp::MAX).map_err(
+    //                     |err| K2Error::other_src("failed to set interval for block", err),
+    //                 )?,
+    //             ),
+    //         )
+    //         .await
+    //         .map_err(|err| K2Error::other_src("failed to block agent", err))
+    //     }
+    //         self.kitsune.space(dna_hash.to_k2_space()).await?.blocks().
+    //         self.kitsune.space(dna_hash.to_k2_space()).await?.blocks().block(BlockTarget::Agent(agent_pub_key.to_k2_agent())).await
+    //     }
 }
 
 macro_rules! timing_trace_out {

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -4,7 +4,7 @@
 use crate::*;
 use holochain_types::activity::AgentActivityResponse;
 use holochain_types::prelude::ValidationReceiptBundle;
-use kitsune2_api::{SpaceId, StoredOp};
+use kitsune2_api::{BlockTarget, SpaceId, StoredOp};
 use std::collections::HashMap;
 
 /// Get options help control how the get is processed at various levels.
@@ -369,6 +369,13 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug {
         &self,
         dna_hash: DnaHash,
     ) -> BoxFut<'_, HolochainP2pResult<Vec<kitsune2_api::DhtArc>>>;
+
+    /// Block an agent for a DNA.
+    fn block(
+        &self,
+        dna_hash: DnaHash,
+        agent_pub_key: AgentPubKey,
+    ) -> BoxFut<'_, HolochainP2pResult<()>>;
 }
 
 /// Trait-object HcP2p

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -4,7 +4,7 @@
 use crate::*;
 use holochain_types::activity::AgentActivityResponse;
 use holochain_types::prelude::ValidationReceiptBundle;
-use kitsune2_api::{BlockTarget, SpaceId, StoredOp};
+use kitsune2_api::{SpaceId, StoredOp};
 use std::collections::HashMap;
 
 /// Get options help control how the get is processed at various levels.

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -370,12 +370,11 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug {
         dna_hash: DnaHash,
     ) -> BoxFut<'_, HolochainP2pResult<Vec<kitsune2_api::DhtArc>>>;
 
-    /// Block an agent for a DNA.
-    fn block(
-        &self,
-        dna_hash: DnaHash,
-        agent_pub_key: AgentPubKey,
-    ) -> BoxFut<'_, HolochainP2pResult<()>>;
+    /// Block an agent for a DNA with a block reason.
+    fn block(&self, block_target: BlockTarget) -> BoxFut<'_, HolochainP2pResult<()>>;
+
+    /// Get the conductor database getter.
+    fn conductor_db_getter(&self) -> crate::GetDbConductor;
 }
 
 /// Trait-object HcP2p

--- a/crates/holochain_p2p/tests/tests/blocks.rs
+++ b/crates/holochain_p2p/tests/tests/blocks.rs
@@ -1,5 +1,3 @@
-use std::{sync::Arc, time::Duration};
-
 use ::fixt::fixt;
 use holo_hash::fixt::{AgentPubKeyFixturator, DnaHashFixturator};
 use holo_hash::{AgentPubKey, DnaHash};

--- a/crates/holochain_p2p/tests/tests/blocks.rs
+++ b/crates/holochain_p2p/tests/tests/blocks.rs
@@ -1,3 +1,5 @@
+use std::{sync::Arc, time::Duration};
+
 use ::fixt::fixt;
 use holo_hash::fixt::{AgentPubKeyFixturator, DnaHashFixturator};
 use holo_hash::{AgentPubKey, DnaHash};

--- a/crates/holochain_p2p/tests/tests/blocks.rs
+++ b/crates/holochain_p2p/tests/tests/blocks.rs
@@ -1,0 +1,191 @@
+use ::fixt::fixt;
+use holo_hash::fixt::{AgentPubKeyFixturator, DnaHashFixturator};
+use holo_hash::{AgentPubKey, DnaHash};
+use holochain_p2p::HolochainBlocks;
+use holochain_state::block::block;
+use holochain_state::prelude::{test_conductor_db, DbWrite};
+use holochain_timestamp::{InclusiveTimestampInterval, Timestamp};
+use holochain_types::db::DbKindConductor;
+use holochain_types::prelude::{Block, CellBlockReason, CellId};
+use kitsune2_api::{AgentId, BlockTarget, Blocks};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn block_someone() {
+    let dna_hash = fixt!(DnaHash);
+    let agent = fixt!(AgentPubKey).to_k2_agent();
+    let db = test_conductor_db().to_db();
+    let blocks = HolochainBlocks::new(dna_hash.clone(), db.clone());
+    assert!(!blocks
+        .is_blocked(BlockTarget::Agent(agent.clone()))
+        .await
+        .unwrap());
+    assert!(!blocks.are_all_blocked(vec![]).await.unwrap());
+    assert!(!blocks
+        .are_all_blocked(vec![BlockTarget::Agent(agent.clone())])
+        .await
+        .unwrap());
+
+    // Block an agent.
+    block_agent(&db, &dna_hash, &agent).await;
+
+    // Check agent is blocked now.
+    assert!(blocks
+        .is_blocked(BlockTarget::Agent(agent.clone()))
+        .await
+        .unwrap());
+    assert!(blocks
+        .are_all_blocked(vec![BlockTarget::Agent(agent.clone())])
+        .await
+        .unwrap());
+    // Empty target vector is still not blocked.
+    assert!(!blocks.are_all_blocked(vec![]).await.unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn are_all_blocked_mixed_then_all_blocked() {
+    let dna_hash = fixt!(DnaHash);
+    let agent1 = fixt!(AgentPubKey).to_k2_agent();
+    let agent2 = fixt!(AgentPubKey).to_k2_agent();
+    let db = test_conductor_db().to_db();
+    let blocks = HolochainBlocks::new(dna_hash.clone(), db.clone());
+
+    // Initially not blocked.
+    assert!(!blocks
+        .are_all_blocked(vec![
+            BlockTarget::Agent(agent1.clone()),
+            BlockTarget::Agent(agent2.clone()),
+        ])
+        .await
+        .unwrap());
+
+    // Block agent1 only.
+    block_agent(&db, &dna_hash, &agent1).await;
+
+    // Mixed list should yield false.
+    assert!(!blocks
+        .are_all_blocked(vec![
+            BlockTarget::Agent(agent1.clone()),
+            BlockTarget::Agent(agent2.clone()),
+        ])
+        .await
+        .unwrap());
+
+    // Block agent2 as well.
+    block_agent(&db, &dna_hash, &agent2).await;
+
+    // Now all should be blocked.
+    assert!(blocks
+        .are_all_blocked(vec![
+            BlockTarget::Agent(agent1.clone()),
+            BlockTarget::Agent(agent2.clone()),
+        ])
+        .await
+        .unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn are_all_blocked_with_duplicate_targets() {
+    let dna_hash = fixt!(DnaHash);
+    let agent = fixt!(AgentPubKey).to_k2_agent();
+    let db = test_conductor_db().to_db();
+    let blocks = HolochainBlocks::new(dna_hash.clone(), db.clone());
+
+    // Not blocked initially even with duplicates in query.
+    assert!(!blocks
+        .are_all_blocked(vec![
+            BlockTarget::Agent(agent.clone()),
+            BlockTarget::Agent(agent.clone()),
+            BlockTarget::Agent(agent.clone()),
+        ])
+        .await
+        .unwrap());
+
+    // Block the agent.
+    block_agent(&db, &dna_hash, &agent).await;
+
+    // Duplicates in the query should still resolve to true once blocked.
+    assert!(blocks
+        .are_all_blocked(vec![
+            BlockTarget::Agent(agent.clone()),
+            BlockTarget::Agent(agent.clone()),
+        ])
+        .await
+        .unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn blocking_same_agent_twice_is_ok() {
+    let dna_hash = fixt!(DnaHash);
+    let agent = fixt!(AgentPubKey).to_k2_agent();
+    let db = test_conductor_db().to_db();
+    let blocks = HolochainBlocks::new(dna_hash.clone(), db.clone());
+
+    // First block.
+    block_agent(&db, &dna_hash, &agent).await;
+
+    // Second block should not error.
+    block_agent(&db, &dna_hash, &agent).await;
+
+    // Still blocked.
+    assert!(blocks
+        .is_blocked(BlockTarget::Agent(agent.clone()))
+        .await
+        .unwrap());
+}
+
+// Same conductor DB, but two different DNA hashes.
+#[tokio::test(flavor = "multi_thread")]
+async fn block_is_scoped_per_dna() {
+    let agent = fixt!(AgentPubKey).to_k2_agent();
+    let db = test_conductor_db().to_db();
+
+    let dna_hash_1 = fixt!(DnaHash);
+    let dna_hash_2 = fixt!(DnaHash);
+
+    let blocks1 = HolochainBlocks::new(dna_hash_1.clone(), db.clone());
+    let blocks2 = HolochainBlocks::new(dna_hash_2.clone(), db.clone());
+
+    // Initially not blocked in either DNA.
+    assert!(!blocks1
+        .is_blocked(BlockTarget::Agent(agent.clone()))
+        .await
+        .unwrap());
+    assert!(!blocks2
+        .is_blocked(BlockTarget::Agent(agent.clone()))
+        .await
+        .unwrap());
+
+    // Block in DNA1 only.
+    block_agent(&db, &dna_hash_1, &agent).await;
+
+    // Blocked in DNA1.
+    assert!(blocks1
+        .is_blocked(BlockTarget::Agent(agent.clone()))
+        .await
+        .unwrap());
+
+    // Still not blocked in DNA2.
+    assert!(!blocks2
+        .is_blocked(BlockTarget::Agent(agent.clone()))
+        .await
+        .unwrap());
+
+    // All-blocked checks respect DNA scoping too.
+    assert!(blocks1
+        .are_all_blocked(vec![BlockTarget::Agent(agent.clone())])
+        .await
+        .unwrap());
+    assert!(!blocks2
+        .are_all_blocked(vec![BlockTarget::Agent(agent.clone())])
+        .await
+        .unwrap());
+}
+
+async fn block_agent(db: &DbWrite<DbKindConductor>, dna_hash: &DnaHash, agent_id: &AgentId) {
+    let cell_id = CellId::new(dna_hash.clone(), AgentPubKey::from_k2_agent(agent_id));
+    let block_data = Block::new(
+        holochain_types::prelude::BlockTarget::Cell(cell_id, CellBlockReason::App(vec![])),
+        InclusiveTimestampInterval::try_new(Timestamp::now(), Timestamp::MAX).unwrap(),
+    );
+    block(&db, block_data).await.unwrap();
+}

--- a/crates/holochain_p2p/tests/tests/mod.rs
+++ b/crates/holochain_p2p/tests/tests/mod.rs
@@ -1,3 +1,4 @@
+mod blocks;
 mod local_agent;
 mod node_messaging;
 mod op_store;

--- a/crates/holochain_p2p/tests/tests/node_messaging.rs
+++ b/crates/holochain_p2p/tests/tests/node_messaging.rs
@@ -1442,6 +1442,7 @@ async fn spawn_test(
     let db_peer_meta =
         DbWrite::test_in_mem(DbKindPeerMetaStore(Arc::new(dna_hash.clone()))).unwrap();
     let db_op = DbWrite::test_in_mem(DbKindDht(Arc::new(dna_hash.clone()))).unwrap();
+    let conductor_db = DbWrite::test_in_mem(DbKindConductor).unwrap();
     let lair_client = test_keystore();
 
     let agent = lair_client.new_sign_keypair_random().await.unwrap();
@@ -1455,6 +1456,10 @@ async fn spawn_test(
             get_db_op_store: Arc::new(move |_| {
                 let db_op = db_op.clone();
                 Box::pin(async move { Ok(db_op.clone()) })
+            }),
+            get_conductor_db: Arc::new(move || {
+                let conductor_db = conductor_db.clone();
+                Box::pin(async move { conductor_db })
             }),
             k2_test_builder: true,
             request_timeout: Duration::from_secs(1),

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -31,6 +31,7 @@ holochain_zome_types = { version = "^0.6.0-dev.17", path = "../holochain_zome_ty
 ] }
 holochain_state_types = { version = "^0.6.0-dev.14", path = "../holochain_state_types" }
 holochain_nonce = { version = "^0.6.0-dev.3", path = "../holochain_nonce" }
+holochain_timestamp = { version = "^0.6.0-dev.3", path = "../timestamp", optional = true }
 one_err = "0.0.8"
 shrinkwraprs = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -77,6 +78,7 @@ test_utils = [
   "holochain_types/test_utils",
   "holochain_zome_types/test_utils",
   "holochain_sqlite/test_utils",
+  "dep:holochain_timestamp",
   "base64",
   "contrafact",
   "tempfile",

--- a/crates/holochain_zome_types/src/block.rs
+++ b/crates/holochain_zome_types/src/block.rs
@@ -116,7 +116,26 @@ impl ToSql for BlockTargetId {
     }
 }
 
-#[derive(Debug, serde::Serialize, Clone)]
+#[cfg(feature = "rusqlite")]
+impl FromSql for BlockTargetId {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        let bytes = match value {
+            rusqlite::types::ValueRef::Blob(b) => b,
+            _ => {
+                // Anything else is a type‑mismatch.
+                return Err(rusqlite::types::FromSqlError::InvalidType);
+            }
+        };
+
+        // Decode the byte slice back into a [`BlockTargetId`].
+        holochain_serialized_bytes::decode::<_, BlockTargetId>(bytes).map_err(|_| {
+            // Propagate the decoding error as an invalid type error.
+            rusqlite::types::FromSqlError::InvalidType
+        })
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone)]
 pub enum BlockTargetReason {
     Cell(CellBlockReason),
     #[deprecated(since = "0.6.0", note = "not respected, use cell instead")]
@@ -134,6 +153,25 @@ impl ToSql for BlockTargetReason {
                 .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?
                 .into(),
         ))
+    }
+}
+
+#[cfg(feature = "rusqlite")]
+impl FromSql for BlockTargetReason {
+    fn column_result(value: rusqlite::types::ValueRef<'_>) -> rusqlite::types::FromSqlResult<Self> {
+        let bytes = match value {
+            rusqlite::types::ValueRef::Blob(b) => b,
+            _ => {
+                // Anything else is a type‑mismatch.
+                return Err(rusqlite::types::FromSqlError::InvalidType);
+            }
+        };
+
+        // Decode the byte slice back into a [`BlockTargetReason`].
+        holochain_serialized_bytes::decode::<_, BlockTargetReason>(bytes).map_err(|_| {
+            // Propagate the decoding error as an invalid type error.
+            rusqlite::types::FromSqlError::InvalidType
+        })
     }
 }
 

--- a/crates/holochain_zome_types/src/block.rs
+++ b/crates/holochain_zome_types/src/block.rs
@@ -8,6 +8,8 @@ use holo_hash::DnaHash;
 use holochain_integrity_types::Timestamp;
 use holochain_timestamp::InclusiveTimestampInterval;
 #[cfg(feature = "rusqlite")]
+use rusqlite::types::FromSql;
+#[cfg(feature = "rusqlite")]
 use rusqlite::types::ToSqlOutput;
 #[cfg(feature = "rusqlite")]
 use rusqlite::ToSql;
@@ -37,7 +39,7 @@ pub enum CellBlockReason {
 
 /// Reason why we might want to block a node.
 #[deprecated(since = "0.6.0")]
-#[derive(Clone, serde::Serialize, Debug)]
+#[derive(Clone, serde::Serialize, serde::Deserialize, Debug)]
 pub enum NodeBlockReason {
     /// The node did some bad cryptography.
     BadCrypto,
@@ -47,14 +49,14 @@ pub enum NodeBlockReason {
 
 /// Reason for a Node/Space Block.
 #[deprecated(since = "0.6.0")]
-#[derive(Clone, serde::Serialize, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, serde::Serialize, serde::Deserialize, Debug, Eq, PartialEq, Hash)]
 pub enum NodeSpaceBlockReason {
     /// Bad message encoding.
     BadWire,
 }
 
 /// Reason why we might want to block an IP.
-#[derive(Clone, serde::Serialize, Debug)]
+#[derive(Clone, serde::Serialize, serde::Deserialize, Debug)]
 pub enum IpBlockReason {
     /// Classic DoS.
     DoS,


### PR DESCRIPTION
### Summary

part of #5124 

- Implement `kitsune2_api::blocks::Blocks` trait in `holochain_p2p.`
- Tests that implementation at a unit level. Integration tests to be added once blocks completed in kitsune2.
- Adds a test that the HDK call `block_agent` leads to a block in the database.

I'll create another PR for the remaining test work. The tests are mostly written, but would fail now without kitsune respecting blocks, and this PR is long enough already.

The HDK call `block_agent` has another test which is a blocks integration test. I plan to move that to the holochain integration tests and add more tests that check that blocks are effective for incoming and outgoing connections.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Network-level agent blocking per DNA exposed via P2P API, with checks, batch checks, and blocking operations backed by the conductor DB accessor.

- **Documentation**
  - Changelog updated noting Blocks integration.

- **Tests**
  - Extensive tests added validating blocking behavior, DNA scoping, duplicates, empty sets, and repeated operations.

- **Chores**
  - DB/serialization enhancements and new test utilities for inspecting block records; dependency/test tooling updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->