### PR TITLE
feat!: split auth material into bootstrap and relay auth material

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4574,9 +4574,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2"
-version = "0.4.0-dev.5"
+version = "0.4.0-dev.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1508b8ece10c135114e735fa3920d445e13af9ed85101e7f9a44f3d9ff438d7d"
+checksum = "15045d1e36ecf0da3ce3362c8dc15f5f702496499fa170e8583375dc5380fb4f"
 dependencies = [
  "bytes",
  "kitsune2_api",
@@ -4589,9 +4589,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_api"
-version = "0.4.0-dev.5"
+version = "0.4.0-dev.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415a1a47ca9016a10fcddd450fad3b21bb0b4adae4abc1a4aeb770d9619b7f2c"
+checksum = "c37dd0222ad9417f26de3c74c50e40ece18365f1f44667f342a263500a5eb588"
 dependencies = [
  "base64",
  "bytes",
@@ -4606,9 +4606,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_client"
-version = "0.4.0-dev.5"
+version = "0.4.0-dev.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e5cf9d87ec6fe9c12134c4c6ff5afefe9e1494f409b6233757860e47b940312"
+checksum = "6e0f10bc554a8547fcd97ee55a81fcc8608d21a67f819403a8980f546b05c565"
 dependencies = [
  "base64",
  "kitsune2_api",
@@ -4621,9 +4621,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_srv"
-version = "0.4.0-dev.5"
+version = "0.4.0-dev.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313f2170164bbd55ee64baba0a2c8db91654b10df110685ad6bbbf4cf7b2e5fe"
+checksum = "03ff2c57c668459e2f4496f08395442570403f4d560e8b34212abd9ddb48df2b"
 dependencies = [
  "async-channel",
  "axum",
@@ -4655,9 +4655,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_core"
-version = "0.4.0-dev.5"
+version = "0.4.0-dev.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999de8004b42a82b89303a0654c028f38070b41ea565150ebdcea0e9c5e59957"
+checksum = "4994a88e9c0cce5bfe525703644fe6aeadab14e662cbe6e61b5a096b32a6db91"
 dependencies = [
  "bytes",
  "ed25519-dalek 2.2.0",
@@ -4687,9 +4687,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_gossip"
-version = "0.4.0-dev.5"
+version = "0.4.0-dev.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8f5933befbe4496c29dc4fc6e2c426a0423f94d578cf0ab6b8dc8c27c728b6"
+checksum = "fb3f3bd94e68d773db18aca99951d246044923230bdad5cc6a01542b64f19089"
 dependencies = [
  "bytes",
  "futures",
@@ -4708,9 +4708,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_test_utils"
-version = "0.4.0-dev.5"
+version = "0.4.0-dev.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf3f36e9d4d2679e316d89c84098b7a1fb020e765373ade2d79ea47b1efbc69"
+checksum = "2f08ebbfb453397ae09bafc479043d6b6e16141bc74fd2a13beb878499d6f36f"
 dependencies = [
  "axum",
  "bytes",
@@ -4725,9 +4725,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_iroh"
-version = "0.4.0-dev.5"
+version = "0.4.0-dev.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998bf890bc038a4025d7c551d27be15c4d4085fc935defa3504890d412e9bbad"
+checksum = "94b65c638c1daf6ff7483fa7a9e6323c1ddb519e41f9f8c7efbb50909cd52cfe"
 dependencies = [
  "bytes",
  "iroh",
@@ -4743,9 +4743,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_tx5"
-version = "0.4.0-dev.5"
+version = "0.4.0-dev.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479a4f37cf31a8ab0d386773197ba7b090c33e763720e07d85015f1cefe727d4"
+checksum = "330cb6bfbf34003072264d0dd3a423d79fa2ca9540636a791649023695cb006b"
 dependencies = [
  "base64",
  "bytes",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -26,7 +26,7 @@ holochain_nonce = { version = "^0.7.0-dev.1", path = "../holochain_nonce" }
 holochain_types = { version = "^0.7.0-dev.16", path = "../holochain_types" }
 holochain_websocket = { version = "^0.7.0-dev.16", path = "../holochain_websocket" }
 holochain_zome_types = { version = "^0.7.0-dev.10", path = "../holochain_zome_types" }
-kitsune2_api = "0.4.0-dev.5"
+kitsune2_api = "0.4.0-dev.6"
 lair_keystore_api = { version = "0.6.3", optional = true }
 parking_lot = "0.12.1"
 rand = { version = "0.8" }
@@ -42,8 +42,8 @@ holochain = { version = "^0.7.0-dev.17", path = "../holochain", default-features
 ] }
 holochain_wasm_test_utils = { version = "^0.7.0-dev.17", path = "../test_utils/wasm" }
 
-kitsune2_core = "0.4.0-dev.5"
-kitsune2_test_utils = "0.4.0-dev.5"
+kitsune2_core = "0.4.0-dev.6"
+kitsune2_test_utils = "0.4.0-dev.6"
 serde_yaml = "0.9"
 
 [features]

--- a/crates/hc_client/Cargo.toml
+++ b/crates/hc_client/Cargo.toml
@@ -35,8 +35,8 @@ holochain_types = { path = "../holochain_types", version = "^0.7.0-dev.16", feat
 holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util", features = [
   "pw",
 ] }
-kitsune2_api = "0.4.0-dev.5"
-kitsune2_core = "0.4.0-dev.5"
+kitsune2_api = "0.4.0-dev.6"
+kitsune2_core = "0.4.0-dev.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -30,7 +30,7 @@ fixt = { version = "^0.7.0-dev.0", path = "../fixt", optional = true }
 futures = { version = "0.3", optional = true }
 holochain_serialized_bytes = { version = "=0.0.56", optional = true }
 holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util", default-features = false }
-kitsune2_api = { version = "0.4.0-dev.5", optional = true }
+kitsune2_api = { version = "0.4.0-dev.6", optional = true }
 must_future = { version = "0.1", optional = true }
 proptest = { version = "1", optional = true }
 proptest-derive = { version = "0", optional = true }

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -1,11 +1,14 @@
 ---
 default_semver_increment_mode: !pre_minor dev
 ---
+
 # Changelog
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+- **BREAKING CHANGE:** Split combined auth material into auth material for bootstrap service and auth material for relay service.
 
 ## 0.7.0-dev.17
 
@@ -138,7 +141,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.7.0-dev.0
 
-- *BREAKING CHANGE* Unrecognized fields in app and webapp manifests are now rejected. This helps prevent typos and stray fields that have been left behind after manifest schema changes. \#5467
+- _BREAKING CHANGE_ Unrecognized fields in app and webapp manifests are now rejected. This helps prevent typos and stray fields that have been left behind after manifest schema changes. \#5467
 - Refactor: Use production transport for all tests instead of in-memory implementations. \#5442
 
 ## 0.6.0
@@ -325,7 +328,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 0.6.0-dev.23
 
 - Support binding admin and app websocket interfaces on designated listen addresses. \#5271
-- Remove obsolete kitsune\_p2p types that were used with the previous version of kitsune.
+- Remove obsolete kitsune_p2p types that were used with the previous version of kitsune.
 - Add tests for filtered `AgentInfo` calls. \#5293
 
 ## 0.6.0-dev.22
@@ -354,7 +357,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.6.0-dev.19
 
-- Changed holochain\_metrics dashboards to match available metrics.
+- Changed holochain_metrics dashboards to match available metrics.
 - Internal refactor to remove the `same_dht` field of `SysValDeps`. This field was redundant because the `SysValDeps` are always for the same DHT as the cell they are part of. \#5243
 - **BREAKING CHANGE**: The agent activity response has been changed to return warrants as a `Vec<SignedWarrant>` instead of a `Vec<Warrant>`. This change ensures that warrant integrity can be checked and discovered warrants can be validated. Note that this also affects the HDK’s `get_agent_activity` function which will now also return `SignedWarrant`s instead of `Warrant`s. \#5237
 - **BREAKING CHANGE**: Move `ChainOpType` from `holochain_types` to `holochain_zome_types`. \#5236
@@ -388,7 +391,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed issue [\#2145](https://github.com/holochain/holochain/issues/2145) in ([\#5189](https://github.com/holochain/holochain/pull/5189)) by
   - indexing Ribosomes by cell id instead of by dna hash in the in-memory RibosomeStore
   - indexing DnaFiles by cell id instead of by dna hash in the DnaDef database on disk
-  - fixing the update\_coordinators() method in the conductor and the associated SQL query to actually update DnaDef’s in the database if a DnaDef already exists in the database for the given cell id.
+  - fixing the update_coordinators() method in the conductor and the associated SQL query to actually update DnaDef’s in the database if a DnaDef already exists in the database for the given cell id.
 - Panic when attempting to bundle a dna from a DnaFile with inline zomes or when attempting to construct a dna manifest from a DnaDef with inline zomes ([\#5185](https://github.com/holochain/holochain/issues/5185)).
 - Refactor chain head coordinator related tests to not rely on the ability to install dnas by specifying the `installed_hash` in the manifest only ([\#5185](https://github.com/holochain/holochain/issues/5185)).
 - **BREAKING CHANGE** Remove support for installing a dna (as part of an app) only by specifying an `installed_hash` and without bundling the actual dna code ([\#5185](https://github.com/holochain/holochain/issues/5185)).
@@ -398,7 +401,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Removed redundant usages of `register_dna()` in test code and removed unused test utils ([\#5174](https://github.com/holochain/holochain/pull/5174)).
 - Fixes the type of the `expires_at` field in `PeerMetaInfo` returned by the admin API from `Timestamp` to `Option<Timestamp>` ([\#5183](https://github.com/holochain/holochain/pull/5183)).
 - **BREAKING CHANGE**: The admin call `RegisterDna` has been removed ([\#5175](https://github.com/holochain/holochain/pull/5175))
-- As part of the fix below, the Holo hash method `to_k2_op` on a DhtOpHash` has been deprecated and replaced with  `to\_located\_k2\_op\_id\`.
+- As part of the fix below, the Holo hash method `to_k2_op` on a DhtOpHash`has been deprecated and replaced with `to_located_k2_op_id\`.
 - Fixes a bug where the wrong DhtOp location was reported to Kitsune2. This resulted in conductors not being able to sync with each other. This change can upgrade existing conductors and new data should sync correctly. However, part of the DHT model gets persisted and to fix bad data in the persisted model, the model has to be wiped and rebuilt. This will result in a short startup delay when upgrading to this version. After the first startup, the startup time should be back to normal.
 - **BREAKING CHANGE**: `hc-sandbox` API and behavior changes:
   - Remove `--existing-paths` and `--last` options.
@@ -530,7 +533,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.5.0-rc.1
 
-- ***BREAKING*** Kitsune2 Integrated: Holochain has now transitioned from the legacy Kitsune networking implementation, to the new [Kitsune2](https://crates.io/crates/kitsune2). [\#4791](https://github.com/holochain/holochain/pull/4791)
+- **_BREAKING_** Kitsune2 Integrated: Holochain has now transitioned from the legacy Kitsune networking implementation, to the new [Kitsune2](https://crates.io/crates/kitsune2). [\#4791](https://github.com/holochain/holochain/pull/4791)
   - breaking protocol changes
   - differences in the networking section of the conductor config
   - changes to agent info encoding
@@ -563,7 +566,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.5.0-dev.19
 
-- Break dependency from holochain\_state to holochain\_p2p
+- Break dependency from holochain_state to holochain_p2p
 - remove `serde(flatten)` attributes from certain enum variants of enums used in admin payloads (\#4719), thereby fixing an oversight of \#4616.
 
 ## 0.5.0-dev.18
@@ -575,8 +578,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.5.0-dev.17
 
-- added admin\_api capability\_grant\_info for getting a list of grants valid and revoked from the source chain
-- create an independent `Share` type in the holochain crate in order to not depend on the one from kitsune\_p2p
+- added admin_api capability_grant_info for getting a list of grants valid and revoked from the source chain
+- create an independent `Share` type in the holochain crate in order to not depend on the one from kitsune_p2p
 
 ## 0.5.0-dev.16
 
@@ -596,7 +599,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.5.0-dev.14
 
-- Remove support for x86\_64-darwin in Holonix. This is becoming hard to support in this version of Holonix. If you are relying on support for a mac with an Intel chip then please migrate to the new [Holonix](https://github.com/holochain/holonix?tab=readme-ov-file#holonix)
+- Remove support for x86_64-darwin in Holonix. This is becoming hard to support in this version of Holonix. If you are relying on support for a mac with an Intel chip then please migrate to the new [Holonix](https://github.com/holochain/holonix?tab=readme-ov-file#holonix)
 - Add two new commands to the `hc sandbox` for authenticating and making zome calls to a running conductor. See the sandbox documentation for usage instructions. \#4587
 - Update `holochain_wasmer_host`, remove temporary fork of wasmer and update wasmer to 5.x.
 - Disable wasmer module caching when using the feature flag `wasmer_wamr`, as caching is not relevevant when wasms are interpreted.
@@ -619,7 +622,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.5.0-dev.8
 
-- made holo\_hash encoding default in hdk cargo.toml for common B64 hashes
+- made holo_hash encoding default in hdk cargo.toml for common B64 hashes
 
 ## 0.5.0-dev.7
 
@@ -649,15 +652,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **BREAKING**: As the DPKI feature is unstable and incomplete, it is disabled with default cargo features and put behind a feature called `unstable-dpki`. If this feature is specified at compile time, DPKI is enabled by default.
 - **BREAKING**: Issuing and persisting warrants is behind a feature `unstable-warrants` now. Warrants have not been tested extensively and there is no way to recover from a warrant. Hence the feature is considered unstable and must be explicitly enabled. Note that once warrants are issued some functions or calls may not work correctly.
-- **BREAKING**: Conductor::get\_dna\_definitions now returns an `IndexMap` to ensure consistent ordering.
+- **BREAKING**: Conductor::get_dna_definitions now returns an `IndexMap` to ensure consistent ordering.
 - Add test to make sure sys validation rejects deleting a delete. Unit tests to get zomes to invoke for app validation were removed for these cases of deleting a delete, because the code path cannot be reached by the system.
 - Added a new feature “unstable-sharding” which puts the network sharding behind a feature flag. It will not be possible to configure network sharding unless Holochain is built with this feature enabled. By default, the network tuning parameter `gossip_dynamic_arcs` is ignored, and the parameter `gossip_arc_clamping` must be set to either `"full"` or `"empty"`, the previous default value of `"none"` will prevent the conductor from starting. We intend to stabilise this feature in the future, and it will return to being available without a feature flag. \#4344
 
 ## 0.5.0-dev.3
 
-- Use of WasmZome preserialized\_path has been **deprecated**. Please use the wasm interpreter instead.
+- Use of WasmZome preserialized_path has been **deprecated**. Please use the wasm interpreter instead.
 
-- Conductor::get\_dna\_definitions now returns an `IndexMap` to ensure consistent ordering.
+- Conductor::get_dna_definitions now returns an `IndexMap` to ensure consistent ordering.
 
 ## 0.5.0-dev.2
 
@@ -743,15 +746,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Possible performance improvement: better async handling of wasm function calls which should allow more concurrent throughput system during long-running zome calls \#4111
 - New protections are put in place for apps which are depended upon by other apps via `UseExisting`. Any “protected” inter-app dependency will prevent a dependency app from being uninstalled until the dependent app is also uninstalled, or if the `force` parameter is set to true in the `UninstallApp` call.
 - CountersigningSuccess signal that is emitted when a countersigning session is successfully completed now includes the
-- *BREAKING* Introduced a new workflow error, `IncompleteCommit`. When inline validation fails with missing dependencies. I.e. Validation for actions that are being committed to the source chain during a zome call discovers missing dependencies. The generic `InvalidCommit` is replaced by this new error. That allows the caller to distinguish between errors that are fatal and errors that can be retried. For now, the only retryable error is caused by missing dependencies. \#4129
+- _BREAKING_ Introduced a new workflow error, `IncompleteCommit`. When inline validation fails with missing dependencies. I.e. Validation for actions that are being committed to the source chain during a zome call discovers missing dependencies. The generic `InvalidCommit` is replaced by this new error. That allows the caller to distinguish between errors that are fatal and errors that can be retried. For now, the only retryable error is caused by missing dependencies. \#4129
 - Based on the change above, about adding `IncompleteCommit`, a countersigning session will no longer terminate on missing dependencies. You may retry committing the countersigned entry if you get this error. \#4129
-- *BREAKING* CountersigningSuccess signal that is emitted when a countersigning session is successfully completed now includes the `app_entry_hash` from the `PreflightRequest` rather than the `EntryHash` that is created when you commit the countersigned entry. This value is easier for clients to get at and use to check that the countersigning session they joined has succeeded. \#4124
+- _BREAKING_ CountersigningSuccess signal that is emitted when a countersigning session is successfully completed now includes the `app_entry_hash` from the `PreflightRequest` rather than the `EntryHash` that is created when you commit the countersigned entry. This value is easier for clients to get at and use to check that the countersigning session they joined has succeeded. \#4124
 
 ## 0.4.0-dev.15
 
-- *BREAKING* Introduced a new workflow error, `IncompleteCommit`. When inline validation fails with missing dependencies. I.e. Validation for actions that are being committed to the source chain during a zome call discovers missing dependencies. The generic `InvalidCommit` is replaced by this new error. That allows the caller to distinguish between errors that are fatal and errors that can be retried. For now, the only retryable error is caused by missing dependencies. \#4129
+- _BREAKING_ Introduced a new workflow error, `IncompleteCommit`. When inline validation fails with missing dependencies. I.e. Validation for actions that are being committed to the source chain during a zome call discovers missing dependencies. The generic `InvalidCommit` is replaced by this new error. That allows the caller to distinguish between errors that are fatal and errors that can be retried. For now, the only retryable error is caused by missing dependencies. \#4129
 - Based on the change above, about adding `IncompleteCommit`, a countersigning session will no longer terminate on missing dependencies. You may retry committing the countersigned entry if you get this error. \#4129
-- *BREAKING* CountersigningSuccess signal that is emitted when a countersigning session is successfully completed now includes the `app_entry_hash` from the `PreflightRequest` rather than the `EntryHash` that is created when you commit the countersigned entry. This value is easier for clients to get at and use to check that the countersigning session they joined has succeeded. \#4124
+- _BREAKING_ CountersigningSuccess signal that is emitted when a countersigning session is successfully completed now includes the `app_entry_hash` from the `PreflightRequest` rather than the `EntryHash` that is created when you commit the countersigned entry. This value is easier for clients to get at and use to check that the countersigning session they joined has succeeded. \#4124
 
 ## 0.4.0-dev.14
 
@@ -764,7 +767,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Adds a new app interface method `AppRequest::EnableAfterMemproofsProvided`, which allows enabling an app only if the app is in the `AppStatus::Disabled(DisabledAppReason::NotStartedAfterProvidingMemproofs)` state. Attempting to enable the app from other states (other than Running) will fail.
 - Warrants are used under-the-hood in more places now:
   - When gossiping amongst authorities, if an authority has a warrant for some data being requested, they will send the warrant instead of the data to indicate the invalid status of that data
-  - When requesting data through must\_get calls, warrants will be returned with the data. The data returned to the client remains the same, but under the hood any warrants will be cached for later use.
+  - When requesting data through must_get calls, warrants will be returned with the data. The data returned to the client remains the same, but under the hood any warrants will be cached for later use.
 - Adds a `lineage` field to the DNA manifest, which declares forward compatibility for any hash in that list with this DNA
 - Adds a `AdminRequest::GetCompatibleCells` method which returns CellId for all installed cells which use a DNA that is forward-compatible with a given DNA hash. This can be used to find a compatible cell for use with the `UseExisting` cell provisioning method (still to be implemented)
 
@@ -816,7 +819,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 <!-- end list -->
 
-``` rust
+```rust
 enum Enum {
   Variant1,
   Variant2,
@@ -826,7 +829,7 @@ let value = Enum::Variant1;
 
 was serialized as (JSON representation)
 
-``` json
+```json
 {
   "value": {
     "variant1": null
@@ -836,7 +839,7 @@ was serialized as (JSON representation)
 
 Now it serializes to
 
-``` json
+```json
 {
   "value": "variant1"
 }
@@ -952,13 +955,12 @@ Now it serializes to
 - Fix: Countersigning test `lock_chain` which ensures that source chain is locked while in a countersigning session.
 
 - Major refactor of the sys validation workflow to improve reliability and performance:
-  
   - Reliability: The workflow will now prioritise validating ops that have their dependencies available locally. As soon as it has finished with those it will trigger app validation before dealing with missing dependencies.
   - Reliability: For ops which have dependencies we aren’t holding locally, the network get will now be retried. This was a cause of undesirable behaviour for validation where a failed get would result in validation for ops with missing dependencies not being retried until new ops arrived. The workflow now retries the get on an interval until it finds dependencies and can proceed with validation.
   - Performance and correctness: A feature which captured and processed ops that were discovered during validation has been removed. This had been added as an attempt to avoid deadlocks within validation but if that happens there’s a bug somewhere else. Sys validation needs to trust that Holochain will correctly manage its current arc and that we will get that data eventually through publishing or gossip. This probably wasn’t doing a lot of harm but it was uneccessary and doing database queries so it should be good to have that gone.
   - Performance: In-memory caching for sys validation dependencies. When we have to wait to validate an op because it has a missing dependency, any other actions required by that op will be held in memory rather than being refetched from the database. This has a fairly small memory footprint because actions are relatively small but saves repeatedly hitting the cascade for the same data if it takes a bit of time to find a dependency on the network.
 
-- **BREAKING* CHANGE*: The `ConductorConfig` has been updated to add a new option for configuring conductor behaviour. This should be compatible with existing conductor config YAML files but if you are creating the struct directly then you will need to include the new field. Currently this just has one setting which controls how fast the sys validation workflow will retry network gets for missing dependencies. It’s likely this option will change in the near future.
+- \*_BREAKING_ CHANGE\*: The `ConductorConfig` has been updated to add a new option for configuring conductor behaviour. This should be compatible with existing conductor config YAML files but if you are creating the struct directly then you will need to include the new field. Currently this just has one setting which controls how fast the sys validation workflow will retry network gets for missing dependencies. It’s likely this option will change in the near future.
 
 ## 0.3.0-beta-dev.26
 
@@ -1079,7 +1081,7 @@ Now it serializes to
 - When uninstalling an app, local data is now cleaned up where appropriate. [\#1805](https://github.com/holochain/holochain/pull/1805)
   - Detail: any time an app is uninstalled, if the removal of that app’s cells would cause there to be no cell installed which uses a given DNA, the databases for that DNA space are deleted. So, if you have an app installed twice under two different agents and uninstall one of them, no data will be removed, but if you uninstall both, then all local data will be cleaned up. If any of your data was gossiped to other peers though, it will live on in the DHT, and even be gossiped back to you if you reinstall that same app with a new agent.
 - Renames `OpType` to `FlatOp`, and `Op::to_type()` to `Op::flattened()`. Aliases for the old names still exist, so this is not a breaking change. [\#1909](https://github.com/holochain/holochain/pull/1909)
-- Fixed a [problem with validation of Ops with private entry data](https://github.com/holochain/holochain/issues/1861), where  `Op::to_type()` would fail for private `StoreEntry` ops. [\#1910](https://github.com/holochain/holochain/pull/1910)
+- Fixed a [problem with validation of Ops with private entry data](https://github.com/holochain/holochain/issues/1861), where `Op::to_type()` would fail for private `StoreEntry` ops. [\#1910](https://github.com/holochain/holochain/pull/1910)
 
 ## 0.1.0
 
@@ -1171,7 +1173,7 @@ Now it serializes to
 
 ## 0.0.159
 
-- Updates TLS certificate handling so that multiple conductors can share the same lair, but use different TLS certificates by storing a “tag” in the conductor state database. This should not be a breaking change, but *will* result in a new TLS certificate being used per conductor. [\#1519](https://github.com/holochain/holochain/pull/1519)
+- Updates TLS certificate handling so that multiple conductors can share the same lair, but use different TLS certificates by storing a “tag” in the conductor state database. This should not be a breaking change, but _will_ result in a new TLS certificate being used per conductor. [\#1519](https://github.com/holochain/holochain/pull/1519)
 
 ## 0.0.158
 
@@ -1179,7 +1181,7 @@ Now it serializes to
 
 ## 0.0.156
 
-- Effectively disable Wasm metering by setting the cranelift cost\_function to always return 0. This is meant as a temporary stop-gap and give us time to figure out a configurable approach. [\#1535](https://github.com/holochain/holochain/pull/1535)
+- Effectively disable Wasm metering by setting the cranelift cost_function to always return 0. This is meant as a temporary stop-gap and give us time to figure out a configurable approach. [\#1535](https://github.com/holochain/holochain/pull/1535)
 
 ## 0.0.155
 
@@ -1189,8 +1191,8 @@ Now it serializes to
 ## 0.0.154
 
 - Revert: “Add the `hdi_version_req` key:value field to the output of the `--build-info` argument” because it broke. [\#1521](https://github.com/holochain/holochain/pull/1521)
-  
-  Reason: it causes a build failure of the *holochain*  crate on crates.io
+
+  Reason: it causes a build failure of the _holochain_ crate on crates.io
 
 ## 0.0.153
 
@@ -1203,7 +1205,7 @@ Now it serializes to
 ## 0.0.151
 
 - BREAKING CHANGE - Refactor: Property `integrity.uid` of DNA Yaml files renamed to `integrity.network_seed`. Functionality has not changed. [\#1493](https://github.com/holochain/holochain/pull/1493)
-- Allow deterministic bindings (dna\_info() & zome\_info()) to the genesis self check [\#1491](https://github.com/holochain/holochain/pull/1491).
+- Allow deterministic bindings (dna_info() & zome_info()) to the genesis self check [\#1491](https://github.com/holochain/holochain/pull/1491).
 
 ## 0.0.150
 
@@ -1280,11 +1282,11 @@ As Holochain has evolved, the meaning behind these concepts, as well as our unde
 
 ## 0.0.128
 
-- Proxy server chosen from bootstrap server proxy\_list [1242](https://github.com/holochain/holochain/pull/1242)
+- Proxy server chosen from bootstrap server proxy_list [1242](https://github.com/holochain/holochain/pull/1242)
 
 <!-- end list -->
 
-``` yaml
+```yaml
 network:
   transport_pool:
     - type: proxy
@@ -1355,7 +1357,6 @@ network:
 - **BREAKING CHANGE** `entry_defs` added to `zome_info` and referenced by macros [PR1055](https://github.com/holochain/holochain/pull/1055)
 
 - **BREAKING CHANGE**: The notion of “cell nicknames” (“nicks”) and “app slots” has been unified into the notion of “app roles”. This introduces several breaking changes. In general, you will need to rebuild any app bundles you are using, and potentially update some usages of the admin interface. In particular:
-  
   - The `slots` field in App manifests is now called `roles`
   - The `InstallApp` admin method now takes a `role_id` field instead of a `nick` field
   - In the return value for any admin method which lists installed apps, e.g. `ListEnabledApps`, any reference to `"slots"` is now named `"roles"`
@@ -1385,7 +1386,6 @@ network:
 - `call_info` is now implemented [1047](https://github.com/holochain/holochain/pull/1047)
 
 - `dna_info` now returns `DnaInfo` correctly [\#1044](https://github.com/holochain/holochain/pull/1044)
-  
   - `ZomeInfo` no longer includes what is now on `DnaInfo`
   - `ZomeInfo` renames `zome_name` and `zome_id` to `name` and `id`
   - `DnaInfo` includes `name`, `hash`, `properties`
@@ -1398,14 +1398,14 @@ network:
 
 <!-- end list -->
 
-``` yaml
+```yaml
 keystore:
   type: danger_test_keystore
 ```
 
 or
 
-``` yaml
+```yaml
 keystore:
   type: lair_server
   connection_url: "unix:///my/path/socket?k=Foo"
@@ -1424,7 +1424,7 @@ keystore:
 
 Where previously, you might have had:
 
-``` yaml
+```yaml
 use_dangerous_test_keystore: false
 keystore_path: /my/path
 passphrase_service:
@@ -1434,7 +1434,7 @@ passphrase_service:
 
 now you will use:
 
-``` yaml
+```yaml
 keystore:
   type: lair_server_legacy_deprecated
   keystore_path: /my/path
@@ -1443,7 +1443,7 @@ keystore:
 
 or:
 
-``` yaml
+```yaml
 keystore:
   type: danger_test_keystore_legacy_deprecated
 ```
@@ -1514,7 +1514,7 @@ keystore:
 ### Added
 
 - `InstallAppBundle` command added to admin conductor API. [\#665](https://github.com/holochain/holochain/pull/665)
-- `DnaSource` in conductor\_api `RegisterDna` call now can take a `DnaBundle` [\#665](https://github.com/holochain/holochain/pull/665)
+- `DnaSource` in conductor_api `RegisterDna` call now can take a `DnaBundle` [\#665](https://github.com/holochain/holochain/pull/665)
 - New admin interface methods:
   - `EnableApp` (replaces `ActivateApp`)
   - `DisableApp` (replaces `DeactivateApp`)
@@ -1525,7 +1525,7 @@ keystore:
 
 This version contains breaking changes to the conductor API as well as a major upgrade to the underlying Wasm runtime.
 
-***:exclamation: Performance impact***
+**_:exclamation: Performance impact_**
 
 The version of wasmer that is used in this holochain release contains bugs in the scoping of wasmer modules vs. instances, such that it blocks the proper release of memory and slows down execution of concurrent Wasm instances. While we were able to at least mitigate these effects and are coordinating with wasmer to find a proper solution as soon as possible.
 
@@ -1534,12 +1534,12 @@ The severity of these issues increases with cell concurrency, i.e. using multipl
 ### Added
 
 - `InstallAppBundle` command added to admin conductor API. [\#665](https://github.com/holochain/holochain/pull/665)
-- `DnaSource` in conductor\_api `RegisterDna` call now can take a `DnaBundle` [\#665](https://github.com/holochain/holochain/pull/665)
+- `DnaSource` in conductor_api `RegisterDna` call now can take a `DnaBundle` [\#665](https://github.com/holochain/holochain/pull/665)
 
 ### Removed
 
-- BREAKING:  `InstallAppDnaPayload` in admin conductor API `InstallApp` command now only accepts a hash.  Both properties and path have been removed as per deprecation warning.  Use either `RegisterDna` or `InstallAppBundle` instead. [\#665](https://github.com/holochain/holochain/pull/665)
-- BREAKING: `DnaSource(Path)` in conductor\_api `RegisterDna` call now must point to `DnaBundle` as created by `hc dna pack` not a `DnaFile` created by `dna_util` [\#665](https://github.com/holochain/holochain/pull/665)
+- BREAKING: `InstallAppDnaPayload` in admin conductor API `InstallApp` command now only accepts a hash. Both properties and path have been removed as per deprecation warning. Use either `RegisterDna` or `InstallAppBundle` instead. [\#665](https://github.com/holochain/holochain/pull/665)
+- BREAKING: `DnaSource(Path)` in conductor_api `RegisterDna` call now must point to `DnaBundle` as created by `hc dna pack` not a `DnaFile` created by `dna_util` [\#665](https://github.com/holochain/holochain/pull/665)
 
 ### CHANGED
 
@@ -1552,4 +1552,4 @@ This is the first version number for the version of Holochain with a refactored 
 
 ## 0.0.52-alpha2
 
-*Note: Versions 0.0.52-alpha2 and older are belong to previous iterations of the Holochain architecture and are not tracked here.*
+_Note: Versions 0.0.52-alpha2 and older are belong to previous iterations of the Holochain architecture and are not tracked here._

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -52,8 +52,8 @@ holochain_conductor_config = { version = "^0.7.0-dev.16", path = "../holochain_c
 holochain_timestamp = { version = "^0.7.0-dev.0", path = "../timestamp" }
 human-panic = "2.0"
 itertools = { version = "0.14" }
-kitsune2_api = "0.4.0-dev.5"
-kitsune2_core = "0.4.0-dev.5"
+kitsune2_api = "0.4.0-dev.6"
+kitsune2_core = "0.4.0-dev.6"
 mockall = "0.13"
 mr_bundle = { version = "^0.7.0-dev.1", path = "../mr_bundle", features = [
   "fs",
@@ -104,7 +104,7 @@ matches = { version = "0.1.8", optional = true }
 holochain_wasm_test_utils = { version = "^0.7.0-dev.17", path = "../test_utils/wasm", optional = true }
 holochain_test_wasm_common = { version = "^0.7.0-dev.11", path = "../test_utils/wasm_common", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
-kitsune2_bootstrap_srv = { version = "0.4.0-dev.5", default-features = false, optional = true }
+kitsune2_bootstrap_srv = { version = "0.4.0-dev.6", default-features = false, optional = true }
 schemars = "0.9"
 
 [target.'cfg(unix)'.dependencies]
@@ -130,7 +130,7 @@ tokio = { version = "1.36.0", features = ["full", "test-util"] }
 tokio-tungstenite = "0.27"
 predicates = "3.1"
 assert2 = "0.3.15"
-kitsune2_test_utils = "0.4.0-dev.5"
+kitsune2_test_utils = "0.4.0-dev.6"
 rand_dalek = { version = "0.8", package = "rand" }
 
 [build-dependencies]

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -212,9 +212,18 @@ impl ConductorBuilder {
         let net_spaces3 = spaces.clone();
         let conductor_db = spaces.conductor_db.clone();
         let p2p_config = holochain_p2p::HolochainP2pConfig {
-            auth_material: config
+            auth_material_bootstrap: config
                 .network
-                .base64_auth_material
+                .base64_auth_material_bootstrap
+                .as_ref()
+                .map(|m| {
+                    use base64::prelude::*;
+                    BASE64_STANDARD.decode(m).map_err(ConductorError::other)
+                })
+                .transpose()?,
+            auth_material_relay: config
+                .network
+                .base64_auth_material_relay
                 .as_ref()
                 .map(|m| {
                     use base64::prelude::*;
@@ -434,9 +443,18 @@ impl ConductorBuilder {
         let net_spaces3 = spaces.clone();
         let conductor_db = spaces.conductor_db.clone();
         let p2p_config = holochain_p2p::HolochainP2pConfig {
-            auth_material: config
+            auth_material_bootstrap: config
                 .network
-                .base64_auth_material
+                .base64_auth_material_bootstrap
+                .as_ref()
+                .map(|m| {
+                    use base64::prelude::*;
+                    BASE64_STANDARD.decode(m).map_err(ConductorError::other)
+                })
+                .transpose()?,
+            auth_material_relay: config
+                .network
+                .base64_auth_material_relay
                 .as_ref()
                 .map(|m| {
                     use base64::prelude::*;

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = "2.0"
 tracing = "0.1"
 opentelemetry = "0.31"
 
-kitsune2_api = "0.4.0-dev.5"
+kitsune2_api = "0.4.0-dev.6"
 
 async-trait = "0.1"
 mockall = { version = "0.13", optional = true }

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-kitsune2_transport_tx5 = { version = "0.4.0-dev.5", optional = true, default-features = false }
-kitsune2_transport_iroh = { version = "0.4.0-dev.5", optional = true, default-features = false }
+kitsune2_transport_tx5 = { version = "0.4.0-dev.6", optional = true, default-features = false }
+kitsune2_transport_iroh = { version = "0.4.0-dev.6", optional = true, default-features = false }
 derive_more = { version = "2.0", features = ["from"] }
 holo_hash = { version = "^0.7.0-dev.7", path = "../holo_hash", features = [
   "full",
@@ -23,9 +23,9 @@ holochain_zome_types = { version = "^0.7.0-dev.10", path = "../holochain_zome_ty
 holochain_util = { version = "^0.7.0-dev.1", default-features = false, path = "../holochain_util", features = [
   "jsonschema",
 ] }
-kitsune2_api = "0.4.0-dev.5"
-kitsune2_core = { version = "0.4.0-dev.5" }
-kitsune2_gossip = { version = "0.4.0-dev.5", optional = true }
+kitsune2_api = "0.4.0-dev.6"
+kitsune2_core = { version = "0.4.0-dev.6" }
+kitsune2_gossip = { version = "0.4.0-dev.6", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -259,12 +259,14 @@ pub enum ReportConfig {
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct NetworkConfig {
     /// Authentication material if required by the bootstrap service.
-    /// This material should be specified as a base64 string
+    ///
+    /// This material should be specified as a base64 url-safe, with no padding, string.
     #[serde(default)]
     pub base64_auth_material_bootstrap: Option<String>,
 
     /// Authentication material if required by the relay service.
-    /// This material should be specified as a base64 string
+    ///
+    /// This material should be specified as a base64 url-safe, with no padding, string.
     #[serde(default)]
     pub base64_auth_material_relay: Option<String>,
 

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -258,10 +258,15 @@ pub enum ReportConfig {
 #[derive(Clone, Deserialize, Serialize, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct NetworkConfig {
-    /// Authentication material if required by sbd/signal/bootstrap services.
+    /// Authentication material if required by the bootstrap service.
     /// This material should be specified as a base64 string
     #[serde(default)]
-    pub base64_auth_material: Option<String>,
+    pub base64_auth_material_bootstrap: Option<String>,
+
+    /// Authentication material if required by the relay service.
+    /// This material should be specified as a base64 string
+    #[serde(default)]
+    pub base64_auth_material_relay: Option<String>,
 
     /// The Kitsune2 bootstrap server to use for WAN discovery.
     #[schemars(schema_with = "holochain_util::jsonschema::url2_schema")]
@@ -328,7 +333,8 @@ pub struct NetworkConfig {
 impl Default for NetworkConfig {
     fn default() -> Self {
         Self {
-            base64_auth_material: None,
+            base64_auth_material_bootstrap: None,
+            base64_auth_material_relay: None,
             bootstrap_url: url2::Url2::parse("https://dev-test-bootstrap2.holochain.org"),
             signal_url: url2::Url2::parse("wss://dev-test-bootstrap2.holochain.org"),
             relay_url: url2::Url2::parse("https://use1-1.relay.n0.iroh-canary.iroh.link./"),

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -255,7 +255,7 @@ pub enum ReportConfig {
 }
 
 /// All the network config information for the conductor.
-#[derive(Clone, Deserialize, Serialize, Debug, PartialEq, JsonSchema)]
+#[derive(Clone, Deserialize, Serialize, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct NetworkConfig {
     /// Authentication material if required by the bootstrap service.
@@ -359,6 +359,41 @@ const fn default_request_timeout_s() -> u64 {
 
 const fn default_target_arc_factor() -> u32 {
     1
+}
+
+impl std::fmt::Debug for NetworkConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut s = f.debug_struct("NetworkConfig");
+        s.field(
+            "base64_auth_material_bootstrap",
+            &self
+                .base64_auth_material_bootstrap
+                .as_ref()
+                .map(|_| "<redacted>"),
+        );
+        s.field(
+            "base64_auth_material_relay",
+            &self
+                .base64_auth_material_relay
+                .as_ref()
+                .map(|_| "<redacted>"),
+        );
+        s.field("bootstrap_url", &self.bootstrap_url);
+        s.field("signal_url", &self.signal_url);
+        s.field("relay_url", &self.relay_url);
+        s.field("request_timeout_s", &self.request_timeout_s);
+        s.field("webrtc_config", &self.webrtc_config);
+        s.field("target_arc_factor", &self.target_arc_factor);
+        s.field("report", &self.report);
+        s.field("advanced", &self.advanced);
+        #[cfg(feature = "test-utils")]
+        {
+            s.field("disable_bootstrap", &self.disable_bootstrap);
+            s.field("disable_publish", &self.disable_publish);
+            s.field("disable_gossip", &self.disable_gossip);
+        }
+        s.finish()
+    }
 }
 
 impl NetworkConfig {

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -40,12 +40,12 @@ tracing-appender = "0.2.3"
 opentelemetry = "0.31"
 strum_macros = "0.27.2"
 
-kitsune2 = { version = "0.4.0-dev.5", default-features = false }
-kitsune2_bootstrap_srv = { version = "0.4.0-dev.5", default-features = false, optional = true }
-kitsune2_api = "0.4.0-dev.5"
-kitsune2_core = "0.4.0-dev.5"
-kitsune2_transport_iroh = { version = "0.4.0-dev.5", default-features = false, optional = true }
-kitsune2_transport_tx5 = { version = "0.4.0-dev.5", default-features = false, optional = true }
+kitsune2 = { version = "0.4.0-dev.6", default-features = false }
+kitsune2_bootstrap_srv = { version = "0.4.0-dev.6", default-features = false, optional = true }
+kitsune2_api = "0.4.0-dev.6"
+kitsune2_core = "0.4.0-dev.6"
+kitsune2_transport_iroh = { version = "0.4.0-dev.6", default-features = false, optional = true }
+kitsune2_transport_tx5 = { version = "0.4.0-dev.6", default-features = false, optional = true }
 bytes = "1.10"
 holochain_sqlite = { version = "^0.7.0-dev.13", path = "../holochain_sqlite" }
 parking_lot = "0.12.3"

--- a/crates/holochain_p2p/src/spawn.rs
+++ b/crates/holochain_p2p/src/spawn.rs
@@ -119,8 +119,11 @@ pub struct HolochainP2pConfig {
     /// The arc factor to apply to target arc hints.
     pub target_arc_factor: u32,
 
-    /// Authentication material if required by sbd/signal/bootstrap services.
-    pub auth_material: Option<Vec<u8>>,
+    /// Authentication material if required by the bootstrap service.
+    pub auth_material_bootstrap: Option<Vec<u8>>,
+
+    /// Authentication material if required by the relay service.
+    pub auth_material_relay: Option<Vec<u8>>,
 
     /// Configuration to pass to Kitsune2.
     ///
@@ -171,7 +174,8 @@ impl std::fmt::Debug for HolochainP2pConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut dbg = f.debug_struct("HolochainP2pConfig");
         dbg.field("compat", &self.compat);
-        dbg.field("auth_material", &self.auth_material);
+        dbg.field("auth_material_bootstrap", &self.auth_material_bootstrap);
+        dbg.field("auth_material_relay", &self.auth_material_relay);
         dbg.field("request_timeout", &self.request_timeout);
         dbg.field("target_arc_factor", &self.target_arc_factor);
         dbg.field("network_config", &self.network_config);
@@ -211,7 +215,8 @@ impl Default for HolochainP2pConfig {
             get_db_cache: Arc::new(|_| unimplemented!()),
             get_conductor_db: Arc::new(|| unimplemented!()),
             target_arc_factor: 1,
-            auth_material: None,
+            auth_material_bootstrap: None,
+            auth_material_relay: None,
             network_config: None,
             compat: Default::default(),
             request_timeout: Duration::from_secs(60),

--- a/crates/holochain_p2p/src/spawn.rs
+++ b/crates/holochain_p2p/src/spawn.rs
@@ -174,8 +174,14 @@ impl std::fmt::Debug for HolochainP2pConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut dbg = f.debug_struct("HolochainP2pConfig");
         dbg.field("compat", &self.compat);
-        dbg.field("auth_material_bootstrap", &self.auth_material_bootstrap);
-        dbg.field("auth_material_relay", &self.auth_material_relay);
+        dbg.field(
+            "auth_material_bootstrap",
+            &self.auth_material_bootstrap.as_ref().map(|_| "<redacted>"),
+        );
+        dbg.field(
+            "auth_material_relay",
+            &self.auth_material_relay.as_ref().map(|_| "<redacted>"),
+        );
         dbg.field("request_timeout", &self.request_timeout);
         dbg.field("target_arc_factor", &self.target_arc_factor);
         dbg.field("network_config", &self.network_config);

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -520,7 +520,8 @@ impl HolochainP2pActor {
             }
         }
 
-        builder.auth_material = config.auth_material;
+        builder.auth_material_bootstrap = config.auth_material_bootstrap;
+        builder.auth_material_relay = config.auth_material_relay;
 
         let evt_sender = Arc::new(std::sync::OnceLock::new());
 

--- a/crates/holochain_sqlite/Cargo.toml
+++ b/crates/holochain_sqlite/Cargo.toml
@@ -55,7 +55,7 @@ getrandom = "0.3"
 opentelemetry = "0.31"
 schemars = "0.9"
 
-kitsune2_api = "0.4.0-dev.5"
+kitsune2_api = "0.4.0-dev.6"
 
 rusqlite = { version = "0.37", features = [
   "blob",      # better integration with blob types (Read, Write, etc)

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -45,7 +45,7 @@ tracing = "0.1.26"
 cron = "0.15"
 async-recursion = "1.1"
 
-kitsune2_api = "0.4.0-dev.5"
+kitsune2_api = "0.4.0-dev.6"
 
 tempfile = { version = "3.3", optional = true }
 base64 = { version = "0.22", optional = true }

--- a/crates/holochain_terminal/Cargo.toml
+++ b/crates/holochain_terminal/Cargo.toml
@@ -31,9 +31,9 @@ holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util" }
 holochain_conductor_api = { version = "^0.7.0-dev.16", path = "../holochain_conductor_api", default-features = false }
 holochain_types = { version = "^0.7.0-dev.16", path = "../holochain_types" }
 tokio = { version = "1.36.0", features = ["full"] }
-kitsune2_api = "0.4.0-dev.5"
-kitsune2_core = "0.4.0-dev.5"
-kitsune2_bootstrap_client = "0.4.0-dev.5"
+kitsune2_api = "0.4.0-dev.6"
+kitsune2_core = "0.4.0-dev.6"
+kitsune2_bootstrap_client = "0.4.0-dev.6"
 
 [lints]
 workspace = true

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -34,7 +34,7 @@ holochain_zome_types = { path = "../holochain_zome_types", version = "^0.7.0-dev
   "full",
 ] }
 holochain_timestamp = { version = "^0.7.0-dev.0", path = "../timestamp" }
-kitsune2_api = "0.4.0-dev.5"
+kitsune2_api = "0.4.0-dev.6"
 itertools = { version = "0.14" }
 mr_bundle = { path = "../mr_bundle", features = [
   "fs",


### PR DESCRIPTION
### Summary



### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Kitsune2-related dependencies across the workspace to the next development version.

* **Documentation**
  * Changelog formatting cleaned up and clarified.

* **Breaking Change**
  * Authentication configuration split: separate credentials for bootstrap and relay services replace the previous single credential.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->