### PR TITLE
WIP bisect: warrant fix only — checking Windows node_messaging

### DIFF
--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1386,16 +1386,21 @@ mod app_impls {
             if force || deps.is_empty() {
                 let app = state.get_app(installed_app_id)?;
                 let cells_to_remove = app.all_cells().collect::<Vec<_>>();
-                // Delete the cells' databases.
-                self.delete_cell_databases(app.id(), cells_to_remove.clone())
-                    .await?;
 
-                // Delete app from DB and state.
+                // Remove the app from state first so app-status reconciliation
+                // cannot restart its cells while they are being torn down.
                 self.remove_app_from_db(installed_app_id).await?;
                 tracing::debug!(msg = "Removed app from db.", app = ?app);
 
-                // Remove the cells from conductor state.
+                // Stop the cells next so their workflows and networking release
+                // the databases before we delete them. Deleting databases out
+                // from under running cells leaves background tasks querying
+                // files that no longer exist.
                 self.remove_cells(&cells_to_remove).await;
+
+                // Delete the cells' databases and drop the now-unused spaces.
+                self.delete_cell_databases(app.id(), cells_to_remove.clone())
+                    .await?;
 
                 // Remove the app's signal broadcast from conductor.
                 let installed_app_ids = self
@@ -3158,6 +3163,11 @@ impl Conductor {
                     tracing::info!("Deleted file {}", support_path.display());
                 }
             }
+
+            // Drop the cached space now its databases are gone, so a reinstall
+            // of this DNA opens fresh, migrated databases rather than reusing
+            // pools that point at the deleted files.
+            self.spaces.remove_space(dna_hash);
         }
 
         Ok(())

--- a/crates/holochain/src/conductor/space.rs
+++ b/crates/holochain/src/conductor/space.rs
@@ -353,6 +353,22 @@ impl Spaces {
         self.get_or_create_space_ref(dna_hash, |s| s.clone())
     }
 
+    /// Drop the cached space for a DNA, releasing its database handles and
+    /// queue consumer triggers.
+    ///
+    /// Called once the last cell for a DNA has been removed and its database
+    /// files deleted. Without this, a reinstall of the same DNA would reuse the
+    /// cached space's connection pools, which point at the deleted files; the
+    /// pool would lazily reopen them as empty, un-migrated databases (migrations
+    /// only run when a database is opened). Dropping the space forces a
+    /// subsequent install to open fresh, migrated databases.
+    pub(crate) fn remove_space(&self, dna_hash: &DnaHash) {
+        self.map.share_mut(|spaces| {
+            spaces.remove(dna_hash);
+        });
+        self.queue_consumer_map.remove_all_for_dna(dna_hash);
+    }
+
     fn get_or_create_space_ref<F, R>(&self, dna_hash: &DnaHash, f: F) -> DatabaseResult<R>
     where
         F: Fn(&Space) -> R,

--- a/crates/holochain/src/core/queue_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer.rs
@@ -121,7 +121,6 @@ pub async fn spawn_queue_consumer_tasks(
     let tx_integration = queue_consumer_map.spawn_once_integration(dna_hash.clone(), || {
         spawn_integrate_dht_ops_consumer(
             dna_hash.clone(),
-            dht_db.clone(),
             space.dht_store.clone(),
             conductor.task_manager(),
             tx_receipt.clone(),

--- a/crates/holochain/src/core/queue_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer.rs
@@ -121,6 +121,7 @@ pub async fn spawn_queue_consumer_tasks(
     let tx_integration = queue_consumer_map.spawn_once_integration(dna_hash.clone(), || {
         spawn_integrate_dht_ops_consumer(
             dna_hash.clone(),
+            dht_db.clone(),
             space.dht_store.clone(),
             conductor.task_manager(),
             tx_receipt.clone(),

--- a/crates/holochain/src/core/queue_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer.rs
@@ -330,6 +330,16 @@ impl QueueConsumerMap {
             }
         })
     }
+
+    /// Drop this map's trigger senders for every queue of the given DNA.
+    ///
+    /// Once the removed cells have also dropped their copies, the consumer
+    /// workflows terminate. Used when a DNA's space is torn down so that a
+    /// later reinstall re-spawns fresh consumers bound to the new databases.
+    pub fn remove_all_for_dna(&self, dna_hash: &DnaHash) {
+        self.map
+            .share_mut(|map| map.retain(|QueueEntry(dna, _), _| dna.as_ref() != dna_hash));
+    }
 }
 
 #[derive(Hash, Eq, PartialEq, Clone, Debug)]

--- a/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
@@ -3,19 +3,17 @@
 use super::*;
 use crate::conductor::manager::TaskManagerClient;
 use crate::core::workflow::integrate_dht_ops_workflow::integrate_dht_ops_workflow;
-use holochain_sqlite::db::DbKindDht;
-use holochain_sqlite::prelude::DbWrite;
 use holochain_state::dht_store::DhtStore;
 use std::sync::Arc;
 
 /// Spawn the QueueConsumer for DhtOpIntegration workflow
 #[cfg_attr(
     feature = "instrument",
-    tracing::instrument(skip(vault, dht_store, trigger_receipt, tm, network, conductor))
+    tracing::instrument(skip(env, dht_store, trigger_receipt, tm, network, conductor))
 )]
 pub fn spawn_integrate_dht_ops_consumer(
     dna_hash: Arc<DnaHash>,
-    vault: DbWrite<DbKindDht>,
+    env: DbWrite<DbKindDht>,
     dht_store: DhtStore,
     tm: TaskManagerClient,
     trigger_receipt: TriggerSender,
@@ -31,7 +29,7 @@ pub fn spawn_integrate_dht_ops_consumer(
         (tx.clone(), rx),
         move || {
             integrate_dht_ops_workflow(
-                vault.clone(),
+                env.clone(),
                 dht_store.clone(),
                 trigger_receipt.clone(),
                 network.clone(),

--- a/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
@@ -3,16 +3,19 @@
 use super::*;
 use crate::conductor::manager::TaskManagerClient;
 use crate::core::workflow::integrate_dht_ops_workflow::integrate_dht_ops_workflow;
+use holochain_sqlite::db::DbKindDht;
+use holochain_sqlite::prelude::DbWrite;
 use holochain_state::dht_store::DhtStore;
 use std::sync::Arc;
 
 /// Spawn the QueueConsumer for DhtOpIntegration workflow
 #[cfg_attr(
     feature = "instrument",
-    tracing::instrument(skip(dht_store, trigger_receipt, tm, network, conductor))
+    tracing::instrument(skip(vault, dht_store, trigger_receipt, tm, network, conductor))
 )]
 pub fn spawn_integrate_dht_ops_consumer(
     dna_hash: Arc<DnaHash>,
+    vault: DbWrite<DbKindDht>,
     dht_store: DhtStore,
     tm: TaskManagerClient,
     trigger_receipt: TriggerSender,
@@ -28,6 +31,7 @@ pub fn spawn_integrate_dht_ops_consumer(
         (tx.clone(), rx),
         move || {
             integrate_dht_ops_workflow(
+                vault.clone(),
                 dht_store.clone(),
                 trigger_receipt.clone(),
                 network.clone(),

--- a/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
+++ b/crates/holochain/src/core/queue_consumer/integrate_dht_ops_consumer.rs
@@ -9,11 +9,10 @@ use std::sync::Arc;
 /// Spawn the QueueConsumer for DhtOpIntegration workflow
 #[cfg_attr(
     feature = "instrument",
-    tracing::instrument(skip(env, dht_store, trigger_receipt, tm, network, conductor))
+    tracing::instrument(skip(dht_store, trigger_receipt, tm, network, conductor))
 )]
 pub fn spawn_integrate_dht_ops_consumer(
     dna_hash: Arc<DnaHash>,
-    env: DbWrite<DbKindDht>,
     dht_store: DhtStore,
     tm: TaskManagerClient,
     trigger_receipt: TriggerSender,
@@ -29,7 +28,6 @@ pub fn spawn_integrate_dht_ops_consumer(
         (tx.clone(), rx),
         move || {
             integrate_dht_ops_workflow(
-                env.clone(),
                 dht_store.clone(),
                 trigger_receipt.clone(),
                 network.clone(),

--- a/crates/holochain/src/core/workflow/app_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow.rs
@@ -92,7 +92,6 @@
 //! is triggered, which completes integration of ops after successful validation.
 
 use super::error::WorkflowResult;
-use super::sys_validation_workflow::validation_query;
 use crate::conductor::entry_def_store::get_entry_def;
 use crate::conductor::Conductor;
 use crate::conductor::ConductorHandle;
@@ -200,8 +199,11 @@ async fn app_validation_workflow_inner(
     network: DynHolochainP2pDna,
     _representative_agent: AgentPubKey,
 ) -> WorkflowResult<OutcomeSummary> {
-    let db = workspace.dht_db.clone().into();
-    let sorted_dht_ops = validation_query::get_ops_to_app_validate(&db).await?;
+    let sorted_dht_ops = workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await?;
     let num_ops_to_validate = sorted_dht_ops.len();
 
     let cascade = Arc::new(workspace.full_cascade(network.clone()));

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -22,6 +22,7 @@ use holochain_conductor_api::conductor::paths::DataRootPath;
 use holochain_p2p::actor::MockHcP2p;
 use holochain_p2p::HolochainP2pDna;
 use holochain_sqlite::error::DatabaseResult;
+use holochain_state::dht_store::SysOutcome;
 use holochain_state::mutations::insert_op_dht;
 use holochain_state::prelude::{from_blob, insert_op_cache, StateQueryResult};
 use holochain_state::test_utils::test_db_dir;
@@ -119,10 +120,26 @@ async fn main_workflow() {
     let dht_delete_op_hashed = DhtOpHashed::from_content_sync(dht_delete_op);
 
     // insert op to validate in dht db and mark ready for app validation
+    let dht_delete_op_hashed_for_store = dht_delete_op_hashed.clone();
+    let dht_delete_op_hash_for_store = dht_delete_op_hash.clone();
     app_validation_workspace.dht_db.test_write(move |txn| {
         insert_op_dht(txn, &dht_delete_op_hashed, 0, None).unwrap();
         put_validation_limbo(txn, &dht_delete_op_hash, ValidationStage::SysValidated).unwrap();
     });
+    // Mirror into the new DhtStore so the workflow can read from it.
+    app_validation_workspace
+        .dht_store
+        .record_incoming_ops(vec![dht_delete_op_hashed_for_store])
+        .await
+        .unwrap();
+    app_validation_workspace
+        .dht_store
+        .record_chain_op_sys_validation_outcomes(vec![(
+            dht_delete_op_hash_for_store,
+            SysOutcome::Accepted,
+        )])
+        .await
+        .unwrap();
 
     // check delete op is now counted as op to validate
     let ops_to_validate =
@@ -316,6 +333,10 @@ async fn validate_ops_in_sequence_must_get_agent_activity() {
     assert_eq!(ops_to_validate, 0);
 
     // insert create and delete op in dht db and mark ready for app validation
+    let dht_delete_op_hashed_for_store = dht_delete_op_hashed.clone();
+    let dht_delete_op_hash_for_store = dht_delete_op_hash.clone();
+    let dht_create_op_hashed_for_store = dht_create_op_hashed.clone();
+    let dht_create_op_hash_for_store = dht_create_op_hashed.as_hash().clone();
     app_validation_workspace.dht_db.test_write(move |txn| {
         insert_op_dht(txn, &dht_delete_op_hashed, 0, None).unwrap();
         put_validation_limbo(txn, &dht_delete_op_hash, ValidationStage::SysValidated).unwrap();
@@ -327,6 +348,23 @@ async fn validate_ops_in_sequence_must_get_agent_activity() {
         )
         .unwrap();
     });
+    // Mirror into the new DhtStore so the workflow can read from it.
+    app_validation_workspace
+        .dht_store
+        .record_incoming_ops(vec![
+            dht_delete_op_hashed_for_store,
+            dht_create_op_hashed_for_store,
+        ])
+        .await
+        .unwrap();
+    app_validation_workspace
+        .dht_store
+        .record_chain_op_sys_validation_outcomes(vec![
+            (dht_delete_op_hash_for_store, SysOutcome::Accepted),
+            (dht_create_op_hash_for_store, SysOutcome::Accepted),
+        ])
+        .await
+        .unwrap();
 
     // check create and delete op are now counted as ops to validate
     let ops_to_validate =
@@ -457,6 +495,10 @@ async fn validate_ops_in_sequence_must_get_action() {
     let dht_delete_op_hashed = DhtOpHashed::from_content_sync(dht_delete_op);
 
     // insert create and delete op in dht db and mark ready for app validation
+    let dht_delete_op_hashed_for_store = dht_delete_op_hashed.clone();
+    let dht_delete_op_hash_for_store = dht_delete_op_hash.clone();
+    let dht_create_op_hashed_for_store = dht_create_op_hashed.clone();
+    let dht_create_op_hash_for_store = dht_create_op_hashed.as_hash().clone();
     app_validation_workspace.dht_db.test_write(move |txn| {
         insert_op_dht(txn, &dht_delete_op_hashed, 0, None).unwrap();
         put_validation_limbo(txn, &dht_delete_op_hash, ValidationStage::SysValidated).unwrap();
@@ -468,6 +510,23 @@ async fn validate_ops_in_sequence_must_get_action() {
         )
         .unwrap();
     });
+    // Mirror into the new DhtStore so the workflow can read from it.
+    app_validation_workspace
+        .dht_store
+        .record_incoming_ops(vec![
+            dht_delete_op_hashed_for_store,
+            dht_create_op_hashed_for_store,
+        ])
+        .await
+        .unwrap();
+    app_validation_workspace
+        .dht_store
+        .record_chain_op_sys_validation_outcomes(vec![
+            (dht_delete_op_hash_for_store, SysOutcome::Accepted),
+            (dht_create_op_hash_for_store, SysOutcome::Accepted),
+        ])
+        .await
+        .unwrap();
 
     // check create and delete op are now counted as ops to validate
     let ops_to_validate =
@@ -627,12 +686,33 @@ async fn handle_error_in_op_validation() {
 
     // insert both ops in dht db and mark ready for app validation
     let expected_failed_dht_op_hash = dht_create_op_hash.clone();
+    let dht_create_op_hashed_for_store = dht_create_op_hashed.clone();
+    let dht_create_op_hash_for_store = dht_create_op_hash.clone();
+    let dht_store_entry_op_hashed_for_store = dht_store_entry_op_hashed.clone();
+    let dht_store_entry_op_hash_for_store = dht_store_entry_op_hash.clone();
     app_validation_workspace.dht_db.test_write(move |txn| {
         insert_op_dht(txn, &dht_create_op_hashed, 0, None).unwrap();
         put_validation_limbo(txn, &dht_create_op_hash, ValidationStage::SysValidated).unwrap();
         insert_op_dht(txn, &dht_store_entry_op_hashed, 0, None).unwrap();
         put_validation_limbo(txn, &dht_store_entry_op_hash, ValidationStage::SysValidated).unwrap();
     });
+    // Mirror into the new DhtStore so the workflow can read from it.
+    app_validation_workspace
+        .dht_store
+        .record_incoming_ops(vec![
+            dht_create_op_hashed_for_store,
+            dht_store_entry_op_hashed_for_store,
+        ])
+        .await
+        .unwrap();
+    app_validation_workspace
+        .dht_store
+        .record_chain_op_sys_validation_outcomes(vec![
+            (dht_create_op_hash_for_store, SysOutcome::Accepted),
+            (dht_store_entry_op_hash_for_store, SysOutcome::Accepted),
+        ])
+        .await
+        .unwrap();
 
     // check ops are now counted as ops to validate
     let ops_to_validate =
@@ -1013,10 +1093,26 @@ async fn app_validation_workflow_correctly_sets_state_and_status() {
     let dht_create_op_hashed = DhtOpHashed::from_content_sync(dht_create_op);
 
     // Insert op to validate in DHT DB and mark ready for app validation
+    let dht_create_op_hashed_for_store = dht_create_op_hashed.clone();
+    let dht_create_op_hash_for_store = dht_create_op_hash.clone();
     app_validation_workspace.dht_db.test_write(move |txn| {
         insert_op_dht(txn, &dht_create_op_hashed, 0, None).unwrap();
         put_validation_limbo(txn, &dht_create_op_hash, ValidationStage::SysValidated).unwrap();
     });
+    // Mirror into the new DhtStore so the workflow can read from it.
+    app_validation_workspace
+        .dht_store
+        .record_incoming_ops(vec![dht_create_op_hashed_for_store])
+        .await
+        .unwrap();
+    app_validation_workspace
+        .dht_store
+        .record_chain_op_sys_validation_outcomes(vec![(
+            dht_create_op_hash_for_store,
+            SysOutcome::Accepted,
+        )])
+        .await
+        .unwrap();
 
     // Check op is now counted as op to validate
     let ops_to_validate =

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -5,7 +5,6 @@ use crate::core::workflow::app_validation_workflow::{
     app_validation_workflow_inner, check_app_entry_def, put_validation_limbo,
     AppValidationWorkspace, OutcomeSummary,
 };
-use crate::core::workflow::sys_validation_workflow::validation_query;
 use crate::core::{SysValidationError, ValidationOutcome};
 use crate::sweettest::*;
 use crate::test_utils::{
@@ -93,11 +92,13 @@ async fn main_workflow() {
 
     // check there are no ops to app validate
     // genesis entries have already been validated at this stage
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 0);
 
     // create op that following delete op depends on
@@ -119,34 +120,27 @@ async fn main_workflow() {
     let dht_delete_op_hash = DhtOpHash::with_data_sync(&dht_delete_op);
     let dht_delete_op_hashed = DhtOpHashed::from_content_sync(dht_delete_op);
 
-    // insert op to validate in dht db and mark ready for app validation
-    let dht_delete_op_hashed_for_store = dht_delete_op_hashed.clone();
-    let dht_delete_op_hash_for_store = dht_delete_op_hash.clone();
-    app_validation_workspace.dht_db.test_write(move |txn| {
-        insert_op_dht(txn, &dht_delete_op_hashed, 0, None).unwrap();
-        put_validation_limbo(txn, &dht_delete_op_hash, ValidationStage::SysValidated).unwrap();
-    });
-    // Mirror into the new DhtStore so the workflow can read from it.
+    // Record the op into the new DhtStore as sys-validated and ready for app
+    // validation; the workflow reads ops to validate from the new store.
     app_validation_workspace
         .dht_store
-        .record_incoming_ops(vec![dht_delete_op_hashed_for_store])
+        .record_incoming_ops(vec![dht_delete_op_hashed])
         .await
         .unwrap();
     app_validation_workspace
         .dht_store
-        .record_chain_op_sys_validation_outcomes(vec![(
-            dht_delete_op_hash_for_store,
-            SysOutcome::Accepted,
-        )])
+        .record_chain_op_sys_validation_outcomes(vec![(dht_delete_op_hash, SysOutcome::Accepted)])
         .await
         .unwrap();
 
     // check delete op is now counted as op to validate
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 1);
 
     let mut hc_p2p = MockHcP2p::new();
@@ -191,11 +185,13 @@ async fn main_workflow() {
     });
 
     // there is still the 1 delete op to be validated
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 1);
 
     // run validation workflow
@@ -226,11 +222,13 @@ async fn main_workflow() {
     );
 
     // check ops to validate is 0 now after having been validated
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 0);
 }
 
@@ -325,21 +323,21 @@ async fn validate_ops_in_sequence_must_get_agent_activity() {
 
     // check there are no ops to app validate
     // genesis entries have already been validated at this stage
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 0);
 
-    // insert create and delete op in dht db and mark ready for app validation
-    let dht_delete_op_hashed_for_store = dht_delete_op_hashed.clone();
-    let dht_delete_op_hash_for_store = dht_delete_op_hash.clone();
+    // Record both ops into the new DhtStore as sys-validated. The create is
+    // also kept in the legacy DB because app validation of the delete resolves
+    // it as a dependency via the cascade, which reads the legacy DB.
     let dht_create_op_hashed_for_store = dht_create_op_hashed.clone();
     let dht_create_op_hash_for_store = dht_create_op_hashed.as_hash().clone();
     app_validation_workspace.dht_db.test_write(move |txn| {
-        insert_op_dht(txn, &dht_delete_op_hashed, 0, None).unwrap();
-        put_validation_limbo(txn, &dht_delete_op_hash, ValidationStage::SysValidated).unwrap();
         insert_op_dht(txn, &dht_create_op_hashed, 0, None).unwrap();
         put_validation_limbo(
             txn,
@@ -348,30 +346,28 @@ async fn validate_ops_in_sequence_must_get_agent_activity() {
         )
         .unwrap();
     });
-    // Mirror into the new DhtStore so the workflow can read from it.
     app_validation_workspace
         .dht_store
-        .record_incoming_ops(vec![
-            dht_delete_op_hashed_for_store,
-            dht_create_op_hashed_for_store,
-        ])
+        .record_incoming_ops(vec![dht_delete_op_hashed, dht_create_op_hashed_for_store])
         .await
         .unwrap();
     app_validation_workspace
         .dht_store
         .record_chain_op_sys_validation_outcomes(vec![
-            (dht_delete_op_hash_for_store, SysOutcome::Accepted),
+            (dht_delete_op_hash, SysOutcome::Accepted),
             (dht_create_op_hash_for_store, SysOutcome::Accepted),
         ])
         .await
         .unwrap();
 
     // check create and delete op are now counted as ops to validate
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 2);
 
     // run validation workflow
@@ -402,11 +398,13 @@ async fn validate_ops_in_sequence_must_get_agent_activity() {
     );
 
     // check ops to validate is also 0
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 0);
 }
 
@@ -467,11 +465,13 @@ async fn validate_ops_in_sequence_must_get_action() {
 
     // check there are no ops to app validate
     // genesis entries have already been validated at this stage
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 0);
 
     // create op that following delete op depends on
@@ -494,14 +494,12 @@ async fn validate_ops_in_sequence_must_get_action() {
     let dht_delete_op_hash = DhtOpHash::with_data_sync(&dht_delete_op);
     let dht_delete_op_hashed = DhtOpHashed::from_content_sync(dht_delete_op);
 
-    // insert create and delete op in dht db and mark ready for app validation
-    let dht_delete_op_hashed_for_store = dht_delete_op_hashed.clone();
-    let dht_delete_op_hash_for_store = dht_delete_op_hash.clone();
+    // Record both ops into the new DhtStore as sys-validated. The create is
+    // also kept in the legacy DB because app validation of the delete resolves
+    // it as a dependency via the cascade, which reads the legacy DB.
     let dht_create_op_hashed_for_store = dht_create_op_hashed.clone();
     let dht_create_op_hash_for_store = dht_create_op_hashed.as_hash().clone();
     app_validation_workspace.dht_db.test_write(move |txn| {
-        insert_op_dht(txn, &dht_delete_op_hashed, 0, None).unwrap();
-        put_validation_limbo(txn, &dht_delete_op_hash, ValidationStage::SysValidated).unwrap();
         insert_op_dht(txn, &dht_create_op_hashed, 0, None).unwrap();
         put_validation_limbo(
             txn,
@@ -510,30 +508,28 @@ async fn validate_ops_in_sequence_must_get_action() {
         )
         .unwrap();
     });
-    // Mirror into the new DhtStore so the workflow can read from it.
     app_validation_workspace
         .dht_store
-        .record_incoming_ops(vec![
-            dht_delete_op_hashed_for_store,
-            dht_create_op_hashed_for_store,
-        ])
+        .record_incoming_ops(vec![dht_delete_op_hashed, dht_create_op_hashed_for_store])
         .await
         .unwrap();
     app_validation_workspace
         .dht_store
         .record_chain_op_sys_validation_outcomes(vec![
-            (dht_delete_op_hash_for_store, SysOutcome::Accepted),
+            (dht_delete_op_hash, SysOutcome::Accepted),
             (dht_create_op_hash_for_store, SysOutcome::Accepted),
         ])
         .await
         .unwrap();
 
     // check create and delete op are now counted as ops to validate
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 2);
 
     // run validation workflow
@@ -564,11 +560,13 @@ async fn validate_ops_in_sequence_must_get_action() {
     );
 
     // check ops to validate is also 0
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 0);
 }
 
@@ -684,42 +682,31 @@ async fn handle_error_in_op_validation() {
     let dht_store_entry_op_hash = DhtOpHash::with_data_sync(&dht_store_entry_op);
     let dht_store_entry_op_hashed = DhtOpHashed::from_content_sync(dht_store_entry_op);
 
-    // insert both ops in dht db and mark ready for app validation
+    // Record both ops into the new DhtStore as sys-validated and ready for app
+    // validation.
     let expected_failed_dht_op_hash = dht_create_op_hash.clone();
-    let dht_create_op_hashed_for_store = dht_create_op_hashed.clone();
-    let dht_create_op_hash_for_store = dht_create_op_hash.clone();
-    let dht_store_entry_op_hashed_for_store = dht_store_entry_op_hashed.clone();
-    let dht_store_entry_op_hash_for_store = dht_store_entry_op_hash.clone();
-    app_validation_workspace.dht_db.test_write(move |txn| {
-        insert_op_dht(txn, &dht_create_op_hashed, 0, None).unwrap();
-        put_validation_limbo(txn, &dht_create_op_hash, ValidationStage::SysValidated).unwrap();
-        insert_op_dht(txn, &dht_store_entry_op_hashed, 0, None).unwrap();
-        put_validation_limbo(txn, &dht_store_entry_op_hash, ValidationStage::SysValidated).unwrap();
-    });
-    // Mirror into the new DhtStore so the workflow can read from it.
     app_validation_workspace
         .dht_store
-        .record_incoming_ops(vec![
-            dht_create_op_hashed_for_store,
-            dht_store_entry_op_hashed_for_store,
-        ])
+        .record_incoming_ops(vec![dht_create_op_hashed, dht_store_entry_op_hashed])
         .await
         .unwrap();
     app_validation_workspace
         .dht_store
         .record_chain_op_sys_validation_outcomes(vec![
-            (dht_create_op_hash_for_store, SysOutcome::Accepted),
-            (dht_store_entry_op_hash_for_store, SysOutcome::Accepted),
+            (dht_create_op_hash, SysOutcome::Accepted),
+            (dht_store_entry_op_hash, SysOutcome::Accepted),
         ])
         .await
         .unwrap();
 
     // check ops are now counted as ops to validate
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 2);
 
     // running validation workflow should finish without errors
@@ -752,11 +739,13 @@ async fn handle_error_in_op_validation() {
         } if actual_failed == expected_failed
     );
 
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 1);
 }
 
@@ -1070,11 +1059,13 @@ async fn app_validation_workflow_correctly_sets_state_and_status() {
     ));
 
     // Check there are no ops to app validate as genesis entries should have already been validated
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 0);
 
     // Create op to validate
@@ -1115,11 +1106,13 @@ async fn app_validation_workflow_correctly_sets_state_and_status() {
         .unwrap();
 
     // Check op is now counted as op to validate
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 1);
 
     // Check that genesis ops are currently validated and integrated
@@ -1157,11 +1150,13 @@ async fn app_validation_workflow_correctly_sets_state_and_status() {
     );
 
     // There should be no more ops to validate
-    let ops_to_validate =
-        validation_query::get_ops_to_app_validate(&app_validation_workspace.dht_db)
-            .await
-            .unwrap()
-            .len();
+    let ops_to_validate = app_validation_workspace
+        .dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap()
+        .len();
     assert_eq!(ops_to_validate, 0);
 
     // The op should be marked as valid but not integrated.

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
@@ -200,13 +200,9 @@ pub async fn incoming_dht_ops_workflow(
                         let ops_to_mirror = pending_ops.lock().drain(..).collect::<Vec<_>>();
                         if ops_to_mirror.is_empty() {
                             mirror_ok = true;
-                        } else if let Err(err) =
-                            dht_store.record_incoming_ops(ops_to_mirror).await
+                        } else if let Err(err) = dht_store.record_incoming_ops(ops_to_mirror).await
                         {
-                            tracing::error!(
-                                ?err,
-                                "incoming_dht_ops_workflow new-DB mirror error"
-                            );
+                            tracing::error!(?err, "incoming_dht_ops_workflow new-DB mirror error");
                         } else {
                             mirror_ok = true;
                         }

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
@@ -172,6 +172,7 @@ pub async fn incoming_dht_ops_workflow(
                     // into DhtStore after the legacy txn commits.
                     let pending_ops = Arc::new(parking_lot::Mutex::new(Vec::new()));
                     let pending_ops2 = pending_ops.clone();
+                    let mut mirror_ok = false;
                     if let Err(err) = dht_db
                         .write_async(move |txn| {
                             for entry in entries {
@@ -193,16 +194,21 @@ pub async fn incoming_dht_ops_workflow(
                         tracing::error!(?err, "incoming_dht_ops_workflow error");
                     } else {
                         // Mirror the committed ops into the new DHT DB.
-                        // Errors are logged rather than propagated because this code runs inside
-                        // a spawned task that has no caller to return a WorkflowResult to.
+                        // sys-validation now reads from the new DB, so the
+                        // trigger below is only meaningful once the mirror
+                        // succeeds.
                         let ops_to_mirror = pending_ops.lock().drain(..).collect::<Vec<_>>();
-                        if !ops_to_mirror.is_empty() {
-                            if let Err(err) = dht_store.record_incoming_ops(ops_to_mirror).await {
-                                tracing::error!(
-                                    ?err,
-                                    "incoming_dht_ops_workflow new-DB mirror error"
-                                );
-                            }
+                        if ops_to_mirror.is_empty() {
+                            mirror_ok = true;
+                        } else if let Err(err) =
+                            dht_store.record_incoming_ops(ops_to_mirror).await
+                        {
+                            tracing::error!(
+                                ?err,
+                                "incoming_dht_ops_workflow new-DB mirror error"
+                            );
+                        } else {
+                            mirror_ok = true;
                         }
                     }
 
@@ -210,11 +216,15 @@ pub async fn incoming_dht_ops_workflow(
                         let _ = snd.send(res);
                     }
 
-                    // trigger validation of queued ops
-                    tracing::debug!(
-                        "Incoming dht ops workflow is now triggering the sys_validation_trigger"
-                    );
-                    sys_validation_trigger.trigger(&"incoming_dht_ops_workflow");
+                    // trigger validation of queued ops only when the new-DB
+                    // mirror succeeded — sys-validation reads from the new
+                    // DB and would find no ops to process otherwise.
+                    if mirror_ok {
+                        tracing::debug!(
+                            "Incoming dht ops workflow is now triggering the sys_validation_trigger"
+                        );
+                        sys_validation_trigger.trigger(&"incoming_dht_ops_workflow");
+                    }
 
                     maybe_batch = incoming_ops_batch.check_end();
                 }

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
@@ -67,6 +67,9 @@ impl Drop for OpsClaim {
     }
 }
 
+// TODO(read-migration): once legacy DhtOp writes are removed, switch
+// this intra-transaction dedup to rely on the new DhtStore. For now
+// it remains on the legacy txn to preserve same-transaction semantics.
 #[cfg_attr(feature = "instrument", tracing::instrument(skip(txn, ops)))]
 fn batch_process_entry(
     txn: &mut Txn<DbKindDht>,
@@ -139,8 +142,12 @@ pub async fn incoming_dht_ops_workflow(
         }
     }
 
-    // Filter the list of ops to only include those that are not already in the database.
-    filter_ops = filter_existing_ops(&dht_db, filter_ops).await?;
+    // Filter the list of ops to only include those that are not already in the new DHT store.
+    filter_ops = dht_store
+        .as_read()
+        .filter_existing_ops(filter_ops)
+        .await
+        .map_err(super::error::WorkflowError::from)?;
 
     // Check again whether everything has been filtered out and avoid launching a Tokio task if so
     if filter_ops.is_empty() {
@@ -271,17 +278,5 @@ fn op_exists_inner(txn: &rusqlite::Transaction<'_>, hash: &DhtOpHash) -> Databas
 pub async fn op_exists(vault: &DbWrite<DbKindDht>, hash: DhtOpHash) -> DatabaseResult<bool> {
     vault
         .read_async(move |txn| op_exists_inner(txn, &hash))
-        .await
-}
-
-pub async fn filter_existing_ops(
-    vault: &DbWrite<DbKindDht>,
-    mut ops: Vec<DhtOpHashed>,
-) -> DatabaseResult<Vec<DhtOpHashed>> {
-    vault
-        .read_async(move |txn| {
-            ops.retain(|op| !op_exists_inner(txn, &op.hash).unwrap_or(true));
-            Ok(ops)
-        })
         .await
 }

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
@@ -150,6 +150,13 @@ pub async fn incoming_dht_ops_workflow(
     // mirror could never catch up (and vice versa). Each write path below
     // deduplicates against its own store, so both stores self-heal.
     if filter_ops.is_empty() {
+        // TODO(read-migration): restore this trace once dedup-filtering moves
+        // onto the new DhtStore (after the legacy DhtOp table is removed). At
+        // that point an empty `filter_ops` again means "all ops were already
+        // present", which is worth tracing.
+        // tracing::trace!(
+        //     "Skipping the rest of the incoming_dht_ops_workflow because all ops were filtered out"
+        // );
         return Ok(());
     }
 

--- a/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/incoming_dht_ops_workflow.rs
@@ -142,18 +142,14 @@ pub async fn incoming_dht_ops_workflow(
         }
     }
 
-    // Filter the list of ops to only include those that are not already in the new DHT store.
-    filter_ops = dht_store
-        .as_read()
-        .filter_existing_ops(filter_ops)
-        .await
-        .map_err(super::error::WorkflowError::from)?;
-
-    // Check again whether everything has been filtered out and avoid launching a Tokio task if so
+    // Do not pre-filter against the new store here. The legacy DHT table and
+    // the new store deduplicate independently, so an op present in one but
+    // missing from the other must still be written to the other; filtering up
+    // front against only the new store would let an op that is in the new store
+    // but missing from the legacy table be skipped forever, so the legacy
+    // mirror could never catch up (and vice versa). Each write path below
+    // deduplicates against its own store, so both stores self-heal.
     if filter_ops.is_empty() {
-        tracing::trace!(
-            "Skipping the rest of the incoming_dht_ops_workflow because all ops were filtered out"
-        );
         return Ok(());
     }
 
@@ -168,43 +164,53 @@ pub async fn incoming_dht_ops_workflow(
                 while let Some(entries) = maybe_batch {
                     let senders = Arc::new(parking_lot::Mutex::new(Vec::new()));
                     let senders2 = senders.clone();
-                    // Collect ops actually inserted (post-dedupe) so we can mirror them
-                    // into DhtStore after the legacy txn commits.
-                    let pending_ops = Arc::new(parking_lot::Mutex::new(Vec::new()));
-                    let pending_ops2 = pending_ops.clone();
-                    let mut mirror_ok = false;
-                    if let Err(err) = dht_db
+
+                    // All ops received in this batch, written to both stores.
+                    let batch_ops: Vec<DhtOpHashed> =
+                        entries.iter().flat_map(|e| e.ops.iter().cloned()).collect();
+
+                    // Legacy DHT table — still read by the cascade for
+                    // dependency resolution. `batch_process_entry` skips ops
+                    // already in the table, so this is a safe backfill.
+                    let legacy_result = dht_db
                         .write_async(move |txn| {
                             for entry in entries {
                                 let InOpBatchEntry { snd, ops } = entry;
                                 let res = batch_process_entry(txn, ops);
-
-                                // we can't send the results here...
-                                // we haven't committed
-                                if let Ok(ref inserted) = res {
-                                    pending_ops2.lock().extend(inserted.iter().cloned());
-                                }
                                 senders2.lock().push((snd, res.map(|_| ())));
                             }
 
                             WorkflowResult::Ok(())
                         })
-                        .await
-                    {
-                        tracing::error!(?err, "incoming_dht_ops_workflow error");
+                        .await;
+
+                    // New DHT store — read by sys-validation. Skip ops already
+                    // present anywhere in the store so integrated ops are not
+                    // re-added to limbo, then record the genuinely new ops.
+                    // Gate this on the legacy write succeeding: if legacy failed
+                    // we leave the ops un-stored so they are redelivered, rather
+                    // than recording them only in the new store (which would be a
+                    // permanent mirror gap, since gossip would then consider us
+                    // to already hold them).
+                    let mut recorded_new = false;
+                    if let Err(err) = legacy_result {
+                        tracing::error!(?err, "incoming_dht_ops_workflow legacy mirror error");
                     } else {
-                        // Mirror the committed ops into the new DHT DB.
-                        // sys-validation now reads from the new DB, so the
-                        // trigger below is only meaningful once the mirror
-                        // succeeds.
-                        let ops_to_mirror = pending_ops.lock().drain(..).collect::<Vec<_>>();
-                        if ops_to_mirror.is_empty() {
-                            mirror_ok = true;
-                        } else if let Err(err) = dht_store.record_incoming_ops(ops_to_mirror).await
-                        {
-                            tracing::error!(?err, "incoming_dht_ops_workflow new-DB mirror error");
-                        } else {
-                            mirror_ok = true;
+                        match dht_store.as_read().filter_existing_ops(batch_ops).await {
+                            Ok(new_ops) if new_ops.is_empty() => {}
+                            Ok(new_ops) => match dht_store.record_incoming_ops(new_ops).await {
+                                Ok(()) => recorded_new = true,
+                                Err(err) => tracing::error!(
+                                    ?err,
+                                    "incoming_dht_ops_workflow new-DB write error"
+                                ),
+                            },
+                            Err(err) => {
+                                tracing::error!(
+                                    ?err,
+                                    "incoming_dht_ops_workflow new-DB filter error"
+                                )
+                            }
                         }
                     }
 
@@ -212,10 +218,9 @@ pub async fn incoming_dht_ops_workflow(
                         let _ = snd.send(res);
                     }
 
-                    // trigger validation of queued ops only when the new-DB
-                    // mirror succeeded — sys-validation reads from the new
-                    // DB and would find no ops to process otherwise.
-                    if mirror_ok {
+                    // sys-validation reads the new store, so only trigger when
+                    // genuinely new ops were recorded there.
+                    if recorded_new {
                         tracing::debug!(
                             "Incoming dht ops workflow is now triggering the sys_validation_trigger"
                         );

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -8,6 +8,8 @@ use crate::core::queue_consumer::TriggerSender;
 use crate::core::queue_consumer::WorkComplete;
 use holo_hash::{AgentPubKey, DhtOpHash, DnaHash};
 use holochain_p2p::DynHolochainP2pDna;
+use holochain_sqlite::db::DbKindDht;
+use holochain_sqlite::prelude::DbWrite;
 use holochain_state::dht_store::DhtStore;
 use holochain_state::prelude::*;
 use holochain_zome_types::dht_v2::OpValidity;
@@ -21,6 +23,7 @@ mod tests;
 #[cfg_attr(
     feature = "instrument",
     tracing::instrument(skip(
+        vault,
         dht_store,
         trigger_receipt,
         network,
@@ -29,6 +32,7 @@ mod tests;
     ))
 )]
 pub async fn integrate_dht_ops_workflow(
+    vault: DbWrite<DbKindDht>,
     dht_store: DhtStore,
     trigger_receipt: TriggerSender,
     network: DynHolochainP2pDna,
@@ -44,6 +48,23 @@ pub async fn integrate_dht_ops_workflow(
         .integrate_ready_ops(when_integrated)
         .await
         .map_err(WorkflowError::from)?;
+
+    // Dual-write: mark all awaiting-integration ops in the legacy DhtOp table
+    // so legacy readers (tests, integration dumps) see consistent state during
+    // the read-migration window. This mirrors the former
+    // SET_VALIDATED_OPS_TO_INTEGRATED SQL and covers both network-received ops
+    // (which flow through the new DhtStore's limbo pathway) and locally-authored
+    // ops (genesis, call_zome) which are inserted into the legacy DB as
+    // validation_stage=3 but directly into the new DB as already-integrated.
+    // This will be removed once the legacy DhtOp table is retired.
+    let legacy_marked = vault
+        .write_async(move |txn| -> StateMutationResult<usize> {
+            holochain_state::mutations::set_all_awaiting_integration_to_integrated(
+                txn,
+                when_integrated,
+            )
+        })
+        .await?;
 
     let changed = summaries.len();
     let ops_ps = changed as f64 / start.elapsed().as_micros() as f64 * 1_000_000.0;
@@ -156,6 +177,10 @@ pub async fn integrate_dht_ops_workflow(
         }
 
         trigger_receipt.trigger(&"integrate_dht_ops_workflow");
+        Ok(WorkComplete::Incomplete(None))
+    } else if legacy_marked > 0 {
+        // New-DB had nothing to integrate, but legacy ops were marked.
+        // Loop so any further legacy stragglers are caught before yielding.
         Ok(WorkComplete::Incomplete(None))
     } else {
         Ok(WorkComplete::Complete)

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -8,9 +8,9 @@ use crate::core::queue_consumer::TriggerSender;
 use crate::core::queue_consumer::WorkComplete;
 use holo_hash::{AgentPubKey, DhtOpHash, DnaHash};
 use holochain_p2p::DynHolochainP2pDna;
-use holochain_sqlite::sql::sql_cell::*;
 use holochain_state::dht_store::DhtStore;
 use holochain_state::prelude::*;
+use holochain_zome_types::dht_v2::OpValidity;
 use kitsune2_api::StoredOp;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -21,7 +21,6 @@ mod tests;
 #[cfg_attr(
     feature = "instrument",
     tracing::instrument(skip(
-        vault,
         dht_store,
         trigger_receipt,
         network,
@@ -30,7 +29,6 @@ mod tests;
     ))
 )]
 pub async fn integrate_dht_ops_workflow(
-    vault: DbWrite<DbKindDht>,
     dht_store: DhtStore,
     trigger_receipt: TriggerSender,
     network: DynHolochainP2pDna,
@@ -41,112 +39,53 @@ pub async fn integrate_dht_ops_workflow(
 ) -> WorkflowResult<WorkComplete> {
     let start = std::time::Instant::now();
     let when_integrated = Timestamp::now();
-    let (stored_ops, block_agents, integrated_pairs, when_stored_times, validation_attempts) =
-        vault
-            .write_async(move |txn| {
-                let mut stored_ops = Vec::new();
-                let mut block_agents = Vec::new();
-                let mut integrated_pairs: Vec<(DhtOpHash, Option<AgentPubKey>)> = Vec::new();
-                let mut when_stored_times: Vec<Option<Timestamp>> = Vec::new();
-                let mut validation_attempts: Vec<Option<u32>> = Vec::new();
-                let mut stmt = txn.prepare_cached(SET_VALIDATED_OPS_TO_INTEGRATED)?;
-                let integrated_ops = stmt.query_map(
-                    named_params! {
-                        ":when_integrated": when_integrated,
-                    },
-                    |row| {
-                        let op_hash = row.get::<_, DhtOpHash>(0)?;
-                        let op_basis = row.get::<_, OpBasis>(1)?;
-                        let created_at = row.get::<_, Timestamp>(2)?;
-                        let stored_op = StoredOp {
-                            created_at: kitsune2_api::Timestamp::from_micros(
-                                created_at.as_micros(),
-                            ),
-                            op_id: op_hash.to_located_k2_op_id(&op_basis),
-                        };
-                        let validation_status = row.get::<_, ValidationStatus>(3)?;
-                        let when_stored = row.get::<_, Option<Timestamp>>(4)?;
-                        let num_validation_attempts = row.get::<_, Option<u32>>(5)?;
-                        let action_author = row.get::<_, Option<AgentPubKey>>(6)?;
-                        let warrant_author = row.get::<_, Option<AgentPubKey>>(7)?;
-                        let warrantee = row.get::<_, Option<AgentPubKey>>(8)?;
-                        if let Some(ref warrantee) = warrantee {
-                            let Some(ref warrant_author) = warrant_author else {
-                                tracing::warn!(
-                                    ?op_hash,
-                                    "Warrant missing author while integrating"
-                                );
-                                return Ok((
-                                    stored_op,
-                                    op_hash,
-                                    action_author,
-                                    when_stored,
-                                    num_validation_attempts,
-                                ));
-                            };
 
-                            let op_clone_for_block = op_hash.clone();
-                            match validation_status {
-                                ValidationStatus::Valid => {
-                                    tracing::info!(
-                                        ?warrantee,
-                                        ?op_hash,
-                                        "Warrant op is valid, will block the warrantee"
-                                    );
-                                    block_agents.push((warrantee.clone(), op_clone_for_block));
-                                }
-                                ValidationStatus::Rejected => {
-                                    tracing::info!(
-                                        ?warrant_author,
-                                        ?op_hash,
-                                        "Warrant op is invalid, will block the author"
-                                    );
-                                    block_agents.push((warrant_author.clone(), op_clone_for_block));
-                                }
-                                _ => {
-                                    tracing::warn!(
-                                        ?validation_status,
-                                        ?op_hash,
-                                        "Unexpected validation status for op being integrated"
-                                    );
-                                }
-                            }
-                        }
+    let summaries = dht_store
+        .integrate_ready_ops(when_integrated)
+        .await
+        .map_err(WorkflowError::from)?;
 
-                        Ok((
-                            stored_op,
-                            op_hash,
-                            action_author,
-                            when_stored,
-                            num_validation_attempts,
-                        ))
-                    },
-                )?;
-                for integrated_op in integrated_ops {
-                    let (stored_op, op_hash, author, when_stored, num_attempts) = integrated_op?;
-                    stored_ops.push(stored_op);
-                    integrated_pairs.push((op_hash, author));
-                    when_stored_times.push(when_stored);
-                    validation_attempts.push(num_attempts);
-                }
-
-                WorkflowResult::Ok((
-                    stored_ops,
-                    block_agents,
-                    integrated_pairs,
-                    when_stored_times,
-                    validation_attempts,
-                ))
-            })
-            .await?;
-    let new_promoted_result = dht_store.integrate_ready_ops(when_integrated).await;
-    let changed = stored_ops.len();
+    let changed = summaries.len();
     let ops_ps = changed as f64 / start.elapsed().as_micros() as f64 * 1_000_000.0;
     tracing::debug!(?changed, %ops_ps, "ops integrated");
     let dna_hash = network.dna_hash().clone();
+    let dna_hash_str = dna_hash.to_string();
+
+    let mut stored_ops: Vec<StoredOp> = Vec::with_capacity(summaries.len());
+    let mut block_agents: Vec<(AgentPubKey, DhtOpHash)> = Vec::new();
+    let mut integrated_pairs: Vec<(DhtOpHash, Option<AgentPubKey>)> =
+        Vec::with_capacity(summaries.len());
+
+    for s in &summaries {
+        stored_ops.push(StoredOp {
+            created_at: kitsune2_api::Timestamp::from_micros(s.authored_timestamp.as_micros()),
+            op_id: s.op_hash.to_located_k2_op_id(&s.basis_hash),
+        });
+        integrated_pairs.push((s.op_hash.clone(), s.action_author.clone()));
+
+        if let (Some(warrantee), Some(warrant_author)) = (&s.warrantee, &s.warrant_author) {
+            match s.validation_status {
+                OpValidity::Accepted => {
+                    tracing::info!(
+                        ?warrantee,
+                        op_hash = ?s.op_hash,
+                        "Warrant op is valid, will block the warrantee"
+                    );
+                    block_agents.push((warrantee.clone(), s.op_hash.clone()));
+                }
+                OpValidity::Rejected => {
+                    tracing::info!(
+                        ?warrant_author,
+                        op_hash = ?s.op_hash,
+                        "Warrant op is invalid, will block the author"
+                    );
+                    block_agents.push((warrant_author.clone(), s.op_hash.clone()));
+                }
+            }
+        }
+    }
 
     // Record integrated ops metric.
-    let dna_hash_str = dna_hash.to_string();
     workflow_integrated_op_metric().add(
         changed as u64,
         &[opentelemetry::KeyValue::new(
@@ -156,38 +95,30 @@ pub async fn integrate_dht_ops_workflow(
     );
 
     // Record op integration delay metric.
-    let metric = op_integration_delay_metric();
-    when_stored_times
-        .into_iter()
-        // discard None values
-        .flatten()
-        .for_each(|when_stored| {
-            let delay_secs =
-                (when_integrated.as_micros() - when_stored.as_micros()).max(0) as f64 / 1_000_000.0;
-            metric.record(
-                delay_secs,
-                &[opentelemetry::KeyValue::new(
-                    "dna_hash",
-                    dna_hash_str.clone(),
-                )],
-            );
-        });
+    let delay_metric = op_integration_delay_metric();
+    for s in &summaries {
+        let delay_secs =
+            (when_integrated.as_micros() - s.when_received.as_micros()).max(0) as f64 / 1_000_000.0;
+        delay_metric.record(
+            delay_secs,
+            &[opentelemetry::KeyValue::new(
+                "dna_hash",
+                dna_hash_str.clone(),
+            )],
+        );
+    }
 
     // Record op validation attempts metric.
-    let metric = op_validation_attempts_metric();
-    validation_attempts
-        .into_iter()
-        // discard None values
-        .flatten()
-        .for_each(|attempts| {
-            metric.record(
-                attempts as u64,
-                &[opentelemetry::KeyValue::new(
-                    "dna_hash",
-                    dna_hash_str.clone(),
-                )],
-            );
-        });
+    let attempts_metric = op_validation_attempts_metric();
+    for s in &summaries {
+        attempts_metric.record(
+            s.validation_attempts as u64,
+            &[opentelemetry::KeyValue::new(
+                "dna_hash",
+                dna_hash_str.clone(),
+            )],
+        );
+    }
 
     if changed > 0 {
         network.new_integrated_data(stored_ops).await?;
@@ -205,7 +136,6 @@ pub async fn integrate_dht_ops_workflow(
         match InclusiveTimestampInterval::try_new(Timestamp::now(), Timestamp::max()) {
             Ok(interval) => {
                 for (block_agent, invalid_op_hash) in block_agents {
-                    // Block agent
                     if let Err(err) = network
                         .block(Block::new(
                             BlockTarget::Cell(
@@ -226,10 +156,8 @@ pub async fn integrate_dht_ops_workflow(
         }
 
         trigger_receipt.trigger(&"integrate_dht_ops_workflow");
-        new_promoted_result.map_err(WorkflowError::from)?;
         Ok(WorkComplete::Incomplete(None))
     } else {
-        new_promoted_result.map_err(WorkflowError::from)?;
         Ok(WorkComplete::Complete)
     }
 }

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -57,16 +57,19 @@ pub async fn integrate_dht_ops_workflow(
     // ops (genesis, call_zome) which are inserted into the legacy DB as
     // validation_stage=3 but directly into the new DB as already-integrated.
     // This will be removed once the legacy DhtOp table is retired.
-    let legacy_marked = vault
-        .write_async(move |txn| -> StateMutationResult<usize> {
-            holochain_state::mutations::set_all_awaiting_integration_to_integrated(
-                txn,
-                when_integrated,
-            )
-        })
+    let legacy_marked_pairs: Vec<(DhtOpHash, Option<AgentPubKey>)> = vault
+        .write_async(
+            move |txn| -> StateMutationResult<Vec<(DhtOpHash, Option<AgentPubKey>)>> {
+                holochain_state::mutations::set_all_awaiting_integration_to_integrated(
+                    txn,
+                    when_integrated,
+                )
+            },
+        )
         .await?;
 
     let changed = summaries.len();
+    let legacy_marked = legacy_marked_pairs.len();
     let ops_ps = changed as f64 / start.elapsed().as_micros() as f64 * 1_000_000.0;
     tracing::debug!(?changed, %ops_ps, "ops integrated");
     let dna_hash = network.dna_hash().clone();
@@ -74,7 +77,8 @@ pub async fn integrate_dht_ops_workflow(
 
     let mut stored_ops: Vec<StoredOp> = Vec::with_capacity(summaries.len());
     let mut block_agents: Vec<(AgentPubKey, DhtOpHash)> = Vec::new();
-    let mut integrated_pairs: Vec<(DhtOpHash, Option<AgentPubKey>)> =
+    // Pairs from the new-DB summaries (network-received ops that went through limbo).
+    let mut new_db_pairs: Vec<(DhtOpHash, Option<AgentPubKey>)> =
         Vec::with_capacity(summaries.len());
 
     for s in &summaries {
@@ -82,7 +86,7 @@ pub async fn integrate_dht_ops_workflow(
             created_at: kitsune2_api::Timestamp::from_micros(s.authored_timestamp.as_micros()),
             op_id: s.op_hash.to_located_k2_op_id(&s.basis_hash),
         });
-        integrated_pairs.push((s.op_hash.clone(), s.action_author.clone()));
+        new_db_pairs.push((s.op_hash.clone(), s.action_author.clone()));
 
         if let (Some(warrantee), Some(warrant_author)) = (&s.warrantee, &s.warrant_author) {
             match s.validation_status {
@@ -141,46 +145,54 @@ pub async fn integrate_dht_ops_workflow(
         );
     }
 
-    if changed > 0 {
-        network.new_integrated_data(stored_ops).await?;
+    if changed > 0 || legacy_marked > 0 {
+        // Combine new-DB pairs with legacy-only pairs (e.g. locally-authored ops
+        // that bypassed LimboChainOp). Deduplicate in case an op appears in both.
+        let mut seen = std::collections::HashSet::new();
+        let all_integrated_pairs: Vec<(DhtOpHash, Option<AgentPubKey>)> = new_db_pairs
+            .into_iter()
+            .chain(legacy_marked_pairs)
+            .filter(|(h, _)| seen.insert(h.clone()))
+            .collect();
 
         update_local_authored_status(
             authored_db_provider.clone(),
             publish_trigger_provider,
             &dna_hash,
             when_integrated,
-            integrated_pairs,
+            all_integrated_pairs,
         )
         .await?;
 
-        // Block agents warranted for invalid ops.
-        match InclusiveTimestampInterval::try_new(Timestamp::now(), Timestamp::max()) {
-            Ok(interval) => {
-                for (block_agent, invalid_op_hash) in block_agents {
-                    if let Err(err) = network
-                        .block(Block::new(
-                            BlockTarget::Cell(
-                                CellId::new(network.dna_hash(), block_agent),
-                                CellBlockReason::InvalidOp(invalid_op_hash),
-                            ),
-                            interval.clone(),
-                        ))
-                        .await
-                    {
-                        tracing::warn!(?err, "Error blocking agent");
+        if changed > 0 {
+            network.new_integrated_data(stored_ops).await?;
+
+            // Block agents warranted for invalid ops.
+            match InclusiveTimestampInterval::try_new(Timestamp::now(), Timestamp::max()) {
+                Ok(interval) => {
+                    for (block_agent, invalid_op_hash) in block_agents {
+                        if let Err(err) = network
+                            .block(Block::new(
+                                BlockTarget::Cell(
+                                    CellId::new(network.dna_hash(), block_agent),
+                                    CellBlockReason::InvalidOp(invalid_op_hash),
+                                ),
+                                interval.clone(),
+                            ))
+                            .await
+                        {
+                            tracing::warn!(?err, "Error blocking agent");
+                        }
                     }
                 }
+                Err(err) => {
+                    tracing::error!(?err, "Invalid interval when blocking agents")
+                }
             }
-            Err(err) => {
-                tracing::error!(?err, "Invalid interval when blocking agents")
-            }
+
+            trigger_receipt.trigger(&"integrate_dht_ops_workflow");
         }
 
-        trigger_receipt.trigger(&"integrate_dht_ops_workflow");
-        Ok(WorkComplete::Incomplete(None))
-    } else if legacy_marked > 0 {
-        // New-DB had nothing to integrate, but legacy ops were marked.
-        // Loop so any further legacy stragglers are caught before yielding.
         Ok(WorkComplete::Incomplete(None))
     } else {
         Ok(WorkComplete::Complete)

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow.rs
@@ -44,10 +44,7 @@ pub async fn integrate_dht_ops_workflow(
     let start = std::time::Instant::now();
     let when_integrated = Timestamp::now();
 
-    let summaries = dht_store
-        .integrate_ready_ops(when_integrated)
-        .await
-        .map_err(WorkflowError::from)?;
+    let summaries = dht_store.integrate_ready_ops(when_integrated).await?;
 
     // Dual-write: mark all awaiting-integration ops in the legacy DhtOp table
     // so legacy readers (tests, integration dumps) see consistent state during
@@ -221,8 +218,7 @@ async fn update_local_authored_status(
     for (author, op_hashes) in by_author {
         let Some(db) = authored_db_provider
             .get_authored_db(dna_hash, &author)
-            .await
-            .map_err(WorkflowError::from)?
+            .await?
         else {
             continue;
         };

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
@@ -572,6 +572,9 @@ fn mock_publish_trigger_provider_with_triggers(
         if has_trigger {
             let (tx, _rx) = TriggerSender::new();
             let count = trigger_count_clone.clone();
+            // When trigger is called, increment the counter.
+            // Note: In reality we'd hook into the actual trigger, but for
+            // testing we just track that get_publish_trigger was called.
             count.fetch_add(1, Ordering::SeqCst);
             MustBoxFuture::new(async move { Some(tx) })
         } else {

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
@@ -8,1009 +8,32 @@ use holo_hash::{AgentPubKey, DhtOpHash, DnaHash};
 use holochain_p2p::MockHolochainP2pDnaT;
 use holochain_sqlite::db::DbKindAuthored;
 use holochain_sqlite::error::{DatabaseError, DatabaseResult};
+use holochain_state::dht_store::DhtStore;
 use holochain_state::mutations;
-use holochain_state::query::link::{GetLinksFilter, GetLinksQuery};
-use holochain_state::test_utils::{
-    test_authored_db_with_id, test_dht_db, test_dht_db_with_dna_hash, test_dht_store, TestDb,
-};
-use holochain_state::validation_db::ValidationStage;
-use holochain_types::prelude::{ChainOp, DhtOp, DhtOpHashed, Signature};
+use holochain_state::prelude::SysOutcome;
+use holochain_state::test_utils::{test_authored_db_with_id, test_dht_store, TestDb};
+use holochain_types::prelude::{ChainOp, DhtOp, DhtOpHashed};
 use kitsune2_api::StoredOp;
 use must_future::MustBoxFuture;
-use rusqlite::{named_params, OptionalExtension};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-#[derive(Clone)]
-struct TestData {
-    signature: Signature,
-    original_entry: Entry,
-    new_entry: Entry,
-    entry_update_action: Update,
-    entry_update_entry: Update,
-    original_action_hash: ActionHash,
-    original_entry_hash: EntryHash,
-    original_action: NewEntryAction,
-    entry_delete: Delete,
-    link_add: CreateLink,
-    link_remove: DeleteLink,
-}
-
-impl TestData {
-    fn new() -> Self {
-        // original entry
-        let original_entry = EntryFixturator::new(AppEntry).next().unwrap();
-        // New entry
-        let new_entry = EntryFixturator::new(AppEntry).next().unwrap();
-        Self::new_inner(original_entry, new_entry)
-    }
-
-    #[cfg_attr(feature = "instrument", tracing::instrument())]
-    fn new_inner(original_entry: Entry, new_entry: Entry) -> Self {
-        // original entry
-        let original_entry_hash =
-            EntryHashed::from_content_sync(original_entry.clone()).into_hash();
-
-        // New entry
-        let new_entry_hash = EntryHashed::from_content_sync(new_entry.clone()).into_hash();
-
-        // Original entry and action for updates
-        let mut original_action = fixt!(NewEntryAction, PublicCurve);
-        tracing::debug!(?original_action);
-
-        match &mut original_action {
-            NewEntryAction::Create(c) => c.entry_hash = original_entry_hash.clone(),
-            NewEntryAction::Update(u) => u.entry_hash = original_entry_hash.clone(),
-        }
-
-        let original_action_hash =
-            ActionHashed::from_content_sync(original_action.clone()).into_hash();
-
-        // Action for the new entry
-        let mut new_entry_action = fixt!(NewEntryAction, PublicCurve);
-
-        // Update to new entry
-        match &mut new_entry_action {
-            NewEntryAction::Create(c) => c.entry_hash = new_entry_hash.clone(),
-            NewEntryAction::Update(u) => u.entry_hash = new_entry_hash.clone(),
-        }
-
-        // Entry update for action
-        let mut entry_update_action = fixt!(Update, PublicCurve);
-        entry_update_action.entry_hash = new_entry_hash.clone();
-        entry_update_action.original_action_address = original_action_hash.clone();
-
-        // Entry update for entry
-        let mut entry_update_entry = fixt!(Update, PublicCurve);
-        entry_update_entry.entry_hash = new_entry_hash.clone();
-        entry_update_entry.original_entry_address = original_entry_hash.clone();
-        entry_update_entry.original_action_address = original_action_hash.clone();
-
-        // Entry delete
-        let mut entry_delete = fixt!(Delete);
-        entry_delete.deletes_address = original_action_hash.clone();
-
-        // Link add
-        let mut link_add = fixt!(CreateLink);
-        link_add.base_address = original_entry_hash.clone().into();
-        link_add.target_address = new_entry_hash.clone().into();
-        link_add.tag = fixt!(LinkTag);
-
-        let link_add_hash = ActionHashed::from_content_sync(link_add.clone()).into_hash();
-
-        // Link remove
-        let mut link_remove = fixt!(DeleteLink);
-        link_remove.base_address = original_entry_hash.clone().into();
-        link_remove.link_add_address = link_add_hash.clone();
-
-        // Any Action
-        let mut any_action = fixt!(Action, PublicCurve);
-        match &mut any_action {
-            Action::Create(ec) => {
-                ec.entry_hash = original_entry_hash.clone();
-            }
-            Action::Update(eu) => {
-                eu.entry_hash = original_entry_hash.clone();
-            }
-            _ => {}
-        };
-
-        Self {
-            signature: fixt!(Signature),
-            original_entry,
-            new_entry,
-            entry_update_action,
-            entry_update_entry,
-            original_action,
-            original_action_hash,
-            original_entry_hash,
-            entry_delete,
-            link_add,
-            link_remove,
-        }
-    }
-}
-
-#[derive(Clone)]
-enum Db {
-    Integrated(DhtOp),
-    IntQueue(DhtOp),
-    IntQueueEmpty,
-    ValidateQueue(DhtOp),
-    MetaActivity(Action),
-    MetaUpdate(AnyDhtHash, Action),
-    MetaDelete(ActionHash, Action),
-    MetaLinkEmpty(CreateLink),
-}
-
-impl Db {
-    /// Checks that the database is in a state
-    #[cfg_attr(feature = "instrument", tracing::instrument(skip(expects, env)))]
-    async fn check(expects: Vec<Self>, env: DbWrite<DbKindDht>, here: String) {
-        env.read_async(move |txn| -> DatabaseResult<()> {
-            for expect in expects {
-                match expect {
-                    Db::Integrated(op) => {
-                        let op_hash = DhtOpHash::with_data_sync(&op);
-
-                        let found: bool = txn
-                            .query_row(
-                                "
-                                SELECT EXISTS(
-                                    SELECT 1 FROM DhtOp
-                                    WHERE when_integrated IS NOT NULL
-                                    AND hash = :hash
-                                    AND validation_status = :status
-                                )
-                                ",
-                                named_params! {
-                                    ":hash": op_hash,
-                                    ":status": ValidationStatus::Valid,
-                                },
-                                |row| row.get(0),
-                            )
-                            .unwrap();
-                        assert!(found, "{here}\n{op:?}");
-                    }
-                    Db::IntQueue(op) => {
-                        let op_hash = DhtOpHash::with_data_sync(&op);
-
-                        let found: bool = txn
-                            .query_row(
-                                "
-                                SELECT EXISTS(
-                                    SELECT 1 FROM DhtOp
-                                    WHERE when_integrated IS NULL
-                                    AND validation_stage = 3
-                                    AND hash = :hash
-                                    AND validation_status = :status
-                                )
-                                ",
-                                named_params! {
-                                    ":hash": op_hash,
-                                    ":status": ValidationStatus::Valid,
-                                },
-                                |row| row.get(0),
-                            )
-                            .unwrap();
-                        assert!(found, "{here}\n{op:?}");
-                    }
-                    Db::ValidateQueue(op) => {
-                        let op_hash = DhtOpHash::with_data_sync(&op);
-
-                        let found: bool = txn
-                            .query_row(
-                                "
-                                SELECT EXISTS(
-                                    SELECT 1 FROM DhtOp
-                                    WHERE when_integrated IS NULL
-                                    AND validation_stage IS NULL
-                                    AND hash = :hash
-                                )
-                                ",
-                                named_params! {
-                                    ":hash": op_hash,
-                                },
-                                |row| row.get(0),
-                            )
-                            .unwrap();
-                        assert!(found, "{here}\n{op:?}");
-                    }
-                    Db::MetaActivity(action) => {
-                        let hash = ActionHash::with_data_sync(&action);
-                        let basis: AnyDhtHash = action.author().clone().into();
-                        let found: bool = txn
-                            .query_row(
-                                "
-                                SELECT EXISTS(
-                                    SELECT 1 FROM DhtOp
-                                    WHERE when_integrated IS NOT NULL
-                                    AND basis_hash = :basis
-                                    AND action_hash = :hash
-                                    AND validation_status = :status
-                                    AND type = :activity
-                                )
-                                ",
-                                named_params! {
-                                    ":basis": basis,
-                                    ":hash": hash,
-                                    ":status": ValidationStatus::Valid,
-                                    ":activity": ChainOpType::RegisterAgentActivity,
-                                },
-                                |row| row.get(0),
-                            )
-                            .unwrap();
-                        assert!(found, "{here}\n{action:?}");
-                    }
-                    Db::MetaUpdate(base, action) => {
-                        let hash = ActionHash::with_data_sync(&action);
-                        let found: bool = txn
-                            .query_row(
-                                "
-                                SELECT EXISTS(
-                                    SELECT 1 FROM DhtOp
-                                    WHERE when_integrated IS NOT NULL
-                                    AND basis_hash = :basis
-                                    AND action_hash = :hash
-                                    AND validation_status = :status
-                                    AND (type = :update_content OR type = :update_record)
-                                )
-                                ",
-                                named_params! {
-                                    ":basis": base,
-                                    ":hash": hash,
-                                    ":status": ValidationStatus::Valid,
-                                    ":update_content": ChainOpType::RegisterUpdatedContent,
-                                    ":update_record": ChainOpType::RegisterUpdatedRecord,
-                                },
-                                |row| row.get(0),
-                            )
-                            .unwrap();
-                        assert!(found, "{here}\n{action:?}");
-                    }
-                    Db::MetaDelete(deleted_action_hash, action) => {
-                        let hash = ActionHash::with_data_sync(&action);
-                        let found: bool = txn
-                            .query_row(
-                                "
-                                SELECT EXISTS(
-                                    SELECT 1 FROM DhtOp
-                                    JOIN Action on DhtOp.action_hash = Action.hash
-                                    WHERE when_integrated IS NOT NULL
-                                    AND validation_status = :status
-                                    AND (
-                                        (DhtOp.type = :deleted_entry_action AND Action.deletes_action_hash = :deleted_action_hash)
-                                        OR
-                                        (DhtOp.type = :deleted_by AND action_hash = :hash)
-                                    )
-                                )
-                                ",
-                                named_params! {
-                                    ":deleted_action_hash": deleted_action_hash,
-                                    ":hash": hash,
-                                    ":status": ValidationStatus::Valid,
-                                    ":deleted_by": ChainOpType::RegisterDeletedBy,
-                                    ":deleted_entry_action": ChainOpType::RegisterDeletedEntryAction,
-                                },
-                                |row| row.get(0),
-                            )
-                            .unwrap();
-                        assert!(found, "{here}\n{action:?}");
-                    }
-                    Db::IntQueueEmpty => {
-                        let not_empty: bool = txn
-                            .query_row(
-                                "SELECT EXISTS(SELECT 1 FROM DhtOp WHERE when_integrated IS NULL)",
-                                [],
-                                |row| row.get(0),
-                            )
-                            .unwrap();
-                        assert!(!not_empty, "{}", here);
-                    }
-                    Db::MetaLinkEmpty(link_add) => {
-                        let query = GetLinksQuery::new(
-                            link_add.base_address.clone(),
-                            LinkTypeFilter::single_type(link_add.zome_index, link_add.link_type),
-                            Some(link_add.tag.clone()),
-                            GetLinksFilter::default(),
-                        );
-                        let res = query.run(CascadeTxnWrapper::from(txn)).unwrap();
-                        assert_eq!(res.len(), 0, "{here}");
-                    }
-                }
-            }
-
-            Ok(())
-        }).await.unwrap();
-    }
-
-    // Sets the database to a certain state
-    #[cfg_attr(feature = "instrument", tracing::instrument(skip(pre_state, env)))]
-    async fn set(pre_state: Vec<Self>, env: DbWrite<DbKindDht>) {
-        env.write_async(move |txn| -> DatabaseResult<()> {
-            for state in pre_state {
-                match state {
-                    Db::Integrated(op) => {
-                        let op = DhtOpHashed::from_content_sync(op.clone());
-                        let hash = op.as_hash().clone();
-                        mutations::insert_op_dht(txn, &op, 0, None).unwrap();
-                        mutations::set_when_integrated(txn, &hash, Timestamp::now()).unwrap();
-                        mutations::set_validation_status(txn, &hash, ValidationStatus::Valid)
-                            .unwrap();
-                    }
-                    Db::IntQueue(op) => {
-                        let op = DhtOpHashed::from_content_sync(op.clone());
-                        let hash = op.as_hash().clone();
-                        mutations::insert_op_dht(txn, &op, 0, None).unwrap();
-                        mutations::set_validation_stage(
-                            txn,
-                            &hash,
-                            ValidationStage::AwaitingIntegration,
-                        )
-                        .unwrap();
-                        mutations::set_validation_status(txn, &hash, ValidationStatus::Valid)
-                            .unwrap();
-                    }
-                    Db::ValidateQueue(op) => {
-                        let op = DhtOpHashed::from_content_sync(op.clone());
-                        let hash = op.as_hash().clone();
-                        mutations::insert_op_dht(txn, &op, 0, None).unwrap();
-                        mutations::set_validation_stage(txn, &hash, ValidationStage::Pending)
-                            .unwrap();
-                    }
-                    _ => {
-                        unimplemented!("Use Db::Integrated");
-                    }
-                }
-            }
-            Ok(())
-        })
-        .await
-        .unwrap();
-    }
-}
-
-async fn call_workflow(env: DbWrite<DbKindDht>, dna_hash: DnaHash) {
-    let (qt, _rx) = TriggerSender::new();
-    let dht_store = test_dht_store(dna_hash.clone()).await;
-
-    let mut mock_hc_p2p = MockHolochainP2pDnaT::new();
-    mock_hc_p2p.expect_dna_hash().return_const(dna_hash);
-    mock_hc_p2p
-        .expect_new_integrated_data()
-        .returning(move |_| Ok(()));
-
-    let mock_network = Arc::new(mock_hc_p2p);
-    integrate_dht_ops_workflow(
-        env,
-        dht_store,
-        qt,
-        mock_network,
-        mock_authored_db_provider_none(),
-        mock_publish_trigger_provider_none(),
-    )
-    .await
-    .unwrap();
-}
-
-// Need to clear the data from the previous test
-async fn clear_dbs(env: DbWrite<DbKindDht>) {
-    env.write_async(move |txn| -> StateMutationResult<()> {
-        txn.execute("DELETE FROM DhtOp", []).unwrap();
-        txn.execute("DELETE FROM Action", []).unwrap();
-        txn.execute("DELETE FROM Entry", []).unwrap();
-        Ok(())
-    })
-    .await
-    .unwrap();
-}
-
 // TESTS BEGIN HERE
-// The following show an op or ops that you want to test
-// with a desired pre-state that you want the database in
-// and the expected state of the database after the workflow is run
-
-fn register_store_record(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    let op: DhtOp = ChainOp::StoreRecord(
-        a.signature.clone(),
-        a.original_action.clone().into(),
-        a.original_entry.clone().into(),
-    )
-    .into();
-    let pre_state = vec![Db::IntQueue(op.clone())];
-    let expect = vec![Db::Integrated(op.clone())];
-    (pre_state, expect, "store record", op)
-}
-
-fn register_store_entry(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    let op: DhtOp = ChainOp::StoreEntry(
-        a.signature.clone(),
-        a.original_action.clone(),
-        a.original_entry.clone(),
-    )
-    .into();
-    let pre_state = vec![Db::IntQueue(op.clone())];
-    let expect = vec![Db::Integrated(op.clone())];
-    (pre_state, expect, "store entry", op)
-}
-
-fn register_agent_activity_dna(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    let new_action = fixt!(Dna);
-    let op: DhtOp = ChainOp::RegisterAgentActivity(a.signature.clone(), new_action.into()).into();
-    let pre_state = vec![Db::IntQueue(op.clone())];
-    let expect = vec![Db::Integrated(op.clone())];
-    (
-        pre_state,
-        expect,
-        "register agent activity for dna action",
-        op,
-    )
-}
-
-#[allow(unused)] // Due to unusual calling pattern
-fn register_agent_activity_agent_validation_pkg(
-    a: TestData,
-) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    // Previous op to depend on
-    let mut prev_create_action = fixt!(Create);
-    prev_create_action.action_seq = 10;
-    let previous_action = Action::Create(prev_create_action.clone());
-    let previous_op: DhtOp =
-        ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Create(prev_create_action)).into();
-
-    // Op to integrate, to go in the dht database
-    let mut agent_validation_pkg_action = fixt!(AgentValidationPkg);
-    agent_validation_pkg_action.author = previous_action.author().clone();
-    agent_validation_pkg_action.action_seq = previous_action.action_seq() + 1;
-    let new_dht_op: DhtOp = ChainOp::RegisterAgentActivity(
-        fixt!(Signature),
-        Action::AgentValidationPkg(agent_validation_pkg_action),
-    )
-    .into();
-
-    let pre_state = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::IntQueue(new_dht_op.clone()),
-    ];
-    let expect = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::Integrated(new_dht_op.clone()),
-    ];
-    (
-        pre_state,
-        expect,
-        "register agent activity for agent validation pkg",
-        new_dht_op,
-    )
-}
-
-#[allow(unused)] // Due to unusual calling pattern
-fn register_agent_activity_init_zomes_complete(
-    a: TestData,
-) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    // Previous op to depend on
-    let mut prev_create_action = fixt!(Create);
-    prev_create_action.action_seq = 10;
-    let previous_action = Action::Create(prev_create_action.clone());
-    let previous_op: DhtOp =
-        ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Create(prev_create_action)).into();
-
-    // Op to integrate
-    let mut init_zomes_action = fixt!(InitZomesComplete);
-    init_zomes_action.author = previous_action.author().clone();
-    init_zomes_action.action_seq = previous_action.action_seq() + 1;
-    let new_dht_op: DhtOp = ChainOp::RegisterAgentActivity(
-        fixt!(Signature),
-        Action::InitZomesComplete(init_zomes_action),
-    )
-    .into();
-
-    let pre_state = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::IntQueue(new_dht_op.clone()),
-    ];
-    let expect = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::Integrated(new_dht_op.clone()),
-    ];
-    (
-        pre_state,
-        expect,
-        "register agent activity for init zomes complete action",
-        new_dht_op,
-    )
-}
-
-fn register_agent_activity_create_link(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    a.link_add.action_seq = 5;
-    let previous_op: DhtOp =
-        ChainOp::RegisterAgentActivity(a.signature.clone(), a.link_add.clone().into()).into();
-    let mut new_action = a.link_add.clone();
-    new_action.action_seq += 1;
-    let op: DhtOp =
-        ChainOp::RegisterAgentActivity(a.signature.clone(), new_action.clone().into()).into();
-    let pre_state = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::IntQueue(op.clone()),
-    ];
-    let expect = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::MetaActivity(a.link_add.clone().into()),
-        Db::Integrated(op.clone()),
-        Db::MetaActivity(new_action.clone().into()),
-    ];
-    (
-        pre_state,
-        expect,
-        "register agent activity for create link action",
-        op,
-    )
-}
-
-fn register_agent_activity_delete_link(mut a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    a.link_remove.action_seq = 5;
-    let previous_op: DhtOp =
-        ChainOp::RegisterAgentActivity(a.signature.clone(), a.link_remove.clone().into()).into();
-    let mut new_action = a.link_remove.clone();
-    new_action.action_seq += 1;
-    let new_op: DhtOp =
-        ChainOp::RegisterAgentActivity(a.signature.clone(), new_action.clone().into()).into();
-    let pre_state = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::IntQueue(new_op.clone()),
-    ];
-    let expect = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::MetaActivity(a.link_remove.clone().into()),
-        Db::Integrated(new_op.clone()),
-        Db::MetaActivity(new_action.clone().into()),
-    ];
-    (
-        pre_state,
-        expect,
-        "register agent activity for delete link action",
-        new_op,
-    )
-}
-
-#[allow(unused)] // Due to unusual calling pattern
-fn register_agent_activity_close_chain(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    // Previous op to depend on
-    let mut prev_create_action = fixt!(Create);
-    prev_create_action.action_seq = 10;
-    let previous_action = Action::Create(prev_create_action.clone());
-    let previous_op: DhtOp =
-        ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Create(prev_create_action)).into();
-
-    // Op to integrate
-    let mut close_chain_action = fixt!(CloseChain);
-    close_chain_action.author = previous_action.author().clone();
-    close_chain_action.action_seq = previous_action.action_seq() + 1;
-    let new_dht_op: DhtOp =
-        ChainOp::RegisterAgentActivity(fixt!(Signature), Action::CloseChain(close_chain_action))
-            .into();
-
-    let pre_state = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::IntQueue(new_dht_op.clone()),
-    ];
-    let expect = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::Integrated(new_dht_op.clone()),
-    ];
-    (
-        pre_state,
-        expect,
-        "register agent activity for close chain action",
-        new_dht_op,
-    )
-}
-
-#[allow(unused)] // Due to unusual calling pattern
-fn register_agent_activity_open_chain(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    // Previous op to depend on
-    let mut prev_create_action = fixt!(Create);
-    prev_create_action.action_seq = 10;
-    let previous_action = Action::Create(prev_create_action.clone());
-    let previous_op: DhtOp =
-        ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Create(prev_create_action)).into();
-
-    // Op to integrate
-    let mut open_chain_action = fixt!(OpenChain);
-    open_chain_action.author = previous_action.author().clone();
-    open_chain_action.action_seq = previous_action.action_seq() + 1;
-    let new_dht_op: DhtOp =
-        ChainOp::RegisterAgentActivity(fixt!(Signature), Action::OpenChain(open_chain_action))
-            .into();
-
-    let pre_state = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::IntQueue(new_dht_op.clone()),
-    ];
-    let expect = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::Integrated(new_dht_op.clone()),
-    ];
-    (
-        pre_state,
-        expect,
-        "register agent activity for open chain action",
-        new_dht_op,
-    )
-}
-
-#[allow(unused)] // Due to unusual calling pattern
-fn register_agent_activity_create(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    // Previous op to depend on
-    let mut prev_create_action = fixt!(Create);
-    prev_create_action.action_seq = 10;
-    let previous_action = Action::Create(prev_create_action.clone());
-    let previous_op: DhtOp =
-        ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Create(prev_create_action)).into();
-
-    // Op to integrate
-    let mut create_action = fixt!(Create);
-    create_action.author = previous_action.author().clone();
-    create_action.action_seq = previous_action.action_seq() + 1;
-    let new_dht_op: DhtOp =
-        ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Create(create_action)).into();
-
-    let pre_state = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::IntQueue(new_dht_op.clone()),
-    ];
-    let expect = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::Integrated(new_dht_op.clone()),
-    ];
-    (
-        pre_state,
-        expect,
-        "register agent activity for create action",
-        new_dht_op,
-    )
-}
-
-#[allow(unused)] // Due to unusual calling pattern
-fn register_agent_activity_update(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    // Previous op to depend on
-    let mut prev_create_action = fixt!(Create);
-    prev_create_action.action_seq = 10;
-    let previous_action = Action::Create(prev_create_action.clone());
-    let previous_op: DhtOp =
-        ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Create(prev_create_action)).into();
-
-    // Op to integrate
-    let mut update_action = fixt!(Update);
-    update_action.author = previous_action.author().clone();
-    update_action.action_seq = previous_action.action_seq() + 1;
-    let new_dht_op: DhtOp =
-        ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Update(update_action)).into();
-
-    let pre_state = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::IntQueue(new_dht_op.clone()),
-    ];
-    let expect = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::Integrated(new_dht_op.clone()),
-    ];
-    (
-        pre_state,
-        expect,
-        "register agent activity for update action",
-        new_dht_op,
-    )
-}
-
-#[allow(unused)] // Due to unusual calling pattern
-fn register_agent_activity_delete(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    // Previous op to depend on
-    let mut prev_create_action = fixt!(Create);
-    prev_create_action.action_seq = 10;
-    let previous_action = Action::Create(prev_create_action.clone());
-    let previous_op: DhtOp =
-        ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Create(prev_create_action)).into();
-
-    // Op to integrate
-    let mut delete_action = fixt!(Delete);
-    delete_action.author = previous_action.author().clone();
-    delete_action.action_seq = previous_action.action_seq() + 1;
-    let new_dht_op: DhtOp =
-        ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Delete(delete_action)).into();
-
-    let pre_state = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::IntQueue(new_dht_op.clone()),
-    ];
-    let expect = vec![
-        Db::Integrated(previous_op.clone()),
-        Db::Integrated(new_dht_op.clone()),
-    ];
-    (
-        pre_state,
-        expect,
-        "register agent activity for delete action",
-        new_dht_op,
-    )
-}
-
-fn register_updated_record(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    let original_op = ChainOp::StoreRecord(
-        a.signature.clone(),
-        a.original_action.clone().into(),
-        a.original_entry.clone().into(),
-    )
-    .into();
-    let op: DhtOp = ChainOp::RegisterUpdatedRecord(
-        a.signature.clone(),
-        a.entry_update_action.clone(),
-        a.new_entry.clone().into(),
-    )
-    .into();
-    let pre_state = vec![Db::Integrated(original_op), Db::IntQueue(op.clone())];
-    let expect = vec![
-        Db::Integrated(op.clone()),
-        Db::MetaUpdate(
-            a.original_action_hash.clone().into(),
-            a.entry_update_action.clone().into(),
-        ),
-    ];
-    (pre_state, expect, "register updated record", op)
-}
-
-fn register_replaced_by_for_entry(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    let original_op: DhtOp = ChainOp::StoreEntry(
-        a.signature.clone(),
-        a.original_action.clone(),
-        a.original_entry.clone(),
-    )
-    .into();
-    let op: DhtOp = ChainOp::RegisterUpdatedContent(
-        a.signature.clone(),
-        a.entry_update_entry.clone(),
-        a.new_entry.clone().into(),
-    )
-    .into();
-    let pre_state = vec![Db::Integrated(original_op), Db::IntQueue(op.clone())];
-    let expect = vec![
-        Db::Integrated(op.clone()),
-        Db::MetaUpdate(
-            a.original_entry_hash.clone().into(),
-            a.entry_update_entry.clone().into(),
-        ),
-    ];
-    (pre_state, expect, "register replaced by for entry", op)
-}
-
-fn register_deleted_by(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    let original_op = ChainOp::StoreEntry(
-        a.signature.clone(),
-        a.original_action.clone(),
-        a.original_entry.clone(),
-    )
-    .into();
-    let op: DhtOp =
-        ChainOp::RegisterDeletedEntryAction(a.signature.clone(), a.entry_delete.clone()).into();
-    let pre_state = vec![Db::Integrated(original_op), Db::IntQueue(op.clone())];
-    let expect = vec![
-        Db::IntQueueEmpty,
-        Db::Integrated(op.clone()),
-        Db::MetaDelete(
-            a.original_action_hash.clone(),
-            a.entry_delete.clone().into(),
-        ),
-    ];
-    (pre_state, expect, "register deleted by", op)
-}
-
-fn register_deleted_action_by(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    let original_op = ChainOp::StoreRecord(
-        a.signature.clone(),
-        a.original_action.clone().into(),
-        a.original_entry.clone().into(),
-    )
-    .into();
-    let op: DhtOp = ChainOp::RegisterDeletedBy(a.signature.clone(), a.entry_delete.clone()).into();
-    let pre_state = vec![Db::IntQueue(op.clone()), Db::Integrated(original_op)];
-    let expect = vec![
-        Db::Integrated(op.clone()),
-        Db::MetaDelete(
-            a.original_action_hash.clone(),
-            a.entry_delete.clone().into(),
-        ),
-    ];
-    (pre_state, expect, "register deleted action by", op)
-}
-
-fn register_create_link(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    let op: DhtOp = ChainOp::RegisterAddLink(a.signature.clone(), a.link_add.clone()).into();
-    let pre_state = vec![Db::IntQueue(op.clone())];
-    let expect = vec![Db::Integrated(op.clone())];
-    (pre_state, expect, "register link create", op)
-}
-
-fn register_delete_link(a: TestData) -> (Vec<Db>, Vec<Db>, &'static str, DhtOp) {
-    let original_op = ChainOp::StoreEntry(
-        a.signature.clone(),
-        a.original_action.clone(),
-        a.original_entry.clone(),
-    )
-    .into();
-    let original_link_op = ChainOp::RegisterAddLink(a.signature.clone(), a.link_add.clone()).into();
-    let op: DhtOp = ChainOp::RegisterRemoveLink(a.signature.clone(), a.link_remove.clone()).into();
-    let pre_state = vec![
-        Db::Integrated(original_op),
-        Db::Integrated(original_link_op),
-        Db::IntQueue(op.clone()),
-    ];
-    let expect = vec![
-        Db::Integrated(op.clone()),
-        Db::MetaLinkEmpty(a.link_add.clone()),
-    ];
-    (pre_state, expect, "register link remove", op)
-}
-
-// This runs the above tests
-#[tokio::test(flavor = "multi_thread")]
-async fn test_ops_state() {
-    holochain_trace::test_run();
-    let env = test_dht_db().to_db();
-
-    let tests = [
-        register_store_record,
-        register_store_entry,
-        register_agent_activity_dna,
-        register_agent_activity_agent_validation_pkg,
-        register_agent_activity_init_zomes_complete,
-        register_agent_activity_create_link,
-        register_agent_activity_delete_link,
-        register_agent_activity_close_chain,
-        register_agent_activity_open_chain,
-        register_agent_activity_create,
-        register_agent_activity_update,
-        register_agent_activity_delete,
-        register_replaced_by_for_entry,
-        register_updated_record,
-        register_deleted_by,
-        register_deleted_action_by,
-        register_create_link,
-        register_delete_link,
-    ];
-
-    for t in tests.iter() {
-        clear_dbs(env.clone()).await;
-        let td = TestData::new();
-        let (pre_state, expect, name, _) = t(td);
-        println!("test_ops_state on function {name}");
-        Db::set(pre_state, env.clone()).await;
-        call_workflow(env.clone(), fixt!(DnaHash)).await;
-        Db::check(
-            expect,
-            env.clone(),
-            format!("{}: {}", name, crate::here!("")),
-        )
-        .await;
-    }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn publish_trigger_provider_is_called() {
-    holochain_trace::test_run();
-    let dna_hash = fixt!(DnaHash);
-    let author = fixt!(AgentPubKey);
-    let cell_id = CellId::new(dna_hash.clone(), author.clone());
-
-    // Create databases
-    let dht_env = test_dht_db_with_dna_hash(dna_hash.clone()).to_db();
-    let authored_db = Arc::new(test_authored_db_with_id(1));
-
-    // Create an op for the local author
-    let (_op, hashed) = make_store_entry_op(author.clone());
-
-    // Insert the op into the DHT database as validated and ready to integrate
-    insert_validated_op(&dht_env, &hashed).await;
-
-    // Also insert into the authored DB so we can mark it as integrated there
-    authored_db
-        .to_db()
-        .write_async({
-            let hashed = hashed.clone();
-            move |txn| -> DatabaseResult<()> {
-                mutations::insert_op_authored(txn, &hashed)
-                    .map_err(|e| DatabaseError::Other(e.into()))
-            }
-        })
-        .await
-        .unwrap();
-
-    // Set up the authored db provider mock to return our authored DB
-    let (authored_mock, _, _) = mock_authored_db_provider_with_db(
-        dna_hash.clone(),
-        vec![(author.clone(), Arc::clone(&authored_db))],
-    );
-
-    // Set up publish trigger provider that tracks whether it was called
-    let (publish_mock, trigger_count) = mock_publish_trigger_provider_with_triggers(vec![cell_id]);
-
-    // Set up network mock
-    let (qt, _rx) = TriggerSender::new();
-    let dht_store = test_dht_store(dna_hash.clone()).await;
-    let mut hc_p2p = MockHolochainP2pDnaT::new();
-    hc_p2p.expect_dna_hash().return_const(dna_hash.clone());
-    hc_p2p
-        .expect_new_integrated_data()
-        .return_once(move |_| Ok(()));
-    let mock_network = Arc::new(hc_p2p);
-
-    // Run the workflow
-    integrate_dht_ops_workflow(
-        dht_env.clone(),
-        dht_store,
-        qt,
-        mock_network,
-        authored_mock,
-        publish_mock,
-    )
-    .await
-    .unwrap();
-
-    // Verify that the publish trigger provider was called for the local author
-    assert_eq!(
-        trigger_count.load(Ordering::SeqCst),
-        1,
-        "Publish trigger should be called once for the local author"
-    );
-
-    // Also verify the op was marked as integrated in both databases
-    let hash = hashed.as_hash().clone();
-    assert!(
-        dht_when_integrated(&dht_env, &hash).await.is_some(),
-        "Op should be marked as integrated in DHT database"
-    );
-    assert!(
-        authored_when_integrated(&authored_db, &hash)
-            .await
-            .is_some(),
-        "Op should be marked as integrated in authored database"
-    );
-}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn inform_kitsune_about_integrated_ops() {
     let tests = [
-        register_store_entry,
-        register_store_record,
-        // These are not distinct cases, because all agent activity is treated equally,
-        // but they're cheap to run and were already written.
-        register_agent_activity_dna,
-        register_agent_activity_agent_validation_pkg,
-        register_agent_activity_init_zomes_complete,
-        register_agent_activity_create_link,
-        register_agent_activity_delete_link,
-        register_agent_activity_close_chain,
-        register_agent_activity_open_chain,
-        register_agent_activity_create,
-        register_agent_activity_update,
-        register_agent_activity_delete,
-        register_replaced_by_for_entry,
-        register_updated_record,
-        register_deleted_by,
-        register_deleted_action_by,
-        register_create_link,
-        register_delete_link,
+        make_store_entry_op_pair as fn() -> (DhtOp, DhtOpHashed),
+        make_store_record_op_pair,
     ];
-    for test in tests.iter() {
-        let env = test_dht_db().to_db();
-        let test_data = TestData::new();
-        let (pre_state, _, test_name, op) = test(test_data);
-        println!("inform_kitsune_about {test_name}");
-        Db::set(pre_state, env.clone()).await;
+    for (i, make_op) in tests.iter().enumerate() {
+        let dna_hash = fixt!(DnaHash);
+        let (op, hashed) = make_op();
+        let dht_store = test_dht_store(dna_hash.clone()).await;
+        insert_validated_op_to_store(&dht_store, &hashed).await;
 
         let (tx, _rx) = TriggerSender::new();
-        let dna_hash = fixt!(DnaHash);
-        let dht_store = test_dht_store(dna_hash.clone()).await;
         let mut hc_p2p = MockHolochainP2pDnaT::new();
         hc_p2p.expect_dna_hash().return_const(dna_hash.clone());
         hc_p2p
@@ -1021,12 +44,11 @@ async fn inform_kitsune_about_integrated_ops() {
                     op_id: op.to_hash().to_located_k2_op_id(&op.dht_basis()),
                     created_at: kitsune2_api::Timestamp::from_micros(op.timestamp().as_micros()),
                 };
-                assert_eq!(ops, vec![expected_op]);
+                assert_eq!(ops, vec![expected_op], "test case {i}");
                 Ok(())
             });
         let hc_p2p = Arc::new(hc_p2p);
         integrate_dht_ops_workflow(
-            env,
             dht_store,
             tx,
             hc_p2p,
@@ -1041,21 +63,15 @@ async fn inform_kitsune_about_integrated_ops() {
 #[tokio::test(flavor = "multi_thread")]
 async fn kitsune_not_informed_when_no_ops_integrated() {
     let dna_hash = fixt!(DnaHash);
-    let env = test_dht_db().to_db();
-    let test_data = TestData::new();
-    let op: DhtOp =
-        ChainOp::RegisterAgentActivity(test_data.signature.clone(), fixt!(Action)).into();
-    let pre_state = vec![Db::ValidateQueue(op)];
-    Db::set(pre_state, env.clone()).await;
+    // An empty store — nothing ready for integration.
+    let dht_store = test_dht_store(dna_hash.clone()).await;
 
     let (tx, _rx) = TriggerSender::new();
-    let dht_store = test_dht_store(dna_hash.clone()).await;
     let mut hc_p2p = MockHolochainP2pDnaT::new();
     hc_p2p.expect_dna_hash().return_const(dna_hash.clone());
     hc_p2p.expect_new_integrated_data().never();
     let hc_p2p = Arc::new(hc_p2p);
     integrate_dht_ops_workflow(
-        env,
         dht_store,
         tx,
         hc_p2p,
@@ -1073,8 +89,8 @@ async fn single_local_author_marks_both_databases() {
     let author = fixt!(AgentPubKey);
     let (_op, hashed) = make_store_entry_op(author.clone());
 
-    let dht_env = test_dht_db_with_dna_hash(dna_hash.clone()).to_db();
-    insert_validated_op(&dht_env, &hashed).await;
+    let dht_store = test_dht_store(dna_hash.clone()).await;
+    insert_validated_op_to_store(&dht_store, &hashed).await;
 
     let authored_db = Arc::new(test_authored_db_with_id(1));
 
@@ -1097,19 +113,16 @@ async fn single_local_author_marks_both_databases() {
     );
 
     let (tx, _rx) = TriggerSender::new();
-    let dht_store = test_dht_store(dna_hash.clone()).await;
     let mut hc_p2p = MockHolochainP2pDnaT::new();
     hc_p2p.expect_dna_hash().return_const(dna_hash.clone());
     hc_p2p.expect_new_integrated_data().return_once(move |ops| {
         assert_eq!(ops.len(), 1);
-        // Expecting the single op we inserted to be integrated
         Ok(())
     });
     let mock_network = Arc::new(hc_p2p);
 
     integrate_dht_ops_workflow(
-        dht_env.clone(),
-        dht_store,
+        dht_store.clone(),
         tx,
         mock_network,
         mock,
@@ -1119,10 +132,16 @@ async fn single_local_author_marks_both_databases() {
     .unwrap();
 
     let hash = hashed.as_hash().clone();
-    assert!(dht_when_integrated(&dht_env, &hash).await.is_some());
-    assert!(authored_when_integrated(&authored_db, &hash)
-        .await
-        .is_some());
+    assert!(
+        dht_store.when_integrated(&hash).await.unwrap().is_some(),
+        "Op should be marked as integrated in DHT store"
+    );
+    assert!(
+        authored_when_integrated(&authored_db, &hash)
+            .await
+            .is_some(),
+        "Op should be marked as integrated in authored database"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1134,10 +153,9 @@ async fn multiple_local_authors_marked_integrated() {
     let (_op_a, hashed_a) = make_store_entry_op(author_a.clone());
     let (_op_b, hashed_b) = make_store_entry_op(author_b.clone());
 
-    let dht_env = test_dht_db_with_dna_hash(dna_hash.clone()).to_db();
-    for hashed in [&hashed_a, &hashed_b] {
-        insert_validated_op(&dht_env, hashed).await;
-    }
+    let dht_store = test_dht_store(dna_hash.clone()).await;
+    insert_validated_op_to_store(&dht_store, &hashed_a).await;
+    insert_validated_op_to_store(&dht_store, &hashed_b).await;
 
     let authored_a = Arc::new(test_authored_db_with_id(1));
     let authored_b = Arc::new(test_authored_db_with_id(2));
@@ -1176,22 +194,19 @@ async fn multiple_local_authors_marked_integrated() {
     );
 
     let (tx, _rx) = TriggerSender::new();
-    let dht_store = test_dht_store(dna_hash.clone()).await;
     let mut hc_p2p = MockHolochainP2pDnaT::new();
     hc_p2p.expect_dna_hash().return_const(dna_hash.clone());
     hc_p2p
         .expect_new_integrated_data()
         .return_once(move |mut ops| {
             ops.sort_by(|a, b| a.op_id.cmp(&b.op_id));
-            // Expecting 2 integrated ops, one for each author
             assert_eq!(ops.len(), 2);
             Ok(())
         });
     let mock_network = Arc::new(hc_p2p);
 
     integrate_dht_ops_workflow(
-        dht_env.clone(),
-        dht_store,
+        dht_store.clone(),
         tx,
         mock_network,
         mock,
@@ -1208,8 +223,85 @@ async fn multiple_local_authors_marked_integrated() {
     assert!(authored_when_integrated(&authored_b, &hash_b)
         .await
         .is_some());
-    assert!(dht_when_integrated(&dht_env, &hash_a).await.is_some());
-    assert!(dht_when_integrated(&dht_env, &hash_b).await.is_some());
+    assert!(dht_store.when_integrated(&hash_a).await.unwrap().is_some());
+    assert!(dht_store.when_integrated(&hash_b).await.unwrap().is_some());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publish_trigger_provider_is_called() {
+    holochain_trace::test_run();
+    let dna_hash = fixt!(DnaHash);
+    let author = fixt!(AgentPubKey);
+    let cell_id = CellId::new(dna_hash.clone(), author.clone());
+
+    let dht_store = test_dht_store(dna_hash.clone()).await;
+    let authored_db = Arc::new(test_authored_db_with_id(1));
+
+    let (_op, hashed) = make_store_entry_op(author.clone());
+
+    insert_validated_op_to_store(&dht_store, &hashed).await;
+
+    // Also insert into the authored DB so we can mark it as integrated there
+    authored_db
+        .to_db()
+        .write_async({
+            let hashed = hashed.clone();
+            move |txn| -> DatabaseResult<()> {
+                mutations::insert_op_authored(txn, &hashed)
+                    .map_err(|e| DatabaseError::Other(e.into()))
+            }
+        })
+        .await
+        .unwrap();
+
+    // Set up the authored db provider mock to return our authored DB
+    let (authored_mock, _, _) = mock_authored_db_provider_with_db(
+        dna_hash.clone(),
+        vec![(author.clone(), Arc::clone(&authored_db))],
+    );
+
+    // Set up publish trigger provider that tracks whether it was called
+    let (publish_mock, trigger_count) = mock_publish_trigger_provider_with_triggers(vec![cell_id]);
+
+    // Set up network mock
+    let (qt, _rx) = TriggerSender::new();
+    let mut hc_p2p = MockHolochainP2pDnaT::new();
+    hc_p2p.expect_dna_hash().return_const(dna_hash.clone());
+    hc_p2p
+        .expect_new_integrated_data()
+        .return_once(move |_| Ok(()));
+    let mock_network = Arc::new(hc_p2p);
+
+    // Run the workflow
+    integrate_dht_ops_workflow(
+        dht_store.clone(),
+        qt,
+        mock_network,
+        authored_mock,
+        publish_mock,
+    )
+    .await
+    .unwrap();
+
+    // Verify that the publish trigger provider was called for the local author
+    assert_eq!(
+        trigger_count.load(Ordering::SeqCst),
+        1,
+        "Publish trigger should be called once for the local author"
+    );
+
+    // Also verify the op was marked as integrated in both databases
+    let hash = hashed.as_hash().clone();
+    assert!(
+        dht_store.when_integrated(&hash).await.unwrap().is_some(),
+        "Op should be marked as integrated in DHT store"
+    );
+    assert!(
+        authored_when_integrated(&authored_db, &hash)
+            .await
+            .is_some(),
+        "Op should be marked as integrated in authored database"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1221,8 +313,7 @@ async fn publish_triggered_for_integrated_local_authored_ops() {
     let cell_id1 = CellId::new(dna_hash.clone(), author1.clone());
     let cell_id2 = CellId::new(dna_hash.clone(), author2.clone());
 
-    // Create DHT and authored databases
-    let dht_env = test_dht_db_with_dna_hash(dna_hash.clone()).to_db();
+    let dht_store = test_dht_store(dna_hash.clone()).await;
     let authored_db1 = test_authored_db_with_id(1);
     let authored_db2 = test_authored_db_with_id(2);
 
@@ -1231,10 +322,10 @@ async fn publish_triggered_for_integrated_local_authored_ops() {
     let (_op2, hashed2) = make_store_entry_op(author2.clone());
     let (_op3, hashed3) = make_store_entry_op(author3.clone()); // This author has no local DB
 
-    // Insert ops into the DHT database as validated
-    insert_validated_op(&dht_env, &hashed1).await;
-    insert_validated_op(&dht_env, &hashed2).await;
-    insert_validated_op(&dht_env, &hashed3).await;
+    // Insert ops into the DHT store as validated
+    insert_validated_op_to_store(&dht_store, &hashed1).await;
+    insert_validated_op_to_store(&dht_store, &hashed2).await;
+    insert_validated_op_to_store(&dht_store, &hashed3).await;
 
     // Also insert into authored databases as not yet integrated
     authored_db1
@@ -1311,12 +402,10 @@ async fn publish_triggered_for_integrated_local_authored_ops() {
 
     // Create trigger
     let (tx, _rx) = TriggerSender::new();
-    let dht_store = test_dht_store(dna_hash.clone()).await;
 
     // Run workflow
     integrate_dht_ops_workflow(
-        dht_env.clone(),
-        dht_store,
+        dht_store.clone(),
         tx,
         mock_network,
         Arc::new(authored_mock),
@@ -1326,13 +415,14 @@ async fn publish_triggered_for_integrated_local_authored_ops() {
     .unwrap();
 
     // Verify publish triggers were called for the two local authors
-    // The mock increments the counter each time get_publish_trigger is called for a cell with a trigger
     assert_eq!(
         trigger_count.load(Ordering::SeqCst),
         2,
         "Should trigger publish for both local authors"
     );
 }
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
 
 fn mock_authored_db_provider_none() -> Arc<MockAuthoredDbProvider> {
     let mut mock = MockAuthoredDbProvider::new();
@@ -1377,22 +467,25 @@ fn mock_authored_db_provider_with_db(
     (Arc::new(mock), state, lookup_count)
 }
 
-async fn insert_validated_op(env: &DbWrite<DbKindDht>, op: &DhtOpHashed) {
-    env.write_async({
-        let op = op.clone();
-        move |txn| -> DatabaseResult<()> {
-            let hash = op.as_hash().clone();
-            mutations::insert_op_dht(txn, &op, 0, None)
-                .map_err(|e| holochain_sqlite::error::DatabaseError::Other(e.into()))?;
-            mutations::set_validation_status(txn, &hash, ValidationStatus::Valid)
-                .map_err(|e| holochain_sqlite::error::DatabaseError::Other(e.into()))?;
-            mutations::set_validation_stage(txn, &hash, ValidationStage::AwaitingIntegration)
-                .map_err(|e| holochain_sqlite::error::DatabaseError::Other(e.into()))?;
-            Ok(())
-        }
-    })
-    .await
-    .unwrap();
+/// Write an op to the new DhtStore as fully validated and ready for
+/// integration (sys + app validation both accepted).
+async fn insert_validated_op_to_store(dht_store: &DhtStore, op: &DhtOpHashed) {
+    let op_hash = op.as_hash().clone();
+    dht_store
+        .record_incoming_ops(vec![op.clone()])
+        .await
+        .unwrap();
+    dht_store
+        .record_chain_op_sys_validation_outcomes(vec![(op_hash.clone(), SysOutcome::Accepted)])
+        .await
+        .unwrap();
+    dht_store
+        .record_app_validation_outcomes(vec![(
+            op_hash,
+            holochain_state::prelude::AppOutcome::Accepted,
+        )])
+        .await
+        .unwrap();
 }
 
 fn make_store_entry_op(author: AgentPubKey) -> (DhtOp, DhtOpHashed) {
@@ -1405,10 +498,27 @@ fn make_store_entry_op(author: AgentPubKey) -> (DhtOp, DhtOpHashed) {
     (op, hashed)
 }
 
+fn make_store_entry_op_pair() -> (DhtOp, DhtOpHashed) {
+    make_store_entry_op(fixt!(AgentPubKey))
+}
+
+fn make_store_record_op_pair() -> (DhtOp, DhtOpHashed) {
+    let entry = EntryFixturator::new(AppEntry).next().unwrap();
+    let mut action = fixt!(Create);
+    action.author = fixt!(AgentPubKey);
+    action.entry_hash = EntryHashed::from_content_sync(entry.clone()).into_hash();
+    let op: DhtOp =
+        ChainOp::StoreRecord(fixt!(Signature), action.clone().into(), entry.into()).into();
+    let hashed = DhtOpHashed::from_content_sync(op.clone());
+    (op, hashed)
+}
+
 async fn authored_when_integrated(
     db: &TestDb<DbKindAuthored>,
     hash: &DhtOpHash,
 ) -> Option<Timestamp> {
+    use holochain_sqlite::rusqlite::named_params;
+    use holochain_sqlite::rusqlite::OptionalExtension;
     db.to_db()
         .read_async({
             let hash = hash.clone();
@@ -1424,23 +534,6 @@ async fn authored_when_integrated(
         })
         .await
         .unwrap()
-}
-
-async fn dht_when_integrated(db: &DbWrite<DbKindDht>, hash: &DhtOpHash) -> Option<Timestamp> {
-    db.read_async({
-        let hash = hash.clone();
-        move |txn| -> DatabaseResult<Option<Timestamp>> {
-            txn.query_row(
-                "SELECT when_integrated FROM DhtOp WHERE hash = :hash",
-                named_params! { ":hash": hash },
-                |row| row.get(0),
-            )
-            .optional()
-            .map_err(DatabaseError::from)
-        }
-    })
-    .await
-    .unwrap()
 }
 
 fn mock_publish_trigger_provider_none() -> Arc<MockPublishTriggerProvider> {
@@ -1465,9 +558,6 @@ fn mock_publish_trigger_provider_with_triggers(
         if has_trigger {
             let (tx, _rx) = TriggerSender::new();
             let count = trigger_count_clone.clone();
-            // When trigger is called, increment the counter
-            // Note: In reality we'd hook into the actual trigger,
-            // but for testing we just track that get_publish_trigger was called
             count.fetch_add(1, Ordering::SeqCst);
             MustBoxFuture::new(async move { Some(tx) })
         } else {

--- a/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/integrate_dht_ops_workflow/tests.rs
@@ -11,7 +11,9 @@ use holochain_sqlite::error::{DatabaseError, DatabaseResult};
 use holochain_state::dht_store::DhtStore;
 use holochain_state::mutations;
 use holochain_state::prelude::SysOutcome;
-use holochain_state::test_utils::{test_authored_db_with_id, test_dht_store, TestDb};
+use holochain_state::test_utils::{
+    test_authored_db_with_id, test_dht_db_with_dna_hash, test_dht_store, TestDb,
+};
 use holochain_types::prelude::{ChainOp, DhtOp, DhtOpHashed};
 use kitsune2_api::StoredOp;
 use must_future::MustBoxFuture;
@@ -31,6 +33,7 @@ async fn inform_kitsune_about_integrated_ops() {
         let dna_hash = fixt!(DnaHash);
         let (op, hashed) = make_op();
         let dht_store = test_dht_store(dna_hash.clone()).await;
+        let vault = test_dht_db_with_dna_hash(dna_hash.clone()).to_db();
         insert_validated_op_to_store(&dht_store, &hashed).await;
 
         let (tx, _rx) = TriggerSender::new();
@@ -49,6 +52,7 @@ async fn inform_kitsune_about_integrated_ops() {
             });
         let hc_p2p = Arc::new(hc_p2p);
         integrate_dht_ops_workflow(
+            vault,
             dht_store,
             tx,
             hc_p2p,
@@ -65,6 +69,7 @@ async fn kitsune_not_informed_when_no_ops_integrated() {
     let dna_hash = fixt!(DnaHash);
     // An empty store — nothing ready for integration.
     let dht_store = test_dht_store(dna_hash.clone()).await;
+    let vault = test_dht_db_with_dna_hash(dna_hash.clone()).to_db();
 
     let (tx, _rx) = TriggerSender::new();
     let mut hc_p2p = MockHolochainP2pDnaT::new();
@@ -72,6 +77,7 @@ async fn kitsune_not_informed_when_no_ops_integrated() {
     hc_p2p.expect_new_integrated_data().never();
     let hc_p2p = Arc::new(hc_p2p);
     integrate_dht_ops_workflow(
+        vault,
         dht_store,
         tx,
         hc_p2p,
@@ -90,6 +96,7 @@ async fn single_local_author_marks_both_databases() {
     let (_op, hashed) = make_store_entry_op(author.clone());
 
     let dht_store = test_dht_store(dna_hash.clone()).await;
+    let vault = test_dht_db_with_dna_hash(dna_hash.clone()).to_db();
     insert_validated_op_to_store(&dht_store, &hashed).await;
 
     let authored_db = Arc::new(test_authored_db_with_id(1));
@@ -122,6 +129,7 @@ async fn single_local_author_marks_both_databases() {
     let mock_network = Arc::new(hc_p2p);
 
     integrate_dht_ops_workflow(
+        vault,
         dht_store.clone(),
         tx,
         mock_network,
@@ -154,6 +162,7 @@ async fn multiple_local_authors_marked_integrated() {
     let (_op_b, hashed_b) = make_store_entry_op(author_b.clone());
 
     let dht_store = test_dht_store(dna_hash.clone()).await;
+    let vault = test_dht_db_with_dna_hash(dna_hash.clone()).to_db();
     insert_validated_op_to_store(&dht_store, &hashed_a).await;
     insert_validated_op_to_store(&dht_store, &hashed_b).await;
 
@@ -206,6 +215,7 @@ async fn multiple_local_authors_marked_integrated() {
     let mock_network = Arc::new(hc_p2p);
 
     integrate_dht_ops_workflow(
+        vault,
         dht_store.clone(),
         tx,
         mock_network,
@@ -235,6 +245,7 @@ async fn publish_trigger_provider_is_called() {
     let cell_id = CellId::new(dna_hash.clone(), author.clone());
 
     let dht_store = test_dht_store(dna_hash.clone()).await;
+    let vault = test_dht_db_with_dna_hash(dna_hash.clone()).to_db();
     let authored_db = Arc::new(test_authored_db_with_id(1));
 
     let (_op, hashed) = make_store_entry_op(author.clone());
@@ -274,6 +285,7 @@ async fn publish_trigger_provider_is_called() {
 
     // Run the workflow
     integrate_dht_ops_workflow(
+        vault,
         dht_store.clone(),
         qt,
         mock_network,
@@ -314,6 +326,7 @@ async fn publish_triggered_for_integrated_local_authored_ops() {
     let cell_id2 = CellId::new(dna_hash.clone(), author2.clone());
 
     let dht_store = test_dht_store(dna_hash.clone()).await;
+    let vault = test_dht_db_with_dna_hash(dna_hash.clone()).to_db();
     let authored_db1 = test_authored_db_with_id(1);
     let authored_db2 = test_authored_db_with_id(2);
 
@@ -405,6 +418,7 @@ async fn publish_triggered_for_integrated_local_authored_ops() {
 
     // Run workflow
     integrate_dht_ops_workflow(
+        vault,
         dht_store.clone(),
         tx,
         mock_network,

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -619,84 +619,6 @@ async fn fetch_missing_dependencies(
     .sum()
 }
 
-/// Read an op from the cache by action hash + op type and write it into the new DHT
-/// store via `record_incoming_ops`, so that `ops_pending_sys_validation` can pick it
-/// up on the next pass.  This is the companion write to `copy_cached_op_to_dht`
-/// which only writes to the legacy DB.
-async fn mirror_cache_op_to_dht_store(
-    cache: DbRead<DbKindCache>,
-    dht_store: &DhtStore,
-    action_hash: ActionHash,
-    op_type: ChainOpType,
-) {
-    let op_opt = cache
-        .read_async(move |txn| {
-            let maybe_row = txn
-                .query_row(
-                    r#"
-                    SELECT
-                        Action.blob AS action_blob,
-                        Entry.blob AS entry_blob
-                    FROM Action
-                        LEFT JOIN Entry ON Action.entry_hash = Entry.hash
-                    WHERE
-                        Action.hash = :action_hash
-                    "#,
-                    rusqlite::named_params! { ":action_hash": action_hash },
-                    |row| {
-                        let action_blob = row.get::<_, Vec<u8>>(0)?;
-                        let entry_blob = row.get::<_, Option<Vec<u8>>>(1)?;
-                        Ok((action_blob, entry_blob))
-                    },
-                )
-                .optional()?;
-
-            WorkflowResult::Ok(maybe_row)
-        })
-        .await;
-
-    let (action_blob, entry_blob) = match op_opt {
-        Ok(Some(row)) => row,
-        Ok(None) => return,
-        Err(e) => {
-            tracing::error!(error = ?e, "Error reading op from cache for DHT-store mirror");
-            return;
-        }
-    };
-
-    let signed_action: SignedAction = match from_blob(action_blob) {
-        Ok(sa) => sa,
-        Err(e) => {
-            tracing::error!(error = ?e, "Error decoding signed action for DHT-store mirror");
-            return;
-        }
-    };
-
-    let maybe_entry: Option<Entry> = match entry_blob {
-        Some(blob) => match from_blob(blob) {
-            Ok(e) => Some(e),
-            Err(err) => {
-                tracing::error!(error = ?err, "Error decoding entry for DHT-store mirror");
-                return;
-            }
-        },
-        None => None,
-    };
-
-    let chain_op = match ChainOp::from_type(op_type, signed_action, maybe_entry) {
-        Ok(op) => op,
-        Err(e) => {
-            tracing::error!(error = ?e, "Error building ChainOp for DHT-store mirror");
-            return;
-        }
-    };
-
-    let op_hashed = DhtOpHashed::from_content_sync(DhtOp::ChainOp(Box::new(chain_op)));
-    if let Err(e) = dht_store.record_incoming_ops(vec![op_hashed]).await {
-        tracing::error!(error = ?e, "Error mirroring warranted op to new DHT store");
-    }
-}
-
 // - Move any cached warranted ops because they need to be validated now.
 // - Check the validation status of any warranted ops that are in the DHT database.
 // - Any ops that have a validation status can be used to mark warrants as ready to validate.
@@ -721,15 +643,18 @@ async fn move_and_check_warrant_deps(
             Ok(copied) if copied => {
                 *warrant_deps_copied += 1;
 
-                // Also mirror the op into the new DHT store so that
-                // `ops_pending_sys_validation` can pick it up on the next pass.
-                mirror_cache_op_to_dht_store(
-                    workspace.cache.clone().into(),
-                    &workspace.dht_store,
-                    action_hash.clone(),
-                    op_type,
-                )
-                .await;
+                // Re-queue the cache-derived op for validation in the new
+                // DHT database. In the new schema cached ops live in
+                // `ChainOp` with `locally_validated = 0`; this moves the
+                // row into `LimboChainOp` so the next pass through
+                // `ops_pending_sys_validation` picks it up.
+                if let Err(e) = workspace
+                    .dht_store
+                    .move_warranted_op_to_limbo(&action_hash, op_type)
+                    .await
+                {
+                    tracing::error!(error = ?e, "Error moving cached warranted op to limbo");
+                }
             }
             Ok(_) => {
                 // It's in the DHT already.

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -113,11 +113,9 @@ use holochain_cascade::CascadeImpl;
 use holochain_keystore::MetaLairClient;
 use holochain_p2p::DynHolochainP2pDna;
 use holochain_sqlite::prelude::*;
-use holochain_sqlite::sql::sql_cell::ACTION_HASH_BY_PREV;
 use holochain_state::dht_store::DhtStore;
 use holochain_state::integrate::insert_locally_validated_op;
 use holochain_state::prelude::*;
-use holochain_state::query::StateQueryError;
 use rusqlite::Transaction;
 use std::convert::TryInto;
 use std::sync::Arc;
@@ -237,8 +235,12 @@ async fn sys_validation_workflow_inner(
     _keystore: MetaLairClient,
     _representative_agent: AgentPubKey,
 ) -> WorkflowResult<OutcomeSummary> {
-    let db = workspace.dht_db.clone();
-    let sorted_ops = validation_query::get_ops_to_sys_validate(&db).await?;
+    let sorted_ops = workspace
+        .dht_store
+        .as_read()
+        .ops_pending_sys_validation(10_000)
+        .await
+        .map_err(WorkflowError::from)?;
 
     // Forget what dependencies are currently in use
     current_validation_dependencies
@@ -305,95 +307,113 @@ async fn sys_validation_workflow_inner(
         }
     }
 
-    let (mut summary, invalid_ops, _forked_pairs, chain_op_sys_outcomes, warrant_sys_outcomes) =
-        workspace
-            .dht_db
-            .write_async(move |txn| {
-                let mut summary = OutcomeSummary {
-                    warrant_deps_copied,
-                    ..Default::default()
-                };
-                let mut invalid_ops = vec![];
-                let mut forked_pairs: Vec<(AgentPubKey, ForkedPair)> = Vec::with_capacity(0);
-                let mut chain_op_sys_outcomes: Vec<(DhtOpHash, SysOutcome)> = Vec::new();
-                let mut warrant_sys_outcomes: Vec<(DhtOpHash, SysOutcome)> = Vec::new();
+    let (
+        mut summary,
+        invalid_ops,
+        pending_fork_checks,
+        chain_op_sys_outcomes,
+        warrant_sys_outcomes,
+    ) = workspace
+        .dht_db
+        .write_async(move |txn| {
+            let mut summary = OutcomeSummary {
+                warrant_deps_copied,
+                ..Default::default()
+            };
+            let mut invalid_ops = vec![];
+            // Collect (action, incoming_signature, incoming_hash) for each chain op so
+            // that fork detection can run asynchronously after this transaction closes.
+            let mut pending_fork_checks: Vec<(Action, Signature, ActionHash)> =
+                Vec::with_capacity(0);
+            let mut chain_op_sys_outcomes: Vec<(DhtOpHash, SysOutcome)> = Vec::new();
+            let mut warrant_sys_outcomes: Vec<(DhtOpHash, SysOutcome)> = Vec::new();
 
-                for (hashed_op, outcome) in validation_outcomes {
-                    let (op, op_hash) = hashed_op.into_inner();
-                    let op_type = op.get_type();
+            for (hashed_op, outcome) in validation_outcomes {
+                let (op, op_hash) = hashed_op.into_inner();
+                let op_type = op.get_type();
 
-                    if let DhtOp::ChainOp(chain_op) = &op {
-                        // Author a ChainFork warrant if fork is detected
-                        let action = chain_op.action();
-                        if let Some(forked_action) = detect_fork(txn, &action)? {
-                            let signature = chain_op.signature().clone();
-                            let action_hash = action.to_hash();
-                            forked_pairs.push((
-                                action.author().clone(),
-                                ForkedPair {
-                                    action_pair: ((action_hash, signature), forked_action),
-                                    seq: action.action_seq(),
-                                },
-                            ));
-                        }
-                    }
+                if let DhtOp::ChainOp(chain_op) = &op {
+                    // Collect the data needed for async fork detection after this txn.
+                    let action = chain_op.action();
+                    let signature = chain_op.signature().clone();
+                    let action_hash = action.to_hash();
+                    pending_fork_checks.push((action, signature, action_hash));
+                }
 
-                    match outcome {
-                        Outcome::Accepted => {
-                            summary.accepted += 1;
-                            match op_type {
-                                DhtOpType::Chain(_) => {
-                                    chain_op_sys_outcomes
-                                        .push((op_hash.clone(), SysOutcome::Accepted));
-                                    put_validation_limbo(
-                                        txn,
-                                        &op_hash,
-                                        ValidationStage::SysValidated,
-                                    )?
-                                }
-                                DhtOpType::Warrant(_) => {
-                                    warrant_sys_outcomes
-                                        .push((op_hash.clone(), SysOutcome::Accepted));
-                                    put_integration_limbo(txn, &op_hash, ValidationStatus::Valid)?
-                                }
-                            };
-                        }
-                        Outcome::MissingDhtDep => {
-                            summary.missing += 1;
-                            // Awaiting dependencies — status stays NULL in the new DB;
-                            // no outcome to record.
-                            let status = ValidationStage::AwaitingSysDeps;
-                            put_validation_limbo(txn, &op_hash, status)?;
-                        }
-                        Outcome::Rejected(reason) => {
-                            invalid_ops.push((op_hash.clone(), op.clone(), reason));
-
-                            match op {
-                                DhtOp::ChainOp(_) => {
-                                    summary.rejected += 1;
-                                    chain_op_sys_outcomes
-                                        .push((op_hash.clone(), SysOutcome::Rejected));
-                                }
-                                DhtOp::WarrantOp(_) => {
-                                    summary.warrants_rejected += 1;
-                                    warrant_sys_outcomes
-                                        .push((op_hash.clone(), SysOutcome::Rejected));
-                                }
+                match outcome {
+                    Outcome::Accepted => {
+                        summary.accepted += 1;
+                        match op_type {
+                            DhtOpType::Chain(_) => {
+                                chain_op_sys_outcomes.push((op_hash.clone(), SysOutcome::Accepted));
+                                put_validation_limbo(txn, &op_hash, ValidationStage::SysValidated)?
                             }
+                            DhtOpType::Warrant(_) => {
+                                warrant_sys_outcomes.push((op_hash.clone(), SysOutcome::Accepted));
+                                put_integration_limbo(txn, &op_hash, ValidationStatus::Valid)?
+                            }
+                        };
+                    }
+                    Outcome::MissingDhtDep => {
+                        summary.missing += 1;
+                        // Awaiting dependencies — status stays NULL in the new DB;
+                        // no outcome to record.
+                        let status = ValidationStage::AwaitingSysDeps;
+                        put_validation_limbo(txn, &op_hash, status)?;
+                    }
+                    Outcome::Rejected(reason) => {
+                        invalid_ops.push((op_hash.clone(), op.clone(), reason));
 
-                            put_integration_limbo(txn, &op_hash, ValidationStatus::Rejected)?;
+                        match op {
+                            DhtOp::ChainOp(_) => {
+                                summary.rejected += 1;
+                                chain_op_sys_outcomes.push((op_hash.clone(), SysOutcome::Rejected));
+                            }
+                            DhtOp::WarrantOp(_) => {
+                                summary.warrants_rejected += 1;
+                                warrant_sys_outcomes.push((op_hash.clone(), SysOutcome::Rejected));
+                            }
                         }
+
+                        put_integration_limbo(txn, &op_hash, ValidationStatus::Rejected)?;
                     }
                 }
-                WorkflowResult::Ok((
-                    summary,
-                    invalid_ops,
-                    forked_pairs,
-                    chain_op_sys_outcomes,
-                    warrant_sys_outcomes,
-                ))
-            })
-            .await?;
+            }
+            WorkflowResult::Ok((
+                summary,
+                invalid_ops,
+                pending_fork_checks,
+                chain_op_sys_outcomes,
+                warrant_sys_outcomes,
+            ))
+        })
+        .await?;
+
+    // Fork detection is read-only; run it async outside the legacy write
+    // transaction now that find_fork_for_action is async.
+    let mut forked_pairs: Vec<(AgentPubKey, ForkedPair)> = Vec::with_capacity(0);
+    for (action, incoming_sig, incoming_hash) in pending_fork_checks {
+        match workspace
+            .dht_store
+            .as_read()
+            .find_fork_for_action(&action)
+            .await
+        {
+            Ok(Some((sibling_hash, sibling_sig))) => {
+                forked_pairs.push((
+                    action.author().clone(),
+                    ForkedPair {
+                        action_pair: ((incoming_hash, incoming_sig), (sibling_hash, sibling_sig)),
+                        seq: action.action_seq(),
+                    },
+                ));
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::error!(error = ?e, "Error detecting chain fork");
+            }
+        }
+    }
 
     workspace
         .dht_store
@@ -459,7 +479,7 @@ async fn sys_validation_workflow_inner(
             warrants.push(warrant_op);
         }
 
-        for (author, fork) in _forked_pairs {
+        for (author, fork) in forked_pairs {
             let warrant_op = make_fork_warrant_op_inner(
                 &_keystore,
                 _representative_agent.clone(),
@@ -599,6 +619,84 @@ async fn fetch_missing_dependencies(
     .sum()
 }
 
+/// Read an op from the cache by action hash + op type and write it into the new DHT
+/// store via `record_incoming_ops`, so that `ops_pending_sys_validation` can pick it
+/// up on the next pass.  This is the companion write to `copy_cached_op_to_dht`
+/// which only writes to the legacy DB.
+async fn mirror_cache_op_to_dht_store(
+    cache: DbRead<DbKindCache>,
+    dht_store: &DhtStore,
+    action_hash: ActionHash,
+    op_type: ChainOpType,
+) {
+    let op_opt = cache
+        .read_async(move |txn| {
+            let maybe_row = txn
+                .query_row(
+                    r#"
+                    SELECT
+                        Action.blob AS action_blob,
+                        Entry.blob AS entry_blob
+                    FROM Action
+                        LEFT JOIN Entry ON Action.entry_hash = Entry.hash
+                    WHERE
+                        Action.hash = :action_hash
+                    "#,
+                    rusqlite::named_params! { ":action_hash": action_hash },
+                    |row| {
+                        let action_blob = row.get::<_, Vec<u8>>(0)?;
+                        let entry_blob = row.get::<_, Option<Vec<u8>>>(1)?;
+                        Ok((action_blob, entry_blob))
+                    },
+                )
+                .optional()?;
+
+            WorkflowResult::Ok(maybe_row)
+        })
+        .await;
+
+    let (action_blob, entry_blob) = match op_opt {
+        Ok(Some(row)) => row,
+        Ok(None) => return,
+        Err(e) => {
+            tracing::error!(error = ?e, "Error reading op from cache for DHT-store mirror");
+            return;
+        }
+    };
+
+    let signed_action: SignedAction = match from_blob(action_blob) {
+        Ok(sa) => sa,
+        Err(e) => {
+            tracing::error!(error = ?e, "Error decoding signed action for DHT-store mirror");
+            return;
+        }
+    };
+
+    let maybe_entry: Option<Entry> = match entry_blob {
+        Some(blob) => match from_blob(blob) {
+            Ok(e) => Some(e),
+            Err(err) => {
+                tracing::error!(error = ?err, "Error decoding entry for DHT-store mirror");
+                return;
+            }
+        },
+        None => None,
+    };
+
+    let chain_op = match ChainOp::from_type(op_type, signed_action, maybe_entry) {
+        Ok(op) => op,
+        Err(e) => {
+            tracing::error!(error = ?e, "Error building ChainOp for DHT-store mirror");
+            return;
+        }
+    };
+
+    let op_hashed = DhtOpHashed::from_content_sync(DhtOp::ChainOp(Box::new(chain_op)));
+    if let Err(e) = dht_store.record_incoming_ops(vec![op_hashed]).await {
+        tracing::error!(error = ?e, "Error mirroring warranted op to new DHT store");
+    }
+}
+
 // - Move any cached warranted ops because they need to be validated now.
 // - Check the validation status of any warranted ops that are in the DHT database.
 // - Any ops that have a validation status can be used to mark warrants as ready to validate.
@@ -622,6 +720,16 @@ async fn move_and_check_warrant_deps(
         {
             Ok(copied) if copied => {
                 *warrant_deps_copied += 1;
+
+                // Also mirror the op into the new DHT store so that
+                // `ops_pending_sys_validation` can pick it up on the next pass.
+                mirror_cache_op_to_dht_store(
+                    workspace.cache.clone().into(),
+                    &workspace.dht_store,
+                    action_hash.clone(),
+                    op_type,
+                )
+                .await;
             }
             Ok(_) => {
                 // It's in the DHT already.
@@ -1651,10 +1759,16 @@ pub async fn make_fork_warrant_op_inner(
 /// different hash. The author check is performed in memory: if the authors
 /// match, a fork is confirmed. If they differ, a cross-author `prev_action`
 /// collision error is returned.
+///
+/// This function is retained for unit tests; production code uses the async
+/// [`DhtStoreRead::find_fork_for_action`] instead.
+#[cfg(test)]
 fn detect_fork(
     txn: &mut Transaction<'_>,
     action: &Action,
 ) -> StateQueryResult<Option<(ActionHash, Signature)>> {
+    use holochain_sqlite::sql::sql_cell::ACTION_HASH_BY_PREV;
+    use holochain_state::query::StateQueryError;
     let mut statement = txn.prepare(ACTION_HASH_BY_PREV)?;
     let items = statement
         .query_map(

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -640,24 +640,30 @@ async fn move_and_check_warrant_deps(
         )
         .await
         {
-            Ok(copied) if copied => {
+            Ok(Some(op)) => {
                 *warrant_deps_copied += 1;
 
-                // Re-queue the cache-derived op for validation in the new
-                // DHT database. In the new schema cached ops live in
-                // `ChainOp` with `locally_validated = 0`; this moves the
-                // row into `LimboChainOp` so the next pass through
-                // `ops_pending_sys_validation` picks it up.
+                // Mirror the warrant dep into the new DhtStore as a limbo op so
+                // `ops_pending_sys_validation` picks it up for validation.
+                // `move_warranted_op_to_limbo` relies on the op already being in
+                // the new DhtStore's `ChainOp` table (cache path), but warrant
+                // deps arrive via the network cascade and only land in the legacy
+                // DHT DB via `copy_cached_op_to_dht`. We therefore insert the op
+                // directly into `LimboChainOp` via `record_incoming_ops`.
+                if let Err(e) = workspace.dht_store.record_incoming_ops(vec![op]).await {
+                    tracing::error!(error = ?e, "Error mirroring warrant dep op into new DhtStore limbo");
+                }
+            }
+            Ok(None) => {
+                // It's in the legacy DHT DB already; the new DhtStore may still
+                // need it — attempt the limbo move in case it was missed earlier.
                 if let Err(e) = workspace
                     .dht_store
                     .move_warranted_op_to_limbo(&action_hash, op_type)
                     .await
                 {
-                    tracing::error!(error = ?e, "Error moving cached warranted op to limbo");
+                    tracing::debug!(error = ?e, "Could not move warranted op to limbo (may already be integrated)");
                 }
-            }
-            Ok(_) => {
-                // It's in the DHT already.
             }
             Err(StateMutationError::OpNotFoundInCache) => {
                 tracing::debug!("Warranted op {} not found in cache", action_hash);

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -239,8 +239,7 @@ async fn sys_validation_workflow_inner(
         .dht_store
         .as_read()
         .ops_pending_sys_validation(10_000)
-        .await
-        .map_err(WorkflowError::from)?;
+        .await?;
 
     // Forget what dependencies are currently in use
     current_validation_dependencies
@@ -656,13 +655,62 @@ async fn move_and_check_warrant_deps(
             }
             Ok(None) => {
                 // It's in the legacy DHT DB already; the new DhtStore may still
-                // need it — attempt the limbo move in case it was missed earlier.
-                if let Err(e) = workspace
+                // need it. First try moving a cache-mirrored copy into limbo.
+                match workspace
                     .dht_store
                     .move_warranted_op_to_limbo(&action_hash, op_type)
                     .await
                 {
-                    tracing::debug!(error = ?e, "Could not move warranted op to limbo (may already be integrated)");
+                    Ok(true) => {}
+                    Ok(false) => {
+                        // No cache-only row was moved: the op is either already
+                        // integrated/in limbo (fine) or absent from the new
+                        // store entirely. Backfill the latter case by reading it
+                        // from the legacy DB and recording it, but only if it is
+                        // genuinely missing (filter_existing_ops drops ops that
+                        // are already validated or in limbo).
+                        match holochain_state::mutations::read_chain_op_from_dht(
+                            workspace.dht_db.clone().into(),
+                            action_hash.clone(),
+                            op_type,
+                        )
+                        .await
+                        {
+                            Ok(Some(op)) => {
+                                match workspace
+                                    .dht_store
+                                    .as_read()
+                                    .filter_existing_ops(vec![op])
+                                    .await
+                                {
+                                    Ok(missing) if !missing.is_empty() => {
+                                        if let Err(e) =
+                                            workspace.dht_store.record_incoming_ops(missing).await
+                                        {
+                                            tracing::error!(error = ?e, ?action_hash, ?op_type, "Error backfilling warranted op into new DhtStore limbo");
+                                        }
+                                    }
+                                    Ok(_) => {}
+                                    Err(e) => {
+                                        tracing::error!(error = ?e, ?action_hash, "Error checking warranted op presence in new DhtStore");
+                                    }
+                                }
+                            }
+                            Ok(None) => {
+                                tracing::warn!(
+                                    ?action_hash,
+                                    ?op_type,
+                                    "Warranted op not found in legacy DHT DB for backfill"
+                                );
+                            }
+                            Err(e) => {
+                                tracing::error!(error = ?e, ?action_hash, "Error reading warranted op from legacy DHT DB");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        tracing::debug!(error = ?e, "Could not move warranted op to limbo (may already be integrated)");
+                    }
                 }
             }
             Err(StateMutationError::OpNotFoundInCache) => {

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -64,12 +64,20 @@ async fn sys_validation_produces_invalid_chain_op_warrant() {
     .unwrap();
     matches::assert_matches!(outcome, Outcome::Rejected(_));
 
-    //- Inject the invalid op directly into bob's DHT db
+    //- Inject the invalid op directly into bob's DHT db (legacy) and new DHT store
     let op = DhtOpHashed::from_content_sync(op);
     let db = conductor.spaces.dht_db(dna.dna_hash()).unwrap();
+    let op_for_legacy = op.clone();
     db.test_write(move |txn| {
-        insert_op_dht(txn, &op, 0, None).unwrap();
+        insert_op_dht(txn, &op_for_legacy, 0, None).unwrap();
     });
+    conductor
+        .spaces
+        .dht_store(dna.dna_hash())
+        .unwrap()
+        .record_incoming_ops(vec![op])
+        .await
+        .unwrap();
 
     //- Trigger sys validation
     conductor
@@ -196,16 +204,26 @@ async fn sys_validation_produces_forked_chain_warrant() {
     matches::assert_matches!(outcome, Outcome::Accepted);
 
     // Inject genesis + original action (as already-integrated data) and the
-    // forked op (as pending validation) into Bob's DHT db
+    // forked op (as pending validation) into Bob's DHT db (legacy) and new DHT store
     let prev_op_hashed = DhtOpHashed::from_content_sync(prev_op);
     let original_op_hashed = DhtOpHashed::from_content_sync(original_op);
     let forked_op_hashed = DhtOpHashed::from_content_sync(forked_op);
     let db = conductor.spaces.dht_db(dna.dna_hash()).unwrap();
+    let prev_for_legacy = prev_op_hashed.clone();
+    let orig_for_legacy = original_op_hashed.clone();
+    let fork_for_legacy = forked_op_hashed.clone();
     db.test_write(move |txn| {
-        insert_op_dht(txn, &prev_op_hashed, 0, None).unwrap();
-        insert_op_dht(txn, &original_op_hashed, 0, None).unwrap();
-        insert_op_dht(txn, &forked_op_hashed, 0, None).unwrap();
+        insert_op_dht(txn, &prev_for_legacy, 0, None).unwrap();
+        insert_op_dht(txn, &orig_for_legacy, 0, None).unwrap();
+        insert_op_dht(txn, &fork_for_legacy, 0, None).unwrap();
     });
+    conductor
+        .spaces
+        .dht_store(dna.dna_hash())
+        .unwrap()
+        .record_incoming_ops(vec![prev_op_hashed, original_op_hashed, forked_op_hashed])
+        .await
+        .unwrap();
 
     // Check that Bob authored a chain fork warrant with the correct action hashes
     retry_until_timeout!(60_000, 500, {
@@ -355,16 +373,26 @@ async fn sys_validation_produces_two_warrants_when_receiving_both_forked_ops() {
     .unwrap();
     matches::assert_matches!(outcome2, Outcome::Accepted);
 
-    // Inject the previous action and both forked ops into Bob's DHT db
+    // Inject the previous action and both forked ops into Bob's DHT db (legacy) and new DHT store
     let prev_op_hashed = DhtOpHashed::from_content_sync(prev_op);
     let op1_hashed = DhtOpHashed::from_content_sync(op1);
     let op2_hashed = DhtOpHashed::from_content_sync(op2);
     let db = conductor.spaces.dht_db(dna.dna_hash()).unwrap();
+    let prev_for_legacy = prev_op_hashed.clone();
+    let op1_for_legacy = op1_hashed.clone();
+    let op2_for_legacy = op2_hashed.clone();
     db.test_write(move |txn| {
-        insert_op_dht(txn, &prev_op_hashed, 0, None).unwrap();
-        insert_op_dht(txn, &op1_hashed, 0, None).unwrap();
-        insert_op_dht(txn, &op2_hashed, 0, None).unwrap();
+        insert_op_dht(txn, &prev_for_legacy, 0, None).unwrap();
+        insert_op_dht(txn, &op1_for_legacy, 0, None).unwrap();
+        insert_op_dht(txn, &op2_for_legacy, 0, None).unwrap();
     });
+    conductor
+        .spaces
+        .dht_store(dna.dna_hash())
+        .unwrap()
+        .record_incoming_ops(vec![prev_op_hashed, op1_hashed, op2_hashed])
+        .await
+        .unwrap();
 
     // Check that Bob authored 2 chain fork warrants
     retry_until_timeout!(60_000, 500, {

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -2,13 +2,10 @@ use super::*;
 use crate::retry_until_timeout;
 use crate::sweettest::*;
 use crate::test_utils::host_fn_caller::*;
-use crate::test_utils::wait_for_integration;
 use crate::{conductor::ConductorHandle, core::MAX_TAG_SIZE};
 use holo_hash::fixt::{AgentPubKeyFixturator, EntryHashFixturator};
 use holochain_types::test_utils::ActionRefMut;
 use holochain_wasm_test_utils::TestWasm;
-use rusqlite::named_params;
-use rusqlite::Transaction;
 use std::convert::TryFrom;
 use std::time::Duration;
 use {
@@ -458,130 +455,78 @@ async fn run_test(
     conductors: SweetConductorBatch,
     dna_file: DnaFile,
 ) {
-    // Check if the correct number of ops are integrated
-    // every 100 ms for a maximum of 10 seconds but early exit
-    // if they are there.
+    // Assert against the new `holochain_data` DHT store, which is the
+    // authoritative source for integration during the migration; the legacy
+    // `DhtOp` table is now a downstream mirror. Poll every 100 ms for up to
+    // 10 seconds, exiting early once the expected ops are integrated.
     let num_attempts = 100;
     let delay_per_attempt = Duration::from_millis(100);
 
+    let dht_store = conductors[0]
+        .spaces
+        .dht_store(alice_cell_id.dna_hash())
+        .unwrap();
+
     bob_links_in_a_legit_way(&bob_cell_id, &conductors[1].raw_handle(), &dna_file).await;
 
-    // Integration should have 9 ops in it.
-    // Plus another 14 for genesis.
+    // 9 ops from the three authored records plus 14 genesis ops (both agents).
     // Init is not run because we aren't calling the zome.
-    let expected_count = 9 + 14;
+    let expected_count: i64 = 9 + 14;
 
-    let alice_dht_db = conductors[0].get_dht_db(alice_cell_id.dna_hash()).unwrap();
-    wait_for_integration(
-        &alice_dht_db,
-        expected_count,
-        num_attempts,
-        delay_per_attempt,
-    )
-    .await
-    .unwrap();
+    wait_for_new_store_integration(&dht_store, expected_count, num_attempts, delay_per_attempt)
+        .await;
+    assert_new_store_limbo_empty(&dht_store).await;
 
-    let limbo_is_empty = |txn: &Transaction| {
-        let not_empty: bool = txn
-            .query_row(
-                "SELECT EXISTS(SELECT 1 FROM DhtOp WHERE when_integrated IS NULL)",
-                [],
-                |row| row.get(0),
-            )
-            .unwrap();
-        !not_empty
-    };
+    // Authors an op with an oversized link tag, which is rejected and produces
+    // an InvalidChainOp warrant.
+    bob_makes_a_large_link(&bob_cell_id, &conductors[1].raw_handle(), &dna_file).await;
 
-    // holochain_state::prelude::dump_tmp(&alice_dht_db);
-    // Validation should be empty
-    alice_dht_db.read_async(move |txn| -> DatabaseResult<()> {
-        let limbo = show_limbo(txn);
-        assert!(limbo_is_empty(txn), "{limbo:?}");
-
-        let num_valid_ops: usize = txn
-            .query_row("SELECT COUNT(hash) FROM DhtOp WHERE when_integrated IS NOT NULL AND validation_status = :status",
-            named_params!{
-                ":status": ValidationStatus::Valid,
-            },
-            |row| row.get(0))
-            .unwrap();
-
-        assert_eq!(num_valid_ops, expected_count);
-
-        Ok(())
-    }).await.unwrap();
-
-    let (bad_update_action, bad_update_entry_hash, link_add_hash) =
-        bob_makes_a_large_link(&bob_cell_id, &conductors[1].raw_handle(), &dna_file).await;
-
-    // Integration should have 14 chain ops in it + 1 warrant op + the running tally
+    // 14 chain ops + 1 warrant op on top of the running tally. The rejected ops
+    // are still integrated (with a rejected status), so they count here too.
     let expected_count = 14 + 1 + expected_count;
 
-    let alice_db = conductors[0].get_dht_db(alice_cell_id.dna_hash()).unwrap();
-    wait_for_integration(&alice_db, expected_count, num_attempts, delay_per_attempt)
+    wait_for_new_store_integration(&dht_store, expected_count, num_attempts, delay_per_attempt)
+        .await;
+    assert_new_store_limbo_empty(&dht_store).await;
+}
+
+/// Poll the new DHT store until at least `expected` ops are integrated, or
+/// panic after `num_attempts`.
+async fn wait_for_new_store_integration(
+    dht_store: &holochain_state::dht_store::DhtStore,
+    expected: i64,
+    num_attempts: usize,
+    delay: Duration,
+) {
+    for _ in 0..num_attempts {
+        let integrated = dht_store.as_read().count_integrated_ops().await.unwrap();
+        if integrated >= expected {
+            return;
+        }
+        tokio::time::sleep(delay).await;
+    }
+    let integrated = dht_store.as_read().count_integrated_ops().await.unwrap();
+    panic!("new-store integration not reached: expected {expected}, integrated {integrated}");
+}
+
+/// Assert that nothing is awaiting validation in the new DHT store.
+async fn assert_new_store_limbo_empty(dht_store: &holochain_state::dht_store::DhtStore) {
+    let pending_sys = dht_store
+        .as_read()
+        .ops_pending_sys_validation(10_000)
         .await
         .unwrap();
-
-    let bad_update_entry_hash: AnyDhtHash = bad_update_entry_hash.into();
-    let num_valid_ops = move |txn: &Transaction| -> DatabaseResult<usize> {
-        let valid_ops: usize = txn
-                .query_row(
-                    "
-                    SELECT COUNT(hash) FROM DhtOp
-                    WHERE
-                    when_integrated IS NOT NULL
-                    AND
-                    (validation_status = :valid
-                        OR (validation_status = :rejected
-                            AND (
-                                (type = :store_entry AND basis_hash = :bad_update_entry_hash AND action_hash = :bad_update_action)
-                                OR
-                                (type = :store_record AND action_hash = :bad_update_action)
-                                OR
-                                (type = :add_link AND action_hash = :link_add_hash)
-                                OR
-                                (type = :update_content AND action_hash = :bad_update_action)
-                                OR
-                                (type = :update_record AND action_hash = :bad_update_action)
-                            )
-                        )
-                    )
-                    ",
-                named_params!{
-                    ":valid": ValidationStatus::Valid,
-                    ":rejected": ValidationStatus::Rejected,
-                    ":store_entry": ChainOpType::StoreEntry,
-                    ":store_record": ChainOpType::StoreRecord,
-                    ":add_link": ChainOpType::RegisterAddLink,
-                    ":update_content": ChainOpType::RegisterUpdatedContent,
-                    ":update_record": ChainOpType::RegisterUpdatedRecord,
-                    ":bad_update_entry_hash": bad_update_entry_hash,
-                    ":bad_update_action": bad_update_action,
-                    ":link_add_hash": link_add_hash,
-                },
-                |row| row.get(0))
-                .unwrap();
-
-        Ok(valid_ops)
-    };
-
-    let (limbo, empty) = alice_db
-        .read_async(move |txn| {
-            // Validation should be empty
-            let limbo = show_limbo(txn);
-            let empty = limbo_is_empty(txn);
-            DatabaseResult::Ok((limbo, empty))
-        })
+    let pending_app = dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
         .await
         .unwrap();
-
-    assert!(empty, "{limbo:?}");
-
-    let valid_ops = alice_db
-        .read_async(move |txn| num_valid_ops(txn))
-        .await
-        .unwrap();
-    assert_eq!(valid_ops, expected_count);
+    assert!(
+        pending_sys.is_empty() && pending_app.is_empty(),
+        "new-store limbo not empty: {} pending sys validation, {} pending app validation",
+        pending_sys.len(),
+        pending_app.len()
+    );
 }
 
 async fn bob_links_in_a_legit_way(
@@ -705,37 +650,6 @@ async fn bob_makes_a_large_link(
         .integrate_dht_ops
         .trigger(&"bob_makes_a_large_link");
     (bad_update_action, bad_update_entry_hash, link_add_address)
-}
-
-fn show_limbo(txn: &Transaction) -> Vec<DhtOpLite> {
-    txn.prepare(
-        "
-        SELECT DhtOp.type, Action.hash, Action.blob, Action.author
-        FROM DhtOp
-        JOIN Action ON DhtOp.action_hash = Action.hash
-        WHERE
-        when_integrated IS NULL
-    ",
-    )
-    .unwrap()
-    .query_and_then([], |row| {
-        let op_type: DhtOpType = row.get("type")?;
-        match op_type {
-            DhtOpType::Chain(op_type) => {
-                let hash: ActionHash = row.get("hash")?;
-
-                let action: SignedAction = from_blob(row.get("blob")?)?;
-                Ok(ChainOpLite::from_type(op_type, hash, &action)?.into())
-            }
-            DhtOpType::Warrant(_) => {
-                let warrant: SignedWarrant = from_blob(row.get("blob")?)?;
-                Ok(warrant.into())
-            }
-        }
-    })
-    .unwrap()
-    .collect::<StateQueryResult<Vec<DhtOpLite>>>()
-    .unwrap()
 }
 
 /// Test the detect_fork function against different situations,

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::retry_until_timeout;
 use crate::sweettest::*;
 use crate::test_utils::host_fn_caller::*;
+use crate::test_utils::{assert_new_store_limbo_empty, wait_for_new_store_integration};
 use crate::{conductor::ConductorHandle, core::MAX_TAG_SIZE};
 use holo_hash::fixt::{AgentPubKeyFixturator, EntryHashFixturator};
 use holochain_types::test_utils::ActionRefMut;
@@ -488,45 +489,6 @@ async fn run_test(
     wait_for_new_store_integration(&dht_store, expected_count, num_attempts, delay_per_attempt)
         .await;
     assert_new_store_limbo_empty(&dht_store).await;
-}
-
-/// Poll the new DHT store until at least `expected` ops are integrated, or
-/// panic after `num_attempts`.
-async fn wait_for_new_store_integration(
-    dht_store: &holochain_state::dht_store::DhtStore,
-    expected: i64,
-    num_attempts: usize,
-    delay: Duration,
-) {
-    for _ in 0..num_attempts {
-        let integrated = dht_store.as_read().count_integrated_ops().await.unwrap();
-        if integrated >= expected {
-            return;
-        }
-        tokio::time::sleep(delay).await;
-    }
-    let integrated = dht_store.as_read().count_integrated_ops().await.unwrap();
-    panic!("new-store integration not reached: expected {expected}, integrated {integrated}");
-}
-
-/// Assert that nothing is awaiting validation in the new DHT store.
-async fn assert_new_store_limbo_empty(dht_store: &holochain_state::dht_store::DhtStore) {
-    let pending_sys = dht_store
-        .as_read()
-        .ops_pending_sys_validation(10_000)
-        .await
-        .unwrap();
-    let pending_app = dht_store
-        .as_read()
-        .ops_pending_app_validation(10_000)
-        .await
-        .unwrap();
-    assert!(
-        pending_sys.is_empty() && pending_app.is_empty(),
-        "new-store limbo not empty: {} pending sys validation, {} pending app validation",
-        pending_sys.len(),
-        pending_app.len()
-    );
 }
 
 async fn bob_links_in_a_legit_way(

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
@@ -64,10 +64,7 @@ async fn validate_op_with_no_dependency() {
     };
     let op = ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Dna(dna_action));
 
-    let op_hash = test_case
-        .save_op_to_db(test_case.dht_db_handle(), op.into())
-        .await
-        .unwrap();
+    let op_hash = test_case.save_op_to_dht(op.into()).await.unwrap();
 
     test_case.run().await;
 
@@ -115,10 +112,7 @@ async fn validate_op_with_dependency_held_in_cache() {
     });
     let op = ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Create(create_action)).into();
 
-    let op_hash = test_case
-        .save_op_to_db(test_case.dht_db_handle(), op)
-        .await
-        .unwrap();
+    let op_hash = test_case.save_op_to_dht(op).await.unwrap();
 
     let mut network = MockHolochainP2pDnaT::default();
     network
@@ -166,10 +160,7 @@ async fn validate_op_with_dependency_not_held() {
     });
     let op = ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Create(create_action)).into();
 
-    let op_hash = test_case
-        .save_op_to_db(test_case.dht_db_handle(), op)
-        .await
-        .unwrap();
+    let op_hash = test_case.save_op_to_dht(op).await.unwrap();
 
     let mut network = MockHolochainP2pDnaT::default();
     let mut ops: WireRecordOps = WireRecordOps::new();
@@ -230,10 +221,7 @@ async fn validate_op_with_dependency_not_found_on_the_dht() {
     });
     let op = ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Create(create_action)).into();
 
-    test_case
-        .save_op_to_db(test_case.dht_db_handle(), op)
-        .await
-        .unwrap();
+    test_case.save_op_to_dht(op).await.unwrap();
 
     let mut network = MockHolochainP2pDnaT::new();
     // Just return an empty response, nothing found for the request
@@ -297,10 +285,7 @@ async fn validate_op_with_wrong_sequence_number_rejected_and_not_forwarded_to_ap
         visibility: EntryVisibility::Public,
     });
     let op = ChainOp::RegisterAgentActivity(fixt!(Signature), Action::Create(create_action)).into();
-    test_case
-        .save_op_to_db(test_case.dht_db_handle(), op)
-        .await
-        .unwrap();
+    test_case.save_op_to_dht(op).await.unwrap();
 
     test_case.run().await;
 
@@ -362,10 +347,7 @@ async fn validate_valid_warrant_with_cached_dependency() {
     let warrant_op_hash = DhtOpHashed::from_content_sync(warrant_op.clone()).hash;
 
     test_case
-        .save_op_to_db(
-            test_case.dht_db_handle(),
-            DhtOp::WarrantOp(warrant_op.into()),
-        )
+        .save_op_to_dht(DhtOp::WarrantOp(warrant_op.into()))
         .await
         .unwrap();
 
@@ -448,10 +430,7 @@ async fn validate_valid_warrant_with_fetched_dependency() {
     let warrant_op_hash = DhtOpHashed::from_content_sync(warrant_op.clone()).hash;
 
     test_case
-        .save_op_to_db(
-            test_case.dht_db_handle(),
-            DhtOp::WarrantOp(warrant_op.into()),
-        )
+        .save_op_to_dht(DhtOp::WarrantOp(warrant_op.into()))
         .await
         .unwrap();
 
@@ -517,10 +496,7 @@ async fn reject_invalid_warrant() {
         crate::prelude::RecordEntry::Present(entry),
     );
     let valid_op_hash = DhtOpHashed::from_content_sync(valid_op.clone()).hash;
-    test_case
-        .save_op_to_db(test_case.dht_db_handle(), valid_op.into())
-        .await
-        .unwrap();
+    test_case.save_op_to_dht(valid_op.into()).await.unwrap();
 
     // Invalid warrant against a valid action
     let warrant_op = test_case
@@ -535,10 +511,7 @@ async fn reject_invalid_warrant() {
     let warrant_op_hash = DhtOpHashed::from_content_sync(warrant_op.clone()).hash;
 
     test_case
-        .save_op_to_db(
-            test_case.dht_db_handle(),
-            DhtOp::WarrantOp(warrant_op.into()),
-        )
+        .save_op_to_dht(DhtOp::WarrantOp(warrant_op.into()))
         .await
         .unwrap();
 
@@ -627,10 +600,7 @@ async fn validate_warrant_with_validated_dependency() {
         crate::prelude::RecordEntry::Present(entry),
     );
     let valid_op_hash = DhtOpHashed::from_content_sync(valid_op.clone()).hash;
-    test_case
-        .save_op_to_db(test_case.dht_db_handle(), valid_op.into())
-        .await
-        .unwrap();
+    test_case.save_op_to_dht(valid_op.into()).await.unwrap();
     test_case
         .test_space
         .space
@@ -658,10 +628,7 @@ async fn validate_warrant_with_validated_dependency() {
     let warrant_op_hash = DhtOpHashed::from_content_sync(warrant_op.clone()).hash;
 
     test_case
-        .save_op_to_db(
-            test_case.dht_db_handle(),
-            DhtOp::WarrantOp(warrant_op.into()),
-        )
+        .save_op_to_dht(DhtOp::WarrantOp(warrant_op.into()))
         .await
         .unwrap();
 
@@ -717,10 +684,7 @@ async fn avoid_duplicate_warrant() {
         Action::Create(create),
         crate::prelude::RecordEntry::Present(entry),
     );
-    test_case
-        .save_op_to_db(test_case.dht_db_handle(), invalid_op.into())
-        .await
-        .unwrap();
+    test_case.save_op_to_dht(invalid_op.into()).await.unwrap();
 
     // Valid warrant against the invalid action
     let warrant_op = test_case
@@ -733,10 +697,7 @@ async fn avoid_duplicate_warrant() {
         .unwrap();
     let warrant_op_hash = DhtOpHashed::from_content_sync(warrant_op.clone()).hash;
     test_case
-        .save_op_to_db(
-            test_case.dht_db_handle(),
-            DhtOp::WarrantOp(warrant_op.into()),
-        )
+        .save_op_to_dht(DhtOp::WarrantOp(warrant_op.into()))
         .await
         .unwrap();
 
@@ -879,6 +840,37 @@ impl TestCase {
         .unwrap();
 
         Ok(test_op_hash)
+    }
+
+    /// Write an op to both the legacy DHT database and the new DHT store so that
+    /// both the legacy write path and the new `ops_pending_sys_validation` read
+    /// path see the op.
+    async fn save_op_to_dht(&self, op: DhtOp) -> StateMutationResult<DhtOpHash> {
+        let op_hashed = DhtOpHashed::from_content_sync(op);
+        let hash = op_hashed.as_hash().clone();
+
+        // Write to the legacy DB so that other legacy paths (app-validation query,
+        // integration, etc.) also see this op.
+        let op_for_legacy = op_hashed.clone();
+        self.test_space
+            .space
+            .dht_db
+            .write_async(move |txn| -> StateMutationResult<()> {
+                holochain_state::mutations::insert_op_untyped(txn, &op_for_legacy, 0)?;
+                Ok(())
+            })
+            .await
+            .unwrap();
+
+        // Write to the new DHT store so that `ops_pending_sys_validation` returns it.
+        self.test_space
+            .space
+            .dht_store
+            .record_incoming_ops(vec![op_hashed])
+            .await
+            .unwrap();
+
+        Ok(hash)
     }
 
     async fn create_and_sign_warrant(

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
@@ -329,7 +329,7 @@ async fn validate_valid_warrant_with_cached_dependency() {
         crate::prelude::RecordEntry::Present(entry),
     );
     test_case
-        .save_chain_op_to_cache(warranted_op)
+        .save_chain_op_as_cached(warranted_op)
         .await
         .unwrap();
 
@@ -840,12 +840,10 @@ impl TestCase {
         Ok(test_op_hash)
     }
 
-    /// Write a chain op to both the legacy cache database and the new DHT store so
-    /// that the op is visible to both the legacy `copy_cached_op_to_dht` path and
-    /// to `move_warranted_op_to_limbo`. In production, cascade's `cache_chain_ops`
-    /// performs this dual write; this helper replicates that for test fixtures that
-    /// bypass cascade.
-    async fn save_chain_op_to_cache(&self, chain_op: ChainOp) -> StateMutationResult<DhtOpHash> {
+    /// Write a chain op to the legacy cache database and to the new DHT store as
+    /// a cached (not locally-validated) row, so it is visible to both the legacy
+    /// `copy_cached_op_to_dht` path and to `move_warranted_op_to_limbo`.
+    async fn save_chain_op_as_cached(&self, chain_op: ChainOp) -> StateMutationResult<DhtOpHash> {
         // Build the RenderedOps first so we can pass it to cache_chain_ops.
         let action = chain_op.action();
         let signature = chain_op.signature().clone();
@@ -994,6 +992,7 @@ impl TestCase {
         self.test_space
             .space
             .dht_store
+            .as_read()
             .ops_pending_app_validation(10_000)
             .await
             .unwrap()

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
@@ -1,6 +1,5 @@
 use super::sys_validation_workflow;
 use super::validation_deps::SysValDeps;
-use super::validation_query::get_ops_to_app_validate;
 use super::SysValidationWorkspace;
 use crate::conductor::space::TestSpace;
 use crate::core::queue_consumer::TriggerReceiver;
@@ -992,7 +991,10 @@ impl TestCase {
 
     /// This provides a quick and reliable way to check that ops have been sys validated
     async fn get_ops_pending_app_validation(&self) -> HashSet<DhtOpHash> {
-        get_ops_to_app_validate(&self.dht_db_handle().into())
+        self.test_space
+            .space
+            .dht_store
+            .ops_pending_app_validation(10_000)
             .await
             .unwrap()
             .into_iter()

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
@@ -328,10 +328,9 @@ async fn validate_valid_warrant_with_cached_dependency() {
         fixt!(Signature),
         Action::Create(create),
         crate::prelude::RecordEntry::Present(entry),
-    )
-    .into();
+    );
     test_case
-        .save_op_to_db(test_case.cache_db_handle(), warranted_op)
+        .save_chain_op_to_cache(warranted_op)
         .await
         .unwrap();
 
@@ -840,6 +839,47 @@ impl TestCase {
         .unwrap();
 
         Ok(test_op_hash)
+    }
+
+    /// Write a chain op to both the legacy cache database and the new DHT store so
+    /// that the op is visible to both the legacy `copy_cached_op_to_dht` path and
+    /// to `move_warranted_op_to_limbo`. In production, cascade's `cache_chain_ops`
+    /// performs this dual write; this helper replicates that for test fixtures that
+    /// bypass cascade.
+    async fn save_chain_op_to_cache(&self, chain_op: ChainOp) -> StateMutationResult<DhtOpHash> {
+        // Build the RenderedOps first so we can pass it to cache_chain_ops.
+        let action = chain_op.action();
+        let signature = chain_op.signature().clone();
+        let op_type = chain_op.get_type();
+        let entry = match chain_op.entry() {
+            holochain_zome_types::record::RecordEntry::Present(e) => Some(
+                holochain_zome_types::entry::EntryHashed::from_content_sync(e.clone()),
+            ),
+            _ => None,
+        };
+
+        let rendered_op =
+            holochain_types::dht_op::RenderedOp::new(action, signature, None, op_type)
+                .expect("render op for test fixture");
+        let rendered_ops = holochain_types::dht_op::RenderedOps {
+            entry,
+            ops: vec![rendered_op],
+            warrant: None,
+        };
+
+        // Legacy cache write (required by copy_cached_op_to_dht).
+        let op_hash = self
+            .save_op_to_db(self.cache_db_handle(), DhtOp::ChainOp(Box::new(chain_op)))
+            .await?;
+
+        // New DhtStore write so move_warranted_op_to_limbo can find the row.
+        self.test_space
+            .space
+            .dht_store
+            .cache_chain_ops(&rendered_ops)
+            .await?;
+
+        Ok(op_hash)
     }
 
     /// Write an op to both the legacy DHT database and the new DHT store so that

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
@@ -48,7 +48,10 @@ pub async fn validation_receipt_workflow(
         .collect::<Vec<_>>();
 
     // Get out all ops that are marked for sending receipt.
-    let receipts = pending_receipts(&vault, validators.clone()).await?;
+    let receipts = dht_store
+        .pending_validation_receipts(validators.clone())
+        .await
+        .map_err(WorkflowError::from)?;
 
     let validators: HashSet<_> = validators.into_iter().collect();
 
@@ -187,14 +190,4 @@ async fn sign_and_send_receipts_to_author(
     .await?;
 
     Ok(())
-}
-
-#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
-async fn pending_receipts(
-    vault: &DbRead<DbKindDht>,
-    validators: Vec<AgentPubKey>,
-) -> StateQueryResult<Vec<(ValidationReceipt, AgentPubKey)>> {
-    vault
-        .read_async(move |txn| get_pending_validation_receipts(txn, validators))
-        .await
 }

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
@@ -1,4 +1,4 @@
-use super::error::{WorkflowError, WorkflowResult};
+use super::error::WorkflowResult;
 use crate::core::queue_consumer::WorkComplete;
 use futures::{stream, StreamExt};
 use holochain_keystore::MetaLairClient;
@@ -50,8 +50,7 @@ pub async fn validation_receipt_workflow(
     // Get out all ops that are marked for sending receipt.
     let receipts = dht_store
         .pending_validation_receipts(validators.clone())
-        .await
-        .map_err(WorkflowError::from)?;
+        .await?;
 
     let validators: HashSet<_> = validators.into_iter().collect();
 
@@ -93,10 +92,7 @@ pub async fn validation_receipt_workflow(
                         .await?;
                 }
                 // Mirror: clear `require_receipt` on the new-DB `ChainOp` rows.
-                dht_store
-                    .clear_require_receipts(op_hashes)
-                    .await
-                    .map_err(WorkflowError::from)?;
+                dht_store.clear_require_receipts(op_hashes).await?;
                 continue;
             }
         }
@@ -123,10 +119,7 @@ pub async fn validation_receipt_workflow(
                         .await?;
                 }
                 // Mirror: clear `require_receipt` on the new-DB `ChainOp` rows.
-                dht_store
-                    .clear_require_receipts(op_hashes)
-                    .await
-                    .map_err(WorkflowError::from)?;
+                dht_store.clear_require_receipts(op_hashes).await?;
             }
             Err(e) => {
                 info!(failed_to_sign_and_send_receipt = ?e);

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
@@ -49,6 +49,7 @@ pub async fn validation_receipt_workflow(
 
     // Get out all ops that are marked for sending receipt.
     let receipts = dht_store
+        .as_read()
         .pending_validation_receipts(validators.clone())
         .await?;
 

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/unit_tests.rs
@@ -12,6 +12,7 @@ use holo_hash::{AgentPubKey, DhtOpHash};
 use holochain_p2p::MockHolochainP2pDnaT;
 use holochain_sqlite::error::DatabaseResult;
 use holochain_sqlite::prelude::{DbKindDht, DbWrite};
+use holochain_state::dht_store::DhtStore;
 use holochain_state::prelude::*;
 use holochain_state::test_utils::test_dht_store;
 use rusqlite::named_params;
@@ -57,15 +58,22 @@ async fn do_not_block_or_send_to_self() {
     let dna_hash = fixt!(DnaHash);
     let author = fixt!(AgentPubKey);
 
+    let dht_store = test_dht_store(dna_hash.clone()).await;
+
     // Create a valid op that would require a validation receipt except that it's created by us
-    let (_, valid_op_hash) =
-        create_op_with_status(vault.clone(), Some(author.clone()), ValidationStatus::Valid)
-            .await
-            .unwrap();
+    let (_, valid_op_hash) = create_op_with_status(
+        vault.clone(),
+        &dht_store,
+        Some(author.clone()),
+        ValidationStatus::Valid,
+    )
+    .await
+    .unwrap();
 
     // Create a rejected op which would usually cause a block but it's created by us
     let (_, rejected_op_hash) = create_op_with_status(
         vault.clone(),
+        &dht_store,
         Some(author.clone()),
         ValidationStatus::Rejected,
     )
@@ -78,7 +86,6 @@ async fn do_not_block_or_send_to_self() {
 
     let validator = CellId::new(dna_hash.clone(), author);
 
-    let dht_store = test_dht_store(dna_hash.clone()).await;
     let work_complete = validation_receipt_workflow(
         Arc::new(dna_hash),
         vault.clone(),
@@ -104,10 +111,14 @@ async fn block_invalid_op_author() {
     let vault = test_db.to_db();
     let keystore = holochain_keystore::test_keystore();
 
+    let dna_hash = fixt!(DnaHash);
+    let dht_store = test_dht_store(dna_hash.clone()).await;
+
     // Any op created by somebody else, which has been rejected by validation.
-    let (_author, op_hash) = create_op_with_status(vault.clone(), None, ValidationStatus::Rejected)
-        .await
-        .unwrap();
+    let (_author, op_hash) =
+        create_op_with_status(vault.clone(), &dht_store, None, ValidationStatus::Rejected)
+            .await
+            .unwrap();
 
     // We'll still send a validation receipt, but we should also block them
     let mut dna = MockHolochainP2pDnaT::new();
@@ -117,13 +128,11 @@ async fn block_invalid_op_author() {
         .return_once(|_, _| Ok(()));
     let dna = Arc::new(dna);
 
-    let dna_hash = fixt!(DnaHash);
     let validator = CellId::new(
         dna_hash.clone(),
         keystore.new_sign_keypair_random().await.unwrap(),
     );
 
-    let dht_store = test_dht_store(dna_hash.clone()).await;
     let work_complete = validation_receipt_workflow(
         Arc::new(dna_hash),
         vault.clone(),
@@ -150,10 +159,14 @@ async fn continues_if_receipt_cannot_be_signed() {
     let vault = test_db.to_db();
     let keystore = holochain_keystore::test_keystore();
 
+    let dna_hash = fixt!(DnaHash);
+    let dht_store = test_dht_store(dna_hash.clone()).await;
+
     // Any op created by somebody else, which is valid
-    let (_, op_hash) = create_op_with_status(vault.clone(), None, ValidationStatus::Valid)
-        .await
-        .unwrap();
+    let (_, op_hash) =
+        create_op_with_status(vault.clone(), &dht_store, None, ValidationStatus::Valid)
+            .await
+            .unwrap();
 
     let mut dna = MockHolochainP2pDnaT::new();
     dna.expect_was_agent_recently_online()
@@ -161,14 +174,11 @@ async fn continues_if_receipt_cannot_be_signed() {
     dna.expect_send_validation_receipts().never();
     let dna = Arc::new(dna);
 
-    let dna_hash = fixt!(DnaHash);
-
     let invalid_validator = CellId::new(
         dna_hash.clone(),
         fixt!(AgentPubKey), // Not valid because it won't be found in Lair
     );
 
-    let dht_store = test_dht_store(dna_hash.clone()).await;
     let work_complete = validation_receipt_workflow(
         Arc::new(dna_hash),
         vault.clone(),
@@ -192,10 +202,14 @@ async fn send_validation_receipt() {
     let vault = test_db.to_db();
     let keystore = holochain_keystore::test_keystore();
 
+    let dna_hash = fixt!(DnaHash);
+    let dht_store = test_dht_store(dna_hash.clone()).await;
+
     // Any op created by somebody else, which is valid
-    let (_, op_hash) = create_op_with_status(vault.clone(), None, ValidationStatus::Valid)
-        .await
-        .unwrap();
+    let (_, op_hash) =
+        create_op_with_status(vault.clone(), &dht_store, None, ValidationStatus::Valid)
+            .await
+            .unwrap();
 
     let mut dna = MockHolochainP2pDnaT::new();
     dna.expect_was_agent_recently_online()
@@ -204,14 +218,11 @@ async fn send_validation_receipt() {
         .return_once(|_, _| Ok(()));
     let dna = Arc::new(dna);
 
-    let dna_hash = fixt!(DnaHash);
-
     let validator = CellId::new(
         dna_hash.clone(),
         keystore.new_sign_keypair_random().await.unwrap(),
     );
 
-    let dht_store = test_dht_store(dna_hash.clone()).await;
     let work_complete = validation_receipt_workflow(
         Arc::new(dna_hash),
         vault.clone(),
@@ -237,13 +248,18 @@ async fn errors_for_some_ops_does_not_prevent_the_workflow_proceeding() {
     let vault = test_db.to_db();
     let keystore = holochain_keystore::test_keystore();
 
-    let (author1, op_hash1) = create_op_with_status(vault.clone(), None, ValidationStatus::Valid)
-        .await
-        .unwrap();
+    let dna_hash = fixt!(DnaHash);
+    let dht_store = test_dht_store(dna_hash.clone()).await;
 
-    let (author2, op_hash2) = create_op_with_status(vault.clone(), None, ValidationStatus::Valid)
-        .await
-        .unwrap();
+    let (author1, op_hash1) =
+        create_op_with_status(vault.clone(), &dht_store, None, ValidationStatus::Valid)
+            .await
+            .unwrap();
+
+    let (author2, op_hash2) =
+        create_op_with_status(vault.clone(), &dht_store, None, ValidationStatus::Valid)
+            .await
+            .unwrap();
 
     let mut dna = MockHolochainP2pDnaT::new();
     dna.expect_was_agent_recently_online()
@@ -262,14 +278,11 @@ async fn errors_for_some_ops_does_not_prevent_the_workflow_proceeding() {
         .returning(|_, _| Ok(()));
     let dna = Arc::new(dna);
 
-    let dna_hash = fixt!(DnaHash);
-
     let validator = CellId::new(
         dna_hash.clone(),
         keystore.new_sign_keypair_random().await.unwrap(),
     );
 
-    let dht_store = test_dht_store(dna_hash.clone()).await;
     let work_complete = validation_receipt_workflow(
         Arc::new(dna_hash),
         vault.clone(),
@@ -301,14 +314,19 @@ async fn skips_authors_not_recently_online_and_clears_require_receipt() {
     let vault = test_db.to_db();
     let keystore = holochain_keystore::test_keystore();
 
-    // Create ops from two different authors
-    let (author1, op_hash1) = create_op_with_status(vault.clone(), None, ValidationStatus::Valid)
-        .await
-        .unwrap();
+    let dna_hash = fixt!(DnaHash);
+    let dht_store = test_dht_store(dna_hash.clone()).await;
 
-    let (author2, op_hash2) = create_op_with_status(vault.clone(), None, ValidationStatus::Valid)
-        .await
-        .unwrap();
+    // Create ops from two different authors
+    let (author1, op_hash1) =
+        create_op_with_status(vault.clone(), &dht_store, None, ValidationStatus::Valid)
+            .await
+            .unwrap();
+
+    let (author2, op_hash2) =
+        create_op_with_status(vault.clone(), &dht_store, None, ValidationStatus::Valid)
+            .await
+            .unwrap();
 
     let author1_clone = author1.clone();
     let mut dna = MockHolochainP2pDnaT::new();
@@ -332,14 +350,11 @@ async fn skips_authors_not_recently_online_and_clears_require_receipt() {
 
     let dna = Arc::new(dna);
 
-    let dna_hash = fixt!(DnaHash);
-
     let validator = CellId::new(
         dna_hash.clone(),
         keystore.new_sign_keypair_random().await.unwrap(),
     );
 
-    let dht_store = test_dht_store(dna_hash.clone()).await;
     let work_complete = validation_receipt_workflow(
         Arc::new(dna_hash),
         vault.clone(),
@@ -363,9 +378,12 @@ async fn skips_authors_not_recently_online_and_clears_require_receipt() {
 
 async fn create_op_with_status(
     vault: DbWrite<DbKindDht>,
+    dht_store: &DhtStore,
     author: Option<AgentPubKey>,
     validation_status: ValidationStatus,
 ) -> StateMutationResult<(AgentPubKey, DhtOpHash)> {
+    use holochain_state::dht_store::{AppOutcome, SysOutcome};
+
     // The actual op does not matter, just some of the status fields
     let mut create_action = fixt!(Create);
     let author = author.unwrap_or_else(|| fixt!(AgentPubKey));
@@ -376,9 +394,12 @@ async fn create_op_with_status(
         DhtOpHashed::from_content_sync(ChainOp::RegisterAgentActivity(fixt!(Signature), action));
 
     let test_op_hash = op.as_hash().clone();
+
+    // Legacy DB: write the op in integrated + require_receipt state.
     vault
         .write_async({
             let test_op_hash = test_op_hash.clone();
+            let op = op.clone();
             move |txn| -> StateMutationResult<()> {
                 holochain_state::mutations::insert_op_dht(txn, &op, 0, None)?;
                 set_require_receipt(txn, &test_op_hash, true)?;
@@ -390,6 +411,35 @@ async fn create_op_with_status(
         })
         .await
         .unwrap();
+
+    // New-DB: write the same op through the full validation + integration
+    // pipeline so that DhtStore::pending_validation_receipts sees it.
+    // The hash is derived from the same op content, so test_op_hash matches.
+    dht_store.record_incoming_ops(vec![op]).await.unwrap();
+
+    let sys_outcome = match validation_status {
+        ValidationStatus::Valid => SysOutcome::Accepted,
+        _ => SysOutcome::Rejected,
+    };
+    dht_store
+        .record_chain_op_sys_validation_outcomes(vec![(test_op_hash.clone(), sys_outcome)])
+        .await
+        .unwrap();
+
+    let app_outcome = match validation_status {
+        ValidationStatus::Valid => AppOutcome::Accepted,
+        _ => AppOutcome::Rejected,
+    };
+    dht_store
+        .record_app_validation_outcomes(vec![(test_op_hash.clone(), app_outcome)])
+        .await
+        .unwrap();
+
+    dht_store
+        .integrate_ready_ops(Timestamp::now())
+        .await
+        .unwrap();
+    // record_incoming_ops sets require_receipt = true, matching the legacy fixture.
 
     Ok((author, test_op_hash))
 }

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow/unit_tests.rs
@@ -264,17 +264,16 @@ async fn errors_for_some_ops_does_not_prevent_the_workflow_proceeding() {
     let mut dna = MockHolochainP2pDnaT::new();
     dna.expect_was_agent_recently_online()
         .returning(|_| Ok(true));
-    let mut seq = mockall::Sequence::new();
+    // Both authors are processed; the order is not guaranteed by the DB query.
+    // Author1's send returns an error; author2's send succeeds.
     dna.expect_send_validation_receipts()
         .times(1)
         .withf(move |author: &AgentPubKey, _| *author == author1)
-        .in_sequence(&mut seq)
         .returning(|_, _| Err("I'm a test error".into()));
 
     dna.expect_send_validation_receipts()
         .times(1)
         .withf(move |author: &AgentPubKey, _| *author == author2)
-        .in_sequence(&mut seq)
         .returning(|_, _| Ok(()));
     let dna = Arc::new(dna);
 

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -295,6 +295,84 @@ pub async fn wait_for_integration<Db: ReadAccess<DbKindDht>>(
     ))
 }
 
+/// Poll the new DHT store until at least `expected` ops are integrated, or
+/// panic after `num_attempts`. On failure the ops still awaiting validation are
+/// listed so a failing test shows what did not progress.
+pub async fn wait_for_new_store_integration(
+    dht_store: &holochain_state::dht_store::DhtStore,
+    expected: i64,
+    num_attempts: usize,
+    delay: Duration,
+) {
+    for _ in 0..num_attempts {
+        let integrated = dht_store.as_read().count_integrated_ops().await.unwrap();
+        if integrated >= expected {
+            return;
+        }
+        tokio::time::sleep(delay).await;
+    }
+    let integrated = dht_store.as_read().count_integrated_ops().await.unwrap();
+    panic!(
+        "new-store integration not reached: expected {expected}, integrated {integrated}\n{}",
+        new_store_pending_summary(dht_store).await
+    );
+}
+
+/// Assert that nothing is awaiting validation in the new DHT store. On failure
+/// the still-pending ops are listed so the cause is visible.
+pub async fn assert_new_store_limbo_empty(dht_store: &holochain_state::dht_store::DhtStore) {
+    let pending_sys = dht_store
+        .as_read()
+        .ops_pending_sys_validation(10_000)
+        .await
+        .unwrap();
+    let pending_app = dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap();
+    assert!(
+        pending_sys.is_empty() && pending_app.is_empty(),
+        "new-store limbo not empty: {} pending sys validation, {} pending app validation\n{}{}",
+        pending_sys.len(),
+        pending_app.len(),
+        format_pending_ops("sys", &pending_sys),
+        format_pending_ops("app", &pending_app),
+    );
+}
+
+/// Summarise the ops still awaiting validation in the new DHT store.
+async fn new_store_pending_summary(dht_store: &holochain_state::dht_store::DhtStore) -> String {
+    let pending_sys = dht_store
+        .as_read()
+        .ops_pending_sys_validation(10_000)
+        .await
+        .unwrap_or_default();
+    let pending_app = dht_store
+        .as_read()
+        .ops_pending_app_validation(10_000)
+        .await
+        .unwrap_or_default();
+    format!(
+        "{}{}",
+        format_pending_ops("sys", &pending_sys),
+        format_pending_ops("app", &pending_app)
+    )
+}
+
+/// Render a stage's pending ops, listing each op hash, so a failing test shows
+/// exactly which ops did not progress.
+fn format_pending_ops(stage: &str, ops: &[holochain_types::dht_op::DhtOpHashed]) -> String {
+    if ops.is_empty() {
+        return format!("  pending {stage}-validation: none\n");
+    }
+    let mut out = format!("  pending {stage}-validation ({}):\n", ops.len());
+    for op in ops {
+        out += &format!("    {}\n", op.as_hash());
+    }
+    out
+}
+
 /// Show authored data for each cell environment
 #[cfg_attr(feature = "instrument", tracing::instrument(skip(envs)))]
 pub async fn show_authored<Db: ReadAccess<DbKindAuthored>>(envs: &[&Db]) {

--- a/crates/holochain_data/src/dht.rs
+++ b/crates/holochain_data/src/dht.rs
@@ -555,8 +555,11 @@ mod tests {
         action.as_hash().clone()
     }
 
-    fn sample_basis(seed: u8) -> AnyDhtHash {
-        AnyDhtHash::from_raw_36_and_type(vec![seed; 36], holo_hash::hash_type::AnyDht::Entry)
+    fn sample_basis(seed: u8) -> AnyLinkableHash {
+        AnyLinkableHash::from_raw_36_and_type(
+            vec![seed; 36],
+            holo_hash::hash_type::AnyLinkable::Entry,
+        )
     }
 
     #[tokio::test]
@@ -781,7 +784,11 @@ mod tests {
         assert_eq!(row.validation_status, 1);
         assert_eq!(row.locally_validated, 1);
 
-        let by_basis = db.as_ref().get_chain_ops_by_basis(basis).await.unwrap();
+        let by_basis = db
+            .as_ref()
+            .get_chain_ops_by_basis(AnyDhtHash::try_from(basis).unwrap())
+            .await
+            .unwrap();
         assert_eq!(by_basis.len(), 1);
 
         let for_action = db
@@ -1469,8 +1476,10 @@ mod tests {
             .unwrap();
 
         let op_hash = DhtOpHash::from_raw_36(vec![9u8; 36]);
-        let basis_hash =
-            AnyDhtHash::from_raw_36_and_type(vec![9u8; 36], holo_hash::hash_type::AnyDht::Action);
+        let basis_hash = AnyLinkableHash::from_raw_36_and_type(
+            vec![9u8; 36],
+            holo_hash::hash_type::AnyLinkable::Action,
+        );
 
         db.insert_chain_op(InsertChainOp {
             op_hash: &op_hash,

--- a/crates/holochain_data/src/dht.rs
+++ b/crates/holochain_data/src/dht.rs
@@ -21,6 +21,7 @@ pub use inner::chain_op::InsertChainOp;
 pub use inner::deleted_link::InsertDeletedLink;
 pub use inner::deleted_record::InsertDeletedRecord;
 pub use inner::limbo_chain_op::InsertLimboChainOp;
+pub use inner::limbo_chain_op::LimboChainOpJoinedRow;
 pub use inner::limbo_warrant::InsertLimboWarrant;
 pub use inner::link::InsertLink;
 pub use inner::scheduled_function::InsertScheduledFunction;

--- a/crates/holochain_data/src/dht/db_operations.rs
+++ b/crates/holochain_data/src/dht/db_operations.rs
@@ -16,6 +16,7 @@ mod entry;
 mod limbo_chain_op;
 mod limbo_warrant;
 mod link;
+mod op_exists;
 mod scheduled_function;
 mod slice_hash;
 mod sync_queries;

--- a/crates/holochain_data/src/dht/db_operations.rs
+++ b/crates/holochain_data/src/dht/db_operations.rs
@@ -16,6 +16,7 @@ mod entry;
 mod limbo_chain_op;
 mod limbo_warrant;
 mod link;
+mod move_to_limbo;
 mod op_exists;
 mod scheduled_function;
 mod slice_hash;

--- a/crates/holochain_data/src/dht/db_operations/action.rs
+++ b/crates/holochain_data/src/dht/db_operations/action.rs
@@ -32,4 +32,14 @@ impl DbRead<Dht> {
     ) -> sqlx::Result<Vec<SignedActionHashed>> {
         action::get_actions_by_author(self.pool(), author).await
     }
+
+    /// Fetch all actions with `prev_hash = prev_hash` and `hash != exclude_hash`.
+    /// Used to detect chain forks during sys-validation.
+    pub async fn get_actions_by_prev_hash(
+        &self,
+        prev_hash: &ActionHash,
+        exclude_hash: &ActionHash,
+    ) -> sqlx::Result<Vec<SignedActionHashed>> {
+        action::get_actions_by_prev_hash(self.pool(), prev_hash, exclude_hash).await
+    }
 }

--- a/crates/holochain_data/src/dht/db_operations/chain_op.rs
+++ b/crates/holochain_data/src/dht/db_operations/chain_op.rs
@@ -44,7 +44,7 @@ impl DbRead<Dht> {
         chain_op::get_chain_ops_for_action(self.pool(), action_hash).await
     }
 
-    /// Return integrated, validated [`ChainOp`] rows that still require a
+    /// Return integrated, validated `ChainOp` rows that still require a
     /// validation receipt to be sent.
     pub async fn pending_validation_receipts(&self) -> sqlx::Result<Vec<PendingReceiptRow>> {
         chain_op::pending_validation_receipts(self.pool()).await

--- a/crates/holochain_data/src/dht/db_operations/chain_op.rs
+++ b/crates/holochain_data/src/dht/db_operations/chain_op.rs
@@ -1,6 +1,6 @@
 //! `DbRead<Dht>` / `DbWrite<Dht>` API for the `ChainOp` table.
 
-use super::super::inner::chain_op::{self, InsertChainOp};
+use super::super::inner::chain_op::{self, InsertChainOp, PendingReceiptRow};
 use crate::handles::{DbRead, DbWrite};
 use crate::kind::Dht;
 use crate::models::dht::ChainOpRow;
@@ -42,5 +42,11 @@ impl DbRead<Dht> {
         action_hash: ActionHash,
     ) -> sqlx::Result<Vec<ChainOpRow>> {
         chain_op::get_chain_ops_for_action(self.pool(), action_hash).await
+    }
+
+    /// Return integrated, validated [`ChainOp`] rows that still require a
+    /// validation receipt to be sent.
+    pub async fn pending_validation_receipts(&self) -> sqlx::Result<Vec<PendingReceiptRow>> {
+        chain_op::pending_validation_receipts(self.pool()).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/limbo_chain_op.rs
+++ b/crates/holochain_data/src/dht/db_operations/limbo_chain_op.rs
@@ -87,4 +87,22 @@ impl DbRead<Dht> {
     ) -> sqlx::Result<Vec<LimboChainOpRow>> {
         limbo_chain_op::limbo_chain_ops_ready_for_integration(self.pool(), limit).await
     }
+
+    /// Fetch limbo chain ops pending sys-validation joined with their `Action`
+    /// and optional `Entry` in a single round-trip.
+    pub async fn limbo_chain_ops_pending_sys_validation_with_action(
+        &self,
+        limit: u32,
+    ) -> sqlx::Result<Vec<limbo_chain_op::LimboChainOpJoinedRow>> {
+        limbo_chain_op::limbo_chain_ops_pending_sys_validation_with_action(self.pool(), limit).await
+    }
+
+    /// Fetch limbo chain ops pending app-validation joined with their `Action`
+    /// and optional `Entry` in a single round-trip.
+    pub async fn limbo_chain_ops_pending_app_validation_with_action(
+        &self,
+        limit: u32,
+    ) -> sqlx::Result<Vec<limbo_chain_op::LimboChainOpJoinedRow>> {
+        limbo_chain_op::limbo_chain_ops_pending_app_validation_with_action(self.pool(), limit).await
+    }
 }

--- a/crates/holochain_data/src/dht/db_operations/move_to_limbo.rs
+++ b/crates/holochain_data/src/dht/db_operations/move_to_limbo.rs
@@ -7,12 +7,10 @@ use crate::kind::Dht;
 use holo_hash::ActionHash;
 
 impl DbWrite<Dht> {
-    /// See [`crate::dht::inner::move_to_limbo::move_chain_op_to_limbo`].
-    ///
-    /// Wraps the atomic move in a transaction. Returns `true` if a cached
-    /// `ChainOp` row (with `locally_validated = 0`) matching `(action_hash,
-    /// op_type)` was moved into `LimboChainOp`, or `false` if no such row
-    /// exists.
+    /// Move a cached `ChainOp` row back into `LimboChainOp`, wrapped in a
+    /// transaction. Returns `true` if a cached `ChainOp` row (with
+    /// `locally_validated = 0`) matching `(action_hash, op_type)` was moved
+    /// into `LimboChainOp`, or `false` if no such row exists.
     pub async fn move_chain_op_to_limbo(
         &self,
         action_hash: &ActionHash,

--- a/crates/holochain_data/src/dht/db_operations/move_to_limbo.rs
+++ b/crates/holochain_data/src/dht/db_operations/move_to_limbo.rs
@@ -1,0 +1,27 @@
+//! `DbWrite<Dht>` API for moving a cached `ChainOp` row back into
+//! `LimboChainOp`.
+
+use super::super::inner::move_to_limbo;
+use crate::handles::DbWrite;
+use crate::kind::Dht;
+use holo_hash::ActionHash;
+
+impl DbWrite<Dht> {
+    /// See [`crate::dht::inner::move_to_limbo::move_chain_op_to_limbo`].
+    ///
+    /// Wraps the atomic move in a transaction. Returns `true` if a cached
+    /// `ChainOp` row (with `locally_validated = 0`) matching `(action_hash,
+    /// op_type)` was moved into `LimboChainOp`, or `false` if no such row
+    /// exists.
+    pub async fn move_chain_op_to_limbo(
+        &self,
+        action_hash: &ActionHash,
+        op_type: i64,
+    ) -> sqlx::Result<bool> {
+        let mut tx = self.begin().await?;
+        let moved =
+            move_to_limbo::move_chain_op_to_limbo(tx.conn_mut(), action_hash, op_type).await?;
+        tx.commit().await?;
+        Ok(moved)
+    }
+}

--- a/crates/holochain_data/src/dht/db_operations/op_exists.rs
+++ b/crates/holochain_data/src/dht/db_operations/op_exists.rs
@@ -1,0 +1,20 @@
+//! `DbRead<Dht>` API for op-existence checks.
+
+use super::super::inner::op_exists;
+use crate::handles::DbRead;
+use crate::kind::Dht;
+use holo_hash::DhtOpHash;
+
+impl DbRead<Dht> {
+    /// Returns `true` if the given op hash appears in any op-bearing
+    /// table (`ChainOp`, `LimboChainOp`, `Warrant`, `LimboWarrant`).
+    pub async fn op_exists(&self, hash: &DhtOpHash) -> sqlx::Result<bool> {
+        op_exists::op_exists(self.pool(), hash).await
+    }
+
+    /// For each input hash, return whether it appears in any
+    /// op-bearing table. Result aligns 1:1 with the input.
+    pub async fn op_hashes_present(&self, hashes: &[DhtOpHash]) -> sqlx::Result<Vec<bool>> {
+        op_exists::op_hashes_present(self.pool(), hashes).await
+    }
+}

--- a/crates/holochain_data/src/dht/inner.rs
+++ b/crates/holochain_data/src/dht/inner.rs
@@ -18,6 +18,7 @@ pub(crate) mod entry;
 pub(crate) mod limbo_chain_op;
 pub(crate) mod limbo_warrant;
 pub(crate) mod link;
+pub(crate) mod op_exists;
 pub(crate) mod scheduled_function;
 pub(crate) mod slice_hash;
 pub(crate) mod sync_queries;

--- a/crates/holochain_data/src/dht/inner.rs
+++ b/crates/holochain_data/src/dht/inner.rs
@@ -18,6 +18,7 @@ pub(crate) mod entry;
 pub(crate) mod limbo_chain_op;
 pub(crate) mod limbo_warrant;
 pub(crate) mod link;
+pub(crate) mod move_to_limbo;
 pub(crate) mod op_exists;
 pub(crate) mod scheduled_function;
 pub(crate) mod slice_hash;

--- a/crates/holochain_data/src/dht/inner/action.rs
+++ b/crates/holochain_data/src/dht/inner/action.rs
@@ -127,3 +127,25 @@ where
     .await?;
     rows.into_iter().map(row_to_signed_action_hashed).collect()
 }
+
+/// Return actions whose `prev_hash = :prev_hash` and `hash != :exclude_hash`.
+/// Used by the sys-validation workflow to detect chain forks.
+pub(crate) async fn get_actions_by_prev_hash<'e, E>(
+    executor: E,
+    prev_hash: &ActionHash,
+    exclude_hash: &ActionHash,
+) -> sqlx::Result<Vec<SignedActionHashed>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let rows: Vec<ActionRow> = sqlx::query_as(
+        "SELECT hash, author, seq, prev_hash, timestamp, action_type,
+                action_data, signature, entry_hash, private_entry, record_validity
+         FROM Action WHERE prev_hash = ? AND hash != ?",
+    )
+    .bind(prev_hash.get_raw_36())
+    .bind(exclude_hash.get_raw_36())
+    .fetch_all(executor)
+    .await?;
+    rows.into_iter().map(row_to_signed_action_hashed).collect()
+}

--- a/crates/holochain_data/src/dht/inner/chain_op.rs
+++ b/crates/holochain_data/src/dht/inner/chain_op.rs
@@ -1,7 +1,7 @@
 //! Free-standing operations against the `ChainOp` table.
 
 use crate::models::dht::ChainOpRow;
-use holo_hash::{ActionHash, AnyDhtHash, DhtOpHash};
+use holo_hash::{ActionHash, AnyDhtHash, AnyLinkableHash, DhtOpHash};
 use holochain_integrity_types::dht_v2::OpValidity;
 use holochain_timestamp::Timestamp;
 use sqlx::{Executor, Sqlite};
@@ -16,7 +16,7 @@ pub struct InsertChainOp<'a> {
     /// [`From<ChainOpType> for i64`](holochain_zome_types::dht_v2).
     pub op_type: i64,
     /// DHT basis hash (where the op is stored).
-    pub basis_hash: &'a AnyDhtHash,
+    pub basis_hash: &'a AnyLinkableHash,
     /// Numeric storage center derived from `basis_hash`.
     pub storage_center_loc: u32,
     /// Final validation outcome.

--- a/crates/holochain_data/src/dht/inner/chain_op.rs
+++ b/crates/holochain_data/src/dht/inner/chain_op.rs
@@ -15,7 +15,9 @@ pub struct InsertChainOp<'a> {
     /// `ChainOpType` discriminant; see
     /// [`From<ChainOpType> for i64`](holochain_zome_types::dht_v2).
     pub op_type: i64,
-    /// DHT basis hash (where the op is stored).
+    /// DHT basis hash (`OpBasis`) where the op is stored.
+    /// `AnyLinkableHash`, not `AnyDhtHash`: link-op bases may be `External`
+    /// hashes, which `AnyDhtHash` cannot hold.
     pub basis_hash: &'a AnyLinkableHash,
     /// Numeric storage center derived from `basis_hash`.
     pub storage_center_loc: u32,

--- a/crates/holochain_data/src/dht/inner/chain_op.rs
+++ b/crates/holochain_data/src/dht/inner/chain_op.rs
@@ -152,3 +152,41 @@ where
         .fetch_all(executor)
         .await
 }
+
+/// Row returned by [`pending_validation_receipts`]: op metadata plus the
+/// underlying action's author so receipts can be addressed.
+#[derive(Debug, sqlx::FromRow)]
+pub struct PendingReceiptRow {
+    /// Raw 36-byte op hash from `ChainOp.hash`.
+    pub op_hash: Vec<u8>,
+    /// Validation status integer (`1` = Accepted, `2` = Rejected).
+    pub validation_status: i64,
+    /// Microsecond timestamp at which the op was integrated.
+    pub when_integrated: i64,
+    /// Raw 36-byte author public key from `Action.author`.
+    pub action_author: Vec<u8>,
+}
+
+/// Return integrated, validated [`ChainOp`] rows that still require a
+/// validation receipt to be sent to the action author.
+pub(crate) async fn pending_validation_receipts<'e, E>(
+    executor: E,
+) -> sqlx::Result<Vec<PendingReceiptRow>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    sqlx::query_as(
+        "SELECT
+            ChainOp.hash AS op_hash,
+            ChainOp.validation_status AS validation_status,
+            ChainOp.when_integrated AS when_integrated,
+            Action.author AS action_author
+         FROM ChainOp
+         JOIN Action ON ChainOp.action_hash = Action.hash
+         WHERE ChainOp.require_receipt = 1
+           AND ChainOp.when_integrated IS NOT NULL
+           AND ChainOp.validation_status IS NOT NULL",
+    )
+    .fetch_all(executor)
+    .await
+}

--- a/crates/holochain_data/src/dht/inner/limbo_chain_op.rs
+++ b/crates/holochain_data/src/dht/inner/limbo_chain_op.rs
@@ -7,7 +7,7 @@ use holochain_timestamp::Timestamp;
 use sqlx::{Executor, Sqlite, SqliteConnection};
 
 /// A row joining `LimboChainOp` with its associated `Action` and optional
-/// `Entry` blob. Enables reconstructing a [`DhtOpHashed`] without an N+1
+/// `Entry` blob. Enables reconstructing a `DhtOpHashed` without an N+1
 /// round-trip per row.
 #[derive(Debug, sqlx::FromRow)]
 pub struct LimboChainOpJoinedRow {

--- a/crates/holochain_data/src/dht/inner/limbo_chain_op.rs
+++ b/crates/holochain_data/src/dht/inner/limbo_chain_op.rs
@@ -50,7 +50,9 @@ pub struct InsertLimboChainOp<'a> {
     /// `ChainOpType` discriminant; see
     /// [`From<ChainOpType> for i64`](holochain_zome_types::dht_v2).
     pub op_type: i64,
-    /// DHT basis hash (where the op is stored).
+    /// DHT basis hash (`OpBasis`) where the op is stored.
+    /// `AnyLinkableHash`, not `AnyDhtHash`: link-op bases may be `External`
+    /// hashes, which `AnyDhtHash` cannot hold.
     pub basis_hash: &'a AnyLinkableHash,
     /// Numeric storage center derived from `basis_hash`.
     pub storage_center_loc: u32,

--- a/crates/holochain_data/src/dht/inner/limbo_chain_op.rs
+++ b/crates/holochain_data/src/dht/inner/limbo_chain_op.rs
@@ -6,6 +6,41 @@ use holochain_integrity_types::dht_v2::OpValidity;
 use holochain_timestamp::Timestamp;
 use sqlx::{Executor, Sqlite, SqliteConnection};
 
+/// A row joining `LimboChainOp` with its associated `Action` and optional
+/// `Entry` blob. Enables reconstructing a [`DhtOpHashed`] without an N+1
+/// round-trip per row.
+#[derive(Debug, sqlx::FromRow)]
+pub struct LimboChainOpJoinedRow {
+    // --- LimboChainOp columns ---
+    pub hash: Vec<u8>,
+    pub op_type: i64,
+    pub action_hash: Vec<u8>,
+    pub basis_hash: Vec<u8>,
+    pub storage_center_loc: i64,
+    pub sys_validation_status: Option<i64>,
+    pub app_validation_status: Option<i64>,
+    pub abandoned_at: Option<i64>,
+    pub require_receipt: i64,
+    pub when_received: i64,
+    pub sys_validation_attempts: i64,
+    pub app_validation_attempts: i64,
+    pub last_validation_attempt: Option<i64>,
+    pub serialized_size: i64,
+    // --- Action columns (aliased to avoid collision) ---
+    pub action_author: Vec<u8>,
+    pub action_seq: i64,
+    pub action_prev_hash: Option<Vec<u8>>,
+    pub action_timestamp: i64,
+    pub action_type: i64,
+    pub action_data: Vec<u8>,
+    pub action_signature: Vec<u8>,
+    pub action_entry_hash: Option<Vec<u8>>,
+    pub action_private_entry: Option<i64>,
+    pub action_record_validity: Option<i64>,
+    // --- Entry columns (LEFT JOIN — may be NULL) ---
+    pub entry_blob: Option<Vec<u8>>,
+}
+
 /// Parameters for inserting a row into `LimboChainOp`.
 pub struct InsertLimboChainOp<'a> {
     /// DHT op hash (primary key).
@@ -101,6 +136,102 @@ where
         "SELECT * FROM LimboChainOp
          WHERE sys_validation_status = 1 AND app_validation_status IS NULL
          ORDER BY app_validation_attempts, when_received
+         LIMIT ?",
+    )
+    .bind(limit as i64)
+    .fetch_all(executor)
+    .await
+}
+
+/// Fetch limbo chain ops pending sys-validation, joined with their `Action`
+/// and (optionally) their `Entry`, in a single query.
+pub(crate) async fn limbo_chain_ops_pending_sys_validation_with_action<'e, E>(
+    executor: E,
+    limit: u32,
+) -> sqlx::Result<Vec<LimboChainOpJoinedRow>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    sqlx::query_as(
+        "SELECT
+            l.hash              AS hash,
+            l.op_type           AS op_type,
+            l.action_hash       AS action_hash,
+            l.basis_hash        AS basis_hash,
+            l.storage_center_loc AS storage_center_loc,
+            l.sys_validation_status AS sys_validation_status,
+            l.app_validation_status AS app_validation_status,
+            l.abandoned_at      AS abandoned_at,
+            l.require_receipt   AS require_receipt,
+            l.when_received     AS when_received,
+            l.sys_validation_attempts AS sys_validation_attempts,
+            l.app_validation_attempts AS app_validation_attempts,
+            l.last_validation_attempt AS last_validation_attempt,
+            l.serialized_size   AS serialized_size,
+            a.author            AS action_author,
+            a.seq               AS action_seq,
+            a.prev_hash         AS action_prev_hash,
+            a.timestamp         AS action_timestamp,
+            a.action_type       AS action_type,
+            a.action_data       AS action_data,
+            a.signature         AS action_signature,
+            a.entry_hash        AS action_entry_hash,
+            a.private_entry     AS action_private_entry,
+            a.record_validity   AS action_record_validity,
+            e.blob              AS entry_blob
+         FROM LimboChainOp l
+         JOIN Action a ON l.action_hash = a.hash
+         LEFT JOIN Entry e ON a.entry_hash = e.hash
+         WHERE l.sys_validation_status IS NULL
+         ORDER BY l.sys_validation_attempts, l.when_received
+         LIMIT ?",
+    )
+    .bind(limit as i64)
+    .fetch_all(executor)
+    .await
+}
+
+/// Fetch limbo chain ops pending app-validation, joined with their `Action`
+/// and (optionally) their `Entry`, in a single query.
+pub(crate) async fn limbo_chain_ops_pending_app_validation_with_action<'e, E>(
+    executor: E,
+    limit: u32,
+) -> sqlx::Result<Vec<LimboChainOpJoinedRow>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    sqlx::query_as(
+        "SELECT
+            l.hash              AS hash,
+            l.op_type           AS op_type,
+            l.action_hash       AS action_hash,
+            l.basis_hash        AS basis_hash,
+            l.storage_center_loc AS storage_center_loc,
+            l.sys_validation_status AS sys_validation_status,
+            l.app_validation_status AS app_validation_status,
+            l.abandoned_at      AS abandoned_at,
+            l.require_receipt   AS require_receipt,
+            l.when_received     AS when_received,
+            l.sys_validation_attempts AS sys_validation_attempts,
+            l.app_validation_attempts AS app_validation_attempts,
+            l.last_validation_attempt AS last_validation_attempt,
+            l.serialized_size   AS serialized_size,
+            a.author            AS action_author,
+            a.seq               AS action_seq,
+            a.prev_hash         AS action_prev_hash,
+            a.timestamp         AS action_timestamp,
+            a.action_type       AS action_type,
+            a.action_data       AS action_data,
+            a.signature         AS action_signature,
+            a.entry_hash        AS action_entry_hash,
+            a.private_entry     AS action_private_entry,
+            a.record_validity   AS action_record_validity,
+            e.blob              AS entry_blob
+         FROM LimboChainOp l
+         JOIN Action a ON l.action_hash = a.hash
+         LEFT JOIN Entry e ON a.entry_hash = e.hash
+         WHERE l.sys_validation_status = 1 AND l.app_validation_status IS NULL
+         ORDER BY l.app_validation_attempts, l.when_received
          LIMIT ?",
     )
     .bind(limit as i64)

--- a/crates/holochain_data/src/dht/inner/limbo_chain_op.rs
+++ b/crates/holochain_data/src/dht/inner/limbo_chain_op.rs
@@ -1,7 +1,7 @@
 //! Free-standing operations against the `LimboChainOp` table.
 
 use crate::models::dht::LimboChainOpRow;
-use holo_hash::{ActionHash, AnyDhtHash, DhtOpHash};
+use holo_hash::{ActionHash, AnyLinkableHash, DhtOpHash};
 use holochain_integrity_types::dht_v2::OpValidity;
 use holochain_timestamp::Timestamp;
 use sqlx::{Executor, Sqlite, SqliteConnection};
@@ -16,7 +16,7 @@ pub struct InsertLimboChainOp<'a> {
     /// [`From<ChainOpType> for i64`](holochain_zome_types::dht_v2).
     pub op_type: i64,
     /// DHT basis hash (where the op is stored).
-    pub basis_hash: &'a AnyDhtHash,
+    pub basis_hash: &'a AnyLinkableHash,
     /// Numeric storage center derived from `basis_hash`.
     pub storage_center_loc: u32,
     /// Whether the receiving authority should issue a validation receipt.

--- a/crates/holochain_data/src/dht/inner/move_to_limbo.rs
+++ b/crates/holochain_data/src/dht/inner/move_to_limbo.rs
@@ -1,0 +1,67 @@
+//! Move a `ChainOp` row (cached, `locally_validated = 0`) back into
+//! `LimboChainOp` with cleared validation status.
+
+use holo_hash::ActionHash;
+use sqlx::SqliteConnection;
+
+/// Columns read from `ChainOp` when moving a cached row to `LimboChainOp`:
+/// `(hash, basis_hash, storage_center_loc, when_received, serialized_size)`.
+type CachedChainOpRow = (Vec<u8>, Vec<u8>, i64, i64, i64);
+
+/// Move a `ChainOp` row with `locally_validated = 0` matching
+/// `(action_hash, op_type)` back into `LimboChainOp` with cleared
+/// validation status. Used by sys-validation to re-validate
+/// warrant-dependency ops that were originally inserted via the cache
+/// path (which bypasses limbo).
+///
+/// Returns `Ok(true)` if a row was moved, `Ok(false)` if no matching
+/// cached row exists. **Caller must wrap in a transaction** to ensure
+/// atomicity.
+pub(crate) async fn move_chain_op_to_limbo(
+    conn: &mut SqliteConnection,
+    action_hash: &ActionHash,
+    op_type: i64,
+) -> sqlx::Result<bool> {
+    // Look up the ChainOp row we want to move.
+    let row: Option<CachedChainOpRow> = sqlx::query_as(
+        "SELECT hash, basis_hash, storage_center_loc, when_received, serialized_size
+         FROM ChainOp
+         WHERE action_hash = ?1 AND op_type = ?2 AND locally_validated = 0",
+    )
+    .bind(action_hash.get_raw_36())
+    .bind(op_type)
+    .fetch_optional(&mut *conn)
+    .await?;
+
+    let Some((op_hash, basis_hash, storage_center_loc, when_received, serialized_size)) = row
+    else {
+        return Ok(false);
+    };
+
+    // Delete the ChainOp row.
+    sqlx::query("DELETE FROM ChainOp WHERE hash = ?")
+        .bind(&op_hash)
+        .execute(&mut *conn)
+        .await?;
+
+    // Insert a LimboChainOp row with cleared validation status.
+    sqlx::query(
+        "INSERT INTO LimboChainOp
+            (hash, op_type, action_hash, basis_hash, storage_center_loc,
+             require_receipt, when_received, serialized_size,
+             sys_validation_status, app_validation_status, abandoned_at,
+             sys_validation_attempts, app_validation_attempts, last_validation_attempt)
+         VALUES (?, ?, ?, ?, ?, 0, ?, ?, NULL, NULL, NULL, 0, 0, NULL)",
+    )
+    .bind(&op_hash)
+    .bind(op_type)
+    .bind(action_hash.get_raw_36())
+    .bind(&basis_hash)
+    .bind(storage_center_loc)
+    .bind(when_received)
+    .bind(serialized_size)
+    .execute(&mut *conn)
+    .await?;
+
+    Ok(true)
+}

--- a/crates/holochain_data/src/dht/inner/move_to_limbo.rs
+++ b/crates/holochain_data/src/dht/inner/move_to_limbo.rs
@@ -38,13 +38,9 @@ pub(crate) async fn move_chain_op_to_limbo(
         return Ok(false);
     };
 
-    // Delete the ChainOp row.
-    sqlx::query("DELETE FROM ChainOp WHERE hash = ?")
-        .bind(&op_hash)
-        .execute(&mut *conn)
-        .await?;
-
-    // Insert a LimboChainOp row with cleared validation status.
+    // Insert a LimboChainOp row with cleared validation status, then delete
+    // the ChainOp row. Creating the new state before destroying the old keeps
+    // the intent clear; both statements run in the caller's transaction.
     sqlx::query(
         "INSERT INTO LimboChainOp
             (hash, op_type, action_hash, basis_hash, storage_center_loc,
@@ -62,6 +58,12 @@ pub(crate) async fn move_chain_op_to_limbo(
     .bind(serialized_size)
     .execute(&mut *conn)
     .await?;
+
+    // Delete the ChainOp row.
+    sqlx::query("DELETE FROM ChainOp WHERE hash = ?")
+        .bind(&op_hash)
+        .execute(&mut *conn)
+        .await?;
 
     Ok(true)
 }

--- a/crates/holochain_data/src/dht/inner/op_exists.rs
+++ b/crates/holochain_data/src/dht/inner/op_exists.rs
@@ -4,7 +4,7 @@ use holo_hash::DhtOpHash;
 use sqlx::{Executor, Sqlite};
 
 /// Returns `true` if the given op hash appears in any of the op-bearing
-/// tables (`ChainOp`, `LimboChainOp`, `Warrant`, `LimboWarrant`).
+/// tables (`ChainOp`, `LimboChainOp`, `WarrantOp`, `LimboWarrantOp`).
 ///
 /// Used by the incoming-ops workflow to filter ops that have already
 /// been recorded locally so we don't re-process duplicates from the
@@ -20,9 +20,9 @@ where
             UNION ALL
             SELECT 1 FROM LimboChainOp WHERE hash = ?1
             UNION ALL
-            SELECT 1 FROM Warrant WHERE hash = ?1
+            SELECT 1 FROM WarrantOp WHERE hash = ?1
             UNION ALL
-            SELECT 1 FROM LimboWarrant WHERE hash = ?1
+            SELECT 1 FROM LimboWarrantOp WHERE hash = ?1
             LIMIT 1
          )",
     )

--- a/crates/holochain_data/src/dht/inner/op_exists.rs
+++ b/crates/holochain_data/src/dht/inner/op_exists.rs
@@ -8,7 +8,9 @@ use sqlx::{Executor, Sqlite};
 ///
 /// Used by the incoming-ops workflow to filter ops that have already
 /// been recorded locally so we don't re-process duplicates from the
-/// network.
+/// network. Cache-only `ChainOp` rows (`locally_validated = 0`) are
+/// excluded, so an op mirrored into the cache but not yet validated is
+/// still re-delivered into the validation/integration path.
 pub(crate) async fn op_exists<'e, E>(executor: E, hash: &DhtOpHash) -> sqlx::Result<bool>
 where
     E: Executor<'e, Database = Sqlite>,
@@ -16,7 +18,7 @@ where
     let bytes = hash.get_raw_36();
     let row: (i64,) = sqlx::query_as(
         "SELECT EXISTS (
-            SELECT 1 FROM ChainOp WHERE hash = ?1
+            SELECT 1 FROM ChainOp WHERE locally_validated = 1 AND hash = ?1
             UNION ALL
             SELECT 1 FROM LimboChainOp WHERE hash = ?1
             UNION ALL

--- a/crates/holochain_data/src/dht/inner/op_exists.rs
+++ b/crates/holochain_data/src/dht/inner/op_exists.rs
@@ -1,0 +1,52 @@
+//! Existence checks for op hashes across all op-bearing DHT tables.
+
+use holo_hash::DhtOpHash;
+use sqlx::{Executor, Sqlite};
+
+/// Returns `true` if the given op hash appears in any of the op-bearing
+/// tables (`ChainOp`, `LimboChainOp`, `Warrant`, `LimboWarrant`).
+///
+/// Used by the incoming-ops workflow to filter ops that have already
+/// been recorded locally so we don't re-process duplicates from the
+/// network.
+pub(crate) async fn op_exists<'e, E>(executor: E, hash: &DhtOpHash) -> sqlx::Result<bool>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let bytes = hash.get_raw_36();
+    let row: (i64,) = sqlx::query_as(
+        "SELECT EXISTS (
+            SELECT 1 FROM ChainOp WHERE hash = ?1
+            UNION ALL
+            SELECT 1 FROM LimboChainOp WHERE hash = ?1
+            UNION ALL
+            SELECT 1 FROM Warrant WHERE hash = ?1
+            UNION ALL
+            SELECT 1 FROM LimboWarrant WHERE hash = ?1
+            LIMIT 1
+         )",
+    )
+    .bind(bytes)
+    .fetch_one(executor)
+    .await?;
+    Ok(row.0 != 0)
+}
+
+/// For each input hash, return whether it appears in any op-bearing
+/// table. Result vector aligns 1:1 with the input.
+///
+/// Performs N round-trips for simplicity. If profiling shows it
+/// matters, switch to a single `WHERE ... IN (?, ?, ...)` query later.
+pub(crate) async fn op_hashes_present<'e, E>(
+    executor: E,
+    hashes: &[DhtOpHash],
+) -> sqlx::Result<Vec<bool>>
+where
+    E: Executor<'e, Database = Sqlite> + Copy,
+{
+    let mut out = Vec::with_capacity(hashes.len());
+    for h in hashes {
+        out.push(op_exists(executor, h).await?);
+    }
+    Ok(out)
+}

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -328,19 +328,16 @@ impl DhtStore<DbWrite<Dht>> {
         let signature_bytes = holochain_serialized_bytes::encode(&receipt.validators_signatures)
             .map_err(StateMutationError::from)?;
 
-        let mut tx = self.db.begin().await.map_err(StateMutationError::from)?;
-
-        tx.insert_validation_receipt(
-            &receipt_hash,
-            &op_hash,
-            &validators_bytes,
-            &signature_bytes,
-            holochain_types::prelude::Timestamp::now(),
-        )
-        .await
-        .map_err(StateMutationError::from)?;
-
-        tx.commit().await.map_err(StateMutationError::from)?;
+        self.db
+            .insert_validation_receipt(
+                &receipt_hash,
+                &op_hash,
+                &validators_bytes,
+                &signature_bytes,
+                holochain_types::prelude::Timestamp::now(),
+            )
+            .await
+            .map_err(StateMutationError::from)?;
 
         let op_hash_bytes = op_hash.get_raw_36().to_vec();
         let count: i64 =
@@ -941,8 +938,7 @@ impl DhtStore<DbWrite<Dht>> {
         &self,
         op_hash: &holo_hash::DhtOpHash,
     ) -> DhtStoreResult<Option<Timestamp>> {
-        let mut tx = self.db.begin().await?;
-        let row = tx.as_mut().get_chain_op(op_hash.clone()).await?;
+        let row = self.db.as_ref().get_chain_op(op_hash.clone()).await?;
         Ok(row.map(|r| Timestamp::from_micros(r.when_integrated)))
     }
 }

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -748,6 +748,27 @@ impl DhtStore<DbWrite<Dht>> {
         Ok(())
     }
 
+    /// Re-queue a cache-derived op for validation.
+    ///
+    /// If a `ChainOp` row matching `(action_hash, op_type)` with
+    /// `locally_validated = false` exists, move it back into `LimboChainOp`
+    /// with cleared validation status so the next sys-validation pass picks it
+    /// up via `ops_pending_sys_validation`.
+    ///
+    /// Returns `Ok(true)` if a row was moved, `Ok(false)` if no matching
+    /// cached row exists (e.g. the op was never cached, or was already locally
+    /// validated).
+    pub async fn move_warranted_op_to_limbo(
+        &self,
+        action_hash: &holo_hash::ActionHash,
+        op_type: holochain_zome_types::op::ChainOpType,
+    ) -> StateMutationResult<bool> {
+        Ok(self
+            .db
+            .move_chain_op_to_limbo(action_hash, i64::from(op_type))
+            .await?)
+    }
+
     /// Downgrade this writable store to a read-only store.
     pub fn as_read(&self) -> DhtStoreRead {
         DhtStore::new(self.db.as_ref().clone())

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -939,6 +939,18 @@ impl DhtStore<DbWrite<Dht>> {
         let db = holochain_data::test_open_db(dht).await?;
         Ok(Self::new(db))
     }
+
+    /// Return the `when_integrated` timestamp for the given op hash if the op
+    /// is present in the `ChainOp` table (i.e. it has been promoted from limbo
+    /// and fully integrated). Returns `None` when the op is not yet integrated.
+    pub async fn when_integrated(
+        &self,
+        op_hash: &holo_hash::DhtOpHash,
+    ) -> DhtStoreResult<Option<Timestamp>> {
+        let mut tx = self.db.begin().await?;
+        let row = tx.as_mut().get_chain_op(op_hash.clone()).await?;
+        Ok(row.map(|r| Timestamp::from_micros(r.when_integrated)))
+    }
 }
 
 pub(crate) mod action_indexes;

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -26,7 +26,9 @@ use crate::mutations::{StateMutationError, StateMutationResult};
 pub struct IntegratedOpSummary {
     /// Op hash (chain-op hash or warrant hash).
     pub op_hash: holo_hash::DhtOpHash,
-    /// DHT basis hash (where the op is stored).
+    /// DHT basis hash (`OpBasis`) where the op is stored.
+    /// `AnyLinkableHash`, not `AnyDhtHash`: link-op bases may be `External`
+    /// hashes, which `AnyDhtHash` cannot hold.
     pub basis_hash: holo_hash::AnyLinkableHash,
     /// Authored timestamp of the underlying action or warrant.
     pub authored_timestamp: Timestamp,
@@ -650,7 +652,7 @@ impl DhtStore<DbWrite<Dht>> {
     ///
     /// Returns per-op summary data for each promoted op (chain ops and warrants
     /// together). The summary includes the basis hash, authored timestamp,
-    /// validation status, reception time, validation attempt counts, and
+    /// validation status, received time, validation attempt counts, and
     /// author/warrantee fields needed by the integration workflow for metrics,
     /// agent blocking, and `new_integrated_data` notifications.
     ///

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -805,6 +805,7 @@ impl DhtStore<DbWrite<Dht>> {
 
 pub(crate) mod action_indexes;
 mod cache;
+mod reads;
 mod sync_reads;
 
 #[cfg(test)]

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -591,9 +591,15 @@ impl DhtStore<DbWrite<Dht>> {
         Ok(())
     }
 
-    /// Insert self-authored warrants directly into the `Warrant` + `WarrantOp`
-    /// tables, bypassing limbo (`LimboWarrantOp`).  Self-authored warrants are
-    /// locally trusted and do not need to go through the limbo/validation cycle.
+    /// Insert self-authored warrants into limbo (`Warrant` + `LimboWarrantOp`)
+    /// already marked sys-validation accepted, so they are immediately ready
+    /// for integration.
+    ///
+    /// Self-authored warrants are locally trusted, but they must still pass
+    /// through the integration workflow: that is where the warrantee is blocked
+    /// (via [`integrate_ready_ops`](Self::integrate_ready_ops)'s
+    /// [`IntegratedOpSummary`]). Inserting them straight into `WarrantOp` would
+    /// bypass that path and the block would never fire.
     ///
     /// Any op that is not a `WarrantOp` is skipped with a warning log.  All
     /// inserts happen in a single transaction.
@@ -601,8 +607,6 @@ impl DhtStore<DbWrite<Dht>> {
         &self,
         warrants: Vec<DhtOpHashed>,
     ) -> StateMutationResult<()> {
-        use holochain_data::dht::InsertWarrant;
-
         let mut tx = self.db.begin().await.map_err(StateMutationError::from)?;
         let now = Timestamp::now();
         for op in warrants {
@@ -622,7 +626,7 @@ impl DhtStore<DbWrite<Dht>> {
             let proof_bytes = holochain_serialized_bytes::encode(&warrant_op.proof)
                 .map_err(StateMutationError::from)?;
             let signature_bytes = warrant_op.signature().0;
-            tx.insert_warrant(InsertWarrant {
+            tx.insert_limbo_warrant(InsertLimboWarrant {
                 hash,
                 author: &warrant_op.author,
                 timestamp: warrant_op.timestamp,
@@ -632,11 +636,15 @@ impl DhtStore<DbWrite<Dht>> {
                 reason: warrant_op.proof.reason(),
                 storage_center_loc: warrant_op.warrantee.get_loc(),
                 when_received: now,
-                when_integrated: now,
                 serialized_size,
             })
             .await
             .map_err(StateMutationError::from)?;
+            // Mark accepted so `integrate_ready_ops` promotes it on the next
+            // integration tick (warrants have no app-validation stage).
+            tx.set_limbo_warrant_sys_validation_status(hash, Some(1))
+                .await
+                .map_err(StateMutationError::from)?;
         }
         tx.commit().await.map_err(StateMutationError::from)?;
         Ok(())

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -15,6 +15,35 @@ use holochain_zome_types::schedule::ScheduleError;
 
 use crate::mutations::{StateMutationError, StateMutationResult};
 
+/// Summary of a single op promoted by [`DhtStore::integrate_ready_ops`].
+///
+/// Captures the fields the integration workflow needs for metrics,
+/// authored-op tracking, agent blocking, and `new_integrated_data`
+/// notifications. The `basis_hash` field uses [`holo_hash::AnyLinkableHash`]
+/// (the `OpBasis` alias) so that it covers Action, Entry, Agent, and link
+/// base addresses — matching what `DhtOpHash::to_located_k2_op_id` expects.
+#[derive(Debug, Clone)]
+pub struct IntegratedOpSummary {
+    /// Op hash (chain-op hash or warrant hash).
+    pub op_hash: holo_hash::DhtOpHash,
+    /// DHT basis hash (where the op is stored).
+    pub basis_hash: holo_hash::AnyLinkableHash,
+    /// Authored timestamp of the underlying action or warrant.
+    pub authored_timestamp: Timestamp,
+    /// Terminal validation status for this op.
+    pub validation_status: holochain_zome_types::dht_v2::OpValidity,
+    /// When the op was received (used for the integration-delay metric).
+    pub when_received: Timestamp,
+    /// Combined validation attempts captured before promotion.
+    pub validation_attempts: u32,
+    /// Authoring agent for chain ops; `None` for warrants.
+    pub action_author: Option<holo_hash::AgentPubKey>,
+    /// Authoring agent for warrant ops; `None` for chain ops.
+    pub warrant_author: Option<holo_hash::AgentPubKey>,
+    /// Warrantee for warrant ops; `None` for chain ops.
+    pub warrantee: Option<holo_hash::AgentPubKey>,
+}
+
 /// Result of system validation for a single DHT op.
 #[derive(Debug, Clone, Copy)]
 pub enum SysOutcome {
@@ -628,15 +657,20 @@ impl DhtStore<DbWrite<Dht>> {
     /// Warrants are promoted by moving their op metadata from `LimboWarrantOp`
     /// → `WarrantOp`; the shared `Warrant` content row stays put.
     ///
-    /// Returns the set of promoted op hashes (chain ops and warrant hashes
-    /// together).  A generous batch limit is used; if more than that are ready
-    /// in a single tick, the next tick handles the remainder.
+    /// Returns per-op summary data for each promoted op (chain ops and warrants
+    /// together). The summary includes the basis hash, authored timestamp,
+    /// validation status, reception time, validation attempt counts, and
+    /// author/warrantee fields needed by the integration workflow for metrics,
+    /// agent blocking, and `new_integrated_data` notifications.
+    ///
+    /// A generous batch limit is used; if more than that are ready in a single
+    /// tick, the next tick handles the remainder.
     pub async fn integrate_ready_ops(
         &self,
         when_integrated: Timestamp,
-    ) -> StateMutationResult<Vec<DhtOpHash>> {
+    ) -> StateMutationResult<Vec<IntegratedOpSummary>> {
         let mut tx = self.db.begin().await.map_err(StateMutationError::from)?;
-        let mut promoted = Vec::new();
+        let mut out: Vec<IntegratedOpSummary> = Vec::new();
 
         let chain_ready = tx
             .as_mut()
@@ -646,12 +680,44 @@ impl DhtStore<DbWrite<Dht>> {
         for row in chain_ready {
             let op_hash = DhtOpHash::from_raw_36(row.hash.clone());
             let validation_status = compute_chain_op_validation_status(&row);
+
+            // Reconstruct the basis hash from op_type + raw bytes.
+            // The new-schema DB stores only 36 raw bytes (no type prefix), so
+            // we recover the type from the op_type discriminant.
+            let basis_hash = chain_op_basis_hash_from_row(row.op_type, row.basis_hash.clone());
+
+            // Look up the action to recover author + authored timestamp.
+            let action_hash = holo_hash::ActionHash::from_raw_36(row.action_hash.clone());
+            let v2_action = tx
+                .as_mut()
+                .get_action(action_hash)
+                .await
+                .map_err(StateMutationError::from)?;
+            let (action_author, authored_timestamp) = match v2_action {
+                Some(sah) => (
+                    Some(sah.hashed.content.header.author.clone()),
+                    sah.hashed.content.header.timestamp,
+                ),
+                None => (None, Timestamp::from_micros(0)),
+            };
+
             let promoted_ok = tx
                 .promote_limbo_chain_op(&op_hash, validation_status, when_integrated)
                 .await
                 .map_err(StateMutationError::from)?;
             if promoted_ok {
-                promoted.push(op_hash);
+                out.push(IntegratedOpSummary {
+                    op_hash,
+                    basis_hash,
+                    authored_timestamp,
+                    validation_status,
+                    when_received: Timestamp::from_micros(row.when_received),
+                    validation_attempts: (row.sys_validation_attempts + row.app_validation_attempts)
+                        as u32,
+                    action_author,
+                    warrant_author: None,
+                    warrantee: None,
+                });
             }
         }
 
@@ -661,18 +727,35 @@ impl DhtStore<DbWrite<Dht>> {
             .await
             .map_err(StateMutationError::from)?;
         for row in warrant_ready {
-            let hash = DhtOpHash::from_raw_36(row.hash.clone());
+            let op_hash = DhtOpHash::from_raw_36(row.hash.clone());
             let promoted_ok = tx
-                .promote_limbo_warrant(&hash, when_integrated)
+                .promote_limbo_warrant(&op_hash, when_integrated)
                 .await
                 .map_err(StateMutationError::from)?;
             if promoted_ok {
-                promoted.push(hash);
+                let validation_status = match row.sys_validation_status {
+                    Some(2) => holochain_zome_types::dht_v2::OpValidity::Rejected,
+                    _ => holochain_zome_types::dht_v2::OpValidity::Accepted,
+                };
+                // Warrant basis = warrantee (AgentPubKey hash).
+                let warrantee = holo_hash::AgentPubKey::from_raw_36(row.warrantee.clone());
+                let basis_hash: holo_hash::AnyLinkableHash = warrantee.clone().into();
+                out.push(IntegratedOpSummary {
+                    op_hash,
+                    basis_hash,
+                    authored_timestamp: Timestamp::from_micros(row.timestamp),
+                    validation_status,
+                    when_received: Timestamp::from_micros(row.when_received),
+                    validation_attempts: row.sys_validation_attempts as u32,
+                    action_author: None,
+                    warrant_author: Some(holo_hash::AgentPubKey::from_raw_36(row.author.clone())),
+                    warrantee: Some(warrantee),
+                });
             }
         }
 
         tx.commit().await.map_err(StateMutationError::from)?;
-        Ok(promoted)
+        Ok(out)
     }
 
     /// Clear `require_receipt = 0` on the `ChainOp` row for each given op hash.
@@ -786,6 +869,40 @@ fn entry_hash_from_chain_op_action(
     chain_op.action().entry_hash().cloned().ok_or_else(|| {
         StateMutationError::Other("op carries entry but action has no entry_hash".into())
     })
+}
+
+/// Reconstruct a DHT basis hash from a `LimboChainOp` row.
+///
+/// The new schema stores `basis_hash` as raw 36 bytes (no type prefix), so
+/// the type must be inferred from `op_type`. The mapping follows
+/// `docs/design/state_model.md` and `holochain_zome_types::dht_v2::ChainOpType`:
+///
+/// | `op_type` | Basis hash type |
+/// |-----------|-----------------|
+/// | 1 (StoreRecord)                 | `ActionHash`  |
+/// | 2 (StoreEntry)                  | `EntryHash`   |
+/// | 3 (RegisterAgentActivity)       | `AgentPubKey` |
+/// | 4 (RegisterUpdatedContent)      | `EntryHash`   |
+/// | 5 (RegisterUpdatedRecord)       | `ActionHash`  |
+/// | 6 (RegisterDeletedEntryAction)  | `EntryHash`   |
+/// | 7 (RegisterDeletedBy)           | `ActionHash`  |
+/// | 8 (RegisterAddLink)             | `EntryHash`   |
+/// | 9 (RegisterRemoveLink)          | `EntryHash`   |
+///
+/// Link bases (8, 9) can technically be any `AnyLinkableHash` variant, but
+/// the new schema stores them in the same 36-byte slot. Non-Holochain external
+/// hashes are not representable in this schema and would not reach integration;
+/// `EntryHash` is used as the fallback for those rows.
+fn chain_op_basis_hash_from_row(op_type: i64, raw: Vec<u8>) -> holo_hash::AnyLinkableHash {
+    match op_type {
+        // StoreRecord, RegisterUpdatedRecord, RegisterDeletedBy → ActionHash basis
+        1 | 5 | 7 => holo_hash::ActionHash::from_raw_36(raw).into(),
+        // RegisterAgentActivity → AgentPubKey basis
+        3 => holo_hash::AgentPubKey::from_raw_36(raw).into(),
+        // StoreEntry, RegisterUpdatedContent, RegisterDeletedEntryAction,
+        // RegisterAddLink, RegisterRemoveLink → EntryHash basis (or Agent as Entry)
+        _ => holo_hash::EntryHash::from_raw_36(raw).into(),
+    }
 }
 
 /// Compute the terminal [`OpValidity`](holochain_zome_types::dht_v2::OpValidity)

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -5,7 +5,7 @@
 //! obtain a reference from [`Space`](crate) and invoke named methods; they do
 //! not need to interact with the underlying handle directly.
 
-use holo_hash::{AgentPubKey, AnyDhtHash, DhtOpHash, HasHash};
+use holo_hash::{AgentPubKey, DhtOpHash, HasHash};
 use holochain_data::dht::{InsertLimboChainOp, InsertLimboWarrant, InsertScheduledFunction};
 use holochain_data::kind::Dht;
 use holochain_data::DbWrite;
@@ -480,14 +480,8 @@ impl DhtStore<DbWrite<Dht>> {
                     }
 
                     // Compute basis hash and storage_center_loc.
-                    let linkable_basis = chain_op.dht_basis();
-                    let storage_center_loc = linkable_basis.get_loc();
-                    let basis_hash: AnyDhtHash =
-                        AnyDhtHash::try_from(linkable_basis).map_err(|e| {
-                            StateMutationError::Other(format!(
-                                "cannot convert op basis to AnyDhtHash: {e:?}"
-                            ))
-                        })?;
+                    let basis_hash = chain_op.dht_basis();
+                    let storage_center_loc = basis_hash.get_loc();
 
                     tx.insert_limbo_chain_op(InsertLimboChainOp {
                         op_hash: &op_hash,

--- a/crates/holochain_state/src/dht_store/cache.rs
+++ b/crates/holochain_state/src/dht_store/cache.rs
@@ -5,7 +5,7 @@
 //! through limbo (`LimboWarrantOp`) so the local conductor can validate them
 //! regardless of arc coverage.
 
-use holo_hash::{AnyDhtHash, HasHash};
+use holo_hash::HasHash;
 use holochain_data::dht::{InsertChainOp, InsertLimboWarrant};
 use holochain_data::kind::Dht;
 use holochain_data::DbWrite;
@@ -56,13 +56,8 @@ impl DhtStore<DbWrite<Dht>> {
             )
             .await?;
 
-            let linkable_basis = op.op_light.dht_basis();
-            let storage_center_loc = linkable_basis.get_loc();
-            let basis_hash: AnyDhtHash = AnyDhtHash::try_from(linkable_basis).map_err(|e| {
-                StateMutationError::Other(format!(
-                    "cannot convert cached op basis to AnyDhtHash: {e:?}"
-                ))
-            })?;
+            let basis_hash = op.op_light.dht_basis();
+            let storage_center_loc = basis_hash.get_loc();
 
             let op_type = match op.op_light.get_type() {
                 holochain_types::dht_op::DhtOpType::Chain(t) => i64::from(t),

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -49,7 +49,8 @@ impl DhtStore<DbRead<Dht>> {
     pub async fn find_fork_for_action(
         &self,
         action: &holochain_zome_types::action::Action,
-    ) -> StateQueryResult<Option<(holo_hash::ActionHash, holochain_types::prelude::Signature)>> {
+    ) -> StateQueryResult<Option<(holo_hash::ActionHash, holochain_types::prelude::Signature)>>
+    {
         let Some(prev) = action.prev_action() else {
             return Ok(None);
         };
@@ -139,7 +140,8 @@ impl DhtStore<DbWrite<Dht>> {
     pub async fn find_fork_for_action(
         &self,
         action: &holochain_zome_types::action::Action,
-    ) -> StateQueryResult<Option<(holo_hash::ActionHash, holochain_types::prelude::Signature)>> {
+    ) -> StateQueryResult<Option<(holo_hash::ActionHash, holochain_types::prelude::Signature)>>
+    {
         self.as_read().find_fork_for_action(action).await
     }
 }

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -42,12 +42,14 @@ impl DhtStore<DbRead<Dht>> {
     /// sibling exists. Returns `Err` with a descriptive message if a
     /// sibling action by a different author is found (cross-author
     /// `prev_action` collision).
+    ///
+    /// The returned tuple is `(hash, signature)` for the sibling action —
+    /// the exact shape the sys-validation workflow needs to author a
+    /// `ChainFork` warrant.
     pub async fn find_fork_for_action(
         &self,
         action: &holochain_zome_types::action::Action,
-    ) -> StateQueryResult<Option<holochain_types::prelude::SignedAction>> {
-        use holochain_zome_types::dht_v2::to_legacy_signed_action;
-
+    ) -> StateQueryResult<Option<(holo_hash::ActionHash, holochain_types::prelude::Signature)>> {
         let Some(prev) = action.prev_action() else {
             return Ok(None);
         };
@@ -59,28 +61,19 @@ impl DhtStore<DbRead<Dht>> {
             .await?;
 
         let incoming_author = action.author();
-        if let Some(v2_sibling) = siblings.into_iter().next() {
-            let legacy_sibling = to_legacy_signed_action(&v2_sibling).map_err(|e| {
-                crate::query::StateQueryError::Other(format!(
-                    "to_legacy_signed_action on sibling: {e}"
-                ))
-            })?;
-            let existing_author = legacy_sibling.action().author();
+        if let Some(sibling) = siblings.into_iter().next() {
+            let existing_author = &sibling.hashed.content.header.author;
             if existing_author != incoming_author {
                 return Err(crate::query::StateQueryError::Other(format!(
                     "Cross-author prev_action collision: incoming author {incoming_author} \
                      differs from existing author {existing_author} for prev_action {prev:?}"
                 )));
             }
-            // Return the SignedAction (action + signature, no hash).
-            let signature = legacy_sibling.signature().clone();
-            let action = legacy_sibling.action().clone();
-            Ok(Some(holochain_types::prelude::SignedAction::new(
-                action, signature,
-            )))
-        } else {
-            Ok(None)
+            let hash = sibling.as_hash().clone();
+            let signature = sibling.signature().clone();
+            return Ok(Some((hash, signature)));
         }
+        Ok(None)
     }
 
     /// Return ops awaiting system validation, sorted across chain ops and
@@ -146,7 +139,7 @@ impl DhtStore<DbWrite<Dht>> {
     pub async fn find_fork_for_action(
         &self,
         action: &holochain_zome_types::action::Action,
-    ) -> StateQueryResult<Option<holochain_types::prelude::SignedAction>> {
+    ) -> StateQueryResult<Option<(holo_hash::ActionHash, holochain_types::prelude::Signature)>> {
         self.as_read().find_fork_for_action(action).await
     }
 }
@@ -529,6 +522,16 @@ mod tests {
         let op_a = make_fork_op(&author, &prev_action_hash, 2, 32);
         let op_b = make_fork_op(&author, &prev_action_hash, 2, 33);
 
+        // Capture op_a's action hash and signature before moving op_a into the store.
+        let expected_hash = match op_a.as_content() {
+            DhtOp::ChainOp(c) => ActionHash::with_data_sync(&c.action()),
+            _ => unreachable!(),
+        };
+        let expected_sig = match op_a.as_content() {
+            DhtOp::ChainOp(c) => c.signature().clone(),
+            _ => unreachable!(),
+        };
+
         let action_b = match op_b.as_content() {
             DhtOp::ChainOp(c) => c.action().clone(),
             _ => unreachable!(),
@@ -537,6 +540,8 @@ mod tests {
         store.record_incoming_ops(vec![op_a]).await.unwrap();
 
         let result = store.find_fork_for_action(&action_b).await.unwrap();
-        assert!(result.is_some(), "fork should be detected");
+        let (got_hash, got_sig) = result.expect("fork should be detected");
+        assert_eq!(got_hash, expected_hash, "sibling hash should match op_a");
+        assert_eq!(got_sig, expected_sig, "sibling signature should match op_a");
     }
 }

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -1,15 +1,15 @@
 //! Read operations on the per-DNA DHT store.
 //!
-//! Methods on [`DhtStoreRead`] expose domain-meaningful reads for the
-//! holochain crate's workflows. They delegate to `holochain_data`'s
-//! `DbRead<Dht>` primitives and return values in terms of the project's
-//! existing domain types.
+//! Methods on [`DhtStoreRead`] expose domain-meaningful reads that delegate to
+//! `holochain_data`'s `DbRead<Dht>` primitives and return values in terms of
+//! the project's existing domain types. The parent module holds the
+//! corresponding write operations.
 
-use super::{DhtStore, DhtStoreRead};
+use super::DhtStore;
 use crate::query::StateQueryResult;
 use holo_hash::{DhtOpHash, HasHash};
 use holochain_data::kind::Dht;
-use holochain_data::{DbRead, DbWrite};
+use holochain_data::DbRead;
 use holochain_types::dht_op::DhtOpHashed;
 use holochain_zome_types::dht_v2::RecordValidity;
 
@@ -187,67 +187,6 @@ impl DhtStore<DbRead<Dht>> {
         Ok(out.into_iter().map(|(_, _, op)| op).collect())
     }
 }
-
-impl DhtStore<DbWrite<Dht>> {
-    /// Returns `true` if `hash` appears in any op-bearing DHT table.
-    ///
-    /// Delegates to the read-only view of this store.
-    pub async fn op_exists(&self, hash: &DhtOpHash) -> StateQueryResult<bool> {
-        self.as_read().op_exists(hash).await
-    }
-
-    /// See [`DhtStore::pending_validation_receipts`].
-    pub async fn pending_validation_receipts(
-        &self,
-        validators: Vec<holo_hash::AgentPubKey>,
-    ) -> StateQueryResult<
-        Vec<(
-            holochain_types::prelude::ValidationReceipt,
-            holo_hash::AgentPubKey,
-        )>,
-    > {
-        self.as_read().pending_validation_receipts(validators).await
-    }
-
-    /// Drop any op whose hash is already recorded in the DHT store.
-    ///
-    /// Delegates to the read-only view of this store.
-    pub async fn filter_existing_ops(
-        &self,
-        ops: Vec<DhtOpHashed>,
-    ) -> StateQueryResult<Vec<DhtOpHashed>> {
-        self.as_read().filter_existing_ops(ops).await
-    }
-
-    /// See [`DhtStore::ops_pending_app_validation`].
-    pub async fn ops_pending_app_validation(
-        &self,
-        limit: u32,
-    ) -> StateQueryResult<Vec<DhtOpHashed>> {
-        self.as_read().ops_pending_app_validation(limit).await
-    }
-
-    /// See [`DhtStore::ops_pending_sys_validation`].
-    pub async fn ops_pending_sys_validation(
-        &self,
-        limit: u32,
-    ) -> StateQueryResult<Vec<DhtOpHashed>> {
-        self.as_read().ops_pending_sys_validation(limit).await
-    }
-
-    /// See [`DhtStore::find_fork_for_action`].
-    pub async fn find_fork_for_action(
-        &self,
-        action: &holochain_zome_types::action::Action,
-    ) -> StateQueryResult<Option<(holo_hash::ActionHash, holochain_types::prelude::Signature)>>
-    {
-        self.as_read().find_fork_for_action(action).await
-    }
-}
-
-// Compile-only sanity check that the read-only alias resolves correctly.
-#[allow(dead_code)]
-fn _read_only_alias_compiles(_: DhtStoreRead) {}
 
 /// Reconstruct a [`DhtOpHashed`] (`ChainOp` variant) from a
 /// [`LimboChainOpJoinedRow`] without any additional database round-trips.
@@ -530,7 +469,7 @@ mod tests {
             .await
             .unwrap();
         let unknown = DhtOpHash::from_raw_36(vec![99u8; 36]);
-        let exists = store.op_exists(&unknown).await.unwrap();
+        let exists = store.as_read().op_exists(&unknown).await.unwrap();
         assert!(!exists);
     }
 
@@ -544,7 +483,7 @@ mod tests {
 
         store.record_incoming_ops(vec![op]).await.unwrap();
 
-        let exists = store.op_exists(&hash).await.unwrap();
+        let exists = store.as_read().op_exists(&hash).await.unwrap();
         assert!(exists, "op_exists should be true after record_incoming_ops");
     }
 
@@ -576,7 +515,11 @@ mod tests {
 
         store.record_incoming_ops(vec![op]).await.unwrap();
 
-        let pending = store.ops_pending_sys_validation(1_000).await.unwrap();
+        let pending = store
+            .as_read()
+            .ops_pending_sys_validation(1_000)
+            .await
+            .unwrap();
         let hashes: Vec<_> = pending.iter().map(|o| o.as_hash().clone()).collect();
         assert!(hashes.contains(&hash));
     }
@@ -597,7 +540,11 @@ mod tests {
             .await
             .unwrap();
 
-        let pending = store.ops_pending_sys_validation(1_000).await.unwrap();
+        let pending = store
+            .as_read()
+            .ops_pending_sys_validation(1_000)
+            .await
+            .unwrap();
         let hashes: Vec<_> = pending.iter().map(|o| o.as_hash().clone()).collect();
         assert!(!hashes.contains(&hash));
     }
@@ -610,7 +557,7 @@ mod tests {
         let ops: Vec<_> = (12..16).map(make_chain_op).collect();
         store.record_incoming_ops(ops).await.unwrap();
 
-        let pending = store.ops_pending_sys_validation(2).await.unwrap();
+        let pending = store.as_read().ops_pending_sys_validation(2).await.unwrap();
         assert_eq!(pending.len(), 2);
     }
 
@@ -630,7 +577,11 @@ mod tests {
             .await
             .unwrap();
 
-        let pending = store.ops_pending_app_validation(1_000).await.unwrap();
+        let pending = store
+            .as_read()
+            .ops_pending_app_validation(1_000)
+            .await
+            .unwrap();
         let hashes: Vec<_> = pending.iter().map(|o| o.as_hash().clone()).collect();
         assert!(hashes.contains(&hash));
     }
@@ -646,7 +597,11 @@ mod tests {
         // Insert but don't record sys-validation outcome.
         store.record_incoming_ops(vec![op]).await.unwrap();
 
-        let pending = store.ops_pending_app_validation(1_000).await.unwrap();
+        let pending = store
+            .as_read()
+            .ops_pending_app_validation(1_000)
+            .await
+            .unwrap();
         let hashes: Vec<_> = pending.iter().map(|o| o.as_hash().clone()).collect();
         assert!(
             !hashes.contains(&hash),
@@ -674,7 +629,11 @@ mod tests {
             .await
             .unwrap();
 
-        let pending = store.ops_pending_app_validation(1_000).await.unwrap();
+        let pending = store
+            .as_read()
+            .ops_pending_app_validation(1_000)
+            .await
+            .unwrap();
         let hashes: Vec<_> = pending.iter().map(|o| o.as_hash().clone()).collect();
         assert!(
             !hashes.contains(&hash),
@@ -693,7 +652,7 @@ mod tests {
             _ => unreachable!(),
         };
 
-        let result = store.find_fork_for_action(&action).await.unwrap();
+        let result = store.as_read().find_fork_for_action(&action).await.unwrap();
         assert!(result.is_none());
     }
 
@@ -728,7 +687,11 @@ mod tests {
 
         store.record_incoming_ops(vec![op_a]).await.unwrap();
 
-        let result = store.find_fork_for_action(&action_b).await.unwrap();
+        let result = store
+            .as_read()
+            .find_fork_for_action(&action_b)
+            .await
+            .unwrap();
         let (got_hash, got_sig) = result.expect("fork should be detected");
         assert_eq!(got_hash, expected_hash, "sibling hash should match op_a");
         assert_eq!(got_sig, expected_sig, "sibling signature should match op_a");
@@ -764,6 +727,7 @@ mod tests {
 
         let validators = vec![AgentPubKey::from_raw_36(vec![0xFF; 36])];
         let receipts = store
+            .as_read()
             .pending_validation_receipts(validators.clone())
             .await
             .unwrap();
@@ -801,7 +765,11 @@ mod tests {
             .await
             .unwrap();
 
-        let receipts = store.pending_validation_receipts(vec![]).await.unwrap();
+        let receipts = store
+            .as_read()
+            .pending_validation_receipts(vec![])
+            .await
+            .unwrap();
         assert!(
             receipts.iter().all(|(r, _)| r.dht_op_hash != hash),
             "op with cleared require_receipt should not appear"

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -77,6 +77,22 @@ impl DhtStore<DbRead<Dht>> {
         Ok(None)
     }
 
+    /// Return chain ops that have passed system validation and are awaiting
+    /// app validation. Warrants have no app-validation stage, so they are not
+    /// included.
+    pub async fn ops_pending_app_validation(
+        &self,
+        limit: u32,
+    ) -> StateQueryResult<Vec<DhtOpHashed>> {
+        let db = self.db();
+        let rows = db.limbo_chain_ops_pending_app_validation(limit).await?;
+        let mut out = Vec::with_capacity(rows.len());
+        for row in rows {
+            out.push(chain_op_from_limbo_row(db, &row).await?);
+        }
+        Ok(out)
+    }
+
     /// Return ops awaiting system validation, sorted across chain ops and
     /// warrants by `(sys_validation_attempts, when_received)`, up to `limit`
     /// rows total.
@@ -126,6 +142,14 @@ impl DhtStore<DbWrite<Dht>> {
         ops: Vec<DhtOpHashed>,
     ) -> StateQueryResult<Vec<DhtOpHashed>> {
         self.as_read().filter_existing_ops(ops).await
+    }
+
+    /// See [`DhtStore::ops_pending_app_validation`].
+    pub async fn ops_pending_app_validation(
+        &self,
+        limit: u32,
+    ) -> StateQueryResult<Vec<DhtOpHashed>> {
+        self.as_read().ops_pending_app_validation(limit).await
     }
 
     /// See [`DhtStore::ops_pending_sys_validation`].
@@ -493,6 +517,74 @@ mod tests {
 
         let pending = store.ops_pending_sys_validation(2).await.unwrap();
         assert_eq!(pending.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn ops_pending_app_validation_returns_sys_validated_chain_op() {
+        use crate::dht_store::SysOutcome;
+
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let op = make_chain_op(50);
+        let hash = op.as_hash().clone();
+
+        store.record_incoming_ops(vec![op]).await.unwrap();
+        store
+            .record_chain_op_sys_validation_outcomes(vec![(hash.clone(), SysOutcome::Accepted)])
+            .await
+            .unwrap();
+
+        let pending = store.ops_pending_app_validation(1_000).await.unwrap();
+        let hashes: Vec<_> = pending.iter().map(|o| o.as_hash().clone()).collect();
+        assert!(hashes.contains(&hash));
+    }
+
+    #[tokio::test]
+    async fn ops_pending_app_validation_excludes_pending_sys() {
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let op = make_chain_op(51);
+        let hash = op.as_hash().clone();
+
+        // Insert but don't record sys-validation outcome.
+        store.record_incoming_ops(vec![op]).await.unwrap();
+
+        let pending = store.ops_pending_app_validation(1_000).await.unwrap();
+        let hashes: Vec<_> = pending.iter().map(|o| o.as_hash().clone()).collect();
+        assert!(
+            !hashes.contains(&hash),
+            "op not yet sys-validated should not appear"
+        );
+    }
+
+    #[tokio::test]
+    async fn ops_pending_app_validation_excludes_app_validated() {
+        use crate::dht_store::{AppOutcome, SysOutcome};
+
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let op = make_chain_op(52);
+        let hash = op.as_hash().clone();
+
+        store.record_incoming_ops(vec![op]).await.unwrap();
+        store
+            .record_chain_op_sys_validation_outcomes(vec![(hash.clone(), SysOutcome::Accepted)])
+            .await
+            .unwrap();
+        store
+            .record_app_validation_outcomes(vec![(hash.clone(), AppOutcome::Accepted)])
+            .await
+            .unwrap();
+
+        let pending = store.ops_pending_app_validation(1_000).await.unwrap();
+        let hashes: Vec<_> = pending.iter().map(|o| o.as_hash().clone()).collect();
+        assert!(
+            !hashes.contains(&hash),
+            "fully-validated op should not appear"
+        );
     }
 
     #[tokio::test]

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -33,6 +33,38 @@ impl DhtStore<DbRead<Dht>> {
             .filter_map(|(op, exists)| if exists { None } else { Some(op) })
             .collect())
     }
+
+    /// Return ops awaiting system validation, sorted across chain ops and
+    /// warrants by `(sys_validation_attempts, when_received)`, up to `limit`
+    /// rows total.
+    pub async fn ops_pending_sys_validation(
+        &self,
+        limit: u32,
+    ) -> StateQueryResult<Vec<DhtOpHashed>> {
+        let db = self.db();
+        let chain_rows = db.limbo_chain_ops_pending_sys_validation(limit).await?;
+        let warrant_rows = db.limbo_warrants_pending_sys_validation(limit).await?;
+
+        let mut out: Vec<(i64, i64, DhtOpHashed)> =
+            Vec::with_capacity(chain_rows.len() + warrant_rows.len());
+
+        for row in chain_rows {
+            let attempts = row.sys_validation_attempts;
+            let when_received = row.when_received;
+            let op = chain_op_from_limbo_row(db, &row).await?;
+            out.push((attempts, when_received, op));
+        }
+        for row in warrant_rows {
+            let attempts = row.sys_validation_attempts;
+            let when_received = row.when_received;
+            let op = warrant_from_limbo_row(&row)?;
+            out.push((attempts, when_received, op));
+        }
+
+        out.sort_by_key(|(attempts, when_received, _)| (*attempts, *when_received));
+        out.truncate(limit as usize);
+        Ok(out.into_iter().map(|(_, _, op)| op).collect())
+    }
 }
 
 impl DhtStore<DbWrite<Dht>> {
@@ -52,11 +84,214 @@ impl DhtStore<DbWrite<Dht>> {
     ) -> StateQueryResult<Vec<DhtOpHashed>> {
         self.as_read().filter_existing_ops(ops).await
     }
+
+    /// See [`DhtStore::ops_pending_sys_validation`].
+    pub async fn ops_pending_sys_validation(
+        &self,
+        limit: u32,
+    ) -> StateQueryResult<Vec<DhtOpHashed>> {
+        self.as_read().ops_pending_sys_validation(limit).await
+    }
 }
 
 // Compile-only sanity check that the read-only alias resolves correctly.
 #[allow(dead_code)]
 fn _read_only_alias_compiles(_: DhtStoreRead) {}
+
+/// Reconstruct a [`DhtOpHashed`] (`ChainOp` variant) from a `LimboChainOp`
+/// row by fetching the action (and entry when required) from the database.
+async fn chain_op_from_limbo_row(
+    db: &DbRead<Dht>,
+    row: &holochain_data::models::dht::LimboChainOpRow,
+) -> StateQueryResult<DhtOpHashed> {
+    use holochain_types::action::NewEntryAction;
+    use holochain_types::dht_op::{ChainOp, DhtOp};
+    use holochain_types::prelude::{RecordEntry, Signature};
+    use holochain_zome_types::action::Action;
+    use holochain_zome_types::dht_v2::to_legacy_signed_action;
+    use holochain_zome_types::op::ChainOpType;
+
+    let op_type = ChainOpType::try_from(row.op_type).map_err(|n| {
+        crate::query::StateQueryError::Other(format!("invalid op_type {n} in LimboChainOp row"))
+    })?;
+
+    let action_hash = holo_hash::ActionHash::from_raw_36(row.action_hash.clone());
+    let v2_action = db.get_action(action_hash.clone()).await?.ok_or_else(|| {
+        crate::query::StateQueryError::Other(format!(
+            "Action {action_hash:?} referenced by LimboChainOp not found"
+        ))
+    })?;
+
+    let legacy = to_legacy_signed_action(&v2_action).map_err(|e| {
+        crate::query::StateQueryError::Other(format!("to_legacy_signed_action: {e}"))
+    })?;
+    let signature: Signature = legacy.signature().clone();
+    let action: Action = legacy.action().clone();
+
+    // Look up the entry referenced by the given action, returning
+    // `RecordEntry::Present` when found or `RecordEntry::NA` when the action
+    // carries no entry hash.
+    async fn fetch_entry_for_action(
+        db: &DbRead<Dht>,
+        action: &Action,
+    ) -> StateQueryResult<RecordEntry> {
+        match action.entry_hash() {
+            None => Ok(RecordEntry::NA),
+            Some(h) => {
+                let entry = db.get_entry(h.clone(), None).await?.ok_or_else(|| {
+                    crate::query::StateQueryError::Other(format!(
+                        "Entry {h:?} referenced by Action not found"
+                    ))
+                })?;
+                Ok(RecordEntry::Present(entry))
+            }
+        }
+    }
+
+    // Look up the entry referenced by an Update action, always returning
+    // `RecordEntry::Present`.
+    async fn fetch_entry_for_update(
+        db: &DbRead<Dht>,
+        update: &holochain_zome_types::action::Update,
+    ) -> StateQueryResult<RecordEntry> {
+        let entry_hash = update.entry_hash.clone();
+        let entry = db
+            .get_entry(entry_hash.clone(), None)
+            .await?
+            .ok_or_else(|| {
+                crate::query::StateQueryError::Other(format!(
+                    "Entry {entry_hash:?} for Update not found"
+                ))
+            })?;
+        Ok(RecordEntry::Present(entry))
+    }
+
+    let chain_op = match op_type {
+        ChainOpType::StoreRecord => {
+            let entry = fetch_entry_for_action(db, &action).await?;
+            ChainOp::StoreRecord(signature, action, entry)
+        }
+        ChainOpType::StoreEntry => {
+            let entry_hash = action.entry_hash().cloned().ok_or_else(|| {
+                crate::query::StateQueryError::Other("StoreEntry action has no entry_hash".into())
+            })?;
+            let entry = db
+                .get_entry(entry_hash.clone(), None)
+                .await?
+                .ok_or_else(|| {
+                    crate::query::StateQueryError::Other(format!(
+                        "Entry {entry_hash:?} for StoreEntry not found"
+                    ))
+                })?;
+            let new_entry_action = NewEntryAction::try_from(action).map_err(|_| {
+                crate::query::StateQueryError::Other(
+                    "StoreEntry action is not a Create/Update".into(),
+                )
+            })?;
+            ChainOp::StoreEntry(signature, new_entry_action, entry)
+        }
+        ChainOpType::RegisterAgentActivity => ChainOp::RegisterAgentActivity(signature, action),
+        ChainOpType::RegisterUpdatedContent => {
+            let update = match action {
+                Action::Update(u) => u,
+                _ => {
+                    return Err(crate::query::StateQueryError::Other(
+                        "RegisterUpdatedContent action is not Update".into(),
+                    ))
+                }
+            };
+            let entry = fetch_entry_for_update(db, &update).await?;
+            ChainOp::RegisterUpdatedContent(signature, update, entry)
+        }
+        ChainOpType::RegisterUpdatedRecord => {
+            let update = match action {
+                Action::Update(u) => u,
+                _ => {
+                    return Err(crate::query::StateQueryError::Other(
+                        "RegisterUpdatedRecord action is not Update".into(),
+                    ))
+                }
+            };
+            let entry = fetch_entry_for_update(db, &update).await?;
+            ChainOp::RegisterUpdatedRecord(signature, update, entry)
+        }
+        ChainOpType::RegisterDeletedEntryAction => {
+            let delete = match action {
+                Action::Delete(d) => d,
+                _ => {
+                    return Err(crate::query::StateQueryError::Other(
+                        "RegisterDeletedEntryAction action is not Delete".into(),
+                    ))
+                }
+            };
+            ChainOp::RegisterDeletedEntryAction(signature, delete)
+        }
+        ChainOpType::RegisterDeletedBy => {
+            let delete = match action {
+                Action::Delete(d) => d,
+                _ => {
+                    return Err(crate::query::StateQueryError::Other(
+                        "RegisterDeletedBy action is not Delete".into(),
+                    ))
+                }
+            };
+            ChainOp::RegisterDeletedBy(signature, delete)
+        }
+        ChainOpType::RegisterAddLink => {
+            let create_link = match action {
+                Action::CreateLink(c) => c,
+                _ => {
+                    return Err(crate::query::StateQueryError::Other(
+                        "RegisterAddLink action is not CreateLink".into(),
+                    ))
+                }
+            };
+            ChainOp::RegisterAddLink(signature, create_link)
+        }
+        ChainOpType::RegisterRemoveLink => {
+            let delete_link = match action {
+                Action::DeleteLink(d) => d,
+                _ => {
+                    return Err(crate::query::StateQueryError::Other(
+                        "RegisterRemoveLink action is not DeleteLink".into(),
+                    ))
+                }
+            };
+            ChainOp::RegisterRemoveLink(signature, delete_link)
+        }
+    };
+
+    let op = DhtOp::ChainOp(Box::new(chain_op));
+    let op_hash = holo_hash::DhtOpHash::from_raw_36(row.hash.clone());
+    Ok(DhtOpHashed::with_pre_hashed(op, op_hash))
+}
+
+/// Reconstruct a [`DhtOpHashed`] (`WarrantOp` variant) from a `LimboWarrant` row.
+fn warrant_from_limbo_row(
+    row: &holochain_data::models::dht::LimboWarrantRow,
+) -> StateQueryResult<DhtOpHashed> {
+    use holochain_types::dht_op::DhtOp;
+    use holochain_types::prelude::Signature;
+    use holochain_types::warrant::WarrantOp;
+    use holochain_zome_types::warrant::{SignedWarrant, Warrant, WarrantProof};
+
+    let proof: WarrantProof = holochain_serialized_bytes::decode(&row.proof)?;
+    let author = holo_hash::AgentPubKey::from_raw_36(row.author.clone());
+    let warrantee = holo_hash::AgentPubKey::from_raw_36(row.warrantee.clone());
+    let timestamp = holochain_types::prelude::Timestamp::from_micros(row.timestamp);
+
+    let warrant = Warrant::new(proof, author, timestamp, warrantee);
+    // The signature is not stored in the limbo row — warrants are self-proving
+    // via their proof content.  Use a zeroed signature as a placeholder, the
+    // same approach used elsewhere in the codebase when reconstructing
+    // WarrantOps from storage without a separate signature column.
+    let signature = Signature::from([0u8; 64]);
+    let signed_warrant = SignedWarrant::new(warrant, signature);
+    let warrant_op = WarrantOp::from(signed_warrant);
+    let op = DhtOp::WarrantOp(Box::new(warrant_op));
+    let op_hash = holo_hash::DhtOpHash::from_raw_36(row.hash.clone());
+    Ok(DhtOpHashed::with_pre_hashed(op, op_hash))
+}
 
 #[cfg(test)]
 mod tests {
@@ -140,5 +375,53 @@ mod tests {
         let filtered = store.as_read().filter_existing_ops(input).await.unwrap();
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].as_hash(), &unknown_hash);
+    }
+
+    #[tokio::test]
+    async fn ops_pending_sys_validation_returns_recorded_chain_op() {
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let op = make_chain_op(10);
+        let hash = op.as_hash().clone();
+
+        store.record_incoming_ops(vec![op]).await.unwrap();
+
+        let pending = store.ops_pending_sys_validation(1_000).await.unwrap();
+        let hashes: Vec<_> = pending.iter().map(|o| o.as_hash().clone()).collect();
+        assert!(hashes.contains(&hash));
+    }
+
+    #[tokio::test]
+    async fn ops_pending_sys_validation_excludes_completed() {
+        use crate::dht_store::SysOutcome;
+
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let op = make_chain_op(11);
+        let hash = op.as_hash().clone();
+
+        store.record_incoming_ops(vec![op]).await.unwrap();
+        store
+            .record_chain_op_sys_validation_outcomes(vec![(hash.clone(), SysOutcome::Accepted)])
+            .await
+            .unwrap();
+
+        let pending = store.ops_pending_sys_validation(1_000).await.unwrap();
+        let hashes: Vec<_> = pending.iter().map(|o| o.as_hash().clone()).collect();
+        assert!(!hashes.contains(&hash));
+    }
+
+    #[tokio::test]
+    async fn ops_pending_sys_validation_respects_limit_across_union() {
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let ops: Vec<_> = (12..16).map(make_chain_op).collect();
+        store.record_incoming_ops(ops).await.unwrap();
+
+        let pending = store.ops_pending_sys_validation(2).await.unwrap();
+        assert_eq!(pending.len(), 2);
     }
 }

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -11,6 +11,7 @@ use holo_hash::{DhtOpHash, HasHash};
 use holochain_data::kind::Dht;
 use holochain_data::{DbRead, DbWrite};
 use holochain_types::dht_op::DhtOpHashed;
+use holochain_zome_types::dht_v2::RecordValidity;
 
 impl DhtStore<DbRead<Dht>> {
     /// Returns `true` if `hash` appears in any op-bearing DHT table
@@ -93,6 +94,58 @@ impl DhtStore<DbRead<Dht>> {
         Ok(out)
     }
 
+    /// Return pending validation receipts: one entry per integrated, validated
+    /// op that still has `require_receipt = 1`. Each tuple is
+    /// `(ValidationReceipt, action_author)` so the caller can group by author.
+    ///
+    /// The `validators` field on each [`ValidationReceipt`] is populated from
+    /// the supplied `validators` argument (the locally-running agents for this
+    /// DNA).
+    pub async fn pending_validation_receipts(
+        &self,
+        validators: Vec<holo_hash::AgentPubKey>,
+    ) -> StateQueryResult<
+        Vec<(
+            holochain_types::prelude::ValidationReceipt,
+            holo_hash::AgentPubKey,
+        )>,
+    > {
+        let rows = self.db().pending_validation_receipts().await?;
+        rows.into_iter()
+            .map(|r| {
+                let dht_op_hash = holo_hash::DhtOpHash::from_raw_36(r.op_hash);
+                let author = holo_hash::AgentPubKey::from_raw_36(r.action_author);
+                // Map from RecordValidity (Accepted=1, Rejected=2) to
+                // ValidationStatus (Valid=0, Rejected=1).
+                let record_validity =
+                    RecordValidity::try_from(r.validation_status).map_err(|v| {
+                        crate::query::StateQueryError::Other(format!(
+                            "invalid validation_status {v} in ChainOp row"
+                        ))
+                    })?;
+                let validation_status = match record_validity {
+                    RecordValidity::Accepted => {
+                        holochain_zome_types::validate::ValidationStatus::Valid
+                    }
+                    RecordValidity::Rejected => {
+                        holochain_zome_types::validate::ValidationStatus::Rejected
+                    }
+                };
+                let when_integrated =
+                    holochain_types::prelude::Timestamp::from_micros(r.when_integrated);
+                Ok((
+                    holochain_types::prelude::ValidationReceipt {
+                        dht_op_hash,
+                        validation_status,
+                        validators: validators.clone(),
+                        when_integrated,
+                    },
+                    author,
+                ))
+            })
+            .collect()
+    }
+
     /// Return ops awaiting system validation, sorted across chain ops and
     /// warrants by `(sys_validation_attempts, when_received)`, up to `limit`
     /// rows total.
@@ -132,6 +185,19 @@ impl DhtStore<DbWrite<Dht>> {
     /// Delegates to the read-only view of this store.
     pub async fn op_exists(&self, hash: &DhtOpHash) -> StateQueryResult<bool> {
         self.as_read().op_exists(hash).await
+    }
+
+    /// See [`DhtStore::pending_validation_receipts`].
+    pub async fn pending_validation_receipts(
+        &self,
+        validators: Vec<holo_hash::AgentPubKey>,
+    ) -> StateQueryResult<
+        Vec<(
+            holochain_types::prelude::ValidationReceipt,
+            holo_hash::AgentPubKey,
+        )>,
+    > {
+        self.as_read().pending_validation_receipts(validators).await
     }
 
     /// Drop any op whose hash is already recorded in the DHT store.
@@ -647,5 +713,79 @@ mod tests {
         let (got_hash, got_sig) = result.expect("fork should be detected");
         assert_eq!(got_hash, expected_hash, "sibling hash should match op_a");
         assert_eq!(got_sig, expected_sig, "sibling signature should match op_a");
+    }
+
+    #[tokio::test]
+    async fn pending_validation_receipts_returns_integrated_require_receipt_ops() {
+        use crate::dht_store::{AppOutcome, SysOutcome};
+
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let op = make_chain_op(60);
+        let hash = op.as_hash().clone();
+        let author = match op.as_content() {
+            DhtOp::ChainOp(c) => c.action().author().clone(),
+            _ => unreachable!(),
+        };
+
+        store.record_incoming_ops(vec![op]).await.unwrap();
+        store
+            .record_chain_op_sys_validation_outcomes(vec![(hash.clone(), SysOutcome::Accepted)])
+            .await
+            .unwrap();
+        store
+            .record_app_validation_outcomes(vec![(hash.clone(), AppOutcome::Accepted)])
+            .await
+            .unwrap();
+        store
+            .integrate_ready_ops(holochain_types::prelude::Timestamp::now())
+            .await
+            .unwrap();
+
+        let validators = vec![AgentPubKey::from_raw_36(vec![0xFF; 36])];
+        let receipts = store
+            .pending_validation_receipts(validators.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(receipts.len(), 1);
+        assert_eq!(receipts[0].0.dht_op_hash, hash);
+        assert_eq!(receipts[0].1, author);
+        assert_eq!(receipts[0].0.validators, validators);
+    }
+
+    #[tokio::test]
+    async fn pending_validation_receipts_excludes_ops_without_require_receipt() {
+        use crate::dht_store::{AppOutcome, SysOutcome};
+
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let op = make_chain_op(61);
+        let hash = op.as_hash().clone();
+        store.record_incoming_ops(vec![op]).await.unwrap();
+        store
+            .record_chain_op_sys_validation_outcomes(vec![(hash.clone(), SysOutcome::Accepted)])
+            .await
+            .unwrap();
+        store
+            .record_app_validation_outcomes(vec![(hash.clone(), AppOutcome::Accepted)])
+            .await
+            .unwrap();
+        store
+            .integrate_ready_ops(holochain_types::prelude::Timestamp::now())
+            .await
+            .unwrap();
+        store
+            .clear_require_receipts(vec![hash.clone()])
+            .await
+            .unwrap();
+
+        let receipts = store.pending_validation_receipts(vec![]).await.unwrap();
+        assert!(
+            receipts.iter().all(|(r, _)| r.dht_op_hash != hash),
+            "op with cleared require_receipt should not appear"
+        );
     }
 }

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -86,10 +86,12 @@ impl DhtStore<DbRead<Dht>> {
         limit: u32,
     ) -> StateQueryResult<Vec<DhtOpHashed>> {
         let db = self.db();
-        let rows = db.limbo_chain_ops_pending_app_validation(limit).await?;
+        let rows = db
+            .limbo_chain_ops_pending_app_validation_with_action(limit)
+            .await?;
         let mut out = Vec::with_capacity(rows.len());
         for row in rows {
-            out.push(chain_op_from_limbo_row(db, &row).await?);
+            out.push(chain_op_from_joined_row(&row)?);
         }
         Ok(out)
     }
@@ -154,7 +156,9 @@ impl DhtStore<DbRead<Dht>> {
         limit: u32,
     ) -> StateQueryResult<Vec<DhtOpHashed>> {
         let db = self.db();
-        let chain_rows = db.limbo_chain_ops_pending_sys_validation(limit).await?;
+        let chain_rows = db
+            .limbo_chain_ops_pending_sys_validation_with_action(limit)
+            .await?;
         let warrant_rows = db.limbo_warrants_pending_sys_validation(limit).await?;
 
         let mut out: Vec<(i64, i64, DhtOpHashed)> =
@@ -163,7 +167,7 @@ impl DhtStore<DbRead<Dht>> {
         for row in chain_rows {
             let attempts = row.sys_validation_attempts;
             let when_received = row.when_received;
-            let op = chain_op_from_limbo_row(db, &row).await?;
+            let op = chain_op_from_joined_row(&row)?;
             out.push((attempts, when_received, op));
         }
         for row in warrant_rows {
@@ -240,57 +244,78 @@ impl DhtStore<DbWrite<Dht>> {
 #[allow(dead_code)]
 fn _read_only_alias_compiles(_: DhtStoreRead) {}
 
-/// Reconstruct a [`DhtOpHashed`] (`ChainOp` variant) from a `LimboChainOp`
-/// row by fetching the action (and entry when required) from the database.
-async fn chain_op_from_limbo_row(
-    db: &DbRead<Dht>,
-    row: &holochain_data::models::dht::LimboChainOpRow,
+/// Reconstruct a [`DhtOpHashed`] (`ChainOp` variant) from a
+/// [`LimboChainOpJoinedRow`] without any additional database round-trips.
+/// The action and entry blobs are decoded in-process from the joined columns.
+fn chain_op_from_joined_row(
+    row: &holochain_data::dht::LimboChainOpJoinedRow,
 ) -> StateQueryResult<DhtOpHashed> {
+    use holo_hash::{ActionHash, AgentPubKey};
     use holochain_types::action::NewEntryAction;
     use holochain_types::dht_op::{ChainOp, DhtOp};
     use holochain_types::prelude::{RecordEntry, Signature};
-    use holochain_zome_types::action::Action;
-    use holochain_zome_types::dht_v2::to_legacy_signed_action;
+    use holochain_zome_types::action::Action as LegacyAction;
+    use holochain_zome_types::dht_v2::{
+        to_legacy_signed_action, Action, ActionData, ActionHeader, SignedActionHashed,
+    };
     use holochain_zome_types::op::ChainOpType;
+    use holochain_zome_types::prelude::Signature as V2Signature;
 
     let op_type = ChainOpType::try_from(row.op_type).map_err(|n| {
         crate::query::StateQueryError::Other(format!("invalid op_type {n} in LimboChainOp row"))
     })?;
 
-    let action_hash = holo_hash::ActionHash::from_raw_36(row.action_hash.clone());
-    let v2_action = db.get_action(action_hash.clone()).await?.ok_or_else(|| {
+    // Decode the v2 Action from the joined columns.
+    let action_data: ActionData = holochain_serialized_bytes::decode(&row.action_data)
+        .map_err(|e| crate::query::StateQueryError::Other(format!("decode ActionData: {e}")))?;
+    let action_v2 = Action {
+        header: ActionHeader {
+            author: AgentPubKey::from_raw_36(row.action_author.clone()),
+            timestamp: holochain_types::prelude::Timestamp::from_micros(row.action_timestamp),
+            action_seq: row.action_seq as u32,
+            prev_action: row
+                .action_prev_hash
+                .as_ref()
+                .map(|h| ActionHash::from_raw_36(h.clone())),
+        },
+        data: action_data,
+    };
+    let sig_bytes: [u8; 64] = row.action_signature.as_slice().try_into().map_err(|_| {
         crate::query::StateQueryError::Other(format!(
-            "Action {action_hash:?} referenced by LimboChainOp not found"
+            "signature column has {} bytes, expected 64",
+            row.action_signature.len()
         ))
     })?;
+    let action_hash = ActionHash::from_raw_36(row.action_hash.clone());
+    let hashed = holo_hash::HoloHashed::with_pre_hashed(action_v2, action_hash);
+    let v2_signed: SignedActionHashed =
+        SignedActionHashed::with_presigned(hashed, V2Signature(sig_bytes));
 
-    let legacy = to_legacy_signed_action(&v2_action).map_err(|e| {
+    let legacy = to_legacy_signed_action(&v2_signed).map_err(|e| {
         crate::query::StateQueryError::Other(format!("to_legacy_signed_action: {e}"))
     })?;
     let signature: Signature = legacy.signature().clone();
-    let action: Action = legacy.action().clone();
+    let action: LegacyAction = legacy.action().clone();
 
-    // Look up the entry referenced by the given action.
-    //
-    // Returns:
-    //   - `RecordEntry::NA`       — action carries no entry hash
-    //   - `RecordEntry::Present`  — entry found in the database
-    //   - `RecordEntry::Hidden`   — action references a private entry (not stored on this node)
-    //   - `RecordEntry::NotStored`— action references a public entry we don't have locally
-    async fn fetch_entry_for_action(
-        db: &DbRead<Dht>,
-        action: &Action,
-    ) -> StateQueryResult<RecordEntry> {
-        let Some(entry_hash) = action.entry_hash() else {
+    // Decode the optional entry blob from the LEFT JOIN.
+    let decoded_entry: Option<holochain_types::prelude::Entry> = row
+        .entry_blob
+        .as_ref()
+        .map(|blob| {
+            holochain_serialized_bytes::decode(blob)
+                .map_err(|e| crate::query::StateQueryError::Other(format!("decode Entry: {e}")))
+        })
+        .transpose()?;
+
+    // Helper: build RecordEntry from legacy action + decoded entry.
+    let entry_for_action = |action: &LegacyAction| -> StateQueryResult<RecordEntry> {
+        use holochain_zome_types::entry_def::EntryVisibility;
+        if action.entry_hash().is_none() {
             return Ok(RecordEntry::NA);
-        };
-        match db.get_entry(entry_hash.clone(), None).await? {
+        }
+        match decoded_entry.clone() {
             Some(entry) => Ok(RecordEntry::Present(entry)),
             None => {
-                // Entry not in the database. Use the entry type visibility to
-                // distinguish private entries (Hidden) from public ones we
-                // simply don't have yet (NotStored).
-                use holochain_zome_types::entry_def::EntryVisibility;
                 if action.entry_visibility() == Some(&EntryVisibility::Private) {
                     Ok(RecordEntry::Hidden)
                 } else {
@@ -298,43 +323,34 @@ async fn chain_op_from_limbo_row(
                 }
             }
         }
-    }
+    };
 
-    // Look up the entry referenced by an Update action, always returning
-    // `RecordEntry::Present`.
-    async fn fetch_entry_for_update(
-        db: &DbRead<Dht>,
-        update: &holochain_zome_types::action::Update,
-    ) -> StateQueryResult<RecordEntry> {
-        let entry_hash = update.entry_hash.clone();
-        let entry = db
-            .get_entry(entry_hash.clone(), None)
-            .await?
-            .ok_or_else(|| {
-                crate::query::StateQueryError::Other(format!(
-                    "Entry {entry_hash:?} for Update not found"
-                ))
-            })?;
-        Ok(RecordEntry::Present(entry))
-    }
+    // Helper: entry required to be present (Update ops).
+    let entry_for_update =
+        |update: &holochain_zome_types::action::Update| -> StateQueryResult<RecordEntry> {
+            match decoded_entry.clone() {
+                Some(entry) => Ok(RecordEntry::Present(entry)),
+                None => Err(crate::query::StateQueryError::Other(format!(
+                    "Entry {:?} for Update not found",
+                    update.entry_hash
+                ))),
+            }
+        };
 
     let chain_op = match op_type {
         ChainOpType::StoreRecord => {
-            let entry = fetch_entry_for_action(db, &action).await?;
+            let entry = entry_for_action(&action)?;
             ChainOp::StoreRecord(signature, action, entry)
         }
         ChainOpType::StoreEntry => {
             let entry_hash = action.entry_hash().cloned().ok_or_else(|| {
                 crate::query::StateQueryError::Other("StoreEntry action has no entry_hash".into())
             })?;
-            let entry = db
-                .get_entry(entry_hash.clone(), None)
-                .await?
-                .ok_or_else(|| {
-                    crate::query::StateQueryError::Other(format!(
-                        "Entry {entry_hash:?} for StoreEntry not found"
-                    ))
-                })?;
+            let entry = decoded_entry.clone().ok_or_else(|| {
+                crate::query::StateQueryError::Other(format!(
+                    "Entry {entry_hash:?} for StoreEntry not found"
+                ))
+            })?;
             let new_entry_action = NewEntryAction::try_from(action).map_err(|_| {
                 crate::query::StateQueryError::Other(
                     "StoreEntry action is not a Create/Update".into(),
@@ -345,31 +361,31 @@ async fn chain_op_from_limbo_row(
         ChainOpType::RegisterAgentActivity => ChainOp::RegisterAgentActivity(signature, action),
         ChainOpType::RegisterUpdatedContent => {
             let update = match action {
-                Action::Update(u) => u,
+                LegacyAction::Update(u) => u,
                 _ => {
                     return Err(crate::query::StateQueryError::Other(
                         "RegisterUpdatedContent action is not Update".into(),
                     ))
                 }
             };
-            let entry = fetch_entry_for_update(db, &update).await?;
+            let entry = entry_for_update(&update)?;
             ChainOp::RegisterUpdatedContent(signature, update, entry)
         }
         ChainOpType::RegisterUpdatedRecord => {
             let update = match action {
-                Action::Update(u) => u,
+                LegacyAction::Update(u) => u,
                 _ => {
                     return Err(crate::query::StateQueryError::Other(
                         "RegisterUpdatedRecord action is not Update".into(),
                     ))
                 }
             };
-            let entry = fetch_entry_for_update(db, &update).await?;
+            let entry = entry_for_update(&update)?;
             ChainOp::RegisterUpdatedRecord(signature, update, entry)
         }
         ChainOpType::RegisterDeletedEntryAction => {
             let delete = match action {
-                Action::Delete(d) => d,
+                LegacyAction::Delete(d) => d,
                 _ => {
                     return Err(crate::query::StateQueryError::Other(
                         "RegisterDeletedEntryAction action is not Delete".into(),
@@ -380,7 +396,7 @@ async fn chain_op_from_limbo_row(
         }
         ChainOpType::RegisterDeletedBy => {
             let delete = match action {
-                Action::Delete(d) => d,
+                LegacyAction::Delete(d) => d,
                 _ => {
                     return Err(crate::query::StateQueryError::Other(
                         "RegisterDeletedBy action is not Delete".into(),
@@ -391,7 +407,7 @@ async fn chain_op_from_limbo_row(
         }
         ChainOpType::RegisterAddLink => {
             let create_link = match action {
-                Action::CreateLink(c) => c,
+                LegacyAction::CreateLink(c) => c,
                 _ => {
                     return Err(crate::query::StateQueryError::Other(
                         "RegisterAddLink action is not CreateLink".into(),
@@ -402,7 +418,7 @@ async fn chain_op_from_limbo_row(
         }
         ChainOpType::RegisterRemoveLink => {
             let delete_link = match action {
-                Action::DeleteLink(d) => d,
+                LegacyAction::DeleteLink(d) => d,
                 _ => {
                     return Err(crate::query::StateQueryError::Other(
                         "RegisterRemoveLink action is not DeleteLink".into(),

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -1,0 +1,25 @@
+//! Read operations on the per-DNA DHT store.
+//!
+//! Methods on [`DhtStoreRead`] expose domain-meaningful reads for the
+//! holochain crate's workflows. They delegate to `holochain_data`'s
+//! `DbRead<Dht>` primitives and return values in terms of the project's
+//! existing domain types.
+
+use super::{DhtStore, DhtStoreRead};
+
+impl<Db> DhtStore<Db>
+where
+    Db: AsRef<holochain_data::DbRead<holochain_data::kind::Dht>>,
+{
+    // Read methods are added in the following tasks. Keep this module
+    // separate so it stays focused on reads.
+}
+
+// Compile-only sanity check that the read-only alias resolves correctly.
+#[allow(dead_code)]
+fn _read_only_alias_compiles(_: DhtStoreRead) {}
+
+#[cfg(test)]
+mod tests {
+    // Per-method tests are added alongside their read methods below.
+}

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -6,13 +6,52 @@
 //! existing domain types.
 
 use super::{DhtStore, DhtStoreRead};
+use crate::query::StateQueryResult;
+use holo_hash::{DhtOpHash, HasHash};
+use holochain_data::kind::Dht;
+use holochain_data::{DbRead, DbWrite};
+use holochain_types::dht_op::DhtOpHashed;
 
-impl<Db> DhtStore<Db>
-where
-    Db: AsRef<holochain_data::DbRead<holochain_data::kind::Dht>>,
-{
-    // Read methods are added in the following tasks. Keep this module
-    // separate so it stays focused on reads.
+impl DhtStore<DbRead<Dht>> {
+    /// Returns `true` if `hash` appears in any op-bearing DHT table
+    /// (`ChainOp`, `LimboChainOp`, `Warrant`, `LimboWarrant`).
+    pub async fn op_exists(&self, hash: &DhtOpHash) -> StateQueryResult<bool> {
+        Ok(self.db().op_exists(hash).await?)
+    }
+
+    /// Drop any op whose hash is already recorded in the DHT store.
+    /// Input order is preserved for surviving ops.
+    pub async fn filter_existing_ops(
+        &self,
+        ops: Vec<DhtOpHashed>,
+    ) -> StateQueryResult<Vec<DhtOpHashed>> {
+        let hashes: Vec<DhtOpHash> = ops.iter().map(|o| o.as_hash().clone()).collect();
+        let present = self.db().op_hashes_present(&hashes).await?;
+        Ok(ops
+            .into_iter()
+            .zip(present)
+            .filter_map(|(op, exists)| if exists { None } else { Some(op) })
+            .collect())
+    }
+}
+
+impl DhtStore<DbWrite<Dht>> {
+    /// Returns `true` if `hash` appears in any op-bearing DHT table.
+    ///
+    /// Delegates to the read-only view of this store.
+    pub async fn op_exists(&self, hash: &DhtOpHash) -> StateQueryResult<bool> {
+        self.as_read().op_exists(hash).await
+    }
+
+    /// Drop any op whose hash is already recorded in the DHT store.
+    ///
+    /// Delegates to the read-only view of this store.
+    pub async fn filter_existing_ops(
+        &self,
+        ops: Vec<DhtOpHashed>,
+    ) -> StateQueryResult<Vec<DhtOpHashed>> {
+        self.as_read().filter_existing_ops(ops).await
+    }
 }
 
 // Compile-only sanity check that the read-only alias resolves correctly.
@@ -21,5 +60,85 @@ fn _read_only_alias_compiles(_: DhtStoreRead) {}
 
 #[cfg(test)]
 mod tests {
-    // Per-method tests are added alongside their read methods below.
+    use super::*;
+    use holo_hash::{ActionHash, AgentPubKey, DhtOpHash, EntryHash, HoloHashed};
+    use holochain_data::kind::Dht;
+    use holochain_types::dht_op::{ChainOp, DhtOp, DhtOpHashed};
+    use holochain_types::prelude::Signature;
+    use holochain_types::prelude::Timestamp;
+    use holochain_zome_types::action::{Action, Create, EntryType};
+    use holochain_zome_types::entry_def::EntryVisibility;
+    use holochain_zome_types::prelude::AppEntryDef;
+    use std::sync::Arc;
+
+    fn dht_id() -> Dht {
+        Dht::new(Arc::new(holo_hash::DnaHash::from_raw_36(vec![0u8; 36])))
+    }
+
+    fn make_chain_op(seed: u8) -> DhtOpHashed {
+        let author = AgentPubKey::from_raw_36(vec![seed; 36]);
+        let action = Action::Create(Create {
+            author,
+            timestamp: Timestamp::from_micros(seed as i64 * 1000),
+            action_seq: 1,
+            prev_action: ActionHash::from_raw_36(vec![seed.wrapping_add(200); 36]),
+            entry_type: EntryType::App(AppEntryDef::new(
+                0.into(),
+                0.into(),
+                EntryVisibility::Public,
+            )),
+            entry_hash: EntryHash::from_raw_36(vec![seed.wrapping_add(100); 36]),
+            weight: Default::default(),
+        });
+        let chain_op = ChainOp::RegisterAgentActivity(Signature::from([seed; 64]), action);
+        DhtOpHashed::from_content_sync(DhtOp::ChainOp(Box::new(chain_op)))
+    }
+
+    /// Build a synthetic `DhtOpHashed` with the given pre-computed hash.
+    fn make_chain_op_with_hash(seed: u8, hash: DhtOpHash) -> DhtOpHashed {
+        let op = make_chain_op(seed);
+        HoloHashed::with_pre_hashed(op.into_inner().0, hash)
+    }
+
+    #[tokio::test]
+    async fn op_exists_returns_false_for_unknown_hash() {
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let unknown = DhtOpHash::from_raw_36(vec![99u8; 36]);
+        let exists = store.op_exists(&unknown).await.unwrap();
+        assert!(!exists);
+    }
+
+    #[tokio::test]
+    async fn op_exists_returns_true_after_record_incoming_ops() {
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let op = make_chain_op(1);
+        let hash = op.as_hash().clone();
+
+        store.record_incoming_ops(vec![op]).await.unwrap();
+
+        let exists = store.op_exists(&hash).await.unwrap();
+        assert!(exists, "op_exists should be true after record_incoming_ops");
+    }
+
+    #[tokio::test]
+    async fn filter_existing_ops_removes_known_hashes() {
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let known = make_chain_op(2);
+        let unknown = make_chain_op(3);
+        let known_hash = known.as_hash().clone();
+        let unknown_hash = unknown.as_hash().clone();
+
+        store.record_incoming_ops(vec![known]).await.unwrap();
+
+        let input = vec![make_chain_op_with_hash(20, known_hash.clone()), unknown];
+        let filtered = store.as_read().filter_existing_ops(input).await.unwrap();
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].as_hash(), &unknown_hash);
+    }
 }

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -204,22 +204,32 @@ async fn chain_op_from_limbo_row(
     let signature: Signature = legacy.signature().clone();
     let action: Action = legacy.action().clone();
 
-    // Look up the entry referenced by the given action, returning
-    // `RecordEntry::Present` when found or `RecordEntry::NA` when the action
-    // carries no entry hash.
+    // Look up the entry referenced by the given action.
+    //
+    // Returns:
+    //   - `RecordEntry::NA`       — action carries no entry hash
+    //   - `RecordEntry::Present`  — entry found in the database
+    //   - `RecordEntry::Hidden`   — action references a private entry (not stored on this node)
+    //   - `RecordEntry::NotStored`— action references a public entry we don't have locally
     async fn fetch_entry_for_action(
         db: &DbRead<Dht>,
         action: &Action,
     ) -> StateQueryResult<RecordEntry> {
-        match action.entry_hash() {
-            None => Ok(RecordEntry::NA),
-            Some(h) => {
-                let entry = db.get_entry(h.clone(), None).await?.ok_or_else(|| {
-                    crate::query::StateQueryError::Other(format!(
-                        "Entry {h:?} referenced by Action not found"
-                    ))
-                })?;
-                Ok(RecordEntry::Present(entry))
+        let Some(entry_hash) = action.entry_hash() else {
+            return Ok(RecordEntry::NA);
+        };
+        match db.get_entry(entry_hash.clone(), None).await? {
+            Some(entry) => Ok(RecordEntry::Present(entry)),
+            None => {
+                // Entry not in the database. Use the entry type visibility to
+                // distinguish private entries (Hidden) from public ones we
+                // simply don't have yet (NotStored).
+                use holochain_zome_types::entry_def::EntryVisibility;
+                if action.entry_visibility() == Some(&EntryVisibility::Private) {
+                    Ok(RecordEntry::Hidden)
+                } else {
+                    Ok(RecordEntry::NotStored)
+                }
             }
         }
     }

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -34,6 +34,55 @@ impl DhtStore<DbRead<Dht>> {
             .collect())
     }
 
+    /// Find an existing action that shares `prev_action` with the given
+    /// `action` but has a different hash. Used by sys-validation to detect
+    /// chain forks.
+    ///
+    /// Returns `Ok(None)` if `action` has no `prev_action`, or if no
+    /// sibling exists. Returns `Err` with a descriptive message if a
+    /// sibling action by a different author is found (cross-author
+    /// `prev_action` collision).
+    pub async fn find_fork_for_action(
+        &self,
+        action: &holochain_zome_types::action::Action,
+    ) -> StateQueryResult<Option<holochain_types::prelude::SignedAction>> {
+        use holochain_zome_types::dht_v2::to_legacy_signed_action;
+
+        let Some(prev) = action.prev_action() else {
+            return Ok(None);
+        };
+        let incoming_hash = holo_hash::ActionHash::with_data_sync(action);
+
+        let siblings = self
+            .db()
+            .get_actions_by_prev_hash(prev, &incoming_hash)
+            .await?;
+
+        let incoming_author = action.author();
+        if let Some(v2_sibling) = siblings.into_iter().next() {
+            let legacy_sibling = to_legacy_signed_action(&v2_sibling).map_err(|e| {
+                crate::query::StateQueryError::Other(format!(
+                    "to_legacy_signed_action on sibling: {e}"
+                ))
+            })?;
+            let existing_author = legacy_sibling.action().author();
+            if existing_author != incoming_author {
+                return Err(crate::query::StateQueryError::Other(format!(
+                    "Cross-author prev_action collision: incoming author {incoming_author} \
+                     differs from existing author {existing_author} for prev_action {prev:?}"
+                )));
+            }
+            // Return the SignedAction (action + signature, no hash).
+            let signature = legacy_sibling.signature().clone();
+            let action = legacy_sibling.action().clone();
+            Ok(Some(holochain_types::prelude::SignedAction::new(
+                action, signature,
+            )))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Return ops awaiting system validation, sorted across chain ops and
     /// warrants by `(sys_validation_attempts, when_received)`, up to `limit`
     /// rows total.
@@ -91,6 +140,14 @@ impl DhtStore<DbWrite<Dht>> {
         limit: u32,
     ) -> StateQueryResult<Vec<DhtOpHashed>> {
         self.as_read().ops_pending_sys_validation(limit).await
+    }
+
+    /// See [`DhtStore::find_fork_for_action`].
+    pub async fn find_fork_for_action(
+        &self,
+        action: &holochain_zome_types::action::Action,
+    ) -> StateQueryResult<Option<holochain_types::prelude::SignedAction>> {
+        self.as_read().find_fork_for_action(action).await
     }
 }
 
@@ -306,6 +363,24 @@ mod tests {
     use holochain_zome_types::prelude::AppEntryDef;
     use std::sync::Arc;
 
+    fn make_fork_op(author: &AgentPubKey, prev: &ActionHash, seq: u32, seed: u8) -> DhtOpHashed {
+        let action = Action::Create(Create {
+            author: author.clone(),
+            timestamp: Timestamp::from_micros(seed as i64 * 1000),
+            action_seq: seq,
+            prev_action: prev.clone(),
+            entry_type: EntryType::App(AppEntryDef::new(
+                0.into(),
+                0.into(),
+                EntryVisibility::Public,
+            )),
+            entry_hash: EntryHash::from_raw_36(vec![seed.wrapping_add(100); 36]),
+            weight: Default::default(),
+        });
+        let chain_op = ChainOp::RegisterAgentActivity(Signature::from([seed; 64]), action);
+        DhtOpHashed::from_content_sync(DhtOp::ChainOp(Box::new(chain_op)))
+    }
+
     fn dht_id() -> Dht {
         Dht::new(Arc::new(holo_hash::DnaHash::from_raw_36(vec![0u8; 36])))
     }
@@ -423,5 +498,45 @@ mod tests {
 
         let pending = store.ops_pending_sys_validation(2).await.unwrap();
         assert_eq!(pending.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn find_fork_for_action_returns_none_when_no_sibling() {
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let op = make_chain_op(30);
+        let action = match op.as_content() {
+            DhtOp::ChainOp(c) => c.action().clone(),
+            _ => unreachable!(),
+        };
+
+        let result = store.find_fork_for_action(&action).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn find_fork_for_action_returns_sibling() {
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+
+        let author = AgentPubKey::from_raw_36(vec![31u8; 36]);
+        let prev_action_hash = ActionHash::from_raw_36(vec![231u8; 36]);
+
+        // Two ops sharing the same prev_action and author but with different
+        // timestamps/entry_hashes (seeds differ) — different hashes overall.
+        let op_a = make_fork_op(&author, &prev_action_hash, 2, 32);
+        let op_b = make_fork_op(&author, &prev_action_hash, 2, 33);
+
+        let action_b = match op_b.as_content() {
+            DhtOp::ChainOp(c) => c.action().clone(),
+            _ => unreachable!(),
+        };
+
+        store.record_incoming_ops(vec![op_a]).await.unwrap();
+
+        let result = store.find_fork_for_action(&action_b).await.unwrap();
+        assert!(result.is_some(), "fork should be detected");
     }
 }

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -105,9 +105,10 @@ impl DhtStore<DbRead<Dht>> {
     /// op that still has `require_receipt = 1`. Each tuple is
     /// `(ValidationReceipt, action_author)` so the caller can group by author.
     ///
-    /// The `validators` field on each [`ValidationReceipt`] is populated from
-    /// the supplied `validators` argument (the locally-running agents for this
-    /// DNA).
+    /// The `validators` field on each
+    /// [`ValidationReceipt`](holochain_types::prelude::ValidationReceipt) is
+    /// populated from the supplied `validators` argument (the locally-running
+    /// agents for this DNA).
     pub async fn pending_validation_receipts(
         &self,
         validators: Vec<holo_hash::AgentPubKey>,

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -15,9 +15,14 @@ use holochain_zome_types::dht_v2::RecordValidity;
 
 impl DhtStore<DbRead<Dht>> {
     /// Returns `true` if `hash` appears in any op-bearing DHT table
-    /// (`ChainOp`, `LimboChainOp`, `Warrant`, `LimboWarrant`).
+    /// (`ChainOp`, `LimboChainOp`, `WarrantOp`, `LimboWarrantOp`).
     pub async fn op_exists(&self, hash: &DhtOpHash) -> StateQueryResult<bool> {
         Ok(self.db().op_exists(hash).await?)
+    }
+
+    /// Count integrated ops (chain ops plus warrants) held in the DHT store.
+    pub async fn count_integrated_ops(&self) -> StateQueryResult<i64> {
+        Ok(self.db().count_integrated_ops().await?)
     }
 
     /// Drop any op whose hash is already recorded in the DHT store.
@@ -291,9 +296,7 @@ fn chain_op_from_joined_row(
     let v2_signed: SignedActionHashed =
         SignedActionHashed::with_presigned(hashed, V2Signature(sig_bytes));
 
-    let legacy = to_legacy_signed_action(&v2_signed).map_err(|e| {
-        crate::query::StateQueryError::Other(format!("to_legacy_signed_action: {e}"))
-    })?;
+    let legacy = to_legacy_signed_action(&v2_signed);
     let signature: Signature = legacy.signature().clone();
     let action: LegacyAction = legacy.action().clone();
 

--- a/crates/holochain_state/src/dht_store/tests.rs
+++ b/crates/holochain_state/src/dht_store/tests.rs
@@ -949,6 +949,28 @@ async fn record_locally_validated_warrants_inserts_warrant() {
         .record_locally_validated_warrants(vec![warrant_op.clone()])
         .await
         .unwrap();
+
+    // warrantee is seed.wrapping_add(50) = 80 for seed=30.
+    let expected_warrantee = AgentPubKey::from_raw_36(vec![80u8; 36]);
+
+    // Self-issued warrants are recorded into limbo ready for integration (not
+    // straight into the integrated table), so the integration workflow runs and
+    // can block the warrantee. Integrating emits a summary carrying the
+    // warrantee, which drives that block.
+    let summaries = store
+        .integrate_ready_ops(holochain_types::prelude::Timestamp::now())
+        .await
+        .unwrap();
+    let summary = summaries
+        .iter()
+        .find(|s| s.op_hash == *warrant_op.as_hash())
+        .expect("warrant not integrated");
+    assert_eq!(summary.warrantee.as_ref(), Some(&expected_warrantee));
+    assert_eq!(
+        summary.validation_status,
+        holochain_zome_types::dht_v2::OpValidity::Accepted
+    );
+
     let row = store
         .db()
         .as_ref()
@@ -956,8 +978,6 @@ async fn record_locally_validated_warrants_inserts_warrant() {
         .await
         .unwrap()
         .expect("warrant row missing");
-    // warrantee is seed.wrapping_add(50) = 80 for seed=30.
-    let expected_warrantee = AgentPubKey::from_raw_36(vec![80u8; 36]);
     assert_eq!(row.warrantee, expected_warrantee.get_raw_36().to_vec());
     // The rejection reason is extracted from the warrant proof and stored in
     // its own column.

--- a/crates/holochain_state/src/dht_store/tests.rs
+++ b/crates/holochain_state/src/dht_store/tests.rs
@@ -451,11 +451,12 @@ async fn integrate_ready_ops_promotes_ready_chain_op() {
         .await
         .unwrap();
 
-    let promoted = store
+    let summaries = store
         .integrate_ready_ops(Timestamp::from_micros(999))
         .await
         .unwrap();
-    assert_eq!(promoted, vec![op.as_hash().clone()]);
+    let promoted_hashes: Vec<_> = summaries.iter().map(|s| s.op_hash.clone()).collect();
+    assert_eq!(promoted_hashes, vec![op.as_hash().clone()]);
 
     assert!(store
         .db()
@@ -484,11 +485,11 @@ async fn integrate_ready_ops_skips_unready() {
     let op = build_test_store_record_op_hashed(51);
     store.record_incoming_ops(vec![op.clone()]).await.unwrap();
     // No validation outcomes recorded — sys/app are NULL, not ready.
-    let promoted = store
+    let summaries = store
         .integrate_ready_ops(Timestamp::from_micros(999))
         .await
         .unwrap();
-    assert!(promoted.is_empty());
+    assert!(summaries.is_empty());
 
     // Op still in limbo, not in ChainOp.
     assert!(store
@@ -524,11 +525,12 @@ async fn integrate_ready_ops_promotes_warrant() {
         .await
         .unwrap();
 
-    let promoted = store
+    let summaries = store
         .integrate_ready_ops(Timestamp::from_micros(999))
         .await
         .unwrap();
-    assert_eq!(promoted, vec![warrant.as_hash().clone()]);
+    let promoted_hashes: Vec<_> = summaries.iter().map(|s| s.op_hash.clone()).collect();
+    assert_eq!(promoted_hashes, vec![warrant.as_hash().clone()]);
 
     assert!(store
         .db()

--- a/crates/holochain_state/src/dht_store/tests.rs
+++ b/crates/holochain_state/src/dht_store/tests.rs
@@ -1,5 +1,12 @@
 use super::*;
 use holo_hash::DnaHash;
+use holochain_types::dht_op::RenderedOp;
+use holochain_types::dht_op::RenderedOps;
+use holochain_types::prelude::Signature;
+use holochain_zome_types::action::{Action, Create, EntryType};
+use holochain_zome_types::entry_def::EntryVisibility;
+use holochain_zome_types::op::ChainOpType;
+use holochain_zome_types::prelude::AppEntryDef;
 use std::sync::Arc;
 
 fn dht_id() -> Dht {
@@ -783,6 +790,153 @@ async fn reject_chain_op_rejects_limbo_op() {
         .unwrap();
     assert_eq!(row.sys_validation_status, Some(2));
     assert_eq!(row.app_validation_status, None);
+}
+
+/// Build a single-op `RenderedOps` for a `StoreRecord(Create)` using the
+/// same style as `cache.rs` tests.  Returns `(RenderedOps, action_hash)`.
+fn build_rendered_store_record_for_move(seed: u8) -> (RenderedOps, holo_hash::ActionHash) {
+    use holo_hash::{ActionHash, EntryHash};
+    use holochain_serialized_bytes::UnsafeBytes;
+    use holochain_types::prelude::{AppEntryBytes, Entry, EntryHashed};
+
+    let author = AgentPubKey::from_raw_36(vec![seed; 36]);
+    let entry_hash = EntryHash::from_raw_36(vec![seed.wrapping_add(100); 36]);
+    let entry = Entry::App(AppEntryBytes(
+        holochain_serialized_bytes::SerializedBytes::from(UnsafeBytes::from(vec![seed; 8])),
+    ));
+    let sig = Signature::from([seed; 64]);
+    let action = Action::Create(Create {
+        author,
+        timestamp: Timestamp::from_micros(seed as i64 * 1000),
+        action_seq: 1,
+        prev_action: ActionHash::from_raw_36(vec![seed.wrapping_add(200); 36]),
+        entry_type: EntryType::App(AppEntryDef::new(
+            0.into(),
+            0.into(),
+            EntryVisibility::Public,
+        )),
+        entry_hash: entry_hash.clone(),
+        weight: Default::default(),
+    });
+    let entry_hashed = EntryHashed::with_pre_hashed(entry, entry_hash);
+    let rendered =
+        RenderedOp::new(action, sig, None, ChainOpType::StoreRecord).expect("rendered op build");
+    let action_hash = rendered.action.as_hash().clone();
+    let ops = RenderedOps {
+        entry: Some(entry_hashed),
+        ops: vec![rendered],
+        warrant: None,
+    };
+    (ops, action_hash)
+}
+
+#[tokio::test]
+async fn move_warranted_op_to_limbo_moves_locally_validated_false() {
+    let store = DhtStore::new_test(dht_id()).await.unwrap();
+    let (rendered, action_hash) = build_rendered_store_record_for_move(42);
+    let op_hash = rendered.ops[0].op_hash.clone();
+
+    // Cache the op: inserts into ChainOp with locally_validated = 0.
+    store.cache_chain_ops(&rendered).await.unwrap();
+
+    // Confirm the op is in ChainOp with locally_validated = 0.
+    let chain_row = store
+        .db()
+        .as_ref()
+        .get_chain_op(op_hash.clone())
+        .await
+        .unwrap()
+        .expect("ChainOp row missing after cache_chain_ops");
+    assert_eq!(chain_row.locally_validated, 0);
+
+    // Move to limbo.
+    let moved = store
+        .move_warranted_op_to_limbo(&action_hash, ChainOpType::StoreRecord)
+        .await
+        .unwrap();
+    assert!(moved, "expected row to be moved");
+
+    // ChainOp row should be gone.
+    let chain_row_after = store
+        .db()
+        .as_ref()
+        .get_chain_op(op_hash.clone())
+        .await
+        .unwrap();
+    assert!(
+        chain_row_after.is_none(),
+        "ChainOp row should be removed after move_warranted_op_to_limbo"
+    );
+
+    // LimboChainOp row should exist with cleared validation status.
+    let limbo_row = store
+        .db()
+        .as_ref()
+        .get_limbo_chain_op(op_hash)
+        .await
+        .unwrap()
+        .expect("LimboChainOp row missing after move_warranted_op_to_limbo");
+    assert_eq!(
+        limbo_row.sys_validation_status, None,
+        "sys_validation_status should be NULL"
+    );
+    assert_eq!(
+        limbo_row.app_validation_status, None,
+        "app_validation_status should be NULL"
+    );
+    assert_eq!(limbo_row.require_receipt, 0);
+}
+
+#[tokio::test]
+async fn move_warranted_op_to_limbo_returns_false_when_not_cached() {
+    let store = DhtStore::new_test(dht_id()).await.unwrap();
+    let action_hash = holo_hash::ActionHash::from_raw_36(vec![0xBB; 36]);
+
+    let moved = store
+        .move_warranted_op_to_limbo(&action_hash, ChainOpType::StoreRecord)
+        .await
+        .unwrap();
+    assert!(!moved, "expected false when no matching cached row exists");
+}
+
+#[tokio::test]
+async fn move_warranted_op_to_limbo_no_match_for_locally_validated_true() {
+    // An op that is locally validated (locally_validated = 1 via incoming ops path)
+    // should NOT be moved, because the predicate requires locally_validated = 0.
+    let store = DhtStore::new_test(dht_id()).await.unwrap();
+    let op = build_test_store_record_op_hashed(43);
+    let op_hash = op.as_hash().clone();
+    let action_hash = {
+        let action = op.as_content().as_chain_op().unwrap().action();
+        holo_hash::ActionHash::with_data_sync(&action)
+    };
+
+    // record_incoming_ops → LimboChainOp (not ChainOp), then promote to ChainOp
+    // with locally_validated = 1.
+    store.record_incoming_ops(vec![op]).await.unwrap();
+    store
+        .record_chain_op_sys_validation_outcomes(vec![(op_hash.clone(), SysOutcome::Accepted)])
+        .await
+        .unwrap();
+    store
+        .record_app_validation_outcomes(vec![(op_hash.clone(), AppOutcome::Accepted)])
+        .await
+        .unwrap();
+    store
+        .integrate_ready_ops(Timestamp::from_micros(1))
+        .await
+        .unwrap();
+
+    // ChainOp now has locally_validated = 1. The move should not match it.
+    let moved = store
+        .move_warranted_op_to_limbo(&action_hash, ChainOpType::StoreRecord)
+        .await
+        .unwrap();
+    assert!(!moved, "should not move a locally_validated = 1 row");
+
+    // Verify the row is still in ChainOp.
+    let row = store.db().as_ref().get_chain_op(op_hash).await.unwrap();
+    assert!(row.is_some(), "ChainOp row should still be present");
 }
 
 #[tokio::test]

--- a/crates/holochain_state/src/mutations.rs
+++ b/crates/holochain_state/src/mutations.rs
@@ -652,7 +652,9 @@ pub fn set_when_integrated(
 /// validation_status IS NOT NULL) as integrated in the legacy `DhtOp` table.
 ///
 /// Sets `when_integrated = time` and clears `validation_stage` on all matching
-/// rows. Returns the number of rows updated.
+/// rows. Returns the `(DhtOpHash, Option<AgentPubKey>)` pairs of the ops it
+/// marked, so callers can drive publish-trigger updates for locally-authored
+/// ops that bypass the new-DB limbo path.
 ///
 /// Used as a dual-write shim during the read-migration window so that legacy
 /// readers see consistent integration state. Will be removed once the legacy
@@ -660,18 +662,32 @@ pub fn set_when_integrated(
 pub fn set_all_awaiting_integration_to_integrated(
     txn: &mut Txn<DbKindDht>,
     time: Timestamp,
-) -> StateMutationResult<usize> {
-    let n = txn.execute(
+) -> StateMutationResult<Vec<(DhtOpHash, Option<AgentPubKey>)>> {
+    let mut stmt = txn.prepare(
         "UPDATE DhtOp
          SET when_integrated = :when_integrated,
              validation_stage = NULL
          WHERE validation_stage = 3
-           AND validation_status IS NOT NULL",
-        holochain_sqlite::rusqlite::named_params! {
+           AND validation_status IS NOT NULL
+         RETURNING
+           hash,
+           COALESCE(
+             (SELECT author FROM Action  WHERE Action.hash  = DhtOp.action_hash LIMIT 1),
+             (SELECT author FROM Warrant WHERE Warrant.hash = DhtOp.action_hash LIMIT 1)
+           )",
+    )?;
+    let rows = stmt.query_map(
+        named_params! {
             ":when_integrated": time,
         },
+        |row| {
+            let hash: DhtOpHash = row.get(0)?;
+            let author: Option<AgentPubKey> = row.get(1)?;
+            Ok((hash, author))
+        },
     )?;
-    Ok(n)
+    let out: Vec<(DhtOpHash, Option<AgentPubKey>)> = rows.collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(out)
 }
 
 /// Set when a [DhtOp] was last publish time
@@ -1153,13 +1169,14 @@ pub fn remove_countersigning_session(
 /// This function will fail on database errors or serialization errors but succeed if there was
 /// nothing to be done.
 ///
-/// Returns `true` if the op was copied, `false` if it already existed in the DHT database.
+/// Returns `Some(op)` with the copied op if the op was copied, `None` if it already existed
+/// in the DHT database.
 pub async fn copy_cached_op_to_dht(
     dht: DbWrite<DbKindDht>,
     cache: DbRead<DbKindCache>,
     action_hash: ActionHash,
     chain_op_type: ChainOpType,
-) -> StateMutationResult<bool> {
+) -> StateMutationResult<Option<DhtOpHashed>> {
     let dht_permit = dht.acquire_write_permit().await?;
 
     let (exists_in_dht, dht_permit) = dht
@@ -1179,7 +1196,7 @@ pub async fn copy_cached_op_to_dht(
 
     // Nothing further to do, a DhtOp with the same action_hash and type already exists
     if exists_in_dht {
-        return Ok(false);
+        return Ok(None);
     }
 
     let maybe_action_entry = cache
@@ -1237,6 +1254,7 @@ pub async fn copy_cached_op_to_dht(
 
     let serialized_size = encode(&dht_op)?.len() as u32;
     let dht_op_hashed = DhtOpHashed::from_content_sync(dht_op);
+    let op_to_return = dht_op_hashed.clone();
 
     let _ = dht
         .write_async_with_permit(dht_permit, move |txn| {
@@ -1244,7 +1262,7 @@ pub async fn copy_cached_op_to_dht(
         })
         .await?;
 
-    Ok(true)
+    Ok(Some(op_to_return))
 }
 
 #[cfg(test)]
@@ -1279,7 +1297,10 @@ mod tests {
         )
         .await
         .unwrap();
-        assert!(copied, "Op should have been copied to DHT database");
+        assert!(
+            copied.is_some(),
+            "Op should have been copied to DHT database"
+        );
 
         let found: bool = dht_db
             .read_async(move |txn| -> StateMutationResult<bool> {
@@ -1324,7 +1345,10 @@ mod tests {
         )
         .await
         .unwrap();
-        assert!(!copied, "Op should not have been copied to DHT database");
+        assert!(
+            copied.is_none(),
+            "Op should not have been copied to DHT database"
+        );
 
         let validation_status = dht_db
             .read_async(

--- a/crates/holochain_state/src/mutations.rs
+++ b/crates/holochain_state/src/mutations.rs
@@ -648,6 +648,32 @@ pub fn set_when_integrated(
     Ok(())
 }
 
+/// Mark every [DhtOp] that is awaiting integration (validation_stage = 3,
+/// validation_status IS NOT NULL) as integrated in the legacy `DhtOp` table.
+///
+/// Sets `when_integrated = time` and clears `validation_stage` on all matching
+/// rows. Returns the number of rows updated.
+///
+/// Used as a dual-write shim during the read-migration window so that legacy
+/// readers see consistent integration state. Will be removed once the legacy
+/// `DhtOp` table is retired.
+pub fn set_all_awaiting_integration_to_integrated(
+    txn: &mut Txn<DbKindDht>,
+    time: Timestamp,
+) -> StateMutationResult<usize> {
+    let n = txn.execute(
+        "UPDATE DhtOp
+         SET when_integrated = :when_integrated,
+             validation_stage = NULL
+         WHERE validation_stage = 3
+           AND validation_status IS NOT NULL",
+        holochain_sqlite::rusqlite::named_params! {
+            ":when_integrated": time,
+        },
+    )?;
+    Ok(n)
+}
+
 /// Set when a [DhtOp] was last publish time
 pub fn set_last_publish_time(
     txn: &mut Txn<DbKindAuthored>,

--- a/crates/holochain_state/src/mutations.rs
+++ b/crates/holochain_state/src/mutations.rs
@@ -1265,6 +1265,54 @@ pub async fn copy_cached_op_to_dht(
     Ok(Some(op_to_return))
 }
 
+/// Read a single chain op of `chain_op_type` for `action_hash` from a DHT
+/// database, reconstructing it from the stored action and (optional) entry.
+///
+/// Returns `None` if the action is not present. Used to backfill an op from
+/// the legacy DHT database into the new `DhtStore` when it is missing there.
+pub async fn read_chain_op_from_dht(
+    dht: DbRead<DbKindDht>,
+    action_hash: ActionHash,
+    chain_op_type: ChainOpType,
+) -> StateMutationResult<Option<DhtOpHashed>> {
+    let maybe_action_entry = dht
+        .read_async(
+            move |txn| -> StateMutationResult<Option<(SignedAction, Option<Entry>)>> {
+                let mut stmt = txn.prepare(
+                    "SELECT Action.blob, Entry.blob \
+                     FROM Action LEFT JOIN Entry ON Action.entry_hash = Entry.hash \
+                     WHERE Action.hash = :action_hash",
+                )?;
+                let maybe = stmt
+                    .query_row(named_params! { ":action_hash": action_hash }, |row| {
+                        Ok((
+                            row.get::<_, Vec<u8>>(0)?,
+                            row.get::<_, Option<Vec<u8>>>(1)?,
+                        ))
+                    })
+                    .optional()?
+                    .map(
+                        |(action_blob, entry_blob): (Vec<u8>, Option<Vec<u8>>)| -> StateMutationResult<(SignedAction, Option<Entry>)> {
+                            Ok((
+                                from_blob::<SignedAction>(action_blob)?,
+                                entry_blob.map(from_blob).transpose()?,
+                            ))
+                        },
+                    )
+                    .transpose()?;
+                Ok(maybe)
+            },
+        )
+        .await?;
+
+    let Some((action, maybe_entry)) = maybe_action_entry else {
+        return Ok(None);
+    };
+
+    let dht_op = DhtOp::from(ChainOp::from_type(chain_op_type, action, maybe_entry)?);
+    Ok(Some(DhtOpHashed::from_content_sync(dht_op)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -10,7 +10,6 @@ use async_recursion::async_recursion;
 pub use error::*;
 use holo_hash::ActionHash;
 use holo_hash::AgentPubKey;
-use holo_hash::AnyDhtHash;
 use holo_hash::DhtOpHash;
 use holo_hash::DnaHash;
 use holo_hash::EntryHash;
@@ -538,26 +537,8 @@ impl SourceChain {
                         if !inserted_action_hashes.contains(op_as_chain.action_hash()) {
                             continue;
                         }
-                        let linkable_basis = op_as_chain.dht_basis().clone();
-                        let storage_center_loc = linkable_basis.get_loc();
-                        // ChainOp.basis_hash in the new schema is AnyDhtHash (all
-                        // authored ops' bases are DHT-addressable entries or actions).
-                        // TODO: ChainOp.basis_hash uses AnyDhtHash, which lacks External.
-                        // Authored CreateLink with External basis cannot be inserted into
-                        // ChainOp until the new schema widens basis_hash to AnyLinkableHash.
-                        // Action and Link rows are still inserted; the legacy DB still has
-                        // the ChainOp row.
-                        let basis_hash: AnyDhtHash = match AnyDhtHash::try_from(linkable_basis) {
-                            Ok(h) => h,
-                            Err(e) => {
-                                tracing::debug!(
-                                    op_hash = ?op_hash,
-                                    "new DB skip: op with external-hash basis is not yet \
-                                     representable in ChainOp; legacy DB has it. op_hash={op_hash:?} err={e:?}"
-                                );
-                                continue;
-                            }
-                        };
+                        let basis_hash = op_as_chain.dht_basis().clone();
+                        let storage_center_loc = basis_hash.get_loc();
 
                         let serialized_size = encoded_chain_op_size(
                             op_as_chain,
@@ -1514,18 +1495,8 @@ pub async fn genesis(
 
         // Insert chain ops for all three genesis actions.
         for (op, op_hash, timestamp) in &ops_with_hashes_for_new_db {
-            let linkable_basis = op.dht_basis().clone();
-            let storage_center_loc = linkable_basis.get_loc();
-            let basis_hash: AnyDhtHash = match AnyDhtHash::try_from(linkable_basis) {
-                Ok(h) => h,
-                Err(e) => {
-                    tracing::debug!(
-                        op_hash = ?op_hash,
-                        "genesis new DB skip: op with external-hash basis; err={e:?}"
-                    );
-                    continue;
-                }
-            };
+            let basis_hash = op.dht_basis().clone();
+            let storage_center_loc = basis_hash.get_loc();
 
             let genesis_actions_slice: Vec<SignedActionHashed> = vec![
                 dna_action_for_new_db.clone(),

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -632,11 +632,13 @@ impl SourceChain {
                     }
                 }
 
-                // Write warrants to DHT database
-                let total_inserted_warrants = match self
+                // Write warrants to DHT database (legacy) and collect the
+                // successfully-inserted ops for mirroring into the new DhtStore.
+                let (total_inserted_warrants, warrant_ops_for_new_db) = match self
                     .dht_db
-                    .write_async(|txn| -> DatabaseResult<u32> {
-                        let mut inserted_warrants = 0;
+                    .write_async(|txn| -> DatabaseResult<(u32, Vec<DhtOpHashed>)> {
+                        let mut inserted_warrants = 0u32;
+                        let mut inserted_ops: Vec<DhtOpHashed> = Vec::new();
                         for warrant in warrants_to_insert {
                             let warrant_op = DhtOpHashed::from_content_sync(DhtOp::from(
                                 WarrantOp::from(warrant),
@@ -647,28 +649,42 @@ impl SourceChain {
                                 // TODO: This should only be increased if the op has actually been inserted.
                                 //       It's not possible to determine that, because mutations don't return
                                 //       the row count. Fix this once row count is returned.
-                                Ok(_) => inserted_warrants += 1,
+                                Ok(_) => {
+                                    inserted_warrants += 1;
+                                    inserted_ops.push(warrant_op);
+                                }
                                 Err(err) => {
                                     tracing::warn!(
                                         ?err,
                                         "Could not insert warrant from scratch space into DHT database"
                                     );
-
                                 }
                             }
                         }
-                        Ok(inserted_warrants)
+                        Ok((inserted_warrants, inserted_ops))
                     })
                     .await {
-                        Ok(count) => count,
+                        Ok(pair) => pair,
                         Err(err) => {
                             tracing::warn!(
                                 ?err,
                                 "Error inserting warrants from scratch space into DHT database"
                             );
-                            0
+                            (0, Vec::new())
                         }
                     };
+
+                // Mirror warrants into the new DhtStore so `ops_pending_sys_validation`
+                // picks them up via `LimboWarrant`.
+                if !warrant_ops_for_new_db.is_empty() {
+                    if let Err(err) = self
+                        .dht_store
+                        .record_incoming_ops(warrant_ops_for_new_db)
+                        .await
+                    {
+                        tracing::warn!(?err, "Error mirroring warrant ops into new DhtStore");
+                    }
+                }
 
                 SourceChainResult::Ok((actions, total_inserted_warrants))
             }


### PR DESCRIPTION
Temporary bisect branch at edd1b026c3 (just the warrant fix on top of the conductor lifecycle fix). Goal: isolate whether the warrant fix alone causes the Windows node_messaging::test_get_empty_data_better_than_no_response failure seen on PR #5796 starting at commit 9782acaef2.

Will be closed and branch deleted as soon as the test-matrix Windows job result is in.