### PR TITLE
test: increase timeout in warranted_agent_is_blocked to handle slower CI

### DIFF
--- a/crates/holochain/tests/tests/warrants.rs
+++ b/crates/holochain/tests/tests/warrants.rs
@@ -77,7 +77,7 @@ async fn warranted_agent_is_blocked() {
 
             warrants.len() == 1 && warrants[0].warrant().warrantee == *alice_cell.agent_pubkey()
         },
-        Some(10_000),
+        Some(30_000),
         None,
     )
     .await


### PR DESCRIPTION
### Summary

The test was timing out on CI because 10 seconds wasn't sufficient for Bob to validate Alice's invalid action and issue a warrant. Increased timeout from 10s to 30s to match similar warrant validation tests in the codebase.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced reliability of security validation tests through timeout adjustments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->