### PR TITLE
ci: allow CI to pass when wasmer_wamr tests fail

### DIFF
--- a/.github/actions/common-test/action.yml
+++ b/.github/actions/common-test/action.yml
@@ -1,0 +1,92 @@
+name: 'Common Test Running Actions'
+
+inputs:
+  os:
+    required: true
+  target:
+    required: true
+  influx-token:
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    # we cannot use cmake 4 until openssl-src is updated
+    - name: cmake
+      uses: jwlawson/actions-setup-cmake@v2
+      with:
+        cmake-version: "3.31.x"
+
+    - name: llvm & clang
+      if: inputs.os == 'depot-windows-2022-8'
+      uses: KyleMayes/install-llvm-action@v2.0.8
+      with:
+        version: "21"
+
+    - name: build (depot-windows-2022-8)
+      if: inputs.os == 'depot-windows-2022-8'
+      shell: pwsh
+      run: |-
+        vcpkg install libsodium
+        $env:SODIUM_LIB_DIR="C:\vcpkg\packages\libsodium_x64-windows\lib"
+
+        make build-workspace-${{ inputs.target }}
+
+    - name: build
+      if: inputs.os != 'depot-windows-2022-8'
+      shell: bash
+      run: |
+        make build-workspace-${{ inputs.target }}
+
+    - name: install nextest
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-nextest@0.9.96
+
+    - name: test (depot-windows-2022-8)
+      if: inputs.os == 'depot-windows-2022-8'
+      id: test-windows
+      continue-on-error: true
+      shell: pwsh
+      run: |-
+        $env:SODIUM_LIB_DIR="C:\vcpkg\packages\libsodium_x64-windows\lib"
+        make test-workspace-${{ inputs.target }}
+
+    - name: test
+      if: inputs.os != 'depot-windows-2022-8'
+      id: test-unix
+      continue-on-error: true
+      shell: bash
+      run: make test-workspace-${{ inputs.target }}
+
+    - name: Upload test results to InfluxDB
+      if: always() && env.INFLUX_TOKEN != ''
+      continue-on-error: true
+      env:
+        INFLUX_TOKEN: ${{ inputs.influx-token }}
+      uses: holochain/junit-to-influx-action@v1.1.0
+      with:
+        junit-file: target/nextest/default/junit.xml
+        influx-url: https://ifdb.holochain.org
+        influx-org: holo
+        influx-bucket: holochain-test-results
+        influx-token: ${{ inputs.influx-token }}
+        runner-name: ${{ inputs.os }}
+        tags: >-
+          {
+            "run_id": "${{ github.run_id }}",
+            "test_target": "${{ inputs.target }}",
+            "branch": "${{ github.ref_name }}",
+            "commit": "${{ github.sha }}",
+            "workflow": "${{ github.workflow }}",
+            "pr_number": "${{ github.event.pull_request.number }}",
+            "actor": "${{ github.actor }}"
+          }
+
+    - name: Fail job if tests failed
+      if: always() && (steps.test-windows.outcome == 'failure' || steps.test-unix.outcome == 'failure')
+      shell: bash
+      run: exit 1
+
+    - name: "Common Test Teardown Actions"
+      uses: ./.github/actions/common-post

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  static-job-id:
+  static:
     name: static
     runs-on: ubuntu-latest
     steps:
@@ -50,8 +50,8 @@ jobs:
       - name: "Common Test Teardown Actions"
         uses: ./.github/actions/common-post
 
-  test-job-id:
-    name: test
+  test-wasmer_sys:
+    name: test (wasmer_sys)
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -67,11 +67,6 @@ jobs:
             target: wasmer_sys
           - os: ubuntu-latest
             target: wasmer_sys-unstable
-
-          # Our intended target for wasmer_wamr feature is iOS and Android.
-          # For now, wasmer_wamr tests are only run on macos-latest
-          - os: macos-latest
-            target: wasmer_wamr
     steps:
       - name: checkout
         uses: actions/checkout@v5
@@ -79,96 +74,52 @@ jobs:
       - name: "Common Test Setup Actions"
         uses: ./.github/actions/common-pre
 
-      # we cannot use cmake 4 until openssl-src is updated
-      - name: cmake
-        uses: jwlawson/actions-setup-cmake@v2
+      - name: "Common Test Actions"
+        uses: ./.github/actions/common-test
         with:
-          cmake-version: "3.31.x"
+          os: ${{ matrix.os }}
+          target: ${{ matrix.target }}
+          influx-token: ${{ secrets.INFLUX_TOKEN }}
 
