### PR TITLE
fix: `cargo install` not working for the hc-client

### DIFF
--- a/crates/hc_client/Cargo.toml
+++ b/crates/hc_client/Cargo.toml
@@ -44,8 +44,10 @@ sodoken = "0.1.0"
 tokio = { version = "1.36.0", features = ["full"] }
 indexmap = "2.0"
 
+holochain = { version = "^0.6.0", path = "../holochain", default-features = false, optional = true }
+
 [dev-dependencies]
-holochain = { version = "^0.6.0-rc.1", path = "../holochain", default-features = false, features = [
+holochain = { version = "^0.6.0", path = "../holochain", default-features = false, features = [
   "sweettest",
   "datachannel-vendored",
 ] }
@@ -56,8 +58,8 @@ tempfile = "3.0"
 [features]
 default = ["wasmer_sys"]
 
-wasmer_sys = ["holochain_client/wasmer_sys", "holochain/wasmer_sys"]
-wasmer_wamr = ["holochain_client/wasmer_wamr", "holochain/wasmer_wamr"]
+wasmer_sys = ["holochain_client/wasmer_sys", "holochain?/wasmer_sys"]
+wasmer_wamr = ["holochain_client/wasmer_wamr", "holochain?/wasmer_wamr"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Holochain runtime to a newer release and marked it optional for more flexible installs.
  * Adjusted WebAssembly runtime feature mappings to broaden compatibility.
  * Aligned development tooling to the updated runtime release.

* **Tests**
  * Kept test infrastructure improvements and expanded validation to match the runtime updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->