### PR TITLE
Remove agent from peer store when blocked

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Remove agents from peer store when they are blocked.
+- Refactor HDK call `block_agent` to use `HolochainP2pActor::block`.
+
 ## 0.6.0-dev.23
 
 - Support binding admin and app websocket interfaces on designated listen addresses. \#5271

--- a/crates/holochain/src/conductor/api/api_cell.rs
+++ b/crates/holochain/src/conductor/api/api_cell.rs
@@ -9,6 +9,7 @@ use crate::core::ribosome::real_ribosome::RealRibosome;
 use crate::core::workflow::ZomeCallResult;
 use async_trait::async_trait;
 use holochain_keystore::MetaLairClient;
+use holochain_p2p::HolochainP2pResult;
 use holochain_state::host_fn_workspace::SourceChainWorkspace;
 use holochain_state::nonce::WitnessNonceResult;
 use holochain_state::prelude::DatabaseResult;
@@ -154,7 +155,7 @@ pub trait CellConductorReadHandleT: Send + Sync {
     ) -> ConductorResult<Option<CellId>>;
 
     /// Expose block functionality to zomes.
-    async fn block(&self, input: Block) -> DatabaseResult<()>;
+    async fn block(&self, input: Block) -> HolochainP2pResult<()>;
 
     /// Expose unblock functionality to zomes.
     async fn unblock(&self, input: Block) -> DatabaseResult<()>;
@@ -256,8 +257,8 @@ impl CellConductorReadHandleT for CellConductorApi {
             .await
     }
 
-    async fn block(&self, input: Block) -> DatabaseResult<()> {
-        self.conductor_handle.block(input).await
+    async fn block(&self, input: Block) -> HolochainP2pResult<()> {
+        self.conductor_handle.holochain_p2p().block(input).await
     }
 
     async fn unblock(&self, input: Block) -> DatabaseResult<()> {

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -947,11 +947,6 @@ mod network_impls {
             .await?)
         }
 
-        /// Block some target.
-        pub async fn block(&self, input: Block) -> DatabaseResult<()> {
-            self.spaces.block(input).await
-        }
-
         /// Unblock some target.
         pub async fn unblock(&self, input: Block) -> DatabaseResult<()> {
             self.spaces.unblock(input).await

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -193,14 +193,6 @@ impl Spaces {
         })
     }
 
-    /// Block some target.
-    pub async fn block(&self, input: Block) -> DatabaseResult<()> {
-        tracing::warn!(
-            "Creating block, but this is currently not being respected by holochain_p2p!"
-        );
-        holochain_state::block::block(&self.conductor_db, input).await
-    }
-
     /// Unblock some target.
     pub async fn unblock(&self, input: Block) -> DatabaseResult<()> {
         holochain_state::block::unblock(&self.conductor_db, input).await

--- a/crates/holochain/src/core/queue_consumer/validation_receipt_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/validation_receipt_consumer.rs
@@ -35,7 +35,7 @@ pub fn spawn_validation_receipt_consumer(
                     move |block| {
                         let conductor = conductor.clone();
                         // This can be cleaned up when the compiler is smarter - https://github.com/rust-lang/rust/issues/69663
-                        async move { conductor.block(block).await }.boxed()
+                        async move { conductor.holochain_p2p().block(block).await }.boxed()
                     }
                 },
             )

