### PR TITLE
Abstract the type conversion stuff out of the Wasm database table modules

### DIFF
--- a/crates/holochain_data/src/wasm.rs
+++ b/crates/holochain_data/src/wasm.rs
@@ -5,6 +5,7 @@
 mod inner_reads;
 mod inner_writes;
 mod reads;
+mod writes;
 
 pub mod db_operations;
 pub mod tx_operations;

--- a/crates/holochain_data/src/wasm.rs
+++ b/crates/holochain_data/src/wasm.rs
@@ -4,6 +4,7 @@
 
 mod inner_reads;
 mod inner_writes;
+mod reads;
 
 pub mod db_operations;
 pub mod tx_operations;

--- a/crates/holochain_data/src/wasm/db_operations.rs
+++ b/crates/holochain_data/src/wasm/db_operations.rs
@@ -8,47 +8,47 @@ use holochain_types::prelude::{CellId, DnaDef, DnaWasmHashed, EntryDef};
 use crate::handles::{DbRead, DbWrite};
 use crate::kind::Wasm;
 
-use super::{inner_reads, inner_writes};
+use super::{inner_writes, reads};
 
 impl DbRead<Wasm> {
     /// Check if WASM bytecode exists in the database.
     pub async fn wasm_exists(&self, hash: &WasmHash) -> sqlx::Result<bool> {
-        inner_reads::wasm_exists(self.pool(), hash).await
+        reads::wasm_exists(self.pool(), hash).await
     }
 
     /// Get WASM bytecode by hash.
     pub async fn get_wasm(&self, hash: &WasmHash) -> sqlx::Result<Option<DnaWasmHashed>> {
-        inner_reads::get_wasm(self.pool(), hash).await
+        reads::get_wasm(self.pool(), hash).await
     }
 
     /// Check if a DNA definition exists in the database.
     pub async fn dna_def_exists(&self, cell_id: &CellId) -> sqlx::Result<bool> {
-        inner_reads::dna_def_exists(self.pool(), cell_id).await
+        reads::dna_def_exists(self.pool(), cell_id).await
     }
 
     /// Get a DNA definition for the passed [`CellId`].
     pub async fn get_dna_def(&self, cell_id: &CellId) -> sqlx::Result<Option<DnaDef>> {
-        inner_reads::get_dna_def(self.pool(), cell_id).await
+        reads::get_dna_def(self.pool(), cell_id).await
     }
 
     /// Check if an entry definition exists in the database.
     pub async fn entry_def_exists(&self, key: &[u8]) -> sqlx::Result<bool> {
-        inner_reads::entry_def_exists(self.pool(), key).await
+        reads::entry_def_exists(self.pool(), key).await
     }
 
     /// Get an entry definition by key.
     pub async fn get_entry_def(&self, key: &[u8]) -> sqlx::Result<Option<EntryDef>> {
-        inner_reads::get_entry_def(self.pool(), key).await
+        reads::get_entry_def(self.pool(), key).await
     }
 
     /// Get all entry definitions.
     pub async fn get_all_entry_defs(&self) -> sqlx::Result<Vec<(Vec<u8>, EntryDef)>> {
-        inner_reads::get_all_entry_defs(self.pool()).await
+        reads::get_all_entry_defs(self.pool()).await
     }
 
     /// Get all DNA definitions with their associated cell IDs.
     pub async fn get_all_dna_defs(&self) -> sqlx::Result<Vec<(CellId, DnaDef)>> {
-        inner_reads::get_all_dna_defs(self.pool()).await
+        reads::get_all_dna_defs(self.pool()).await
     }
 }
 

--- a/crates/holochain_data/src/wasm/db_operations.rs
+++ b/crates/holochain_data/src/wasm/db_operations.rs
@@ -8,7 +8,7 @@ use holochain_types::prelude::{CellId, DnaDef, DnaWasmHashed, EntryDef};
 use crate::handles::{DbRead, DbWrite};
 use crate::kind::Wasm;
 
-use super::{inner_writes, reads};
+use super::{reads, writes};
 
 impl DbRead<Wasm> {
     /// Check if WASM bytecode exists in the database.
@@ -55,19 +55,19 @@ impl DbRead<Wasm> {
 impl DbWrite<Wasm> {
     /// Store WASM bytecode.
     pub async fn put_wasm(&self, wasm: DnaWasmHashed) -> sqlx::Result<()> {
-        inner_writes::put_wasm(self.pool(), wasm).await
+        writes::put_wasm(self.pool(), wasm).await
     }
 
     /// Store a DNA definition and its associated zomes.
     ///
     /// This operation is transactional - either all data is stored or none is.
     pub async fn put_dna_def(&self, agent: &AgentPubKey, dna_def: &DnaDef) -> sqlx::Result<()> {
-        inner_writes::put_dna_def(self.pool(), agent, dna_def).await
+        writes::put_dna_def(self.pool(), agent, dna_def).await
     }
 
     /// Store an entry definition.
     pub async fn put_entry_def(&self, key: Vec<u8>, entry_def: &EntryDef) -> sqlx::Result<()> {
-        inner_writes::put_entry_def(self.pool(), key, entry_def).await
+        writes::put_entry_def(self.pool(), key, entry_def).await
     }
 }
 

--- a/crates/holochain_data/src/wasm/inner_reads.rs
+++ b/crates/holochain_data/src/wasm/inner_reads.rs
@@ -1,123 +1,99 @@
-use holo_hash::WasmHash;
-use holochain_types::prelude::{CellId, DnaDef, DnaWasmHashed, EntryDef};
-use sqlx::{Acquire, Executor, Sqlite};
+use sqlx::{Executor, Sqlite};
 
 use crate::models::wasm::{
     CoordinatorZomeModel, DnaDefModel, EntryDefModel, IntegrityZomeModel, WasmModel,
 };
 
-fn new_decode_error(e: String) -> sqlx::Error {
-    sqlx::Error::Decode(Box::new(std::io::Error::new(
-        std::io::ErrorKind::InvalidData,
-        e,
-    )))
-}
-
 /// Check if WASM bytecode exists in the database.
-pub(super) async fn wasm_exists<'e, E>(executor: E, hash: &WasmHash) -> sqlx::Result<bool>
+pub(super) async fn wasm_exists<'e, E>(executor: E, hash: &[u8]) -> sqlx::Result<bool>
 where
     E: Executor<'e, Database = Sqlite>,
 {
-    let hash_bytes = hash.get_raw_32();
-    let exists: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM Wasm WHERE hash = ?)")
-        .bind(hash_bytes)
+    sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM Wasm WHERE hash = ?)")
+        .bind(hash)
         .fetch_one(executor)
-        .await?;
-    Ok(exists)
+        .await
 }
 
 /// Get WASM bytecode by hash.
