### PR TITLE
chore: suspend automated dev releases temporarily

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,9 @@
 name: release holochain
 
 on:
-  schedule:
-    - cron: "0 0 * * 3" # At 12:00am on Wednesday
+  # suspend automated releases during release candidate phase
+  # schedule:
+  #   - cron: "0 0 * * 3" # At 12:00am on Wednesday
   workflow_dispatch:
     inputs:
       holochain_source_branch:


### PR DESCRIPTION
### Summary

It's easier to release 0.6 from the `develop` branch, instead of a `develop-0.6` branch. While we're preparing the 0.6 release through release candidates, the automated dev releases need to be suspended.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Suspended scheduled automatic releases; the release workflow no longer runs on a schedule and must be started manually via the workflow dispatch trigger. Automated cadence is paused and releases require manual initiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->