### PR TITLE
wip: IncompleteChain includes set of missing action seqs

### DIFF
--- a/crates/holochain_cascade/src/authority/get_agent_activity_query/must_get_agent_activity.rs
+++ b/crates/holochain_cascade/src/authority/get_agent_activity_query/must_get_agent_activity.rs
@@ -48,7 +48,7 @@ pub fn get_bounded_activity(
                 }
             })
         }
-        // One of the actions specified in the filter does not exist in the database.
+        // The chain top ActionHash specified in the filter was not found in the database.
         Sequences::ChainTopNotFound(a) => {
             Ok(BoundedMustGetAgentActivityResponse::ChainTopNotFound(a))
         }
@@ -68,17 +68,17 @@ pub fn filter_then_check(
             filter,
             warrants,
         } => {
-            // Filter the activity from the database and check the invariants of the
-            // filter still hold.
+            // Filter the activity from the database and check that we have a complete chain of activity within the filter.
             filter.filter_then_check(activity, warrants)
         }
-        BoundedMustGetAgentActivityResponse::IncompleteChain => {
-            MustGetAgentActivityResponse::IncompleteChain
+        BoundedMustGetAgentActivityResponse::IncompleteChain(s) => {
+            MustGetAgentActivityResponse::IncompleteChain(s)
         }
         BoundedMustGetAgentActivityResponse::ChainTopNotFound(a) => {
             MustGetAgentActivityResponse::ChainTopNotFound(a)
         }
         BoundedMustGetAgentActivityResponse::EmptyRange => MustGetAgentActivityResponse::EmptyRange,
+        BoundedMustGetAgentActivityResponse::NoResponse => MustGetAgentActivityResponse::NoResponse,
     }
 }
 

--- a/crates/holochain_cascade/src/authority/get_agent_activity_query/must_get_agent_activity/test.rs
+++ b/crates/holochain_cascade/src/authority/get_agent_activity_query/must_get_agent_activity/test.rs
@@ -123,7 +123,7 @@ async fn returns_full_sequence_from_filter(
 
 #[test_case(
     agent_chain(&[(0, 0..3), (0, 5..10)]), agent_hash(&[0]), ChainFilter::new(action_hash(&[8]))
-    => MustGetAgentActivityResponse::IncompleteChain ; "8 to genesis with 0 till 2 and 5 till 9")]
+    => MustGetAgentActivityResponse::IncompleteChain(std::collections::BTreeSet::from([3, 4])) ; "8 to genesis with 0 till 2 and 5 till 9")]
 #[test_case(
     agent_chain(&[(0, 0..10)]), agent_hash(&[1]), ChainFilter::new(action_hash(&[8]))
     => MustGetAgentActivityResponse::ChainTopNotFound(action_hash(&[8])) ; "Different agent")]
@@ -139,7 +139,7 @@ async fn returns_full_sequence_from_filter(
 #[test_case(
     vec![(agent_hash(&[0]), forked_chain(&[0..6, 3..8]))], agent_hash(&[0]),
     ChainFilter::new(action_hash(&[5, 0])).until_hash(action_hash(&[4, 1]))
-    => MustGetAgentActivityResponse::IncompleteChain ; "Unit hash on fork")]
+    => MustGetAgentActivityResponse::IncompleteChain(std::collections::BTreeSet::from([0, 1, 2])) ; "Unit hash on fork")]
 #[test_case(
     agent_chain(&[(0, 0..10)]), agent_hash(&[0]), ChainFilter::new(action_hash(&[8])).until_hash(action_hash(&[9]))
     => matches MustGetAgentActivityResponse::Activity { .. }; "Until is higher then chain_top")]

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -367,7 +367,7 @@ impl CascadeImpl {
 
         let cache = some_or_return!(
             self.cache.as_ref(),
-            response.unwrap_or(MustGetAgentActivityResponse::IncompleteChain)
+            response.unwrap_or(MustGetAgentActivityResponse::NoResponse)
         );
 
         // Commit the activity to the chain.
@@ -392,8 +392,8 @@ impl CascadeImpl {
                 Ok(MustGetAgentActivityResponse::Activity { activity, warrants })
             }
             Some(response) => Ok(response),
-            // Got no responses so the chain is incomplete.
-            None => Ok(MustGetAgentActivityResponse::IncompleteChain),
+            // Got no responses
+            None => Ok(MustGetAgentActivityResponse::NoResponse),
         }
     }
 
