### PR TITLE
chore: Add `clean` target for make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,3 +101,10 @@ test-workspace-wasmer_wamr:
 		--locked \
 		--no-default-features \
 		--features $(DEFAULT_FEATURES),wasmer_wamr
+
+clean:
+	cargo clean
+    # Remove untracked .dna files
+	git ls-files -z --others --ignored --exclude-standard -- '*.dna' | xargs -0 rm --
+    # Remove untracked .happ files
+	git ls-files -z --others --ignored --exclude-standard '*.happ' | xargs -0 rm --


### PR DESCRIPTION
### Summary

Would have made it possible to catch the problems on https://github.com/holochain/holochain/pull/5467 without manually finding and deleting these files.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Makefile `clean` target to perform project cleanup: runs the build-system cleanup and removes untracked package files to streamline housekeeping, reduce clutter, and reclaim disk space.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->