### PR TITLE
feat(p2p)!: smarter peer selection using latency estimation

### DIFF
--- a/crates/holochain_p2p/src/lib.rs
+++ b/crates/holochain_p2p/src/lib.rs
@@ -20,8 +20,12 @@ pub use spawn::*;
 mod peer_meta_store;
 pub use peer_meta_store::*;
 
+mod peer_latency_store;
+
 mod local_agent;
 pub use local_agent::*;
+
+mod weighted_selection;
 
 mod op_store;
 pub use op_store::*;

--- a/crates/holochain_p2p/src/peer_latency_store.rs
+++ b/crates/holochain_p2p/src/peer_latency_store.rs
@@ -1,0 +1,965 @@
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use kitsune2_api::{DynSpace, Url};
+use std::collections::{HashMap, VecDeque};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tokio::task::AbortHandle;
+
+/// Maximum number of latency samples kept per peer URL in the rolling window.
+const MAX_SAMPLES: usize = 10;
+
+/// Estimates are considered stale after `recorded_at + EXPIRY_DURATION`.
+const EXPIRY_DURATION: Duration = Duration::from_secs(60 * 60);
+
+/// Entries older than this are permanently evicted from the store to bound memory.
+/// Set to twice [`EXPIRY_DURATION`] so stale fallback data is available during re-ping.
+const EVICTION_DURATION: Duration = Duration::from_secs(2 * 60 * 60);
+
+/// How far before [`EXPIRY_DURATION`] to schedule a proactive refresh ping.
+const REFRESH_BUFFER: Duration = Duration::from_secs(10 * 60);
+
+/// Number of sequential ping samples to collect per peer URL.
+const PING_SAMPLE_COUNT: usize = 10;
+
+/// Maximum number of peer URLs to ping concurrently in the background worker.
+const MAX_CONCURRENT_PINGS: usize = 8;
+
+/// After this many consecutive all-failure ping rounds, a peer is
+/// considered to have failed pings and will not be pinged again until
+/// re-touched.
+const CONSECUTIVE_FAILURE_THRESHOLD: u32 = 3;
+
+/// Default tick interval for the worker when no peer is immediately due.
+const WORKER_TICK_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Function type for sending a single ping and measuring RTT.
+///
+/// The actor provides an implementation that sends a `PingReq` wire message
+/// and waits for the `PingRes`, returning the measured round-trip time.
+pub(crate) type PingFn = Arc<
+    dyn Fn(DynSpace, Url) -> Pin<Box<dyn Future<Output = Option<Duration>> + Send>> + Send + Sync,
+>;
+
+/// Rolling-window latency estimate for a single peer URL.
+///
+/// Maintains up to [`MAX_SAMPLES`] RTT samples and a cached average.
+/// Entries are considered stale after `recorded_at + EXPIRY_DURATION`.
+#[derive(Debug)]
+pub(crate) struct LatencyEstimate {
+    samples: VecDeque<Duration>,
+    average: Duration,
+    recorded_at: Instant,
+}
+
+impl LatencyEstimate {
+    /// Creates a new estimate seeded with a single sample.
+    fn new(sample: Duration) -> Self {
+        let mut samples = VecDeque::with_capacity(MAX_SAMPLES);
+        samples.push_back(sample);
+        Self {
+            samples,
+            average: sample,
+            recorded_at: Instant::now(),
+        }
+    }
+
+    /// Appends a sample to the rolling window, evicting the oldest when
+    /// the window is full, then recomputes the cached average and
+    /// updates `recorded_at`.
+    fn push_sample(&mut self, rtt: Duration) {
+        if self.samples.len() == MAX_SAMPLES {
+            let _ = self.samples.pop_front();
+        }
+        self.samples.push_back(rtt);
+        self.recorded_at = Instant::now();
+
+        let total = self
+            .samples
+            .iter()
+            .copied()
+            .fold(Duration::ZERO, |acc, sample| acc + sample);
+        self.average = total / (self.samples.len() as u32);
+    }
+
+    /// Returns `true` if this estimate is older than [`EXPIRY_DURATION`]
+    /// relative to the given reference instant.
+    fn is_expired_at(&self, now: Instant) -> bool {
+        now.duration_since(self.recorded_at) >= EXPIRY_DURATION
+    }
+
+    /// Returns `true` when this estimate is within [`REFRESH_BUFFER`] of
+    /// [`EXPIRY_DURATION`], indicating it should be proactively refreshed
+    /// before it expires.
+    fn is_due_for_refresh(&self, now: Instant) -> bool {
+        let refresh_threshold = EXPIRY_DURATION.saturating_sub(REFRESH_BUFFER);
+        now.duration_since(self.recorded_at) >= refresh_threshold
+    }
+
+    /// Returns the selection weight for this estimate: `1 / latency_ms`.
+    ///
+    /// Lower-latency peers get higher weights. Latency is clamped to a
+    /// minimum of 1 ms to avoid division by zero.
+    pub(crate) fn weight(&self) -> f64 {
+        1.0 / (self.average.as_secs_f64() * 1000.0).max(1.0)
+    }
+}
+
+/// Pure latency data: estimates and failure bookkeeping. No async, no tasks.
+#[derive(Debug, Default)]
+pub(crate) struct LatencyData {
+    estimates: HashMap<Url, LatencyEstimate>,
+    consecutive_failures: HashMap<Url, u32>,
+}
+
+impl LatencyData {
+    /// Records a new RTT sample for the given URL.
+    ///
+    /// Maintains a rolling window of at most [`MAX_SAMPLES`] entries,
+    /// evicting the oldest when full. Recalculates the cached average
+    /// and updates `recorded_at`. Also clears any consecutive failure count.
+    pub(crate) fn record_sample(&mut self, url: Url, rtt: Duration) {
+        self.consecutive_failures.remove(&url);
+
+        match self.estimates.get_mut(&url) {
+            Some(entry) => entry.push_sample(rtt),
+            None => {
+                self.estimates.insert(url, LatencyEstimate::new(rtt));
+            }
+        }
+    }
+
+    /// Returns the rolling-average latency for the given URL if the entry
+    /// exists and has not expired. Returns `None` otherwise.
+    #[cfg(test)]
+    fn get_latency(&self, url: &Url) -> Option<Duration> {
+        self.get_latency_at(url, Instant::now())
+    }
+
+    /// Returns the rolling-average latency relative to the given reference
+    /// instant. Used in tests to avoid platform-dependent `Instant` arithmetic.
+    #[cfg(test)]
+    fn get_latency_at(&self, url: &Url, now: Instant) -> Option<Duration> {
+        self.estimates.get(url).and_then(|entry| {
+            if entry.is_expired_at(now) {
+                None
+            } else {
+                Some(entry.average)
+            }
+        })
+    }
+
+    /// Returns the rolling-average latency even if the entry has expired.
+    /// Used as a soft fallback during re-ping to avoid sudden weight changes.
+    #[cfg(test)]
+    fn get_latency_including_stale(&self, url: &Url) -> Option<Duration> {
+        self.estimates.get(url).map(|entry| entry.average)
+    }
+
+    /// Returns the selection weight for any known URL.
+    ///
+    /// Returns `None` if the URL has never been seen. Freshness is not
+    /// checked here — the worker proactively refreshes entries before
+    /// [`EXPIRY_DURATION`] via [`REFRESH_BUFFER`], and [`evict_stale`]
+    /// removes entries past [`EVICTION_DURATION`]. Any entry still in
+    /// the store is considered usable for weighting.
+    pub(crate) fn get_weight(&self, url: &Url) -> Option<f64> {
+        self.estimates.get(url).map(|entry| entry.weight())
+    }
+
+    /// Records a full-round ping failure for a URL, incrementing the
+    /// consecutive failure counter.
+    pub(crate) fn record_failure(&mut self, url: &Url) {
+        *self.consecutive_failures.entry(url.clone()).or_insert(0) += 1;
+    }
+
+    /// Returns `true` if the URL has exceeded [`CONSECUTIVE_FAILURE_THRESHOLD`]
+    /// consecutive ping failures and should not be pinged again.
+    ///
+    /// This is a ping-specific signal distinct from the transport-level
+    /// unresponsive marker maintained in the peer meta store.
+    pub(crate) fn has_failed_pings(&self, url: &Url) -> bool {
+        self.consecutive_failures
+            .get(url)
+            .is_some_and(|&count| count >= CONSECUTIVE_FAILURE_THRESHOLD)
+    }
+
+    /// Clears the consecutive failure counter for a URL, re-enabling pings.
+    fn clear_failures(&mut self, url: &Url) {
+        self.consecutive_failures.remove(url);
+    }
+
+    /// Returns `true` if the URL has no estimate, an expired estimate,
+    /// or an estimate due for proactive refresh.
+    fn needs_ping(&self, url: &Url) -> bool {
+        self.needs_ping_at(url, Instant::now())
+    }
+
+    /// Returns `true` if the URL has no estimate, an expired estimate,
+    /// or an estimate due for proactive refresh, relative to the given
+    /// reference instant.
+    fn needs_ping_at(&self, url: &Url, now: Instant) -> bool {
+        self.estimates
+            .get(url)
+            .is_none_or(|e| e.is_expired_at(now) || e.is_due_for_refresh(now))
+    }
+
+    /// Removes entries whose `recorded_at` is older than [`EVICTION_DURATION`],
+    /// bounding memory growth under peer churn.
+    fn evict_stale(&mut self) {
+        self.evict_stale_at(Instant::now());
+    }
+
+    /// Removes entries whose `recorded_at` is older than [`EVICTION_DURATION`]
+    /// relative to the given reference instant.
+    fn evict_stale_at(&mut self, now: Instant) {
+        self.estimates
+            .retain(|_, entry| now.duration_since(entry.recorded_at) < EVICTION_DURATION);
+    }
+}
+
+/// Request to register or refresh a peer URL for latency tracking.
+struct TouchRequest {
+    url: Url,
+    space: DynSpace,
+}
+
+/// Per-URL bookkeeping inside the background worker.
+struct PeerWorkState {
+    space: DynSpace,
+    last_touched_at: Instant,
+}
+
+/// Active latency-estimation service.
+///
+/// Owns a single background Tokio task that pings peers on a schedule.
+/// The actor interacts only through [`touch`](Self::touch) and
+/// [`store`](Self::store).
+pub(crate) struct PeerLatencyService {
+    touch_tx: mpsc::UnboundedSender<TouchRequest>,
+    store: Arc<Mutex<LatencyData>>,
+    abort_handle: AbortHandle,
+}
+
+impl PeerLatencyService {
+    /// Spawns the background worker task and returns the service handle.
+    pub(crate) fn new(ping_fn: PingFn) -> Self {
+        let (touch_tx, touch_rx) = mpsc::unbounded_channel();
+        let store = Arc::new(Mutex::new(LatencyData::default()));
+        let task_store = Arc::clone(&store);
+        let handle = tokio::spawn(run_worker(touch_rx, task_store, ping_fn));
+        let abort_handle = handle.abort_handle();
+        Self {
+            touch_tx,
+            store,
+            abort_handle,
+        }
+    }
+
+    /// Notifies the service that a peer URL was encountered.
+    ///
+    /// If the URL is new, the worker will schedule pings for it.
+    /// If the URL previously had failed pings, it is re-activated.
+    pub(crate) fn touch(&self, url: Url, space: DynSpace) {
+        let _ = self.touch_tx.send(TouchRequest { url, space });
+    }
+
+    /// Returns a shared handle to the latency data for read access
+    /// (e.g., weighted selection).
+    pub(crate) fn store(&self) -> Arc<Mutex<LatencyData>> {
+        Arc::clone(&self.store)
+    }
+}
+
+impl Drop for PeerLatencyService {
+    fn drop(&mut self) {
+        self.abort_handle.abort();
+    }
+}
+
+/// Computes how long the worker should sleep before the next peer is due
+/// for a ping.
+fn compute_next_wake_duration(
+    peer_state: &HashMap<Url, PeerWorkState>,
+    store: &Mutex<LatencyData>,
+) -> Duration {
+    if peer_state.is_empty() {
+        return WORKER_TICK_INTERVAL;
+    }
+
+    let data = store.lock().expect("latency data lock poisoned");
+    let now = Instant::now();
+    let mut min_wait = WORKER_TICK_INTERVAL;
+
+    for url in peer_state.keys() {
+        if data.has_failed_pings(url) {
+            continue;
+        }
+        match data.estimates.get(url) {
+            None => return Duration::ZERO,
+            Some(est) => {
+                let refresh_at = est.recorded_at + EXPIRY_DURATION.saturating_sub(REFRESH_BUFFER);
+                if now >= refresh_at {
+                    return Duration::ZERO;
+                }
+                let wait = refresh_at - now;
+                if wait < min_wait {
+                    min_wait = wait;
+                }
+            }
+        }
+    }
+
+    min_wait
+}
+
+/// Prunes worker-side state for URLs whose estimate has been evicted and
+/// that haven't been touched within [`EVICTION_DURATION`].
+///
+/// Also drops orphan `consecutive_failures` entries for pruned URLs to keep
+/// failure bookkeeping bounded under peer churn.
+fn prune_peer_state_at(
+    peer_state: &mut HashMap<Url, PeerWorkState>,
+    data: &mut LatencyData,
+    now: Instant,
+) {
+    peer_state.retain(|url, state| {
+        data.estimates.contains_key(url)
+            || now.duration_since(state.last_touched_at) < EVICTION_DURATION
+    });
+    data.consecutive_failures
+        .retain(|url, _| peer_state.contains_key(url));
+}
+
+/// Background worker loop that schedules and executes pings.
+async fn run_worker(
+    mut touch_rx: mpsc::UnboundedReceiver<TouchRequest>,
+    store: Arc<Mutex<LatencyData>>,
+    ping_fn: PingFn,
+) {
+    let mut peer_state: HashMap<Url, PeerWorkState> = HashMap::new();
+
+    loop {
+        let next_wait = compute_next_wake_duration(&peer_state, &store);
+
+        tokio::select! {
+            biased;
+
+            msg = touch_rx.recv() => {
+                match msg {
+                    Some(touch) => {
+                        store
+                            .lock()
+                            .expect("latency data lock poisoned")
+                            .clear_failures(&touch.url);
+                        let now = Instant::now();
+                        peer_state
+                            .entry(touch.url)
+                            .and_modify(|state| {
+                                state.space = touch.space.clone();
+                                state.last_touched_at = now;
+                            })
+                            .or_insert_with(|| PeerWorkState {
+                                space: touch.space,
+                                last_touched_at: now,
+                            });
+                    }
+                    None => break,
+                }
+            }
+
+            _ = tokio::time::sleep(next_wait) => {
+                ping_due_peers(&peer_state, &store, &ping_fn).await;
+                let mut data = store.lock().expect("latency data lock poisoned");
+                data.evict_stale();
+                prune_peer_state_at(&mut peer_state, &mut data, Instant::now());
+            }
+        }
+    }
+}
+
+/// Finds peers that are due for pinging and pings them with bounded concurrency.
+async fn ping_due_peers(
+    peer_state: &HashMap<Url, PeerWorkState>,
+    store: &Arc<Mutex<LatencyData>>,
+    ping_fn: &PingFn,
+) {
+    let urls_to_ping: Vec<(Url, DynSpace)> = {
+        let data = store.lock().expect("latency data lock poisoned");
+        peer_state
+            .iter()
+            .filter(|(url, _)| !data.has_failed_pings(url) && data.needs_ping(url))
+            .map(|(url, state)| (url.clone(), state.space.clone()))
+            .collect()
+    };
+
+    if urls_to_ping.is_empty() {
+        return;
+    }
+
+    let mut futures = FuturesUnordered::new();
+
+    for (url, space) in urls_to_ping {
+        let ping_fn = Arc::clone(ping_fn);
+        let task_store = Arc::clone(store);
+        futures.push(async move {
+            let mut success_count = 0u32;
+            for _ in 0..PING_SAMPLE_COUNT {
+                match ping_fn(space.clone(), url.clone()).await {
+                    Some(rtt) => {
+                        task_store
+                            .lock()
+                            .expect("latency data lock poisoned")
+                            .record_sample(url.clone(), rtt);
+                        success_count += 1;
+                    }
+                    None => {
+                        // Bail early: a failed sample usually means
+                        // send_notify error or timeout, so spending
+                        // the full PING_TIMEOUT budget on the remaining
+                        // samples would just delay the failure round.
+                        break;
+                    }
+                }
+            }
+            (url, success_count)
+        });
+
+        // Drain completed futures when we hit the concurrency limit.
+        while futures.len() >= MAX_CONCURRENT_PINGS {
+            if let Some((url, success_count)) = futures.next().await {
+                handle_ping_result(store, &url, success_count);
+            }
+        }
+    }
+
+    // Drain remaining futures.
+    while let Some((url, success_count)) = futures.next().await {
+        handle_ping_result(store, &url, success_count);
+    }
+}
+
+/// Records ping outcome: logs the result and tracks consecutive failures.
+fn handle_ping_result(store: &Arc<Mutex<LatencyData>>, url: &Url, success_count: u32) {
+    if success_count == 0 {
+        tracing::debug!(%url, "All ping samples failed for peer");
+        store
+            .lock()
+            .expect("latency data lock poisoned")
+            .record_failure(url);
+    } else {
+        tracing::debug!(%url, success_count, "Ping sampling complete for peer");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_url(name: &str) -> Url {
+        Url::from_str(format!("ws://test-{name}:1234")).unwrap()
+    }
+
+    /// Returns a synthetic future `Instant` that is `offset` ahead of now.
+    ///
+    /// Tests use this instead of trying to create an `Instant` in the past,
+    /// which fails on platforms where `Instant` cannot represent times before
+    /// process start (e.g., short-lived Windows processes).
+    fn future_instant(offset: Duration) -> Instant {
+        Instant::now() + offset
+    }
+
+    // -- LatencyEstimate tests --
+
+    #[test]
+    fn weight_inverse_of_latency_ms() {
+        let est = LatencyEstimate::new(Duration::from_millis(100));
+        let w = est.weight();
+        // 1 / 100 = 0.01
+        assert!((w - 0.01).abs() < 1e-9, "weight was {w}");
+    }
+
+    #[test]
+    fn weight_clamps_zero_latency_to_one_ms() {
+        let est = LatencyEstimate::new(Duration::ZERO);
+        let w = est.weight();
+        // 1 / 1 = 1.0
+        assert!((w - 1.0).abs() < 1e-9, "weight was {w}");
+    }
+
+    #[test]
+    fn is_due_for_refresh_before_threshold() {
+        let est = LatencyEstimate::new(Duration::from_millis(50));
+        // 40 min: not yet at 50 min threshold
+        let future = future_instant(Duration::from_secs(40 * 60));
+        assert!(!est.is_due_for_refresh(future));
+    }
+
+    #[test]
+    fn is_due_for_refresh_at_threshold() {
+        let est = LatencyEstimate::new(Duration::from_millis(50));
+        // 50 min: at the refresh threshold (EXPIRY - REFRESH_BUFFER = 50 min)
+        let future = future_instant(Duration::from_secs(50 * 60));
+        assert!(est.is_due_for_refresh(future));
+    }
+
+    #[test]
+    fn is_due_for_refresh_after_expiry() {
+        let est = LatencyEstimate::new(Duration::from_millis(50));
+        // 65 min: past expiry
+        let future = future_instant(Duration::from_secs(65 * 60));
+        assert!(est.is_due_for_refresh(future));
+    }
+
+    // -- LatencyData tests --
+
+    #[test]
+    fn get_latency_returns_none_for_unknown_peer() {
+        let data = LatencyData::default();
+        assert!(data.get_latency(&test_url("a")).is_none());
+    }
+
+    #[test]
+    fn record_sample_and_get_latency() {
+        let mut data = LatencyData::default();
+        let url = test_url("a");
+        data.record_sample(url.clone(), Duration::from_millis(100));
+        data.record_sample(url.clone(), Duration::from_millis(200));
+
+        assert_eq!(data.get_latency(&url), Some(Duration::from_millis(150)));
+    }
+
+    #[test]
+    fn rolling_window_evicts_oldest_at_max_samples() {
+        let mut data = LatencyData::default();
+        let url = test_url("a");
+
+        for _ in 0..MAX_SAMPLES {
+            data.record_sample(url.clone(), Duration::from_millis(100));
+        }
+
+        assert_eq!(data.get_latency(&url), Some(Duration::from_millis(100)));
+
+        data.record_sample(url.clone(), Duration::from_millis(200));
+
+        assert_eq!(data.get_latency(&url), Some(Duration::from_millis(110)));
+    }
+
+    #[test]
+    fn expired_entry_returns_none_and_needs_ping() {
+        let mut data = LatencyData::default();
+        let url = test_url("a");
+        data.record_sample(url.clone(), Duration::from_millis(50));
+
+        let future = future_instant(Duration::from_secs(2 * 60 * 60));
+
+        assert!(data.get_latency_at(&url, future).is_none());
+        assert!(data.needs_ping_at(&url, future));
+    }
+
+    #[test]
+    fn get_latency_including_stale_returns_expired_average() {
+        let mut data = LatencyData::default();
+        let url = test_url("a");
+        data.record_sample(url.clone(), Duration::from_millis(50));
+
+        let future = future_instant(Duration::from_secs(2 * 60 * 60));
+
+        assert!(data.get_latency_at(&url, future).is_none());
+        assert_eq!(
+            data.get_latency_including_stale(&url),
+            Some(Duration::from_millis(50))
+        );
+    }
+
+    #[test]
+    fn get_weight_returns_estimate_weight() {
+        let mut data = LatencyData::default();
+        let url = test_url("a");
+        data.record_sample(url.clone(), Duration::from_millis(100));
+
+        let w = data.get_weight(&url).unwrap();
+        assert!((w - 0.01).abs() < 1e-9, "weight was {w}");
+    }
+
+    #[test]
+    fn get_weight_returns_none_for_unknown() {
+        let data = LatencyData::default();
+        assert!(data.get_weight(&test_url("a")).is_none());
+    }
+
+    #[test]
+    fn evict_stale_removes_entries_older_than_eviction_duration() {
+        let mut data = LatencyData::default();
+        let fresh_url = test_url("fresh");
+        let stale_url = test_url("stale");
+
+        data.record_sample(fresh_url.clone(), Duration::from_millis(50));
+        data.record_sample(stale_url.clone(), Duration::from_millis(100));
+
+        let future = future_instant(Duration::from_secs(3 * 60 * 60));
+        data.estimates.get_mut(&fresh_url).unwrap().recorded_at =
+            future - Duration::from_secs(30 * 60);
+
+        data.evict_stale_at(future);
+
+        assert!(data.get_latency_at(&fresh_url, future).is_some());
+        assert!(data.get_latency_including_stale(&stale_url).is_none());
+    }
+
+    #[test]
+    fn evict_stale_keeps_entries_within_eviction_window() {
+        let mut data = LatencyData::default();
+        let url = test_url("a");
+
+        data.record_sample(url.clone(), Duration::from_millis(50));
+
+        // 1.5 hours: past EXPIRY (1h) but within EVICTION (2h).
+        let future = future_instant(Duration::from_secs(90 * 60));
+
+        data.evict_stale_at(future);
+
+        assert!(data.get_latency_at(&url, future).is_none());
+        assert!(data.get_latency_including_stale(&url).is_some());
+    }
+
+    #[test]
+    fn needs_ping_returns_true_for_unknown_peer() {
+        let data = LatencyData::default();
+        assert!(data.needs_ping(&test_url("a")));
+    }
+
+    #[test]
+    fn needs_ping_returns_false_for_fresh_peer() {
+        let mut data = LatencyData::default();
+        let url = test_url("a");
+        data.record_sample(url.clone(), Duration::from_millis(50));
+        assert!(!data.needs_ping(&url));
+    }
+
+    #[test]
+    fn needs_ping_returns_true_near_expiry() {
+        let mut data = LatencyData::default();
+        let url = test_url("a");
+        data.record_sample(url.clone(), Duration::from_millis(50));
+
+        // 55 min: past the refresh threshold (50 min)
+        let future = future_instant(Duration::from_secs(55 * 60));
+        assert!(data.needs_ping_at(&url, future));
+    }
+
+    // -- Ping-failure detection tests --
+
+    #[test]
+    fn has_failed_pings_after_consecutive_failures() {
+        let mut data = LatencyData::default();
+        let url = test_url("a");
+
+        for _ in 0..CONSECUTIVE_FAILURE_THRESHOLD {
+            assert!(!data.has_failed_pings(&url));
+            data.record_failure(&url);
+        }
+        assert!(data.has_failed_pings(&url));
+    }
+
+    #[test]
+    fn record_sample_clears_failures() {
+        let mut data = LatencyData::default();
+        let url = test_url("a");
+
+        for _ in 0..CONSECUTIVE_FAILURE_THRESHOLD - 1 {
+            data.record_failure(&url);
+        }
+        assert!(!data.has_failed_pings(&url));
+
+        data.record_sample(url.clone(), Duration::from_millis(50));
+        assert!(!data.has_failed_pings(&url));
+        assert_eq!(data.consecutive_failures.get(&url), None);
+    }
+
+    #[test]
+    fn clear_failures_reactivates_peer_with_failed_pings() {
+        let mut data = LatencyData::default();
+        let url = test_url("a");
+
+        for _ in 0..CONSECUTIVE_FAILURE_THRESHOLD {
+            data.record_failure(&url);
+        }
+        assert!(data.has_failed_pings(&url));
+
+        data.clear_failures(&url);
+        assert!(!data.has_failed_pings(&url));
+    }
+
+    // -- PeerLatencyService integration tests --
+
+    /// Minimal mock of [`kitsune2_api::Space`] for testing.
+    /// The ping function in tests ignores the space, so all methods
+    /// are stubs that panic if called.
+    mod mock_space {
+        use kitsune2_api::*;
+        use std::sync::Arc;
+
+        #[derive(Debug)]
+        pub(super) struct StubSpace;
+
+        impl Space for StubSpace {
+            fn peer_store(&self) -> &DynPeerStore {
+                unimplemented!("stub")
+            }
+            fn local_agent_store(&self) -> &DynLocalAgentStore {
+                unimplemented!("stub")
+            }
+            fn op_store(&self) -> &DynOpStore {
+                unimplemented!("stub")
+            }
+            fn fetch(&self) -> &DynFetch {
+                unimplemented!("stub")
+            }
+            fn publish(&self) -> &DynPublish {
+                unimplemented!("stub")
+            }
+            fn gossip(&self) -> &DynGossip {
+                unimplemented!("stub")
+            }
+            fn peer_meta_store(&self) -> &DynPeerMetaStore {
+                unimplemented!("stub")
+            }
+            fn blocks(&self) -> &DynBlocks {
+                unimplemented!("stub")
+            }
+            fn current_url(&self) -> Option<Url> {
+                None
+            }
+            fn local_agent_join(&self, _local_agent: DynLocalAgent) -> BoxFut<'_, K2Result<()>> {
+                unimplemented!("stub")
+            }
+            fn local_agent_leave(&self, _local_agent: AgentId) -> BoxFut<'_, ()> {
+                unimplemented!("stub")
+            }
+            fn send_notify(&self, _to_peer: Url, _data: bytes::Bytes) -> BoxFut<'_, K2Result<()>> {
+                unimplemented!("stub")
+            }
+            fn inform_ops_stored(&self, _ops: Vec<StoredOp>) -> BoxFut<'_, K2Result<()>> {
+                unimplemented!("stub")
+            }
+        }
+
+        pub(super) fn stub_space() -> DynSpace {
+            Arc::new(StubSpace)
+        }
+    }
+
+    #[tokio::test]
+    async fn service_touch_triggers_ping_and_records_sample() {
+        let ping_fn: PingFn =
+            Arc::new(|_space, _url| Box::pin(async { Some(Duration::from_millis(42)) }));
+
+        let service = PeerLatencyService::new(ping_fn);
+        let space = mock_space::stub_space();
+        let url = test_url("ping-me");
+
+        service.touch(url.clone(), space);
+
+        // Give the worker time to process the touch and run pings.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let store = service.store();
+        let data = store.lock().expect("latency data lock poisoned");
+        assert!(
+            data.get_latency(&url).is_some(),
+            "expected latency sample to be recorded"
+        );
+    }
+
+    #[tokio::test]
+    async fn service_ping_failing_peer_stops_pinging() {
+        let call_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let call_count_fn = Arc::clone(&call_count);
+
+        let ping_fn: PingFn = Arc::new(move |_space, _url| {
+            call_count_fn.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Box::pin(async { None }) // Always fail
+        });
+
+        let service = PeerLatencyService::new(ping_fn);
+        let space = mock_space::stub_space();
+        let url = test_url("ping-failing");
+
+        service.touch(url.clone(), space);
+
+        // Wait for initial round of pings + a few worker ticks.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let initial_calls = call_count.load(std::sync::atomic::Ordering::Relaxed);
+
+        // Wait more — if ping-failure detection works, no more pings.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let final_calls = call_count.load(std::sync::atomic::Ordering::Relaxed);
+
+        // Each round bails on the first failing sample, so an always-failing
+        // peer should stop being pinged after CONSECUTIVE_FAILURE_THRESHOLD
+        // rounds. Stay lenient in case timing lets one extra round slip in.
+        assert!(
+            final_calls <= initial_calls + (PING_SAMPLE_COUNT as u32),
+            "expected pinging to stop, but calls went from {initial_calls} to {final_calls}"
+        );
+    }
+
+    #[tokio::test]
+    async fn ping_round_bails_early_on_first_failure() {
+        let call_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let call_count_fn = Arc::clone(&call_count);
+
+        let ping_fn: PingFn = Arc::new(move |_space, _url| {
+            call_count_fn.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Box::pin(async { None }) // Always fail on first sample
+        });
+
+        let service = PeerLatencyService::new(ping_fn);
+        let space = mock_space::stub_space();
+        service.touch(test_url("dead"), space);
+
+        // Worker loops without delay until the peer is marked as having failed pings,
+        // so 300ms is comfortably enough to exhaust CONSECUTIVE_FAILURE_THRESHOLD.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        let count = call_count.load(std::sync::atomic::Ordering::Relaxed);
+
+        // With the early-exit, each round calls ping_fn exactly once before
+        // bailing. Without it, each round would have called it
+        // PING_SAMPLE_COUNT times.
+        assert!(count >= 1, "expected at least one ping attempt");
+        assert!(
+            count < PING_SAMPLE_COUNT as u32,
+            "expected short-circuit: got {count} calls, should be < {PING_SAMPLE_COUNT} per round"
+        );
+    }
+
+    #[tokio::test]
+    async fn ping_round_records_every_successful_sample() {
+        let call_count = Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let call_count_fn = Arc::clone(&call_count);
+
+        let ping_fn: PingFn = Arc::new(move |_space, _url| {
+            call_count_fn.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Box::pin(async { Some(Duration::from_millis(5)) })
+        });
+
+        let service = PeerLatencyService::new(ping_fn);
+        let space = mock_space::stub_space();
+        let url = test_url("alive");
+        service.touch(url.clone(), space);
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        // On a healthy peer, every sample in the round should fire — no
+        // early exit — so the first round alone accounts for
+        // PING_SAMPLE_COUNT calls.
+        let count = call_count.load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            count >= PING_SAMPLE_COUNT as u32,
+            "expected at least {PING_SAMPLE_COUNT} pings for healthy peer, got {count}"
+        );
+    }
+
+    // -- prune_peer_state_at tests --
+
+    #[test]
+    fn prune_keeps_entries_with_live_estimate() {
+        let mut peer_state: HashMap<Url, PeerWorkState> = HashMap::new();
+        let mut data = LatencyData::default();
+        let url = test_url("a");
+
+        // Insert with a last_touched_at far in the past relative to `now`
+        // below, so the only reason to keep the entry is the live estimate.
+        let touched_at = Instant::now();
+        peer_state.insert(
+            url.clone(),
+            PeerWorkState {
+                space: mock_space::stub_space(),
+                last_touched_at: touched_at,
+            },
+        );
+        data.record_sample(url.clone(), Duration::from_millis(50));
+
+        let now = touched_at + EVICTION_DURATION + Duration::from_secs(60);
+        prune_peer_state_at(&mut peer_state, &mut data, now);
+        assert!(peer_state.contains_key(&url));
+    }
+
+    #[test]
+    fn prune_keeps_recently_touched_entries_without_estimate() {
+        let mut peer_state: HashMap<Url, PeerWorkState> = HashMap::new();
+        let mut data = LatencyData::default();
+        let url = test_url("pending");
+        let now = Instant::now();
+
+        // Newly touched peer: no estimate yet (initial ping in flight).
+        peer_state.insert(
+            url.clone(),
+            PeerWorkState {
+                space: mock_space::stub_space(),
+                last_touched_at: now,
+            },
+        );
+
+        prune_peer_state_at(&mut peer_state, &mut data, now);
+        assert!(peer_state.contains_key(&url));
+    }
+
+    #[test]
+    fn prune_drops_abandoned_ping_failed_entries() {
+        let mut peer_state: HashMap<Url, PeerWorkState> = HashMap::new();
+        let mut data = LatencyData::default();
+        let url = test_url("dead");
+        let now = Instant::now();
+
+        peer_state.insert(
+            url.clone(),
+            PeerWorkState {
+                space: mock_space::stub_space(),
+                last_touched_at: now,
+            },
+        );
+        for _ in 0..CONSECUTIVE_FAILURE_THRESHOLD {
+            data.record_failure(&url);
+        }
+        assert!(data.has_failed_pings(&url));
+
+        let future = future_instant(EVICTION_DURATION + Duration::from_secs(60));
+        prune_peer_state_at(&mut peer_state, &mut data, future);
+
+        assert!(!peer_state.contains_key(&url));
+        // Failure entry dropped alongside peer_state entry.
+        assert!(!data.consecutive_failures.contains_key(&url));
+        assert!(!data.has_failed_pings(&url));
+    }
+
+    #[test]
+    fn prune_drops_entries_with_evicted_estimate_and_stale_touch() {
+        let mut peer_state: HashMap<Url, PeerWorkState> = HashMap::new();
+        let mut data = LatencyData::default();
+        let url = test_url("abandoned");
+        let now = Instant::now();
+
+        data.record_sample(url.clone(), Duration::from_millis(50));
+        peer_state.insert(
+            url.clone(),
+            PeerWorkState {
+                space: mock_space::stub_space(),
+                last_touched_at: now,
+            },
+        );
+
+        let future = future_instant(EVICTION_DURATION + Duration::from_secs(60));
+        data.evict_stale_at(future);
+        prune_peer_state_at(&mut peer_state, &mut data, future);
+
+        assert!(!peer_state.contains_key(&url));
+    }
+}

