### PR TITLE
Add the peer meta store to `holochain_data` (not used yet)

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 0.7.0-dev.22
 
 - **BREAKING CHANGE** switch from `holochain_sqlite`/`holochain_state` for the conductor database, to the new store defined by `holochain_data`. There is no migration path for existing installs of Holochain, and startup errors would be expected if the data state is not cleared.
+- Add peer metadata store database table to `holochain_data` along with full CRUD API. \#5732
 
 ## 0.7.0-dev.21
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **BREAKING CHANGE** switch from `holochain_sqlite`/`holochain_state` for the conductor database, to the new store defined by `holochain_data`. There is no migration path for existing installs of Holochain, and startup errors would be expected if the data state is not cleared.
 - Add peer metadata store database table to `holochain_data` along with full CRUD API. \#5732
-  - In the new peer metadata store database the entries now correctly expire at the `expires_at` time instead of just after.
+  - In the new peer metadata store database, the entries now store `expires_at` as seconds from the Unix epoch instead of microseconds and they correctly expire at the `expires_at` time instead of just after.
 
 ## 0.7.0-dev.21
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **BREAKING CHANGE** switch from `holochain_sqlite`/`holochain_state` for the conductor database, to the new store defined by `holochain_data`. There is no migration path for existing installs of Holochain, and startup errors would be expected if the data state is not cleared.
 - Add peer metadata store database table to `holochain_data` along with full CRUD API. \#5732
+  - In the new peer metadata store database the entries now correctly expire at the `expires_at` time instead of just after.
 
 ## 0.7.0-dev.21
 

--- a/crates/holochain_data/migrations/peer_meta_store/20260424000000_initial_schema.up.sql
+++ b/crates/holochain_data/migrations/peer_meta_store/20260424000000_initial_schema.up.sql
@@ -10,4 +10,4 @@ CREATE TABLE IF NOT EXISTS peer_meta (
 ) STRICT;
 
 CREATE INDEX IF NOT EXISTS meta_key_idx ON peer_meta (meta_key);
-CREATE INDEX IF NOT EXISTS expires_at_idx ON peer_meta (expires_at);
+CREATE INDEX IF NOT EXISTS expires_at_idx ON peer_meta (expires_at) WHERE expires_at IS NOT NULL;

--- a/crates/holochain_data/migrations/peer_meta_store/20260424000000_initial_schema.up.sql
+++ b/crates/holochain_data/migrations/peer_meta_store/20260424000000_initial_schema.up.sql
@@ -1,0 +1,13 @@
+-- Peer metadata store schema
+-- Stores arbitrary key-value metadata about peers, with optional expiry.
+
+CREATE TABLE IF NOT EXISTS peer_meta (
+    peer_url TEXT NOT NULL,
+    meta_key TEXT NOT NULL,
+    meta_value BLOB NOT NULL,
+    expires_at INTEGER,
+    PRIMARY KEY (peer_url, meta_key) ON CONFLICT REPLACE
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS meta_key_idx ON peer_meta (meta_key);
+CREATE INDEX IF NOT EXISTS expires_at_idx ON peer_meta (expires_at);

--- a/crates/holochain_data/src/kind.rs
+++ b/crates/holochain_data/src/kind.rs
@@ -16,6 +16,8 @@ pub enum DbKind {
     Wasm,
     /// Conductor state, installed apps, and related metadata.
     Conductor,
+    /// Peer metadata for a specific DNA.
+    PeerMetaStore,
 }
 
 /// Specifies the database used for authoring data by a specific cell.
@@ -139,7 +141,7 @@ impl DatabaseIdentifier for PeerMetaStore {
     }
 
     fn db_kind(&self) -> DbKind {
-        todo!("PeerMetaStore migrations not yet implemented")
+        DbKind::PeerMetaStore
     }
 }
 

--- a/crates/holochain_data/src/lib.rs
+++ b/crates/holochain_data/src/lib.rs
@@ -19,6 +19,7 @@ pub use handles::{DbRead, DbWrite, TxRead, TxWrite};
 pub mod conductor;
 pub mod kind;
 pub mod models;
+pub mod peer_meta_store;
 pub mod wasm;
 
 /// Embedded migrations for the Wasm database.

--- a/crates/holochain_data/src/lib.rs
+++ b/crates/holochain_data/src/lib.rs
@@ -27,11 +27,16 @@ static WASM_MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations/was
 /// Embedded migrations for the Conductor database.
 static CONDUCTOR_MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations/conductor");
 
