### PR TITLE
test: increase timeout in consistency_not_reached_when_ops_not_integrated

### DIFF
--- a/crates/holochain/src/sweettest/sweet_consistency.rs
+++ b/crates/holochain/src/sweettest/sweet_consistency.rs
@@ -357,7 +357,7 @@ mod tests {
             .unwrap()
             .into_tuples();
 
-        await_consistency(20, &[alice.clone(), bob.clone()])
+        await_consistency(40, &[alice.clone(), bob.clone()])
             .await
             .unwrap();
 


### PR DESCRIPTION
### Summary

The initial consistency check was timing out on slower CI machines. Increased the timeout from 20s to 40s to allow more time for Alice and Bob to reach initial consistency before inserting the unintegrated op that should prevent further consistency.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased the timeout used in a consistency validation test (from 20s to 40s) to reduce flakiness and help ensure the test completes reliably during runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->