-pub(super) async fn get_wasm<'e, E>(
-    executor: E,
-    hash: &WasmHash,
-) -> sqlx::Result<Option<DnaWasmHashed>>
+pub(super) async fn get_wasm<'e, E>(executor: E, hash: &[u8]) -> sqlx::Result<Option<WasmModel>>
 where
     E: Executor<'e, Database = Sqlite>,
 {
-    let hash_bytes = hash.get_raw_32();
-    let model: Option<WasmModel> = sqlx::query_as("SELECT hash, code FROM Wasm WHERE hash = ?")
-        .bind(hash_bytes)
+    sqlx::query_as("SELECT hash, code FROM Wasm WHERE hash = ?")
+        .bind(hash)
         .fetch_optional(executor)
-        .await?;
-
-    match model {
-        Some(model) => {
-            let wasm_hash = model.wasm_hash();
-            Ok(Some(DnaWasmHashed::with_pre_hashed(
-                model.code.into(),
-                wasm_hash,
-            )))
-        }
-        None => Ok(None),
-    }
+        .await
 }
 
 /// Check if a DNA definition exists in the database.
-pub(super) async fn dna_def_exists<'e, E>(executor: E, cell_id: &CellId) -> sqlx::Result<bool>
+pub(super) async fn dna_def_exists<'e, E>(
+    executor: E,
+    dna_hash: &[u8],
+    agent: &[u8],
+) -> sqlx::Result<bool>
 where
     E: Executor<'e, Database = Sqlite>,
 {
-    let hash_bytes = cell_id.dna_hash().get_raw_32();
-    let agent_bytes = cell_id.agent_pubkey().get_raw_32();
-
-    let exists: bool =
-        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM DnaDef WHERE hash = ? AND agent = ?)")
-            .bind(hash_bytes)
-            .bind(agent_bytes)
-            .fetch_one(executor)
-            .await?;
-    Ok(exists)
+    sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM DnaDef WHERE hash = ? AND agent = ?)")
+        .bind(dna_hash)
+        .bind(agent)
+        .fetch_one(executor)
+        .await
 }
 
-/// Get a DNA definition by hash.
-///
-/// Acquires a single connection for the DnaDef + IntegrityZome + CoordinatorZome queries.
-pub(super) async fn get_dna_def<'c, A>(conn: A, cell_id: &CellId) -> sqlx::Result<Option<DnaDef>>
+/// Get a single DNA definition row by hash and agent.
+pub(super) async fn get_dna_def<'e, E>(
+    executor: E,
+    dna_hash: &[u8],
+    agent: &[u8],
+) -> sqlx::Result<Option<DnaDefModel>>
 where
-    A: Acquire<'c, Database = Sqlite>,
+    E: Executor<'e, Database = Sqlite>,
 {
-    let mut conn = conn.acquire().await?;
-
-    let hash_bytes = cell_id.dna_hash().get_raw_32();
-    let agent_bytes = cell_id.agent_pubkey().get_raw_32();
-
-    // Fetch the DnaDef model
-    let dna_model: Option<DnaDefModel> = sqlx::query_as(
+    sqlx::query_as(
         "SELECT hash, agent, name, network_seed, properties, lineage FROM DnaDef WHERE hash = ? AND agent = ?",
     )
-    .bind(hash_bytes)
-    .bind(agent_bytes)
-    .fetch_optional(&mut *conn)
-    .await?;
+    .bind(dna_hash)
+    .bind(agent)
+    .fetch_optional(executor)
+    .await
+}
 
-    let dna_model = match dna_model {
-        Some(m) => m,
-        None => return Ok(None),
-    };
-
-    // Fetch integrity zomes
-    let integrity_zomes: Vec<IntegrityZomeModel> = sqlx::query_as(
+/// Get all integrity zome rows for a given DNA hash and agent.
+pub(super) async fn get_integrity_zomes<'e, E>(
+    executor: E,
+    dna_hash: &[u8],
+    agent: &[u8],
+) -> sqlx::Result<Vec<IntegrityZomeModel>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    sqlx::query_as(
         "SELECT dna_hash, agent, zome_index, zome_name, wasm_hash, dependencies FROM IntegrityZome WHERE dna_hash = ? AND agent = ? ORDER BY zome_index",
     )
-    .bind(hash_bytes)
-    .bind(agent_bytes)
-    .fetch_all(&mut *conn)
-    .await?;
+    .bind(dna_hash)
+    .bind(agent)
+    .fetch_all(executor)
+    .await
+}
 
-    // Fetch coordinator zomes
-    let coordinator_zomes: Vec<CoordinatorZomeModel> = sqlx::query_as(
+/// Get all coordinator zome rows for a given DNA hash and agent.
+pub(super) async fn get_coordinator_zomes<'e, E>(
+    executor: E,
+    dna_hash: &[u8],
+    agent: &[u8],
+) -> sqlx::Result<Vec<CoordinatorZomeModel>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    sqlx::query_as(
         "SELECT dna_hash, agent, zome_index, zome_name, wasm_hash, dependencies FROM CoordinatorZome WHERE dna_hash = ? AND agent = ? ORDER BY zome_index",
     )
-    .bind(hash_bytes)
-    .bind(agent_bytes)
-    .fetch_all(&mut *conn)
-    .await?;
-
-    // Convert to DnaDef
-    dna_model
-        .to_dna_def(integrity_zomes, coordinator_zomes)
-        .map(Some)
-        .map_err(new_decode_error)
+    .bind(dna_hash)
+    .bind(agent)
+    .fetch_all(executor)
+    .await
 }
 
 /// Check if an entry definition exists in the database.
@@ -125,103 +101,46 @@ pub(super) async fn entry_def_exists<'e, E>(executor: E, key: &[u8]) -> sqlx::Re
 where
     E: Executor<'e, Database = Sqlite>,
 {
-    let exists: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM EntryDef WHERE key = ?)")
+    sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM EntryDef WHERE key = ?)")
         .bind(key)
         .fetch_one(executor)
-        .await?;
-    Ok(exists)
+        .await
 }
 
-/// Get an entry definition by key.
-pub(super) async fn get_entry_def<'e, E>(executor: E, key: &[u8]) -> sqlx::Result<Option<EntryDef>>
+/// Get a single entry definition row by key.
+pub(super) async fn get_entry_def<'e, E>(
+    executor: E,
+    key: &[u8],
+) -> sqlx::Result<Option<EntryDefModel>>
 where
     E: Executor<'e, Database = Sqlite>,
 {
-    let model: Option<EntryDefModel> = sqlx::query_as(
+    sqlx::query_as(
         "SELECT key, entry_def_id, entry_def_id_type, visibility, required_validations FROM EntryDef WHERE key = ?",
     )
     .bind(key)
     .fetch_optional(executor)
-    .await?;
-
-    match model {
-        Some(model) => model.to_entry_def().map(Some).map_err(new_decode_error),
-        None => Ok(None),
-    }
+    .await
 }
 
-/// Get all entry definitions.
-pub(super) async fn get_all_entry_defs<'e, E>(executor: E) -> sqlx::Result<Vec<(Vec<u8>, EntryDef)>>
+/// Get all entry definition rows.
+pub(super) async fn get_all_entry_defs<'e, E>(executor: E) -> sqlx::Result<Vec<EntryDefModel>>
 where
     E: Executor<'e, Database = Sqlite>,
 {
-    let models: Vec<EntryDefModel> = sqlx::query_as(
+    sqlx::query_as(
         "SELECT key, entry_def_id, entry_def_id_type, visibility, required_validations FROM EntryDef",
     )
     .fetch_all(executor)
-    .await?;
-
-    models
-        .into_iter()
-        .map(|model| {
-            let key = model.key.clone();
-            model
-                .to_entry_def()
-                .map(|entry_def| (key, entry_def))
-                .map_err(new_decode_error)
-        })
-        .collect()
+    .await
 }
 
-/// Get all DNA definitions with their associated cell IDs.
-///
-/// Acquires a single connection for the outer scan and per-row zome queries.
-pub(super) async fn get_all_dna_defs<'c, A>(conn: A) -> sqlx::Result<Vec<(CellId, DnaDef)>>
+/// Get all DNA definition rows (without zomes).
+pub(super) async fn get_all_dna_defs<'e, E>(executor: E) -> sqlx::Result<Vec<DnaDefModel>>
 where
-    A: Acquire<'c, Database = Sqlite>,
+    E: Executor<'e, Database = Sqlite>,
 {
-    let mut conn = conn.acquire().await?;
-
-    // First, fetch all DnaDef records
-    let dna_models: Vec<DnaDefModel> =
-        sqlx::query_as("SELECT hash, agent, name, network_seed, properties, lineage FROM DnaDef")
-            .fetch_all(&mut *conn)
-            .await?;
-
-    let mut results = Vec::new();
-
-    for dna_model in dna_models {
-        let hash_bytes = dna_model.hash.clone();
-        let agent_bytes = dna_model.agent.clone();
-
-        // Fetch integrity zomes for this DNA
-        let integrity_zomes: Vec<IntegrityZomeModel> = sqlx::query_as(
-            "SELECT dna_hash, agent, zome_index, zome_name, wasm_hash, dependencies FROM IntegrityZome WHERE dna_hash = ? AND agent = ? ORDER BY zome_index",
-        )
-        .bind(&hash_bytes)
-        .bind(&agent_bytes)
-        .fetch_all(&mut *conn)
-        .await?;
-
-        // Fetch coordinator zomes for this DNA
-        let coordinator_zomes: Vec<CoordinatorZomeModel> = sqlx::query_as(
-            "SELECT dna_hash, agent, zome_index, zome_name, wasm_hash, dependencies FROM CoordinatorZome WHERE dna_hash = ? AND agent = ? ORDER BY zome_index",
-        )
-        .bind(&hash_bytes)
-        .bind(&agent_bytes)
-        .fetch_all(&mut *conn)
-        .await?;
-
-        // Convert to DnaDef
-        let dna_def = dna_model
-            .to_dna_def(integrity_zomes, coordinator_zomes)
-            .map_err(new_decode_error)?;
-
-        // Create CellId from the hash and agent
-        let cell_id = dna_model.to_cell_id();
-
-        results.push((cell_id, dna_def));
-    }
-
-    Ok(results)
+    sqlx::query_as("SELECT hash, agent, name, network_seed, properties, lineage FROM DnaDef")
+        .fetch_all(executor)
+        .await
 }

--- a/crates/holochain_data/src/wasm/inner_reads.rs
+++ b/crates/holochain_data/src/wasm/inner_reads.rs
@@ -6,6 +6,13 @@ use crate::models::wasm::{
     CoordinatorZomeModel, DnaDefModel, EntryDefModel, IntegrityZomeModel, WasmModel,
 };
 
+fn new_decode_error(e: String) -> sqlx::Error {
+    sqlx::Error::Decode(Box::new(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        e,
+    )))
+}
+
 /// Check if WASM bytecode exists in the database.
 pub(super) async fn wasm_exists<'e, E>(executor: E, hash: &WasmHash) -> sqlx::Result<bool>
 where
@@ -110,12 +117,7 @@ where
     dna_model
         .to_dna_def(integrity_zomes, coordinator_zomes)
         .map(Some)
-        .map_err(|e| {
-            sqlx::Error::Decode(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                e,
-            )))
-        })
+        .map_err(new_decode_error)
 }
 
 /// Check if an entry definition exists in the database.
