### PR TITLE
fix: propagate transport feature from hc to hc-sandbox

### DIFF
--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -37,7 +37,8 @@ tokio = { version = "1.36.0", features = ["full"] }
 workspace = true
 
 [features]
-default = ["wasmer_sys"]
+
+default = ["wasmer_sys", "transport-tx5-datachannel-vendored"]
 
 wasmer_sys = [
   "holochain_cli_sandbox/wasmer_sys",
@@ -47,5 +48,17 @@ wasmer_wamr = [
   "holochain_cli_sandbox/wasmer_wamr",
   "holochain_cli_client/wasmer_wamr",
 ]
+
+transport-tx5-datachannel-vendored = [
+  "holochain_cli_sandbox/transport-tx5-datachannel-vendored",
+]
+transport-tx5-backend-libdatachannel = [
+  "holochain_cli_sandbox/transport-tx5-backend-libdatachannel",
+]
+transport-tx5-backend-go-pion = [
+  "holochain_cli_sandbox/transport-tx5-backend-go-pion",
+]
+transport-iroh = ["holochain_cli_sandbox/transport-iroh"]
+
 
 chc = ["holochain_cli_sandbox/chc"]


### PR DESCRIPTION
### Summary

When `hc` is built, it'll not pass a transport feature down to `hc-sandbox`, because it disables its default features, but doesn't set the transport feature. Fixed by propagating the transport feature.


### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded default transport capabilities by enabling new datachannel and backend transport options including vendored, libdatachannel, go-pion, and iroh variants. These transport methods are now available to the workspace by default.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->