+/// Embedded migrations for the [`kind::DbKind::PeerMetaStore`] database.
+static PEER_META_STORE_MIGRATOR: sqlx::migrate::Migrator =
+    sqlx::migrate!("./migrations/peer_meta_store");
+
 /// Select the appropriate migrator for a database kind.
 fn migrator_for(db_kind: kind::DbKind) -> &'static sqlx::migrate::Migrator {
     match db_kind {
         kind::DbKind::Wasm => &WASM_MIGRATOR,
         kind::DbKind::Conductor => &CONDUCTOR_MIGRATOR,
+        kind::DbKind::PeerMetaStore => &PEER_META_STORE_MIGRATOR,
     }
 }
 

--- a/crates/holochain_data/src/peer_meta_store.rs
+++ b/crates/holochain_data/src/peer_meta_store.rs
@@ -15,7 +15,7 @@ pub struct PeerMetaEntry {
     pub meta_key: String,
     /// The raw metadata value.
     pub meta_value: Vec<u8>,
-    /// Expiry time in microseconds since the Unix epoch, [`None`] if the entry never expires.
+    /// Expiry time in seconds since the Unix epoch, [`None`] if the entry never expires.
     pub expires_at: Option<i64>,
 }
 

--- a/crates/holochain_data/src/peer_meta_store.rs
+++ b/crates/holochain_data/src/peer_meta_store.rs
@@ -42,4 +42,22 @@ mod tests {
 
         assert!(tables.contains(&"peer_meta".to_string()));
     }
+
+    #[tokio::test]
+    async fn expires_at_index_is_partial() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        let partial: Option<i64> = sqlx::query_scalar(
+            "SELECT partial FROM pragma_index_list('peer_meta') WHERE name = 'expires_at_idx'",
+        )
+        .fetch_optional(db.pool())
+        .await
+        .unwrap();
+
+        assert_eq!(
+            partial,
+            Some(1),
+            "expires_at_idx should exist and be a partial index"
+        );
+    }
 }

--- a/crates/holochain_data/src/peer_meta_store.rs
+++ b/crates/holochain_data/src/peer_meta_store.rs
@@ -1,0 +1,45 @@
+//! Operations for the peer metadata store database.
+//!
+//! This module provides operations that can be performed on the peer metadata store database, which
+//! holds arbitrary key-value metadata about peers with optional expiry times.
+
+mod inner;
+
+pub mod db_operations;
+pub mod tx_operations;
+
+/// A single entry read from the peer metadata store database.
+#[derive(Debug, Clone, PartialEq, sqlx::FromRow)]
+pub struct PeerMetaEntry {
+    /// The key of the metadata in the store.
+    pub meta_key: String,
+    /// The raw metadata value.
+    pub meta_value: Vec<u8>,
+    /// Expiry time in microseconds since the Unix epoch, [`None`] if the entry never expires.
+    pub expires_at: Option<i64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::kind::PeerMetaStore;
+    use crate::test_open_db;
+    use holo_hash::DnaHash;
+    use std::sync::Arc;
+
+    fn test_db_id() -> PeerMetaStore {
+        PeerMetaStore::new(Arc::new(DnaHash::from_raw_36(vec![0u8; 36])))
+    }
+
+    #[tokio::test]
+    async fn schema_created() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        let tables: Vec<String> =
+            sqlx::query_scalar("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+                .fetch_all(db.pool())
+                .await
+                .unwrap();
+
+        assert!(tables.contains(&"peer_meta".to_string()));
+    }
+}

--- a/crates/holochain_data/src/peer_meta_store/db_operations.rs
+++ b/crates/holochain_data/src/peer_meta_store/db_operations.rs
@@ -25,14 +25,16 @@ impl DbRead<PeerMetaStore> {
 
 impl DbWrite<PeerMetaStore> {
     /// Insert or replace a peer metadata entry.
+    ///
+    /// `expires_at` is seconds since the Unix epoch.
     pub async fn put(
         &self,
         peer_url: &str,
         meta_key: &str,
         meta_value: &[u8],
-        expires_at: Option<i64>,
+        expires_at_secs: Option<i64>,
     ) -> sqlx::Result<()> {
-        inner::put(self.pool(), peer_url, meta_key, meta_value, expires_at).await
+        inner::put(self.pool(), peer_url, meta_key, meta_value, expires_at_secs).await
     }
 
     /// Delete a specific peer metadata entry.

--- a/crates/holochain_data/src/peer_meta_store/db_operations.rs
+++ b/crates/holochain_data/src/peer_meta_store/db_operations.rs
@@ -1,0 +1,356 @@
+//! Database handle operations for the peer metadata store.
+//!
+//! Provides [`DbRead`] and [`DbWrite`] impls for querying and mutating the peer metadata store.
+
+use super::{inner, PeerMetaEntry};
+use crate::handles::{DbRead, DbWrite};
+use crate::kind::PeerMetaStore;
+
+impl DbRead<PeerMetaStore> {
+    /// Get the value for a specific peer URL and key, if it exists and has not expired.
+    pub async fn get(&self, peer_url: &str, meta_key: &str) -> sqlx::Result<Option<Vec<u8>>> {
+        inner::get(self.pool(), peer_url, meta_key).await
+    }
+
+    /// Get all non-expired peer URLs and values for a given metadata key.
+    pub async fn get_all_by_key(&self, meta_key: &str) -> sqlx::Result<Vec<(String, Vec<u8>)>> {
+        inner::get_all_by_key(self.pool(), meta_key).await
+    }
+
+    /// Get all non-expired metadata entries for a given peer URL.
+    pub async fn get_all_by_url(&self, peer_url: &str) -> sqlx::Result<Vec<PeerMetaEntry>> {
+        inner::get_all_by_url(self.pool(), peer_url).await
+    }
+}
+
+impl DbWrite<PeerMetaStore> {
+    /// Insert or replace a peer metadata entry.
+    pub async fn put(
+        &self,
+        peer_url: &str,
+        meta_key: &str,
+        meta_value: &[u8],
+        expires_at: Option<i64>,
+    ) -> sqlx::Result<()> {
+        inner::put(self.pool(), peer_url, meta_key, meta_value, expires_at).await
+    }
+
+    /// Delete a specific peer metadata entry.
+    pub async fn delete(&self, peer_url: &str, meta_key: &str) -> sqlx::Result<()> {
+        inner::delete(self.pool(), peer_url, meta_key).await
+    }
+
+    /// Delete all expired entries. Returns the number of rows removed.
+    pub async fn prune(&self) -> sqlx::Result<u64> {
+        inner::prune(self.pool()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::kind::PeerMetaStore;
+    use crate::peer_meta_store::PeerMetaEntry;
+    use crate::test_open_db;
+    use holo_hash::DnaHash;
+    use std::sync::Arc;
+
+    fn test_db_id() -> PeerMetaStore {
+        PeerMetaStore::new(Arc::new(DnaHash::from_raw_36(vec![0u8; 36])))
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_for_missing_entry() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        let value = db.as_ref().get("wss://peer.example", "foo").await.unwrap();
+        assert_eq!(value, None);
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_for_expired_entry() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        // expires_at set to Unix epoch
+        db.put("wss://peer.example", "foo", b"123", Some(0))
+            .await
+            .unwrap();
+
+        let value = db.as_ref().get("wss://peer.example", "foo").await.unwrap();
+        assert_eq!(value, None);
+    }
+
+    #[tokio::test]
+    async fn get_data_that_was_put() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer.example", "foo", b"123", None)
+            .await
+            .unwrap();
+
+        let value = db.as_ref().get("wss://peer.example", "foo").await.unwrap();
+        assert_eq!(value, Some(b"123".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn put_replaces_existing_entry() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer.example", "foo", b"100", None)
+            .await
+            .unwrap();
+        db.put("wss://peer.example", "foo", b"200", None)
+            .await
+            .unwrap();
+
+        let entries = db.as_ref().get_all_by_key("foo").await.unwrap();
+
+        // Only one entry should exist with the new value
+        assert_eq!(
+            entries,
+            [("wss://peer.example".to_string(), b"200".to_vec())]
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_removes_valid_entry() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer.example", "foo", b"123", None)
+            .await
+            .unwrap();
+        db.delete("wss://peer.example", "foo").await.unwrap();
+
+        let value = db.as_ref().get("wss://peer.example", "foo").await.unwrap();
+        assert_eq!(value, None);
+    }
+
+    #[tokio::test]
+    async fn delete_succeeds_with_invalid_entry() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer.example", "foo", b"123", None)
+            .await
+            .unwrap();
+        let result = db.delete("wss://peer.example", "bar").await;
+
+        assert!(result.is_ok());
+
+        let value = db.as_ref().get("wss://peer.example", "foo").await.unwrap();
+        assert_eq!(value, Some(b"123".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn get_all_by_key_returns_empty_if_no_entries() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        let entries = db.as_ref().get_all_by_key("foo").await.unwrap();
+        assert!(entries.is_empty(),);
+    }
+
+    #[tokio::test]
+    async fn get_all_by_key_returns_only_that_key() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer.example", "foo", b"100", None)
+            .await
+            .unwrap();
+        db.put("wss://peer.example", "bar", b"999", None)
+            .await
+            .unwrap();
+
+        let entries = db.as_ref().get_all_by_key("foo").await.unwrap();
+        assert_eq!(
+            entries,
+            [("wss://peer.example".to_string(), b"100".to_vec())]
+        );
+    }
+
+    #[tokio::test]
+    async fn get_all_by_key_returns_for_all_peers() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer-a.example", "foo", b"100", None)
+            .await
+            .unwrap();
+        db.put("wss://peer-b.example", "foo", b"200", None)
+            .await
+            .unwrap();
+
+        let entries = db.as_ref().get_all_by_key("foo").await.unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.contains(&("wss://peer-a.example".to_string(), b"100".to_vec())));
+        assert!(entries.contains(&("wss://peer-b.example".to_string(), b"200".to_vec())));
+    }
+
+    #[tokio::test]
+    async fn get_all_by_key_returns_only_non_expired() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer-a.example", "foo", b"100", None)
+            .await
+            .unwrap();
+        db.put("wss://peer-b.example", "foo", b"200", Some(0))
+            .await
+            .unwrap();
+
+        let entries = db.as_ref().get_all_by_key("foo").await.unwrap();
+        assert_eq!(
+            entries,
+            [("wss://peer-a.example".to_string(), b"100".to_vec())]
+        );
+    }
+
+    #[tokio::test]
+    async fn get_all_by_url_returns_empty_if_no_entries() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        let entries = db
+            .as_ref()
+            .get_all_by_url("wss://peer.example")
+            .await
+            .unwrap();
+        assert!(entries.is_empty(),);
+    }
+
+    #[tokio::test]
+    async fn get_all_by_url_returns_only_that_url() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer-a.example", "foo", b"100", None)
+            .await
+            .unwrap();
+        db.put("wss://peer-b.example", "foo", b"999", None)
+            .await
+            .unwrap();
+
+        let entries = db
+            .as_ref()
+            .get_all_by_url("wss://peer-a.example")
+            .await
+            .unwrap();
+        assert_eq!(
+            entries,
+            [PeerMetaEntry {
+                meta_key: "foo".to_string(),
+                meta_value: b"100".to_vec(),
+                expires_at: None,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn get_all_by_url_returns_for_that_url() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer.example", "foo", b"100", None)
+            .await
+            .unwrap();
+        db.put("wss://peer.example", "bar", b"200", None)
+            .await
+            .unwrap();
+
+        let entries = db
+            .as_ref()
+            .get_all_by_url("wss://peer.example")
+            .await
+            .unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.contains(&PeerMetaEntry {
+            meta_key: "foo".to_string(),
+            meta_value: b"100".to_vec(),
+            expires_at: None,
+        }));
+        assert!(entries.contains(&PeerMetaEntry {
+            meta_key: "bar".to_string(),
+            meta_value: b"200".to_vec(),
+            expires_at: None,
+        }));
+    }
+
+    #[tokio::test]
+    async fn get_all_by_url_returns_only_non_expired() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer.example", "foo", b"100", None)
+            .await
+            .unwrap();
+        db.put("wss://peer.example", "bar", b"200", Some(0))
+            .await
+            .unwrap();
+
+        let entries = db
+            .as_ref()
+            .get_all_by_url("wss://peer.example")
+            .await
+            .unwrap();
+        assert_eq!(
+            entries,
+            [PeerMetaEntry {
+                meta_key: "foo".to_string(),
+                meta_value: b"100".to_vec(),
+                expires_at: None,
+            },]
+        );
+    }
+
+    #[tokio::test]
+    async fn prune_returns_zero_if_no_entries_to_prune() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer.example", "foo", b"123", None)
+            .await
+            .unwrap();
+        db.put("wss://peer.example", "bar", b"234", None)
+            .await
+            .unwrap();
+
+        let pruned = db.prune().await.unwrap();
+        assert_eq!(pruned, 0);
+
+        let entries = db
+            .as_ref()
+            .get_all_by_url("wss://peer.example")
+            .await
+            .unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.contains(&PeerMetaEntry {
+            meta_key: "foo".to_string(),
+            meta_value: b"123".to_vec(),
+            expires_at: None,
+        }));
+        assert!(entries.contains(&PeerMetaEntry {
+            meta_key: "bar".to_string(),
+            meta_value: b"234".to_vec(),
+            expires_at: None,
+        }));
+    }
+
+    #[tokio::test]
+    async fn prune_removes_expired_entries() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer.example", "expired", b"123", Some(1))
+            .await
+            .unwrap();
+        db.put("wss://peer.example", "live", b"234", None)
+            .await
+            .unwrap();
+
+        let pruned = db.prune().await.unwrap();
+        assert_eq!(pruned, 1);
+
+        let entries = db
+            .as_ref()
+            .get_all_by_url("wss://peer.example")
+            .await
+            .unwrap();
+        assert_eq!(
+            entries,
+            [PeerMetaEntry {
+                meta_key: "live".to_string(),
+                meta_value: b"234".to_vec(),
+                expires_at: None,
+            },]
+        );
+    }
+}

--- a/crates/holochain_data/src/peer_meta_store/inner.rs
+++ b/crates/holochain_data/src/peer_meta_store/inner.rs
@@ -1,0 +1,123 @@
+use super::PeerMetaEntry;
+use sqlx::{Executor, Sqlite};
+
+/// Insert or replace a peer metadata entry.
+pub(super) async fn put<'e, E>(
+    executor: E,
+    peer_url: &str,
+    meta_key: &str,
+    meta_value: &[u8],
+    expires_at: Option<i64>,
+) -> sqlx::Result<()>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    sqlx::query(
+        "INSERT INTO peer_meta (peer_url, meta_key, meta_value, expires_at) VALUES (?, ?, ?, ?)",
+    )
+    .bind(peer_url)
+    .bind(meta_key)
+    .bind(meta_value)
+    .bind(expires_at)
+    .execute(executor)
+    .await?;
+
+    Ok(())
+}
+
+/// Get the value for a specific peer URL and key, if it exists and has not expired.
+pub(super) async fn get<'e, E>(
+    executor: E,
+    peer_url: &str,
+    meta_key: &str,
+) -> sqlx::Result<Option<Vec<u8>>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let value: Option<Vec<u8>> = sqlx::query_scalar(
+        "SELECT meta_value FROM peer_meta
+         WHERE peer_url = ? AND meta_key = ?
+         AND (expires_at IS NULL OR expires_at >= unixepoch() * 1000000)",
+    )
+    .bind(peer_url)
+    .bind(meta_key)
+    .fetch_optional(executor)
+    .await?;
+
+    Ok(value)
+}
+
+/// Get all non-expired values for a given key, keyed by peer URL.
+pub(super) async fn get_all_by_key<'e, E>(
+    executor: E,
+    meta_key: &str,
+) -> sqlx::Result<Vec<(String, Vec<u8>)>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    #[derive(sqlx::FromRow)]
+    struct Row {
+        peer_url: String,
+        meta_value: Vec<u8>,
+    }
+
+    let rows: Vec<Row> = sqlx::query_as(
+        "SELECT peer_url, meta_value FROM peer_meta
+         WHERE meta_key = ?
+         AND (expires_at IS NULL OR expires_at >= unixepoch() * 1000000)",
+    )
+    .bind(meta_key)
+    .fetch_all(executor)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| (r.peer_url, r.meta_value))
+        .collect())
+}
+
+/// Get all non-expired metadata entries for a given peer URL.
+pub(super) async fn get_all_by_url<'e, E>(
+    executor: E,
+    peer_url: &str,
+) -> sqlx::Result<Vec<PeerMetaEntry>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let entries: Vec<PeerMetaEntry> = sqlx::query_as(
+        "SELECT meta_key, meta_value, expires_at FROM peer_meta
+         WHERE peer_url = ?
+         AND (expires_at IS NULL OR expires_at >= unixepoch() * 1000000)",
+    )
+    .bind(peer_url)
+    .fetch_all(executor)
+    .await?;
+
+    Ok(entries)
+}
+
+/// Delete a specific peer metadata entry.
+pub(super) async fn delete<'e, E>(executor: E, peer_url: &str, meta_key: &str) -> sqlx::Result<()>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    sqlx::query("DELETE FROM peer_meta WHERE peer_url = ? AND meta_key = ?")
+        .bind(peer_url)
+        .bind(meta_key)
+        .execute(executor)
+        .await?;
+
+    Ok(())
+}
+
+/// Delete all expired entries. Returns the number of rows removed.
+pub(super) async fn prune<'e, E>(executor: E) -> sqlx::Result<u64>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let result = sqlx::query("DELETE FROM peer_meta WHERE expires_at < unixepoch() * 1000000")
+        .execute(executor)
+        .await?;
+
+    Ok(result.rows_affected())
+}

--- a/crates/holochain_data/src/peer_meta_store/inner.rs
+++ b/crates/holochain_data/src/peer_meta_store/inner.rs
@@ -37,7 +37,7 @@ where
     let value: Option<Vec<u8>> = sqlx::query_scalar(
         "SELECT meta_value FROM peer_meta
          WHERE peer_url = ? AND meta_key = ?
-         AND (expires_at IS NULL OR expires_at >= unixepoch() * 1000000)",
+         AND (expires_at IS NULL OR expires_at > unixepoch() * 1000000)",
     )
     .bind(peer_url)
     .bind(meta_key)
@@ -64,7 +64,7 @@ where
     let rows: Vec<Row> = sqlx::query_as(
         "SELECT peer_url, meta_value FROM peer_meta
          WHERE meta_key = ?
-         AND (expires_at IS NULL OR expires_at >= unixepoch() * 1000000)",
+         AND (expires_at IS NULL OR expires_at > unixepoch() * 1000000)",
     )
     .bind(meta_key)
     .fetch_all(executor)
@@ -87,7 +87,7 @@ where
     let entries: Vec<PeerMetaEntry> = sqlx::query_as(
         "SELECT meta_key, meta_value, expires_at FROM peer_meta
          WHERE peer_url = ?
-         AND (expires_at IS NULL OR expires_at >= unixepoch() * 1000000)",
+         AND (expires_at IS NULL OR expires_at > unixepoch() * 1000000)",
     )
     .bind(peer_url)
     .fetch_all(executor)
