### PR TITLE
fix: Clear validation receipt requirement for agents who have gone offline

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- When Holochain attempts to prepare validation receipts but the author of the data has not been recently online, by being
+  present in our peer store, then clear the receipt request and skip attempting to send. The author may request validation
+  receipts again by republishing their content.
+
 ## 0.7.0-dev.19
 
 ## 0.7.0-dev.18

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
@@ -19,7 +19,7 @@ mod unit_tests;
     feature = "instrument",
     tracing::instrument(skip(vault, network, keystore, apply_block))
 )]
-/// Send validation receipts to their authors in serial and without waiting for responses.
+/// Send validation receipts to their authors in serial, skipping authors not recently online.
 pub async fn validation_receipt_workflow(
     dna_hash: Arc<DnaHash>,
     vault: DbWrite<DbKindDht>,
@@ -63,6 +63,32 @@ pub async fn validation_receipt_workflow(
         .collect::<Vec<(AgentPubKey, Vec<ValidationReceipt>)>>();
 
     for (author, receipts) in grouped_by_author {
+        // Don't need to check online status for our own agents — the self-send
+        // is handled inside sign_and_send_receipts_to_author.
+        if !validators.contains(&author) {
+            // Check if the author was recently online before doing any signing/sending work.
+            // If they're not in the peer store, clear the flag so we don't retry until
+            // a new publish from them re-sets it.
+            let recently_online = match network.was_agent_recently_online(author.clone()).await {
+                Ok(recently_online) => recently_online,
+                Err(e) => {
+                    info!(failed_to_check_agent_online_status = ?e);
+                    continue;
+                }
+            };
+
+            if !recently_online {
+                for receipt in receipts {
+                    vault
+                        .write_async(move |txn| {
+                            set_require_receipt(txn, &receipt.dht_op_hash, false)
+                        })
+                        .await?;
+                }
+                continue;
+            }
+        }
+
         // Try to send the validation receipts
         match sign_and_send_receipts_to_author(
             network.clone(),

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/unit_tests.rs
@@ -104,6 +104,8 @@ async fn block_invalid_op_author() {
 
     // We'll still send a validation receipt, but we should also block them
     let mut dna = MockHolochainP2pDnaT::new();
+    dna.expect_was_agent_recently_online()
+        .return_once(|_| Ok(true));
     dna.expect_send_validation_receipts()
         .return_once(|_, _| Ok(()));
     let dna = Arc::new(dna);
@@ -145,6 +147,8 @@ async fn continues_if_receipt_cannot_be_signed() {
         .unwrap();
 
     let mut dna = MockHolochainP2pDnaT::new();
+    dna.expect_was_agent_recently_online()
+        .return_once(|_| Ok(true));
     dna.expect_send_validation_receipts().never();
     let dna = Arc::new(dna);
 
@@ -183,6 +187,8 @@ async fn send_validation_receipt() {
         .unwrap();
 
     let mut dna = MockHolochainP2pDnaT::new();
+    dna.expect_was_agent_recently_online()
+        .return_once(|_| Ok(true));
     dna.expect_send_validation_receipts()
         .return_once(|_, _| Ok(()));
     let dna = Arc::new(dna);
@@ -227,6 +233,8 @@ async fn errors_for_some_ops_does_not_prevent_the_workflow_proceeding() {
         .unwrap();
 
     let mut dna = MockHolochainP2pDnaT::new();
+    dna.expect_was_agent_recently_online()
+        .returning(|_| Ok(true));
     let mut seq = mockall::Sequence::new();
     dna.expect_send_validation_receipts()
         .times(1)
@@ -267,6 +275,72 @@ async fn errors_for_some_ops_does_not_prevent_the_workflow_proceeding() {
     // But even after we got the above error, we proceeded to
     // send the receipt for the second author which DID work,
     // so its flag is cleared.
+    assert!(!get_requires_receipt(vault.clone(), op_hash2).await);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn skips_authors_not_recently_online_and_clears_require_receipt() {
+    holochain_trace::test_run();
+
+    let test_db = holochain_state::test_utils::test_dht_db();
+    let vault = test_db.to_db();
+    let keystore = holochain_keystore::test_keystore();
+
+    // Create ops from two different authors
+    let (author1, op_hash1) = create_op_with_status(vault.clone(), None, ValidationStatus::Valid)
+        .await
+        .unwrap();
+
+    let (author2, op_hash2) = create_op_with_status(vault.clone(), None, ValidationStatus::Valid)
+        .await
+        .unwrap();
+
+    let author1_clone = author1.clone();
+    let mut dna = MockHolochainP2pDnaT::new();
+
+    // Author1 is not recently online, author2 is
+    dna.expect_was_agent_recently_online()
+        .times(2)
+        .returning(move |agent| Ok(agent != author1_clone));
+
+    // Author1 was not recently online, so no receipts should be sent to them
+    let author1_clone2 = author1.clone();
+    dna.expect_send_validation_receipts()
+        .never()
+        .withf(move |author: &AgentPubKey, _| *author == author1_clone2);
+
+    // Author2 was recently online, so receipts should be sent
+    dna.expect_send_validation_receipts()
+        .times(1)
+        .withf(move |author: &AgentPubKey, _| *author == author2)
+        .returning(|_, _| Ok(()));
+
+    let dna = Arc::new(dna);
+
+    let dna_hash = fixt!(DnaHash);
+
+    let validator = CellId::new(
+        dna_hash.clone(),
+        keystore.new_sign_keypair_random().await.unwrap(),
+    );
+
+    let work_complete = validation_receipt_workflow(
+        Arc::new(dna_hash),
+        vault.clone(),
+        dna,
+        keystore,
+        vec![validator].into_iter().collect(),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(WorkComplete::Complete, work_complete);
+
+    // Author1 was not recently online, so require_receipt should be cleared
+    // without attempting to send. A new publish will re-set it.
+    assert!(!get_requires_receipt(vault.clone(), op_hash1).await);
+
+    // Author2 was online and sending succeeded, so require_receipt is also cleared.
     assert!(!get_requires_receipt(vault.clone(), op_hash2).await);
 }
 

--- a/crates/holochain_cascade/src/test_utils.rs
+++ b/crates/holochain_cascade/src/test_utils.rs
@@ -208,6 +208,10 @@ impl HolochainP2pDnaT for PassThroughNetwork {
         todo!()
     }
 
+    async fn was_agent_recently_online(&self, _agent: AgentPubKey) -> HolochainP2pResult<bool> {
+        Ok(false)
+    }
+
     async fn send_validation_receipts(
         &self,
         _to_agent: AgentPubKey,

--- a/crates/holochain_p2p/src/lib.rs
+++ b/crates/holochain_p2p/src/lib.rs
@@ -190,6 +190,12 @@ pub trait HolochainP2pDnaT: Send + Sync + 'static {
         zome_call_origin: Option<(ZomeName, FunctionName)>,
     ) -> HolochainP2pResult<Vec<MustGetAgentActivityResponse>>;
 
+    /// Check if an agent was recently online in this network.
+    ///
+    /// Returns `true` if the agent has a known URL in the peer store and that URL is not marked as
+    /// unresponsive in the peer meta store.
+    async fn was_agent_recently_online(&self, agent: AgentPubKey) -> HolochainP2pResult<bool>;
+
     /// Send a validation receipt to a remote node.
     async fn send_validation_receipts(
         &self,
@@ -393,6 +399,12 @@ impl HolochainP2pDnaT for HolochainP2pDna {
     ) -> HolochainP2pResult<Vec<MustGetAgentActivityResponse>> {
         self.sender
             .must_get_agent_activity(self.dna_hash(), author, filter, options, zome_call_origin)
+            .await
+    }
+
+    async fn was_agent_recently_online(&self, agent: AgentPubKey) -> HolochainP2pResult<bool> {
+        self.sender
+            .was_agent_recently_online(self.dna_hash(), agent)
             .await
     }
 

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -2092,6 +2092,39 @@ impl actor::HcP2p for HolochainP2pActor {
         })
     }
 
+    fn was_agent_recently_online(
+        &self,
+        dna_hash: DnaHash,
+        agent: AgentPubKey,
+    ) -> BoxFut<'_, HolochainP2pResult<bool>> {
+        Box::pin(async move {
+            let space_id = dna_hash.to_k2_space();
+            let space = self
+                .kitsune
+                .space_if_exists(space_id.clone())
+                .await
+                .ok_or(HolochainP2pError::K2SpaceNotFound(space_id))?;
+
+            let agent_id = agent.to_k2_agent();
+            let agent_url = space
+                .peer_store()
+                .get(agent_id)
+                .await?
+                .and_then(|i| i.url.clone());
+
+            if let Some(agent_url) = agent_url {
+                let unresponsive = space.peer_meta_store().get_unresponsive(agent_url).await?;
+
+                // We have a peer URL and haven't marked this peer as unresponsive, so as far as we know,
+                // they're online and will accept a connection.
+                Ok(unresponsive.is_none())
+            } else {
+                // No peer URL available, we have no evidence the agent is online.
+                Ok(false)
+            }
+        })
+    }
+
     fn send_validation_receipts(
         &self,
         dna_hash: DnaHash,

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -292,6 +292,13 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug + Any {
         zome_call_origin: Option<(ZomeName, FunctionName)>,
     ) -> BoxFut<'_, HolochainP2pResult<Vec<MustGetAgentActivityResponse>>>;
 
+    /// Check if an agent was recently online in this network.
+    fn was_agent_recently_online(
+        &self,
+        dna_hash: DnaHash,
+        agent: AgentPubKey,
+    ) -> BoxFut<'_, HolochainP2pResult<bool>>;
+
     /// Send a validation receipt to a remote node.
     fn send_validation_receipts(
         &self,


### PR DESCRIPTION
### Summary

This isn't ideal, really we should only have the receipt flag set when we get a publish. We're currently setting it for any ops we receive which is what's causing the problem really. Ops received through gossip while the author is offline will result in failures to send receipts. Usually we'd expect the author to stay online until they've received receipts for their work.

However, this does catch the useful case where an author shuts their conductor down cleanly and goes offline before receipts are published. With no peer URL, we'll treat them as offline with this change and not attempt to send receipts. So the fix is valid, even if there's another problem at play that will also need addressing later.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation receipts are no longer sent to authors who haven’t been recently online; the system clears the receipt requirement for those authors to avoid futile send attempts. Authors can request receipts again by republishing their content.

* **Tests**
  * Added unit tests ensuring offline authors are skipped, online authors still receive receipts, and receipt requirements are cleared appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->