### PR TITLE
Update `holochain` and `holochain_p2p` to use the new peer metadata store from `holochain_data`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,6 +3384,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "sqlx",
  "strum_macros 0.27.2",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 0.7.0-dev.22
 
 - **BREAKING CHANGE** switch from `holochain_sqlite`/`holochain_state` for the conductor database, to the new store defined by `holochain_data`. There is no migration path for existing installs of Holochain, and startup errors would be expected if the data state is not cleared.
-- Add peer metadata store database table to `holochain_data` along with full CRUD API. \#5732
+- Add peer metadata store database table to `holochain_data` along with full CRUD API. \#5746
   - In the new peer metadata store database, the entries now store `expires_at` as seconds from the Unix epoch instead of microseconds and they correctly expire at the `expires_at` time instead of just after.
 - **BREAKING CHANGE** switch peer metadata store database from `holochain_sqlite` for the new one defined by `holochain_data`. There is no migration path for existing installs of Holochain, and startup errors would be expected if the data state is not cleared. \#5748
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - **BREAKING CHANGE** switch from `holochain_sqlite`/`holochain_state` for the conductor database, to the new store defined by `holochain_data`. There is no migration path for existing installs of Holochain, and startup errors would be expected if the data state is not cleared.
 - Add peer metadata store database table to `holochain_data` along with full CRUD API. \#5732
   - In the new peer metadata store database, the entries now store `expires_at` as seconds from the Unix epoch instead of microseconds and they correctly expire at the `expires_at` time instead of just after.
+- **BREAKING CHANGE** switch peer metadata store database from `holochain_sqlite` for the new one defined by `holochain_data`. There is no migration path for existing installs of Holochain, and startup errors would be expected if the data state is not cleared. \#5748
 
 ## 0.7.0-dev.21
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,12 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- **BREAKING CHANGE** switch peer metadata store database from `holochain_sqlite` for the new one defined by `holochain_data`. There is no migration path for existing installs of Holochain, and startup errors would be expected if the data state is not cleared. \#5748
 - Remove the custom `ConductorStoreError` and `ConductorStoreResult` from `holochain_state`, use the `StateQueryError` and `StateQueryResult` instead.
 - Switch from `serde_yaml` to `yaml_serde`, to stay with the actively supported fork of the now deprecated library.
 
 ## 0.7.0-dev.23
 
 - Added the per-DNA DHT v2 database schema and skeleton read/write API surface in `holochain_data`, with transitional DHT v2 domain types exposed across the Holochain type crates (`holochain_integrity_types`, `holochain_zome_types`, `holochain_types`). \#5743
+- Add peer metadata store database table to `holochain_data` along with full CRUD API. \#5746
+  - In the new peer metadata store database, the entries now store `expires_at` as seconds from the Unix epoch instead of microseconds and they correctly expire at the `expires_at` time instead of just after.
 - **BREAKING CHANGE** Switch from WAMR to Wasmi as the interpreter backend. This is a temporary change and Wasmi will also be replaced. Please do not use it.
 - **BREAKING CHANGE** Upgrade Wasmer from version 6 to 7, Kitsune2 from 0.4.x to 0.5.x, holochain\_serialized\_bytes to 0.0.57, Lair from 0.6.x to 0.7.x
 - **BREAKING CHANGE** Rename feature flags for Wasmer. The `wasmer_sys` feature flag is now `wasmer-sys-cranelift`. There is an additional `wasmer-sys-llvm` option. The `wasmer_wamr` feature flag is replaced by a roughly equivalent `wasmer-wasmi` feature flag which has fewer build-time requirements. The two control flags for wasmer have been renamed too, so `error_as_host` has become `error-as-host` and `wasmer_debug_memory` has become `wasmer-debug-memory`.
@@ -21,9 +24,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 0.7.0-dev.22
 
 - **BREAKING CHANGE** switch from `holochain_sqlite`/`holochain_state` for the conductor database, to the new store defined by `holochain_data`. There is no migration path for existing installs of Holochain, and startup errors would be expected if the data state is not cleared.
