### PR TITLE
docs: Remove stray double doc comment in HDK `query` docs

### DIFF
--- a/crates/hdk/src/chain.rs
+++ b/crates/hdk/src/chain.rs
@@ -46,7 +46,7 @@ pub fn get_agent_activity(
 ///
 /// ## Unbounded query
 ///
-/// /// Using [`ChainQueryFilterRange::Unbounded`] does not apply any bounds when retrieving data
+/// Using [`ChainQueryFilterRange::Unbounded`] does not apply any bounds when retrieving data
 /// from the database.
 ///
 /// Its characteristics are equivalent to [`ChainQueryFilterRange::ActionSeqRange`] with `start=0`


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected formatting in the Unbounded query documentation comment to fix an extra leading marker; purely cosmetic documentation change with no functional or public API impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->