### PR TITLE
feat: Upgrade to Kitsune2 0.4.0-dev.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -562,7 +562,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3906,7 +3906,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4599,9 +4599,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2"
-version = "0.4.0-dev.3"
+version = "0.4.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abffb5db34bf72501d04ed934b299d7ff31b980395b5e52130125c7c6785e3e0"
+checksum = "b528af51448aed2da863356880abd22091b2db33041bbdc1596adbaa2d8f6027"
 dependencies = [
  "bytes",
  "kitsune2_api",
@@ -4614,9 +4614,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_api"
-version = "0.4.0-dev.3"
+version = "0.4.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154a5b33e3678c9bbabe7f864f742feb2681c5be0933b917ffcb05134dbffb98"
+checksum = "f520eb0c66a79ea8f1112ee2b062ae423e5cb9399b05eb26bb3bedcd81172664"
 dependencies = [
  "base64",
  "bytes",
@@ -4631,9 +4631,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_client"
-version = "0.4.0-dev.3"
+version = "0.4.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b7d0b429153e1d0edb037803f0bfa42f10bbba3613c30544c95c757e3397d5"
+checksum = "ec32dd2c280a7e9c3585dde2c40be62c9be396a7255fe3aaf536679267dc8c7f"
 dependencies = [
  "base64",
  "kitsune2_api",
@@ -4646,9 +4646,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_srv"
-version = "0.4.0-dev.3"
+version = "0.4.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c83f6eb8e683f45d9cec33610e806d302816f3198fdb97b089b2298ee967f5"
+checksum = "632723bf060aa977b682a343c8f4f190640af7866cee48515271322ef6082d44"
 dependencies = [
  "async-channel",
  "axum",
@@ -4661,6 +4661,7 @@ dependencies = [
  "futures",
  "http",
  "iroh",
+ "iroh-base",
  "iroh-relay-holochain",
  "num_cpus",
  "opentelemetry 0.30.0",
@@ -4679,9 +4680,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_core"
-version = "0.4.0-dev.3"
+version = "0.4.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d218e19b1f2e453d71e32b777ad8f82f7cbec2f236788bc95f69da8cd9ec6ec7"
+checksum = "99aaef93b5bcc2afc187c0c9dc76148df73cfce3e754ce3fd1e43891a2f56844"
 dependencies = [
  "bytes",
  "ed25519-dalek 2.2.0",
@@ -4700,9 +4701,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_dht"
-version = "0.4.0-dev.2"
+version = "0.4.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5e4ab4fa9feca18fe5b5e99df46916e47a143043761c7a7f2be7d7b6676184"
+checksum = "e23f47bec2401f302f779bca2dd09f8d0541f04fa6765f1496691db585f447d3"
 dependencies = [
  "bytes",
  "kitsune2_api",
@@ -4711,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_gossip"
-version = "0.4.0-dev.3"
+version = "0.4.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46752e966411545245341c6a1010cd3bd455dd58f6a68a99819b03b3e984d6a3"
+checksum = "6456b6951fabf32d8a7ceb78fde7d274b74c666abde3ac46c97f8c64f8947189"
 dependencies = [
  "bytes",
  "futures",
@@ -4732,9 +4733,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_test_utils"
-version = "0.4.0-dev.3"
+version = "0.4.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b90194a1f96f0c0006058465ffd4898892a538c48bdcd76924ad9c01b82dec"
+checksum = "af081ce641ea1e1bad868e3f46aca1169a78b6705ba5b95e772f6ab6606250fb"
 dependencies = [
  "axum",
  "bytes",
@@ -4749,13 +4750,14 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_iroh"
-version = "0.4.0-dev.3"
+version = "0.4.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4920ee3e4b03db6fd693c398a783c0cef851626e90e1eb3965ba09ec5be5408e"
+checksum = "f2eddc8ee1602e5b94454a5026c7f25eaf32d842ec39c4109a7e27d0f3774299"
 dependencies = [
  "bytes",
  "iroh",
  "kitsune2_api",
+ "kitsune2_bootstrap_client",
  "n0-watcher",
  "schemars 0.9.0",
  "serde",
@@ -4766,9 +4768,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_tx5"
-version = "0.4.0-dev.3"
+version = "0.4.0-dev.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35893dce4cf7d97d9f691eea036ef9583eefff1bf7f3f218125e9403f7d95c9f"
+checksum = "636e3e218afa45c650b4331e8652529b12b5014db0fd2a5a271121730e7dcfc2"
 dependencies = [
  "base64",
  "bytes",
@@ -6543,7 +6545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6556,7 +6558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10759,8 +10761,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -26,7 +26,7 @@ holochain_nonce = { version = "^0.7.0-dev.1", path = "../holochain_nonce" }
 holochain_types = { version = "^0.7.0-dev.14", path = "../holochain_types" }
 holochain_websocket = { version = "^0.7.0-dev.14", path = "../holochain_websocket" }
 holochain_zome_types = { version = "^0.7.0-dev.8", path = "../holochain_zome_types" }
-kitsune2_api = "0.4.0-dev.3"
+kitsune2_api = "0.4.0-dev.4"
 lair_keystore_api = { version = "0.6.3", optional = true }
 parking_lot = "0.12.1"
 rand = { version = "0.8" }
@@ -42,8 +42,8 @@ holochain = { version = "^0.7.0-dev.15", path = "../holochain", default-features
 ] }
 holochain_wasm_test_utils = { version = "^0.7.0-dev.15", path = "../test_utils/wasm" }
 
-kitsune2_core = "0.4.0-dev.3"
-kitsune2_test_utils = "0.4.0-dev.3"
+kitsune2_core = "0.4.0-dev.4"
+kitsune2_test_utils = "0.4.0-dev.4"
 serde_yaml = "0.9"
 
 [features]

--- a/crates/hc_client/Cargo.toml
+++ b/crates/hc_client/Cargo.toml
@@ -35,8 +35,8 @@ holochain_types = { path = "../holochain_types", version = "^0.7.0-dev.14", feat
 holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util", features = [
   "pw",
 ] }
-kitsune2_api = "0.4.0-dev.3"
-kitsune2_core = "0.4.0-dev.3"
+kitsune2_api = "0.4.0-dev.4"
+kitsune2_core = "0.4.0-dev.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -30,7 +30,7 @@ fixt = { version = "^0.7.0-dev.0", path = "../fixt", optional = true }
 futures = { version = "0.3", optional = true }
 holochain_serialized_bytes = { version = "=0.0.56", optional = true }
 holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util", default-features = false }
-kitsune2_api = { version = "0.4.0-dev.3", optional = true }
+kitsune2_api = { version = "0.4.0-dev.4", optional = true }
 must_future = { version = "0.1", optional = true }
 proptest = { version = "1", optional = true }
 proptest-derive = { version = "0", optional = true }

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Update kitsune2 dependencies to `0.4.0-dev.4`.
+  - Implements new required `OpStore::query_total_op_count` method, counting integrated ops across both the DHT and cache databases.
+  - Adds `GossipStateSummary::local_op_count` field to the gossip state summary.
+  - **BREAKING** Adds `HolochainP2pConfig::get_db_cache` callback (required when constructing the p2p config) to supply the cache database handle per space.
+
 ## 0.7.0-dev.15
 
 - Update kitsune2 dependencies to `0.4.0-dev.3`. \#5673

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -52,8 +52,8 @@ holochain_conductor_config = { version = "^0.7.0-dev.14", path = "../holochain_c
 holochain_timestamp = { version = "^0.7.0-dev.0", path = "../timestamp" }
 human-panic = "2.0"
 itertools = { version = "0.14" }
-kitsune2_api = "0.4.0-dev.3"
-kitsune2_core = "0.4.0-dev.3"
+kitsune2_api = "0.4.0-dev.4"
+kitsune2_core = "0.4.0-dev.4"
 mockall = "0.13"
 mr_bundle = { version = "^0.7.0-dev.1", path = "../mr_bundle", features = [
   "fs",
@@ -104,7 +104,7 @@ matches = { version = "0.1.8", optional = true }
 holochain_wasm_test_utils = { version = "^0.7.0-dev.15", path = "../test_utils/wasm", optional = true }
 holochain_test_wasm_common = { version = "^0.7.0-dev.9", path = "../test_utils/wasm_common", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
-kitsune2_bootstrap_srv = { version = "0.4.0-dev.3", default-features = false, optional = true }
+kitsune2_bootstrap_srv = { version = "0.4.0-dev.4", default-features = false, optional = true }
 schemars = "0.9"
 
 [target.'cfg(unix)'.dependencies]
@@ -130,7 +130,7 @@ tokio = { version = "1.36.0", features = ["full", "test-util"] }
 tokio-tungstenite = "0.27"
 predicates = "3.1"
 assert2 = "0.3.15"
-kitsune2_test_utils = "0.4.0-dev.3"
+kitsune2_test_utils = "0.4.0-dev.4"
 rand_dalek = { version = "0.8", package = "rand" }
 
 [build-dependencies]

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -209,6 +209,7 @@ impl ConductorBuilder {
 
         let net_spaces1 = spaces.clone();
         let net_spaces2 = spaces.clone();
+        let net_spaces3 = spaces.clone();
         let conductor_db = spaces.conductor_db.clone();
         let p2p_config = holochain_p2p::HolochainP2pConfig {
             auth_material: config
@@ -226,6 +227,10 @@ impl ConductorBuilder {
             }),
             get_db_op_store: Arc::new(move |dna_hash| {
                 let res = net_spaces2.dht_db(&dna_hash);
+                Box::pin(async move { res.map_err(holochain_p2p::HolochainP2pError::other) })
+            }),
+            get_db_cache: Arc::new(move |dna_hash| {
+                let res = net_spaces3.cache(&dna_hash);
                 Box::pin(async move { res.map_err(holochain_p2p::HolochainP2pError::other) })
             }),
             get_conductor_db: Arc::new(move || {
@@ -435,6 +440,7 @@ impl ConductorBuilder {
 
         let net_spaces1 = spaces.clone();
         let net_spaces2 = spaces.clone();
+        let net_spaces3 = spaces.clone();
         let conductor_db = spaces.conductor_db.clone();
         let p2p_config = holochain_p2p::HolochainP2pConfig {
             auth_material: config
@@ -452,6 +458,10 @@ impl ConductorBuilder {
             }),
             get_db_op_store: Arc::new(move |dna_hash| {
                 let res = net_spaces2.dht_db(&dna_hash);
+                Box::pin(async move { res.map_err(holochain_p2p::HolochainP2pError::other) })
+            }),
+            get_db_cache: Arc::new(move |dna_hash| {
+                let res = net_spaces3.cache(&dna_hash);
                 Box::pin(async move { res.map_err(holochain_p2p::HolochainP2pError::other) })
             }),
             get_conductor_db: Arc::new(move || {

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = "2.0"
 tracing = "0.1"
 opentelemetry_api = { version = "=0.20.0", features = ["metrics"] }
 
-kitsune2_api = "0.4.0-dev.3"
+kitsune2_api = "0.4.0-dev.4"
 
 async-trait = "0.1"
 mockall = { version = "0.13", optional = true }

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-kitsune2_transport_tx5 = { version = "0.4.0-dev.3", optional = true }
-kitsune2_transport_iroh = { version = "0.4.0-dev.3", optional = true }
+kitsune2_transport_tx5 = { version = "0.4.0-dev.4", optional = true }
+kitsune2_transport_iroh = { version = "0.4.0-dev.4", optional = true }
 derive_more = { version = "2.0", features = ["from"] }
 holo_hash = { version = "^0.7.0-dev.5", path = "../holo_hash", features = [
   "full",
@@ -23,9 +23,9 @@ holochain_zome_types = { version = "^0.7.0-dev.8", path = "../holochain_zome_typ
 holochain_util = { version = "^0.7.0-dev.1", default-features = false, path = "../holochain_util", features = [
   "jsonschema",
 ] }
-kitsune2_api = "0.4.0-dev.3"
-kitsune2_core = { version = "0.4.0-dev.3" }
-kitsune2_gossip = { version = "0.4.0-dev.3", optional = true }
+kitsune2_api = "0.4.0-dev.4"
+kitsune2_core = { version = "0.4.0-dev.4" }
+kitsune2_gossip = { version = "0.4.0-dev.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -41,13 +41,13 @@ opentelemetry_api = { version = "=0.20.0", features = ["metrics"] }
 strum = "0.27.2"
 strum_macros = "0.27.2"
 
-kitsune2 = { version = "0.4.0-dev.3", default-features = false }
-kitsune2_bootstrap_srv = { version = "0.4.0-dev.3", default-features = false, optional = true }
-kitsune2_api = "0.4.0-dev.3"
-kitsune2_core = "0.4.0-dev.3"
-kitsune2_gossip = "0.4.0-dev.3"
-kitsune2_transport_iroh = { version = "0.4.0-dev.3", default-features = false, optional = true }
-kitsune2_transport_tx5 = { version = "0.4.0-dev.3", default-features = false, optional = true }
+kitsune2 = { version = "0.4.0-dev.4", default-features = false }
+kitsune2_bootstrap_srv = { version = "0.4.0-dev.4", default-features = false, optional = true }
+kitsune2_api = "0.4.0-dev.4"
+kitsune2_core = "0.4.0-dev.4"
+kitsune2_gossip = "0.4.0-dev.4"
+kitsune2_transport_iroh = { version = "0.4.0-dev.4", default-features = false, optional = true }
+kitsune2_transport_tx5 = { version = "0.4.0-dev.4", default-features = false, optional = true }
 bytes = "1.10"
 holochain_sqlite = { version = "^0.7.0-dev.11", path = "../holochain_sqlite" }
 lair_keystore_api = "=0.6.3"

--- a/crates/holochain_p2p/src/op_store.rs
+++ b/crates/holochain_p2p/src/op_store.rs
@@ -2,11 +2,11 @@ use bytes::Bytes;
 use futures::future::BoxFuture;
 use holo_hash::{DhtOpHash, DnaHash, OpBasis};
 use holochain_serialized_bytes::prelude::decode;
-use holochain_sqlite::db::{DbKindDht, DbWrite, ReadAccess};
+use holochain_sqlite::db::{DbKindCache, DbKindDht, DbWrite, ReadAccess};
 use holochain_sqlite::rusqlite::types::Value;
 use holochain_sqlite::sql::sql_dht::{
     CHECK_OP_IDS_PRESENT, EARLIEST_TIMESTAMP, OPS_BY_ID, OP_HASHES_IN_TIME_SLICE,
-    OP_HASHES_SINCE_TIME_BATCH,
+    OP_HASHES_SINCE_TIME_BATCH, TOTAL_OP_COUNT,
 };
 use holochain_state::prelude::{named_params, StateMutationResult};
 use holochain_types::dht_op::DhtOpHashed;
@@ -21,6 +21,8 @@ use std::sync::Arc;
 pub struct HolochainOpStoreFactory {
     /// The database connection getter.
     pub getter: crate::GetDbOpStore,
+    /// The cache database connection getter.
+    pub cache_getter: crate::GetDbCache,
     /// The event handler.
     pub handler: Arc<std::sync::OnceLock<crate::spawn::WrapEvtSender>>,
 }
@@ -46,14 +48,18 @@ impl kitsune2_api::OpStoreFactory for HolochainOpStoreFactory {
         space: kitsune2_api::SpaceId,
     ) -> BoxFut<'static, kitsune2_api::K2Result<kitsune2_api::DynOpStore>> {
         let getter = self.getter.clone();
+        let cache_getter = self.cache_getter.clone();
         let handler = self.handler.clone();
         Box::pin(async move {
             let dna_hash = DnaHash::from_k2_space(&space);
             let db = getter(dna_hash.clone()).await.map_err(|err| {
                 kitsune2_api::K2Error::other_src("failed to get op_store db", err)
             })?;
+            let cache_db = cache_getter(dna_hash.clone())
+                .await
+                .map_err(|err| kitsune2_api::K2Error::other_src("failed to get cache db", err))?;
             let op_store: kitsune2_api::DynOpStore =
-                Arc::new(HolochainOpStore::new(db, dna_hash, handler));
+                Arc::new(HolochainOpStore::new(db, cache_db, dna_hash, handler));
 
             Ok(op_store)
         })
@@ -63,6 +69,7 @@ impl kitsune2_api::OpStoreFactory for HolochainOpStoreFactory {
 /// Holochain implementation of the Kitsune2 [OpStore].
 pub struct HolochainOpStore {
     db: DbWrite<DbKindDht>,
+    cache_db: DbWrite<DbKindCache>,
     dna_hash: DnaHash,
     sender: Arc<std::sync::OnceLock<crate::spawn::WrapEvtSender>>,
 }
@@ -71,6 +78,7 @@ impl Debug for HolochainOpStore {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HolochainOpStore")
             .field("db", &self.db)
+            .field("cache_db", &self.cache_db)
             .finish()
     }
 }
@@ -79,11 +87,13 @@ impl HolochainOpStore {
     /// Create a new [HolochainOpStore].
     pub fn new(
         db: DbWrite<DbKindDht>,
+        cache_db: DbWrite<DbKindCache>,
         dna_hash: DnaHash,
         sender: Arc<std::sync::OnceLock<crate::spawn::WrapEvtSender>>,
     ) -> HolochainOpStore {
         Self {
             db,
+            cache_db,
             dna_hash,
             sender,
         }
@@ -348,6 +358,29 @@ impl OpStore for HolochainOpStore {
             })
             .await
             .map_err(|e| K2Error::other_src("Failed to retrieve earliest timestamp in arc", e))
+        })
+    }
+
+    fn query_total_op_count(&self) -> BoxFuture<'_, K2Result<u64>> {
+        let db = self.db.clone();
+        let cache_db = self.cache_db.clone();
+
+        Box::pin(async move {
+            let dht_count = db
+                .read_async(move |txn| -> StateMutationResult<u64> {
+                    Ok(txn.query_row(TOTAL_OP_COUNT, [], |row| row.get(0))?)
+                })
+                .await
+                .map_err(|e| K2Error::other_src("Failed to query total op count from dht", e))?;
+
+            let cache_count = cache_db
+                .read_async(move |txn| -> StateMutationResult<u64> {
+                    Ok(txn.query_row(TOTAL_OP_COUNT, [], |row| row.get(0))?)
+                })
+                .await
+                .map_err(|e| K2Error::other_src("Failed to query total op count from cache", e))?;
+
+            Ok(dht_count + cache_count)
         })
     }
 

--- a/crates/holochain_p2p/src/spawn.rs
+++ b/crates/holochain_p2p/src/spawn.rs
@@ -23,9 +23,17 @@ pub type GetDbPeerMeta = Arc<
         + Sync,
 >;
 
-/// Callback function to retrieve a op store database handle for a dna hash.
+/// Callback function to retrieve an op store database handle for a dna hash.
 pub type GetDbOpStore = Arc<
     dyn Fn(DnaHash) -> BoxFut<'static, HolochainP2pResult<DbWrite<DbKindDht>>>
+        + 'static
+        + Send
+        + Sync,
+>;
+
+/// Callback function to retrieve a cache database handle for a dna hash.
+pub type GetDbCache = Arc<
+    dyn Fn(DnaHash) -> BoxFut<'static, HolochainP2pResult<DbWrite<DbKindCache>>>
         + 'static
         + Send
         + Sync,
@@ -49,6 +57,15 @@ pub enum ReportConfig {
 /// HolochainP2p config struct.
 pub struct HolochainP2pConfig {
     /// Callback function to retrieve a peer meta database handle for a dna hash.
+    ///
+    /// **Must be set explicitly** — the [`Default`] value panics when called. Example:
+    ///
+    /// ```ignore
+    /// get_db_peer_meta: Arc::new(move |dna_hash| {
+    ///     let res = spaces.peer_meta(&dna_hash);
+    ///     Box::pin(async move { res.map_err(HolochainP2pError::other) })
+    /// }),
+    /// ```
     pub get_db_peer_meta: GetDbPeerMeta,
 
     /// Interval for a pruning task to remove expired values from the peer meta store.
@@ -57,9 +74,46 @@ pub struct HolochainP2pConfig {
     pub peer_meta_pruning_interval_ms: u64,
 
     /// Callback function to retrieve an op store database handle for a dna hash.
+    ///
+    /// Called when a new space is created to open the DHT [`DbWrite`] for that DNA. Gossip uses
+    /// the returned handle to read and write ops for that space.
+    ///
+    /// **Must be set explicitly** — the [`Default`] value panics when called. Example:
+    ///
+    /// ```ignore
+    /// get_db_op_store: Arc::new(move |dna_hash| {
+    ///     let res = spaces.dht(&dna_hash);
+    ///     Box::pin(async move { res.map_err(HolochainP2pError::other) })
+    /// }),
+    /// ```
     pub get_db_op_store: GetDbOpStore,
 
+    /// Callback function to retrieve a cache database handle for a dna hash.
+    ///
+    /// Called when a new space is created to open the cache [`DbWrite`] for that DNA.
+    /// The returned handle is used alongside [`get_db_op_store`](Self::get_db_op_store)
+    /// to report the total local op count to gossip.
+    ///
+    /// **Must be set explicitly** — the [`Default`] value panics when called. Example:
+    ///
+    /// ```ignore
+    /// get_db_cache: Arc::new(move |dna_hash| {
+    ///     let res = spaces.cache(&dna_hash);
+    ///     Box::pin(async move { res.map_err(HolochainP2pError::other) })
+    /// }),
+    /// ```
+    pub get_db_cache: GetDbCache,
+
     /// Callback function to retrieve the conductor database handle.
+    ///
+    /// **Must be set explicitly** — the [`Default`] value panics when called. Example:
+    ///
+    /// ```ignore
+    /// get_conductor_db: Arc::new(|| {
+    ///     let res = conductor_db.clone();
+    ///     Box::pin(async move { Ok(res) })
+    /// }),
+    /// ```
     pub get_conductor_db: GetDbConductor,
 
     /// The arc factor to apply to target arc hints.
@@ -134,11 +188,27 @@ impl std::fmt::Debug for HolochainP2pConfig {
 }
 
 impl Default for HolochainP2pConfig {
+    /// Returns a config with placeholder values.
+    ///
+    /// The database callbacks (`get_db_peer_meta`, `get_db_op_store`, `get_db_cache`,
+    /// `get_conductor_db`) all panic with `unimplemented!()` when invoked — they will
+    /// be called the first time a space is created, so **always supply concrete
+    /// implementations** before passing this config to [`spawn_holochain_p2p`].
+    /// Use struct-update syntax rather than relying on this default entirely:
+    ///
+    /// ```ignore
+    /// let config = HolochainP2pConfig {
+    ///     get_db_op_store: Arc::new(move |dna_hash| { ... }),
+    ///     get_db_cache: Arc::new(move |dna_hash| { ... }),
+    ///     ..HolochainP2pConfig::default()
+    /// };
+    /// ```
     fn default() -> Self {
         Self {
             get_db_peer_meta: Arc::new(|_| unimplemented!()),
             peer_meta_pruning_interval_ms: 10_000,
             get_db_op_store: Arc::new(|_| unimplemented!()),
+            get_db_cache: Arc::new(|_| unimplemented!()),
             get_conductor_db: Arc::new(|| unimplemented!()),
             target_arc_factor: 1,
             auth_material: None,

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -538,6 +538,7 @@ impl HolochainP2pActor {
         });
         builder.op_store = Arc::new(HolochainOpStoreFactory {
             getter: config.get_db_op_store.clone(),
+            cache_getter: config.get_db_cache.clone(),
             handler: evt_sender.clone(),
         });
         let preflight = Arc::new(Mutex::new(

--- a/crates/holochain_p2p/src/test.rs
+++ b/crates/holochain_p2p/src/test.rs
@@ -39,6 +39,7 @@ impl Gossip for NoopGossip {
                 accepted_rounds: Default::default(),
                 dht_summary: Default::default(),
                 initiated_round: Default::default(),
+                local_op_count: Default::default(),
                 peer_meta: Default::default(),
             })
         })

--- a/crates/holochain_p2p/tests/tests/blocks.rs
+++ b/crates/holochain_p2p/tests/tests/blocks.rs
@@ -13,7 +13,7 @@ use holochain_p2p::{
 use holochain_state::{block::get_all_cell_blocks, prelude::test_conductor_db};
 use holochain_timestamp::{InclusiveTimestampInterval, Timestamp};
 use holochain_types::{
-    db::{DbKindConductor, DbKindDht, DbKindPeerMetaStore, DbWrite},
+    db::{DbKindCache, DbKindConductor, DbKindDht, DbKindPeerMetaStore, DbWrite},
     prelude::{Block, BlockTargetId, CellBlockReason, CellId},
     record::WireRecordOps,
 };
@@ -506,6 +506,7 @@ impl TestActor {
         bootstrap_addr: &SocketAddr,
     ) -> Self {
         let op_db = DbWrite::test_in_mem(DbKindDht(Arc::new(dna_hash.clone()))).unwrap();
+        let cache_db = DbWrite::test_in_mem(DbKindCache(Arc::new(dna_hash.clone()))).unwrap();
         let peer_meta_db =
             DbWrite::test_in_mem(DbKindPeerMetaStore(Arc::new(dna_hash.clone()))).unwrap();
         let config = HolochainP2pConfig {
@@ -516,6 +517,10 @@ impl TestActor {
             get_db_op_store: Arc::new(move |_| {
                 let op_db = op_db.clone();
                 Box::pin(async move { Ok(op_db) })
+            }),
+            get_db_cache: Arc::new(move |_| {
+                let cache_db = cache_db.clone();
+                Box::pin(async move { Ok(cache_db) })
             }),
             get_db_peer_meta: Arc::new(move |_| {
                 let peer_meta_db = peer_meta_db.clone();

--- a/crates/holochain_p2p/tests/tests/node_messaging.rs
+++ b/crates/holochain_p2p/tests/tests/node_messaging.rs
@@ -1212,6 +1212,7 @@ async fn spawn_test(
     let db_peer_meta =
         DbWrite::test_in_mem(DbKindPeerMetaStore(Arc::new(dna_hash.clone()))).unwrap();
     let db_op = DbWrite::test_in_mem(DbKindDht(Arc::new(dna_hash.clone()))).unwrap();
+    let db_cache = DbWrite::test_in_mem(DbKindCache(Arc::new(dna_hash.clone()))).unwrap();
     let conductor_db = DbWrite::test_in_mem(DbKindConductor).unwrap();
     let lair_client = test_keystore();
 
@@ -1226,6 +1227,10 @@ async fn spawn_test(
             get_db_op_store: Arc::new(move |_| {
                 let db_op = db_op.clone();
                 Box::pin(async move { Ok(db_op.clone()) })
+            }),
+            get_db_cache: Arc::new(move |_| {
+                let db_cache = db_cache.clone();
+                Box::pin(async move { Ok(db_cache) })
             }),
             get_conductor_db: Arc::new(move || {
                 let conductor_db = conductor_db.clone();

--- a/crates/holochain_p2p/tests/tests/op_store.rs
+++ b/crates/holochain_p2p/tests/tests/op_store.rs
@@ -7,7 +7,7 @@ use holochain_p2p::event::{
 };
 use holochain_p2p::{HolochainOpStore, HolochainP2pResult};
 use holochain_serialized_bytes::SerializedBytes;
-use holochain_sqlite::db::{DbKindDht, DbWrite};
+use holochain_sqlite::db::{DbKindCache, DbKindDht, DbWrite};
 use holochain_state::prelude::{
     ChainFilter, ExternIO, RecordEntry, Signature, StateMutationResult,
 };
@@ -530,12 +530,13 @@ async fn overwrite_slice_hashes() {
 async fn setup_test() -> (DbWrite<DbKindDht>, HolochainOpStore) {
     let dna_hash = DnaHash::from_raw_36(vec![0; 36]);
     let db = DbWrite::test_in_mem(DbKindDht(Arc::new(dna_hash.clone()))).unwrap();
+    let cache_db = DbWrite::test_in_mem(DbKindCache(Arc::new(dna_hash.clone()))).unwrap();
 
     let sender: DynHcP2pHandler = Arc::new(StubHost { db: db.clone() });
     let sender_w = Arc::new(std::sync::OnceLock::new());
     sender_w.set(holochain_p2p::WrapEvtSender(sender)).unwrap();
 
-    let op_store = HolochainOpStore::new(db.clone(), dna_hash, sender_w);
+    let op_store = HolochainOpStore::new(db.clone(), cache_db, dna_hash, sender_w);
 
     (db, op_store)
 }

--- a/crates/holochain_p2p/tests/tests/space_shutdown.rs
+++ b/crates/holochain_p2p/tests/tests/space_shutdown.rs
@@ -2,7 +2,9 @@ use crate::tests::common::Handler;
 use holo_hash::{AgentPubKey, DnaHash};
 use holochain_keystore::test_keystore;
 use holochain_p2p::{spawn_holochain_p2p, HolochainP2pConfig};
-use holochain_state::prelude::{test_conductor_db, test_dht_db, test_peer_meta_store_db};
+use holochain_state::prelude::{
+    test_cache_db_with_dna_hash, test_conductor_db, test_dht_db, test_peer_meta_store_db,
+};
 use kitsune2_api::LocalAgent;
 use std::sync::Arc;
 
@@ -12,6 +14,7 @@ async fn space_shutdown() {
     let space_id = dna_hash.to_k2_space();
 
     let dht_db = test_dht_db().to_db();
+    let cache_db = test_cache_db_with_dna_hash(dna_hash.clone()).to_db();
     let conductor_db = test_conductor_db().to_db();
     let peer_meta_db = test_peer_meta_store_db(dna_hash.clone()).to_db();
 
@@ -32,6 +35,10 @@ async fn space_shutdown() {
             get_db_op_store: Arc::new(move |_space| {
                 let dht_db = dht_db.clone();
                 Box::pin(async move { Ok(dht_db) })
+            }),
+            get_db_cache: Arc::new(move |_space| {
+                let cache_db = cache_db.clone();
+                Box::pin(async move { Ok(cache_db) })
             }),
             get_conductor_db: Arc::new(move || {
                 let conductor_db = conductor_db.clone();

--- a/crates/holochain_p2p/tests/tests/unresponsive_url_pruning.rs
+++ b/crates/holochain_p2p/tests/tests/unresponsive_url_pruning.rs
@@ -5,7 +5,7 @@ use holochain_p2p::{
     HolochainP2pLocalAgent,
 };
 use holochain_state::prelude::{named_params, test_db_dir};
-use holochain_types::db::{DbKindConductor, DbKindDht, DbKindPeerMetaStore, DbWrite};
+use holochain_types::db::{DbKindCache, DbKindConductor, DbKindDht, DbKindPeerMetaStore, DbWrite};
 use kitsune2_api::{
     AgentInfo, AgentInfoSigned, DhtArc, DynPeerMetaStore, SpaceId, Timestamp, Url, KEY_PREFIX_ROOT,
     META_KEY_UNRESPONSIVE,
@@ -234,6 +234,7 @@ impl TestCase {
         let db_peer_meta =
             DbWrite::test(&db_dir, DbKindPeerMetaStore(Arc::new(dna_hash.clone()))).unwrap();
         let db_op = DbWrite::test_in_mem(DbKindDht(Arc::new(dna_hash.clone()))).unwrap();
+        let db_cache = DbWrite::test_in_mem(DbKindCache(Arc::new(dna_hash.clone()))).unwrap();
         let db_conductor = DbWrite::test_in_mem(DbKindConductor).unwrap();
         let lair_client = test_keystore();
         let db_peer_meta2 = db_peer_meta.clone();
@@ -247,6 +248,10 @@ impl TestCase {
                 get_db_op_store: Arc::new(move |_| {
                     let db_op = db_op.clone();
                     Box::pin(async move { Ok(db_op) })
+                }),
+                get_db_cache: Arc::new(move |_| {
+                    let db_cache = db_cache.clone();
+                    Box::pin(async move { Ok(db_cache) })
                 }),
                 get_conductor_db: Arc::new(move || {
                     let db_conductor = db_conductor.clone();

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -55,7 +55,7 @@ getrandom = "0.3"
 opentelemetry = "0.31"
 schemars = "0.9"
 
-kitsune2_api = "0.4.0-dev.3"
+kitsune2_api = "0.4.0-dev.4"
 
 rusqlite = { version = "0.37", features = [
   "blob",      # better integration with blob types (Read, Write, etc)

--- a/crates/holochain_sqlite/src/sql.rs
+++ b/crates/holochain_sqlite/src/sql.rs
@@ -56,6 +56,8 @@ pub mod sql_dht {
     pub const CHECK_OP_IDS_PRESENT: &str = include_str!("sql/dht/check_op_ids_present.sql");
 
     pub const EARLIEST_TIMESTAMP: &str = include_str!("sql/dht/earliest_timestamp.sql");
+
+    pub const TOTAL_OP_COUNT: &str = include_str!("sql/dht/total_op_count.sql");
 }
 
 pub mod sql_conductor {

--- a/crates/holochain_sqlite/src/sql/dht/total_op_count.sql
+++ b/crates/holochain_sqlite/src/sql/dht/total_op_count.sql
@@ -1,0 +1,7 @@
+SELECT
+  COUNT(*)
+FROM
+  DhtOp
+WHERE
+  -- ops are integrated, i.e. not in limbo
+  when_integrated IS NOT NULL

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -45,7 +45,7 @@ tracing = "0.1.26"
 cron = "0.15"
 async-recursion = "1.1"
 
-kitsune2_api = "0.4.0-dev.3"
+kitsune2_api = "0.4.0-dev.4"
 
 tempfile = { version = "3.3", optional = true }
 base64 = { version = "0.22", optional = true }

--- a/crates/holochain_terminal/Cargo.toml
+++ b/crates/holochain_terminal/Cargo.toml
@@ -31,9 +31,9 @@ holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util" }
 holochain_conductor_api = { version = "^0.7.0-dev.14", path = "../holochain_conductor_api", default-features = false }
 holochain_types = { version = "^0.7.0-dev.14", path = "../holochain_types" }
 tokio = { version = "1.36.0", features = ["full"] }
-kitsune2_api = "0.4.0-dev.3"
-kitsune2_core = "0.4.0-dev.3"
-kitsune2_bootstrap_client = "0.4.0-dev.3"
+kitsune2_api = "0.4.0-dev.4"
+kitsune2_core = "0.4.0-dev.4"
+kitsune2_bootstrap_client = "0.4.0-dev.4"
 
 [lints]
 workspace = true

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -34,7 +34,7 @@ holochain_zome_types = { path = "../holochain_zome_types", version = "^0.7.0-dev
   "full",
 ] }
 holochain_timestamp = { version = "^0.7.0-dev.0", path = "../timestamp" }
-kitsune2_api = "0.4.0-dev.3"
+kitsune2_api = "0.4.0-dev.4"
 itertools = { version = "0.14" }
 mr_bundle = { path = "../mr_bundle", features = [
   "fs",


### PR DESCRIPTION
### Summary

Upgrades to Kitsune2 0.4.0-dev.4 and implements the new DHT size hint mechanism for the op store.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Kitsune-related dependencies to 0.4.0-dev.4 across the codebase.

* **New Features**
  * Added optional cache-backed datastore integration with a configuration hook to supply per-space cache.
  * Operation counting now aggregates totals from both DHT and cache stores.
  * Added a total-op-count query and surface local operation counts in gossip summaries for improved visibility.

* **Breaking Changes**
  * P2P configuration now requires a cache-supply hook when using the new cache integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->