### PR TITLE
feat: Permit fetching data from the network when using `must_get_valid_record` from a coordinator zome

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Permit `must_get_valid_record` to retrieve data from the network when called from a coordinator zome. #5304
 - Remove agents from peer store when they are blocked.
 - Refactor HDK call `block_agent` to use `HolochainP2pActor::block`.
 

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_valid_record.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_valid_record.rs
@@ -51,7 +51,7 @@ pub fn must_get_valid_record(
                             &workspace,
                             call_context.host_context.network().clone(),
                         ),
-                        GetOptions::local(),
+                        GetOptions::network(),
                     ),
                 };
                 match cascade

--- a/crates/holochain/tests/tests/mod.rs
+++ b/crates/holochain/tests/tests/mod.rs
@@ -32,3 +32,4 @@ mod validate;
 mod warrant_issuance;
 mod websocket;
 mod websocket_stress;
+mod zero_arc;

--- a/crates/holochain/tests/tests/zero_arc/mod.rs
+++ b/crates/holochain/tests/tests/zero_arc/mod.rs
@@ -1,0 +1,102 @@
+use hdk::link::GetLinksInputBuilder;
+use hdk::prelude::{
+    Entry, EntryDef, EntryDefIndex, EntryVisibility, LinkType, LinkTypeFilter, Op, Record,
+    ValidateCallbackResult,
+};
+use holo_hash::ExternalHash;
+use holochain::sweettest::{
+    SweetConductorBatch, SweetConductorConfig, SweetDnaFile, SweetInlineZomes,
+};
+use holochain_state::prelude::MustGetValidRecordInput;
+use holochain_types::inline_zome::InlineZomeSet;
+use holochain_zome_types::action::ChainTopOrdering;
+use holochain_zome_types::entry::CreateInput;
+use holochain_zome_types::prelude::CreateLinkInput;
+
+/// Test that zero arc nodes can use must_get_valid_record to get dependencies during validation.
+#[tokio::test(flavor = "multi_thread")]
+async fn must_get_valid_record() {
+    holochain_trace::test_run();
+
+    let base_addr = ExternalHash::from_raw_32(vec![0; 32]);
+
+    let entry_def = EntryDef::default_from_id("entry");
+    let zomes = SweetInlineZomes::new(vec![entry_def], 1)
+        .function("create", {
+            let base_addr = base_addr.clone();
+            move |api, _: ()| {
+                let entry = Entry::app(().try_into().unwrap()).unwrap();
+                let hash = api.create(CreateInput::new(
+                    InlineZomeSet::get_entry_location(&api, EntryDefIndex(0)),
+                    EntryVisibility::Public,
+                    entry,
+                    ChainTopOrdering::default(),
+                ))?;
+                api.create_link(CreateLinkInput::new(
+                    base_addr.clone().into(),
+                    hash.into(),
+                    0.into(),
+                    LinkType(0),
+                    ().into(),
+                    ChainTopOrdering::default(),
+                ))?;
+
+                Ok(())
+            }
+        })
+        .function("get", move |api, _: ()| {
+            let links = api.get_links(vec![GetLinksInputBuilder::try_new(
+                base_addr.clone(),
+                LinkTypeFilter::Types(vec![(0.into(), vec![LinkType(0)])]),
+            )
+            .unwrap()
+            .build()])?;
+
+            let mut out = vec![];
+            for link in links.into_iter().flatten() {
+                let record = api.must_get_valid_record(MustGetValidRecordInput::new(
+                    link.target.try_into().unwrap(),
+                ))?;
+                out.push(record);
+            }
+
+            Ok(out)
+        })
+        .integrity_function("validate", |_, _: Op| Ok(ValidateCallbackResult::Valid))
+        .0;
+
+    let (test_dna, _, _) = SweetDnaFile::unique_from_inline_zomes(zomes).await;
+
+    // Standard config with target arc factor 1
+    let standard_config = SweetConductorConfig::rendezvous(true);
+    // Standard config with target arc factor 0
+    let empty_arc_conductor_config =
+        SweetConductorConfig::rendezvous(true).tune_network_config(|nc| {
+            nc.target_arc_factor = 0;
+        });
+    let mut conductors =
+        SweetConductorBatch::from_configs_rendezvous([standard_config, empty_arc_conductor_config])
+            .await;
+
+    let apps = conductors.setup_app("", [&test_dna]).await.unwrap();
+    let ((alice,), (bob,)) = apps.into_tuples();
+
+    conductors[0]
+        .declare_full_storage_arcs(test_dna.dna_hash())
+        .await;
+    conductors.exchange_peer_info().await;
+
+    tracing::info!("Creating record for Alice");
+    let alice_zome = alice.zome(SweetInlineZomes::COORDINATOR);
+    let _: () = conductors[0].call(&alice_zome, "create", ()).await;
+
+    tracing::info!("Getting record for Bob");
+    let bob_zome = bob.zome(SweetInlineZomes::COORDINATOR);
+    let records: Vec<Record> = conductors[1].call(&bob_zome, "get", ()).await;
+
+    assert_eq!(
+        records.len(),
+        1,
+        "Expected Bob to be able to get Alice's record"
+    );
+}


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent fallback to network retrieval for valid records called from coordinator zomes, improving cross-node access in low-coverage or zero-arc scenarios. No public API changes.

* **Tests**
  * Added an end-to-end test that creates, links, and retrieves a record across peers with differing arc configurations (including zero-arc) to exercise cross-node retrieval and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->