### PR TITLE
refactor: use serde tag='type' syntax for ReportConfig enum

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- **BREAKING CHANGE** Chore: Change `ReportConfig` enum serialization to follow convention of `tag = "type"`, i.e. `type: json_lines`.
+
 ## 0.6.0-rc.2
 
 - Feat: Upgrade Kitsune2 to v0.3.2 \#5449

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -743,6 +743,10 @@ mod tests {
           { "urls": ["stun:test-stun.tld:443"] },
         ]
       }
+      report:
+        type: json_lines
+        days_retained: 10
+        fetched_op_interval_s: 5
       advanced: {
         "my": {
           "totally": {
@@ -768,6 +772,10 @@ mod tests {
                 { "urls": ["stun:test-stun.tld:443"] },
             ]
         }));
+        network_config.report = ReportConfig::JsonLines {
+            days_retained: 10,
+            fetched_op_interval_s: 5,
+        };
         network_config.advanced = Some(serde_json::json!({
             "my": {
                 "totally": {


### PR DESCRIPTION
### Summary
Other enums in the conductor config are serialized with `tag = "type"`, so this makes ReportConfig consistent with that convention.


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * ReportConfig serialization now uses the "type: json_lines" convention.

* **Tests**
  * Tests updated to cover JSON Lines reporting configuration, including retention days and fetch interval parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->