### PR TITLE
chore: remove `steveeJ` from crate owners

### DIFF
--- a/crates/release-automation/src/lib/crate_.rs
+++ b/crates/release-automation/src/lib/crate_.rs
@@ -104,7 +104,7 @@ pub struct CrateCheckArgs {
 
 /// These crate.io handles are used as the default minimum crate owners for all published crates.
 pub const MINIMUM_CRATE_OWNERS: &str =
-    "github:holochain:core-dev,holochain-release-automation,holochain-release-automation2,zippy,steveeJ";
+    "github:holochain:core-dev,holochain-release-automation,holochain-release-automation2,zippy";
 
 #[derive(Debug, StructOpt)]
 pub struct EnsureCrateOwnersArgs {


### PR DESCRIPTION
this makes me less of a hack target and also stops a few emails coming into my inbox :-)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated default crate owners used by release automation by removing an outdated owner, aligning defaults with current maintainers. This affects newly created or synchronized crates using the automation, which will now apply a reduced, up-to-date owner set by default. No behavioral changes beyond the updated default list. Existing owners remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->