### PR TITLE
chore: clean up chrono TODO FIXME comments in hc_client

### DIFF
--- a/crates/hc_client/src/calls.rs
+++ b/crates/hc_client/src/calls.rs
@@ -5,7 +5,7 @@
 //! connections in tooling.
 
 use anyhow::anyhow;
-use chrono::{DateTime, Duration, NaiveDateTime, Utc};
+use chrono::{DateTime, Utc};
 use clap::{Args, Parser, Subcommand};
 use holo_hash::{ActionHash, AgentPubKeyB64, DnaHashB64};
 use holochain_client::AdminWebsocket;
@@ -466,20 +466,10 @@ async fn call_inner(client: &mut AdminWebsocket, call: AdminRequestCli) -> anyho
             for info in agent_infos {
                 let this_agent = agents.iter().find(|a| info.agent == a.1);
                 let this_dna = dnas.iter().find(|d| info.space == d.1).unwrap();
-                let duration = Duration::try_milliseconds(info.created_at.as_micros() / 1000)
-                    .ok_or_else(|| anyhow!("Agent info timestamp out of range"))?;
-                let s = duration.num_seconds();
-                let n = duration.clone().to_std().unwrap().subsec_nanos();
-                // TODO FIXME
-                #[allow(deprecated)]
-                let dt = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(s, n), Utc);
-                let duration = Duration::try_milliseconds(info.expires_at.as_micros() / 1000)
-                    .ok_or_else(|| anyhow!("Agent info timestamp out of range"))?;
-                let s = duration.num_seconds();
-                let n = duration.clone().to_std().unwrap().subsec_nanos();
-                // TODO FIXME
-                #[allow(deprecated)]
-                let exp = DateTime::<Utc>::from_utc(NaiveDateTime::from_timestamp(s, n), Utc);
+                let dt = DateTime::from_timestamp_micros(info.created_at.as_micros())
+                    .ok_or_else(|| anyhow!("Agent info created_at timestamp out of range"))?;
+                let exp = DateTime::from_timestamp_micros(info.expires_at.as_micros())
+                    .ok_or_else(|| anyhow!("Agent info expires_at timestamp out of range"))?;
 
                 out.push(AgentResponse {
                     agent_pub_key: this_agent.map(|a| a.0.clone().into()),


### PR DESCRIPTION
### Summary

Replace deprecated chrono methods with modern alternatives:
- Remove use of deprecated `DateTime::from_utc` and `NaiveDateTime::from_timestamp`
- Use `DateTime::from_timestamp_micros` directly since AgentInfoSigned stores microseconds
- Remove unnecessary Duration conversions and unused imports
- Clean up error messages to be more specific

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error messages for timestamp fields so out-of-range inputs are reported more clearly.

* **Chores**
  * Internal refactor of timestamp conversion to a more robust, direct conversion method (no public API changes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->