### PR TITLE
Chore: backport #5816 to 0.6

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Make Sweettest documentation available on docs.rs.
+
 ## 0.6.1
 
 ## 0.6.1-rc.8

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -318,3 +318,6 @@ unstable-countersigning = [
   "holochain_zome_types/unstable-countersigning",
   "holochain_conductor_api/unstable-countersigning",
 ]
+
+[package.metadata.docs.rs]
+features = ["test_utils"]


### PR DESCRIPTION
### Summary

Backport #5816 (output Sweettest docs on docs.rs build) to 0.6 line. I hope this is an appropriate way to do backports!

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs