### PR TITLE
Refactor: split get_agent_activity query into actions and warrants

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Refactor: `get_agent_activity` uses two queries to select actions and warrants from the database. There was a legacy query which selected both from when warrants were stored in the Action table. \#5390
 - Refactor: `retrieve` in the cascade only returns a record if it is complete. For actions with an associated entry, the entry must be included if it is public. If it is not present or private, `retrieve` returns `None`, where before it would return the record without the entry. `retrieve` is also renamed to `retrieve_public_record`. \#5385
 - Fix: Make sure that warrants in the DHT database are always queried filtered by valid status in tests. \#5389
 - Remove the restriction on using action type, entry type, and entry hash filters with bounded queries using the `query` host function. #5384

--- a/crates/holochain_cascade/src/authority/get_agent_activity_query/hashes.rs
+++ b/crates/holochain_cascade/src/authority/get_agent_activity_query/hashes.rs
@@ -1,5 +1,5 @@
 use crate::authority::get_agent_activity_query::{fold, render, Item, State};
-use holo_hash::{ActionHash, AgentPubKey, AnyLinkableHash, WarrantHash};
+use holo_hash::{ActionHash, AgentPubKey, WarrantHash};
 use holochain_p2p::event::GetActivityOptions;
 use holochain_sqlite::rusqlite::{named_params, Row};
 use holochain_state::prelude::{
@@ -8,7 +8,6 @@ use holochain_state::prelude::{
 use holochain_state::query::QueryData;
 use holochain_types::activity::AgentActivityResponse;
 use holochain_types::dht_op::DhtOpType;
-use holochain_types::prelude::WarrantOpType;
 use holochain_zome_types::judged::Judged;
 use holochain_zome_types::op::ChainOpType;
 use holochain_zome_types::prelude::{
@@ -19,7 +18,6 @@ use std::sync::Arc;
 #[derive(Debug, Clone)]
 pub struct GetAgentActivityHashesQuery {
     pub(super) agent: AgentPubKey,
-    pub(super) agent_basis: AnyLinkableHash,
     pub(super) filter: ChainQueryFilter,
     pub(super) options: GetActivityOptions,
 }
@@ -27,7 +25,6 @@ pub struct GetAgentActivityHashesQuery {
 impl GetAgentActivityHashesQuery {
     pub fn new(agent: AgentPubKey, filter: ChainQueryFilter, options: GetActivityOptions) -> Self {
         Self {
-            agent_basis: agent.clone().into(),
             agent,
             filter,
             options,
@@ -43,28 +40,19 @@ impl Query for GetAgentActivityHashesQuery {
     fn query(&self) -> String {
         "
             SELECT
-            Action.hash,
-            Action.blob AS action_blob,
-            DhtOp.type AS dht_type,
-            DhtOp.validation_status,
-            DhtOp.when_integrated
-            FROM Action
-            JOIN DhtOp ON DhtOp.action_hash = Action.hash
+                Action.hash,
+                Action.blob AS action_blob,
+                DhtOp.type AS dht_type,
+                DhtOp.validation_status,
+                DhtOp.when_integrated
+            FROM
+                Action
+                JOIN DhtOp ON DhtOp.action_hash = Action.hash
             WHERE
-            (
-                -- is an action authored by this agent
                 Action.author = :author
                 AND DhtOp.type = :chain_op_type
-            )
-            OR
-            (
-                -- is an integrated, valid warrant
-                DhtOp.basis_hash = :author_basis
-                AND DhtOp.type = :warrant_op_type
-                AND DhtOp.validation_status = :valid_status
-                AND DhtOp.when_integrated IS NOT NULL
-            )
-            ORDER BY Action.seq ASC
+            ORDER BY
+                Action.seq ASC
         "
         .to_string()
     }
@@ -72,10 +60,7 @@ impl Query for GetAgentActivityHashesQuery {
     fn params(&self) -> Vec<holochain_state::query::Params<'_>> {
         let params = named_params! {
             ":author": self.agent,
-            ":author_basis": self.agent_basis,
             ":chain_op_type": ChainOpType::RegisterAgentActivity,
-            ":warrant_op_type": WarrantOpType::ChainIntegrityWarrant,
-            ":valid_status": ValidationStatus::Valid,
         };
 
         params.to_vec()


### PR DESCRIPTION
### Summary

see changelog

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Agent activity retrieval now performs separate queries for actions and warrants for more consistent results.
  * Warrant data is consistently applied from fetched results, ensuring activity responses include the correct warrants.
  * Activity-query logic simplified by removing redundant basis references, reducing ambiguity and improving reliability of activity listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->