### PR TITLE
ci: run windows tests on windows 2025 runners

### DIFF
--- a/.github/actions/common-test/action.yml
+++ b/.github/actions/common-test/action.yml
@@ -18,13 +18,13 @@ runs:
         cmake-version: "3.31.x"
 
     - name: llvm & clang
-      if: inputs.os == 'depot-windows-2022-8'
+      if: inputs.os == 'depot-windows-2025-8'
       uses: KyleMayes/install-llvm-action@v2.0.8
       with:
         version: "21"
 
-    - name: build (depot-windows-2022-8)
-      if: inputs.os == 'depot-windows-2022-8'
+    - name: build (depot-windows-2025-8)
+      if: inputs.os == 'depot-windows-2025-8'
       shell: pwsh
       run: |-
         vcpkg install libsodium
@@ -33,7 +33,7 @@ runs:
         make build-workspace-${{ inputs.target }}
 
     - name: build
-      if: inputs.os != 'depot-windows-2022-8'
+      if: inputs.os != 'depot-windows-2025-8'
       shell: bash
       run: |
         make build-workspace-${{ inputs.target }}
@@ -43,8 +43,8 @@ runs:
       with:
         tool: cargo-nextest@0.9.96
 
-    - name: test (depot-windows-2022-8)
-      if: inputs.os == 'depot-windows-2022-8'
+    - name: test (depot-windows-2025-8)
+      if: inputs.os == 'depot-windows-2025-8'
       id: test-windows
       continue-on-error: true
       shell: pwsh
@@ -53,7 +53,7 @@ runs:
         make test-workspace-${{ inputs.target }}
 
     - name: test
-      if: inputs.os != 'depot-windows-2022-8'
+      if: inputs.os != 'depot-windows-2025-8'
       id: test-unix
       continue-on-error: true
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
             target: wasmer_sys
           - os: macos-15-intel
             target: wasmer_sys
-          - os: depot-windows-2022-8
+          - os: depot-windows-2025-8
             target: wasmer_sys
     steps:
       - name: checkout

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- CI: Run windows test workflow on windows 2025 runners. \#5594
 - **BREAKING CHANGE**: Remove features for tx5 transport variants `datachannel-vendored` and `backend-libdatachannel`. The only supported tx5 transport is `backend-go-pion` now.
 - **BREAKING CHANGE**: Default to iroh transport for all binaries.
 - Revert to iroh's public relay server URL `https://use1-1.relay.n0.iroh-canary.iroh.link./` in the conductor config.


### PR DESCRIPTION
### Summary
Depot.dev now has windows 2025 runners. Switching to those.


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved Windows CI to 2025 runners, renaming Windows build/test steps and updating CI conditionals to match.
  * Set Windows-specific environment variable for native library paths used during build and test.

* **Documentation**
  * Added unreleased changelog entry noting Windows CI run on 2025 runners.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->