### PR TITLE
test: conditionally enable flaky tests with Iroh transport

### DIFF
--- a/crates/holochain/src/local_network_tests.rs
+++ b/crates/holochain/src/local_network_tests.rs
@@ -7,7 +7,10 @@ use test_case::test_case;
 #[test_case(2)]
 #[test_case(4)]
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "flaky local networking test; re-check after Iroh upgrade"]
+#[cfg_attr(
+    not(feature = "transport-iroh"),
+    ignore = "requires Iroh transport for stability"
+)]
 async fn conductors_call_remote(num_conductors: usize) {
     holochain_trace::test_run();
 

--- a/crates/holochain/src/sweettest/sweet_consistency.rs
+++ b/crates/holochain/src/sweettest/sweet_consistency.rs
@@ -219,7 +219,10 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     #[tokio::test(flavor = "multi_thread")]
-    #[ignore = "flaky under current networking; re-check after Iroh upgrade"]
+    #[cfg_attr(
+        not(feature = "transport-iroh"),
+        ignore = "requires Iroh transport for stability"
+    )]
     async fn consistency_reached() {
         holochain_trace::test_run();
         let mut conductors = SweetConductorBatch::from_standard_config_rendezvous(2).await;
@@ -270,7 +273,10 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    #[ignore = "flaky under current networking; re-check after Iroh upgrade"]
+    #[cfg_attr(
+        not(feature = "transport-iroh"),
+        ignore = "requires Iroh transport for stability"
+    )]
     async fn consistency_reached_with_private_entry() {
         holochain_trace::test_run();
         let mut conductors = SweetConductorBatch::from_standard_config_rendezvous(2).await;
@@ -307,7 +313,10 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    #[ignore = "flaky under current networking; re-check after Iroh upgrade"]
+    #[cfg_attr(
+        not(feature = "transport-iroh"),
+        ignore = "requires Iroh transport for stability"
+    )]
     async fn consistency_not_reached_when_ops_not_synced() {
         holochain_trace::test_run();
         // No bootstrap service.

--- a/crates/holochain/tests/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/tests/multi_conductor/mod.rs
@@ -70,7 +70,10 @@ async fn test_publish() {
 
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "flaky multi conductor test; re-check after Iroh upgrade"]
+#[cfg_attr(
+    not(feature = "transport-iroh"),
+    ignore = "requires Iroh transport for stability"
+)]
 async fn multi_conductor() -> anyhow::Result<()> {
     use holochain::test_utils::inline_zomes::simple_create_read_zome;
 
@@ -120,7 +123,10 @@ async fn multi_conductor() -> anyhow::Result<()> {
 /// Flaky on Windows separately from the pending fixes alongside Iroh networking upgrade.
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "flaky multi conductor private entry propagation; re-check after Iroh upgrade"]
+#[cfg_attr(
+    not(feature = "transport-iroh"),
+    ignore = "requires Iroh transport for stability"
+)]
 async fn private_entries_update_consistency() {
     use holochain::sweettest::SweetInlineZomes;
     use holochain_types::inline_zome::InlineZomeSet;
@@ -182,7 +188,10 @@ async fn private_entries_update_consistency() {
 /// Flaky on Windows separately from the pending fixes alongside Iroh networking upgrade.
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "flaky multi conductor private entry propagation; re-check after Iroh upgrade"]
+#[cfg_attr(
+    not(feature = "transport-iroh"),
+    ignore = "requires Iroh transport for stability"
+)]
 async fn private_entries_dont_leak() {
     use holochain::sweettest::SweetInlineZomes;
     use holochain_types::inline_zome::InlineZomeSet;

--- a/crates/holochain/tests/tests/publish/mod.rs
+++ b/crates/holochain/tests/tests/publish/mod.rs
@@ -96,7 +96,10 @@ async fn publish_terminates_after_receiving_required_validation_receipts() {
 // Carol has warrant issuance disabled and receives the warrant from Bob
 // as he publishes it.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "flaky warrant publish integration; re-check after Iroh upgrade"]
+#[cfg_attr(
+    not(feature = "transport-iroh"),
+    ignore = "requires Iroh transport for stability"
+)]
 async fn warrant_is_published() {
     holochain_trace::test_run();
 

--- a/crates/holochain/tests/tests/warrants.rs
+++ b/crates/holochain/tests/tests/warrants.rs
@@ -31,7 +31,10 @@ use serde::{Deserialize, Serialize};
 // Alice creates an invalid op and publishes it to Bob. Bob issues a warrant and
 // blocks Alice.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "flaky warrant blocking integration; re-check after Iroh upgrade"]
+#[cfg_attr(
+    not(feature = "transport-iroh"),
+    ignore = "requires Iroh transport for stability"
+)]
 async fn warranted_agent_is_blocked() {
     holochain_trace::test_run();
 

--- a/crates/holochain_p2p/tests/tests/peer_meta_store.rs
+++ b/crates/holochain_p2p/tests/tests/peer_meta_store.rs
@@ -207,7 +207,10 @@ async fn set_peer_unresponsive_in_peer_meta_store() {
 }
 
 #[tokio::test]
-#[ignore = "flaky until Iroh networking upgrade"]
+#[cfg_attr(
+    not(feature = "transport-iroh"),
+    ignore = "requires Iroh transport for stability"
+)]
 async fn unresponsive_peers_are_removed_from_store_after_expiry() {
     let db = DbWrite::test_in_mem(DbKindPeerMetaStore(Arc::new(DnaHash::from_raw_36(
         vec![0x0a; 36],


### PR DESCRIPTION
### Summary

Re-enable previously flaky tests when the transport-iroh feature is activated. These tests were disabled due to networking instability but are expected to be more reliable with the Iroh transport.

Tests are now ignored by default but enabled with transport-iroh feature.

Part of #5543

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Several previously always-skipped stability tests are now feature-gated: they run when the transport-Iroh feature is enabled and remain skipped otherwise. This allows those tests to execute in environments with the Iroh transport while preserving prior stability behavior across other environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->