--- a/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/block_agent.rs
@@ -41,13 +41,11 @@ pub fn block_agent(
 mod test {
     use crate::conductor::api::error::ConductorApiResult;
     use crate::sweettest::*;
-    use crate::test_utils::conditional_consistency::*;
     use crate::test_utils::RibosomeTestFixture;
     use holo_hash::ActionHash;
     use holo_hash::AgentPubKey;
     use holochain_state::block::get_all_cell_blocks;
     use holochain_types::prelude::CapSecret;
-    use holochain_types::prelude::Record;
     use holochain_types::prelude::ZomeCallResponse;
     use holochain_wasm_test_utils::TestWasm;
     use holochain_zome_types::block::{BlockTarget, CellBlockReason};
@@ -90,94 +88,6 @@ mod test {
         let _: () = conductor.call(&bob, "unblock_agent", alice_pubkey).await;
 
         let _response3: ZomeCallResponse = conductor.call(&alice, "try_cap_claim", cap_for).await;
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    #[cfg(feature = "slow_tests")]
-    async fn zome_call_get_block() {
-        holochain_trace::test_run();
-
-        let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
-
-        let config = SweetConductorConfig::standard()
-            .tune_conductor(|c| {
-                c.min_publish_interval = Some(std::time::Duration::from_secs(2));
-                c.publish_trigger_interval = Some(std::time::Duration::from_secs(3));
-                c.sys_validation_retry_delay = Some(std::time::Duration::from_secs(1));
-            })
-            .tune_network_config(|nc| {
-                // Gossip would share peer info
-                nc.disable_gossip = true;
-                // Want to control the sharing of peer info in this test
-                nc.disable_bootstrap = true;
-            });
-        let mut conductors = SweetConductorBatch::from_config(3, config).await;
-        let apps = conductors.setup_app("create", [&dna_file]).await.unwrap();
-
-        let ((alice_cell,), (bob_cell,), (carol_cell,)) = apps.into_tuples();
-
-        conductors[0]
-            .declare_full_storage_arcs(alice_cell.dna_hash())
-            .await;
-        conductors[1]
-            .declare_full_storage_arcs(alice_cell.dna_hash())
-            .await;
-        conductors[2]
-            .declare_full_storage_arcs(alice_cell.dna_hash())
-            .await;
-
-        let alice = alice_cell.zome(TestWasm::Create);
-        let bob = bob_cell.zome(TestWasm::Create);
-
-        let bob_pubkey = bob_cell.cell_id().agent_pubkey();
-
-        conductors.reveal_peer_info(0, 1).await;
-        conductors.reveal_peer_info(1, 0).await;
-
-        let alice_conductor = conductors.get(0).unwrap();
-        let bob_conductor = conductors.get(1).unwrap();
-
-        let action0: ActionHash = alice_conductor.call(&alice, "create_entry", ()).await;
-
-        await_consistency(30, [&alice_cell, &bob_cell])
-            .await
-            .unwrap();
-
-        // Before bob is blocked he can get posts just fine.
-        let bob_get0: Option<Record> = bob_conductor.call(&bob, "get_post", action0).await;
-        // Await bob's init to propagate to alice.
-        await_consistency(30, [&alice_cell, &bob_cell])
-            .await
-            .unwrap();
-        assert!(bob_get0.is_some());
-
-        // Bob gets blocked by alice.
-        let _block: () = alice_conductor
-            .call(&alice, "block_agent", bob_pubkey)
-            .await;
-
-        let action1: ActionHash = alice_conductor.call(&alice, "create_entry", ()).await;
-
-        // Now that bob is blocked by alice he cannot get data from alice.
-        await_conditional_consistency(10, vec![], [(&alice_cell, true), (&bob_cell, false)])
-            .await
-            .unwrap();
-        let bob_get1: Option<Record> = bob_conductor.call(&bob, "get_post", action1.clone()).await;
-
-        assert!(bob_get1.is_none());
-
-        // If carol joins the party but DOES NOT block bob then she will
-        // give access to data once more for bob.
-
-        conductors.exchange_peer_info().await;
-
-        await_consistency(60, [&alice_cell, &bob_cell, &carol_cell])
-            .await
-            .unwrap();
-
-        // Bob can get data from alice via. carol.
-        let bob_get2: Option<Record> = bob_conductor.call(&bob, "get_post", action1).await;
-        assert!(bob_get2.is_some());
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
@@ -3,7 +3,7 @@ use crate::core::queue_consumer::WorkComplete;
 use futures::future::BoxFuture;
 use futures::{stream, StreamExt};
 use holochain_keystore::MetaLairClient;
-use holochain_p2p::DynHolochainP2pDna;
+use holochain_p2p::{DynHolochainP2pDna, HolochainP2pResult};
 use holochain_state::prelude::*;
 use holochain_zome_types::block::Block;
 use holochain_zome_types::block::BlockTarget;
@@ -33,7 +33,7 @@ pub async fn validation_receipt_workflow<B>(
     apply_block: B,
 ) -> WorkflowResult<WorkComplete>
 where
-    B: Fn(Block) -> BoxFuture<'static, DatabaseResult<()>> + Clone,
+    B: Fn(Block) -> BoxFuture<'static, HolochainP2pResult<()>> + Clone,
 {
     if running_cell_ids.is_empty() {
         return Ok(WorkComplete::Complete);
@@ -114,7 +114,7 @@ async fn sign_and_send_receipts_to_author<B>(
     apply_block: B,
 ) -> WorkflowResult<()>
 where
-    B: Fn(Block) -> BoxFuture<'static, DatabaseResult<()>>,
+    B: Fn(Block) -> BoxFuture<'static, HolochainP2pResult<()>>,
 {
     // Don't send receipt to self. Don't block self.
     if validators.contains(op_author) {

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/unit_tests.rs
@@ -11,6 +11,7 @@ use holo_hash::fixt::AgentPubKeyFixturator;
 use holo_hash::fixt::DnaHashFixturator;
 use holo_hash::HasHash;
 use holo_hash::{AgentPubKey, DhtOpHash};
+use holochain_p2p::HolochainP2pResult;
 use holochain_p2p::MockHolochainP2pDnaT;
 use holochain_sqlite::error::DatabaseResult;
 use holochain_sqlite::prelude::{DbKindDht, DbWrite};
@@ -129,7 +130,7 @@ async fn block_invalid_op_author() {
         vec![validator].into_iter().collect(),
         {
             let blocks = blocks.clone();
-            move |block| -> BoxFuture<DatabaseResult<()>> {
+            move |block| -> BoxFuture<HolochainP2pResult<()>> {
                 blocks.write().push(block);
                 async move { Ok(()) }.boxed()
             }

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -371,7 +371,7 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug {
     ) -> BoxFut<'_, HolochainP2pResult<Vec<kitsune2_api::DhtArc>>>;
 
     /// Block an agent for a DNA with a block reason.
-    fn block(&self, block_target: BlockTarget) -> BoxFut<'_, HolochainP2pResult<()>>;
+    fn block(&self, block: Block) -> BoxFut<'_, HolochainP2pResult<()>>;
 
     /// Get the conductor database getter.
     fn conductor_db_getter(&self) -> crate::GetDbConductor;

--- a/crates/holochain_p2p/tests/tests/blocks.rs
+++ b/crates/holochain_p2p/tests/tests/blocks.rs
@@ -3,9 +3,10 @@ use holo_hash::{
     fixt::{AgentPubKeyFixturator, DhtOpHashFixturator, DnaHashFixturator},
     DnaHash,
 };
-use holochain_keystore::test_keystore;
+use holochain_keystore::{test_keystore, MetaLairClient};
 use holochain_p2p::{
     actor::DynHcP2p, event::MockHcP2pHandler, spawn_holochain_p2p, HolochainP2pConfig,
+    HolochainP2pLocalAgent,
 };
 use holochain_state::{block::get_all_cell_blocks, prelude::test_conductor_db};
 use holochain_types::{
@@ -13,23 +14,16 @@ use holochain_types::{
     prelude::{CellBlockReason, CellId},
 };
 use holochain_zome_types::block::BlockTarget;
-use kitsune2_api::DynBlocks;
-use std::sync::Arc;
+use kitsune2_api::{AgentInfo, AgentInfoSigned, DhtArc, DynBlocks, Timestamp};
+use std::{i64, sync::Arc};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn cell_blocks_are_committed_to_database() {
-    let conductor_db = test_conductor_db().to_db();
-    let conductor_db2 = conductor_db.clone();
-    let config = HolochainP2pConfig {
-        get_conductor_db: Arc::new(move || {
-            let conductor_db2 = conductor_db2.clone();
-            Box::pin(async move { conductor_db2 })
-        }),
-        k2_test_builder: true,
-        ..Default::default()
-    };
-    let actor = spawn_holochain_p2p(config, test_keystore()).await.unwrap();
-    let cell_id = CellId::new(fixt!(DnaHash), fixt!(AgentPubKey));
+    let conductor_db = DbWrite::test_in_mem(DbKindConductor).unwrap();
+    let dna_hash = fixt!(DnaHash);
+    let TestCase { actor, .. } =
+        TestCase::new_with_conductor_db(&dna_hash, conductor_db.clone()).await;
+    let cell_id = CellId::new(dna_hash, fixt!(AgentPubKey));
     let cell_block_reason = CellBlockReason::InvalidOp(fixt!(DhtOpHash));
     let block_target = BlockTarget::Cell(cell_id.clone(), cell_block_reason.clone());
 
@@ -80,6 +74,50 @@ async fn block_someone() {
         .unwrap());
     // Empty target vector is still not blocked.
     assert!(!blocks_module.are_all_blocked(vec![]).await.unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_is_removed_from_peer_store_when_blocked() {
+    let dna_hash = fixt!(DnaHash);
+    let keystore = test_keystore();
+    let agent = keystore.new_sign_keypair_random().await.unwrap();
+    let cell_id = CellId::new(dna_hash.clone(), agent.clone());
+
+    let TestCase { actor, .. } = TestCase::new_with_keystore(&dna_hash, &keystore).await;
+    let space = actor
+        .test_kitsune()
+        .space(dna_hash.to_k2_space())
+        .await
+        .unwrap();
+    let peer_store = space.peer_store();
+
+    let local_agent = HolochainP2pLocalAgent::new(agent.clone(), DhtArc::FULL, 1, keystore.clone());
+    let agent_info_signed = AgentInfoSigned::sign(
+        &local_agent,
+        AgentInfo {
+            agent: agent.to_k2_agent(),
+            created_at: Timestamp::now(),
+            expires_at: Timestamp::from_micros(i64::MAX),
+            space: dna_hash.to_k2_space(),
+            is_tombstone: false,
+            storage_arc: DhtArc::Empty,
+            url: None,
+        },
+    )
+    .await
+    .unwrap();
+    peer_store.insert(vec![agent_info_signed]).await.unwrap();
+
+    assert!(peer_store.get(agent.to_k2_agent()).await.unwrap().is_some());
+
+    // Block an agent.
+    actor
+        .block(BlockTarget::Cell(cell_id, CellBlockReason::BadCrypto))
+        .await
+        .unwrap();
+
+    // Check agent has been removed from peer store.
+    assert!(peer_store.get(agent.to_k2_agent()).await.unwrap().is_none());
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -269,22 +307,34 @@ struct TestCase {
 
 impl TestCase {
     async fn new(dna_hash: &DnaHash) -> Self {
-        let conductor_db = test_conductor_db().to_db();
-        Self::new_with_conductor_db(dna_hash, conductor_db).await
+        let conductor_db = DbWrite::test_in_mem(DbKindConductor).unwrap();
+        Self::create_test_case(dna_hash, conductor_db, test_keystore()).await
     }
 
     async fn new_with_conductor_db(
         dna_hash: &DnaHash,
         conductor_db: DbWrite<DbKindConductor>,
     ) -> Self {
+        Self::create_test_case(dna_hash, conductor_db, test_keystore()).await
+    }
+
+    async fn new_with_keystore(dna_hash: &DnaHash, keystore: &MetaLairClient) -> Self {
+        let conductor_db = DbWrite::test_in_mem(DbKindConductor).unwrap();
+        Self::create_test_case(dna_hash, conductor_db, keystore.clone()).await
+    }
+
+    async fn create_test_case(
+        dna_hash: &DnaHash,
+        conductor_db: DbWrite<DbKindConductor>,
+        keystore: MetaLairClient,
+    ) -> Self {
         let op_db = DbWrite::test_in_mem(DbKindDht(Arc::new(dna_hash.clone()))).unwrap();
         let peer_meta_db =
             DbWrite::test_in_mem(DbKindPeerMetaStore(Arc::new(dna_hash.clone()))).unwrap();
-        let conductor_db2 = conductor_db.clone();
         let config = HolochainP2pConfig {
             get_conductor_db: Arc::new(move || {
-                let conductor_db2 = conductor_db2.clone();
-                Box::pin(async move { conductor_db2 })
+                let conductor_db = conductor_db.clone();
+                Box::pin(async move { conductor_db })
             }),
             get_db_op_store: Arc::new(move |_| {
                 let op_db = op_db.clone();
@@ -297,7 +347,7 @@ impl TestCase {
             k2_test_builder: true,
             ..Default::default()
         };
-        let actor = spawn_holochain_p2p(config, test_keystore()).await.unwrap();
+        let actor = spawn_holochain_p2p(config, keystore).await.unwrap();
         actor
             .register_handler(Arc::new(MockHcP2pHandler::new()))
             .await


### PR DESCRIPTION
### Summary

- Remove agents from peer store when they're blocked.
- Refactor HDK call `block_agent` to use `HolochainP2pActor::block`.
- Remove `block` from `Conductor`.

part of #5124 

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Blocking an agent now also removes them from the peer store for improved enforcement and visibility.
  - Public prelude now exposes a Block type for blocking operations.

- Refactor
  - Blocking flow streamlined through the networking layer for clearer, more consistent handling.

- Tests
  - Expanded tests covering peer-store removal, per-DNA scoping, and multi-instance scenarios.

- Documentation
  - Changelog updated to describe the new blocking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->