### PR TITLE
refactor: drop the isotest dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3053,7 +3053,6 @@ dependencies = [
  "holochain_types",
  "holochain_util",
  "holochain_zome_types",
- "isotest",
  "kitsune2_api",
  "mockall",
  "opentelemetry 0.31.0",
@@ -3584,7 +3583,6 @@ dependencies = [
  "holochain_util",
  "holochain_zome_types",
  "indexmap 2.14.0",
- "isotest",
  "itertools 0.14.0",
  "kitsune2_api",
  "matches",
@@ -4411,16 +4409,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "isotest"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868ab2c0c71eff3fca21f4ea4673ade85ca0149c45a55c79016147562737aef8"
-dependencies = [
- "futures",
- "paste",
-]
 
 [[package]]
 name = "itertools"

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Mirror DHT-database writes from workflows and cell into the new
   `holochain_data` DHT store (parallel-write DHT slice).
+- Remove the `isotest` dependency from `holochain_types` and `holochain_cascade`. In `holochain_types::test_utils::chain`, the conversions between `TestChainHash` and `ActionHash` are now plain `From` impls; out-of-tree test code should use `TestChainHash::from(&action_hash)` instead of `TestChainHash::test(&action_hash)`.
 
 ## 0.7.0-dev.25
 

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -40,7 +40,6 @@ holochain_cascade = { path = ".", default-features = false, features = [
   "test_utils",
 ] }
 
-isotest = "0"
 pretty_assertions = "1.4"
 test-case = "3.3"
 

--- a/crates/holochain_cascade/src/authority/get_agent_activity_query/must_get_agent_activity/test.rs
+++ b/crates/holochain_cascade/src/authority/get_agent_activity_query/must_get_agent_activity/test.rs
@@ -8,7 +8,6 @@ use holo_hash::AgentPubKey;
 use holo_hash::DnaHash;
 use holochain_sqlite::prelude::DbKindDht;
 use holochain_types::test_utils::chain::*;
-use isotest::Iso;
 use std::sync::Arc;
 use test_case::test_case;
 
@@ -103,8 +102,8 @@ async fn returns_expected_filtered_sequence_from_filter(
                  }| TestChainItem {
                     seq: a.hashed.action_seq(),
                     timestamp: a.action().timestamp(),
-                    hash: TestChainHash::test(a.as_hash()),
-                    prev: a.hashed.prev_action().map(TestChainHash::test),
+                    hash: TestChainHash::from(a.as_hash()),
+                    prev: a.hashed.prev_action().map(TestChainHash::from),
                 },
             )
             .collect(),

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -62,14 +62,12 @@ schemars = "0.9"
 bytes = { version = "1.10.1", features = ["serde"] }
 
 fixt = { path = "../fixt", version = "^0.7.0-dev.1", optional = true }
-isotest = { version = "0", optional = true }
 proptest = { version = "1", optional = true }
 proptest-derive = { version = "0", optional = true }
 
 [dev-dependencies]
 holochain_types = { path = ".", features = ["test_utils", "fuzzing"] }
 
-isotest = { version = "0" }
 matches = "0.1"
 pretty_assertions = "1.4"
 serde_json = "1.0"
@@ -87,7 +85,6 @@ fixturators = ["dep:fixt", "holochain_zome_types/fixturators"]
 test_utils = [
   "fixturators",
   "fuzzing",
-  "dep:isotest",
   "holochain_keystore/test_utils",
   "holochain_zome_types/test_utils",
 ]

--- a/crates/holochain_types/src/test_utils/chain.rs
+++ b/crates/holochain_types/src/test_utils/chain.rs
@@ -1,4 +1,5 @@
-//! Implements TestChainItem, a type used with isotest
+//! Implements TestChainItem, a minimal `ChainItem` used to drive chain-shape tests
+//! without constructing real signed actions.
 
 use crate::prelude::ChainItem;
 use ::fixt::prelude::*;
@@ -41,18 +42,16 @@ impl TestChainHash {
     }
 }
 
-isotest::iso! {
-    TestChainHash => |h| hash_from_u32(*h),
-    ActionHash => |h| Self(u32::from_le_bytes(h.get_raw_32()[0..4].try_into().unwrap())),
-    test_cases: [
-        TestChainHash(0),
-        TestChainHash(256),
-        TestChainHash(u32::MAX)
-    ],
-    real_cases: [
-        ActionHash::from_raw_32(vec![0; 32]),
-        ActionHash::from_raw_32(vec![255; 32])
-    ],
+impl From<TestChainHash> for ActionHash {
+    fn from(h: TestChainHash) -> Self {
+        hash_from_u32(*h)
+    }
+}
+
+impl From<&ActionHash> for TestChainHash {
+    fn from(h: &ActionHash) -> Self {
+        Self(u32::from_le_bytes(h.get_raw_32()[0..4].try_into().unwrap()))
+    }
 }
 
 /// A test implementation of a minimal ChainItem which uses simple numbers for hashes


### PR DESCRIPTION
## Summary

Closes https://github.com/holochain/holochain/issues/5775

- Remove the `isotest` dev/optional dependency from `holochain_types` and `holochain_cascade`. It was only used to declare a tiny `TestChainHash <-> ActionHash` conversion that already had its forward direction available as a free function (`hash_from_u32`), and whose `Iso` impls were exercised at exactly two call sites in one cascade test.
- Replace the `isotest::iso! { ... }` macro in `holochain_types::test_utils::chain` with hand-written `From<TestChainHash> for ActionHash` and `From<&ActionHash> for TestChainHash` impls.
- Update the two `TestChainHash::test(...)` call sites in `crates/holochain_cascade/.../must_get_agent_activity/test.rs` to `TestChainHash::from(...)`.
- Note the change in `crates/holochain/CHANGELOG.md` under `Unreleased`. This is a small public-API break in `holochain_types::test_utils` (a feature-gated test helper) — acceptable for the 0.7.0 development line.