### PR TITLE
Backport 5631

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix: DbKind display implementation now properly includes the associated CellId or DnaHash of the database, instead of escaped rust code.
+
 ## 0.6.1-rc.2
 
 ## 0.6.1-rc.1

--- a/crates/holochain_sqlite/src/db/kind.rs
+++ b/crates/holochain_sqlite/src/db/kind.rs
@@ -7,13 +7,10 @@ use std::sync::Arc;
 #[derive(Clone, Debug, PartialEq, Eq, Hash, derive_more::Display)]
 pub enum DbKind {
     /// Specifies the environment used for authoring data by all cells on the same [`DnaHash`].
-    #[display("{:?}-{:?}", "_0.dna_hash()", "_0.agent_pubkey()")]
     Authored(Arc<CellId>),
     /// Specifies the environment used for dht data by all cells on the same [`DnaHash`].
-    #[display("{:?}", "_0")]
     Dht(Arc<DnaHash>),
     /// Specifies the environment used by each Cache (one per dna).
-    #[display("{:?}", "_0")]
     Cache(Arc<DnaHash>),
     /// Specifies the environment used by a Conductor
     Conductor,


### PR DESCRIPTION
### Summary
Backport #5631


### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs