### PR TITLE
ci: switch wasmer_wamr test run from macos-latest to ubuntu-latest

### DIFF
--- a/.github/actions/common-pre/action.yml
+++ b/.github/actions/common-pre/action.yml
@@ -1,4 +1,5 @@
 name: 'Common Test Setup Actions'
+description: Steps common to setting up any test job
 runs:
   using: 'composite'
   steps:

--- a/.github/actions/common-test/action.yml
+++ b/.github/actions/common-test/action.yml
@@ -1,4 +1,5 @@
 name: 'Common Test Running Actions'
+description: Steps common to running any test job
 
 inputs:
   os:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
     name: test (wasmer_wamr)
     # Our intended target for wasmer_wamr feature is iOS and Android.
     # For now, wasmer_wamr tests are only run on macos-latest
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
     steps:
@@ -97,15 +97,10 @@ jobs:
       - name: "Common Test Setup Actions"
         uses: ./.github/actions/common-pre
         
-      - name: install build dependencies (macos-latest, wasmer_wamr)
-        run: |
-          brew install llvm
-          echo "PATH=/opt/homebrew/opt/llvm/bin:$PATH" >> "$GITHUB_ENV"
-
       - name: "Build workspace and run tests"
         uses: ./.github/actions/common-test
         with:
-          os: "macos-latest"
+          os: "ubuntu-latest"
           target: "wasmer_wamr"
           influx-token: ${{ secrets.INFLUX_TOKEN }}
 


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched a CI test job to run on Ubuntu instead of macOS and removed macOS-specific setup steps.
  * Added descriptive top-level metadata to shared CI actions to clarify their purpose.
  * No other workflow structure or public-facing behavior changes introduced.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->