### PR TITLE
fix: Don't set when integrated early

### DIFF
--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -661,6 +661,27 @@ async fn bob_makes_a_large_link(
         )
         .await;
 
+    // The next step calls `update_entry`, which uses the cascade to look up the original
+    // action's `StoreRecord` op. The cascade query requires `when_integrated IS NOT NULL`, but
+    // this test bypasses the normal author-flush-then-integrate flow, so manually mark Bob's
+    // just-flushed ops as integrated in his authored DB so the cascade can find them. This
+    // matches the invariant the test was written against and keeps publish/integrate as a
+    // single batch at the end.
+    let bob_authored_db = handle
+        .spaces
+        .get_or_create_authored_db(dna_file.dna_hash(), bob_cell_id.agent_pubkey().clone())
+        .unwrap();
+    bob_authored_db
+        .write_async(|txn| -> DatabaseResult<()> {
+            txn.execute(
+                "UPDATE DhtOp SET when_integrated = :now WHERE when_integrated IS NULL",
+                named_params! { ":now": Timestamp::now() },
+            )?;
+            Ok(())
+        })
+        .await
+        .unwrap();
+
     // 9
     // Commit a bad update entry
     let bad_update_action = call_data

--- a/crates/holochain_state/src/integrate.rs
+++ b/crates/holochain_state/src/integrate.rs
@@ -16,18 +16,25 @@ pub async fn authored_ops_to_dht_db(
     hashes: Vec<(DhtOpHash, AnyLinkableHash)>,
     authored_db: DbRead<DbKindAuthored>,
     dht_db: DbWrite<DbKindDht>,
-) -> StateMutationResult<()> {
+) -> StateMutationResult<Vec<DhtOpHash>> {
     // Check if any agents in this space are an authority for these hashes.
     let mut should_hold_hashes = Vec::new();
+    // For hashes of ops that won't go to the DHT, we should publish those ops by directly setting
+    // them to integrated.
+    let mut should_publish_hashes = Vec::new();
 
     for (op_hash, basis) in hashes {
         if storage_arcs.iter().any(|arc| arc.contains(basis.get_loc())) {
             should_hold_hashes.push(op_hash);
+        } else {
+            should_publish_hashes.push(op_hash);
         }
     }
 
     // Clone the ops into the dht db for the hashes that should be held.
-    authored_ops_to_dht_db_without_check(should_hold_hashes, authored_db, dht_db).await
+    authored_ops_to_dht_db_without_check(should_hold_hashes, authored_db, dht_db).await?;
+
+    Ok(should_publish_hashes)
 }
 
 /// Insert any authored ops that have been locally validated

--- a/crates/holochain_state/src/mutations.rs
+++ b/crates/holochain_state/src/mutations.rs
@@ -270,7 +270,6 @@ pub fn insert_op_lite_into_authored(
     set_validation_status(txn, hash, ValidationStatus::Valid)?;
     set_when_sys_validated(txn, hash, Timestamp::now())?;
     set_when_app_validated(txn, hash, Timestamp::now())?;
-    set_when_integrated(txn, hash, Timestamp::now())?;
     Ok(())
 }
 

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -438,13 +438,24 @@ impl SourceChain {
             Ok((actions, permit)) => {
                 drop(permit);
 
-                authored_ops_to_dht_db(
+                let not_copied_hashes = authored_ops_to_dht_db(
                     storage_arcs,
                     ops_to_integrate,
                     self.vault.clone().into(),
                     self.dht_db.clone(),
                 )
                 .await?;
+
+                // Any ops that didn't get copied to the DHT are outside our local storage arcs.
+                // Therefore, integration won't run and set these ops to integrated. Do it directly.
+                self.vault.write_async(|txn| -> StateMutationResult<()> {
+                    let now = Timestamp::now();
+                    for publish_hash in not_copied_hashes {
+                        set_when_integrated(txn, &publish_hash, now)?;
+                    }
+
+                    Ok(())
+                }).await?;
 
                 // Insert warrants into DHT database.
                 // Check signatures first

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -448,14 +448,16 @@ impl SourceChain {
 
                 // Any ops that didn't get copied to the DHT are outside our local storage arcs.
                 // Therefore, integration won't run and set these ops to integrated. Do it directly.
-                self.vault.write_async(|txn| -> StateMutationResult<()> {
-                    let now = Timestamp::now();
-                    for publish_hash in not_copied_hashes {
-                        set_when_integrated(txn, &publish_hash, now)?;
-                    }
+                self.vault
+                    .write_async(|txn| -> StateMutationResult<()> {
+                        let now = Timestamp::now();
+                        for publish_hash in not_copied_hashes {
+                            set_when_integrated(txn, &publish_hash, now)?;
+                        }
 
-                    Ok(())
-                }).await?;
+                        Ok(())
+                    })
+                    .await?;
 
                 // Insert warrants into DHT database.
                 // Check signatures first


### PR DESCRIPTION
### Summary

We had put in a fix to copy authored content to the DHT and let it be integrated, then when updating the DHT also update the authored `when_integrated` flag. That would only work for content within your arc, otherwise you need to set the `when_integrated` as the content is created in the authored database. We were ending up publishing with reflection of ops before integration and creating a state that Holochain couldn't recover from with an unexpected mixture of validation/integration flags set.

This fix stops setting the `when_integrated` flag up front and any ops that aren't going to the DHT will immediately get it set in the authored database where the integration workflow would miss. All of this becomes much simpler with the new data model and not having state duplicated+split across multiple databases.

I propose getting this fix in now and backporting it but not trying to figure out how to test it. With the new data model, we can write tests against the database queries directly to ensure that the workflows can't get this stuff wrong like it can when everything is spread out.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs