### PR TITLE
ci: switch test workflow to iroh transport

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,15 +59,15 @@ jobs:
         include:
           - os: ubuntu-latest
             target: wasmer_sys
+          - os: ubuntu-latest
+            target: wasmer_sys-unstable-transport_iroh
+          - os: ubuntu-latest
+            target: wasmer_sys-transport_iroh
           - os: macos-latest
-            target: wasmer_sys
+            target: wasmer_sys-transport_iroh
           - os: macos-15-intel
-            target: wasmer_sys
+            target: wasmer_sys-transport_iroh
           - os: depot-windows-2022-8
-            target: wasmer_sys
-          - os: ubuntu-latest
-            target: wasmer_sys-unstable
-          - os: ubuntu-latest
             target: wasmer_sys-transport_iroh
     steps:
       - name: checkout

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 COMMON_DEFAULT_FEATURES=slow_tests,build_wasms,sqlite-encrypted
 DEFAULT_FEATURES=transport-tx5-datachannel-vendored,$(COMMON_DEFAULT_FEATURES)
 DEFAULT_FEATURES_TRANSPORT_IROH=transport-iroh,$(COMMON_DEFAULT_FEATURES)
-UNSTABLE_FEATURES=chc,unstable-sharding,unstable-warrants,unstable-functions,unstable-migration,$(DEFAULT_FEATURES)
+UNSTABLE_FEATURES_TRANSPORT_IROH=chc,unstable-sharding,unstable-warrants,unstable-functions,unstable-migration,$(DEFAULT_FEATURES_TRANSPORT_IROH)
 
 # mark everything as phony because it doesn't represent a file-system output
 .PHONY: default \
@@ -46,7 +46,7 @@ static-clippy:
 	CHK_SQL_FMT=1 cargo clippy --all-targets --features $(DEFAULT_FEATURES)
 
 static-clippy-unstable:
-	CHK_SQL_FMT=1 cargo clippy --all-targets --features $(UNSTABLE_FEATURES)
+	CHK_SQL_FMT=1 cargo clippy --all-targets --features $(UNSTABLE_FEATURES_TRANSPORT_IROH)
 
 # ensure we can build the docs
 static-doc:
@@ -73,13 +73,13 @@ build-workspace-wasmer_sys-transport_iroh:
 		--no-default-features \
 		--features $(DEFAULT_FEATURES_TRANSPORT_IROH),wasmer_sys
 
-build-workspace-wasmer_sys-unstable:
+build-workspace-wasmer_sys-unstable-transport_iroh:
 	cargo build \
 		--workspace \
 		--locked \
 		--all-targets \
 		--no-default-features \
-		--features $(UNSTABLE_FEATURES),wasmer_sys
+		--features $(UNSTABLE_FEATURES_TRANSPORT_IROH),wasmer_sys
 
 build-workspace-wasmer_wamr:
 	cargo build \
@@ -87,9 +87,9 @@ build-workspace-wasmer_wamr:
 		--locked \
 		--all-targets \
 		--no-default-features \
-		--features $(DEFAULT_FEATURES),wasmer_wamr
+		--features $(DEFAULT_FEATURES_TRANSPORT_IROH),wasmer_wamr
 
-# execute tests on all crates with wasmer compiler
+# execute tests on all crates with wasmer compiler and tx5 transport
 test-workspace-wasmer_sys:
 	RUST_BACKTRACE=1 cargo nextest run \
 		--workspace \
@@ -106,12 +106,12 @@ test-workspace-wasmer_sys-transport_iroh:
 		--features $(DEFAULT_FEATURES_TRANSPORT_IROH),wasmer_sys
 
 # executes tests on all crates with wasmer compiler
-test-workspace-wasmer_sys-unstable:
+test-workspace-wasmer_sys-unstable-transport_iroh:
 	RUST_BACKTRACE=1 cargo nextest run \
 		--workspace \
 		--locked \
 		--no-default-features \
-		--features $(UNSTABLE_FEATURES),wasmer_sys
+		--features $(UNSTABLE_FEATURES_TRANSPORT_IROH),wasmer_sys
 
 # execute tests on all crates with wasmer interpreter
 test-workspace-wasmer_wamr:
@@ -119,7 +119,7 @@ test-workspace-wasmer_wamr:
 		--workspace \
 		--locked \
 		--no-default-features \
-		--features $(DEFAULT_FEATURES),wasmer_wamr
+		--features $(DEFAULT_FEATURES_TRANSPORT_IROH),wasmer_wamr
 
 clean:
 	cargo clean

