### PR TITLE
fix: revert to iroh's public relay server url in the conductor config

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Revert to iroh's public relay server URL `https://use1-1.relay.n0.iroh-canary.iroh.link./` in the conductor config.
 - Delete deprecated block targets to block a node by its ID or a DNA of a node.
 - Remove unusable block variant `CellBlockReason::App`.
 - Reinstate tests that ensure publish and gossip doesn't contact blocked nodes.

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -280,7 +280,7 @@ impl Default for NetworkConfig {
             base64_auth_material: None,
             bootstrap_url: url2::Url2::parse("https://dev-test-bootstrap2.holochain.org"),
             signal_url: url2::Url2::parse("wss://dev-test-bootstrap2.holochain.org"),
-            relay_url: url2::Url2::parse("https://dev-test-bootstrap2-iroh-relay.holochain.org./"),
+            relay_url: url2::Url2::parse("https://use1-1.relay.n0.iroh-canary.iroh.link./"),
             request_timeout_s: default_request_timeout_s(),
             webrtc_config: None,
             target_arc_factor: default_target_arc_factor(),
@@ -906,7 +906,7 @@ mod tests {
                     "signalAllowPlainText": "true"
                 },
                 "irohTransport": {
-                    "relayUrl": "https://dev-test-bootstrap2-iroh-relay.holochain.org./",
+                    "relayUrl": "https://use1-1.relay.n0.iroh-canary.iroh.link./",
                     "relayAllowPlainText": "true"
                 },
                 "coreSpace": {
@@ -955,7 +955,7 @@ mod tests {
                     "webrtcConnectTimeoutS": 22
                 },
                 "irohTransport": {
-                    "relayUrl": "https://dev-test-bootstrap2-iroh-relay.holochain.org./",
+                    "relayUrl": "https://use1-1.relay.n0.iroh-canary.iroh.link./",
                 },
             })
         );
@@ -989,7 +989,7 @@ mod tests {
                     "webrtcConnectTimeoutS": 22
                 },
                 "irohTransport": {
-                    "relayUrl": "https://dev-test-bootstrap2-iroh-relay.holochain.org./",
+                    "relayUrl": "https://use1-1.relay.n0.iroh-canary.iroh.link./",
                 },
                 "k2Gossip": {
                     "roundTimeoutMs": 100,


### PR DESCRIPTION
### Summary

Our deployed iroh relay server doesn't support QUIC address discovery. Revert to the public relay server until we can properly embed it into our bootstrap.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs