### PR TITLE
fix: stabilize chain fork warrants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 COMMON_DEFAULT_FEATURES=slow_tests,build_wasms,sqlite-encrypted
 DEFAULT_FEATURES=transport-iroh,$(COMMON_DEFAULT_FEATURES)
 DEFAULT_FEATURES_TRANSPORT_TX5=transport-tx5-backend-go-pion,$(COMMON_DEFAULT_FEATURES)
-UNSTABLE_FEATURES=chc,unstable-sharding,unstable-warrants,unstable-functions,unstable-migration,$(DEFAULT_FEATURES)
+UNSTABLE_FEATURES=chc,unstable-sharding,unstable-functions,unstable-migration,$(DEFAULT_FEATURES)
 
 # mark everything as phony because it doesn't represent a file-system output
 .PHONY: default \

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Stabilized chain fork warrants that were previously behind the `unstable-warrants` feature; the feature has now been removed. \#5641
 - **BREAKING CHANGE** The `Spaces` struct now contains dedicated `wasm_store`, `dna_def_store`, and `entry_def_store` fields instead of directly exposing the underlying `wasm_db`. These are using the new WASM database from `holochain_data` under the hood. There is no migration path from an existing installation to this version.
 
 ## 0.7.0-dev.11

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -308,12 +308,6 @@ unstable-migration = [
   "holochain_conductor_api/unstable-migration",
 ]
 