--- a/crates/hc_sandbox/tests/cli.rs
+++ b/crates/hc_sandbox/tests/cli.rs
@@ -639,7 +639,14 @@ async fn generate_sandbox_with_target_arc_factor_override() {
         .unwrap()
         .join("tests/fixtures/my-app/");
 
-    #[cfg(feature = "transport-iroh")]
+    #[cfg(all(
+        feature = "transport-iroh",
+        not(any(
+            feature = "transport-tx5-datachannel-vendored",
+            feature = "transport-tx5-backend-libdatachannel",
+            feature = "transport-tx5-backend-go-pion"
+        ))
+    ))]
     let (network_type, relay_url) = ("quic", "https://iroh-relay");
     #[cfg(any(
         feature = "transport-tx5-datachannel-vendored",

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Run test workflow for all platforms with iroh transport. One job to test tx5 on Ubuntu is kept in the workflow.
 - **BREAKING CHANGE**: Completely removed `block_agent` and `unblock_agent` host and HDK functions from Holochain. Blocking is a system-level behavior, triggered by warrants, not application-level logic. Any WASM that references these host functions will fail to instantiate. Applications must be recompiled without calls to these functions. [#5518]
 
 ## 0.7.0-dev.7

--- a/crates/holochain/src/sweettest/sweet_conductor_config_rendezvous.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor_config_rendezvous.rs
@@ -90,14 +90,21 @@ impl SweetLocalRendezvous {
 
         Arc::new(Self {
             bs_addr: format!("http://{bootstrap_addr}"),
-            #[cfg(feature = "transport-iroh")]
-            sig_addr: format!("http://{bootstrap_addr}"),
             #[cfg(any(
                 feature = "transport-tx5-datachannel-vendored",
                 feature = "transport-tx5-backend-libdatachannel",
                 feature = "transport-tx5-backend-go-pion"
             ))]
             sig_addr: format!("ws://{bootstrap_addr}"),
+            #[cfg(all(
+                feature = "transport-iroh",
+                not(any(
+                    feature = "transport-tx5-datachannel-vendored",
+                    feature = "transport-tx5-backend-libdatachannel",
+                    feature = "transport-tx5-backend-go-pion"
+                ))
+            ))]
+            sig_addr: format!("http://{bootstrap_addr}"),
             bootstrap_hnd,
             bootstrap_addr,
         })

--- a/crates/holochain/tests/tests/websocket/mod.rs
+++ b/crates/holochain/tests/tests/websocket/mod.rs
@@ -784,7 +784,15 @@ async fn network_stats() {
     const EXPECT: &str = "BackendLibDataChannel";
     #[cfg(feature = "transport-tx5-backend-go-pion")]
     const EXPECT: &str = "BackendGoPion";
-    #[cfg(feature = "transport-iroh")]
+    #[cfg(all(
+        feature = "transport-iroh",
+        not(any(
+            feature = "transport-tx5-datachannel-vendored",
+            feature = "transport-tx5-backend-libdatachannel",
+            feature = "transport-tx5-backend-go-pion"
+        ))
+    ))]
+
     const EXPECT: &str = "iroh";
 
     let req = AdminRequest::DumpNetworkStats;

--- a/crates/holochain_p2p/tests/tests/blocks.rs
+++ b/crates/holochain_p2p/tests/tests/blocks.rs
@@ -578,7 +578,14 @@ impl TestActor {
                     "webrtcConnectTimeoutS": 25,
                 }
             })),
-            #[cfg(feature = "transport-iroh")]
+            #[cfg(all(
+                feature = "transport-iroh",
+                not(any(
+                    feature = "transport-tx5-datachannel-vendored",
+                    feature = "transport-tx5-backend-libdatachannel",
+                    feature = "transport-tx5-backend-go-pion"
+                ))
+            ))]
             network_config: Some(serde_json::json!({
                 "coreBootstrap": {
                     "serverUrl": format!("http://{bootstrap_addr}"),

--- a/crates/holochain_p2p/tests/tests/node_messaging.rs
+++ b/crates/holochain_p2p/tests/tests/node_messaging.rs
@@ -1247,7 +1247,14 @@ async fn spawn_test(
                     "webrtcConnectTimeoutS": 25,
                 }
             })),
-            #[cfg(feature = "transport-iroh")]
+            #[cfg(all(
+                feature = "transport-iroh",
+                not(any(
+                    feature = "transport-tx5-datachannel-vendored",
+                    feature = "transport-tx5-backend-libdatachannel",
+                    feature = "transport-tx5-backend-go-pion"
+                ))
+            ))]
             network_config: Some(serde_json::json!({
                 "coreBootstrap": {
                     "serverUrl": format!("http://{bootstrap_addr}"),


### PR DESCRIPTION
### Summary

resolves #5552 

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated CI matrix to focus on iroh transport variants and updated build/test targets to use transport-iroh feature sets.
  * Renamed unstable feature variables and updated build/test targets; enhanced cleanup to remove additional artifact files.
  * Documented iroh transport testing in the changelog.

* **Tests**
  * Tightened test gating and conditional compilation so iroh-backed tests run only when iroh is enabled without conflicting TX5 transport backends.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->