### PR TITLE
ci: upgrade Go version to 1.25.5

### DIFF
--- a/.github/actions/common-pre/action.yml
+++ b/.github/actions/common-pre/action.yml
@@ -21,7 +21,7 @@ runs:
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
     - name: go toolchain
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: '1.25.5'
         cache: 'false'


### PR DESCRIPTION
### Summary

Updates Go from 1.20.0 to 1.25.5, and the install action from v5 to v6 to resolve CI installation issues. The old version was failing with 403 errors when attempting to download from the Go distribution servers.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain and runtime to version 1.25.5 for development and CI/CD processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->