-# Enables unstable warrants feature.
-#
-# Invalid op warrants are now stabilized, but this feature flag is retained for
-# chain fork warrants.
-unstable-warrants = []
-
 # Enable sharding for networks. This is currently considered an unstable feature
 # and with the feature disabled you will only be able to configure nodes that have
 # a full or empty arc.

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validate_warrant_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validate_warrant_tests.rs
@@ -1,0 +1,475 @@
+//! Note: Testing bad action signatures within a ChainFork warrant is not covered here because:
+//!
+//! 1. Warrants with bad warrant-level signatures are caught by `verify_warrant_signature` before
+//!    they reach `validate_warrant_op` in the sys validation workflow
+//! 2. Bad action signatures within the warrant would hit the unreachable code path for
+//!    `CounterfeitAction` since counterfeit ops are expected to be filtered before sys validation
+//!
+//! The signature verification for actions in warrants is still exercised by the valid warrant test.
+
+use super::validation_deps::SysValDeps;
+use super::validation_deps::ValidationDependencies;
+use crate::core::workflow::sys_validation_workflow::types::Outcome;
+use crate::core::workflow::sys_validation_workflow::validate_op;
+use crate::core::workflow::WorkflowResult;
+use crate::prelude::*;
+use ::fixt::prelude::*;
+use holo_hash::fixt::ActionHashFixturator;
+use holo_hash::fixt::EntryHashFixturator;
+use holochain_cascade::CascadeSource;
+
+/// Test that a valid ChainFork warrant is accepted when both actions:
+/// - Have the same author
+/// - Have the same prev_action (proving the fork)
+/// - Have valid signatures
+#[tokio::test(flavor = "multi_thread")]
+async fn validate_chain_fork_warrant_accepted() {
+    holochain_trace::test_run();
+
+    let mut test_case = ChainForkWarrantTestCase::new().await;
+
+    // Create the fork scenario: two actions with the same prev_action
+    let (action1, action2, _prev_action_hash) = test_case.create_forking_actions().await;
+
+    // Create a valid ChainFork warrant
+    let warrant_op = test_case
+        .create_chain_fork_warrant(&action1, &action2)
+        .await;
+
+    // Insert dependencies so validation can find the actions
+    test_case.insert_action_dependency(&action1);
+    test_case.insert_action_dependency(&action2);
+
+    let outcome = test_case.validate_warrant(warrant_op).await.unwrap();
+
+    assert!(
+        matches!(outcome, Outcome::Accepted),
+        "Expected Accepted but actual outcome was {outcome:?}"
+    );
+}
+
+/// Test that a ChainFork warrant is rejected when the author being warranted is
+/// not the author of at least one of the referenced actions
+#[tokio::test(flavor = "multi_thread")]
+async fn validate_chain_fork_warrant_rejected_chain_author_mismatch() {
+    holochain_trace::test_run();
+
+    let mut test_case = ChainForkWarrantTestCase::new().await;
+
+    // Create the fork scenario
+    let (action1, action2, _) = test_case.create_forking_actions().await;
+
+    // Create a warrant with a mismatched chain_author
+    let wrong_author = test_case.keystore.new_sign_keypair_random().await.unwrap();
+    let warrant_op = test_case
+        .create_chain_fork_warrant_with_chain_author(&action1, &action2, wrong_author)
+        .await;
+
+    // Insert dependencies
+    test_case.insert_action_dependency(&action1);
+    test_case.insert_action_dependency(&action2);
+
+    let outcome = test_case.validate_warrant(warrant_op).await.unwrap();
+
+    match outcome {
+        Outcome::Rejected(reason) => {
+            assert!(
+                reason.contains("chain author mismatch"),
+                "Expected 'chain author mismatch' in rejection reason, got: {reason}"
+            );
+        }
+        _ => panic!("Expected Rejected outcome but got: {outcome:?}"),
+    }
+}
+
+/// Test that a ChainFork warrant is rejected when the two actions have different authors.
+///
+/// This also serves as defense-in-depth for cross-author collisions: `detect_fork` checks the
+/// author in memory after the SQL query, so two actions from different agents sharing a
+/// `prev_action` won't produce warrants in practice. This test verifies that even if such a
+/// warrant were somehow constructed, validation would correctly reject it.
+#[tokio::test(flavor = "multi_thread")]
+async fn validate_chain_fork_warrant_rejected_action_authors_differ() {
+    holochain_trace::test_run();
+
+    let mut test_case = ChainForkWarrantTestCase::new().await;
+
+    // Create actions with different authors
+    let (action1, action2) = test_case.create_actions_with_different_authors().await;
+
+    // Create a warrant (using action1's author as chain_author)
+    let warrant_op = test_case
+        .create_chain_fork_warrant(&action1, &action2)
+        .await;
+
+    // Insert dependencies
+    test_case.insert_action_dependency(&action1);
+    test_case.insert_action_dependency(&action2);
+
+    let outcome = test_case.validate_warrant(warrant_op).await.unwrap();
+
+    match outcome {
+        Outcome::Rejected(reason) => {
+            assert!(
+                reason.contains("action pair author mismatch"),
+                "Expected 'action pair author mismatch' in rejection reason, got: {reason}"
+            );
+        }
+        _ => panic!("Expected Rejected outcome but got: {outcome:?}"),
+    }
+}
+
+/// Test that a ChainFork warrant is rejected when prev_action differs (not a real fork)
+#[tokio::test(flavor = "multi_thread")]
+async fn validate_chain_fork_warrant_rejected_prev_actions_differ() {
+    holochain_trace::test_run();
+
+    let mut test_case = ChainForkWarrantTestCase::new().await;
+
+    // Create actions with different prev_actions (not a fork)
+    let (action1, action2) = test_case.create_non_forking_actions().await;
+
+    // Create a warrant
+    let warrant_op = test_case
+        .create_chain_fork_warrant(&action1, &action2)
+        .await;
+
+    // Insert dependencies
+    test_case.insert_action_dependency(&action1);
+    test_case.insert_action_dependency(&action2);
+
+    let outcome = test_case.validate_warrant(warrant_op).await.unwrap();
+
+    match outcome {
+        Outcome::Rejected(reason) => {
+            assert!(
+                reason.contains("action pair prev_action mismatch"),
+                "Expected 'action pair prev_action mismatch' in rejection reason, got: {reason}"
+            );
+        }
+        _ => panic!("Expected Rejected outcome but got: {outcome:?}"),
+    }
+}
+
+/// Test that a ChainFork warrant is rejected when the two actions have different sequence numbers
+#[tokio::test(flavor = "multi_thread")]
+async fn validate_chain_fork_warrant_rejected_action_seq_differs() {
+    holochain_trace::test_run();
+
+    let mut test_case = ChainForkWarrantTestCase::new().await;
+
+    // Create two actions with same prev_action but different action_seq values
+    let prev_action_hash = fixt!(ActionHash);
+
+    let mut create1 = fixt!(Create);
+    create1.author = test_case.chain_author.clone();
+    create1.prev_action = prev_action_hash.clone();
+    create1.action_seq = 5;
+    create1.timestamp = Timestamp::now();
+    create1.entry_type = EntryType::App(AppEntryDef {
+        entry_index: 0.into(),
+        zome_index: 0.into(),
+        visibility: EntryVisibility::Public,
+    });
+    create1.entry_hash = fixt!(EntryHash);
+    let action1 = test_case.sign_action(Action::Create(create1)).await;
+
+    let mut create2 = fixt!(Create);
+    create2.author = test_case.chain_author.clone();
+    create2.prev_action = prev_action_hash;
+    create2.action_seq = 6; // Different seq
+    create2.timestamp = Timestamp::now();
+    create2.entry_type = EntryType::App(AppEntryDef {
+        entry_index: 0.into(),
+        zome_index: 0.into(),
+        visibility: EntryVisibility::Public,
+    });
+    create2.entry_hash = fixt!(EntryHash);
+    let action2 = test_case.sign_action(Action::Create(create2)).await;
+
+    let warrant_op = test_case
+        .create_chain_fork_warrant(&action1, &action2)
+        .await;
+
+    test_case.insert_action_dependency(&action1);
+    test_case.insert_action_dependency(&action2);
+
+    let outcome = test_case.validate_warrant(warrant_op).await.unwrap();
+
+    match outcome {
+        Outcome::Rejected(reason) => {
+            assert!(
+                reason.contains("action pair seq mismatch"),
+                "Expected 'action pair seq mismatch' in rejection reason, got: {reason}"
+            );
+        }
+        _ => panic!("Expected Rejected outcome but got: {outcome:?}"),
+    }
+}
+
+/// Test that a ChainFork warrant is rejected when the warrant seq doesn't match the actions' seq
+#[tokio::test(flavor = "multi_thread")]
+async fn validate_chain_fork_warrant_rejected_seq_mismatch() {
+    holochain_trace::test_run();
+
+    let mut test_case = ChainForkWarrantTestCase::new().await;
+
+    // Create a valid fork scenario (same author, same prev_action, same action_seq)
+    let (action1, action2, _) = test_case.create_forking_actions().await;
+
+    // Create a warrant with a mismatched seq (actions have seq=5, warrant declares seq=99)
+    let chain_author = action1.action().author().clone();
+    let warrant_op = test_case
+        .create_chain_fork_warrant_with_seq(&action1, &action2, chain_author, 99)
+        .await;
+
+    test_case.insert_action_dependency(&action1);
+    test_case.insert_action_dependency(&action2);
+
+    let outcome = test_case.validate_warrant(warrant_op).await.unwrap();
+
+    match outcome {
+        Outcome::Rejected(reason) => {
+            assert!(
+                reason.contains("warrant seq mismatch"),
+                "Expected 'warrant seq mismatch' in rejection reason, got: {reason}"
+            );
+        }
+        _ => panic!("Expected Rejected outcome but got: {outcome:?}"),
+    }
+}
+
+/// Test that a ChainFork warrant returns MissingDhtDep when forked actions are not available
+#[tokio::test(flavor = "multi_thread")]
+async fn validate_chain_fork_warrant_missing_dependency() {
+    holochain_trace::test_run();
+
+    let test_case = ChainForkWarrantTestCase::new().await;
+
+    // Create the fork scenario
+    let (action1, action2, _) = test_case.create_forking_actions().await;
+
+    // Create a valid warrant but DON'T insert the action dependencies
+    let warrant_op = test_case
+        .create_chain_fork_warrant(&action1, &action2)
+        .await;
+
+    let outcome = test_case.validate_warrant(warrant_op).await.unwrap();
+
+    assert!(
+        matches!(outcome, Outcome::MissingDhtDep),
+        "Expected MissingDhtDep but actual outcome was {outcome:?}"
+    );
+}
+
+/// Test helper for ChainFork warrant validation tests
+struct ChainForkWarrantTestCase {
+    keystore: holochain_keystore::MetaLairClient,
+    validation_dependencies: SysValDeps,
+    chain_author: AgentPubKey,
+    warrant_author: AgentPubKey,
+    dna_def: DnaDef,
+}
+
+impl ChainForkWarrantTestCase {
+    async fn new() -> Self {
+        let keystore = holochain_keystore::test_keystore();
+        let chain_author = keystore.new_sign_keypair_random().await.unwrap();
+        let warrant_author = keystore.new_sign_keypair_random().await.unwrap();
+        let dna_def = DnaDef::unique_from_zomes(vec![], vec![]);
+
+        Self {
+            keystore,
+            validation_dependencies: SysValDeps::default(),
+            chain_author,
+            warrant_author,
+            dna_def,
+        }
+    }
+
+    /// Create two actions that fork (same prev_action, same author, different content)
+    async fn create_forking_actions(&self) -> (SignedActionHashed, SignedActionHashed, ActionHash) {
+        let prev_action_hash = fixt!(ActionHash);
+
+        // First action
+        let mut create1 = fixt!(Create);
+        create1.author = self.chain_author.clone();
+        create1.prev_action = prev_action_hash.clone();
+        create1.action_seq = 5;
+        create1.timestamp = Timestamp::now();
+        create1.entry_type = EntryType::App(AppEntryDef {
+            entry_index: 0.into(),
+            zome_index: 0.into(),
+            visibility: EntryVisibility::Public,
+        });
+        create1.entry_hash = fixt!(EntryHash);
+        let action1 = self.sign_action(Action::Create(create1)).await;
+
+        // Second action (different entry hash makes it a different action)
+        let mut create2 = fixt!(Create);
+        create2.author = self.chain_author.clone();
+        create2.prev_action = prev_action_hash.clone();
+        create2.action_seq = 5;
+        create2.timestamp = Timestamp::now();
+        create2.entry_type = EntryType::App(AppEntryDef {
+            entry_index: 0.into(),
+            zome_index: 0.into(),
+            visibility: EntryVisibility::Public,
+        });
+        create2.entry_hash = fixt!(EntryHash); // Different entry hash
+        let action2 = self.sign_action(Action::Create(create2)).await;
+
+        (action1, action2, prev_action_hash)
+    }
+
+    /// Create two actions with different authors (invalid fork scenario)
+    async fn create_actions_with_different_authors(
+        &self,
+    ) -> (SignedActionHashed, SignedActionHashed) {
+        let prev_action_hash = fixt!(ActionHash);
+        let other_author = self.keystore.new_sign_keypair_random().await.unwrap();
+
+        // First action with chain_author
+        let mut create1 = fixt!(Create);
+        create1.author = self.chain_author.clone();
+        create1.prev_action = prev_action_hash.clone();
+        create1.action_seq = 5;
+        create1.timestamp = Timestamp::now();
+        create1.entry_type = EntryType::App(AppEntryDef {
+            entry_index: 0.into(),
+            zome_index: 0.into(),
+            visibility: EntryVisibility::Public,
+        });
+        let action1 = self.sign_action(Action::Create(create1)).await;
+
+        // Second action with different author
+        let mut create2 = fixt!(Create);
+        create2.author = other_author;
+        create2.prev_action = prev_action_hash.clone();
+        create2.action_seq = 5;
+        create2.timestamp = Timestamp::now();
+        create2.entry_type = EntryType::App(AppEntryDef {
+            entry_index: 0.into(),
+            zome_index: 0.into(),
+            visibility: EntryVisibility::Public,
+        });
+        let action2 = self.sign_action(Action::Create(create2)).await;
+
+        (action1, action2)
+    }
+
+    /// Create two actions with different prev_actions (not a real fork)
+    async fn create_non_forking_actions(&self) -> (SignedActionHashed, SignedActionHashed) {
+        // First action
+        let mut create1 = fixt!(Create);
+        create1.author = self.chain_author.clone();
+        create1.prev_action = fixt!(ActionHash);
+        create1.action_seq = 5;
+        create1.timestamp = Timestamp::now();
+        create1.entry_type = EntryType::App(AppEntryDef {
+            entry_index: 0.into(),
+            zome_index: 0.into(),
+            visibility: EntryVisibility::Public,
+        });
+        let action1 = self.sign_action(Action::Create(create1)).await;
+
+        // Second action with DIFFERENT prev_action
+        let mut create2 = fixt!(Create);
+        create2.author = self.chain_author.clone();
+        create2.prev_action = fixt!(ActionHash); // Different prev_action
+        create2.action_seq = 5;
+        create2.timestamp = Timestamp::now();
+        create2.entry_type = EntryType::App(AppEntryDef {
+            entry_index: 0.into(),
+            zome_index: 0.into(),
+            visibility: EntryVisibility::Public,
+        });
+        let action2 = self.sign_action(Action::Create(create2)).await;
+
+        (action1, action2)
+    }
+
+    async fn sign_action(&self, action: Action) -> SignedActionHashed {
+        use holochain_zome_types::action::ActionHashed;
+        let action_hashed = ActionHashed::from_content_sync(action);
+        SignedActionHashed::sign(&self.keystore, action_hashed)
+            .await
+            .unwrap()
+    }
+
+    /// Create a valid ChainFork warrant
+    async fn create_chain_fork_warrant(
+        &self,
+        action1: &SignedActionHashed,
+        action2: &SignedActionHashed,
+    ) -> holochain_types::warrant::WarrantOp {
+        let chain_author = action1.action().author().clone();
+        self.create_chain_fork_warrant_with_chain_author(action1, action2, chain_author)
+            .await
+    }
+
+    /// Create a ChainFork warrant with a specified chain_author
+    async fn create_chain_fork_warrant_with_chain_author(
+        &self,
+        action1: &SignedActionHashed,
+        action2: &SignedActionHashed,
+        chain_author: AgentPubKey,
+    ) -> holochain_types::warrant::WarrantOp {
+        let seq = action1.action().action_seq();
+        self.create_chain_fork_warrant_with_seq(action1, action2, chain_author, seq)
+            .await
+    }
+
+    /// Create a ChainFork warrant with a specified chain_author and explicit seq
+    async fn create_chain_fork_warrant_with_seq(
+        &self,
+        action1: &SignedActionHashed,
+        action2: &SignedActionHashed,
+        chain_author: AgentPubKey,
+        seq: u32,
+    ) -> holochain_types::warrant::WarrantOp {
+        use holochain_zome_types::warrant::{ChainIntegrityWarrant, Warrant, WarrantProof};
+
+        let warrant = Warrant::new(
+            WarrantProof::ChainIntegrity(ChainIntegrityWarrant::ChainFork {
+                chain_author: chain_author.clone(),
+                action_pair: (
+                    (action1.as_hash().clone(), action1.signature.clone()),
+                    (action2.as_hash().clone(), action2.signature.clone()),
+                ),
+                seq,
+            }),
+            self.warrant_author.clone(),
+            Timestamp::now(),
+            chain_author,
+        );
+
+        holochain_types::warrant::WarrantOp::sign(&self.keystore, warrant)
+            .await
+            .unwrap()
+    }
+
+    /// Insert an action into the validation dependencies
+    fn insert_action_dependency(&mut self, action: &SignedActionHashed) {
+        use super::validation_deps::{ValidationDependencyState, ValidationDependencyValue};
+
+        let mut deps = self.validation_dependencies.lock().expect("poisoned");
+        let state = ValidationDependencyState::new_present(
+            ValidationDependencyValue::Action(action.clone()),
+            CascadeSource::Local,
+        );
+        let new_deps =
+            ValidationDependencies::new_from_iter(vec![(action.as_hash().clone(), state)]);
+        deps.merge(new_deps);
+    }
+
+    async fn validate_warrant(
+        &self,
+        warrant_op: holochain_types::warrant::WarrantOp,
+    ) -> WorkflowResult<Outcome> {
+        let dna_hash = DnaDefHashed::from_content_sync(self.dna_def.clone()).hash;
+        let op = DhtOp::WarrantOp(Box::new(warrant_op));
+
+        validate_op(&op, &dna_hash, self.validation_dependencies.clone()).await
+    }
+}