-- Add peer metadata store database table to `holochain_data` along with full CRUD API. \#5746
-  - In the new peer metadata store database, the entries now store `expires_at` as seconds from the Unix epoch instead of microseconds and they correctly expire at the `expires_at` time instead of just after.
-- **BREAKING CHANGE** switch peer metadata store database from `holochain_sqlite` for the new one defined by `holochain_data`. There is no migration path for existing installs of Holochain, and startup errors would be expected if the data state is not cleared. \#5748
 
 ## 0.7.0-dev.21
 

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
-- **BREAKING CHANGE** switch peer metadata store database from `holochain_sqlite` for the new one defined by `holochain_data`. There is no migration path for existing installs of Holochain, and startup errors would be expected if the data state is not cleared. \#5748
+- **BREAKING CHANGE** switch peer metadata store from using the database from `holochain_sqlite` to using the new one defined in `holochain_state`. There is no migration path for existing installs of Holochain, and startup errors would be expected if the data state is not cleared. \#5748
+- Add peer metadata store in `holochain_state` that wraps the database added in `holochain_data`. \#5748
 - Remove the custom `ConductorStoreError` and `ConductorStoreResult` from `holochain_state`, use the `StateQueryError` and `StateQueryResult` instead.
 - Switch from `serde_yaml` to `yaml_serde`, to stay with the actively supported fork of the now deprecated library.
 

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -834,8 +834,6 @@ mod network_impls {
     use futures::future::join_all;
     use holochain_conductor_api::ZomeCallParamsSigned;
     use holochain_conductor_api::{DnaStorageInfo, StorageBlob, StorageInfo};
-    use holochain_sqlite::helpers::BytesSql;
-    use holochain_sqlite::sql::sql_peer_meta_store;
     use holochain_sqlite::stats::{get_size_on_disk, get_used_size};
     use holochain_state::conductor::WitnessNonceResult;
     use holochain_zome_types::block::BlockTargetId;
@@ -922,43 +920,28 @@ mod network_impls {
 
             for dna_hash in space_ids {
                 let db = self.spaces.peer_meta_store_db(&dna_hash)?;
-                let url2 = url.clone();
+                let entries = db
+                    .as_ref()
+                    .get_all_by_url(url.as_str())
+                    .await
+                    .map_err(|e| ConductorApiError::Other(e.into()))?;
 
-                let infos = db
-                    .read_async(
-                        move |txn| -> DatabaseResult<BTreeMap<String, PeerMetaInfo>> {
-                            let mut infos: BTreeMap<String, PeerMetaInfo> = BTreeMap::new();
+                let infos = entries
+                    .into_iter()
+                    .map(|entry| {
+                        let meta_value: serde_json::Value =
+                            serde_json::from_slice(&entry.meta_value)
+                                .map_err(|e| ConductorApiError::Other(e.into()))?;
+                        let peer_meta_info = PeerMetaInfo {
+                            meta_value,
+                            expires_at: entry
+                                .expires_at
+                                .map(|seconds| Timestamp::from_micros(seconds * 1_000_000)),
+                        };
 
-                            let mut stmt = txn.prepare(sql_peer_meta_store::GET_ALL_BY_URL)?;
-                            let mut rows = stmt.query(named_params! {
-                                ":peer_url": url2.as_str()
-                            })?;
-
-                            while let Some(row) = rows.next()? {
-                                let meta_key = row.get::<_, String>(0)?;
-                                let meta_value: serde_json::Value =
-                                    serde_json::from_slice(&(row.get::<_, BytesSql>(1)?.0))
-                                        .map_err(|e| {
-                                            rusqlite::Error::FromSqlConversionFailure(
-                                                2,
-                                                rusqlite::types::Type::Blob,
-                                                e.into(),
-                                            )
-                                        })?;
-                                let expires_at = row.get::<_, Option<i64>>(2)?;
-
-                                let peer_meta_info = PeerMetaInfo {
-                                    meta_value,
-                                    expires_at: expires_at.map(Timestamp),
-                                };
-
-                                infos.insert(meta_key, peer_meta_info);
-                            }
-
-                            Ok(infos)
-                        },
-                    )
-                    .await?;
+                        Ok((entry.meta_key, peer_meta_info))
+                    })
+                    .collect::<ConductorApiResult<_>>()?;
 
                 all_infos.insert(dna_hash, infos);
             }

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -919,9 +919,9 @@ mod network_impls {
             let mut all_infos = BTreeMap::new();
 
             for dna_hash in space_ids {
-                let db = self.spaces.peer_meta_store_db(&dna_hash)?;
-                let entries = db
-                    .as_ref()
+                let store = self.spaces.peer_meta_store(&dna_hash)?;
+                let entries = store
+                    .as_read()
                     .get_all_by_url(url.as_str())
                     .await
                     .map_err(|e| ConductorApiError::Other(e.into()))?;

--- a/crates/holochain/src/conductor/conductor/builder.rs
+++ b/crates/holochain/src/conductor/conductor/builder.rs
@@ -231,7 +231,7 @@ impl ConductorBuilder {
                 })
                 .transpose()?,
             get_db_peer_meta: Arc::new(move |dna_hash| {
-                let res = net_spaces1.peer_meta_store_db(&dna_hash);
+                let res = net_spaces1.peer_meta_store(&dna_hash);
                 Box::pin(async move { res.map_err(holochain_p2p::HolochainP2pError::other) })
             }),
             get_db_op_store: Arc::new(move |dna_hash| {
@@ -462,7 +462,7 @@ impl ConductorBuilder {
                 })
                 .transpose()?,
             get_db_peer_meta: Arc::new(move |dna_hash| {
-                let res = net_spaces1.peer_meta_store_db(&dna_hash);
+                let res = net_spaces1.peer_meta_store(&dna_hash);
                 Box::pin(async move { res.map_err(holochain_p2p::HolochainP2pError::other) })
             }),
             get_db_op_store: Arc::new(move |dna_hash| {

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -50,6 +50,7 @@ pub struct Spaces {
     pub(crate) dna_def_store: holochain_state::dna_def::DnaDefStore,
     pub(crate) entry_def_store: holochain_state::entry_def::EntryDefStore,
     db_key: DbKey,
+    data_db_key: holochain_data::DbKey,
 }
 
 /// This is the set of data required at the
@@ -74,7 +75,7 @@ pub struct Space {
     pub dht_db: DbWrite<DbKindDht>,
 
     /// The peer meta store database. One per unique Dna.
-    pub peer_meta_store_db: DbWrite<DbKindPeerMetaStore>,
+    pub peer_meta_store_db: holochain_data::DbWrite<holochain_data::kind::PeerMetaStore>,
 
     /// Countersigning workspace for session state.
     pub countersigning_workspaces:
@@ -191,7 +192,7 @@ impl Spaces {
             root_db_dir.as_ref(),
             holochain_data::kind::Wasm,
             holochain_data::HolochainDataConfig {
-                key: Some(data_db_key),
+                key: Some(data_db_key.clone()),
                 sync_level: db_sync,
                 max_readers: config.db_max_readers,
             },
@@ -214,6 +215,7 @@ impl Spaces {
             dna_def_store,
             entry_def_store,
             db_key,
+            data_db_key,
         })
     }
 
@@ -357,6 +359,7 @@ impl Spaces {
                             self.config.db_sync_strategy,
                             self.db_key.clone(),
                             self.config.db_max_readers,
+                            Some(self.data_db_key.clone()),
                         )?;
 
                         let r = f(&space);
@@ -412,7 +415,7 @@ impl Spaces {
     pub fn peer_meta_store_db(
         &self,
         dna_hash: &DnaHash,
-    ) -> DatabaseResult<DbWrite<DbKindPeerMetaStore>> {
+    ) -> DatabaseResult<holochain_data::DbWrite<holochain_data::kind::PeerMetaStore>> {
         self.get_or_create_space_ref(dna_hash, |space| space.peer_meta_store_db.clone())
     }
 
@@ -477,10 +480,11 @@ impl Space {
         db_sync_strategy: DbSyncStrategy,
         db_key: DbKey,
         db_max_readers: u16,
+        data_db_key: Option<holochain_data::DbKey>,
     ) -> DatabaseResult<Self> {
-        let db_sync_level = match db_sync_strategy {
-            DbSyncStrategy::Fast => DbSyncLevel::Off,
-            DbSyncStrategy::Resilient => DbSyncLevel::Normal,
+        let (db_sync_level, data_db_sync_level) = match db_sync_strategy {
+            DbSyncStrategy::Fast => (DbSyncLevel::Off, holochain_data::DbSyncLevel::Off),
+            DbSyncStrategy::Resilient => (DbSyncLevel::Normal, holochain_data::DbSyncLevel::Normal),
         };
 
         let (cache, dht_db, peer_meta_store_db) = tokio::task::block_in_place(|| {
@@ -502,15 +506,17 @@ impl Space {
                     max_readers: db_max_readers,
                 },
             )?;
-            let peer_meta_store_db = DbWrite::open_with_pool_config(
-                root_db_dir.as_ref(),
-                DbKindPeerMetaStore(dna_hash.clone()),
-                PoolConfig {
-                    synchronous_level: db_sync_level,
-                    key: db_key.clone(),
-                    max_readers: db_max_readers,
-                },
-            )?;
+            let peer_meta_store_db = tokio::runtime::Handle::current()
+                .block_on(holochain_data::open_db(
+                    &root_db_dir,
+                    holochain_data::kind::PeerMetaStore::new(dna_hash.clone()),
+                    holochain_data::HolochainDataConfig {
+                        key: data_db_key,
+                        sync_level: data_db_sync_level,
+                        max_readers: db_max_readers,
+                    },
+                ))
+                .map_err(|e| holochain_sqlite::error::DatabaseError::Other(e.into()))?;
             DatabaseResult::Ok((cache, dht_db, peer_meta_store_db))
         })?;
 
@@ -688,6 +694,7 @@ impl TestSpace {
                 Default::default(),
                 Default::default(),
                 ConductorConfig::default().db_max_readers,
+                None,
             )
             .unwrap(),
             _temp_dir: temp_dir,

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -65,9 +65,6 @@ pub struct Space {
     /// There is one per unique Dna.
     pub cache_db: DbWrite<DbKindCache>,
 
-    /// The conductor database. There is only one of these.
-    pub conductor_db: DbWrite<DbKindConductor>,
-
     /// The authored databases. These are per-agent.
     /// There is one per unique combination of Dna and AgentPubKey.
     pub authored_dbs: Arc<parking_lot::Mutex<HashMap<AgentPubKey, DbWrite<DbKindAuthored>>>>,
@@ -486,46 +483,36 @@ impl Space {
             DbSyncStrategy::Resilient => DbSyncLevel::Normal,
         };
 
-        let (cache, dht_db, peer_meta_store_db, conductor_db) =
-            tokio::task::block_in_place(|| {
-                let cache = DbWrite::open_with_pool_config(
-                    root_db_dir.as_ref(),
-                    DbKindCache(dna_hash.clone()),
-                    PoolConfig {
-                        synchronous_level: db_sync_level,
-                        key: db_key.clone(),
-                        max_readers: db_max_readers,
-                    },
-                )?;
-                let dht_db = DbWrite::open_with_pool_config(
-                    root_db_dir.as_ref(),
-                    DbKindDht(dna_hash.clone()),
-                    PoolConfig {
-                        synchronous_level: db_sync_level,
-                        key: db_key.clone(),
-                        max_readers: db_max_readers,
-                    },
-                )?;
-                let peer_meta_store_db = DbWrite::open_with_pool_config(
-                    root_db_dir.as_ref(),
-                    DbKindPeerMetaStore(dna_hash.clone()),
-                    PoolConfig {
-                        synchronous_level: db_sync_level,
-                        key: db_key.clone(),
-                        max_readers: db_max_readers,
-                    },
-                )?;
-                let conductor_db: DbWrite<DbKindConductor> = DbWrite::open_with_pool_config(
-                    root_db_dir.as_ref(),
-                    DbKindConductor,
-                    PoolConfig {
-                        synchronous_level: db_sync_level,
-                        key: db_key.clone(),
-                        max_readers: db_max_readers,
-                    },
-                )?;
-                DatabaseResult::Ok((cache, dht_db, peer_meta_store_db, conductor_db))
-            })?;
+        let (cache, dht_db, peer_meta_store_db) = tokio::task::block_in_place(|| {
+            let cache = DbWrite::open_with_pool_config(
+                root_db_dir.as_ref(),
+                DbKindCache(dna_hash.clone()),
+                PoolConfig {
+                    synchronous_level: db_sync_level,
+                    key: db_key.clone(),
+                    max_readers: db_max_readers,
+                },
+            )?;
+            let dht_db = DbWrite::open_with_pool_config(
+                root_db_dir.as_ref(),
+                DbKindDht(dna_hash.clone()),
+                PoolConfig {
+                    synchronous_level: db_sync_level,
+                    key: db_key.clone(),
+                    max_readers: db_max_readers,
+                },
+            )?;
+            let peer_meta_store_db = DbWrite::open_with_pool_config(
+                root_db_dir.as_ref(),
+                DbKindPeerMetaStore(dna_hash.clone()),
+                PoolConfig {
+                    synchronous_level: db_sync_level,
+                    key: db_key.clone(),
+                    max_readers: db_max_readers,
+                },
+            )?;
+            DatabaseResult::Ok((cache, dht_db, peer_meta_store_db))
+        })?;
 
         let witnessing_workspace = WitnessingWorkspace::default();
         let incoming_op_hashes = IncomingOpHashes::default();
@@ -540,7 +527,6 @@ impl Space {
             witnessing_workspace,
             incoming_op_hashes,
             incoming_ops_batch,
-            conductor_db,
             root_db_dir: Arc::new(root_db_dir),
             db_key,
             db_max_readers,

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -74,8 +74,8 @@ pub struct Space {
     /// There is one per unique Dna.
     pub dht_db: DbWrite<DbKindDht>,
 
-    /// The peer meta store database. One per unique Dna.
-    pub peer_meta_store_db: holochain_data::DbWrite<holochain_data::kind::PeerMetaStore>,
+    /// The peer meta store. One per unique Dna.
+    pub peer_meta_store: holochain_state::peer_metadata_store::PeerMetaStore,
 
     /// Countersigning workspace for session state.
     pub countersigning_workspaces:
@@ -411,12 +411,12 @@ impl Spaces {
         self.get_or_create_space_ref(dna_hash, |space| space.dht_db.clone())
     }
 
-    /// Get the peer_meta_store database.
-    pub fn peer_meta_store_db(
+    /// Get the peer meta store for a DNA space.
+    pub fn peer_meta_store(
         &self,
         dna_hash: &DnaHash,
-    ) -> DatabaseResult<holochain_data::DbWrite<holochain_data::kind::PeerMetaStore>> {
-        self.get_or_create_space_ref(dna_hash, |space| space.peer_meta_store_db.clone())
+    ) -> DatabaseResult<holochain_state::peer_metadata_store::PeerMetaStore> {
+        self.get_or_create_space_ref(dna_hash, |space| space.peer_meta_store.clone())
     }
 
     /// we are receiving a "publish" event from the network.
@@ -487,7 +487,7 @@ impl Space {
             DbSyncStrategy::Resilient => (DbSyncLevel::Normal, holochain_data::DbSyncLevel::Normal),
         };
 
-        let (cache, dht_db, peer_meta_store_db) = tokio::task::block_in_place(|| {
+        let (cache, dht_db, peer_meta_store) = tokio::task::block_in_place(|| {
             let cache = DbWrite::open_with_pool_config(
                 root_db_dir.as_ref(),
                 DbKindCache(dna_hash.clone()),
@@ -517,7 +517,9 @@ impl Space {
                     },
                 ))
                 .map_err(|e| holochain_sqlite::error::DatabaseError::Other(e.into()))?;
-            DatabaseResult::Ok((cache, dht_db, peer_meta_store_db))
+            let peer_meta_store =
+                holochain_state::peer_metadata_store::PeerMetaStore::new(peer_meta_store_db);
+            DatabaseResult::Ok((cache, dht_db, peer_meta_store))
         })?;
 
         let witnessing_workspace = WitnessingWorkspace::default();
@@ -528,7 +530,7 @@ impl Space {
             cache_db: cache,
             authored_dbs: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             dht_db,
-            peer_meta_store_db,
+            peer_meta_store,
             countersigning_workspaces: Default::default(),
             witnessing_workspace,
             incoming_op_hashes,

--- a/crates/holochain/src/conductor/tests/peer_meta_info.rs
+++ b/crates/holochain/src/conductor/tests/peer_meta_info.rs
@@ -42,10 +42,10 @@ async fn peer_meta_info() {
     // Write a 1-2 peer meta entries into each space's peer meta store
     let db1 = conductor
         .spaces
-        .peer_meta_store_db(dna1.dna_hash())
+        .peer_meta_store(dna1.dna_hash())
         .unwrap();
 
-    let peer_meta_store1 = Arc::new(HolochainPeerMetaStore::create(db1.clone()).await.unwrap());
+    let peer_meta_store1 = Arc::new(HolochainPeerMetaStore::create(db1).await.unwrap());
     peer_meta_store1
         .put(
             url.clone(),
@@ -66,10 +66,10 @@ async fn peer_meta_info() {
 
     let db2 = conductor
         .spaces
-        .peer_meta_store_db(dna2.dna_hash())
+        .peer_meta_store(dna2.dna_hash())
         .unwrap();
 
-    let peer_meta_store2 = Arc::new(HolochainPeerMetaStore::create(db2.clone()).await.unwrap());
+    let peer_meta_store2 = Arc::new(HolochainPeerMetaStore::create(db2).await.unwrap());
     peer_meta_store2
         .put(
             url.clone(),
@@ -172,10 +172,10 @@ async fn app_peer_meta_info() {
     // Write a peer meta entry into app1's peer meta store
     let db1 = conductor
         .spaces
-        .peer_meta_store_db(dna1.dna_hash())
+        .peer_meta_store(dna1.dna_hash())
         .unwrap();
 
-    let peer_meta_store1 = Arc::new(HolochainPeerMetaStore::create(db1.clone()).await.unwrap());
+    let peer_meta_store1 = Arc::new(HolochainPeerMetaStore::create(db1).await.unwrap());
     peer_meta_store1
         .put(
             url.clone(),

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -61,6 +61,7 @@ holochain_sqlite = { version = "^0.7.0-dev.18", path = "../holochain_sqlite", fe
   "test_utils",
 ] }
 holochain_state = { path = "../holochain_state", features = ["test_utils"] }
+sqlx = "0.9.0-alpha.1"
 tempfile = "3.21.0"
 # used for setting default crypto provider with iroh relay
 rustls = "0.23"

--- a/crates/holochain_p2p/src/peer_meta_store.rs
+++ b/crates/holochain_p2p/src/peer_meta_store.rs
@@ -1,7 +1,6 @@
 use bytes::Bytes;
 use futures::future::BoxFuture;
-use holochain_data::kind::PeerMetaStore;
-use holochain_data::DbWrite;
+use holochain_state::peer_metadata_store::PeerMetaStore;
 use kitsune2_api::{BoxFut, K2Error, K2Result, Timestamp, Url};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -34,13 +33,13 @@ impl kitsune2_api::PeerMetaStoreFactory for HolochainPeerMetaStoreFactory {
     ) -> BoxFut<'static, kitsune2_api::K2Result<kitsune2_api::DynPeerMetaStore>> {
         let getter = self.getter.clone();
         Box::pin(async move {
-            let db = getter(holo_hash::DnaHash::from_k2_space(&space))
+            let store = getter(holo_hash::DnaHash::from_k2_space(&space))
                 .await
                 .map_err(|err| {
-                    kitsune2_api::K2Error::other_src("failed to get peer_meta_store db", err)
+                    kitsune2_api::K2Error::other_src("failed to get peer_meta_store", err)
                 })?;
             let peer_meta_store: kitsune2_api::DynPeerMetaStore =
-                Arc::new(HolochainPeerMetaStore::create(db).await.map_err(|err| {
+                Arc::new(HolochainPeerMetaStore::create(store).await.map_err(|err| {
                     K2Error::other_src("failed to connect to peer store database", err)
                 })?);
 
@@ -52,12 +51,12 @@ impl kitsune2_api::PeerMetaStoreFactory for HolochainPeerMetaStoreFactory {
 /// Holochain implementation of a Kitsune2 [kitsune2_api::PeerMetaStore].
 #[derive(Debug)]
 pub struct HolochainPeerMetaStore {
-    db: DbWrite<PeerMetaStore>,
+    db: PeerMetaStore,
 }
 
 impl HolochainPeerMetaStore {
-    /// Create a new [HolochainPeerMetaStore] from a database handle.
-    pub async fn create(db: DbWrite<PeerMetaStore>) -> K2Result<Self> {
+    /// Create a new [HolochainPeerMetaStore] from a [`PeerMetaStore`].
+    pub async fn create(db: PeerMetaStore) -> K2Result<Self> {
         // Prune any expired entries on startup.
         let prune_count = db
             .prune()
@@ -93,7 +92,7 @@ impl kitsune2_api::PeerMetaStore for HolochainPeerMetaStore {
     fn get(&self, peer: Url, key: String) -> BoxFuture<'_, K2Result<Option<Bytes>>> {
         let db = self.db.clone();
         Box::pin(async move {
-            db.as_ref()
+            db.as_read()
                 .get(peer.as_str(), &key)
                 .await
                 .map(|value| value.map(Bytes::from))
@@ -105,7 +104,7 @@ impl kitsune2_api::PeerMetaStore for HolochainPeerMetaStore {
         let db = self.db.clone();
         Box::pin(async move {
             let entries = db
-                .as_ref()
+                .as_read()
                 .get_all_by_key(&key)
                 .await
                 .map_err(|e| K2Error::other_src("Failed to get all values", e))?;

--- a/crates/holochain_p2p/src/peer_meta_store.rs
+++ b/crates/holochain_p2p/src/peer_meta_store.rs
@@ -1,16 +1,12 @@
 use bytes::Bytes;
 use futures::future::BoxFuture;
-use holochain_sqlite::db::DbWrite;
-use holochain_sqlite::error::{DatabaseError, DatabaseResult};
-use holochain_sqlite::helpers::BytesSql;
-use holochain_sqlite::prelude::DbKindPeerMetaStore;
-use holochain_sqlite::rusqlite::named_params;
-use holochain_sqlite::sql::sql_peer_meta_store;
-use kitsune2_api::{BoxFut, K2Error, K2Result, PeerMetaStore, Timestamp, Url};
+use holochain_data::kind::PeerMetaStore;
+use holochain_data::DbWrite;
+use kitsune2_api::{BoxFut, K2Error, K2Result, Timestamp, Url};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-/// Holochain implementation of the Kitsune2 [kitsune2_api::OpStoreFactory].
+/// Holochain implementation of the Kitsune2 [kitsune2_api::PeerMetaStoreFactory].
 pub struct HolochainPeerMetaStoreFactory {
     /// The database connection getter.
     pub getter: crate::GetDbPeerMeta,
@@ -53,28 +49,27 @@ impl kitsune2_api::PeerMetaStoreFactory for HolochainPeerMetaStoreFactory {
     }
 }
 
-/// Holochain implementation of a Kitsune2 [PeerMetaStore].
+/// Holochain implementation of a Kitsune2 [kitsune2_api::PeerMetaStore].
 #[derive(Debug)]
 pub struct HolochainPeerMetaStore {
-    db: DbWrite<DbKindPeerMetaStore>,
+    db: DbWrite<PeerMetaStore>,
 }
 
 impl HolochainPeerMetaStore {
     /// Create a new [HolochainPeerMetaStore] from a database handle.
-    pub async fn create(db: DbWrite<DbKindPeerMetaStore>) -> DatabaseResult<Self> {
+    pub async fn create(db: DbWrite<PeerMetaStore>) -> K2Result<Self> {
         // Prune any expired entries on startup.
-        db.write_async(|txn| -> DatabaseResult<()> {
-            let prune_count = txn.execute(sql_peer_meta_store::PRUNE, [])?;
-            tracing::debug!("pruned {prune_count} rows from peer meta store");
-            Ok(())
-        })
-        .await?;
+        let prune_count = db
+            .prune()
+            .await
+            .map_err(|e| K2Error::other_src("Failed to prune peer meta store on startup", e))?;
+        tracing::debug!("pruned {prune_count} rows from peer meta store");
 
         Ok(Self { db })
     }
 }
 
-impl PeerMetaStore for HolochainPeerMetaStore {
+impl kitsune2_api::PeerMetaStore for HolochainPeerMetaStore {
     fn put(
         &self,
         peer: Url,
@@ -83,21 +78,13 @@ impl PeerMetaStore for HolochainPeerMetaStore {
         expiry: Option<Timestamp>,
     ) -> BoxFuture<'_, K2Result<()>> {
         let db = self.db.clone();
-
         Box::pin(async move {
-            db.write_async(move |txn| -> DatabaseResult<()> {
-                txn.execute(
-                    sql_peer_meta_store::INSERT,
-                    named_params! {
-                        ":peer_url": peer.as_str(),
-                        ":meta_key": key,
-                        ":meta_value": BytesSql(value),
-                        ":expires_at": expiry.map(|e| e.as_micros()),
-                    },
-                )?;
-
-                Ok(())
-            })
+            db.put(
+                peer.as_str(),
+                &key,
+                &value,
+                expiry.map(|expiry| expiry.as_micros() / 1_000_000),
+            )
             .await
             .map_err(|e| K2Error::other_src("Failed to put peer meta", e))
         })
@@ -105,66 +92,39 @@ impl PeerMetaStore for HolochainPeerMetaStore {
 
     fn get(&self, peer: Url, key: String) -> BoxFuture<'_, K2Result<Option<Bytes>>> {
         let db = self.db.clone();
-
         Box::pin(async move {
-            db.read_async(move |txn| -> DatabaseResult<Option<Bytes>> {
-                let value = match txn.query_row(
-                    sql_peer_meta_store::GET,
-                    named_params! {
-                        ":peer_url": peer.as_str(),
-                        ":meta_key": key,
-                    },
-                    |row| row.get::<_, BytesSql>(0),
-                ) {
-                    Ok(value) => Some(value.0),
-                    Err(holochain_sqlite::rusqlite::Error::QueryReturnedNoRows) => None,
-                    Err(e) => return Err(e.into()),
-                };
-
-                Ok(value)
-            })
-            .await
-            .map_err(|e| K2Error::other_src("Failed to get peer meta", e))
+            db.as_ref()
+                .get(peer.as_str(), &key)
+                .await
+                .map(|value| value.map(Bytes::from))
+                .map_err(|e| K2Error::other_src("Failed to get peer meta", e))
         })
     }
 
     fn get_all_by_key(&self, key: String) -> BoxFuture<'_, K2Result<HashMap<Url, Bytes>>> {
         let db = self.db.clone();
         Box::pin(async move {
-            db.read_async(move |txn| -> DatabaseResult<HashMap<Url, Bytes>> {
-                let mut stmt = txn.prepare(sql_peer_meta_store::GET_ALL_BY_KEY)?;
-                let mut rows = stmt.query(named_params! {":meta_key": key})?;
-                let mut all_values = HashMap::new();
-                while let Some(row) = rows.next()? {
-                    let peer_url = Url::from_str(row.get::<_, String>(0)?)
-                        .map_err(|err| DatabaseError::Other(err.into()))?;
-                    let value = row.get::<_, BytesSql>(1)?;
-                    all_values.insert(peer_url, value.0);
-                }
-                Ok(all_values)
-            })
-            .await
-            .map_err(|e| K2Error::other_src("Failed to get all values", e))
+            let entries = db
+                .as_ref()
+                .get_all_by_key(&key)
+                .await
+                .map_err(|e| K2Error::other_src("Failed to get all values", e))?;
+            let mut map = HashMap::with_capacity(entries.len());
+            for (url_str, value) in entries {
+                let url = Url::from_str(url_str)
+                    .map_err(|e| K2Error::other_src("Invalid peer URL in peer meta store", e))?;
+                map.insert(url, Bytes::from(value));
+            }
+            Ok(map)
         })
     }
 
     fn delete(&self, peer: Url, key: String) -> BoxFuture<'_, K2Result<()>> {
         let db = self.db.clone();
-
         Box::pin(async move {
-            db.write_async(move |txn| -> DatabaseResult<()> {
-                txn.execute(
-                    sql_peer_meta_store::DELETE,
-                    named_params! {
-                        ":peer_url": peer.as_str(),
-                        ":meta_key": key,
-                    },
-                )?;
-
-                Ok(())
-            })
-            .await
-            .map_err(|e| K2Error::other_src("Failed to delete peer meta", e))
+            db.delete(peer.as_str(), &key)
+                .await
+                .map_err(|e| K2Error::other_src("Failed to delete peer meta", e))
         })
     }
 }

--- a/crates/holochain_p2p/src/spawn.rs
+++ b/crates/holochain_p2p/src/spawn.rs
@@ -15,13 +15,13 @@ pub async fn spawn_holochain_p2p(
     actor::HolochainP2pActor::create(config, lair_client).await
 }
 
-/// Callback function to retrieve a peer meta database handle for a dna hash.
+/// Callback function to retrieve a peer meta store for a dna hash.
 pub type GetDbPeerMeta = Arc<
     dyn Fn(
             DnaHash,
         ) -> BoxFut<
             'static,
-            HolochainP2pResult<holochain_data::DbWrite<holochain_data::kind::PeerMetaStore>>,
+            HolochainP2pResult<holochain_state::peer_metadata_store::PeerMetaStore>,
         >
         + 'static
         + Send
@@ -62,13 +62,13 @@ pub enum ReportConfig {
 
 /// HolochainP2p config struct.
 pub struct HolochainP2pConfig {
-    /// Callback function to retrieve a peer meta database handle for a dna hash.
+    /// Callback function to retrieve a [`holochain_state::peer_metadata_store::PeerMetaStore`] for a dna hash.
     ///
     /// **Must be set explicitly** — the [`Default`] value panics when called. Example:
     ///
     /// ```ignore
     /// get_db_peer_meta: Arc::new(move |dna_hash| {
-    ///     let res = spaces.peer_meta(&dna_hash);
+    ///     let res = spaces.peer_meta_store(&dna_hash);
     ///     Box::pin(async move { res.map_err(HolochainP2pError::other) })
     /// }),
     /// ```

--- a/crates/holochain_p2p/src/spawn.rs
+++ b/crates/holochain_p2p/src/spawn.rs
@@ -17,7 +17,12 @@ pub async fn spawn_holochain_p2p(
 
 /// Callback function to retrieve a peer meta database handle for a dna hash.
 pub type GetDbPeerMeta = Arc<
-    dyn Fn(DnaHash) -> BoxFut<'static, HolochainP2pResult<DbWrite<DbKindPeerMetaStore>>>
+    dyn Fn(
+            DnaHash,
+        ) -> BoxFut<
+            'static,
+            HolochainP2pResult<holochain_data::DbWrite<holochain_data::kind::PeerMetaStore>>,
+        >
         + 'static
         + Send
         + Sync,

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -738,7 +738,7 @@ impl HolochainP2pActor {
                         let unresponsive_key =
                             format!("{KEY_PREFIX_ROOT}:{META_KEY_UNRESPONSIVE}");
                         let unresponsive_entries = db
-                            .as_ref()
+                            .as_read()
                             .get_all_by_key(&unresponsive_key)
                             .await
                             .map_err(HolochainP2pError::other)?;

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -749,18 +749,16 @@ impl HolochainP2pActor {
                             let timestamp: kitsune2_api::Timestamp =
                                 serde_json::from_slice(&meta_value)
                                     .map_err(HolochainP2pError::other)?;
-                            if let Some(agent) = agents
-                                .iter()
-                                .find(|agent| agent.url == Some(peer_url.clone()))
-                            {
-                                if agent.created_at > timestamp {
-                                    db.delete(peer_url.as_str(), &unresponsive_key)
-                                        .await
-                                        .map_err(HolochainP2pError::other)?;
-                                    tracing::debug!(
-                                        "Pruned {KEY_PREFIX_ROOT}:{META_KEY_UNRESPONSIVE} row for {peer_url} from peer meta store because we have newer agent info"
-                                    );
-                                }
+                            if agents.iter().any(|agent| {
+                                agent.url == Some(peer_url.clone())
+                                    && agent.created_at > timestamp
+                            }) {
+                                db.delete(peer_url.as_str(), &unresponsive_key)
+                                    .await
+                                    .map_err(HolochainP2pError::other)?;
+                                tracing::debug!(
+                                    "Pruned {KEY_PREFIX_ROOT}:{META_KEY_UNRESPONSIVE} row for {peer_url} from peer meta store because we have newer agent info"
+                                );
                             }
                         }
 

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -7,17 +7,11 @@ use crate::metrics::{
 };
 use crate::peer_latency_store::{PeerLatencyService, PingFn};
 use crate::*;
-use holochain_sqlite::error::{DatabaseError, DatabaseResult};
-use holochain_sqlite::helpers::BytesSql;
-use holochain_sqlite::rusqlite::types::Value;
-use holochain_sqlite::sql::sql_peer_meta_store;
-use holochain_state::prelude::named_params;
 use holochain_types::cell_config_overrides::CellConfigOverrides;
 use kitsune2_api::*;
 use kitsune2_core::get_responsive_remote_agents_near_location;
 use std::collections::HashMap;
 use std::future::Future;
-use std::rc::Rc;
 use std::sync::{Mutex, Weak};
 use std::time::Duration;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
@@ -718,79 +712,68 @@ impl HolochainP2pActor {
                 tokio::time::sleep(Duration::from_millis(interval_ms)).await;
 
                 let spaces = kitsune2.list_spaces();
-                let pruning_futs =
-                    spaces.into_iter().map(|space_id| {
-                        let db_getter = db_getter.clone();
-                        let kitsune2 = kitsune2.clone();
-                        async move {
-                            let Some(space) = kitsune2.clone().space_if_exists(space_id.clone()).await else {
-                                tracing::warn!("Cannot prune expired URLs from peer meta store for k2 space that does not exist with space id {space_id}");
-                                return Ok::<_, HolochainP2pError>(());
-                            };
+                let pruning_futs = spaces.into_iter().map(|space_id| {
+                    let db_getter = db_getter.clone();
+                    let kitsune2 = kitsune2.clone();
+                    async move {
+                        let Some(space) = kitsune2.clone().space_if_exists(space_id.clone()).await
+                        else {
+                            tracing::warn!("Cannot prune expired URLs from peer meta store for k2 space that does not exist with space id {space_id}");
+                            return Ok::<_, HolochainP2pError>(());
+                        };
 
-                            let peer_store = space.peer_store().clone();
-                            let db = db_getter(DnaHash::from_k2_space(&space_id)).await?;
-                            // Prune any expired entries.
-                            db.write_async(|txn| -> DatabaseResult<()> {
-                                let prune_count = txn.execute(sql_peer_meta_store::PRUNE, [])?;
-                                tracing::debug!("Pruned {prune_count} expired rows from peer meta store");
-                                Ok(())
-                            })
-                                .await
+                        let peer_store = space.peer_store().clone();
+                        let db = db_getter(DnaHash::from_k2_space(&space_id)).await?;
+
+                        // Prune any expired entries.
+                        let prune_count = db.prune().await.map_err(HolochainP2pError::other)?;
+                        tracing::debug!(
+                            "Pruned {prune_count} expired rows from peer meta store"
+                        );
+
+                        // Get agent infos from peer store and compare if there are any up-to-date
+                        // ones with any of the unresponsive URLs. That would indicate that the URL
+                        // was unresponsive temporarily and has since become responsive again.
+                        let agents = peer_store.get_all().await?;
+                        let unresponsive_key =
+                            format!("{KEY_PREFIX_ROOT}:{META_KEY_UNRESPONSIVE}");
+                        let unresponsive_entries = db
+                            .as_ref()
+                            .get_all_by_key(&unresponsive_key)
+                            .await
+                            .map_err(HolochainP2pError::other)?;
+
+                        for (peer_url_str, meta_value) in unresponsive_entries {
+                            let peer_url = Url::from_str(peer_url_str)
                                 .map_err(HolochainP2pError::other)?;
-
-                            // Get agent infos from peer store and compare if there are any up-to-date ones with
-                            // any of the unresponsive URLs.
-                            // That would indicate that the URL was unresponsive temporarily and has become
-                            // responsive again.
-                            let agents = peer_store.get_all().await?;
-                            let urls_to_prune = db
-                                .read_async(move |txn| -> DatabaseResult<Vec<Value>> {
-                                    let mut stmt = txn.prepare(sql_peer_meta_store::GET_ALL_BY_KEY)?;
-                                    let mut rows = stmt.query(
-                                        named_params! {":meta_key":format!("{KEY_PREFIX_ROOT}:{META_KEY_UNRESPONSIVE}")},
-                                    )?;
-                                    let mut urls = Vec::new();
-                                    while let Some(row) = rows.next()? {
-                                        // Expecting is safe here, because the inserted values must have been URLs.
-                                        let peer_url = Url::from_str(row.get::<_, String>(0)?).map_err(|err| DatabaseError::Other(err.into()))?;
-                                        let meta_value = row.get::<_, BytesSql>("meta_value")?;
-                                        let timestamp: kitsune2_api::Timestamp = serde_json::from_slice(&meta_value.0).map_err(|err| DatabaseError::Other(err.into()))?;
-                                        if let Some(agent) = agents
-                                            .iter()
-                                            .find(|agent| agent.url == Some(peer_url.clone()))
-                                        {
-                                            if agent.created_at > timestamp {
-                                                urls.push(Value::Text(peer_url.to_string()));
-                                            }
-                                        }
-                                    }
-                                    Ok(urls)
-                                })
-                                .await
-                                .map_err(HolochainP2pError::other)?;
-
-                            // Delete all urls to be pruned from the table.
-                            db.write_async(|txn| -> DatabaseResult<()> {
-                                let values = Rc::new(urls_to_prune);
-                                let mut stmt = txn.prepare(sql_peer_meta_store::DELETE_URLS)?;
-                                stmt.execute(named_params! {":urls": values, ":meta_key": format!("{KEY_PREFIX_ROOT}:{META_KEY_UNRESPONSIVE}")})?;
-                                tracing::debug!("Pruned {} unexpired {KEY_PREFIX_ROOT}:{META_KEY_UNRESPONSIVE} rows from peer meta store because we have newer agent info", values.len());
-                                Ok(())
-                            })
-                                .await
-                                .map_err(HolochainP2pError::other)?;
-
-                            Ok::<_, HolochainP2pError>(())
+                            let timestamp: kitsune2_api::Timestamp =
+                                serde_json::from_slice(&meta_value)
+                                    .map_err(HolochainP2pError::other)?;
+                            if let Some(agent) = agents
+                                .iter()
+                                .find(|agent| agent.url == Some(peer_url.clone()))
+                            {
+                                if agent.created_at > timestamp {
+                                    db.delete(peer_url.as_str(), &unresponsive_key)
+                                        .await
+                                        .map_err(HolochainP2pError::other)?;
+                                    tracing::debug!(
+                                        "Pruned {KEY_PREFIX_ROOT}:{META_KEY_UNRESPONSIVE} row for {peer_url} from peer meta store because we have newer agent info"
+                                    );
+                                }
+                            }
                         }
-                    });
+
+                        Ok::<_, HolochainP2pError>(())
+                    }
+                });
                 let results = futures::future::join_all(pruning_futs).await;
                 for err in results.into_iter().filter_map(Result::err) {
                     tracing::warn!("Pruning peer meta store failed: {err}");
                 }
             }
         })
-            .abort_handle()
+        .abort_handle()
     }
 
     async fn get_peers_for_location(

--- a/crates/holochain_p2p/tests/tests/blocks.rs
+++ b/crates/holochain_p2p/tests/tests/blocks.rs
@@ -4,6 +4,7 @@ use holo_hash::{
     fixt::{ActionHashFixturator, AgentPubKeyFixturator, DhtOpHashFixturator, DnaHashFixturator},
     DnaHash,
 };
+use holochain_data::kind::PeerMetaStore;
 use holochain_keystore::{test_keystore, MetaLairClient};
 use holochain_p2p::actor::NetworkRequestOptions;
 use holochain_p2p::{
@@ -12,7 +13,7 @@ use holochain_p2p::{
 };
 use holochain_timestamp::{InclusiveTimestampInterval, Timestamp};
 use holochain_types::{
-    db::{DbKindCache, DbKindDht, DbKindPeerMetaStore, DbWrite},
+    db::{DbKindCache, DbKindDht, DbWrite},
     prelude::{Block, BlockTargetId, CellBlockReason, CellId},
     record::WireRecordOps,
 };
@@ -521,7 +522,9 @@ impl TestActor {
         let op_db = DbWrite::test_in_mem(DbKindDht(Arc::new(dna_hash.clone()))).unwrap();
         let cache_db = DbWrite::test_in_mem(DbKindCache(Arc::new(dna_hash.clone()))).unwrap();
         let peer_meta_db =
-            DbWrite::test_in_mem(DbKindPeerMetaStore(Arc::new(dna_hash.clone()))).unwrap();
+            holochain_data::test_open_db(PeerMetaStore::new(Arc::new(dna_hash.clone())))
+                .await
+                .unwrap();
         let config = HolochainP2pConfig {
             get_conductor_store: Arc::new(move || {
                 let conductor_store = conductor_store.clone();

--- a/crates/holochain_p2p/tests/tests/blocks.rs
+++ b/crates/holochain_p2p/tests/tests/blocks.rs
@@ -521,10 +521,11 @@ impl TestActor {
     ) -> Self {
         let op_db = DbWrite::test_in_mem(DbKindDht(Arc::new(dna_hash.clone()))).unwrap();
         let cache_db = DbWrite::test_in_mem(DbKindCache(Arc::new(dna_hash.clone()))).unwrap();
-        let peer_meta_db =
+        let peer_meta_db = holochain_state::peer_metadata_store::PeerMetaStore::new(
             holochain_data::test_open_db(PeerMetaStore::new(Arc::new(dna_hash.clone())))
                 .await
-                .unwrap();
+                .unwrap(),
+        );
         let config = HolochainP2pConfig {
             get_conductor_store: Arc::new(move || {
                 let conductor_store = conductor_store.clone();

--- a/crates/holochain_p2p/tests/tests/node_messaging.rs
+++ b/crates/holochain_p2p/tests/tests/node_messaging.rs
@@ -1,4 +1,5 @@
 use crate::tests::common::{spawn_test_bootstrap, Handler};
+use holochain_data::kind::PeerMetaStore;
 use holochain_keystore::*;
 use holochain_p2p::actor::{GetLinksRequestOptions, NetworkRequestOptions};
 use holochain_p2p::event::*;
@@ -1180,8 +1181,9 @@ async fn spawn_test(
     handler: DynHcP2pHandler,
     bootstrap_addr: &SocketAddr,
 ) -> (AgentPubKey, actor::DynHcP2p, MetaLairClient) {
-    let db_peer_meta =
-        DbWrite::test_in_mem(DbKindPeerMetaStore(Arc::new(dna_hash.clone()))).unwrap();
+    let db_peer_meta = holochain_data::test_open_db(PeerMetaStore::new(Arc::new(dna_hash.clone())))
+        .await
+        .unwrap();
     let db_op = DbWrite::test_in_mem(DbKindDht(Arc::new(dna_hash.clone()))).unwrap();
     let db_cache = DbWrite::test_in_mem(DbKindCache(Arc::new(dna_hash.clone()))).unwrap();
     let conductor_store = holochain_state::conductor::ConductorStore::new_test()

--- a/crates/holochain_p2p/tests/tests/node_messaging.rs
+++ b/crates/holochain_p2p/tests/tests/node_messaging.rs
@@ -1181,9 +1181,11 @@ async fn spawn_test(
     handler: DynHcP2pHandler,
     bootstrap_addr: &SocketAddr,
 ) -> (AgentPubKey, actor::DynHcP2p, MetaLairClient) {
-    let db_peer_meta = holochain_data::test_open_db(PeerMetaStore::new(Arc::new(dna_hash.clone())))
-        .await
-        .unwrap();
+    let db_peer_meta = holochain_state::peer_metadata_store::PeerMetaStore::new(
+        holochain_data::test_open_db(PeerMetaStore::new(Arc::new(dna_hash.clone())))
+            .await
+            .unwrap(),
+    );
     let db_op = DbWrite::test_in_mem(DbKindDht(Arc::new(dna_hash.clone()))).unwrap();
     let db_cache = DbWrite::test_in_mem(DbKindCache(Arc::new(dna_hash.clone()))).unwrap();
     let conductor_store = holochain_state::conductor::ConductorStore::new_test()

--- a/crates/holochain_p2p/tests/tests/peer_meta_store.rs
+++ b/crates/holochain_p2p/tests/tests/peer_meta_store.rs
@@ -1,18 +1,18 @@
 use bytes::Bytes;
 use holo_hash::DnaHash;
+use holochain_data::kind::PeerMetaStore;
 use holochain_p2p::HolochainPeerMetaStore;
-use holochain_sqlite::db::{DbKindPeerMetaStore, DbWrite, ReadAccess};
-use holochain_sqlite::error::DatabaseResult;
-use kitsune2_api::{PeerMetaStore, Timestamp, Url, KEY_PREFIX_ROOT, META_KEY_UNRESPONSIVE};
+use kitsune2_api::{PeerMetaStore as _, Timestamp, Url, KEY_PREFIX_ROOT, META_KEY_UNRESPONSIVE};
 use std::sync::Arc;
 use std::time::Duration;
 
+fn test_db_id() -> PeerMetaStore {
+    PeerMetaStore::new(Arc::new(DnaHash::from_raw_36(vec![0xdb; 36])))
+}
+
 #[tokio::test]
 async fn peer_meta_crd() {
-    let db = DbWrite::test_in_mem(DbKindPeerMetaStore(Arc::new(DnaHash::from_raw_36(
-        vec![0xdb; 36],
-    ))))
-    .unwrap();
+    let db = holochain_data::test_open_db(test_db_id()).await.unwrap();
 
     let store = HolochainPeerMetaStore::create(db).await.unwrap();
 
@@ -43,10 +43,7 @@ async fn peer_meta_crd() {
 
 #[tokio::test]
 async fn get_all_urls_by_key() {
-    let db = DbWrite::test_in_mem(DbKindPeerMetaStore(Arc::new(DnaHash::from_raw_36(
-        vec![0xdb; 36],
-    ))))
-    .unwrap();
+    let db = holochain_data::test_open_db(test_db_id()).await.unwrap();
     let store = HolochainPeerMetaStore::create(db).await.unwrap();
 
     // Insert 2 URLs with a key into the store.
@@ -86,10 +83,7 @@ async fn get_all_urls_by_key() {
 
 #[tokio::test]
 async fn get_all_unresponsive_urls_by_key() {
-    let db = DbWrite::test_in_mem(DbKindPeerMetaStore(Arc::new(DnaHash::from_raw_36(
-        vec![0xdb; 36],
-    ))))
-    .unwrap();
+    let db = holochain_data::test_open_db(test_db_id()).await.unwrap();
     let store = HolochainPeerMetaStore::create(db).await.unwrap();
 
     // Insert 2 unresponsive URLs into store.
@@ -98,7 +92,7 @@ async fn get_all_unresponsive_urls_by_key() {
     store
         .set_unresponsive(
             unresponsive_url_1.clone(),
-            Timestamp::now(),
+            Timestamp::from_micros(i64::MAX),
             Timestamp::now(),
         )
         .await
@@ -106,7 +100,7 @@ async fn get_all_unresponsive_urls_by_key() {
     store
         .set_unresponsive(
             unresponsive_url_2.clone(),
-            Timestamp::now(),
+            Timestamp::from_micros(i64::MAX),
             Timestamp::now(),
         )
         .await
@@ -137,10 +131,7 @@ async fn get_all_unresponsive_urls_by_key() {
 
 #[tokio::test]
 async fn prune_on_create() {
-    let db = DbWrite::test_in_mem(DbKindPeerMetaStore(Arc::new(DnaHash::from_raw_36(
-        vec![0xdb; 36],
-    ))))
-    .unwrap();
+    let db = holochain_data::test_open_db(test_db_id()).await.unwrap();
 
     {
         let store = HolochainPeerMetaStore::create(db.clone()).await.unwrap();
@@ -158,13 +149,8 @@ async fn prune_on_create() {
             .await
             .unwrap();
 
-        let count = db
-            .read_async(|txn| -> DatabaseResult<u32> {
-                let count = txn.query_row("SELECT COUNT(*) FROM peer_meta", [], |row| {
-                    row.get::<_, u32>(0)
-                })?;
-                Ok(count)
-            })
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM peer_meta")
+            .fetch_one(db.pool())
             .await
             .unwrap();
 
@@ -174,13 +160,8 @@ async fn prune_on_create() {
     // Setting up a new store should clear expired values
     HolochainPeerMetaStore::create(db.clone()).await.unwrap();
 
-    let count = db
-        .read_async(|txn| -> DatabaseResult<u32> {
-            let count = txn.query_row("SELECT COUNT(*) FROM peer_meta", [], |row| {
-                row.get::<_, u32>(0)
-            })?;
-            Ok(count)
-        })
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM peer_meta")
+        .fetch_one(db.pool())
         .await
         .unwrap();
 
@@ -189,17 +170,14 @@ async fn prune_on_create() {
 
 #[tokio::test]
 async fn set_peer_unresponsive_in_peer_meta_store() {
-    let db = DbWrite::test_in_mem(DbKindPeerMetaStore(Arc::new(DnaHash::from_raw_36(
-        vec![0x0a; 36],
-    ))))
-    .unwrap();
+    let db = holochain_data::test_open_db(test_db_id()).await.unwrap();
     let store = Arc::new(HolochainPeerMetaStore::create(db.clone()).await.unwrap());
     let peer_url = Url::from_str("ws://test:80/1").unwrap();
     let when_peer_set_unresponsive = store.get_unresponsive(peer_url.clone()).await.unwrap();
     assert!(when_peer_set_unresponsive.is_none());
     let when = Timestamp::now();
     store
-        .set_unresponsive(peer_url.clone(), Timestamp::now(), when)
+        .set_unresponsive(peer_url.clone(), Timestamp::from_micros(i64::MAX), when)
         .await
         .unwrap();
     let when_peer_marked_unresponsive = store.get_unresponsive(peer_url).await.unwrap();
@@ -212,33 +190,26 @@ async fn set_peer_unresponsive_in_peer_meta_store() {
     ignore = "requires Iroh transport for stability"
 )]
 async fn unresponsive_peers_are_removed_from_store_after_expiry() {
-    let db = DbWrite::test_in_mem(DbKindPeerMetaStore(Arc::new(DnaHash::from_raw_36(
-        vec![0x0a; 36],
-    ))))
-    .unwrap();
+    let db = holochain_data::test_open_db(test_db_id()).await.unwrap();
     let store = Arc::new(HolochainPeerMetaStore::create(db.clone()).await.unwrap());
 
     let peer_url = Url::from_str("ws://test:80/1").unwrap();
-    // Expiry after 100 ms
-    let expiry = Timestamp::from_micros(Timestamp::now().as_micros() + 100_000);
+    // Expiry time needs to be more than 1 second in the future as we might be on the boundary of
+    // this second.
+    let expiry = Timestamp::now() + Duration::from_secs(2);
     let when = Timestamp::now();
     store
         .set_unresponsive(peer_url.clone(), expiry, when)
         .await
         .unwrap();
-    let after_set_unresponsive = Timestamp::now();
 
     // Waiting until the next pruning, but before the expiry, to make sure expiry is respected.
     tokio::time::sleep(Duration::from_millis(10)).await;
     let when_peer_marked_unresponsive = store.get_unresponsive(peer_url.clone()).await.unwrap();
     assert_eq!(when_peer_marked_unresponsive, Some(when));
 
-    // Wait until after expiry.
-    // Test has to wait at least until the next second, because the expiry is compared with the unixepoch function in SQLite which returns
-    // the timestamp in full seconds. Add 1 ms as a safety buffer to prevent flakiness.
-    let micros_to_wait =
-        1_000_000_u64.saturating_sub(after_set_unresponsive.as_micros() as u64 % 1_000_000) + 1000;
-    tokio::time::sleep(Duration::from_micros(micros_to_wait)).await;
+    // Wait until expiry time.
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     // Manually trigger pruning by recreating the store (which prunes on startup).
     drop(store);

--- a/crates/holochain_p2p/tests/tests/peer_meta_store.rs
+++ b/crates/holochain_p2p/tests/tests/peer_meta_store.rs
@@ -14,7 +14,11 @@ fn test_db_id() -> PeerMetaStore {
 async fn peer_meta_crd() {
     let db = holochain_data::test_open_db(test_db_id()).await.unwrap();
 
-    let store = HolochainPeerMetaStore::create(db).await.unwrap();
+    let store = HolochainPeerMetaStore::create(
+        holochain_state::peer_metadata_store::PeerMetaStore::new(db),
+    )
+    .await
+    .unwrap();
 
     let peer_url = Url::from_str("ws://test:80/1").unwrap();
     let key = "test".to_string();
@@ -44,7 +48,11 @@ async fn peer_meta_crd() {
 #[tokio::test]
 async fn get_all_urls_by_key() {
     let db = holochain_data::test_open_db(test_db_id()).await.unwrap();
-    let store = HolochainPeerMetaStore::create(db).await.unwrap();
+    let store = HolochainPeerMetaStore::create(
+        holochain_state::peer_metadata_store::PeerMetaStore::new(db),
+    )
+    .await
+    .unwrap();
 
     // Insert 2 URLs with a key into the store.
     let key = "key".to_string();
@@ -84,7 +92,11 @@ async fn get_all_urls_by_key() {
 #[tokio::test]
 async fn get_all_unresponsive_urls_by_key() {
     let db = holochain_data::test_open_db(test_db_id()).await.unwrap();
-    let store = HolochainPeerMetaStore::create(db).await.unwrap();
+    let store = HolochainPeerMetaStore::create(
+        holochain_state::peer_metadata_store::PeerMetaStore::new(db),
+    )
+    .await
+    .unwrap();
 
     // Insert 2 unresponsive URLs into store.
     let unresponsive_url_1 = Url::from_str("ws://test:80/1").unwrap();
@@ -134,7 +146,11 @@ async fn prune_on_create() {
     let db = holochain_data::test_open_db(test_db_id()).await.unwrap();
 
     {
-        let store = HolochainPeerMetaStore::create(db.clone()).await.unwrap();
+        let store = HolochainPeerMetaStore::create(
+            holochain_state::peer_metadata_store::PeerMetaStore::new(db.clone()),
+        )
+        .await
+        .unwrap();
 
         let peer_url = Url::from_str("ws://test:80/1").unwrap();
         let key = "test".to_string();
@@ -158,7 +174,11 @@ async fn prune_on_create() {
     }
 
     // Setting up a new store should clear expired values
-    HolochainPeerMetaStore::create(db.clone()).await.unwrap();
+    HolochainPeerMetaStore::create(holochain_state::peer_metadata_store::PeerMetaStore::new(
+        db.clone(),
+    ))
+    .await
+    .unwrap();
 
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM peer_meta")
         .fetch_one(db.pool())
@@ -171,7 +191,13 @@ async fn prune_on_create() {
 #[tokio::test]
 async fn set_peer_unresponsive_in_peer_meta_store() {
     let db = holochain_data::test_open_db(test_db_id()).await.unwrap();
-    let store = Arc::new(HolochainPeerMetaStore::create(db.clone()).await.unwrap());
+    let store = Arc::new(
+        HolochainPeerMetaStore::create(holochain_state::peer_metadata_store::PeerMetaStore::new(
+            db.clone(),
+        ))
+        .await
+        .unwrap(),
+    );
     let peer_url = Url::from_str("ws://test:80/1").unwrap();
     let when_peer_set_unresponsive = store.get_unresponsive(peer_url.clone()).await.unwrap();
     assert!(when_peer_set_unresponsive.is_none());
@@ -191,7 +217,13 @@ async fn set_peer_unresponsive_in_peer_meta_store() {
 )]
 async fn unresponsive_peers_are_removed_from_store_after_expiry() {
     let db = holochain_data::test_open_db(test_db_id()).await.unwrap();
-    let store = Arc::new(HolochainPeerMetaStore::create(db.clone()).await.unwrap());
+    let store = Arc::new(
+        HolochainPeerMetaStore::create(holochain_state::peer_metadata_store::PeerMetaStore::new(
+            db.clone(),
+        ))
+        .await
+        .unwrap(),
+    );
 
     let peer_url = Url::from_str("ws://test:80/1").unwrap();
     // Expiry time needs to be more than 1 second in the future as we might be on the boundary of
@@ -213,7 +245,13 @@ async fn unresponsive_peers_are_removed_from_store_after_expiry() {
 
     // Manually trigger pruning by recreating the store (which prunes on startup).
     drop(store);
-    let store = Arc::new(HolochainPeerMetaStore::create(db.clone()).await.unwrap());
+    let store = Arc::new(
+        HolochainPeerMetaStore::create(holochain_state::peer_metadata_store::PeerMetaStore::new(
+            db.clone(),
+        ))
+        .await
+        .unwrap(),
+    );
 
     let when_peer_set_unresponsive = store.get_unresponsive(peer_url).await.unwrap();
     assert!(when_peer_set_unresponsive.is_none());

--- a/crates/holochain_p2p/tests/tests/space_shutdown.rs
+++ b/crates/holochain_p2p/tests/tests/space_shutdown.rs
@@ -1,8 +1,9 @@
 use crate::tests::common::Handler;
 use holo_hash::{AgentPubKey, DnaHash};
+use holochain_data::kind::PeerMetaStore;
 use holochain_keystore::test_keystore;
 use holochain_p2p::{spawn_holochain_p2p, HolochainP2pConfig};
-use holochain_state::prelude::{test_cache_db_with_dna_hash, test_dht_db, test_peer_meta_store_db};
+use holochain_state::prelude::{test_cache_db_with_dna_hash, test_dht_db};
 use kitsune2_api::LocalAgent;
 use std::sync::Arc;
 
@@ -16,7 +17,9 @@ async fn space_shutdown() {
     let conductor_store = holochain_state::conductor::ConductorStore::new_test()
         .await
         .unwrap();
-    let peer_meta_db = test_peer_meta_store_db(dna_hash.clone()).to_db();
+    let peer_meta_db = holochain_data::test_open_db(PeerMetaStore::new(Arc::new(dna_hash.clone())))
+        .await
+        .unwrap();
 
     let keystore = test_keystore();
 

--- a/crates/holochain_p2p/tests/tests/space_shutdown.rs
+++ b/crates/holochain_p2p/tests/tests/space_shutdown.rs
@@ -17,9 +17,11 @@ async fn space_shutdown() {
     let conductor_store = holochain_state::conductor::ConductorStore::new_test()
         .await
         .unwrap();
-    let peer_meta_db = holochain_data::test_open_db(PeerMetaStore::new(Arc::new(dna_hash.clone())))
-        .await
-        .unwrap();
+    let peer_meta_db = holochain_state::peer_metadata_store::PeerMetaStore::new(
+        holochain_data::test_open_db(PeerMetaStore::new(Arc::new(dna_hash.clone())))
+            .await
+            .unwrap(),
+    );
 
     let keystore = test_keystore();
 

--- a/crates/holochain_p2p/tests/tests/unresponsive_url_pruning.rs
+++ b/crates/holochain_p2p/tests/tests/unresponsive_url_pruning.rs
@@ -215,6 +215,96 @@ async fn urls_are_pruned_when_updated_agent_info_available() {
     .unwrap();
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn new_agent_with_same_url_prunes_old_unresponsive_entry() {
+    holochain_trace::test_run();
+    let TestCase {
+        p2p,
+        space_id,
+        lair_client,
+        peer_meta_store,
+        db_peer_meta,
+        _dir,
+    } = TestCase::spawn().await;
+
+    let max_expiry = Timestamp::from_micros(i64::MAX);
+    let shared_url = Url::from_str("ws://shared:80").unwrap();
+
+    // Mark the shared URL as unresponsive now.
+    let unresponsive_at = Timestamp::now();
+    peer_meta_store
+        .set_unresponsive(shared_url.clone(), max_expiry, unresponsive_at)
+        .await
+        .unwrap();
+
+    // Agent 1 has `created_at` before the unresponsive timestamp.
+    let pubkey1 = lair_client.new_sign_keypair_random().await.unwrap();
+    let agent1 = HolochainP2pLocalAgent::new(pubkey1.clone(), DhtArc::FULL, 1, lair_client.clone());
+    let agent1_info = AgentInfoSigned::sign(
+        &agent1,
+        AgentInfo {
+            agent: pubkey1.to_k2_agent(),
+            created_at: (unresponsive_at - Duration::from_secs(1)).unwrap(),
+            expires_at: max_expiry,
+            is_tombstone: false,
+            space: space_id.clone(),
+            storage_arc: DhtArc::FULL,
+            url: Some(shared_url.clone()),
+        },
+    )
+    .await
+    .unwrap();
+
+    // Agent 2 has `created_at` after the unresponsive timestamp.
+    let pubkey2 = lair_client.new_sign_keypair_random().await.unwrap();
+    let agent2 = HolochainP2pLocalAgent::new(pubkey2.clone(), DhtArc::FULL, 1, lair_client.clone());
+    let agent2_info = AgentInfoSigned::sign(
+        &agent2,
+        AgentInfo {
+            agent: pubkey2.to_k2_agent(),
+            created_at: unresponsive_at + Duration::from_secs(1),
+            expires_at: max_expiry,
+            is_tombstone: false,
+            space: space_id.clone(),
+            storage_arc: DhtArc::FULL,
+            url: Some(shared_url.clone()),
+        },
+    )
+    .await
+    .unwrap();
+
+    // Insert the older agent 1.
+    p2p.test_kitsune()
+        .space_if_exists(space_id.clone())
+        .await
+        .unwrap()
+        .peer_store()
+        .insert(vec![agent1_info])
+        .await
+        .unwrap();
+
+    // Check that the URL is marked as unresponsive.
+    let unresponsive_urls = count_rows_in_peer_meta_store(&db_peer_meta).await;
+    assert_eq!(unresponsive_urls, 1);
+
+    // Insert the new agent 2 that was created after the unresponsive_at time.
+    p2p.test_kitsune()
+        .space_if_exists(space_id.clone())
+        .await
+        .unwrap()
+        .peer_store()
+        .insert(vec![agent2_info])
+        .await
+        .unwrap();
+
+    // Allow the pruning to happen after a new agent is added with the previously unresponsive URL.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Check that the URL is marked as unresponsive.
+    let unresponsive_urls = count_rows_in_peer_meta_store(&db_peer_meta).await;
+    assert_eq!(unresponsive_urls, 0);
+}
+
 struct TestCase {
     p2p: DynHcP2p,
     space_id: SpaceId,

--- a/crates/holochain_p2p/tests/tests/unresponsive_url_pruning.rs
+++ b/crates/holochain_p2p/tests/tests/unresponsive_url_pruning.rs
@@ -1,11 +1,12 @@
 use holo_hash::DnaHash;
+use holochain_data::kind::PeerMetaStore;
 use holochain_keystore::{test_keystore, MetaLairClient};
 use holochain_p2p::{
     actor::DynHcP2p, event::MockHcP2pHandler, spawn_holochain_p2p, HolochainP2pConfig,
     HolochainP2pLocalAgent,
 };
-use holochain_state::prelude::{named_params, test_db_dir};
-use holochain_types::db::{DbKindCache, DbKindDht, DbKindPeerMetaStore, DbWrite};
+use holochain_state::prelude::test_db_dir;
+use holochain_types::db::{DbKindCache, DbKindDht, DbWrite};
 use kitsune2_api::{
     AgentInfo, AgentInfoSigned, DhtArc, DynPeerMetaStore, SpaceId, Timestamp, Url, KEY_PREFIX_ROOT,
     META_KEY_UNRESPONSIVE,
@@ -22,15 +23,17 @@ async fn urls_are_pruned_at_an_interval() {
     } = TestCase::spawn().await;
 
     // Insert an unresponsive URL into peer meta store.
+    // Expiry time needs to be more than 1 second in the future as we might be on the boundary of
+    // this second.
     let unresponsive_peer = Url::from_str("ws://nowhere.land:80").unwrap();
-    let expiry = Timestamp::from_micros(Timestamp::now().as_micros() + 500_000); // 500 ms from now
+    let expiry = Timestamp::now() + Duration::from_secs(2);
     let when = Timestamp::now();
     peer_meta_store
         .set_unresponsive(unresponsive_peer.clone(), expiry, when)
         .await
         .unwrap();
 
-    // Waiting until the next pruning, but before the expiry, to make sure expiry is respected.
+    // Waiting until the next pruning, but before the expiry, to make sure it has not expired yet.
     tokio::time::sleep(Duration::from_millis(100)).await;
     let when_peer_set_unresponsive = peer_meta_store
         .get_unresponsive(unresponsive_peer.clone())
@@ -38,12 +41,10 @@ async fn urls_are_pruned_at_an_interval() {
         .unwrap();
     assert_eq!(when_peer_set_unresponsive, Some(when));
 
-    let unresponsive_urls = count_rows_in_peer_meta_store(db_peer_meta.clone());
+    let unresponsive_urls = count_rows_in_peer_meta_store(&db_peer_meta).await;
     assert_eq!(unresponsive_urls, 1);
 
-    // Waiting until the next pruning, after expiry.
-    // Test has to wait at least until the next second, because the expiry is compared with the unixepoch function in SQLite which returns
-    // the timestamp in full seconds, plus the pruning interval.
+    // The entries should be pruned after their expiry, keep checking up until the expiry time.
     tokio::time::timeout(Duration::from_secs(2), async {
         loop {
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -53,7 +54,7 @@ async fn urls_are_pruned_at_an_interval() {
                 .await
                 .unwrap();
             // Check the row has actually been deleted from the table.
-            let unresponsive_urls = count_rows_in_peer_meta_store(db_peer_meta.clone());
+            let unresponsive_urls = count_rows_in_peer_meta_store(&db_peer_meta).await;
             if when_peer_marked_unresponsive.is_none() && unresponsive_urls == 0 {
                 break;
             }
@@ -144,7 +145,7 @@ async fn urls_are_pruned_when_updated_agent_info_available() {
         loop {
             tokio::time::sleep(Duration::from_millis(100)).await;
 
-            let peer_meta_store_count = count_rows_in_peer_meta_store(db_peer_meta.clone());
+            let peer_meta_store_count = count_rows_in_peer_meta_store(&db_peer_meta).await;
             if peer_meta_store_count == 2 {
                 break;
             }
@@ -161,7 +162,7 @@ async fn urls_are_pruned_when_updated_agent_info_available() {
         .is_some());
 
     // Alice and Bob's URLs should still be in the peer meta store.
-    let peer_meta_store_count = count_rows_in_peer_meta_store(db_peer_meta.clone());
+    let peer_meta_store_count = count_rows_in_peer_meta_store(&db_peer_meta).await;
     assert_eq!(peer_meta_store_count, 2);
 
     // Insert Alice's updated AgentInfo into peer store.
@@ -202,7 +203,7 @@ async fn urls_are_pruned_when_updated_agent_info_available() {
 
             // Alice's URL should have been removed from the store
             // and Bob's URL should still be in the store.
-            let peer_meta_store_count = count_rows_in_peer_meta_store(db_peer_meta.clone());
+            let peer_meta_store_count = count_rows_in_peer_meta_store(&db_peer_meta).await;
             if maybe_alice_entry.is_none() && peer_meta_store_count == 1 {
                 break;
             }
@@ -217,7 +218,7 @@ struct TestCase {
     space_id: SpaceId,
     lair_client: MetaLairClient,
     peer_meta_store: DynPeerMetaStore,
-    db_peer_meta: DbWrite<DbKindPeerMetaStore>,
+    db_peer_meta: holochain_data::DbWrite<PeerMetaStore>,
 }
 
 impl TestCase {
@@ -230,9 +231,14 @@ impl TestCase {
         // The DB logic expects the folder to have a parent folder.
         let dir = test_db_dir();
         let db_dir = dir.path().join("tmp_database");
-        std::fs::create_dir(db_dir.clone()).unwrap();
-        let db_peer_meta =
-            DbWrite::test(&db_dir, DbKindPeerMetaStore(Arc::new(dna_hash.clone()))).unwrap();
+        std::fs::create_dir(&db_dir).unwrap();
+        let db_peer_meta = holochain_data::open_db(
+            &db_dir,
+            PeerMetaStore::new(Arc::new(dna_hash.clone())),
+            holochain_data::HolochainDataConfig::default(),
+        )
+        .await
+        .unwrap();
         let db_op = DbWrite::test_in_mem(DbKindDht(Arc::new(dna_hash.clone()))).unwrap();
         let db_cache = DbWrite::test_in_mem(DbKindCache(Arc::new(dna_hash.clone()))).unwrap();
         let conductor_store = holochain_state::conductor::ConductorStore::new_test()
@@ -285,6 +291,7 @@ impl TestCase {
             .unwrap()
             .peer_meta_store()
             .clone();
+
         Self {
             p2p,
             space_id,
@@ -295,15 +302,12 @@ impl TestCase {
     }
 }
 
-fn count_rows_in_peer_meta_store(db: DbWrite<DbKindPeerMetaStore>) -> usize {
-    db.test_read(|txn| {
-        let mut stmt = txn
-            .prepare("SELECT COUNT(*) FROM peer_meta WHERE meta_key = :meta_key")
-            .unwrap();
-        stmt.query_row(
-            named_params! {":meta_key": format!("{KEY_PREFIX_ROOT}:{META_KEY_UNRESPONSIVE}")},
-            |row| row.get::<_, usize>(0),
-        )
-        .unwrap()
-    })
+async fn count_rows_in_peer_meta_store(db: &holochain_data::DbWrite<PeerMetaStore>) -> usize {
+    let key = format!("{KEY_PREFIX_ROOT}:{META_KEY_UNRESPONSIVE}");
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM peer_meta WHERE meta_key = ?")
+        .bind(&key)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    count as usize
 }

--- a/crates/holochain_p2p/tests/tests/unresponsive_url_pruning.rs
+++ b/crates/holochain_p2p/tests/tests/unresponsive_url_pruning.rs
@@ -310,7 +310,7 @@ struct TestCase {
     space_id: SpaceId,
     lair_client: MetaLairClient,
     peer_meta_store: DynPeerMetaStore,
-    db_peer_meta: holochain_data::DbWrite<PeerMetaStore>,
+    db_peer_meta: holochain_state::peer_metadata_store::PeerMetaStore,
     _dir: tempfile::TempDir,
 }
 
@@ -325,13 +325,15 @@ impl TestCase {
         let dir = test_db_dir();
         let db_dir = dir.path().join("tmp_database");
         std::fs::create_dir(&db_dir).unwrap();
-        let db_peer_meta = holochain_data::open_db(
-            &db_dir,
-            PeerMetaStore::new(Arc::new(dna_hash.clone())),
-            holochain_data::HolochainDataConfig::default(),
-        )
-        .await
-        .unwrap();
+        let db_peer_meta = holochain_state::peer_metadata_store::PeerMetaStore::new(
+            holochain_data::open_db(
+                &db_dir,
+                PeerMetaStore::new(Arc::new(dna_hash.clone())),
+                holochain_data::HolochainDataConfig::default(),
+            )
+            .await
+            .unwrap(),
+        );
         let db_op = DbWrite::test_in_mem(DbKindDht(Arc::new(dna_hash.clone()))).unwrap();
         let db_cache = DbWrite::test_in_mem(DbKindCache(Arc::new(dna_hash.clone()))).unwrap();
         let conductor_store = holochain_state::conductor::ConductorStore::new_test()
@@ -396,11 +398,13 @@ impl TestCase {
     }
 }
 
-async fn count_rows_in_peer_meta_store(db: &holochain_data::DbWrite<PeerMetaStore>) -> usize {
+async fn count_rows_in_peer_meta_store(
+    db: &holochain_state::peer_metadata_store::PeerMetaStore,
+) -> usize {
     let key = format!("{KEY_PREFIX_ROOT}:{META_KEY_UNRESPONSIVE}");
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM peer_meta WHERE meta_key = ?")
         .bind(&key)
-        .fetch_one(db.pool())
+        .fetch_one(db.raw_db_read().pool())
         .await
         .unwrap();
     count as usize

--- a/crates/holochain_p2p/tests/tests/unresponsive_url_pruning.rs
+++ b/crates/holochain_p2p/tests/tests/unresponsive_url_pruning.rs
@@ -19,6 +19,7 @@ async fn urls_are_pruned_at_an_interval() {
     let TestCase {
         peer_meta_store,
         db_peer_meta,
+        _dir,
         ..
     } = TestCase::spawn().await;
 
@@ -73,6 +74,7 @@ async fn urls_are_pruned_when_updated_agent_info_available() {
         lair_client,
         peer_meta_store,
         db_peer_meta,
+        _dir,
     } = TestCase::spawn().await;
 
     let earliest_timestamp = Timestamp::from_micros(Timestamp::now().as_micros() - 10_000_000); // 10s ago
@@ -219,6 +221,7 @@ struct TestCase {
     lair_client: MetaLairClient,
     peer_meta_store: DynPeerMetaStore,
     db_peer_meta: holochain_data::DbWrite<PeerMetaStore>,
+    _dir: tempfile::TempDir,
 }
 
 impl TestCase {
@@ -298,6 +301,7 @@ impl TestCase {
             lair_client,
             peer_meta_store,
             db_peer_meta,
+            _dir: dir,
         }
     }
 }

--- a/crates/holochain_state/src/lib.rs
+++ b/crates/holochain_state/src/lib.rs
@@ -33,6 +33,7 @@ pub mod entry_def;
 pub mod host_fn_workspace;
 pub mod integrate;
 pub mod mutations;
+pub mod peer_metadata_store;
 #[allow(missing_docs)]
 pub mod prelude;
 pub mod query;

--- a/crates/holochain_state/src/peer_metadata_store.rs
+++ b/crates/holochain_state/src/peer_metadata_store.rs
@@ -1,0 +1,192 @@
+//! Module to wrap the Peer Metadata Store database from the [`holochain_data`] crate.
+
+use crate::prelude::StateMutationError;
+use crate::prelude::StateMutationResult;
+use crate::prelude::StateQueryResult;
+use crate::query::StateQueryError;
+
+pub use holochain_data::peer_meta_store::PeerMetaEntry;
+
+/// A type to hold the Peer Metadata Store database from [`holochain_data`].
+#[derive(Debug, Clone)]
+pub struct PeerMetaStore<Db = holochain_data::DbWrite<holochain_data::kind::PeerMetaStore>> {
+    db: Db,
+}
+
+/// A read-only view of the Peer Metadata Store.
+pub type PeerMetaStoreRead =
+    PeerMetaStore<holochain_data::DbRead<holochain_data::kind::PeerMetaStore>>;
+
+impl<Db> PeerMetaStore<Db> {
+    /// Create a new [`PeerMetaStore`] from a database handle.
+    pub fn new(db: Db) -> Self {
+        Self { db }
+    }
+}
+
+impl PeerMetaStore<holochain_data::DbRead<holochain_data::kind::PeerMetaStore>> {
+    /// Get the value for a specific peer URL and key, if it exists and has not expired.
+    pub async fn get(&self, peer_url: &str, meta_key: &str) -> StateQueryResult<Option<Vec<u8>>> {
+        self.db
+            .get(peer_url, meta_key)
+            .await
+            .map_err(StateQueryError::from)
+    }
+
+    /// Get all non-expired peer URLs and values for a given metadata key.
+    pub async fn get_all_by_key(&self, meta_key: &str) -> StateQueryResult<Vec<(String, Vec<u8>)>> {
+        self.db
+            .get_all_by_key(meta_key)
+            .await
+            .map_err(StateQueryError::from)
+    }
+
+    /// Get all non-expired metadata entries for a given peer URL.
+    pub async fn get_all_by_url(&self, peer_url: &str) -> StateQueryResult<Vec<PeerMetaEntry>> {
+        self.db
+            .get_all_by_url(peer_url)
+            .await
+            .map_err(StateQueryError::from)
+    }
+}
+
+impl PeerMetaStore<holochain_data::DbWrite<holochain_data::kind::PeerMetaStore>> {
+    /// Downgrade this writable store to a read-only store.
+    pub fn as_read(&self) -> PeerMetaStoreRead {
+        PeerMetaStoreRead::new(self.db.as_ref().clone())
+    }
+
+    /// Convert this writable store into a read-only store.
+    pub fn into_read(self) -> PeerMetaStoreRead {
+        PeerMetaStoreRead::new(self.db.into())
+    }
+
+    /// Insert or replace a peer metadata entry.
+    ///
+    /// `expires_at` is seconds since the Unix epoch.
+    pub async fn put(
+        &self,
+        peer_url: &str,
+        meta_key: &str,
+        meta_value: &[u8],
+        expires_at_secs: Option<i64>,
+    ) -> StateMutationResult<()> {
+        self.db
+            .put(peer_url, meta_key, meta_value, expires_at_secs)
+            .await
+            .map_err(StateMutationError::from)
+    }
+
+    /// Delete a specific peer metadata entry.
+    pub async fn delete(&self, peer_url: &str, meta_key: &str) -> StateMutationResult<()> {
+        self.db
+            .delete(peer_url, meta_key)
+            .await
+            .map_err(StateMutationError::from)
+    }
+
+    /// Delete all expired entries. Returns the number of rows removed.
+    pub async fn prune(&self) -> StateMutationResult<u64> {
+        self.db.prune().await.map_err(StateMutationError::from)
+    }
+}
+
+impl From<PeerMetaStore<holochain_data::DbWrite<holochain_data::kind::PeerMetaStore>>>
+    for PeerMetaStoreRead
+{
+    fn from(
+        store: PeerMetaStore<holochain_data::DbWrite<holochain_data::kind::PeerMetaStore>>,
+    ) -> Self {
+        store.into_read()
+    }
+}
+
+#[cfg(feature = "test_utils")]
+impl<Db> PeerMetaStore<Db>
+where
+    Db: AsRef<holochain_data::DbRead<holochain_data::kind::PeerMetaStore>>,
+{
+    /// Get a reference to the raw database handle for testing purposes.
+    pub fn raw_db_read(&self) -> &holochain_data::DbRead<holochain_data::kind::PeerMetaStore> {
+        self.db.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use holo_hash::DnaHash;
+
+    use super::*;
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn peer_meta_store_round_trip() -> StateQueryResult<()> {
+        holochain_trace::test_run();
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let db = holochain_data::open_db(
+            tempdir.path(),
+            holochain_data::kind::PeerMetaStore::new(Arc::new(DnaHash::from_raw_36(vec![0u8; 36]))),
+            holochain_data::HolochainDataConfig {
+                key: None,
+                sync_level: holochain_data::DbSyncLevel::Off,
+                max_readers: 8,
+            },
+        )
+        .await
+        .map_err(StateQueryError::from)?;
+
+        let store = PeerMetaStore::new(db);
+        store
+            .put("wss://peer.example", "foo", b"123", None)
+            .await
+            .unwrap();
+        let read = store
+            .as_read()
+            .get("wss://peer.example", "foo")
+            .await?
+            .unwrap();
+        assert_eq!(read, b"123");
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn peer_meta_store_downgrade() -> StateQueryResult<()> {
+        holochain_trace::test_run();
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let db = holochain_data::open_db(
+            tempdir.path(),
+            holochain_data::kind::PeerMetaStore::new(Arc::new(DnaHash::from_raw_36(vec![0u8; 36]))),
+            holochain_data::HolochainDataConfig {
+                key: None,
+                sync_level: holochain_data::DbSyncLevel::Off,
+                max_readers: 8,
+            },
+        )
+        .await
+        .map_err(StateQueryError::from)?;
+
+        let store = PeerMetaStore::new(db);
+
+        // Write with the writable store
+        store
+            .put("wss://peer.example", "foo", b"123", None)
+            .await
+            .unwrap();
+
+        // Downgrade to read-only store using as_read()
+        let read_store = store.as_read();
+        let read = read_store.get("wss://peer.example", "foo").await?.unwrap();
+        assert_eq!(read, b"123");
+
+        // Test into_read() conversion
+        let read_store2: PeerMetaStoreRead = store.into();
+        let read2 = read_store2.get("wss://peer.example", "foo").await?.unwrap();
+        assert_eq!(read2, b"123");
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Summary

The issue #5733 does state to only change `holochain_p2p` but some changes to `holochain` are also required. I assume this is expected and matches the previous PR for the condutor DB.

Closes #5733

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs