### PR TITLE
test: Improve flaky test `warrant_is_published`

### DIFF
--- a/crates/holochain/tests/tests/publish/mod.rs
+++ b/crates/holochain/tests/tests/publish/mod.rs
@@ -147,11 +147,13 @@ async fn warrant_is_published() {
     );
     let dna_hash = dna_without_validation.dna_hash();
 
-    let config = SweetConductorConfig::rendezvous(true);
+    let config = SweetConductorConfig::rendezvous(true)
+        .tune_conductor(|cc| cc.publish_trigger_interval = Some(Duration::from_secs(2)));
     // Disable warrants on Carol's conductor, so that she doesn't issue warrants herself
     // but receives them from Bob.
-    let config_no_warranting = SweetConductorConfig::rendezvous(true)
-        .tune_conductor(|tc| tc.disable_warrant_issuance = true);
+    let config_no_warranting = SweetConductorConfig::rendezvous(true).tune_conductor(|tc| {
+        tc.disable_warrant_issuance = true;
+    });
     let mut conductors = SweetConductorBatch::from_configs_rendezvous([
         config.clone(),
         config,


### PR DESCRIPTION
### Summary

The test was different to some other warrant publish tests because it didn't configure the publish trigger interval. This can lead to a long wait for the warrant to be published.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Tuned publish trigger intervals to 2 seconds across warrant-related test configurations.
  * Ensured configurations that disable warrant issuance also use the 2s trigger interval.
  * Updated multi-conductor test setup to apply the new trigger timing for consistent and faster publish checks across instances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->