### PR TITLE
feat: Remove publish reflection

### DIFF
--- a/crates/holochain/src/core/queue_consumer/tests.rs
+++ b/crates/holochain/src/core/queue_consumer/tests.rs
@@ -261,12 +261,10 @@ async fn publish_loop() {
     .unwrap();
     let mut dna_network = MockHolochainP2pDnaT::new();
     let (tx, mut op_published) = tokio::sync::mpsc::channel(100);
-    dna_network
-        .expect_publish()
-        .returning(move |_, _, _, _, _| {
-            tx.try_send(()).unwrap();
-            Ok(())
-        });
+    dna_network.expect_publish().returning(move |_, _, _, _| {
+        tx.try_send(()).unwrap();
+        Ok(())
+    });
     let dna_network = Arc::new(dna_network);
 
     let (ts, mut trigger_recv) =

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -54,16 +54,9 @@ pub async fn publish_dht_ops_workflow(
 
     // Commit to the network
     let mut success = Vec::with_capacity(to_publish.len());
-    for (basis, list) in to_publish {
-        let (op_hash_list, op_data_list): (Vec<_>, Vec<_>) = list.into_iter().unzip();
+    for (basis, op_hash_list) in to_publish {
         match network
-            .publish(
-                basis,
-                agent.clone(),
-                op_hash_list.clone(),
-                None,
-                Some(op_data_list),
-            )
+            .publish(basis, agent.clone(), op_hash_list.clone(), None)
             .await
         {
             Err(e) => {
@@ -121,17 +114,17 @@ pub async fn publish_dht_ops_workflow_inner(
     db: DbRead<DbKindAuthored>,
     agent: AgentPubKey,
     min_publish_interval: Duration,
-) -> WorkflowResult<HashMap<OpBasis, Vec<(DhtOpHash, crate::prelude::DhtOp)>>> {
+) -> WorkflowResult<HashMap<OpBasis, Vec<DhtOpHash>>> {
     // Ops to publish by basis
     let mut to_publish = HashMap::new();
 
-    for (basis, op_hash, op) in get_ops_to_publish(agent, &db, min_publish_interval).await? {
+    for (basis, op_hash) in get_ops_to_publish(agent, &db, min_publish_interval).await? {
         // For every op publish a request
         // Collect and sort ops by basis
         to_publish
             .entry(basis)
             .or_insert_with(Vec::new)
-            .push((op_hash, op));
+            .push(op_hash);
     }
 
     Ok(to_publish)

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow/publish_query.rs
@@ -4,7 +4,6 @@ use holo_hash::DhtOpHash;
 use holochain_sqlite::db::DbKindAuthored;
 use holochain_sqlite::prelude::ReadAccess;
 use holochain_state::prelude::*;
-use holochain_state::query::map_sql_dht_op;
 use rusqlite::named_params;
 use rusqlite::Transaction;
 use std::time::Duration;
@@ -19,7 +18,7 @@ pub async fn get_ops_to_publish<AuthorDb>(
     agent: AgentPubKey,
     db: &AuthorDb,
     min_publish_interval: Duration,
-) -> WorkflowResult<Vec<(OpBasis, DhtOpHash, DhtOp)>>
+) -> WorkflowResult<Vec<(OpBasis, DhtOpHash)>>
 where
     AuthorDb: ReadAccess<DbKindAuthored>,
 {
@@ -34,16 +33,8 @@ where
         let mut stmt = txn.prepare(
             "
             SELECT
-            Action.blob as action_blob,
-            Action.author as author,
-            LENGTH(Action.blob) AS action_size,
-            CASE
-              WHEN DhtOp.type IN ('StoreEntry', 'StoreRecord') THEN LENGTH(Entry.blob)
-              ELSE 0
-            END AS entry_size,
-            Entry.blob as entry_blob,
-            DhtOp.type as dht_type,
             DhtOp.hash as dht_hash,
+            DhtOp.basis_hash as basis_hash,
             DhtOp.op_order as op_order
             FROM Action
             JOIN
@@ -67,13 +58,8 @@ where
             ALL
 
             SELECT
-            Warrant.blob as action_blob,
-            Warrant.author as author,
-            LENGTH(Warrant.blob) AS action_size,
-            0 AS entry_size,
-            NULL as entry_blob,
-            DhtOp.type as dht_type,
             DhtOp.hash as dht_hash,
+            DhtOp.basis_hash as basis_hash,
             DhtOp.op_order as op_order
             FROM Warrant
             JOIN
@@ -95,10 +81,9 @@ where
                 ":store_entry": ChainOpType::StoreEntry,
             },
             |row| {
-                let op = map_sql_dht_op(false, "dht_type", row)?;
+                let basis: OpBasis = row.get("basis_hash")?;
                 let op_hash: DhtOpHash = row.get("dht_hash")?;
-                let basis = op.dht_basis();
-                WorkflowResult::Ok((basis, op_hash, op))
+                WorkflowResult::Ok((basis, op_hash))
             },
         )?;
         WorkflowResult::Ok(r.collect::<Result<Vec<_>, _>>())
@@ -449,7 +434,10 @@ mod tests {
             },
         )
         .content;
+        let chain_op_hash = DhtOpHashed::from_content_sync_exact(chain_op);
+
         let warrant_op = insert_invalid_chain_op_warrant_op(&db, &agent).content;
+        let warrant_op_hash = DhtOpHashed::from_content_sync_exact(warrant_op);
 
         let agent_clone = agent.clone();
         let num_to_publish = db
@@ -465,9 +453,15 @@ mod tests {
         .await
         .unwrap()
         .into_iter()
-        .map(|(_, _, op)| op)
+        .map(|(_, hash)| hash.get_raw_39().to_owned())
         .collect::<Vec<_>>();
-        assert_eq!(ops_to_publish, vec![chain_op, warrant_op]);
+        assert_eq!(
+            ops_to_publish,
+            vec![
+                chain_op_hash.hash.get_raw_39().to_owned(),
+                warrant_op_hash.hash.get_raw_39().to_owned()
+            ]
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow/unit_tests.rs
@@ -59,7 +59,7 @@ async fn workflow_incomplete_on_routing_error() {
     let op_hash = create_op(vault.clone(), agent.clone()).await.unwrap();
 
     let mut network = MockHolochainP2pDnaT::new();
-    network.expect_publish().return_once(|_, _, _, _, _| {
+    network.expect_publish().return_once(|_, _, _, _| {
         Err(holochain_p2p::HolochainP2pError::RoutingDnaError(fixt!(
             DnaHash
         )))
@@ -97,7 +97,7 @@ async fn workflow_handles_publish_errors() {
     let op_hash = create_op(vault.clone(), agent.clone()).await.unwrap();
 
     let mut network = MockHolochainP2pDnaT::new();
-    network.expect_publish().return_once(|_, _, _, _, _| {
+    network.expect_publish().return_once(|_, _, _, _| {
         Err(holochain_p2p::HolochainP2pError::InvalidP2pMessage(
             "test error".to_string(),
         ))
@@ -135,7 +135,7 @@ async fn retry_publish_until_receipts_received() {
     let op_hash = create_op(vault.clone(), agent.clone()).await.unwrap();
 
     let mut network = MockHolochainP2pDnaT::new();
-    network.expect_publish().returning(|_, _, _, _, _| Ok(()));
+    network.expect_publish().returning(|_, _, _, _| Ok(()));
 
     let (tx, rx) =
         TriggerSender::new_with_loop(Duration::from_secs(5)..Duration::from_secs(30), true);
@@ -187,7 +187,7 @@ async fn loop_resumes_on_new_data() {
     let agent = fixt!(AgentPubKey);
 
     let mut network = MockHolochainP2pDnaT::new();
-    network.expect_publish().returning(|_, _, _, _, _| Ok(()));
+    network.expect_publish().returning(|_, _, _, _| Ok(()));
 
     let (tx, rx) =
         TriggerSender::new_with_loop(Duration::from_secs(5)..Duration::from_secs(30), true);
@@ -328,8 +328,9 @@ async fn private_entries_are_not_published() {
     // StoreRecord contains the entry and is expected to not be published.
     let mut network = MockHolochainP2pDnaT::new();
     let agent2 = agent.clone();
-    network.expect_publish().returning(
-        move |_basis_hash, source, op_hash_list, _timeout_ms, _reflect_ops| {
+    network
+        .expect_publish()
+        .returning(move |_basis_hash, source, op_hash_list, _timeout_ms| {
             assert_eq!(source, agent2);
             assert!(
                 op_hash_list.contains(&register_agent_activity_op_hash)
@@ -337,8 +338,7 @@ async fn private_entries_are_not_published() {
             );
             assert!(!op_hash_list.contains(&store_entry_op_hash));
             Ok(())
-        },
-    );
+        });
     let network = Arc::new(network);
 
     let (tx, _rx) =

--- a/crates/holochain/tests/tests/app_disable.rs
+++ b/crates/holochain/tests/tests/app_disable.rs
@@ -50,7 +50,6 @@ async fn space_removed_on_disable() {
             cell.agent_pubkey().clone(),
             vec![],
             None,
-            None,
         )
         .await;
 

--- a/crates/holochain/tests/tests/app_uninstall.rs
+++ b/crates/holochain/tests/tests/app_uninstall.rs
@@ -49,7 +49,6 @@ async fn space_removed_on_uninstall() {
             cell.agent_pubkey().clone(),
             vec![],
             None,
-            None,
         )
         .await;
 

--- a/crates/holochain_cascade/src/test_utils.rs
+++ b/crates/holochain_cascade/src/test_utils.rs
@@ -197,7 +197,6 @@ impl HolochainP2pDnaT for PassThroughNetwork {
         _source: AgentPubKey,
         _op_hash_list: Vec<DhtOpHash>,
         _timeout_ms: Option<u64>,
-        _reflect_ops: Option<Vec<crate::DhtOp>>,
     ) -> HolochainP2pResult<()> {
         todo!()
     }

--- a/crates/holochain_p2p/src/lib.rs
+++ b/crates/holochain_p2p/src/lib.rs
@@ -145,7 +145,6 @@ pub trait HolochainP2pDnaT: Send + Sync + 'static {
         source: AgentPubKey,
         op_hash_list: Vec<DhtOpHash>,
         timeout_ms: Option<u64>,
-        reflect_ops: Option<Vec<DhtOp>>,
     ) -> HolochainP2pResult<()>;
 
     /// Publish a countersigning op.
@@ -316,7 +315,6 @@ impl HolochainP2pDnaT for HolochainP2pDna {
         source: AgentPubKey,
         op_hash_list: Vec<DhtOpHash>,
         timeout_ms: Option<u64>,
-        reflect_ops: Option<Vec<DhtOp>>,
     ) -> HolochainP2pResult<()> {
         self.sender
             .publish(
@@ -325,7 +323,6 @@ impl HolochainP2pDnaT for HolochainP2pDna {
                 source,
                 op_hash_list,
                 timeout_ms,
-                reflect_ops,
             )
             .await
     }

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -1763,19 +1763,8 @@ impl actor::HcP2p for HolochainP2pActor {
         _source: AgentPubKey,
         op_hash_list: Vec<DhtOpHash>,
         _timeout_ms: Option<u64>,
-        reflect_ops: Option<Vec<DhtOp>>,
     ) -> BoxFut<'_, HolochainP2pResult<()>> {
         Box::pin(async move {
-            use crate::types::event::HcP2pHandler;
-
-            if let Some(reflect_ops) = reflect_ops {
-                self.evt_sender
-                    .get()
-                    .ok_or_else(|| HolochainP2pError::other(EVT_REG_ERR))?
-                    .handle_publish(dna_hash.clone(), reflect_ops)
-                    .await?;
-            }
-
             let space_id = dna_hash.to_k2_space();
 
             let space = self

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -230,7 +230,6 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug + Any {
         source: AgentPubKey,
         op_hash_list: Vec<DhtOpHash>,
         timeout_ms: Option<u64>,
-        reflect_ops: Option<Vec<DhtOp>>,
     ) -> BoxFut<'_, HolochainP2pResult<()>>;
 
     /// Publish a countersigning op.

--- a/crates/holochain_p2p/tests/tests/node_messaging.rs
+++ b/crates/holochain_p2p/tests/tests/node_messaging.rs
@@ -292,51 +292,6 @@ async fn test_publish() {
                 AgentPubKey::from_raw_32(vec![2; 32]),
                 vec![op_hash.clone()],
                 None,
-                None,
-            )
-            .await
-            .unwrap();
-
-            if let Some(res) = handler.calls.lock().unwrap().first() {
-                assert_eq!("publish", res);
-                break;
-            }
-        }
-    })
-    .await
-    .unwrap();
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_publish_reflect() {
-    let dna_hash = DnaHash::from_raw_36(vec![0; 36]);
-    let space = dna_hash.to_k2_space();
-    let handler = Arc::new(Handler::default());
-
-    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
-    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
-    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
-
-    hc1.test_set_full_arcs(space.clone()).await;
-    hc2.test_set_full_arcs(space.clone()).await;
-
-    tokio::time::timeout(UNRESPONSIVE_TIMEOUT, async {
-        loop {
-            tokio::time::sleep(WAIT_BETWEEN_CALLS).await;
-
-            let op = test_dht_op(holochain_types::prelude::Timestamp::now());
-            let op_hash = op.as_hash();
-
-            hc2.publish(
-                dna_hash.clone(),
-                HoloHash::from_raw_36_and_type(
-                    op_hash.get_raw_36().to_vec(),
-                    holo_hash::hash_type::AnyLinkable::Action,
-                ),
-                AgentPubKey::from_raw_32(vec![2; 32]),
-                vec![],
-                None,
-                Some(vec![op.into_content()]),
             )
             .await
             .unwrap();


### PR DESCRIPTION
### Summary

Replaces https://github.com/holochain/holochain/pull/5749. This is not a guaranteed fix for the problem like I was attempting with the previous PR but the logic from the previous PR is just broken. The problem is the split logic between the authored and DHT databases, combined with flags on the DHT ops that are serving multiple purposes.

The bug I was trying to fix still exists but now it requires a loop over the network to receive your own ops accidentally, rather than being a local race condition - that makes it much less likely and unlike the other fix, it passes our tests.

The publish reflection was an attempt to treat locally authored ops like network authored ops and is now dead code. The normal authoring and the countersigning authoring flows have dedicated functions to copy data from authored to DHT and this publish reflection is therefore not needed.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs