### PR TITLE
docs: Better documentation for TypedPath::ensure

### DIFF
--- a/crates/hdk/src/hash_path/path.rs
+++ b/crates/hdk/src/hash_path/path.rs
@@ -101,9 +101,17 @@ impl HdkPathExt for TypedPath {
     ///
     /// # Notes
     ///
-    /// This function does **not** create entries; it only creates links between
-    /// already-existing path entries. It assumes that the entry corresponding to
-    /// this path can be resolved to a hash via [`Path::path_entry_hash`].
+    /// This function does **not** create entries; it only creates links at
+    /// deterministic path hashes.
+    ///
+    /// `Path` operates on so-called *ghost entries*: no entry is ever written to
+    /// the DHT for a path itself. Instead, the hash that *would* correspond to a
+    /// path entry is deterministically derived and used as the base or target
+    /// address for links.
+    ///
+    /// In other words, [`Path::path_entry_hash`] does not require a prior
+    /// entry create; it computes a stable hash that is used purely as a link
+    /// anchor in the DHT.
     ///
     /// The operation is idempotent: calling [`Self::ensure`] multiple times for the same
     /// path will not create duplicate links, given that [`Self::exists`] correctly


### PR DESCRIPTION
## Summary

Better docs for `TypedPath::ensure`

closes #2401

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded documentation for path initialization and the ensure behavior: details recursive creation of missing parents for non-root paths, distinct root vs non-root link semantics, idempotent no-op when a path already exists, explicit error conditions, and "ghost-entry" guidance clarifying that only links are created (no entries written) and that a deterministic link anchor is used. Public API signatures unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->