+  # The `wasmer_wamr` tests are split out into a separate job so we can ignore its failures in the `ci-pass` job.
+  # This allows the workflow to pass, while still showing the `test-wasmer_wamr` job as failed in the UI.
+  test-wasmer_wamr:
+    name: test (wasmer_wamr)
+    # Our intended target for wasmer_wamr feature is iOS and Android.
+    # For now, wasmer_wamr tests are only run on macos-latest
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+
+      - name: "Common Test Setup Actions"
+        uses: ./.github/actions/common-pre
+        
       - name: install build dependencies (macos-latest, wasmer_wamr)
-        if: matrix.os == 'macos-latest' && matrix.target == 'wasmer_wamr'
         run: |
           brew install llvm
           echo "PATH=/opt/homebrew/opt/llvm/bin:$PATH" >> "$GITHUB_ENV"
-        
-      - name: llvm & clang
-        if: matrix.os == 'depot-windows-2022-8'
-        uses: KyleMayes/install-llvm-action@v2.0.8
+
+      - name: "Common Test Actions"
+        uses: ./.github/actions/common-test
         with:
-          version: "21"
-
-      - name: build (depot-windows-2022-8)
-        if: matrix.os == 'depot-windows-2022-8'
-        run: |-
-          vcpkg install libsodium
-          $env:SODIUM_LIB_DIR="C:\vcpkg\packages\libsodium_x64-windows\lib"
-
-          make build-workspace-${{ matrix.target }}
-
-      - name: build
-        if: matrix.os != 'depot-windows-2022-8'
-        run: |
-          make build-workspace-${{ matrix.target }}
-
-      - name: install nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest@0.9.96
-
-      - name: test (depot-windows-2022-8)
-        if: matrix.os == 'depot-windows-2022-8'
-        id: test-windows
-        continue-on-error: true
-        run: |-
-          $env:SODIUM_LIB_DIR="C:\vcpkg\packages\libsodium_x64-windows\lib"
-          make test-workspace-${{ matrix.target }}
-
-      - name: test
-        if: matrix.os != 'depot-windows-2022-8'
-        id: test-unix
-        continue-on-error: true
-        run: make test-workspace-${{ matrix.target }}
-
-      - name: Upload test results to InfluxDB
-        if: always() && env.INFLUX_TOKEN != ''
-        continue-on-error: true
-        env:
-          INFLUX_TOKEN: ${{ secrets.INFLUX_TOKEN }}
-        uses: holochain/junit-to-influx-action@v1.1.0
-        with:
-          junit-file: target/nextest/default/junit.xml
-          influx-url: https://ifdb.holochain.org
-          influx-org: holo
-          influx-bucket: holochain-test-results
+          os: "macos-latest"
+          target: "wasmer_wamr"
           influx-token: ${{ secrets.INFLUX_TOKEN }}
-          runner-name: ${{ matrix.os }}
-          tags: >-
-            {
-              "run_id": "${{ github.run_id }}",
-              "test_target": "${{ matrix.target }}",
-              "branch": "${{ github.ref_name }}",
-              "commit": "${{ github.sha }}",
-              "workflow": "${{ github.workflow }}",
-              "pr_number": "${{ github.event.pull_request.number }}",
-              "actor": "${{ github.actor }}"
-            }
-
-      - name: Fail job if tests failed
-        if: always() && (steps.test-windows.outcome == 'failure' || steps.test-unix.outcome == 'failure')
-        run: exit 1
-
-      - name: "Common Test Teardown Actions"
-        uses: ./.github/actions/common-post
 
   ci-pass:
     if: ${{ always() }}
     name: "All Jobs Pass"
     runs-on: "ubuntu-latest"
     needs:
-      - static-job-id
-      - test-job-id
+      - static
+      - test-wasmer_sys
+      - test-wasmer_wamr
     steps:
       - name: check status
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+          allowed-failures: test-wasmer_wamr

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- CI: Allow test workflow to pass when tests of the feature `wasmer_wamr` fail. WAMR is not actively used, so investigating flaky tests on WAMR is not a priority. \#5523
 - Docs: Outline process for updating all Holochain tooling in an issue template. \#5472.
 - CI: Run windows test workflow on Depot.dev runners for improved performance. \#5473
 - **BREAKING CHANGE** Refactor: The `ConductorConfig` field `request_timeout_s` has moved into the `NetworkConfig`, so is now available at the sub-field `network.request_timeout_s`.


### PR DESCRIPTION
### Summary
Resolves #5512 

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow restructured: tests split into separate jobs for two runtimes, test jobs renamed, main job focused on the primary runtime, unified common test actions replaced per-target steps, job dependencies updated, and one runtime marked allowed-to-fail.
  * Added a reusable composite action to standardize cross-platform build, test, result upload, and teardown.

* **Documentation**
  * Changelog updated to note the new CI/test workflow and the allowed-failure test target.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->