@@ -471,7 +471,7 @@ impl CascadeImpl {
     ) -> CascadeResult<MustGetAgentActivityResponse> {
         let network = some_or_return!(
             self.network.as_ref(),
-            MustGetAgentActivityResponse::IncompleteChain
+            MustGetAgentActivityResponse::NoResponse
         );
         let results = match network.must_get_agent_activity(author, filter).await {
             Ok(response) => response,

--- a/crates/holochain_types/src/chain/test.rs
+++ b/crates/holochain_types/src/chain/test.rs
@@ -126,13 +126,13 @@ fn matches_chain(a: &Vec<RegisterAgentActivity>, seq: &[u32]) -> bool {
     => matches MustGetAgentActivityResponse::Activity {activity, ..} if matches_chain(&activity, &[15, 14]) ; "chain_top 15 until 10 take 2 chain 10 to 15")]
 #[test_case(
     chain(1..6), ChainFilter::new(action_hash(&[5])).until_hash(action_hash(&[0])).take(6), hash_to_seq(&[0, 5])
-    => matches MustGetAgentActivityResponse::IncompleteChain ; "chain_top 5 until 0 take 6 chain 1 to 5")]
+    => matches MustGetAgentActivityResponse::IncompleteChain(_) ; "chain_top 5 until 0 take 6 chain 1 to 5")]
 #[test_case(
     chain(0..5), ChainFilter::new(action_hash(&[5])).until_hash(action_hash(&[0])).take(6), hash_to_seq(&[0, 5])
-    => matches MustGetAgentActivityResponse::IncompleteChain ; "chain_top 5 until 0 take 6 chain 0 to 4")]
+    => matches MustGetAgentActivityResponse::IncompleteChain(_) ; "chain_top 5 until 0 take 6 chain 0 to 4")]
 #[test_case(
     gap_chain(&[0..4, 5..10]), ChainFilter::new(action_hash(&[7])).until_hash(action_hash(&[0])).take(8), hash_to_seq(&[0, 7])
-    => matches MustGetAgentActivityResponse::IncompleteChain ; "chain_top 7 until 0 take 8 chain 0 to 3 then 5 to 10")]
+    => matches MustGetAgentActivityResponse::IncompleteChain(_) ; "chain_top 7 until 0 take 8 chain 0 to 3 then 5 to 10")]
 #[test_case(
     gap_chain(&[0..4, 5..10]), ChainFilter::new(action_hash(&[7])).until_hash(action_hash(&[5])).take(8), hash_to_seq(&[5, 7])
     => matches MustGetAgentActivityResponse::Activity {activity, ..} if matches_chain(&activity, &[7, 6, 5]) ; "chain_top 7 until 5 take 8 chain 0 to 3 then 5 to 10")]
@@ -147,7 +147,7 @@ fn matches_chain(a: &Vec<RegisterAgentActivity>, seq: &[u32]) -> bool {
     => matches MustGetAgentActivityResponse::Activity {activity, ..} if matches_chain(&activity, &[7, 6, 5, 4, 3, 2, 1, 0]) ; "chain_top (7,1) take 8 chain 0 to 5 and 3 to 7")]
 #[test_case(
     forked_chain(&[4..6, 3..8]), ChainFilter::new(action_hash(&[5, 0])).until_hash(action_hash(&[4, 1])), |h| if *h == action_hash(&[5, 0]) { Some(5) } else { Some(4) }
-    => matches MustGetAgentActivityResponse::IncompleteChain ; "chain_top (5,0) until (4,1) chain (0,0) to (5,0) and (3,1) to (7,1)")]
+    => matches MustGetAgentActivityResponse::IncompleteChain(_) ; "chain_top (5,0) until (4,1) chain (0,0) to (5,0) and (3,1) to (7,1)")]
 fn test_filter_then_check(
     chain: Vec<TestChainItem>,
     filter: ChainFilter,


### PR DESCRIPTION
### Summary
Follow up to #5312 with some refactoring related to MustGetAgentActivityResponse logic.

- IncompleteChain now contains a set of action seqs which are missing. This clarifies the intended meaning of this response type: we have the chain head but are missing some of the prior actions requested.
- Additional variant NoResponse for unexpected or empty responses, so that we no longer use IncompleteChain for that purpose.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs