### PR TITLE
chore: extra space typo

### DIFF
--- a/crates/hc_demo_cli/src/demo.rs
+++ b/crates/hc_demo_cli/src/demo.rs
@@ -40,7 +40,7 @@ impl RunOpts {
 }
 
 /// The default configured signal server url.
-pub const DEF_SIGNAL_URL: &str = "wss://dev-test-bootstrap2.holochain.org ";
+pub const DEF_SIGNAL_URL: &str = "wss://dev-test-bootstrap2.holochain.org";
 
 /// The default configured bootstrap server url.
 pub const DEF_BOOTSTRAP_URL: &str = "https://dev-test-bootstrap2.holochain.org";


### PR DESCRIPTION
### Summary
Tiny typo that did not affect functionality.


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the default signal server URL by removing an extraneous whitespace character that could affect connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->