### PR TITLE
fix: Avoid making parallel requests during validation

### DIFF
--- a/crates/holochain/src/core/ribosome/host_fn/get_links.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_links.rs
@@ -4,7 +4,7 @@ use crate::core::ribosome::RibosomeError;
 use crate::core::ribosome::RibosomeT;
 use futures::StreamExt;
 use holochain_cascade::CascadeImpl;
-use holochain_p2p::actor::GetLinksOptions;
+use holochain_p2p::actor::GetLinksRequestOptions;
 use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::*;
 use std::sync::Arc;
@@ -53,7 +53,7 @@ pub fn get_links(
                                 )
                                 .dht_get_links(
                                     key,
-                                    GetLinksOptions {
+                                    GetLinksRequestOptions {
                                         get_options,
                                         ..Default::default()
                                     },

--- a/crates/holochain/src/core/ribosome/host_fn/get_links_details.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_links_details.rs
@@ -4,7 +4,7 @@ use crate::core::ribosome::RibosomeError;
 use crate::core::ribosome::RibosomeT;
 use futures::future::join_all;
 use holochain_cascade::CascadeImpl;
-use holochain_p2p::actor::GetLinksOptions;
+use holochain_p2p::actor::GetLinksRequestOptions;
 use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::*;
 use std::sync::Arc;
@@ -45,7 +45,7 @@ pub fn get_links_details(
                         )
                         .get_links_details(
                             key,
-                            GetLinksOptions {
+                            GetLinksRequestOptions {
                                 get_options,
                                 ..Default::default()
                             },

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_action.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_action.rs
@@ -3,11 +3,11 @@ use crate::core::ribosome::HostContext;
 use crate::core::ribosome::RibosomeError;
 use crate::core::ribosome::RibosomeT;
 use holochain_cascade::{Cascade, CascadeImpl};
-use holochain_p2p::actor::GetOptions as NetworkGetOptions;
 use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::*;
 use std::sync::Arc;
 use wasmer::RuntimeError;
+use holochain_p2p::actor::NetworkRequestOptions;
 
 #[cfg_attr(
     feature = "instrument",
@@ -47,7 +47,7 @@ pub fn must_get_action(
                     ),
                 };
                 match cascade
-                    .retrieve_action(action_hash.clone(), NetworkGetOptions::must_get_options())
+                    .retrieve_action(action_hash.clone(), NetworkRequestOptions::must_get_options())
                     .await
                     .map_err(|cascade_error| -> RuntimeError {
                         wasm_error!(WasmErrorInner::Host(cascade_error.to_string())).into()

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_agent_activity.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_agent_activity.rs
@@ -9,6 +9,7 @@ use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::*;
 use std::sync::Arc;
 use wasmer::RuntimeError;
+use holochain_p2p::actor::NetworkRequestOptions;
 
 #[cfg_attr(
     feature = "instrument",
@@ -51,7 +52,7 @@ pub fn must_get_agent_activity(
                     ),
                 };
                 let result = cascade
-                    .must_get_agent_activity(author.clone(), chain_filter.clone())
+                    .must_get_agent_activity(author.clone(), chain_filter.clone(), NetworkRequestOptions::must_get_options())
                     .await
                     .map_err(|cascade_error| -> RuntimeError {
                         wasm_error!(WasmErrorInner::Host(cascade_error.to_string())).into()

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_entry.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_entry.rs
@@ -3,7 +3,7 @@ use crate::core::ribosome::HostContext;
 use crate::core::ribosome::RibosomeError;
 use crate::core::ribosome::RibosomeT;
 use holochain_cascade::{Cascade, CascadeImpl};
-use holochain_p2p::actor::GetOptions as NetworkGetOptions;
+use holochain_p2p::actor::NetworkRequestOptions;
 use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::*;
 use std::sync::Arc;
@@ -46,7 +46,7 @@ pub fn must_get_entry(
                     ),
                 };
                 match cascade
-                    .retrieve_entry(entry_hash.clone(), NetworkGetOptions::must_get_options())
+                    .retrieve_entry(entry_hash.clone(), NetworkRequestOptions::must_get_options())
                     .await
                     .map_err(|cascade_error| -> RuntimeError {
                         wasm_error!(WasmErrorInner::Host(cascade_error.to_string())).into()

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_valid_record.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_valid_record.rs
@@ -2,11 +2,12 @@ use crate::core::ribosome::CallContext;
 use crate::core::ribosome::HostContext;
 use crate::core::ribosome::RibosomeError;
 use crate::core::ribosome::RibosomeT;
-use holochain_cascade::CascadeImpl;
+use holochain_cascade::{CascadeImpl, CascadeOptions};
 use holochain_types::prelude::*;
 use holochain_wasmer_host::prelude::*;
 use std::sync::Arc;
 use wasmer::RuntimeError;
+use holochain_p2p::actor::NetworkRequestOptions;
 
 #[cfg_attr(
     feature = "instrument",
@@ -37,12 +38,18 @@ pub fn must_get_valid_record(
                                     &workspace,
                                     call_context.host_context.network().clone(),
                                 ),
-                                GetOptions::network(),
+                                CascadeOptions {
+                                    network_request_options: NetworkRequestOptions::must_get_options(),
+                                    get_options: GetOptions::network(),
+                                }
                             )
                         } else {
                             (
                                 CascadeImpl::from_workspace_stores(workspace.stores(), None),
-                                GetOptions::local(),
+                                CascadeOptions {
+                                    network_request_options: NetworkRequestOptions::must_get_options(),
+                                    get_options: GetOptions::local(),
+                                }
                             )
                         }
                     }
@@ -51,7 +58,10 @@ pub fn must_get_valid_record(
                             &workspace,
                             call_context.host_context.network().clone(),
                         ),
-                        GetOptions::network(),
+                        CascadeOptions {
+                            network_request_options: NetworkRequestOptions::must_get_options(),
+                            get_options: GetOptions::network(),
+                        }
                     ),
                 };
                 match cascade

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -112,7 +112,7 @@ use holo_hash::DhtOpHash;
 use holochain_cascade::Cascade;
 use holochain_cascade::CascadeImpl;
 use holochain_keystore::MetaLairClient;
-use holochain_p2p::actor::GetOptions as NetworkGetOptions;
+use holochain_p2p::actor::{NetworkRequestOptions as NetworkGetOptions, NetworkRequestOptions};
 use holochain_p2p::DynHolochainP2pDna;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
 use holochain_state::host_fn_workspace::HostFnWorkspaceRead;
@@ -727,7 +727,7 @@ async fn retrieve_deleted_action(
 ) -> AppValidationOutcome<SignedActionHashed> {
     let cascade = CascadeImpl::from_workspace_and_network(workspace, network.clone());
     let (deleted_action, _) = cascade
-        .retrieve_action(deletes_address.clone(), NetworkGetOptions::default())
+        .retrieve_action(deletes_address.clone(), NetworkRequestOptions::default())
         .await?
         .ok_or_else(|| Outcome::awaiting(deletes_address))?;
     Ok(deleted_action)
@@ -775,7 +775,7 @@ async fn run_validation_callback(
                 let cascade = cascade.clone();
                 async move {
                     let result = cascade
-                        .fetch_record(hash.clone(), NetworkGetOptions::must_get_options())
+                        .fetch_record(hash.clone(), NetworkRequestOptions::must_get_options())
                         .await;
                     if let Err(err) = result {
                         tracing::warn!("error fetching dependent hash {hash:?}: {err}");
@@ -806,7 +806,11 @@ async fn run_validation_callback(
                 let author = author.clone();
                 async move {
                     let result = cascade
-                        .must_get_agent_activity(author.clone(), filter)
+                        .must_get_agent_activity(
+                            author.clone(),
+                            filter,
+                            NetworkGetOptions::must_get_options(),
+                        )
                         .await;
                     if let Err(err) = result {
                         tracing::warn!("error fetching dependent chain of agent {author:?}: {err}");

--- a/crates/holochain/src/core/workflow/app_validation_workflow/run_validation_callback_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/run_validation_callback_tests.rs
@@ -180,7 +180,7 @@ async fn validation_callback_awaiting_deps_hashes() {
     // mock network that returns the requested create action
     let mut network = MockHolochainP2pDnaT::new();
     let action_to_return = create_action_signed_hashed.clone();
-    network.expect_get().returning(move |hash| {
+    network.expect_get().returning(move |hash, _| {
         assert_eq!(hash, action_to_return.as_hash().clone().into());
         Ok(vec![WireOps::Record(WireRecordOps {
             action: Some(Judged::new(
@@ -300,7 +300,7 @@ async fn validation_callback_awaiting_deps_agent_activity() {
         let expected_chain_top = expected_chain_top.clone();
         let create_action_signed_hashed = create_action_signed_hashed.clone();
         let delete_action_signed_hashed = delete_action_signed_hashed.clone();
-        move |author, filter| {
+        move |author, filter, _| {
             assert_eq!(author, alice);
             assert_eq!(&filter.chain_top, expected_chain_top.as_hash());
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -136,7 +136,7 @@ async fn main_workflow() {
     hc_p2p
         .expect_get()
         .times(1)
-        .return_once(|_, _| Box::pin(async { Ok(vec![]) }));
+        .return_once(|_, _, _| Box::pin(async { Ok(vec![]) }));
     hc_p2p
         .expect_target_arcs()
         .returning(|_| Box::pin(async move { Ok(vec![]) }));

--- a/crates/holochain/src/core/workflow/countersigning_workflow/incomplete.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/incomplete.rs
@@ -8,13 +8,12 @@ use crate::prelude::{Entry, PreflightRequest, RecordEntry};
 use either::Either;
 use holo_hash::AgentPubKey;
 use holochain_cascade::CascadeImpl;
-use holochain_p2p::actor::GetActivityOptions;
+use holochain_p2p::actor::{GetActivityOptions, NetworkRequestOptions};
 use holochain_p2p::DynHolochainP2pDna;
 use holochain_state::prelude::{
     current_countersigning_session, CurrentCountersigningSessionOpt, SourceChainResult,
 };
 use holochain_types::activity::ChainItems;
-use holochain_zome_types::entry::GetOptions;
 use holochain_zome_types::prelude::{
     ChainQueryFilter, ChainQueryFilterRange, ChainStatus, SignedAction,
 };
@@ -79,12 +78,14 @@ pub async fn inner_countersigning_session_incomplete(
     let cascade = CascadeImpl::empty().with_network(network, space.cache_db.clone());
 
     let get_activity_options = GetActivityOptions {
+        network_req_options: NetworkRequestOptions {
+            // We're going to be potentially running quite a lot of these requests, so set the timeout reasonably low.
+            timeout_ms: Some(10_000),
+            ..Default::default()
+        },
         include_warrants: false, // TODO document that apps should consider checking for warrants before completing preflight
         include_valid_activity: true,
         include_full_records: true,
-        get_options: GetOptions::network(),
-        // We're going to be potentially running quite a lot of these requests, so set the timeout reasonably low.
-        timeout_ms: Some(10_000),
         ..Default::default()
     };
 

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
@@ -177,7 +177,7 @@ async fn validate_op_with_dependency_not_held() {
     let response = WireOps::Record(ops);
     network
         .expect_get()
-        .return_once(move |_| Ok(vec![response]));
+        .return_once(move |_, _| Ok(vec![response]));
 
     network
         .expect_target_arcs()
@@ -240,7 +240,7 @@ async fn validate_op_with_dependency_not_found_on_the_dht() {
     let response = WireOps::Record(WireRecordOps::new());
     network
         .expect_get()
-        .return_once(move |_| Ok(vec![response]));
+        .return_once(move |_, _| Ok(vec![response]));
 
     network
         .expect_target_arcs()
@@ -425,7 +425,7 @@ async fn validate_valid_warrant_with_fetched_dependency() {
 
     network.expect_get().return_once({
         let warranted_action = warranted_action.clone();
-        move |_hash| {
+        move |_hash, _| {
             let mut ops: WireRecordOps = WireRecordOps::new();
             ops.action = Some(Judged::valid(warranted_action.clone().into()));
             ops.entry = Some(entry);

--- a/crates/holochain/src/test_utils/host_fn_caller.rs
+++ b/crates/holochain/src/test_utils/host_fn_caller.rs
@@ -18,7 +18,7 @@ use holo_hash::ActionHash;
 use holo_hash::AgentPubKey;
 use holo_hash::AnyDhtHash;
 use holochain_keystore::MetaLairClient;
-use holochain_p2p::actor::GetLinksOptions;
+use holochain_p2p::actor::GetLinksRequestOptions;
 use holochain_p2p::{HolochainP2pDna, HolochainP2pDnaT};
 use holochain_state::host_fn_workspace::SourceChainWorkspace;
 use holochain_types::prelude::*;
@@ -416,7 +416,7 @@ impl HostFnCaller {
         base: AnyLinkableHash,
         type_query: LinkTypeFilter,
         link_tag: Option<LinkTag>,
-        _options: GetLinksOptions,
+        _options: GetLinksRequestOptions,
     ) -> Vec<Link> {
         let (ribosome, call_context, workspace) = self.unpack().await;
         let mut input = GetLinksInputBuilder::try_new(base, type_query).unwrap();
@@ -449,7 +449,7 @@ impl HostFnCaller {
         base: AnyLinkableHash,
         type_query: LinkTypeFilter,
         tag: LinkTag,
-        _options: GetLinksOptions,
+        _options: GetLinksRequestOptions,
     ) -> Vec<(SignedActionHashed, Vec<SignedActionHashed>)> {
         let (ribosome, call_context, workspace) = self.unpack().await;
         let input = GetLinksInputBuilder::try_new(base, type_query)

--- a/crates/holochain_cascade/src/authority/test.rs
+++ b/crates/holochain_cascade/src/authority/test.rs
@@ -132,7 +132,7 @@ async fn get_links() {
 
     fill_db(&db.to_db(), td.store_entry_op.clone()).await;
     fill_db(&db.to_db(), td.create_link_op.clone()).await;
-    let options = actor::GetLinksOptions::default();
+    let options = actor::GetLinksRequestOptions::default();
 
     let result = handle_get_links(db.to_db().into(), td.link_key.clone(), (&options).into())
         .await

--- a/crates/holochain_cascade/src/test_utils.rs
+++ b/crates/holochain_cascade/src/test_utils.rs
@@ -12,6 +12,7 @@ use holo_hash::AnyDhtHashPrimitive;
 use holo_hash::EntryHash;
 use holochain_chc::ChcImpl;
 use holochain_p2p::actor;
+use holochain_p2p::actor::{GetLinksRequestOptions, NetworkRequestOptions};
 use holochain_p2p::event::CountersigningSessionNegotiationMessage;
 use holochain_p2p::HolochainP2pDnaT;
 use holochain_p2p::HolochainP2pError;
@@ -64,7 +65,11 @@ impl PassThroughNetwork {
 
 #[async_trait::async_trait]
 impl HolochainP2pDnaT for PassThroughNetwork {
-    async fn get(&self, dht_hash: holo_hash::AnyDhtHash) -> HolochainP2pResult<Vec<WireOps>> {
+    async fn get(
+        &self,
+        dht_hash: holo_hash::AnyDhtHash,
+        _options: NetworkRequestOptions,
+    ) -> HolochainP2pResult<Vec<WireOps>> {
         let mut out = Vec::new();
         match dht_hash.into_primitive() {
             AnyDhtHashPrimitive::Entry(hash) => {
@@ -90,7 +95,7 @@ impl HolochainP2pDnaT for PassThroughNetwork {
     async fn get_links(
         &self,
         link_key: WireLinkKey,
-        options: actor::GetLinksOptions,
+        options: GetLinksRequestOptions,
     ) -> HolochainP2pResult<Vec<WireLinkOps>> {
         let mut out = Vec::new();
         for db in &self.envs {
@@ -102,7 +107,11 @@ impl HolochainP2pDnaT for PassThroughNetwork {
         Ok(out)
     }
 
-    async fn count_links(&self, query: WireLinkQuery) -> HolochainP2pResult<CountLinksResponse> {
+    async fn count_links(
+        &self,
+        query: WireLinkQuery,
+        _options: NetworkRequestOptions,
+    ) -> HolochainP2pResult<CountLinksResponse> {
         let mut out = HashSet::new();
 
         for db in &self.envs {
@@ -144,6 +153,7 @@ impl HolochainP2pDnaT for PassThroughNetwork {
         &self,
         agent: AgentPubKey,
         filter: ChainFilter,
+        _options: NetworkRequestOptions,
     ) -> HolochainP2pResult<Vec<MustGetAgentActivityResponse>> {
         let mut out = Vec::new();
         for db in &self.envs {

--- a/crates/holochain_cascade/tests/tests/count_links.rs
+++ b/crates/holochain_cascade/tests/tests/count_links.rs
@@ -113,7 +113,7 @@ async fn count_links_authoring() {
     let mut mock = MockHolochainP2pDnaT::new();
     mock.expect_authority_for_hash().returning(|_| Ok(false));
     mock.expect_count_links()
-        .returning(|_| Ok(CountLinksResponse::new(vec![action_hash(&[1, 2, 3])])));
+        .returning(|_, _| Ok(CountLinksResponse::new(vec![action_hash(&[1, 2, 3])])));
     let mock = Arc::new(mock);
 
     // Cascade

--- a/crates/holochain_cascade/tests/tests/get_activity.rs
+++ b/crates/holochain_cascade/tests/tests/get_activity.rs
@@ -3,7 +3,7 @@ use holo_hash::DnaHash;
 use holochain_cascade::error::CascadeResult;
 use holochain_cascade::test_utils::*;
 use holochain_cascade::CascadeImpl;
-use holochain_p2p::actor::GetActivityOptions;
+use holochain_p2p::actor::{GetActivityOptions, NetworkRequestOptions};
 use holochain_sqlite::db::DbKindAuthored;
 use holochain_sqlite::db::DbKindCache;
 use holochain_sqlite::db::DbKindDht;
@@ -681,7 +681,7 @@ async fn test_must_get_agent_activity_inner(
         cascade = cascade.with_scratch(sync_scratch);
     }
     cascade
-        .must_get_agent_activity(author, filter)
+        .must_get_agent_activity(author, filter, NetworkRequestOptions::must_get_options())
         .await
         .unwrap()
 }

--- a/crates/holochain_cascade/tests/tests/get_entry.rs
+++ b/crates/holochain_cascade/tests/tests/get_entry.rs
@@ -1,6 +1,7 @@
 use holo_hash::HasHash;
 use holochain_cascade::test_utils::*;
 use holochain_cascade::{Cascade, CascadeImpl};
+use holochain_p2p::actor::NetworkRequestOptions;
 use holochain_p2p::MockHolochainP2pDnaT;
 use holochain_state::mutations::insert_op_scratch;
 use holochain_state::prelude::*;
@@ -168,10 +169,13 @@ async fn assert_rejected(
     assert_eq!(r, expected);
 }
 
-async fn assert_can_retrieve(td_entry: &EntryTestData, cascade: &CascadeImpl, options: GetOptions) {
+async fn assert_can_retrieve(td_entry: &EntryTestData, cascade: &CascadeImpl) {
     // - Retrieve via entry hash
     let (r, _) = cascade
-        .retrieve_public_record(td_entry.hash.clone().into(), options.clone().into())
+        .retrieve_public_record(
+            td_entry.hash.clone().into(),
+            NetworkRequestOptions::default(),
+        )
         .await
         .unwrap()
         .expect("Failed to retrieve record");
@@ -181,7 +185,10 @@ async fn assert_can_retrieve(td_entry: &EntryTestData, cascade: &CascadeImpl, op
 
     // - Retrieve via action hash
     let (r, _) = cascade
-        .retrieve_public_record(td_entry.create_hash.clone().into(), options.clone().into())
+        .retrieve_public_record(
+            td_entry.create_hash.clone().into(),
+            NetworkRequestOptions::default(),
+        )
         .await
         .unwrap()
         .expect("Failed to retrieve record");
@@ -191,7 +198,7 @@ async fn assert_can_retrieve(td_entry: &EntryTestData, cascade: &CascadeImpl, op
 
     // - Retrieve entry
     let (r, _) = cascade
-        .retrieve_entry(td_entry.hash.clone(), options.clone().into())
+        .retrieve_entry(td_entry.hash.clone(), NetworkRequestOptions::default())
         .await
         .unwrap()
         .expect("Failed to retrieve entry");
@@ -200,7 +207,10 @@ async fn assert_can_retrieve(td_entry: &EntryTestData, cascade: &CascadeImpl, op
 
     // - Retrieve action
     let (r, _) = cascade
-        .retrieve_action(td_entry.create_hash.clone(), options.clone().into())
+        .retrieve_action(
+            td_entry.create_hash.clone(),
+            NetworkRequestOptions::default(),
+        )
         .await
         .unwrap()
         .expect("Failed to retrieve action");
@@ -482,7 +492,7 @@ async fn test_pending_data_isnt_returned() {
 
     assert_is_none(&td_entry, &td_record, &cascade, GetOptions::network()).await;
 
-    assert_can_retrieve(&td_entry, &cascade, GetOptions::network()).await;
+    assert_can_retrieve(&td_entry, &cascade).await;
 
     let network = PassThroughNetwork::authority_for_all(vec![authority.to_db().clone().into()]);
 
@@ -491,7 +501,7 @@ async fn test_pending_data_isnt_returned() {
 
     assert_is_none(&td_entry, &td_record, &cascade, GetOptions::network()).await;
 
-    assert_can_retrieve(&td_entry, &cascade, GetOptions::network()).await;
+    assert_can_retrieve(&td_entry, &cascade).await;
 }
 
 mod zero_arc {

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -7,101 +7,71 @@ use holochain_types::prelude::ValidationReceiptBundle;
 use kitsune2_api::{DhtArc, SpaceId, StoredOp};
 use std::collections::HashMap;
 
-/// Get options help control how the get is processed at various levels.
-/// Fields tagged with `[Network]` are network-level controls.
-/// Fields tagged with `[Remote]` are controls that will be forwarded to the
-/// remote agent processing this `Get` request.
+/// Get options used to control how data fetching over the network is performed.
 #[derive(Clone, Debug)]
-pub struct GetOptions {
-    /// `[Network]`
-    /// How many remote nodes should we make requests of / aggregate.
-    /// Set to `None` for a default "best-effort".
-    pub remote_agent_count: Option<u8>,
+pub struct NetworkRequestOptions {
+    /// Make requests to this number of remote agents in parallel.
+    ///
+    /// When `GetOptions::as_race` is `true`, the first response received will be returned.
+    /// When `GetOptions::as_race` is `false`, responses will be aggregated until the timeout is
+    /// reached. This is not implemented.
+    ///
+    /// Defaults to `3`.
+    pub remote_agent_count: u8,
 
-    /// `[Network]`
-    /// Timeout to await responses for aggregation.
-    /// Set to `None` for a default "best-effort".
-    /// Note - if all requests time-out you will receive an empty result,
-    /// not a timeout error.
+    /// Timeout within which responses must arrive.
+    ///
+    /// When `None` is specified, the conductor settings will be used to determine the timeout.
     pub timeout_ms: Option<u64>,
 
-    /// `[Network]`
-    /// We are interested in speed. If `true` and we have any results
-    /// when `race_timeout_ms` is expired, those results will be returned.
-    /// After `race_timeout_ms` and before `timeout_ms` the first result
-    /// received will be returned.
+    /// Whether to treat the get as a race, returning the first response received.
+    ///
+    /// Defaults to `true`.
     pub as_race: bool,
-
-    /// `[Network]`
-    /// See `as_race` for details.
-    /// Set to `None` for a default "best-effort" race.
-    pub race_timeout_ms: Option<u64>,
 }
 
-impl Default for GetOptions {
+impl Default for NetworkRequestOptions {
     fn default() -> Self {
         Self {
-            remote_agent_count: None,
+            remote_agent_count: 3,
             timeout_ms: None,
             as_race: true,
-            race_timeout_ms: None,
         }
     }
 }
 
-impl GetOptions {
+impl NetworkRequestOptions {
     /// Using defaults is dangerous in a must_get as it can undermine determinism.
     /// We want refactors to explicitly consider this.
     pub fn must_get_options() -> Self {
         Self {
-            remote_agent_count: None,
+            remote_agent_count: 1,
             timeout_ms: None,
             as_race: true,
-            race_timeout_ms: None,
         }
     }
 }
 
-impl From<holochain_zome_types::entry::GetOptions> for GetOptions {
-    fn from(_: holochain_zome_types::entry::GetOptions) -> Self {
-        Self::default()
-    }
-}
-
-/// Get links from the DHT.
-/// Fields tagged with `[Network]` are network-level controls.
-/// Fields tagged with `[Remote]` are controls that will be forwarded to the
-/// remote agent processing this `GetLinks` request.
+/// Options for getting links from the network.
 #[derive(Debug, Clone, Default)]
-pub struct GetLinksOptions {
-    /// `[Network]`
-    /// Timeout to await responses for aggregation.
-    /// Set to `None` for a default "best-effort".
-    /// Note - if all requests time-out you will receive an empty result,
-    /// not a timeout error.
-    pub timeout_ms: Option<u64>,
+pub struct GetLinksRequestOptions {
+    /// The base network options to use for this call.
+    pub network_req_options: NetworkRequestOptions,
+
     /// Whether to fetch links from the network or return only
     /// locally available links. Defaults to fetching links from network.
     pub get_options: holochain_zome_types::entry::GetOptions,
 }
 
 /// Get agent activity from the DHT.
+///
 /// Fields tagged with `[Network]` are network-level controls.
 /// Fields tagged with `[Remote]` are controls that will be forwarded to the
 /// remote agent processing this `GetLinks` request.
 #[derive(Debug, Clone)]
 pub struct GetActivityOptions {
-    /// `[Network]`
-    /// Timeout to await responses for aggregation.
-    /// Set to `None` for a default "best-effort".
-    /// Note - if all requests time-out you will receive an empty result,
-    /// not a timeout error.
-    pub timeout_ms: Option<u64>,
-    /// Number of times to retry getting records in parallel.
-    /// For a small dht a large parallel get can overwhelm a single
-    /// agent and it can be worth retrying the records that didn't
-    /// get found.
-    pub retry_gets: u8,
+    /// The base network options to use for this call.
+    pub network_req_options: NetworkRequestOptions,
     /// `[Remote]`
     /// Include the all valid activity actions in the response.
     /// If this is false the call becomes a lightweight response with
@@ -116,14 +86,13 @@ pub struct GetActivityOptions {
     /// Include the full signed records in the response, instead of just the hashes.
     pub include_full_records: bool,
     /// Configure how the data should be fetched.
-    pub get_options: holochain_zome_types::entry::GetOptions,
+    pub get_options: GetOptions,
 }
 
 impl Default for GetActivityOptions {
     fn default() -> Self {
         Self {
-            timeout_ms: None,
-            retry_gets: 0,
+            network_req_options: NetworkRequestOptions::default(),
             include_valid_activity: true,
             include_rejected_activity: false,
             include_warrants: true,
@@ -142,7 +111,7 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug {
 
     /// Test utility to force local agents to report full storage arcs.
     #[cfg(feature = "test_utils")]
-    fn test_set_full_arcs(&self, space: kitsune2_api::SpaceId) -> BoxFut<'_, ()> {
+    fn test_set_full_arcs(&self, space: SpaceId) -> BoxFut<'_, ()> {
         Box::pin(async move {
             let mut updated_agents = Vec::new();
             for agent in self
@@ -155,8 +124,8 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug {
                 .await
                 .unwrap()
             {
-                agent.set_cur_storage_arc(kitsune2_api::DhtArc::FULL);
-                agent.set_tgt_storage_arc_hint(kitsune2_api::DhtArc::FULL);
+                agent.set_cur_storage_arc(DhtArc::FULL);
+                agent.set_tgt_storage_arc_hint(DhtArc::FULL);
                 agent.invoke_cb();
                 updated_agents.push(agent);
             }
@@ -250,7 +219,7 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug {
     fn publish(
         &self,
         dna_hash: DnaHash,
-        basis_hash: holo_hash::OpBasis,
+        basis_hash: OpBasis,
         source: AgentPubKey,
         op_hash_list: Vec<DhtOpHash>,
         timeout_ms: Option<u64>,
@@ -261,7 +230,7 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug {
     fn publish_countersign(
         &self,
         dna_hash: DnaHash,
-        basis_hash: holo_hash::OpBasis,
+        basis_hash: OpBasis,
         op: ChainOp,
     ) -> BoxFut<'_, HolochainP2pResult<()>>;
 
@@ -269,7 +238,8 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug {
     fn get(
         &self,
         dna_hash: DnaHash,
-        dht_hash: holo_hash::AnyDhtHash,
+        dht_hash: AnyDhtHash,
+        options: NetworkRequestOptions,
     ) -> BoxFut<'_, HolochainP2pResult<Vec<WireOps>>>;
 
     /// Get links from the DHT.
@@ -277,7 +247,7 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug {
         &self,
         dna_hash: DnaHash,
         link_key: WireLinkKey,
-        options: GetLinksOptions,
+        options: GetLinksRequestOptions,
     ) -> BoxFut<'_, HolochainP2pResult<Vec<WireLinkOps>>>;
 
     /// Get a count of links from the DHT.
@@ -285,6 +255,7 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug {
         &self,
         dna_hash: DnaHash,
         query: WireLinkQuery,
+        options: NetworkRequestOptions,
     ) -> BoxFut<'_, HolochainP2pResult<CountLinksResponse>>;
 
     /// Get agent activity from the DHT.
@@ -302,6 +273,7 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug {
         dna_hash: DnaHash,
         author: AgentPubKey,
         filter: holochain_zome_types::chain::ChainFilter,
+        options: NetworkRequestOptions,
     ) -> BoxFut<'_, HolochainP2pResult<Vec<MustGetAgentActivityResponse>>>;
 
     /// Send a validation receipt to a remote node.

--- a/crates/holochain_p2p/src/types/event.rs
+++ b/crates/holochain_p2p/src/types/event.rs
@@ -8,8 +8,8 @@ use holochain_zome_types::signature::Signature;
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct GetLinksOptions {}
 
-impl From<&actor::GetLinksOptions> for GetLinksOptions {
-    fn from(_a: &actor::GetLinksOptions) -> Self {
+impl From<&actor::GetLinksRequestOptions> for GetLinksOptions {
+    fn from(_a: &actor::GetLinksRequestOptions) -> Self {
         Self {}
     }
 }

--- a/crates/holochain_p2p/tests/tests/blocks.rs
+++ b/crates/holochain_p2p/tests/tests/blocks.rs
@@ -5,6 +5,7 @@ use holo_hash::{
     DnaHash,
 };
 use holochain_keystore::{test_keystore, MetaLairClient};
+use holochain_p2p::actor::NetworkRequestOptions;
 use holochain_p2p::{
     actor::DynHcP2p, event::MockHcP2pHandler, spawn_holochain_p2p, HolochainP2pConfig,
     HolochainP2pError, HolochainP2pLocalAgent,
@@ -398,7 +399,13 @@ async fn get_to_blocked_agent_fails() {
     exchange_agent_infos(alice.clone(), bob.clone(), &dna_hash).await;
 
     // Before the block Alice can make get request and Bob answers them.
-    let response = alice.get(dna_hash.clone(), fixt!(ActionHash).into()).await;
+    let response = alice
+        .get(
+            dna_hash.clone(),
+            fixt!(ActionHash).into(),
+            NetworkRequestOptions::default(),
+        )
+        .await;
     assert!(
         response.is_ok(),
         "Expected get to succeed before block but got: {response:?}"
@@ -425,7 +432,13 @@ async fn get_to_blocked_agent_fails() {
     // implementation internally discards blocked agents when inserting.
 
     // Alice makes a get request. Bob is blocked, so there should be no one to respond.
-    let response = alice.get(dna_hash.clone(), fixt!(ActionHash).into()).await;
+    let response = alice
+        .get(
+            dna_hash.clone(),
+            fixt!(ActionHash).into(),
+            NetworkRequestOptions::default(),
+        )
+        .await;
     assert!(matches!(
         response,
         Err(HolochainP2pError::NoPeersForLocation(_, _))
@@ -458,7 +471,13 @@ async fn get_by_blocked_agent_fails() {
     exchange_agent_infos(alice.clone(), bob.clone(), &dna_hash).await;
 
     // Before the block Bob can make get requests and Alice answers them.
-    let response = bob.get(dna_hash.clone(), fixt!(ActionHash).into()).await;
+    let response = bob
+        .get(
+            dna_hash.clone(),
+            fixt!(ActionHash).into(),
+            NetworkRequestOptions::default(),
+        )
+        .await;
     assert!(response.is_ok());
 
     alice
@@ -478,7 +497,13 @@ async fn get_by_blocked_agent_fails() {
 
     // Bob makes a get request. Alice could respond, but must not, to prove the block for incoming
     // requests is effective.
-    let response = bob.get(dna_hash.clone(), fixt!(ActionHash).into()).await;
+    let response = bob
+        .get(
+            dna_hash.clone(),
+            fixt!(ActionHash).into(),
+            NetworkRequestOptions::default(),
+        )
+        .await;
     assert!(response.is_err(), "expected error, got {response:?}");
 }
 

--- a/crates/holochain_p2p/tests/tests/node_messaging.rs
+++ b/crates/holochain_p2p/tests/tests/node_messaging.rs
@@ -1,5 +1,6 @@
 use crate::tests::common::{spawn_test_bootstrap, Handler};
 use holochain_keystore::*;
+use holochain_p2p::actor::{GetLinksRequestOptions, NetworkRequestOptions};
 use holochain_p2p::event::*;
 use holochain_p2p::*;
 use holochain_trace::test_run;
@@ -373,6 +374,7 @@ async fn test_get() {
                         vec![1; 36],
                         holo_hash::hash_type::AnyDht::Entry,
                     ),
+                    NetworkRequestOptions::default(),
                 )
                 .await
                 .is_ok()
@@ -421,6 +423,7 @@ async fn test_get_with_unresponsive_agents() {
                         vec![1; 36],
                         holo_hash::hash_type::AnyDht::Entry,
                     ),
+                    NetworkRequestOptions::default(),
                 )
                 .await
                 .is_ok()
@@ -471,6 +474,7 @@ async fn test_get_when_not_all_agents_have_data() {
                         vec![1; 36],
                         holo_hash::hash_type::AnyDht::Entry,
                     ),
+                    NetworkRequestOptions::default(),
                 )
                 .await
             {
@@ -533,6 +537,7 @@ async fn test_get_when_not_all_agents_have_data_and_unresponsive_agent() {
                         vec![1; 36],
                         holo_hash::hash_type::AnyDht::Entry,
                     ),
+                    NetworkRequestOptions::default(),
                 )
                 .await
             {
@@ -586,6 +591,7 @@ async fn test_get_empty_data_better_than_no_response() {
                         vec![1; 36],
                         holo_hash::hash_type::AnyDht::Entry,
                     ),
+                    NetworkRequestOptions::default(),
                 )
                 .await
                 .is_ok()
@@ -634,7 +640,7 @@ async fn test_get_links() {
                         before: None,
                         author: None,
                     },
-                    holochain_p2p::actor::GetLinksOptions::default(),
+                    GetLinksRequestOptions::default(),
                 )
                 .await
                 .is_ok()
@@ -685,7 +691,7 @@ async fn test_get_links_with_unresponsive_agents() {
                         before: None,
                         author: None,
                     },
-                    holochain_p2p::actor::GetLinksOptions::default(),
+                    GetLinksRequestOptions::default(),
                 )
                 .await
                 .is_ok()
@@ -734,6 +740,7 @@ async fn test_count_links() {
                         after: None,
                         author: None,
                     },
+                    NetworkRequestOptions::default(),
                 )
                 .await
                 .is_ok()
@@ -784,6 +791,7 @@ async fn test_count_links_with_unresponsive_agents() {
                         after: None,
                         author: None,
                     },
+                    NetworkRequestOptions::default(),
                 )
                 .await
                 .is_ok()
@@ -920,6 +928,7 @@ async fn test_must_get_agent_activity() {
                         limit_conditions: LimitConditions::ToGenesis,
                         include_cached_entries: false,
                     },
+                    NetworkRequestOptions::default(),
                 )
                 .await
                 .is_ok()
@@ -964,6 +973,7 @@ async fn test_must_get_agent_activity_with_unresponsive_agents() {
                         limit_conditions: LimitConditions::ToGenesis,
                         include_cached_entries: false,
                     },
+                    NetworkRequestOptions::default(),
                 )
                 .await
                 .is_ok()


### PR DESCRIPTION
### Summary

I'm looking for ways to reduce network traffic. One way is for validation to not aggressively query the network. The existing options for fetching during validation were configured (but not used, or consistently) to explicitly not race requests to multiple peers. This change effectively fixes that situation by making the `must_get` functions consistently avoid configuring parallel requests and then actually mapping that configuration down to the network.

Addresses https://github.com/holochain/holochain/issues/5422

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Network requests now use a consolidated per-request options model, enabling consistent timeout and peer-selection behavior across operations.
  * Per-request timeouts and peer sampling are configurable, improving reliability and responsiveness of fetches (links, entries, activity).
  * Internal retrieval APIs and tests updated to propagate these options, increasing consistency and test coverage for network interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->