### PR TITLE
docs: inaccurate comment, target_arc_factor must be 1 or 0

### DIFF
--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -258,7 +258,6 @@ pub struct NetworkConfig {
     /// The target arc factor to apply when receiving hints from kitsune2.
     /// In normal operation, leave this as the default 1.
     /// For leacher nodes that do not contribute to gossip, set to zero.
-    /// To take on additional gossip burden, set to > 1.
     #[serde(default = "one")]
     pub target_arc_factor: u32,
 


### PR DESCRIPTION
### Summary
This doc comment was inaccurate. The setting must be 0 or 1. See https://github.com/holochain/holochain/blob/develop/crates/holochain_p2p/src/local_agent.rs#L131-L140


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed inline documentation regarding network configuration guidance. No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->