### PR TITLE
ci: Remove upterm

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -223,14 +223,3 @@ jobs:
           echo "latest_holochain_release_version=${LATEST_HOLOCHAIN_RELEASE_VERSION}" >> $GITHUB_OUTPUT
           echo "release_branch=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
           echo "repo_nix_store_path=${STORE_PATH}" >> $GITHUB_OUTPUT
-
-      - name: Setup SSH session
-        uses: steveeJ-forks/action-upterm@main
-        if: ${{ failure() && inputs.debug == 'true' }}
-        env:
-          HRA_GITHUB_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
-        with:
-          ## limits ssh access and adds the ssh public key for the user which triggered the workflow
-          limit-access-to-actor: true
-          ## limits ssh access and adds the ssh public keys of the listed GitHub users
-          limit-access-to-users: jost-s,ThetaSinner,cdunster,matthme,veeso,mattyg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,19 +389,6 @@ jobs:
           cd "${GITHUB_WORKSPACE}"
           ./scripts/ci-gh-release.sh
 
-      - name: Setup SSH session
-        uses: steveeJ-forks/action-upterm@main
-        if: ${{ failure() && needs.vars.outputs.debug == 'true' }}
-        env:
-          GITHUB_ACTION_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_HRA_ACTION_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        with:
-          ## limits ssh access and adds the ssh public key for the user which triggered the workflow
-          limit-access-to-actor: true
-          ## limits ssh access and adds the ssh public keys of the listed GitHub users
-          limit-access-to-users: jost-s,ThetaSinner,cdunster,matthme,veeso,mattyg
-
   github-actions-ci-jobs-succeed:
     if: ${{ always() && github.event_name == 'pull_request' }}
     runs-on: "ubuntu-latest"

--- a/.github/workflows/ssh-session.yml
+++ b/.github/workflows/ssh-session.yml
@@ -54,15 +54,3 @@ jobs:
           nix-shell --version
           nix --version
           pwd
-
-      - name: Setup SSH session
-        uses: lhotari/action-upterm@v1
-        env:
-          ORIG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HRA_GITHUB_TOKEN: ${{ secrets.HRA_GITHUB_TOKEN }}
-        if: ${{ always() }}
-        with:
-          ## limits ssh access and adds the ssh public key for the user which triggered the workflow
-          limit-access-to-actor: true
-          ## limits ssh access and adds the ssh public keys of the listed GitHub users
-          limit-access-to-users: jost-s,ThetaSinner,cdunster,matthme,veeso,mattyg


### PR DESCRIPTION
### Summary

As discussed after the last release failure, we don't use this and it's a pain when it can't be cancelled and we can't access it to shut it down that way. It means that CI jobs can just run for 6 hours and we can't do a thing about it.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed debug SSH session functionality from release workflows to streamline the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->