### PR TITLE
chore: output sweettest documentation for holochain crate on docs.rs

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Make Sweettest documentation available on docs.rs.
+
 ## 0.7.0-dev.27
 
 - Serve Kitsune2 gossip op-store reads — op hashes, op data, presence checks, and the slice-hash cache — from the new `holochain_data` DHT store instead of the legacy databases. Warrant storage is split into shared `Warrant` content plus `LimboWarrantOp`/`WarrantOp` metadata tables, mirroring the action/chain-op split. The `Warrant` table also persists the `InvalidChainOp` rejection reason in a queryable `reason` column (denormalized from the proof), completing the persistence the reason feature intended. \#5731

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -297,3 +297,6 @@ unstable-countersigning = [
   "holochain_zome_types/unstable-countersigning",
   "holochain_conductor_api/unstable-countersigning",
 ]
+
+[package.metadata.docs.rs]
+features = ["test_utils"]


### PR DESCRIPTION
### Summary

Currently we're recommending people write tests with Sweettest but provide no documentation for it beyond documentation-by-example in scaffolded tests. This PR enables the `test_utils` feature for the `holochain` crate when publishing to docs.rs.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs