### PR TITLE
fix: Broken feature logic for switching between datachannel and go-pion backends

### DIFF
--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -40,7 +40,7 @@ tracing = "0.1"
 tracing-appender = "0.2.3"
 opentelemetry_api = { version = "=0.20.0", features = ["metrics"] }
 
-kitsune2 = "0.3.0-dev.3"
+kitsune2 = { version = "0.3.0-dev.3", default-features = false }
 kitsune2_api = "0.3.0-dev.3"
 kitsune2_core = "0.3.0-dev.3"
 kitsune2_gossip = "0.3.0-dev.3"


### PR DESCRIPTION
### Summary

See the evidence that this is working now:

```
$ cargo tree -i datachannel-sys --no-default-features --features backend-go-pion
error: package ID specification `datachannel-sys` did not match any packages
$ cargo tree -i tx5-go-pion --no-default-features --features backend-go-pion    
tx5-go-pion v0.8.0
└── tx5-connection v0.8.0
    └── tx5 v0.8.0
        └── kitsune2_transport_tx5 v0.3.0-dev.3
            └── kitsune2 v0.3.0-dev.3
                └── holochain_p2p v0.6.0-dev.25 (/home/thetasinner/source/holo/holochain/crates/holochain_p2p)
                    ├── holochain v0.6.0-dev.25 (/home/thetasinner/source/holo/holochain/crates/holochain)
                    │   [dev-dependencies]
                    │   └── holochain v0.6.0-dev.25 (/home/thetasinner/source/holo/holochain/crates/holochain) (*)
                    └── holochain_cascade v0.6.0-dev.25 (/home/thetasinner/source/holo/holochain/crates/holochain_cascade)
                        └── holochain v0.6.0-dev.25 (/home/thetasinner/source/holo/holochain/crates/holochain) (*)
```

The situation before:

```
$ cargo tree -i datachannel-sys --no-default-features --features backend-go-pion
datachannel-sys v0.22.3+0.22.6
└── datachannel v0.15.0
    └── tx5-connection v0.8.0
        └── tx5 v0.8.0
            └── kitsune2_transport_tx5 v0.3.0-dev.3
                └── kitsune2 v0.3.0-dev.3
                    └── holochain_p2p v0.6.0-dev.25 (/home/thetasinner/source/holo/holochain/crates/holochain_p2p)
                        ├── holochain v0.6.0-dev.25 (/home/thetasinner/source/holo/holochain/crates/holochain)
                        │   [dev-dependencies]
                        │   └── holochain v0.6.0-dev.25 (/home/thetasinner/source/holo/holochain/crates/holochain) (*)
                        └── holochain_cascade v0.6.0-dev.25 (/home/thetasinner/source/holo/holochain/crates/holochain_cascade)
                            └── holochain v0.6.0-dev.25 (/home/thetasinner/source/holo/holochain/crates/holochain) (*)
```

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Adjusted a third‑party networking dependency configuration to explicitly disable default features while keeping the same version. This standardizes builds and reduces implicit feature inclusion.
  - No user-facing behavior changes, performance impact, or migrations required. Existing functionality remains unchanged and compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->