--- a/crates/holochain_p2p/src/spawn.rs
+++ b/crates/holochain_p2p/src/spawn.rs
@@ -238,7 +238,7 @@ impl Default for HolochainP2pConfig {
     }
 }
 
-/// See [NetworkCompatParams::proto_ver].
+/// See [`NetworkCompatParams::proto_ver`].
 pub const HCP2P_PROTO_VER: u32 = 2;
 
 /// Some parameters used as part of a protocol compatibility check during tx5 preflight

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -5,6 +5,7 @@ use crate::metrics::{
     p2p_handle_incoming_request_duration_metric, p2p_handle_incoming_request_ignored_metric,
     p2p_outgoing_request_duration_metric, p2p_recv_remote_signal_metric,
 };
+use crate::peer_latency_store::{PeerLatencyService, PingFn};
 use crate::*;
 use holochain_sqlite::error::{DatabaseError, DatabaseResult};
 use holochain_sqlite::helpers::BytesSql;
@@ -14,7 +15,6 @@ use holochain_state::prelude::named_params;
 use holochain_types::cell_config_overrides::CellConfigOverrides;
 use kitsune2_api::*;
 use kitsune2_core::get_responsive_remote_agents_near_location;
-use rand::prelude::IndexedRandom;
 use std::collections::HashMap;
 use std::future::Future;
 use std::rc::Rc;
@@ -217,6 +217,10 @@ type Respond = tokio::sync::oneshot::Sender<crate::wire::WireMessage>;
 struct Pending {
     this: Weak<Mutex<Self>>,
     map: HashMap<u64, Respond>,
+    /// Maps `msg_id` to the expected responder URL for outbound pings.
+    /// Used to drop `PingRes` responses whose `from_peer` does not match
+    /// the pinged URL, preventing latency poisoning via `msg_id` race.
+    ping_expected: HashMap<u64, Url>,
 }
 
 impl Pending {
@@ -230,8 +234,34 @@ impl Pending {
         }
     }
 
+    /// Registers an outbound ping, recording the URL we expect the
+    /// `PingRes` to come from. See [`Self::respond_ping`].
+    fn register_ping(&mut self, msg_id: u64, expected_url: Url, resp: Respond, timeout: Duration) {
+        self.ping_expected.insert(msg_id, expected_url);
+        self.register(msg_id, resp, timeout);
+    }
+
     fn respond(&mut self, msg_id: u64) -> Option<Respond> {
+        self.ping_expected.remove(&msg_id);
         self.map.remove(&msg_id)
+    }
+
+    /// Resolves a `PingRes` only if `from_peer` matches the URL that was
+    /// pinged for this `msg_id`. Drops the response otherwise.
+    fn respond_ping(&mut self, msg_id: u64, from_peer: &Url) -> Option<Respond> {
+        match self.ping_expected.remove(&msg_id) {
+            Some(expected) if &expected == from_peer => self.map.remove(&msg_id),
+            Some(expected) => {
+                tracing::warn!(
+                    ?msg_id,
+                    %expected,
+                    %from_peer,
+                    "PingRes from unexpected peer, dropping"
+                );
+                None
+            }
+            None => None,
+        }
     }
 }
 
@@ -246,6 +276,7 @@ pub(crate) struct HolochainP2pActor {
     kitsune2_config: Config,
     blocks_db_getter: GetDbConductor,
     pending: Arc<Mutex<Pending>>,
+    latency_service: PeerLatencyService,
     pruning_task_abort_handle: AbortHandle,
     request_timeout: Duration,
     incoming_request_concurrency_limit_semaphore: Arc<Semaphore>,
@@ -258,6 +289,8 @@ impl std::fmt::Debug for HolochainP2pActor {
 }
 
 const EVT_REG_ERR: &str = "event handler not registered";
+/// Timeout for each individual ping request.
+const PING_TIMEOUT: Duration = Duration::from_secs(5);
 
 impl SpaceHandler for HolochainP2pActor {
     fn recv_notify(&self, from_peer: Url, space: SpaceId, data: bytes::Bytes) -> K2Result<()> {
@@ -373,7 +406,10 @@ impl kitsune2_api::KitsuneHandler for HolochainP2pActor {
                         None => continue,
                         Some(space) => space,
                     };
-                    space.peer_store().insert(vec![agent]).await?;
+                    space.peer_store().insert(vec![agent.clone()]).await?;
+                    if let Some(url) = agent.url.clone() {
+                        self.latency_service.touch(url, space.clone());
+                    }
                 }
             }
 
@@ -607,6 +643,7 @@ impl HolochainP2pActor {
             Mutex::new(Pending {
                 this: this.clone(),
                 map: HashMap::new(),
+                ping_expected: HashMap::new(),
             })
         });
 
@@ -619,6 +656,12 @@ impl HolochainP2pActor {
             kitsune2,
             db_getter,
         );
+        let ping_pending = pending.clone();
+        let ping_fn: PingFn = Arc::new(move |space: DynSpace, url: Url| {
+            let pending = Arc::clone(&ping_pending);
+            Box::pin(async move { Self::send_ping(&space, &pending, url).await })
+        });
+        let latency_service = PeerLatencyService::new(ping_fn);
 
         Ok(Arc::new_cyclic(|this| Self {
             this: this.clone(),
@@ -630,6 +673,7 @@ impl HolochainP2pActor {
             kitsune,
             blocks_db_getter: config.get_conductor_db.clone(),
             pending,
+            latency_service,
             kitsune2_config,
             pruning_task_abort_handle,
             request_timeout: config.request_timeout,
@@ -782,11 +826,11 @@ impl HolochainP2pActor {
             .collect::<Vec<_>>())
     }
 
-    /// Randomly selects and returns [`PARALLEL_GET_AGENTS_COUNT`] agents with a peer URL whose
-    /// storage arcs contain the given location.
+    /// Selects agents whose storage arcs contain the given location, using
+    /// latency-weighted random selection to prefer lower-latency peers.
     ///
     /// Returns an error if failed to get peers or no peers are found.
-    async fn get_random_peers_for_location(
+    async fn get_peers_for_location_weighted(
         &self,
         tag: &'static str,
         space: &DynSpace,
@@ -801,10 +845,47 @@ impl HolochainP2pActor {
             ));
         }
 
-        Ok(agents
-            .choose_multiple(&mut rand::rng(), options.remote_agent_count as usize)
-            .cloned()
-            .collect())
+        // Touch all peer URLs so the latency service tracks them.
+        for (_, url) in &agents {
+            self.latency_service.touch(url.clone(), space.clone());
+        }
+
+        // Deduplicate by URL, run weighted selection, then map back to
+        // (AgentPubKey, Url) pairs.
+        let url_to_agent: HashMap<Url, AgentPubKey> =
+            agents
+                .iter()
+                .fold(HashMap::new(), |mut by_url, (agent, url)| {
+                    by_url.entry(url.clone()).or_insert_with(|| agent.clone());
+                    by_url
+                });
+        let unique_urls: Vec<Url> = url_to_agent.keys().cloned().collect();
+
+        let selected_urls = {
+            let store = self.latency_service.store();
+            let data = store.lock().expect("latency data lock poisoned");
+            crate::weighted_selection::select_weighted_urls(
+                &data,
+                &unique_urls,
+                options.remote_agent_count as usize,
+            )
+        };
+
+        // `select_weighted_urls` filters out URLs with failed pings; if every
+        // candidate has failed pings we treat this as no peers available.
+        if selected_urls.is_empty() {
+            return Err(HolochainP2pError::NoPeersForLocation(
+                String::from(tag),
+                loc,
+            ));
+        }
+
+        let selected = selected_urls
+            .into_iter()
+            .filter_map(|url| url_to_agent.get(&url).map(|agent| (agent.clone(), url)))
+            .collect();
+
+        Ok(selected)
     }
 
     /// Check whether a message should be bridged locally to some other agent on this node.
@@ -924,6 +1005,33 @@ impl HolochainP2pActor {
         }
     }
 
+    /// Sends a single [`PingReq`](WireMessage::PingReq) to a peer and
+    /// returns the measured round-trip time, or `None` on failure/timeout.
+    async fn send_ping(
+        space: &DynSpace,
+        pending: &Arc<Mutex<Pending>>,
+        to_url: Url,
+    ) -> Option<Duration> {
+        let (msg_id, req) = WireMessage::ping_req();
+        let req = WireMessage::encode_batch(&[&req]).ok()?;
+
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        pending
+            .lock()
+            .expect("pending lock poisoned")
+            .register_ping(msg_id, to_url.clone(), sender, PING_TIMEOUT);
+
+        let start = std::time::Instant::now();
+        if space.send_notify(to_url, req).await.is_err() {
+            return None;
+        }
+
+        match receiver.await {
+            Ok(WireMessage::PingRes { .. }) => Some(start.elapsed()),
+            _ => None,
+        }
+    }
+
     async fn inform_ops_stored(
         &self,
         space_id: SpaceId,
@@ -1019,6 +1127,15 @@ impl HolochainP2pActor {
                 | MustGetAgentActivityRes { msg_id, .. }
                 | SendValidationReceiptsRes { msg_id } => {
                     if let Some(resp) = pending.lock().unwrap().respond(msg_id) {
+                        let _ = resp.send(msg);
+                    }
+                    record_incoming_request_duration(&[]);
+                }
+                PingRes { msg_id } => {
+                    // Only resolve PingRes if the responder URL matches the
+                    // peer we pinged — otherwise a racing peer could poison
+                    // the RTT recorded for the target URL.
+                    if let Some(resp) = pending.lock().unwrap().respond_ping(msg_id, &from_peer) {
                         let _ = resp.send(msg);
                     }
                     record_incoming_request_duration(&[]);
@@ -1268,6 +1385,20 @@ impl HolochainP2pActor {
                         "to_agent",
                         format!("{to_agent:?}"),
                     )]);
+                }
+                PingReq { msg_id } => {
+                    let resp = crate::wire::WireMessage::ping_res(msg_id);
+                    let resp = crate::wire::WireMessage::encode_batch(&[&resp])?;
+                    if let Err(err) = kitsune
+                        .space_if_exists(space_id)
+                        .await
+                        .ok_or_else(|| HolochainP2pError::other("no such space"))?
+                        .send_notify(from_peer, resp)
+                        .await
+                    {
+                        tracing::debug!(?err, "Error sending ping response");
+                    }
+                    record_incoming_request_duration(&[]);
                 }
                 RemoteSignalEvt {
                     to_agent,
@@ -1760,7 +1891,7 @@ impl actor::HcP2p for HolochainP2pActor {
 
             let loc = dht_hash.get_loc();
             let agents = self
-                .get_random_peers_for_location("get", &space, loc, &options)
+                .get_peers_for_location_weighted("get", &space, loc, &options)
                 .await?;
 
             let start = std::time::Instant::now();
@@ -1840,7 +1971,7 @@ impl actor::HcP2p for HolochainP2pActor {
                 .ok_or(HolochainP2pError::K2SpaceNotFound(space_id))?;
             let loc = link_key.base.get_loc();
             let agents = self
-                .get_random_peers_for_location(
+                .get_peers_for_location_weighted(
                     "get_links",
                     &space,
                     loc,
@@ -1908,7 +2039,7 @@ impl actor::HcP2p for HolochainP2pActor {
                 .ok_or(HolochainP2pError::K2SpaceNotFound(space_id))?;
             let loc = query.base.get_loc();
             let agents = self
-                .get_random_peers_for_location("count_links", &space, loc, &options)
+                .get_peers_for_location_weighted("count_links", &space, loc, &options)
                 .await?;
 
             let start = std::time::Instant::now();
@@ -1966,7 +2097,7 @@ impl actor::HcP2p for HolochainP2pActor {
                 .ok_or(HolochainP2pError::K2SpaceNotFound(space_id))?;
             let loc = agent.get_loc();
             let agents = self
-                .get_random_peers_for_location(
+                .get_peers_for_location_weighted(
                     "get_agent_activity",
                     &space,
                     loc,
@@ -2046,7 +2177,7 @@ impl actor::HcP2p for HolochainP2pActor {
                 .ok_or(HolochainP2pError::K2SpaceNotFound(space_id))?;
             let loc = author.get_loc();
             let agents = self
-                .get_random_peers_for_location("must_get_agent_activity", &space, loc, &options)
+                .get_peers_for_location_weighted("must_get_agent_activity", &space, loc, &options)
                 .await?;
 
             let start = std::time::Instant::now();
@@ -2894,6 +3025,21 @@ mod tests {
                 .register(msg_id, s, Duration::from_secs(60));
             r
         }
+
+        fn register_pending_ping_response_handler(
+            &self,
+            msg_id: u64,
+            expected_url: kitsune2_api::Url,
+        ) -> tokio::sync::oneshot::Receiver<WireMessage> {
+            let (s, r) = tokio::sync::oneshot::channel();
+            self.actor.pending.lock().unwrap().register_ping(
+                msg_id,
+                expected_url,
+                s,
+                Duration::from_secs(60),
+            );
+            r
+        }
     }
 
     fn create_encode_wire_message_get_req(msg_id: u64) -> bytes::Bytes {
@@ -3292,6 +3438,18 @@ mod tests {
         // Message was handled
         assert!(msg_receiver.await.is_ok());
 
+        // PingRes is not limited
+        let msg = WireMessage::PingRes { msg_id: 11 };
+        let msg_data = WireMessage::encode_batch(&[&msg]).unwrap();
+
+        let msg_receiver = harness.register_pending_ping_response_handler(11, from_peer.clone());
+        harness
+            .recv_notify(from_peer.clone(), space_id.clone(), msg_data)
+            .unwrap();
+
+        // Message was handled
+        assert!(msg_receiver.await.is_ok());
+
         // CallRemoteReq is not limited
         let msg = WireMessage::CallRemoteReq {
             msg_id: 9,
@@ -3520,5 +3678,108 @@ mod tests {
 
         // The non limited message is handled
         assert!(unlimited_message_reciever.await.is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ping_req_is_not_concurrency_limited() {
+        let dna_hash = DnaHash::from_raw_32(vec![0; 32]);
+        let space_id = dna_hash.to_k2_space();
+        let from_peer = kitsune2_api::Url::from_str("ws://test:80/1").unwrap();
+
+        // Use a concurrency limit of 1 so the single GetReq saturates it.
+        let harness = TestP2pActorHarness::new(1).await;
+
+        // Saturate the concurrency limit with a blocking GetReq.
+        let msg_data = create_encode_wire_message_get_req(1);
+        harness
+            .recv_notify(from_peer.clone(), space_id.clone(), msg_data)
+            .unwrap();
+
+        let is_handled = retry_fn_until_timeout(
+            async || {
+                let count = harness.event_handler.handle_get_count.lock().unwrap();
+                *count == 1
+            },
+            None,
+            None,
+        )
+        .await;
+        assert!(is_handled.is_ok());
+
+        // All concurrency permits are now taken.
+        assert_eq!(
+            harness
+                .actor
+                .incoming_request_concurrency_limit_semaphore
+                .available_permits(),
+            0
+        );
+
+        // PingReq should still be accepted (not concurrency-limited).
+        // It will fail to send a response (no real space), but it must not
+        // block or consume a concurrency permit.
+        let msg = WireMessage::PingReq { msg_id: 42 };
+        let msg_data = WireMessage::encode_batch(&[&msg]).unwrap();
+        harness
+            .recv_notify(from_peer.clone(), space_id.clone(), msg_data)
+            .unwrap();
+
+        // Verify permits are still exhausted (PingReq did not take one).
+        assert_eq!(
+            harness
+                .actor
+                .incoming_request_concurrency_limit_semaphore
+                .available_permits(),
+            0
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ping_res_from_expected_peer_resolves() {
+        let dna_hash = DnaHash::from_raw_32(vec![0; 32]);
+        let space_id = dna_hash.to_k2_space();
+        let expected_peer = kitsune2_api::Url::from_str("ws://expected:80/1").unwrap();
+        let harness = TestP2pActorHarness::new(10).await;
+
+        let msg_receiver =
+            harness.register_pending_ping_response_handler(42, expected_peer.clone());
+
+        let msg = WireMessage::PingRes { msg_id: 42 };
+        let msg_data = WireMessage::encode_batch(&[&msg]).unwrap();
+        harness
+            .recv_notify(expected_peer, space_id, msg_data)
+            .unwrap();
+
+        let result = tokio::time::timeout(Duration::from_millis(500), msg_receiver).await;
+        let received = result.expect("receiver should resolve before timeout");
+        assert!(
+            matches!(received, Ok(WireMessage::PingRes { msg_id: 42 })),
+            "expected matching PingRes, got {received:?}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn ping_res_from_wrong_peer_is_dropped() {
+        let dna_hash = DnaHash::from_raw_32(vec![0; 32]);
+        let space_id = dna_hash.to_k2_space();
+        let expected_peer = kitsune2_api::Url::from_str("ws://expected:80/1").unwrap();
+        let wrong_peer = kitsune2_api::Url::from_str("ws://attacker:80/2").unwrap();
+        let harness = TestP2pActorHarness::new(10).await;
+
+        // Register a ping for msg_id 99 targeting `expected_peer`.
+        let msg_receiver =
+            harness.register_pending_ping_response_handler(99, expected_peer.clone());
+
+        // A PingRes with the same msg_id arrives from a different peer.
+        let msg = WireMessage::PingRes { msg_id: 99 };
+        let msg_data = WireMessage::encode_batch(&[&msg]).unwrap();
+        harness.recv_notify(wrong_peer, space_id, msg_data).unwrap();
+
+        // The receiver should not resolve — the response was dropped.
+        let result = tokio::time::timeout(Duration::from_millis(200), msg_receiver).await;
+        assert!(
+            result.is_err(),
+            "PingRes from wrong peer should not resolve the pending ping"
+        );
     }
 }

--- a/crates/holochain_p2p/src/types/wire.rs
+++ b/crates/holochain_p2p/src/types/wire.rs
@@ -132,6 +132,14 @@ pub enum WireMessage {
         to_agent: AgentPubKey,
         message: event::CountersigningSessionNegotiationMessage,
     },
+    /// Lightweight ping request for measuring peer round-trip latency.
+    PingReq {
+        msg_id: u64,
+    },
+    /// Response to a [`PingReq`](Self::PingReq), sent immediately upon receipt.
+    PingRes {
+        msg_id: u64,
+    },
 }
 
 fn next_msg_id() -> u64 {
@@ -168,6 +176,8 @@ impl WireMessage {
             WireMessage::MustGetAgentActivityRes { msg_id, .. } => Some(*msg_id),
             WireMessage::SendValidationReceiptsReq { msg_id, .. } => Some(*msg_id),
             WireMessage::SendValidationReceiptsRes { msg_id, .. } => Some(*msg_id),
+            WireMessage::PingReq { msg_id, .. } => Some(*msg_id),
+            WireMessage::PingRes { msg_id, .. } => Some(*msg_id),
             _ => None,
         }
     }
@@ -351,5 +361,16 @@ impl WireMessage {
         message: event::CountersigningSessionNegotiationMessage,
     ) -> WireMessage {
         Self::CountersigningSessionNegotiationEvt { to_agent, message }
+    }
+
+    /// Outgoing "Ping" request for latency measurement.
+    pub fn ping_req() -> (u64, WireMessage) {
+        let msg_id = next_msg_id();
+        (msg_id, Self::PingReq { msg_id })
+    }
+
+    /// Incoming "Ping" response.
+    pub fn ping_res(msg_id: u64) -> WireMessage {
+        Self::PingRes { msg_id }
     }
 }

--- a/crates/holochain_p2p/src/weighted_selection.rs
+++ b/crates/holochain_p2p/src/weighted_selection.rs
@@ -1,0 +1,231 @@
+use crate::peer_latency_store::LatencyData;
+use kitsune2_api::Url;
+use rand::prelude::IndexedRandom;
+
+/// Selects `count` URLs using latency-aware weighted random selection without replacement.
+///
+/// URLs flagged by the latency store as having failed pings are filtered out
+/// before selection so they cannot receive real traffic while they fail
+/// health pings. Returns an empty `Vec` if every input URL has failed pings.
+///
+/// Lower-latency URLs receive higher weights (`1 / latency_ms`). URLs
+/// without a latency estimate receive the median weight of known URLs.
+/// Falls back to uniform random if no latency data exists for any URL.
+pub(crate) fn select_weighted_urls(store: &LatencyData, urls: &[Url], count: usize) -> Vec<Url> {
+    if urls.is_empty() || count == 0 {
+        return Vec::new();
+    }
+
+    let selectable: Vec<Url> = urls
+        .iter()
+        .filter(|url| !store.has_failed_pings(url))
+        .cloned()
+        .collect();
+
+    if selectable.is_empty() {
+        return Vec::new();
+    }
+
+    let count = count.min(selectable.len());
+
+    let mut known_weights: Vec<f64> = selectable
+        .iter()
+        .filter_map(|url| store.get_weight(url))
+        .collect();
+
+    if known_weights.is_empty() {
+        return selectable
+            .choose_multiple(&mut rand::rng(), count)
+            .cloned()
+            .collect();
+    }
+
+    known_weights.sort_by(f64::total_cmp);
+    let median_weight = if known_weights.len().is_multiple_of(2) {
+        let upper = known_weights.len() / 2;
+        (known_weights[upper - 1] + known_weights[upper]) / 2.0
+    } else {
+        known_weights[known_weights.len() / 2]
+    };
+
+    selectable
+        .choose_multiple_weighted(&mut rand::rng(), count, |url| {
+            store.get_weight(url).unwrap_or(median_weight)
+        })
+        .map(|selection| selection.cloned().collect())
+        .unwrap_or_else(|_| {
+            selectable
+                .choose_multiple(&mut rand::rng(), count)
+                .cloned()
+                .collect()
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::time::Duration;
+
+    fn test_url(name: &str) -> Url {
+        Url::from_str(format!("ws://test-{name}:1234")).unwrap()
+    }
+
+    /// Drives `record_failure` until the URL crosses the ping-failure
+    /// threshold without depending on the private constant.
+    fn mark_ping_failed(store: &mut LatencyData, url: &Url) {
+        for _ in 0..100 {
+            if store.has_failed_pings(url) {
+                return;
+            }
+            store.record_failure(url);
+        }
+        panic!("failed to mark url as ping-failed within 100 failures");
+    }
+
+    #[test]
+    fn all_unknown_urls_uses_uniform_selection() {
+        let store = LatencyData::default();
+        let urls = vec![test_url("1"), test_url("2"), test_url("3")];
+
+        let selected = select_weighted_urls(&store, &urls, 2);
+        assert_eq!(selected.len(), 2);
+    }
+
+    #[test]
+    fn low_latency_url_selected_more_often() {
+        let mut store = LatencyData::default();
+        let fast_url = test_url("fast");
+        let slow_url = test_url("slow");
+
+        store.record_sample(fast_url.clone(), Duration::from_millis(10));
+        store.record_sample(slow_url.clone(), Duration::from_millis(1000));
+
+        let urls = vec![fast_url.clone(), slow_url];
+
+        let mut fast_count = 0;
+        for _ in 0..1000 {
+            let selected = select_weighted_urls(&store, &urls, 1);
+            if selected[0] == fast_url {
+                fast_count += 1;
+            }
+        }
+
+        assert!(
+            fast_count > 900,
+            "fast url selected {fast_count}/1000 times"
+        );
+    }
+
+    #[test]
+    fn unknown_urls_get_median_weight() {
+        let mut store = LatencyData::default();
+        let known_url = test_url("known");
+        let unknown_url = test_url("unknown");
+        store.record_sample(known_url.clone(), Duration::from_millis(100));
+
+        let urls = vec![known_url, unknown_url.clone()];
+
+        let mut unknown_count = 0;
+        for _ in 0..1000 {
+            let selected = select_weighted_urls(&store, &urls, 1);
+            if selected[0] == unknown_url {
+                unknown_count += 1;
+            }
+        }
+
+        assert!(
+            (300..700).contains(&unknown_count),
+            "unknown url selected {unknown_count}/1000 times"
+        );
+    }
+
+    #[test]
+    fn zero_latency_clamped_to_one_ms() {
+        let mut store = LatencyData::default();
+        let url = test_url("zero");
+        store.record_sample(url.clone(), Duration::ZERO);
+
+        let selected = select_weighted_urls(&store, &[url], 1);
+        assert_eq!(selected.len(), 1);
+    }
+
+    #[test]
+    fn single_url_always_selected() {
+        let store = LatencyData::default();
+        let selected = select_weighted_urls(&store, &[test_url("1")], 1);
+
+        assert_eq!(selected.len(), 1);
+    }
+
+    #[test]
+    fn request_more_than_available_returns_all() {
+        let store = LatencyData::default();
+        let urls = vec![test_url("1"), test_url("2")];
+
+        let selected = select_weighted_urls(&store, &urls, 5);
+        assert_eq!(selected.len(), 2);
+    }
+
+    #[test]
+    fn duplicate_urls_are_preserved() {
+        let mut store = LatencyData::default();
+        let url1 = test_url("1");
+        let url2 = test_url("2");
+
+        store.record_sample(url1.clone(), Duration::from_millis(10));
+        store.record_sample(url2.clone(), Duration::from_millis(10));
+
+        // Caller is responsible for deduplication; this function
+        // just selects from the given slice.
+        let urls = vec![url1, url2];
+        let selected = select_weighted_urls(&store, &urls, 2);
+        let unique: HashSet<_> = selected.into_iter().collect();
+        assert_eq!(unique.len(), 2);
+    }
+
+    #[test]
+    fn ping_failed_urls_are_excluded() {
+        let mut store = LatencyData::default();
+        let healthy = test_url("healthy");
+        let dead = test_url("dead");
+
+        store.record_sample(healthy.clone(), Duration::from_millis(10));
+        mark_ping_failed(&mut store, &dead);
+
+        let urls = vec![healthy.clone(), dead.clone()];
+        for _ in 0..50 {
+            let selected = select_weighted_urls(&store, &urls, 1);
+            assert_eq!(selected, vec![healthy.clone()]);
+        }
+    }
+
+    #[test]
+    fn all_ping_failed_returns_empty() {
+        let mut store = LatencyData::default();
+        let a = test_url("a");
+        let b = test_url("b");
+        mark_ping_failed(&mut store, &a);
+        mark_ping_failed(&mut store, &b);
+
+        let selected = select_weighted_urls(&store, &[a, b], 2);
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn ping_failed_count_does_not_consume_selection_slot() {
+        let mut store = LatencyData::default();
+        let healthy1 = test_url("h1");
+        let healthy2 = test_url("h2");
+        let dead = test_url("dead");
+
+        store.record_sample(healthy1.clone(), Duration::from_millis(10));
+        store.record_sample(healthy2.clone(), Duration::from_millis(10));
+        mark_ping_failed(&mut store, &dead);
+
+        let urls = vec![healthy1, healthy2, dead];
+        let selected = select_weighted_urls(&store, &urls, 3);
+        // Only 2 selectable URLs remain after filtering the dead one.
+        assert_eq!(selected.len(), 2);
+    }
+}


### PR DESCRIPTION
### Summary

Implements latency-aware peer selection for the P2P layer, replacing random peer selection with weighted random selection that prefers lower-latency peers. Closes #5602.

**Key changes:**

- **Ping/pong wire messages** (`PingReq`/`PingRes`): lightweight RTT measurement sent in the background as peers are discovered. 10 samples per peer, rolling average cached with 1-hour TTL.
- **`PeerLatencyStore`**: in-memory cache of per-URL latency estimates with rolling window, expiry, in-flight deduplication, and stale entry eviction (2-hour eviction window bounds memory under peer churn).
- **Weighted peer selection**: peers covering the target content are selected via `1/latency_ms` weighting. Unknown peers receive the median weight. Falls back to uniform random if no latency data exists.
- **Concurrency controls**: semaphore limits concurrent ping tasks to 16; `PingGuard` drop guard prevents in-flight marker leaks.
- **BREAKING**: bumps `HCP2P_PROTO_VER` from 2 to 3 due to new wire message variants.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs