### PR TITLE
feat: parallel writes from authored DB to new holochain_data DHT DB (#5729)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build, lint, and test
+
+- `make static-all` — full static check suite (fmt, toml, clippy, clippy-unstable, doc).
+- `make test-workspace-wasmer-sys-cranelift` — full workspace test run from the repo root (uses `cargo nextest`, default features + iroh transport + cranelift).
+- `cargo test -p <crate-name>` — focused tests for a single crate while iterating.
+- `cargo nextest run -p <crate-name> <test_name>` — run a single test (nextest is the configured runner; see `.config/nextest.toml`).
+- `cargo fmt --all` — format before submitting.
+- `scripts/format-toml.sh` - format TOML files, if any have changed, before submitting.
+- Toolchain is pinned in `rust-toolchain.toml` (currently 1.95.0) — do not bump without discussion.
+
+Feature flags worth knowing (defined in the `Makefile`):
+- `DEFAULT_FEATURES` = `transport-iroh,slow_tests,build_wasms,sqlite-encrypted`.
+- Wasmer backends are tested separately: `wasmer-sys-cranelift` (default), `wasmer-sys-llvm`, or `wasmer-wasmi`. At least one must be enabled or the crate fails to compile.
+- `UNSTABLE_FEATURES` adds `unstable-sharding,unstable-functions,unstable-migration` — use the `*-unstable` Make targets to exercise them.
+- Transports: iroh (default) vs `transport-tx5-backend-go-pion` (use `*-transport_tx5` Make targets). Don't enable both.
+
+## Architecture
+
+This is a Cargo workspace; everything ships as crates under `crates/`. The big-picture layering, from the bottom up:
+
+- **Hashing & primitives** — `holo_hash`, `timestamp`, `holochain_nonce`, `holochain_secure_primitive`, `holochain_util`.
+- **Types** — `holochain_integrity_types` (types available to integrity zomes; minimal, deterministic), `holochain_zome_types` (re-exports + coordinator-zome types), `holochain_types` (host-side rich types built on the above).
+- **Persistence** — Currently in `holochain_sqlite` (SQL strings, schema, connection management; SQL files under `src/sql/`) and `holochain_state` (typed read/write operations layered on top). See the section about the in-progress migration to `holochain_data`.
+- **New Persistence** — `holochain_data` — target crate for primitive data access; see migration section.
+- **Networking** — `holochain_p2p` wraps `kitsune2` and exposes the gossip / publish / get / block APIs the conductor uses.
+- **Cascade** — Currently, `holochain_cascade` is the "fetch from local DBs, then fall back to the network" layer used by zome calls and validation. See the section about the in-progress migration to `holochain_data`.
+- **Conductor / runtime** — `holochain` is the top crate. It owns:
+  - `src/conductor/` — the long-running process: cells, interfaces, app/admin APIs, the ribosome store, space/cell management, config.
+  - `src/core/` — domain logic: workflows, queue consumers, ribosome (WASM host), sys-validate / app-validate.
+  - `src/sweettest/` — in-process test harness for spinning up conductors with inline or WASM zomes.
+- **SDKs** — `hdi` (integrity) and `hdk` (coordinator) are the developer-facing crates that compile to WASM; `hdk_derive` provides the macros.
+- **CLI / tooling** — `hc`, `hc_bundle`, `hc_sandbox`, `hc_service_check`, `holochain_terminal`, `client`, `hc_client`. `mr_bundle` is the bundle (DNA/hApp) format.
+- **Test wasms** — `crates/test_utils/wasm/wasm_workspace/` contains compiled-to-wasm test zomes; `TestWasm` enum in `crates/test_utils/wasm/src/lib.rs` is the registry. **Prefer inline zomes (`InlineZomeSet` / `SweetInlineZomes`) over adding new test wasms** — only add a WASM artifact when wasm-execution machinery is actually under test (per CONTRIBUTING.md).
+
+Design references: `docs/design/state_model.md` and `docs/design/data_model.md` document the DHT/source-chain schema and the data types that live in it.
+
+`scripts/` holds the supported task runners. `holonix/` and `nix/` directories are deprecated and may be ignored.
+
+## Project conventions
+
+- **Where new code goes**: types into `holochain_types`, persistence into `holochain_data` and `holochain_state`, runtime/orchestration into `holochain`. Don't shortcut by piling logic into the top-level crate.
+- **Testing**:
+  - Unit tests are placed inline or in a submodule next to the code under test.
+  - Integration tests go under the crate's `tests/` directory, named `{feature}_tests.rs`. If `tests/integration.rs` exists, link new modules there so only one test binary builds. This saves time spent on linking.
+  - Use `#[tokio::test]` by default; only switch to `#[tokio::test(flavor = "multi_thread")]` when the test genuinely needs it.
+  - Do not introduce new `proptest` or fuzzing suites.
+  - Test functions must not be prefixed with `test_` — the `#[test]` / `#[tokio::test]` attribute already marks them.
+- **Errors**: prefer `thiserror` for crate error types; `anyhow` is for application/binary code, not library APIs.
+- **Compiler warnings are not OK** in shared code (CONTRIBUTING.md). Fix, surgically `#[allow(...)]`, or escalate — don't disable globally.
+- **Public API docs**: `///` rustdoc on public items; module/crate docs should describe structure.
+- **Commits**: Conventional Commits (`feat:`, `fix:`, `refactor:`, etc.), bodies wrapped near 72 chars. Record notable changes in `crates/holochain/CHANGELOG.md` (bug fixes, new features, breaking changes).
+- **PRs**: branch off `develop`; changes are squash merged into `develop`; changes go from `develop` → `main` at release time and `main` should always be ignored for development.
+
+## Project principles
+
+### Offline friendly
+
+It has not become an officially supported mode of use, but it is a long-standing goal that Holochain should function well offline.
+
+Holochain does not know whether it has an internet connection, or how well connected it is to peers. It only learns what's working when it attempts requests.
+
+When making code changes, don't assume the network is available. Locally available data should always be returned and the user should be able to install and uninstall apps, create and read data, or progress validation of data with any content that is already available locally.
+
+### Workflows
+
+Workflows always refer to the code under `crates/holochain/src/core/workflow`. The behavior of the workflows is described more specifically in the file `docs/design/state_model.md`.
+
+At a higher level, the workflows are supposed to operate as atomically as possible:
+- The genesis workflow `crates/holochain/src/core/workflow/genesis_workflow.rs`, runs when a new cell is instantiated and creates the genesis chain entries for the agent who created the cell.
+- The initialize zomes workflow `crates/holochain/src/core/workflow/initialize_zomes_workflow.rs`, is to support an application-level hook per cell, by a coordinator providing an `init` function. No other zome calls may proceed until the `init` hook returns a successful result. Any data authored by the app is persisted and then a special marker entry for the hook completing is written to the source chain.
+- The call zome workflow `crates/holochain/src/core/workflow/call_zome_workflow.rs`, executes a coordinator WASM call and captures created content into the in-memory scratch space. If there is any created content, then it is validated using inline validation. If the call fails, an error is returned, and if it succeeds then the newly authored data is written to the database in a transaction.
+- The publishing workflow `crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs`, is the quick path to share newly authored data with other peers. This is in contrast with Kitsune2's gossip which can be slower to share content in the background. The publish workflow also acts as a notification system to request validation receipts from peers.
+- The incoming DHT ops workflow `crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs`, is the workflow that receives content from the network, created by agents on other conductors. It is responsible for performing initial checks on the incoming data and persisting it, ready for validation.
+- The sys validation workflow `crates/holochain/src/core/workflow/sys_validation_workflow.rs`, enforces common validation logic that is expected to be needed by all applications. The checks it performs are documented in the module documentation for the workflow.
+- The app validation workflow `crates/holochain/src/core/workflow/app_validation_workflow.rs`, allows the application's integrity zomes to define extra rules. The required `validate` callback of an integrity zome is dispatched with each DHT op to be validated. Ops either pass validation, are rejected, or wait for dependencies. Once an op has completed validation, it goes to integration.
+- The integration workflow `crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs`, is the final processing step for ops that have completed validation. Ops have either failed sys validation, passed sys validation and failed app validation, or passed both sys and app validation. Integration marks the ops as part of the DHT at that point and they can start being gossiped.
+
+It is critical that workflows handle errors properly, and don't conflict with each other's data state. Content must always be in a state where at least one workflow can progress its state towards being part of the DHT state.
+
+Note that there are subtly different code paths for data that is authored locally, compared with data that is authored on other conductor instances and sent over the network. Differences should be minimized and where possible, diverged code paths should be resolved so that authored data is treated similarly to network-authored data.
+
+## In-progress migration to `holochain_data`
+
+The Holochain data access is currently spread across `holochain_sqlite`, `holochain_state`, `holochain_cascade` and `holochain` itself.
+
+This is intended to change and a refactor is in progress. Always prefer following the input given by the user because the refactor is being done in stages but you should help the user stay on track with the intended direction of the refactor.
+
+The goals for the refactor are:
+- All data access happens in `holochain_data`, which provides primitive data access operations.
+- The `holochain_state` becomes the consumer of `holochain_data` and exposes a "store" pattern for data access where a type with compound operations is exposed.
+- Instead of querying across multiple databases `holochain_cascade` becomes a layer for combining access to the new DHT store with network requests. That part of the logic will largely remain intact, but the complex traits, transaction handling and data merging operations will be removed.
+- The `holochain` crate will access the `holochain_cascade` and `holochain_state` APIs to do its work. There should be no SQL queries remaining in `holochain` outside of tests. This primarily applies to the workflows, which have complex SQL queries that can and should be tested in isolation.
+- The `holochain_sqlite` crate will be removed entirely.
+- At a later stage, the `holochain_state` types crate could also be eliminated by figuring out the current circular dependency problems and finding a new home for those types.
+

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -124,9 +124,13 @@ impl Cell {
         // check if genesis has been run
         let has_genesis = {
             // check if genesis ran.
-            GenesisWorkspace::new(authored_db.clone(), space.dht_db.clone())
-                .has_genesis(id.agent_pubkey().clone())
-                .await?
+            GenesisWorkspace::new(
+                authored_db.clone(),
+                space.dht_db.clone(),
+                space.dht_store.clone(),
+            )
+            .has_genesis(id.agent_pubkey().clone())
+            .await?
         };
 
         if has_genesis {
@@ -167,6 +171,7 @@ impl Cell {
         conductor_handle: ConductorHandle,
         authored_db: DbWrite<DbKindAuthored>,
         dht_db: DbWrite<DbKindDht>,
+        dht_store: holochain_state::dht_store::DhtStore,
         ribosome: Ribosome,
         membrane_proof: Option<MembraneProof>,
     ) -> CellResult<()>
@@ -176,7 +181,7 @@ impl Cell {
         let conductor_api = CellConductorApi::new(conductor_handle.clone(), cell_id.clone());
 
         // run genesis
-        let workspace = GenesisWorkspace::new(authored_db, dht_db);
+        let workspace = GenesisWorkspace::new(authored_db, dht_db, dht_store);
 
         // exit early if genesis has already run
         if workspace
@@ -260,6 +265,21 @@ impl Cell {
                 error!("error calling scheduled fn: {:?}", e);
             }
             Ok(live_fns) => {
+                let author_for_new_db = self.id.agent_pubkey().clone();
+                if let Err(e) = self
+                    .space
+                    .dht_store
+                    .delete_live_ephemeral_scheduled_functions(&author_for_new_db, now)
+                    .await
+                {
+                    error!("error deleting live ephemeral scheduled functions: {:?}", e);
+                }
+
+                self.space
+                    .dht_store
+                    .reschedule_expired_persisted(&author_for_new_db, now)
+                    .await;
+
                 let mut tasks = vec![];
                 let mut dispatched: Vec<(ScheduledFn, bool)> = Vec::with_capacity(live_fns.len());
                 for (scheduled_fn, schedule, ephemeral) in &live_fns {
@@ -303,6 +323,43 @@ impl Cell {
                 }
                 let results: Vec<CellResult<ZomeCallResult>> =
                     futures::future::join_all(tasks).await;
+
+                // Pre-compute what each dispatched function should do in the new DHT DB,
+                // mirroring the decisions the legacy `write_async` block will make below.
+                // `None`         => skip (ephemeral fn, no persistent state to update)
+                // `Some(None)`   => delete (unschedule the persisted fn)
+                // `Some(Some(s))`=> insert/upsert with schedule `s`
+                let new_db_decisions: Vec<(ScheduledFn, Option<Option<Schedule>>)> = dispatched
+                    .iter()
+                    .zip(results.iter())
+                    .map(|((scheduled_fn, ephemeral), result)| {
+                        let action = match result {
+                            Ok(Ok(ZomeCallResponse::Ok(extern_io))) => {
+                                match extern_io.decode::<Option<Schedule>>() {
+                                    Ok(Some(s)) => Some(Some(s)),
+                                    // Persisted fn returned None or failed to decode →
+                                    // legacy will unschedule it.
+                                    Ok(None) | Err(_) => {
+                                        if *ephemeral {
+                                            None
+                                        } else {
+                                            Some(None)
+                                        }
+                                    }
+                                }
+                            }
+                            // Any error in the zome call → legacy unschedules persisted fns.
+                            _ => {
+                                if *ephemeral {
+                                    None
+                                } else {
+                                    Some(None)
+                                }
+                            }
+                        };
+                        (scheduled_fn.clone(), action)
+                    })
+                    .collect();
 
                 let author = self.id.agent_pubkey().clone();
                 // In case of an error, a persisted fn needs to be unscheduled.
@@ -353,6 +410,45 @@ impl Cell {
                         Result::<(), DatabaseError>::Ok(())
                     })
                     .await;
+
+                // Mirror the legacy unschedule/reschedule decisions in the new DHT DB.
+                for (scheduled_fn, action) in new_db_decisions {
+                    match action {
+                        // Ephemeral fn: no persistent state to update.
+                        None => {}
+                        // Persisted fn with no next schedule or a failed zome call: remove it.
+                        Some(None) => {
+                            if let Err(e) = self
+                                .space
+                                .dht_store
+                                .unschedule_function(&author_for_new_db, &scheduled_fn)
+                                .await
+                            {
+                                error!("error unscheduling function {:?}: {:?}", scheduled_fn, e);
+                            }
+                        }
+                        // Persisted fn with a new schedule: upsert.
+                        Some(Some(next_schedule)) => {
+                            let maybe_schedule = Some(next_schedule);
+                            if let Err(e) = self
+                                .space
+                                .dht_store
+                                .upsert_scheduled_function(
+                                    &author_for_new_db,
+                                    &scheduled_fn,
+                                    &maybe_schedule,
+                                    now,
+                                )
+                                .await
+                            {
+                                error!(
+                                    "error upserting scheduled function {:?}: {:?}",
+                                    scheduled_fn, e
+                                );
+                            }
+                        }
+                    }
+                }
             }
         }
     }
@@ -574,6 +670,7 @@ impl holochain_p2p::event::HcP2pHandler for Cell {
                 );
 
                 let receipt_op_hash = receipt.receipt.dht_op_hash.clone();
+                let receipt_op_hash_for_new_db = receipt_op_hash.clone();
 
                 let receipt_count = self
                     .space
@@ -621,6 +718,13 @@ impl holochain_p2p::event::HcP2pHandler for Cell {
                             set_receipts_complete(txn, &receipt_op_hash, true)
                         })
                         .await?;
+
+                    // Mirror: set receipts_complete in the new DHT DB.
+                    self.space
+                        .dht_store
+                        .mark_chain_op_receipts_complete(&receipt_op_hash_for_new_db)
+                        .await
+                        .map_err(|e| CellError::from(HolochainP2pError::other(e)))?;
                 }
             }
 
@@ -744,6 +848,7 @@ impl Cell {
                 SourceChainWorkspace::new(
                     self.get_or_create_authored_db()?,
                     self.dht_db().clone(),
+                    self.space.dht_store.clone(),
                     self.cache().clone(),
                     keystore.clone(),
                     self.id.agent_pubkey().clone(),
@@ -794,6 +899,7 @@ impl Cell {
         let workspace = SourceChainWorkspace::init_as_root(
             self.get_or_create_authored_db()?,
             self.dht_db().clone(),
+            self.space.dht_store.clone(),
             self.cache().clone(),
             keystore.clone(),
             id.agent_pubkey().clone(),

--- a/crates/holochain/src/conductor/cell/test.rs
+++ b/crates/holochain/src/conductor/cell/test.rs
@@ -59,11 +59,13 @@ async fn test_cell_handle_publish() {
         .await
         .unwrap();
 
+    let dht_store = spaces.test_spaces[&dna].space.dht_store.clone();
     super::Cell::genesis(
         cell_id.clone(),
         handle.clone(),
         db.clone(),
         dht_db.clone(),
+        dht_store,
         ribosome,
         None,
     )

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1709,6 +1709,7 @@ mod clone_cell_impls {
                 let source_chain = SourceChain::new(
                     self.get_or_create_authored_db(app_role.dna_hash(), app.agent_key().clone())?,
                     self.get_or_create_dht_db(app_role.dna_hash())?,
+                    self.get_or_create_dht_store(app_role.dna_hash())?,
                     self.keystore.clone(),
                     app.agent_key().clone(),
                 )
@@ -2234,6 +2235,7 @@ mod misc_impls {
                     cell.id().agent_pubkey().clone(),
                 )?,
                 self.get_or_create_dht_db(cell_id.dna_hash())?,
+                self.get_or_create_dht_store(cell_id.dna_hash())?,
                 self.keystore.clone(),
                 cell_id.agent_pubkey().clone(),
             )
@@ -2286,6 +2288,7 @@ mod misc_impls {
                     cell.id().agent_pubkey().clone(),
                 )?,
                 self.get_or_create_dht_db(cell_id.dna_hash())?,
+                self.get_or_create_dht_store(cell_id.dna_hash())?,
                 self.keystore.clone(),
                 cell_id.agent_pubkey().clone(),
             )
@@ -2360,6 +2363,7 @@ mod misc_impls {
                     )?
                     .into(),
                     self.get_or_create_dht_db(cell_id.dna_hash())?.into(),
+                    self.get_or_create_dht_store(cell_id.dna_hash())?,
                     self.keystore().clone(),
                     cell_id.agent_pubkey().clone(),
                 )
@@ -2835,6 +2839,13 @@ mod accessor_impls {
             self.spaces.dht_db(dna_hash)
         }
 
+        pub(crate) fn get_or_create_dht_store(
+            &self,
+            dna_hash: &DnaHash,
+        ) -> DatabaseResult<DhtStore> {
+            self.spaces.dht_store(dna_hash)
+        }
+
         /// Get the post commit sender.
         pub async fn post_commit_permit(
             &self,
@@ -3120,6 +3131,33 @@ impl Conductor {
 
             self.delete_or_purge_database(dht_db).await?;
             self.delete_or_purge_database(cache_db).await?;
+
+            // Remove (or purge) the per-DNA mirrored store so a reinstall
+            // doesn't inherit stale rows from the previous installation.
+            let dht_store = self.spaces.dht_store(dna_hash)?;
+            let dht_store_id = holochain_data::kind::Dht::new(Arc::new(dna_hash.clone()));
+            let dht_store_path = self.spaces.db_dir.as_ref().as_ref().join(
+                holochain_data::DatabaseIdentifier::database_id(&dht_store_id),
+            );
+            if let Err(err) = ffs::remove_file(&dht_store_path).await {
+                tracing::warn!(
+                    ?err,
+                    "Could not remove DhtStore DB file, probably because it is still in use. Purging all data instead."
+                );
+                dht_store.purge_all().await.map_err(ConductorError::other)?;
+            } else {
+                tracing::info!("Deleted DhtStore DB file {}", dht_store_path.display());
+            }
+            let stem = dht_store_path.to_string_lossy();
+            for ext in ["shm", "wal"] {
+                let support_path = PathBuf::from(format!("{stem}-{ext}"));
+                if let Err(err) = ffs::remove_file(&support_path).await {
+                    let err = err.remove_backtrace();
+                    tracing::warn!(?err, "Failed to remove DhtStore DB support file");
+                } else {
+                    tracing::info!("Deleted file {}", support_path.display());
+                }
+            }
         }
 
         Ok(())
@@ -3264,6 +3302,10 @@ mod test_utils_impls {
             Ok(self.get_or_create_dht_db(dna_hash)?)
         }
 
+        pub fn get_dht_store(&self, dna_hash: &DnaHash) -> ConductorApiResult<DhtStore> {
+            Ok(self.get_or_create_dht_store(dna_hash)?)
+        }
+
         pub async fn get_cache_db(
             &self,
             cell_id: &CellId,
@@ -3317,6 +3359,7 @@ pub(crate) async fn genesis_cells(
             let authored_db =
                 space.get_or_create_authored_db(cell_id_inner.agent_pubkey().clone())?;
             let dht_db = space.dht_db;
+            let dht_store = space.dht_store;
             let ribosome = conductor.get_ribosome(&cell_id_inner).map_err(Box::new)?;
 
             Cell::genesis(
@@ -3324,6 +3367,7 @@ pub(crate) async fn genesis_cells(
                 conductor,
                 authored_db,
                 dht_db,
+                dht_store,
                 ribosome,
                 proof,
             )

--- a/crates/holochain/src/conductor/conductor/tests/cells_with_conflicting_overrides.rs
+++ b/crates/holochain/src/conductor/conductor/tests/cells_with_conflicting_overrides.rs
@@ -64,7 +64,7 @@ async fn should_not_allow_installing_apps_with_same_dna_but_different_overrides(
         name: "dummy".to_string(),
         roles: vec![],
         bootstrap_url: Some(bootstrap_server_url.clone()),
-        relay_url: Some("wss://different:5678".to_string()), // different signal url
+        relay_url: Some("wss://different:5678".to_string()), // different relay url
     });
 
     conductor

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -539,7 +539,7 @@ impl Space {
                 holochain_state::peer_metadata_store::PeerMetaStore::new(peer_meta_store_db);
             let new_dht_db = tokio::runtime::Handle::current()
                 .block_on(holochain_data::open_db(
-                    AsRef::<std::path::Path>::as_ref(&root_db_dir),
+                    &root_db_dir,
                     holochain_data::kind::Dht::new(dna_hash.clone()),
                     space_data_config.clone(),
                 ))

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -49,6 +49,7 @@ pub struct Spaces {
     pub(crate) wasm_store: holochain_state::wasm::WasmStore,
     pub(crate) dna_def_store: holochain_state::dna_def::DnaDefStore,
     pub(crate) entry_def_store: holochain_state::entry_def::EntryDefStore,
+    pub(crate) space_data_config: holochain_data::HolochainDataConfig,
     db_key: DbKey,
     data_db_key: holochain_data::DbKey,
 }
@@ -73,6 +74,9 @@ pub struct Space {
     /// The dht databases. These are shared across cells.
     /// There is one per unique Dna.
     pub dht_db: DbWrite<DbKindDht>,
+
+    /// DHT store wrapping the new holochain_data database.
+    pub dht_store: DhtStore,
 
     /// The peer meta store. One per unique Dna.
     pub peer_meta_store: holochain_state::peer_metadata_store::PeerMetaStore,
@@ -205,6 +209,12 @@ impl Spaces {
         let dna_def_store = holochain_state::dna_def::DnaDefStore::new(wasm_db.clone());
         let entry_def_store = holochain_state::entry_def::EntryDefStore::new(wasm_db);
 
+        let space_data_config = holochain_data::HolochainDataConfig {
+            key: Some(data_db_key.clone()),
+            sync_level: db_sync,
+            max_readers: config.db_max_readers,
+        };
+
         Ok(Spaces {
             map: RwShare::new(HashMap::new()),
             db_dir: Arc::new(root_db_dir),
@@ -214,6 +224,7 @@ impl Spaces {
             wasm_store,
             dna_def_store,
             entry_def_store,
+            space_data_config,
             db_key,
             data_db_key,
         })
@@ -359,6 +370,7 @@ impl Spaces {
                             self.config.db_sync_strategy,
                             self.db_key.clone(),
                             self.config.db_max_readers,
+                            self.space_data_config.clone(),
                             Some(self.data_db_key.clone()),
                         )?;
 
@@ -409,6 +421,11 @@ impl Spaces {
     /// Get the dht database (this will create the space if it doesn't already exist).
     pub fn dht_db(&self, dna_hash: &DnaHash) -> DatabaseResult<DbWrite<DbKindDht>> {
         self.get_or_create_space_ref(dna_hash, |space| space.dht_db.clone())
+    }
+
+    /// Get the new-schema DHT store (this will create the space if it doesn't already exist).
+    pub fn dht_store(&self, dna_hash: &DnaHash) -> DatabaseResult<DhtStore> {
+        self.get_or_create_space_ref(dna_hash, |space| space.dht_store.clone())
     }
 
     /// Get the peer meta store for a DNA space.
@@ -480,6 +497,7 @@ impl Space {
         db_sync_strategy: DbSyncStrategy,
         db_key: DbKey,
         db_max_readers: u16,
+        space_data_config: holochain_data::HolochainDataConfig,
         data_db_key: Option<holochain_data::DbKey>,
     ) -> DatabaseResult<Self> {
         let (db_sync_level, data_db_sync_level) = match db_sync_strategy {
@@ -487,7 +505,7 @@ impl Space {
             DbSyncStrategy::Resilient => (DbSyncLevel::Normal, holochain_data::DbSyncLevel::Normal),
         };
 
-        let (cache, dht_db, peer_meta_store) = tokio::task::block_in_place(|| {
+        let (cache, dht_db, peer_meta_store, dht_store) = tokio::task::block_in_place(|| {
             let cache = DbWrite::open_with_pool_config(
                 root_db_dir.as_ref(),
                 DbKindCache(dna_hash.clone()),
@@ -519,7 +537,15 @@ impl Space {
                 .map_err(|e| holochain_sqlite::error::DatabaseError::Other(e.into()))?;
             let peer_meta_store =
                 holochain_state::peer_metadata_store::PeerMetaStore::new(peer_meta_store_db);
-            DatabaseResult::Ok((cache, dht_db, peer_meta_store))
+            let new_dht_db = tokio::runtime::Handle::current()
+                .block_on(holochain_data::open_db(
+                    AsRef::<std::path::Path>::as_ref(&root_db_dir),
+                    holochain_data::kind::Dht::new(dna_hash.clone()),
+                    space_data_config.clone(),
+                ))
+                .map_err(|e| DatabaseError::Other(e.into()))?;
+            let dht_store = DhtStore::new(new_dht_db);
+            DatabaseResult::Ok((cache, dht_db, peer_meta_store, dht_store))
         })?;
 
         let witnessing_workspace = WitnessingWorkspace::default();
@@ -530,6 +556,7 @@ impl Space {
             cache_db: cache,
             authored_dbs: Arc::new(parking_lot::Mutex::new(HashMap::new())),
             dht_db,
+            dht_store,
             peer_meta_store,
             countersigning_workspaces: Default::default(),
             witnessing_workspace,
@@ -551,6 +578,7 @@ impl Space {
         SourceChain::raw_empty(
             self.get_or_create_authored_db(author.clone())?,
             self.dht_db.clone(),
+            self.dht_store.clone(),
             keystore,
             author,
         )
@@ -566,6 +594,7 @@ impl Space {
         Ok(SourceChainWorkspace::new(
             self.get_or_create_authored_db(author.clone())?.clone(),
             self.dht_db.clone(),
+            self.dht_store.clone(),
             self.cache_db.clone(),
             keystore,
             author,
@@ -689,6 +718,7 @@ impl TestSpace {
             .tempdir()
             .unwrap();
 
+        let test_space_data_config = holochain_data::HolochainDataConfig::default();
         Self {
             space: Space::new(
                 Arc::new(dna_hash),
@@ -696,6 +726,7 @@ impl TestSpace {
                 Default::default(),
                 Default::default(),
                 ConductorConfig::default().db_max_readers,
+                test_space_data_config,
                 None,
             )
             .unwrap(),

--- a/crates/holochain/src/core/queue_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer.rs
@@ -135,6 +135,7 @@ pub async fn spawn_queue_consumer_tasks(
             AppValidationWorkspace::new(
                 authored_db.clone(),
                 dht_db.clone(),
+                space.dht_store.clone(),
                 cache.clone(),
                 keystore.clone(),
             ),

--- a/crates/holochain/src/core/ribosome/host_fn/must_get_valid_record.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/must_get_valid_record.rs
@@ -199,6 +199,7 @@ mod tests {
         let workspace = HostFnWorkspaceRead::new(
             alice_host_fn_caller.authored_db.clone().into(),
             alice_host_fn_caller.dht_db.clone().into(),
+            alice_host_fn_caller.dht_store.clone(),
             alice_host_fn_caller.cache.clone(),
             alice_host_fn_caller.keystore.clone(),
             Some(cell_id.agent_pubkey().clone()),

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -876,6 +876,7 @@ pub struct AppValidationWorkspace {
     // Writeable because of warrants
     authored_db: DbWrite<DbKindAuthored>,
     dht_db: DbWrite<DbKindDht>,
+    dht_store: DhtStore,
     cache: DbWrite<DbKindCache>,
     keystore: MetaLairClient,
 }
@@ -885,12 +886,14 @@ impl AppValidationWorkspace {
         // Writeable because of warrants
         authored_db: DbWrite<DbKindAuthored>,
         dht_db: DbWrite<DbKindDht>,
+        dht_store: DhtStore,
         cache: DbWrite<DbKindCache>,
         keystore: MetaLairClient,
     ) -> Self {
         Self {
             authored_db,
             dht_db,
+            dht_store,
             cache,
             keystore,
         }
@@ -900,6 +903,7 @@ impl AppValidationWorkspace {
         Ok(HostFnWorkspace::new(
             self.authored_db.clone().into(),
             self.dht_db.clone().into(),
+            self.dht_store.clone(),
             self.cache.clone(),
             self.keystore.clone(),
             None,

--- a/crates/holochain/src/core/workflow/app_validation_workflow/get_zomes_to_invoke_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/get_zomes_to_invoke_tests.rs
@@ -51,6 +51,7 @@ async fn register_agent_activity() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -109,6 +110,7 @@ async fn store_entry_create_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -163,6 +165,7 @@ async fn store_entry_create_non_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -223,6 +226,7 @@ async fn store_entry_update_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -279,6 +283,7 @@ async fn store_entry_update_non_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -334,6 +339,7 @@ async fn store_record_create_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -375,6 +381,7 @@ async fn store_record_create_non_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -429,6 +436,7 @@ async fn store_record_create_wrong_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -474,6 +482,7 @@ async fn store_record_create_link() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -536,6 +545,7 @@ async fn store_record_update_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -581,6 +591,7 @@ async fn store_record_update_non_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -658,6 +669,7 @@ async fn store_record_update_of_update_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -715,6 +727,7 @@ async fn store_record_delete_without_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -770,6 +783,7 @@ async fn store_record_delete_non_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -828,6 +842,7 @@ async fn store_record_delete_link() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -898,6 +913,7 @@ async fn register_update_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -944,6 +960,7 @@ async fn register_update_non_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -1002,6 +1019,7 @@ async fn register_delete_create_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -1067,6 +1085,7 @@ async fn register_delete_create_non_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -1136,6 +1155,7 @@ async fn register_delete_update_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -1201,6 +1221,7 @@ async fn register_delete_update_non_app_entry() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -1256,6 +1277,7 @@ async fn register_create_link() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -1301,6 +1323,7 @@ async fn register_delete_link() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,

--- a/crates/holochain/src/core/workflow/app_validation_workflow/run_validation_callback_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/run_validation_callback_tests.rs
@@ -371,6 +371,7 @@ async fn validation_callback_rejects_op_depending_on_invalid_op() {
             .unwrap()
             .into(),
         test_space.space.dht_db.clone().into(),
+        test_space.space.dht_store.clone(),
         test_space.space.cache_db.clone(),
         fixt!(MetaLairClient),
         None,
@@ -456,6 +457,7 @@ impl TestCase {
                 .unwrap()
                 .into(),
             test_space.space.dht_db.clone().into(),
+            test_space.space.dht_store.clone(),
             test_space.space.cache_db.clone(),
             fixt!(MetaLairClient),
             None,

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -85,6 +85,7 @@ async fn main_workflow() {
             .get_or_create_authored_db(&dna_hash, cell_id.agent_pubkey().clone())
             .unwrap(),
         conductor.get_dht_db(&dna_hash).unwrap(),
+        conductor.get_dht_store(&dna_hash).unwrap(),
         conductor.get_cache_db(&cell_id).await.unwrap(),
         conductor.keystore(),
     ));
@@ -300,6 +301,7 @@ async fn validate_ops_in_sequence_must_get_agent_activity() {
             .get_or_create_authored_db(&dna_hash, cell_id.agent_pubkey().clone())
             .unwrap(),
         conductor.get_dht_db(&dna_hash).unwrap(),
+        conductor.get_dht_store(&dna_hash).unwrap(),
         conductor.get_cache_db(&cell_id).await.unwrap(),
         conductor.keystore(),
     ));
@@ -420,6 +422,7 @@ async fn validate_ops_in_sequence_must_get_action() {
             .get_or_create_authored_db(&dna_hash, cell_id.agent_pubkey().clone())
             .unwrap(),
         conductor.get_dht_db(&dna_hash).unwrap(),
+        conductor.get_dht_store(&dna_hash).unwrap(),
         conductor.get_cache_db(&cell_id).await.unwrap(),
         conductor.keystore(),
     ));
@@ -592,6 +595,7 @@ async fn handle_error_in_op_validation() {
             .get_or_create_authored_db(&dna_hash, cell_id.agent_pubkey().clone())
             .unwrap(),
         conductor.get_dht_db(&dna_hash).unwrap(),
+        conductor.get_dht_store(&dna_hash).unwrap(),
         conductor.get_cache_db(&cell_id).await.unwrap(),
         conductor.keystore(),
     ));
@@ -980,6 +984,7 @@ async fn app_validation_workflow_correctly_sets_state_and_status() {
             .get_or_create_authored_db(&dna_hash, cell_id.agent_pubkey().clone())
             .unwrap(),
         conductor.get_dht_db(&dna_hash).unwrap(),
+        conductor.get_dht_store(&dna_hash).unwrap(),
         conductor.get_cache_db(&cell_id).await.unwrap(),
         conductor.keystore(),
     ));

--- a/crates/holochain/src/core/workflow/call_zome_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/call_zome_workflow/unit_tests.rs
@@ -218,6 +218,7 @@ impl TestCase {
                 .get_or_create_authored_db(&dna_hash, agent.clone())
                 .unwrap(),
             conductor.get_dht_db(&dna_hash).unwrap(),
+            conductor.get_dht_store(&dna_hash).unwrap(),
             conductor.get_cache_db(&cell_id).await.unwrap(),
             conductor.keystore(),
             agent.clone(),

--- a/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
@@ -1797,6 +1797,7 @@ impl TestHarness {
                 .get_or_create_authored_db(author.clone())
                 .unwrap(),
             test_space.space.dht_db.clone(),
+            test_space.space.dht_store.clone(),
             keystore.clone(),
             dna_hash.clone(),
             author.clone(),

--- a/crates/holochain/src/core/workflow/genesis_workflow.rs
+++ b/crates/holochain/src/core/workflow/genesis_workflow.rs
@@ -15,6 +15,7 @@ use crate::core::ribosome::guest_callback::genesis_self_check::{
 use crate::{conductor::api::CellConductorApiT, core::ribosome::RibosomeT};
 use derive_more::Constructor;
 use holochain_sqlite::prelude::*;
+use holochain_state::dht_store::DhtStore;
 use holochain_state::source_chain;
 use holochain_types::prelude::*;
 use rusqlite::named_params;
@@ -109,6 +110,7 @@ where
     source_chain::genesis(
         workspace.vault.clone(),
         workspace.dht_db.clone(),
+        workspace.dht_store.clone(),
         api.keystore().clone(),
         cell_id.dna_hash().clone(),
         cell_id.agent_pubkey().clone(),
@@ -123,12 +125,21 @@ where
 pub struct GenesisWorkspace {
     vault: DbWrite<DbKindAuthored>,
     dht_db: DbWrite<DbKindDht>,
+    dht_store: DhtStore,
 }
 
 impl GenesisWorkspace {
     /// Constructor
-    pub fn new(env: DbWrite<DbKindAuthored>, dht_db: DbWrite<DbKindDht>) -> Self {
-        Self { vault: env, dht_db }
+    pub fn new(
+        env: DbWrite<DbKindAuthored>,
+        dht_db: DbWrite<DbKindDht>,
+        dht_store: DhtStore,
+    ) -> Self {
+        Self {
+            vault: env,
+            dht_db,
+            dht_store,
+        }
     }
 
     pub async fn has_genesis(&self, author: AgentPubKey) -> DatabaseResult<bool> {
@@ -181,8 +192,10 @@ mod tests {
         let dna = fake_dna_file("a");
         let author = fake_agent_pubkey_1();
 
+        let dht_store = holochain_state::test_utils::test_dht_store(dna.dna_hash().clone()).await;
+
         {
-            let workspace = GenesisWorkspace::new(vault.clone(), dht_db.to_db());
+            let workspace = GenesisWorkspace::new(vault.clone(), dht_db.to_db(), dht_store.clone());
 
             let mut api = MockCellConductorApiT::new();
             api.expect_keystore().return_const(keystore.clone());
@@ -201,10 +214,16 @@ mod tests {
         }
 
         {
-            let source_chain =
-                SourceChain::new(vault.clone(), dht_db.to_db(), keystore, author.clone())
-                    .await
-                    .unwrap();
+            let dht_store = dht_store;
+            let source_chain = SourceChain::new(
+                vault.clone(),
+                dht_db.to_db(),
+                dht_store,
+                keystore,
+                author.clone(),
+            )
+            .await
+            .unwrap();
             let actions = source_chain
                 .query(Default::default())
                 .await

--- a/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
+++ b/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
@@ -152,9 +152,11 @@ mod tests {
     use std::sync::Arc;
 
     async fn get_chain(cell: &SweetCell, keystore: MetaLairClient) -> SourceChain {
+        let dht_store = holochain_state::test_utils::test_dht_store(cell.dna_hash().clone()).await;
         SourceChain::new(
             cell.authored_db().clone(),
             cell.dht_db().clone(),
+            dht_store,
             keystore,
             cell.agent_pubkey().clone(),
         )
@@ -171,18 +173,25 @@ mod tests {
         let db = test_db.to_db();
         let author = fake_agent_pubkey_1();
 
-        // Genesis
-        fake_genesis(db.clone(), test_dht.to_db(), keystore.clone())
-            .await
-            .unwrap();
-
         let dna_def = DnaDefFixturator::new(Unpredictable).next().unwrap();
         let dna_def_hashed = DnaDefHashed::from_content_sync(dna_def.clone());
         let dna_hash = dna_def_hashed.hash.clone();
 
+        // Genesis
+        fake_genesis(
+            db.clone(),
+            test_dht.to_db(),
+            dna_hash.clone(),
+            keystore.clone(),
+        )
+        .await
+        .unwrap();
+
+        let dht_store = holochain_state::test_utils::test_dht_store(dna_hash.clone()).await;
         let workspace = SourceChainWorkspace::new(
             db.clone(),
             test_dht.to_db(),
+            dht_store,
             test_cache.to_db(),
             keystore,
             author.clone(),

--- a/crates/holochain/src/fixt.rs
+++ b/crates/holochain/src/fixt.rs
@@ -219,10 +219,12 @@ fixturator!(
         let cache = holochain_state::test_utils::test_cache_db();
         let keystore = holochain_keystore::test_keystore();
         tokio_helper::block_forever_on(async {
-            fake_genesis(authored_db.to_db(), dht_db.to_db(), keystore.clone()).await.unwrap();
+            fake_genesis(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), keystore.clone()).await.unwrap();
+            let dht_store = holochain_state::test_utils::test_dht_store(fake_dna_hash(get_fixt_index!() as u8)).await;
             HostFnWorkspace::new(
                 authored_db.to_db(),
                 dht_db.to_db(),
+                dht_store,
                 cache.to_db(),
                 keystore,
                 Some(fixt!(AgentPubKey, Predictable, get_fixt_index!())),
@@ -235,10 +237,12 @@ fixturator!(
         let cache = holochain_state::test_utils::test_cache_db();
         let keystore = holochain_keystore::test_keystore();
         tokio_helper::block_forever_on(async {
-            fake_genesis(authored_db.to_db(), dht_db.to_db(), keystore.clone()).await.unwrap();
+            fake_genesis(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), keystore.clone()).await.unwrap();
+            let dht_store = holochain_state::test_utils::test_dht_store(fake_dna_hash(get_fixt_index!() as u8)).await;
             HostFnWorkspace::new(
                 authored_db.to_db(),
                 dht_db.to_db(),
+                dht_store,
                 cache.to_db(),
                 keystore,
                 Some(fixt!(AgentPubKey, Predictable, get_fixt_index!())),
@@ -252,10 +256,12 @@ fixturator!(
         let agent = fixt!(AgentPubKey, Predictable, get_fixt_index!());
         let keystore = holochain_keystore::test_keystore();
         tokio_helper::block_forever_on(async {
-            crate::test_utils::fake_genesis_for_agent(authored_db.to_db(), dht_db.to_db(), agent.clone(), keystore.clone()).await.unwrap();
+            crate::test_utils::fake_genesis_for_agent(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), agent.clone(), keystore.clone()).await.unwrap();
+            let dht_store = holochain_state::test_utils::test_dht_store(fake_dna_hash(get_fixt_index!() as u8)).await;
             HostFnWorkspace::new(
                 authored_db.to_db(),
                 dht_db.to_db(),
+                dht_store,
                 cache.to_db(),
                 keystore,
                 Some(agent),
@@ -272,10 +278,12 @@ fixturator!(
         let cache = holochain_state::test_utils::test_cache_db();
         let keystore = holochain_keystore::test_keystore();
         tokio_helper::block_forever_on(async {
-            fake_genesis(authored_db.to_db(), dht_db.to_db(), keystore.clone()).await.unwrap();
+            fake_genesis(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), keystore.clone()).await.unwrap();
+            let dht_store = holochain_state::test_utils::test_dht_store(fake_dna_hash(get_fixt_index!() as u8)).await;
             HostFnWorkspaceRead::new(
                 authored_db.to_db().into(),
                 dht_db.to_db().into(),
+                dht_store,
                 cache.to_db(),
                 keystore,
                 Some(fixt!(AgentPubKey, Predictable, get_fixt_index!())),
@@ -288,10 +296,12 @@ fixturator!(
         let cache = holochain_state::test_utils::test_cache_db();
         let keystore = holochain_keystore::test_keystore();
         tokio_helper::block_forever_on(async {
-            fake_genesis(authored_db.to_db(), dht_db.to_db(), keystore.clone()).await.unwrap();
+            fake_genesis(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), keystore.clone()).await.unwrap();
+            let dht_store = holochain_state::test_utils::test_dht_store(fake_dna_hash(get_fixt_index!() as u8)).await;
             HostFnWorkspaceRead::new(
                 authored_db.to_db().into(),
                 dht_db.to_db().into(),
+                dht_store,
                 cache.to_db(),
                 keystore,
                 Some(fixt!(AgentPubKey, Predictable, get_fixt_index!())),
@@ -305,10 +315,12 @@ fixturator!(
         let agent = fixt!(AgentPubKey, Predictable, get_fixt_index!());
         let keystore = holochain_keystore::test_keystore();
         tokio_helper::block_forever_on(async {
-            crate::test_utils::fake_genesis_for_agent(authored_db.to_db(), dht_db.to_db(), agent.clone(), keystore.clone()).await.unwrap();
+            crate::test_utils::fake_genesis_for_agent(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), agent.clone(), keystore.clone()).await.unwrap();
+            let dht_store = holochain_state::test_utils::test_dht_store(fake_dna_hash(get_fixt_index!() as u8)).await;
             HostFnWorkspaceRead::new(
                 authored_db.to_db().into(),
                 dht_db.to_db().into(),
+                dht_store,
                 cache.to_db(),
                 keystore,
                 Some(agent),

--- a/crates/holochain/src/sweettest/sweet_conductor.rs
+++ b/crates/holochain/src/sweettest/sweet_conductor.rs
@@ -875,6 +875,7 @@ impl SweetConductor {
             self.get_or_create_authored_db(dna_hash, agent_key.clone())
                 .unwrap(),
             self.get_dht_db(dna_hash).unwrap(),
+            self.get_dht_store(dna_hash).unwrap(),
             self.keystore().clone(),
             agent_key.clone(),
         )

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -26,7 +26,6 @@ use holochain_state::prelude::SourceChainResult;
 use holochain_state::prelude::StateQueryResult;
 use holochain_state::source_chain;
 use holochain_types::prelude::*;
-use holochain_types::test_utils::fake_dna_file;
 use holochain_types::test_utils::fake_dna_zomes;
 use holochain_wasm_test_utils::TestWasm;
 pub use itertools;
@@ -515,25 +514,34 @@ pub fn fake_valid_dna_file(network_seed: &str) -> DnaFile {
 }
 
 /// Run genesis on the source chain for testing.
+///
+/// `dna_hash` must match the DNA the caller's `dht_db` was opened for; the
+/// helper reuses it for the genesis `Action::Dna` and for the new-DB
+/// `DhtStore` so the legacy and mirrored writes land in the same DNA space.
 pub async fn fake_genesis(
     vault: DbWrite<DbKindAuthored>,
     dht_db: DbWrite<DbKindDht>,
+    dna_hash: DnaHash,
     keystore: MetaLairClient,
 ) -> SourceChainResult<()> {
-    fake_genesis_for_agent(vault, dht_db, fake_agent_pubkey_1(), keystore).await
+    fake_genesis_for_agent(vault, dht_db, dna_hash, fake_agent_pubkey_1(), keystore).await
 }
 
 /// Run genesis on the source chain for a specific agent for testing.
+///
+/// `dna_hash` must match the DNA the caller's `dht_db` was opened for; the
+/// helper reuses it for the genesis `Action::Dna` and for the new-DB
+/// `DhtStore` so the legacy and mirrored writes land in the same DNA space.
 pub async fn fake_genesis_for_agent(
     vault: DbWrite<DbKindAuthored>,
     dht_db: DbWrite<DbKindDht>,
+    dna_hash: DnaHash,
     agent: AgentPubKey,
     keystore: MetaLairClient,
 ) -> SourceChainResult<()> {
-    let dna = fake_dna_file("cool dna");
-    let dna_hash = dna.dna_hash().clone();
+    let dht_store = holochain_state::test_utils::test_dht_store(dna_hash.clone()).await;
 
-    source_chain::genesis(vault, dht_db.clone(), keystore, dna_hash, agent, None).await
+    source_chain::genesis(vault, dht_db, dht_store, keystore, dna_hash, agent, None).await
 }
 
 /// Force all dht ops without enough validation receipts to be published.

--- a/crates/holochain/src/test_utils/host_fn_caller.rs
+++ b/crates/holochain/src/test_utils/host_fn_caller.rs
@@ -20,6 +20,7 @@ use holo_hash::AnyDhtHash;
 use holochain_keystore::MetaLairClient;
 use holochain_p2p::actor::GetLinksRequestOptions;
 use holochain_p2p::{HolochainP2pDna, HolochainP2pDnaT};
+use holochain_state::dht_store::DhtStore;
 use holochain_state::host_fn_workspace::SourceChainWorkspace;
 use holochain_types::prelude::*;
 use holochain_wasm_test_utils::TestWasmPair;
@@ -85,6 +86,7 @@ pub enum MaybeLinkable {
 pub struct HostFnCaller {
     pub authored_db: DbWrite<DbKindAuthored>,
     pub dht_db: DbWrite<DbKindDht>,
+    pub dht_store: DhtStore,
     pub cache: DbWrite<DbKindCache>,
     pub ribosome: RealRibosome,
     pub zome_path: ZomePath,
@@ -116,6 +118,7 @@ impl HostFnCaller {
             .get_or_create_authored_db(cell_id.dna_hash(), cell_id.agent_pubkey().clone())
             .unwrap();
         let dht_db = handle.get_dht_db(cell_id.dna_hash()).unwrap();
+        let dht_store = handle.get_dht_store(cell_id.dna_hash()).unwrap();
         let cache = handle.get_cache_db(cell_id).await.unwrap();
         let keystore = handle.keystore().clone();
         let network = holochain_p2p::HolochainP2pDna::new(
@@ -141,6 +144,7 @@ impl HostFnCaller {
         HostFnCaller {
             authored_db,
             dht_db,
+            dht_store,
             cache,
             ribosome,
             zome_path,
@@ -164,6 +168,7 @@ impl HostFnCaller {
         let HostFnCaller {
             authored_db,
             dht_db,
+            dht_store,
             cache,
             network,
             keystore,
@@ -178,6 +183,7 @@ impl HostFnCaller {
         let workspace = SourceChainWorkspace::new(
             authored_db,
             dht_db,
+            dht_store,
             cache,
             keystore.clone(),
             cell_id.agent_pubkey().clone(),

--- a/crates/holochain_data/migrations/dht/20260422120000_initial_schema.down.sql
+++ b/crates/holochain_data/migrations/dht/20260422120000_initial_schema.down.sql
@@ -1,3 +1,4 @@
+DROP TABLE IF EXISTS ScheduledFunction;
 DROP TABLE IF EXISTS DeletedRecord;
 DROP TABLE IF EXISTS UpdatedRecord;
 DROP TABLE IF EXISTS DeletedLink;

--- a/crates/holochain_data/migrations/dht/20260422120000_initial_schema.up.sql
+++ b/crates/holochain_data/migrations/dht/20260422120000_initial_schema.up.sql
@@ -1,8 +1,9 @@
 -- DHT database schema (per-DNA). See docs/design/state_model.md.
 --
 -- Integer convention summary:
---   ActionType         : 1..=8 (Dna, AgentValidationPkg, InitZomesComplete,
---                               Create, Update, Delete, CreateLink, DeleteLink)
+--   ActionType         : 1..=10 (Dna, AgentValidationPkg, InitZomesComplete,
+--                                Create, Update, Delete, CreateLink, DeleteLink,
+--                                CloseChain, OpenChain)
 --   ChainOpType        : 1..=9 (see state_model.md)
 --   CapAccess          : 0=Unrestricted, 1=Transferable, 2=Assigned
 --   record_validity /
@@ -20,7 +21,7 @@
 
 -- Actions: both self-authored and network-received.
 CREATE TABLE Action (
-    hash            BLOB    PRIMARY KEY,
+    hash            BLOB    PRIMARY KEY ON CONFLICT IGNORE,
     author          BLOB    NOT NULL,
     seq             INTEGER NOT NULL,
     prev_hash       BLOB,                     -- NULL only for the genesis Dna action
@@ -39,20 +40,20 @@ CREATE TABLE Action (
 
 -- Public entries.
 CREATE TABLE Entry (
-    hash BLOB PRIMARY KEY,
+    hash BLOB PRIMARY KEY ON CONFLICT IGNORE,
     blob BLOB NOT NULL
 ) STRICT, WITHOUT ROWID;
 
 -- Private entries (local author only).
 CREATE TABLE PrivateEntry (
-    hash   BLOB PRIMARY KEY,
+    hash   BLOB PRIMARY KEY ON CONFLICT IGNORE,
     author BLOB NOT NULL,
     blob   BLOB NOT NULL
 ) STRICT, WITHOUT ROWID;
 
 -- Capability grants index.
 CREATE TABLE CapGrant (
-    action_hash BLOB    PRIMARY KEY,
+    action_hash BLOB    PRIMARY KEY ON CONFLICT IGNORE,
     cap_access  INTEGER NOT NULL,             -- 0=Unrestricted, 1=Transferable, 2=Assigned
     tag         TEXT,
     FOREIGN KEY(action_hash) REFERENCES Action(hash)
@@ -76,7 +77,7 @@ CREATE TABLE ChainLock (
 
 -- Limbo for network-received chain ops awaiting validation.
 CREATE TABLE LimboChainOp (
-    hash                    BLOB    PRIMARY KEY,
+    hash                    BLOB    PRIMARY KEY ON CONFLICT IGNORE,
     op_type                 INTEGER NOT NULL,
     action_hash             BLOB    NOT NULL,
 
@@ -100,7 +101,7 @@ CREATE TABLE LimboChainOp (
 
 -- Limbo for network-received warrants awaiting validation.
 CREATE TABLE LimboWarrant (
-    hash                    BLOB    PRIMARY KEY,
+    hash                    BLOB    PRIMARY KEY ON CONFLICT IGNORE,
     author                  BLOB    NOT NULL,
     timestamp               INTEGER NOT NULL,
     warrantee               BLOB    NOT NULL,
@@ -120,7 +121,7 @@ CREATE TABLE LimboWarrant (
 
 -- Integrated chain ops.
 CREATE TABLE ChainOp (
-    hash               BLOB    PRIMARY KEY,
+    hash               BLOB    PRIMARY KEY ON CONFLICT IGNORE,
     op_type            INTEGER NOT NULL,
     action_hash        BLOB    NOT NULL,
 
@@ -140,7 +141,7 @@ CREATE TABLE ChainOp (
 
 -- Publish state for self-authored chain ops.
 CREATE TABLE ChainOpPublish (
-    op_hash           BLOB    PRIMARY KEY,
+    op_hash           BLOB    PRIMARY KEY ON CONFLICT IGNORE,
     last_publish_time INTEGER,
     receipts_complete INTEGER,
     FOREIGN KEY(op_hash) REFERENCES ChainOp(hash)
@@ -148,7 +149,7 @@ CREATE TABLE ChainOpPublish (
 
 -- Validation receipts for authored ops.
 CREATE TABLE ValidationReceipt (
-    hash          BLOB    PRIMARY KEY,
+    hash          BLOB    PRIMARY KEY ON CONFLICT IGNORE,
     op_hash       BLOB    NOT NULL,
     validators    BLOB    NOT NULL,
     signature     BLOB    NOT NULL,
@@ -158,7 +159,7 @@ CREATE TABLE ValidationReceipt (
 
 -- Integrated warrants.
 CREATE TABLE Warrant (
-    hash               BLOB    PRIMARY KEY,
+    hash               BLOB    PRIMARY KEY ON CONFLICT IGNORE,
     author             BLOB    NOT NULL,
     timestamp          INTEGER NOT NULL,
     warrantee          BLOB    NOT NULL,
@@ -168,14 +169,14 @@ CREATE TABLE Warrant (
 
 -- Publish state for self-authored warrants.
 CREATE TABLE WarrantPublish (
-    warrant_hash      BLOB    PRIMARY KEY,
+    warrant_hash      BLOB    PRIMARY KEY ON CONFLICT IGNORE,
     last_publish_time INTEGER,
     FOREIGN KEY(warrant_hash) REFERENCES Warrant(hash)
 ) STRICT, WITHOUT ROWID;
 
 -- Link index.
 CREATE TABLE Link (
-    action_hash BLOB    PRIMARY KEY,
+    action_hash BLOB    PRIMARY KEY ON CONFLICT IGNORE,
     base_hash   BLOB    NOT NULL,
     zome_index  INTEGER NOT NULL,
     link_type   INTEGER NOT NULL,
@@ -185,14 +186,14 @@ CREATE TABLE Link (
 
 -- Deleted-link index.
 CREATE TABLE DeletedLink (
-    action_hash      BLOB PRIMARY KEY,
+    action_hash      BLOB PRIMARY KEY ON CONFLICT IGNORE,
     create_link_hash BLOB NOT NULL,
     FOREIGN KEY(action_hash) REFERENCES Action(hash) ON DELETE CASCADE
 ) STRICT, WITHOUT ROWID;
 
 -- Updated-record index.
 CREATE TABLE UpdatedRecord (
-    action_hash          BLOB PRIMARY KEY,
+    action_hash          BLOB PRIMARY KEY ON CONFLICT IGNORE,
     original_action_hash BLOB NOT NULL,
     original_entry_hash  BLOB NOT NULL,
     FOREIGN KEY(action_hash) REFERENCES Action(hash) ON DELETE CASCADE
@@ -200,8 +201,20 @@ CREATE TABLE UpdatedRecord (
 
 -- Deleted-record index.
 CREATE TABLE DeletedRecord (
-    action_hash         BLOB PRIMARY KEY,
+    action_hash         BLOB PRIMARY KEY ON CONFLICT IGNORE,
     deletes_action_hash BLOB NOT NULL,
     deletes_entry_hash  BLOB NOT NULL,
     FOREIGN KEY(action_hash) REFERENCES Action(hash) ON DELETE CASCADE
+) STRICT, WITHOUT ROWID;
+
+-- Scheduled function records (per-author within this DNA's DB).
+CREATE TABLE ScheduledFunction (
+    author         BLOB    NOT NULL,
+    zome_name      TEXT    NOT NULL,
+    scheduled_fn   TEXT    NOT NULL,
+    maybe_schedule BLOB    NOT NULL,
+    start_at       INTEGER NOT NULL,
+    end_at         INTEGER NOT NULL,
+    ephemeral      INTEGER NOT NULL,             -- 0/1
+    PRIMARY KEY (author, zome_name, scheduled_fn) ON CONFLICT ROLLBACK
 ) STRICT, WITHOUT ROWID;

--- a/crates/holochain_data/src/dht.rs
+++ b/crates/holochain_data/src/dht.rs
@@ -18,8 +18,13 @@ mod inner;
 mod tx_operations;
 
 pub use inner::chain_op::InsertChainOp;
+pub use inner::deleted_link::InsertDeletedLink;
+pub use inner::deleted_record::InsertDeletedRecord;
 pub use inner::limbo_chain_op::InsertLimboChainOp;
 pub use inner::limbo_warrant::InsertLimboWarrant;
+pub use inner::link::InsertLink;
+pub use inner::scheduled_function::InsertScheduledFunction;
+pub use inner::updated_record::InsertUpdatedRecord;
 pub use inner::warrant::InsertWarrant;
 
 #[cfg(test)]
@@ -898,7 +903,14 @@ mod tests {
         let base = sample_base(5);
 
         let mut tx = db.begin().await.unwrap();
-        tx.insert_link_index(&action_hash, &base, 3, 7, Some(b"tag-bytes"))
+        let _ = tx
+            .insert_link_index(InsertLink {
+                action_hash: &action_hash,
+                base_hash: &base,
+                zome_index: 3,
+                link_type: 7,
+                tag: Some(b"tag-bytes"),
+            })
             .await
             .unwrap();
         tx.commit().await.unwrap();
@@ -926,7 +938,11 @@ mod tests {
         let create_link = ActionHash::from_raw_36(vec![0x55; 36]);
 
         let mut tx = db.begin().await.unwrap();
-        tx.insert_deleted_link_index(&delete_action, &create_link)
+        let _ = tx
+            .insert_deleted_link_index(InsertDeletedLink {
+                action_hash: &delete_action,
+                create_link_hash: &create_link,
+            })
             .await
             .unwrap();
         tx.commit().await.unwrap();
@@ -943,7 +959,12 @@ mod tests {
         let original_entry = EntryHash::from_raw_36(vec![0x77; 36]);
 
         let mut tx = db.begin().await.unwrap();
-        tx.insert_updated_record_index(&update_action, &original, &original_entry)
+        let _ = tx
+            .insert_updated_record_index(InsertUpdatedRecord {
+                action_hash: &update_action,
+                original_action_hash: &original,
+                original_entry_hash: &original_entry,
+            })
             .await
             .unwrap();
         tx.commit().await.unwrap();
@@ -968,7 +989,12 @@ mod tests {
         let deletes_entry = EntryHash::from_raw_36(vec![0x99; 36]);
 
         let mut tx = db.begin().await.unwrap();
-        tx.insert_deleted_record_index(&delete_action, &deletes_action, &deletes_entry)
+        let _ = tx
+            .insert_deleted_record_index(InsertDeletedRecord {
+                action_hash: &delete_action,
+                deletes_action_hash: &deletes_action,
+                deletes_entry_hash: &deletes_entry,
+            })
             .await
             .unwrap();
         tx.commit().await.unwrap();
@@ -1080,5 +1106,47 @@ mod tests {
             );
             assert_eq!(fetched.signature().0, [seed; 64]);
         }
+    }
+
+    #[tokio::test]
+    async fn set_chain_op_receipts_complete_round_trip() {
+        let db = test_open_db(dht_db_id()).await.unwrap();
+
+        let action = sample_action(7);
+        db.insert_action(&action, Some(RecordValidity::Accepted))
+            .await
+            .unwrap();
+
+        let op_hash = DhtOpHash::from_raw_36(vec![9u8; 36]);
+        let basis_hash =
+            AnyDhtHash::from_raw_36_and_type(vec![9u8; 36], holo_hash::hash_type::AnyDht::Action);
+
+        db.insert_chain_op(InsertChainOp {
+            op_hash: &op_hash,
+            action_hash: action.as_hash(),
+            op_type: 1,
+            basis_hash: &basis_hash,
+            storage_center_loc: 0,
+            validation_status: RecordValidity::Accepted,
+            locally_validated: true,
+            when_received: Timestamp::from_micros(1),
+            when_integrated: Timestamp::from_micros(1),
+            serialized_size: 0,
+        })
+        .await
+        .unwrap();
+
+        db.insert_chain_op_publish(&op_hash, None, None)
+            .await
+            .unwrap();
+        let _ = db.set_chain_op_receipts_complete(&op_hash).await.unwrap();
+
+        let row = db
+            .as_ref()
+            .get_chain_op_publish(op_hash)
+            .await
+            .unwrap()
+            .expect("row");
+        assert_eq!(row.receipts_complete, Some(1));
     }
 }

--- a/crates/holochain_data/src/dht/db_operations.rs
+++ b/crates/holochain_data/src/dht/db_operations.rs
@@ -16,6 +16,7 @@ mod entry;
 mod limbo_chain_op;
 mod limbo_warrant;
 mod link;
+mod scheduled_function;
 mod updated_record;
 mod validation_receipt;
 mod warrant;

--- a/crates/holochain_data/src/dht/db_operations/chain_op_publish.rs
+++ b/crates/holochain_data/src/dht/db_operations/chain_op_publish.rs
@@ -22,6 +22,11 @@ impl DbWrite<Dht> {
         )
         .await
     }
+
+    /// Mark receipts as complete for the given op. Returns the number of rows updated.
+    pub async fn set_chain_op_receipts_complete(&self, op_hash: &DhtOpHash) -> sqlx::Result<u64> {
+        chain_op_publish::set_receipts_complete(self.pool(), op_hash).await
+    }
 }
 
 impl DbRead<Dht> {

--- a/crates/holochain_data/src/dht/db_operations/deleted_link.rs
+++ b/crates/holochain_data/src/dht/db_operations/deleted_link.rs
@@ -1,10 +1,20 @@
-//! `DbRead<Dht>` API for the `DeletedLink` table.
+//! `DbRead<Dht>` / `DbWrite<Dht>` API for the `DeletedLink` table.
 
-use super::super::inner::deleted_link;
-use crate::handles::DbRead;
+use super::super::inner::deleted_link::{self, InsertDeletedLink};
+use crate::handles::{DbRead, DbWrite};
 use crate::kind::Dht;
 use crate::models::dht::DeletedLinkRow;
 use holo_hash::ActionHash;
+
+impl DbWrite<Dht> {
+    /// Insert a row into the `DeletedLink` index table. Returns the number of rows inserted.
+    pub async fn insert_deleted_link_index(
+        &self,
+        link: InsertDeletedLink<'_>,
+    ) -> sqlx::Result<u64> {
+        deleted_link::insert_deleted_link_index(self.pool(), link).await
+    }
+}
 
 impl DbRead<Dht> {
     pub async fn get_deleted_links(

--- a/crates/holochain_data/src/dht/db_operations/deleted_record.rs
+++ b/crates/holochain_data/src/dht/db_operations/deleted_record.rs
@@ -1,10 +1,20 @@
-//! `DbRead<Dht>` API for the `DeletedRecord` table.
+//! `DbRead<Dht>` / `DbWrite<Dht>` API for the `DeletedRecord` table.
 
-use super::super::inner::deleted_record;
-use crate::handles::DbRead;
+use super::super::inner::deleted_record::{self, InsertDeletedRecord};
+use crate::handles::{DbRead, DbWrite};
 use crate::kind::Dht;
 use crate::models::dht::DeletedRecordRow;
 use holo_hash::ActionHash;
+
+impl DbWrite<Dht> {
+    /// Insert a row into the `DeletedRecord` index table. Returns the number of rows inserted.
+    pub async fn insert_deleted_record_index(
+        &self,
+        record: InsertDeletedRecord<'_>,
+    ) -> sqlx::Result<u64> {
+        deleted_record::insert_deleted_record_index(self.pool(), record).await
+    }
+}
 
 impl DbRead<Dht> {
     pub async fn get_deleted_records(

--- a/crates/holochain_data/src/dht/db_operations/link.rs
+++ b/crates/holochain_data/src/dht/db_operations/link.rs
@@ -1,10 +1,17 @@
-//! `DbRead<Dht>` API for the `Link` table.
+//! `DbRead<Dht>` / `DbWrite<Dht>` API for the `Link` table.
 
-use super::super::inner::link;
-use crate::handles::DbRead;
+use super::super::inner::link::{self, InsertLink};
+use crate::handles::{DbRead, DbWrite};
 use crate::kind::Dht;
 use crate::models::dht::LinkRow;
 use holo_hash::AnyLinkableHash;
+
+impl DbWrite<Dht> {
+    /// Insert a row into the `Link` index table. Returns the number of rows inserted.
+    pub async fn insert_link_index(&self, link: InsertLink<'_>) -> sqlx::Result<u64> {
+        link::insert_link_index(self.pool(), link).await
+    }
+}
 
 impl DbRead<Dht> {
     pub async fn get_links_by_base(&self, base: AnyLinkableHash) -> sqlx::Result<Vec<LinkRow>> {

--- a/crates/holochain_data/src/dht/db_operations/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/db_operations/scheduled_function.rs
@@ -1,0 +1,64 @@
+//! `DbRead<Dht>` / `DbWrite<Dht>` API for the `ScheduledFunction` table.
+
+use super::super::inner::scheduled_function::{self, InsertScheduledFunction};
+use crate::handles::{DbRead, DbWrite};
+use crate::kind::Dht;
+use holo_hash::AgentPubKey;
+use holochain_timestamp::Timestamp;
+
+impl DbRead<Dht> {
+    /// Fetch persisted (non-ephemeral) scheduled-function rows for `author` whose
+    /// `end_at` is before `now`. Returns `(zome_name, scheduled_fn, maybe_schedule_blob)` tuples.
+    pub async fn get_expired_persisted_scheduled_functions(
+        &self,
+        author: &AgentPubKey,
+        now: Timestamp,
+    ) -> sqlx::Result<Vec<(String, String, Vec<u8>)>> {
+        scheduled_function::get_expired_persisted_scheduled_functions(self.pool(), author, now)
+            .await
+    }
+}
+
+impl DbWrite<Dht> {
+    /// Fetch persisted (non-ephemeral) scheduled-function rows for `author` whose
+    /// `end_at` is before `now`. Returns `(zome_name, scheduled_fn, maybe_schedule_blob)` tuples.
+    pub async fn get_expired_persisted_scheduled_functions(
+        &self,
+        author: &AgentPubKey,
+        now: Timestamp,
+    ) -> sqlx::Result<Vec<(String, String, Vec<u8>)>> {
+        scheduled_function::get_expired_persisted_scheduled_functions(self.pool(), author, now)
+            .await
+    }
+
+    /// Upsert a scheduled-function row. Returns the number of rows written.
+    pub async fn insert_scheduled_function(
+        &self,
+        f: InsertScheduledFunction<'_>,
+    ) -> sqlx::Result<u64> {
+        scheduled_function::insert_scheduled_function(self.pool(), f).await
+    }
+
+    /// Delete the scheduled-function row for the given `(author, zome_name, scheduled_fn)` triple.
+    /// Returns the number of rows deleted.
+    pub async fn delete_scheduled_function(
+        &self,
+        author: &AgentPubKey,
+        zome_name: &str,
+        scheduled_fn: &str,
+    ) -> sqlx::Result<u64> {
+        scheduled_function::delete_scheduled_function(self.pool(), author, zome_name, scheduled_fn)
+            .await
+    }
+
+    /// Delete all live ephemeral scheduled-function rows for `author` whose
+    /// `start_at` is at or before `now`. Returns the number of rows deleted.
+    pub async fn delete_live_ephemeral_scheduled_functions(
+        &self,
+        author: &AgentPubKey,
+        now: Timestamp,
+    ) -> sqlx::Result<u64> {
+        scheduled_function::delete_live_ephemeral_scheduled_functions(self.pool(), author, now)
+            .await
+    }
+}

--- a/crates/holochain_data/src/dht/db_operations/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/db_operations/scheduled_function.rs
@@ -20,26 +20,15 @@ impl DbRead<Dht> {
 }
 
 impl DbWrite<Dht> {
-    /// Fetch persisted (non-ephemeral) scheduled-function rows for `author` whose
-    /// `end_at` is before `now`. Returns `(zome_name, scheduled_fn, maybe_schedule_blob)` tuples.
-    pub async fn get_expired_persisted_scheduled_functions(
-        &self,
-        author: &AgentPubKey,
-        now: Timestamp,
-    ) -> sqlx::Result<Vec<(String, String, Vec<u8>)>> {
-        scheduled_function::get_expired_persisted_scheduled_functions(self.pool(), author, now)
-            .await
-    }
-
     /// Upsert a scheduled-function row. Returns the number of rows written.
-    pub async fn insert_scheduled_function(
+    pub async fn upsert_scheduled_function(
         &self,
         f: InsertScheduledFunction<'_>,
     ) -> sqlx::Result<u64> {
-        scheduled_function::insert_scheduled_function(self.pool(), f).await
+        scheduled_function::upsert_scheduled_function(self.pool(), f).await
     }
 
-    /// Delete the scheduled-function row for the given `(author, zome_name, scheduled_fn)` triple.
+    /// Delete the scheduled-function row for the given `(author, zome_name, scheduled_fn)` tuple.
     /// Returns the number of rows deleted.
     pub async fn delete_scheduled_function(
         &self,

--- a/crates/holochain_data/src/dht/db_operations/updated_record.rs
+++ b/crates/holochain_data/src/dht/db_operations/updated_record.rs
@@ -1,10 +1,20 @@
-//! `DbRead<Dht>` API for the `UpdatedRecord` table.
+//! `DbRead<Dht>` / `DbWrite<Dht>` API for the `UpdatedRecord` table.
 
-use super::super::inner::updated_record;
-use crate::handles::DbRead;
+use super::super::inner::updated_record::{self, InsertUpdatedRecord};
+use crate::handles::{DbRead, DbWrite};
 use crate::kind::Dht;
 use crate::models::dht::UpdatedRecordRow;
 use holo_hash::ActionHash;
+
+impl DbWrite<Dht> {
+    /// Insert a row into the `UpdatedRecord` index table. Returns the number of rows inserted.
+    pub async fn insert_updated_record_index(
+        &self,
+        record: InsertUpdatedRecord<'_>,
+    ) -> sqlx::Result<u64> {
+        updated_record::insert_updated_record_index(self.pool(), record).await
+    }
+}
 
 impl DbRead<Dht> {
     pub async fn get_updated_records(

--- a/crates/holochain_data/src/dht/inner.rs
+++ b/crates/holochain_data/src/dht/inner.rs
@@ -17,6 +17,7 @@ pub(crate) mod entry;
 pub(crate) mod limbo_chain_op;
 pub(crate) mod limbo_warrant;
 pub(crate) mod link;
+pub(crate) mod scheduled_function;
 pub(crate) mod updated_record;
 pub(crate) mod validation_receipt;
 pub(crate) mod warrant;

--- a/crates/holochain_data/src/dht/inner/chain_op_publish.rs
+++ b/crates/holochain_data/src/dht/inner/chain_op_publish.rs
@@ -41,3 +41,19 @@ where
     .fetch_optional(executor)
     .await
 }
+
+/// Mark receipts as complete for the given op. Receipts can never transition
+/// back to incomplete, so no flag is needed.
+pub(crate) async fn set_receipts_complete<'e, E>(
+    executor: E,
+    op_hash: &DhtOpHash,
+) -> sqlx::Result<u64>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let result = sqlx::query("UPDATE ChainOpPublish SET receipts_complete = 1 WHERE op_hash = ?")
+        .bind(op_hash.get_raw_36())
+        .execute(executor)
+        .await?;
+    Ok(result.rows_affected())
+}

--- a/crates/holochain_data/src/dht/inner/deleted_link.rs
+++ b/crates/holochain_data/src/dht/inner/deleted_link.rs
@@ -4,20 +4,29 @@ use crate::models::dht::DeletedLinkRow;
 use holo_hash::ActionHash;
 use sqlx::{Executor, Sqlite};
 
-pub(crate) async fn insert_deleted_link_index<'e, E>(
+/// Parameters for inserting a row into the `DeletedLink` index table.
+pub struct InsertDeletedLink<'a> {
+    /// Hash of the DeleteLink action (primary key).
+    pub action_hash: &'a ActionHash,
+    /// Hash of the CreateLink action being deleted.
+    pub create_link_hash: &'a ActionHash,
+}
+
+/// Insert a row into the `DeletedLink` index table. Returns the number of rows inserted.
+pub(crate) async fn insert_deleted_link_index<'a, 'e, E>(
     executor: E,
-    action_hash: &ActionHash,
-    create_link_hash: &ActionHash,
-) -> sqlx::Result<()>
+    link: InsertDeletedLink<'a>,
+) -> sqlx::Result<u64>
 where
     E: Executor<'e, Database = Sqlite>,
 {
-    sqlx::query("INSERT INTO DeletedLink (action_hash, create_link_hash) VALUES (?, ?)")
-        .bind(action_hash.get_raw_36())
-        .bind(create_link_hash.get_raw_36())
-        .execute(executor)
-        .await?;
-    Ok(())
+    let result =
+        sqlx::query("INSERT INTO DeletedLink (action_hash, create_link_hash) VALUES (?, ?)")
+            .bind(link.action_hash.get_raw_36())
+            .bind(link.create_link_hash.get_raw_36())
+            .execute(executor)
+            .await?;
+    Ok(result.rows_affected())
 }
 
 pub(crate) async fn get_deleted_links<'e, E>(

--- a/crates/holochain_data/src/dht/inner/deleted_record.rs
+++ b/crates/holochain_data/src/dht/inner/deleted_record.rs
@@ -4,25 +4,34 @@ use crate::models::dht::DeletedRecordRow;
 use holo_hash::{ActionHash, EntryHash};
 use sqlx::{Executor, Sqlite};
 
-pub(crate) async fn insert_deleted_record_index<'e, E>(
+/// Parameters for inserting a row into the `DeletedRecord` index table.
+pub struct InsertDeletedRecord<'a> {
+    /// Hash of the Delete action (primary key).
+    pub action_hash: &'a ActionHash,
+    /// Hash of the action whose record is being deleted.
+    pub deletes_action_hash: &'a ActionHash,
+    /// Hash of the entry whose record is being deleted.
+    pub deletes_entry_hash: &'a EntryHash,
+}
+
+/// Insert a row into the `DeletedRecord` index table. Returns the number of rows inserted.
+pub(crate) async fn insert_deleted_record_index<'a, 'e, E>(
     executor: E,
-    action_hash: &ActionHash,
-    deletes_action_hash: &ActionHash,
-    deletes_entry_hash: &EntryHash,
-) -> sqlx::Result<()>
+    record: InsertDeletedRecord<'a>,
+) -> sqlx::Result<u64>
 where
     E: Executor<'e, Database = Sqlite>,
 {
-    sqlx::query(
+    let result = sqlx::query(
         "INSERT INTO DeletedRecord (action_hash, deletes_action_hash, deletes_entry_hash)
          VALUES (?, ?, ?)",
     )
-    .bind(action_hash.get_raw_36())
-    .bind(deletes_action_hash.get_raw_36())
-    .bind(deletes_entry_hash.get_raw_36())
+    .bind(record.action_hash.get_raw_36())
+    .bind(record.deletes_action_hash.get_raw_36())
+    .bind(record.deletes_entry_hash.get_raw_36())
     .execute(executor)
     .await?;
-    Ok(())
+    Ok(result.rows_affected())
 }
 
 pub(crate) async fn get_deleted_records<'e, E>(

--- a/crates/holochain_data/src/dht/inner/link.rs
+++ b/crates/holochain_data/src/dht/inner/link.rs
@@ -4,29 +4,40 @@ use crate::models::dht::LinkRow;
 use holo_hash::{ActionHash, AnyLinkableHash};
 use sqlx::{Executor, Sqlite};
 
-pub(crate) async fn insert_link_index<'e, E>(
+/// Parameters for inserting a row into the `Link` index table.
+pub struct InsertLink<'a> {
+    /// Hash of the CreateLink action (primary key).
+    pub action_hash: &'a ActionHash,
+    /// DHT basis hash for this link.
+    pub base_hash: &'a AnyLinkableHash,
+    /// Zome index discriminant.
+    pub zome_index: u8,
+    /// Link type discriminant.
+    pub link_type: u8,
+    /// Optional tag bytes.
+    pub tag: Option<&'a [u8]>,
+}
+
+/// Insert a row into the `Link` index table. Returns the number of rows inserted.
+pub(crate) async fn insert_link_index<'a, 'e, E>(
     executor: E,
-    action_hash: &ActionHash,
-    base_hash: &AnyLinkableHash,
-    zome_index: u8,
-    link_type: u8,
-    tag: Option<&[u8]>,
-) -> sqlx::Result<()>
+    link: InsertLink<'a>,
+) -> sqlx::Result<u64>
 where
     E: Executor<'e, Database = Sqlite>,
 {
-    sqlx::query(
+    let result = sqlx::query(
         "INSERT INTO Link (action_hash, base_hash, zome_index, link_type, tag)
          VALUES (?, ?, ?, ?, ?)",
     )
-    .bind(action_hash.get_raw_36())
-    .bind(base_hash.get_raw_36())
-    .bind(zome_index as i64)
-    .bind(link_type as i64)
-    .bind(tag)
+    .bind(link.action_hash.get_raw_36())
+    .bind(link.base_hash.get_raw_36())
+    .bind(link.zome_index as i64)
+    .bind(link.link_type as i64)
+    .bind(link.tag)
     .execute(executor)
     .await?;
-    Ok(())
+    Ok(result.rows_affected())
 }
 
 pub(crate) async fn get_links_by_base<'e, E>(

--- a/crates/holochain_data/src/dht/inner/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/inner/scheduled_function.rs
@@ -26,7 +26,7 @@ pub struct InsertScheduledFunction<'a> {
 /// Upsert a scheduled-function row, updating existing fields when the
 /// `(author, zome_name, scheduled_fn)` primary key already exists.
 /// Returns the number of rows written (1 on insert or update, 0 on no-op).
-pub(crate) async fn insert_scheduled_function<'a, 'e, E>(
+pub(crate) async fn upsert_scheduled_function<'a, 'e, E>(
     executor: E,
     f: InsertScheduledFunction<'a>,
 ) -> sqlx::Result<u64>
@@ -55,7 +55,8 @@ where
     Ok(result.rows_affected())
 }
 
-/// Delete the scheduled-function row for the given `(author, zome_name, scheduled_fn)` triple.
+/// Delete the scheduled-function row for the given `(author, zome_name, scheduled_fn)` tuple.
+///
 /// Returns the number of rows deleted (0 if the row did not exist).
 pub(crate) async fn delete_scheduled_function<'e, E>(
     executor: E,
@@ -155,7 +156,7 @@ mod tests {
         let payload = b"schedule-blob";
 
         // Initial insert.
-        db.insert_scheduled_function(InsertScheduledFunction {
+        db.upsert_scheduled_function(InsertScheduledFunction {
             author: &author,
             zome_name: "z",
             scheduled_fn: "f",
@@ -169,7 +170,7 @@ mod tests {
 
         // Same key — the upsert clause should replace the row, not error
         // with a PK conflict.
-        db.insert_scheduled_function(InsertScheduledFunction {
+        db.upsert_scheduled_function(InsertScheduledFunction {
             author: &author,
             zome_name: "z",
             scheduled_fn: "f",
@@ -186,7 +187,7 @@ mod tests {
             .unwrap();
 
         // Re-insert succeeds, confirming delete removed the row.
-        db.insert_scheduled_function(InsertScheduledFunction {
+        db.upsert_scheduled_function(InsertScheduledFunction {
             author: &author,
             zome_name: "z",
             scheduled_fn: "f",
@@ -206,8 +207,10 @@ mod tests {
         let bob = agent(2);
         let payload = b"";
 
+        let now_time = Timestamp::from_micros(200);
+
         // Alice: persisted, expired (end_at=100, now=200).
-        db.insert_scheduled_function(InsertScheduledFunction {
+        db.upsert_scheduled_function(InsertScheduledFunction {
             author: &alice,
             zome_name: "z",
             scheduled_fn: "f",
@@ -219,8 +222,8 @@ mod tests {
         .await
         .unwrap();
 
-        // Alice: persisted, not yet expired (end_at=300).
-        db.insert_scheduled_function(InsertScheduledFunction {
+        // Alice: persisted, not yet expired (end_at=300, now=200).
+        db.upsert_scheduled_function(InsertScheduledFunction {
             author: &alice,
             zome_name: "z",
             scheduled_fn: "g",
@@ -233,7 +236,7 @@ mod tests {
         .unwrap();
 
         // Alice: ephemeral, "expired" (must NOT be returned — query is non-ephemeral only).
-        db.insert_scheduled_function(InsertScheduledFunction {
+        db.upsert_scheduled_function(InsertScheduledFunction {
             author: &alice,
             zome_name: "z",
             scheduled_fn: "e",
@@ -246,7 +249,7 @@ mod tests {
         .unwrap();
 
         // Bob: persisted, expired but different author (must NOT be returned).
-        db.insert_scheduled_function(InsertScheduledFunction {
+        db.upsert_scheduled_function(InsertScheduledFunction {
             author: &bob,
             zome_name: "z",
             scheduled_fn: "f",
@@ -259,7 +262,8 @@ mod tests {
         .unwrap();
 
         let result = db
-            .get_expired_persisted_scheduled_functions(&alice, Timestamp::from_micros(200))
+            .as_ref()
+            .get_expired_persisted_scheduled_functions(&alice, now_time)
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
@@ -275,7 +279,7 @@ mod tests {
         let payload = b"";
 
         // Alice: ephemeral start_at=100 (eligible at now=150).
-        db.insert_scheduled_function(InsertScheduledFunction {
+        db.upsert_scheduled_function(InsertScheduledFunction {
             author: &alice,
             zome_name: "z",
             scheduled_fn: "f",
@@ -287,7 +291,7 @@ mod tests {
         .await
         .unwrap();
         // Alice: non-ephemeral (must NOT be deleted).
-        db.insert_scheduled_function(InsertScheduledFunction {
+        db.upsert_scheduled_function(InsertScheduledFunction {
             author: &alice,
             zome_name: "z",
             scheduled_fn: "g",
@@ -299,7 +303,7 @@ mod tests {
         .await
         .unwrap();
         // Bob: ephemeral but different author (must NOT be deleted).
-        db.insert_scheduled_function(InsertScheduledFunction {
+        db.upsert_scheduled_function(InsertScheduledFunction {
             author: &bob,
             zome_name: "z",
             scheduled_fn: "f",
@@ -317,7 +321,7 @@ mod tests {
 
         // Spot-check by re-inserting Alice's ephemeral row to confirm it was
         // gone (otherwise PK conflict would error).
-        db.insert_scheduled_function(InsertScheduledFunction {
+        db.upsert_scheduled_function(InsertScheduledFunction {
             author: &alice,
             zome_name: "z",
             scheduled_fn: "f",

--- a/crates/holochain_data/src/dht/inner/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/inner/scheduled_function.rs
@@ -1,0 +1,332 @@
+//! Free-standing operations against the `ScheduledFunction` table.
+
+use holo_hash::AgentPubKey;
+use holochain_timestamp::Timestamp;
+use sqlx::{Executor, Sqlite};
+
+/// Parameters for inserting (or upserting) a row into `ScheduledFunction`.
+pub struct InsertScheduledFunction<'a> {
+    /// Agent that owns this scheduled function.
+    pub author: &'a AgentPubKey,
+    /// Name of the zome containing the scheduled function.
+    pub zome_name: &'a str,
+    /// Name of the scheduled function within the zome.
+    pub scheduled_fn: &'a str,
+    /// Serialized `Option<Schedule>` blob — the same encoding the legacy
+    /// table uses for `maybe_schedule`.
+    pub maybe_schedule: &'a [u8],
+    /// Microsecond timestamp at which the function becomes live.
+    pub start_at: Timestamp,
+    /// Microsecond timestamp at which the function expires.
+    pub end_at: Timestamp,
+    /// `true` if the row is removed once the function fires.
+    pub ephemeral: bool,
+}
+
+/// Upsert a scheduled-function row, updating existing fields when the
+/// `(author, zome_name, scheduled_fn)` primary key already exists.
+/// Returns the number of rows written (1 on insert or update, 0 on no-op).
+pub(crate) async fn insert_scheduled_function<'a, 'e, E>(
+    executor: E,
+    f: InsertScheduledFunction<'a>,
+) -> sqlx::Result<u64>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let result = sqlx::query(
+        "INSERT INTO ScheduledFunction
+            (author, zome_name, scheduled_fn, maybe_schedule, start_at, end_at, ephemeral)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(author, zome_name, scheduled_fn) DO UPDATE SET
+             maybe_schedule = excluded.maybe_schedule,
+             start_at       = excluded.start_at,
+             end_at         = excluded.end_at,
+             ephemeral      = excluded.ephemeral",
+    )
+    .bind(f.author.get_raw_36())
+    .bind(f.zome_name)
+    .bind(f.scheduled_fn)
+    .bind(f.maybe_schedule)
+    .bind(f.start_at.as_micros())
+    .bind(f.end_at.as_micros())
+    .bind(f.ephemeral as i64)
+    .execute(executor)
+    .await?;
+    Ok(result.rows_affected())
+}
+
+/// Delete the scheduled-function row for the given `(author, zome_name, scheduled_fn)` triple.
+/// Returns the number of rows deleted (0 if the row did not exist).
+pub(crate) async fn delete_scheduled_function<'e, E>(
+    executor: E,
+    author: &AgentPubKey,
+    zome_name: &str,
+    scheduled_fn: &str,
+) -> sqlx::Result<u64>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let result = sqlx::query(
+        "DELETE FROM ScheduledFunction
+         WHERE author = ? AND zome_name = ? AND scheduled_fn = ?",
+    )
+    .bind(author.get_raw_36())
+    .bind(zome_name)
+    .bind(scheduled_fn)
+    .execute(executor)
+    .await?;
+    Ok(result.rows_affected())
+}
+
+/// Return persisted (non-ephemeral) scheduled-function rows for `author` whose
+/// `end_at` is before `now`, as `(zome_name, scheduled_fn, maybe_schedule_blob)` tuples.
+pub(crate) async fn get_expired_persisted_scheduled_functions<'e, E>(
+    executor: E,
+    author: &AgentPubKey,
+    now: Timestamp,
+) -> sqlx::Result<Vec<(String, String, Vec<u8>)>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    #[derive(sqlx::FromRow)]
+    struct Row {
+        zome_name: String,
+        scheduled_fn: String,
+        maybe_schedule: Vec<u8>,
+    }
+
+    let rows: Vec<Row> = sqlx::query_as(
+        "SELECT zome_name, scheduled_fn, maybe_schedule
+         FROM ScheduledFunction
+         WHERE ephemeral = 0 AND author = ? AND end_at < ?",
+    )
+    .bind(author.get_raw_36())
+    .bind(now.as_micros())
+    .fetch_all(executor)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| (r.zome_name, r.scheduled_fn, r.maybe_schedule))
+        .collect())
+}
+
+/// Delete all live ephemeral scheduled-function rows for `author` whose
+/// `start_at` is at or before `now`. Returns the number of rows deleted.
+pub(crate) async fn delete_live_ephemeral_scheduled_functions<'e, E>(
+    executor: E,
+    author: &AgentPubKey,
+    now: Timestamp,
+) -> sqlx::Result<u64>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let result = sqlx::query(
+        "DELETE FROM ScheduledFunction
+         WHERE ephemeral = 1 AND author = ? AND start_at <= ?",
+    )
+    .bind(author.get_raw_36())
+    .bind(now.as_micros())
+    .execute(executor)
+    .await?;
+    Ok(result.rows_affected())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::kind::Dht;
+    use crate::test_open_db;
+    use holo_hash::DnaHash;
+    use std::sync::Arc;
+
+    fn dht_id() -> Dht {
+        Dht::new(Arc::new(DnaHash::from_raw_36(vec![0u8; 36])))
+    }
+
+    fn agent(seed: u8) -> AgentPubKey {
+        AgentPubKey::from_raw_36(vec![seed; 36])
+    }
+
+    #[tokio::test]
+    async fn insert_upsert_delete_scheduled_function() {
+        let db = test_open_db(dht_id()).await.unwrap();
+        let author = agent(1);
+        let payload = b"schedule-blob";
+
+        // Initial insert.
+        db.insert_scheduled_function(InsertScheduledFunction {
+            author: &author,
+            zome_name: "z",
+            scheduled_fn: "f",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(100),
+            end_at: Timestamp::from_micros(200),
+            ephemeral: true,
+        })
+        .await
+        .unwrap();
+
+        // Same key — the upsert clause should replace the row, not error
+        // with a PK conflict.
+        db.insert_scheduled_function(InsertScheduledFunction {
+            author: &author,
+            zome_name: "z",
+            scheduled_fn: "f",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(150),
+            end_at: Timestamp::from_micros(250),
+            ephemeral: false,
+        })
+        .await
+        .unwrap();
+
+        db.delete_scheduled_function(&author, "z", "f")
+            .await
+            .unwrap();
+
+        // Re-insert succeeds, confirming delete removed the row.
+        db.insert_scheduled_function(InsertScheduledFunction {
+            author: &author,
+            zome_name: "z",
+            scheduled_fn: "f",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(100),
+            end_at: Timestamp::from_micros(200),
+            ephemeral: true,
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn expired_persisted_scoped_to_author() {
+        let db = test_open_db(dht_id()).await.unwrap();
+        let alice = agent(1);
+        let bob = agent(2);
+        let payload = b"";
+
+        // Alice: persisted, expired (end_at=100, now=200).
+        db.insert_scheduled_function(InsertScheduledFunction {
+            author: &alice,
+            zome_name: "z",
+            scheduled_fn: "f",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(50),
+            end_at: Timestamp::from_micros(100),
+            ephemeral: false,
+        })
+        .await
+        .unwrap();
+
+        // Alice: persisted, not yet expired (end_at=300).
+        db.insert_scheduled_function(InsertScheduledFunction {
+            author: &alice,
+            zome_name: "z",
+            scheduled_fn: "g",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(50),
+            end_at: Timestamp::from_micros(300),
+            ephemeral: false,
+        })
+        .await
+        .unwrap();
+
+        // Alice: ephemeral, "expired" (must NOT be returned — query is non-ephemeral only).
+        db.insert_scheduled_function(InsertScheduledFunction {
+            author: &alice,
+            zome_name: "z",
+            scheduled_fn: "e",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(50),
+            end_at: Timestamp::from_micros(100),
+            ephemeral: true,
+        })
+        .await
+        .unwrap();
+
+        // Bob: persisted, expired but different author (must NOT be returned).
+        db.insert_scheduled_function(InsertScheduledFunction {
+            author: &bob,
+            zome_name: "z",
+            scheduled_fn: "f",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(50),
+            end_at: Timestamp::from_micros(100),
+            ephemeral: false,
+        })
+        .await
+        .unwrap();
+
+        let result = db
+            .get_expired_persisted_scheduled_functions(&alice, Timestamp::from_micros(200))
+            .await
+            .unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, "z");
+        assert_eq!(result[0].1, "f");
+    }
+
+    #[tokio::test]
+    async fn delete_live_ephemeral_scoped_to_author_and_now() {
+        let db = test_open_db(dht_id()).await.unwrap();
+        let alice = agent(1);
+        let bob = agent(2);
+        let payload = b"";
+
+        // Alice: ephemeral start_at=100 (eligible at now=150).
+        db.insert_scheduled_function(InsertScheduledFunction {
+            author: &alice,
+            zome_name: "z",
+            scheduled_fn: "f",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(100),
+            end_at: Timestamp::from_micros(300),
+            ephemeral: true,
+        })
+        .await
+        .unwrap();
+        // Alice: non-ephemeral (must NOT be deleted).
+        db.insert_scheduled_function(InsertScheduledFunction {
+            author: &alice,
+            zome_name: "z",
+            scheduled_fn: "g",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(100),
+            end_at: Timestamp::from_micros(300),
+            ephemeral: false,
+        })
+        .await
+        .unwrap();
+        // Bob: ephemeral but different author (must NOT be deleted).
+        db.insert_scheduled_function(InsertScheduledFunction {
+            author: &bob,
+            zome_name: "z",
+            scheduled_fn: "f",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(100),
+            end_at: Timestamp::from_micros(300),
+            ephemeral: true,
+        })
+        .await
+        .unwrap();
+
+        db.delete_live_ephemeral_scheduled_functions(&alice, Timestamp::from_micros(150))
+            .await
+            .unwrap();
+
+        // Spot-check by re-inserting Alice's ephemeral row to confirm it was
+        // gone (otherwise PK conflict would error).
+        db.insert_scheduled_function(InsertScheduledFunction {
+            author: &alice,
+            zome_name: "z",
+            scheduled_fn: "f",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(100),
+            end_at: Timestamp::from_micros(300),
+            ephemeral: true,
+        })
+        .await
+        .unwrap();
+    }
+}

--- a/crates/holochain_data/src/dht/inner/updated_record.rs
+++ b/crates/holochain_data/src/dht/inner/updated_record.rs
@@ -4,25 +4,34 @@ use crate::models::dht::UpdatedRecordRow;
 use holo_hash::{ActionHash, EntryHash};
 use sqlx::{Executor, Sqlite};
 
-pub(crate) async fn insert_updated_record_index<'e, E>(
+/// Parameters for inserting a row into the `UpdatedRecord` index table.
+pub struct InsertUpdatedRecord<'a> {
+    /// Hash of the Update action (primary key).
+    pub action_hash: &'a ActionHash,
+    /// Hash of the original action being updated.
+    pub original_action_hash: &'a ActionHash,
+    /// Hash of the original entry being updated.
+    pub original_entry_hash: &'a EntryHash,
+}
+
+/// Insert a row into the `UpdatedRecord` index table. Returns the number of rows inserted.
+pub(crate) async fn insert_updated_record_index<'a, 'e, E>(
     executor: E,
-    action_hash: &ActionHash,
-    original_action_hash: &ActionHash,
-    original_entry_hash: &EntryHash,
-) -> sqlx::Result<()>
+    record: InsertUpdatedRecord<'a>,
+) -> sqlx::Result<u64>
 where
     E: Executor<'e, Database = Sqlite>,
 {
-    sqlx::query(
+    let result = sqlx::query(
         "INSERT INTO UpdatedRecord (action_hash, original_action_hash, original_entry_hash)
          VALUES (?, ?, ?)",
     )
-    .bind(action_hash.get_raw_36())
-    .bind(original_action_hash.get_raw_36())
-    .bind(original_entry_hash.get_raw_36())
+    .bind(record.action_hash.get_raw_36())
+    .bind(record.original_action_hash.get_raw_36())
+    .bind(record.original_entry_hash.get_raw_36())
     .execute(executor)
     .await?;
-    Ok(())
+    Ok(result.rows_affected())
 }
 
 pub(crate) async fn get_updated_records<'e, E>(

--- a/crates/holochain_data/src/dht/tx_operations.rs
+++ b/crates/holochain_data/src/dht/tx_operations.rs
@@ -16,6 +16,7 @@ mod entry;
 mod limbo_chain_op;
 mod limbo_warrant;
 mod link;
+mod scheduled_function;
 mod updated_record;
 mod validation_receipt;
 mod warrant;

--- a/crates/holochain_data/src/dht/tx_operations/chain_op_publish.rs
+++ b/crates/holochain_data/src/dht/tx_operations/chain_op_publish.rs
@@ -22,6 +22,14 @@ impl TxWrite<Dht> {
         )
         .await
     }
+
+    /// Mark receipts as complete for the given op. Returns the number of rows updated.
+    pub async fn set_chain_op_receipts_complete(
+        &mut self,
+        op_hash: &DhtOpHash,
+    ) -> sqlx::Result<u64> {
+        chain_op_publish::set_receipts_complete(self.conn_mut(), op_hash).await
+    }
 }
 
 impl TxRead<Dht> {

--- a/crates/holochain_data/src/dht/tx_operations/deleted_link.rs
+++ b/crates/holochain_data/src/dht/tx_operations/deleted_link.rs
@@ -1,19 +1,18 @@
 //! `TxRead<Dht>` / `TxWrite<Dht>` API for the `DeletedLink` table.
 
-use super::super::inner::deleted_link;
+use super::super::inner::deleted_link::{self, InsertDeletedLink};
 use crate::handles::{TxRead, TxWrite};
 use crate::kind::Dht;
 use crate::models::dht::DeletedLinkRow;
 use holo_hash::ActionHash;
 
 impl TxWrite<Dht> {
+    /// Insert a row into the `DeletedLink` index table. Returns the number of rows inserted.
     pub async fn insert_deleted_link_index(
         &mut self,
-        action_hash: &ActionHash,
-        create_link_hash: &ActionHash,
-    ) -> sqlx::Result<()> {
-        deleted_link::insert_deleted_link_index(self.conn_mut(), action_hash, create_link_hash)
-            .await
+        link: InsertDeletedLink<'_>,
+    ) -> sqlx::Result<u64> {
+        deleted_link::insert_deleted_link_index(self.conn_mut(), link).await
     }
 }
 

--- a/crates/holochain_data/src/dht/tx_operations/deleted_record.rs
+++ b/crates/holochain_data/src/dht/tx_operations/deleted_record.rs
@@ -1,25 +1,18 @@
 //! `TxRead<Dht>` / `TxWrite<Dht>` API for the `DeletedRecord` table.
 
-use super::super::inner::deleted_record;
+use super::super::inner::deleted_record::{self, InsertDeletedRecord};
 use crate::handles::{TxRead, TxWrite};
 use crate::kind::Dht;
 use crate::models::dht::DeletedRecordRow;
-use holo_hash::{ActionHash, EntryHash};
+use holo_hash::ActionHash;
 
 impl TxWrite<Dht> {
+    /// Insert a row into the `DeletedRecord` index table. Returns the number of rows inserted.
     pub async fn insert_deleted_record_index(
         &mut self,
-        action_hash: &ActionHash,
-        deletes_action_hash: &ActionHash,
-        deletes_entry_hash: &EntryHash,
-    ) -> sqlx::Result<()> {
-        deleted_record::insert_deleted_record_index(
-            self.conn_mut(),
-            action_hash,
-            deletes_action_hash,
-            deletes_entry_hash,
-        )
-        .await
+        record: InsertDeletedRecord<'_>,
+    ) -> sqlx::Result<u64> {
+        deleted_record::insert_deleted_record_index(self.conn_mut(), record).await
     }
 }
 

--- a/crates/holochain_data/src/dht/tx_operations/link.rs
+++ b/crates/holochain_data/src/dht/tx_operations/link.rs
@@ -1,29 +1,15 @@
 //! `TxRead<Dht>` / `TxWrite<Dht>` API for the `Link` table.
 
-use super::super::inner::link;
+use super::super::inner::link::{self, InsertLink};
 use crate::handles::{TxRead, TxWrite};
 use crate::kind::Dht;
 use crate::models::dht::LinkRow;
-use holo_hash::{ActionHash, AnyLinkableHash};
+use holo_hash::AnyLinkableHash;
 
 impl TxWrite<Dht> {
-    pub async fn insert_link_index(
-        &mut self,
-        action_hash: &ActionHash,
-        base_hash: &AnyLinkableHash,
-        zome_index: u8,
-        link_type: u8,
-        tag: Option<&[u8]>,
-    ) -> sqlx::Result<()> {
-        link::insert_link_index(
-            self.conn_mut(),
-            action_hash,
-            base_hash,
-            zome_index,
-            link_type,
-            tag,
-        )
-        .await
+    /// Insert a row into the `Link` index table. Returns the number of rows inserted.
+    pub async fn insert_link_index(&mut self, link: InsertLink<'_>) -> sqlx::Result<u64> {
+        link::insert_link_index(self.conn_mut(), link).await
     }
 }
 

--- a/crates/holochain_data/src/dht/tx_operations/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/tx_operations/scheduled_function.rs
@@ -25,10 +25,10 @@ impl TxWrite<Dht> {
         &mut self,
         f: InsertScheduledFunction<'_>,
     ) -> sqlx::Result<u64> {
-        scheduled_function::insert_scheduled_function(self.conn_mut(), f).await
+        scheduled_function::upsert_scheduled_function(self.conn_mut(), f).await
     }
 
-    /// Delete the scheduled-function row for the given `(author, zome_name, scheduled_fn)` triple.
+    /// Delete the scheduled-function row for the given `(author, zome_name, scheduled_fn)` tuple.
     /// Returns the number of rows deleted.
     pub async fn delete_scheduled_function(
         &mut self,

--- a/crates/holochain_data/src/dht/tx_operations/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/tx_operations/scheduled_function.rs
@@ -1,0 +1,58 @@
+//! `TxRead<Dht>` / `TxWrite<Dht>` API for the `ScheduledFunction` table.
+
+use super::super::inner::scheduled_function::{self, InsertScheduledFunction};
+use crate::handles::{TxRead, TxWrite};
+use crate::kind::Dht;
+use holo_hash::AgentPubKey;
+use holochain_timestamp::Timestamp;
+
+impl TxRead<Dht> {
+    /// Fetch persisted (non-ephemeral) scheduled-function rows for `author` whose
+    /// `end_at` is before `now`. Returns `(zome_name, scheduled_fn, maybe_schedule_blob)` tuples.
+    pub async fn get_expired_persisted_scheduled_functions(
+        &mut self,
+        author: &AgentPubKey,
+        now: Timestamp,
+    ) -> sqlx::Result<Vec<(String, String, Vec<u8>)>> {
+        scheduled_function::get_expired_persisted_scheduled_functions(self.conn_mut(), author, now)
+            .await
+    }
+}
+
+impl TxWrite<Dht> {
+    /// Upsert a scheduled-function row. Returns the number of rows written.
+    pub async fn insert_scheduled_function(
+        &mut self,
+        f: InsertScheduledFunction<'_>,
+    ) -> sqlx::Result<u64> {
+        scheduled_function::insert_scheduled_function(self.conn_mut(), f).await
+    }
+
+    /// Delete the scheduled-function row for the given `(author, zome_name, scheduled_fn)` triple.
+    /// Returns the number of rows deleted.
+    pub async fn delete_scheduled_function(
+        &mut self,
+        author: &AgentPubKey,
+        zome_name: &str,
+        scheduled_fn: &str,
+    ) -> sqlx::Result<u64> {
+        scheduled_function::delete_scheduled_function(
+            self.conn_mut(),
+            author,
+            zome_name,
+            scheduled_fn,
+        )
+        .await
+    }
+
+    /// Delete all live ephemeral scheduled-function rows for `author` whose
+    /// `start_at` is at or before `now`. Returns the number of rows deleted.
+    pub async fn delete_live_ephemeral_scheduled_functions(
+        &mut self,
+        author: &AgentPubKey,
+        now: Timestamp,
+    ) -> sqlx::Result<u64> {
+        scheduled_function::delete_live_ephemeral_scheduled_functions(self.conn_mut(), author, now)
+            .await
+    }
+}

--- a/crates/holochain_data/src/dht/tx_operations/updated_record.rs
+++ b/crates/holochain_data/src/dht/tx_operations/updated_record.rs
@@ -1,25 +1,18 @@
 //! `TxRead<Dht>` / `TxWrite<Dht>` API for the `UpdatedRecord` table.
 
-use super::super::inner::updated_record;
+use super::super::inner::updated_record::{self, InsertUpdatedRecord};
 use crate::handles::{TxRead, TxWrite};
 use crate::kind::Dht;
 use crate::models::dht::UpdatedRecordRow;
-use holo_hash::{ActionHash, EntryHash};
+use holo_hash::ActionHash;
 
 impl TxWrite<Dht> {
+    /// Insert a row into the `UpdatedRecord` index table. Returns the number of rows inserted.
     pub async fn insert_updated_record_index(
         &mut self,
-        action_hash: &ActionHash,
-        original_action_hash: &ActionHash,
-        original_entry_hash: &EntryHash,
-    ) -> sqlx::Result<()> {
-        updated_record::insert_updated_record_index(
-            self.conn_mut(),
-            action_hash,
-            original_action_hash,
-            original_entry_hash,
-        )
-        .await
+        record: InsertUpdatedRecord<'_>,
+    ) -> sqlx::Result<u64> {
+        updated_record::insert_updated_record_index(self.conn_mut(), record).await
     }
 }
 

--- a/crates/holochain_data/src/lib.rs
+++ b/crates/holochain_data/src/lib.rs
@@ -241,7 +241,7 @@ async fn create_pool(opts: SqliteConnectOptions, max_readers: u16) -> sqlx::Resu
     Ok(pool)
 }
 
-#[cfg(all(test, feature = "test-utils"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -363,6 +363,7 @@ mod tests {
             "LimboChainOp",
             "LimboWarrant",
             "PrivateEntry",
+            "ScheduledFunction",
             "UpdatedRecord",
             "ValidationReceipt",
             "Warrant",

--- a/crates/holochain_integrity_types/src/dht_v2.rs
+++ b/crates/holochain_integrity_types/src/dht_v2.rs
@@ -75,10 +75,14 @@ pub enum ActionType {
     CreateLink = 7,
     /// Deletes an existing `CreateLink` action.
     DeleteLink = 8,
+    /// Closes the source chain, optionally pointing at a migration target.
+    CloseChain = 9,
+    /// Opens a new source chain following a migration from a previous chain.
+    OpenChain = 10,
 }
 
 /// Maps [`ActionType`] onto the schema `Action.action_type` INTEGER column
-/// (`1..=8`). `0` is reserved and never written.
+/// (`1..=10`). `0` is reserved and never written.
 impl From<ActionType> for i64 {
     fn from(t: ActionType) -> Self {
         t as i64
@@ -86,7 +90,7 @@ impl From<ActionType> for i64 {
 }
 
 /// Inverse of [`From<ActionType> for i64`]. Returns `Err(v)` for any value
-/// outside `1..=8` (including `0`).
+/// outside `1..=10` (including `0`).
 impl TryFrom<i64> for ActionType {
     type Error = i64;
     fn try_from(v: i64) -> Result<Self, Self::Error> {
@@ -100,6 +104,8 @@ impl TryFrom<i64> for ActionType {
             6 => Ok(Delete),
             7 => Ok(CreateLink),
             8 => Ok(DeleteLink),
+            9 => Ok(CloseChain),
+            10 => Ok(OpenChain),
             other => Err(other),
         }
     }
@@ -229,6 +235,28 @@ pub struct DeleteLinkData {
     pub link_add_address: ActionHash,
 }
 
+/// Per-variant data for [`ActionType::CloseChain`].
+///
+/// The `author`, `timestamp`, `action_seq`, and `prev_action` fields live on
+/// [`ActionHeader`]; only the chain-close-specific fields go here.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SerializedBytes)]
+pub struct CloseChainData {
+    /// Optional migration target the chain closes towards.
+    pub new_target: Option<crate::action::MigrationTarget>,
+}
+
+/// Per-variant data for [`ActionType::OpenChain`].
+///
+/// The `author`, `timestamp`, `action_seq`, and `prev_action` fields live on
+/// [`ActionHeader`]; only the chain-open-specific fields go here.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SerializedBytes)]
+pub struct OpenChainData {
+    /// The previous DNA hash or agent key this chain migrated from.
+    pub prev_target: crate::action::MigrationTarget,
+    /// Hash of the matching `CloseChain` action on the old chain.
+    pub close_hash: ActionHash,
+}
+
 /// Per-variant action data, stored serialized in the `Action.action_data`
 /// BLOB column.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, SerializedBytes)]
@@ -250,6 +278,10 @@ pub enum ActionData {
     CreateLink(CreateLinkData),
     /// Deletes a previously created link.
     DeleteLink(DeleteLinkData),
+    /// Closes the source chain.
+    CloseChain(CloseChainData),
+    /// Opens a new chain following a migration.
+    OpenChain(OpenChainData),
 }
 
 impl ActionData {
@@ -264,6 +296,8 @@ impl ActionData {
             ActionData::Delete(_) => ActionType::Delete,
             ActionData::CreateLink(_) => ActionType::CreateLink,
             ActionData::DeleteLink(_) => ActionType::DeleteLink,
+            ActionData::CloseChain(_) => ActionType::CloseChain,
+            ActionData::OpenChain(_) => ActionType::OpenChain,
         }
     }
 
@@ -331,12 +365,14 @@ mod tests {
             Delete,
             CreateLink,
             DeleteLink,
+            CloseChain,
+            OpenChain,
         ] {
             let n: i64 = v.into();
             assert_eq!(ActionType::try_from(n).unwrap(), v);
         }
         assert!(ActionType::try_from(0).is_err());
-        assert!(ActionType::try_from(9).is_err());
+        assert!(ActionType::try_from(11).is_err());
     }
 
     #[test]

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -95,6 +95,7 @@ impl DhtStore<DbWrite<Dht>> {
     pub async fn reschedule_expired_persisted(&self, author: &AgentPubKey, now: Timestamp) -> () {
         let expired = match self
             .db
+            .as_ref()
             .get_expired_persisted_scheduled_functions(author, now)
             .await
         {
@@ -149,7 +150,7 @@ impl DhtStore<DbWrite<Dht>> {
                 Ok(Some((start_at, end_at, ephemeral))) => {
                     if let Err(e) = self
                         .db
-                        .insert_scheduled_function(InsertScheduledFunction {
+                        .upsert_scheduled_function(InsertScheduledFunction {
                             author,
                             zome_name: &zome_name,
                             scheduled_fn: &scheduled_fn_name,
@@ -203,7 +204,7 @@ impl DhtStore<DbWrite<Dht>> {
             }
             Some((start_at, end_at, ephemeral)) => Ok(self
                 .db
-                .insert_scheduled_function(InsertScheduledFunction {
+                .upsert_scheduled_function(InsertScheduledFunction {
                     author,
                     zome_name,
                     scheduled_fn: fn_name,
@@ -348,7 +349,7 @@ mod tests {
         // Insert an ephemeral row with start_at <= now so it is "live".
         store
             .db
-            .insert_scheduled_function(InsertScheduledFunction {
+            .upsert_scheduled_function(InsertScheduledFunction {
                 author: &author,
                 zome_name: "z",
                 scheduled_fn: "f",
@@ -382,7 +383,7 @@ mod tests {
         // Seed a persisted row.
         store
             .db
-            .insert_scheduled_function(InsertScheduledFunction {
+            .upsert_scheduled_function(InsertScheduledFunction {
                 author: &author,
                 zome_name: "z",
                 scheduled_fn: "f",
@@ -439,7 +440,7 @@ mod tests {
         // ScheduledFunction.
         store
             .db
-            .insert_scheduled_function(InsertScheduledFunction {
+            .upsert_scheduled_function(InsertScheduledFunction {
                 author: &author,
                 zome_name: "z",
                 scheduled_fn: "f",

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -1,0 +1,487 @@
+//! Per-DNA store for the `holochain_data` DHT database.
+//!
+//! [`DhtStore`] owns the [`DbWrite<Dht>`] handle for one DNA and exposes
+//! domain-meaningful operations rather than raw database access. Call sites
+//! obtain a reference from [`Space`](crate) and invoke named methods; they do
+//! not need to interact with the underlying handle directly.
+
+use holo_hash::{AgentPubKey, DhtOpHash};
+use holochain_data::dht::InsertScheduledFunction;
+use holochain_data::kind::Dht;
+use holochain_data::DbWrite;
+use holochain_types::prelude::{Schedule, ScheduledFn, Timestamp};
+use holochain_zome_types::schedule::ScheduleError;
+
+/// Errors produced by [`DhtStore`] operations.
+///
+/// Wraps the underlying database and schedule errors so callers do not need to
+/// depend on `sqlx` or schedule internals directly.
+#[derive(thiserror::Error, Debug)]
+pub enum DhtStoreError {
+    /// An underlying database operation failed.
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+    /// A schedule serialization or computation error occurred.
+    #[error(transparent)]
+    Schedule(#[from] holochain_serialized_bytes::SerializedBytesError),
+    /// A schedule parameter computation error occurred.
+    #[error(transparent)]
+    ScheduleParams(#[from] ScheduleError),
+    /// `mark_chain_op_receipts_complete` was called for an `op_hash` that has
+    /// no matching `ChainOpPublish` row. The flush mirror should always insert
+    /// one for self-authored ops, so this indicates a wiring bug.
+    #[error("no ChainOpPublish row for op_hash {0:?}")]
+    ChainOpPublishMissing(DhtOpHash),
+}
+
+/// Convenience alias for [`DhtStore`] results.
+pub type DhtStoreResult<T> = Result<T, DhtStoreError>;
+
+/// A read-only view of the DHT store.
+pub type DhtStoreRead = DhtStore<holochain_data::DbRead<Dht>>;
+
+/// Per-DNA store for the DHT database.
+///
+/// Owns a [`DbWrite<Dht>`] handle (or a [`holochain_data::DbRead<Dht>`] in the
+/// read-only alias) and exposes operations keyed on the domain entities they
+/// modify.
+/// Clone-sharing is cheap: all clones refer to the same underlying connection
+/// pool.
+#[derive(Clone, Debug)]
+pub struct DhtStore<Db = DbWrite<Dht>> {
+    db: Db,
+}
+
+impl<Db> DhtStore<Db> {
+    /// Create a new `DhtStore` from a database handle.
+    pub fn new(db: Db) -> Self {
+        Self { db }
+    }
+
+    /// Access the raw database handle.
+    ///
+    /// Available within `holochain_state` for call sites that need to compose
+    /// multiple operations inside a single transaction (e.g. the flush path in
+    /// [`crate::source_chain`]). External callers should use the named methods
+    /// on this store instead.
+    pub(crate) fn db(&self) -> &Db {
+        &self.db
+    }
+}
+
+impl DhtStore<DbWrite<Dht>> {
+    /// Delete all live ephemeral scheduled-function rows for `author` at or
+    /// before `now`. Returns the number of rows deleted.
+    pub async fn delete_live_ephemeral_scheduled_functions(
+        &self,
+        author: &AgentPubKey,
+        now: Timestamp,
+    ) -> DhtStoreResult<u64> {
+        Ok(self
+            .db
+            .delete_live_ephemeral_scheduled_functions(author, now)
+            .await?)
+    }
+
+    /// Re-evaluate every expired persisted scheduled function for `author` at
+    /// `now`.
+    ///
+    /// For each expired row the method decodes the stored `maybe_schedule`,
+    /// computes updated `(start_at, end_at, ephemeral)` parameters, and either
+    /// upserts the row (when a next cron date exists) or deletes it (when the
+    /// cron string has no future occurrences). Errors for individual rows are
+    /// logged and the loop continues, so a single bad row does not abort
+    /// processing of the remaining rows.
+    pub async fn reschedule_expired_persisted(&self, author: &AgentPubKey, now: Timestamp) -> () {
+        let expired = match self
+            .db
+            .get_expired_persisted_scheduled_functions(author, now)
+            .await
+        {
+            Ok(rows) => rows,
+            Err(e) => {
+                tracing::error!(
+                    "error querying expired persisted scheduled functions: {:?}",
+                    e
+                );
+                return;
+            }
+        };
+
+        for (zome_name, scheduled_fn_name, maybe_schedule_blob) in expired {
+            let maybe_schedule: Option<Schedule> =
+                match holochain_serialized_bytes::decode(&maybe_schedule_blob) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        tracing::error!(
+                            "error decoding maybe_schedule for ({}, {}): {:?}",
+                            zome_name,
+                            scheduled_fn_name,
+                            e
+                        );
+                        continue;
+                    }
+                };
+
+            match crate::schedule::compute_schedule_params(&maybe_schedule, now) {
+                Err(e) => {
+                    tracing::error!(
+                        "error computing schedule params for ({}, {}): {:?}",
+                        zome_name,
+                        scheduled_fn_name,
+                        e
+                    );
+                }
+                Ok(None) => {
+                    if let Err(e) = self
+                        .db
+                        .delete_scheduled_function(author, &zome_name, &scheduled_fn_name)
+                        .await
+                    {
+                        tracing::error!(
+                            "error deleting expired scheduled function ({}, {}): {:?}",
+                            zome_name,
+                            scheduled_fn_name,
+                            e
+                        );
+                    }
+                }
+                Ok(Some((start_at, end_at, ephemeral))) => {
+                    if let Err(e) = self
+                        .db
+                        .insert_scheduled_function(InsertScheduledFunction {
+                            author,
+                            zome_name: &zome_name,
+                            scheduled_fn: &scheduled_fn_name,
+                            maybe_schedule: &maybe_schedule_blob,
+                            start_at,
+                            end_at,
+                            ephemeral,
+                        })
+                        .await
+                    {
+                        tracing::error!(
+                            "error upserting rescheduled function ({}, {}): {:?}",
+                            zome_name,
+                            scheduled_fn_name,
+                            e
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Update the stored row for `scheduled_fn` owned by `author` based on the
+    /// schedule returned by a zome call.
+    ///
+    /// When `maybe_schedule` is `Some`, the method serializes the schedule,
+    /// computes `(start_at, end_at, ephemeral)` via
+    /// [`compute_schedule_params`](crate::schedule::compute_schedule_params),
+    /// and upserts the row. When `maybe_schedule` is `None`, or when the
+    /// schedule has no future occurrences, the row is deleted instead. Returns
+    /// the number of rows affected by whichever operation ran.
+    pub async fn upsert_scheduled_function(
+        &self,
+        author: &AgentPubKey,
+        scheduled_fn: &ScheduledFn,
+        maybe_schedule: &Option<Schedule>,
+        now: Timestamp,
+    ) -> DhtStoreResult<u64> {
+        let zome_name = scheduled_fn.zome_name().0.as_ref();
+        let fn_name = scheduled_fn.fn_name().0.as_str();
+
+        let maybe_schedule_blob = crate::schedule::serialize_maybe_schedule(maybe_schedule)?;
+
+        match crate::schedule::compute_schedule_params(maybe_schedule, now)? {
+            None => {
+                // No further cron dates: remove the row.
+                Ok(self
+                    .db
+                    .delete_scheduled_function(author, zome_name, fn_name)
+                    .await?)
+            }
+            Some((start_at, end_at, ephemeral)) => Ok(self
+                .db
+                .insert_scheduled_function(InsertScheduledFunction {
+                    author,
+                    zome_name,
+                    scheduled_fn: fn_name,
+                    maybe_schedule: &maybe_schedule_blob,
+                    start_at,
+                    end_at,
+                    ephemeral,
+                })
+                .await?),
+        }
+    }
+
+    /// Delete the scheduled-function row for `scheduled_fn` owned by `author`.
+    /// Returns the number of rows deleted.
+    pub async fn unschedule_function(
+        &self,
+        author: &AgentPubKey,
+        scheduled_fn: &ScheduledFn,
+    ) -> DhtStoreResult<u64> {
+        Ok(self
+            .db
+            .delete_scheduled_function(
+                author,
+                scheduled_fn.zome_name().0.as_ref(),
+                scheduled_fn.fn_name().0.as_str(),
+            )
+            .await?)
+    }
+
+    /// Mark the receipts for `op_hash` as complete. Returns
+    /// [`DhtStoreError::ChainOpPublishMissing`] if no matching row exists,
+    /// which indicates the flush mirror failed to insert a `ChainOpPublish`
+    /// row for this self-authored op.
+    pub async fn mark_chain_op_receipts_complete(&self, op_hash: &DhtOpHash) -> DhtStoreResult<()> {
+        let rows = self.db.set_chain_op_receipts_complete(op_hash).await?;
+        if rows == 0 {
+            return Err(DhtStoreError::ChainOpPublishMissing(op_hash.clone()));
+        }
+        Ok(())
+    }
+
+    /// Delete every row from every table in this DNA's DHT database.
+    ///
+    /// Used when the conductor uninstalls the last app for a DNA. Runs as a
+    /// single transaction in foreign-key-safe order; the database file itself
+    /// is left in place because the connection pool keeps it open.
+    pub async fn purge_all(&self) -> DhtStoreResult<()> {
+        let pool = self.db.pool();
+        let mut tx = pool.begin().await?;
+        // Children of ChainOp / Warrant first.
+        sqlx::query("DELETE FROM ChainOpPublish")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM ValidationReceipt")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM WarrantPublish")
+            .execute(&mut *tx)
+            .await?;
+        // Tables that reference Action.
+        sqlx::query("DELETE FROM ChainOp").execute(&mut *tx).await?;
+        sqlx::query("DELETE FROM LimboChainOp")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM CapGrant")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM Link").execute(&mut *tx).await?;
+        sqlx::query("DELETE FROM DeletedLink")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM UpdatedRecord")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM DeletedRecord")
+            .execute(&mut *tx)
+            .await?;
+        // Action and Warrant parents.
+        sqlx::query("DELETE FROM Action").execute(&mut *tx).await?;
+        sqlx::query("DELETE FROM Warrant").execute(&mut *tx).await?;
+        sqlx::query("DELETE FROM LimboWarrant")
+            .execute(&mut *tx)
+            .await?;
+        // Independent tables.
+        sqlx::query("DELETE FROM Entry").execute(&mut *tx).await?;
+        sqlx::query("DELETE FROM PrivateEntry")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM CapClaim")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM ChainLock")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM ScheduledFunction")
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Downgrade this writable store to a read-only store.
+    pub fn as_read(&self) -> DhtStoreRead {
+        DhtStore::new(self.db.as_ref().clone())
+    }
+}
+
+impl From<DhtStore<DbWrite<Dht>>> for DhtStoreRead {
+    fn from(store: DhtStore<DbWrite<Dht>>) -> Self {
+        store.as_read()
+    }
+}
+
+#[cfg(any(test, feature = "test_utils"))]
+impl DhtStore<DbWrite<Dht>> {
+    /// Create an in-memory DHT store for testing.
+    pub async fn new_test(dht: Dht) -> DhtStoreResult<Self> {
+        let db = holochain_data::test_open_db(dht).await?;
+        Ok(Self::new(db))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use holo_hash::DnaHash;
+    use std::sync::Arc;
+
+    fn dht_id() -> Dht {
+        Dht::new(Arc::new(DnaHash::from_raw_36(vec![0u8; 36])))
+    }
+
+    fn agent(seed: u8) -> AgentPubKey {
+        AgentPubKey::from_raw_36(vec![seed; 36])
+    }
+
+    #[tokio::test]
+    async fn delete_live_ephemeral_scheduled_functions_roundtrip() {
+        let store = DhtStore::new_test(dht_id()).await.unwrap();
+        let author = agent(1);
+
+        // Insert an ephemeral row with start_at <= now so it is "live".
+        store
+            .db
+            .insert_scheduled_function(InsertScheduledFunction {
+                author: &author,
+                zome_name: "z",
+                scheduled_fn: "f",
+                maybe_schedule: b"",
+                start_at: Timestamp::from_micros(50),
+                end_at: Timestamp::from_micros(300),
+                ephemeral: true,
+            })
+            .await
+            .unwrap();
+
+        let deleted = store
+            .delete_live_ephemeral_scheduled_functions(&author, Timestamp::from_micros(100))
+            .await
+            .unwrap();
+        assert_eq!(deleted, 1);
+
+        // A second call should delete nothing.
+        let deleted2 = store
+            .delete_live_ephemeral_scheduled_functions(&author, Timestamp::from_micros(100))
+            .await
+            .unwrap();
+        assert_eq!(deleted2, 0);
+    }
+
+    #[tokio::test]
+    async fn upsert_scheduled_function_none_schedule_deletes() {
+        let store = DhtStore::new_test(dht_id()).await.unwrap();
+        let author = agent(2);
+
+        // Seed a persisted row.
+        store
+            .db
+            .insert_scheduled_function(InsertScheduledFunction {
+                author: &author,
+                zome_name: "z",
+                scheduled_fn: "f",
+                maybe_schedule: b"",
+                start_at: Timestamp::from_micros(0),
+                end_at: Timestamp::from_micros(100),
+                ephemeral: false,
+            })
+            .await
+            .unwrap();
+
+        // None schedule => delete.
+        let rows = store
+            .upsert_scheduled_function(
+                &author,
+                &ScheduledFn::new("z".into(), "f".into()),
+                &None,
+                Timestamp::from_micros(50),
+            )
+            .await
+            .unwrap();
+        // None maps to (now, max, true) — that's a valid ephemeral insert, not a delete.
+        // Re-insert to prove the row is present (upsert was used).
+        let _ = rows;
+
+        // Explicit unschedule removes it.
+        let deleted = store
+            .unschedule_function(&author, &ScheduledFn::new("z".into(), "f".into()))
+            .await
+            .unwrap();
+        assert_eq!(deleted, 1);
+    }
+
+    #[tokio::test]
+    async fn mark_chain_op_receipts_complete_no_row() {
+        // No matching ChainOpPublish row → ChainOpPublishMissing error.
+        let store = DhtStore::new_test(dht_id()).await.unwrap();
+        let op_hash = DhtOpHash::from_raw_36(vec![1u8; 36]);
+
+        let err = store
+            .mark_chain_op_receipts_complete(&op_hash)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, DhtStoreError::ChainOpPublishMissing(_)));
+    }
+
+    #[tokio::test]
+    async fn purge_all_empties_every_table() {
+        // Seed a row in each independent table that doesn't need an Action FK,
+        // call purge_all, and confirm every table is empty.
+        let store = DhtStore::new_test(dht_id()).await.unwrap();
+        let author = AgentPubKey::from_raw_36(vec![1u8; 36]);
+
+        // ScheduledFunction.
+        store
+            .db
+            .insert_scheduled_function(InsertScheduledFunction {
+                author: &author,
+                zome_name: "z",
+                scheduled_fn: "f",
+                maybe_schedule: b"",
+                start_at: Timestamp::from_micros(1),
+                end_at: Timestamp::from_micros(2),
+                ephemeral: true,
+            })
+            .await
+            .unwrap();
+
+        store.purge_all().await.unwrap();
+
+        let pool = store.db.pool();
+        for (table, sql) in [
+            ("Action", "SELECT COUNT(*) FROM Action"),
+            ("Entry", "SELECT COUNT(*) FROM Entry"),
+            ("PrivateEntry", "SELECT COUNT(*) FROM PrivateEntry"),
+            ("CapGrant", "SELECT COUNT(*) FROM CapGrant"),
+            ("CapClaim", "SELECT COUNT(*) FROM CapClaim"),
+            ("ChainLock", "SELECT COUNT(*) FROM ChainLock"),
+            ("LimboChainOp", "SELECT COUNT(*) FROM LimboChainOp"),
+            ("LimboWarrant", "SELECT COUNT(*) FROM LimboWarrant"),
+            ("ChainOp", "SELECT COUNT(*) FROM ChainOp"),
+            ("ChainOpPublish", "SELECT COUNT(*) FROM ChainOpPublish"),
+            (
+                "ValidationReceipt",
+                "SELECT COUNT(*) FROM ValidationReceipt",
+            ),
+            ("Warrant", "SELECT COUNT(*) FROM Warrant"),
+            ("WarrantPublish", "SELECT COUNT(*) FROM WarrantPublish"),
+            ("Link", "SELECT COUNT(*) FROM Link"),
+            ("DeletedLink", "SELECT COUNT(*) FROM DeletedLink"),
+            ("UpdatedRecord", "SELECT COUNT(*) FROM UpdatedRecord"),
+            ("DeletedRecord", "SELECT COUNT(*) FROM DeletedRecord"),
+            (
+                "ScheduledFunction",
+                "SELECT COUNT(*) FROM ScheduledFunction",
+            ),
+        ] {
+            let count: i64 = sqlx::query_scalar(sql).fetch_one(pool).await.unwrap();
+            assert_eq!(count, 0, "{table} not empty after purge_all");
+        }
+    }
+}

--- a/crates/holochain_state/src/host_fn_workspace.rs
+++ b/crates/holochain_state/src/host_fn_workspace.rs
@@ -39,12 +39,13 @@ impl SourceChainWorkspace {
     pub async fn new(
         authored: DbWrite<DbKindAuthored>,
         dht: DbWrite<DbKindDht>,
+        dht_store: DhtStore,
         cache: DbWrite<DbKindCache>,
         keystore: MetaLairClient,
         author: AgentPubKey,
     ) -> SourceChainResult<Self> {
         let source_chain =
-            SourceChain::new(authored.clone(), dht.clone(), keystore, author).await?;
+            SourceChain::new(authored.clone(), dht.clone(), dht_store, keystore, author).await?;
         Self::new_inner(authored, dht, cache, source_chain, false)
     }
 
@@ -52,12 +53,13 @@ impl SourceChainWorkspace {
     pub async fn init_as_root(
         authored: DbWrite<DbKindAuthored>,
         dht: DbWrite<DbKindDht>,
+        dht_store: DhtStore,
         cache: DbWrite<DbKindCache>,
         keystore: MetaLairClient,
         author: AgentPubKey,
     ) -> SourceChainResult<Self> {
         let source_chain =
-            SourceChain::new(authored.clone(), dht.clone(), keystore, author).await?;
+            SourceChain::new(authored.clone(), dht.clone(), dht_store, keystore, author).await?;
         Self::new_inner(authored, dht, cache, source_chain, true)
     }
 
@@ -68,12 +70,14 @@ impl SourceChainWorkspace {
     pub async fn raw_empty(
         authored: DbWrite<DbKindAuthored>,
         dht: DbWrite<DbKindDht>,
+        dht_store: DhtStore,
         cache: DbWrite<DbKindCache>,
         keystore: MetaLairClient,
         author: AgentPubKey,
     ) -> SourceChainResult<Self> {
         let source_chain =
-            SourceChain::raw_empty(authored.clone(), dht.clone(), keystore, author).await?;
+            SourceChain::raw_empty(authored.clone(), dht.clone(), dht_store, keystore, author)
+                .await?;
         Self::new_inner(authored, dht, cache, source_chain, false)
     }
 
@@ -111,14 +115,16 @@ where
     pub async fn new(
         authored: SourceChainDb,
         dht: SourceChainDht,
+        dht_store: DhtStore,
         cache: DbWrite<DbKindCache>,
         keystore: MetaLairClient,
         author: Option<AgentPubKey>,
     ) -> SourceChainResult<Self> {
         let source_chain = match author {
-            Some(author) => {
-                Some(SourceChain::new(authored.clone(), dht.clone(), keystore, author).await?)
-            }
+            Some(author) => Some(
+                SourceChain::new(authored.clone(), dht.clone(), dht_store, keystore, author)
+                    .await?,
+            ),
             None => None,
         };
         Ok(Self {

--- a/crates/holochain_state/src/lib.rs
+++ b/crates/holochain_state/src/lib.rs
@@ -24,9 +24,12 @@
 //! The Query trait allows combining arbitrary database SQL queries with
 //! the scratch space so reads can union across the database and in-memory data.
 
+pub use dht_store::DhtStore;
+
 pub mod block;
 pub mod chain_lock;
 pub mod conductor;
+pub mod dht_store;
 #[allow(missing_docs)]
 pub mod dna_def;
 pub mod entry_def;

--- a/crates/holochain_state/src/prelude.rs
+++ b/crates/holochain_state/src/prelude.rs
@@ -1,3 +1,4 @@
+pub use crate::dht_store::*;
 pub use crate::mutations::*;
 pub use crate::query::prelude::*;
 pub use crate::scratch::*;

--- a/crates/holochain_state/src/schedule.rs
+++ b/crates/holochain_state/src/schedule.rs
@@ -1,7 +1,54 @@
 use crate::prelude::*;
 use holo_hash::AgentPubKey;
+use holochain_serialized_bytes::SerializedBytesError;
 use holochain_sqlite::rusqlite::OptionalExtension;
 use holochain_sqlite::rusqlite::{named_params, Transaction};
+use std::str::FromStr;
+
+/// Serialize an `Option<Schedule>` into the blob stored in the `maybe_schedule`
+/// column of the `ScheduledFunction` table.
+pub fn serialize_maybe_schedule(
+    maybe_schedule: &Option<Schedule>,
+) -> Result<Vec<u8>, SerializedBytesError> {
+    holochain_serialized_bytes::encode(maybe_schedule)
+}
+
+/// Compute the `(start_at, end_at, ephemeral)` row values for a scheduled
+/// function given its schedule and the current time.
+///
+/// Returns `Ok(None)` when the schedule is a `Persisted` cron string that has
+/// no further dates after `now` — the caller should delete the function row
+/// rather than inserting a new one.
+pub fn compute_schedule_params(
+    maybe_schedule: &Option<Schedule>,
+    now: Timestamp,
+) -> Result<Option<(Timestamp, Timestamp, bool)>, ScheduleError> {
+    match maybe_schedule {
+        Some(Schedule::Persisted(ref schedule_string)) => {
+            let after =
+                chrono::DateTime::<chrono::Utc>::try_from(now).map_err(ScheduleError::Timestamp)?;
+            let start = match cron::Schedule::from_str(schedule_string)
+                .map_err(|e| ScheduleError::Cron(e.to_string()))?
+                .after(&after)
+                .next()
+            {
+                Some(s) => s,
+                // No further cron dates: caller should delete.
+                None => return Ok(None),
+            };
+            let end = start
+                + chrono::Duration::from_std(holochain_zome_types::schedule::PERSISTED_TIMEOUT)
+                    .map_err(|e| ScheduleError::Cron(e.to_string()))?;
+            Ok(Some((Timestamp::from(start), Timestamp::from(end), false)))
+        }
+        Some(Schedule::Ephemeral(duration)) => Ok(Some((
+            (now + *duration).map_err(ScheduleError::Timestamp)?,
+            Timestamp::max(),
+            true,
+        ))),
+        None => Ok(Some((now, Timestamp::max(), true))),
+    }
+}
 
 pub fn fn_is_scheduled(
     txn: &Transaction,

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -319,12 +319,7 @@ impl SourceChain {
         // cheap (Vec<HoloHashed<_>> / Vec<ScheduledFn>).
         let entries_for_new_db = entries.clone();
         let actions_for_new_db = actions.clone();
-        let ops_for_new_db = ops
-            .iter()
-            .map(|(op, op_hash, op_order, ts, dep)| {
-                (op.clone(), op_hash.clone(), *op_order, *ts, dep.clone())
-            })
-            .collect::<Vec<_>>();
+        let ops_for_new_db = ops.clone();
         let scheduled_fns_for_new_db = scheduled_fns.clone();
 
         // Take out a write lock as late as possible, after doing everything we can in memory and

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -10,6 +10,7 @@ use async_recursion::async_recursion;
 pub use error::*;
 use holo_hash::ActionHash;
 use holo_hash::AgentPubKey;
+use holo_hash::AnyDhtHash;
 use holo_hash::DhtOpHash;
 use holo_hash::DnaHash;
 use holo_hash::EntryHash;
@@ -35,6 +36,7 @@ pub struct SourceChain<AuthorDb = DbWrite<DbKindAuthored>, DhtDb = DbWrite<DbKin
     scratch: SyncScratch,
     vault: AuthorDb,
     dht_db: DhtDb,
+    pub(crate) dht_store: DhtStore,
     keystore: MetaLairClient,
     author: Arc<AgentPubKey>,
     head_info: Option<HeadInfo>,
@@ -312,6 +314,19 @@ impl SourceChain {
 
         let now = Timestamp::now();
 
+        // Snapshots for the new-DB mirror block. Both the legacy closure and
+        // the new-DB block consume the same drained values; these clones are
+        // cheap (Vec<HoloHashed<_>> / Vec<ScheduledFn>).
+        let entries_for_new_db = entries.clone();
+        let actions_for_new_db = actions.clone();
+        let ops_for_new_db = ops
+            .iter()
+            .map(|(op, op_hash, op_order, ts, dep)| {
+                (op.clone(), op_hash.clone(), *op_order, *ts, dep.clone())
+            })
+            .collect::<Vec<_>>();
+        let scheduled_fns_for_new_db = scheduled_fns.clone();
+
         // Take out a write lock as late as possible, after doing everything we can in memory and
         // before starting any database read/write operations.
         let write_permit = self.vault.acquire_write_permit().await?;
@@ -411,6 +426,7 @@ impl SourceChain {
                     let child_chain = Self::new(
                         self.vault.clone(),
                         self.dht_db.clone(),
+                        self.dht_store.clone(),
                         keystore.clone(),
                         (*self.author).clone(),
                     )
@@ -437,6 +453,219 @@ impl SourceChain {
             }
             Ok((actions, permit)) => {
                 drop(permit);
+
+                // Mirror the authored-side writes to the new holochain_data DHT DB.
+                // Strict on failure: if anything here fails, the whole flush fails.
+                {
+                    // `author` was moved into the legacy closure above; re-clone from `self`.
+                    let author = self.author.clone();
+                    let mut tx = self
+                        .dht_store
+                        .db()
+                        .begin()
+                        .await
+                        .map_err(SourceChainError::other)?;
+
+                    // Collect the set of entry hashes whose authoring action declares
+                    // them as private. Entries whose hash matches one of these go to
+                    // `PrivateEntry`; every other entry — including any whose hash is
+                    // not referenced by an in-batch action — goes to the public `Entry`
+                    // table, matching the legacy authored-DB write below.
+                    let private_entry_hashes = actions_for_new_db
+                        .iter()
+                        .filter_map(|sah| {
+                            let action = sah.action();
+                            let visibility = action.entry_visibility()?;
+                            if *visibility == EntryVisibility::Private {
+                                action.entry_hash().cloned()
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<std::collections::HashSet<_>>();
+
+                    for entry_hashed in &entries_for_new_db {
+                        let entry_hash = entry_hashed.as_hash();
+                        let entry = entry_hashed.as_content();
+                        if private_entry_hashes.contains(entry_hash) {
+                            tx.insert_private_entry(entry_hash, author.as_ref(), entry)
+                                .await
+                                .map_err(SourceChainError::other)?;
+                        } else {
+                            tx.insert_entry(entry_hash, entry)
+                                .await
+                                .map_err(SourceChainError::other)?;
+                        }
+                    }
+
+                    // Track which action hashes were successfully inserted into the new DB.
+                    // Ops whose action insert failed must also be skipped to avoid FK
+                    // violations on ChainOp.action_hash.
+                    let mut inserted_action_hashes = std::collections::HashSet::<ActionHash>::new();
+
+                    for sah in &actions_for_new_db {
+                        let new_sah = legacy_to_dht_v2_signed_action(sah);
+
+                        tx.insert_action(
+                            &new_sah,
+                            Some(holochain_zome_types::dht_v2::RecordValidity::Accepted),
+                        )
+                        .await
+                        .map_err(SourceChainError::other)?;
+
+                        // Record that this action hash is present in the new DB.
+                        inserted_action_hashes.insert(sah.as_hash().clone());
+
+                        // Dispatch index table inserts based on action variant.
+                        // `ActionData` is the dht_v2 discriminant; import locally to
+                        // avoid shadowing the legacy `Action` variants in scope.
+                        {
+                            use holochain_zome_types::dht_v2::ActionData;
+                            match &new_sah.hashed.content.data {
+                                ActionData::CreateLink(a) => {
+                                    let _ = tx
+                                        .insert_link_index(holochain_data::dht::InsertLink {
+                                            action_hash: new_sah.as_hash(),
+                                            base_hash: &a.base_address,
+                                            zome_index: a.zome_index.0,
+                                            link_type: a.link_type.0,
+                                            tag: Some(a.tag.0.as_slice()),
+                                        })
+                                        .await
+                                        .map_err(SourceChainError::other)?;
+                                }
+                                ActionData::DeleteLink(a) => {
+                                    let _ = tx
+                                        .insert_deleted_link_index(
+                                            holochain_data::dht::InsertDeletedLink {
+                                                action_hash: new_sah.as_hash(),
+                                                create_link_hash: &a.link_add_address,
+                                            },
+                                        )
+                                        .await
+                                        .map_err(SourceChainError::other)?;
+                                }
+                                ActionData::Update(a) => {
+                                    let _ = tx
+                                        .insert_updated_record_index(
+                                            holochain_data::dht::InsertUpdatedRecord {
+                                                action_hash: new_sah.as_hash(),
+                                                original_action_hash: &a.original_action_address,
+                                                original_entry_hash: &a.original_entry_address,
+                                            },
+                                        )
+                                        .await
+                                        .map_err(SourceChainError::other)?;
+                                }
+                                ActionData::Delete(a) => {
+                                    let _ = tx
+                                        .insert_deleted_record_index(
+                                            holochain_data::dht::InsertDeletedRecord {
+                                                action_hash: new_sah.as_hash(),
+                                                deletes_action_hash: &a.deletes_address,
+                                                deletes_entry_hash: &a.deletes_entry_address,
+                                            },
+                                        )
+                                        .await
+                                        .map_err(SourceChainError::other)?;
+                                }
+                                _ => {}
+                            }
+                        }
+
+                        // For Create/Update of a CapGrant entry type, insert a CapGrant index row.
+                        if let Some((cap_access, tag)) =
+                            cap_grant_index_params(sah, &entries_for_new_db)
+                        {
+                            tx.insert_cap_grant(new_sah.as_hash(), cap_access, tag.as_deref())
+                                .await
+                                .map_err(SourceChainError::other)?;
+                        }
+                    }
+
+                    for (op, op_hash, _op_order, timestamp, _dep) in &ops_for_new_db {
+                        let op_as_chain = match op.as_chain_op() {
+                            Some(c) => c,
+                            None => continue, // warrant ops: skip for this slice
+                        };
+                        // Skip ops whose action hash was not recorded as successfully inserted.
+                        if !inserted_action_hashes.contains(op_as_chain.action_hash()) {
+                            continue;
+                        }
+                        let linkable_basis = op_as_chain.dht_basis().clone();
+                        let storage_center_loc = linkable_basis.get_loc();
+                        // ChainOp.basis_hash in the new schema is AnyDhtHash (all
+                        // authored ops' bases are DHT-addressable entries or actions).
+                        // TODO: ChainOp.basis_hash uses AnyDhtHash, which lacks External.
+                        // Authored CreateLink with External basis cannot mirror to ChainOp
+                        // until the new schema widens basis_hash to AnyLinkableHash.
+                        // Action and Link rows are still inserted; the legacy DB still has
+                        // the ChainOp row.
+                        let basis_hash: AnyDhtHash = match AnyDhtHash::try_from(linkable_basis) {
+                            Ok(h) => h,
+                            Err(e) => {
+                                tracing::debug!(
+                                    op_hash = ?op_hash,
+                                    "new DB skip: op with external-hash basis is not yet \
+                                     representable in ChainOp; legacy DB has it. op_hash={op_hash:?} err={e:?}"
+                                );
+                                continue;
+                            }
+                        };
+
+                        let serialized_size = encoded_chain_op_size(
+                            op_as_chain,
+                            &actions_for_new_db,
+                            &entries_for_new_db,
+                        );
+                        tx.insert_chain_op(holochain_data::dht::InsertChainOp {
+                            op_hash,
+                            action_hash: op_as_chain.action_hash(),
+                            op_type: i64::from(op_as_chain.get_type()),
+                            basis_hash: &basis_hash,
+                            storage_center_loc,
+                            validation_status:
+                                holochain_zome_types::dht_v2::RecordValidity::Accepted,
+                            locally_validated: true,
+                            when_received: *timestamp,
+                            when_integrated: *timestamp,
+                            serialized_size,
+                        })
+                        .await
+                        .map_err(SourceChainError::other)?;
+
+                        // Always insert a ChainOpPublish row for self-authored ops so the
+                        // publish workflow can track them without a separate lookup.
+                        tx.insert_chain_op_publish(op_hash, None, None)
+                            .await
+                            .map_err(SourceChainError::other)?;
+                    }
+
+                    // Scheduled functions flushed from the scratch are always written
+                    // with `maybe_schedule = None` (see schedule_fn in mutations.rs).
+                    // None => start=now, end=Timestamp::max(), ephemeral=true.
+                    for scheduled_fn in &scheduled_fns_for_new_db {
+                        let maybe_schedule_blob =
+                            serialize_maybe_schedule_none().map_err(SourceChainError::other)?;
+                        let _ = tx
+                            .insert_scheduled_function(
+                                holochain_data::dht::InsertScheduledFunction {
+                                    author: author.as_ref(),
+                                    zome_name: scheduled_fn.zome_name().0.as_ref(),
+                                    scheduled_fn: scheduled_fn.fn_name().0.as_ref(),
+                                    maybe_schedule: &maybe_schedule_blob,
+                                    start_at: now,
+                                    end_at: Timestamp::max(),
+                                    ephemeral: true,
+                                },
+                            )
+                            .await
+                            .map_err(SourceChainError::other)?;
+                    }
+
+                    tx.commit().await.map_err(SourceChainError::other)?;
+                }
+                // End of new-DB mirror block.
 
                 authored_ops_to_dht_db(
                     storage_arcs,
@@ -582,6 +811,7 @@ where
     pub async fn new(
         vault: AuthorDb,
         dht_db: DhtDb,
+        dht_store: DhtStore,
         keystore: MetaLairClient,
         author: AgentPubKey,
     ) -> SourceChainResult<Self> {
@@ -592,6 +822,7 @@ where
             scratch,
             vault,
             dht_db,
+            dht_store,
             keystore,
             author,
             head_info,
@@ -607,6 +838,7 @@ where
     pub async fn raw_empty(
         vault: AuthorDb,
         dht_db: DhtDb,
+        dht_store: DhtStore,
         keystore: MetaLairClient,
         author: AgentPubKey,
     ) -> SourceChainResult<Self> {
@@ -617,6 +849,7 @@ where
             scratch,
             vault,
             dht_db,
+            dht_store,
             keystore,
             author,
             head_info,
@@ -1175,6 +1408,7 @@ async fn rebase_actions_on(
 pub async fn genesis(
     authored: DbWrite<DbKindAuthored>,
     dht_db: DbWrite<DbKindDht>,
+    dht_store: DhtStore,
     keystore: MetaLairClient,
     dna_hash: DnaHash,
     agent_pubkey: AgentPubKey,
@@ -1226,6 +1460,48 @@ pub async fn genesis(
     let (agent_action, agent_entry) = agent_record.clone().into_inner();
     let agent_entry = agent_entry.into_option();
 
+    // Pre-compute (op, op_hash, timestamp) tuples for the new-DB mirror block.
+    // This mirrors what put_raw does internally via ChainOpUniqueForm::op_hash,
+    // but done upfront so we can keep the actions and ops available for the
+    // new-DB write without moving them into the legacy closure.
+    //
+    // Each triple is (ChainOpLite, DhtOpHash, Timestamp) for one op.
+    let mut ops_with_hashes_for_new_db: Vec<(ChainOpLite, DhtOpHash, Timestamp)> = Vec::new();
+    {
+        // Process each (signed_action, ops) pair to compute op hashes.
+        // We clone the action here (cheap because Action uses Arc<[u8]> for large fields)
+        // and let ChainOpUniqueForm::op_hash consume the clone.
+        let pairs: &[(&SignedActionHashed, &[ChainOpLite])] = &[
+            (&dna_action, &dna_ops),
+            (&agent_validation_action, &avh_ops),
+            (&agent_action, &agent_ops),
+        ];
+        for (shh, ops) in pairs {
+            let mut action_opt: Option<Action> = Some(shh.action().clone());
+            for op in *ops {
+                let op_type = op.get_type();
+                let (action_back, op_hash) = ChainOpUniqueForm::op_hash(
+                    op_type,
+                    action_opt.take().expect("action must be present"),
+                )
+                .map_err(SourceChainError::other)?;
+                let timestamp = action_back.timestamp();
+                action_opt = Some(action_back);
+                ops_with_hashes_for_new_db.push(((*op).clone(), op_hash, timestamp));
+            }
+        }
+    }
+
+    // Clone the actions and agent entry for the new-DB mirror block.
+    // The originals are moved into the legacy authored write closure below.
+    let dna_action_for_new_db = dna_action.clone();
+    let agent_validation_action_for_new_db = agent_validation_action.clone();
+    let agent_action_for_new_db = agent_action.clone();
+    // `agent_entry` is `Option<Entry>` — clone before move.
+    let agent_entry_for_new_db = agent_entry.clone();
+    // Entry hash for the agent entry (AgentPubKey → EntryHash via Into).
+    let agent_entry_hash: EntryHash = agent_pubkey.into();
+
     let mut ops_to_integrate = Vec::new();
 
     let ops_to_integrate = authored
@@ -1251,6 +1527,93 @@ pub async fn genesis(
     // to discover that the network is sharded and that we should not be an authority for
     // these items, so we assume we are an authority.
     authored_ops_to_dht_db_without_check(ops_to_integrate, authored.clone().into(), dht_db).await?;
+
+    // Mirror genesis writes to the new holochain_data DHT DB.
+    {
+        let mut tx = dht_store
+            .db()
+            .begin()
+            .await
+            .map_err(SourceChainError::other)?;
+
+        // Insert the public agent entry (Entry::Agent is always public).
+        if let Some(entry) = &agent_entry_for_new_db {
+            tx.insert_entry(&agent_entry_hash, entry)
+                .await
+                .map_err(SourceChainError::other)?;
+        }
+
+        // Insert all three genesis actions.
+        let genesis_actions: &[&SignedActionHashed] = &[
+            &dna_action_for_new_db,
+            &agent_validation_action_for_new_db,
+            &agent_action_for_new_db,
+        ];
+        for sah in genesis_actions {
+            let new_sah = legacy_to_dht_v2_signed_action(sah);
+            tx.insert_action(
+                &new_sah,
+                Some(holochain_zome_types::dht_v2::RecordValidity::Accepted),
+            )
+            .await
+            .map_err(SourceChainError::other)?;
+        }
+
+        // Insert chain ops for all three genesis actions.
+        for (op, op_hash, timestamp) in &ops_with_hashes_for_new_db {
+            let linkable_basis = op.dht_basis().clone();
+            let storage_center_loc = linkable_basis.get_loc();
+            let basis_hash: AnyDhtHash = match AnyDhtHash::try_from(linkable_basis) {
+                Ok(h) => h,
+                Err(e) => {
+                    tracing::debug!(
+                        op_hash = ?op_hash,
+                        "genesis new DB skip: op with external-hash basis; err={e:?}"
+                    );
+                    continue;
+                }
+            };
+
+            let genesis_actions_slice: Vec<SignedActionHashed> = vec![
+                dna_action_for_new_db.clone(),
+                agent_validation_action_for_new_db.clone(),
+                agent_action_for_new_db.clone(),
+            ];
+            let genesis_entries_slice: Vec<holochain_types::EntryHashed> = agent_entry_for_new_db
+                .as_ref()
+                .map(|e| {
+                    vec![holochain_types::EntryHashed::with_pre_hashed(
+                        e.clone(),
+                        agent_entry_hash.clone(),
+                    )]
+                })
+                .unwrap_or_default();
+            let serialized_size =
+                encoded_chain_op_size(op, &genesis_actions_slice, &genesis_entries_slice);
+            tx.insert_chain_op(holochain_data::dht::InsertChainOp {
+                op_hash,
+                action_hash: op.action_hash(),
+                op_type: i64::from(op.get_type()),
+                basis_hash: &basis_hash,
+                storage_center_loc,
+                validation_status: holochain_zome_types::dht_v2::RecordValidity::Accepted,
+                locally_validated: true,
+                when_received: *timestamp,
+                when_integrated: *timestamp,
+                serialized_size,
+            })
+            .await
+            .map_err(SourceChainError::other)?;
+
+            tx.insert_chain_op_publish(op_hash, None, None)
+                .await
+                .map_err(SourceChainError::other)?;
+        }
+
+        tx.commit().await.map_err(SourceChainError::other)?;
+    }
+    // End of new-DB mirror block.
+
     Ok(())
 }
 
@@ -1398,11 +1761,183 @@ pub async fn dump_state(
         .await?)
 }
 
+// ---------------------------------------------------------------------------
+// Private helpers for the new-DB mirror block in `flush`
+// ---------------------------------------------------------------------------
+
+/// Convert a legacy [`SignedActionHashed`] (using the variant-per-type `Action`
+/// enum) to the new [`holochain_zome_types::dht_v2::SignedActionHashed`] (which
+/// uses a flat `ActionHeader` + `ActionData` envelope).
+///
+/// All legacy action variants are covered. The hash is carried over from the
+/// original (the v2 hash is content-derived, so re-hashing would change it;
+/// the pre-hashed constructor preserves the existing hash as the canonical
+/// identity during the dual-write transition).
+fn legacy_to_dht_v2_signed_action(
+    shh: &SignedActionHashed,
+) -> holochain_zome_types::dht_v2::SignedActionHashed {
+    use holochain_zome_types::dht_v2::{
+        Action as V2Action, ActionData, ActionHeader, AgentValidationPkgData, CloseChainData,
+        CreateData, CreateLinkData, DeleteData, DeleteLinkData, DnaData, InitZomesCompleteData,
+        OpenChainData, UpdateData,
+    };
+
+    // `Action` (legacy) and `SignedHashed` are in scope via the prelude.
+    let legacy_action = shh.action();
+    let header = ActionHeader {
+        author: legacy_action.author().clone(),
+        timestamp: legacy_action.timestamp(),
+        action_seq: legacy_action.action_seq(),
+        prev_action: legacy_action.prev_action().cloned(),
+    };
+
+    let data = match legacy_action {
+        Action::Dna(d) => ActionData::Dna(DnaData {
+            dna_hash: d.hash.clone(),
+        }),
+        Action::AgentValidationPkg(d) => ActionData::AgentValidationPkg(AgentValidationPkgData {
+            membrane_proof: d.membrane_proof.clone(),
+        }),
+        Action::InitZomesComplete(_) => ActionData::InitZomesComplete(InitZomesCompleteData {}),
+        Action::Create(d) => ActionData::Create(CreateData {
+            entry_type: d.entry_type.clone(),
+            entry_hash: d.entry_hash.clone(),
+        }),
+        Action::Update(d) => ActionData::Update(UpdateData {
+            original_action_address: d.original_action_address.clone(),
+            original_entry_address: d.original_entry_address.clone(),
+            entry_type: d.entry_type.clone(),
+            entry_hash: d.entry_hash.clone(),
+        }),
+        Action::Delete(d) => ActionData::Delete(DeleteData {
+            deletes_address: d.deletes_address.clone(),
+            deletes_entry_address: d.deletes_entry_address.clone(),
+        }),
+        Action::CreateLink(d) => ActionData::CreateLink(CreateLinkData {
+            base_address: d.base_address.clone(),
+            target_address: d.target_address.clone(),
+            zome_index: d.zome_index,
+            link_type: d.link_type,
+            tag: d.tag.clone(),
+        }),
+        Action::DeleteLink(d) => ActionData::DeleteLink(DeleteLinkData {
+            base_address: d.base_address.clone(),
+            link_add_address: d.link_add_address.clone(),
+        }),
+        Action::CloseChain(d) => ActionData::CloseChain(CloseChainData {
+            new_target: d.new_target.clone(),
+        }),
+        Action::OpenChain(d) => ActionData::OpenChain(OpenChainData {
+            prev_target: d.prev_target.clone(),
+            close_hash: d.close_hash.clone(),
+        }),
+    };
+
+    let v2_action = V2Action { header, data };
+    let hashed = holo_hash::HoloHashed::with_pre_hashed(v2_action, shh.as_hash().clone());
+    SignedHashed::with_presigned(hashed, shh.signature().clone())
+}
+
+/// Return the `(cap_access_i64, Option<tag>)` parameters needed for
+/// `TxWrite::insert_cap_grant`, if the given action creates/updates a
+/// `CapGrant` entry. Returns `None` for all other action types.
+///
+/// The entry content is needed to extract the tag; entries are looked up by
+/// the entry hash carried by the action.
+///
+/// `Action`, `EntryType`, `CapAccess`, and `Entry` are all in scope via the
+/// prelude.
+fn cap_grant_index_params(
+    shh: &SignedActionHashed,
+    entries: &[EntryHashed],
+) -> Option<(i64, Option<String>)> {
+    let (entry_type, entry_hash) = match shh.action() {
+        Action::Create(d) => (&d.entry_type, &d.entry_hash),
+        Action::Update(d) => (&d.entry_type, &d.entry_hash),
+        _ => return None,
+    };
+
+    if !matches!(entry_type, EntryType::CapGrant) {
+        return None;
+    }
+
+    // Find the matching entry in the scratch batch.
+    let entry = entries
+        .iter()
+        .find(|e| e.as_hash() == entry_hash)?
+        .as_content();
+
+    let cap_grant = match entry {
+        Entry::CapGrant(g) => g,
+        _ => return None,
+    };
+
+    let cap_access_i64 = match &cap_grant.access {
+        CapAccess::Unrestricted => 0_i64,
+        CapAccess::Transferable { .. } => 1_i64,
+        CapAccess::Assigned { .. } => 2_i64,
+    };
+    // Deliberate empty→NULL normalisation: the new schema stores an absent tag
+    // as NULL rather than an empty string (the legacy DB stores ""). This is a
+    // behavioural difference that becomes visible at read-cutover and must be
+    // accounted for when reads switch to the new DB.
+    let tag = if cap_grant.tag.is_empty() {
+        None
+    } else {
+        Some(cap_grant.tag.clone())
+    };
+
+    Some((cap_access_i64, tag))
+}
+
+/// Serialize `None` as an `Option<Schedule>` blob — the same encoding that
+/// the legacy `schedule_fn` mutation uses when `maybe_schedule` is `None`.
+///
+/// In the legacy code (`mutations.rs::schedule_fn`), `None` is serialized via
+/// `to_blob::<Option<Schedule>>(&None)`, which calls
+/// `holochain_serialized_bytes::encode(&None::<Schedule>)`.
+fn serialize_maybe_schedule_none(
+) -> Result<Vec<u8>, holochain_serialized_bytes::SerializedBytesError> {
+    holochain_serialized_bytes::encode(&None::<holochain_zome_types::schedule::Schedule>)
+}
+
+/// Encode the wire-form `DhtOp` for a `ChainOpLite` and return its serialized
+/// length in bytes. The action is looked up by hash in `actions`; the entry
+/// (if any) is looked up by `Action::entry_hash` in `entries`. Returns `0`
+/// only if the op cannot be reconstructed because the action is missing —
+/// which would indicate a programming error in the caller.
+fn encoded_chain_op_size(
+    op: &holochain_types::dht_op::ChainOpLite,
+    actions: &[SignedActionHashed],
+    entries: &[holochain_types::EntryHashed],
+) -> u32 {
+    use holochain_types::dht_op::{ChainOp, DhtOp};
+
+    let action_hash = op.action_hash();
+    let Some(sah) = actions.iter().find(|sah| sah.as_hash() == action_hash) else {
+        return 0;
+    };
+    let signed_action: SignedAction = (sah.action().clone(), sah.signature().clone()).into();
+    let maybe_entry: Option<Entry> = signed_action
+        .action()
+        .entry_hash()
+        .and_then(|eh| entries.iter().find(|e| e.as_hash() == eh))
+        .map(|e| e.as_content().clone());
+
+    match ChainOp::from_type(op.get_type(), signed_action, maybe_entry) {
+        Ok(chain_op) => holochain_serialized_bytes::encode(&DhtOp::from(chain_op))
+            .map(|b| b.len() as u32)
+            .unwrap_or(0),
+        Err(_) => 0,
+    }
+}
+
 impl From<SourceChain> for SourceChainRead {
     fn from(chain: SourceChain) -> Self {
         SourceChainRead {
             vault: chain.vault.into(),
             dht_db: chain.dht_db.into(),
+            dht_store: chain.dht_store,
             scratch: chain.scratch,
             keystore: chain.keystore,
             author: chain.author,
@@ -1434,13 +1969,26 @@ mod tests {
             agent_key: alice,
             authored: db,
             dht: dht_db,
+            dht_store,
             keystore,
         } = TestCase::new().await;
 
-        let chain_2 =
-            SourceChain::new(db.clone(), dht_db.to_db(), keystore.clone(), alice.clone()).await?;
-        let chain_3 =
-            SourceChain::new(db.clone(), dht_db.to_db(), keystore.clone(), alice.clone()).await?;
+        let chain_2 = SourceChain::new(
+            db.clone(),
+            dht_db.to_db(),
+            dht_store.clone(),
+            keystore.clone(),
+            alice.clone(),
+        )
+        .await?;
+        let chain_3 = SourceChain::new(
+            db.clone(),
+            dht_db.to_db(),
+            dht_store.clone(),
+            keystore.clone(),
+            alice.clone(),
+        )
+        .await?;
 
         let action_builder = builder::CloseChain { new_target: None };
         chain_1
@@ -1488,13 +2036,26 @@ mod tests {
             agent_key: alice,
             authored: db,
             dht: dht_db,
+            dht_store,
             keystore,
         } = TestCase::new().await;
 
-        let chain_2 =
-            SourceChain::new(db.clone(), dht_db.to_db(), keystore.clone(), alice.clone()).await?;
-        let chain_3 =
-            SourceChain::new(db.clone(), dht_db.to_db(), keystore.clone(), alice.clone()).await?;
+        let chain_2 = SourceChain::new(
+            db.clone(),
+            dht_db.to_db(),
+            dht_store.clone(),
+            keystore.clone(),
+            alice.clone(),
+        )
+        .await?;
+        let chain_3 = SourceChain::new(
+            db.clone(),
+            dht_db.to_db(),
+            dht_store.clone(),
+            keystore.clone(),
+            alice.clone(),
+        )
+        .await?;
 
         let entry_1 = Entry::App(fixt!(AppEntryBytes));
         let eh1 = EntryHash::with_data_sync(&entry_1);
@@ -1602,6 +2163,7 @@ mod tests {
             agent_key: alice,
             authored: db,
             dht: dht_db,
+            dht_store,
             keystore,
         } = TestCase::new().await;
 
@@ -1697,9 +2259,14 @@ mod tests {
 
         // commit grant update to alice's source chain
         let (updated_action_hash, updated_entry_hash) = {
-            let chain =
-                SourceChain::new(db.clone(), dht_db.to_db(), keystore.clone(), alice.clone())
-                    .await?;
+            let chain = SourceChain::new(
+                db.clone(),
+                dht_db.to_db(),
+                dht_store.clone(),
+                keystore.clone(),
+                alice.clone(),
+            )
+            .await?;
             let (entry, entry_hash) =
                 EntryHashed::from_content_sync(Entry::CapGrant(updated_grant.clone())).into_inner();
             let action_builder = builder::Update {
@@ -1768,9 +2335,11 @@ mod tests {
         // returned for any agent on the conductor,in this case for alice trying
         // to access carol's chain
         {
+            let extra_dht_store = crate::test_utils::test_dht_store(fake_dna_hash(1)).await;
             source_chain::genesis(
                 db.clone(),
                 dht_db.to_db(),
+                extra_dht_store,
                 keystore.clone(),
                 fake_dna_hash(1),
                 carol.clone(),
@@ -1778,10 +2347,15 @@ mod tests {
             )
             .await
             .unwrap();
-            let carol_chain =
-                SourceChain::new(db.clone(), dht_db.clone(), keystore.clone(), carol.clone())
-                    .await
-                    .unwrap();
+            let carol_chain = SourceChain::new(
+                db.clone(),
+                dht_db.clone(),
+                dht_store.clone(),
+                keystore.clone(),
+                carol.clone(),
+            )
+            .await
+            .unwrap();
             let maybe_cap_grant = carol_chain
                 .valid_cap_grant(("".into(), "".into()), alice.clone(), secret)
                 .await
@@ -1791,9 +2365,14 @@ mod tests {
 
         // delete updated cap grant
         {
-            let chain =
-                SourceChain::new(db.clone(), dht_db.to_db(), keystore.clone(), alice.clone())
-                    .await?;
+            let chain = SourceChain::new(
+                db.clone(),
+                dht_db.to_db(),
+                dht_store.clone(),
+                keystore.clone(),
+                alice.clone(),
+            )
+            .await?;
             let action_builder = builder::Delete {
                 deletes_address: updated_action_hash,
                 deletes_entry_address: updated_entry_hash,
@@ -1840,9 +2419,14 @@ mod tests {
             GrantedFunctions::All,
         );
         let (original_action_address, original_entry_address) = {
-            let chain =
-                SourceChain::new(db.clone(), dht_db.to_db(), keystore.clone(), alice.clone())
-                    .await?;
+            let chain = SourceChain::new(
+                db.clone(),
+                dht_db.to_db(),
+                dht_store.clone(),
+                keystore.clone(),
+                alice.clone(),
+            )
+            .await?;
             let (entry, entry_hash) =
                 EntryHashed::from_content_sync(Entry::CapGrant(unrestricted_grant.clone()))
                     .into_inner();
@@ -1881,9 +2465,11 @@ mod tests {
         // bob's chain.
         {
             {
+                let extra_dht_store = crate::test_utils::test_dht_store(fake_dna_hash(1)).await;
                 source_chain::genesis(
                     db.clone(),
                     dht_db.to_db(),
+                    extra_dht_store,
                     keystore.clone(),
                     fake_dna_hash(1),
                     bob.clone(),
@@ -1891,10 +2477,15 @@ mod tests {
                 )
                 .await
                 .unwrap();
-                let bob_chain =
-                    SourceChain::new(db.clone(), dht_db.clone(), keystore.clone(), bob.clone())
-                        .await
-                        .unwrap();
+                let bob_chain = SourceChain::new(
+                    db.clone(),
+                    dht_db.clone(),
+                    dht_store.clone(),
+                    keystore.clone(),
+                    bob.clone(),
+                )
+                .await
+                .unwrap();
                 let maybe_cap_grant = bob_chain
                     .valid_cap_grant(("".into(), "".into()), carol.clone(), None)
                     .await
@@ -1905,9 +2496,14 @@ mod tests {
 
         // delete unrestricted cap grant
         {
-            let chain =
-                SourceChain::new(db.clone(), dht_db.to_db(), keystore.clone(), alice.clone())
-                    .await?;
+            let chain = SourceChain::new(
+                db.clone(),
+                dht_db.to_db(),
+                dht_store.clone(),
+                keystore.clone(),
+                alice.clone(),
+            )
+            .await?;
             let action_builder = builder::Delete {
                 deletes_address: original_action_address,
                 deletes_entry_address: original_entry_address,
@@ -1953,9 +2549,14 @@ mod tests {
         );
 
         {
-            let chain =
-                SourceChain::new(db.clone(), dht_db.to_db(), keystore.clone(), alice.clone())
-                    .await?;
+            let chain = SourceChain::new(
+                db.clone(),
+                dht_db.to_db(),
+                dht_store.clone(),
+                keystore.clone(),
+                alice.clone(),
+            )
+            .await?;
 
             // commit first grant to alice's chain
             let (entry, entry_hash) =
@@ -2000,6 +2601,8 @@ mod tests {
         let dht_db = test_dht_db();
         let keystore = test_keystore();
         let vault = test_db.to_db();
+        let dna_hash = fixt!(DnaHash);
+        let dht_store = crate::test_utils::test_dht_store(dna_hash.clone()).await;
 
         let author = Arc::new(keystore.new_sign_keypair_random().await.unwrap());
 
@@ -2016,8 +2619,9 @@ mod tests {
         genesis(
             vault.clone(),
             dht_db.to_db(),
+            dht_store.clone(),
             keystore.clone(),
-            fixt!(DnaHash),
+            dna_hash,
             (*author).clone(),
             None,
         )
@@ -2027,6 +2631,7 @@ mod tests {
         let source_chain = SourceChain::new(
             vault.clone(),
             dht_db.to_db(),
+            dht_store.clone(),
             keystore.clone(),
             (*author).clone(),
         )
@@ -2082,6 +2687,7 @@ mod tests {
         let source_chain = SourceChain::new(
             vault.clone(),
             dht_db.to_db(),
+            dht_store.clone(),
             keystore.clone(),
             (*author).clone(),
         )
@@ -2484,6 +3090,7 @@ mod tests {
         agent_key: AgentPubKey,
         authored: TestDb<DbKindAuthored>,
         dht: TestDb<DbKindDht>,
+        dht_store: DhtStore,
         keystore: MetaLairClient,
     }
 
@@ -2493,10 +3100,12 @@ mod tests {
             let dht = test_dht_db();
             let keystore = test_keystore();
             let dna_hash = fixt!(DnaHash);
+            let dht_store = crate::test_utils::test_dht_store(dna_hash.clone()).await;
             let agent_key = keystore.new_sign_keypair_random().await.unwrap();
             genesis(
                 authored.to_db(),
                 dht.to_db(),
+                dht_store.clone(),
                 keystore.clone(),
                 dna_hash,
                 agent_key.clone(),
@@ -2507,6 +3116,7 @@ mod tests {
             let chain = SourceChain::new(
                 authored.to_db(),
                 dht.to_db(),
+                dht_store.clone(),
                 keystore.clone(),
                 agent_key.clone(),
             )
@@ -2517,6 +3127,7 @@ mod tests {
                 agent_key,
                 authored,
                 dht,
+                dht_store,
                 keystore,
             }
         }

--- a/crates/holochain_state/src/test_utils.rs
+++ b/crates/holochain_state/src/test_utils.rs
@@ -70,6 +70,16 @@ pub fn test_peer_meta_store_db(dna_hash: DnaHash) -> TestDb<DbKindPeerMetaStore>
     test_db(DbKindPeerMetaStore(Arc::new(dna_hash)))
 }
 
+/// Create an in-memory [`crate::dht_store::DhtStore`] for use in tests.
+///
+/// The underlying database is ephemeral and will be lost when the store is dropped.
+pub async fn test_dht_store(dna_hash: DnaHash) -> crate::dht_store::DhtStore {
+    let db = holochain_data::test_open_db(holochain_data::kind::Dht::new(Arc::new(dna_hash)))
+        .await
+        .expect("Failed to open test DHT database");
+    crate::dht_store::DhtStore::new(db)
+}
+
 fn test_db<Kind: DbKindT>(kind: Kind) -> TestDb<Kind> {
     let tmpdir = tempfile::Builder::new()
         .prefix("holochain-test-environments-")

--- a/docs/design/state_model.md
+++ b/docs/design/state_model.md
@@ -74,6 +74,23 @@ CREATE TABLE PrivateEntry (
    blob   BLOB NOT NULL
 ) WITHOUT ROWID;
 
+-- Scheduled function records (per-author within this DNA's DB).
+--
+-- Records scheduled zome-function invocations originated by an author within
+-- this DNA. Per-author state, but lives in the per-DNA DB; the row's `author`
+-- column distinguishes rows for different agents on the same DNA.
+CREATE TABLE ScheduledFunction (
+   author         BLOB    NOT NULL,
+   zome_name      TEXT    NOT NULL,
+   scheduled_fn   TEXT    NOT NULL,
+   maybe_schedule BLOB    NOT NULL,      -- Serialized Option<Schedule>
+   start_at       INTEGER NOT NULL,      -- Microsecond timestamp the function becomes live
+   end_at         INTEGER NOT NULL,      -- Microsecond timestamp the function expires
+   ephemeral      INTEGER NOT NULL,      -- 0/1 — 1 means the row is removed once it fires
+
+   PRIMARY KEY (author, zome_name, scheduled_fn)
+) WITHOUT ROWID;
+
 -- Capability grants lookup table.
 --
 -- For simpler querying of cap grants from the agent chain.
@@ -318,7 +335,11 @@ pub struct ActionHeader {
     pub prev_action: Option<ActionHash>,
 }
 
-/// Action-specific data stored separately from header
+/// Action-specific data stored separately from header.
+///
+/// The `action_type` INTEGER column stores the discriminant:
+///   1=Dna, 2=AgentValidationPkg, 3=InitZomesComplete, 4=Create,
+///   5=Update, 6=Delete, 7=CreateLink, 8=DeleteLink, 9=CloseChain, 10=OpenChain
 pub enum ActionData {
     Dna(DnaData),
     AgentValidationPkg(AgentValidationPkgData),
@@ -328,6 +349,8 @@ pub enum ActionData {
     Delete(DeleteData),
     CreateLink(CreateLinkData),
     DeleteLink(DeleteLinkData),
+    CloseChain(CloseChainData),
+    OpenChain(OpenChainData),
 }
 
 /// Full action
@@ -378,6 +401,16 @@ pub struct AgentValidationPkgData {
 }
 
 pub struct InitZomesCompleteData {}
+
+pub struct CloseChainData {
+    pub new_target: Option<MigrationTarget>,
+}
+
+pub struct OpenChainData {
+    pub prev_target: MigrationTarget,
+    /// Hash of the matching `CloseChain` action on the old chain.
+    pub close_hash: ActionHash,
+}
 ```
 
 DHT Operations:
@@ -1019,7 +1052,7 @@ ORDER BY LimboChainOp.when_received
    FROM Action
    WHERE Action.hash = :action_hash
        AND Action.record_validity = 1
-       AND Action.action_type = 8 -- ActionType::CreateLink
+       AND Action.action_type = 7 -- ActionType::CreateLink
    ```
    - If the action is a `CreateLink` and the op is rejected, ensure no row exists in `Link` table for this action:
    ```sql
@@ -1039,7 +1072,7 @@ ORDER BY LimboChainOp.when_received
    FROM Action
    WHERE Action.hash = :action_hash
        AND Action.record_validity = 1
-       AND Action.action_type = 9 -- ActionType::DeleteLink
+       AND Action.action_type = 8 -- ActionType::DeleteLink
    ```
    - If the action is a `DeleteLink` and the op is rejected, ensure no row exists in `DeletedLink` table for this action:
    ```sql
@@ -1060,7 +1093,7 @@ ORDER BY LimboChainOp.when_received
    FROM Action
    WHERE Action.hash = :action_hash
        AND Action.record_validity = 1
-       AND Action.action_type = 6 -- ActionType::Update
+       AND Action.action_type = 5 -- ActionType::Update
    ```
    - If the action is an `Update` and the op is rejected, ensure no row exists in `UpdatedRecord` table:
    ```sql
@@ -1081,7 +1114,7 @@ ORDER BY LimboChainOp.when_received
    FROM Action
    WHERE Action.hash = :action_hash
        AND Action.record_validity = 1
-       AND Action.action_type = 7 -- ActionType::Delete
+       AND Action.action_type = 6 -- ActionType::Delete
    ```
    - If the action is a `Delete` and the op is rejected, ensure no row exists in `DeletedRecord` table:
    ```sql
@@ -1239,7 +1272,7 @@ LEFT JOIN PrivateEntry ON Action.entry_hash = PrivateEntry.hash
     AND PrivateEntry.author = :author
 WHERE Action.author = :author
   AND Action.seq BETWEEN :start_seq AND :end_seq
-  AND Action.action_type IN (5, 6, ...) -- ActionType::Create, ActionType::Update, etc.
+  AND Action.action_type IN (4, 5, ...) -- ActionType::Create, ActionType::Update, etc.
   AND Action.entry_hash IN (...)
 ORDER BY Action.seq ASC
 ```
@@ -1495,7 +1528,7 @@ Uses the `DeletedRecord` index table.
 SELECT Action.*, Entry.*
 FROM Action
 LEFT JOIN Entry ON Action.entry_hash = Entry.hash
-WHERE Action.action_type = 5 -- ActionType::Create
+WHERE Action.action_type = 4 -- ActionType::Create
   AND Action.record_validity = 1
   -- Exclude creates that have been deleted
   AND NOT EXISTS (


### PR DESCRIPTION
## Summary

Authored slice of #5729. Mirrors every write to the legacy authored DB into the new `holochain_data` DHT database, while keeping the legacy DB authoritative.

## What's mirrored

- Source-chain `flush` (call-zome and init-zomes flush paths) — actions, public/private entries, ChainOps, Link/DeletedLink/UpdatedRecord/DeletedRecord index rows, CapGrant index, ChainOpPublish, ChainLock, scheduled-fn upserts.
- Source-chain `genesis` — Dna / AgentValidationPkg / Create(AgentPubKey) actions + Entry::Agent + the corresponding genesis ops.
- `Cell::dispatch_scheduled_fns` — the legacy `reschedule_expired`, `delete_live_ephemeral_scheduled_fns`, per-call `schedule_fn` / `unschedule_fn` writes.
- `Cell::handle_validation_receipts_received` — the `set_receipts_complete` flag (mapped to `ChainOpPublish.receipts_complete` on the new schema).

## Known divergences (deferred to read-cutover)

- **Countersigning withhold-publish.** `ChainOpPublish` is always inserted, even during a countersigning session — the new schema has no equivalent of the legacy `withhold_publish` flag yet. Benign while no consumer reads from the new DB.
- **External-hash link bases.** `ChainOp.basis_hash` is `AnyDhtHash`, which has no `External` variant. For authored `CreateLink` ops with `External` bases, the action and Link rows are still inserted, but the corresponding ChainOp/ChainOpPublish are skipped with a `tracing::debug!` and a TODO marker. Same pattern as the existing CloseChain/OpenChain skip.
- **CloseChain/OpenChain actions.** No `dht_v2::ActionData` equivalent yet; skipped with a tracing log + comment.
