### PR TITLE
fix: Schema for Iroh transport should only be enabled when the transport is

### DIFF
--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -65,7 +65,7 @@ schema = [
   "kitsune2_gossip/schema",
   "kitsune2_core/schema",
   "kitsune2_transport_tx5?/schema",
-  "kitsune2_transport_iroh/schema",
+  "kitsune2_transport_iroh?/schema",
 ]
 sqlite = [
   "holo_hash/sqlite",

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -742,6 +742,7 @@ fn kitsune2_config_schema(generator: &mut schemars::SchemaGenerator) -> Schema {
         #[cfg(feature = "kitsune2_transport_tx5")]
         #[serde(flatten)]
         tx5_transport: Option<kitsune2_transport_tx5::Tx5TransportModConfig>,
+        #[cfg(feature = "kitsune2_transport_iroh")]
         #[serde(flatten)]
         iroh_transport: Option<kitsune2_transport_iroh::IrohTransportModConfig>,
     }


### PR DESCRIPTION
### Summary

Closes https://github.com/holochain/holochain/issues/5687

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs