### PR TITLE
fix: ensure CI job fails when tests fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,7 @@ jobs:
 
       - name: test (depot-windows-2022-8)
         if: matrix.os == 'depot-windows-2022-8'
+        id: test-windows
         continue-on-error: true
         run: |-
           $env:SODIUM_LIB_DIR="C:\vcpkg\packages\libsodium_x64-windows\lib"
@@ -124,6 +125,7 @@ jobs:
 
       - name: test
         if: matrix.os != 'depot-windows-2022-8'
+        id: test-unix
         continue-on-error: true
         run: make test-workspace-${{ matrix.target }}
 
@@ -150,6 +152,10 @@ jobs:
               "pr_number": "${{ github.event.pull_request.number }}",
               "actor": "${{ github.actor }}"
             }
+
+      - name: Fail job if tests failed
+        if: always() && (steps.test-windows.outcome == 'failure' || steps.test-unix.outcome == 'failure')
+        run: exit 1
 
       - name: "Common Test Teardown Actions"
         uses: ./.github/actions/common-post


### PR DESCRIPTION
### Summary

The test steps use continue-on-error to allow the InfluxDB upload to run even when tests fail. However, this also prevented the job from reporting a failure status. Now we capture the test step outcome and explicitly fail the job after the upload if tests failed.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline reliability by improving test failure detection and propagation in automated workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->