### PR TITLE
refactor!: await_consistency now hard-coded to 60s timeout. await_conistency_s allows this to be overriden

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- **BREAKING CHANGE** Test utility `await_consistency` has been renamed to `await_consistency_s`. The function `await_consistency` now has a hard-coded 60 second timeout and should always be used by default to reduce test flakiness.
 - Set default iroh relay server to `dev-test-bootstrap2-iroh-relay.holochain.org`.
 - Run test workflow for all platforms with iroh transport. One job to test tx5 on Ubuntu is kept in the workflow.
 - **BREAKING CHANGE**: Completely removed `block_agent` and `unblock_agent` host and HDK functions from Holochain. Blocking is a system-level behavior, triggered by warrants, not application-level logic. Any WASM that references these host functions will fail to instantiate. Applications must be recompiled without calls to these functions. [#5518]

--- a/crates/holochain/benches/consistency.rs
+++ b/crates/holochain/benches/consistency.rs
@@ -36,7 +36,7 @@ fn consistency(bench: &mut Criterion) {
             producer.fill(num_ops).await;
             let mut cells = vec![&consumer.cell, &producer.cell];
             cells.extend(others.cells.iter());
-            await_consistency(50, cells).await.unwrap();
+            await_consistency(cells).await.unwrap();
             // holochain_state::prelude::dump_tmp(consumer.cell.env());
         });
     }
@@ -131,7 +131,7 @@ impl Consumer {
             num = hashes.0.len();
             if start.elapsed().as_secs() > 1 {
                 for cell in cells {
-                    await_consistency(1, [cell]).await.unwrap();
+                    await_consistency_s(1, [cell]).await.unwrap();
                 }
             }
             // dump_tmp(self.cell.env());

--- a/crates/holochain/src/conductor/cell/gossip_test.rs
+++ b/crates/holochain/src/conductor/cell/gossip_test.rs
@@ -21,7 +21,7 @@ async fn gossip_test() {
         .call(&cell_1.zome(TestWasm::Anchor), "anchor", anchor)
         .await;
 
-    await_consistency(30, [&cell_1, &cell_2]).await.unwrap();
+    await_consistency([&cell_1, &cell_2]).await.unwrap();
 
     let hashes: EntryHashes = conductors[1]
         .call(

--- a/crates/holochain/src/conductor/conductor/tests/cells_with_conflicting_overrides.rs
+++ b/crates/holochain/src/conductor/conductor/tests/cells_with_conflicting_overrides.rs
@@ -79,8 +79,7 @@ async fn should_not_allow_installing_apps_with_same_dna_but_different_overrides(
             err,
             ConductorError::InternalCellError(CellError::P2pConfigOverridesConflict { .. })
         ),
-        "expected P2pConfigOverridesConflict error, got {:?}",
-        err
+        "expected P2pConfigOverridesConflict error, got {err:?}",
     );
 }
 

--- a/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
@@ -747,7 +747,7 @@ pub mod wasm_test {
             )
             .await;
 
-        await_consistency(60, [&alice_cell, &bob_cell, &witness_cell])
+        await_consistency([&alice_cell, &bob_cell, &witness_cell])
             .await
             .unwrap();
 
@@ -1022,7 +1022,7 @@ pub mod wasm_test {
             )
             .await;
 
-        await_consistency(10, [&alice_cell, &bob_cell])
+        await_consistency([&alice_cell, &bob_cell])
             .await
             .unwrap();
 
@@ -1183,7 +1183,7 @@ pub mod wasm_test {
             )
             .await;
 
-        await_consistency(10, [&alice_cell, &bob_cell])
+        await_consistency([&alice_cell, &bob_cell])
             .await
             .unwrap();
 
@@ -1254,7 +1254,7 @@ pub mod wasm_test {
 
         // NON ENZYMATIC
         {
-            await_consistency(10, [&alice_cell, &bob_cell, &carol_cell])
+            await_consistency([&alice_cell, &bob_cell, &carol_cell])
                 .await
                 .unwrap();
 
@@ -1326,7 +1326,7 @@ pub mod wasm_test {
                     unreachable!();
                 };
 
-            await_consistency(10, [&alice_cell, &bob_cell, &carol_cell])
+            await_consistency([&alice_cell, &bob_cell, &carol_cell])
                 .await
                 .unwrap();
 
@@ -1348,7 +1348,7 @@ pub mod wasm_test {
                 )
                 .await;
 
-            await_consistency(10, [&alice_cell, &bob_cell, &carol_cell])
+            await_consistency( [&alice_cell, &bob_cell, &carol_cell])
                 .await
                 .unwrap();
 

--- a/crates/holochain/src/core/ribosome/host_fn/get_links.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/get_links.rs
@@ -368,7 +368,7 @@ pub mod slow_tests {
             .call(&bob, "create_tagged_link", "b.a".to_string())
             .await;
 
-        await_consistency(30, [&alice_cell, &bob_cell])
+        await_consistency([&alice_cell, &bob_cell])
             .await
             .unwrap();
 
@@ -476,7 +476,7 @@ pub mod slow_tests {
             .call(&bob, "create_tagged_link", "d".to_string())
             .await;
 
-        await_consistency(30, [&alice_cell, &bob_cell])
+        await_consistency([&alice_cell, &bob_cell])
             .await
             .unwrap();
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -552,7 +552,7 @@ async fn multi_create_link_validation() {
         .call(&alice_zome, "create_post", post.clone())
         .await;
 
-    await_consistency(Duration::from_secs(20), [&alice, &bobbo])
+    await_consistency([&alice, &bobbo])
         .await
         .expect("Timed out waiting for consistency");
 
@@ -805,7 +805,7 @@ async fn test_private_entries_are_passed_to_validation_only_when_authored_with_f
         .call(&alice.zome("coordinator"), "create", ())
         .await;
 
-    await_consistency(30, [&alice, &bob]).await.unwrap();
+    await_consistency([&alice, &bob]).await.unwrap();
 
     {
         let vfs = validation_failures.lock();
@@ -1168,7 +1168,7 @@ async fn app_validation_produces_warrants() {
 
     conductors.exchange_peer_info().await;
 
-    await_consistency(15, [&alice, &bob, &carol]).await.unwrap();
+    await_consistency([&alice, &bob, &carol]).await.unwrap();
 
     conductors[2].shutdown().await;
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/validation_tests.rs
@@ -379,7 +379,7 @@ async fn app_validation_ops() {
         .call(&alice.zome("zome1"), "create_a", ())
         .await;
 
-    await_consistency(15, [&alice, &bob]).await.unwrap();
+    await_consistency([&alice, &bob]).await.unwrap();
 
     let mut expected = Expected(HashSet::new());
 

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/chain_test.rs
@@ -41,5 +41,5 @@ async fn sys_validation_agent_activity_test() {
     assert_eq!(changed, 2);
 
     conductors.exchange_peer_info().await;
-    await_consistency(15, [&cell_1, &cell_2]).await.unwrap();
+    await_consistency([&cell_1, &cell_2]).await.unwrap();
 }

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -164,7 +164,7 @@ async fn sys_validation_produces_forked_chain_warrant() {
         .test_write(move |txn| detect_fork(txn, &action).unwrap());
     assert!(maybe_fork.is_some());
 
-    await_consistency(30, [&alice, &bob]).await.unwrap();
+    await_consistency([&alice, &bob]).await.unwrap();
 
     //- Inject the forked op directly into bob's DHT db
     let forked_op = DhtOpHashed::from_content_sync(forked_op);

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/tests.rs
@@ -26,9 +26,7 @@ async fn test_validation_receipt() {
         .call(&alice.zome("simple"), "create", ())
         .await;
 
-    await_consistency(15, [&alice, &bobbo, &carol])
-        .await
-        .unwrap();
+    await_consistency([&alice, &bobbo, &carol]).await.unwrap();
 
     // Get op hashes
     let vault = alice.dht_db();

--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -24,7 +24,7 @@ async fn conductors_call_remote(num_conductors: usize) {
         .map(|c| c.into_cells().into_iter().next().unwrap())
         .collect();
 
-    await_consistency(30, cells.iter()).await.unwrap();
+    await_consistency(cells.iter()).await.unwrap();
 
     let agents: Vec<_> = cells.iter().map(|c| c.agent_pubkey().clone()).collect();
 
@@ -56,5 +56,5 @@ async fn conductors_call_remote(num_conductors: usize) {
         .await;
 
     // Ensure that all the create requests were received and published.
-    await_consistency(60, cells.iter()).await.unwrap();
+    await_consistency(cells.iter()).await.unwrap();
 }

--- a/crates/holochain/src/sweettest/sweet_consistency.rs
+++ b/crates/holochain/src/sweettest/sweet_consistency.rs
@@ -27,16 +27,26 @@ impl DurationOrSeconds {
     }
 }
 
-/// Wait 20 s for all cells to reach consistency.
-pub async fn await_consistency_20_s<'a, I: IntoIterator<Item = &'a SweetCell>>(
+/// Wait 60s for all cells to reach consistency.
+///
+/// This should be used as the default, unless your test case specifically requires a longer duration,
+/// or requires immediate consistency
+pub async fn await_consistency<'a, I: IntoIterator<Item = &'a SweetCell>>(
     cells: I,
 ) -> Result<(), String> {
-    await_consistency(20, cells).await
+    await_consistency_s(60, cells).await
+}
+
+/// Check cell consistency.
+pub async fn check_consistency<'a, I: IntoIterator<Item = &'a SweetCell>>(
+    cells: I,
+) -> Result<(), String> {
+    await_consistency_s(Duration::ZERO, cells).await
 }
 
 /// Wait for all cells to reach consistency
 #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
-pub async fn await_consistency<'a, I: IntoIterator<Item = &'a SweetCell>>(
+pub async fn await_consistency_s<'a, I: IntoIterator<Item = &'a SweetCell>>(
     timeout: impl Into<DurationOrSeconds>,
     cells: I,
 ) -> Result<(), String> {
@@ -188,7 +198,7 @@ async fn await_op_integration(
 mod tests {
     use crate::{
         prelude::holochain_serial,
-        sweettest::{await_consistency, SweetConductorBatch, SweetDnaFile},
+        sweettest::{await_consistency, check_consistency, SweetConductorBatch, SweetDnaFile},
         test_utils::retry_fn_until_timeout,
     };
     use ::fixt::fixt;
@@ -207,7 +217,6 @@ mod tests {
         Entry,
     };
     use serde::{Deserialize, Serialize};
-    use std::time::Duration;
 
     #[tokio::test(flavor = "multi_thread")]
     #[ignore = "flaky under current networking; re-check after Iroh upgrade"]
@@ -245,7 +254,7 @@ mod tests {
             .unwrap()
             .into_tuples();
 
-        await_consistency(15, &[alice.clone(), bob.clone()])
+        await_consistency(&[alice.clone(), bob.clone()])
             .await
             .unwrap();
 
@@ -257,7 +266,7 @@ mod tests {
             .call::<_, ()>(&bob.zome("integrity"), "make_some_noise", ())
             .await;
 
-        await_consistency(5, &[alice, bob]).await.unwrap();
+        await_consistency(&[alice, bob]).await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -274,7 +283,7 @@ mod tests {
             .unwrap()
             .into_tuples();
 
-        await_consistency(15, &[alice.clone(), bob.clone()])
+        await_consistency(&[alice.clone(), bob.clone()])
             .await
             .unwrap();
 
@@ -294,7 +303,7 @@ mod tests {
             )
             .await;
 
-        await_consistency(5, &[alice, bob]).await.unwrap();
+        await_consistency(&[alice, bob]).await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -339,9 +348,7 @@ mod tests {
         .unwrap();
 
         // Genesis actions will be integrated but not gossiped. Consistency cannot be reached.
-        await_consistency(Duration::from_micros(1), &[alice, bob])
-            .await
-            .unwrap_err();
+        await_consistency(&[alice, bob]).await.unwrap_err();
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -360,7 +367,7 @@ mod tests {
             .unwrap()
             .into_tuples();
 
-        await_consistency(40, &[alice.clone(), bob.clone()])
+        await_consistency(&[alice.clone(), bob.clone()])
             .await
             .unwrap();
 
@@ -373,8 +380,6 @@ mod tests {
             .unwrap();
 
         // Unintegrated op will prevent consistency.
-        await_consistency(Duration::from_micros(1), &[alice, bob])
-            .await
-            .unwrap_err();
+        check_consistency(&[alice, bob]).await.unwrap_err();
     }
 }

--- a/crates/holochain/tests/tests/agent_activity.rs
+++ b/crates/holochain/tests/tests/agent_activity.rs
@@ -1,5 +1,5 @@
 use holo_hash::ActionHash;
-use holochain::sweettest::{await_consistency, SweetConductorBatch, SweetDnaFile};
+use holochain::sweettest::{await_consistency_s, SweetConductorBatch, SweetDnaFile};
 use holochain_wasm_test_utils::TestWasm;
 use holochain_zome_types::prelude::AgentActivity;
 use holochain_zome_types::query::ChainStatus;
@@ -42,7 +42,7 @@ async fn get_agent_activity() {
 
     // TODO No way to force a network call to get the agent activity, so we have to wait for a sync
     //      first and then check the agent activity
-    await_consistency(std::time::Duration::from_secs(60), [alice_cell, bob_cell])
+    await_consistency_s(std::time::Duration::from_secs(60), [alice_cell, bob_cell])
         .await
         .unwrap();
 

--- a/crates/holochain/tests/tests/agent_scaling/mod.rs
+++ b/crates/holochain/tests/tests/agent_scaling/mod.rs
@@ -59,7 +59,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
     let alice = cells[0].zome("links");
 
     // Must have integrated or be able to get the agent key to link from it
-    await_consistency(15, &cells[..]).await.unwrap();
+    await_consistency(&cells[..]).await.unwrap();
 
     let base: AnyLinkableHash = cells[0].agent_pubkey().clone().into();
     let target: AnyLinkableHash = cells[1].agent_pubkey().clone().into();
@@ -72,7 +72,7 @@ async fn many_agents_can_reach_consistency_agent_links() {
         )
         .await;
 
-    await_consistency(15, &cells[..]).await.unwrap();
+    await_consistency(&cells[..]).await.unwrap();
 
     let mut seen = [0usize; NUM_AGENTS];
 
@@ -108,7 +108,7 @@ async fn many_agents_can_reach_consistency_normal_links() {
 
     let _: ActionHash = conductor.call(&alice, "create_link", ()).await;
 
-    await_consistency(15, &cells[..]).await.unwrap();
+    await_consistency(&cells[..]).await.unwrap();
 
     let mut num_seen = 0;
 

--- a/crates/holochain/tests/tests/countersigning.rs
+++ b/crates/holochain/tests/tests/countersigning.rs
@@ -59,7 +59,7 @@ async fn listen_for_countersigning_completion() {
         .await
         .unwrap();
 
-    await_consistency(30, vec![alice, bob, &cells[2]])
+    await_consistency(vec![alice, bob, &cells[2]])
         .await
         .unwrap();
 
@@ -387,9 +387,7 @@ async fn alice_can_recover_when_bob_abandons_a_countersigning_session() {
         .await
         .unwrap();
 
-    await_consistency(30, vec![alice, bob, carol])
-        .await
-        .unwrap();
+    await_consistency(vec![alice, bob, carol]).await.unwrap();
 
     // Set up the session and accept it for both agents
     let preflight_request: PreflightRequest = conductors[0]
@@ -456,7 +454,7 @@ async fn alice_can_recover_when_bob_abandons_a_countersigning_session() {
         .unwrap();
 
     // Everyone's DHT should sync
-    await_consistency(60, [alice, bob, carol]).await.unwrap();
+    await_consistency([alice, bob, carol]).await.unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -500,9 +498,7 @@ async fn alice_can_recover_from_a_session_timeout() {
         .await
         .unwrap();
 
-    await_consistency(30, vec![alice, bob, carol])
-        .await
-        .unwrap();
+    await_consistency(vec![alice, bob, carol]).await.unwrap();
 
     // Set up the session and accept it for both agents
     let preflight_request: PreflightRequest = conductors[0]
@@ -601,7 +597,7 @@ async fn alice_can_recover_from_a_session_timeout() {
         .unwrap();
 
     // Everyone's DHT should sync
-    await_consistency(60, [alice, bob, carol]).await.unwrap();
+    await_consistency([alice, bob, carol]).await.unwrap();
 }
 
 #[cfg(feature = "chc")]
@@ -648,7 +644,7 @@ async fn complete_session_with_chc_enabled() {
         .await
         .unwrap();
 
-    await_consistency(60, vec![alice, bob, &cells[2]])
+    await_consistency(vec![alice, bob, &cells[2]])
         .await
         .unwrap();
 
@@ -774,7 +770,7 @@ async fn session_rollback_with_chc_enabled() {
         .await
         .unwrap();
 
-    await_consistency(30, vec![alice, bob]).await.unwrap();
+    await_consistency(vec![alice, bob]).await.unwrap();
 
     // Set up the session and accept it for both agents
     let preflight_request: PreflightRequest = conductors[0]
@@ -856,7 +852,7 @@ async fn session_rollback_with_chc_enabled() {
     assert_eq!(before_chain.len() + 1, future_chain.len());
 
     // Everyone's DHT should sync
-    await_consistency(60, [alice, bob]).await.unwrap();
+    await_consistency([alice, bob]).await.unwrap();
 }
 
 #[cfg(feature = "chc")]
@@ -920,7 +916,7 @@ async fn multiple_agents_on_same_conductor_with_chc_enabled() {
         .await
         .unwrap();
 
-    await_consistency(60, vec![alice, bob, &cells[2], carol])
+    await_consistency(vec![alice, bob, &cells[2], carol])
         .await
         .unwrap();
 
@@ -1000,7 +996,7 @@ async fn multiple_agents_on_same_conductor_with_chc_enabled() {
     // Should appear in the CHC after publish
     assert_eq!(before_chain.len() + 1, after_chain.len());
 
-    await_consistency(30, vec![alice, bob, &cells[2], carol])
+    await_consistency(vec![alice, bob, &cells[2], carol])
         .await
         .unwrap();
 
@@ -1125,7 +1121,7 @@ async fn chc_should_respect_chain_lock() {
         .await
         .unwrap();
 
-    await_consistency(30, vec![alice, bob, &cells[2]])
+    await_consistency(vec![alice, bob, &cells[2]])
         .await
         .unwrap();
 
@@ -1244,7 +1240,7 @@ async fn should_be_able_to_schedule_functions_during_session() {
         .await
         .unwrap();
 
-    await_consistency(30, vec![alice, bob]).await.unwrap();
+    await_consistency(vec![alice, bob]).await.unwrap();
 
     // Set up the session and accept it for both agents
     let preflight_request: PreflightRequest = conductors[0]
@@ -1359,7 +1355,7 @@ async fn alice_can_force_abandon_session_when_automatic_resolution_has_failed_af
         .await;
     conductors.exchange_peer_info().await;
 
-    await_consistency(30, vec![alice, bob]).await.unwrap();
+    await_consistency(vec![alice, bob]).await.unwrap();
 
     // Need authority logic to work, so force setting full arcs.
     conductors[0]
@@ -1538,7 +1534,7 @@ async fn alice_can_force_publish_session_when_automatic_resolution_has_failed_af
         .await
         .unwrap();
 
-    await_consistency(30, vec![alice, bob]).await.unwrap();
+    await_consistency(vec![alice, bob]).await.unwrap();
 
     // Set up the session and accept it for both agents.
     let preflight_request: PreflightRequest = conductors[0]

--- a/crates/holochain/tests/tests/gossip/mod.rs
+++ b/crates/holochain/tests/tests/gossip/mod.rs
@@ -88,7 +88,7 @@ async fn gossip_resumes_after_restart() {
     conductors.exchange_peer_info().await;
 
     // Ensure that gossip loops resume upon startup.
-    await_consistency(30, [&cell_0, &cell_1]).await.unwrap();
+    await_consistency([&cell_0, &cell_1]).await.unwrap();
     let record: Option<Record> = conductors[1].call(&zome_1, "read", hash.clone()).await;
     assert_eq!(record.unwrap().action_address(), &hash);
 }
@@ -116,7 +116,7 @@ async fn new_conductor_reaches_consistency_with_existing_conductor() {
     // Startup and do peer discovery
     let (conductor1, cell1, zome1) = mk_conductor().await;
 
-    await_consistency(60, [&cell0, &cell1]).await.unwrap();
+    await_consistency([&cell0, &cell1]).await.unwrap();
     let record: Option<Record> = conductor1.call(&zome1, "read", hash.clone()).await;
     assert_eq!(record.unwrap().action_address(), &hash);
 }

--- a/crates/holochain/tests/tests/inline_zome_spec/mod.rs
+++ b/crates/holochain/tests/tests/inline_zome_spec/mod.rs
@@ -38,7 +38,7 @@ async fn inline_zome_2_agents_1_dna() -> anyhow::Result<()> {
         )
         .await;
 
-    await_consistency(15, [&alice, &bobbo]).await.unwrap();
+    await_consistency([&alice, &bobbo]).await.unwrap();
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let records: Option<Record> = conductor
@@ -100,10 +100,10 @@ async fn inline_zome_3_agents_2_dnas() -> anyhow::Result<()> {
     assert_ne!(hash_foo, hash_bar);
 
     // Wait long enough for others to receive gossip
-    await_consistency(15, [&alice_foo, &bobbo_foo, &carol_foo])
+    await_consistency([&alice_foo, &bobbo_foo, &carol_foo])
         .await
         .unwrap();
-    await_consistency(15, [&alice_bar, &bobbo_bar, &carol_bar])
+    await_consistency([&alice_bar, &bobbo_bar, &carol_bar])
         .await
         .unwrap();
 
@@ -172,7 +172,7 @@ async fn get_deleted() -> anyhow::Result<()> {
         )
         .await;
 
-    await_consistency(15, [&alice]).await.unwrap();
+    await_consistency([&alice]).await.unwrap();
 
     let records: Option<Record> = conductor
         .call(
@@ -198,7 +198,7 @@ async fn get_deleted() -> anyhow::Result<()> {
         )
         .await;
 
-    await_consistency(15, [&alice]).await.unwrap();
+    await_consistency([&alice]).await.unwrap();
 
     let records: Vec<Option<Record>> = conductor
         .call(

--- a/crates/holochain/tests/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/tests/multi_conductor/mod.rs
@@ -103,9 +103,7 @@ async fn multi_conductor() -> anyhow::Result<()> {
         .await;
 
     // Wait long enough for Bob to receive gossip
-    await_consistency(20, [&alice, &bobbo, &carol])
-        .await
-        .unwrap();
+    await_consistency([&alice, &bobbo, &carol]).await.unwrap();
 
     // Verify that bobbo can run "read" on his cell and get alice's Action
     let record: Option<Record> = conductors[1]
@@ -167,14 +165,14 @@ async fn private_entries_update_consistency() {
     let apps = conductors.setup_app("app", &dnas).await.unwrap();
     let ((alice,), (bobbo,)) = apps.into_tuples();
 
-    await_consistency(20, [&alice, &bobbo]).await.unwrap();
+    await_consistency([&alice, &bobbo]).await.unwrap();
 
     // Call the "create" zome fn on Alice's app
     let hash: ActionHash = conductors[0]
         .call(&alice.zome(SweetInlineZomes::COORDINATOR), "create", ())
         .await;
 
-    await_consistency(15, [&alice, &bobbo]).await.unwrap();
+    await_consistency([&alice, &bobbo]).await.unwrap();
 
     // Call the "update" zome fn on Alice's app to update the previously created private entry
     let _: ActionHash = conductors[0]
@@ -182,7 +180,7 @@ async fn private_entries_update_consistency() {
         .await;
 
     // Make sure that the update of the private entry reaches consistency
-    await_consistency(15, [&alice, &bobbo]).await.unwrap();
+    await_consistency([&alice, &bobbo]).await.unwrap();
 }
 
 /// Flaky on Windows separately from the pending fixes alongside Iroh networking upgrade.
@@ -228,14 +226,14 @@ async fn private_entries_dont_leak() {
     let apps = conductors.setup_app("app", &dnas).await.unwrap();
     let ((alice,), (bobbo,)) = apps.into_tuples();
 
-    await_consistency(20, [&alice, &bobbo]).await.unwrap();
+    await_consistency([&alice, &bobbo]).await.unwrap();
 
     // Call the "create" zome fn on Alice's app
     let hash: ActionHash = conductors[0]
         .call(&alice.zome(SweetInlineZomes::COORDINATOR), "create", ())
         .await;
 
-    await_consistency(15, [&alice, &bobbo]).await.unwrap();
+    await_consistency([&alice, &bobbo]).await.unwrap();
 
     let entry_hash =
         EntryHash::with_data_sync(&Entry::app(PrivateEntry {}.try_into().unwrap()).unwrap());
@@ -259,7 +257,7 @@ async fn private_entries_dont_leak() {
     let bob_hash: ActionHash = conductors[1]
         .call(&bobbo.zome(SweetInlineZomes::COORDINATOR), "create", ())
         .await;
-    await_consistency(15, [&alice, &bobbo]).await.unwrap();
+    await_consistency([&alice, &bobbo]).await.unwrap();
 
     check_all_gets_for_private_entry(
         &conductors[0],

--- a/crates/holochain/tests/tests/paths.rs
+++ b/crates/holochain/tests/tests/paths.rs
@@ -1,6 +1,5 @@
 use holochain::sweettest::{await_consistency, SweetConductor, SweetConductorBatch, SweetDnaFile};
 use holochain_wasm_test_utils::TestWasm;
-use std::time::Duration;
 
 #[derive(Debug, PartialEq, Eq, serde::Deserialize)]
 pub struct BookEntry {
@@ -30,9 +29,7 @@ async fn agents_can_find_entries_at_paths() {
         .await;
     conductor_batch.exchange_peer_info().await;
 
-    await_consistency(Duration::from_secs(30), [&alice_cell, &bob_cell])
-        .await
-        .unwrap();
+    await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
     // There should be no books created yet.
     let books: Vec<BookEntry> = conductor_batch[0]
@@ -77,9 +74,7 @@ async fn agents_can_find_entries_at_paths() {
         }]
     );
 
-    await_consistency(Duration::from_secs(60), [&alice_cell, &bob_cell])
-        .await
-        .unwrap();
+    await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
     // After consistency, Bob should see Alice's entry.
     let books: Vec<BookEntry> = conductor_batch[1]
@@ -120,9 +115,7 @@ async fn agents_can_find_multiple_entries_at_same_path() {
         .await;
     conductor_batch.exchange_peer_info().await;
 
-    await_consistency(Duration::from_secs(30), [&alice_cell, &bob_cell])
-        .await
-        .unwrap();
+    await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
     // There should be no books created yet.
     let books: Vec<BookEntry> = conductor_batch[0]
@@ -185,9 +178,7 @@ async fn agents_can_find_multiple_entries_at_same_path() {
         name: "Strange Case of Dr Jekyll and Mr Hyde".to_string()
     }));
 
-    await_consistency(Duration::from_secs(60), [&alice_cell, &bob_cell])
-        .await
-        .unwrap();
+    await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
     // After consistency, both should see each other's entries.
     let books: Vec<BookEntry> = conductor_batch[0]
@@ -251,9 +242,7 @@ async fn agents_can_find_entries_with_partial_path() {
         .await;
     conductor_batch.exchange_peer_info().await;
 
-    await_consistency(Duration::from_secs(30), [&alice_cell, &bob_cell])
-        .await
-        .unwrap();
+    await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
     // There should be no books created yet.
     let books: Vec<BookEntry> = conductor_batch[0]
@@ -292,9 +281,7 @@ async fn agents_can_find_entries_with_partial_path() {
         )
         .await;
 
-    await_consistency(Duration::from_secs(60), [&alice_cell, &bob_cell])
-        .await
-        .unwrap();
+    await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
     // After consistency, both should see each other's entries.
     let books: Vec<BookEntry> = conductor_batch[0]
@@ -425,9 +412,7 @@ async fn paths_can_be_created_fully_or_with_path_sharding() {
         .await;
     conductor_batch.exchange_peer_info().await;
 
-    await_consistency(Duration::from_secs(30), [&alice_cell, &bob_cell])
-        .await
-        .unwrap();
+    await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
     // Alice adds a book entry.
     let () = conductor_batch[0]
@@ -438,9 +423,7 @@ async fn paths_can_be_created_fully_or_with_path_sharding() {
         )
         .await;
 
-    await_consistency(Duration::from_secs(60), [&alice_cell, &bob_cell])
-        .await
-        .unwrap();
+    await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
     // Can find book using path-sharding.
     let books: Vec<BookEntry> = conductor_batch[0]

--- a/crates/holochain/tests/tests/publish/mod.rs
+++ b/crates/holochain/tests/tests/publish/mod.rs
@@ -208,7 +208,7 @@ async fn warrant_is_published() {
             .peer_urls[0]
     );
 
-    await_consistency(15, [&alice, &bob, &carol]).await.unwrap();
+    await_consistency([&alice, &bob, &carol]).await.unwrap();
 
     // Alice creates an invalid action.
     let _: ActionHash = conductors[0]
@@ -219,7 +219,7 @@ async fn warrant_is_published() {
         )
         .await;
 
-    await_consistency(15, [&alice, &bob]).await.unwrap();
+    await_consistency([&alice, &bob]).await.unwrap();
 
     // Bob should have issued a warrant against Alice.
 

--- a/crates/holochain/tests/tests/regression/dht_location.rs
+++ b/crates/holochain/tests/tests/regression/dht_location.rs
@@ -48,7 +48,7 @@ async fn dht_location_consistency() {
         .call::<_, ActionHash>(&alice_zome, "create_string", "alright guv'nor".to_string())
         .await;
 
-    await_consistency(30, &[alice.clone(), bob.clone()])
+    await_consistency(&[alice.clone(), bob.clone()])
         .await
         .unwrap();
 

--- a/crates/holochain/tests/tests/regression/must_get_agent_activity_saturation.rs
+++ b/crates/holochain/tests/tests/regression/must_get_agent_activity_saturation.rs
@@ -11,7 +11,7 @@ use rand::{rng, Rng};
 #[cfg(feature = "slow_tests")]
 #[cfg_attr(target_os = "windows", ignore = "flaky")]
 async fn must_get_agent_activity_saturation() {
-    use holochain::sweettest::await_consistency;
+    use holochain::sweettest::await_consistency_s;
 
     holochain_trace::test_run();
 
@@ -43,7 +43,7 @@ async fn must_get_agent_activity_saturation() {
     }
 
     // let conductors catch up
-    await_consistency(120, [alice_cell, bob_cell])
+    await_consistency_s(120, [alice_cell, bob_cell])
         .await
         .unwrap();
 

--- a/crates/holochain/tests/tests/warrant_issuance.rs
+++ b/crates/holochain/tests/tests/warrant_issuance.rs
@@ -61,7 +61,7 @@ async fn invalid_op_warrant_issuance_can_be_disabled() {
         .unwrap()
         .into_tuple();
 
-    await_consistency(15, [&alice, &bob]).await.unwrap();
+    await_consistency([&alice, &bob]).await.unwrap();
 
     // Bob must not have issued a warrant against Alice.
     // A warrant would have been created as part of app validating all of Alice's
@@ -134,7 +134,7 @@ async fn skip_self_validation_to_cause_warrant() {
         .unwrap()
         .into_tuple();
 
-    await_consistency(15, [&alice, &bob]).await.unwrap();
+    await_consistency([&alice, &bob]).await.unwrap();
 
     // Now Alice creates some data that Bob will reject, causing Bob to issue a warrant against Alice.
     let _: ActionHash = conductors[0]
@@ -142,7 +142,7 @@ async fn skip_self_validation_to_cause_warrant() {
         .await;
 
     // Should sync the data to Bob.
-    await_consistency(15, [&alice, &bob]).await.unwrap();
+    await_consistency([&alice, &bob]).await.unwrap();
 
     let alice_pubkey = alice.agent_pubkey().clone();
     let warrants = conductors[1]

--- a/crates/holochain/tests/tests/warrants.rs
+++ b/crates/holochain/tests/tests/warrants.rs
@@ -44,9 +44,7 @@ async fn warranted_agent_is_blocked() {
     let (bob_conductor, bob_cell) = conductors_and_cells.remove(0);
 
     // Let all agents sync.
-    await_consistency(15, [&alice_cell, &bob_cell])
-        .await
-        .unwrap();
+    await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
     // Alice creates an invalid action.
     let _: ActionHash = alice_conductor
@@ -57,9 +55,7 @@ async fn warranted_agent_is_blocked() {
         )
         .await;
 
-    await_consistency(15, [&alice_cell, &bob_cell])
-        .await
-        .unwrap();
+    await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
     // The warrant against Alice and the warrant op should have been written to Bob's authored database.
     retry_fn_until_timeout(
@@ -122,7 +118,7 @@ async fn warrant_is_gossiped() {
     let (_bob_conductor, bob_cell) = conductors_and_cells.remove(0);
     let (carol_conductor, carol_cell) = conductors_and_cells.remove(0);
 
-    await_consistency(15, [&alice_cell, &bob_cell, &carol_cell])
+    await_consistency([&alice_cell, &bob_cell, &carol_cell])
         .await
         .unwrap();
 
@@ -141,9 +137,7 @@ async fn warrant_is_gossiped() {
         )
         .await;
 
-    await_consistency(60, [&alice_cell, &bob_cell])
-        .await
-        .unwrap();
+    await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
     // Bob should have issued a warrant against Alice.
 
@@ -239,7 +233,7 @@ async fn author_of_invalid_warrant_is_blocked() {
         .await;
 
     // Wait for Alice and Bob to sync.
-    await_consistency(15, [&alice, &bob]).await.unwrap();
+    await_consistency([&alice, &bob]).await.unwrap();
 
     let alice_authored_db = conductors[0]
         .get_spaces()
@@ -289,7 +283,7 @@ async fn author_of_invalid_warrant_is_blocked() {
         });
 
     // Wait for Alice and Bob to sync so that Alice receives the warrant.
-    await_consistency(15, [&alice, &bob]).await.unwrap();
+    await_consistency([&alice, &bob]).await.unwrap();
 
     tokio::time::timeout(std::time::Duration::from_secs(30), async {
         loop {
@@ -369,9 +363,7 @@ mod zero_arc {
         let (bob_conductor, bob_cell) = conductors_and_cells.remove(0);
         let (carol_conductor, carol_cell) = conductors_and_cells.remove(0);
 
-        await_consistency(15, [&alice_cell, &bob_cell])
-            .await
-            .unwrap();
+        await_consistency([&alice_cell, &bob_cell]).await.unwrap();
         bob_conductor
             .holochain_p2p()
             .test_set_full_arcs(dna_hash.to_k2_space())
@@ -388,9 +380,7 @@ mod zero_arc {
             )
             .await;
 
-        await_consistency(15, [&alice_cell, &bob_cell])
-            .await
-            .unwrap();
+        await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
         // Bob should have issued a warrant against Alice.
 
@@ -450,9 +440,7 @@ mod zero_arc {
         let (bob_conductor, bob_cell) = conductors_and_cells.remove(0);
         let (carol_conductor, carol_cell) = conductors_and_cells.remove(0);
 
-        await_consistency(15, [&alice_cell, &bob_cell])
-            .await
-            .unwrap();
+        await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
         // Ensure that Carol knows about Bob's full arc.
         bob_conductor
@@ -471,9 +459,7 @@ mod zero_arc {
             )
             .await;
 
-        await_consistency(15, [&alice_cell, &bob_cell])
-            .await
-            .unwrap();
+        await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
         // Bob should have issued a warrant against Alice.
 
@@ -555,9 +541,7 @@ mod zero_arc {
         let (bob_conductor, bob_cell) = conductors_and_cells.remove(0);
         let (carol_conductor, carol_cell) = conductors_and_cells.remove(0);
 
-        await_consistency(15, [&alice_cell, &bob_cell])
-            .await
-            .unwrap();
+        await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
         // Ensure that Carol knows about Bob's full arc.
         bob_conductor
@@ -576,9 +560,7 @@ mod zero_arc {
             )
             .await;
 
-        await_consistency(20, [&alice_cell, &bob_cell])
-            .await
-            .unwrap();
+        await_consistency([&alice_cell, &bob_cell]).await.unwrap();
 
         // Bob should have issued a warrant against Alice.
 


### PR DESCRIPTION
### Summary
This is an attempt to make general progress on flaky tests. Most flaky tests appear to be caused by timeouts from `await_consistency`. The timeouts we're using in `await_consistency` are all over the place -- mostly from 15s - 60s. 

The makes `await_consistency`'s timeout a hard-coded 60s and should always be used by default. A new function `await_consistency_s` lets you override this timeout if your specific test case requires it. Another new function `check_consistency` runs the check immediately.


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Test consistency utilities reworked: breaking rename plus a simpler single-argument wait API, an explicit/custom-timeout variant, and an immediate-check helper. Test call sites updated to the new API.

* **Bug Fixes**
  * Default consistency wait increased to 60s to reduce intermittent test flakiness and improve reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->