@@ -115,7 +115,7 @@ pub(super) async fn prune<'e, E>(executor: E) -> sqlx::Result<u64>
 where
     E: Executor<'e, Database = Sqlite>,
 {
-    let result = sqlx::query("DELETE FROM peer_meta WHERE expires_at < unixepoch() * 1000000")
+    let result = sqlx::query("DELETE FROM peer_meta WHERE expires_at <= unixepoch() * 1000000")
         .execute(executor)
         .await?;
 

--- a/crates/holochain_data/src/peer_meta_store/inner.rs
+++ b/crates/holochain_data/src/peer_meta_store/inner.rs
@@ -1,7 +1,9 @@
 use super::PeerMetaEntry;
 use sqlx::{Executor, Sqlite};
 
-/// Insert or replace a peer metadata entry.
+/// Insert or replace an arbitrary key-value-pair into the peer metadata store.
+///
+/// `expires_at` is seconds since the Unix epoch.
 pub(super) async fn put<'e, E>(
     executor: E,
     peer_url: &str,
@@ -37,7 +39,7 @@ where
     let value: Option<Vec<u8>> = sqlx::query_scalar(
         "SELECT meta_value FROM peer_meta
          WHERE peer_url = ? AND meta_key = ?
-         AND (expires_at IS NULL OR expires_at > unixepoch() * 1000000)",
+         AND (expires_at IS NULL OR expires_at > unixepoch())",
     )
     .bind(peer_url)
     .bind(meta_key)
@@ -64,7 +66,7 @@ where
     let rows: Vec<Row> = sqlx::query_as(
         "SELECT peer_url, meta_value FROM peer_meta
          WHERE meta_key = ?
-         AND (expires_at IS NULL OR expires_at > unixepoch() * 1000000)",
+         AND (expires_at IS NULL OR expires_at > unixepoch())",
     )
     .bind(meta_key)
     .fetch_all(executor)
@@ -87,7 +89,7 @@ where
     let entries: Vec<PeerMetaEntry> = sqlx::query_as(
         "SELECT meta_key, meta_value, expires_at FROM peer_meta
          WHERE peer_url = ?
-         AND (expires_at IS NULL OR expires_at > unixepoch() * 1000000)",
+         AND (expires_at IS NULL OR expires_at > unixepoch())",
     )
     .bind(peer_url)
     .fetch_all(executor)
@@ -115,7 +117,7 @@ pub(super) async fn prune<'e, E>(executor: E) -> sqlx::Result<u64>
 where
     E: Executor<'e, Database = Sqlite>,
 {
-    let result = sqlx::query("DELETE FROM peer_meta WHERE expires_at <= unixepoch() * 1000000")
+    let result = sqlx::query("DELETE FROM peer_meta WHERE expires_at <= unixepoch()")
         .execute(executor)
         .await?;
 

--- a/crates/holochain_data/src/peer_meta_store/tx_operations.rs
+++ b/crates/holochain_data/src/peer_meta_store/tx_operations.rs
@@ -1,0 +1,228 @@
+//! Transaction-scoped operations for the peer metadata store.
+//!
+//! Provides [`TxRead`] and [`TxWrite`] impls for querying and mutating the peer metadata store.
+
+use super::{inner, PeerMetaEntry};
+use crate::handles::{TxRead, TxWrite};
+use crate::kind::PeerMetaStore;
+
+impl TxRead<PeerMetaStore> {
+    /// Get the value for a specific peer URL and key, if it exists and has not expired.
+    pub async fn get(&mut self, peer_url: &str, meta_key: &str) -> sqlx::Result<Option<Vec<u8>>> {
+        inner::get(self.conn_mut(), peer_url, meta_key).await
+    }
+
+    /// Get all non-expired peer URLs and values for a given metadata key.
+    pub async fn get_all_by_key(&mut self, meta_key: &str) -> sqlx::Result<Vec<(String, Vec<u8>)>> {
+        inner::get_all_by_key(self.conn_mut(), meta_key).await
+    }
+
+    /// Get all non-expired metadata entries for a given peer URL.
+    pub async fn get_all_by_url(&mut self, peer_url: &str) -> sqlx::Result<Vec<PeerMetaEntry>> {
+        inner::get_all_by_url(self.conn_mut(), peer_url).await
+    }
+}
+
+impl TxWrite<PeerMetaStore> {
+    /// Insert or replace a peer metadata entry.
+    pub async fn put(
+        &mut self,
+        peer_url: &str,
+        meta_key: &str,
+        meta_value: &[u8],
+        expires_at: Option<i64>,
+    ) -> sqlx::Result<()> {
+        inner::put(self.conn_mut(), peer_url, meta_key, meta_value, expires_at).await
+    }
+
+    /// Delete a specific peer metadata entry.
+    pub async fn delete(&mut self, peer_url: &str, meta_key: &str) -> sqlx::Result<()> {
+        inner::delete(self.conn_mut(), peer_url, meta_key).await
+    }
+
+    /// Delete all expired entries. Returns the number of rows removed.
+    pub async fn prune(&mut self) -> sqlx::Result<u64> {
+        inner::prune(self.conn_mut()).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::kind::PeerMetaStore;
+    use crate::peer_meta_store::PeerMetaEntry;
+    use crate::test_open_db;
+    use holo_hash::DnaHash;
+    use std::sync::Arc;
+
+    fn test_db_id() -> PeerMetaStore {
+        PeerMetaStore::new(Arc::new(DnaHash::from_raw_36(vec![0u8; 36])))
+    }
+
+    #[tokio::test]
+    async fn tx_write_commit_persists_puts() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        let mut tx = db.begin().await.unwrap();
+        tx.put("wss://peer.example", "foo", b"42", None)
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
+
+        let value = db.as_ref().get("wss://peer.example", "foo").await.unwrap();
+        assert_eq!(value, Some(b"42".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn tx_write_rollback_discards_puts() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        let mut tx = db.begin().await.unwrap();
+        tx.put("wss://peer.example", "foo", b"42", None)
+            .await
+            .unwrap();
+        tx.rollback().await.unwrap();
+
+        let value = db.as_ref().get("wss://peer.example", "foo").await.unwrap();
+        assert_eq!(value, None);
+    }
+
+    #[tokio::test]
+    async fn tx_write_commit_persists_deletes() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer.example", "foo", b"42", None)
+            .await
+            .unwrap();
+
+        let mut tx = db.begin().await.unwrap();
+        tx.delete("wss://peer.example", "foo").await.unwrap();
+        tx.commit().await.unwrap();
+
+        let value = db.as_ref().get("wss://peer.example", "foo").await.unwrap();
+        assert_eq!(value, None);
+    }
+
+    #[tokio::test]
+    async fn tx_write_rollback_discards_deletes() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer.example", "foo", b"42", None)
+            .await
+            .unwrap();
+
+        let mut tx = db.begin().await.unwrap();
+        tx.delete("wss://peer.example", "foo").await.unwrap();
+        tx.rollback().await.unwrap();
+
+        let value = db.as_ref().get("wss://peer.example", "foo").await.unwrap();
+        assert_eq!(value, Some(b"42".to_vec()));
+    }
+
+    #[tokio::test]
+    async fn tx_write_commit_persists_prunes() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer.example", "expired", b"old", Some(1))
+            .await
+            .unwrap();
+        db.put("wss://peer.example", "live", b"current", None)
+            .await
+            .unwrap();
+
+        let mut tx = db.begin().await.unwrap();
+        let pruned = tx.prune().await.unwrap();
+        assert_eq!(pruned, 1);
+        tx.commit().await.unwrap();
+
+        let entries = db
+            .as_ref()
+            .get_all_by_url("wss://peer.example")
+            .await
+            .unwrap();
+        assert_eq!(
+            entries,
+            [PeerMetaEntry {
+                meta_key: "live".to_string(),
+                meta_value: b"current".to_vec(),
+                expires_at: None,
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn tx_write_rollback_discards_prunes() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        db.put("wss://peer.example", "expired", b"old", Some(1))
+            .await
+            .unwrap();
+
+        let mut tx = db.begin().await.unwrap();
+        tx.prune().await.unwrap();
+        tx.rollback().await.unwrap();
+
+        // Can't use get here because it filters expired entries.
+        let all: Vec<_> = sqlx::query_scalar::<_, String>(
+            "SELECT meta_key FROM peer_meta WHERE peer_url = 'wss://peer.example'",
+        )
+        .fetch_all(db.pool())
+        .await
+        .unwrap();
+        assert!(all.contains(&"expired".to_string()));
+    }
+
+    #[tokio::test]
+    async fn tx_read_get_sees_own_puts() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        let mut tx = db.begin().await.unwrap();
+        tx.put("wss://peer.example", "foo", b"42", None)
+            .await
+            .unwrap();
+
+        let value = tx.as_mut().get("wss://peer.example", "foo").await.unwrap();
+        assert_eq!(value, Some(b"42".to_vec()));
+
+        tx.rollback().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn tx_read_get_all_by_key_sees_own_puts() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        let mut tx = db.begin().await.unwrap();
+        tx.put("wss://peer-a.example", "foo", b"1", None)
+            .await
+            .unwrap();
+        tx.put("wss://peer-b.example", "foo", b"2", None)
+            .await
+            .unwrap();
+
+        let entries = tx.as_mut().get_all_by_key("foo").await.unwrap();
+        assert_eq!(entries.len(), 2);
+
+        tx.rollback().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn tx_read_get_all_by_url_sees_own_puts() {
+        let db = test_open_db(test_db_id()).await.unwrap();
+
+        let mut tx = db.begin().await.unwrap();
+        tx.put("wss://peer.example", "foo", b"1", None)
+            .await
+            .unwrap();
+        tx.put("wss://peer.example", "bar", b"2", None)
+            .await
+            .unwrap();
+
+        let entries = tx
+            .as_mut()
+            .get_all_by_url("wss://peer.example")
+            .await
+            .unwrap();
+        assert_eq!(entries.len(), 2);
+
+        tx.rollback().await.unwrap();
+    }
+}

--- a/crates/holochain_data/src/peer_meta_store/tx_operations.rs
+++ b/crates/holochain_data/src/peer_meta_store/tx_operations.rs
@@ -25,14 +25,23 @@ impl TxRead<PeerMetaStore> {
 
 impl TxWrite<PeerMetaStore> {
     /// Insert or replace a peer metadata entry.
+    ///
+    /// `expires_at` is seconds since the Unix epoch.
     pub async fn put(
         &mut self,
         peer_url: &str,
         meta_key: &str,
         meta_value: &[u8],
-        expires_at: Option<i64>,
+        expires_at_secs: Option<i64>,
     ) -> sqlx::Result<()> {
-        inner::put(self.conn_mut(), peer_url, meta_key, meta_value, expires_at).await
+        inner::put(
+            self.conn_mut(),
+            peer_url,
+            meta_key,
+            meta_value,
+            expires_at_secs,
+        )
+        .await
     }
 
     /// Delete a specific peer metadata entry.


### PR DESCRIPTION
### Summary

This PR implements the peer metadata store database table in `holochain_data`, merging all the existing migrations into a single new schema. It also adds the API to expose the operations and adds tests for them but the new API is not yet used as that will be done in a follow-up PR.

Closes #5732.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs