### PR TITLE
feat: per-DNA relay URL override

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,7 +1485,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest 0.11.2",
+ "digest 0.11.3",
  "fiat-crypto 0.3.0",
  "rand_core 0.10.1",
  "rustc_version",
@@ -1804,9 +1804,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -1919,7 +1919,7 @@ checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
 dependencies = [
  "pkcs8 0.11.0-rc.10",
  "serde",
- "signature 3.0.0-rc.10",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -1948,7 +1948,7 @@ dependencies = [
  "rand_core 0.10.1",
  "serde",
  "sha2 0.11.0-rc.5",
- "signature 3.0.0-rc.10",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -2025,18 +2025,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.10"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
+checksum = "7f96a4a12fe60ac746ae295a1a4ecb5bb02debc20856506c8635288065f142de"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -2563,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2925,7 +2925,7 @@ dependencies = [
  "kitsune2_api",
  "must_future",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.8.0",
  "rand 0.9.4",
  "rusqlite",
  "schemars 0.9.0",
@@ -3274,7 +3274,7 @@ dependencies = [
  "holochain_timestamp",
  "holochain_util",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.8.0",
  "schemars 0.9.0",
  "serde",
  "serde_bytes",
@@ -3411,7 +3411,7 @@ dependencies = [
  "arbitrary",
  "holochain_serialized_bytes_derive",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.5.1",
  "rmp-serde",
  "serde",
  "serde-transcode",
@@ -3593,7 +3593,7 @@ dependencies = [
  "parking_lot",
  "pretty_assertions",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.8.0",
  "rand 0.9.4",
  "regex",
  "rusqlite",
@@ -3722,7 +3722,7 @@ dependencies = [
  "num_enum",
  "once_cell",
  "proptest",
- "proptest-derive",
+ "proptest-derive 0.8.0",
  "rand 0.9.4",
  "rusqlite",
  "schemars 0.9.0",
@@ -4222,16 +4222,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "iroh"
 version = "0.98.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4296,7 +4286,7 @@ dependencies = [
  "data-encoding",
  "data-encoding-macro",
  "derive_more",
- "digest 0.11.2",
+ "digest 0.11.3",
  "ed25519-dalek 3.0.0-pre.6",
  "getrandom 0.4.2",
  "n0-error",
@@ -4559,9 +4549,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4600,9 +4590,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c6b6de8745d13f398170c7b11ce646b49377240379b9ede65ca62a3e278ec3"
+checksum = "a86971ba2e9a8cfc06ea704d7c5a645cffd33ae52d24cb0df289131bf20297a8"
 dependencies = [
  "bytes",
  "kitsune2_api",
@@ -4615,9 +4605,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_api"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223244160922893c1a787327689648ff346eb0cd97c3e201715a2b7feb8532d4"
+checksum = "54b4dbf1377b02d63418824ec03c1a90e3faead4504c72c84df752051ced8fd3"
 dependencies = [
  "base64",
  "bytes",
@@ -4632,9 +4622,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_client"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a817cfff49116381c923f73926e926620c58e951eca107a8ad62f3e9b5d070d"
+checksum = "f721547ad042cf80530ea5509341cef5f850f1cabb68cc7b65ccb759dd9e6b37"
 dependencies = [
  "base64",
  "kitsune2_api",
@@ -4647,9 +4637,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_srv"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c286b40e0684841c7f3dd27df5f3e7ce674270694a310d46d5214d60d653b57b"
+checksum = "2334c7eccbc1b17ecc2cfb7f5b33a74916f6838f4fd7005105f7f7893c0c021e"
 dependencies = [
  "async-channel",
  "axum",
@@ -4683,10 +4673,11 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_core"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dde2958e36aa45487f78f459808fb984df23d20ffa56eb95e7f3f7d02ef3ef"
+checksum = "80706f86e0b3f340348d3a5d5ace854d435c8bb1b5aa7e9e389010a46b592691"
 dependencies = [
+ "base64",
  "bytes",
  "ed25519-dalek 2.2.0",
  "futures",
@@ -4704,9 +4695,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_dht"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52743b90d0e4a59e90189ce026b04545e77f364b45b69ad5b9915bb7d3a3c1d4"
+checksum = "30d6d642af3626f10cbbc1f031764c5a12bf11182971ca486422df0f50bca967"
 dependencies = [
  "bytes",
  "kitsune2_api",
@@ -4715,9 +4706,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_gossip"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c8a7a261abb9154c932abf696c26b67db557dc79184faf74c69fda6a95d110"
+checksum = "e38ad7750e627b402fe06de279be563fe20b281575e9f8a318997191f861044b"
 dependencies = [
  "bytes",
  "futures",
@@ -4736,9 +4727,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_test_utils"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e890e3df294526ac97be6fb7a33697437bce55750e016488c2f618fa6ff"
+checksum = "28d32bb8e230657180ec4887b9c6e6622a3daa028a0c549a7963f6be9621d444"
 dependencies = [
  "axum",
  "bytes",
@@ -4753,10 +4744,11 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_iroh"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ea28656b6cea5624eaed7476e53427f4207d3b198c9501a8aea207280278c20"
+checksum = "4459a47712ab6199283a3083b2e3dca1c5f4de26d56554fcbffa466cc28c0422"
 dependencies = [
+ "base64",
  "bytes",
  "iroh",
  "kitsune2_api",
@@ -4771,9 +4763,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_tx5"
-version = "0.5.0-dev.1"
+version = "0.5.0-dev.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f98d9b605b9fe3f0a12d1b8fcc61186a133b1e7ba3dd1c97c1345cb507c7120"
+checksum = "61387a0ad0a2b17c62d4f97125b651b3043997668cf57f43e06ea8fed05d2552"
 dependencies = [
  "base64",
  "bytes",
@@ -4927,7 +4919,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -5565,9 +5557,9 @@ dependencies = [
 
 [[package]]
 name = "no_std_io2"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
  "memchr",
 ]
@@ -5959,15 +5951,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -6000,9 +5991,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -6312,18 +6303,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6558,9 +6549,9 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
 dependencies = [
  "either",
  "ipnet",
@@ -6695,6 +6686,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c57924a81864dddafba92e1bf92f9bf82f97096c44489548a60e888e1547549b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6768,9 +6770,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
 dependencies = [
  "memchr",
 ]
@@ -6828,7 +6830,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7063,9 +7065,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -7392,9 +7394,9 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "7.5.1"
+version = "7.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2501c67132bd19c3005b0111fba298907ef002c8c1cf68e25634707e38bf66fe"
+checksum = "5ac5b223d9738ef56e0b98305410be40fa0941bf6036c56f1506751e43552d64"
 dependencies = [
  "libc",
  "rtoolbox",
@@ -7997,9 +7999,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
  "base64",
  "chrono",
@@ -8016,9 +8018,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -8045,7 +8047,7 @@ checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -8073,7 +8075,7 @@ checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -8157,9 +8159,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.10"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"
@@ -8194,9 +8196,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -8930,9 +8932,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -8978,9 +8980,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls-acme"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31fcc374ec87d754358a5d0709ed1ab7671d51e0f70ddc3b17a11ac36604cfa"
+checksum = "1af8573b15fdad8d66da116198cd8fd8d87ff62a67c1c6c3df7f62da1170793f"
 dependencies = [
  "async-trait",
  "base64",
@@ -8991,7 +8993,7 @@ dependencies = [
  "pem",
  "proc-macro2",
  "rcgen 0.14.7",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "ring",
  "rustls",
  "serde",
@@ -9170,20 +9172,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -9829,9 +9831,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9842,9 +9844,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9852,9 +9854,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9862,9 +9864,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -9875,9 +9877,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -10267,9 +10269,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10535,6 +10537,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -10566,11 +10577,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -10595,6 +10623,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10605,6 +10639,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10619,10 +10659,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -10637,6 +10689,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10647,6 +10705,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -10661,6 +10725,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10671,6 +10741,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/crates/client/tests/app.rs
+++ b/crates/client/tests/app.rs
@@ -199,7 +199,7 @@ async fn deferred_memproof_installation() {
         name: "".to_string(),
         roles: original_bundle.manifest().app_roles(),
         bootstrap_url: None,
-        signal_url: None,
+        relay_url: None,
     };
     let app_bundle_deferred_memproofs = AppBundle::from(
         original_bundle

--- a/crates/client/tests/fixture/mod.rs
+++ b/crates/client/tests/fixture/mod.rs
@@ -72,7 +72,7 @@ fn make_fixture_app_bundle() -> Bytes {
             },
         }],
         bootstrap_url: None,
-        signal_url: None,
+        relay_url: None,
     });
 
     let app = AppBundle::new(app_manifest, vec![("test.dna".to_string(), dna_bundle)]).unwrap();

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -2065,7 +2065,7 @@ mod app_status_impls {
             match manifest {
                 AppManifest::V0(manifest) => {
                     overrides.bootstrap_url = manifest.bootstrap_url.clone();
-                    overrides.signal_url = manifest.signal_url.clone();
+                    overrides.relay_url = manifest.relay_url.clone();
                 }
             }
             if overrides.is_overriding() {

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -75,7 +75,7 @@ async fn app_ids_are_unique() {
             name: "".to_string(),
             roles: vec![],
             bootstrap_url: None,
-            signal_url: None,
+            relay_url: None,
         }),
         Timestamp::now(),
     )
@@ -116,7 +116,7 @@ async fn role_names_must_be_unique() {
             roles: vec![],
             allow_deferred_memproofs: false,
             bootstrap_url: None,
-            signal_url: None,
+            relay_url: None,
         }),
         Timestamp::now(),
     );
@@ -146,7 +146,7 @@ async fn role_names_must_be_unique() {
             roles: vec![],
             allow_deferred_memproofs: false,
             bootstrap_url: None,
-            signal_url: None,
+            relay_url: None,
         }),
         Timestamp::now(),
     );

--- a/crates/holochain/src/conductor/conductor/tests/app_state.rs
+++ b/crates/holochain/src/conductor/conductor/tests/app_state.rs
@@ -90,7 +90,7 @@ async fn can_update_state() {
             description: None,
             roles: vec![],
             bootstrap_url: None,
-            signal_url: None,
+            relay_url: None,
         }),
         Timestamp::now(),
     )

--- a/crates/holochain/src/conductor/conductor/tests/cells_with_conflicting_overrides.rs
+++ b/crates/holochain/src/conductor/conductor/tests/cells_with_conflicting_overrides.rs
@@ -37,7 +37,7 @@ async fn should_not_allow_installing_apps_with_same_dna_but_different_overrides(
         name: "dummy".to_string(),
         roles: vec![],
         bootstrap_url: Some(bootstrap_server_url.clone()),
-        signal_url: None,
+        relay_url: None,
     });
 
     conductor
@@ -64,7 +64,7 @@ async fn should_not_allow_installing_apps_with_same_dna_but_different_overrides(
         name: "dummy".to_string(),
         roles: vec![],
         bootstrap_url: Some(bootstrap_server_url.clone()),
-        signal_url: Some("wss://different:5678".to_string()), // different signal url
+        relay_url: Some("wss://different:5678".to_string()), // different signal url
     });
 
     conductor
@@ -113,7 +113,7 @@ async fn should_install_apps_with_same_dna_and_same_overrides() {
         name: "dummy".to_string(),
         roles: vec![],
         bootstrap_url: Some(bootstrap_server_url.clone()),
-        signal_url: None,
+        relay_url: None,
     });
 
     conductor
@@ -140,7 +140,7 @@ async fn should_install_apps_with_same_dna_and_same_overrides() {
         name: "dummy".to_string(),
         roles: vec![],
         bootstrap_url: Some(bootstrap_server_url.clone()),
-        signal_url: None,
+        relay_url: None,
     });
 
     conductor

--- a/crates/holochain/src/conductor/conductor/tests/p2p_config_override.rs
+++ b/crates/holochain/src/conductor/conductor/tests/p2p_config_override.rs
@@ -116,7 +116,7 @@ fn should_get_override_config_with_bootstrap_url() {
 }
 
 #[test]
-fn should_get_override_config_with_bootstrap_url_and_signal_url() {
+fn should_get_override_config_with_bootstrap_url_and_relay_url() {
     let manifest = AppManifest::V0(AppManifestV0 {
         allow_deferred_memproofs: false,
         description: None,

--- a/crates/holochain/src/conductor/conductor/tests/p2p_config_override.rs
+++ b/crates/holochain/src/conductor/conductor/tests/p2p_config_override.rs
@@ -91,11 +91,8 @@ async fn should_override_space_config_with_relay_url() {
     .await;
 
     let rendezvous = SweetLocalRendezvous::new().await;
-    let mut conductor = SweetConductor::from_config_rendezvous(
-        ConductorConfig::default(),
-        rendezvous,
-    )
-    .await;
+    let mut conductor =
+        SweetConductor::from_config_rendezvous(ConductorConfig::default(), rendezvous).await;
 
     let role_name = "role".to_string();
     let override_relay_url = "wss://override-relay.test:5678".to_string();

--- a/crates/holochain/src/conductor/conductor/tests/p2p_config_override.rs
+++ b/crates/holochain/src/conductor/conductor/tests/p2p_config_override.rs
@@ -82,6 +82,64 @@ async fn should_override_space_config() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn should_override_space_config_with_relay_url() {
+    holochain_trace::test_run();
+    let (dna, _, _) = crate::conductor::conductor::tests::mk_dna(
+        crate::test_utils::inline_zomes::simple_crud_zome(),
+    )
+    .await;
+
+    let rendezvous = SweetLocalRendezvous::new().await;
+    let mut conductor = SweetConductor::from_config_rendezvous(
+        ConductorConfig::default(),
+        rendezvous,
+    )
+    .await;
+
+    let role_name = "role".to_string();
+    let override_relay_url = "wss://override-relay.test:5678".to_string();
+
+    let app_id = "app_id".to_string();
+    let manifest = AppManifest::V0(AppManifestV0 {
+        allow_deferred_memproofs: false,
+        description: None,
+        name: "dummy".to_string(),
+        roles: vec![],
+        bootstrap_url: None,
+        relay_url: Some(override_relay_url.clone()),
+    });
+
+    conductor
+        .install_app_with_manifest(&app_id, None, [&(role_name.clone(), dna)], None, manifest)
+        .await
+        .expect("failed to install app");
+
+    conductor
+        .enable_app(app_id.clone())
+        .await
+        .expect("failed to enable app");
+
+    let cell_id = conductor
+        .running_cell_ids()
+        .iter()
+        .next()
+        .cloned()
+        .expect("should have cell");
+    let cell = conductor
+        .cell_by_id(&cell_id)
+        .await
+        .expect("should get cell");
+    assert_eq!(
+        cell.overrides()
+            .relay_url
+            .as_deref()
+            .expect("should have relay url override"),
+        override_relay_url.as_str(),
+        "cell relay url should be overridden by app manifest"
+    );
+}
+
 #[test]
 fn should_not_get_override_configuration_if_no_urls() {
     let manifest = AppManifest::V0(AppManifestV0 {

--- a/crates/holochain/src/conductor/conductor/tests/p2p_config_override.rs
+++ b/crates/holochain/src/conductor/conductor/tests/p2p_config_override.rs
@@ -37,7 +37,7 @@ async fn should_override_space_config() {
         name: "dummy".to_string(),
         roles: vec![],
         bootstrap_url: Some(bootstrap_server_url.clone()),
-        signal_url: None,
+        relay_url: None,
     });
 
     conductor
@@ -90,7 +90,7 @@ fn should_not_get_override_configuration_if_no_urls() {
         name: "dummy".to_string(),
         roles: vec![],
         bootstrap_url: None,
-        signal_url: None,
+        relay_url: None,
     });
     let config = Conductor::p2p_config_overrides(&manifest);
 
@@ -105,7 +105,7 @@ fn should_get_override_config_with_bootstrap_url() {
         name: "dummy".to_string(),
         roles: vec![],
         bootstrap_url: Some("http://localhost:1234".to_string()),
-        signal_url: None,
+        relay_url: None,
     });
     let config = Conductor::p2p_config_overrides(&manifest).expect("no config override returned");
 
@@ -123,7 +123,7 @@ fn should_get_override_config_with_bootstrap_url_and_signal_url() {
         name: "dummy".to_string(),
         roles: vec![],
         bootstrap_url: Some("http://localhost:1234".to_string()),
-        signal_url: Some("http://localhost:5678".to_string()),
+        relay_url: Some("http://localhost:5678".to_string()),
     });
     let config = Conductor::p2p_config_overrides(&manifest).expect("no config override returned");
 
@@ -131,5 +131,5 @@ fn should_get_override_config_with_bootstrap_url_and_signal_url() {
         config.bootstrap_url.as_deref(),
         Some("http://localhost:1234")
     );
-    assert_eq!(config.signal_url.as_deref(), Some("http://localhost:5678"));
+    assert_eq!(config.relay_url.as_deref(), Some("http://localhost:5678"));
 }

--- a/crates/holochain/tests/tests/publish/mod.rs
+++ b/crates/holochain/tests/tests/publish/mod.rs
@@ -192,7 +192,8 @@ async fn warrant_is_published() {
             .await
             .unwrap()
             .transport_stats
-            .peer_urls[0]
+            .peer_urls
+            .first()
     );
     println!(
         "1 bob   {} url {:?}",
@@ -202,7 +203,8 @@ async fn warrant_is_published() {
             .await
             .unwrap()
             .transport_stats
-            .peer_urls[0]
+            .peer_urls
+            .first()
     );
     println!(
         "2 carol {} url {:?}",
@@ -212,7 +214,8 @@ async fn warrant_is_published() {
             .await
             .unwrap()
             .transport_stats
-            .peer_urls[0]
+            .peer_urls
+            .first()
     );
 
     await_consistency([&alice, &bob, &carol]).await.unwrap();

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -2686,7 +2686,7 @@ mod tests {
         // should not override if default
         let space_overrides = CellConfigOverrides {
             bootstrap_url: Some("http://override:1234".to_string()),
-            signal_url: Some("wss://override:5678".to_string()),
+            relay_url: Some("wss://override:5678".to_string()),
         };
         let overrides = actor_p2p
             .space_config_override(space_overrides)

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -1053,11 +1053,11 @@ impl HolochainP2pActor {
             override_needed = true;
         }
         #[cfg(feature = "transport-tx5-backend-go-pion")]
-        if let Some(signal_url) = space_overrides.signal_url.as_ref() {
+        if let Some(relay_url) = space_overrides.relay_url.as_ref() {
             // get current tx5 transport config and override server_url
             let mut tx5_transport_config: kitsune2_transport_tx5::Tx5TransportModConfig =
                 config.get_module_config().unwrap_or_default();
-            tx5_transport_config.tx5_transport.server_url = signal_url.clone();
+            tx5_transport_config.tx5_transport.server_url = relay_url.clone();
             config.set_module_config(&tx5_transport_config)?;
             override_needed = true;
         }
@@ -2716,7 +2716,7 @@ mod tests {
             .expect("failed to get tx5 transport config");
         assert_eq!(
             tx5_transport_config.tx5_transport.server_url, "wss://override:5678",
-            "signal_url should match"
+            "relay_url should match"
         );
     }
 
@@ -2763,6 +2763,7 @@ mod tests {
         let bootstrap = CoreBootstrapModConfig {
             core_bootstrap: CoreBootstrapConfig {
                 server_url: None,
+                auth_material_base64: None,
                 backoff_max_ms: 5_000,
                 backoff_min_ms: 100,
             },

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -1043,6 +1043,15 @@ impl HolochainP2pActor {
             config.set_module_config(&core_bootstrap_config)?;
             override_needed = true;
         }
+        #[cfg(feature = "transport-iroh")]
+        if let Some(relay_url) = space_overrides.relay_url.as_ref() {
+            // get current iroh transport config and override relay_url
+            let mut iroh_transport_config: kitsune2_transport_iroh::IrohTransportModConfig =
+                config.get_module_config().unwrap_or_default();
+            iroh_transport_config.iroh_transport.relay_url = Some(relay_url.clone());
+            config.set_module_config(&iroh_transport_config)?;
+            override_needed = true;
+        }
         #[cfg(feature = "transport-tx5-backend-go-pion")]
         if let Some(signal_url) = space_overrides.signal_url.as_ref() {
             // get current tx5 transport config and override server_url

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -2711,6 +2711,41 @@ mod tests {
         );
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg(feature = "transport-iroh")]
+    async fn should_get_overrides_for_space_with_iroh_relay_url() {
+        let actor = test_p2p_actor_iroh().await;
+        let actor_p2p: Arc<HolochainP2pActor> =
+            Arc::downcast(actor).expect("failed to downcast actor");
+
+        let space_overrides = CellConfigOverrides {
+            bootstrap_url: Some("http://override:1234".to_string()),
+            relay_url: Some("wss://override:5678".to_string()),
+        };
+        let overrides = actor_p2p
+            .space_config_override(space_overrides)
+            .expect("failed to get overrides")
+            .expect("overrides should be some");
+
+        let bootstrap_config: kitsune2_core::factories::CoreBootstrapModConfig = overrides
+            .get_module_config()
+            .expect("failed to get bootstrap config");
+        assert_eq!(
+            bootstrap_config.core_bootstrap.server_url,
+            Some("http://override:1234".to_string()),
+            "bootstrap_url should match"
+        );
+
+        let iroh_transport_config: kitsune2_transport_iroh::IrohTransportModConfig = overrides
+            .get_module_config()
+            .expect("failed to get iroh transport config");
+        assert_eq!(
+            iroh_transport_config.iroh_transport.relay_url,
+            Some("wss://override:5678".to_string()),
+            "relay_url should match"
+        );
+    }
+
     #[cfg(feature = "kitsune2_transport_tx5")]
     async fn test_p2p_actor() -> Arc<dyn HcP2p> {
         use kitsune2_core::factories::{CoreBootstrapConfig, CoreBootstrapModConfig};
@@ -2736,6 +2771,36 @@ mod tests {
             .expect("failed to set config");
         kitsune_config
             .set_module_config(&tx_config)
+            .expect("failed to set config");
+
+        let kitsune_config_json =
+            serde_json::to_value(&kitsune_config).expect("failed to serialize kitsune config");
+
+        let config = HolochainP2pConfig {
+            network_config: Some(kitsune_config_json),
+            ..Default::default()
+        };
+
+        HolochainP2pActor::create(config, holochain_keystore::test_keystore())
+            .await
+            .expect("failed to create actor")
+    }
+
+    #[cfg(feature = "transport-iroh")]
+    async fn test_p2p_actor_iroh() -> Arc<dyn HcP2p> {
+        use kitsune2_core::factories::{CoreBootstrapConfig, CoreBootstrapModConfig};
+
+        let bootstrap = CoreBootstrapModConfig {
+            core_bootstrap: CoreBootstrapConfig {
+                server_url: None,
+                auth_material_base64: None,
+                backoff_max_ms: 5_000,
+                backoff_min_ms: 100,
+            },
+        };
+        let kitsune_config = Config::default();
+        kitsune_config
+            .set_module_config(&bootstrap)
             .expect("failed to set config");
 
         let kitsune_config_json =

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -931,7 +931,7 @@ mod tests {
                 description: None,
                 roles: vec![],
                 allow_deferred_memproofs: false,
-                signal_url: None,
+                relay_url: None,
                 bootstrap_url: None,
             }),
             Timestamp::now(),
@@ -952,7 +952,7 @@ mod tests {
             description: None,
             roles: vec![],
             allow_deferred_memproofs: false,
-            signal_url: None,
+            relay_url: None,
             bootstrap_url: None,
         });
         let mut app = InstalledAppCommon::new(
@@ -1052,7 +1052,7 @@ mod tests {
             roles: vec![],
             allow_deferred_memproofs: false,
             bootstrap_url: None,
-            signal_url: None,
+            relay_url: None,
         });
         let mut app = InstalledAppCommon::new(
             "app",

--- a/crates/holochain_types/src/app/app_manifest/app_manifest_v0.rs
+++ b/crates/holochain_types/src/app/app_manifest/app_manifest_v0.rs
@@ -62,12 +62,12 @@ pub struct AppManifestV0 {
     #[builder(default)]
     pub bootstrap_url: Option<String>,
 
-    /// URL of the signal server to use for all Cells created
-    /// for this app. If not provided here, the signal server
+    /// URL of the relay server to use for all Cells created
+    /// for this app. If not provided here, the relay server
     /// specified in the conductor config file will be used.
     #[serde(default)]
     #[builder(default)]
-    pub signal_url: Option<String>,
+    pub relay_url: Option<String>,
 }
 
 /// Description of an app "role" defined by this app.
@@ -240,7 +240,7 @@ impl AppManifestV0 {
             description: _,
             allow_deferred_memproofs: _,
             bootstrap_url: _,
-            signal_url: _,
+            relay_url: _,
         } = self;
         let roles = roles
             .into_iter()
@@ -338,7 +338,7 @@ pub mod tests {
             roles,
             allow_deferred_memproofs: false,
             bootstrap_url: Some("https://bootstrap.test".to_string()),
-            signal_url: Some("wss://sbd.test".to_string()),
+            relay_url: Some("wss://sbd.test".to_string()),
         }
     }
 
@@ -406,7 +406,7 @@ roles:
             roles: vec![],
             allow_deferred_memproofs: false,
             bootstrap_url: None,
-            signal_url: None,
+            relay_url: None,
         };
         manifest.roles = vec![
             AppRoleManifest {

--- a/crates/holochain_types/src/cell_config_overrides.rs
+++ b/crates/holochain_types/src/cell_config_overrides.rs
@@ -6,17 +6,17 @@
 /// Overrides for Cell configuration settings.
 ///
 /// This struct holds optional override values for Cell configurations
-/// such as bootstrap URLs and signal server URLs.
+/// such as bootstrap URLs and relay server URLs.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct CellConfigOverrides {
     /// URL of the bootstrap server to use for all Cells created
     /// for an app. If not overridden, the bootstrap server
     /// specified in the conductor config file will be used.
     pub bootstrap_url: Option<String>,
-    /// URL of the signal server to use for all Cells created
-    /// for an app. If not overridden, the signal server
+    /// URL of the relay server to use for all Cells created
+    /// for an app. If not overridden, the relay server
     /// specified in the conductor config file will be used.
-    pub signal_url: Option<String>,
+    pub relay_url: Option<String>,
 }
 
 impl CellConfigOverrides {
@@ -24,7 +24,7 @@ impl CellConfigOverrides {
     ///
     /// Returns `true` if at least one override field is [`Some`], otherwise returns `false`.
     pub fn is_overriding(&self) -> bool {
-        self.bootstrap_url.is_some() || self.signal_url.is_some()
+        self.bootstrap_url.is_some() || self.relay_url.is_some()
     }
 }
 
@@ -36,25 +36,25 @@ mod tests {
     fn test_should_tell_whether_is_overriding() {
         let overrides = CellConfigOverrides {
             bootstrap_url: None,
-            signal_url: None,
+            relay_url: None,
         };
         assert!(!overrides.is_overriding());
 
         let overrides = CellConfigOverrides {
             bootstrap_url: Some("http://localhost:1234".to_string()),
-            signal_url: None,
+            relay_url: None,
         };
         assert!(overrides.is_overriding());
 
         let overrides = CellConfigOverrides {
             bootstrap_url: None,
-            signal_url: Some("ws://localhost:5678".to_string()),
+            relay_url: Some("ws://localhost:5678".to_string()),
         };
         assert!(overrides.is_overriding());
 
         let overrides = CellConfigOverrides {
             bootstrap_url: Some("http://localhost:1234".to_string()),
-            signal_url: Some("ws://localhost:5678".to_string()),
+            relay_url: Some("ws://localhost:5678".to_string()),
         };
         assert!(overrides.is_overriding());
     }


### PR DESCRIPTION
## Summary

- Adds per-app `relay_url` override on `AppManifestV0` in place of `signal_url`, plumbed through `CellConfigOverrides` into the per-space Kitsune2 `Config` for the iroh transport (`IrohTransportConfig.relay_url`, default) and the tx5 transport (`Tx5TransportConfig.server_url`).
- Picks up upstream Kitsune2 `0.5.0-dev.2` which adds `Transport::configure_for_space` / `unconfigure_for_space` (see [kitsune2#670aeb4e](https://github.com/holochain/kitsune2/commit/670aeb4e8e74ccac6a4349d30826ca766adb388a)).