@@ -143,12 +145,7 @@ where
     .await?;
 
     match model {
-        Some(model) => model.to_entry_def().map(Some).map_err(|e| {
-            sqlx::Error::Decode(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                e,
-            )))
-        }),
+        Some(model) => model.to_entry_def().map(Some).map_err(new_decode_error),
         None => Ok(None),
     }
 }
@@ -171,12 +168,7 @@ where
             model
                 .to_entry_def()
                 .map(|entry_def| (key, entry_def))
-                .map_err(|e| {
-                    sqlx::Error::Decode(Box::new(std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        e,
-                    )))
-                })
+                .map_err(new_decode_error)
         })
         .collect()
 }
@@ -223,12 +215,7 @@ where
         // Convert to DnaDef
         let dna_def = dna_model
             .to_dna_def(integrity_zomes, coordinator_zomes)
-            .map_err(|e| {
-                sqlx::Error::Decode(Box::new(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    e,
-                )))
-            })?;
+            .map_err(new_decode_error)?;
 
         // Create CellId from the hash and agent
         let cell_id = dna_model.to_cell_id();

--- a/crates/holochain_data/src/wasm/inner_writes.rs
+++ b/crates/holochain_data/src/wasm/inner_writes.rs
@@ -4,6 +4,13 @@ use sqlx::{Acquire, Executor, Sqlite};
 
 use crate::models::wasm::EntryDefModel;
 
+fn new_encode_error(e: holochain_types::prelude::ZomeError) -> sqlx::Error {
+    sqlx::Error::Encode(Box::new(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        e.to_string(),
+    )))
+}
+
 /// Store WASM bytecode.
 pub(super) async fn put_wasm<'e, E>(executor: E, wasm: DnaWasmHashed) -> sqlx::Result<()>
 where
@@ -81,12 +88,7 @@ where
 
     // Insert integrity zomes
     for (zome_index, (zome_name, zome_def)) in dna_def.integrity_zomes.iter().enumerate() {
-        let wasm_hash = zome_def.wasm_hash(zome_name).map_err(|e| {
-            sqlx::Error::Encode(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                e.to_string(),
-            )))
-        })?;
+        let wasm_hash = zome_def.wasm_hash(zome_name).map_err(new_encode_error)?;
         let wasm_hash_bytes = wasm_hash.get_raw_32();
 
         // Extract dependencies from the ZomeDef
@@ -116,12 +118,7 @@ where
 
     // Insert coordinator zomes
     for (zome_index, (zome_name, zome_def)) in dna_def.coordinator_zomes.iter().enumerate() {
-        let wasm_hash = zome_def.wasm_hash(zome_name).map_err(|e| {
-            sqlx::Error::Encode(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                e.to_string(),
-            )))
-        })?;
+        let wasm_hash = zome_def.wasm_hash(zome_name).map_err(new_encode_error)?;
         let wasm_hash_bytes = wasm_hash.get_raw_32();
 
         // Extract dependencies from the ZomeDef

--- a/crates/holochain_data/src/wasm/inner_writes.rs
+++ b/crates/holochain_data/src/wasm/inner_writes.rs
@@ -1,27 +1,14 @@
-use holo_hash::{AgentPubKey, HashableContentExtSync};
-use holochain_types::prelude::{DnaDef, DnaWasmHashed, EntryDef, WasmZome, ZomeDef};
-use sqlx::{Acquire, Executor, Sqlite};
+use sqlx::{Executor, Sqlite};
 
-use crate::models::wasm::EntryDefModel;
-
-fn new_encode_error(e: holochain_types::prelude::ZomeError) -> sqlx::Error {
-    sqlx::Error::Encode(Box::new(std::io::Error::new(
-        std::io::ErrorKind::InvalidData,
-        e.to_string(),
-    )))
-}
+use crate::models::wasm::{CoordinatorZomeModel, DnaDefModel, EntryDefModel, IntegrityZomeModel};
 
 /// Store WASM bytecode.
-pub(super) async fn put_wasm<'e, E>(executor: E, wasm: DnaWasmHashed) -> sqlx::Result<()>
+pub(super) async fn put_wasm<'e, E>(executor: E, hash: &[u8], code: &[u8]) -> sqlx::Result<()>
 where
     E: Executor<'e, Database = Sqlite>,
 {
-    let (wasm, hash) = wasm.into_inner();
-    let hash_bytes = hash.get_raw_32();
-    let code = wasm.code.to_vec();
-
     sqlx::query("INSERT OR REPLACE INTO Wasm (hash, code) VALUES (?, ?)")
-        .bind(hash_bytes)
+        .bind(hash)
         .bind(code)
         .execute(executor)
         .await?;
@@ -29,146 +16,123 @@ where
     Ok(())
 }
 
-/// Store a DNA definition and its associated zomes.
-///
-/// This operation is transactional — either all data is stored or none is.
-/// When called with `&Pool`, a new transaction is started. When called with
-/// `&mut Transaction`, a savepoint is used so the outer transaction remains
-/// in control.
-pub(super) async fn put_dna_def<'c, A>(
-    conn: A,
-    agent: &AgentPubKey,
-    dna_def: &DnaDef,
-) -> sqlx::Result<()>
+/// Insert or replace a single DNA definition row.
+pub(super) async fn insert_dna_def<'e, E>(executor: E, model: &DnaDefModel) -> sqlx::Result<()>
 where
