### PR TITLE
chore: Remove unnecessary `Ok()?` wrapper and rename `create_and_store_warrant` to `create_and_sign_warrant`

### DIFF
--- a/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
@@ -348,7 +348,7 @@ async fn validate_valid_warrant_with_cached_dependency() {
         .unwrap();
 
     let warrant_op = test_case
-        .create_and_store_warrant(
+        .create_and_sign_warrant(
             &warranted_action,
             &warrant_agent,
             holochain_zome_types::op::ChainOpType::StoreRecord,
@@ -427,7 +427,7 @@ async fn validate_valid_warrant_with_fetched_dependency() {
     test_case.with_network_behaviour(network);
 
     let warrant_op = test_case
-        .create_and_store_warrant(
+        .create_and_sign_warrant(
             &warranted_action,
             &warrant_agent,
             holochain_zome_types::op::ChainOpType::StoreRecord,
@@ -508,7 +508,7 @@ async fn reject_invalid_warrant() {
 
     // Invalid warrant against a valid action
     let warrant_op = test_case
-        .create_and_store_warrant(
+        .create_and_sign_warrant(
             &valid_action,
             &bad_warrant_agent,
             holochain_zome_types::op::ChainOpType::StoreRecord,
@@ -625,7 +625,7 @@ async fn validate_warrant_with_validated_dependency() {
 
     // Invalid warrant against a valid action
     let warrant_op = test_case
-        .create_and_store_warrant(
+        .create_and_sign_warrant(
             &valid_action,
             &bad_warrant_agent,
             holochain_zome_types::op::ChainOpType::StoreRecord,
@@ -741,7 +741,7 @@ impl TestCase {
     }
 
     #[cfg(feature = "unstable-warrants")]
-    async fn create_and_store_warrant(
+    async fn create_and_sign_warrant(
         &self,
         warranted_action: &SignedActionHashed,
         issuing_agent: &AgentPubKey,

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validation_query.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validation_query.rs
@@ -110,9 +110,7 @@ async fn get_ops_to_validate(
     db.read_async(move |txn| {
         let mut stmt = txn.prepare(&sql)?;
         let r = stmt.query_and_then([], |row| {
-            let op = WorkflowResult::Ok(holochain_state::query::map_sql_dht_op(
-                true, "dht_type", row,
-            )?)?;
+            let op = holochain_state::query::map_sql_dht_op(true, "dht_type", row)?;
             let hash = row.get("dht_hash")?;
             Ok(DhtOpHashed::with_pre_hashed(op, hash))
         })?;


### PR DESCRIPTION
### Summary

Found some pointless code, and an unhelpfully named method.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Simplified validation query result handling to remove an extra wrapper and streamline error propagation, improving clarity and minor performance/stability during validation.

- Tests
  - Renamed and replaced a warrant helper used in tests to better reflect signing behavior; test behavior and coverage remain unchanged.

- Chores
  - Internal cleanup only; no user-facing changes or configuration updates required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->