### PR TITLE
Chore: update default URL of bootstrap with iroh relay

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Set default iroh relay server to `dev-test-bootstrap2-iroh-relay.holochain.org`.
 - Run test workflow for all platforms with iroh transport. One job to test tx5 on Ubuntu is kept in the workflow.
 - **BREAKING CHANGE**: Completely removed `block_agent` and `unblock_agent` host and HDK functions from Holochain. Blocking is a system-level behavior, triggered by warrants, not application-level logic. Any WASM that references these host functions will fail to instantiate. Applications must be recompiled without calls to these functions. [#5518]
 

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -83,7 +83,7 @@ pub async fn integrate_dht_ops_workflow(
         .await?;
     let changed = stored_ops.len();
     let ops_ps = changed as f64 / start.elapsed().as_micros() as f64 * 1_000_000.0;
-    tracing::debug!(?changed, %ops_ps);
+    tracing::info!(?changed, %ops_ps, "ops integrated");
     if changed > 0 {
         network.new_integrated_data(stored_ops).await?;
 

--- a/crates/holochain/src/sweettest/sweet_conductor_config.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor_config.rs
@@ -69,6 +69,10 @@ impl SweetConductorConfig {
             network.signal_url = url2::url2!("{}", rendezvous.sig_addr());
         }
 
+        if network.relay_url.as_str() == "rendezvous:" {
+            network.relay_url = url2::url2!("{}", rendezvous.sig_addr());
+        }
+
         self
     }
 
@@ -94,6 +98,7 @@ impl SweetConductorConfig {
         }
 
         config.network.signal_url = url2::url2!("rendezvous:");
+        config.network.relay_url = url2::url2!("rendezvous:");
 
         config
     }

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -280,7 +280,6 @@ impl Default for NetworkConfig {
             base64_auth_material: None,
             bootstrap_url: url2::Url2::parse("https://dev-test-bootstrap2.holochain.org"),
             signal_url: url2::Url2::parse("wss://dev-test-bootstrap2.holochain.org"),
-            // Replace with the Holochain hosted dev relay server
             relay_url: url2::Url2::parse("https://dev-test-bootstrap2-iroh-relay.holochain.org./"),
             request_timeout_s: default_request_timeout_s(),
             webrtc_config: None,


### PR DESCRIPTION
### Summary

resolves #5570 

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Changed the default network relay URL and ensured rendezvous placeholders are populated for rendezvous-mode setups.

* **Tests**
  * Updated gossip tests to use a rendezvous-based conductor setup, added a rendezvous-based test factory, and increased consistency wait thresholds.

* **Style**
  * Promoted a diagnostic log from debug to info to better surface operation integration progress.

* **Documentation**
  * Recorded the new default relay server in the changelog.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->