### PR TITLE
feat: add metrics to record handling of notify messages

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Add metrics to record incoming notify requests [#5451](https://github.com/holochain/holochain/pull/5451)
+
 ## 0.6.0-rc.2
 
 - Feat: Upgrade Kitsune2 to v0.3.2 \#5449

--- a/crates/holochain_metrics/src/dashboards/conductor.json
+++ b/crates/holochain_metrics/src/dashboards/conductor.json
@@ -2,54 +2,28 @@
   {
     "apiVersion": "influxdata.com/v2alpha1",
     "kind": "Dashboard",
-    "metadata": {
-      "name": "ecstatic-benz-6ba001"
-    },
+    "metadata": { "name": "upbeat-goodall-cd5001" },
     "spec": {
       "charts": [
         {
-          "axes": [
-            {
-              "name": "x"
-            },
-            {
-              "label": "seconds",
-              "name": "y"
-            }
-          ],
+          "axes": [{ "name": "x" }, { "label": "seconds", "name": "y" }],
           "binSize": 10,
           "colors": [
-            {
-              "hex": "#000000"
-            },
-            {
-              "hex": "#E69F00"
-            },
-            {
-              "hex": "#56B4E9"
-            },
-            {
-              "hex": "#009E73"
-            },
-            {
-              "hex": "#F0E442"
-            },
-            {
-              "hex": "#0072B2"
-            },
-            {
-              "hex": "#D55E00"
-            },
-            {
-              "hex": "#CC79A7"
-            }
+            { "hex": "#000000" },
+            { "hex": "#E69F00" },
+            { "hex": "#56B4E9" },
+            { "hex": "#009E73" },
+            { "hex": "#F0E442" },
+            { "hex": "#0072B2" },
+            { "hex": "#D55E00" },
+            { "hex": "#CC79A7" }
           ],
           "height": 4,
           "kind": "Heatmap",
           "legendColorizeRows": true,
           "legendOpacity": 1,
           "legendOrientationThreshold": 100000000,
-          "name": "P2P Event duration",
+          "name": "P2P outgoing request duration",
           "queries": [
             {
               "query": "from(bucket: \"influxive\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"hc.holochain_p2p.request.duration.s\")"
@@ -61,41 +35,17 @@
           "yCol": "_value"
         },
         {
-          "axes": [
-            {
-              "name": "x"
-            },
-            {
-              "label": "seconds",
-              "name": "y"
-            }
-          ],
+          "axes": [{ "name": "x" }, { "label": "seconds", "name": "y" }],
           "binSize": 10,
           "colors": [
-            {
-              "hex": "#000000"
-            },
-            {
-              "hex": "#E69F00"
-            },
-            {
-              "hex": "#56B4E9"
-            },
-            {
-              "hex": "#009E73"
-            },
-            {
-              "hex": "#F0E442"
-            },
-            {
-              "hex": "#0072B2"
-            },
-            {
-              "hex": "#D55E00"
-            },
-            {
-              "hex": "#CC79A7"
-            }
+            { "hex": "#000000" },
+            { "hex": "#E69F00" },
+            { "hex": "#56B4E9" },
+            { "hex": "#009E73" },
+            { "hex": "#F0E442" },
+            { "hex": "#0072B2" },
+            { "hex": "#D55E00" },
+            { "hex": "#CC79A7" }
           ],
           "height": 4,
           "kind": "Heatmap",
@@ -115,41 +65,77 @@
           "yPos": 4
         },
         {
-          "axes": [
-            {
-              "name": "x"
-            },
-            {
-              "label": "seconds",
-              "name": "y"
-            }
-          ],
+          "axes": [{ "name": "x" }, { "label": "seconds", "name": "y" }],
           "binSize": 10,
           "colors": [
+            { "hex": "#000000" },
+            { "hex": "#E69F00" },
+            { "hex": "#56B4E9" },
+            { "hex": "#009E73" },
+            { "hex": "#F0E442" },
+            { "hex": "#0072B2" },
+            { "hex": "#D55E00" },
+            { "hex": "#CC79A7" }
+          ],
+          "height": 4,
+          "kind": "Heatmap",
+          "legendColorizeRows": true,
+          "legendOpacity": 1,
+          "legendOrientationThreshold": 100000000,
+          "name": "Sys validation workflow duration",
+          "queries": [
             {
-              "hex": "#000000"
-            },
-            {
-              "hex": "#E69F00"
-            },
-            {
-              "hex": "#56B4E9"
-            },
-            {
-              "hex": "#009E73"
-            },
-            {
-              "hex": "#F0E442"
-            },
-            {
-              "hex": "#0072B2"
-            },
-            {
-              "hex": "#D55E00"
-            },
-            {
-              "hex": "#CC79A7"
+              "query": "from(bucket: \"influxive\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"hc.conductor.workflow.duration.s\")\n  |> filter(fn: (r) => r[\"workflow\"] == \"sys_validation_consumer\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")"
             }
+          ],
+          "staticLegend": {},
+          "width": 4,
+          "xCol": "_time",
+          "yCol": "_value",
+          "yPos": 8
+        },
+        {
+          "axes": [{ "name": "x" }, { "label": "seconds", "name": "y" }],
+          "binSize": 10,
+          "colors": [
+            { "hex": "#000000" },
+            { "hex": "#E69F00" },
+            { "hex": "#56B4E9" },
+            { "hex": "#009E73" },
+            { "hex": "#F0E442" },
+            { "hex": "#0072B2" },
+            { "hex": "#D55E00" },
+            { "hex": "#CC79A7" }
+          ],
+          "height": 4,
+          "kind": "Heatmap",
+          "legendColorizeRows": true,
+          "legendOpacity": 1,
+          "legendOrientationThreshold": 100000000,
+          "name": "P2P handle incoming request duration",
+          "queries": [
+            {
+              "query": "from(bucket: \"influxive\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"hc.holochain_p2p.handle_request.duration.s\")"
+            }
+          ],
+          "staticLegend": {},
+          "width": 4,
+          "xCol": "_time",
+          "xPos": 4,
+          "yCol": "_value"
+        },
+        {
+          "axes": [{ "name": "x" }, { "label": "seconds", "name": "y" }],
+          "binSize": 10,
+          "colors": [
+            { "hex": "#000000" },
+            { "hex": "#E69F00" },
+            { "hex": "#56B4E9" },
+            { "hex": "#009E73" },
+            { "hex": "#F0E442" },
+            { "hex": "#0072B2" },
+            { "hex": "#D55E00" },
+            { "hex": "#CC79A7" }
           ],
           "height": 4,
           "kind": "Heatmap",
@@ -166,99 +152,21 @@
           "width": 4,
           "xCol": "_time",
           "xPos": 4,
-          "yCol": "_value"
-        },
-        {
-          "axes": [
-            {
-              "name": "x"
-            },
-            {
-              "label": "seconds",
-              "name": "y"
-            }
-          ],
-          "binSize": 10,
-          "colors": [
-            {
-              "hex": "#000000"
-            },
-            {
-              "hex": "#E69F00"
-            },
-            {
-              "hex": "#56B4E9"
-            },
-            {
-              "hex": "#009E73"
-            },
-            {
-              "hex": "#F0E442"
-            },
-            {
-              "hex": "#0072B2"
-            },
-            {
-              "hex": "#D55E00"
-            },
-            {
-              "hex": "#CC79A7"
-            }
-          ],
-          "height": 4,
-          "kind": "Heatmap",
-          "legendColorizeRows": true,
-          "legendOpacity": 1,
-          "legendOrientationThreshold": 100000000,
-          "name": "Sys validation workflow duration",
-          "queries": [
-            {
-              "query": "from(bucket: \"influxive\")\n  |> range(start: v.timeRangeStart, stop: v.timeRangeStop)\n  |> filter(fn: (r) => r[\"_measurement\"] == \"hc.conductor.workflow.duration.s\")\n  |> filter(fn: (r) => r[\"workflow\"] == \"sys_validation_consumer\")\n  |> filter(fn: (r) => r[\"_field\"] == \"value\")\n  |> aggregateWindow(every: v.windowPeriod, fn: mean, createEmpty: false)\n  |> yield(name: \"mean\")"
-            }
-          ],
-          "staticLegend": {},
-          "width": 4,
-          "xCol": "_time",
-          "xPos": 4,
           "yCol": "_value",
           "yPos": 4
         },
         {
-          "axes": [
-            {
-              "name": "x"
-            },
-            {
-              "label": "seconds",
-              "name": "y"
-            }
-          ],
+          "axes": [{ "name": "x" }, { "label": "seconds", "name": "y" }],
           "binSize": 10,
           "colors": [
-            {
-              "hex": "#000000"
-            },
-            {
-              "hex": "#E69F00"
-            },
-            {
-              "hex": "#56B4E9"
-            },
-            {
-              "hex": "#009E73"
-            },
-            {
-              "hex": "#F0E442"
-            },
-            {
-              "hex": "#0072B2"
-            },
-            {
-              "hex": "#D55E00"
-            },
-            {
-              "hex": "#CC79A7"
-            }
+            { "hex": "#000000" },
+            { "hex": "#E69F00" },
+            { "hex": "#56B4E9" },
+            { "hex": "#009E73" },
+            { "hex": "#F0E442" },
+            { "hex": "#0072B2" },
+            { "hex": "#D55E00" },
+            { "hex": "#CC79A7" }
           ],
           "height": 4,
           "kind": "Heatmap",
@@ -278,41 +186,17 @@
           "yCol": "_value"
         },
         {
-          "axes": [
-            {
-              "name": "x"
-            },
-            {
-              "label": "seconds",
-              "name": "y"
-            }
-          ],
+          "axes": [{ "name": "x" }, { "label": "seconds", "name": "y" }],
           "binSize": 10,
           "colors": [
-            {
-              "hex": "#000000"
-            },
-            {
-              "hex": "#E69F00"
-            },
-            {
-              "hex": "#56B4E9"
-            },
-            {
-              "hex": "#009E73"
-            },
-            {
-              "hex": "#F0E442"
-            },
-            {
-              "hex": "#0072B2"
-            },
-            {
-              "hex": "#D55E00"
-            },
-            {
-              "hex": "#CC79A7"
-            }
+            { "hex": "#000000" },
+            { "hex": "#E69F00" },
+            { "hex": "#56B4E9" },
+            { "hex": "#009E73" },
+            { "hex": "#F0E442" },
+            { "hex": "#0072B2" },
+            { "hex": "#D55E00" },
+            { "hex": "#CC79A7" }
           ],
           "height": 4,
           "kind": "Heatmap",

--- a/crates/holochain_metrics/src/lib.rs
+++ b/crates/holochain_metrics/src/lib.rs
@@ -86,7 +86,8 @@
 //!
 //! | Full Metric Name | Type | Unit (optional) | Description | Attributes |
 //! | ---------------- | ---- | --------------- | ----------- | ---------- |
-//! | `hc.holochain_p2p.request.duration` | `f64_histogram` | `s` | The time waiting for a response from a p2p request. |- `dna_hash`: The DNA hash that the request is being sent on behalf of.<br />- `tag`: The name of the host fn requested to the remote peer.<br />- `url`: The remote peer url called.<br />- `error`: Flag indicating if the request failed.|
+//! | `hc.holochain_p2p.request.duration` | `f64_histogram` | `s` | The time spent sending an outgoing p2p request awaiting the response. |- `dna_hash`: The DNA hash that the request is being sent on behalf of.<br />- `tag`: The name of the host fn requested to the remote peer.<br />- `url`: The remote peer url called.<br />- `error`: Flag indicating if the request failed.|
+//! | `hc.holochain_p2p.handle_request.duration` | `f64_histogram` | `s` | The time spent handling an incoming p2p request. |- `message_type`: The message type.<br />- `dna_hash`: The DNA hash that the request is being sent on behalf of.<br />- `to_agent`: The agent to which the request is made.<br />- `agent`: The agent for which the request is made (in case of `get_agent_activity` and `must_get_agent_activity` requests).<br />|
 //! | `hc.conductor.post_commit.duration` | `f64_histogram` | `s` | The time spent executing a post commit. |- `dna_hash`: The DNA hash that this post commit is running for.<br />- `agent`: The agent running the post commit. |
 //! | `hc.conductor.workflow.duration` | `f64_histogram` | `s` | The time spent running a workflow. |- `workflow`: The name of the workflow.<br />- `dna_hash`: The DNA hash that this workflow is running for.<br />- `agent`: (optional) The agent that this workflow is running for if the workflow is cell bound. |
 //! | `hc.cascade.duration` | `f64_histogram` | `s` | The time taken to execute a cascade query. | |

--- a/crates/holochain_p2p/src/metrics.rs
+++ b/crates/holochain_p2p/src/metrics.rs
@@ -5,7 +5,7 @@ use opentelemetry_api::metrics::{Histogram, Unit};
 pub type P2pRequestDurationMetric = Histogram<f64>;
 
 /// Create a new histogram metric for measuring the duration of p2p requests.
-pub fn create_p2p_request_duration_metric() -> P2pRequestDurationMetric {
+pub fn create_p2p_outgoing_request_duration_metric() -> P2pRequestDurationMetric {
     meter_with_version(
         "hc.holochain_p2p",
         None::<&'static str>,
@@ -14,6 +14,20 @@ pub fn create_p2p_request_duration_metric() -> P2pRequestDurationMetric {
     )
     .f64_histogram("hc.holochain_p2p.request.duration")
     .with_unit(Unit::new("s"))
-    .with_description("The time spent processing a p2p event")
+    .with_description("The time spent sending an outgoing p2p request awaiting the response")
+    .init()
+}
+
+/// Create a new histogram metric for measuring the duration of p2p requests.
+pub fn create_p2p_handle_incoming_request_duration_metric() -> P2pRequestDurationMetric {
+    meter_with_version(
+        "hc.holochain_p2p",
+        None::<&'static str>,
+        None::<&'static str>,
+        Some(vec![]),
+    )
+    .f64_histogram("hc.holochain_p2p.handle_request.duration")
+    .with_unit(Unit::new("s"))
+    .with_description("The time spent handling an incoming p2p request")
     .init()
 }


### PR DESCRIPTION
### Summary

Adds metrics for incoming notify requests. Will e.g. be used to track the number of get requests served by full arc nodes as part of https://github.com/holochain/wind-tunnel/issues/214.


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Split P2P metrics to separately track outgoing and incoming request durations for clearer network telemetry.
  * Extended per-message metrics across many P2P handlers for richer diagnostics.
  * Updated dashboard charts and visual metadata to reflect new metric names and layouts.

* **Documentation**
  * Added a changelog entry for incoming notify request metrics and updated metric registry descriptions to document the new incoming-request metric.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->