### PR TITLE
feat(holochain_metrics): stamp host tag on all emitted metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3262,6 +3262,7 @@ dependencies = [
  "futures",
  "hex",
  "hex-literal",
+ "hostname",
  "influxdb",
  "opentelemetry 0.31.0",
  "opentelemetry_sdk 0.31.0",

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- All influxive metrics modes now automatically stamp a `host` tag on every emitted metric, defaulting to the OS hostname. Override with the `HOLOCHAIN_INFLUXIVE_HOST_TAG` environment variable. #5686
 - Fix an issue with the Holochain configuration schema generation which caused a panic. This is now properly tested to prevent regressions. #5683
 
 ## 0.7.0-dev.16

--- a/crates/holochain_metrics/Cargo.toml
+++ b/crates/holochain_metrics/Cargo.toml
@@ -16,6 +16,7 @@ opentelemetry = "0.31"
 tracing = "0.1"
 
 # influxive dependencies
+hostname = "0.4"
 influxdb = "0.8"
 opentelemetry_sdk = "0.31"
 tempfile = "3"

--- a/crates/holochain_metrics/src/influxive/otel/mod.rs
+++ b/crates/holochain_metrics/src/influxive/otel/mod.rs
@@ -14,9 +14,17 @@ mod tests;
 /// The writer
 pub struct InfluxiveOtelWriter {
     influxive: DynMetricWriter,
+    global_tags: Vec<(String, String)>,
 }
 
 impl InfluxiveOtelWriter {
+    fn apply_global_tags(&self, mut metric: super::types::Metric) -> super::types::Metric {
+        for (k, v) in &self.global_tags {
+            metric = metric.with_tag(k.clone(), v.clone());
+        }
+        metric
+    }
+
     fn write(&self, otel_metric: &Metric) {
         match otel_metric.data() {
             AggregatedMetrics::F64(metric_data) => match metric_data {
@@ -32,6 +40,7 @@ impl InfluxiveOtelWriter {
                             influxive_metric = influxive_metric
                                 .with_tag(attribute.key.to_string(), attribute.value.to_string());
                         }
+                        influxive_metric = self.apply_global_tags(influxive_metric);
                         self.influxive.write_metric(influxive_metric);
                     }
                 }
@@ -65,6 +74,7 @@ impl InfluxiveOtelWriter {
                 influxive_metric = influxive_metric
                     .with_tag(attribute.key.to_string(), attribute.value.to_string());
             }
+            influxive_metric = self.apply_global_tags(influxive_metric);
             self.influxive.write_metric(influxive_metric);
         }
     }
@@ -90,6 +100,7 @@ impl InfluxiveOtelWriter {
                 influxive_metric = influxive_metric
                     .with_tag(attribute.key.to_string(), attribute.value.to_string());
             }
+            influxive_metric = self.apply_global_tags(influxive_metric);
             self.influxive.write_metric(influxive_metric);
         }
     }
@@ -135,6 +146,11 @@ pub struct InfluxiveMeterProviderConfig {
     ///
     /// Defaults to None, which results in a 10 second interval.
     pub report_interval: Option<std::time::Duration>,
+
+    /// Tags stamped on every metric written by this provider.
+    ///
+    /// Use [`InfluxiveMeterProviderConfig::with_global_tag`] to add entries.
+    pub global_tags: Vec<(String, String)>,
 }
 
 impl Default for InfluxiveMeterProviderConfig {
@@ -148,7 +164,10 @@ impl Default for InfluxiveMeterProviderConfig {
             // If env var isn't set, default to 10 seconds.
             Some(std::time::Duration::from_secs(10))
         };
-        Self { report_interval }
+        Self {
+            report_interval,
+            global_tags: Vec::new(),
+        }
     }
 }
 
@@ -156,6 +175,12 @@ impl InfluxiveMeterProviderConfig {
     /// Apply [`InfluxiveMeterProviderConfig::report_interval`].
     pub fn with_report_interval(mut self, report_interval: Option<std::time::Duration>) -> Self {
         self.report_interval = report_interval;
+        self
+    }
+
+    /// Add a tag that will be stamped on every metric written by this provider.
+    pub fn with_global_tag(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.global_tags.push((key.into(), value.into()));
         self
     }
 }
