### PR TITLE
ci: remove test workflow run on intel mac runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,8 +65,6 @@ jobs:
             target: wasmer_sys-transport_tx5
           - os: macos-latest
             target: wasmer_sys
-          - os: macos-15-intel
-            target: wasmer_sys
           - os: depot-windows-2025-8
             target: wasmer_sys
     steps:


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined CI test configuration to optimize the testing pipeline.
  * Reduced the set of OS-target combinations by removing one macOS Intel test target, simplifying matrix coverage and speeding up runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->