-    A: Acquire<'c, Database = Sqlite>,
+    E: Executor<'e, Database = Sqlite>,
 {
-    let mut tx = conn.begin().await?;
-
-    let hash = dna_def.to_hash();
-    let hash_bytes = hash.get_raw_32();
-    let agent_bytes = agent.get_raw_32();
-    let name = dna_def.name.clone();
-    let network_seed = dna_def.modifiers.network_seed.clone();
-    let properties = dna_def.modifiers.properties.bytes().to_vec();
-
-    // Serialize lineage if present
-    #[cfg(feature = "unstable-migration")]
-    let lineage_json = Some(sqlx::types::Json(&dna_def.lineage));
-    #[cfg(not(feature = "unstable-migration"))]
-    let lineage_json: Option<
-        sqlx::types::Json<&std::collections::HashSet<holochain_types::dna::DnaHash>>,
-    > = None;
-
-    // Insert DnaDef
     sqlx::query(
         "INSERT OR REPLACE INTO DnaDef (hash, agent, name, network_seed, properties, lineage) VALUES (?, ?, ?, ?, ?, ?)",
     )
-        .bind(hash_bytes)
-        .bind(agent_bytes)
-        .bind(name)
-        .bind(network_seed)
-        .bind(properties)
-        .bind(lineage_json)
-        .execute(&mut *tx)
-        .await?;
+    .bind(&model.hash)
+    .bind(&model.agent)
+    .bind(&model.name)
+    .bind(&model.network_seed)
+    .bind(&model.properties)
+    .bind(&model.lineage)
+    .execute(executor)
+    .await?;
 
-    // Delete existing zomes for this DNA to avoid orphans when updating
-    sqlx::query("DELETE FROM IntegrityZome WHERE dna_hash = ? AND agent = ?")
-        .bind(hash_bytes)
-        .bind(agent_bytes)
-        .execute(&mut *tx)
-        .await?;
-
-    sqlx::query("DELETE FROM CoordinatorZome WHERE dna_hash = ? AND agent = ?")
-        .bind(hash_bytes)
-        .bind(agent_bytes)
-        .execute(&mut *tx)
-        .await?;
-
-    // Insert integrity zomes
-    for (zome_index, (zome_name, zome_def)) in dna_def.integrity_zomes.iter().enumerate() {
-        let wasm_hash = zome_def.wasm_hash(zome_name).map_err(new_encode_error)?;
-        let wasm_hash_bytes = wasm_hash.get_raw_32();
-
-        // Extract dependencies from the ZomeDef
-        let dependencies = match zome_def.as_any_zome_def() {
-            ZomeDef::Wasm(WasmZome { dependencies, .. }) => dependencies
-                .iter()
-                .map(|n| n.0.as_ref().to_string())
-                .collect::<Vec<_>>(),
-            ZomeDef::Inline { dependencies, .. } => dependencies
-                .iter()
-                .map(|n| n.0.as_ref().to_string())
-                .collect::<Vec<_>>(),
-        };
-
-        sqlx::query(
-            "INSERT OR REPLACE INTO IntegrityZome (dna_hash, agent, zome_index, zome_name, wasm_hash, dependencies) VALUES (?, ?, ?, ?, ?, ?)",
-        )
-        .bind(hash_bytes)
-        .bind(agent_bytes)
-        .bind(zome_index as i64)
-        .bind(&zome_name.0)
-        .bind(wasm_hash_bytes)
-        .bind(sqlx::types::Json(&dependencies))
-        .execute(&mut *tx)
-        .await?;
-    }
-
-    // Insert coordinator zomes
-    for (zome_index, (zome_name, zome_def)) in dna_def.coordinator_zomes.iter().enumerate() {
-        let wasm_hash = zome_def.wasm_hash(zome_name).map_err(new_encode_error)?;
-        let wasm_hash_bytes = wasm_hash.get_raw_32();
-
-        // Extract dependencies from the ZomeDef
-        let dependencies = match zome_def.as_any_zome_def() {
-            ZomeDef::Wasm(WasmZome { dependencies, .. }) => dependencies
-                .iter()
-                .map(|n| n.0.as_ref().to_string())
-                .collect::<Vec<_>>(),
-            ZomeDef::Inline { dependencies, .. } => dependencies
-                .iter()
-                .map(|n| n.0.as_ref().to_string())
-                .collect::<Vec<_>>(),
-        };
-
-        sqlx::query(
-            "INSERT OR REPLACE INTO CoordinatorZome (dna_hash, agent, zome_index, zome_name, wasm_hash, dependencies) VALUES (?, ?, ?, ?, ?, ?)",
-        )
-        .bind(hash_bytes)
-        .bind(agent_bytes)
-        .bind(zome_index as i64)
-        .bind(&zome_name.0)
-        .bind(wasm_hash_bytes)
-        .bind(sqlx::types::Json(&dependencies))
-        .execute(&mut *tx)
-        .await?;
-    }
-
-    tx.commit().await?;
     Ok(())
 }
 
-/// Store an entry definition.
-pub(super) async fn put_entry_def<'e, E>(
+/// Delete all integrity zome rows for a given DNA hash and agent.
+pub(super) async fn delete_integrity_zomes<'e, E>(
     executor: E,
-    key: Vec<u8>,
-    entry_def: &EntryDef,
+    dna_hash: &[u8],
+    agent: &[u8],
 ) -> sqlx::Result<()>
 where
     E: Executor<'e, Database = Sqlite>,
 {
-    let model = EntryDefModel::from_entry_def(key, entry_def);
+    sqlx::query("DELETE FROM IntegrityZome WHERE dna_hash = ? AND agent = ?")
+        .bind(dna_hash)
+        .bind(agent)
+        .execute(executor)
+        .await?;
+
+    Ok(())
+}
+
+/// Delete all coordinator zome rows for a given DNA hash and agent.
+pub(super) async fn delete_coordinator_zomes<'e, E>(
+    executor: E,
+    dna_hash: &[u8],
+    agent: &[u8],
+) -> sqlx::Result<()>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    sqlx::query("DELETE FROM CoordinatorZome WHERE dna_hash = ? AND agent = ?")
+        .bind(dna_hash)
+        .bind(agent)
+        .execute(executor)
+        .await?;
+
+    Ok(())
+}
+
+/// Insert a single integrity zome row.
+pub(super) async fn insert_integrity_zome<'e, E>(
+    executor: E,
+    model: &IntegrityZomeModel,
+) -> sqlx::Result<()>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    sqlx::query(
+        "INSERT OR REPLACE INTO IntegrityZome (dna_hash, agent, zome_index, zome_name, wasm_hash, dependencies) VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&model.dna_hash)
+    .bind(&model.agent)
+    .bind(model.zome_index)
+    .bind(&model.zome_name)
+    .bind(model.wasm_hash.as_deref())
+    .bind(&model.dependencies)
+    .execute(executor)
+    .await?;
+
+    Ok(())
+}
+
+/// Insert a single coordinator zome row.
+pub(super) async fn insert_coordinator_zome<'e, E>(
+    executor: E,
+    model: &CoordinatorZomeModel,
+) -> sqlx::Result<()>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    sqlx::query(
+        "INSERT OR REPLACE INTO CoordinatorZome (dna_hash, agent, zome_index, zome_name, wasm_hash, dependencies) VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&model.dna_hash)
+    .bind(&model.agent)
+    .bind(model.zome_index)
+    .bind(&model.zome_name)
+    .bind(model.wasm_hash.as_deref())
+    .bind(&model.dependencies)
+    .execute(executor)
+    .await?;
+
+    Ok(())
+}
+
+/// Insert or replace a single entry definition row.
+pub(super) async fn put_entry_def<'e, E>(executor: E, model: &EntryDefModel) -> sqlx::Result<()>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
     sqlx::query(
         "INSERT OR REPLACE INTO EntryDef (key, entry_def_id, entry_def_id_type, visibility, required_validations) VALUES (?, ?, ?, ?, ?)",
     )
-    .bind(model.key)
-    .bind(model.entry_def_id)
-    .bind(model.entry_def_id_type)
-    .bind(model.visibility)
+    .bind(&model.key)
+    .bind(&model.entry_def_id)
+    .bind(&model.entry_def_id_type)
+    .bind(&model.visibility)
     .bind(model.required_validations)
     .execute(executor)
     .await?;
+
     Ok(())
 }

--- a/crates/holochain_data/src/wasm/reads.rs
+++ b/crates/holochain_data/src/wasm/reads.rs
@@ -1,0 +1,141 @@
+use holo_hash::WasmHash;
+use holochain_types::prelude::{CellId, DnaDef, DnaWasmHashed, EntryDef};
+use sqlx::{Acquire, Executor, Sqlite};
+
+use super::inner_reads;
+
+fn new_decode_error(e: String) -> sqlx::Error {
+    sqlx::Error::Decode(Box::new(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        e,
+    )))
+}
+
+/// Check if WASM bytecode exists in the database.
+pub(super) async fn wasm_exists<'e, E>(executor: E, hash: &WasmHash) -> sqlx::Result<bool>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    inner_reads::wasm_exists(executor, hash.get_raw_32()).await
+}
+
+/// Get WASM bytecode by hash.
+pub(super) async fn get_wasm<'e, E>(
+    executor: E,
+    hash: &WasmHash,
+) -> sqlx::Result<Option<DnaWasmHashed>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    inner_reads::get_wasm(executor, hash.get_raw_32())
+        .await?
+        .map(|model| {
+            let wasm_hash = model.wasm_hash();
+            Ok(DnaWasmHashed::with_pre_hashed(model.code.into(), wasm_hash))
+        })
+        .transpose()
+}
+
+/// Check if a DNA definition exists in the database.
+pub(super) async fn dna_def_exists<'e, E>(executor: E, cell_id: &CellId) -> sqlx::Result<bool>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    inner_reads::dna_def_exists(
+        executor,
+        cell_id.dna_hash().get_raw_32(),
+        cell_id.agent_pubkey().get_raw_32(),
+    )
+    .await
+}
+
+/// Get a DNA definition for the passed [`CellId`].
+pub(super) async fn get_dna_def<'c, A>(conn: A, cell_id: &CellId) -> sqlx::Result<Option<DnaDef>>
+where
+    A: Acquire<'c, Database = Sqlite>,
+{
+    let dna_hash = cell_id.dna_hash().get_raw_32();
+    let agent = cell_id.agent_pubkey().get_raw_32();
+
+    // Acquire a connection for the three queries.
+    let mut conn = conn.acquire().await?;
+
+    if let Some(dna_model) = inner_reads::get_dna_def(&mut *conn, dna_hash, agent).await? {
+        let integrity_zomes = inner_reads::get_integrity_zomes(&mut *conn, dna_hash, agent).await?;
+        let coordinator_zomes =
+            inner_reads::get_coordinator_zomes(&mut *conn, dna_hash, agent).await?;
+
+        dna_model
+            .to_dna_def(integrity_zomes, coordinator_zomes)
+            .map(Some)
+            .map_err(new_decode_error)
+    } else {
+        Ok(None)
+    }
+}
+
+/// Check if an entry definition exists in the database.
+pub(super) async fn entry_def_exists<'e, E>(executor: E, key: &[u8]) -> sqlx::Result<bool>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    inner_reads::entry_def_exists(executor, key).await
+}
+
+/// Get an entry definition by key.
+pub(super) async fn get_entry_def<'e, E>(executor: E, key: &[u8]) -> sqlx::Result<Option<EntryDef>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    inner_reads::get_entry_def(executor, key)
+        .await?
+        .map(|model| model.to_entry_def().map_err(new_decode_error))
+        .transpose()
+}
+
+/// Get all entry definitions.
+pub(super) async fn get_all_entry_defs<'e, E>(executor: E) -> sqlx::Result<Vec<(Vec<u8>, EntryDef)>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    inner_reads::get_all_entry_defs(executor)
+        .await?
+        .into_iter()
+        .map(|model| {
+            let key = model.key.clone();
+            model
+                .to_entry_def()
+                .map(|def| (key, def))
+                .map_err(new_decode_error)
+        })
+        .collect()
+}
+
+/// Get all DNA definitions with their associated [`CellId`]s.
+pub(super) async fn get_all_dna_defs<'c, A>(conn: A) -> sqlx::Result<Vec<(CellId, DnaDef)>>
+where
+    A: Acquire<'c, Database = Sqlite>,
+{
+    // Acquires a connection for all the per-row zome queries.
+    let mut conn = conn.acquire().await?;
+
+    let dna_models = inner_reads::get_all_dna_defs(&mut *conn).await?;
+
+    let mut results = Vec::with_capacity(dna_models.len());
+    for dna_model in dna_models {
+        let integrity_zomes =
+            inner_reads::get_integrity_zomes(&mut *conn, &dna_model.hash, &dna_model.agent).await?;
+        let coordinator_zomes =
+            inner_reads::get_coordinator_zomes(&mut *conn, &dna_model.hash, &dna_model.agent)
+                .await?;
+
+        let cell_id = dna_model.to_cell_id();
+        let dna_def = dna_model
+            .to_dna_def(integrity_zomes, coordinator_zomes)
+            .map_err(new_decode_error)?;
+
+        results.push((cell_id, dna_def));
+    }
+
+    Ok(results)
+}

