### PR TITLE
Fix: look up warrants from dht db filtered by validation status in tests

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix: Make sure that warrants in the DHT database are always queried filtered by valid status in tests. \#5389
 - Remove the restriction on using action type, entry type, and entry hash filters with bounded queries using the `query` host function. #5384
 - Implementation and test blocking of agents who issue invalid warrants. #5358
 

--- a/crates/holochain/tests/tests/publish/mod.rs
+++ b/crates/holochain/tests/tests/publish/mod.rs
@@ -223,8 +223,7 @@ async fn warrant_is_published() {
                 .unwrap()
                 .test_read(move |txn| {
                     let store = CascadeTxnWrapper::from(txn);
-                    // TODO: The check_valid argument of get_warrants_for_agents should be removed once warrants are validated.
-                    store.get_warrants_for_agent(&alice_pubkey, false).unwrap()
+                    store.get_warrants_for_agent(&alice_pubkey, true).unwrap()
                 });
 
             if warrants.len() == 3 {

--- a/crates/holochain/tests/tests/warrant_issuance.rs
+++ b/crates/holochain/tests/tests/warrant_issuance.rs
@@ -74,7 +74,6 @@ async fn invalid_op_warrant_issuance_can_be_disabled() {
         .unwrap()[0]
         .test_read(move |txn| {
             let store = CascadeTxnWrapper::from(txn);
-            // TODO: The check_valid argument of get_warrants_for_agents should be removed once warrants are validated.
             let warrants = store.get_warrants_for_agent(&alice_pubkey, false).unwrap();
             assert!(warrants.is_empty());
         });
@@ -154,7 +153,6 @@ async fn skip_self_validation_to_cause_warrant() {
             let alice_pubkey = alice_pubkey.clone();
             move |txn| {
                 let store = CascadeTxnWrapper::from(txn);
-                // TODO: The check_valid argument of get_warrants_for_agents should be removed once warrants are validated.
                 store.get_warrants_for_agent(&alice_pubkey, false).unwrap()
             }
         });

--- a/crates/holochain/tests/tests/warrants.rs
+++ b/crates/holochain/tests/tests/warrants.rs
@@ -161,8 +161,7 @@ async fn warrant_is_gossiped() {
                     .unwrap()
                     .test_read(move |txn| {
                         let store = CascadeTxnWrapper::from(txn);
-                        // TODO: check_valid here should be removed once warrants are validated.
-                        store.get_warrants_for_agent(&alice_pubkey, false).unwrap()
+                        store.get_warrants_for_agent(&alice_pubkey, true).unwrap()
                     });
                 warrants.len() == 3
                     && warrants[0].warrant().warrantee == *alice_cell.agent_pubkey()


### PR DESCRIPTION
### Summary

In a few cases warrants were looked up without paying attention to validation status. In the DHT database warrants must be validated.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed warrant queries in the DHT to ensure only validated warrants are considered during retrieval.

* **Tests**
  * Updated test suite to rely on and verify warrant validation during retrieval; removed obsolete TODOs related to validation.

* **Chores**
  * Updated changelog to reflect the above test and warrant validation changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->