### PR TITLE
chore: direct signals

### DIFF
--- a/crates/holochain/src/conductor/api/api_external.rs
+++ b/crates/holochain/src/conductor/api/api_external.rs
@@ -1,11 +1,12 @@
 use crate::conductor::interface::error::InterfaceResult;
 use holochain_serialized_bytes::prelude::*;
+use holochain_types::prelude::InstalledAppId;
 
 mod admin_interface;
 mod app_interface;
+
 pub use admin_interface::*;
 pub use app_interface::*;
-use holochain_types::prelude::InstalledAppId;
 
 /// A trait that unifies both the admin and app interfaces
 #[async_trait::async_trait]

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -221,6 +221,18 @@ impl AppInterfaceApi {
                     )),
                 }
             }
+            AppRequest::SendDirectSignal {
+                dna_hash,
+                agents,
+                signal,
+            } => {
+                self.conductor_handle
+                    .clone()
+                    .send_direct_signal(installed_app_id, dna_hash, agents, signal)
+                    .await?;
+
+                Ok(AppResponse::Ok)
+            }
         }
     }
 }

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -508,7 +508,10 @@ impl holochain_p2p::event::HcP2pHandler for Cell {
             // Add 3 to allow for msgpack overhead for an "array 16"
             if signal.len() > DIRECT_SIGNAL_MAX_SIZE + 3 {
                 let signal_length = signal.len();
-                warn!("Received signal payload that is {signal_length:?} > 1024**2");
+                warn!(
+                    "Received signal payload that is {signal_length:?} > {}",
+                    DIRECT_SIGNAL_MAX_SIZE + 3
+                );
                 return Err(HolochainP2pError::other(
                     "Received signal payload that was too long",
                 ));

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -496,6 +496,48 @@ impl holochain_p2p::event::HcP2pHandler for Cell {
         Box::pin(async move { fut.await.map_err(HolochainP2pError::other) })
     }
 
+    fn handle_remote_signal_direct(
+        &self,
+        dna_hash: DnaHash,
+        to_agent: AgentPubKey,
+        signal: Vec<u8>,
+        from_agent: AgentPubKey,
+        signature: Signature,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        Box::pin(async move {
+            if signal.len() > DIRECT_SIGNAL_MAX_SIZE {
+                let signal_length = signal.len();
+                warn!("Received signal payload that is {signal_length:?} > 1024**2");
+                return Err(HolochainP2pError::other(
+                    "Received signal payload that was too long",
+                ));
+            }
+
+            #[derive(Debug, serde::Serialize, serde::Deserialize, SerializedBytes)]
+            struct Signed(Vec<u8>);
+
+            let valid_sig = from_agent
+                .verify_signature(&signature, Signed(signal.clone()))
+                .await
+                .map_err(HolochainP2pError::other)?;
+            if !valid_sig {
+                warn!("Received signal payload with an invalid signature");
+                return Err(HolochainP2pError::other(
+                    "Received signal with an invalid signature",
+                ));
+            }
+
+            if let Err(e) = self.signal_tx.send(Signal::AppDirect {
+                cell_id: CellId::new(dna_hash, to_agent),
+                signal,
+            }) {
+                info!(?e, "Failed to relay direct signal to app")
+            }
+
+            Ok(())
+        })
+    }
+
     fn handle_publish(
         &self,
         _dna_hash: DnaHash,

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -505,7 +505,8 @@ impl holochain_p2p::event::HcP2pHandler for Cell {
         signature: Signature,
     ) -> BoxFut<'_, HolochainP2pResult<()>> {
         Box::pin(async move {
-            if signal.len() > DIRECT_SIGNAL_MAX_SIZE {
+            // Add 3 to allow for msgpack overhead for an "array 16"
+            if signal.len() > DIRECT_SIGNAL_MAX_SIZE + 3 {
                 let signal_length = signal.len();
                 warn!("Received signal payload that is {signal_length:?} > 1024**2");
                 return Err(HolochainP2pError::other(
@@ -513,11 +514,10 @@ impl holochain_p2p::event::HcP2pHandler for Cell {
                 ));
             }
 
-            #[derive(Debug, serde::Serialize, serde::Deserialize, SerializedBytes)]
-            struct Signed(Vec<u8>);
+            let signal: DirectSignal = decode(&signal).map_err(HolochainP2pError::other)?;
 
             let valid_sig = from_agent
-                .verify_signature(&signature, Signed(signal.clone()))
+                .verify_signature(&signature, &signal)
                 .await
                 .map_err(HolochainP2pError::other)?;
             if !valid_sig {
@@ -529,7 +529,7 @@ impl holochain_p2p::event::HcP2pHandler for Cell {
 
             if let Err(e) = self.signal_tx.send(Signal::AppDirect {
                 cell_id: CellId::new(dna_hash, to_agent),
-                signal,
+                signal: signal.0,
             }) {
                 info!(?e, "Failed to relay direct signal to app")
             }

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -2807,7 +2807,13 @@ mod misc_impls {
                 .await?;
 
             self.holochain_p2p()
-                .send_remote_signal_direct(dna_hash, agents, signal_bytes, app_info.agent_pub_key, sig)
+                .send_remote_signal_direct(
+                    dna_hash,
+                    agents,
+                    signal_bytes,
+                    app_info.agent_pub_key,
+                    sig,
+                )
                 .await?;
 
             Ok(())

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -2799,13 +2799,15 @@ mod misc_impls {
                 return Err(ConductorError::Other(format!("Attempted to send to DNA hash {dna_hash:?} but it was not found in app {installed_app_id}").into()));
             }
 
+            let signal_bytes = holochain_serialized_bytes::encode(&DirectSignal(signal))?;
+
             let sig = self
                 .keystore()
-                .sign(app_info.agent_pub_key.clone(), signal.clone().into())
+                .sign(app_info.agent_pub_key.clone(), signal_bytes.clone().into())
                 .await?;
 
             self.holochain_p2p()
-                .send_remote_signal_direct(dna_hash, agents, signal, app_info.agent_pub_key, sig)
+                .send_remote_signal_direct(dna_hash, agents, signal_bytes, app_info.agent_pub_key, sig)
                 .await?;
 
             Ok(())

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -2777,7 +2777,11 @@ mod misc_impls {
 
             if signal.len() > DIRECT_SIGNAL_MAX_SIZE {
                 return Err(ConductorError::Other(
-                    "Signal payload larger than 1 MiB".into(),
+                    format!(
+                        "Signal payload larger than {} bytes",
+                        DIRECT_SIGNAL_MAX_SIZE
+                    )
+                    .into(),
                 ));
             }
 

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -2217,7 +2217,7 @@ mod scheduler_impls {
 /// Miscellaneous methods
 mod misc_impls {
     use super::{state_dump_helpers::peer_store_dump, *};
-    use holochain_conductor_api::JsonDump;
+    use holochain_conductor_api::{CellInfo, JsonDump};
     use holochain_zome_types::{action::builder, Entry};
     use kitsune2_api::{SpaceId, TransportStats};
     use std::sync::atomic::Ordering;
@@ -2759,6 +2759,54 @@ mod misc_impls {
                 .share_mut(|d| d.add_ribosome(cell_id, ribosome));
 
             // TODO: Remove old wasm code? (Maybe this needs to be done on restart as it could be in use).
+
+            Ok(())
+        }
+
+        /// Send a signal directly to the specified agents, bypassing WASM execution
+        pub async fn send_direct_signal(
+            &self,
+            installed_app_id: InstalledAppId,
+            dna_hash: DnaHash,
+            agents: Vec<AgentPubKey>,
+            signal: Vec<u8>,
+        ) -> ConductorResult<()> {
+            if agents.is_empty() {
+                return Err(ConductorError::Other("No agents to signal".into()));
+            }
+
+            if signal.len() > DIRECT_SIGNAL_MAX_SIZE {
+                return Err(ConductorError::Other(
+                    "Signal payload larger than 1 MiB".into(),
+                ));
+            }
+
+            let app_info = self.get_app_info(&installed_app_id).await?.ok_or_else(|| {
+                ConductorError::other(format!("App not installed: {installed_app_id}"))
+            })?;
+
+            let dna_belongs_to_app = app_info
+                .cell_info
+                .values()
+                .flatten()
+                .find(|c| match c {
+                    CellInfo::Provisioned(cell) => cell.cell_id.dna_hash() == &dna_hash,
+                    CellInfo::Cloned(cell) => cell.cell_id.dna_hash() == &dna_hash,
+                    CellInfo::Stem(cell) => cell.original_dna_hash == dna_hash,
+                })
+                .is_some();
+            if !dna_belongs_to_app {
+                return Err(ConductorError::Other(format!("Attempted to send to DNA hash {dna_hash:?} but it was not found in app {installed_app_id}").into()));
+            }
+
+            let sig = self
+                .keystore()
+                .sign(app_info.agent_pub_key.clone(), signal.clone().into())
+                .await?;
+
+            self.holochain_p2p()
+                .send_remote_signal_direct(dna_hash, agents, signal, app_info.agent_pub_key, sig)
+                .await?;
 
             Ok(())
         }

--- a/crates/holochain/src/conductor/conductor/hc_p2p_handler_impl.rs
+++ b/crates/holochain/src/conductor/conductor/hc_p2p_handler_impl.rs
@@ -31,6 +31,22 @@ impl holochain_p2p::event::HcP2pHandler for Conductor {
         })
     }
 
+    fn handle_remote_signal_direct(
+        &self,
+        dna_hash: DnaHash,
+        to_agent: AgentPubKey,
+        signal: Vec<u8>,
+        from_agent: AgentPubKey,
+        signature: Signature,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        Box::pin(async {
+            self.cell_by_parts(&dna_hash, &to_agent)
+                .await?
+                .handle_remote_signal_direct(dna_hash, to_agent, signal, from_agent, signature)
+                .await
+        })
+    }
+
     fn handle_publish(
         &self,
         dna_hash: DnaHash,

--- a/crates/holochain/tests/tests/signals/direct.rs
+++ b/crates/holochain/tests/tests/signals/direct.rs
@@ -120,9 +120,13 @@ async fn direct_signal_to_another_conductor() {
     holochain_trace::test_run();
 
     let mut conductors =
-        SweetConductorBatch::from_config_rendezvous(2, SweetConductorConfig::rendezvous(true)).await;
+        SweetConductorBatch::from_config_rendezvous(2, SweetConductorConfig::rendezvous(true))
+            .await;
     let dna = SweetDnaFile::unique_empty().await;
-    let app_batch = conductors.setup_app("app", &[dna.clone()]).await.unwrap();
+    let app_batch = conductors
+        .setup_app("app", std::slice::from_ref(&dna))
+        .await
+        .unwrap();
     let ((alice,), (bob,)): ((SweetCell,), (SweetCell,)) = app_batch.into_tuples();
 
     let dna_hash = dna.dna_hash().clone();
@@ -167,8 +171,14 @@ async fn direct_signal_to_agent_on_same_conductor() {
     let mut conductor = SweetConductor::standard().await;
     let dna = SweetDnaFile::unique_empty().await;
 
-    let _alice_app = conductor.setup_app("alice-app", &[dna.clone()]).await.unwrap();
-    let bob_app = conductor.setup_app("bob-app", &[dna.clone()]).await.unwrap();
+    let _alice_app = conductor
+        .setup_app("alice-app", std::slice::from_ref(&dna))
+        .await
+        .unwrap();
+    let bob_app = conductor
+        .setup_app("bob-app", std::slice::from_ref(&dna))
+        .await
+        .unwrap();
 
     let dna_hash = dna.dna_hash().clone();
     let bob_agent = bob_app.agent().clone();
@@ -203,9 +213,13 @@ async fn direct_signal_to_multiple_agents() {
     holochain_trace::test_run();
 
     let mut conductors =
-        SweetConductorBatch::from_config_rendezvous(3, SweetConductorConfig::rendezvous(true)).await;
+        SweetConductorBatch::from_config_rendezvous(3, SweetConductorConfig::rendezvous(true))
+            .await;
     let dna = SweetDnaFile::unique_empty().await;
-    let app_batch = conductors.setup_app("app", &[dna.clone()]).await.unwrap();
+    let app_batch = conductors
+        .setup_app("app", std::slice::from_ref(&dna))
+        .await
+        .unwrap();
     let ((alice,), (bob,), (carol,)): ((SweetCell,), (SweetCell,), (SweetCell,)) =
         app_batch.into_tuples();
 
@@ -256,7 +270,10 @@ async fn direct_signal_to_unknown_agent_is_dropped() {
 
     let mut conductor = SweetConductor::standard().await;
     let dna = SweetDnaFile::unique_empty().await;
-    let _app = conductor.setup_app("app", &[dna.clone()]).await.unwrap();
+    let _app = conductor
+        .setup_app("app", std::slice::from_ref(&dna))
+        .await
+        .unwrap();
     let dna_hash = dna.dna_hash().clone();
 
     // One socket to send on (its receiver is drained for responses)...
@@ -269,8 +286,13 @@ async fn direct_signal_to_unknown_agent_is_dropped() {
     // A made-up agent key that has no known URL in the peer store.
     let unknown_agent = AgentPubKey::from_raw_36(vec![0; 36]);
 
-    let response =
-        send_direct_signal(&alice_tx, dna_hash, vec![unknown_agent], b"nobody home".to_vec()).await;
+    let response = send_direct_signal(
+        &alice_tx,
+        dna_hash,
+        vec![unknown_agent],
+        b"nobody home".to_vec(),
+    )
+    .await;
     // Sending to an agent with no known URL is a best-effort no-op, not an error.
     assert!(
         matches!(response, AppResponse::Ok),
@@ -293,7 +315,10 @@ async fn direct_signal_with_no_agents_is_rejected() {
 
     let mut conductor = SweetConductor::standard().await;
     let dna = SweetDnaFile::unique_empty().await;
-    let _app = conductor.setup_app("app", &[dna.clone()]).await.unwrap();
+    let _app = conductor
+        .setup_app("app", std::slice::from_ref(&dna))
+        .await
+        .unwrap();
     let dna_hash = dna.dna_hash().clone();
 
     let (tx, rx) = connect_app_ws(&conductor, "app").await;
@@ -309,7 +334,10 @@ async fn direct_signal_over_max_size_is_rejected() {
 
     let mut conductor = SweetConductor::standard().await;
     let dna = SweetDnaFile::unique_empty().await;
-    let app = conductor.setup_app("app", &[dna.clone()]).await.unwrap();
+    let app = conductor
+        .setup_app("app", std::slice::from_ref(&dna))
+        .await
+        .unwrap();
     let agent = app.agent().clone();
     let dna_hash = dna.dna_hash().clone();
 
@@ -327,7 +355,10 @@ async fn direct_signal_to_dna_not_in_app_is_rejected() {
 
     let mut conductor = SweetConductor::standard().await;
     let dna = SweetDnaFile::unique_empty().await;
-    let app = conductor.setup_app("app", &[dna.clone()]).await.unwrap();
+    let app = conductor
+        .setup_app("app", std::slice::from_ref(&dna))
+        .await
+        .unwrap();
     let agent = app.agent().clone();
 
     // A DNA that the app does not contain.

--- a/crates/holochain/tests/tests/signals/direct.rs
+++ b/crates/holochain/tests/tests/signals/direct.rs
@@ -1,0 +1,342 @@
+//! Integration tests for direct signals (`AppRequest::SendDirectSignal`).
+//!
+//! A direct signal is sent over the app interface and delivered to the target agents' app signal
+//! streams without running any WASM on either side. These tests drive the feature end-to-end over a
+//! real app websocket: the request is sent over the wire and the resulting signal is received over
+//! the wire on the target's app interface.
+
+use std::time::Duration;
+
+use holochain::sweettest::{
+    authenticate_app_ws_client, websocket_client_by_port, SweetCell, SweetConductor,
+    SweetConductorBatch, SweetConductorConfig, SweetDnaFile, WsPollRecv,
+};
+use holochain_conductor_api::{AppRequest, AppResponse, ExternalApiWireError};
+use holochain_types::prelude::*;
+use holochain_types::signal::DIRECT_SIGNAL_MAX_SIZE;
+use holochain_types::websocket::AllowedOrigins;
+use holochain_websocket::{ReceiveMessage, WebsocketReceiver, WebsocketSender};
+
+/// Add an app interface to the conductor, connect a websocket client and authenticate it for the
+/// given installed app.
+///
+/// The returned receiver is *not* polled. A caller that only sends requests should drive it with a
+/// [`WsPollRecv`] so that request responses are delivered; a caller that wants to observe signals
+/// should `recv` from it directly (see [`try_recv_direct_signal`]).
+async fn connect_app_ws(
+    conductor: &SweetConductor,
+    installed_app_id: &str,
+) -> (WebsocketSender, WebsocketReceiver) {
+    let app_port = conductor
+        .raw_handle()
+        .add_app_interface(either::Either::Left(0), None, AllowedOrigins::Any, None)
+        .await
+        .unwrap();
+
+    let (tx, rx) = websocket_client_by_port(app_port).await.unwrap();
+
+    let admin_port = conductor
+        .get_arbitrary_admin_websocket_port()
+        .expect("conductor has no admin port");
+    authenticate_app_ws_client(tx.clone(), admin_port, installed_app_id.to_string()).await;
+
+    (tx, rx)
+}
+
+/// Send a direct signal request over an authenticated sender socket and return the response.
+async fn send_direct_signal(
+    tx: &WebsocketSender,
+    dna_hash: DnaHash,
+    agents: Vec<AgentPubKey>,
+    signal: Vec<u8>,
+) -> AppResponse {
+    tx.request(AppRequest::SendDirectSignal {
+        dna_hash,
+        agents,
+        signal,
+    })
+    .await
+    .unwrap()
+}
+
+/// Wait for the next direct (`Signal::AppDirect`) signal on this socket, returning the target cell
+/// and payload. Other signal kinds are ignored. Returns `None` if `timeout` elapses first.
+async fn try_recv_direct_signal(
+    rx: &mut WebsocketReceiver,
+    timeout: Duration,
+) -> Option<(CellId, Vec<u8>)> {
+    tokio::time::timeout(timeout, async {
+        loop {
+            match rx.recv::<AppResponse>().await.unwrap() {
+                ReceiveMessage::Signal(bytes) => match Signal::try_from_vec(bytes).unwrap() {
+                    Signal::AppDirect { cell_id, signal } => return (cell_id, signal),
+                    _ => continue,
+                },
+                _ => panic!("expected a signal on the app socket"),
+            }
+        }
+    })
+    .await
+    .ok()
+}
+
+/// Wait until `conductor` can resolve a URL for `agent` in the space identified by `dna_hash`.
+///
+/// A direct signal to an agent whose URL is unknown is silently dropped, so the happy-path tests
+/// must ensure the sender can resolve each target's URL before sending.
+async fn wait_for_agent_url(conductor: &SweetConductor, dna_hash: &DnaHash, agent: &AgentPubKey) {
+    let target = agent.to_k2_agent();
+    tokio::time::timeout(Duration::from_secs(60), async {
+        loop {
+            let known = conductor
+                .get_agent_infos(Some(vec![dna_hash.clone()]))
+                .await
+                .unwrap()
+                .iter()
+                .any(|info| info.agent == target && info.url.is_some());
+            if known {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for the target agent's URL to be discovered");
+}
+
+/// Assert that a response is an internal error whose message contains `expected`.
+fn assert_error_contains(response: &AppResponse, expected: &str) {
+    match response {
+        AppResponse::Error(ExternalApiWireError::InternalError(msg)) => assert!(
+            msg.contains(expected),
+            "error {msg:?} did not contain {expected:?}"
+        ),
+        other => panic!("expected an internal error containing {expected:?}, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn direct_signal_to_another_conductor() {
+    holochain_trace::test_run();
+
+    let mut conductors =
+        SweetConductorBatch::from_config_rendezvous(2, SweetConductorConfig::rendezvous(true)).await;
+    let dna = SweetDnaFile::unique_empty().await;
+    let app_batch = conductors.setup_app("app", &[dna.clone()]).await.unwrap();
+    let ((alice,), (bob,)): ((SweetCell,), (SweetCell,)) = app_batch.into_tuples();
+
+    let dna_hash = dna.dna_hash().clone();
+
+    // Alice must have gossiped with Bob so that she knows his URL before sending.
+    conductors[0]
+        .require_initial_gossip_activity_for_cell(&alice, 1, Duration::from_secs(90))
+        .await
+        .unwrap();
+
+    // Sender socket on Alice's conductor. Drain its receiver so the request response is delivered.
+    let (alice_tx, alice_rx) = connect_app_ws(&conductors[0], "app").await;
+    let _alice_rx = WsPollRecv::new::<AppResponse>(alice_rx);
+
+    // Receiver socket on Bob's conductor. We `recv` from it directly to capture signals.
+    let (_bob_tx, mut bob_rx) = connect_app_ws(&conductors[1], "app").await;
+
+    let payload = b"hello bob".to_vec();
+    let response = send_direct_signal(
+        &alice_tx,
+        dna_hash,
+        vec![bob.agent_pubkey().clone()],
+        payload.clone(),
+    )
+    .await;
+    assert!(
+        matches!(response, AppResponse::Ok),
+        "unexpected response: {response:?}"
+    );
+
+    let (cell_id, signal) = try_recv_direct_signal(&mut bob_rx, Duration::from_secs(60))
+        .await
+        .expect("Bob did not receive the direct signal");
+    assert_eq!(cell_id, *bob.cell_id());
+    assert_eq!(signal, payload);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn direct_signal_to_agent_on_same_conductor() {
+    holochain_trace::test_run();
+
+    let mut conductor = SweetConductor::standard().await;
+    let dna = SweetDnaFile::unique_empty().await;
+
+    let _alice_app = conductor.setup_app("alice-app", &[dna.clone()]).await.unwrap();
+    let bob_app = conductor.setup_app("bob-app", &[dna.clone()]).await.unwrap();
+
+    let dna_hash = dna.dna_hash().clone();
+    let bob_agent = bob_app.agent().clone();
+    let bob_cell_id = bob_app.cells()[0].cell_id().clone();
+
+    // Both agents live on the same conductor, so Bob's URL is published to the shared peer store
+    // once the conductor connects to the network. Wait for it before sending.
+    wait_for_agent_url(&conductor, &dna_hash, &bob_agent).await;
+
+    let (alice_tx, alice_rx) = connect_app_ws(&conductor, "alice-app").await;
+    let _alice_rx = WsPollRecv::new::<AppResponse>(alice_rx);
+
+    let (_bob_tx, mut bob_rx) = connect_app_ws(&conductor, "bob-app").await;
+
+    let payload = b"hello local bob".to_vec();
+    let response = send_direct_signal(&alice_tx, dna_hash, vec![bob_agent], payload.clone()).await;
+    assert!(
+        matches!(response, AppResponse::Ok),
+        "unexpected response: {response:?}"
+    );
+
+    let (cell_id, signal) = try_recv_direct_signal(&mut bob_rx, Duration::from_secs(30))
+        .await
+        .expect("Bob did not receive the direct signal");
+    assert_eq!(cell_id, bob_cell_id);
+    assert_eq!(signal, payload);
+}
+
+#[cfg(feature = "slow_tests")]
+#[tokio::test(flavor = "multi_thread")]
+async fn direct_signal_to_multiple_agents() {
+    holochain_trace::test_run();
+
+    let mut conductors =
+        SweetConductorBatch::from_config_rendezvous(3, SweetConductorConfig::rendezvous(true)).await;
+    let dna = SweetDnaFile::unique_empty().await;
+    let app_batch = conductors.setup_app("app", &[dna.clone()]).await.unwrap();
+    let ((alice,), (bob,), (carol,)): ((SweetCell,), (SweetCell,), (SweetCell,)) =
+        app_batch.into_tuples();
+
+    let dna_hash = dna.dna_hash().clone();
+
+    // Alice must have gossiped with both peers so that she knows their URLs before sending.
+    conductors[0]
+        .require_initial_gossip_activity_for_cell(&alice, 2, Duration::from_secs(90))
+        .await
+        .unwrap();
+
+    let (alice_tx, alice_rx) = connect_app_ws(&conductors[0], "app").await;
+    let _alice_rx = WsPollRecv::new::<AppResponse>(alice_rx);
+
+    let (_bob_tx, mut bob_rx) = connect_app_ws(&conductors[1], "app").await;
+    let (_carol_tx, mut carol_rx) = connect_app_ws(&conductors[2], "app").await;
+
+    let payload = b"hello everyone".to_vec();
+    let response = send_direct_signal(
+        &alice_tx,
+        dna_hash,
+        vec![bob.agent_pubkey().clone(), carol.agent_pubkey().clone()],
+        payload.clone(),
+    )
+    .await;
+    assert!(
+        matches!(response, AppResponse::Ok),
+        "unexpected response: {response:?}"
+    );
+
+    let (bob_cell_id, bob_signal) = try_recv_direct_signal(&mut bob_rx, Duration::from_secs(60))
+        .await
+        .expect("Bob did not receive the direct signal");
+    assert_eq!(bob_cell_id, *bob.cell_id());
+    assert_eq!(bob_signal, payload);
+
+    let (carol_cell_id, carol_signal) =
+        try_recv_direct_signal(&mut carol_rx, Duration::from_secs(60))
+            .await
+            .expect("Carol did not receive the direct signal");
+    assert_eq!(carol_cell_id, *carol.cell_id());
+    assert_eq!(carol_signal, payload);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn direct_signal_to_unknown_agent_is_dropped() {
+    holochain_trace::test_run();
+
+    let mut conductor = SweetConductor::standard().await;
+    let dna = SweetDnaFile::unique_empty().await;
+    let _app = conductor.setup_app("app", &[dna.clone()]).await.unwrap();
+    let dna_hash = dna.dna_hash().clone();
+
+    // One socket to send on (its receiver is drained for responses)...
+    let (alice_tx, alice_rx) = connect_app_ws(&conductor, "app").await;
+    let _alice_rx = WsPollRecv::new::<AppResponse>(alice_rx);
+
+    // ...and a second socket to confirm that no signal is delivered to the app.
+    let (_listen_tx, mut listen_rx) = connect_app_ws(&conductor, "app").await;
+
+    // A made-up agent key that has no known URL in the peer store.
+    let unknown_agent = AgentPubKey::from_raw_36(vec![0; 36]);
+
+    let response =
+        send_direct_signal(&alice_tx, dna_hash, vec![unknown_agent], b"nobody home".to_vec()).await;
+    // Sending to an agent with no known URL is a best-effort no-op, not an error.
+    assert!(
+        matches!(response, AppResponse::Ok),
+        "sending to an unknown agent should be a no-op, got: {response:?}"
+    );
+
+    // No signal can be delivered, since the target agent's URL is unknown. A bounded wait that we
+    // expect to elapse is the only way to assert the absence of a signal.
+    assert!(
+        try_recv_direct_signal(&mut listen_rx, Duration::from_secs(2))
+            .await
+            .is_none(),
+        "a direct signal was delivered for a made-up agent"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn direct_signal_with_no_agents_is_rejected() {
+    holochain_trace::test_run();
+
+    let mut conductor = SweetConductor::standard().await;
+    let dna = SweetDnaFile::unique_empty().await;
+    let _app = conductor.setup_app("app", &[dna.clone()]).await.unwrap();
+    let dna_hash = dna.dna_hash().clone();
+
+    let (tx, rx) = connect_app_ws(&conductor, "app").await;
+    let _rx = WsPollRecv::new::<AppResponse>(rx);
+
+    let response = send_direct_signal(&tx, dna_hash, vec![], b"payload".to_vec()).await;
+    assert_error_contains(&response, "No agents to signal");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn direct_signal_over_max_size_is_rejected() {
+    holochain_trace::test_run();
+
+    let mut conductor = SweetConductor::standard().await;
+    let dna = SweetDnaFile::unique_empty().await;
+    let app = conductor.setup_app("app", &[dna.clone()]).await.unwrap();
+    let agent = app.agent().clone();
+    let dna_hash = dna.dna_hash().clone();
+
+    let (tx, rx) = connect_app_ws(&conductor, "app").await;
+    let _rx = WsPollRecv::new::<AppResponse>(rx);
+
+    let oversized = vec![0u8; DIRECT_SIGNAL_MAX_SIZE + 1];
+    let response = send_direct_signal(&tx, dna_hash, vec![agent], oversized).await;
+    assert_error_contains(&response, "Signal payload larger than 1 MiB");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn direct_signal_to_dna_not_in_app_is_rejected() {
+    holochain_trace::test_run();
+
+    let mut conductor = SweetConductor::standard().await;
+    let dna = SweetDnaFile::unique_empty().await;
+    let app = conductor.setup_app("app", &[dna.clone()]).await.unwrap();
+    let agent = app.agent().clone();
+
+    // A DNA that the app does not contain.
+    let other_dna = SweetDnaFile::unique_empty().await;
+    let other_dna_hash = other_dna.dna_hash().clone();
+
+    let (tx, rx) = connect_app_ws(&conductor, "app").await;
+    let _rx = WsPollRecv::new::<AppResponse>(rx);
+
+    let response = send_direct_signal(&tx, other_dna_hash, vec![agent], b"payload".to_vec()).await;
+    assert_error_contains(&response, "was not found in app");
+}

--- a/crates/holochain/tests/tests/signals/direct.rs
+++ b/crates/holochain/tests/tests/signals/direct.rs
@@ -346,7 +346,7 @@ async fn direct_signal_over_max_size_is_rejected() {
 
     let oversized = vec![0u8; DIRECT_SIGNAL_MAX_SIZE + 1];
     let response = send_direct_signal(&tx, dna_hash, vec![agent], oversized).await;
-    assert_error_contains(&response, "Signal payload larger than 1 MiB");
+    assert_error_contains(&response, "Signal payload larger than");
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/holochain/tests/tests/signals/mod.rs
+++ b/crates/holochain/tests/tests/signals/mod.rs
@@ -1,6 +1,8 @@
 //! Tests for local and remote signals using rendezvous config
 //!
 
+mod direct;
+
 use hdk::prelude::ExternIO;
 use holochain::sweettest::*;
 use holochain_types::prelude::*;

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -251,6 +251,32 @@ pub enum AppRequest {
     ///
     /// [`AppResponse::Ok`]
     EnableApp,
+
+    /// Send a remote signal directly to one or more peers.
+    ///
+    /// Using this app request is equivalent to calling a zome function that forwards to the HDK
+    /// function `send_remote_signal`. On the receiving end, the conductor does not call the
+    /// corresponding zome's `recv_remote_signal` function, which would then have to invoke the HDK
+    /// function `emit_signal`. The result is that signals can be exchanged between peers without
+    /// having to run a WASM function on each side.
+    ///
+    /// Note that this bypasses the usual security mechanism where zomes must create a capability
+    /// grant to permit `recv_remote_signal` to be invoked without restriction.
+    SendDirectSignal {
+        /// The app network to send messages on.
+        dna_hash: DnaHash,
+
+        /// The agents to send the signal payload to.
+        ///
+        /// An empty payload is treated as an error.
+        agents: Vec<AgentPubKey>,
+
+        /// The signal payload.
+        ///
+        /// Treated as opaque by Holochain, it is up to the application to decide how to serialize,
+        /// deserialize and process payloads.
+        signal: Vec<u8>,
+    },
 }
 
 /// Represents the possible responses to an [`AppRequest`].

--- a/crates/holochain_p2p/src/metrics.rs
+++ b/crates/holochain_p2p/src/metrics.rs
@@ -1,5 +1,4 @@
 use opentelemetry::global::meter;
-use opentelemetry::metrics;
 use opentelemetry::metrics::{Counter, Histogram};
 use std::sync::OnceLock;
 
@@ -53,7 +52,7 @@ pub fn p2p_handle_incoming_request_ignored_metric() -> &'static P2pRequestIgnore
 }
 
 /// A counter metric for counting received remote signals.
-pub type P2pRecvRemoteSignalMetric = metrics::Counter<u64>;
+pub type P2pRecvRemoteSignalMetric = Counter<u64>;
 
 static P2P_RECV_REMOTE_SIGNAL_METRIC: OnceLock<P2pRecvRemoteSignalMetric> = OnceLock::new();
 
@@ -68,13 +67,13 @@ pub fn p2p_recv_remote_signal_metric() -> &'static P2pRecvRemoteSignalMetric {
 }
 
 /// A counter metric for counting received direct remote signals.
-pub type P2pRecvRemoteSignalDirectMetric = metrics::Counter<u64>;
+pub type P2pRecvRemoteSignalDirectMetric = Counter<u64>;
 
 static P2P_RECV_REMOTE_SIGNAL_DIRECT_METRIC: OnceLock<P2pRecvRemoteSignalDirectMetric> =
     OnceLock::new();
 
 /// Metric for counting received direct remote signals.
-pub fn p2p_recv_remote_signal_direct_metric() -> &'static P2pRecvRemoteSignalMetric {
+pub fn p2p_recv_remote_signal_direct_metric() -> &'static P2pRecvRemoteSignalDirectMetric {
     P2P_RECV_REMOTE_SIGNAL_DIRECT_METRIC.get_or_init(|| {
         meter("hc.holochain_p2p")
             .u64_counter("hc.holochain_p2p.recv_remote_signal_direct")

--- a/crates/holochain_p2p/src/metrics.rs
+++ b/crates/holochain_p2p/src/metrics.rs
@@ -66,3 +66,19 @@ pub fn p2p_recv_remote_signal_metric() -> &'static P2pRecvRemoteSignalMetric {
             .build()
     })
 }
+
+/// A counter metric for counting received direct remote signals.
+pub type P2pRecvRemoteSignalDirectMetric = metrics::Counter<u64>;
+
+static P2P_RECV_REMOTE_SIGNAL_DIRECT_METRIC: OnceLock<P2pRecvRemoteSignalDirectMetric> =
+    OnceLock::new();
+
+/// Metric for counting received direct remote signals.
+pub fn p2p_recv_remote_signal_direct_metric() -> &'static P2pRecvRemoteSignalMetric {
+    P2P_RECV_REMOTE_SIGNAL_DIRECT_METRIC.get_or_init(|| {
+        meter("hc.holochain_p2p")
+            .u64_counter("hc.holochain_p2p.recv_remote_signal_direct")
+            .with_description("The number of direct remote signals received.")
+            .build()
+    })
+}

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -3,7 +3,8 @@
 use crate::actor::{GetLinksRequestOptions, NetworkRequestOptions};
 use crate::metrics::{
     p2p_handle_incoming_request_duration_metric, p2p_handle_incoming_request_ignored_metric,
-    p2p_outgoing_request_duration_metric, p2p_recv_remote_signal_metric,
+    p2p_outgoing_request_duration_metric, p2p_recv_remote_signal_direct_metric,
+    p2p_recv_remote_signal_metric,
 };
 use crate::peer_latency_store::{PeerLatencyService, PingFn};
 use crate::*;
@@ -67,6 +68,26 @@ impl event::HcP2pHandler for WrapEvtSender {
             },
             byte_count,
             a = "recv_call_remote",
+        )
+    }
+
+    fn handle_remote_signal_direct(
+        &self,
+        dna_hash: DnaHash,
+        to_agent: AgentPubKey,
+        signal: Vec<u8>,
+        from_agent: AgentPubKey,
+        signature: Signature,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        let byte_count = signal.len();
+        timing_trace!(
+            true,
+            {
+                self.0
+                    .handle_remote_signal_direct(dna_hash, to_agent, signal, from_agent, signature)
+            },
+            byte_count,
+            a = "recv_remote_signal_direct",
         )
     }
 
@@ -1418,6 +1439,35 @@ impl HolochainP2pActor {
                         )],
                     );
                 }
+                RemoteSignalDirectEvt {
+                    to_agent,
+                    signal,
+                    from_agent,
+                    signature,
+                } => {
+                    let _response = evt_sender
+                        .get()
+                        .ok_or_else(|| HolochainP2pError::other(EVT_REG_ERR))?
+                        .handle_remote_signal_direct(
+                            dna_hash.clone(),
+                            to_agent.clone(),
+                            signal,
+                            from_agent,
+                            signature,
+                        )
+                        .await;
+                    record_incoming_request_duration(&[opentelemetry::KeyValue::new(
+                        "to_agent",
+                        format!("{to_agent:?}"),
+                    )]);
+                    p2p_recv_remote_signal_direct_metric().add(
+                        1,
+                        &[opentelemetry::KeyValue::new(
+                            "dna_hash",
+                            dna_hash.to_string(),
+                        )],
+                    );
+                }
                 PublishCountersignEvt { op } => {
                     evt_sender
                         .get()
@@ -1699,7 +1749,7 @@ impl actor::HcP2p for HolochainP2pActor {
 
             let byte_count: usize = target_payload_list.iter().map(|(_, p, _)| p.0.len()).sum();
 
-            let mut all = Vec::new();
+            let mut all = Vec::with_capacity(target_payload_list.len());
 
             for (to_agent, payload, signature) in target_payload_list {
                 let to_agent_id = to_agent.to_k2_agent();
@@ -1740,6 +1790,78 @@ impl actor::HcP2p for HolochainP2pActor {
             let out = Ok(());
 
             timing_trace_out!(out, start, byte_count, a = "send_remote_signal");
+
+            out
+        })
+    }
+
+    fn send_remote_signal_direct(
+        &self,
+        dna_hash: DnaHash,
+        agents: Vec<AgentPubKey>,
+        signal: Vec<u8>,
+        from_agent: AgentPubKey,
+        signature: Signature,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        Box::pin(async move {
+            let space_id = dna_hash.to_k2_space();
+            let space = self
+                .kitsune
+                .space_if_exists(space_id.clone())
+                .await
+                .ok_or(HolochainP2pError::K2SpaceNotFound(space_id.clone()))?;
+
+            let mut all = Vec::with_capacity(agents.len());
+
+            for agent in agents {
+                let agent_id = agent.to_k2_agent();
+                let to_url = match space
+                    .peer_store()
+                    .get(agent_id)
+                    .await?
+                    .and_then(|i| i.url.clone())
+                {
+                    Some(to_url) => to_url,
+                    None => continue,
+                };
+
+                let req = WireMessage::remote_signal_direct_evt(
+                    agent.clone(),
+                    signal.clone(),
+                    from_agent.clone(),
+                    signature.clone(),
+                );
+
+                if self.should_bridge(&space, to_url.clone()) {
+                    if let Err(err) = WireMessage::encode_batch(&[&req])
+                        .map(|msg| self.recv_notify(to_url, space_id.clone(), msg))
+                    {
+                        tracing::debug!(?err, "send_remote_signal_direct failed to bridge call");
+                    }
+                } else {
+                    all.push(async {
+                        if let Err(err) = self.send_notify(&space, to_url, req).await {
+                            tracing::debug!(?err, "send_remote_signal_direct failed");
+                        }
+                    });
+                }
+            }
+
+            let start = std::time::Instant::now();
+
+            if !all.is_empty() {
+                // errors handled in individual futures
+                let _ = futures::future::join_all(all).await;
+            }
+
+            let out = Ok(());
+
+            timing_trace_out!(
+                out,
+                start,
+                byte_count = signal.len(),
+                a = "send_remote_signal_direct"
+            );
 
             out
         })
@@ -2833,6 +2955,7 @@ mod tests {
     #[derive(Clone, Debug)]
     struct BlockingEventHandler {
         pub handle_call_remote_count: Arc<Mutex<u32>>,
+        pub handle_remote_signal_direct_count: Arc<Mutex<u32>>,
         pub handle_publish_count: Arc<Mutex<u32>>,
         pub handle_get_count: Arc<Mutex<u32>>,
         pub handle_get_links_count: Arc<Mutex<u32>>,
@@ -2848,6 +2971,7 @@ mod tests {
         fn new() -> Self {
             Self {
                 handle_call_remote_count: Arc::new(Mutex::new(0)),
+                handle_remote_signal_direct_count: Arc::new(Mutex::new(0)),
                 handle_publish_count: Arc::new(Mutex::new(0)),
                 handle_get_count: Arc::new(Mutex::new(0)),
                 handle_get_links_count: Arc::new(Mutex::new(0)),
@@ -2872,6 +2996,22 @@ mod tests {
         ) -> BoxFut<'_, HolochainP2pResult<SerializedBytes>> {
             // Increment counter
             let mut count = self.handle_call_remote_count.lock().unwrap();
+            *count += 1;
+
+            // Block indefinitely
+            Box::pin(std::future::pending())
+        }
+
+        fn handle_remote_signal_direct(
+            &self,
+            _dna_hash: DnaHash,
+            _to_agent: AgentPubKey,
+            _signal: Vec<u8>,
+            _from_agent: AgentPubKey,
+            _signature: Signature,
+        ) -> BoxFut<'_, HolochainP2pResult<()>> {
+            // Increment counter
+            let mut count = self.handle_remote_signal_direct_count.lock().unwrap();
             *count += 1;
 
             // Block indefinitely

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -1765,10 +1765,12 @@ impl actor::HcP2p for HolochainP2pActor {
 
                 let req = WireMessage::remote_signal_evt(to_agent.clone(), payload, signature);
 
+                let wire_msg = WireMessage::encode_batch(&[&req]).inspect_err(|err| {
+                    tracing::error!(?err, "Failed to encode remote signal as a batch message")
+                })?;
+
                 if self.should_bridge(&space, to_url.clone()) {
-                    if let Err(err) = WireMessage::encode_batch(&[&req])
-                        .map(|msg| self.recv_notify(to_url, space_id.clone(), msg))
-                    {
+                    if let Err(err) = self.recv_notify(to_url, space_id.clone(), wire_msg) {
                         tracing::debug!(?err, "send_remote_signal failed to bridge call");
                     }
                 } else {
@@ -1833,9 +1835,14 @@ impl actor::HcP2p for HolochainP2pActor {
                 );
 
                 if self.should_bridge(&space, to_url.clone()) {
-                    if let Err(err) = WireMessage::encode_batch(&[&req])
-                        .map(|msg| self.recv_notify(to_url, space_id.clone(), msg))
-                    {
+                    let wire_msg = WireMessage::encode_batch(&[&req]).inspect_err(|err| {
+                        tracing::error!(
+                            ?err,
+                            "Failed to encode remote signal direct as a batch message"
+                        );
+                    })?;
+
+                    if let Err(err) = self.recv_notify(to_url, space_id.clone(), wire_msg) {
                         tracing::debug!(?err, "send_remote_signal_direct failed to bridge call");
                     }
                 } else {

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -222,6 +222,17 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug + Any {
         to_agent_list: Vec<(AgentPubKey, ExternIO, Signature)>,
     ) -> BoxFut<'_, HolochainP2pResult<()>>;
 
+    /// Similar to `send_remote_signal` but bypasses the WASM when receiving the signal on the
+    /// target conductors.
+    fn send_remote_signal_direct(
+        &self,
+        dna_hash: DnaHash,
+        agents: Vec<AgentPubKey>,
+        signal: Vec<u8>,
+        from_agent: AgentPubKey,
+        signature: Signature,
+    ) -> BoxFut<'_, HolochainP2pResult<()>>;
+
     /// Publish data to the correct neighborhood.
     fn publish(
         &self,

--- a/crates/holochain_p2p/src/types/event.rs
+++ b/crates/holochain_p2p/src/types/event.rs
@@ -72,6 +72,16 @@ pub trait HcP2pHandler: 'static + Send + Sync + std::fmt::Debug {
         signature: Signature,
     ) -> BoxFut<'_, HolochainP2pResult<SerializedBytes>>;
 
+    /// A remote node is sending us a direct signal.
+    fn handle_remote_signal_direct(
+        &self,
+        dna_hash: DnaHash,
+        to_agent: AgentPubKey,
+        signal: Vec<u8>,
+        from_agent: AgentPubKey,
+        signature: Signature,
+    ) -> BoxFut<'_, HolochainP2pResult<()>>;
+
     /// A remote node is publishing data in a range we claim to be holding.
     fn handle_publish(
         &self,

--- a/crates/holochain_p2p/src/types/wire.rs
+++ b/crates/holochain_p2p/src/types/wire.rs
@@ -125,6 +125,12 @@ pub enum WireMessage {
         zome_call_params_serialized: ExternIO,
         signature: Signature,
     },
+    RemoteSignalDirectEvt {
+        to_agent: AgentPubKey,
+        signal: Vec<u8>,
+        from_agent: AgentPubKey,
+        signature: Signature,
+    },
     PublishCountersignEvt {
         op: ChainOp,
     },
@@ -346,6 +352,20 @@ impl WireMessage {
         Self::RemoteSignalEvt {
             to_agent,
             zome_call_params_serialized,
+            signature,
+        }
+    }
+
+    pub fn remote_signal_direct_evt(
+        to_agent: AgentPubKey,
+        signal: Vec<u8>,
+        from_agent: AgentPubKey,
+        signature: Signature,
+    ) -> WireMessage {
+        Self::RemoteSignalDirectEvt {
+            to_agent,
+            signal,
+            from_agent,
             signature,
         }
     }

--- a/crates/holochain_p2p/tests/tests/common/mod.rs
+++ b/crates/holochain_p2p/tests/tests/common/mod.rs
@@ -53,6 +53,24 @@ impl HcP2pHandler for Handler {
         })
     }
 
+    fn handle_remote_signal_direct(
+        &self,
+        _dna_hash: DnaHash,
+        _to_agent: AgentPubKey,
+        signal: Vec<u8>,
+        _from_agent: AgentPubKey,
+        _signature: Signature,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        Box::pin(async move {
+            let respond = format!(
+                "got_remote_signal_direct: {}",
+                String::from_utf8_lossy(&signal),
+            );
+            self.calls.lock().unwrap().push(respond.clone());
+            Ok(())
+        })
+    }
+
     fn handle_publish(
         &self,
         _dna_hash: DnaHash,

--- a/crates/holochain_p2p/tests/tests/node_messaging.rs
+++ b/crates/holochain_p2p/tests/tests/node_messaging.rs
@@ -60,6 +60,17 @@ impl HcP2pHandler for UnresponsiveHandler {
         Box::pin(std::future::pending())
     }
 
+    fn handle_remote_signal_direct(
+        &self,
+        _dna_hash: DnaHash,
+        _to_agent: AgentPubKey,
+        _signal: Vec<u8>,
+        _from_agent: AgentPubKey,
+        _signature: Signature,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        Box::pin(std::future::pending())
+    }
+
     fn handle_publish(
         &self,
         _dna_hash: DnaHash,

--- a/crates/holochain_p2p/tests/tests/op_store.rs
+++ b/crates/holochain_p2p/tests/tests/op_store.rs
@@ -41,6 +41,17 @@ impl HcP2pHandler for StubHost {
         unimplemented!()
     }
 
+    fn handle_remote_signal_direct(
+        &self,
+        _dna_hash: DnaHash,
+        _to_agent: AgentPubKey,
+        _signal: Vec<u8>,
+        _from_agent: AgentPubKey,
+        _signature: Signature,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        unimplemented!()
+    }
+
     fn handle_publish(
         &self,
         _dna_hash: DnaHash,

--- a/crates/holochain_types/src/signal.rs
+++ b/crates/holochain_types/src/signal.rs
@@ -57,3 +57,6 @@ impl_from! {
 
 /// The maximum size that Holochain will permit sending or receiving in a single direct signal.
 pub const DIRECT_SIGNAL_MAX_SIZE: usize = 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize, SerializedBytes)]
+pub struct DirectSignal(pub Vec<u8>);

--- a/crates/holochain_types/src/signal.rs
+++ b/crates/holochain_types/src/signal.rs
@@ -21,6 +21,14 @@ pub enum Signal {
         /// The actual signal that was emitted
         signal: AppSignal,
     },
+    /// A direct signal, sent with an app call to `SendDirectSignal`.
+    AppDirect {
+        /// The receiving `CellId`.
+        cell_id: CellId,
+
+        /// The payload sent by the remote agent.
+        signal: Vec<u8>,
+    },
     /// System-defined signals
     System(SystemSignal),
 }
@@ -46,3 +54,6 @@ pub enum SystemSignal {
 impl_from! {
     SystemSignal => Signal, |s| { Self::System(s) },
 }
+
+/// The maximum size that Holochain will permit sending or receiving in a single direct signal.
+pub const DIRECT_SIGNAL_MAX_SIZE: usize = 1024 * 1024;

--- a/crates/holochain_types/src/signal.rs
+++ b/crates/holochain_types/src/signal.rs
@@ -58,5 +58,6 @@ impl_from! {
 /// The maximum size that Holochain will permit sending or receiving in a single direct signal.
 pub const DIRECT_SIGNAL_MAX_SIZE: usize = 1024 * 1024;
 
+/// Wrapper type for transmitting a signed direct signal over the network.
 #[derive(Debug, Clone, Serialize, Deserialize, SerializedBytes)]
 pub struct DirectSignal(pub Vec<u8>);


### PR DESCRIPTION
### Summary

Closes https://github.com/holochain/holochain/issues/3778

Send signals directly from the app interface, through a new `holochain_p2p` message kind, to the signal receiver on the other side.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs