### PR TITLE
test: increase timeout in warrant_is_gossiped to handle slower CI

### DIFF
--- a/crates/holochain/tests/tests/warrants.rs
+++ b/crates/holochain/tests/tests/warrants.rs
@@ -140,7 +140,7 @@ async fn warrant_is_gossiped() {
         )
         .await;
 
-    await_consistency(30, [&alice_cell, &bob_cell])
+    await_consistency(60, [&alice_cell, &bob_cell])
         .await
         .unwrap();
 


### PR DESCRIPTION
### Summary

The await_consistency timeout of 30 seconds was sometimes insufficient for Alice and Bob to sync on slower CI machines. The test was timing out during the consistency check after Alice creates the invalid action.

Increased the timeout to 60 seconds to provide adequate buffer for slower environments while still maintaining a reasonable test duration.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test robustness by extending timeout duration for warrant gossip verification, improving test reliability under varying conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->