### PR TITLE
test: Remove uses of `.keep()` that leave data in `/tmp/` after test runs

### DIFF
--- a/crates/holochain_sqlite/tests/tests/db_wrapper.rs
+++ b/crates/holochain_sqlite/tests/tests/db_wrapper.rs
@@ -15,7 +15,7 @@ async fn async_read_respects_reader_permit_limits() {
     set_connection_timeout(300);
 
     let tmp_dir = tempfile::TempDir::new().unwrap();
-    let db_handle = DbWrite::test(&tmp_dir.keep(), TestDatabaseKind::new()).unwrap();
+    let db_handle = DbWrite::test(tmp_dir.path(), TestDatabaseKind::new()).unwrap();
 
     let num_readers = num_read_threads();
 
@@ -87,7 +87,7 @@ async fn get_read_txn_respects_reader_permit_limits() {
     set_connection_timeout(300);
 
     let tmp_dir = tempfile::TempDir::new().unwrap();
-    let db_handle = DbWrite::test(&tmp_dir.keep(), TestDatabaseKind::new()).unwrap();
+    let db_handle = DbWrite::test(tmp_dir.path(), TestDatabaseKind::new()).unwrap();
 
     let num_readers = num_read_threads();
 
@@ -158,7 +158,7 @@ async fn read_async_releases_permits() {
     set_connection_timeout(300);
 
     let tmp_dir = tempfile::TempDir::new().unwrap();
-    let db_handle = DbWrite::test(&tmp_dir.keep(), TestDatabaseKind::new()).unwrap();
+    let db_handle = DbWrite::test(tmp_dir.path(), TestDatabaseKind::new()).unwrap();
 
     let num_readers = num_read_threads();
 
@@ -189,7 +189,7 @@ async fn write_permits_can_be_released() {
     set_connection_timeout(300);
 
     let tmp_dir = tempfile::TempDir::new().unwrap();
-    let db_handle = DbWrite::test(&tmp_dir.keep(), TestDatabaseKind::new()).unwrap();
+    let db_handle = DbWrite::test(tmp_dir.path(), TestDatabaseKind::new()).unwrap();
 
     let ran_count = Arc::new(AtomicUsize::new(0));
     for _ in 0..3 {


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved temporary-directory lifecycle handling across test restarts to preserve environment and increase stability.
  * Updated test helpers to use filesystem paths for database/test-directory setup instead of transient temporary handles, simplifying ownership and resource management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->