@@ -166,7 +191,10 @@ pub fn create_meter_provider(
     config: InfluxiveMeterProviderConfig,
     influxive: DynMetricWriter,
 ) -> SdkMeterProvider {
-    let exporter = InfluxiveOtelWriter { influxive };
+    let exporter = InfluxiveOtelWriter {
+        influxive,
+        global_tags: config.global_tags,
+    };
     let mut reader_builder = PeriodicReader::builder(exporter);
     if let Some(interval) = config.report_interval {
         reader_builder = reader_builder.with_interval(interval);

--- a/crates/holochain_metrics/src/lib.rs
+++ b/crates/holochain_metrics/src/lib.rs
@@ -33,6 +33,11 @@
 //!   - The influxdb auth token must have permission to write to all buckets
 //!   - Metrics will be set up to report to this already running InfluxDB.
 //!
+//! All metrics modes automatically stamp a `host` tag on every emitted metric so that metrics from
+//! different nodes can be distinguished when multiple Holochain instances write to a shared
+//! InfluxDB. The value defaults to the OS hostname. Override it with:
+//! - `HOLOCHAIN_INFLUXIVE_HOST_TAG=<my-custom-node-name>`
+//!
 //! To set the interval at which recorded metrics are written to Influx,
 //! use `OTEL_METRIC_EXPORT_INTERVAL`. The value is specified as milliseconds.
 //! 10 s is the default. When the report interval is configured in the code,
@@ -252,6 +257,20 @@ pub enum HolochainMetricsConfig {
     },
 }
 
+fn resolve_host_tag() -> Option<String> {
+    const ENV_HOST_TAG: &str = "HOLOCHAIN_INFLUXIVE_HOST_TAG";
+    if let Ok(tag) = std::env::var(ENV_HOST_TAG) {
+        return Some(tag);
+    }
+    match hostname::get() {
+        Ok(name) => Some(name.to_string_lossy().into_owned()),
+        Err(err) => {
+            tracing::info!(?err, "failed to resolve hostname for metrics host tag");
+            None
+        }
+    }
+}
+
 impl HolochainMetricsConfig {
     /// Initialize a new default metrics config.
     ///
@@ -266,20 +285,36 @@ impl HolochainMetricsConfig {
         file_path: &Path,
         report_interval: Option<Duration>,
     ) -> HolochainMetricsConfig {
+        let mut otel_config = influxive::InfluxiveMeterProviderConfig::default()
+            .with_report_interval(report_interval);
+        if let Some(host_tag) = resolve_host_tag() {
+            otel_config = otel_config.with_global_tag("host", host_tag);
+        }
         HolochainMetricsConfig::InfluxiveFile {
             writer_config: influxive::InfluxiveWriterConfig::create_with_influx_file(
                 PathBuf::from(file_path),
             ),
-            otel_config: influxive::InfluxiveMeterProviderConfig::default()
-                .with_report_interval(report_interval),
+            otel_config,
         }
     }
 
     fn from_env(root_path: &Path, env: HolochainMetricsEnv) -> Self {
+        if matches!(env, HolochainMetricsEnv::None) {
+            return Self::Disabled;
+        }
+
+        let mut otel_config = influxive::InfluxiveMeterProviderConfig::default();
+        if let Some(host_tag) = resolve_host_tag() {
+            otel_config = otel_config.with_global_tag("host", host_tag);
+        }
+
         match env {
-            HolochainMetricsEnv::InfluxiveFile { filepath } => {
-                Self::new_with_file(Path::new(&filepath), None)
-            }
+            HolochainMetricsEnv::InfluxiveFile { filepath } => Self::InfluxiveFile {
+                writer_config: influxive::InfluxiveWriterConfig::create_with_influx_file(
+                    PathBuf::from(filepath),
+                ),
+                otel_config,
+            },
 
             HolochainMetricsEnv::InfluxiveChildSvc => {
                 let mut database_path = PathBuf::from(root_path);
@@ -289,7 +324,7 @@ impl HolochainMetricsConfig {
                         influxive::InfluxiveChildSvcConfig::default()
                             .with_database_path(Some(database_path)),
                     ),
-                    otel_config: influxive::InfluxiveMeterProviderConfig::default(),
+                    otel_config,
                 }
             }
 
@@ -299,12 +334,14 @@ impl HolochainMetricsConfig {
                 token,
             } => Self::InfluxiveExternal {
                 writer_config: influxive::InfluxiveWriterConfig::default(),
-                otel_config: influxive::InfluxiveMeterProviderConfig::default(),
+                otel_config,
                 host,
                 bucket,
                 token,
             },
-            HolochainMetricsEnv::None => Self::Disabled,
+
+            // Handled as a guard condition at the top of the method.
+            HolochainMetricsEnv::None => unreachable!(),
         }
     }
 


### PR DESCRIPTION
Closes #5685.

## Summary

- All influxive metrics modes (file, child-svc, external) now automatically stamp a `host` tag on every emitted metric
- Defaults to the OS hostname via `hostname::get()` — no config required for standard deployments
- Override per-node with `HOLOCHAIN_INFLUXIVE_HOST_TAG=<value>` for custom node names
- Silent failure if hostname resolution fails (operator can set the env var as a fallback)
- The `host` tag key matches the Telegraf/lp-tool convention so Holochain and host metrics align in Wind Tunnel dashboards

## Design notes

Global tags live in `InfluxiveMeterProviderConfig` and are applied uniformly in `InfluxiveOtelWriter.apply_global_tags`. This is called at the end of every write path (`write_sum`, `write_histogram`, gauge branch of `write`), so any new metric type added in future gets it for free by following the existing pattern — nothing to remember at the call site.

The programmatic `new_with_file` path does not auto-resolve hostname since callers using that API are configuring things explicitly and can opt in with `.with_global_tag("host", …)` if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * All influxive metrics modes now automatically add a host tag to every emitted metric, defaulting to the system hostname; override with HOLOCHAIN_INFLUXIVE_HOST_TAG.
  * You can now configure global tags that are applied to every metric via the metrics configuration (builder-style support).
  * Added a convenience constructor to create metrics configuration from environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->