### PR TITLE
feat: parallel writes from cache to new unified DhtStore

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,7 +6,7 @@ holochain-process = { max-threads = 1 }
 # "retries" defines the number of times a test should be retried. If set to a
 # non-zero value, tests that succeed on a subsequent attempt will be marked as
 # flaky. Can be overridden through the `--retries` option.
-retries = 1
+retries = 2
 
 # this will display all of fail, retry, slow
 # see https://nexte.st/book/other-options.html?highlight=failure-output#--status-level-and---final-status-level

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,6 +3044,7 @@ dependencies = [
  "futures",
  "holo_hash",
  "holochain_cascade",
+ "holochain_data",
  "holochain_p2p",
  "holochain_serialized_bytes",
  "holochain_sqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3045,6 +3045,7 @@ dependencies = [
  "holo_hash",
  "holochain_cascade",
  "holochain_data",
+ "holochain_keystore",
  "holochain_p2p",
  "holochain_serialized_bytes",
  "holochain_sqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,7 +3044,6 @@ dependencies = [
  "futures",
  "holo_hash",
  "holochain_cascade",
- "holochain_data",
  "holochain_keystore",
  "holochain_p2p",
  "holochain_serialized_bytes",

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -950,6 +950,7 @@ impl AppValidationWorkspace {
             .with_authored(self.authored_db.clone().into())
             .with_dht(self.dht_db.clone().into())
             .with_network(network, self.cache.clone())
+            .with_dht_store(self.dht_store.clone())
     }
 }
 

