### PR TITLE
feat: source chain restore — types, scaffolding, and Lair-presence check (#5798)

### DIFF
--- a/crates/client/tests/admin.rs
+++ b/crates/client/tests/admin.rs
@@ -54,6 +54,7 @@ async fn signed_zome_call() {
             roles_settings: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -130,6 +131,7 @@ async fn storage_info() {
             roles_settings: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -164,6 +166,7 @@ async fn dump_network_stats() {
             roles_settings: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -194,6 +197,7 @@ async fn agent_info() {
             network_seed: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -252,6 +256,7 @@ async fn peer_meta_info() {
             network_seed: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -299,6 +304,7 @@ async fn install_app_then_list_apps_and_list_cell_ids() {
             network_seed: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -356,6 +362,7 @@ async fn install_app_with_roles_settings() {
             network_seed: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();

--- a/crates/client/tests/app.rs
+++ b/crates/client/tests/app.rs
@@ -50,6 +50,7 @@ async fn handle_signal() {
             roles_settings: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -146,6 +147,7 @@ async fn close_on_drop_is_clone_safe() {
             roles_settings: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -217,6 +219,7 @@ async fn deferred_memproof_installation() {
             roles_settings: None,
             source: AppBundleSource::Bytes(app_bundle_bytes),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -297,6 +300,7 @@ async fn connect_multiple_addresses() {
             roles_settings: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -358,6 +362,7 @@ async fn connect_with_custom_origin() {
             roles_settings: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -424,6 +429,7 @@ async fn dump_network_stats() {
             roles_settings: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -485,6 +491,7 @@ async fn dump_network_metrics() {
             roles_settings: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -533,6 +540,7 @@ async fn agent_info() {
             network_seed: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -607,6 +615,7 @@ async fn peer_meta_info() {
             network_seed: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -674,6 +683,7 @@ async fn call_zome_with_options_custom_timeout() {
             roles_settings: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();

--- a/crates/client/tests/clone_cell.rs
+++ b/crates/client/tests/clone_cell.rs
@@ -36,6 +36,7 @@ async fn clone_cell_management() {
             roles_settings: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -188,6 +189,7 @@ pub async fn app_info_refresh() {
             roles_settings: None,
             source: AppBundleSource::Bytes(fixture::get_fixture_app_bundle()),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();

--- a/crates/hc_client/src/calls.rs
+++ b/crates/hc_client/src/calls.rs
@@ -645,6 +645,7 @@ pub async fn install_app_bundle(
         roles_settings,
         network_seed,
         ignore_genesis_failure: false,
+        restore_from_dht: false,
     };
 
     let installed_app = client.install_app(payload).await?;

--- a/crates/hc_sandbox/examples/setup_5.rs
+++ b/crates/hc_sandbox/examples/setup_5.rs
@@ -51,6 +51,7 @@ async fn main() -> anyhow::Result<()> {
             roles_settings: Default::default(),
             network_seed: None,
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         };
 
         let installed_app = admin_ws.install_app(payload).await?;

--- a/crates/hc_sandbox/src/sandbox.rs
+++ b/crates/hc_sandbox/src/sandbox.rs
@@ -68,6 +68,7 @@ async fn install_app_bundle(
         roles_settings,
         network_seed,
         ignore_genesis_failure: false,
+        restore_from_dht: false,
     };
 
     let installed_app = client.install_app(payload).await?;

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1440,6 +1440,15 @@ mod app_impls {
             let apps_ids: Vec<&String> = match status_filter {
                 Some(Enabled) => conductor_state.enabled_apps().map(|(id, _)| id).collect(),
                 Some(Disabled) => conductor_state.disabled_apps().map(|(id, _)| id).collect(),
+                Some(AwaitingRestore) => {
+                    conductor_state.awaiting_restore_apps().map(|(id, _)| id).collect()
+                }
+                Some(Unrecoverable) => conductor_state
+                    .installed_apps()
+                    .iter()
+                    .filter(|(_, app)| matches!(app.status, AppStatus::Unrecoverable(..)))
+                    .map(|(id, _)| id)
+                    .collect(),
                 None => conductor_state.installed_apps().keys().collect(),
             };
 

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1325,7 +1325,14 @@ mod app_impls {
                 network_seed,
                 roles_settings,
                 ignore_genesis_failure,
+                restore_from_dht,
             } = payload;
+
+            if restore_from_dht && agent_key.is_none() {
+                return Err(ConductorError::AppStatusError(
+                    "restore_from_dht requires agent_key to be specified".to_string(),
+                ));
+            }
 
             let modifiers = get_modifiers_map_from_role_settings(&roles_settings);
             let membrane_proofs = get_memproof_map_from_role_settings(&roles_settings);

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1461,7 +1461,7 @@ mod app_impls {
                 Some(Unrecoverable) => conductor_state
                     .installed_apps()
                     .iter()
-                    .filter(|(_, app)| matches!(app.status, AppStatus::Unrecoverable(..)))
+                    .filter(|(_, app)| matches!(&app.status, AppStatus::Unrecoverable(..)))
                     .map(|(id, _)| id)
                     .collect(),
                 None => conductor_state.installed_apps().keys().collect(),

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1454,9 +1454,10 @@ mod app_impls {
             let apps_ids: Vec<&String> = match status_filter {
                 Some(Enabled) => conductor_state.enabled_apps().map(|(id, _)| id).collect(),
                 Some(Disabled) => conductor_state.disabled_apps().map(|(id, _)| id).collect(),
-                Some(AwaitingRestore) => {
-                    conductor_state.awaiting_restore_apps().map(|(id, _)| id).collect()
-                }
+                Some(AwaitingRestore) => conductor_state
+                    .awaiting_restore_apps()
+                    .map(|(id, _)| id)
+                    .collect(),
                 Some(Unrecoverable) => conductor_state
                     .installed_apps()
                     .iter()

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1334,6 +1334,13 @@ mod app_impls {
                 ));
             }
 
+            if let Some(ref key) = agent_key {
+                let keys_in_lair = self.keystore.list_public_keys().await?;
+                if !keys_in_lair.contains(key) {
+                    return Err(ConductorError::AgentKeyNotInKeystore(key.clone()));
+                }
+            }
+
             let modifiers = get_modifiers_map_from_role_settings(&roles_settings);
             let membrane_proofs = get_memproof_map_from_role_settings(&roles_settings);
             let existing_cells = get_existing_cells_map_from_role_settings(&roles_settings);

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -446,6 +446,7 @@ async fn test_deferred_memproof_provisioning() {
             roles_settings: Default::default(),
             network_seed: None,
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -562,6 +563,7 @@ async fn test_deferred_memproof_provisioning_uninstall() {
             roles_settings: Default::default(),
             network_seed: None,
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();

--- a/crates/holochain/src/conductor/conductor/tests/app_state.rs
+++ b/crates/holochain/src/conductor/conductor/tests/app_state.rs
@@ -668,6 +668,7 @@ async fn app_status_and_cell_state() {
             network_seed: None,
             roles_settings: None,
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -786,6 +787,7 @@ async fn app_status_and_cell_state() {
             network_seed: None,
             roles_settings: None,
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();

--- a/crates/holochain/src/conductor/error.rs
+++ b/crates/holochain/src/conductor/error.rs
@@ -126,6 +126,9 @@ pub enum ConductorError {
     #[error(transparent)]
     RibosomeError(#[from] crate::core::ribosome::error::RibosomeError),
 
+    #[error("Agent key {0} is not present in the local Lair keystore")]
+    AgentKeyNotInKeystore(holo_hash::AgentPubKey),
+
     #[error("Authentication failed with reason: {0}")]
     FailedAuthenticationError(String),
 

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -647,6 +647,7 @@ mod test {
             roles_settings: Default::default(),
             network_seed: None,
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         }));
         let response: AdminResponse = admin_tx.request(request).await.unwrap();
         let app_info = match response {

--- a/crates/holochain/src/conductor/state.rs
+++ b/crates/holochain/src/conductor/state.rs
@@ -401,7 +401,7 @@ mod tests {
         let installed = state.add_app(app).unwrap();
         state.get_app_mut(&app_id.to_string()).unwrap().status = AppStatus::Unrecoverable(
             CellId::new(dna_hash, agent),
-            UnrecoverableCellReason::ChainFork(Box::new(holochain_types::app::WarrantSummary {
+            UnrecoverableCellReason::ChainForkWarrant(Box::new(holochain_types::app::WarrantSummary {
                 author: fixt!(AgentPubKey),
                 warrantee: fixt!(AgentPubKey),
                 timestamp: Timestamp::now(),

--- a/crates/holochain/src/conductor/state.rs
+++ b/crates/holochain/src/conductor/state.rs
@@ -186,6 +186,27 @@ impl ConductorState {
         Ok(app)
     }
 
+    /// Iterate over only the "awaiting_restore" apps.
+    pub fn awaiting_restore_apps(&self) -> impl Iterator<Item = (&InstalledAppId, &InstalledApp)> + '_ {
+        self.installed_apps
+            .iter()
+            .filter(|(_, app)| app.status == AppStatus::AwaitingRestore)
+    }
+
+    /// Add an app in the AwaitingRestore state. Returns an error if an app is already
+    /// present at the given ID.
+    pub fn add_app_awaiting_restore(
+        &mut self,
+        app: InstalledAppCommon,
+    ) -> ConductorResult<InstalledApp> {
+        if self.installed_apps.contains_key(app.id()) {
+            return Err(ConductorError::AppAlreadyInstalled(app.id().clone()));
+        }
+        let app = InstalledApp::new(app, AppStatus::AwaitingRestore);
+        self.installed_apps.insert(app.id().clone(), app.clone());
+        Ok(app)
+    }
+
     /// Returns the interface configuration with the given ID if present
     pub fn interface_by_id(&self, id: &AppInterfaceId) -> Option<AppInterfaceConfig> {
         self.app_interfaces.get(id).cloned()
@@ -352,5 +373,33 @@ mod tests {
             state.find_app_containing_cell(&cell_id).unwrap(),
             &installed_app
         );
+    }
+
+    #[test]
+    fn awaiting_restore_apps_iterator() {
+        let mut state = ConductorState::default();
+        let agent = fixt!(AgentPubKey);
+        let app_manifest = AppManifestV0Builder::default()
+            .name("restore_test".to_string())
+            .description(None)
+            .roles(vec![])
+            .build()
+            .unwrap();
+        let app_id = "restore_app";
+        let app = InstalledAppCommon::new(
+            app_id,
+            agent,
+            [],
+            app_manifest.into(),
+            Timestamp::now(),
+        )
+        .unwrap();
+
+        state.add_app_awaiting_restore(app).unwrap();
+
+        assert_eq!(state.awaiting_restore_apps().count(), 1);
+        assert_eq!(state.enabled_apps().count(), 0);
+        assert_eq!(state.disabled_apps().count(), 0);
+        assert!(state.awaiting_restore_apps().any(|(id, _)| id == app_id));
     }
 }

--- a/crates/holochain/src/conductor/state.rs
+++ b/crates/holochain/src/conductor/state.rs
@@ -376,6 +376,47 @@ mod tests {
     }
 
     #[test]
+    fn unrecoverable_app_not_in_enabled_or_disabled() {
+        use holochain_types::app::UnrecoverableCellReason;
+        let mut state = ConductorState::default();
+        let agent = fixt!(AgentPubKey);
+        let dna_hash = fixt!(DnaHash);
+        let app_manifest = AppManifestV0Builder::default()
+            .name("unrec_test".to_string())
+            .description(None)
+            .roles(vec![])
+            .build()
+            .unwrap();
+        let app_id = "unrec_app";
+        let app = InstalledAppCommon::new(
+            app_id,
+            agent.clone(),
+            [],
+            app_manifest.into(),
+            Timestamp::now(),
+        )
+        .unwrap();
+        let installed = state.add_app(app).unwrap();
+        state.get_app_mut(&app_id.to_string()).unwrap().status =
+            AppStatus::Unrecoverable(
+                CellId::new(dna_hash, agent),
+                UnrecoverableCellReason::ChainFork(
+                    holochain_types::app::WarrantSummary {
+                        author: fixt!(AgentPubKey),
+                        warrantee: fixt!(AgentPubKey),
+                        timestamp: Timestamp::now(),
+                    },
+                ),
+            );
+
+        assert_eq!(state.enabled_apps().count(), 0);
+        assert_eq!(state.disabled_apps().count(), 0);
+        assert_eq!(state.awaiting_restore_apps().count(), 0);
+        assert_eq!(state.installed_apps().len(), 1);
+        let _ = installed;
+    }
+
+    #[test]
     fn awaiting_restore_apps_iterator() {
         let mut state = ConductorState::default();
         let agent = fixt!(AgentPubKey);

--- a/crates/holochain/src/conductor/state.rs
+++ b/crates/holochain/src/conductor/state.rs
@@ -187,7 +187,9 @@ impl ConductorState {
     }
 
     /// Iterate over only the "awaiting_restore" apps.
-    pub fn awaiting_restore_apps(&self) -> impl Iterator<Item = (&InstalledAppId, &InstalledApp)> + '_ {
+    pub fn awaiting_restore_apps(
+        &self,
+    ) -> impl Iterator<Item = (&InstalledAppId, &InstalledApp)> + '_ {
         self.installed_apps
             .iter()
             .filter(|(_, app)| app.status == AppStatus::AwaitingRestore)
@@ -397,17 +399,14 @@ mod tests {
         )
         .unwrap();
         let installed = state.add_app(app).unwrap();
-        state.get_app_mut(&app_id.to_string()).unwrap().status =
-            AppStatus::Unrecoverable(
-                CellId::new(dna_hash, agent),
-                UnrecoverableCellReason::ChainFork(
-                    holochain_types::app::WarrantSummary {
-                        author: fixt!(AgentPubKey),
-                        warrantee: fixt!(AgentPubKey),
-                        timestamp: Timestamp::now(),
-                    },
-                ),
-            );
+        state.get_app_mut(&app_id.to_string()).unwrap().status = AppStatus::Unrecoverable(
+            CellId::new(dna_hash, agent),
+            UnrecoverableCellReason::ChainFork(Box::new(holochain_types::app::WarrantSummary {
+                author: fixt!(AgentPubKey),
+                warrantee: fixt!(AgentPubKey),
+                timestamp: Timestamp::now(),
+            })),
+        );
 
         assert_eq!(state.enabled_apps().count(), 0);
         assert_eq!(state.disabled_apps().count(), 0);
@@ -427,14 +426,8 @@ mod tests {
             .build()
             .unwrap();
         let app_id = "restore_app";
-        let app = InstalledAppCommon::new(
-            app_id,
-            agent,
-            [],
-            app_manifest.into(),
-            Timestamp::now(),
-        )
-        .unwrap();
+        let app = InstalledAppCommon::new(app_id, agent, [], app_manifest.into(), Timestamp::now())
+            .unwrap();
 
         state.add_app_awaiting_restore(app).unwrap();
 

--- a/crates/holochain/src/conductor/state.rs
+++ b/crates/holochain/src/conductor/state.rs
@@ -401,11 +401,13 @@ mod tests {
         let installed = state.add_app(app).unwrap();
         state.get_app_mut(&app_id.to_string()).unwrap().status = AppStatus::Unrecoverable(
             CellId::new(dna_hash, agent),
-            UnrecoverableCellReason::ChainForkWarrant(Box::new(holochain_types::app::WarrantSummary {
-                author: fixt!(AgentPubKey),
-                warrantee: fixt!(AgentPubKey),
-                timestamp: Timestamp::now(),
-            })),
+            UnrecoverableCellReason::ChainForkWarrant(Box::new(
+                holochain_types::app::WarrantSummary {
+                    author: fixt!(AgentPubKey),
+                    warrantee: fixt!(AgentPubKey),
+                    timestamp: Timestamp::now(),
+                },
+            )),
         );
 
         assert_eq!(state.enabled_apps().count(), 0);

--- a/crates/holochain/tests/tests/app_install/mod.rs
+++ b/crates/holochain/tests/tests/app_install/mod.rs
@@ -91,6 +91,7 @@ async fn can_install_app_with_custom_modifiers_overridden_correctly() {
             network_seed: Some(network_seed_override.into()),
             roles_settings: None,
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -104,6 +105,7 @@ async fn can_install_app_with_custom_modifiers_overridden_correctly() {
             network_seed: Some(network_seed_override.into()),
             roles_settings: Some(HashMap::from([role_settings])),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -246,6 +248,7 @@ async fn install_app_with_custom_modifier_fields_none_does_not_override_existing
             network_seed: None,
             roles_settings: Some(HashMap::from([role_settings])),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -299,6 +302,7 @@ async fn installing_with_modifiers_for_non_existing_role_fails() {
             network_seed: Some("final seed".into()),
             roles_settings: Some(HashMap::from([role_settings])),
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await;
 
@@ -335,6 +339,7 @@ async fn providing_membrane_proof_overrides_deferred_provisioning() {
             roles_settings: Some(HashMap::from([role_settings])),
             network_seed: None,
             ignore_genesis_failure: false,
+            restore_from_dht: false,
         })
         .await
         .unwrap();
@@ -355,4 +360,58 @@ async fn providing_membrane_proof_overrides_deferred_provisioning() {
     let app_info = conductor.get_app_info(&app_id).await.unwrap().unwrap();
 
     assert_eq!(app_info.status, AppStatus::Enabled);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_requires_agent_key() {
+    use holochain_types::prelude::*;
+
+    let conductor = SweetConductor::standard().await;
+    let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+    let bundle = AppBundle::new(
+        AppManifestCurrentBuilder::default()
+            .name("test".into())
+            .description(None)
+            .roles(vec![AppRoleManifest {
+                name: "role".into(),
+                dna: AppRoleDnaManifest {
+                    path: Some(format!("{}", dna.dna_hash())),
+                    modifiers: DnaModifiersOpt::default(),
+                    installed_hash: None,
+                    clone_limit: 0,
+                },
+                provisioning: Some(CellProvisioning::Create { deferred: false }),
+            }])
+            .build()
+            .unwrap()
+            .into(),
+        vec![(
+            format!("{}", dna.dna_hash()),
+            DnaBundle::from_dna_file(dna).unwrap(),
+        )],
+    )
+    .unwrap();
+
+    let result = conductor
+        .clone()
+        .install_app_bundle(InstallAppPayload {
+            agent_key: None,
+            source: AppBundleSource::Bytes(bundle.pack().unwrap()),
+            installed_app_id: Some("restore_test".into()),
+            network_seed: None,
+            roles_settings: None,
+            ignore_genesis_failure: false,
+            restore_from_dht: true,
+        })
+        .await;
+
+    assert!(
+        result.is_err(),
+        "expected error when restore_from_dht=true and agent_key=None"
+    );
+    let err = result.unwrap_err();
+    assert!(
+        err.to_string().contains("restore") || err.to_string().contains("agent_key"),
+        "unexpected error: {err}"
+    );
 }

--- a/crates/holochain/tests/tests/app_install/mod.rs
+++ b/crates/holochain/tests/tests/app_install/mod.rs
@@ -415,3 +415,126 @@ async fn restore_requires_agent_key() {
         "unexpected error: {err}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_key_not_in_lair_is_rejected() {
+    use holochain::conductor::error::ConductorError;
+    use holo_hash::fixt::AgentPubKeyFixturator;
+    use holochain_types::prelude::*;
+
+    let conductor = SweetConductor::standard().await;
+    let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+    let bundle = AppBundle::new(
+        AppManifestCurrentBuilder::default()
+            .name("test".into())
+            .description(None)
+            .roles(vec![AppRoleManifest {
+                name: "role".into(),
+                dna: AppRoleDnaManifest {
+                    path: Some(format!("{}", dna.dna_hash())),
+                    modifiers: DnaModifiersOpt::default(),
+                    installed_hash: None,
+                    clone_limit: 0,
+                },
+                provisioning: Some(CellProvisioning::Create { deferred: false }),
+            }])
+            .build()
+            .unwrap()
+            .into(),
+        vec![(
+            format!("{}", dna.dna_hash()),
+            DnaBundle::from_dna_file(dna).unwrap(),
+        )],
+    )
+    .unwrap();
+    let bundle_bytes = bundle.pack().unwrap();
+
+    // A random key that was never registered in the keystore.
+    let key_not_in_lair = ::fixt::fixt!(AgentPubKey, Unpredictable);
+
+    // Plain install with a key not in Lair.
+    let result = conductor
+        .clone()
+        .install_app_bundle(InstallAppPayload {
+            agent_key: Some(key_not_in_lair.clone()),
+            source: AppBundleSource::Bytes(bundle_bytes.clone()),
+            installed_app_id: Some("plain_install".into()),
+            network_seed: None,
+            roles_settings: None,
+            ignore_genesis_failure: false,
+            restore_from_dht: false,
+        })
+        .await;
+    assert!(
+        matches!(result.unwrap_err(), ConductorError::AgentKeyNotInKeystore(_)),
+        "expected AgentKeyNotInKeystore for plain install with key not in Lair"
+    );
+
+    // Restore install with the same key not in Lair.
+    let result = conductor
+        .clone()
+        .install_app_bundle(InstallAppPayload {
+            agent_key: Some(key_not_in_lair),
+            source: AppBundleSource::Bytes(bundle_bytes),
+            installed_app_id: Some("restore_install".into()),
+            network_seed: None,
+            roles_settings: None,
+            ignore_genesis_failure: false,
+            restore_from_dht: true,
+        })
+        .await;
+    assert!(
+        matches!(result.unwrap_err(), ConductorError::AgentKeyNotInKeystore(_)),
+        "expected AgentKeyNotInKeystore for restore install with key not in Lair"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_key_in_lair_is_accepted() {
+    use holochain_types::prelude::*;
+
+    let conductor = SweetConductor::standard().await;
+    let (dna, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+    let bundle = AppBundle::new(
+        AppManifestCurrentBuilder::default()
+            .name("test".into())
+            .description(None)
+            .roles(vec![AppRoleManifest {
+                name: "role".into(),
+                dna: AppRoleDnaManifest {
+                    path: Some(format!("{}", dna.dna_hash())),
+                    modifiers: DnaModifiersOpt::default(),
+                    installed_hash: None,
+                    clone_limit: 0,
+                },
+                provisioning: Some(CellProvisioning::Create { deferred: false }),
+            }])
+            .build()
+            .unwrap()
+            .into(),
+        vec![(
+            format!("{}", dna.dna_hash()),
+            DnaBundle::from_dna_file(dna.clone()).unwrap(),
+        )],
+    )
+    .unwrap();
+    let bundle_bytes = bundle.pack().unwrap();
+
+    // Generate a key that IS in the keystore.
+    let key_in_lair = conductor.keystore().new_sign_keypair_random().await.unwrap();
+
+    let result = conductor
+        .clone()
+        .install_app_bundle(InstallAppPayload {
+            agent_key: Some(key_in_lair),
+            source: AppBundleSource::Bytes(bundle_bytes),
+            installed_app_id: Some("key_in_lair".into()),
+            network_seed: None,
+            roles_settings: None,
+            ignore_genesis_failure: false,
+            restore_from_dht: false,
+        })
+        .await;
+
+    assert!(result.is_ok(), "expected success when key is in Lair: {result:?}");
+}

--- a/crates/holochain/tests/tests/app_install/mod.rs
+++ b/crates/holochain/tests/tests/app_install/mod.rs
@@ -418,8 +418,8 @@ async fn restore_requires_agent_key() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn agent_key_not_in_lair_is_rejected() {
-    use holochain::conductor::error::ConductorError;
     use holo_hash::fixt::AgentPubKeyFixturator;
+    use holochain::conductor::error::ConductorError;
     use holochain_types::prelude::*;
 
     let conductor = SweetConductor::standard().await;
@@ -466,7 +466,10 @@ async fn agent_key_not_in_lair_is_rejected() {
         })
         .await;
     assert!(
-        matches!(result.unwrap_err(), ConductorError::AgentKeyNotInKeystore(_)),
+        matches!(
+            result.unwrap_err(),
+            ConductorError::AgentKeyNotInKeystore(_)
+        ),
         "expected AgentKeyNotInKeystore for plain install with key not in Lair"
     );
 
@@ -484,7 +487,10 @@ async fn agent_key_not_in_lair_is_rejected() {
         })
         .await;
     assert!(
-        matches!(result.unwrap_err(), ConductorError::AgentKeyNotInKeystore(_)),
+        matches!(
+            result.unwrap_err(),
+            ConductorError::AgentKeyNotInKeystore(_)
+        ),
         "expected AgentKeyNotInKeystore for restore install with key not in Lair"
     );
 }
@@ -521,7 +527,11 @@ async fn agent_key_in_lair_is_accepted() {
     let bundle_bytes = bundle.pack().unwrap();
 
     // Generate a key that IS in the keystore.
-    let key_in_lair = conductor.keystore().new_sign_keypair_random().await.unwrap();
+    let key_in_lair = conductor
+        .keystore()
+        .new_sign_keypair_random()
+        .await
+        .unwrap();
 
     let result = conductor
         .clone()
@@ -536,5 +546,8 @@ async fn agent_key_in_lair_is_accepted() {
         })
         .await;
 
-    assert!(result.is_ok(), "expected success when key is in Lair: {result:?}");
+    assert!(
+        result.is_ok(),
+        "expected success when key is in Lair: {result:?}"
+    );
 }

--- a/crates/holochain/tests/tests/app_install/mod.rs
+++ b/crates/holochain/tests/tests/app_install/mod.rs
@@ -417,7 +417,7 @@ async fn restore_requires_agent_key() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn agent_key_not_in_lair_is_rejected() {
+async fn install_with_agent_key_not_in_lair_is_rejected() {
     use holo_hash::fixt::AgentPubKeyFixturator;
     use holochain::conductor::error::ConductorError;
     use holochain_types::prelude::*;
@@ -496,7 +496,7 @@ async fn agent_key_not_in_lair_is_rejected() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn agent_key_in_lair_is_accepted() {
+async fn install_with_existing_agent_key_in_lair_is_accepted() {
     use holochain_types::prelude::*;
 
     let conductor = SweetConductor::standard().await;

--- a/crates/holochain/tests/tests/test_utils/mod.rs
+++ b/crates/holochain/tests/tests/test_utils/mod.rs
@@ -320,6 +320,7 @@ pub async fn register_and_install_dna_named(
         network_seed: None,
         roles_settings: Default::default(),
         ignore_genesis_failure: false,
+        restore_from_dht: false,
     };
     let request = AdminRequest::InstallApp(Box::new(payload));
     let response = client.request(request);

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -603,6 +603,10 @@ pub enum AppStatusFilter {
     Enabled,
     /// Filter on apps which are Disabled.
     Disabled,
+    /// Filter on apps whose source-chain restore is in progress.
+    AwaitingRestore,
+    /// Filter on apps whose source-chain restore has permanently failed.
+    Unrecoverable,
 }
 
 /// Informational response for listing app interfaces.

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -141,6 +141,13 @@ pub struct ConductorConfig {
     #[serde(default = "default_incoming_request_concurrency_limit")]
     pub incoming_request_concurrency_limit: u16,
 
+    /// Number of peers that must agree on the chain head during source-chain restore.
+    ///
+    /// Increasing this value raises the cost of feeding a restoring agent a fabricated history
+    /// but also raises the chance that restore fails on small or poorly-connected DHTs.
+    #[serde(default = "default_restore_chain_quorum")]
+    pub restore_chain_quorum: u8,
+
     /// Tuning parameters to adjust the behaviour of the conductor.
     #[serde(default)]
     pub tuning_params: Option<ConductorTuningParams>,
@@ -166,6 +173,10 @@ fn default_incoming_request_concurrency_limit() -> u16 {
     std::cmp::max(default_db_max_readers() - 3, 1)
 }
 
+fn default_restore_chain_quorum() -> u8 {
+    2
+}
+
 impl Default for ConductorConfig {
     fn default() -> Self {
         Self {
@@ -178,6 +189,7 @@ impl Default for ConductorConfig {
             db_sync_strategy: DbSyncStrategy::default(),
             db_max_readers: default_db_max_readers(),
             incoming_request_concurrency_limit: default_incoming_request_concurrency_limit(),
+            restore_chain_quorum: default_restore_chain_quorum(),
             tuning_params: None,
             tracing_scope: None,
         }
@@ -849,6 +861,7 @@ mod tests {
                 tuning_params: None,
                 tracing_scope: None,
                 incoming_request_concurrency_limit: default_incoming_request_concurrency_limit(),
+                restore_chain_quorum: default_restore_chain_quorum(),
             }
         );
     }
@@ -1032,6 +1045,7 @@ admin_interfaces:
                 db_sync_strategy: DbSyncStrategy::Fast,
                 db_max_readers: 100,
                 incoming_request_concurrency_limit: 100,
+                restore_chain_quorum: default_restore_chain_quorum(),
                 tuning_params: None,
                 tracing_scope: None,
             }
@@ -1063,6 +1077,7 @@ admin_interfaces:
                 tuning_params: None,
                 tracing_scope: None,
                 incoming_request_concurrency_limit: default_incoming_request_concurrency_limit(),
+                restore_chain_quorum: default_restore_chain_quorum(),
             }
         );
     }
@@ -1250,5 +1265,28 @@ admin_interfaces:
         let default_config_json = serde_json::to_value(&default_config).unwrap();
 
         jsonschema::validate(&schema_json, &default_config_json).unwrap();
+    }
+
+    #[test]
+    fn config_restore_chain_quorum_default() {
+        let yaml = r#"---
+    data_root_path: /path/to/env
+    keystore:
+      type: danger_test_keystore
+    "#;
+        let result: ConductorConfig = config_from_yaml(yaml).unwrap();
+        assert_eq!(result.restore_chain_quorum, 2);
+    }
+
+    #[test]
+    fn config_restore_chain_quorum_explicit() {
+        let yaml = r#"---
+    data_root_path: /path/to/env
+    keystore:
+      type: danger_test_keystore
+    restore_chain_quorum: 5
+    "#;
+        let result: ConductorConfig = config_from_yaml(yaml).unwrap();
+        assert_eq!(result.restore_chain_quorum, 5);
     }
 }

--- a/crates/holochain_conductor_api/src/config/conductor.rs
+++ b/crates/holochain_conductor_api/src/config/conductor.rs
@@ -145,7 +145,10 @@ pub struct ConductorConfig {
     ///
     /// Increasing this value raises the cost of feeding a restoring agent a fabricated history
     /// but also raises the chance that restore fails on small or poorly-connected DHTs.
-    #[serde(default = "default_restore_chain_quorum")]
+    #[serde(
+        default = "default_restore_chain_quorum",
+        deserialize_with = "deserialize_restore_chain_quorum"
+    )]
     pub restore_chain_quorum: u8,
 
     /// Tuning parameters to adjust the behaviour of the conductor.
@@ -175,6 +178,19 @@ fn default_incoming_request_concurrency_limit() -> u16 {
 
 fn default_restore_chain_quorum() -> u8 {
     2
+}
+
+fn deserialize_restore_chain_quorum<'de, D>(deserializer: D) -> Result<u8, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = u8::deserialize(deserializer)?;
+    if value == 0 {
+        return Err(serde::de::Error::custom(
+            "restore_chain_quorum must be greater than 0",
+        ));
+    }
+    Ok(value)
 }
 
 impl Default for ConductorConfig {
@@ -1288,5 +1304,17 @@ admin_interfaces:
     "#;
         let result: ConductorConfig = config_from_yaml(yaml).unwrap();
         assert_eq!(result.restore_chain_quorum, 5);
+    }
+
+    #[test]
+    fn config_restore_chain_quorum_rejects_zero() {
+        let yaml = r#"---
+    data_root_path: /path/to/env
+    keystore:
+      type: danger_test_keystore
+    restore_chain_quorum: 0
+    "#;
+        let result: ConductorConfigResult<ConductorConfig> = config_from_yaml(yaml);
+        assert_matches!(result, Err(ConductorConfigError::SerializationError(_)));
     }
 }

--- a/crates/holochain_data/src/models/conductor.rs
+++ b/crates/holochain_data/src/models/conductor.rs
@@ -42,6 +42,12 @@ impl InstalledAppModel {
                 ("disabled".to_string(), Some(reason_json))
             }
             AppStatus::AwaitingMemproofs => ("awaiting_memproofs".to_string(), None),
+            AppStatus::AwaitingRestore => ("awaiting_restore".to_string(), None),
+            AppStatus::Unrecoverable(cell_id, reason) => {
+                let payload = serde_json::to_string(&(cell_id, reason))
+                    .map_err(|e| format!("Failed to serialize unrecoverable payload: {}", e))?;
+                ("unrecoverable".to_string(), Some(payload))
+            }
         };
 
         // Serialize the manifest using serde
@@ -96,6 +102,18 @@ impl InstalledAppModel {
                 AppStatus::Disabled(reason)
             }
             "awaiting_memproofs" => AppStatus::AwaitingMemproofs,
+            "awaiting_restore" => AppStatus::AwaitingRestore,
+            "unrecoverable" => {
+                let payload_str = self
+                    .disabled_reason
+                    .as_ref()
+                    .ok_or_else(|| "Missing unrecoverable payload".to_string())?;
+                let (cell_id, reason): (CellId, UnrecoverableCellReason) =
+                    serde_json::from_str(payload_str).map_err(|e| {
+                        format!("Failed to deserialize unrecoverable payload: {}", e)
+                    })?;
+                AppStatus::Unrecoverable(cell_id, reason)
+            }
             _ => return Err(format!("Unknown status: {}", self.status)),
         };
 

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -741,6 +741,41 @@ impl InstalledAppCommon {
     }
 }
 
+/// Compact, operator-visible summary of a [`SignedWarrant`].
+///
+/// Carries just enough to identify the warrant for debugging;
+/// the variant of [`UnrecoverableCellReason`] tells the operator what kind it is.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, SerializedBytes)]
+pub struct WarrantSummary {
+    /// The peer that authored and signed the warrant.
+    pub author: AgentPubKey,
+    /// The agent against whom the warrant was issued.
+    pub warrantee: AgentPubKey,
+    /// When the warrant was issued.
+    pub timestamp: Timestamp,
+}
+
+impl From<SignedWarrant> for WarrantSummary {
+    fn from(sw: SignedWarrant) -> Self {
+        let w = sw.into_data();
+        Self {
+            author: w.author,
+            warrantee: w.warrantee,
+            timestamp: w.timestamp,
+        }
+    }
+}
+
+/// Reason a cell's source chain is unrecoverable via restore.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, SerializedBytes)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum UnrecoverableCellReason {
+    /// Two or more conflicting actions at the same sequence position (proven chain fork).
+    ChainFork(WarrantSummary),
+    /// Another validated [`ChainIntegrityWarrant`] variant (e.g. `InvalidChainOp`).
+    ChainIntegrityWarrant(WarrantSummary),
+}
+
 /// The status of an installed app.
 ///
 /// Either Enabled or Disabled, set by the user via the conductor admin interface.
@@ -1154,5 +1189,30 @@ mod tests {
             serde_json::to_string(&reason).unwrap(),
             "{\"type\":\"user\"}"
         );
+    }
+
+    #[test]
+    fn warrant_summary_serde_round_trip() {
+        let summary = WarrantSummary {
+            author: fixt!(AgentPubKey),
+            warrantee: fixt!(AgentPubKey),
+            timestamp: Timestamp::from_micros(1_000_000),
+        };
+        let bytes = SerializedBytes::try_from(&summary).unwrap();
+        let recovered: WarrantSummary = bytes.try_into().unwrap();
+        assert_eq!(summary, recovered);
+    }
+
+    #[test]
+    fn unrecoverable_cell_reason_serde_round_trip() {
+        let summary = WarrantSummary {
+            author: fixt!(AgentPubKey),
+            warrantee: fixt!(AgentPubKey),
+            timestamp: Timestamp::from_micros(1_000_000),
+        };
+        let reason = UnrecoverableCellReason::ChainFork(summary);
+        let bytes = SerializedBytes::try_from(&reason).unwrap();
+        let recovered: UnrecoverableCellReason = bytes.try_into().unwrap();
+        assert_eq!(reason, recovered);
     }
 }

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -135,6 +135,12 @@ pub struct InstallAppPayload {
     /// This can be useful for diagnostics.
     #[serde(default)]
     pub ignore_genesis_failure: bool,
+
+    /// If true, suppress genesis for all cells in this app and instead reconstruct each cell's
+    /// source chain by fetching the agent's prior chain from the DHT.
+    /// Requires `agent_key` to be `Some`.
+    #[serde(default)]
+    pub restore_from_dht: bool,
 }
 
 /// Alias

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -777,9 +777,9 @@ impl From<SignedWarrant> for WarrantSummary {
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
 pub enum UnrecoverableCellReason {
     /// Two or more conflicting actions at the same sequence position (proven chain fork).
-    ChainFork(WarrantSummary),
+    ChainFork(Box<WarrantSummary>),
     /// Another validated [`ChainIntegrityWarrant`] variant (e.g. `InvalidChainOp`).
-    ChainIntegrityWarrant(WarrantSummary),
+    ChainIntegrityWarrant(Box<WarrantSummary>),
 }
 
 /// The status of an installed app.
@@ -1224,7 +1224,7 @@ mod tests {
             warrantee: fixt!(AgentPubKey),
             timestamp: Timestamp::from_micros(1_000_000),
         };
-        let reason = UnrecoverableCellReason::ChainFork(summary);
+        let reason = UnrecoverableCellReason::ChainFork(Box::new(summary));
         let bytes = SerializedBytes::try_from(&reason).unwrap();
         let recovered: UnrecoverableCellReason = bytes.try_into().unwrap();
         assert_eq!(reason, recovered);
@@ -1249,7 +1249,7 @@ mod tests {
             warrantee: fixt!(AgentPubKey),
             timestamp: Timestamp::from_micros(1_000_000),
         };
-        let reason = UnrecoverableCellReason::ChainFork(summary);
+        let reason = UnrecoverableCellReason::ChainFork(Box::new(summary));
         let status = AppStatus::Unrecoverable(cell_id, reason);
         let json = serde_json::to_string(&status).unwrap();
         let recovered: AppStatus = serde_json::from_str(&json).unwrap();

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -789,6 +789,14 @@ pub enum AppStatus {
     /// The app is installed, but genesis has not completed because Membrane Proofs
     /// have not been provided.
     AwaitingMemproofs,
+    /// Restore is in progress for one or more of the app's cells. Zome calls are rejected.
+    /// Transitions to Disabled(NeverStarted) once every cell has restored, or to
+    /// Unrecoverable if any cell fails permanently.
+    AwaitingRestore,
+    /// Restore hit a permanent failure: a locally-validated ChainIntegrityWarrant against the
+    /// agent. Terminal — the app cannot be enabled and must be uninstalled.
+    /// The CellId identifies which cell triggered the failure.
+    Unrecoverable(CellId, UnrecoverableCellReason),
 }
 
 /// The reason for an app being in a Disabled state.
@@ -1214,5 +1222,31 @@ mod tests {
         let bytes = SerializedBytes::try_from(&reason).unwrap();
         let recovered: UnrecoverableCellReason = bytes.try_into().unwrap();
         assert_eq!(reason, recovered);
+    }
+
+    #[test]
+    fn app_status_awaiting_restore_serialization() {
+        let status = AppStatus::AwaitingRestore;
+        assert_eq!(
+            serde_json::to_string(&status).unwrap(),
+            r#"{"type":"awaiting_restore"}"#
+        );
+        let recovered: AppStatus = serde_json::from_str(r#"{"type":"awaiting_restore"}"#).unwrap();
+        assert_eq!(status, recovered);
+    }
+
+    #[test]
+    fn app_status_unrecoverable_serialization() {
+        let cell_id = CellId::new(fixt!(DnaHash), fixt!(AgentPubKey));
+        let summary = WarrantSummary {
+            author: fixt!(AgentPubKey),
+            warrantee: fixt!(AgentPubKey),
+            timestamp: Timestamp::from_micros(1_000_000),
+        };
+        let reason = UnrecoverableCellReason::ChainFork(summary);
+        let status = AppStatus::Unrecoverable(cell_id, reason);
+        let json = serde_json::to_string(&status).unwrap();
+        let recovered: AppStatus = serde_json::from_str(&json).unwrap();
+        assert_eq!(status, recovered);
     }
 }

--- a/crates/holochain_types/src/app.rs
+++ b/crates/holochain_types/src/app.rs
@@ -777,7 +777,7 @@ impl From<SignedWarrant> for WarrantSummary {
 #[serde(tag = "type", content = "value", rename_all = "snake_case")]
 pub enum UnrecoverableCellReason {
     /// Two or more conflicting actions at the same sequence position (proven chain fork).
-    ChainFork(Box<WarrantSummary>),
+    ChainForkWarrant(Box<WarrantSummary>),
     /// Another validated [`ChainIntegrityWarrant`] variant (e.g. `InvalidChainOp`).
     ChainIntegrityWarrant(Box<WarrantSummary>),
 }
@@ -1224,7 +1224,7 @@ mod tests {
             warrantee: fixt!(AgentPubKey),
             timestamp: Timestamp::from_micros(1_000_000),
         };
-        let reason = UnrecoverableCellReason::ChainFork(Box::new(summary));
+        let reason = UnrecoverableCellReason::ChainForkWarrant(Box::new(summary));
         let bytes = SerializedBytes::try_from(&reason).unwrap();
         let recovered: UnrecoverableCellReason = bytes.try_into().unwrap();
         assert_eq!(reason, recovered);
@@ -1249,7 +1249,7 @@ mod tests {
             warrantee: fixt!(AgentPubKey),
             timestamp: Timestamp::from_micros(1_000_000),
         };
-        let reason = UnrecoverableCellReason::ChainFork(Box::new(summary));
+        let reason = UnrecoverableCellReason::ChainForkWarrant(Box::new(summary));
         let status = AppStatus::Unrecoverable(cell_id, reason);
         let json = serde_json::to_string(&status).unwrap();
         let recovered: AppStatus = serde_json::from_str(&json).unwrap();

--- a/crates/holochain_types/src/signal.rs
+++ b/crates/holochain_types/src/signal.rs
@@ -60,8 +60,8 @@ pub enum SystemSignal {
         /// The app that finished restoring.
         installed_app_id: InstalledAppId,
     },
-    /// A cell's restore hit a permanent failure (validated ChainIntegrityWarrant). The whole
-    /// app transitions to Unrecoverable at the same moment.
+    /// A cell's restore hit a permanent failure (e.g. validated ChainIntegrityWarrant). The whole
+    /// app transitions to [`AppStatus::Unrecoverable`] at the same moment.
     RestoreFailed {
         /// The cell that failed to restore.
         cell_id: CellId,
@@ -96,7 +96,7 @@ mod tests {
             warrantee: fixt!(AgentPubKey),
             timestamp: Timestamp::from_micros(1_000_000),
         };
-        let reason = UnrecoverableCellReason::ChainFork(Box::new(summary));
+        let reason = UnrecoverableCellReason::ChainForkWarrant(Box::new(summary));
 
         let signals: Vec<SystemSignal> = vec![
             SystemSignal::RestoreComplete {

--- a/crates/holochain_types/src/signal.rs
+++ b/crates/holochain_types/src/signal.rs
@@ -61,7 +61,7 @@ pub enum SystemSignal {
         installed_app_id: InstalledAppId,
     },
     /// A cell's restore hit a permanent failure (e.g. validated ChainIntegrityWarrant). The whole
-    /// app transitions to [`AppStatus::Unrecoverable`] at the same moment.
+    /// app transitions to [`crate::app::AppStatus::Unrecoverable`] at the same moment.
     RestoreFailed {
         /// The cell that failed to restore.
         cell_id: CellId,

--- a/crates/holochain_types/src/signal.rs
+++ b/crates/holochain_types/src/signal.rs
@@ -3,6 +3,7 @@
 //! - App-defined signals are produced via the `emit_signal` host function.
 //! - System-defined signals are produced in various places in the system
 
+use crate::app::{InstalledAppId, UnrecoverableCellReason};
 use crate::impl_from;
 use holochain_serialized_bytes::prelude::*;
 use holochain_zome_types::prelude::*;
@@ -49,6 +50,24 @@ pub enum SystemSignal {
     SuccessfulCountersigning(EntryHash),
     /// A countersigning session has been abandoned.
     AbandonedCountersigning(EntryHash),
+    /// A single cell within an app has finished restoring its source chain from the DHT.
+    RestoreComplete {
+        /// The cell that finished restoring.
+        cell_id: CellId,
+    },
+    /// All cells of an app have finished restoring; the app is now Disabled(NeverStarted).
+    AppRestoreComplete {
+        /// The app that finished restoring.
+        installed_app_id: InstalledAppId,
+    },
+    /// A cell's restore hit a permanent failure (validated ChainIntegrityWarrant). The whole
+    /// app transitions to Unrecoverable at the same moment.
+    RestoreFailed {
+        /// The cell that failed to restore.
+        cell_id: CellId,
+        /// Why the restore is unrecoverable.
+        reason: UnrecoverableCellReason,
+    },
 }
 
 impl_from! {
@@ -61,3 +80,41 @@ pub const DIRECT_SIGNAL_MAX_SIZE: usize = 1024 * 1024;
 /// Wrapper type for transmitting a signed direct signal over the network.
 #[derive(Debug, Clone, Serialize, Deserialize, SerializedBytes)]
 pub struct DirectSignal(pub Vec<u8>);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{UnrecoverableCellReason, WarrantSummary};
+    use ::fixt::prelude::*;
+    use holo_hash::fixt::*;
+
+    #[test]
+    fn restore_system_signals_serde_round_trip() {
+        let cell_id = CellId::new(fixt!(DnaHash), fixt!(AgentPubKey));
+        let summary = WarrantSummary {
+            author: fixt!(AgentPubKey),
+            warrantee: fixt!(AgentPubKey),
+            timestamp: Timestamp::from_micros(1_000_000),
+        };
+        let reason = UnrecoverableCellReason::ChainFork(summary);
+
+        let signals: Vec<SystemSignal> = vec![
+            SystemSignal::RestoreComplete {
+                cell_id: cell_id.clone(),
+            },
+            SystemSignal::AppRestoreComplete {
+                installed_app_id: "my_app".to_string(),
+            },
+            SystemSignal::RestoreFailed {
+                cell_id: cell_id.clone(),
+                reason: reason.clone(),
+            },
+        ];
+
+        for signal in &signals {
+            let json = serde_json::to_string(signal).unwrap();
+            let recovered: SystemSignal = serde_json::from_str(&json).unwrap();
+            assert_eq!(signal, &recovered);
+        }
+    }
+}

--- a/crates/holochain_types/src/signal.rs
+++ b/crates/holochain_types/src/signal.rs
@@ -96,7 +96,7 @@ mod tests {
             warrantee: fixt!(AgentPubKey),
             timestamp: Timestamp::from_micros(1_000_000),
         };
-        let reason = UnrecoverableCellReason::ChainFork(summary);
+        let reason = UnrecoverableCellReason::ChainFork(Box::new(summary));
 
         let signals: Vec<SystemSignal> = vec![
             SystemSignal::RestoreComplete {


### PR DESCRIPTION
Implements the first issue in the source-chain-restore series. Scope is purely type-level groundwork — no workflow logic or p2p changes.

- `WarrantSummary` / `UnrecoverableCellReason` types in `holochain_types`
- `AppStatus::AwaitingRestore` and `AppStatus::Unrecoverable` variants, with `holochain_data` serialisation support
- `ConductorState::add_app_awaiting_restore` / `awaiting_restore_apps` helpers
- `SystemSignal::RestoreComplete`, `AppRestoreComplete`, `RestoreFailed` variants
- `ConductorConfig::restore_chain_quorum: u8` (serde default 2)
- `AppStatusFilter::AwaitingRestore` / `Unrecoverable` and corresponding `list_apps` arms
- `InstallAppPayload::restore_from_dht: bool` (serde default false) with admit-time guard requiring an explicit agent key
- `ConductorError::AgentKeyNotInKeystore` and Lair key-presence check at install-admit time