### PR TITLE
fix: handle op ids with invalid length gracefully

### DIFF
--- a/crates/holo_hash/src/hash.rs
+++ b/crates/holo_hash/src/hash.rs
@@ -212,8 +212,11 @@ impl crate::DhtOpHash {
 
     /// Convert a kitsune2 OpId into a DhtOpHash.
     #[cfg(feature = "hashing")]
-    pub fn from_k2_op(op: &kitsune2_api::OpId) -> Self {
-        Self::from_raw_32(op[..HOLO_HASH_CORE_LEN].to_vec())
+    pub fn try_from_k2_op(op: &kitsune2_api::OpId) -> HoloHashResult<Self> {
+        if op.len() < HOLO_HASH_CORE_LEN {
+            return Err(HoloHashError::BadSize);
+        }
+        Ok(Self::from_raw_32(op[..HOLO_HASH_CORE_LEN].to_vec()))
     }
 }
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.6.0-dev.29
 
+- Handle op ids with invalid length gracefully in `filter_out_existing_ops` and `retrieve_ops` to address [#5244](https://github.com/holochain/holochain/issues/5244) [#5359](https://github.com/holochain/holochain/pull/5359)
 - Remove a check in `holochain_state` that prevented multiple warrants for the same agent being inserted. Not only are multiple warrant types allowed, but it is expected that multiple authorities will issue warrants for the same agent in parallel before discovering each other’s warrants. Failing to store those warrants would result in inconsistent views of the DHT. \#5342
 - **BREAKING CHANGE** Replace `BTreeSet` with `HashSet` in `GrantedFunctions::Listed`. \#5349
 - Add a new conductor tuning parameter `disable_self_validation` to disable self-validation of authored data. Intended only for testing warrants. \#5340

--- a/crates/holochain_p2p/src/op_store.rs
+++ b/crates/holochain_p2p/src/op_store.rs
@@ -177,9 +177,12 @@ impl OpStore for HolochainOpStore {
                     let mut rows = stmt.query([Rc::new(
                         op_ids
                             .iter()
-                            .map(|id| {
-                                let hash = DhtOpHash::from_k2_op(id);
-                                Value::from(hash.into_inner())
+                            .filter_map(|id| match DhtOpHash::try_from_k2_op(id) {
+                                Ok(hash) => Some(Value::from(hash.into_inner())),
+                                Err(e) => {
+                                    tracing::warn!("Cannot retrieve op for invalid op id: {e}");
+                                    None
+                                }
                             })
                             .collect::<Vec<_>>(),
                     )])?;
@@ -211,19 +214,24 @@ impl OpStore for HolochainOpStore {
         Box::pin(async move {
             let out = db
                 .read_async(move |txn| -> StateMutationResult<Vec<OpId>> {
+                    let mut out = op_ids.clone().into_iter().collect::<HashSet<_>>();
+
                     let mut stmt = txn.prepare(CHECK_OP_IDS_PRESENT)?;
 
                     let mut rows = stmt.query([Rc::new(
                         op_ids
                             .iter()
-                            .map(|id| {
-                                let hash = DhtOpHash::from_k2_op(id);
-                                Value::from(hash.into_inner())
+                            .filter_map(|id| match DhtOpHash::try_from_k2_op(id) {
+                                Ok(hash) => Some(Value::from(hash.into_inner())),
+                                Err(e) => {
+                                    tracing::warn!("Got invalid op id: {e}");
+                                    out.remove(id);
+                                    None
+                                }
                             })
                             .collect::<Vec<_>>(),
                     )])?;
 
-                    let mut out = op_ids.into_iter().collect::<HashSet<_>>();
                     while let Some(row) = rows.next()? {
                         let op_hash: DhtOpHash = row.get(0)?;
                         let op_basis: OpBasis = row.get(1)?;

--- a/crates/holochain_p2p/tests/tests/op_store.rs
+++ b/crates/holochain_p2p/tests/tests/op_store.rs
@@ -22,6 +22,7 @@ use holochain_zome_types::fixt::{CreateFixturator, EntryFixturator, SignatureFix
 use holochain_zome_types::prelude::ChainQueryFilter;
 use holochain_zome_types::Action;
 use kitsune2_api::*;
+use kitsune2_test_utils::enable_tracing;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -203,6 +204,18 @@ async fn process_incoming_ops_and_retrieve() {
 }
 
 #[tokio::test]
+async fn retrieve_ops_does_not_panic_with_too_short_op_ids() {
+    enable_tracing();
+    let (_, op_store) = setup_test().await;
+
+    let op_id_too_short = kitsune2_api::OpId::from(bytes::Bytes::from(vec![0u8; 31]));
+    assert_eq!(op_id_too_short.len(), 31);
+
+    let retrieved_ops = op_store.retrieve_ops(vec![op_id_too_short]).await.unwrap();
+    assert_eq!(retrieved_ops.len(), 0);
+}
+
+#[tokio::test]
 async fn filter_out_existing_ops() {
     let (_, op_store) = setup_test().await;
 
@@ -229,7 +242,7 @@ async fn filter_out_existing_ops() {
 
     assert!(all_exist_filtered.is_empty());
 
-    let non_existent_op_id = OpId::from(Bytes::from_static(&[5; 32]));
+    let non_existent_op_id = OpId::from(Bytes::from_static(&[5; 36]));
     let to_check = vec![
         dht_op_1
             .as_hash()
@@ -240,6 +253,28 @@ async fn filter_out_existing_ops() {
 
     assert_eq!(1, some_exists_filtered.len());
     assert_eq!(non_existent_op_id, some_exists_filtered[0]);
+}
+
+#[tokio::test]
+async fn filter_out_existing_ops_filters_invalid_op_ids_as_well() {
+    let (_, op_store) = setup_test().await;
+    enable_tracing();
+
+    let valid_op = test_dht_op(Timestamp::now());
+    let valid_op_id = valid_op
+        .as_hash()
+        .to_located_k2_op_id(&valid_op.dht_basis());
+
+    let op_id_too_short = kitsune2_api::OpId::from(bytes::Bytes::from(vec![0u8; 31]));
+    assert_eq!(op_id_too_short.len(), 31);
+
+    let out = op_store
+        .filter_out_existing_ops(vec![op_id_too_short, valid_op_id.clone()])
+        .await
+        .unwrap();
+
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].clone(), valid_op_id);
 }
 
 #[tokio::test]


### PR DESCRIPTION
### Summary

- Addresses https://github.com/holochain/holochain/issues/5244 by handling the case of op ids with invalid length gracefully in `filter_out_existing_ops` and `retrieve_ops`
- filters out invalid ops as well as part of `filter_out_existing_ops`

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Conversion from external operation identifiers to internal hashes is now fallible and validates input length; callers must handle conversion errors.

- Bug Fixes
  - Invalid operation identifiers are detected, logged as warnings, and skipped during retrieval and filtering to prevent panics and inconsistent results.

- Tests
  - New tests confirm retrieval and filtering handle invalid identifiers safely; tracing enabled for relevant tests.

- Documentation
  - Changelog updated to note improved handling of invalid operation identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->