### PR TITLE
Add per-call timeout option for zome calls

### DIFF
--- a/crates/client/CHANGELOG.md
+++ b/crates/client/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+### Added
+
+- Added `CallZomeOptions` struct and `call_zome_with_options` / `signed_call_zome_with_options` methods to `AppWebsocket` to allow configuring a per-call timeout for zome calls. [\#5644](https://github.com/holochain/holochain/pull/5644)
+
 ## 0.9.0-dev.11
 
 ## 0.9.0-dev.10

--- a/crates/client/src/app_websocket.rs
+++ b/crates/client/src/app_websocket.rs
@@ -23,6 +23,7 @@ use std::collections::BTreeMap;
 use std::fmt::Formatter;
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// A websocket connection to a Holochain app running in a Conductor.
 #[derive(Clone)]
@@ -237,12 +238,38 @@ impl AppWebsocket {
         &self.app_info
     }
 
+    /// Calls a zome function using the connection-level default parameters, including timeout.
+    ///
+    /// In case you need to override the timeout for this call,
+    /// use [`AppWebsocket::call_zome_with_options`] instead with a custom [`CallZomeOptions`].
     pub async fn call_zome(
         &self,
         target: ZomeCallTarget,
         zome_name: ZomeName,
         fn_name: FunctionName,
         payload: ExternIO,
+    ) -> ConductorApiResult<ExternIO> {
+        self.call_zome_with_options(
+            target,
+            zome_name,
+            fn_name,
+            payload,
+            CallZomeOptions::default(),
+        )
+        .await
+    }
+
+    /// Calls a zome function with per-call options.
+    ///
+    /// Use this to override the connection-level timeout for an individual
+    /// zome call via [`CallZomeOptions`].
+    pub async fn call_zome_with_options(
+        &self,
+        target: ZomeCallTarget,
+        zome_name: ZomeName,
+        fn_name: FunctionName,
+        payload: ExternIO,
+        options: CallZomeOptions,
     ) -> ConductorApiResult<ExternIO> {
         let cell_id = match target {
             ZomeCallTarget::CellId(cell_id) => cell_id,
@@ -269,15 +296,36 @@ impl AppWebsocket {
             .await
             .map_err(|e| ConductorApiError::SignZomeCallError(e.to_string()))?;
 
-        self.signed_call_zome(signed_zome_call).await
+        self.signed_call_zome_with_options(signed_zome_call, options)
+            .await
     }
 
+    /// Sends a pre-signed zome call using the connection-level default parameters, including timeout.
+    ///
+    /// In case you need to override the timeout for this call,
+    /// use [`AppWebsocket::signed_call_zome_with_options`] instead with a custom [`CallZomeOptions`].
     pub async fn signed_call_zome(
         &self,
         signed_params: ZomeCallParamsSigned,
     ) -> ConductorApiResult<ExternIO> {
+        self.signed_call_zome_with_options(signed_params, CallZomeOptions::default())
+            .await
+    }
+
+    /// Sends a pre-signed zome call with per-call options.
+    ///
+    /// Use this to override the connection-level timeout for an individual
+    /// zome call via [`CallZomeOptions`].
+    pub async fn signed_call_zome_with_options(
+        &self,
+        signed_params: ZomeCallParamsSigned,
+        options: CallZomeOptions,
+    ) -> ConductorApiResult<ExternIO> {
         let app_request = AppRequest::CallZome(Box::new(signed_params));
-        let response = self.inner.send(app_request).await?;
+        let response = self
+            .inner
+            .send_with_timeout(app_request, options.timeout)
+            .await?;
 
         match response {
             AppResponse::ZomeCalled(result) => Ok(*result),
@@ -495,6 +543,46 @@ impl From<RoleName> for ZomeCallTarget {
 impl From<CloneId> for ZomeCallTarget {
     fn from(clone_id: CloneId) -> Self {
         ZomeCallTarget::CloneId(clone_id)
+    }
+}
+
+/// Options for a single zome call request.
+///
+/// Use this with [`AppWebsocket::call_zome_with_options`] or
+/// [`AppWebsocket::signed_call_zome_with_options`] to override the
+/// connection-level timeout on a per-call basis.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use std::time::Duration;
+/// use holochain_client::CallZomeOptions;
+///
+/// // Use default options (connection-level timeout).
+/// let opts = CallZomeOptions::new();
+///
+/// // Override the timeout for a long-running zome call.
+/// let opts = CallZomeOptions::new().with_timeout(Duration::from_secs(300));
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct CallZomeOptions {
+    /// Per-call timeout override.
+    ///
+    /// When `None`, the connection-level `default_request_timeout` is used.
+    /// When `Some`, this duration is used instead.
+    pub timeout: Option<Duration>,
+}
+
+impl CallZomeOptions {
+    /// Creates default options with no overrides.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the timeout for this zome call.
+    pub fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
     }
 }
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -6,7 +6,7 @@ mod signing;
 mod util;
 
 pub use admin_websocket::{AdminWebsocket, AuthorizeSigningCredentialsPayload, EnableAppResponse};
-pub use app_websocket::{AppWebsocket, ZomeCallTarget};
+pub use app_websocket::{AppWebsocket, CallZomeOptions, ZomeCallTarget};
 pub use error::{ConductorApiError, ConductorApiResult};
 pub use holochain_conductor_api::{
     AdminRequest, AdminResponse, AppAuthenticationRequest, AppAuthenticationToken,

--- a/crates/client/tests/app.rs
+++ b/crates/client/tests/app.rs
@@ -5,8 +5,8 @@ use holochain::{
     sweettest::SweetConductor,
 };
 use holochain_client::{
-    AdminWebsocket, AppWebsocket, AuthorizeSigningCredentialsPayload, ClientAgentSigner,
-    InstallAppPayload, InstalledAppId,
+    AdminWebsocket, AppWebsocket, AuthorizeSigningCredentialsPayload, CallZomeOptions,
+    ClientAgentSigner, ConductorApiError, InstallAppPayload, InstalledAppId,
 };
 use holochain_conductor_api::{CellInfo, IssueAppAuthenticationTokenPayload};
 use holochain_types::{
@@ -654,4 +654,101 @@ async fn peer_meta_info() {
         .get(&dna_hash)
         .expect("No meta infos found for dna hash.");
     assert_eq!(meta_infos.len(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn call_zome_with_options_custom_timeout() {
+    let conductor = SweetConductor::standard().await;
+
+    let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
+    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port), None)
+        .await
+        .unwrap();
+
+    let app_id: InstalledAppId = "test-app".into();
+    admin_ws
+        .install_app(InstallAppPayload {
+            agent_key: None,
+            installed_app_id: Some(app_id.clone()),
+            network_seed: None,
+            roles_settings: None,
+            source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
+            ignore_genesis_failure: false,
+        })
+        .await
+        .unwrap();
+    admin_ws.enable_app(app_id.clone()).await.unwrap();
+
+    let app_ws_port = admin_ws
+        .attach_app_interface(0, None, AllowedOrigins::Any, None)
+        .await
+        .unwrap();
+    let token_issued = admin_ws
+        .issue_app_auth_token(app_id.clone().into())
+        .await
+        .unwrap();
+    let signer = ClientAgentSigner::default();
+
+    let app_ws = AppWebsocket::connect(
+        (Ipv4Addr::LOCALHOST, app_ws_port),
+        token_issued.token,
+        signer.clone().into(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    let installed_app = app_ws.app_info().await.unwrap().unwrap();
+    let cells = installed_app.cell_info.into_values().next().unwrap();
+    let cell_id = match cells[0].clone() {
+        CellInfo::Provisioned(c) => c.cell_id,
+        _ => panic!("Invalid cell type"),
+    };
+
+    let credentials = admin_ws
+        .authorize_signing_credentials(AuthorizeSigningCredentialsPayload {
+            cell_id: cell_id.clone(),
+            functions: None,
+        })
+        .await
+        .unwrap();
+    signer.add_credentials(cell_id.clone(), credentials);
+
+    const TEST_ZOME_NAME: &str = "foo";
+    const TEST_FN_NAME: &str = "emitter";
+
+    // A generous timeout should succeed.
+    let result = app_ws
+        .call_zome_with_options(
+            cell_id.clone().into(),
+            TEST_ZOME_NAME.into(),
+            TEST_FN_NAME.into(),
+            ExternIO::encode(()).unwrap(),
+            CallZomeOptions::new().with_timeout(Duration::from_secs(60)),
+        )
+        .await;
+    assert!(
+        result.is_ok(),
+        "call_zome_with_options should succeed with a generous timeout"
+    );
+
+    // A near-zero timeout should fail with a timeout error.
+    let result = app_ws
+        .call_zome_with_options(
+            cell_id.into(),
+            TEST_ZOME_NAME.into(),
+            TEST_FN_NAME.into(),
+            ExternIO::encode(()).unwrap(),
+            CallZomeOptions::new().with_timeout(Duration::from_nanos(1)),
+        )
+        .await;
+    assert!(
+        matches!(
+            result,
+            Err(ConductorApiError::WebsocketError(
+                holochain_websocket::WebsocketError::Timeout(_)
+            ))
+        ),
+        "Expected a timeout error, got: {result:?}"
+    );
 }


### PR DESCRIPTION
## Summary
- Adds `CallZomeOptions` struct with an optional `timeout` field to override the connection-level timeout on individual zome calls
- Adds `call_zome_with_options` and `signed_call_zome_with_options` methods on `AppWebsocket`
- Existing `call_zome` and `signed_call_zome` signatures are unchanged (no breaking changes) — they delegate internally to the new `_with_options` variants
- Adds `send_with_timeout` to `AppWebsocketInner`, leveraging the existing `WebsocketSender::request_timeout` — no changes to `holochain_websocket`

## Test plan
- [x] Added integration test `call_zome_with_options_custom_timeout` that verifies:
  - A generous timeout succeeds
  - A near-zero timeout produces a `WebsocketError::Timeout` error
- [x] All existing tests pass (`cargo test -p holochain_client`)
- [x] `cargo check` passes for `holochain_client` and `holochain_cli_client`

Closes #5643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* **Per-call timeout configuration**: Added the ability to customize timeout values for individual zome calls, enabling fine-grained control over call-specific timeouts while preserving connection-level defaults.
* **Enhanced API methods**: Introduced new options-based methods for both standard and signed zome calls, providing users with flexible timeout configuration per call.
* **Backwards compatible**: Existing methods continue to work as before, using connection-level timeout defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->