### PR TITLE
fix: DbKind display now shows the dna hash or cell id of the db

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix: DbKind display implementation now properly includes the associated CellId or DnaHash of the database, instead of escaped rust code.
+
 ## 0.7.0-dev.9
 
 - **BREAKING CHANGE** `ConductorConfig` now includes a field `incoming_request_concurrency_limit` for specifying the number of incoming authority requests that will be handled concurrently. Additional requests will be dropped. This limit only applies to incoming requests to `get`, `get_links`, `count_links`, `get_agent_activity`, `must_get_agent_activity`.

--- a/crates/holochain_sqlite/src/db/kind.rs
+++ b/crates/holochain_sqlite/src/db/kind.rs
@@ -7,13 +7,10 @@ use std::sync::Arc;
 #[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::Display)]
 pub enum DbKind {
     /// Specifies the environment used for authoring data by all cells on the same [`DnaHash`].
-    #[display("{:?}-{:?}", "_0.dna_hash()", "_0.agent_pubkey()")]
     Authored(Arc<CellId>),
     /// Specifies the environment used for dht data by all cells on the same [`DnaHash`].
-    #[display("{:?}", "_0")]
     Dht(Arc<DnaHash>),
     /// Specifies the environment used by each Cache (one per dna).
-    #[display("{:?}", "_0")]
     Cache(Arc<DnaHash>),
     /// Specifies the environment used by a Conductor
     Conductor,


### PR DESCRIPTION
### Summary
Previously it was failing to render the formatted content, so the display value was "_0" or "_0.dna_hash()-_0.agent_pubkey()"


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database identification now shows meaningful associated identifiers (CellId or DnaHash) instead of escaped Rust code representations.
  * Changelog updated under "Unreleased" to reflect the display fix for database kinds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->