--- a/crates/holochain/src/core/workflow/countersigning_workflow/incomplete.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/incomplete.rs
@@ -75,7 +75,9 @@ pub async fn inner_countersigning_session_incomplete(
         .filter(|a| **a != author)
         .collect::<Vec<_>>();
 
-    let cascade = CascadeImpl::empty().with_network(network, space.cache_db.clone());
+    let cascade = CascadeImpl::empty()
+        .with_network(network, space.cache_db.clone())
+        .with_dht_store(space.dht_store.clone());
 
     let get_activity_options = GetActivityOptions {
         network_req_options: NetworkRequestOptions {

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -114,6 +114,7 @@ use holochain_keystore::MetaLairClient;
 use holochain_p2p::DynHolochainP2pDna;
 use holochain_sqlite::prelude::*;
 use holochain_sqlite::sql::sql_cell::ACTION_HASH_BY_PREV;
+use holochain_state::dht_store::DhtStore;
 use holochain_state::integrate::insert_locally_validated_op;
 use holochain_state::prelude::*;
 use holochain_state::query::StateQueryError;
@@ -1539,7 +1540,9 @@ impl SysValidationWorkspace {
     }
 
     pub fn network_and_cache_cascade(&self, network: DynHolochainP2pDna) -> CascadeImpl {
-        CascadeImpl::empty().with_network(network, self.cache.clone())
+        CascadeImpl::empty()
+            .with_network(network, self.cache.clone())
+            .with_dht_store(self.dht_store.clone())
     }
 }
 

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -16,7 +16,6 @@ holo_hash = { version = "^0.7.0-dev.9", path = "../holo_hash", features = [
   "full",
 ] }
 holochain_sqlite = { version = "^0.7.0-dev.20", path = "../holochain_sqlite" }
-holochain_data = { version = "^0.7.0-dev.14", path = "../holochain_data" }
 holochain_keystore = { version = "^0.7.0-dev.16", path = "../holochain_keystore" }
 holochain_p2p = { version = "^0.7.0-dev.25", default-features = false, path = "../holochain_p2p" }
 holochain_serialized_bytes = "=0.0.57"

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -16,6 +16,7 @@ holo_hash = { version = "^0.7.0-dev.9", path = "../holo_hash", features = [
   "full",
 ] }
 holochain_sqlite = { version = "^0.7.0-dev.20", path = "../holochain_sqlite" }
+holochain_data = { version = "^0.7.0-dev.14", path = "../holochain_data" }
 holochain_p2p = { version = "^0.7.0-dev.25", default-features = false, path = "../holochain_p2p" }
 holochain_serialized_bytes = "=0.0.57"
 holochain_state = { version = "^0.7.0-dev.25", path = "../holochain_state" }

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -17,6 +17,7 @@ holo_hash = { version = "^0.7.0-dev.9", path = "../holo_hash", features = [
 ] }
 holochain_sqlite = { version = "^0.7.0-dev.20", path = "../holochain_sqlite" }
 holochain_data = { version = "^0.7.0-dev.14", path = "../holochain_data" }
+holochain_keystore = { version = "^0.7.0-dev.16", path = "../holochain_keystore" }
 holochain_p2p = { version = "^0.7.0-dev.25", default-features = false, path = "../holochain_p2p" }
 holochain_serialized_bytes = "=0.0.57"
 holochain_state = { version = "^0.7.0-dev.25", path = "../holochain_state" }

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -360,15 +360,28 @@ impl CascadeImpl {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     async fn merge_ops_into_cache(&self, responses: Vec<WireOps>) -> CascadeResult<()> {
         let cache = some_or_return!(self.cache.as_ref());
+
+        // Pre-render outside the legacy transaction so the rendered data is
+        // available both for the legacy cache write and for the DhtStore
+        // mirror below. A render failure short-circuits here rather than
+        // rolling back the legacy transaction.
+        let rendered_all: Vec<RenderedOps> = responses
+            .into_iter()
+            .map(|r| r.render())
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let rendered_for_legacy = rendered_all.clone();
         cache
-            .write_async(|txn| {
-                for response in responses {
-                    let ops = response.render()?;
-                    Self::insert_rendered_ops(txn, &ops)?;
+            .write_async(move |txn| {
+                for ops in &rendered_for_legacy {
+                    Self::insert_rendered_ops(txn, ops)?;
                 }
                 CascadeResult::Ok(())
             })
             .await?;
+
+        self.mirror_rendered_to_dht_store(&rendered_all).await;
+
         Ok(())
     }
 
@@ -379,16 +392,56 @@ impl CascadeImpl {
         key: WireLinkKey,
     ) -> CascadeResult<()> {
         let cache = some_or_return!(self.cache.as_ref());
+
+        // Pre-render outside the legacy transaction so the rendered data is
+        // available both for the legacy cache write and for the DhtStore
+        // mirror below.
+        let rendered_all: Vec<RenderedOps> = responses
+            .into_iter()
+            .map(|r| r.render(&key))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let rendered_for_legacy = rendered_all.clone();
         cache
             .write_async(move |txn| {
-                for response in responses {
-                    let ops = response.render(&key)?;
-                    Self::insert_rendered_ops(txn, &ops)?;
+                for ops in &rendered_for_legacy {
+                    Self::insert_rendered_ops(txn, ops)?;
                 }
                 CascadeResult::Ok(())
             })
             .await?;
+
+        self.mirror_rendered_to_dht_store(&rendered_all).await;
+
         Ok(())
+    }
+
+    /// Mirror cached rendered ops to the new `DhtStore`, if configured.
+    ///
+    /// The legacy cache write is authoritative: any failure here is logged
+    /// and swallowed so a misbehaving mirror cannot break the cascade.
+    async fn mirror_rendered_to_dht_store(&self, rendered_all: &[RenderedOps]) {
+        let Some(dht_store) = self.dht_store.as_ref() else {
+            return;
+        };
+
+        for rendered_ops in rendered_all {
+            if !rendered_ops.ops.is_empty() || rendered_ops.entry.is_some() {
+                if let Err(err) = dht_store.record_cached_chain_ops(rendered_ops).await {
+                    tracing::warn!(?err, "cache mirror: record_cached_chain_ops failed");
+                }
+            }
+
+            if let Some(warrant) = rendered_ops.warrant.as_ref() {
+                let op = DhtOpHashed::from_content_sync(warrant.clone());
+                if let Err(err) = dht_store.record_incoming_cached_warrants(vec![op]).await {
+                    tracing::warn!(
+                        ?err,
+                        "cache mirror: record_incoming_cached_warrants failed"
+                    );
+                }
+            }
+        }
     }
 
     /// Add new activity to the Cache.

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -37,9 +37,12 @@ use holo_hash::ActionHash;
 use holo_hash::AgentPubKey;
 use holo_hash::AnyDhtHash;
 use holo_hash::EntryHash;
+use holochain_data::kind::Dht;
+use holochain_data::DbWrite as DataDbWrite;
 use holochain_p2p::actor::GetLinksRequestOptions;
 use holochain_p2p::actor::{GetActivityOptions, NetworkRequestOptions};
 use holochain_p2p::{DynHolochainP2pDna, HolochainP2pError};
+use holochain_state::dht_store::DhtStore;
 use holochain_state::host_fn_workspace::HostFnStores;
 use holochain_state::host_fn_workspace::HostFnWorkspace;
 use holochain_state::mutations::insert_action;
@@ -123,6 +126,7 @@ pub struct CascadeImpl {
     scratch: Option<SyncScratch>,
     network: Option<DynHolochainP2pDna>,
     private_data: Option<Arc<AgentPubKey>>,
+    dht_store: Option<DhtStore<DataDbWrite<Dht>>>,
     duration_metric: &'static CascadeDurationMetric,
     /// Optional zome call origin for metrics attribution.
     zome_call_origin: Option<(ZomeName, FunctionName)>,
@@ -169,6 +173,14 @@ impl CascadeImpl {
         }
     }
 
+    /// Add the DhtStore mirror target for cache writes.
+    pub fn with_dht_store(self, dht_store: DhtStore<DataDbWrite<Dht>>) -> Self {
+        Self {
+            dht_store: Some(dht_store),
+            ..self
+        }
+    }
+
     /// Add the cache to the cascade.
     pub fn with_scratch(self, scratch: SyncScratch) -> Self {
         Self {
@@ -190,6 +202,7 @@ impl CascadeImpl {
             private_data: self.private_data,
             cache: Some(cache_db),
             network: Some(network),
+            dht_store: self.dht_store,
             duration_metric: create_cascade_duration_metric(),
             zome_call_origin: self.zome_call_origin,
         }
@@ -204,6 +217,7 @@ impl CascadeImpl {
             cache: None,
             scratch: None,
             private_data: None,
+            dht_store: None,
             duration_metric: create_cascade_duration_metric(),
             zome_call_origin: None,
         }
@@ -223,6 +237,7 @@ impl CascadeImpl {
             dht,
             cache,
             scratch,
+            dht_store,
         } = workspace.stores();
         let private_data = workspace.author();
         CascadeImpl {
@@ -232,6 +247,7 @@ impl CascadeImpl {
             private_data,
             scratch,
             network: Some(network),
+            dht_store,
             duration_metric: create_cascade_duration_metric(),
             zome_call_origin: None,
         }
@@ -244,6 +260,7 @@ impl CascadeImpl {
             dht,
             cache,
             scratch,
+            dht_store,
         } = stores;
         Self {
             authored: Some(authored),
@@ -252,6 +269,7 @@ impl CascadeImpl {
             scratch,
             network: None,
             private_data: author,
+            dht_store,
             duration_metric: create_cascade_duration_metric(),
             zome_call_origin: None,
         }

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -37,8 +37,6 @@ use holo_hash::ActionHash;
 use holo_hash::AgentPubKey;
 use holo_hash::AnyDhtHash;
 use holo_hash::EntryHash;
-use holochain_data::kind::Dht;
-use holochain_data::DbWrite as DataDbWrite;
 use holochain_keystore::AgentPubKeyExt;
 use holochain_p2p::actor::GetLinksRequestOptions;
 use holochain_p2p::actor::{GetActivityOptions, NetworkRequestOptions};
@@ -127,7 +125,7 @@ pub struct CascadeImpl {
     scratch: Option<SyncScratch>,
     network: Option<DynHolochainP2pDna>,
     private_data: Option<Arc<AgentPubKey>>,
-    dht_store: Option<DhtStore<DataDbWrite<Dht>>>,
+    dht_store: Option<DhtStore>,
     duration_metric: &'static CascadeDurationMetric,
     /// Optional zome call origin for metrics attribution.
     zome_call_origin: Option<(ZomeName, FunctionName)>,
@@ -175,7 +173,7 @@ impl CascadeImpl {
     }
 
     /// Add the DhtStore mirror target for cache writes.
-    pub fn with_dht_store(self, dht_store: DhtStore<DataDbWrite<Dht>>) -> Self {
+    pub fn with_dht_store(self, dht_store: DhtStore) -> Self {
         Self {
             dht_store: Some(dht_store),
             ..self

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -361,10 +361,9 @@ impl CascadeImpl {
     async fn merge_ops_into_cache(&self, responses: Vec<WireOps>) -> CascadeResult<()> {
         let cache = some_or_return!(self.cache.as_ref());
 
-        // Pre-render outside the legacy transaction so the rendered data is
-        // available both for the legacy cache write and for the DhtStore
-        // mirror below. A render failure short-circuits here rather than
-        // rolling back the legacy transaction.
+        // Render outside the cache transaction so the transform is not
+        // counted as transaction time, and so the rendered data can be
+        // reused by the `DhtStore` cache call below.
         let rendered_all: Vec<RenderedOps> = responses
             .into_iter()
             .map(|r| r.render())
@@ -380,7 +379,7 @@ impl CascadeImpl {
             })
             .await?;
 
-        self.mirror_rendered_to_dht_store(&rendered_all).await;
+        self.cache_rendered_ops(&rendered_all).await;
 
         Ok(())
     }
@@ -393,9 +392,9 @@ impl CascadeImpl {
     ) -> CascadeResult<()> {
         let cache = some_or_return!(self.cache.as_ref());
 
-        // Pre-render outside the legacy transaction so the rendered data is
-        // available both for the legacy cache write and for the DhtStore
-        // mirror below.
+        // Render outside the cache transaction so the transform is not
+        // counted as transaction time, and so the rendered data can be
+        // reused by the `DhtStore` cache call below.
         let rendered_all: Vec<RenderedOps> = responses
             .into_iter()
             .map(|r| r.render(&key))
@@ -411,34 +410,29 @@ impl CascadeImpl {
             })
             .await?;
 
-        self.mirror_rendered_to_dht_store(&rendered_all).await;
+        self.cache_rendered_ops(&rendered_all).await;
 
         Ok(())
     }
 
-    /// Mirror cached rendered ops to the new `DhtStore`, if configured.
+    /// Write a batch of rendered ops to the `DhtStore`, if one is configured.
     ///
-    /// The legacy cache write is authoritative: any failure here is logged
-    /// and swallowed so a misbehaving mirror cannot break the cascade.
-    async fn mirror_rendered_to_dht_store(&self, rendered_all: &[RenderedOps]) {
+    /// Failures are logged at warn and swallowed: the cache write above is
+    /// the source of truth for now, so a `DhtStore` failure must not break
+    /// the cascade.
+    async fn cache_rendered_ops(&self, rendered_all: &[RenderedOps]) {
         let Some(dht_store) = self.dht_store.as_ref() else {
             return;
         };
 
         for rendered_ops in rendered_all {
-            if !rendered_ops.ops.is_empty() || rendered_ops.entry.is_some() {
-                if let Err(err) = dht_store.record_cached_chain_ops(rendered_ops).await {
-                    tracing::warn!(?err, "cache mirror: record_cached_chain_ops failed");
-                }
+            if let Err(err) = dht_store.cache_chain_ops(rendered_ops).await {
+                tracing::warn!(?err, "DhtStore: cache_chain_ops failed");
             }
 
             if let Some(warrant) = rendered_ops.warrant.as_ref() {
-                let op = DhtOpHashed::from_content_sync(warrant.clone());
-                if let Err(err) = dht_store.record_incoming_cached_warrants(vec![op]).await {
-                    tracing::warn!(
-                        ?err,
-                        "cache mirror: record_incoming_cached_warrants failed"
-                    );
+                if let Err(err) = dht_store.cache_warrants(vec![warrant.clone()]).await {
+                    tracing::warn!(?err, "DhtStore: cache_warrants failed");
                 }
             }
         }
@@ -472,6 +466,34 @@ impl CascadeImpl {
                     }
                 })
                 .await?;
+
+            if let Some(dht_store) = self.dht_store.as_ref() {
+                let activity_rendered = RenderedOps {
+                    entry: None,
+                    ops: activity
+                        .iter()
+                        .map(|ra| {
+                            RenderedOp::new(
+                                ra.action.action().clone(),
+                                ra.action.signature().clone(),
+                                None,
+                                ChainOpType::RegisterAgentActivity,
+                            )
+                        })
+                        .collect::<Result<Vec<_>, _>>()?,
+                    warrant: None,
+                };
+
+                if let Err(err) = dht_store.cache_chain_ops(&activity_rendered).await {
+                    tracing::warn!(?err, "DhtStore: cache_chain_ops failed for activity");
+                }
+
+                if !warrants.is_empty() {
+                    if let Err(err) = dht_store.cache_warrants(warrants).await {
+                        tracing::warn!(?err, "DhtStore: cache_warrants failed");
+                    }
+                }
+            }
         }
 
         Ok(())

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -39,6 +39,7 @@ use holo_hash::AnyDhtHash;
 use holo_hash::EntryHash;
 use holochain_data::kind::Dht;
 use holochain_data::DbWrite as DataDbWrite;
+use holochain_keystore::AgentPubKeyExt;
 use holochain_p2p::actor::GetLinksRequestOptions;
 use holochain_p2p::actor::{GetActivityOptions, NetworkRequestOptions};
 use holochain_p2p::{DynHolochainP2pDna, HolochainP2pError};
@@ -287,6 +288,7 @@ impl CascadeImpl {
             op_hash,
             action,
             validation_status,
+            ..
         } = op;
         let op_order = OpOrder::new(op_light.get_type(), action.action().timestamp());
         let timestamp = action.action().timestamp();
@@ -379,7 +381,12 @@ impl CascadeImpl {
             })
             .await?;
 
-        self.cache_rendered_ops(&rendered_all).await;
+        // Signature verification gates writes into the new `DhtStore`.
+        // The legacy cache write above keeps its existing behaviour so the
+        // long tail of tests using synthetic signatures continues to work
+        // while the legacy path is in place.
+        let verified = verify_rendered_ops_batch(rendered_all).await;
+        self.cache_rendered_ops(&verified).await;
 
         Ok(())
     }
@@ -410,7 +417,8 @@ impl CascadeImpl {
             })
             .await?;
 
-        self.cache_rendered_ops(&rendered_all).await;
+        let verified = verify_rendered_ops_batch(rendered_all).await;
+        self.cache_rendered_ops(&verified).await;
 
         Ok(())
     }
@@ -468,6 +476,9 @@ impl CascadeImpl {
                 .await?;
 
             if let Some(dht_store) = self.dht_store.as_ref() {
+                // Signature verification gates writes into the new `DhtStore`.
+                let (activity, warrants) = verify_activity_signatures(activity, warrants).await;
+
                 let activity_rendered = RenderedOps {
                     entry: None,
                     ops: activity
@@ -1515,6 +1526,123 @@ impl CascadeImpl {
             None => Q::without_private_data_access(hash),
         }
     }
+}
+
+/// Verify the action signatures (and warrant signature, if present) on every
+/// `RenderedOps` in the batch. Batches where any signature fails verification
+/// are logged at warn and dropped.
+async fn verify_rendered_ops_batch(rendered_all: Vec<RenderedOps>) -> Vec<RenderedOps> {
+    let mut verified = Vec::with_capacity(rendered_all.len());
+    for rendered in rendered_all {
+        if verify_rendered_ops_signatures(&rendered).await {
+            verified.push(rendered);
+        }
+    }
+    verified
+}
+
+async fn verify_rendered_ops_signatures(rendered: &RenderedOps) -> bool {
+    for op in &rendered.ops {
+        let action = op.action.action();
+        match action
+            .signer()
+            .verify_signature(op.action.signature(), action)
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::warn!(
+                    signer = ?action.signer(),
+                    "Rendered op signature failed verification; dropping batch"
+                );
+                return false;
+            }
+            Err(err) => {
+                tracing::warn!(
+                    ?err,
+                    "Error verifying rendered op signature; dropping batch"
+                );
+                return false;
+            }
+        }
+    }
+
+    if let Some(warrant_op) = &rendered.warrant {
+        match warrant_op
+            .author
+            .verify_signature(warrant_op.signature(), warrant_op.warrant().clone())
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::warn!(
+                    author = ?warrant_op.author,
+                    "Rendered warrant signature failed verification; dropping batch"
+                );
+                return false;
+            }
+            Err(err) => {
+                tracing::warn!(
+                    ?err,
+                    "Error verifying rendered warrant signature; dropping batch"
+                );
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+/// Verify each agent-activity record and warrant in a
+/// `MustGetAgentActivityResponse::Activity`. Records or warrants with bad
+/// signatures are logged at warn and dropped.
+async fn verify_activity_signatures(
+    activity: Vec<RegisterAgentActivity>,
+    warrants: Vec<WarrantOp>,
+) -> (Vec<RegisterAgentActivity>, Vec<WarrantOp>) {
+    let mut verified_activity = Vec::with_capacity(activity.len());
+    for ra in activity {
+        let action = ra.action.action();
+        match action
+            .signer()
+            .verify_signature(ra.action.signature(), action)
+            .await
+        {
+            Ok(true) => verified_activity.push(ra),
+            Ok(false) => {
+                tracing::warn!(
+                    signer = ?action.signer(),
+                    "Activity record signature failed verification; dropping"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(?err, "Error verifying activity record signature; dropping");
+            }
+        }
+    }
+
+    let mut verified_warrants = Vec::with_capacity(warrants.len());
+    for warrant_op in warrants {
+        match warrant_op
+            .author
+            .verify_signature(warrant_op.signature(), warrant_op.warrant().clone())
+            .await
+        {
+            Ok(true) => verified_warrants.push(warrant_op),
+            Ok(false) => {
+                tracing::warn!(
+                    author = ?warrant_op.author,
+                    "Activity warrant signature failed verification; dropping"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(?err, "Error verifying activity warrant signature; dropping");
+            }
+        }
+    }
+
+    (verified_activity, verified_warrants)
 }
 
 /// TODO

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -774,5 +774,8 @@ impl DhtStore<DbWrite<Dht>> {
     }
 }
 
+pub(crate) mod action_indexes;
+mod cache;
+
 #[cfg(test)]
 mod tests;

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -418,7 +418,7 @@ impl DhtStore<DbWrite<Dht>> {
                         ),
                         signed_action.signature().clone(),
                     );
-                    let new_sah = crate::source_chain::legacy_to_dht_v2_signed_action(&sah);
+                    let new_sah = holochain_zome_types::dht_v2::from_legacy_signed_action(&sah);
                     tx.insert_action(&new_sah, None)
                         .await
                         .map_err(StateMutationError::from)?;

--- a/crates/holochain_state/src/dht_store/action_indexes.rs
+++ b/crates/holochain_state/src/dht_store/action_indexes.rs
@@ -1,0 +1,69 @@
+//! Shared dispatch for populating the per-action index tables
+//! (`Link`, `DeletedLink`, `UpdatedRecord`, `DeletedRecord`).
+//!
+//! Both the source-chain authored-data writer and the cache writer convert
+//! incoming actions to the v2 [`ActionData`] form and then need to insert
+//! into the same index tables based on the action variant. This helper
+//! holds the single dispatch.
+
+use holo_hash::ActionHash;
+use holochain_data::dht::{
+    InsertDeletedLink, InsertDeletedRecord, InsertLink, InsertUpdatedRecord,
+};
+use holochain_data::kind::Dht;
+use holochain_data::TxWrite;
+use holochain_zome_types::dht_v2::ActionData;
+
+use crate::mutations::{StateMutationError, StateMutationResult};
+
+/// Insert into the appropriate index table for the given action variant.
+///
+/// `CreateLink`, `DeleteLink`, `Update`, and `Delete` populate their
+/// respective indices; all other variants are no-ops.
+pub(crate) async fn insert_action_indexes(
+    tx: &mut TxWrite<Dht>,
+    action_hash: &ActionHash,
+    action_data: &ActionData,
+) -> StateMutationResult<()> {
+    match action_data {
+        ActionData::CreateLink(a) => {
+            tx.insert_link_index(InsertLink {
+                action_hash,
+                base_hash: &a.base_address,
+                zome_index: a.zome_index.0,
+                link_type: a.link_type.0,
+                tag: Some(a.tag.0.as_slice()),
+            })
+            .await
+            .map_err(StateMutationError::from)?;
+        }
+        ActionData::DeleteLink(a) => {
+            tx.insert_deleted_link_index(InsertDeletedLink {
+                action_hash,
+                create_link_hash: &a.link_add_address,
+            })
+            .await
+            .map_err(StateMutationError::from)?;
+        }
+        ActionData::Update(a) => {
+            tx.insert_updated_record_index(InsertUpdatedRecord {
+                action_hash,
+                original_action_hash: &a.original_action_address,
+                original_entry_hash: &a.original_entry_address,
+            })
+            .await
+            .map_err(StateMutationError::from)?;
+        }
+        ActionData::Delete(a) => {
+            tx.insert_deleted_record_index(InsertDeletedRecord {
+                action_hash,
+                deletes_action_hash: &a.deletes_address,
+                deletes_entry_hash: &a.deletes_entry_address,
+            })
+            .await
+            .map_err(StateMutationError::from)?;
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/crates/holochain_state/src/dht_store/cache.rs
+++ b/crates/holochain_state/src/dht_store/cache.rs
@@ -45,12 +45,16 @@ impl DhtStore<DbWrite<Dht>> {
         }
 
         for op in &ops.ops {
-            let new_sah = crate::source_chain::legacy_to_dht_v2_signed_action(&op.action);
-            tx.insert_action(&new_sah, None)
+            tx.insert_action(&op.signed_action_v2, None)
                 .await
                 .map_err(StateMutationError::from)?;
 
-            insert_action_indexes(&mut tx, new_sah.as_hash(), &new_sah.hashed.content.data).await?;
+            insert_action_indexes(
+                &mut tx,
+                op.signed_action_v2.as_hash(),
+                &op.signed_action_v2.hashed.content.data,
+            )
+            .await?;
 
             let linkable_basis = op.op_light.dht_basis();
             let storage_center_loc = linkable_basis.get_loc();
@@ -71,7 +75,7 @@ impl DhtStore<DbWrite<Dht>> {
 
             tx.insert_chain_op(InsertChainOp {
                 op_hash: &op.op_hash,
-                action_hash: new_sah.as_hash(),
+                action_hash: op.signed_action_v2.as_hash(),
                 op_type,
                 basis_hash: &basis_hash,
                 storage_center_loc,

--- a/crates/holochain_state/src/dht_store/cache.rs
+++ b/crates/holochain_state/src/dht_store/cache.rs
@@ -1,0 +1,523 @@
+//! Cache operations on the per-DNA DHT store.
+//!
+//! Chain ops fetched from peer authorities are inserted with
+//! `locally_validated = false`, bypassing limbo. Warrants are always routed
+//! through `LimboWarrant` so the local conductor can validate them
+//! regardless of arc coverage.
+
+use holo_hash::{AnyDhtHash, HasHash};
+use holochain_data::dht::{InsertChainOp, InsertLimboWarrant};
+use holochain_data::kind::Dht;
+use holochain_data::DbWrite;
+use holochain_types::dht_op::RenderedOps;
+use holochain_types::prelude::Timestamp;
+use holochain_types::warrant::WarrantOp;
+use holochain_zome_types::dht_v2::RecordValidity;
+
+use super::action_indexes::insert_action_indexes;
+use super::DhtStore;
+use crate::mutations::{StateMutationError, StateMutationResult};
+
+impl DhtStore<DbWrite<Dht>> {
+    /// Insert a batch of chain ops into the DHT store cache.
+    ///
+    /// Each op is recorded with `locally_validated = false`,
+    /// `validation_status = Accepted`, and `when_received` /
+    /// `when_integrated` set to the current time. The integration indices
+    /// (`Link`, `DeletedLink`, `UpdatedRecord`, `DeletedRecord`) are
+    /// populated based on the action variant.
+    ///
+    /// The shared entry, if present, is inserted once for the whole
+    /// `RenderedOps`. Any `ops.warrant` is ignored; warrants are inserted
+    /// via [`Self::cache_warrants`].
+    pub async fn cache_chain_ops(&self, ops: &RenderedOps) -> StateMutationResult<()> {
+        if ops.ops.is_empty() && ops.entry.is_none() {
+            return Ok(());
+        }
+
+        let mut tx = self.db().begin().await.map_err(StateMutationError::from)?;
+        let now = Timestamp::now();
+
+        if let Some(entry) = ops.entry.as_ref() {
+            tx.insert_entry(entry.as_hash(), entry.as_content())
+                .await
+                .map_err(StateMutationError::from)?;
+        }
+
+        for op in &ops.ops {
+            let new_sah = crate::source_chain::legacy_to_dht_v2_signed_action(&op.action);
+            tx.insert_action(&new_sah, None)
+                .await
+                .map_err(StateMutationError::from)?;
+
+            insert_action_indexes(&mut tx, new_sah.as_hash(), &new_sah.hashed.content.data).await?;
+
+            let linkable_basis = op.op_light.dht_basis();
+            let storage_center_loc = linkable_basis.get_loc();
+            let basis_hash: AnyDhtHash = AnyDhtHash::try_from(linkable_basis).map_err(|e| {
+                StateMutationError::Other(format!(
+                    "cannot convert cached op basis to AnyDhtHash: {e:?}"
+                ))
+            })?;
+
+            let op_type = match op.op_light.get_type() {
+                holochain_types::dht_op::DhtOpType::Chain(t) => i64::from(t),
+                holochain_types::dht_op::DhtOpType::Warrant(_) => {
+                    return Err(StateMutationError::Other(
+                        "RenderedOp had a Warrant op_light; expected Chain".into(),
+                    ));
+                }
+            };
+
+            tx.insert_chain_op(InsertChainOp {
+                op_hash: &op.op_hash,
+                action_hash: new_sah.as_hash(),
+                op_type,
+                basis_hash: &basis_hash,
+                storage_center_loc,
+                validation_status: RecordValidity::Accepted,
+                locally_validated: false,
+                require_receipt: false,
+                when_received: now,
+                when_integrated: now,
+                serialized_size: 0,
+            })
+            .await
+            .map_err(StateMutationError::from)?;
+        }
+
+        tx.commit().await.map_err(StateMutationError::from)?;
+        Ok(())
+    }
+
+    /// Insert cached warrants into `LimboWarrant`.
+    ///
+    /// Warrants must be locally validated regardless of arc coverage, so they
+    /// are routed through limbo rather than inserted directly.
+    pub async fn cache_warrants(&self, warrants: Vec<WarrantOp>) -> StateMutationResult<()> {
+        if warrants.is_empty() {
+            return Ok(());
+        }
+
+        let mut tx = self.db().begin().await.map_err(StateMutationError::from)?;
+        let now = Timestamp::now();
+
+        for warrant_op in warrants {
+            let op_hash = holo_hash::DhtOpHash::with_data_sync(&warrant_op);
+            let proof_bytes = holochain_serialized_bytes::encode(&warrant_op.proof)
+                .map_err(StateMutationError::from)?;
+            let storage_center_loc = warrant_op.warrantee.get_loc();
+
+            tx.insert_limbo_warrant(InsertLimboWarrant {
+                hash: &op_hash,
+                author: &warrant_op.author,
+                timestamp: warrant_op.timestamp,
+                warrantee: &warrant_op.warrantee,
+                proof: &proof_bytes,
+                storage_center_loc,
+                when_received: now,
+                serialized_size: 0,
+            })
+            .await
+            .map_err(StateMutationError::from)?;
+        }
+
+        tx.commit().await.map_err(StateMutationError::from)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use holo_hash::{ActionHash, AgentPubKey, AnyLinkableHash, DnaHash, EntryHash};
+    use holochain_serialized_bytes::UnsafeBytes;
+    use holochain_types::dht_op::{RenderedOp, RenderedOps};
+    use holochain_types::prelude::{AppEntryBytes, Entry, EntryHashed, Signature};
+    use holochain_types::warrant::WarrantOp;
+    use holochain_zome_types::action::{
+        Action, Create, CreateLink, Delete, DeleteLink, EntryType, Update,
+    };
+    use holochain_zome_types::entry_def::EntryVisibility;
+    use holochain_zome_types::op::ChainOpType;
+    use holochain_zome_types::prelude::{
+        AppEntryDef, ChainIntegrityWarrant, SignedWarrant, Warrant, WarrantProof,
+    };
+    use std::sync::Arc;
+
+    fn dht_id() -> Dht {
+        Dht::new(Arc::new(DnaHash::from_raw_36(vec![0u8; 36])))
+    }
+
+    /// Build a single-op `RenderedOps` for a `StoreRecord(Create)` chain op
+    /// carrying a public entry.
+    fn build_rendered_store_record(seed: u8) -> RenderedOps {
+        let author = AgentPubKey::from_raw_36(vec![seed; 36]);
+        let entry_hash = EntryHash::from_raw_36(vec![seed.wrapping_add(100); 36]);
+        let entry = Entry::App(AppEntryBytes(
+            holochain_serialized_bytes::SerializedBytes::from(UnsafeBytes::from(vec![seed; 8])),
+        ));
+        let sig = Signature::from([seed; 64]);
+        let action = Action::Create(Create {
+            author,
+            timestamp: Timestamp::from_micros(seed as i64 * 1000),
+            action_seq: 1,
+            prev_action: ActionHash::from_raw_36(vec![seed.wrapping_add(200); 36]),
+            entry_type: EntryType::App(AppEntryDef::new(
+                0.into(),
+                0.into(),
+                EntryVisibility::Public,
+            )),
+            entry_hash: entry_hash.clone(),
+            weight: Default::default(),
+        });
+        let entry_hashed = EntryHashed::with_pre_hashed(entry.clone(), entry_hash);
+
+        let rendered = RenderedOp::new(action, sig, None, ChainOpType::StoreRecord)
+            .expect("rendered op build");
+
+        RenderedOps {
+            entry: Some(entry_hashed),
+            ops: vec![rendered],
+            warrant: None,
+        }
+    }
+
+    /// Build a single-op `RenderedOps` for a CreateLink chain op
+    /// (`RegisterAddLink`). No entry.
+    fn build_rendered_create_link(seed: u8) -> RenderedOps {
+        let author = AgentPubKey::from_raw_36(vec![seed; 36]);
+        let base = AnyLinkableHash::from_raw_36_and_type(
+            vec![seed.wrapping_add(50); 36],
+            holo_hash::hash_type::AnyLinkable::Entry,
+        );
+        let target = AnyLinkableHash::from_raw_36_and_type(
+            vec![seed.wrapping_add(60); 36],
+            holo_hash::hash_type::AnyLinkable::Entry,
+        );
+        let sig = Signature::from([seed; 64]);
+        let action = Action::CreateLink(CreateLink {
+            author,
+            timestamp: Timestamp::from_micros(seed as i64 * 1000),
+            action_seq: 2,
+            prev_action: ActionHash::from_raw_36(vec![seed.wrapping_add(70); 36]),
+            base_address: base,
+            target_address: target,
+            zome_index: 0.into(),
+            link_type: 0.into(),
+            tag: holochain_zome_types::link::LinkTag(vec![1, 2, 3]),
+            weight: Default::default(),
+        });
+
+        let rendered = RenderedOp::new(action, sig, None, ChainOpType::RegisterAddLink)
+            .expect("rendered op build");
+        RenderedOps {
+            entry: None,
+            ops: vec![rendered],
+            warrant: None,
+        }
+    }
+
+    /// Build a single-op `RenderedOps` for a DeleteLink chain op
+    /// (`RegisterRemoveLink`). No entry.
+    fn build_rendered_delete_link(seed: u8) -> RenderedOps {
+        let author = AgentPubKey::from_raw_36(vec![seed; 36]);
+        let base = AnyLinkableHash::from_raw_36_and_type(
+            vec![seed.wrapping_add(40); 36],
+            holo_hash::hash_type::AnyLinkable::Entry,
+        );
+        let link_add = ActionHash::from_raw_36(vec![seed.wrapping_add(80); 36]);
+        let sig = Signature::from([seed; 64]);
+        let action = Action::DeleteLink(DeleteLink {
+            author,
+            timestamp: Timestamp::from_micros(seed as i64 * 1000),
+            action_seq: 3,
+            prev_action: ActionHash::from_raw_36(vec![seed.wrapping_add(90); 36]),
+            base_address: base,
+            link_add_address: link_add,
+        });
+        let rendered = RenderedOp::new(action, sig, None, ChainOpType::RegisterRemoveLink)
+            .expect("rendered op build");
+        RenderedOps {
+            entry: None,
+            ops: vec![rendered],
+            warrant: None,
+        }
+    }
+
+    /// Build a single-op `RenderedOps` for an Update chain op
+    /// (`RegisterUpdatedRecord`).
+    fn build_rendered_update(seed: u8) -> RenderedOps {
+        let author = AgentPubKey::from_raw_36(vec![seed; 36]);
+        let entry_hash = EntryHash::from_raw_36(vec![seed.wrapping_add(100); 36]);
+        let original_action = ActionHash::from_raw_36(vec![seed.wrapping_add(20); 36]);
+        let original_entry = EntryHash::from_raw_36(vec![seed.wrapping_add(30); 36]);
+        let entry = Entry::App(AppEntryBytes(
+            holochain_serialized_bytes::SerializedBytes::from(UnsafeBytes::from(vec![seed; 8])),
+        ));
+        let sig = Signature::from([seed; 64]);
+        let action = Action::Update(Update {
+            author,
+            timestamp: Timestamp::from_micros(seed as i64 * 1000),
+            action_seq: 2,
+            prev_action: ActionHash::from_raw_36(vec![seed.wrapping_add(70); 36]),
+            original_action_address: original_action,
+            original_entry_address: original_entry,
+            entry_type: EntryType::App(AppEntryDef::new(
+                0.into(),
+                0.into(),
+                EntryVisibility::Public,
+            )),
+            entry_hash: entry_hash.clone(),
+            weight: Default::default(),
+        });
+        let entry_hashed = EntryHashed::with_pre_hashed(entry.clone(), entry_hash);
+        let rendered = RenderedOp::new(action, sig, None, ChainOpType::RegisterUpdatedRecord)
+            .expect("rendered op build");
+        RenderedOps {
+            entry: Some(entry_hashed),
+            ops: vec![rendered],
+            warrant: None,
+        }
+    }
+
+    /// Build a single-op `RenderedOps` for a Delete chain op
+    /// (`RegisterDeletedBy`).
+    fn build_rendered_delete(seed: u8) -> RenderedOps {
+        let author = AgentPubKey::from_raw_36(vec![seed; 36]);
+        let deletes_address = ActionHash::from_raw_36(vec![seed.wrapping_add(20); 36]);
+        let deletes_entry = EntryHash::from_raw_36(vec![seed.wrapping_add(30); 36]);
+        let sig = Signature::from([seed; 64]);
+        let action = Action::Delete(Delete {
+            author,
+            timestamp: Timestamp::from_micros(seed as i64 * 1000),
+            action_seq: 3,
+            prev_action: ActionHash::from_raw_36(vec![seed.wrapping_add(70); 36]),
+            deletes_address,
+            deletes_entry_address: deletes_entry,
+            weight: Default::default(),
+        });
+        let rendered = RenderedOp::new(action, sig, None, ChainOpType::RegisterDeletedBy)
+            .expect("rendered op build");
+        RenderedOps {
+            entry: None,
+            ops: vec![rendered],
+            warrant: None,
+        }
+    }
+
+    /// Build a `RegisterAgentActivity` chain op as `RenderedOps`.
+    fn build_rendered_activity(seed: u8) -> RenderedOps {
+        let author = AgentPubKey::from_raw_36(vec![seed; 36]);
+        let sig = Signature::from([seed; 64]);
+        let action = Action::Create(Create {
+            author,
+            timestamp: Timestamp::from_micros(seed as i64 * 1000),
+            action_seq: 1,
+            prev_action: ActionHash::from_raw_36(vec![seed.wrapping_add(200); 36]),
+            entry_type: EntryType::App(AppEntryDef::new(
+                0.into(),
+                0.into(),
+                EntryVisibility::Public,
+            )),
+            entry_hash: EntryHash::from_raw_36(vec![seed.wrapping_add(100); 36]),
+            weight: Default::default(),
+        });
+        let rendered = RenderedOp::new(action, sig, None, ChainOpType::RegisterAgentActivity)
+            .expect("rendered op build");
+        RenderedOps {
+            entry: None,
+            ops: vec![rendered],
+            warrant: None,
+        }
+    }
+
+    /// Build a `WarrantOp`.
+    fn build_warrant_op(seed: u8) -> WarrantOp {
+        let action_author = AgentPubKey::from_raw_36(vec![seed; 36]);
+        let warrantee = AgentPubKey::from_raw_36(vec![seed.wrapping_add(50); 36]);
+        let action_hash = ActionHash::from_raw_36(vec![seed.wrapping_add(100); 36]);
+        let warrant = SignedWarrant::new(
+            Warrant::new(
+                WarrantProof::ChainIntegrity(ChainIntegrityWarrant::InvalidChainOp {
+                    action_author,
+                    action: (action_hash, Signature::from([seed; 64])),
+                    chain_op_type: ChainOpType::StoreRecord,
+                }),
+                AgentPubKey::from_raw_36(vec![seed.wrapping_add(10); 36]),
+                Timestamp::from_micros(seed as i64 * 1000),
+                warrantee,
+            ),
+            Signature::from([seed.wrapping_add(1); 64]),
+        );
+        WarrantOp::from(warrant)
+    }
+
+    fn op_hash_of(rendered: &RenderedOps) -> holo_hash::DhtOpHash {
+        rendered.ops[0].op_hash.clone()
+    }
+
+    #[tokio::test]
+    async fn cache_chain_ops_inserts_action_and_entry() {
+        let store = DhtStore::new_test(dht_id()).await.unwrap();
+        let rendered = build_rendered_store_record(1);
+        let entry_hash = rendered.entry.as_ref().unwrap().as_hash().clone();
+        let action_hash = rendered.ops[0].action.as_hash().clone();
+        let op_hash = op_hash_of(&rendered);
+
+        store.cache_chain_ops(&rendered).await.unwrap();
+
+        let action = store.db().as_ref().get_action(action_hash).await.unwrap();
+        assert!(action.is_some(), "Action row missing after cache record");
+
+        let entry = store
+            .db()
+            .as_ref()
+            .get_entry(entry_hash, None)
+            .await
+            .unwrap();
+        assert!(entry.is_some(), "Entry row missing after cache record");
+
+        let op = store.db().as_ref().get_chain_op(op_hash).await.unwrap();
+        assert!(op.is_some(), "ChainOp row missing after cache record");
+    }
+
+    #[tokio::test]
+    async fn cache_chain_ops_sets_locally_validated_false() {
+        let store = DhtStore::new_test(dht_id()).await.unwrap();
+        let rendered = build_rendered_store_record(2);
+        let op_hash = op_hash_of(&rendered);
+
+        store.cache_chain_ops(&rendered).await.unwrap();
+
+        let row = store
+            .db()
+            .as_ref()
+            .get_chain_op(op_hash)
+            .await
+            .unwrap()
+            .expect("ChainOp row missing");
+        assert_eq!(
+            row.locally_validated, 0,
+            "cached chain op should have locally_validated = 0"
+        );
+        assert_eq!(
+            row.validation_status,
+            i64::from(RecordValidity::Accepted),
+            "cached chain op should be Accepted"
+        );
+    }
+
+    #[tokio::test]
+    async fn cache_chain_ops_populates_link_index() {
+        let store = DhtStore::new_test(dht_id()).await.unwrap();
+        let rendered = build_rendered_create_link(3);
+        let action_hash = rendered.ops[0].action.as_hash().clone();
+        let base = match rendered.ops[0].action.action() {
+            Action::CreateLink(a) => a.base_address.clone(),
+            _ => panic!("expected CreateLink"),
+        };
+
+        store.cache_chain_ops(&rendered).await.unwrap();
+
+        let rows = store.db().as_ref().get_links_by_base(base).await.unwrap();
+        assert_eq!(rows.len(), 1, "expected one link row for cached CreateLink");
+        assert_eq!(rows[0].action_hash, action_hash.get_raw_36().to_vec());
+    }
+
+    #[tokio::test]
+    async fn cache_chain_ops_populates_deleted_link_index() {
+        let store = DhtStore::new_test(dht_id()).await.unwrap();
+        let rendered = build_rendered_delete_link(4);
+        let create_link_hash = match rendered.ops[0].action.action() {
+            Action::DeleteLink(a) => a.link_add_address.clone(),
+            _ => panic!("expected DeleteLink"),
+        };
+
+        store.cache_chain_ops(&rendered).await.unwrap();
+
+        let rows = store
+            .db()
+            .as_ref()
+            .get_deleted_links(create_link_hash)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "expected one deleted_link row");
+    }
+
+    #[tokio::test]
+    async fn cache_chain_ops_populates_updated_record_index() {
+        let store = DhtStore::new_test(dht_id()).await.unwrap();
+        let rendered = build_rendered_update(5);
+        let original_action = match rendered.ops[0].action.action() {
+            Action::Update(a) => a.original_action_address.clone(),
+            _ => panic!("expected Update"),
+        };
+
+        store.cache_chain_ops(&rendered).await.unwrap();
+
+        let rows = store
+            .db()
+            .as_ref()
+            .get_updated_records(original_action)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "expected one updated_record row");
+    }
+
+    #[tokio::test]
+    async fn cache_chain_ops_populates_deleted_record_index() {
+        let store = DhtStore::new_test(dht_id()).await.unwrap();
+        let rendered = build_rendered_delete(6);
+        let deletes_address = match rendered.ops[0].action.action() {
+            Action::Delete(a) => a.deletes_address.clone(),
+            _ => panic!("expected Delete"),
+        };
+
+        store.cache_chain_ops(&rendered).await.unwrap();
+
+        let rows = store
+            .db()
+            .as_ref()
+            .get_deleted_records(deletes_address)
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "expected one deleted_record row");
+    }
+
+    #[tokio::test]
+    async fn cache_chain_ops_inserts_agent_activity() {
+        let store = DhtStore::new_test(dht_id()).await.unwrap();
+        let rendered = build_rendered_activity(7);
+        let op_hash = op_hash_of(&rendered);
+
+        store.cache_chain_ops(&rendered).await.unwrap();
+
+        let row = store
+            .db()
+            .as_ref()
+            .get_chain_op(op_hash)
+            .await
+            .unwrap()
+            .expect("ChainOp row missing after activity cache record");
+        assert_eq!(row.locally_validated, 0);
+        assert_eq!(row.validation_status, i64::from(RecordValidity::Accepted));
+    }
+
+    #[tokio::test]
+    async fn cache_warrants_enters_limbo() {
+        let store = DhtStore::new_test(dht_id()).await.unwrap();
+        let warrant_op = build_warrant_op(8);
+        let op_hash = holo_hash::DhtOpHash::with_data_sync(&warrant_op);
+
+        store.cache_warrants(vec![warrant_op]).await.unwrap();
+
+        let row = store
+            .db()
+            .as_ref()
+            .get_limbo_warrant(op_hash)
+            .await
+            .unwrap();
+        assert!(row.is_some(), "LimboWarrant row missing for cached warrant");
+    }
+}

--- a/crates/holochain_state/src/host_fn_workspace.rs
+++ b/crates/holochain_state/src/host_fn_workspace.rs
@@ -12,6 +12,7 @@ pub struct HostFnWorkspace<
     authored: DbRead<DbKindAuthored>,
     dht: DbRead<DbKindDht>,
     cache: DbWrite<DbKindCache>,
+    dht_store: DhtStore,
     /// Did the root call that started this call chain
     /// come from an init callback.
     /// This is needed so that we don't run init recursively inside
@@ -31,6 +32,7 @@ pub struct HostFnStores {
     pub dht: DbRead<DbKindDht>,
     pub cache: DbWrite<DbKindCache>,
     pub scratch: Option<SyncScratch>,
+    pub dht_store: Option<DhtStore>,
 }
 
 pub type HostFnWorkspaceRead = HostFnWorkspace<DbRead<DbKindAuthored>, DbRead<DbKindDht>>;
@@ -44,9 +46,15 @@ impl SourceChainWorkspace {
         keystore: MetaLairClient,
         author: AgentPubKey,
     ) -> SourceChainResult<Self> {
-        let source_chain =
-            SourceChain::new(authored.clone(), dht.clone(), dht_store, keystore, author).await?;
-        Self::new_inner(authored, dht, cache, source_chain, false)
+        let source_chain = SourceChain::new(
+            authored.clone(),
+            dht.clone(),
+            dht_store.clone(),
+            keystore,
+            author,
+        )
+        .await?;
+        Self::new_inner(authored, dht, cache, dht_store, source_chain, false)
     }
 
     /// Create a source chain workspace where the root caller is the init callback.
@@ -58,9 +66,15 @@ impl SourceChainWorkspace {
         keystore: MetaLairClient,
         author: AgentPubKey,
     ) -> SourceChainResult<Self> {
-        let source_chain =
-            SourceChain::new(authored.clone(), dht.clone(), dht_store, keystore, author).await?;
-        Self::new_inner(authored, dht, cache, source_chain, true)
+        let source_chain = SourceChain::new(
+            authored.clone(),
+            dht.clone(),
+            dht_store.clone(),
+            keystore,
+            author,
+        )
+        .await?;
+        Self::new_inner(authored, dht, cache, dht_store, source_chain, true)
     }
 
     /// Create a source chain with a blank chain head.
@@ -75,16 +89,22 @@ impl SourceChainWorkspace {
         keystore: MetaLairClient,
         author: AgentPubKey,
     ) -> SourceChainResult<Self> {
-        let source_chain =
-            SourceChain::raw_empty(authored.clone(), dht.clone(), dht_store, keystore, author)
-                .await?;
-        Self::new_inner(authored, dht, cache, source_chain, false)
+        let source_chain = SourceChain::raw_empty(
+            authored.clone(),
+            dht.clone(),
+            dht_store.clone(),
+            keystore,
+            author,
+        )
+        .await?;
+        Self::new_inner(authored, dht, cache, dht_store, source_chain, false)
     }
 
     fn new_inner(
         authored: DbWrite<DbKindAuthored>,
         dht: DbWrite<DbKindDht>,
         cache: DbWrite<DbKindCache>,
+        dht_store: DhtStore,
         source_chain: SourceChain,
         init_is_root: bool,
     ) -> SourceChainResult<Self> {
@@ -94,6 +114,7 @@ impl SourceChainWorkspace {
                 authored: authored.into(),
                 dht: dht.into(),
                 cache,
+                dht_store,
                 init_is_root,
             },
             source_chain,
@@ -122,8 +143,14 @@ where
     ) -> SourceChainResult<Self> {
         let source_chain = match author {
             Some(author) => Some(
-                SourceChain::new(authored.clone(), dht.clone(), dht_store, keystore, author)
-                    .await?,
+                SourceChain::new(
+                    authored.clone(),
+                    dht.clone(),
+                    dht_store.clone(),
+                    keystore,
+                    author,
+                )
+                .await?,
             ),
             None => None,
         };
@@ -132,6 +159,7 @@ where
             authored: authored.into(),
             dht: dht.into(),
             cache,
+            dht_store,
             init_is_root: false,
         })
     }
@@ -150,6 +178,7 @@ where
             dht: self.dht.clone(),
             cache: self.cache.clone(),
             scratch: self.source_chain.as_ref().map(|sc| sc.scratch()),
+            dht_store: Some(self.dht_store.clone()),
         }
     }
 
@@ -177,6 +206,7 @@ impl From<HostFnWorkspace> for HostFnWorkspaceRead {
             authored: workspace.authored,
             dht: workspace.dht,
             cache: workspace.cache,
+            dht_store: workspace.dht_store,
             init_is_root: workspace.init_is_root,
         }
     }
@@ -195,6 +225,7 @@ impl From<SourceChainWorkspace> for HostFnWorkspaceRead {
             authored: workspace.inner.authored,
             dht: workspace.inner.dht,
             cache: workspace.inner.cache,
+            dht_store: workspace.inner.dht_store,
             init_is_root: workspace.inner.init_is_root,
         }
     }

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -499,7 +499,7 @@ impl SourceChain {
                     let mut inserted_action_hashes = std::collections::HashSet::<ActionHash>::new();
 
                     for sah in &actions_for_new_db {
-                        let new_sah = legacy_to_dht_v2_signed_action(sah);
+                        let new_sah = holochain_zome_types::dht_v2::from_legacy_signed_action(sah);
 
                         tx.insert_action(
                             &new_sah,
@@ -1503,7 +1503,7 @@ pub async fn genesis(
             &agent_action_for_new_db,
         ];
         for sah in genesis_actions {
-            let new_sah = legacy_to_dht_v2_signed_action(sah);
+            let new_sah = holochain_zome_types::dht_v2::from_legacy_signed_action(sah);
             tx.insert_action(
                 &new_sah,
                 Some(holochain_zome_types::dht_v2::RecordValidity::Accepted),
@@ -1717,79 +1717,6 @@ pub async fn dump_state(
 // ---------------------------------------------------------------------------
 // Private helpers for the new-DB writes in `flush` and `genesis`
 // ---------------------------------------------------------------------------
-
-/// Convert a legacy [`SignedActionHashed`] (using the variant-per-type `Action`
-/// enum) to the new [`holochain_zome_types::dht_v2::SignedActionHashed`] (which
-/// uses a flat `ActionHeader` + `ActionData` envelope).
-///
-/// All legacy action variants are covered. The hash is carried over from the
-/// original (the v2 hash is content-derived, so re-hashing would change it;
-/// the pre-hashed constructor preserves the existing hash as the canonical
-/// identity during the dual-write transition).
-pub(crate) fn legacy_to_dht_v2_signed_action(
-    shh: &SignedActionHashed,
-) -> holochain_zome_types::dht_v2::SignedActionHashed {
-    use holochain_zome_types::dht_v2::{
-        Action as V2Action, ActionData, ActionHeader, AgentValidationPkgData, CloseChainData,
-        CreateData, CreateLinkData, DeleteData, DeleteLinkData, DnaData, InitZomesCompleteData,
-        OpenChainData, UpdateData,
-    };
-
-    // `Action` (legacy) and `SignedHashed` are in scope via the prelude.
-    let legacy_action = shh.action();
-    let header = ActionHeader {
-        author: legacy_action.author().clone(),
-        timestamp: legacy_action.timestamp(),
-        action_seq: legacy_action.action_seq(),
-        prev_action: legacy_action.prev_action().cloned(),
-    };
-
-    let data = match legacy_action {
-        Action::Dna(d) => ActionData::Dna(DnaData {
-            dna_hash: d.hash.clone(),
-        }),
-        Action::AgentValidationPkg(d) => ActionData::AgentValidationPkg(AgentValidationPkgData {
-            membrane_proof: d.membrane_proof.clone(),
-        }),
-        Action::InitZomesComplete(_) => ActionData::InitZomesComplete(InitZomesCompleteData {}),
-        Action::Create(d) => ActionData::Create(CreateData {
-            entry_type: d.entry_type.clone(),
-            entry_hash: d.entry_hash.clone(),
-        }),
-        Action::Update(d) => ActionData::Update(UpdateData {
-            original_action_address: d.original_action_address.clone(),
-            original_entry_address: d.original_entry_address.clone(),
-            entry_type: d.entry_type.clone(),
-            entry_hash: d.entry_hash.clone(),
-        }),
-        Action::Delete(d) => ActionData::Delete(DeleteData {
-            deletes_address: d.deletes_address.clone(),
-            deletes_entry_address: d.deletes_entry_address.clone(),
-        }),
-        Action::CreateLink(d) => ActionData::CreateLink(CreateLinkData {
-            base_address: d.base_address.clone(),
-            target_address: d.target_address.clone(),
-            zome_index: d.zome_index,
-            link_type: d.link_type,
-            tag: d.tag.clone(),
-        }),
-        Action::DeleteLink(d) => ActionData::DeleteLink(DeleteLinkData {
-            base_address: d.base_address.clone(),
-            link_add_address: d.link_add_address.clone(),
-        }),
-        Action::CloseChain(d) => ActionData::CloseChain(CloseChainData {
-            new_target: d.new_target.clone(),
-        }),
-        Action::OpenChain(d) => ActionData::OpenChain(OpenChainData {
-            prev_target: d.prev_target.clone(),
-            close_hash: d.close_hash.clone(),
-        }),
-    };
-
-    let v2_action = V2Action { header, data };
-    let hashed = holo_hash::HoloHashed::with_pre_hashed(v2_action, shh.as_hash().clone());
-    SignedHashed::with_presigned(hashed, shh.signature().clone())
-}
 
 /// Return the `(cap_access_i64, Option<tag>)` parameters needed for
 /// `TxWrite::insert_cap_grant`, if the given action creates/updates a

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -511,62 +511,13 @@ impl SourceChain {
                         // Record that this action hash is present in the new DB.
                         inserted_action_hashes.insert(sah.as_hash().clone());
 
-                        // Dispatch index table inserts based on action variant.
-                        // `ActionData` is the dht_v2 discriminant; import locally to
-                        // avoid shadowing the legacy `Action` variants in scope.
-                        {
-                            use holochain_zome_types::dht_v2::ActionData;
-                            match &new_sah.hashed.content.data {
-                                ActionData::CreateLink(a) => {
-                                    let _ = tx
-                                        .insert_link_index(holochain_data::dht::InsertLink {
-                                            action_hash: new_sah.as_hash(),
-                                            base_hash: &a.base_address,
-                                            zome_index: a.zome_index.0,
-                                            link_type: a.link_type.0,
-                                            tag: Some(a.tag.0.as_slice()),
-                                        })
-                                        .await
-                                        .map_err(SourceChainError::other)?;
-                                }
-                                ActionData::DeleteLink(a) => {
-                                    let _ = tx
-                                        .insert_deleted_link_index(
-                                            holochain_data::dht::InsertDeletedLink {
-                                                action_hash: new_sah.as_hash(),
-                                                create_link_hash: &a.link_add_address,
-                                            },
-                                        )
-                                        .await
-                                        .map_err(SourceChainError::other)?;
-                                }
-                                ActionData::Update(a) => {
-                                    let _ = tx
-                                        .insert_updated_record_index(
-                                            holochain_data::dht::InsertUpdatedRecord {
-                                                action_hash: new_sah.as_hash(),
-                                                original_action_hash: &a.original_action_address,
-                                                original_entry_hash: &a.original_entry_address,
-                                            },
-                                        )
-                                        .await
-                                        .map_err(SourceChainError::other)?;
-                                }
-                                ActionData::Delete(a) => {
-                                    let _ = tx
-                                        .insert_deleted_record_index(
-                                            holochain_data::dht::InsertDeletedRecord {
-                                                action_hash: new_sah.as_hash(),
-                                                deletes_action_hash: &a.deletes_address,
-                                                deletes_entry_hash: &a.deletes_entry_address,
-                                            },
-                                        )
-                                        .await
-                                        .map_err(SourceChainError::other)?;
-                                }
-                                _ => {}
-                            }
-                        }
+                        crate::dht_store::action_indexes::insert_action_indexes(
+                            &mut tx,
+                            new_sah.as_hash(),
+                            &new_sah.hashed.content.data,
+                        )
+                        .await
+                        .map_err(SourceChainError::other)?;
 
                         // For Create/Update of a CapGrant entry type, insert a CapGrant index row.
                         if let Some((cap_access, tag)) =

--- a/crates/holochain_types/src/dht_op.rs
+++ b/crates/holochain_types/src/dht_op.rs
@@ -1188,7 +1188,7 @@ pub struct RenderedOp {
     /// The action in its legacy form, used by the legacy SQLite cache schema.
     pub action: SignedActionHashed,
     /// The same action in its dht_v2 form (flat `ActionHeader` + `ActionData`),
-    /// used by the new [`holochain_data`] DHT store. Computed at construction
+    /// used by the new `holochain_data` DHT store. Computed at construction
     /// time so callers receive a transformed input rather than converting
     /// per-op themselves.
     pub signed_action_v2: holochain_zome_types::dht_v2::SignedActionHashed,

--- a/crates/holochain_types/src/dht_op.rs
+++ b/crates/holochain_types/src/dht_op.rs
@@ -1185,8 +1185,13 @@ impl WireOps {
 /// The data rendered from a wire op to place in the database.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RenderedOp {
-    /// The action to insert into the database.
+    /// The action in its legacy form, used by the legacy SQLite cache schema.
     pub action: SignedActionHashed,
+    /// The same action in its dht_v2 form (flat `ActionHeader` + `ActionData`),
+    /// used by the new [`holochain_data`] DHT store. Computed at construction
+    /// time so callers receive a transformed input rather than converting
+    /// per-op themselves.
+    pub signed_action_v2: holochain_zome_types::dht_v2::SignedActionHashed,
     /// The action to insert into the database.
     pub op_light: DhtOpLite,
     /// The hash of the [`DhtOp`]
@@ -1207,12 +1212,13 @@ impl RenderedOp {
     ) -> DhtOpResult<Self> {
         let (action, op_hash) = ChainOpUniqueForm::op_hash(op_type, action)?;
         let action_hashed = ActionHashed::from_content_sync(action);
-        // TODO: Verify signature?
         let action = SignedActionHashed::with_presigned(action_hashed, signature);
+        let signed_action_v2 = holochain_zome_types::dht_v2::from_legacy_signed_action(&action);
         let op_light =
             ChainOpLite::from_type(op_type, action.as_hash().clone(), action.action())?.into();
         Ok(Self {
             action,
+            signed_action_v2,
             op_light,
             op_hash,
             validation_status,

--- a/crates/holochain_zome_types/src/dht_v2.rs
+++ b/crates/holochain_zome_types/src/dht_v2.rs
@@ -145,6 +145,106 @@ impl TryFrom<i64> for ChainOpType {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::action::{Create, CreateLink, EntryType};
+    use crate::entry_def::EntryVisibility;
+    use crate::link::LinkTag;
+    use crate::prelude::AppEntryDef;
+    use crate::signature::Signature;
+    use holo_hash::{ActionHash, AgentPubKey, AnyLinkableHash, EntryHash};
+    use holochain_integrity_types::action::Action as LegacyAction;
+    use holochain_integrity_types::record::SignedHashed;
+    use holochain_timestamp::Timestamp;
+
+    fn legacy_signed_create() -> crate::record::SignedActionHashed {
+        let action = LegacyAction::Create(Create {
+            author: AgentPubKey::from_raw_36(vec![1u8; 36]),
+            timestamp: Timestamp::from_micros(1_000),
+            action_seq: 4,
+            prev_action: ActionHash::from_raw_36(vec![2u8; 36]),
+            entry_type: EntryType::App(AppEntryDef::new(
+                0.into(),
+                0.into(),
+                EntryVisibility::Public,
+            )),
+            entry_hash: EntryHash::from_raw_36(vec![3u8; 36]),
+            weight: Default::default(),
+        });
+        let hashed =
+            holo_hash::HoloHashed::with_pre_hashed(action, ActionHash::from_raw_36(vec![9u8; 36]));
+        SignedHashed::with_presigned(hashed, Signature::from([7u8; 64]))
+    }
+
+    fn legacy_signed_create_link() -> crate::record::SignedActionHashed {
+        let action = LegacyAction::CreateLink(CreateLink {
+            author: AgentPubKey::from_raw_36(vec![1u8; 36]),
+            timestamp: Timestamp::from_micros(2_000),
+            action_seq: 5,
+            prev_action: ActionHash::from_raw_36(vec![2u8; 36]),
+            base_address: AnyLinkableHash::from_raw_36_and_type(
+                vec![4u8; 36],
+                holo_hash::hash_type::AnyLinkable::Entry,
+            ),
+            target_address: AnyLinkableHash::from_raw_36_and_type(
+                vec![5u8; 36],
+                holo_hash::hash_type::AnyLinkable::Entry,
+            ),
+            zome_index: 1.into(),
+            link_type: 2.into(),
+            tag: LinkTag(vec![0xAA, 0xBB]),
+            weight: Default::default(),
+        });
+        let hashed =
+            holo_hash::HoloHashed::with_pre_hashed(action, ActionHash::from_raw_36(vec![11u8; 36]));
+        SignedHashed::with_presigned(hashed, Signature::from([8u8; 64]))
+    }
+
+    #[test]
+    fn from_legacy_signed_action_preserves_hash_and_signature() {
+        let legacy = legacy_signed_create();
+        let v2 = from_legacy_signed_action(&legacy);
+
+        assert_eq!(v2.as_hash(), legacy.as_hash());
+        assert_eq!(v2.signature(), legacy.signature());
+    }
+
+    #[test]
+    fn from_legacy_signed_action_maps_create_fields() {
+        let legacy = legacy_signed_create();
+        let v2 = from_legacy_signed_action(&legacy);
+        let action = &v2.hashed.content;
+
+        assert_eq!(&action.header.author, legacy.action().author());
+        assert_eq!(action.header.timestamp, legacy.action().timestamp());
+        assert_eq!(action.header.action_seq, legacy.action().action_seq());
+        assert_eq!(
+            action.header.prev_action.as_ref(),
+            legacy.action().prev_action()
+        );
+        match (&action.data, legacy.action()) {
+            (ActionData::Create(v2_data), LegacyAction::Create(legacy_data)) => {
+                assert_eq!(v2_data.entry_hash, legacy_data.entry_hash);
+                assert_eq!(v2_data.entry_type, legacy_data.entry_type);
+            }
+            _ => panic!("unexpected variant pair"),
+        }
+    }
+
+    #[test]
+    fn from_legacy_signed_action_maps_create_link_fields() {
+        let legacy = legacy_signed_create_link();
+        let v2 = from_legacy_signed_action(&legacy);
+
+        match (&v2.hashed.content.data, legacy.action()) {
+            (ActionData::CreateLink(v2_data), LegacyAction::CreateLink(legacy_data)) => {
+                assert_eq!(v2_data.base_address, legacy_data.base_address);
+                assert_eq!(v2_data.target_address, legacy_data.target_address);
+                assert_eq!(v2_data.zome_index, legacy_data.zome_index);
+                assert_eq!(v2_data.link_type, legacy_data.link_type);
+                assert_eq!(v2_data.tag, legacy_data.tag);
+            }
+            _ => panic!("unexpected variant pair"),
+        }
+    }
 
     #[test]
     fn chain_op_type_i64_roundtrip() {

--- a/crates/holochain_zome_types/src/dht_v2.rs
+++ b/crates/holochain_zome_types/src/dht_v2.rs
@@ -11,6 +11,74 @@ use crate::op::ChainOpType;
 use crate::signature::Signed;
 use holochain_integrity_types::record::SignedHashed;
 
+/// Convert a legacy [`crate::record::SignedActionHashed`] (using the
+/// variant-per-type `Action` enum) into the v2 [`SignedActionHashed`] (which
+/// uses a flat [`ActionHeader`] + [`ActionData`] envelope).
+///
+/// The hash is carried over from the original — the v2 hash is content-derived,
+/// so re-hashing would change it; the pre-hashed constructor preserves the
+/// existing hash as the canonical identity during the dual-write transition.
+pub fn from_legacy_signed_action(shh: &crate::record::SignedActionHashed) -> SignedActionHashed {
+    use crate::action::Action as LegacyAction;
+    let legacy_action = shh.action();
+    let header = ActionHeader {
+        author: legacy_action.author().clone(),
+        timestamp: legacy_action.timestamp(),
+        action_seq: legacy_action.action_seq(),
+        prev_action: legacy_action.prev_action().cloned(),
+    };
+
+    let data = match legacy_action {
+        LegacyAction::Dna(d) => ActionData::Dna(DnaData {
+            dna_hash: d.hash.clone(),
+        }),
+        LegacyAction::AgentValidationPkg(d) => {
+            ActionData::AgentValidationPkg(AgentValidationPkgData {
+                membrane_proof: d.membrane_proof.clone(),
+            })
+        }
+        LegacyAction::InitZomesComplete(_) => {
+            ActionData::InitZomesComplete(InitZomesCompleteData {})
+        }
+        LegacyAction::Create(d) => ActionData::Create(CreateData {
+            entry_type: d.entry_type.clone(),
+            entry_hash: d.entry_hash.clone(),
+        }),
+        LegacyAction::Update(d) => ActionData::Update(UpdateData {
+            original_action_address: d.original_action_address.clone(),
+            original_entry_address: d.original_entry_address.clone(),
+            entry_type: d.entry_type.clone(),
+            entry_hash: d.entry_hash.clone(),
+        }),
+        LegacyAction::Delete(d) => ActionData::Delete(DeleteData {
+            deletes_address: d.deletes_address.clone(),
+            deletes_entry_address: d.deletes_entry_address.clone(),
+        }),
+        LegacyAction::CreateLink(d) => ActionData::CreateLink(CreateLinkData {
+            base_address: d.base_address.clone(),
+            target_address: d.target_address.clone(),
+            zome_index: d.zome_index,
+            link_type: d.link_type,
+            tag: d.tag.clone(),
+        }),
+        LegacyAction::DeleteLink(d) => ActionData::DeleteLink(DeleteLinkData {
+            base_address: d.base_address.clone(),
+            link_add_address: d.link_add_address.clone(),
+        }),
+        LegacyAction::CloseChain(d) => ActionData::CloseChain(CloseChainData {
+            new_target: d.new_target.clone(),
+        }),
+        LegacyAction::OpenChain(d) => ActionData::OpenChain(OpenChainData {
+            prev_target: d.prev_target.clone(),
+            close_hash: d.close_hash.clone(),
+        }),
+    };
+
+    let v2_action = Action { header, data };
+    let hashed = holo_hash::HoloHashed::with_pre_hashed(v2_action, shh.as_hash().clone());
+    SignedHashed::with_presigned(hashed, shh.signature().clone())
+}
+
 /// A v2 [`Action`] with its [`crate::signature::Signature`] (no hash).
 pub type SignedAction = Signed<Action>;
 


### PR DESCRIPTION
## Summary

Mirror every cache write performed by `holochain_cascade::CascadeImpl` into the new unified per-DNA `DhtStore`.

Three cache write sites in `CascadeImpl` are wired in:
- `merge_ops_into_cache` — records fetched via `get`
- `merge_link_ops_into_cache` — link ops fetched via `get_links`
- `add_activity_into_cache` — agent activity + warrants from `must_get_agent_activity`

Mirror routing:
- Cached chain ops → `ChainOp` (bypassing limbo) with `locally_validated = false`, plus the integration index tables (`Link`, `DeletedLink`, `UpdatedRecord`, `DeletedRecord`).
- Warrants → `LimboWarrant` for local validation regardless of arc.

Mirror failures are logged at `warn` level and swallowed — a misbehaving mirror cannot break the cascade. Test cascades that don't have a Space leave `dht_store: None` and skip the mirror silently.