--- a/crates/holochain_cascade/tests/tests/get_activity.rs
+++ b/crates/holochain_cascade/tests/tests/get_activity.rs
@@ -374,6 +374,7 @@ async fn get_activity_with_warrants() {
         let p = WarrantProof::ChainIntegrity(ChainIntegrityWarrant::ChainFork {
             chain_author: td.agent.clone(),
             action_pair,
+            seq: 0,
         });
         let warrant = Warrant::new(
             p,

--- a/crates/holochain_state/tests/warrants/mod.rs
+++ b/crates/holochain_state/tests/warrants/mod.rs
@@ -69,6 +69,7 @@ async fn write_chain_fork_warrant_to_database() {
                 (fixt!(ActionHash), fixt!(Signature)),
                 (fixt!(ActionHash), fixt!(Signature)),
             ),
+            seq: 5,
         }),
         fixt!(AgentPubKey),
         Timestamp::now(),

--- a/crates/holochain_zome_types/src/query.rs
+++ b/crates/holochain_zome_types/src/query.rs
@@ -199,8 +199,6 @@ pub enum ChainStatus {
     /// look at the value of [`AgentActivity::warrants`] and/or call
     /// `hdk::chain::get_agent_activity` with [`ActivityRequest::Full`] and look
     /// at the values in [`AgentActivity::rejected_activity`].
-    ///
-    /// **NOTE**: Chain fork detection is not considered stable at this time.
     Forked(ChainFork),
     /// The chain is not forked, but is invalid from the given action sequence
     /// and action hash forward, by virtue of this authority finding a
@@ -229,8 +227,6 @@ pub struct ChainHead {
 /// of the values in `first_action` and `second_action` is undefined, and in
 /// cases of three or more actions causing a fork, different peers may report
 /// different hash pairs.
-///
-/// **NOTE**: Chain fork detection is not considered stable at this time.
 #[derive(Clone, Debug, Hash, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ChainFork {
     /// The point where the chain has forked.

--- a/crates/holochain_zome_types/src/warrant.rs
+++ b/crates/holochain_zome_types/src/warrant.rs
@@ -153,6 +153,8 @@ pub enum ChainIntegrityWarrant {
         chain_author: AgentPubKey,
         /// Two actions of the same seq number which prove the fork
         action_pair: (ActionHashAndSig, ActionHashAndSig),
+        /// The seq number at which the fork occurs
+        seq: u32,
     },
 }
 


### PR DESCRIPTION
### Summary

Stabilize the chain fork warrants feature by removing the unstable-warrants feature gate and adding comprehensive test coverage. Additionally, add `seq` validation to `ChainFork` warrants so that the sequence number is checked during warrant verification.

Changes:

- Remove `unstable-warrants` feature gate from chain fork warrant code paths
- SQL query (`action_hash_by_prev.sql`): do not filter by author in the query, check after the query and raise an error if it doesn't match
- Add `seq` field to `ChainIntegrityWarrant::ChainFork` and populate it from the detected fork's action sequence number
- Refactor `ForkedPair` from a nested tuple to a named struct for clarity
- Validate `seq` during warrant verification with the following check order:
  1. One or both action hashes can't be found → can't validate (MissingDhtDep)
  2. `chain_author` doesn't match action author → reject
  3. Actions authored by different agents → reject
  4. Actions have different sequence numbers (not a fork) → reject
  5. Sequence numbers match but don't match the warrant's `seq` → reject
  6. Actions don't share a `prev_action` (not a fork) → reject
  7. Everything matches → accept
- Add unit tests for `validate_warrant_op` covering `ChainFork` warrant validation:
  - Accepted: valid warrant with matching authors, seq, and prev_actions
  - Rejected: chain_author mismatch
  - Rejected: action authors differ
  - Rejected: action sequence numbers differ
  - Rejected: warrant seq doesn't match actions' seq
  - Rejected: prev_actions differ (not a real fork)
  - MissingDependencies: when forked actions aren't available
- Enhance integration tests (`sys_validation_produces_forked_chain_warrant`, `sys_validation_produces_two_warrants_when_receiving_both_forked_ops`) to verify the warrant's `seq` and action_pair contain correct values
- Enhance `test_detect_fork` with explicit test for DNA actions (no prev_action)

Closes #5600

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs