### PR TITLE
Test get missing for inline validate

### DIFF
--- a/crates/holochain/tests/tests/zero_arc/mod.rs
+++ b/crates/holochain/tests/tests/zero_arc/mod.rs
@@ -1,10 +1,8 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use holochain_serialized_bytes::{SerializedBytes, UnsafeBytes};
-use schemars::_private::NoSerialize;
-use hdk::prelude::{Deserialize, Entry, EntryDef, EntryDefIndex, EntryHashed, EntryType, EntryVisibility, MustGetActionInput, MustGetEntryInput, Op, Record, Serialize, ValidateCallbackResult};
+use hdk::prelude::{
+    Deserialize, Entry, EntryDef, EntryDefIndex, EntryHashed, EntryType, EntryVisibility,
+    MustGetActionInput, MustGetEntryInput, Op, Record, Serialize, ValidateCallbackResult,
+};
 use holo_hash::{ActionHash, EntryHash};
-use holochain::core::ValidationOutcome;
 use holochain::prelude::{SerializedBytes, SignedActionHashed};
 use holochain::sweettest::{
     SweetConductorBatch, SweetConductorConfig, SweetDnaFile, SweetInlineZomes,
@@ -14,6 +12,8 @@ use holochain_types::inline_zome::InlineZomeSet;
 use holochain_zome_types::action::ChainTopOrdering;
 use holochain_zome_types::entry::{CreateInput, GetInput};
 use holochain_zome_types::prelude::{Details, GetOptions};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 /// Test that zero arc nodes can use the various get host functions to get missing records, actions
 /// and entries from authorities.
@@ -23,29 +23,27 @@ async fn get_missing_from_coordinator() {
 
     let entry_def = EntryDef::default_from_id("entry");
     let zomes = SweetInlineZomes::new(vec![entry_def], 0)
-        .function("create",
-            move |api, _: ()| {
-                let entry = Entry::app(().try_into().unwrap()).unwrap();
-                let hash = api.create(CreateInput::new(
-                    InlineZomeSet::get_entry_location(&api, EntryDefIndex(0)),
-                    EntryVisibility::Public,
-                    entry,
-                    ChainTopOrdering::default(),
-                ))?;
-                let details = api.get_details(vec![GetInput::new(
-                    hash.clone().into(),
-                    GetOptions::local(),
-                )])?;
-                let entry_hash = match details[0].as_ref().unwrap() {
-                    Details::Record(record_details) => {
-                        record_details.record.action().entry_hash().unwrap().clone()
-                    }
-                    _ => panic!("Expected record details"),
-                };
+        .function("create", move |api, _: ()| {
+            let entry = Entry::app(().try_into().unwrap()).unwrap();
+            let hash = api.create(CreateInput::new(
+                InlineZomeSet::get_entry_location(&api, EntryDefIndex(0)),
+                EntryVisibility::Public,
+                entry,
+                ChainTopOrdering::default(),
+            ))?;
+            let details = api.get_details(vec![GetInput::new(
+                hash.clone().into(),
+                GetOptions::local(),
+            )])?;
+            let entry_hash = match details[0].as_ref().unwrap() {
+                Details::Record(record_details) => {
+                    record_details.record.action().entry_hash().unwrap().clone()
+                }
+                _ => panic!("Expected record details"),
+            };
 
-                Ok((hash, entry_hash))
-            }
-        )
+            Ok((hash, entry_hash))
+        })
         .function("get", move |api, hash: ActionHash| {
             let records = api.get(vec![GetInput::new(hash.into(), GetOptions::network())])?;
             Ok(records)
@@ -59,12 +57,10 @@ async fn get_missing_from_coordinator() {
             let record = api.must_get_valid_record(MustGetValidRecordInput::new(hash))?;
             Ok(record)
         })
-        .function("must_get_action",
-            move |api, hash: ActionHash| {
-                let action = api.must_get_action(MustGetActionInput::new(hash))?;
-                Ok(action)
-            }
-        )
+        .function("must_get_action", move |api, hash: ActionHash| {
+            let action = api.must_get_action(MustGetActionInput::new(hash))?;
+            Ok(action)
+        })
         .function("must_get_entry", move |api, hash: EntryHash| {
             let action = api.must_get_entry(MustGetEntryInput::new(hash))?;
             Ok(action)
@@ -90,7 +86,7 @@ async fn get_missing_from_coordinator() {
             .await;
 
     let apps = conductors.setup_app("", [&test_dna]).await.unwrap();
-    let ((alice, ), (bob, )) = apps.into_tuples();
+    let ((alice,), (bob,)) = apps.into_tuples();
 
     // Alice creates several entries
     let alice_zome = alice.zome(SweetInlineZomes::COORDINATOR);
@@ -200,83 +196,191 @@ async fn self_validation_get_missing() {
     #[derive(Serialize, Deserialize, SerializedBytes, Debug)]
     struct TestDepEntry {
         action_hash: ActionHash,
+        entry_hash: EntryHash,
         num: u8,
     }
 
     let invoked_must_get_valid_record = Arc::new(AtomicBool::new(false));
+    let invoked_must_get_action = Arc::new(AtomicBool::new(false));
+    let invoked_must_get_entry = Arc::new(AtomicBool::new(false));
 
     let entry_def = EntryDef::default_from_id("entry");
     let dep_entry_def = EntryDef::default_from_id("dep_entry");
     let zomes = SweetInlineZomes::new(vec![entry_def, dep_entry_def], 0)
         // A "create" function that can be used to create entries on a full arc node
-        .function("create",
-                  move |api, _: ()| {
-                      let entry = Entry::app(().try_into().unwrap()).unwrap();
-                      let hash = api.create(CreateInput::new(
-                          InlineZomeSet::get_entry_location(&api, EntryDefIndex(0)),
-                          EntryVisibility::Public,
-                          entry,
-                          ChainTopOrdering::default(),
-                      ))?;
-
-                      Ok(hash)
-                  },
-        )
-        // A "createWithDep" function that creates an entry that depends on another entry
-        .function("create_with_dep", async move |api, (num, dep_hash): (u8, ActionHash)| {
-            let data = TestDepEntry {
-                action_hash: dep_hash,
-                num,
-            };
-            let app_bytes: Vec<u8> = data.try_into().unwrap();
-            let entry = Entry::app(SerializedBytes::from(UnsafeBytes::from(app_bytes))).unwrap();
-            api.create(CreateInput::new(
-                InlineZomeSet::get_entry_location(&api, EntryDefIndex(1)),
+        .function("create", move |api, _: ()| {
+            let entry = Entry::app(().try_into().unwrap()).unwrap();
+            let hash = api.create(CreateInput::new(
+                InlineZomeSet::get_entry_location(&api, EntryDefIndex(0)),
                 EntryVisibility::Public,
                 entry,
                 ChainTopOrdering::default(),
             ))?;
-
-            Ok(())
+            let details = api.get_details(vec![GetInput::new(
+                hash.clone().into(),
+                GetOptions::local(),
+            )])?;
+            let entry_hash = match details[0].as_ref().unwrap() {
+                Details::Record(record_details) => {
+                    record_details.record.action().entry_hash().unwrap().clone()
+                }
+                _ => panic!("Expected record details"),
+            };
+            Ok((hash, entry_hash))
         })
+        // A "create_with_dep" function that creates an entry that depends on another entry
+        .function(
+            "create_with_dep",
+            move |api, (num, dep_hash, dep_entry_hash): (u8, ActionHash, EntryHash)| {
+                let data = TestDepEntry {
+                    action_hash: dep_hash,
+                    entry_hash: dep_entry_hash,
+                    num,
+                };
+                let app_bytes: holochain_serialized_bytes::SerializedBytes =
+                    data.try_into().unwrap();
+                let entry = Entry::app(app_bytes).unwrap();
+                api.create(CreateInput::new(
+                    InlineZomeSet::get_entry_location(&api, EntryDefIndex(1)),
+                    EntryVisibility::Public,
+                    entry,
+                    ChainTopOrdering::default(),
+                ))?;
+                Ok(())
+            },
+        )
         .integrity_function("validate", {
             let invoked_must_get_valid_record = invoked_must_get_valid_record.clone();
-            move |api, op: Op| {
-                match op {
-                    Op::StoreRecord(store_record) => {
-                        match store_record.record.action().entry_type() {
-                            Some(EntryType::App(app_entry_def)) => {
-                                if app_entry_def.entry_index.0 != 1 {
-                                    return Ok(ValidateCallbackResult::Valid);
-                                }
-                            }
-                            _ => {
+            let invoked_must_get_action = invoked_must_get_action.clone();
+            let invoked_must_get_entry = invoked_must_get_entry.clone();
+            move |api, op: Op| match op {
+                Op::StoreRecord(store_record) => {
+                    match store_record.record.action().entry_type() {
+                        Some(EntryType::App(app_entry_def)) => {
+                            if app_entry_def.entry_index.0 != 1 {
                                 return Ok(ValidateCallbackResult::Valid);
                             }
                         }
-
-                        let app_entry: Option<TestDepEntry> = store_record.record.entry.to_app_option().unwrap();
-                        let app_entry = app_entry.unwrap();
-
-                        match app_entry.num {
-                            0 => {
-                                let _record = api.must_get_valid_record(MustGetValidRecordInput::new(
-                                    app_entry.action_hash.clone(),
-                                ))?;
-                                invoked_must_get_valid_record.store(true, Ordering::Relaxed);
-                                Ok(ValidateCallbackResult::Valid)
-                            }
-                            _ => {
-                                Ok(ValidateCallbackResult::Invalid(
-                                    "Unhandled value for num".to_string()
-                                ))
-                            }
+                        _ => {
+                            return Ok(ValidateCallbackResult::Valid);
                         }
-
                     }
-                    _ => Ok(ValidateCallbackResult::Valid)
+                    let app_entry: Option<TestDepEntry> =
+                        store_record.record.entry.to_app_option().unwrap();
+                    let app_entry = app_entry.unwrap();
+                    match app_entry.num {
+                        0 => {
+                            let _record = api.must_get_valid_record(
+                                MustGetValidRecordInput::new(app_entry.action_hash.clone()),
+                            )?;
+                            invoked_must_get_valid_record.store(true, Ordering::Relaxed);
+                            Ok(ValidateCallbackResult::Valid)
+                        }
+                        1 => {
+                            let _action = api.must_get_action(MustGetActionInput::new(
+                                app_entry.action_hash.clone(),
+                            ))?;
+                            invoked_must_get_action.store(true, Ordering::Relaxed);
+                            Ok(ValidateCallbackResult::Valid)
+                        }
+                        2 => {
+                            let _entry = api.must_get_entry(MustGetEntryInput::new(
+                                app_entry.entry_hash.clone(),
+                            ))?;
+                            invoked_must_get_entry.store(true, Ordering::Relaxed);
+                            Ok(ValidateCallbackResult::Valid)
+                        }
+                        _ => Ok(ValidateCallbackResult::Invalid(
+                            "Unhandled value for num".to_string(),
+                        )),
+                    }
                 }
+                _ => Ok(ValidateCallbackResult::Valid),
             }
         })
-            .0;
+        .0;
+
+    let (test_dna, _, _) = SweetDnaFile::unique_from_inline_zomes(zomes).await;
+
+    // Standard config with target arc factor 1
+    let standard_config = SweetConductorConfig::rendezvous(false).tune_network_config(|nc| {
+        nc.disable_gossip = true;
+        nc.disable_publish = true;
+    });
+    // Standard config with target arc factor 0
+    let empty_arc_conductor_config =
+        SweetConductorConfig::rendezvous(false).tune_network_config(|nc| {
+            nc.disable_gossip = true;
+            nc.disable_publish = true;
+            nc.target_arc_factor = 0;
+        });
+    let mut conductors =
+        SweetConductorBatch::from_configs_rendezvous([standard_config, empty_arc_conductor_config])
+            .await;
+
+    let apps = conductors.setup_app("", [&test_dna]).await.unwrap();
+    let ((alice,), (bob,)) = apps.into_tuples();
+
+    // Alice creates entries and gets their hashes
+    let alice_zome = alice.zome(SweetInlineZomes::COORDINATOR);
+    let (action_hash_must_get_record, entry_hash_must_get_record): (ActionHash, EntryHash) =
+        conductors[0].call(&alice_zome, "create", ()).await;
+    let (action_hash_must_get_action, entry_hash_must_get_action): (ActionHash, EntryHash) =
+        conductors[0].call(&alice_zome, "create", ()).await;
+    let (action_hash_must_get_entry, entry_hash_must_get_entry): (ActionHash, EntryHash) =
+        conductors[0].call(&alice_zome, "create", ()).await;
+
+    // Simulate Alice reaching a full storage arc
+    conductors[0]
+        .declare_full_storage_arcs(test_dna.dna_hash())
+        .await;
+    // and ensure Bob knows about Alice's full arc.
+    conductors.exchange_peer_info().await;
+
+    let bob_zome = bob.zome(SweetInlineZomes::COORDINATOR);
+
+    // Bob creates dependent entries to trigger each must_get_* operation
+    conductors[1]
+        .call::<_, ()>(
+            &bob_zome,
+            "create_with_dep",
+            (
+                0u8,
+                action_hash_must_get_record.clone(),
+                entry_hash_must_get_record.clone(),
+            ),
+        )
+        .await;
+    conductors[1]
+        .call::<_, ()>(
+            &bob_zome,
+            "create_with_dep",
+            (
+                1u8,
+                action_hash_must_get_action.clone(),
+                entry_hash_must_get_action.clone(),
+            ),
+        )
+        .await;
+    conductors[1]
+        .call::<_, ()>(
+            &bob_zome,
+            "create_with_dep",
+            (2u8, action_hash_must_get_entry, entry_hash_must_get_entry),
+        )
+        .await;
+
+    // Assert that each must_get_* was invoked
+    assert!(
+        invoked_must_get_valid_record.load(Ordering::Relaxed),
+        "must_get_valid_record was not invoked"
+    );
+    assert!(
+        invoked_must_get_action.load(Ordering::Relaxed),
+        "must_get_action was not invoked"
+    );
+    assert!(
+        invoked_must_get_entry.load(Ordering::Relaxed),
+        "must_get_entry was not invoked"
+    );
 }


### PR DESCRIPTION
### Summary

Further 0-arc tests to verify that dependencies can be fetched during self validation. No problems identified so this is just a new test.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Added a new multi-node test that exercises self-validation retrieval across two peers, verifying must-get semantics for records, actions, and entries during validation and full storage propagation with peer-info exchange.
  - Added coordination primitives to simulate cross-task and cross-node interactions for more realistic test orchestration.
- Refactor
  - Simplified inline test control flow and consolidated imports to streamline setup and improve clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->