### PR TITLE
fix: enable clone cell by DNA hash on active clones

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix: `EnableCloneCell` now works consistently when called with either `CloneId` or `DnaHash` on already-enabled clones. Previously, using a `DnaHash` would fail with `CloneCellNotFound` while using a `CloneId` would succeed. #5519
+- **BREAKING CHANGE** Removed the `InstalledAppCommon` function `get_disabled_clone_id`. #5519
 - Removed the unnecessary `hc_stress_test` helper module, its integration test, and example binaries now that performance testing lives in the `holochain/wind-tunnel` repository.
 - Conductor now overrides the Cell bootstrap and signal urls if specified in the app manifest [5524](https://github.com/holochain/holochain/pull/5524).
 

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1751,7 +1751,7 @@ mod clone_cell_impls {
                     let clone_cell_id = payload.clone_cell_id.to_owned();
                     move |mut state| {
                         let app = state.get_app_mut(&app_id)?;
-                        let clone_id = app.get_disabled_clone_id(&clone_cell_id)?;
+                        let clone_id = app.get_clone_id(&clone_cell_id)?;
                         let (cell_id, _) = app.enable_clone_cell(&clone_id)?.into_inner();
                         let app_role = app.primary_role(&clone_id.as_base_role_name())?;
                         let original_dna_hash = app_role.dna_hash().clone();
@@ -1807,7 +1807,7 @@ mod clone_cell_impls {
                             })
                             .expect("disabled clone cell not part of this app")
                             .1;
-                        let clone_id = app.get_disabled_clone_id(&clone_cell_id)?;
+                        let clone_id = app.get_clone_id(&clone_cell_id)?;
                         app.delete_clone_cell(&clone_id)?;
                         Ok((state, cell_id))
                     }

--- a/crates/holochain/tests/tests/regression/enable_clone_cell_by_dna_hash.rs
+++ b/crates/holochain/tests/tests/regression/enable_clone_cell_by_dna_hash.rs
@@ -1,0 +1,62 @@
+use holochain::sweettest::*;
+use holochain_types::prelude::*;
+use holochain_wasm_test_utils::TestWasm;
+
+/// Regression test for https://github.com/holochain/holochain/issues/4572
+///
+/// When calling EnableCloneCell with a DnaHash (instead of CloneId) on an already-enabled clone,
+/// the operation should succeed as a no-op, just as it does when called with a CloneId.
+///
+/// Previously, get_disabled_clone_id only searched disabled_clones when given a DnaHash,
+/// causing a CloneCellNotFound error when the clone was already enabled.
+#[tokio::test(flavor = "multi_thread")]
+async fn enable_clone_cell_by_dna_hash_on_active_clone() {
+    holochain_trace::test_run();
+
+    let mut conductor = SweetConductor::from_standard_config().await;
+
+    let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Clone]).await;
+
+    let app = conductor.setup_app("app", [&dna_file]).await.unwrap();
+    let (cell,) = app.clone().into_tuple();
+
+    let zome = SweetZome::new(
+        cell.cell_id().clone(),
+        TestWasm::Clone.coordinator_zome_name(),
+    );
+    // Create a clone cell
+    let request = CreateCloneCellInput {
+        cell_id: cell.cell_id().clone(),
+        modifiers: DnaModifiersOpt::none().with_network_seed("clone1".to_string()),
+        membrane_proof: None,
+        name: Some("clone1".to_string()),
+    };
+    let cloned_cell: ClonedCell = conductor.call(&zome, "create_clone", request).await;
+
+    let clone_dna_hash = cloned_cell.cell_id.dna_hash().clone();
+
+    // Now try to enable the already-enabled clone using its DnaHash (the bug scenario)
+    // This should succeed as a no-op, not return CloneCellNotFound
+    let request = EnableCloneCellInput {
+        clone_cell_id: CloneCellId::DnaHash(clone_dna_hash.clone()),
+    };
+    let _: ClonedCell = conductor.call(&zome, "enable_clone", request).await;
+
+    // Verify using CloneId also works on enabled clone (this already worked before the fix)
+    let request = EnableCloneCellInput {
+        clone_cell_id: CloneCellId::CloneId(cloned_cell.clone_id.clone()),
+    };
+    let _: ClonedCell = conductor.call(&zome, "enable_clone", request).await;
+
+    // Now test the same with a disabled clone
+    let request = DisableCloneCellInput {
+        clone_cell_id: CloneCellId::DnaHash(clone_dna_hash.clone()),
+    };
+    let _: () = conductor.call(&zome, "disable_clone", request).await;
+
+    // Re-enable using DnaHash should work
+    let request = EnableCloneCellInput {
+        clone_cell_id: CloneCellId::DnaHash(clone_dna_hash.clone()),
+    };
+    let _: ClonedCell = conductor.call(&zome, "enable_clone", request).await;
+}

--- a/crates/holochain/tests/tests/regression/mod.rs
+++ b/crates/holochain/tests/tests/regression/mod.rs
@@ -5,6 +5,7 @@ use holochain::{sweettest::*, test_utils::retry_fn_until_timeout};
 use holochain_wasm_test_utils::TestWasm;
 
 mod dht_location;
+mod enable_clone_cell_by_dna_hash;
 pub mod must_get_agent_activity_saturation;
 mod two_apps_same_dna_hash_different_coordinators;
 mod zome_call_atomic;


### PR DESCRIPTION
### Summary

Previously, the method get_disabled_clone_id() only searched disabled_clones when given a DnaHash, causing CloneCellNotFound errors when the clone was already enabled. This inconsistency meant that calling enable_clone_cell with a CloneId worked on active clones (no-op), but calling it with a DnaHash failed.

The method has been renamed to get_clone_id() and now searches both enabled and disabled clones when resolving a DnaHash to a CloneId. This makes the behavior consistent regardless of whether the caller uses a CloneId or DnaHash.

Added:
- Unit test in holochain_types verifying the method works for both enabled and disabled clones with both CloneId and DnaHash
- Regression test using sweettest to verify the full conductor API behavior

Fixes #4572

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enabling by DNA hash now behaves identically to enabling by clone ID for already-enabled clones (no spurious errors).

* **Breaking Changes**
  * Removed a public API method for looking up disabled clones; use the unified clone lookup instead.

* **Tests**
  * Added regression and unit tests covering enable/disable flows and lookup behavior for enabled and disabled clones.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->