### PR TITLE
fix: Restore the missing `--version` flag for the conductor

### DIFF
--- a/crates/holochain/src/bin/holochain/main.rs
+++ b/crates/holochain/src/bin/holochain/main.rs
@@ -19,6 +19,7 @@ const MAGIC_CONDUCTOR_READY_STRING: &str = "Conductor ready.";
 
 /// The Holochain Conductor.
 #[derive(Debug, Parser)]
+#[clap(version, about, long_about = None)]
 struct Opt {
     /// Outputs structured json from logging:
     ///     - None: No logging at all (fastest)


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced CLI help output with richer version and description metadata.
  * Users can now view the current version via standard flags (e.g., --version) and see clearer “about” information in --help.
  * No changes to commands or runtime behavior; improvements are limited to displayed help text and metadata shown to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->