### PR TITLE
fix: Use of deprecated `cargo_bin` extension method for Command in tests

### DIFF
--- a/crates/hc_bundle/tests/test_cli.rs
+++ b/crates/hc_bundle/tests/test_cli.rs
@@ -32,22 +32,22 @@ async fn read_web_app(path: &Path) -> anyhow::Result<WebAppBundle> {
 #[tokio::test]
 async fn round_trip() {
     {
-        let mut cmd = Command::cargo_bin("hc-dna").unwrap();
+        let mut cmd = Command::new(assert_cmd::cargo_bin!("hc-dna"));
         let cmd = cmd.args(["pack", "tests/fixtures/my-app/dnas/dna1"]);
         cmd.assert().success();
     }
     {
-        let mut cmd = Command::cargo_bin("hc-dna").unwrap();
+        let mut cmd = Command::new(assert_cmd::cargo_bin!("hc-dna"));
         let cmd = cmd.args(["pack", "tests/fixtures/my-app/dnas/dna2"]);
         cmd.assert().success();
     }
     {
-        let mut cmd = Command::cargo_bin("hc-app").unwrap();
+        let mut cmd = Command::new(assert_cmd::cargo_bin!("hc-app"));
         let cmd = cmd.args(["pack", "tests/fixtures/my-app/"]);
         cmd.assert().success();
     }
     {
-        let mut cmd = Command::cargo_bin("hc-web-app").unwrap();
+        let mut cmd = Command::new(assert_cmd::cargo_bin!("hc-web-app"));
         let cmd = cmd.args(["pack", "tests/fixtures/web-app/"]);
         cmd.assert().success();
     }
@@ -72,7 +72,7 @@ async fn test_packed_hash_consistency() {
     let mut i = 0;
     let mut hash = None;
     while i < 5 {
-        let mut cmd = Command::cargo_bin("hc-dna").unwrap();
+        let mut cmd = Command::new(assert_cmd::cargo_bin!("hc-dna"));
         let cmd = cmd.args(["pack", "tests/fixtures/my-app/dnas/dna1"]);
         cmd.assert().success();
 
@@ -97,7 +97,7 @@ async fn test_packed_hash_consistency() {
 #[tokio::test]
 async fn test_integrity() {
     let pack_dna = |path| async move {
-        let mut cmd = Command::cargo_bin("hc-dna").unwrap();
+        let mut cmd = Command::new(assert_cmd::cargo_bin!("hc-dna"));
         let cmd = cmd.args(["pack", path]);
         cmd.assert().success();
         let mut dna_path = PathBuf::from(path);
@@ -171,7 +171,7 @@ async fn test_integrity() {
 #[cfg(not(feature = "unstable-migration"))]
 async fn test_multi_integrity() {
     let pack_dna = |path| async move {
-        let mut cmd = Command::cargo_bin("hc-dna").unwrap();
+        let mut cmd = Command::new(assert_cmd::cargo_bin!("hc-dna"));
         let cmd = cmd.args(["pack", path]);
         cmd.assert().success();
         let dna_path = PathBuf::from(format!("{path}/multi integrity dna.dna"));
@@ -276,7 +276,7 @@ async fn test_multi_integrity() {
 #[cfg(feature = "unstable-migration")]
 async fn test_multi_integrity() {
     let pack_dna = |path| async move {
-        let mut cmd = Command::cargo_bin("hc-dna").unwrap();
+        let mut cmd = Command::new(assert_cmd::cargo_bin!("hc-dna"));
         let cmd = cmd.args(["pack", path]);
         cmd.assert().success();
         let dna_path = PathBuf::from(format!("{path}/multi integrity dna unstable-migration.dna"));
@@ -391,12 +391,12 @@ async fn test_multi_integrity() {
 #[cfg_attr(target_os = "windows", ignore = "theres a hash mismatch - check crlf?")]
 async fn test_hash_dna_function() {
     {
-        let mut cmd = Command::cargo_bin("hc-dna").unwrap();
+        let mut cmd = Command::new(assert_cmd::cargo_bin!("hc-dna"));
         let cmd = cmd.args(["hash", "tests/fixtures/my-app/dnas/dna1/a dna.dna"]);
         cmd.assert().success();
     }
     {
-        let mut cmd = Command::cargo_bin("hc-dna").unwrap();
+        let mut cmd = Command::new(assert_cmd::cargo_bin!("hc-dna"));
         let cmd = cmd.args(["hash", "tests/fixtures/my-app/dnas/dna1/a dna.dna"]);
         let stdout = cmd.assert().success().get_output().stdout.clone();
         let actual = String::from_utf8_lossy(&stdout).replace(['\r', '\n'], ""); // Normalize Windows/linux

--- a/crates/holochain/tests/tests/new_lair/mod.rs
+++ b/crates/holochain/tests/tests/new_lair/mod.rs
@@ -1,5 +1,4 @@
 use super::test_utils::*;
-use assert_cmd::prelude::*;
 use holochain::sweettest::WsPollRecv;
 use holochain_conductor_api::config::conductor::ConductorConfig;
 use holochain_conductor_api::config::conductor::KeystoreConfig;
@@ -62,7 +61,7 @@ async fn test_new_lair_conductor_integration() {
     println!("\n## conductor config ##\n{conductor_config}");
 
     // start a conductor using the new config
-    let cmd = std::process::Command::cargo_bin("holochain").unwrap();
+    let cmd = std::process::Command::new(assert_cmd::cargo_bin!("holochain"));
     let mut cmd = tokio::process::Command::from(cmd);
     cmd.arg("--config-path")
         .arg(cc_path)

--- a/crates/holochain/tests/tests/test_cli/mod.rs
+++ b/crates/holochain/tests/tests/test_cli/mod.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 fn first_experience_with_holochain_is_a_friendly_one() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().join("missing-config.yml");
-    let mut cmd = Command::cargo_bin("holochain").unwrap();
+    let mut cmd = Command::new(assert_cmd::cargo_bin!("holochain"));
     let cmd = cmd.args(["-c", &path.display().to_string()]);
     cmd.assert().failure().code(predicate::eq(42));
     cmd.assert()
@@ -21,7 +21,7 @@ fn malformed_toml_error_is_friendly() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().join("malformed-config.yml");
     std::fs::write(&path, "{{ totally [ not ( valid yaml").unwrap();
-    let mut cmd = Command::cargo_bin("holochain").unwrap();
+    let mut cmd = Command::new(assert_cmd::cargo_bin!("holochain"));
     let cmd = cmd.args(["-c", &path.display().to_string()]);
     cmd.assert().failure().code(predicate::eq(42));
     cmd.assert()
@@ -37,7 +37,7 @@ fn invalid_config_error_is_friendly() {
     let tmp = tempfile::tempdir().unwrap();
     let path = tmp.path().join("malformed-config.yml");
     std::fs::write(&path, "valid:\n  but: wrong").unwrap();
-    let mut cmd = Command::cargo_bin("holochain").unwrap();
+    let mut cmd = Command::new(assert_cmd::cargo_bin!("holochain"));
     let cmd = cmd.args(["-c", &path.display().to_string()]);
     cmd.assert().failure().code(predicate::eq(42));
     cmd.assert()

--- a/crates/holochain/tests/tests/test_utils/mod.rs
+++ b/crates/holochain/tests/tests/test_utils/mod.rs
@@ -2,7 +2,6 @@
 
 use ::fixt::*;
 use anyhow::Result;
-use assert_cmd::prelude::*;
 use ed25519_dalek::{Signer, SigningKey};
 use futures::Future;
 use hdk::prelude::*;
@@ -73,7 +72,7 @@ pub async fn start_holochain_with_lair(
     full_keystore: bool,
 ) -> (SupervisedChild, tokio::sync::oneshot::Receiver<u16>) {
     tracing::info!("\n\n----\nstarting holochain\n----\n\n");
-    let cmd = std::process::Command::cargo_bin("holochain").unwrap();
+    let cmd = std::process::Command::new(assert_cmd::cargo_bin!("holochain"));
     let mut cmd = Command::from(cmd);
     let rust_log = std::env::var("RUST_LOG").unwrap_or_else(|_| "warn".to_string());
     cmd.arg("--config-path")

--- a/crates/holochain_keystore/tests/test_reconnect.rs
+++ b/crates/holochain_keystore/tests/test_reconnect.rs
@@ -1,4 +1,3 @@
-use assert_cmd::cargo::CommandCargoExt;
 use holochain_keystore::lair_keystore::*;
 use holochain_keystore::MetaLairClient;
 use std::io::BufRead;
@@ -31,7 +30,7 @@ impl std::ops::Deref for Cli {
 }
 
 fn run_test_keystore(dir: &std::path::Path) -> (Proc, url2::Url2) {
-    let mut cmd = std::process::Command::cargo_bin("test-keystore-srv").unwrap();
+    let mut cmd = std::process::Command::new(assert_cmd::cargo_bin!("test-keystore-srv"));
     cmd.arg(dir).stdout(std::process::Stdio::piped());
 
     println!("{cmd:?}");


### PR DESCRIPTION
### Summary

Helpfully listed under "compatibility"... -> https://github.com/assert-rs/assert_cmd/blob/master/CHANGELOG.md#210---2025-10-28

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored test command construction patterns across multiple test suites for improved consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->