### PR TITLE
test: Update `holochain_p2p` tests to always use tx5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,6 +3038,7 @@ dependencies = [
  "holochain_zome_types",
  "kitsune2",
  "kitsune2_api",
+ "kitsune2_bootstrap_srv",
  "kitsune2_core",
  "kitsune2_gossip",
  "kitsune2_test_utils",

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -59,6 +59,7 @@ holochain_sqlite = { version = "^0.6.0-dev.29", path = "../holochain_sqlite", fe
 holochain_state = { path = "../holochain_state", features = ["test_utils"] }
 kitsune2_test_utils = "0.3.0-dev.3"
 tempfile = "3.21.0"
+kitsune2_bootstrap_srv = { version = "0.3.0-dev.3" }
 
 [lints]
 workspace = true

--- a/crates/holochain_p2p/src/spawn.rs
+++ b/crates/holochain_p2p/src/spawn.rs
@@ -120,6 +120,8 @@ impl std::fmt::Debug for HolochainP2pConfig {
         dbg.field("compat", &self.compat);
         dbg.field("auth_material", &self.auth_material);
         dbg.field("request_timeout", &self.request_timeout);
+        dbg.field("target_arc_factor", &self.target_arc_factor);
+        dbg.field("network_config", &self.network_config);
 
         #[cfg(feature = "test_utils")]
         {

--- a/crates/holochain_p2p/tests/tests/node_messaging.rs
+++ b/crates/holochain_p2p/tests/tests/node_messaging.rs
@@ -1,13 +1,14 @@
-use crate::tests::common::Handler;
+use crate::tests::common::{spawn_test_bootstrap, Handler};
 use holochain_keystore::*;
 use holochain_p2p::event::*;
 use holochain_p2p::*;
 use holochain_trace::test_run;
 use holochain_types::prelude::*;
 use kitsune2_api::*;
+use std::net::SocketAddr;
 use std::{sync::Arc, time::Duration};
 
-const UNRESPONSIVE_TIMEOUT: Duration = Duration::from_secs(5);
+const UNRESPONSIVE_TIMEOUT: Duration = Duration::from_secs(15);
 const WAIT_BETWEEN_CALLS: Duration = Duration::from_millis(10);
 
 /// An implementation of [`HcP2pHandler`] that doesn't ever respond to requests
@@ -121,13 +122,16 @@ impl HcP2pHandler for UnresponsiveHandler {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_call_remote() {
+    test_run();
+
     let dna_hash = DnaHash::from_raw_36(vec![0; 36]);
     let handler = Arc::new(Handler::default());
 
-    let (agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (agent2, hc2, _) = spawn_test(dna_hash.clone(), handler).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (agent2, hc2, _) = spawn_test(dna_hash.clone(), handler, &addr).await;
 
-    tokio::time::timeout(UNRESPONSIVE_TIMEOUT, async {
+    tokio::time::timeout(Duration::from_secs(60), async {
         loop {
             tokio::time::sleep(WAIT_BETWEEN_CALLS).await;
 
@@ -142,6 +146,23 @@ async fn test_call_remote() {
                 .unwrap()
                 .len()
                 > 0
+            {
+                break;
+            }
+        }
+
+        loop {
+            tokio::time::sleep(WAIT_BETWEEN_CALLS).await;
+
+            // Make sure the hc2 peer store has agent1's address
+            if hc2
+                .peer_store(dna_hash.clone())
+                .await
+                .unwrap()
+                .get(agent1.to_k2_agent())
+                .await
+                .unwrap()
+                .is_some()
             {
                 break;
             }
@@ -200,8 +221,9 @@ async fn test_remote_signal() {
     let dna_hash = DnaHash::from_raw_36(vec![0; 36]);
     let handler = Arc::new(Handler::default());
 
-    let (agent1, _hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (agent1, _hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
 
     hc2.send_remote_signal(
         dna_hash,
@@ -241,8 +263,9 @@ async fn test_publish() {
     let space = dna_hash.to_k2_space();
     let handler = Arc::new(Handler::default());
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -297,8 +320,9 @@ async fn test_publish_reflect() {
     let space = dna_hash.to_k2_space();
     let handler = Arc::new(Handler::default());
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -340,8 +364,9 @@ async fn test_get() {
     let space = dna_hash.to_k2_space();
     let handler = Arc::new(Handler::default());
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler, &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -383,10 +408,11 @@ async fn test_get_with_unresponsive_agents() {
     ));
     let unresponsive_handler = Arc::new(UnresponsiveHandler);
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone()).await;
-    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive_handler).await;
-    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone(), &addr).await;
+    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive_handler, &addr).await;
+    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -434,9 +460,10 @@ async fn test_get_when_not_all_agents_have_data() {
     ));
     let empty_handler = Arc::new(Handler::default());
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), empty_handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), empty_handler.clone()).await;
-    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), empty_handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), empty_handler.clone(), &addr).await;
+    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -467,7 +494,12 @@ async fn test_get_when_not_all_agents_have_data() {
     .unwrap();
 
     let requests = empty_handler.calls.lock().unwrap();
-    assert_eq!(*requests, ["get"]);
+    if !requests.is_empty() {
+        assert!(
+            requests.iter().all(|r| r == "get"),
+            "All requests to empty handler should be 'get'"
+        );
+    }
 
     let requests = handler.calls.lock().unwrap();
     assert_eq!(*requests, ["get"]);
@@ -488,10 +520,11 @@ async fn test_get_when_not_all_agents_have_data_and_unresponsive_agent() {
     let empty_handler = Arc::new(Handler::default());
     let unresponsive_handler = Arc::new(UnresponsiveHandler);
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), empty_handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), empty_handler.clone()).await;
-    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), empty_handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), empty_handler.clone(), &addr).await;
+    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone(), &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -523,7 +556,12 @@ async fn test_get_when_not_all_agents_have_data_and_unresponsive_agent() {
     .unwrap();
 
     let requests = empty_handler.calls.lock().unwrap();
-    assert_eq!(*requests, ["get"]);
+    if !requests.is_empty() {
+        assert!(
+            requests.iter().all(|r| r == "get"),
+            "All requests to empty handler should be 'get'"
+        );
+    }
 
     let requests = handler.calls.lock().unwrap();
     assert_eq!(*requests, ["get"]);
@@ -536,9 +574,10 @@ async fn test_get_empty_data_better_than_no_response() {
     let empty_handler = Arc::new(Handler::default());
     let unresponsive_handler = Arc::new(UnresponsiveHandler);
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), empty_handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), empty_handler.clone()).await;
-    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), empty_handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), empty_handler.clone(), &addr).await;
+    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone(), &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -574,12 +613,15 @@ async fn test_get_empty_data_better_than_no_response() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_meta() {
+    test_run();
+
     let dna_hash = DnaHash::from_raw_36(vec![0; 36]);
     let space = dna_hash.to_k2_space();
     let handler = Arc::new(Handler::default());
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler, &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -616,10 +658,11 @@ async fn test_get_meta_with_unresponsive_agents() {
     let handler = Arc::new(Handler::default());
     let unresponsive_handler = Arc::new(UnresponsiveHandler);
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone()).await;
-    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone()).await;
-    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone(), &addr).await;
+    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone(), &addr).await;
+    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -660,8 +703,9 @@ async fn test_get_links() {
     let space = dna_hash.to_k2_space();
     let handler = Arc::new(Handler::default());
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler, &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -706,10 +750,11 @@ async fn test_get_links_with_unresponsive_agents() {
     let handler = Arc::new(Handler::default());
     let unresponsive_handler = Arc::new(UnresponsiveHandler);
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone()).await;
-    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), unresponsive_handler).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone(), &addr).await;
+    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), unresponsive_handler, &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -758,8 +803,9 @@ async fn test_count_links() {
     let space = dna_hash.to_k2_space();
     let handler = Arc::new(Handler::default());
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler, &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -803,10 +849,11 @@ async fn test_count_links_with_unresponsive_agents() {
     let handler = Arc::new(Handler::default());
     let unresponsive_handler = Arc::new(UnresponsiveHandler);
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone()).await;
-    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), unresponsive_handler).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone(), &addr).await;
+    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), unresponsive_handler, &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -854,8 +901,9 @@ async fn test_get_agent_activity() {
     let space = dna_hash.to_k2_space();
     let handler = Arc::new(Handler::default());
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler, &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -897,10 +945,11 @@ async fn test_get_agent_activity_with_unresponsive_agents() {
     let handler = Arc::new(Handler::default());
     let unresponsive_handler = Arc::new(UnresponsiveHandler);
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone()).await;
-    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive_handler).await;
-    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone(), &addr).await;
+    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive_handler, &addr).await;
+    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -946,8 +995,9 @@ async fn test_must_get_agent_activity() {
     let space = dna_hash.to_k2_space();
     let handler = Arc::new(Handler::default());
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler, &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -985,10 +1035,11 @@ async fn test_must_get_agent_activity_with_unresponsive_agents() {
     let handler = Arc::new(Handler::default());
     let unresponsive_handler = Arc::new(UnresponsiveHandler);
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone()).await;
-    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive_handler).await;
-    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), unresponsive_handler.clone(), &addr).await;
+    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive_handler, &addr).await;
+    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
 
     hc1.test_set_full_arcs(space.clone()).await;
     hc2.test_set_full_arcs(space.clone()).await;
@@ -1029,8 +1080,9 @@ async fn test_validation_receipts() {
     let dna_hash = DnaHash::from_raw_36(vec![0; 36]);
     let handler = Arc::new(Handler::default());
 
-    let (agent1, _hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (agent1, _hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
 
     hc2.send_validation_receipts(
         dna_hash,
@@ -1061,7 +1113,8 @@ async fn test_authority_for_hash() {
     let space = dna_hash.to_k2_space();
     let handler = Arc::new(Handler::default());
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
     hc1.test_set_full_arcs(space.clone()).await;
 
     assert!(hc1
@@ -1078,7 +1131,8 @@ async fn test_target_arcs() {
     let dna_hash = DnaHash::from_raw_36(vec![0; 36]);
     let handler = Arc::new(Handler::default());
 
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
 
     let arcs = hc1.target_arcs(dna_hash).await.unwrap();
     assert_eq!(&[DhtArc::FULL][..], &arcs);
@@ -1092,7 +1146,8 @@ async fn bridged_call_remote() {
     let dna_hash = DnaHash::from_raw_36(vec![0; 36]);
     let handler = Arc::new(Handler::default());
 
-    let (_agent1, hc1, lair_client) = spawn_test(dna_hash.clone(), handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, lair_client) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
 
     let agent2 = lair_client.new_sign_keypair_random().await.unwrap();
     let local_agent2 = HolochainP2pLocalAgent::new(agent2.clone(), DhtArc::FULL, 1, lair_client);
@@ -1163,7 +1218,8 @@ async fn bridged_remote_signal() {
     let dna_hash = DnaHash::from_raw_36(vec![0; 36]);
     let handler = Arc::new(Handler::default());
 
-    let (_agent1, hc1, lair_client) = spawn_test(dna_hash.clone(), handler.clone()).await;
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, lair_client) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
 
     let agent2 = lair_client.new_sign_keypair_random().await.unwrap();
     let local_agent2 = HolochainP2pLocalAgent::new(agent2.clone(), DhtArc::FULL, 1, lair_client);
@@ -1235,6 +1291,7 @@ async fn bridged_remote_signal() {
 async fn spawn_test(
     dna_hash: DnaHash,
     handler: DynHcP2pHandler,
+    bootstrap_addr: &SocketAddr,
 ) -> (AgentPubKey, actor::DynHcP2p, MetaLairClient) {
     let db_peer_meta =
         DbWrite::test_in_mem(DbKindPeerMetaStore(Arc::new(dna_hash.clone()))).unwrap();
@@ -1258,8 +1315,17 @@ async fn spawn_test(
                 let conductor_db = conductor_db.clone();
                 Box::pin(async move { conductor_db })
             }),
-            k2_test_builder: true,
-            request_timeout: Duration::from_secs(1),
+            k2_test_builder: false,
+            network_config: Some(serde_json::json!({
+                "coreBootstrap": {
+                    "serverUrl": format!("http://{bootstrap_addr}"),
+                },
+                "tx5Transport": {
+                    "serverUrl": format!("ws://{bootstrap_addr}"),
+                    "signalAllowPlainText": true,
+                }
+            })),
+            request_timeout: Duration::from_secs(3),
             ..Default::default()
         },
         lair_client.clone(),


### PR DESCRIPTION
### Summary

Part of https://github.com/holochain/holochain/issues/5395

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a bootstrap server dependency and a helper to spawn a test bootstrap server and return its bound address.

* **Tests**
  * Updated tests to start and use the bootstrap server, pass its address into setups, adjust network configuration, increase timeouts, add clearer assertions, and switch off the legacy test builder to rely on bootstrap-driven peer discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->