### PR TITLE
Fix/bound sys validation dep fetch

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Bound concurrent cascade dependency fetches in the sys and app validation workflows to prevent thousands of queued cache DB reads (and the resulting `"Database read connection is saturated"` log spam) when a large op backlog is being validated.
+
 ## 0.7.0-dev.20
 
 - When Holochain attempts to prepare validation receipts but the author of the data has not been recently online, by being present in our peer store, then clear the receipt request and skip attempting to send. The author may request validation receipts again by republishing their content.

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -93,6 +93,7 @@
 
 use super::error::WorkflowResult;
 use super::sys_validation_workflow::validation_query;
+use super::sys_validation_workflow::DEP_FETCH_CONCURRENCY;
 use crate::conductor::entry_def_store::get_entry_def;
 use crate::conductor::Conductor;
 use crate::conductor::ConductorHandle;
@@ -799,8 +800,16 @@ async fn run_validation_callback(
                     }
                 }
             });
-            // await all fetches in a separate task in the background
-            tokio::spawn(async { futures::future::join_all(fetches).await });
+            // await all fetches in a separate task in the background, bounding
+            // concurrency so a large dependency set cannot fan thousands of
+            // parallel cascade reads at the cache DB (see DEP_FETCH_CONCURRENCY
+            // in sys_validation_workflow for rationale).
+            tokio::spawn(async {
+                use futures::stream::StreamExt;
+                futures::stream::iter(fetches)
+                    .for_each_concurrent(DEP_FETCH_CONCURRENCY, |fut| fut)
+                    .await
+            });
             Ok(Outcome::AwaitingDeps(hashes))
         }
         ValidateResult::UnresolvedDependencies(UnresolvedDependencies::AgentActivity(

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -128,6 +128,19 @@ pub mod types;
 pub mod validation_deps;
 pub mod validation_query;
 
+/// Maximum number of validation-dependency fetches allowed to run concurrently.
+///
+/// **Why:** Each dependency fetch goes through the cascade, which reads from the
+/// authored, DHT, and cache databases. With a large op backlog (e.g. after startup
+/// or a big gossip batch), an unbounded `join_all` here fanned thousands of concurrent
+/// reads at the cache DB, massively exceeding its reader pool and producing log-spam
+/// ("Database read connection is saturated. Util NNNNN%") without improving throughput,
+/// since SQLite concurrency is already capped by the pool.
+///
+/// Sized at a few times the cache DB's default `max_readers` so the pool stays
+/// saturated but the queue doesn't explode.
+pub(super) const DEP_FETCH_CONCURRENCY: usize = 16;
+
 #[cfg(test)]
 mod chain_test;
 #[cfg(test)]
@@ -667,7 +680,9 @@ async fn retrieve_dependencies(
                 .boxed()
         });
 
-    let new_deps: ValidationDependencies = ValidationDependencies::new_from_iter(futures::future::join_all(dependency_fetches)
+    let new_deps: ValidationDependencies = ValidationDependencies::new_from_iter(futures::stream::iter(dependency_fetches)
+        .buffer_unordered(DEP_FETCH_CONCURRENCY)
+        .collect::<Vec<_>>()
         .await
         .into_iter()
         .filter_map(|r| {

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
@@ -1066,3 +1066,70 @@ impl TestCase {
         .await
     }
 }
+
+/// Regression test: `retrieve_dependencies` must bound its concurrent cascade
+/// fetches so that a large op backlog cannot fan out thousands of parallel
+/// reads against the cache DB (which caused sustained "Database read connection
+/// is saturated. Util NNNNN%" log spam at startup and provided no throughput
+/// benefit, since SQLite concurrency is already bounded by the reader pool).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn retrieve_dependencies_bounds_concurrent_cascade_calls() {
+    use super::validation_deps::ValidationDependencyType;
+    use super::{retrieve_dependencies, DEP_FETCH_CONCURRENCY};
+    use futures::FutureExt;
+    use holo_hash::fixt::ActionHashFixturator;
+    use holochain_cascade::MockCascade;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+    let calls = Arc::new(AtomicUsize::new(0));
+
+    let mut cascade = MockCascade::new();
+    {
+        let in_flight = in_flight.clone();
+        let peak = peak.clone();
+        let calls = calls.clone();
+        cascade.expect_retrieve_action().returning(move |_, _| {
+            let in_flight = in_flight.clone();
+            let peak = peak.clone();
+            let calls = calls.clone();
+            async move {
+                calls.fetch_add(1, Ordering::Relaxed);
+                let n = in_flight.fetch_add(1, Ordering::Relaxed) + 1;
+                peak.fetch_max(n, Ordering::Relaxed);
+                // Hold the slot long enough that many would-be concurrent
+                // callers would pile up without a bound.
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                in_flight.fetch_sub(1, Ordering::Relaxed);
+                Ok(None)
+            }
+            .boxed()
+        });
+    }
+
+    let deps = SysValDeps::default();
+    // Use far more deps than the cap so that if the cap is absent the peak
+    // would be ~N_OPS rather than ~DEP_FETCH_CONCURRENCY.
+    const N_OPS: usize = 500;
+    let hashes: Vec<_> = (0..N_OPS)
+        .map(|_| (fixt!(ActionHash), ValidationDependencyType::Action))
+        .collect();
+
+    retrieve_dependencies(deps, Arc::new(cascade), hashes.into_iter()).await;
+
+    assert_eq!(calls.load(Ordering::Relaxed), N_OPS, "all deps fetched");
+
+    let peak_val = peak.load(Ordering::Relaxed);
+    assert!(
+        peak_val <= DEP_FETCH_CONCURRENCY,
+        "peak concurrent cascade calls {} exceeded cap {}",
+        peak_val,
+        DEP_FETCH_CONCURRENCY
+    );
+    // With N_OPS >> cap and non-trivial per-call latency, the cap should be reached.
+    assert_eq!(
+        peak_val, DEP_FETCH_CONCURRENCY,
+        "expected concurrent fetches to saturate cap"
+    );
+}


### PR DESCRIPTION
# fix(validation): bound concurrent cascade dependency fetches

## Summary

Validation workflows fan out cascade reads to fetch op dependencies using unbounded `futures::future::join_all`. When a large backlog of ops arrives (e.g. after startup gossip catches up), this produces thousands of concurrent reads against the cache DB, massively overshooting its reader pool.

Observed in a [unyt test log](https://github.com/user-attachments/files/26717001/unyt.v0.85.log.zip): **19,450** `"Database read connection is saturated"` INFO lines during startup, with peak utilization of **26,434%** (~8,459 queued readers against a pool of 32). This produced no throughput benefit — SQLite concurrency is already capped by the reader pool — but generated significant log spam, memory for queued futures, and scheduler/tracing overhead.

## Root cause

Two unbounded fan-outs over unknown-size dependency sets:

- `sys_validation_workflow::retrieve_dependencies` — the dominant contributor. With ~2,769 ops × ~3 deps per op, produced ~8,300 concurrent cascade calls, matching the observed peak almost exactly.
- `app_validation_workflow` unresolved-deps background fetch — smaller secondary source.

## Fix

Replace `join_all` with `buffer_unordered` / `for_each_concurrent` at both call sites, bounded by a shared `DEP_FETCH_CONCURRENCY = 16` (≈ 2× the default cache DB `max_readers`). Behavior is otherwise unchanged: all deps are still fetched, in parallel, with the same result collection — they just can't all be in flight at once.

## Why this doesn't regress throughput

SQLite reader concurrency is pool-bounded regardless, so the unbounded version was only generating queue pressure, not parallelism. With `DEP_FETCH_CONCURRENCY` sized to keep the pool saturated, steady-state throughput is unchanged; only peak queue depth and overhead drop.

## Test

Added `retrieve_dependencies_bounds_concurrent_cascade_calls` in `sys_validation_workflow::unit_tests`. Feeds 500 synthetic deps through `retrieve_dependencies` backed by a `MockCascade` whose `retrieve_action` tracks peak in-flight calls via atomics. Asserts:

- all 500 fetches ran,
- peak concurrent calls ≤ `DEP_FETCH_CONCURRENCY`,
- peak reaches the cap (proving the test is meaningful, not vacuously passing).

Verified the test fails on the pre-fix code (peak = 500) and passes with the fix (peak = 16).

## Test plan

- [x] `cargo test -p holochain --lib retrieve_dependencies_bounds_concurrent_cascade_calls`
- [x] `cargo test -p holochain --lib` (full sys/app validation test suite)

## Not included

- The saturation log itself at `holochain_sqlite::db::access` remains at INFO. With the fan-out bounded, it should fire rarely enough to be useful as a signal rather than spam. A follow-up could downgrade to DEBUG or rate-limit it, but that's orthogonal.
- The agent-activity branch in `app_validation_workflow` is left as-is — it fetches a single activity per call, already bounded by construction.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs