### PR TITLE
refactor: merge_bounded_agent_activity_responses performance

### DIFF
--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -905,16 +905,11 @@ impl CascadeImpl {
         })
             .await??;
 
-        let merged_results = results.iter().fold(
-            // It's sort of arbitrary what the initial value is as long as it's
-            // not an activity response.
-            BoundedMustGetAgentActivityResponse::EmptyRange,
-            holochain_types::chain::merge_bounded_agent_activity_responses,
-        );
-
+        let merged_response =
+            holochain_types::chain::merge_bounded_agent_activity_responses(results);
         let result =
             authority::get_agent_activity_query::must_get_agent_activity::filter_then_check(
-                merged_results,
+                merged_response,
             );
 
         // Short circuit if we have a result.
@@ -927,7 +922,7 @@ impl CascadeImpl {
         if i_am_authority {
             // If I am an authority and I didn't get a result before
             // this point then the chain is incomplete for this request.
-            Ok(MustGetAgentActivityResponse::IncompleteChain)
+            Ok(result)
         } else {
             Ok(self
                 .fetch_must_get_agent_activity(author.clone(), filter)


### PR DESCRIPTION
### Summary
Avoid unnecessary cloning in `merge_bounded_agent_activity_responses` (resolves #5307). I ran this locally with some large mock agent activity data and saw roughly 90% speed improvement for the function.


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs