### PR TITLE
docs: Fix changelog location for get and publish blocks

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add a new conductor tuning parameter `disable_self_validation` to disable self-validation of authored data. Intended only
   for testing warrants. #5340
 - Avoid issuing duplicate warrants for invalid actions during sys validation by checking for existing warrants before creating new ones. #5337
-- Test: Test that blocks are enforced for network get requests and publish.
+- Test: Test that blocks are enforced for outgoing network get requests and publish.
 - **BREAKING CHANGE** Removed unused public SQL queries from `holochain_sqlite`:
   - `ACTIVITY_INTEGRATED_UPPER_BOUND`
   - `ALL_ACTIVITY_AUTHORS`


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Changelog updated to note that outgoing network get requests and publishes are now enforced to block, expanded breaking-changes list for additional removed public queries, and duplicate test entry removed.
* **Tests**
  * Added/updated test coverage documenting the blocking behavior for network requests and publishes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->