--- a/crates/holochain_data/src/wasm/tx_operations.rs
+++ b/crates/holochain_data/src/wasm/tx_operations.rs
@@ -8,7 +8,7 @@ use holochain_types::prelude::{CellId, DnaDef, DnaWasmHashed, EntryDef};
 use crate::handles::{TxRead, TxWrite};
 use crate::kind::Wasm;
 
-use super::{inner_writes, reads};
+use super::{reads, writes};
 
 impl TxRead<Wasm> {
     /// Check if WASM bytecode exists in the database.
@@ -55,7 +55,7 @@ impl TxRead<Wasm> {
 impl TxWrite<Wasm> {
     /// Store WASM bytecode.
     pub async fn put_wasm(&mut self, wasm: DnaWasmHashed) -> sqlx::Result<()> {
-        inner_writes::put_wasm(self.conn_mut(), wasm).await
+        writes::put_wasm(self.conn_mut(), wasm).await
     }
 
     /// Store a DNA definition and its associated zomes.
@@ -63,11 +63,11 @@ impl TxWrite<Wasm> {
     /// Within a [`TxWrite`], this runs as a SAVEPOINT nested inside the
     /// outer transaction — it is atomic with the rest of the transaction.
     pub async fn put_dna_def(&mut self, agent: &AgentPubKey, dna_def: &DnaDef) -> sqlx::Result<()> {
-        inner_writes::put_dna_def(self.tx_mut(), agent, dna_def).await
+        writes::put_dna_def(self.tx_mut(), agent, dna_def).await
     }
 
     /// Store an entry definition.
     pub async fn put_entry_def(&mut self, key: Vec<u8>, entry_def: &EntryDef) -> sqlx::Result<()> {
-        inner_writes::put_entry_def(self.conn_mut(), key, entry_def).await
+        writes::put_entry_def(self.conn_mut(), key, entry_def).await
     }
 }

--- a/crates/holochain_data/src/wasm/tx_operations.rs
+++ b/crates/holochain_data/src/wasm/tx_operations.rs
@@ -8,47 +8,47 @@ use holochain_types::prelude::{CellId, DnaDef, DnaWasmHashed, EntryDef};
 use crate::handles::{TxRead, TxWrite};
 use crate::kind::Wasm;
 
-use super::{inner_reads, inner_writes};
+use super::{inner_writes, reads};
 
 impl TxRead<Wasm> {
     /// Check if WASM bytecode exists in the database.
     pub async fn wasm_exists(&mut self, hash: &WasmHash) -> sqlx::Result<bool> {
-        inner_reads::wasm_exists(self.conn_mut(), hash).await
+        reads::wasm_exists(self.conn_mut(), hash).await
     }
 
     /// Get WASM bytecode by hash.
     pub async fn get_wasm(&mut self, hash: &WasmHash) -> sqlx::Result<Option<DnaWasmHashed>> {
-        inner_reads::get_wasm(self.conn_mut(), hash).await
+        reads::get_wasm(self.conn_mut(), hash).await
     }
 
     /// Check if a DNA definition exists in the database.
     pub async fn dna_def_exists(&mut self, cell_id: &CellId) -> sqlx::Result<bool> {
-        inner_reads::dna_def_exists(self.conn_mut(), cell_id).await
+        reads::dna_def_exists(self.conn_mut(), cell_id).await
     }
 
     /// Get a DNA definition for the passed [`CellId`].
     pub async fn get_dna_def(&mut self, cell_id: &CellId) -> sqlx::Result<Option<DnaDef>> {
-        inner_reads::get_dna_def(self.tx_mut(), cell_id).await
+        reads::get_dna_def(self.tx_mut(), cell_id).await
     }
 
     /// Check if an entry definition exists in the database.
     pub async fn entry_def_exists(&mut self, key: &[u8]) -> sqlx::Result<bool> {
-        inner_reads::entry_def_exists(self.conn_mut(), key).await
+        reads::entry_def_exists(self.conn_mut(), key).await
     }
 
     /// Get an entry definition by key.
     pub async fn get_entry_def(&mut self, key: &[u8]) -> sqlx::Result<Option<EntryDef>> {
-        inner_reads::get_entry_def(self.conn_mut(), key).await
+        reads::get_entry_def(self.conn_mut(), key).await
     }
 
     /// Get all entry definitions.
     pub async fn get_all_entry_defs(&mut self) -> sqlx::Result<Vec<(Vec<u8>, EntryDef)>> {
-        inner_reads::get_all_entry_defs(self.conn_mut()).await
+        reads::get_all_entry_defs(self.conn_mut()).await
     }
 
     /// Get all DNA definitions with their associated cell IDs.
     pub async fn get_all_dna_defs(&mut self) -> sqlx::Result<Vec<(CellId, DnaDef)>> {
-        inner_reads::get_all_dna_defs(self.tx_mut()).await
+        reads::get_all_dna_defs(self.tx_mut()).await
     }
 }
 

--- a/crates/holochain_data/src/wasm/writes.rs
+++ b/crates/holochain_data/src/wasm/writes.rs
@@ -1,0 +1,120 @@
+use holo_hash::{AgentPubKey, HashableContentExtSync};
+use holochain_types::prelude::{DnaDef, DnaWasmHashed, EntryDef, WasmZome, ZomeDef};
+use sqlx::{Acquire, Executor, Sqlite};
+
+use crate::models::wasm::{CoordinatorZomeModel, DnaDefModel, EntryDefModel, IntegrityZomeModel};
+
+use super::inner_writes;
+
+fn new_encode_error(e: impl ToString) -> sqlx::Error {
+    sqlx::Error::Encode(Box::new(std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        e.to_string(),
+    )))
+}
+
+/// Store WASM bytecode.
+pub(super) async fn put_wasm<'e, E>(executor: E, wasm: DnaWasmHashed) -> sqlx::Result<()>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let (wasm, hash) = wasm.into_inner();
+    inner_writes::put_wasm(executor, hash.get_raw_32(), &wasm.code).await
+}
+
+/// Store a DNA definition and its associated zomes.
+///
+/// This operation is transactional — either all data is stored or none is.
+/// When called with `&Pool`, a new transaction is started. When called with
+/// `&mut Transaction`, a savepoint is used so the outer transaction remains
+/// in control.
+pub(super) async fn put_dna_def<'c, A>(
+    conn: A,
+    agent: &AgentPubKey,
+    dna_def: &DnaDef,
+) -> sqlx::Result<()>
+where
+    A: Acquire<'c, Database = Sqlite>,
+{
+    let mut tx = conn.begin().await?;
+
+    let hash = dna_def.to_hash();
+    let hash_bytes = hash.get_raw_32();
+    let agent_bytes = agent.get_raw_32();
+
+    #[cfg(feature = "unstable-migration")]
+    let lineage = Some(serde_json::to_value(&dna_def.lineage).map_err(new_encode_error)?);
+    #[cfg(not(feature = "unstable-migration"))]
+    let lineage: Option<serde_json::Value> = None;
+
+    let dna_model = DnaDefModel {
+        hash: hash_bytes.to_vec(),
+        agent: agent_bytes.to_vec(),
+        name: dna_def.name.clone(),
+        network_seed: dna_def.modifiers.network_seed.clone(),
+        properties: dna_def.modifiers.properties.bytes().to_vec(),
+        lineage,
+    };
+
+    inner_writes::insert_dna_def(&mut *tx, &dna_model).await?;
+    inner_writes::delete_integrity_zomes(&mut *tx, hash_bytes, agent_bytes).await?;
+    inner_writes::delete_coordinator_zomes(&mut *tx, hash_bytes, agent_bytes).await?;
+
+    for (zome_index, (zome_name, zome_def)) in dna_def.integrity_zomes.iter().enumerate() {
+        let wasm_hash = zome_def.wasm_hash(zome_name).map_err(new_encode_error)?;
+        let dependencies = extract_dependencies(zome_def.as_any_zome_def());
+
+        let model = IntegrityZomeModel {
+            dna_hash: hash_bytes.to_vec(),
+            agent: agent_bytes.to_vec(),
+            zome_index: zome_index as i64,
+            zome_name: zome_name.0.as_ref().to_string(),
+            wasm_hash: Some(wasm_hash.get_raw_32().to_vec()),
+            dependencies: sqlx::types::Json(dependencies),
+        };
+        inner_writes::insert_integrity_zome(&mut *tx, &model).await?;
+    }
+
+    for (zome_index, (zome_name, zome_def)) in dna_def.coordinator_zomes.iter().enumerate() {
+        let wasm_hash = zome_def.wasm_hash(zome_name).map_err(new_encode_error)?;
+        let dependencies = extract_dependencies(zome_def.as_any_zome_def());
+
+        let model = CoordinatorZomeModel {
+            dna_hash: hash_bytes.to_vec(),
+            agent: agent_bytes.to_vec(),
+            zome_index: zome_index as i64,
+            zome_name: zome_name.0.as_ref().to_string(),
+            wasm_hash: Some(wasm_hash.get_raw_32().to_vec()),
+            dependencies: sqlx::types::Json(dependencies),
+        };
+        inner_writes::insert_coordinator_zome(&mut *tx, &model).await?;
+    }
+
+    tx.commit().await
+}
+
+/// Store an entry definition.
+pub(super) async fn put_entry_def<'e, E>(
+    executor: E,
+    key: Vec<u8>,
+    entry_def: &EntryDef,
+) -> sqlx::Result<()>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let model = EntryDefModel::from_entry_def(key, entry_def);
+    inner_writes::put_entry_def(executor, &model).await
+}
+
+fn extract_dependencies(zome_def: &ZomeDef) -> Vec<String> {
+    match zome_def {
+        ZomeDef::Wasm(WasmZome { dependencies, .. }) => dependencies
+            .iter()
+            .map(|n| n.0.as_ref().to_string())
+            .collect(),
+        ZomeDef::Inline { dependencies, .. } => dependencies
+            .iter()
+            .map(|n| n.0.as_ref().to_string())
+            .collect(),
+    }
+}


### PR DESCRIPTION
### Summary

This PR makes the functions inside the `inner_reads` and `inner_writes` modules thin wrappers around SQL queries. To do this, two new modules were created named `reads` and `writes`, these new modules perform type conversion and call multiple inner functions where needed. The DB and Tx implementations now call these new `reads` and `writes` functions but other than that they don't change. Some of the larger inner functions that did multiple SQL queries have been split into smaller functions that are now reused in multiple places to remove code duplication.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs