### PR TITLE
refactor: Remove the unused NetId hash type from `holo_hash`

### DIFF
--- a/crates/holo_hash/README.md
+++ b/crates/holo_hash/README.md
@@ -23,7 +23,6 @@ Each primitive HashType has a unique 3-byte prefix associated with it, to easily
 | Entry     | EntryHash      | uhCEk  |
 | DhtOp     | DhtOpHash      | uhCQk  |
 | Dna       | DnaHash        | uhC0k  |
-| NetId     | NetIdHash      | uhCIk  |
 | Action    | ActionHash     | uhCkk  |
 | Wasm      | DnaWasmHash    | uhCok  |
 

--- a/crates/holo_hash/src/aliases.rs
+++ b/crates/holo_hash/src/aliases.rs
@@ -28,9 +28,6 @@ pub type EntryHash = HoloHash<hash_type::Entry>;
 /// The hash of an action
 pub type ActionHash = HoloHash<hash_type::Action>;
 
-/// The hash of a network ID
-pub type NetIdHash = HoloHash<hash_type::NetId>;
-
 /// The hash of some wasm bytecode
 pub type WasmHash = HoloHash<hash_type::Wasm>;
 

--- a/crates/holo_hash/src/fixt.rs
+++ b/crates/holo_hash/src/fixt.rs
@@ -17,8 +17,6 @@ use crate::EntryHash;
 use crate::EntryHashB64;
 use crate::ExternalHash;
 use crate::ExternalHashB64;
-use crate::NetIdHash;
-use crate::NetIdHashB64;
 use crate::WasmHash;
 use crate::WasmHashB64;
 use ::fixt::prelude::*;
