### PR TITLE
ci: Stop building ancient versions

### DIFF
--- a/.github/workflows/holochain-build-and-test.yml
+++ b/.github/workflows/holochain-build-and-test.yml
@@ -35,10 +35,10 @@ jobs:
           # ensure that any Nix changes on this branch don't cause problems for maintenance versions
           - pkgs:
               - build-holonix-tests-integration
-            extra_arg: "--override-input versions ./versions/0_2"
+            extra_arg: "--override-input versions ./versions/0_4"
           - pkgs:
               - build-holonix-tests-integration
-            extra_arg: "--override-input versions ./versions/0_3"
+            extra_arg: "--override-input versions ./versions/0_5"
           # - pkgs:
           #     - build-holonix-tests-integration
           #   extra_arg: "--override-input versions ./versions/weekly"


### PR DESCRIPTION
### Summary

I'd prefer to decomission the whole old Holonix. Perhaps we should do that soon. In the meantime, building more recent versions should reduce CI failures on automated Nix updates.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to test against newer Holochain versions, replacing older version inputs.
  * Ensures builds run against 0.4 and 0.5 tracks for improved alignment with current environments.
  * No changes to product features or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->