### PR TITLE
feat: expose local_socket_addrs via HcP2p trait for WebRTC ICE

### DIFF
--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -2348,6 +2348,13 @@ impl actor::HcP2p for HolochainP2pActor {
         })
     }
 
+    fn local_socket_addrs(&self) -> BoxFut<'_, HolochainP2pResult<Vec<std::net::SocketAddr>>> {
+        let kitsune = self.kitsune.clone();
+        Box::pin(async move {
+            Ok(kitsune.transport().await?.local_socket_addrs().await?)
+        })
+    }
+
     fn conductor_db_getter(&self) -> GetDbConductor {
         self.blocks_db_getter.clone()
     }

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -328,6 +328,14 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug + Any {
     /// Query if an agent is blocked.
     fn is_blocked(&self, target: BlockTargetId) -> BoxFut<'_, HolochainP2pResult<bool>>;
 
+    /// Get the local and reflexive socket addresses discovered by the transport.
+    /// Returns addresses that can be used as WebRTC ICE candidates.
+    /// An empty list may mean either that no addresses have been discovered yet
+    /// or that the underlying transport does not expose socket addresses.
+    fn local_socket_addrs(&self) -> BoxFut<'_, HolochainP2pResult<Vec<std::net::SocketAddr>>> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+
     /// Get the conductor database getter.
     fn conductor_db_getter(&self) -> crate::GetDbConductor;
 }


### PR DESCRIPTION
## Summary

Surfaces `local_socket_addrs()` from the kitsune2 transport layer through the `HcP2p` trait, enabling in-process consumers (e.g. AD4M executor) to retrieve transport-discovered socket addresses for WebRTC ICE candidate extraction.

### Changes

- **`HcP2p` trait:** Added `local_socket_addrs()` with default returning empty vec (non-breaking)
- **`HolochainP2pActor`:** Implements by calling `kitsune.transport().local_socket_addrs()`

### Usage

```rust
let addrs = conductor.holochain_p2p().local_socket_addrs().await?;
// Returns Vec<SocketAddr> — local + reflexive addresses discovered by Iroh
```

### Dependencies

Requires [holochain/kitsune2#476](https://github.com/holochain/kitsune2/pull/476) for the `local_socket_addrs()` addition to the `Transport` trait.

See: https://github.com/coasys/ad4m/issues/719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve local and reflexive socket addresses from the network transport. These addresses can be used as WebRTC ICE candidates to help establish peer-to-peer connections. If the returned list is empty, it may mean addresses are still being discovered or the transport does not expose socket information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->