### PR TITLE
chore: Mark unpublished crates to make it clear to tooling that they aren't supposed to be published

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba2e2516bdf37af57fc6ff047855f54abad0066e5c4fdaaeb76dabb2e05bcf5"
+checksum = "a2b715a6010afb9e457ca2b7c9d2b9c344baa8baed7b38dc476034c171b32575"
 dependencies = [
  "bindgen 0.72.1",
  "cc",
@@ -1558,9 +1558,9 @@ dependencies = [
 
 [[package]]
 name = "deflate64"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
 
 [[package]]
 name = "der"
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "hc_demo_cli"
-version = "0.2.0-beta-rc.0"
+version = "0.6.0-dev.1"
 dependencies = [
  "cfg-if",
  "clap",
@@ -2605,7 +2605,7 @@ dependencies = [
  "kitsune2_api",
  "must_future",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.6.0",
  "rand 0.9.2",
  "rusqlite",
  "schemars 0.9.0",
@@ -2946,7 +2946,7 @@ dependencies = [
  "holochain_timestamp",
  "holochain_util",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.6.0",
  "schemars 0.9.0",
  "serde",
  "serde_bytes",
@@ -3074,7 +3074,7 @@ dependencies = [
  "arbitrary",
  "holochain_serialized_bytes_derive",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.5.1",
  "rmp-serde",
  "serde",
  "serde-transcode",
@@ -3258,7 +3258,7 @@ dependencies = [
  "parking_lot",
  "pretty_assertions",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.6.0",
  "rand 0.9.2",
  "regex",
  "rusqlite",
@@ -3388,7 +3388,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.6.0",
  "rand 0.9.2",
  "rusqlite",
  "schemars 0.9.0",
@@ -5408,6 +5408,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "095a99f75c69734802359b682be8daaf8980296731f6470434ea2c652af1dd30"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6297,7 +6308,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.6",
+ "rustls-webpki 0.103.7",
  "subtle",
  "zeroize",
 ]
@@ -6354,9 +6365,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7094,9 +7105,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.1"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bddd368fda2f82ead69c03d46d351987cfa0c2a57abfa37a017f3aa3e9bf69a"
+checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
 dependencies = [
  "libc",
  "memchr",
@@ -7880,9 +7891,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unarray"

--- a/crates/fixt/test/Cargo.toml
+++ b/crates/fixt/test/Cargo.toml
@@ -9,6 +9,7 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 keywords = ["holochain", "holo", "test", "fixture"]
 categories = ["fixtures"]
 edition = "2021"
+publish = false
 
 # reminder - do not use workspace deps
 [dependencies]

--- a/crates/hc_demo_cli/CHANGELOG.md
+++ b/crates/hc_demo_cli/CHANGELOG.md
@@ -8,3 +8,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 Initial version
+
+## 0.6.0-dev.1

--- a/crates/hc_demo_cli/Cargo.toml
+++ b/crates/hc_demo_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hc_demo_cli"
-version = "0.2.0-beta-rc.0"
+version = "0.6.0-dev.1"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/crates/mock_hdi/Cargo.toml
+++ b/crates/mock_hdi/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 description = "A mock version of the holochain HDI"
 license = "Apache-2.0"
-documentation = "https://docs.rs/holochain_mock_hdi"
+publish = false
 
 # reminder - do not use workspace deps
 [dependencies]

--- a/crates/release-automation/Cargo.toml
+++ b/crates/release-automation/Cargo.toml
@@ -3,7 +3,7 @@ name = "release-automation"
 version = "0.2.0-alpha.1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
-documentation = "https://docs.rs/release-automation"
+publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/crates/test_utils/wasm/Cargo.toml
+++ b/crates/test_utils/wasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "holochain_wasm_test_utils"
 version = "0.6.0-dev.27"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 description = "Utilities for Wasm testing for Holochain"
 license = "Apache-2.0"
 documentation = "https://docs.rs/holochain_wasm_test_utils"

--- a/crates/test_utils/wasm/Cargo.toml
+++ b/crates/test_utils/wasm/Cargo.toml
@@ -3,7 +3,6 @@ name = "holochain_wasm_test_utils"
 version = "0.6.0-dev.27"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
-publish = false
 description = "Utilities for Wasm testing for Holochain"
 license = "Apache-2.0"
 documentation = "https://docs.rs/holochain_wasm_test_utils"

--- a/crates/test_utils/wasm/wasm_workspace/agent_info/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/agent_info/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_agent_info"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_agent_info"

--- a/crates/test_utils/wasm/wasm_workspace/anchor/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/anchor/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_anchor"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_anchor"

--- a/crates/test_utils/wasm/wasm_workspace/app_validation/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/app_validation/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test_wasm_app_validation"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_app_validation"

--- a/crates/test_utils/wasm/wasm_workspace/bench/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/bench/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_bench"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_bench"

--- a/crates/test_utils/wasm/wasm_workspace/capability/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/capability/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_capability"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_capability"

--- a/crates/test_utils/wasm/wasm_workspace/client/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/client/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_client"
 version = "0.0.1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_client"

--- a/crates/test_utils/wasm/wasm_workspace/clone/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/clone/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test_wasm_clone"
 version = "0.0.1"
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_clone"

--- a/crates/test_utils/wasm/wasm_workspace/coordinator_zome/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/coordinator_zome/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_coordinator_zome"
 version = "0.0.1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_coordinator_zome"

--- a/crates/test_utils/wasm/wasm_workspace/coordinator_zome_update/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/coordinator_zome_update/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_coordinator_zome_update"
 version = "0.0.1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_coordinator_zome_update"

--- a/crates/test_utils/wasm/wasm_workspace/countersigning/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/countersigning/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_countersigning"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_countersigning"

--- a/crates/test_utils/wasm/wasm_workspace/crd/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/crd/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_crd"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_crd"

--- a/crates/test_utils/wasm/wasm_workspace/create_entry/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/create_entry/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_create_entry"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_create_entry"

--- a/crates/test_utils/wasm/wasm_workspace/crud/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/crud/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_crud"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_crud"

--- a/crates/test_utils/wasm/wasm_workspace/debug/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/debug/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_debug"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_debug"

--- a/crates/test_utils/wasm/wasm_workspace/dna_properties/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/dna_properties/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test_wasm_dna_properties"
 version = "0.0.1"
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_dna_properties"

--- a/crates/test_utils/wasm/wasm_workspace/emit_signal/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/emit_signal/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_emit_signal"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_emit_signal"

--- a/crates/test_utils/wasm/wasm_workspace/entry_defs/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/entry_defs/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_entry_defs"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_entry_defs"

--- a/crates/test_utils/wasm/wasm_workspace/foo/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/foo/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_foo"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_foo"

--- a/crates/test_utils/wasm/wasm_workspace/genesis_self_check_1/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/genesis_self_check_1/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_genesis_self_check_1"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_genesis_self_check_1"

--- a/crates/test_utils/wasm/wasm_workspace/genesis_self_check_invalid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/genesis_self_check_invalid/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_genesis_self_check_invalid"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_genesis_self_check_invalid"

--- a/crates/test_utils/wasm/wasm_workspace/genesis_self_check_legacy/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/genesis_self_check_legacy/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_genesis_self_check_legacy"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_genesis_self_check_legacy"

--- a/crates/test_utils/wasm/wasm_workspace/genesis_self_check_requires_properties/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/genesis_self_check_requires_properties/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test_wasm_genesis_self_check_requires_properties"
 version = "0.0.1"
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_genesis_self_check_requires_properties"

--- a/crates/test_utils/wasm/wasm_workspace/genesis_self_check_valid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/genesis_self_check_valid/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_genesis_self_check_valid"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_genesis_self_check_valid"

--- a/crates/test_utils/wasm/wasm_workspace/hash_entry/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/hash_entry/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_hash_entry"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_hash_entry"

--- a/crates/test_utils/wasm/wasm_workspace/hash_path/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/hash_path/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_hash_path"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_hash_path"

--- a/crates/test_utils/wasm/wasm_workspace/hc-stress-test-coordinator/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/hc-stress-test-coordinator/Cargo.toml
@@ -2,6 +2,7 @@
 name = "files"
 version = "0.0.1"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/test_utils/wasm/wasm_workspace/hc-stress-test-integrity/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/hc-stress-test-integrity/Cargo.toml
@@ -2,6 +2,7 @@
 name = "files_integrity"
 version = "0.0.1"
 edition = "2021"
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/test_utils/wasm/wasm_workspace/hdk_extern/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/hdk_extern/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_hdk_extern"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_hdk_extern"

--- a/crates/test_utils/wasm/wasm_workspace/init_fail/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/init_fail/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_init_fail"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_init_fail"

--- a/crates/test_utils/wasm/wasm_workspace/init_invalid_params/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/init_invalid_params/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_init_invalid_params"
 version = "0.0.1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_init_invalid_params"

--- a/crates/test_utils/wasm/wasm_workspace/init_pass/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/init_pass/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_init_pass"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_init_pass"

--- a/crates/test_utils/wasm/wasm_workspace/init_single/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/init_single/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_init_single"
 description = "Wasm that will error if init is called more than once"
 version = "0.0.1"
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_init_single"

--- a/crates/test_utils/wasm/wasm_workspace/integrity_zome/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/integrity_zome/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_integrity_zome"
 version = "0.0.1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_integrity_zome"

--- a/crates/test_utils/wasm/wasm_workspace/link/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/link/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_link"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_link"

--- a/crates/test_utils/wasm/wasm_workspace/migrate_initial/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/migrate_initial/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_migrate_initial"
 description = "Test wasm for migration, intended to be the initial version"
 version = "0.0.1"
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_migrate_initial"

--- a/crates/test_utils/wasm/wasm_workspace/migrate_new/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/migrate_new/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_migrate_new"
 description = "Test wasm for DNA migration, intended to be the migration target"
 version = "0.0.1"
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_migrate_new"

--- a/crates/test_utils/wasm/wasm_workspace/multiple_calls/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/multiple_calls/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_multiple_calls"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_multiple_calls"

--- a/crates/test_utils/wasm/wasm_workspace/must_get/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/must_get/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_must_get"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_must_get"

--- a/crates/test_utils/wasm/wasm_workspace/must_get_agent_activity/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/must_get_agent_activity/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test_wasm_must_get_agent_activity"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_must_get_agent_activity"

--- a/crates/test_utils/wasm/wasm_workspace/paths/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/paths/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_paths"
 version = "0.0.1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_paths"

--- a/crates/test_utils/wasm/wasm_workspace/post_commit_signal/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/post_commit_signal/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_post_commit_signal"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_post_commit_signal"

--- a/crates/test_utils/wasm/wasm_workspace/post_commit_success/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/post_commit_success/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_post_commit_success"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_post_commit_success"

--- a/crates/test_utils/wasm/wasm_workspace/post_commit_volley/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/post_commit_volley/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_post_commit_volley"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_post_commit_volley"

--- a/crates/test_utils/wasm/wasm_workspace/query/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/query/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_query"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_query"

--- a/crates/test_utils/wasm/wasm_workspace/random_bytes/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/random_bytes/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_random_bytes"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_random_bytes"

--- a/crates/test_utils/wasm/wasm_workspace/schedule/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/schedule/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_schedule"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_schedule"

--- a/crates/test_utils/wasm/wasm_workspace/ser_regression/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/ser_regression/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_ser_regression"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com", "freesig"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_ser_regression"

--- a/crates/test_utils/wasm/wasm_workspace/sign/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/sign/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_sign"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_sign"

--- a/crates/test_utils/wasm/wasm_workspace/sys_time/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/sys_time/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_sys_time"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_sys_time"

--- a/crates/test_utils/wasm/wasm_workspace/the_incredible_halt/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/the_incredible_halt/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_the_incredible_halt"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_the_incredible_halt"

--- a/crates/test_utils/wasm/wasm_workspace/update_entry/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/update_entry/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_update_entry"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_update_entry"

--- a/crates/test_utils/wasm/wasm_workspace/validate/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_validate"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_validate"

--- a/crates/test_utils/wasm/wasm_workspace/validate_invalid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_invalid/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_validate_invalid"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_validate_invalid"

--- a/crates/test_utils/wasm/wasm_workspace/validate_invalid_params/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_invalid_params/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_validate_invalid_params"
 version = "0.0.1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_validate_invalid_params"

--- a/crates/test_utils/wasm/wasm_workspace/validate_link/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_link/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_validate_link"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_validate_link"

--- a/crates/test_utils/wasm/wasm_workspace/validate_link_add_invalid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_link_add_invalid/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_validate_link_add_invalid"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_validate_link_add_invalid"

--- a/crates/test_utils/wasm/wasm_workspace/validate_link_add_valid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_link_add_valid/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_validate_link_add_valid"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_validate_link_add_valid"

--- a/crates/test_utils/wasm/wasm_workspace/validate_reject_app_types/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_reject_app_types/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test_wasm_validate_reject_app_types"
 version = "0.0.1"
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_validate_reject_app_types"

--- a/crates/test_utils/wasm/wasm_workspace/validate_valid/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/validate_valid/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_validate_valid"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_validate_valid"

--- a/crates/test_utils/wasm/wasm_workspace/whoami/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/whoami/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_whoami"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_whoami"

--- a/crates/test_utils/wasm/wasm_workspace/x_salsa20_poly1305/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/x_salsa20_poly1305/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_x_salsa20_poly1305"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_x_salsa20_poly1305"

--- a/crates/test_utils/wasm/wasm_workspace/zome_info/Cargo.toml
+++ b/crates/test_utils/wasm/wasm_workspace/zome_info/Cargo.toml
@@ -3,6 +3,7 @@ name = "test_wasm_zome_info"
 version = "0.0.1"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
+publish = false
 
 [lib]
 name = "test_wasm_zome_info"

--- a/holonix/test/mold_openssl/Cargo.toml
+++ b/holonix/test/mold_openssl/Cargo.toml
@@ -4,6 +4,7 @@
 name = "holonix_mold_ssl"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [[bin]]
 name = "holonix_mold_ssl"


### PR DESCRIPTION
### Summary

The release automation knows what crates to publish and is configured to ignore some crates. This isn't then known by other tools looking at Holochain crates. 

- Added `publish = false` to all private crates
- Fixed the `hc_demo_cli` so that it should get published in the next release. I think that was accidentally rather than deliberately kept unpublished.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Marked many internal and test packages as non-publishable to package registries (no runtime impact).
  - Bumped hc_demo_cli package version to 0.6.0-dev.1 for ongoing development.
- Documentation
  - Added a new "0.6.0-dev.1" entry to the hc_demo_cli changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->