### PR TITLE
build: rust version in nix flakes matches version in rust-toolchain.toml

### DIFF
--- a/nix/modules/holochain.nix
+++ b/nix/modules/holochain.nix
@@ -5,7 +5,7 @@
     let
       rustToolchain = config.rustHelper.mkRust {
         track = "stable";
-        version = "1.88.0";
+        version = "1.91.1";
       };
 
       craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rustToolchain;

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -30,7 +30,7 @@
         in
         {
           defaultTrack = "stable";
-          defaultVersion = "1.88.0";
+          defaultVersion = "1.91.1";
 
           defaultExtensions = [
             "rust-src"

--- a/versions/weekly/flake.nix
+++ b/versions/weekly/flake.nix
@@ -25,6 +25,6 @@
     };
 
   outputs = { ... }: {
-    rustVersion = "1.88.0";
+    rustVersion = "1.91.1";
   };
 }


### PR DESCRIPTION
### Summary
The rust version in rust-toolchain.toml was already 1.91.1. This updates the versions in nix files to match.


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Upgraded Rust toolchain version from 1.88.0 to 1.91.1 across development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->