@@ -136,15 +134,6 @@ fixturator!(
 fixturator!(
     ActionHashB64;
     constructor fn new(ActionHash);
-);
-
-fixturator!(
-    NetIdHash;
-    constructor fn from_raw_32(ThirtyTwoHashBytes);
-);
-fixturator!(
-    NetIdHashB64;
-    constructor fn new(NetIdHash);
 );
 
 fixturator!(

--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -325,10 +325,6 @@ mod tests {
             DnaHash::from_raw_36(vec![0xdb; HOLO_HASH_UNTYPED_LEN]),
         );
         assert_type(
-            "NetIdHash",
-            NetIdHash::from_raw_36(vec![0xdb; HOLO_HASH_UNTYPED_LEN]),
-        );
-        assert_type(
             "AgentPubKey",
             AgentPubKey::from_raw_36(vec![0xdb; HOLO_HASH_UNTYPED_LEN]),
         );

--- a/crates/holo_hash/src/hash_b64.rs
+++ b/crates/holo_hash/src/hash_b64.rs
@@ -83,9 +83,6 @@ pub type EntryHashB64 = HoloHashB64<hash_type::Entry>;
 /// Base64-ready version of ActionHash
 pub type ActionHashB64 = HoloHashB64<hash_type::Action>;
 
-/// Base64-ready version of NetIdHash
-pub type NetIdHashB64 = HoloHashB64<hash_type::NetId>;
-
 /// Base64-ready version of WasmHash
 pub type WasmHashB64 = HoloHashB64<hash_type::Wasm>;
 

--- a/crates/holo_hash/src/hash_type/primitive.rs
+++ b/crates/holo_hash/src/hash_type/primitive.rs
@@ -7,7 +7,7 @@ use std::convert::TryInto;
 // Valid Holochain options for prefixes:
 // hCAk 4100 <Buffer 84 20 24> * AGENT
 // hCEk 4228 <Buffer 84 21 24> * ENTRY
-// hCIk 4356 <Buffer 84 22 24> * NET_ID
+// hCIk 4356 <Buffer 84 22 24> * reserved
 // hCMk 4484 <Buffer 84 23 24>
 // hCQk 4612 <Buffer 84 24 24> * DHTOP
 // hCUk 4740 <Buffer 84 25 24>
@@ -45,7 +45,6 @@ pub(crate) const ENTRY_PREFIX: &[u8] = &[0x84, 0x21, 0x24]; // uhCEk [132, 33, 3
 pub(crate) const DHTOP_PREFIX: &[u8] = &[0x84, 0x24, 0x24]; // uhCQk [132, 36, 36]
 pub(crate) const WARRANT_PREFIX: &[u8] = &[0x84, 0x2c, 0x24]; // uhCwk [132, 44, 36]
 pub(crate) const DNA_PREFIX: &[u8] = &[0x84, 0x2d, 0x24]; // uhC0k [132, 45, 36]
-pub(crate) const NET_ID_PREFIX: &[u8] = &[0x84, 0x22, 0x24]; // uhCIk [132, 34, 36]
 pub(crate) const ACTION_PREFIX: &[u8] = &[0x84, 0x29, 0x24]; // uhCkk [132, 41, 36]
 pub(crate) const WASM_PREFIX: &[u8] = &[0x84, 0x2a, 0x24]; // uhCok [132, 42, 36]
 pub(crate) const EXTERNAL_PREFIX: &[u8] = &[0x84, 0x2f, 0x24]; // uhC8k [132, 47, 36]
@@ -167,7 +166,6 @@ primitive_hash_type!(Entry, EntryHash, EntryVisitor, ENTRY_PREFIX);
 primitive_hash_type!(Dna, DnaHash, DnaVisitor, DNA_PREFIX);
 primitive_hash_type!(DhtOp, DhtOpHash, DhtOpVisitor, DHTOP_PREFIX);
 primitive_hash_type!(Action, ActionHash, ActionVisitor, ACTION_PREFIX);
-primitive_hash_type!(NetId, NetIdHash, NetIdVisitor, NET_ID_PREFIX);
 primitive_hash_type!(Wasm, WasmHash, WasmVisitor, WASM_PREFIX);
 primitive_hash_type!(Warrant, WarrantHash, WarrantVisitor, WARRANT_PREFIX);
 primitive_hash_type!(External, ExternalHash, ExternalVisitor, EXTERNAL_PREFIX);
@@ -195,7 +193,6 @@ impl HashTypeSync for Warrant {}
 /// data into an external hash (support all data, opaque result).
 impl HashTypeAsync for External {}
 
-impl HashTypeAsync for NetId {}
 impl HashTypeAsync for Wasm {}
 
 impl From<AgentPubKey> for EntryHash {

--- a/crates/holo_hash/src/tests.rs
+++ b/crates/holo_hash/src/tests.rs
@@ -48,13 +48,6 @@ fn holo_hash_parse() {
         &format!("{:?}", h),
     );
 
-    let h = NetIdHash::try_from("uhCIkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm").unwrap();
-    assert_eq!(expected_loc, h.get_loc());
-    assert_eq!(
-        "NetIdHash(uhCIkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm)",
-        &format!("{:?}", h),
-    );
-
     let h = ActionHash::try_from("uhCkkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm").unwrap();
     assert_eq!(expected_loc, h.get_loc());
     assert_eq!(

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- **BREAKING CHANGE**: Remove the NetId hash types from the `holo_hash` crate. These were added speculatively and are not used for anything. #5306
 - Remove the NetIdHash types from the `holo_hash` crate. These were added speculatively and are not used for anything. #5306
 - Permit `must_get_valid_record` to retrieve data from the network when called from a coordinator zome. #5304
 - Remove agents from peer store when they are blocked.

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Remove the NetIdHash types from the `holo_hash` crate. These were added speculatively and are not used for anything. #5306
 - Permit `must_get_valid_record` to retrieve data from the network when called from a coordinator zome. #5304
 - Remove agents from peer store when they are blocked.
 - Refactor HDK call `block_agent` to use `HolochainP2pActor::block`.


### PR DESCRIPTION
### Summary

I was looking at finishing of https://github.com/holochain/holochain/issues/3313 but it's huge. Picking this off as a smaller PR that contributes towards that issue.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Removed the NetId hash type and its Base64 alias from the public API; other hash types remain unchanged.

- Tests
  - Removed NetId-related assertions and parsing tests from the test suite.

- Chores
  - Removed NetId fixtures and updated documentation and changelog entries to reflect the removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->