### PR TITLE
Feat: block agent when must get agent activity returns warrant

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -9,8 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.6.0-dev.31
 
+- Feat: Warrants discovered during host function call `must_get_agent_activity` lead to blocking the warranted agent. \#5405
 - Test: Warrants discovered during host function call `get_agent_activity` lead to blocking the warranted agent. \#5377
 - Feat: Insert warrants discovered during host function `get_agent_activity` into DHT database for validation and integration. \#5387
+- Test: Warrants discovered during host function call `get_agent_activity` lead to blocking the warranted agent. \#5387
 - Refactor: `get_agent_activity` uses two queries to select actions and warrants from the database. There was a legacy query which selected both from when warrants were stored in the Action table. \#5390
 - Refactor: `retrieve` in the cascade only returns a record if it is complete. For actions with an associated entry, the entry must be included if it is public. If it is not present or private, `retrieve` returns `None`, where before it would return the record without the entry. `retrieve` is also renamed to `retrieve_public_record`. \#5385
 - Fix: Make sure that warrants in the DHT database are always queried filtered by valid status in tests. \#5389


### PR DESCRIPTION
### Summary

resolves #5326 

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Warrants discovered during agent activity operations now properly block warranted agents.
  * Warrants from network queries are automatically persisted in the DHT for validation and integration.

* **Tests**
  * Added test coverage for warrant blocking during agent activity operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->