### PR TITLE
Store the source chain in the unified per-DNA database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ Design references: `docs/design/state_model.md` and `docs/design/data_model.md` 
   - Use `#[tokio::test]` by default; only switch to `#[tokio::test(flavor = "multi_thread")]` when the test genuinely needs it.
   - Do not introduce new `proptest` or fuzzing suites.
   - Test functions must not be prefixed with `test_` — the `#[test]` / `#[tokio::test]` attribute already marks them.
+  - Test-support code exposed from library crates must be feature-gated so it never compiles into production builds. Read-only inspection queries (op counts, existence checks) use `#[cfg(any(test, feature = "inspection"))]`; test-only writes and fixture builders use `#[cfg(feature = "test_utils")]` (which also enables `inspection`).
 - **Errors**: prefer `thiserror` for crate error types; `anyhow` is for application/binary code, not library APIs.
 - **Compiler warnings are not OK** in shared code (CONTRIBUTING.md). Fix, surgically `#[allow(...)]`, or escalate — don't disable globally.
 - **Public API docs**: `///` rustdoc on public items; module/crate docs should describe structure.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,6 +3174,7 @@ dependencies = [
  "holochain_zome_types",
  "indexmap 2.14.0",
  "libsqlite3-sys",
+ "opentelemetry 0.31.0",
  "serde_json",
  "sodoken",
  "sqlx",

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- **BREAKING CHANGE**: `DnaStorageInfo` (returned by the `StorageInfo` admin call) drops its `authored_data_size`/`authored_data_size_on_disk` and `cache_data_size`/`cache_data_size_on_disk` fields. An agent's source-chain data now lives in the per-DNA DHT database and is counted in `dht_data_size`/`dht_data_size_on_disk`; the separate cache figure is removed. \#5844
+
 ## 0.7.0-dev.32
 
 - **BREAKING CHANGE** Compiled wasmer modules are now cached in the WASM database (a new `CompiledWasm` table) instead of in a `wasm-cache` directory under the data root. Modules are compiled on demand, persisted as serialized bytes, and rebuilt from those bytes on later loads. The `holochain::conductor::conductor::WASM_CACHE` constant and the on-disk cache directory have been removed. \#5834

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -227,17 +227,6 @@ impl Cell {
     }
 
     pub(super) async fn dispatch_scheduled_fns(self: Arc<Self>, now: Timestamp) {
-        let authored_db = match self.get_or_create_authored_db() {
-            Ok(db) => db,
-            Err(e) => {
-                error!(
-                    "error getting authored db, cannot dispatch scheduled functions: {:?}",
-                    e
-                );
-                return;
-            }
-        };
-
         let author = self.id.agent_pubkey().clone();
         self.space
             .dht_store
@@ -263,25 +252,6 @@ impl Cell {
                     .await
                 {
                     error!("error deleting live ephemeral scheduled functions: {:?}", e);
-                }
-
-                // Also remove live ephemeral rows from the legacy authored DB before
-                // dispatching so that `is_scheduled` checks (which read authored DB)
-                // immediately reflect the correct state when a signal is received.
-                {
-                    let author_for_cleanup = author.clone();
-                    let authored_db_clone = authored_db.clone();
-                    if let Err(e) = authored_db_clone
-                        .write_async(move |txn| {
-                            delete_live_ephemeral_scheduled_fns(txn, now, &author_for_cleanup)
-                        })
-                        .await
-                    {
-                        error!(
-                            "error deleting live ephemeral fns from authored db: {:?}",
-                            e
-                        );
-                    }
                 }
 
                 let mut tasks = vec![];
@@ -328,8 +298,8 @@ impl Cell {
                 let results: Vec<CellResult<ZomeCallResult>> =
                     futures::future::join_all(tasks).await;
 
-                // Pre-compute what each dispatched function should do in the new DHT DB,
-                // mirroring the decisions the legacy `write_async` block will make below.
+                // Decide what each dispatched function should do in the merged
+                // store based on its zome-call result.
                 // `None`         => skip (ephemeral fn, no persistent state to update)
                 // `Some(None)`   => delete (unschedule the persisted fn)
                 // `Some(Some(s))`=> insert/upsert with schedule `s`
@@ -342,7 +312,7 @@ impl Cell {
                                 match extern_io.decode::<Option<Schedule>>() {
                                     Ok(Some(s)) => Some(Some(s)),
                                     // Persisted fn returned None or failed to decode →
-                                    // legacy will unschedule it.
+                                    // unschedule it.
                                     Ok(None) | Err(_) => {
                                         if *ephemeral {
                                             None
@@ -352,7 +322,7 @@ impl Cell {
                                     }
                                 }
                             }
-                            // Any error in the zome call → legacy unschedules persisted fns.
+                            // Any error in the zome call → unschedule persisted fns.
                             _ => {
                                 if *ephemeral {
                                     None
@@ -365,60 +335,7 @@ impl Cell {
                     })
                     .collect();
 
-                let author = self.id.agent_pubkey().clone();
-                // In case of an error, a persisted fn needs to be unscheduled.
-                let legacy_write = authored_db
-                    .write_async(move |txn| {
-                        for ((scheduled_fn, ephemeral), result) in dispatched.into_iter().zip(results.iter()) {
-                            match result {
-                                Ok(Ok(ZomeCallResponse::Ok(extern_io))) => {
-                                    let next_schedule: Schedule = match extern_io.decode() {
-                                        Ok(Some(v)) => v,
-                                        Ok(None) => {
-                                            // If the schedule of a persisted fn is `None` then it should be unscheduled.
-                                            if !ephemeral {
-                                                unschedule_fn(txn, &author, &scheduled_fn);
-                                            }
-                                            continue;
-                                        }
-                                        Err(e) => {
-                                            error!("scheduled zome call error in ExternIO::decode: {:?}", e);
-                                            if !ephemeral {
-                                                unschedule_fn(txn, &author, &scheduled_fn);
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    if let Err(e) = schedule_fn(
-                                        txn,
-                                        &author,
-                                        scheduled_fn.clone(),
-                                        Some(next_schedule),
-                                        now,
-                                    ) {
-                                        error!("scheduled zome call error in schedule_fn: {:?}", e);
-                                        if !ephemeral {
-                                            unschedule_fn(txn, &author, &scheduled_fn);
-                                        }
-                                        continue;
-                                    }
-                                }
-                                errorish => {
-                                    error!("scheduled zome call error: {:?}", errorish);
-                                    if !ephemeral {
-                                        unschedule_fn(txn, &author, &scheduled_fn);
-                                    }
-                                },
-                            }
-                        }
-                        Result::<(), DatabaseError>::Ok(())
-                    })
-                    .await;
-                if let Err(ref err) = legacy_write {
-                    error!("error applying legacy scheduled-fn updates: {:?}", err);
-                }
-
-                // Mirror the unschedule/reschedule decisions in the new DHT DB.
+                // Apply the unschedule/reschedule decisions to the merged store.
                 for (scheduled_fn, action) in new_db_decisions {
                     match action {
                         // Ephemeral fn: no persistent state to update.

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -335,7 +335,7 @@ impl Cell {
                     })
                     .collect();
 
-                // Apply the unschedule/reschedule decisions to the merged store.
+                // Apply the unschedule/reschedule decisions to the DhtStore.
                 for (scheduled_fn, action) in new_db_decisions {
                     match action {
                         // Ephemeral fn: no persistent state to update.

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -37,7 +37,6 @@ use holochain_serialized_bytes::SerializedBytes;
 use holochain_sqlite::prelude::*;
 use holochain_state::host_fn_workspace::SourceChainWorkspace;
 use holochain_state::prelude::*;
-use holochain_state::schedule::live_scheduled_fns;
 use holochain_types::cell_config_overrides::CellConfigOverrides;
 use kitsune2_api::BoxFut;
 use std::hash::Hash;
@@ -240,19 +239,14 @@ impl Cell {
         };
 
         let author = self.id.agent_pubkey().clone();
-        let live_fns = authored_db
-            .write_async(move |txn| {
-                // Rescheduling should not fail as the data in the database
-                // should be valid schedules only.
-                reschedule_expired(txn, now, &author)?;
-                let lives = live_scheduled_fns(txn, now, &author);
-                // We know what to run so we can delete the ephemerals.
-                if lives.is_ok() {
-                    // Failing to delete should rollback this attempt.
-                    delete_live_ephemeral_scheduled_fns(txn, now, &author)?;
-                }
-                lives
-            })
+        self.space
+            .dht_store
+            .reschedule_expired_persisted(&author, now)
+            .await;
+        let live_fns = self
+            .space
+            .dht_store
+            .live_scheduled_functions(&author, now)
             .await;
 
         match live_fns {
@@ -271,10 +265,24 @@ impl Cell {
                     error!("error deleting live ephemeral scheduled functions: {:?}", e);
                 }
 
-                self.space
-                    .dht_store
-                    .reschedule_expired_persisted(&author_for_new_db, now)
-                    .await;
+                // Also remove live ephemeral rows from the legacy authored DB before
+                // dispatching so that `is_scheduled` checks (which read authored DB)
+                // immediately reflect the correct state when a signal is received.
+                {
+                    let author_for_cleanup = author.clone();
+                    let authored_db_clone = authored_db.clone();
+                    if let Err(e) = authored_db_clone
+                        .write_async(move |txn| {
+                            delete_live_ephemeral_scheduled_fns(txn, now, &author_for_cleanup)
+                        })
+                        .await
+                    {
+                        error!(
+                            "error deleting live ephemeral fns from authored db: {:?}",
+                            e
+                        );
+                    }
+                }
 
                 let mut tasks = vec![];
                 let mut dispatched: Vec<(ScheduledFn, bool)> = Vec::with_capacity(live_fns.len());
@@ -444,6 +452,20 @@ impl Cell {
                                     "error upserting scheduled function {:?}: {:?}",
                                     scheduled_fn, e
                                 );
+                                // Upsert failed (e.g. invalid crontab string): remove the
+                                // stale row so it does not trigger an extra dispatch on the
+                                // next scheduler tick.
+                                if let Err(e2) = self
+                                    .space
+                                    .dht_store
+                                    .unschedule_function(&author_for_new_db, &scheduled_fn)
+                                    .await
+                                {
+                                    error!(
+                                        "error unscheduling function {:?} after failed upsert: {:?}",
+                                        scheduled_fn, e2
+                                    );
+                                }
                             }
                         }
                     }

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -843,7 +843,6 @@ mod network_impls {
     };
     use holochain_conductor_api::ZomeCallParamsSigned;
     use holochain_conductor_api::{DnaStorageInfo, StorageBlob, StorageInfo};
-    use holochain_sqlite::stats::{get_size_on_disk, get_used_size};
     use holochain_state::conductor::WitnessNonceResult;
     use holochain_zome_types::block::BlockTargetId;
     use kitsune2_api::Url;
@@ -1021,19 +1020,10 @@ mod network_impls {
         ) -> ConductorResult<StorageBlob> {
             // Get the storage sizes from the DhtStore.
             let dht_store = self.get_or_create_dht_store(dna_hash)?.as_read();
-            let cache_db = self.spaces.cache(dna_hash)?;
 
             Ok(StorageBlob::Dna(DnaStorageInfo {
                 dht_data_size_on_disk: dht_store.size_on_disk().await? as usize,
                 dht_data_size: dht_store.used_size().await? as usize,
-                cache_data_size_on_disk: cache_db
-                    .read_async(get_size_on_disk)
-                    .map_err(ConductorError::DatabaseError)
-                    .await?,
-                cache_data_size: cache_db
-                    .read_async(get_used_size)
-                    .map_err(ConductorError::DatabaseError)
-                    .await?,
                 dna_hash: dna_hash.clone(),
                 used_by: used_by.to_vec(),
             }))

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -841,7 +841,6 @@ mod network_impls {
     use crate::conductor::api::error::{
         zome_call_response_to_conductor_api_result, ConductorApiError,
     };
-    use futures::future::join_all;
     use holochain_conductor_api::ZomeCallParamsSigned;
     use holochain_conductor_api::{DnaStorageInfo, StorageBlob, StorageInfo};
     use holochain_sqlite::stats::{get_size_on_disk, get_used_size};
@@ -1020,39 +1019,15 @@ mod network_impls {
             dna_hash: &DnaHash,
             used_by: &[InstalledAppId],
         ) -> ConductorResult<StorageBlob> {
-            let authored_dbs = self.spaces.get_all_authored_dbs(dna_hash)?;
-            let dht_db = self.spaces.dht_db(dna_hash)?;
+            // The DHT and source-chain (authored) data now live together in the
+            // merged store, so its size is what we report. The legacy
+            // DbKindDht is no longer measured here; it is retired later. // #5370
+            let dht_store = self.get_or_create_dht_store(dna_hash)?.as_read();
             let cache_db = self.spaces.cache(dna_hash)?;
 
             Ok(StorageBlob::Dna(DnaStorageInfo {
-                authored_data_size_on_disk: join_all(
-                    authored_dbs
-                        .iter()
-                        .map(|db| db.read_async(get_size_on_disk)),
-                )
-                .await
-                .into_iter()
-                .map(|r| r.map_err(ConductorError::DatabaseError))
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .sum(),
-                authored_data_size: join_all(
-                    authored_dbs.iter().map(|db| db.read_async(get_used_size)),
-                )
-                .await
-                .into_iter()
-                .map(|r| r.map_err(ConductorError::DatabaseError))
-                .collect::<Result<Vec<_>, _>>()?
-                .into_iter()
-                .sum(),
-                dht_data_size_on_disk: dht_db
-                    .read_async(get_size_on_disk)
-                    .map_err(ConductorError::DatabaseError)
-                    .await?,
-                dht_data_size: dht_db
-                    .read_async(get_used_size)
-                    .map_err(ConductorError::DatabaseError)
-                    .await?,
+                dht_data_size_on_disk: dht_store.size_on_disk().await? as usize,
+                dht_data_size: dht_store.used_size().await? as usize,
                 cache_data_size_on_disk: cache_db
                     .read_async(get_size_on_disk)
                     .map_err(ConductorError::DatabaseError)

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -2559,13 +2559,11 @@ mod misc_impls {
         /// Create a JSON dump of the cell's state
         #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
         pub async fn dump_cell_state(&self, cell_id: &CellId) -> ConductorApiResult<String> {
-            let cell = self.cell_by_id(cell_id).await?;
-            let authored_db = cell.get_or_create_authored_db()?;
             let dht_store = self.get_or_create_dht_store(cell_id.dna_hash())?;
             let agent_pub_key = cell_id.agent_pubkey().clone();
             let peer_dump = peer_store_dump(self, cell_id).await?;
             let source_chain_dump =
-                source_chain::dump_state(authored_db.clone().into(), agent_pub_key).await?;
+                source_chain::dump_state(&dht_store.as_read(), agent_pub_key).await?;
 
             let out = JsonDump {
                 peer_dump,
@@ -2627,11 +2625,9 @@ mod misc_impls {
             cell_id: &CellId,
             dht_ops_cursor: Option<DhtOpsCursor>,
         ) -> ConductorApiResult<FullStateDump> {
-            let authored_db =
-                self.get_or_create_authored_db(cell_id.dna_hash(), cell_id.agent_pubkey().clone())?;
             let dht_store = self.get_or_create_dht_store(cell_id.dna_hash())?;
             let source_chain_dump =
-                source_chain::dump_state(authored_db.into(), cell_id.agent_pubkey().clone())
+                source_chain::dump_state(&dht_store.as_read(), cell_id.agent_pubkey().clone())
                     .await?;
             let peer_dump = peer_store_dump(self, cell_id).await?;
 

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1019,9 +1019,7 @@ mod network_impls {
             dna_hash: &DnaHash,
             used_by: &[InstalledAppId],
         ) -> ConductorResult<StorageBlob> {
-            // The DHT and source-chain (authored) data now live together in the
-            // merged store, so its size is what we report. The legacy
-            // DbKindDht is no longer measured here; it is retired later. // #5370
+            // Get the storage sizes from the DhtStore.
             let dht_store = self.get_or_create_dht_store(dna_hash)?.as_read();
             let cache_db = self.spaces.cache(dna_hash)?;
 
@@ -2265,8 +2263,7 @@ mod scheduler_impls {
             interval_period: std::time::Duration,
         ) -> StateMutationResult<()> {
             // Clear all ephemeral cruft in all spaces before starting a
-            // scheduler. One call per space clears every author, since the
-            // merged store is per-DNA.
+            // scheduler. One call per space clears every author.
             let tasks = self.spaces.get_from_spaces(|space| {
                 let dht_store = space.dht_store.clone();
                 async move {

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -2264,19 +2264,17 @@ mod scheduler_impls {
             self: Arc<Self>,
             interval_period: std::time::Duration,
         ) -> StateMutationResult<()> {
-            // Clear all ephemeral cruft in all cells before starting a scheduler.
-            let tasks = self
-                .spaces
-                .get_from_spaces(|space| {
-                    let all_dbs = space.get_all_authored_dbs();
-
-                    all_dbs.into_iter().map(|db| async move {
-                        db.write_async(|txn| delete_all_ephemeral_scheduled_fns(txn))
-                            .await
-                    })
-                })
-                .into_iter()
-                .flatten();
+            // Clear all ephemeral cruft in all spaces before starting a
+            // scheduler. One call per space clears every author, since the
+            // merged store is per-DNA.
+            let tasks = self.spaces.get_from_spaces(|space| {
+                let dht_store = space.dht_store.clone();
+                async move {
+                    if let Err(e) = dht_store.delete_all_ephemeral_scheduled_functions().await {
+                        error!("error clearing ephemeral scheduled functions: {:?}", e);
+                    }
+                }
+            });
 
             futures::future::join_all(tasks).await;
 

--- a/crates/holochain/src/conductor/conductor/tests/state_dump.rs
+++ b/crates/holochain/src/conductor/conductor/tests/state_dump.rs
@@ -7,6 +7,7 @@ use holo_hash::ActionHash;
 use holochain_conductor_api::FullStateDump;
 use holochain_state::source_chain;
 use holochain_wasm_test_utils::TestWasm;
+use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn dump_full_state() {
@@ -35,6 +36,26 @@ async fn dump_full_state() {
     });
 
     let dht_store = conductor.get_dht_store(cell_id.dna_hash()).unwrap();
+
+    // Wait for publishing to quiesce so the two dumps below observe the same
+    // `published_ops_count`. The publish workflow runs in the background and
+    // raises that count as it records publish times, so building the expected
+    // and actual dumps a moment apart would otherwise race it. With a recency
+    // window wide enough to exclude anything published during the test, an op
+    // only remains in `get_ops_to_publish` until it has been published at least
+    // once; an empty result therefore means every publishable op has a recorded
+    // publish time and the count is stable.
+    retry_until_timeout!(30_000, 100, {
+        let pending = dht_store
+            .as_read()
+            .get_ops_to_publish(cell_id.agent_pubkey(), Duration::from_secs(60 * 60))
+            .await
+            .unwrap();
+        if pending.is_empty() {
+            break;
+        }
+    });
+
     let peer_dump = peer_store_dump(&conductor, cell_id).await.unwrap();
     let source_chain_dump =
         source_chain::dump_state(&dht_store.as_read(), cell_id.agent_pubkey().clone())

--- a/crates/holochain/src/conductor/conductor/tests/state_dump.rs
+++ b/crates/holochain/src/conductor/conductor/tests/state_dump.rs
@@ -34,13 +34,10 @@ async fn dump_full_state() {
         }
     });
 
-    let authored_db = conductor
-        .get_or_create_authored_db(cell_id.dna_hash(), cell_id.agent_pubkey().clone())
-        .unwrap();
     let dht_store = conductor.get_dht_store(cell_id.dna_hash()).unwrap();
     let peer_dump = peer_store_dump(&conductor, cell_id).await.unwrap();
     let source_chain_dump =
-        source_chain::dump_state(authored_db.into(), cell_id.agent_pubkey().clone())
+        source_chain::dump_state(&dht_store.as_read(), cell_id.agent_pubkey().clone())
             .await
             .unwrap();
     let expected_state_dump = FullStateDump {

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -933,8 +933,6 @@ mod test {
                 dbg!(&blob_one);
 
                 assert_eq!(blob_one.used_by, vec!["test app 1".to_string()]);
-                assert!(blob_one.authored_data_size > 12_000);
-                assert!(blob_one.authored_data_size_on_disk > 94_000);
                 assert!(blob_one.dht_data_size > 12_000);
                 assert!(blob_one.dht_data_size_on_disk > 94_000);
                 assert!(blob_one.cache_data_size > 8_000);
@@ -950,9 +948,7 @@ mod test {
                     used_by_two,
                     vec!["test app 2".to_string(), "test app 3".to_string()]
                 );
-                assert!(blob_two.authored_data_size > 24_000);
-                assert!(blob_two.authored_data_size_on_disk > 180_000);
-                assert!(blob_two.dht_data_size > 16_000);
+                assert!(blob_two.dht_data_size > 14_000);
                 assert!(blob_two.dht_data_size_on_disk > 94_000);
                 assert!(blob_two.cache_data_size > 8_000);
                 assert!(blob_two.cache_data_size_on_disk > 94_000);

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -935,8 +935,6 @@ mod test {
                 assert_eq!(blob_one.used_by, vec!["test app 1".to_string()]);
                 assert!(blob_one.dht_data_size > 12_000);
                 assert!(blob_one.dht_data_size_on_disk > 94_000);
-                assert!(blob_one.cache_data_size > 8_000);
-                assert!(blob_one.cache_data_size_on_disk > 94_000);
 
                 let blob_two: &DnaStorageInfo =
                     get_app_data_storage_info(&info, "test app 2".to_string());
@@ -950,8 +948,6 @@ mod test {
                 );
                 assert!(blob_two.dht_data_size > 14_000);
                 assert!(blob_two.dht_data_size_on_disk > 94_000);
-                assert!(blob_two.cache_data_size > 8_000);
-                assert!(blob_two.cache_data_size_on_disk > 94_000);
             }
             other => panic!("unexpected response {other:?}"),
         };

--- a/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
@@ -702,7 +702,7 @@ pub mod wasm_test {
                     agent_pubkey: alice_cell.agent_pubkey().clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
-                    get_options: GetOptions::default(),
+                    get_options: GetOptions::from(GetStrategy::Local),
                 },
             )
             .await;
@@ -777,7 +777,7 @@ pub mod wasm_test {
                     agent_pubkey: alice_cell.agent_pubkey().clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
-                    get_options: GetOptions::default(),
+                    get_options: GetOptions::from(GetStrategy::Local),
                 },
             )
             .await;
@@ -800,7 +800,7 @@ pub mod wasm_test {
                     agent_pubkey: bob_cell.agent_pubkey().clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
-                    get_options: GetOptions::default(),
+                    get_options: GetOptions::from(GetStrategy::Local),
                 },
             )
             .await;
@@ -1131,7 +1131,7 @@ pub mod wasm_test {
                         agent_pubkey: bob_pubkey.clone(),
                         chain_query_filter: ChainQueryFilter::new(),
                         activity_request: ActivityRequest::Full,
-                        get_options: GetOptions::default(),
+                        get_options: GetOptions::from(GetStrategy::Local),
                     },
                 )
                 .await;
@@ -1198,7 +1198,7 @@ pub mod wasm_test {
                     agent_pubkey: alice_pubkey.clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
-                    get_options: GetOptions::default(),
+                    get_options: GetOptions::from(GetStrategy::Local),
                 },
             )
             .await;
@@ -1211,7 +1211,7 @@ pub mod wasm_test {
                     agent_pubkey: bob_pubkey.clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
-                    get_options: GetOptions::default(),
+                    get_options: GetOptions::from(GetStrategy::Local),
                 },
             )
             .await;
@@ -1236,7 +1236,7 @@ pub mod wasm_test {
                     agent_pubkey: alice_pubkey.clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
-                    get_options: GetOptions::default(),
+                    get_options: GetOptions::from(GetStrategy::Local),
                 },
             )
             .await;
@@ -1249,7 +1249,7 @@ pub mod wasm_test {
                     agent_pubkey: bob_pubkey.clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
-                    get_options: GetOptions::default(),
+                    get_options: GetOptions::from(GetStrategy::Local),
                 },
             )
             .await;

--- a/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/accept_countersigning_preflight_request.rs
@@ -163,6 +163,7 @@ pub mod wasm_test {
                     agent_pubkey: alice_cell.agent_pubkey().clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -174,6 +175,7 @@ pub mod wasm_test {
                     agent_pubkey: alice_cell.agent_pubkey().clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -185,6 +187,7 @@ pub mod wasm_test {
                     agent_pubkey: bob_cell.agent_pubkey().clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -196,6 +199,7 @@ pub mod wasm_test {
                     agent_pubkey: bob_cell.agent_pubkey().clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -340,6 +344,7 @@ pub mod wasm_test {
                     agent_pubkey: alice_cell.agent_pubkey().clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -351,6 +356,7 @@ pub mod wasm_test {
                     agent_pubkey: alice_cell.agent_pubkey().clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -362,6 +368,7 @@ pub mod wasm_test {
                     agent_pubkey: bob_cell.agent_pubkey().clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -373,6 +380,7 @@ pub mod wasm_test {
                     agent_pubkey: bob_cell.agent_pubkey().clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -694,6 +702,7 @@ pub mod wasm_test {
                     agent_pubkey: alice_cell.agent_pubkey().clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -768,6 +777,7 @@ pub mod wasm_test {
                     agent_pubkey: alice_cell.agent_pubkey().clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -790,6 +800,7 @@ pub mod wasm_test {
                     agent_pubkey: bob_cell.agent_pubkey().clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -969,6 +980,7 @@ pub mod wasm_test {
                     agent_pubkey: alice_pubkey.clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -1043,6 +1055,7 @@ pub mod wasm_test {
                     agent_pubkey: alice_pubkey.clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -1063,6 +1076,7 @@ pub mod wasm_test {
                     agent_pubkey: bob_pubkey.clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -1117,6 +1131,7 @@ pub mod wasm_test {
                         agent_pubkey: bob_pubkey.clone(),
                         chain_query_filter: ChainQueryFilter::new(),
                         activity_request: ActivityRequest::Full,
+                        get_options: GetOptions::default(),
                     },
                 )
                 .await;
@@ -1183,6 +1198,7 @@ pub mod wasm_test {
                     agent_pubkey: alice_pubkey.clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -1195,6 +1211,7 @@ pub mod wasm_test {
                     agent_pubkey: bob_pubkey.clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -1219,6 +1236,7 @@ pub mod wasm_test {
                     agent_pubkey: alice_pubkey.clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -1231,6 +1249,7 @@ pub mod wasm_test {
                     agent_pubkey: bob_pubkey.clone(),
                     chain_query_filter: ChainQueryFilter::new(),
                     activity_request: ActivityRequest::Full,
+                    get_options: GetOptions::default(),
                 },
             )
             .await;
@@ -1290,6 +1309,7 @@ pub mod wasm_test {
                         agent_pubkey: alice_pubkey.clone(),
                         chain_query_filter: ChainQueryFilter::new(),
                         activity_request: ActivityRequest::Full,
+                        get_options: GetOptions::default(),
                     },
                 )
                 .await;
@@ -1302,6 +1322,7 @@ pub mod wasm_test {
                         agent_pubkey: bob_pubkey.clone(),
                         chain_query_filter: ChainQueryFilter::new(),
                         activity_request: ActivityRequest::Full,
+                        get_options: GetOptions::default(),
                     },
                 )
                 .await;
@@ -1384,6 +1405,7 @@ pub mod wasm_test {
                         agent_pubkey: alice_pubkey.clone(),
                         chain_query_filter: ChainQueryFilter::new(),
                         activity_request: ActivityRequest::Full,
+                        get_options: GetOptions::default(),
                     },
                 )
                 .await;
@@ -1397,6 +1419,7 @@ pub mod wasm_test {
                         agent_pubkey: bob_pubkey.clone(),
                         chain_query_filter: ChainQueryFilter::new(),
                         activity_request: ActivityRequest::Full,
+                        get_options: GetOptions::default(),
                     },
                 )
                 .await;
@@ -1483,6 +1506,7 @@ pub mod wasm_test {
                         agent_pubkey: alice_pubkey.clone(),
                         chain_query_filter: ChainQueryFilter::new(),
                         activity_request: ActivityRequest::Full,
+                        get_options: GetOptions::default(),
                     },
                 )
                 .await;
@@ -1495,6 +1519,7 @@ pub mod wasm_test {
                         agent_pubkey: bob_pubkey.clone(),
                         chain_query_filter: ChainQueryFilter::new(),
                         activity_request: ActivityRequest::Full,
+                        get_options: GetOptions::default(),
                     },
                 )
                 .await;
@@ -1518,6 +1543,7 @@ pub mod wasm_test {
                         agent_pubkey: alice_pubkey.clone(),
                         chain_query_filter: ChainQueryFilter::new(),
                         activity_request: ActivityRequest::Full,
+                        get_options: GetOptions::default(),
                     },
                 )
                 .await;
@@ -1530,6 +1556,7 @@ pub mod wasm_test {
                         agent_pubkey: bob_pubkey.clone(),
                         chain_query_filter: ChainQueryFilter::new(),
                         activity_request: ActivityRequest::Full,
+                        get_options: GetOptions::default(),
                     },
                 )
                 .await;

--- a/crates/holochain/src/core/ribosome/host_fn/call.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call.rs
@@ -342,8 +342,8 @@ pub mod wasm_test {
                 .decode()
                 .unwrap();
 
-        // Check alice's source chain contains the new value. The authored data
-        // now lives in the merged store, so look the action up there.
+        // Check alice's source chain contains the new value by looking the
+        // action up in the DhtStore.
         let has_hash = alice
             .dht_store()
             .as_read()
@@ -384,8 +384,8 @@ pub mod wasm_test {
             )
             .await;
 
-        // Check alice's source chain contains the new value. The authored data
-        // now lives in the merged store, so look the action up there.
+        // Check alice's source chain contains the new value by looking the
+        // action up in the DhtStore.
         let has_hash = alice
             .dht_store()
             .as_read()

--- a/crates/holochain/src/core/ribosome/host_fn/call.rs
+++ b/crates/holochain/src/core/ribosome/host_fn/call.rs
@@ -264,11 +264,9 @@ pub mod wasm_test {
     use holochain_types::prelude::*;
     use holochain_wasm_test_utils::TestWasm;
     use matches::assert_matches;
-    use rusqlite::named_params;
 
     use crate::test_utils::new_zome_call_params;
     use crate::test_utils::RibosomeTestFixture;
-    use holochain_sqlite::prelude::DatabaseResult;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn call_test() {
@@ -344,22 +342,15 @@ pub mod wasm_test {
                 .decode()
                 .unwrap();
 
-        // Check alice's source chain contains the new value
-        let has_hash: bool = handle
-            .get_spaces()
-            .get_or_create_authored_db(alice.dna_hash(), alice.agent_pubkey().clone())
-            .unwrap()
-            .read_async(move |txn| -> DatabaseResult<bool> {
-                Ok(txn.query_row(
-                    "SELECT EXISTS(SELECT 1 FROM DhtOp WHERE action_hash = :hash)",
-                    named_params! {
-                        ":hash": action_hash
-                    },
-                    |row| row.get(0),
-                )?)
-            })
+        // Check alice's source chain contains the new value. The authored data
+        // now lives in the merged store, so look the action up there.
+        let has_hash = alice
+            .dht_store()
+            .as_read()
+            .retrieve_action(&action_hash)
             .await
-            .unwrap();
+            .unwrap()
+            .is_some();
         assert!(has_hash);
     }
 
@@ -393,20 +384,15 @@ pub mod wasm_test {
             )
             .await;
 
-        // Check alice's source chain contains the new value
-        let has_hash: bool = alice
-            .authored_db()
-            .read_async(move |txn| -> DatabaseResult<bool> {
-                Ok(txn.query_row(
-                    "SELECT EXISTS(SELECT 1 FROM DhtOp WHERE action_hash = :hash)",
-                    named_params! {
-                        ":hash": action_hash
-                    },
-                    |row| row.get(0),
-                )?)
-            })
+        // Check alice's source chain contains the new value. The authored data
+        // now lives in the merged store, so look the action up there.
+        let has_hash = alice
+            .dht_store()
+            .as_read()
+            .retrieve_action(&action_hash)
             .await
-            .unwrap();
+            .unwrap()
+            .is_some();
         assert!(has_hash);
     }
 

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -709,6 +709,7 @@ async fn force_abandon_session(
     workspace: Arc<CountersigningWorkspace>,
     signal_tx: &Sender<Signal>,
 ) -> SourceChainResult<()> {
+    // #5370: kept to clean the legacy authored DB in `abandon_session`.
     let authored_db = space.get_or_create_authored_db(author.clone())?;
 
     let abandon_fingerprint = preflight_request.fingerprint()?;
@@ -810,17 +811,32 @@ pub async fn countersigning_publish(
 /// Abandon a countersigning session.
 #[cfg(feature = "unstable-countersigning")]
 async fn abandon_session(
+    // #5370: still needed to keep the legacy authored DB in sync — see the
+    // authored-DB removal below. Drop with `DbKindAuthored`.
     authored_db: DbWrite<DbKindAuthored>,
     dht_store: DhtStore,
     author: AgentPubKey,
     cs_action: Action,
     cs_entry_hash: EntryHash,
 ) -> StateMutationResult<()> {
+    // Do the dangerous thing and remove the countersigning session from the
+    // merged store. The store's published guard is authoritative: it refuses
+    // (with `CannotRemoveFullyPublished`) if any of the session's ops have
+    // already been published. #5370: the session's source-chain rows live in the
+    // merged store.
+    dht_store
+        .remove_countersigning_session(cs_action.to_hash(), cs_entry_hash.clone())
+        .await?;
+
+    // #5370: also remove the session from the legacy authored DB. The
+    // source-chain head is still computed from the authored `Action` table at
+    // flush's as-at check, and — unlike the merged store — it is not filtered by
+    // the withhold-publish flag, so the withheld session entry would otherwise
+    // remain the authored chain head and wedge the next commit. Remove this once
+    // the source-chain authored writes move to the merged store.
     authored_db
         .write_async(move |txn| -> StateMutationResult<()> {
-            // Do the dangerous thing and remove the countersigning session.
             remove_countersigning_session(txn, cs_action, cs_entry_hash)?;
-
             Ok(())
         })
         .await?;

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -599,9 +599,12 @@ async fn apply_timeout(
         return Ok(());
     }
 
-    let authored = space.get_or_create_authored_db(cell_id.agent_pubkey().clone())?;
-
-    let current_session = authored.read_async(current_countersigning_session).await?;
+    // Read the current countersigning session from the merged store (#5370).
+    let current_session = space
+        .dht_store
+        .as_read()
+        .current_countersigning_session(cell_id.agent_pubkey())
+        .await?;
 
     let mut has_committed_session = false;
     if let Some((_, _, session_data)) = current_session {
@@ -710,8 +713,11 @@ async fn force_abandon_session(
 
     let abandon_fingerprint = preflight_request.fingerprint()?;
 
-    let maybe_session_data = authored_db
-        .read_async(current_countersigning_session)
+    // Read the current countersigning session from the merged store (#5370).
+    let maybe_session_data = space
+        .dht_store
+        .as_read()
+        .current_countersigning_session(author)
         .await?;
 
     match maybe_session_data {

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -599,7 +599,7 @@ async fn apply_timeout(
         return Ok(());
     }
 
-    // Read the current countersigning session from the merged store (#5370).
+    // Read the current countersigning session from the DhtStore.
     let current_session = space
         .dht_store
         .as_read()
@@ -711,7 +711,7 @@ async fn force_abandon_session(
 ) -> SourceChainResult<()> {
     let abandon_fingerprint = preflight_request.fingerprint()?;
 
-    // Read the current countersigning session from the merged store (#5370).
+    // Read the current countersigning session from the DhtStore.
     let maybe_session_data = space
         .dht_store
         .as_read()
@@ -733,7 +733,7 @@ async fn force_abandon_session(
         }
         _ => {
             // There is no matching, committed session but there may be a lock to
-            // remove. #5370: the chain lock lives in the merged store.
+            // remove.
             let chain_lock = space
                 .dht_store
                 .as_read()
@@ -813,17 +813,14 @@ async fn abandon_session(
     cs_entry_hash: EntryHash,
 ) -> StateMutationResult<()> {
     // Do the dangerous thing and remove the countersigning session from the
-    // merged store, which is now the sole source-chain write. The store's
-    // published guard is authoritative: it refuses (with
+    // DhtStore. The store's published guard is authoritative: it refuses (with
     // `CannotRemoveFullyPublished`) if any of the session's ops have already
-    // been published. #5370: the session's source-chain rows live in the merged
-    // store.
+    // been published.
     dht_store
         .remove_countersigning_session(cs_action.to_hash(), cs_entry_hash)
         .await?;
 
-    // Once the session is removed we can unlock the chain. #5370: the chain lock
-    // lives in the merged store.
+    // Once the session is removed we can unlock the chain.
     dht_store.release_chain_lock(&author).await?;
 
     Ok(())

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -709,9 +709,6 @@ async fn force_abandon_session(
     workspace: Arc<CountersigningWorkspace>,
     signal_tx: &Sender<Signal>,
 ) -> SourceChainResult<()> {
-    // #5370: kept to clean the legacy authored DB in `abandon_session`.
-    let authored_db = space.get_or_create_authored_db(author.clone())?;
-
     let abandon_fingerprint = preflight_request.fingerprint()?;
 
     // Read the current countersigning session from the merged store (#5370).
@@ -727,7 +724,6 @@ async fn force_abandon_session(
         {
             tracing::info!("There is a committed session to remove for: {:?}", author);
             abandon_session(
-                authored_db,
                 space.dht_store.clone(),
                 author.clone(),
                 cs_action.action().clone(),
@@ -811,34 +807,19 @@ pub async fn countersigning_publish(
 /// Abandon a countersigning session.
 #[cfg(feature = "unstable-countersigning")]
 async fn abandon_session(
-    // #5370: still needed to keep the legacy authored DB in sync — see the
-    // authored-DB removal below. Drop with `DbKindAuthored`.
-    authored_db: DbWrite<DbKindAuthored>,
     dht_store: DhtStore,
     author: AgentPubKey,
     cs_action: Action,
     cs_entry_hash: EntryHash,
 ) -> StateMutationResult<()> {
     // Do the dangerous thing and remove the countersigning session from the
-    // merged store. The store's published guard is authoritative: it refuses
-    // (with `CannotRemoveFullyPublished`) if any of the session's ops have
-    // already been published. #5370: the session's source-chain rows live in the
-    // merged store.
+    // merged store, which is now the sole source-chain write. The store's
+    // published guard is authoritative: it refuses (with
+    // `CannotRemoveFullyPublished`) if any of the session's ops have already
+    // been published. #5370: the session's source-chain rows live in the merged
+    // store.
     dht_store
-        .remove_countersigning_session(cs_action.to_hash(), cs_entry_hash.clone())
-        .await?;
-
-    // #5370: also remove the session from the legacy authored DB. The
-    // source-chain head is still computed from the authored `Action` table at
-    // flush's as-at check, and — unlike the merged store — it is not filtered by
-    // the withhold-publish flag, so the withheld session entry would otherwise
-    // remain the authored chain head and wedge the next commit. Remove this once
-    // the source-chain authored writes move to the merged store.
-    authored_db
-        .write_async(move |txn| -> StateMutationResult<()> {
-            remove_countersigning_session(txn, cs_action, cs_entry_hash)?;
-            Ok(())
-        })
+        .remove_countersigning_session(cs_action.to_hash(), cs_entry_hash)
         .await?;
 
     // Once the session is removed we can unlock the chain. #5370: the chain lock

--- a/crates/holochain/src/core/workflow/countersigning_workflow.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow.rs
@@ -11,7 +11,7 @@ use {
     crate::core::queue_consumer::{TriggerSender, WorkComplete},
     holo_hash::AgentPubKey,
     holochain_keystore::MetaLairClient,
-    holochain_state::chain_lock::get_chain_lock,
+    holochain_state::DhtStore,
     std::sync::Arc,
     tokio::sync::broadcast::Sender,
     tokio::task::AbortHandle,
@@ -721,6 +721,7 @@ async fn force_abandon_session(
             tracing::info!("There is a committed session to remove for: {:?}", author);
             abandon_session(
                 authored_db,
+                space.dht_store.clone(),
                 author.clone(),
                 cs_action.action().clone(),
                 cs_entry_hash,
@@ -728,28 +729,22 @@ async fn force_abandon_session(
             .await?;
         }
         _ => {
-            // There is no matching, committed session but there may be a lock to remove
-            authored_db
-                .write_async({
-                    let author = author.clone();
-                    move |txn| {
-                        let chain_lock = get_chain_lock(txn, &author)?;
-
-                        match chain_lock {
-                            Some(lock) if lock.subject() == abandon_fingerprint => {
-                                unlock_chain(txn, &author)
-                            }
-                            _ => {
-                                tracing::warn!(
-                                    "No matching session or lock to remove for: {:?}",
-                                    author
-                                );
-                                Ok(())
-                            }
-                        }
-                    }
-                })
+            // There is no matching, committed session but there may be a lock to
+            // remove. #5370: the chain lock lives in the merged store.
+            let chain_lock = space
+                .dht_store
+                .as_read()
+                .get_chain_lock(author.clone())
                 .await?;
+
+            match chain_lock {
+                Some(lock) if lock.subject() == abandon_fingerprint => {
+                    space.dht_store.release_chain_lock(author).await?;
+                }
+                _ => {
+                    tracing::warn!("No matching session or lock to remove for: {:?}", author);
+                }
+            }
         }
     }
 
@@ -810,6 +805,7 @@ pub async fn countersigning_publish(
 #[cfg(feature = "unstable-countersigning")]
 async fn abandon_session(
     authored_db: DbWrite<DbKindAuthored>,
+    dht_store: DhtStore,
     author: AgentPubKey,
     cs_action: Action,
     cs_entry_hash: EntryHash,
@@ -819,12 +815,13 @@ async fn abandon_session(
             // Do the dangerous thing and remove the countersigning session.
             remove_countersigning_session(txn, cs_action, cs_entry_hash)?;
 
-            // Once the session is removed we can unlock the chain.
-            unlock_chain(txn, &author)?;
-
             Ok(())
         })
         .await?;
+
+    // Once the session is removed we can unlock the chain. #5370: the chain lock
+    // lives in the merged store.
+    dht_store.release_chain_lock(&author).await?;
 
     Ok(())
 }

--- a/crates/holochain/src/core/workflow/countersigning_workflow/complete.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/complete.rs
@@ -204,23 +204,15 @@ async fn apply_success_state_changes(
     let authored_db = space.get_or_create_authored_db(author.clone())?;
     let dht_db = space.dht_db.clone();
 
-    // Load the op hashes for this session so that we can publish them, and clear
-    // the authored-DB withhold-publish flag for the session's ops. #5370: the
-    // store mirror is cleared below via `clear_op_withhold_publishes`; the
-    // authored clear stays as a dual-write until `remove_countersigning_session`
-    // (which reads the authored withhold flag to guard against removing a
-    // published session) is migrated to read the store.
+    // Load the op hashes for this session so that we can publish them. #5370:
+    // the session's withhold-publish flag is cleared on the merged store below
+    // via `clear_op_withhold_publishes`. The authored-DB withhold flag no longer
+    // needs clearing here: `remove_countersigning_session` now reads the store's
+    // `ChainOpPublish` to guard against removing a published session.
     let this_cell_actions_op_basis_hashes = authored_db
-        .write_async({
+        .read_async({
             let this_cells_action_hash = this_cells_action_hash.clone();
             move |txn| -> SourceChainResult<Vec<DhtOpHash>> {
-                txn.execute(
-                    "UPDATE DhtOp SET withhold_publish = NULL WHERE action_hash = :action_hash",
-                    named_params! {
-                        ":action_hash": this_cells_action_hash,
-                    },
-                )
-                .map_err(holochain_state::prelude::StateMutationError::from)?;
                 Ok(get_countersigning_op_hashes(txn, this_cells_action_hash)?)
             }
         })

--- a/crates/holochain/src/core/workflow/countersigning_workflow/complete.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/complete.rs
@@ -211,11 +211,23 @@ async fn apply_success_state_changes(
     let authored_db = space.get_or_create_authored_db(author.clone())?;
     let dht_db = space.dht_db.clone();
 
-    // Load the op hashes for this session so that we can publish them.
+    // Load the op hashes for this session so that we can publish them, and clear
+    // the authored-DB withhold-publish flag for the session's ops. #5370: the
+    // store mirror is cleared below via `clear_op_withhold_publishes`; the
+    // authored clear stays as a dual-write until `remove_countersigning_session`
+    // (which reads the authored withhold flag to guard against removing a
+    // published session) is migrated to read the store.
     let this_cell_actions_op_basis_hashes = authored_db
-        .read_async({
+        .write_async({
             let this_cells_action_hash = this_cells_action_hash.clone();
             move |txn| -> SourceChainResult<Vec<DhtOpHash>> {
+                txn.execute(
+                    "UPDATE DhtOp SET withhold_publish = NULL WHERE action_hash = :action_hash",
+                    named_params! {
+                        ":action_hash": this_cells_action_hash,
+                    },
+                )
+                .map_err(holochain_state::prelude::StateMutationError::from)?;
                 Ok(get_countersigning_op_hashes(txn, this_cells_action_hash)?)
             }
         })

--- a/crates/holochain/src/core/workflow/countersigning_workflow/complete.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/complete.rs
@@ -8,7 +8,6 @@ use holochain_p2p::DynHolochainP2pDna;
 use holochain_sqlite::db::ReadAccess;
 use holochain_sqlite::error::DatabaseResult;
 use holochain_state::integrate::authored_ops_to_dht_db_without_check;
-use holochain_state::mutations;
 use holochain_state::prelude::*;
 use holochain_timestamp::Timestamp;
 use holochain_types::dht_op::ChainOp;
@@ -39,20 +38,25 @@ pub(crate) async fn inner_countersigning_session_complete(
         None => return Ok(None),
     };
 
+    // Read the chain lock from the merged store (#5370). It isn't necessarily for
+    // the current session; we can't check that until we have the session data.
+    let chain_lock = space
+        .dht_store
+        .as_read()
+        .get_chain_lock(author.clone())
+        .await?;
+
     // Do a quick check to see if this entry hash matches the current locked session, so we don't
     // check signatures unless there is an active session.
     let reader_closure = {
         let entry_hash = entry_hash.clone();
-        let author = author.clone();
         move |txn: &Txn<DbKindAuthored>| {
-            // This chain lock isn't necessarily for the current session, we can't check that until later.
             if let Some((session_record, cs_entry_hash, session_data)) =
                 current_countersigning_session(txn)?
             {
                 let lock_subject = session_data.preflight_request.fingerprint()?;
 
-                let chain_lock = holochain_state::chain_lock::get_chain_lock(txn, &author)?;
-                if let Some(chain_lock) = chain_lock {
+                if let Some(chain_lock) = &chain_lock {
                     // This is the case where we have already locked the chain for another session and are
                     // receiving another signature bundle from a different session. We don't need this, so
                     // it's safe to short circuit.
@@ -207,27 +211,24 @@ async fn apply_success_state_changes(
     let authored_db = space.get_or_create_authored_db(author.clone())?;
     let dht_db = space.dht_db.clone();
 
-    // Unlock the chain and remove the withhold publish flag from all ops in this session.
+    // Load the op hashes for this session so that we can publish them.
     let this_cell_actions_op_basis_hashes = authored_db
-        .write_async({
-            let author = author.clone();
+        .read_async({
+            let this_cells_action_hash = this_cells_action_hash.clone();
             move |txn| -> SourceChainResult<Vec<DhtOpHash>> {
-                // All checks have passed so unlock the chain.
-                mutations::unlock_chain(txn, &author)?;
-                // Update ops to publish.
-                txn.execute(
-                    "UPDATE DhtOp SET withhold_publish = NULL WHERE action_hash = :action_hash",
-                    named_params! {
-                        ":action_hash": this_cells_action_hash,
-                    },
-                )
-                .map_err(holochain_state::prelude::StateMutationError::from)?;
-
-                // Load the op hashes for this session so that we can publish them.
                 Ok(get_countersigning_op_hashes(txn, this_cells_action_hash)?)
             }
         })
         .await?;
+
+    // All checks have passed so unlock the chain. #5370: the lock lives in the
+    // merged store. The withhold-publish flag is cleared on the merged store
+    // below via `clear_op_withhold_publishes`.
+    space
+        .dht_store
+        .release_chain_lock(author)
+        .await
+        .map_err(WorkflowError::from)?;
 
     // If all signatures are valid (above) and i signed then i must have
     // validated it previously so i now agree that i authored it.
@@ -253,7 +254,7 @@ async fn apply_success_state_changes(
 }
 
 fn get_countersigning_op_hashes(
-    txn: &mut Transaction,
+    txn: &Transaction,
     this_cells_action_hash: ActionHash,
 ) -> DatabaseResult<Vec<DhtOpHash>> {
     Ok(txn
@@ -281,20 +282,25 @@ pub(super) async fn force_publish_countersigning_session(
     cell_id: CellId,
     preflight_request: PreflightRequest,
 ) -> WorkflowResult<bool> {
+    // Read the chain lock from the merged store (#5370). It isn't necessarily for
+    // the current session; we can't check that until we have the session data.
+    let chain_lock = space
+        .dht_store
+        .as_read()
+        .get_chain_lock(cell_id.agent_pubkey().clone())
+        .await?;
+
     // Query database for current countersigning session.
     let reader_closure = {
-        let author = cell_id.agent_pubkey().clone();
         let preflight_request = preflight_request.clone();
         move |txn: &Txn<DbKindAuthored>| {
-            // This chain lock isn't necessarily for the current session, we can't check that until later.
             if let Some((session_record, _, session_data)) = current_countersigning_session(txn)? {
                 let lock_subject = session_data.preflight_request.fingerprint()?;
                 if lock_subject != preflight_request.fingerprint()? {
                     return SourceChainResult::Ok(None);
                 }
 
-                let chain_lock = holochain_state::chain_lock::get_chain_lock(txn, &author)?;
-                if let Some(chain_lock) = chain_lock {
+                if let Some(chain_lock) = &chain_lock {
                     // This is the case where we have already locked the chain for another session and are
                     // receiving another signature bundle from a different session. We don't need this, so
                     // it's safe to short circuit.

--- a/crates/holochain/src/core/workflow/countersigning_workflow/complete.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/complete.rs
@@ -2,16 +2,14 @@ use crate::conductor::space::Space;
 use crate::core::queue_consumer::TriggerSender;
 use crate::core::ribosome::weigh_placeholder;
 use crate::core::workflow::{WorkflowError, WorkflowResult};
-use holo_hash::{ActionHash, AgentPubKey, DhtOpHash, EntryHash};
+use holo_hash::{ActionHash, AgentPubKey, EntryHash};
 use holochain_keystore::{AgentPubKeyExt, MetaLairClient};
 use holochain_p2p::DynHolochainP2pDna;
-use holochain_sqlite::error::DatabaseResult;
 use holochain_state::integrate::authored_ops_to_dht_db_without_check;
 use holochain_state::prelude::*;
 use holochain_timestamp::Timestamp;
 use holochain_types::dht_op::ChainOp;
 use holochain_zome_types::prelude::SignedAction;
-use rusqlite::{named_params, Transaction};
 
 pub(crate) async fn inner_countersigning_session_complete(
     space: Space,
@@ -205,17 +203,13 @@ async fn apply_success_state_changes(
     let dht_db = space.dht_db.clone();
 
     // Load the op hashes for this session so that we can publish them. #5370:
-    // the session's withhold-publish flag is cleared on the merged store below
-    // via `clear_op_withhold_publishes`. The authored-DB withhold flag no longer
-    // needs clearing here: `remove_countersigning_session` now reads the store's
-    // `ChainOpPublish` to guard against removing a published session.
-    let this_cell_actions_op_basis_hashes = authored_db
-        .read_async({
-            let this_cells_action_hash = this_cells_action_hash.clone();
-            move |txn| -> SourceChainResult<Vec<DhtOpHash>> {
-                Ok(get_countersigning_op_hashes(txn, this_cells_action_hash)?)
-            }
-        })
+    // read the session's ops from the merged store (now the sole source-chain
+    // write) instead of the legacy authored DB. The session's withhold-publish
+    // flag is cleared on the merged store below via `clear_op_withhold_publishes`.
+    let this_cell_actions_op_basis_hashes = space
+        .dht_store
+        .as_read()
+        .chain_op_hashes_for_action(this_cells_action_hash)
         .await?;
 
     // All checks have passed so unlock the chain. #5370: the lock lives in the
@@ -227,10 +221,10 @@ async fn apply_success_state_changes(
         .await
         .map_err(WorkflowError::from)?;
 
-    // If all signatures are valid (above) and i signed then i must have
-    // validated it previously so i now agree that i authored it.
-    // TODO: perhaps this should be `authored_ops_to_dht_db`, i.e. the arc check should
-    //       be performed, because we may not be an authority for these ops
+    // #5370: legacy authored->dht_db integration. The source chain is no longer
+    // written to the authored DB, so this is now a no-op (the ops are not found
+    // in the authored DB) and remains only until the legacy DbKindDht reader is
+    // retired. The ops are already integrated in the merged store by flush.
     let hashes_for_new_db = this_cell_actions_op_basis_hashes.clone();
     authored_ops_to_dht_db_without_check(
         this_cell_actions_op_basis_hashes,
@@ -248,24 +242,6 @@ async fn apply_success_state_changes(
     integration_trigger.trigger(&"integrate countersigning_success");
 
     Ok(())
-}
-
-fn get_countersigning_op_hashes(
-    txn: &Transaction,
-    this_cells_action_hash: ActionHash,
-) -> DatabaseResult<Vec<DhtOpHash>> {
-    Ok(txn
-        .prepare("SELECT basis_hash, hash FROM DhtOp WHERE action_hash = :action_hash")?
-        .query_map(
-            named_params! {
-                ":action_hash": this_cells_action_hash
-            },
-            |row| {
-                let hash: DhtOpHash = row.get("hash")?;
-                Ok(hash)
-            },
-        )?
-        .collect::<Result<Vec<_>, _>>()?)
 }
 
 /// When the workflow has attempted to resolve a countersigning session but wasn't able to find a deterministic answer by querying peer state,

--- a/crates/holochain/src/core/workflow/countersigning_workflow/complete.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/complete.rs
@@ -5,7 +5,6 @@ use crate::core::workflow::{WorkflowError, WorkflowResult};
 use holo_hash::{ActionHash, AgentPubKey, DhtOpHash, EntryHash};
 use holochain_keystore::{AgentPubKeyExt, MetaLairClient};
 use holochain_p2p::DynHolochainP2pDna;
-use holochain_sqlite::db::ReadAccess;
 use holochain_sqlite::error::DatabaseResult;
 use holochain_state::integrate::authored_ops_to_dht_db_without_check;
 use holochain_state::prelude::*;
@@ -23,8 +22,6 @@ pub(crate) async fn inner_countersigning_session_complete(
     integration_trigger: TriggerSender,
     publish_trigger: TriggerSender,
 ) -> WorkflowResult<Option<EntryHash>> {
-    let authored_db = space.get_or_create_authored_db(author.clone())?;
-
     // Using iterators is fine in this function as there can only be a maximum of 8 actions.
     let (this_cells_action_hash, entry_hash) = match signed_actions
         .iter()
@@ -46,40 +43,36 @@ pub(crate) async fn inner_countersigning_session_complete(
         .get_chain_lock(author.clone())
         .await?;
 
+    // Read the current countersigning session from the merged store (#5370). A
+    // `Some` result guarantees the `CounterSign` entry is present in the store,
+    // so no separate entry-presence check is needed.
+    let maybe_current_session = space
+        .dht_store
+        .as_read()
+        .current_countersigning_session(&author)
+        .await?;
+
     // Do a quick check to see if this entry hash matches the current locked session, so we don't
     // check signatures unless there is an active session.
-    let reader_closure = {
-        let entry_hash = entry_hash.clone();
-        move |txn: &Txn<DbKindAuthored>| {
-            if let Some((session_record, cs_entry_hash, session_data)) =
-                current_countersigning_session(txn)?
-            {
-                let lock_subject = session_data.preflight_request.fingerprint()?;
-
-                if let Some(chain_lock) = &chain_lock {
-                    // This is the case where we have already locked the chain for another session and are
-                    // receiving another signature bundle from a different session. We don't need this, so
-                    // it's safe to short circuit.
-                    if cs_entry_hash != entry_hash || chain_lock.subject() != lock_subject {
-                        return SourceChainResult::Ok(None);
-                    }
-
-                    let transaction: holochain_state::prelude::CascadeTxnWrapper = txn.into();
-
-                    // Ensure that the entry is present in the database.
-                    // We've looked up the session as a Record, but that permits the entry to be
-                    // missing. The cs_entry_hash is stored on the action rather than being a
-                    // guarantee that the action is present.
-                    if transaction.contains_entry(&entry_hash)? {
-                        return Ok(Some((session_record, session_data)));
-                    }
+    let maybe_matched_session = match maybe_current_session {
+        Some((session_record, cs_entry_hash, session_data)) => {
+            let lock_subject = session_data.preflight_request.fingerprint()?;
+            match &chain_lock {
+                // This is the case where we have already locked the chain for another session and are
+                // receiving another signature bundle from a different session. We don't need this, so
+                // it's safe to short circuit.
+                Some(chain_lock)
+                    if cs_entry_hash == entry_hash && chain_lock.subject() == lock_subject =>
+                {
+                    Some((session_record, session_data))
                 }
+                _ => None,
             }
-            SourceChainResult::Ok(None)
         }
+        None => None,
     };
 
-    let (session_record, session_data) = match authored_db.read_async(reader_closure).await? {
+    let (session_record, session_data) = match maybe_matched_session {
         Some(cs) => cs,
         None => {
             // If there is no active session then we can short circuit.
@@ -302,32 +295,34 @@ pub(super) async fn force_publish_countersigning_session(
         .get_chain_lock(cell_id.agent_pubkey().clone())
         .await?;
 
-    // Query database for current countersigning session.
-    let reader_closure = {
-        let preflight_request = preflight_request.clone();
-        move |txn: &Txn<DbKindAuthored>| {
-            if let Some((session_record, _, session_data)) = current_countersigning_session(txn)? {
-                let lock_subject = session_data.preflight_request.fingerprint()?;
-                if lock_subject != preflight_request.fingerprint()? {
-                    return SourceChainResult::Ok(None);
-                }
+    // Read the current countersigning session from the merged store (#5370).
+    let maybe_current_session = space
+        .dht_store
+        .as_read()
+        .current_countersigning_session(cell_id.agent_pubkey())
+        .await?;
 
-                if let Some(chain_lock) = &chain_lock {
+    let maybe_session_record = match maybe_current_session {
+        Some((session_record, _, session_data)) => {
+            let lock_subject = session_data.preflight_request.fingerprint()?;
+            if lock_subject != preflight_request.fingerprint()? {
+                None
+            } else {
+                match &chain_lock {
                     // This is the case where we have already locked the chain for another session and are
                     // receiving another signature bundle from a different session. We don't need this, so
                     // it's safe to short circuit.
-                    if chain_lock.subject() != lock_subject {
-                        return SourceChainResult::Ok(None);
+                    Some(chain_lock) if chain_lock.subject() == lock_subject => {
+                        Some(session_record)
                     }
-
-                    return Ok(Some(session_record));
+                    _ => None,
                 }
             }
-            SourceChainResult::Ok(None)
         }
+        None => None,
     };
-    let authored_db = space.get_or_create_authored_db(cell_id.agent_pubkey().clone())?;
-    let session_record = match authored_db.read_async(reader_closure).await? {
+
+    let session_record = match maybe_session_record {
         Some(cs) => cs,
         None => {
             // If there is no active session then we can short circuit.

--- a/crates/holochain/src/core/workflow/countersigning_workflow/complete.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/complete.rs
@@ -33,17 +33,17 @@ pub(crate) async fn inner_countersigning_session_complete(
         None => return Ok(None),
     };
 
-    // Read the chain lock from the merged store (#5370). It isn't necessarily for
-    // the current session; we can't check that until we have the session data.
+    // Read the chain lock from the DhtStore. It isn't necessarily for the
+    // current session; we can't check that until we have the session data.
     let chain_lock = space
         .dht_store
         .as_read()
         .get_chain_lock(author.clone())
         .await?;
 
-    // Read the current countersigning session from the merged store (#5370). A
-    // `Some` result guarantees the `CounterSign` entry is present in the store,
-    // so no separate entry-presence check is needed.
+    // Read the current countersigning session from the DhtStore. A `Some`
+    // result guarantees the `CounterSign` entry is present in the store, so no
+    // separate entry-presence check is needed.
     let maybe_current_session = space
         .dht_store
         .as_read()
@@ -202,29 +202,24 @@ async fn apply_success_state_changes(
     let authored_db = space.get_or_create_authored_db(author.clone())?;
     let dht_db = space.dht_db.clone();
 
-    // Load the op hashes for this session so that we can publish them. #5370:
-    // read the session's ops from the merged store (now the sole source-chain
-    // write) instead of the legacy authored DB. The session's withhold-publish
-    // flag is cleared on the merged store below via `clear_op_withhold_publishes`.
+    // Load the op hashes for this session so that we can publish them. The
+    // session's withhold-publish flag is cleared on the DhtStore below via
+    // `clear_op_withhold_publishes`.
     let this_cell_actions_op_basis_hashes = space
         .dht_store
         .as_read()
         .chain_op_hashes_for_action(this_cells_action_hash)
         .await?;
 
-    // All checks have passed so unlock the chain. #5370: the lock lives in the
-    // merged store. The withhold-publish flag is cleared on the merged store
-    // below via `clear_op_withhold_publishes`.
+    // All checks have passed so unlock the chain. The withhold-publish flag is
+    // cleared on the DhtStore below via `clear_op_withhold_publishes`.
     space
         .dht_store
         .release_chain_lock(author)
         .await
         .map_err(WorkflowError::from)?;
 
-    // #5370: legacy authored->dht_db integration. The source chain is no longer
-    // written to the authored DB, so this is now a no-op (the ops are not found
-    // in the authored DB) and remains only until the legacy DbKindDht reader is
-    // retired. The ops are already integrated in the merged store by flush.
+    // #5370: no-op; remove once DbKindDht is retired.
     let hashes_for_new_db = this_cell_actions_op_basis_hashes.clone();
     authored_ops_to_dht_db_without_check(
         this_cell_actions_op_basis_hashes,
@@ -255,15 +250,15 @@ pub(super) async fn force_publish_countersigning_session(
     cell_id: CellId,
     preflight_request: PreflightRequest,
 ) -> WorkflowResult<bool> {
-    // Read the chain lock from the merged store (#5370). It isn't necessarily for
-    // the current session; we can't check that until we have the session data.
+    // Read the chain lock from the DhtStore. It isn't necessarily for the
+    // current session; we can't check that until we have the session data.
     let chain_lock = space
         .dht_store
         .as_read()
         .get_chain_lock(cell_id.agent_pubkey().clone())
         .await?;
 
-    // Read the current countersigning session from the merged store (#5370).
+    // Read the current countersigning session from the DhtStore.
     let maybe_current_session = space
         .dht_store
         .as_read()

--- a/crates/holochain/src/core/workflow/countersigning_workflow/incomplete.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/incomplete.rs
@@ -29,7 +29,7 @@ pub async fn inner_countersigning_session_incomplete(
     author: AgentPubKey,
     preflight_request: PreflightRequest,
 ) -> WorkflowResult<(SessionCompletionDecision, Vec<SessionResolutionOutcome>)> {
-    // Read the current countersigning session from the merged store (#5370).
+    // Read the current countersigning session from the DhtStore.
     let maybe_current_session = space
         .dht_store
         .as_read()

--- a/crates/holochain/src/core/workflow/countersigning_workflow/incomplete.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/incomplete.rs
@@ -29,6 +29,7 @@ pub async fn inner_countersigning_session_incomplete(
     author: AgentPubKey,
     preflight_request: PreflightRequest,
 ) -> WorkflowResult<(SessionCompletionDecision, Vec<SessionResolutionOutcome>)> {
+    // #5370: kept to clean the legacy authored DB in `abandon_session`.
     let authored_db = space.get_or_create_authored_db(author.clone())?;
 
     // Read the current countersigning session from the merged store (#5370).

--- a/crates/holochain/src/core/workflow/countersigning_workflow/incomplete.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/incomplete.rs
@@ -29,9 +29,6 @@ pub async fn inner_countersigning_session_incomplete(
     author: AgentPubKey,
     preflight_request: PreflightRequest,
 ) -> WorkflowResult<(SessionCompletionDecision, Vec<SessionResolutionOutcome>)> {
-    // #5370: kept to clean the legacy authored DB in `abandon_session`.
-    let authored_db = space.get_or_create_authored_db(author.clone())?;
-
     // Read the current countersigning session from the merged store (#5370).
     let maybe_current_session = space
         .dht_store
@@ -320,7 +317,6 @@ pub async fn inner_countersigning_session_incomplete(
         // Note that for a two party session, this just means one other agent!
         tracing::debug!("All other agents have abandoned the countersigning session, abandoning session for agent {:?}", author);
         countersigning_workflow::abandon_session(
-            authored_db,
             space.dht_store.clone(),
             author.clone(),
             cs_record.action().clone(),

--- a/crates/holochain/src/core/workflow/countersigning_workflow/incomplete.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/incomplete.rs
@@ -325,6 +325,7 @@ pub async fn inner_countersigning_session_incomplete(
         tracing::debug!("All other agents have abandoned the countersigning session, abandoning session for agent {:?}", author);
         countersigning_workflow::abandon_session(
             authored_db,
+            space.dht_store.clone(),
             author.clone(),
             cs_record.action().clone(),
             cs_entry_hash,

--- a/crates/holochain/src/core/workflow/countersigning_workflow/incomplete.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/incomplete.rs
@@ -10,9 +10,6 @@ use holo_hash::AgentPubKey;
 use holochain_cascade::CascadeImpl;
 use holochain_p2p::actor::{GetActivityOptions, NetworkRequestOptions};
 use holochain_p2p::DynHolochainP2pDna;
-use holochain_state::prelude::{
-    current_countersigning_session, CurrentCountersigningSessionOpt, SourceChainResult,
-};
 use holochain_types::activity::ChainItems;
 use holochain_zome_types::prelude::{
     ChainQueryFilter, ChainQueryFilterRange, ChainStatus, SignedAction,
@@ -34,13 +31,11 @@ pub async fn inner_countersigning_session_incomplete(
 ) -> WorkflowResult<(SessionCompletionDecision, Vec<SessionResolutionOutcome>)> {
     let authored_db = space.get_or_create_authored_db(author.clone())?;
 
-    let maybe_current_session = authored_db
-        .read_async({
-            move |txn| -> SourceChainResult<CurrentCountersigningSessionOpt> {
-                let maybe_current_session = current_countersigning_session(txn)?;
-                Ok(maybe_current_session)
-            }
-        })
+    // Read the current countersigning session from the merged store (#5370).
+    let maybe_current_session = space
+        .dht_store
+        .as_read()
+        .current_countersigning_session(&author)
         .await?;
 
     if maybe_current_session.is_none() {

--- a/crates/holochain/src/core/workflow/countersigning_workflow/refresh.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/refresh.rs
@@ -46,13 +46,19 @@ pub async fn refresh_workspace_state(
         // #5370: the chain lock now lives in the merged store. `get_chain_lock`
         // returns any lock row including expired ones, so a stale lock still marks
         // the chain as locked and drives the recovery path below.
-        let lock = space
-            .dht_store
-            .as_read()
-            .get_chain_lock(agent.clone())
-            .await
-            .ok()
-            .flatten();
+        let lock = match space.dht_store.as_read().get_chain_lock(agent.clone()).await {
+            Ok(lock) => lock,
+            Err(e) => {
+                // A store read failure must not be treated as "no lock": that
+                // would drive the cleanup path below to abandon a live session.
+                tracing::error!(
+                    "Error querying countersigning chain lock for agent {:?}: {:?}",
+                    agent,
+                    e
+                );
+                return;
+            }
+        };
 
         // If the chain is locked, then we need to check the session state.
         if lock.is_some() {

--- a/crates/holochain/src/core/workflow/countersigning_workflow/refresh.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/refresh.rs
@@ -41,12 +41,17 @@ pub async fn refresh_workspace_state(
 
     let agent = cell_id.agent_pubkey().clone();
     // Ensure the authored database exists (genesis path); the session itself is
-    // now read from the merged store (#5370).
+    // read from the DhtStore.
     if space.get_or_create_authored_db(agent.clone()).is_ok() {
-        // #5370: the chain lock now lives in the merged store. `get_chain_lock`
-        // returns any lock row including expired ones, so a stale lock still marks
-        // the chain as locked and drives the recovery path below.
-        let lock = match space.dht_store.as_read().get_chain_lock(agent.clone()).await {
+        // `get_chain_lock` returns any lock row including expired ones, so a
+        // stale lock still marks the chain as locked and drives the recovery
+        // path below.
+        let lock = match space
+            .dht_store
+            .as_read()
+            .get_chain_lock(agent.clone())
+            .await
+        {
             Ok(lock) => lock,
             Err(e) => {
                 // A store read failure must not be treated as "no lock": that

--- a/crates/holochain/src/core/workflow/countersigning_workflow/refresh.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/refresh.rs
@@ -3,10 +3,7 @@ use crate::core::workflow::countersigning_workflow::{
     CountersigningSessionState, CountersigningWorkspace, ResolutionRequiredReason,
     SessionResolutionSummary,
 };
-use holochain_sqlite::db::ReadAccess;
-use holochain_state::prelude::{
-    current_countersigning_session, CurrentCountersigningSessionOpt, SourceChainResult,
-};
+use holochain_state::prelude::{CurrentCountersigningSessionOpt, SourceChainResult};
 use holochain_types::prelude::{Signal, SystemSignal};
 use holochain_zome_types::cell::CellId;
 use std::sync::Arc;
@@ -43,7 +40,9 @@ pub async fn refresh_workspace_state(
     let mut locked_for_agent = false;
 
     let agent = cell_id.agent_pubkey().clone();
-    if let Ok(authored_db) = space.get_or_create_authored_db(agent.clone()) {
+    // Ensure the authored database exists (genesis path); the session itself is
+    // now read from the merged store (#5370).
+    if space.get_or_create_authored_db(agent.clone()).is_ok() {
         // #5370: the chain lock now lives in the merged store. `get_chain_lock`
         // returns any lock row including expired ones, so a stale lock still marks
         // the chain as locked and drives the recovery path below.
@@ -67,8 +66,11 @@ pub async fn refresh_workspace_state(
                 CurrentCountersigningSessionOpt,
                 bool,
             )> = async {
-                let maybe_current_session =
-                    authored_db.read_async(current_countersigning_session).await?;
+                let maybe_current_session = space
+                    .dht_store
+                    .as_read()
+                    .current_countersigning_session(&agent)
+                    .await?;
                 tracing::trace!("Current session: {:?}", maybe_current_session);
 
                 // If we've not made a commit and the entry hasn't been committed then

--- a/crates/holochain/src/core/workflow/countersigning_workflow/refresh.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/refresh.rs
@@ -4,8 +4,6 @@ use crate::core::workflow::countersigning_workflow::{
     SessionResolutionSummary,
 };
 use holochain_sqlite::db::ReadAccess;
-use holochain_state::chain_lock::get_chain_lock;
-use holochain_state::mutations::unlock_chain;
 use holochain_state::prelude::{
     current_countersigning_session, CurrentCountersigningSessionOpt, SourceChainResult,
 };
@@ -46,11 +44,13 @@ pub async fn refresh_workspace_state(
 
     let agent = cell_id.agent_pubkey().clone();
     if let Ok(authored_db) = space.get_or_create_authored_db(agent.clone()) {
-        let lock = authored_db
-            .read_async({
-                let agent = agent.clone();
-                move |txn| get_chain_lock(txn, &agent)
-            })
+        // #5370: the chain lock now lives in the merged store. `get_chain_lock`
+        // returns any lock row including expired ones, so a stale lock still marks
+        // the chain as locked and drives the recovery path below.
+        let lock = space
+            .dht_store
+            .as_read()
+            .get_chain_lock(agent.clone())
             .await
             .ok()
             .flatten();
@@ -63,27 +63,27 @@ pub async fn refresh_workspace_state(
             // the state of the session and need to unlock the chain.
             // This might happen if we were in the coordination phase of countersigning and the
             // conductor restarted.
-            let query_session_and_maybe_unlock_result = authored_db
-                    .write_async({
-                        let agent = agent.clone();
-                        move |txn| -> SourceChainResult<(CurrentCountersigningSessionOpt, bool)> {
-                            let maybe_current_session = current_countersigning_session(txn)?;
-                            tracing::trace!("Current session: {:?}", maybe_current_session);
+            let query_session_and_maybe_unlock_result: SourceChainResult<(
+                CurrentCountersigningSessionOpt,
+                bool,
+            )> = async {
+                let maybe_current_session =
+                    authored_db.read_async(current_countersigning_session).await?;
+                tracing::trace!("Current session: {:?}", maybe_current_session);
 
-                            // If we've not made a commit and the entry hasn't been committed then
-                            // there is no way to recover the session.
-                            // We also can't have published a signature yet, so it's safe to unlock
-                            // the chain here and abandon the session.
-                            if maybe_current_session.is_none() && !session_registered_for_agent {
-                                tracing::info!("Found a chain lock, but no corresponding countersigning session or workspace reference. Unlocking chain for agent {:?}", agent);
-                                unlock_chain(txn, &agent)?;
-                                Ok((None, true))
-                            } else {
-                                Ok((maybe_current_session, false))
-                            }
-                        }
-                    })
-                    .await;
+                // If we've not made a commit and the entry hasn't been committed then
+                // there is no way to recover the session.
+                // We also can't have published a signature yet, so it's safe to unlock
+                // the chain here and abandon the session.
+                if maybe_current_session.is_none() && !session_registered_for_agent {
+                    tracing::info!("Found a chain lock, but no corresponding countersigning session or workspace reference. Unlocking chain for agent {:?}", agent);
+                    space.dht_store.release_chain_lock(&agent).await?;
+                    Ok((None, true))
+                } else {
+                    Ok((maybe_current_session, false))
+                }
+            }
+            .await;
 
             match query_session_and_maybe_unlock_result {
                 Ok((maybe_current_session, unlocked)) => {

--- a/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
@@ -2006,6 +2006,21 @@ impl TestHarness {
             .await
             .unwrap();
 
+        // The real flush emits a `RegisterAgentActivity` op for every action.
+        // The chain-head lookup (used by `current_countersigning_session` and
+        // `read_chain_head_hash`) scopes to the integrated agent-activity op, so
+        // mirror it here — withheld like the session's other ops — otherwise the
+        // committed session head is invisible to the store reads.
+        let agent_activity_op = DhtOpHashed::from_content_sync(DhtOp::ChainOp(Box::new(
+            ChainOp::RegisterAgentActivity(sah.signature().clone(), my_action.clone()),
+        )));
+        self.test_space
+            .space
+            .dht_store
+            .test_insert_additional_integrated_op(agent_activity_op, Some(true))
+            .await
+            .unwrap();
+
         signed
     }
 

--- a/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
@@ -23,14 +23,11 @@ use holo_hash::ActionHash;
 use holo_hash::{AgentPubKey, DnaHash, EntryHash};
 use holochain_keystore::MetaLairClient;
 use holochain_p2p::{HolochainP2pError, MockHolochainP2pDnaT};
-use holochain_state::chain_lock::get_chain_lock;
 use holochain_state::prelude::{
     chain_head_db, current_countersigning_session, insert_op_authored,
     remove_countersigning_session, set_withhold_publish, AppEntryBytesFixturator, HeadInfo,
 };
-use holochain_state::prelude::{
-    insert_action, insert_entry, unlock_chain, CounterSigningSessionData,
-};
+use holochain_state::prelude::{insert_action, insert_entry, CounterSigningSessionData};
 use holochain_state::prelude::{StateMutationError, StateMutationResult};
 use holochain_state::query::from_blob;
 use holochain_state::source_chain;
@@ -1894,16 +1891,11 @@ impl TestHarness {
     }
 
     async fn unlock_chain(&self) {
-        let authored = self
-            .test_space
+        // #5370: the chain lock lives in the merged store.
+        self.test_space
             .space
-            .get_or_create_authored_db(self.author.clone())
-            .unwrap();
-        authored
-            .write_async({
-                let author = self.author.clone();
-                move |txn| unlock_chain(txn, &author)
-            })
+            .dht_store
+            .release_chain_lock(&self.author)
             .await
             .unwrap();
     }
@@ -2097,16 +2089,13 @@ impl TestHarness {
     }
 
     async fn expect_chain_locked(&self) {
-        let authored = self
+        // #5370: the chain lock lives in the merged store.
+        let lock = self
             .test_space
             .space
-            .get_or_create_authored_db(self.author.clone())
-            .unwrap();
-        let lock = authored
-            .read_async({
-                let author = self.author.clone();
-                move |txn| get_chain_lock(txn, &author)
-            })
+            .dht_store
+            .as_read()
+            .get_chain_lock(self.author.clone())
             .await
             .unwrap();
 
@@ -2114,16 +2103,13 @@ impl TestHarness {
     }
 
     pub async fn expect_chain_unlocked(&self) {
-        let authored = self
+        // #5370: the chain lock lives in the merged store.
+        let lock = self
             .test_space
             .space
-            .get_or_create_authored_db(self.author.clone())
-            .unwrap();
-        let lock = authored
-            .read_async({
-                let author = self.author.clone();
-                move |txn| get_chain_lock(txn, &author)
-            })
+            .dht_store
+            .as_read()
+            .get_chain_lock(self.author.clone())
             .await
             .unwrap();
 

--- a/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
@@ -1889,7 +1889,7 @@ impl TestHarness {
     }
 
     async fn unlock_chain(&self) {
-        // #5370: the chain lock lives in the merged store.
+        // The chain lock lives in the DhtStore.
         self.test_space
             .space
             .dht_store
@@ -1953,8 +1953,8 @@ impl TestHarness {
         let signed = SignedAction::from(sah.clone());
 
         // Sign the op with the real action signature. The store record is
-        // reconstructed from this op (#5370), and the completion path verifies
-        // the record's signature, so a fixt signature would be rejected.
+        // reconstructed from this op, and the completion path verifies the
+        // record's signature, so a fixt signature would be rejected.
         let store_entry_op = ChainOp::StoreEntry(
             sah.signature().clone(),
             my_action.clone().try_into().unwrap(),
@@ -1984,8 +1984,8 @@ impl TestHarness {
             .await
             .unwrap();
 
-        // #5370: mirror the commit to the merged store so the store-backed
-        // session reads (`current_countersigning_session`, chain head) see it.
+        // Mirror the commit to the DhtStore so the store-backed session reads
+        // (`current_countersigning_session`, chain head) see it.
         // The session op is withheld from publishing until the session
         // succeeds, matching the flush path. The entry must be routed by
         // visibility so a private session entry lands in `PrivateEntry`.
@@ -2025,8 +2025,7 @@ impl TestHarness {
     }
 
     async fn read_chain_head_hash(&self) -> HeadInfo {
-        // #5370: the chain head lives in the merged store, which is now the sole
-        // source-chain write.
+        // The chain head lives in the DhtStore.
         self.test_space
             .space
             .dht_store
@@ -2041,7 +2040,7 @@ impl TestHarness {
         &self,
         action_hash: ActionHash,
     ) -> StateMutationResult<()> {
-        // #5370: session removal now goes through the merged store, whose guard
+        // Session removal goes through the DhtStore, whose guard
         // refuses to remove a session once any of its ops has been published —
         // i.e. its store `ChainOpPublish` withhold flag has been cleared on
         // success. The entry hash is irrelevant to the published guard.
@@ -2123,7 +2122,7 @@ impl TestHarness {
     }
 
     async fn expect_chain_locked(&self) {
-        // #5370: the chain lock lives in the merged store.
+        // The chain lock lives in the DhtStore.
         let lock = self
             .test_space
             .space
@@ -2137,7 +2136,7 @@ impl TestHarness {
     }
 
     pub async fn expect_chain_unlocked(&self) {
-        // #5370: the chain lock lives in the merged store.
+        // The chain lock lives in the DhtStore.
         let lock = self
             .test_space
             .space
@@ -2151,8 +2150,8 @@ impl TestHarness {
     }
 
     pub async fn expect_session_removed(&self, preflight_request: PreflightRequest) {
-        // #5370: the session lives in the merged store, which is now the sole
-        // source-chain write, so verify removal against the store.
+        // The session lives in the DhtStore, so verify removal against the
+        // store.
         let session = self
             .test_space
             .space

--- a/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
@@ -24,12 +24,11 @@ use holo_hash::{AgentPubKey, DnaHash, EntryHash};
 use holochain_keystore::MetaLairClient;
 use holochain_p2p::{HolochainP2pError, MockHolochainP2pDnaT};
 use holochain_state::prelude::{
-    chain_head_db, current_countersigning_session, insert_op_authored,
-    remove_countersigning_session, set_withhold_publish, AppEntryBytesFixturator, HeadInfo,
+    chain_head_db, current_countersigning_session, insert_op_authored, set_withhold_publish,
+    AppEntryBytesFixturator, HeadInfo,
 };
 use holochain_state::prelude::{insert_action, insert_entry, CounterSigningSessionData};
 use holochain_state::prelude::{StateMutationError, StateMutationResult};
-use holochain_state::query::from_blob;
 use holochain_state::source_chain;
 use holochain_types::activity::AgentActivityResponse;
 use holochain_types::dht_op::{ChainOp, DhtOp, DhtOpHashed};
@@ -2026,26 +2025,14 @@ impl TestHarness {
         &self,
         action_hash: ActionHash,
     ) -> StateMutationResult<()> {
-        let authored = self
-            .test_space
+        // #5370: session removal now goes through the merged store, whose guard
+        // refuses to remove a session once any of its ops has been published —
+        // i.e. its store `ChainOpPublish` withhold flag has been cleared on
+        // success. The entry hash is irrelevant to the published guard.
+        self.test_space
             .space
-            .get_or_create_authored_db(self.author.clone())
-            .unwrap();
-        authored
-            .write_async({
-                move |txn| {
-                    let blob: Vec<u8> = txn.query_row(
-                        "SELECT blob FROM Action WHERE hash = ?",
-                        [action_hash],
-                        |r| r.get(0),
-                    )?;
-                    remove_countersigning_session(
-                        txn,
-                        from_blob::<SignedAction>(blob)?.action().clone(),
-                        fixt!(EntryHash),
-                    )
-                }
-            })
+            .dht_store
+            .remove_countersigning_session(action_hash, fixt!(EntryHash))
             .await
     }
 }

--- a/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
@@ -1954,8 +1954,11 @@ impl TestHarness {
 
         let signed = SignedAction::from(sah.clone());
 
+        // Sign the op with the real action signature. The store record is
+        // reconstructed from this op (#5370), and the completion path verifies
+        // the record's signature, so a fixt signature would be rejected.
         let store_entry_op = ChainOp::StoreEntry(
-            fixt!(Signature),
+            sah.signature().clone(),
             my_action.clone().try_into().unwrap(),
             entry.clone(),
         );
@@ -1966,14 +1969,42 @@ impl TestHarness {
             .space
             .get_or_create_authored_db(self.author.clone())
             .unwrap()
-            .write_async(move |txn| -> StateMutationResult<()> {
-                insert_action(txn, &sah)?;
-                insert_entry(txn, &entry_hash, &entry)?;
-                insert_op_authored(txn, &dht_op)?;
-                set_withhold_publish(txn, &dht_op.hash)?;
+            .write_async({
+                let sah = sah.clone();
+                let entry = entry.clone();
+                let entry_hash = entry_hash.clone();
+                let dht_op = dht_op.clone();
+                move |txn| -> StateMutationResult<()> {
+                    insert_action(txn, &sah)?;
+                    insert_entry(txn, &entry_hash, &entry)?;
+                    insert_op_authored(txn, &dht_op)?;
+                    set_withhold_publish(txn, &dht_op.hash)?;
 
-                Ok(())
+                    Ok(())
+                }
             })
+            .await
+            .unwrap();
+
+        // #5370: mirror the commit to the merged store so the store-backed
+        // session reads (`current_countersigning_session`, chain head) see it.
+        // The session op is withheld from publishing until the session
+        // succeeds, matching the flush path. The entry must be routed by
+        // visibility so a private session entry lands in `PrivateEntry`.
+        let private_author = my_action
+            .entry_visibility()
+            .is_some_and(|v| matches!(v, holochain_zome_types::entry_def::EntryVisibility::Private))
+            .then_some(&self.author);
+        self.test_space
+            .space
+            .dht_store
+            .test_insert_entry(&entry_hash, &entry, private_author)
+            .await
+            .unwrap();
+        self.test_space
+            .space
+            .dht_store
+            .test_insert_authored_chain_op(dht_op, None, None, Some(true))
             .await
             .unwrap();
 

--- a/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
@@ -601,7 +601,7 @@ async fn attempts_resolution_if_only_invalid_signatures_received() {
 
             net.expect_get_agent_activity().returning({
                 let activity_response = activity_response.clone();
-                move |_, _, _| Ok(vec![activity_response.clone()])
+                move |_, _, _, _| Ok(vec![activity_response.clone()])
             });
 
             net
@@ -662,7 +662,7 @@ async fn recover_from_commit_when_other_agent_abandons() {
 
             net.expect_get_agent_activity().returning({
                 let activity_response = activity_response.clone();
-                move |_, _, _| Ok(vec![activity_response.clone()])
+                move |_, _, _, _| Ok(vec![activity_response.clone()])
             });
 
             net
@@ -725,7 +725,7 @@ async fn recover_from_commit_after_restart_when_other_agent_abandons() {
 
             net.expect_get_agent_activity().returning({
                 let activity_response = activity_response.clone();
-                move |_, _, _| Ok(vec![activity_response.clone()])
+                move |_, _, _, _| Ok(vec![activity_response.clone()])
             });
 
             net
@@ -759,7 +759,7 @@ async fn recover_from_commit_after_restart_when_other_agent_abandons() {
 
             net.expect_get_agent_activity().returning({
                 let activity_response = activity_response.clone();
-                move |_, _, _| Ok(vec![activity_response.clone()])
+                move |_, _, _, _| Ok(vec![activity_response.clone()])
             });
 
             net
@@ -822,7 +822,7 @@ async fn recover_from_commit_after_restart_when_other_agent_completes() {
 
             net.expect_get_agent_activity().returning({
                 let activity_response = activity_response.clone();
-                move |_, _, _| Ok(vec![activity_response.clone()])
+                move |_, _, _, _| Ok(vec![activity_response.clone()])
             });
 
             net
@@ -852,7 +852,7 @@ async fn recover_from_commit_after_restart_when_other_agent_completes() {
 
             net.expect_get_agent_activity().returning({
                 let activity_response = activity_response.clone();
-                move |_, _, _| Ok(vec![activity_response.clone()])
+                move |_, _, _, _| Ok(vec![activity_response.clone()])
             });
 
             net.expect_publish_countersign().return_once(|_, _| Ok(()));
@@ -928,7 +928,7 @@ async fn retry_in_unknown_state_when_activity_authorities_do_not_agree() {
             net.expect_get_agent_activity().returning({
                 let pick_response = pick_response.clone();
                 let assorted_responses = assorted_responses.clone();
-                move |_, _, _| {
+                move |_, _, _, _| {
                     let pick = pick_response.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                         % assorted_responses.len();
                     Ok(vec![assorted_responses[pick].clone()])
@@ -1032,7 +1032,7 @@ async fn retry_when_activity_authorities_are_missing_data() {
             net.expect_get_agent_activity().returning({
                 let pick_response = pick_response.clone();
                 let assorted_responses = assorted_responses.clone();
-                move |_, _, _| {
+                move |_, _, _, _| {
                     let pick = pick_response.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                         % assorted_responses.len();
                     Ok(vec![assorted_responses[pick].clone()])
@@ -1136,7 +1136,7 @@ async fn stay_in_unknown_state_when_bad_signatures_are_fetched() {
             net.expect_get_agent_activity().returning({
                 let pick_response = pick_response.clone();
                 let assorted_responses = assorted_responses.clone();
-                move |_, _, _| {
+                move |_, _, _, _| {
                     let pick = pick_response.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
                         % assorted_responses.len();
                     Ok(vec![assorted_responses[pick].clone()])
@@ -1305,7 +1305,7 @@ async fn respect_retry_limit_on_timeout_with_no_signatures_received() {
 
             net.expect_get_agent_activity().returning({
                 let activity_response = activity_response.clone();
-                move |_, _, _| Ok(vec![activity_response.clone()])
+                move |_, _, _, _| Ok(vec![activity_response.clone()])
             });
 
             net
@@ -1375,7 +1375,7 @@ async fn respect_unlimited_retries_on_timeout_with_no_signatures_received() {
 
             net.expect_get_agent_activity().returning({
                 let activity_response = activity_response.clone();
-                move |_, _, _| Ok(vec![activity_response.clone()])
+                move |_, _, _, _| Ok(vec![activity_response.clone()])
             });
 
             net
@@ -1437,7 +1437,7 @@ async fn retry_limit_applies_after_a_restart() {
 
             net.expect_get_agent_activity().returning({
                 let activity_response = activity_response.clone();
-                move |_, _, _| Ok(vec![activity_response.clone()])
+                move |_, _, _, _| Ok(vec![activity_response.clone()])
             });
 
             net
@@ -1503,7 +1503,7 @@ async fn network_errors_do_not_count_towards_retry_limit() {
             net.expect_authority_for_hash().returning(|_| Ok(true));
 
             net.expect_get_agent_activity()
-                .returning(move |_, _, _| Err(HolochainP2pError::Other("test".into())));
+                .returning(move |_, _, _, _| Err(HolochainP2pError::Other("test".into())));
 
             net
         }
@@ -1527,7 +1527,7 @@ async fn network_errors_do_not_count_towards_retry_limit() {
 
             net.expect_get_agent_activity().returning({
                 let activity_response = activity_response.clone();
-                move |_, _, _| Ok(vec![activity_response.clone()])
+                move |_, _, _, _| Ok(vec![activity_response.clone()])
             });
 
             net
@@ -1595,7 +1595,7 @@ async fn recover_and_complete_after_resolution_failures() {
             net.expect_authority_for_hash().returning(|_| Ok(true));
 
             net.expect_get_agent_activity()
-                .returning(move |_, _, _| Err(HolochainP2pError::Other("test".into())));
+                .returning(move |_, _, _, _| Err(HolochainP2pError::Other("test".into())));
 
             net
         }
@@ -1617,7 +1617,7 @@ async fn recover_and_complete_after_resolution_failures() {
 
             net.expect_get_agent_activity().returning({
                 let activity_response = activity_response.clone();
-                move |_, _, _| Ok(vec![activity_response.clone()])
+                move |_, _, _, _| Ok(vec![activity_response.clone()])
             });
 
             net
@@ -1647,7 +1647,7 @@ async fn recover_and_complete_after_resolution_failures() {
 
             net.expect_get_agent_activity().returning({
                 let activity_response = activity_response.clone();
-                move |_, _, _| Ok(vec![activity_response.clone()])
+                move |_, _, _, _| Ok(vec![activity_response.clone()])
             });
 
             net.expect_publish_countersign().return_once(|_, _| Ok(()));
@@ -1679,7 +1679,7 @@ async fn recover_and_complete_after_resolution_failures() {
 
             net.expect_get_agent_activity().returning({
                 let activity_response = activity_response.clone();
-                move |_, _, _| Ok(vec![activity_response.clone()])
+                move |_, _, _, _| Ok(vec![activity_response.clone()])
             });
 
             net.expect_publish_countersign().return_once(|_, _| Ok(()));
@@ -1740,7 +1740,7 @@ async fn retry_on_network_errors_even_with_no_retries_configured() {
             net.expect_authority_for_hash().returning(|_| Ok(true));
 
             net.expect_get_agent_activity()
-                .returning(move |_, _, _| Err(HolochainP2pError::Other("test".into())));
+                .returning(move |_, _, _, _| Err(HolochainP2pError::Other("test".into())));
 
             net
         }

--- a/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/countersigning_workflow/tests.rs
@@ -23,11 +23,10 @@ use holo_hash::ActionHash;
 use holo_hash::{AgentPubKey, DnaHash, EntryHash};
 use holochain_keystore::MetaLairClient;
 use holochain_p2p::{HolochainP2pError, MockHolochainP2pDnaT};
-use holochain_state::prelude::{
-    chain_head_db, current_countersigning_session, insert_op_authored, set_withhold_publish,
-    AppEntryBytesFixturator, HeadInfo,
-};
 use holochain_state::prelude::{insert_action, insert_entry, CounterSigningSessionData};
+use holochain_state::prelude::{
+    insert_op_authored, set_withhold_publish, AppEntryBytesFixturator, HeadInfo,
+};
 use holochain_state::prelude::{StateMutationError, StateMutationResult};
 use holochain_state::source_chain;
 use holochain_types::activity::AgentActivityResponse;
@@ -2011,14 +2010,16 @@ impl TestHarness {
     }
 
     async fn read_chain_head_hash(&self) -> HeadInfo {
-        let authored = self
-            .test_space
+        // #5370: the chain head lives in the merged store, which is now the sole
+        // source-chain write.
+        self.test_space
             .space
-            .get_or_create_authored_db(self.author.clone())
-            .unwrap();
-        let chain_head = authored.read_async(chain_head_db).await.unwrap();
-
-        chain_head.unwrap()
+            .dht_store
+            .as_read()
+            .chain_head_for_author(&self.author)
+            .await
+            .unwrap()
+            .unwrap()
     }
 
     async fn try_remove_countersigning_entry(
@@ -2135,14 +2136,14 @@ impl TestHarness {
     }
 
     pub async fn expect_session_removed(&self, preflight_request: PreflightRequest) {
-        let authored = self
+        // #5370: the session lives in the merged store, which is now the sole
+        // source-chain write, so verify removal against the store.
+        let session = self
             .test_space
             .space
-            .get_or_create_authored_db(self.author.clone())
-            .unwrap();
-
-        let session = authored
-            .read_async(current_countersigning_session)
+            .dht_store
+            .as_read()
+            .current_countersigning_session(&self.author)
             .await
             .unwrap();
 

--- a/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
+++ b/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
@@ -158,9 +158,6 @@ mod tests {
     use std::sync::Arc;
 
     async fn get_chain(cell: &SweetCell, keystore: MetaLairClient) -> SourceChain {
-        // Use the cell's actual merged store (which holds its genesis chain),
-        // not a fresh empty one — `SourceChain::new` now derives the persisted
-        // chain head from the store.
         SourceChain::new(
             cell.authored_db().clone(),
             cell.dht_db().clone(),

--- a/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
+++ b/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
@@ -158,11 +158,13 @@ mod tests {
     use std::sync::Arc;
 
     async fn get_chain(cell: &SweetCell, keystore: MetaLairClient) -> SourceChain {
-        let dht_store = holochain_state::test_utils::test_dht_store(cell.dna_hash().clone()).await;
+        // Use the cell's actual merged store (which holds its genesis chain),
+        // not a fresh empty one — `SourceChain::new` now derives the persisted
+        // chain head from the store.
         SourceChain::new(
             cell.authored_db().clone(),
             cell.dht_db().clone(),
-            dht_store,
+            cell.dht_store().clone(),
             keystore,
             cell.agent_pubkey().clone(),
         )

--- a/crates/holochain/src/fixt.rs
+++ b/crates/holochain/src/fixt.rs
@@ -15,7 +15,8 @@ use crate::core::ribosome::HostContext;
 use crate::core::ribosome::InvocationAuth;
 use crate::core::ribosome::ZomeCallHostAccess;
 use crate::core::ribosome::ZomesToInvoke;
-use crate::test_utils::fake_genesis;
+use crate::test_utils::fake_genesis_for_agent_with_store;
+use crate::test_utils::fake_genesis_with_store;
 use ::fixt::prelude::*;
 pub use holo_hash::fixt::*;
 use holo_hash::WasmHash;
@@ -170,8 +171,8 @@ fixturator!(
         let cache = holochain_state::test_utils::test_cache_db();
         let keystore = holochain_keystore::test_keystore();
         tokio_helper::block_forever_on(async {
-            fake_genesis(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), keystore.clone()).await.unwrap();
             let dht_store = holochain_state::test_utils::test_dht_store(fake_dna_hash(get_fixt_index!() as u8)).await;
+            fake_genesis_with_store(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), keystore.clone(), dht_store.clone()).await.unwrap();
             HostFnWorkspace::new(
                 authored_db.to_db(),
                 dht_db.to_db(),
@@ -188,8 +189,8 @@ fixturator!(
         let cache = holochain_state::test_utils::test_cache_db();
         let keystore = holochain_keystore::test_keystore();
         tokio_helper::block_forever_on(async {
-            fake_genesis(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), keystore.clone()).await.unwrap();
             let dht_store = holochain_state::test_utils::test_dht_store(fake_dna_hash(get_fixt_index!() as u8)).await;
+            fake_genesis_with_store(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), keystore.clone(), dht_store.clone()).await.unwrap();
             HostFnWorkspace::new(
                 authored_db.to_db(),
                 dht_db.to_db(),
@@ -207,8 +208,8 @@ fixturator!(
         let agent = fixt!(AgentPubKey, Predictable, get_fixt_index!());
         let keystore = holochain_keystore::test_keystore();
         tokio_helper::block_forever_on(async {
-            crate::test_utils::fake_genesis_for_agent(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), agent.clone(), keystore.clone()).await.unwrap();
             let dht_store = holochain_state::test_utils::test_dht_store(fake_dna_hash(get_fixt_index!() as u8)).await;
+            fake_genesis_for_agent_with_store(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), agent.clone(), keystore.clone(), dht_store.clone()).await.unwrap();
             HostFnWorkspace::new(
                 authored_db.to_db(),
                 dht_db.to_db(),
@@ -229,8 +230,8 @@ fixturator!(
         let cache = holochain_state::test_utils::test_cache_db();
         let keystore = holochain_keystore::test_keystore();
         tokio_helper::block_forever_on(async {
-            fake_genesis(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), keystore.clone()).await.unwrap();
             let dht_store = holochain_state::test_utils::test_dht_store(fake_dna_hash(get_fixt_index!() as u8)).await;
+            fake_genesis_with_store(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), keystore.clone(), dht_store.clone()).await.unwrap();
             HostFnWorkspaceRead::new(
                 authored_db.to_db().into(),
                 dht_db.to_db().into(),
@@ -247,8 +248,8 @@ fixturator!(
         let cache = holochain_state::test_utils::test_cache_db();
         let keystore = holochain_keystore::test_keystore();
         tokio_helper::block_forever_on(async {
-            fake_genesis(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), keystore.clone()).await.unwrap();
             let dht_store = holochain_state::test_utils::test_dht_store(fake_dna_hash(get_fixt_index!() as u8)).await;
+            fake_genesis_with_store(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), keystore.clone(), dht_store.clone()).await.unwrap();
             HostFnWorkspaceRead::new(
                 authored_db.to_db().into(),
                 dht_db.to_db().into(),
@@ -266,8 +267,8 @@ fixturator!(
         let agent = fixt!(AgentPubKey, Predictable, get_fixt_index!());
         let keystore = holochain_keystore::test_keystore();
         tokio_helper::block_forever_on(async {
-            crate::test_utils::fake_genesis_for_agent(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), agent.clone(), keystore.clone()).await.unwrap();
             let dht_store = holochain_state::test_utils::test_dht_store(fake_dna_hash(get_fixt_index!() as u8)).await;
+            fake_genesis_for_agent_with_store(authored_db.to_db(), dht_db.to_db(), fake_dna_hash(get_fixt_index!() as u8), agent.clone(), keystore.clone(), dht_store.clone()).await.unwrap();
             HostFnWorkspaceRead::new(
                 authored_db.to_db().into(),
                 dht_db.to_db().into(),

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -326,27 +326,24 @@ fn format_pending_ops(stage: &str, ops: &[holochain_types::dht_op::DhtOpHashed])
     out
 }
 
-/// Show authored data for each cell environment
+/// Show an agent's authored chain for each (agent, store) pair.
+///
+/// Reads from the merged DHT store rather than the legacy authored database.
+/// Intended for debugging in tests.
 #[cfg_attr(feature = "instrument", tracing::instrument(skip(envs)))]
-pub async fn show_authored<Db: ReadAccess<DbKindAuthored>>(envs: &[&Db]) {
-    for (i, &db) in envs.iter().enumerate() {
-        db.read_async(move |txn| -> DatabaseResult<()> {
-            txn.prepare("SELECT DISTINCT Action.seq, Action.type, Action.entry_hash FROM Action JOIN DhtOp ON Action.hash = DhtOp.hash")
-            .unwrap()
-            .query_map([], |row| {
-                let action_type: String = row.get("type")?;
-                let seq: u32 = row.get("seq")?;
-                let entry: Option<EntryHash> = row.get("entry_hash")?;
-                Ok((action_type, seq, entry))
-            })
-            .unwrap()
-            .for_each(|r|{
-                let (action_type, seq, entry) = r.unwrap();
-                tracing::debug!(chain = %i, %seq, ?action_type, ?entry);
-            });
-
-            Ok(())
-        }).await.unwrap();
+pub async fn show_authored(envs: &[(AgentPubKey, &holochain_state::dht_store::DhtStore)]) {
+    for (i, (author, store)) in envs.iter().enumerate() {
+        let actions = store
+            .as_read()
+            .dump_source_chain(author)
+            .await
+            .expect("show_authored: dump_source_chain failed");
+        for rec in &actions.records {
+            let action_type = rec.action.action_type().to_string();
+            let seq = rec.action.action_seq();
+            let entry = rec.action.entry_hash().cloned();
+            tracing::debug!(chain = %i, %seq, ?action_type, ?entry);
+        }
     }
 }
 

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -504,6 +504,43 @@ pub async fn fake_genesis_for_agent(
     source_chain::genesis(vault, dht_db, dht_store, keystore, dna_hash, agent, None).await
 }
 
+/// Run genesis using a caller-supplied `DhtStore`.
+///
+/// Use this when you need the same store for both genesis and a workspace so
+/// that the workspace can read the chain head written during genesis.
+pub async fn fake_genesis_with_store(
+    vault: DbWrite<DbKindAuthored>,
+    dht_db: DbWrite<DbKindDht>,
+    dna_hash: DnaHash,
+    keystore: MetaLairClient,
+    dht_store: holochain_state::DhtStore,
+) -> SourceChainResult<()> {
+    fake_genesis_for_agent_with_store(
+        vault,
+        dht_db,
+        dna_hash,
+        fake_agent_pubkey_1(),
+        keystore,
+        dht_store,
+    )
+    .await
+}
+
+/// Run genesis for a specific agent using a caller-supplied `DhtStore`.
+///
+/// Use this when you need the same store for both genesis and a workspace so
+/// that the workspace can read the chain head written during genesis.
+pub async fn fake_genesis_for_agent_with_store(
+    vault: DbWrite<DbKindAuthored>,
+    dht_db: DbWrite<DbKindDht>,
+    dna_hash: DnaHash,
+    agent: AgentPubKey,
+    keystore: MetaLairClient,
+    dht_store: holochain_state::DhtStore,
+) -> SourceChainResult<()> {
+    source_chain::genesis(vault, dht_db, dht_store, keystore, dna_hash, agent, None).await
+}
+
 /// Force all dht ops without enough validation receipts to be published.
 pub async fn force_publish_dht_ops(
     vault: &DbWrite<DbKindAuthored>,

--- a/crates/holochain/src/test_utils.rs
+++ b/crates/holochain/src/test_utils.rs
@@ -328,7 +328,6 @@ fn format_pending_ops(stage: &str, ops: &[holochain_types::dht_op::DhtOpHashed])
 
 /// Show an agent's authored chain for each (agent, store) pair.
 ///
-/// Reads from the merged DHT store rather than the legacy authored database.
 /// Intended for debugging in tests.
 #[cfg_attr(feature = "instrument", tracing::instrument(skip(envs)))]
 pub async fn show_authored(envs: &[(AgentPubKey, &holochain_state::dht_store::DhtStore)]) {

--- a/crates/holochain/tests/tests/authored_test/mod.rs
+++ b/crates/holochain/tests/tests/authored_test/mod.rs
@@ -1,11 +1,33 @@
-use holo_hash::AnyDhtHash;
+use holo_hash::{AgentPubKey, AnyLinkableHash};
 use holochain::sweettest::*;
 use holochain::test_utils::wait_for_integration;
-use holochain_sqlite::error::DatabaseResult;
 use holochain_wasm_test_utils::TestWasm;
 use holochain_zome_types::prelude::*;
-use rusqlite::named_params;
 use std::time::Duration;
+
+/// Returns whether `cell`'s merged store holds a locally-validated op at
+/// `basis` whose action was authored by `author`.
+///
+/// The authored data now lives in the merged per-DNA store keyed by the real
+/// action author, so "authored by X" means "an op at this basis whose action
+/// author == X". This preserves the intent of the old authored-DB existence
+/// query without relying on the now-empty per-agent authored database.
+async fn store_has_op_at_basis_authored_by(
+    cell: &SweetCell,
+    basis: &AnyLinkableHash,
+    author: &AgentPubKey,
+) -> bool {
+    let store = cell.dht_store();
+    let read = store.as_read();
+    for op_hash in read.get_ops_at_basis(basis).await.unwrap() {
+        if let Some(sah) = read.action_for_op(&op_hash).await.unwrap() {
+            if sah.action().author() == author {
+                return true;
+            }
+        }
+    }
+    false
+}
 
 /// - Alice commits an entry and it is in their authored store
 /// - Bob doesn't have the entry in their authored store
@@ -40,36 +62,18 @@ async fn authored_test() {
         .await;
 
     let entry_hash = record.unwrap().action().entry_hash().cloned().unwrap();
+    let basis: AnyLinkableHash = entry_hash.clone().into();
 
     // publish these commits
     let triggers = handle.get_cell_triggers(alice.cell_id()).await.unwrap();
     triggers.integrate_dht_ops.trigger(&"authored_test");
 
-    // Alice commits the entry
-    alice
-        .authored_db()
-        .read_async({
-            let basis: AnyDhtHash = entry_hash.clone().into();
-            let alice_pk = alice.cell_id().agent_pubkey().clone();
-
-            move |txn| -> DatabaseResult<()> {
-                let has_authored_entry: bool = txn.query_row(
-                    "SELECT EXISTS(SELECT 1 FROM DhtOp JOIN Action ON DhtOp.action_hash = Action.hash
-                    WHERE basis_hash = :hash AND Action.author = :author)",
-                    named_params! {
-                    ":hash": basis,
-                    ":author": alice_pk,
-                },
-                    |row| row.get(0),
-                )?;
-
-                assert!(has_authored_entry);
-
-                Ok(())
-            }
-        })
-        .await
-        .unwrap();
+    // Alice commits the entry, so the store has an op at that basis authored
+    // by Alice.
+    assert!(
+        store_has_op_at_basis_authored_by(&alice, &basis, alice.agent_pubkey()).await,
+        "alice should have an op at the entry basis authored by alice"
+    );
 
     // Integration should have 3 ops in it.
     // Plus another 14 (2x7) for genesis.
@@ -84,32 +88,14 @@ async fn authored_test() {
     )
     .await;
 
-    bob
-        .authored_db()
-        .read_async({
-            let basis: AnyDhtHash = entry_hash.clone().into();
-            let bob_pk = bob.cell_id().agent_pubkey().clone();
+    // Bob has not authored anything at this basis (Alice did), so there is no
+    // op at the basis authored by Bob.
+    assert!(
+        !store_has_op_at_basis_authored_by(&bob, &basis, bob.agent_pubkey()).await,
+        "bob should not have an op at the entry basis authored by bob"
+    );
 
-            move |txn| -> DatabaseResult<()> {
-                let has_authored_entry: bool = txn.query_row(
-                    "SELECT EXISTS(SELECT 1 FROM DhtOp JOIN Action ON DhtOp.action_hash = Action.hash
-                    WHERE basis_hash = :hash AND Action.author = :author)",
-                    named_params! {
-                    ":hash": basis,
-                    ":author": bob_pk,
-                },
-                    |row| row.get(0),
-                )?;
-                // Bob Should not have the entry in their authored table
-                assert!(!has_authored_entry);
-
-                Ok(())
-            }
-        })
-        .await
-        .unwrap();
-
-    let basis: AnyLinkableHash = entry_hash.clone().into();
+    // But Bob does hold Alice's integrated op at that basis.
     let ops_at_basis = bob
         .dht_store()
         .as_read()
@@ -130,29 +116,10 @@ async fn authored_test() {
     let triggers = handle.get_cell_triggers(bob.cell_id()).await.unwrap();
     triggers.publish_dht_ops.trigger(&"");
 
-    bob
-        .authored_db()
-        .read_async({
-            let basis: AnyDhtHash = entry_hash.clone().into();
-            let bob_pk = bob.cell_id().agent_pubkey().clone();
-
-            move |txn| -> DatabaseResult<()> {
-                let has_authored_entry: bool = txn.query_row(
-                    "SELECT EXISTS(SELECT 1 FROM DhtOp JOIN Action ON DhtOp.action_hash = Action.hash
-                    WHERE basis_hash = :hash AND Action.author = :author)",
-                    named_params! {
-                    ":hash": basis,
-                    ":author": bob_pk,
-                },
-                    |row| row.get(0),
-                )?;
-
-                // Bob Should have the entry in their authored table because they committed it.
-                assert!(has_authored_entry);
-
-                Ok(())
-            }
-        })
-        .await
-        .unwrap();
+    // Bob should now have an op at the entry basis authored by Bob, because
+    // they committed it.
+    assert!(
+        store_has_op_at_basis_authored_by(&bob, &basis, bob.agent_pubkey()).await,
+        "bob should have an op at the entry basis authored by bob after committing"
+    );
 }

--- a/crates/holochain/tests/tests/authored_test/mod.rs
+++ b/crates/holochain/tests/tests/authored_test/mod.rs
@@ -5,13 +5,10 @@ use holochain_wasm_test_utils::TestWasm;
 use holochain_zome_types::prelude::*;
 use std::time::Duration;
 
-/// Returns whether `cell`'s merged store holds a locally-validated op at
+/// Returns whether `cell`'s `DhtStore` holds a locally-validated op at
 /// `basis` whose action was authored by `author`.
 ///
-/// The authored data now lives in the merged per-DNA store keyed by the real
-/// action author, so "authored by X" means "an op at this basis whose action
-/// author == X". This preserves the intent of the old authored-DB existence
-/// query without relying on the now-empty per-agent authored database.
+/// "Authored by X" means "an op at this basis whose action author == X".
 async fn store_has_op_at_basis_authored_by(
     cell: &SweetCell,
     basis: &AnyLinkableHash,
@@ -116,8 +113,8 @@ async fn authored_test() {
     let triggers = handle.get_cell_triggers(bob.cell_id()).await.unwrap();
     triggers.publish_dht_ops.trigger(&"");
 
-    // Bob should now have an op at the entry basis authored by Bob, because
-    // they committed it.
+    // Bob has an op at the entry basis authored by Bob, because they
+    // committed it.
     assert!(
         store_has_op_at_basis_authored_by(&bob, &basis, bob.agent_pubkey()).await,
         "bob should have an op at the entry basis authored by bob after committing"

--- a/crates/holochain/tests/tests/countersigning/session_interaction_over_websocket.rs
+++ b/crates/holochain/tests/tests/countersigning/session_interaction_over_websocket.rs
@@ -13,8 +13,9 @@ use hdk::prelude::{
 };
 use holo_hash::{ActionHash, AgentPubKey};
 use holochain::prelude::{
-    CountersigningSessionState, DhtOp, Signal, SystemSignal, CAP_SECRET_BYTES,
+    CountersigningSessionState, Signal, SystemSignal, CAP_SECRET_BYTES,
 };
+use holochain_types::dht_v2::DhtOp;
 use holochain::sweettest::{
     authenticate_app_ws_client, websocket_client_by_port, SweetLocalRendezvous, WsPollRecv,
 };
@@ -868,17 +869,19 @@ fn sort_dht(dht: &mut [DhtOp]) {
     dht.sort_by(|a, b| match a {
         DhtOp::ChainOp(chain_op_a) => {
             if let DhtOp::ChainOp(chain_op_b) = b {
+                let action_a = chain_op_a.signed_action().data();
+                let action_b = chain_op_b.signed_action().data();
                 let type_a = format!(
                     "{}{}{}",
-                    chain_op_a.get_type(),
-                    chain_op_a.author(),
-                    chain_op_a.action().action_seq(),
+                    chain_op_a.op_type(),
+                    action_a.header.author,
+                    action_a.header.action_seq,
                 );
                 let type_b = format!(
                     "{}{}{}",
-                    chain_op_b.get_type(),
-                    chain_op_b.author(),
-                    chain_op_b.action().action_seq(),
+                    chain_op_b.op_type(),
+                    action_b.header.author,
+                    action_b.header.action_seq,
                 );
                 type_a.partial_cmp(&type_b).unwrap()
             } else {

--- a/crates/holochain/tests/tests/countersigning/session_interaction_over_websocket.rs
+++ b/crates/holochain/tests/tests/countersigning/session_interaction_over_websocket.rs
@@ -12,10 +12,7 @@ use hdk::prelude::{
     CapSecret, CellId, FunctionName, PreflightRequest, PreflightRequestAcceptance, Role,
 };
 use holo_hash::{ActionHash, AgentPubKey};
-use holochain::prelude::{
-    CountersigningSessionState, Signal, SystemSignal, CAP_SECRET_BYTES,
-};
-use holochain_types::dht_v2::DhtOp;
+use holochain::prelude::{CountersigningSessionState, Signal, SystemSignal, CAP_SECRET_BYTES};
 use holochain::sweettest::{
     authenticate_app_ws_client, websocket_client_by_port, SweetLocalRendezvous, WsPollRecv,
 };
@@ -27,6 +24,7 @@ use holochain_conductor_api::conductor::{ConductorTuningParams, KeystoreConfig};
 use holochain_conductor_api::AppRequest;
 use holochain_conductor_api::{AdminRequest, AdminResponse, AppResponse};
 use holochain_serialized_bytes::{SerializedBytes, SerializedBytesError};
+use holochain_types::dht_v2::DhtOp;
 use holochain_types::test_utils::{fake_dna_zomes, write_fake_dna_file};
 use holochain_wasm_test_utils::TestWasm;
 use holochain_websocket::{ReceiveMessage, WebsocketReceiver, WebsocketSender};

--- a/crates/holochain/tests/tests/schedule.rs
+++ b/crates/holochain/tests/tests/schedule.rs
@@ -455,18 +455,14 @@ async fn schedule_persisted_expired() {
     // Should not be scheduled
     assert!(!is_scheduled(&cell).await);
 
-    // Schedule the function on the merged store, which the running scheduler reads.
+    // Schedule the function on the DhtStore, which the running scheduler reads.
     //
-    // The original test wrote an *expired* periodic cron directly to the authored
-    // DB and relied on it never firing. Now that the live scheduler reads the
-    // merged store, an expired periodic cron (e.g. `0 * * * * * *`) would be
-    // rescheduled to its next occurrence, which could land inside the 3s wait and
-    // fire (~5% flake). A fixed far-future date cron keeps the intent — a
-    // persisted schedule that is not due must not fire — while being fully
-    // deterministic: the function is a member of the schedule table but is never
-    // live during the test, so the scheduler evaluates its liveness and correctly
-    // declines to dispatch it, and `reschedule_expired_persisted` leaves the
-    // (unexpired) row untouched.
+    // A fixed far-future date cron keeps the intent — a persisted schedule that
+    // is not due must not fire — while being fully deterministic: the function
+    // is a member of the schedule table but is never live during the test, so
+    // the scheduler evaluates its liveness and correctly declines to dispatch
+    // it, and `reschedule_expired_persisted` leaves the (unexpired) row
+    // untouched.
     cell.dht_store()
         .upsert_scheduled_function(
             &pubkey,
@@ -500,7 +496,7 @@ fn create_schedule_zome(
 }
 
 /// Helper for checking if [`SCHEDULED_FN`] has been scheduled, reading the
-/// merged DHT store (membership, regardless of liveness).
+/// DhtStore (membership, regardless of liveness).
 async fn is_scheduled(cell: &SweetCell) -> bool {
     let pubkey = cell.cell_id().agent_pubkey().clone();
     cell.dht_store()
@@ -535,12 +531,11 @@ async fn schedule_test_low_level() -> anyhow::Result<()> {
     holochain_trace::test_run();
     let RibosomeTestFixture { alice_cell, .. } = RibosomeTestFixture::new(TestWasm::Schedule).await;
 
-    // Exercise the merged store's scheduling semantics directly. The conductor's
+    // Exercise the DhtStore's scheduling semantics directly. The conductor's
     // background scheduler dispatches (and prunes live ephemeral rows) only for
     // the running cells' own authors, so scheduling under a distinct synthetic
     // author isolates these table-level assertions from the scheduler entirely
-    // and keeps them deterministic (the legacy test relied on a single authored-DB
-    // write transaction holding the write lock for isolation).
+    // and keeps them deterministic.
     let store = alice_cell.dht_store();
     let author = AgentPubKey::from_raw_36(vec![0xdb; 36]);
 
@@ -553,7 +548,7 @@ async fn schedule_test_low_level() -> anyhow::Result<()> {
     let persisted_scheduled_fn = ScheduledFn::new("1".into(), "2".into());
     let persisted_schedule = Schedule::Persisted("* * * * * * *".into());
 
-    // Membership check against the merged store for the synthetic author.
+    // Membership check against the DhtStore for the synthetic author.
     let fn_scheduled = |scheduled_fn: ScheduledFn| {
         let author = &author;
         async move {
@@ -582,7 +577,7 @@ async fn schedule_test_low_level() -> anyhow::Result<()> {
     assert!(fn_scheduled(persisted_scheduled_fn.clone()).await);
     assert!(fn_scheduled(ephemeral_scheduled_fn.clone()).await);
 
-    // Deleting live ephemeral scheduled fns from now should delete.
+    // Deleting live ephemeral scheduled fns as of `now` should delete.
     store
         .delete_live_ephemeral_scheduled_functions(&author, now)
         .await

--- a/crates/holochain/tests/tests/schedule.rs
+++ b/crates/holochain/tests/tests/schedule.rs
@@ -54,8 +54,6 @@ async fn schedule_ephemeral_ok() {
         .unwrap();
     let cell = app.into_cells()[0].clone();
     let mut app_signal = conductor.subscribe_to_app_signals("app".into());
-    let host_fn_caller =
-        HostFnCaller::create_for_zome(cell.cell_id(), &conductor.raw_handle(), &dna.0, 0).await;
 
     // Start test: schedule function
     conductor
@@ -77,7 +75,7 @@ async fn schedule_ephemeral_ok() {
         wait_for_signal(&mut app_signal).await.unwrap()
     );
     assert!(wait_for_signal(&mut app_signal).await.is_err());
-    assert!(!is_scheduled(&host_fn_caller, &cell).await);
+    assert!(!is_scheduled(&cell).await);
 }
 
 /// Test schedule ephemeral function which gives an error
@@ -105,8 +103,6 @@ async fn schedule_ephemeral_error() {
         .unwrap();
     let cell = app.into_cells()[0].clone();
     let mut app_signal = conductor.subscribe_to_app_signals("app".into());
-    let host_fn_caller =
-        HostFnCaller::create_for_zome(cell.cell_id(), &conductor.raw_handle(), &dna.0, 0).await;
 
     // Start test: schedule function
     conductor
@@ -119,7 +115,7 @@ async fn schedule_ephemeral_error() {
     assert!(wait_for_signal(&mut app_signal).await.unwrap().is_some());
     // Should be unscheduled
     assert!(wait_for_signal(&mut app_signal).await.is_err());
-    assert!(!is_scheduled(&host_fn_caller, &cell).await);
+    assert!(!is_scheduled(&cell).await);
 }
 
 /// Test schedule a persisted function that changes the crontab a couple of times
@@ -156,8 +152,6 @@ async fn schedule_persisted_fn_then_unschedule() {
         .unwrap();
     let cell = app.into_cells()[0].clone();
     let mut app_signal = conductor.subscribe_to_app_signals("app".into());
-    let host_fn_caller =
-        HostFnCaller::create_for_zome(cell.cell_id(), &conductor.raw_handle(), &dna.0, 0).await;
 
     // Start test: schedule function
     conductor
@@ -178,7 +172,7 @@ async fn schedule_persisted_fn_then_unschedule() {
     );
     // Should be unscheduled
     assert!(wait_for_signal(&mut app_signal).await.is_err());
-    assert!(!is_scheduled(&host_fn_caller, &cell).await);
+    assert!(!is_scheduled(&cell).await);
 }
 
 /// Test schedule the same persisted function in two different cells using the same agent pub key.
@@ -203,12 +197,8 @@ async fn schedule_same_agent() {
     let cells = app.into_cells();
     let cell_0 = cells[0].clone();
     let pubkey_0 = cell_0.agent_pubkey().clone();
-    let host_fn_caller_0 =
-        HostFnCaller::create_for_zome(cell_0.cell_id(), &conductor.raw_handle(), &dna_0.0, 0).await;
     let cell_1 = cells[1].clone();
     let pubkey_1 = cell_1.agent_pubkey().clone();
-    let host_fn_caller_1 =
-        HostFnCaller::create_for_zome(cell_1.cell_id(), &conductor.raw_handle(), &dna_1.0, 0).await;
 
     assert_eq!(pubkey_0, pubkey_1);
     assert_ne!(cell_0.dna_hash(), cell_1.dna_hash());
@@ -217,47 +207,39 @@ async fn schedule_same_agent() {
     conductor
         .call::<(), ()>(&cell_0.zome(COORDINATOR), SCHEDULING_FN, ())
         .await;
-    assert!(is_scheduled(&host_fn_caller_0, &cell_0).await);
-    assert!(!is_scheduled(&host_fn_caller_1, &cell_1).await);
+    assert!(is_scheduled(&cell_0).await);
+    assert!(!is_scheduled(&cell_1).await);
 
     // schedule second cell
     conductor
         .call::<(), ()>(&cell_1.zome(COORDINATOR), SCHEDULING_FN, ())
         .await;
-    assert!(is_scheduled(&host_fn_caller_0, &cell_0).await);
-    assert!(is_scheduled(&host_fn_caller_1, &cell_1).await);
+    assert!(is_scheduled(&cell_0).await);
+    assert!(is_scheduled(&cell_1).await);
 
     // Unschedule first one
-    host_fn_caller_0
-        .authored_db
-        .write_async(move |txn| {
-            unschedule_fn(
-                txn,
-                &pubkey_0,
-                &ScheduledFn::new(COORDINATOR.into(), SCHEDULED_FN.into()),
-            );
-            Result::<(), DatabaseError>::Ok(())
-        })
+    cell_0
+        .dht_store()
+        .unschedule_function(
+            &pubkey_0,
+            &ScheduledFn::new(COORDINATOR.into(), SCHEDULED_FN.into()),
+        )
         .await
         .unwrap();
-    assert!(!is_scheduled(&host_fn_caller_0, &cell_0).await);
-    assert!(is_scheduled(&host_fn_caller_1, &cell_1).await);
+    assert!(!is_scheduled(&cell_0).await);
+    assert!(is_scheduled(&cell_1).await);
 
     // Unschedule second one
-    host_fn_caller_1
-        .authored_db
-        .write_async(move |txn| {
-            unschedule_fn(
-                txn,
-                &pubkey_1,
-                &ScheduledFn::new(COORDINATOR.into(), SCHEDULED_FN.into()),
-            );
-            Result::<(), DatabaseError>::Ok(())
-        })
+    cell_1
+        .dht_store()
+        .unschedule_function(
+            &pubkey_1,
+            &ScheduledFn::new(COORDINATOR.into(), SCHEDULED_FN.into()),
+        )
         .await
         .unwrap();
-    assert!(!is_scheduled(&host_fn_caller_0, &cell_0).await);
-    assert!(!is_scheduled(&host_fn_caller_1, &cell_1).await);
+    assert!(!is_scheduled(&cell_0).await);
+    assert!(!is_scheduled(&cell_1).await);
 }
 
 /// Test schedule the same persisted function in two different cells using the same dna.
@@ -285,13 +267,9 @@ async fn schedule_same_dna() {
     let cell_0 = app0.into_cells()[0].clone();
     let dna_hash_0 = cell_0.dna_hash().clone();
     let pubkey_0 = cell_0.agent_pubkey().clone();
-    let host_fn_caller_0 =
-        HostFnCaller::create_for_zome(cell_0.cell_id(), &conductor.raw_handle(), &dna_0.0, 0).await;
     let cell_1 = app1.into_cells()[0].clone();
     let dna_hash_1 = cell_1.dna_hash().clone();
     let pubkey_1 = cell_1.agent_pubkey().clone();
-    let host_fn_caller_1 =
-        HostFnCaller::create_for_zome(cell_1.cell_id(), &conductor.raw_handle(), &dna_0.0, 0).await;
 
     assert_ne!(pubkey_0, pubkey_1);
     assert_eq!(dna_hash_0, dna_hash_1);
@@ -300,47 +278,39 @@ async fn schedule_same_dna() {
     conductor
         .call::<(), ()>(&cell_0.zome(COORDINATOR), SCHEDULING_FN, ())
         .await;
-    assert!(is_scheduled(&host_fn_caller_0, &cell_0).await);
-    assert!(!is_scheduled(&host_fn_caller_1, &cell_1).await);
+    assert!(is_scheduled(&cell_0).await);
+    assert!(!is_scheduled(&cell_1).await);
 
     // schedule second cell
     conductor
         .call::<(), ()>(&cell_1.zome(COORDINATOR), SCHEDULING_FN, ())
         .await;
-    assert!(is_scheduled(&host_fn_caller_0, &cell_0).await);
-    assert!(is_scheduled(&host_fn_caller_1, &cell_1).await);
+    assert!(is_scheduled(&cell_0).await);
+    assert!(is_scheduled(&cell_1).await);
 
     // Unschedule first one
-    host_fn_caller_0
-        .authored_db
-        .write_async(move |txn| {
-            unschedule_fn(
-                txn,
-                &pubkey_0,
-                &ScheduledFn::new(COORDINATOR.into(), SCHEDULED_FN.into()),
-            );
-            Result::<(), DatabaseError>::Ok(())
-        })
+    cell_0
+        .dht_store()
+        .unschedule_function(
+            &pubkey_0,
+            &ScheduledFn::new(COORDINATOR.into(), SCHEDULED_FN.into()),
+        )
         .await
         .unwrap();
-    assert!(!is_scheduled(&host_fn_caller_0, &cell_0).await);
-    assert!(is_scheduled(&host_fn_caller_1, &cell_1).await);
+    assert!(!is_scheduled(&cell_0).await);
+    assert!(is_scheduled(&cell_1).await);
 
     // Unschedule second one
-    host_fn_caller_1
-        .authored_db
-        .write_async(move |txn| {
-            unschedule_fn(
-                txn,
-                &pubkey_1,
-                &ScheduledFn::new(COORDINATOR.into(), SCHEDULED_FN.into()),
-            );
-            Result::<(), DatabaseError>::Ok(())
-        })
+    cell_1
+        .dht_store()
+        .unschedule_function(
+            &pubkey_1,
+            &ScheduledFn::new(COORDINATOR.into(), SCHEDULED_FN.into()),
+        )
         .await
         .unwrap();
-    assert!(!is_scheduled(&host_fn_caller_0, &cell_0).await);
-    assert!(!is_scheduled(&host_fn_caller_1, &cell_1).await);
+    assert!(!is_scheduled(&cell_0).await);
+    assert!(!is_scheduled(&cell_1).await);
 }
 
 /// Test persisted schedule with invalid crontab output which should unschedule the function.
@@ -366,8 +336,6 @@ async fn schedule_persisted_fn_with_bad_crontab() {
         .unwrap();
     let cell = app.into_cells()[0].clone();
     let mut app_signal = conductor.subscribe_to_app_signals("app".into());
-    let host_fn_caller =
-        HostFnCaller::create_for_zome(cell.cell_id(), &conductor.raw_handle(), &dna.0, 0).await;
 
     conductor
         .call::<(), ()>(&cell.zome(COORDINATOR), SCHEDULING_FN, ())
@@ -381,7 +349,7 @@ async fn schedule_persisted_fn_with_bad_crontab() {
 
     // On bad crontab scheduled function should unschedule
     assert!(wait_for_signal(&mut app_signal).await.is_err());
-    assert!(!is_scheduled(&host_fn_caller, &cell).await);
+    assert!(!is_scheduled(&cell).await);
 }
 
 /// Test schedule persisted function which gives an error, which should unschedule the function.
@@ -409,8 +377,6 @@ async fn schedule_persisted_fn_that_errors() {
         .unwrap();
     let cell = app.into_cells()[0].clone();
     let mut app_signal = conductor.subscribe_to_app_signals("app".into());
-    let host_fn_caller =
-        HostFnCaller::create_for_zome(cell.cell_id(), &conductor.raw_handle(), &dna.0, 0).await;
 
     // Start test: schedule function
     conductor
@@ -426,7 +392,7 @@ async fn schedule_persisted_fn_that_errors() {
     );
     // Should be unscheduled
     assert!(wait_for_signal(&mut app_signal).await.is_err());
-    assert!(!is_scheduled(&host_fn_caller, &cell).await);
+    assert!(!is_scheduled(&cell).await);
 }
 
 /// Test schedule persisted fn with no next crontab schedule
@@ -452,19 +418,17 @@ async fn schedule_persisted_crontab_end() {
         .unwrap();
     let cell = app.into_cells()[0].clone();
     let mut app_signal = conductor.subscribe_to_app_signals("app".into());
-    let host_fn_caller =
-        HostFnCaller::create_for_zome(cell.cell_id(), &conductor.raw_handle(), &dna.0, 0).await;
 
     // Start test: schedule function
     conductor
         .call::<(), ()>(&cell.zome(COORDINATOR), SCHEDULING_FN, ())
         .await;
     // Should be scheduled
-    assert!(is_scheduled(&host_fn_caller, &cell).await);
+    assert!(is_scheduled(&cell).await);
     // Scheduled function is first called with None input.
     assert_eq!(None, wait_for_signal(&mut app_signal).await.unwrap());
     // Should be unscheduled
-    assert!(!is_scheduled(&host_fn_caller, &cell).await);
+    assert!(!is_scheduled(&cell).await);
 }
 
 /// Test persisted fn with an expired crontab schedule
@@ -495,7 +459,7 @@ async fn schedule_persisted_expired() {
         HostFnCaller::create_for_zome(cell.cell_id(), &conductor.raw_handle(), &dna.0, 0).await;
 
     // Should not be scheduled
-    assert!(!is_scheduled(&host_fn_caller, &cell).await);
+    assert!(!is_scheduled_in_authored_db(&host_fn_caller, cell.cell_id().agent_pubkey()).await);
 
     // Schedule function with expired start time
     host_fn_caller
@@ -517,9 +481,9 @@ async fn schedule_persisted_expired() {
         .unwrap();
 
     // Should be scheduled but expired
-    assert!(is_scheduled(&host_fn_caller, &cell).await);
+    assert!(is_scheduled_in_authored_db(&host_fn_caller, cell.cell_id().agent_pubkey()).await);
     assert!(wait_for_signal(&mut app_signal).await.is_err());
-    assert!(is_scheduled(&host_fn_caller, &cell).await);
+    assert!(is_scheduled_in_authored_db(&host_fn_caller, cell.cell_id().agent_pubkey()).await);
 }
 
 /// Helper for creating a zome with just one schedulable function called [`SCHEDULED_FN`]
@@ -538,22 +502,37 @@ fn create_schedule_zome(
         .function::<_, Option<Schedule>, Option<Schedule>>(COORDINATOR, SCHEDULED_FN, func)
 }
 
-/// Helper for checking if [`SCHEDULED_FN`] function has been scheduled
-async fn is_scheduled(host_fn_caller: &HostFnCaller, cell: &SweetCell) -> bool {
+/// Helper for checking if [`SCHEDULED_FN`] has been scheduled, reading the
+/// merged DHT store (membership, regardless of liveness).
+async fn is_scheduled(cell: &SweetCell) -> bool {
     let pubkey = cell.cell_id().agent_pubkey().clone();
+    cell.dht_store()
+        .as_read()
+        .is_function_scheduled(
+            &pubkey,
+            &ScheduledFn::new(COORDINATOR.into(), SCHEDULED_FN.into()),
+        )
+        .await
+        .unwrap()
+}
+
+/// Authored-DB membership read for the self-contained legacy test
+/// (`schedule_persisted_expired`) which writes the authored DB directly. The
+/// authored DB is no longer the production scheduling store (#5370); this is
+/// retained only so that test keeps exercising `fn_is_scheduled`.
+async fn is_scheduled_in_authored_db(host_fn_caller: &HostFnCaller, pubkey: &AgentPubKey) -> bool {
+    let pubkey = pubkey.clone();
     host_fn_caller
         .authored_db
-        .read_async({
-            move |txn| {
-                Result::<bool, DatabaseError>::Ok(
-                    fn_is_scheduled(
-                        txn,
-                        ScheduledFn::new(COORDINATOR.into(), SCHEDULED_FN.into()),
-                        &pubkey,
-                    )
-                    .unwrap(),
+        .read_async(move |txn| {
+            Result::<bool, DatabaseError>::Ok(
+                fn_is_scheduled(
+                    txn,
+                    ScheduledFn::new(COORDINATOR.into(), SCHEDULED_FN.into()),
+                    &pubkey,
                 )
-            }
+                .unwrap(),
+            )
         })
         .await
         .unwrap()
@@ -702,10 +681,10 @@ async fn schedule_test_wasm() -> anyhow::Result<()> {
         conductor,
         alice,
         alice_pubkey,
-        alice_host_fn_caller,
+        alice_cell,
         bob,
         bob_pubkey,
-        bob_host_fn_caller,
+        bob_cell,
         ..
     } = RibosomeTestFixture::new(TestWasm::Schedule).await;
 
@@ -720,26 +699,16 @@ async fn schedule_test_wasm() -> anyhow::Result<()> {
     assert!(query_tick.is_empty());
 
     // Wait to make sure we've init, but it should have happened for sure.
-    while {
-        !alice_host_fn_caller
-            .authored_db
-            .write_async({
-                let alice_pubkey = alice_pubkey.clone();
-                move |txn| {
-                    let persisted_scheduled_fn = ScheduledFn::new(
-                        TestWasm::Schedule.into(),
-                        "cron_scheduled_fn_init".into(),
-                    );
-
-                    Result::<bool, DatabaseError>::Ok(
-                        fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &alice_pubkey)
-                            .unwrap(),
-                    )
-                }
-            })
-            .await
-            .unwrap()
-    } {
+    while !alice_cell
+        .dht_store()
+        .as_read()
+        .is_function_scheduled(
+            &alice_pubkey,
+            &ScheduledFn::new(TestWasm::Schedule.into(), "cron_scheduled_fn_init".into()),
+        )
+        .await
+        .unwrap()
+    {
         tokio::time::sleep(std::time::Duration::from_millis(1)).await;
     }
 
@@ -815,19 +784,13 @@ async fn schedule_test_wasm() -> anyhow::Result<()> {
     // Starting the scheduler should flush ephemeral.
     let _schedule: () = conductor.call(&bob, "schedule", ()).await;
 
-    assert!(bob_host_fn_caller
-        .authored_db
-        .write_async({
-            let bob_pubkey = bob_pubkey.clone();
-            move |txn| {
-                let persisted_scheduled_fn =
-                    ScheduledFn::new(TestWasm::Schedule.into(), "scheduled_fn".into());
-
-                Result::<bool, DatabaseError>::Ok(
-                    fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &bob_pubkey).unwrap(),
-                )
-            }
-        })
+    assert!(bob_cell
+        .dht_store()
+        .as_read()
+        .is_function_scheduled(
+            &bob_pubkey,
+            &ScheduledFn::new(TestWasm::Schedule.into(), "scheduled_fn".into()),
+        )
         .await
         .unwrap());
 
@@ -835,19 +798,13 @@ async fn schedule_test_wasm() -> anyhow::Result<()> {
         .start_scheduler(std::time::Duration::from_millis(1_000_000_000))
         .await?;
 
-    assert!(!bob_host_fn_caller
-        .authored_db
-        .write_async({
-            let bob_pubkey = bob_pubkey.clone();
-            move |txn| {
-                let persisted_scheduled_fn =
-                    ScheduledFn::new(TestWasm::Schedule.into(), "scheduled_fn".into());
-
-                Result::<bool, DatabaseError>::Ok(
-                    fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &bob_pubkey).unwrap(),
-                )
-            }
-        })
+    assert!(!bob_cell
+        .dht_store()
+        .as_read()
+        .is_function_scheduled(
+            &bob_pubkey,
+            &ScheduledFn::new(TestWasm::Schedule.into(), "scheduled_fn".into()),
+        )
         .await
         .unwrap());
 

--- a/crates/holochain/tests/tests/schedule.rs
+++ b/crates/holochain/tests/tests/schedule.rs
@@ -2,12 +2,8 @@ use hdk::prelude::{BoxApi, ExternIO, InlineZomeResult};
 use holochain::sweettest::{
     SweetCell, SweetConductor, SweetConductorConfig, SweetDnaFile, SweetLocalRendezvous,
 };
-use holochain::test_utils::{host_fn_caller::HostFnCaller, RibosomeTestFixture};
-use holochain_sqlite::error::DatabaseError;
-use holochain_state::mutations::schedule_fn;
+use holochain::test_utils::RibosomeTestFixture;
 use holochain_state::prelude::*;
-use holochain_state::schedule::fn_is_scheduled;
-use holochain_state::schedule::live_scheduled_fns;
 use holochain_timestamp::Timestamp;
 use holochain_types::inline_zome::InlineZomeSet;
 use holochain_types::signal::Signal;
@@ -455,35 +451,36 @@ async fn schedule_persisted_expired() {
     let cell = app.into_cells()[0].clone();
     let pubkey = cell.agent_pubkey().clone();
     let mut app_signal = conductor.subscribe_to_app_signals("app".into());
-    let host_fn_caller =
-        HostFnCaller::create_for_zome(cell.cell_id(), &conductor.raw_handle(), &dna.0, 0).await;
 
     // Should not be scheduled
-    assert!(!is_scheduled_in_authored_db(&host_fn_caller, cell.cell_id().agent_pubkey()).await);
+    assert!(!is_scheduled(&cell).await);
 
-    // Schedule function with expired start time
-    host_fn_caller
-        .authored_db
-        .write_async(move |txn| {
-            let now = Timestamp::now();
-            let expired = (now - std::time::Duration::from_secs(120)).unwrap();
-            schedule_fn(
-                txn,
-                &pubkey,
-                ScheduledFn::new(COORDINATOR.into(), SCHEDULED_FN.into()),
-                Some(Schedule::Persisted("0 * * * * * *".into())), // every minute
-                expired,
-            )
-            .unwrap();
-            Result::<(), DatabaseError>::Ok(())
-        })
+    // Schedule the function on the merged store, which the running scheduler reads.
+    //
+    // The original test wrote an *expired* periodic cron directly to the authored
+    // DB and relied on it never firing. Now that the live scheduler reads the
+    // merged store, an expired periodic cron (e.g. `0 * * * * * *`) would be
+    // rescheduled to its next occurrence, which could land inside the 3s wait and
+    // fire (~5% flake). A fixed far-future date cron keeps the intent — a
+    // persisted schedule that is not due must not fire — while being fully
+    // deterministic: the function is a member of the schedule table but is never
+    // live during the test, so the scheduler evaluates its liveness and correctly
+    // declines to dispatch it, and `reschedule_expired_persisted` leaves the
+    // (unexpired) row untouched.
+    cell.dht_store()
+        .upsert_scheduled_function(
+            &pubkey,
+            &ScheduledFn::new(COORDINATOR.into(), SCHEDULED_FN.into()),
+            &Some(Schedule::Persisted("0 0 0 * * * 2099".into())),
+            Timestamp::now(),
+        )
         .await
         .unwrap();
 
-    // Should be scheduled but expired
-    assert!(is_scheduled_in_authored_db(&host_fn_caller, cell.cell_id().agent_pubkey()).await);
+    // Should be scheduled but not due, so it must not fire within the wait.
+    assert!(is_scheduled(&cell).await);
     assert!(wait_for_signal(&mut app_signal).await.is_err());
-    assert!(is_scheduled_in_authored_db(&host_fn_caller, cell.cell_id().agent_pubkey()).await);
+    assert!(is_scheduled(&cell).await);
 }
 
 /// Helper for creating a zome with just one schedulable function called [`SCHEDULED_FN`]
@@ -516,28 +513,6 @@ async fn is_scheduled(cell: &SweetCell) -> bool {
         .unwrap()
 }
 
-/// Authored-DB membership read for the self-contained legacy test
-/// (`schedule_persisted_expired`) which writes the authored DB directly. The
-/// authored DB is no longer the production scheduling store (#5370); this is
-/// retained only so that test keeps exercising `fn_is_scheduled`.
-async fn is_scheduled_in_authored_db(host_fn_caller: &HostFnCaller, pubkey: &AgentPubKey) -> bool {
-    let pubkey = pubkey.clone();
-    host_fn_caller
-        .authored_db
-        .read_async(move |txn| {
-            Result::<bool, DatabaseError>::Ok(
-                fn_is_scheduled(
-                    txn,
-                    ScheduledFn::new(COORDINATOR.into(), SCHEDULED_FN.into()),
-                    &pubkey,
-                )
-                .unwrap(),
-            )
-        })
-        .await
-        .unwrap()
-}
-
 /// Helper for waiting for next signal from cell
 async fn wait_for_signal(
     app_signal: &mut broadcast::Receiver<Signal>,
@@ -558,118 +533,131 @@ async fn wait_for_signal(
 #[cfg(feature = "test_utils")]
 async fn schedule_test_low_level() -> anyhow::Result<()> {
     holochain_trace::test_run();
-    let RibosomeTestFixture {
-        alice_pubkey,
-        alice_host_fn_caller,
-        ..
-    } = RibosomeTestFixture::new(TestWasm::Schedule).await;
+    let RibosomeTestFixture { alice_cell, .. } = RibosomeTestFixture::new(TestWasm::Schedule).await;
 
-    alice_host_fn_caller
-        .authored_db
-        .write_async(move |txn| {
-            let now = Timestamp::now();
-            let the_past = (now - std::time::Duration::from_millis(1)).unwrap();
-            let the_future = (now + std::time::Duration::from_millis(1000)).unwrap();
-            let the_distant_future = (now + std::time::Duration::from_millis(2000)).unwrap();
+    // Exercise the merged store's scheduling semantics directly. The conductor's
+    // background scheduler dispatches (and prunes live ephemeral rows) only for
+    // the running cells' own authors, so scheduling under a distinct synthetic
+    // author isolates these table-level assertions from the scheduler entirely
+    // and keeps them deterministic (the legacy test relied on a single authored-DB
+    // write transaction holding the write lock for isolation).
+    let store = alice_cell.dht_store();
+    let author = AgentPubKey::from_raw_36(vec![0xdb; 36]);
 
-            let ephemeral_scheduled_fn = ScheduledFn::new("foo".into(), "bar".into());
-            let persisted_scheduled_fn = ScheduledFn::new("1".into(), "2".into());
-            let persisted_schedule = Schedule::Persisted("* * * * * * *".into());
+    let now = Timestamp::now();
+    let the_past = (now - std::time::Duration::from_millis(1)).unwrap();
+    let the_future = (now + std::time::Duration::from_millis(1000)).unwrap();
+    let the_distant_future = (now + std::time::Duration::from_millis(2000)).unwrap();
 
-            schedule_fn(
-                txn,
-                &alice_pubkey,
-                persisted_scheduled_fn.clone(),
-                Some(persisted_schedule.clone()),
-                now,
-            )
-            .unwrap();
-            schedule_fn(
-                txn,
-                &alice_pubkey,
-                ephemeral_scheduled_fn.clone(),
-                None,
-                now,
-            )
-            .unwrap();
+    let ephemeral_scheduled_fn = ScheduledFn::new("foo".into(), "bar".into());
+    let persisted_scheduled_fn = ScheduledFn::new("1".into(), "2".into());
+    let persisted_schedule = Schedule::Persisted("* * * * * * *".into());
 
-            assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &alice_pubkey).unwrap());
-            assert!(fn_is_scheduled(txn, ephemeral_scheduled_fn.clone(), &alice_pubkey).unwrap());
+    // Membership check against the merged store for the synthetic author.
+    let fn_scheduled = |scheduled_fn: ScheduledFn| {
+        let author = &author;
+        async move {
+            store
+                .as_read()
+                .is_function_scheduled(author, &scheduled_fn)
+                .await
+                .unwrap()
+        }
+    };
 
-            // Deleting live ephemeral scheduled fns from now should delete.
-            delete_live_ephemeral_scheduled_fns(txn, now, &alice_pubkey).unwrap();
-            assert!(!fn_is_scheduled(txn, ephemeral_scheduled_fn.clone(), &alice_pubkey,).unwrap());
-            assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &alice_pubkey,).unwrap());
-
-            schedule_fn(
-                txn,
-                &alice_pubkey,
-                ephemeral_scheduled_fn.clone(),
-                None,
-                now,
-            )
-            .unwrap();
-            assert!(fn_is_scheduled(txn, ephemeral_scheduled_fn.clone(), &alice_pubkey,).unwrap());
-            assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &alice_pubkey,).unwrap());
-
-            // Deleting live ephemeral fns from a past time should do nothing.
-            delete_live_ephemeral_scheduled_fns(txn, the_past, &alice_pubkey).unwrap();
-            assert!(fn_is_scheduled(txn, ephemeral_scheduled_fn.clone(), &alice_pubkey,).unwrap());
-            assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &alice_pubkey,).unwrap());
-
-            // Deleting live ephemeral fns from the future should delete.
-            delete_live_ephemeral_scheduled_fns(txn, the_future, &alice_pubkey).unwrap();
-            assert!(!fn_is_scheduled(txn, ephemeral_scheduled_fn.clone(), &alice_pubkey,).unwrap());
-            assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &alice_pubkey,).unwrap());
-
-            // Deleting all ephemeral fns should delete.
-            schedule_fn(
-                txn,
-                &alice_pubkey,
-                ephemeral_scheduled_fn.clone(),
-                None,
-                now,
-            )
-            .unwrap();
-            assert!(fn_is_scheduled(txn, ephemeral_scheduled_fn.clone(), &alice_pubkey,).unwrap());
-            delete_all_ephemeral_scheduled_fns(txn).unwrap();
-            assert!(!fn_is_scheduled(txn, ephemeral_scheduled_fn.clone(), &alice_pubkey,).unwrap());
-            assert!(fn_is_scheduled(txn, persisted_scheduled_fn.clone(), &alice_pubkey,).unwrap());
-
-            let ephemeral_future_schedule =
-                Schedule::Ephemeral(std::time::Duration::from_millis(1001));
-            schedule_fn(
-                txn,
-                &alice_pubkey,
-                ephemeral_scheduled_fn.clone(),
-                Some(ephemeral_future_schedule.clone()),
-                now,
-            )
-            .unwrap();
-            assert_eq!(
-                vec![(
-                    persisted_scheduled_fn.clone(),
-                    Some(persisted_schedule.clone()),
-                    false,
-                )],
-                live_scheduled_fns(txn, the_future, &alice_pubkey,).unwrap(),
-            );
-            assert_eq!(
-                vec![
-                    (persisted_scheduled_fn, Some(persisted_schedule), false),
-                    (
-                        ephemeral_scheduled_fn,
-                        Some(ephemeral_future_schedule),
-                        true
-                    ),
-                ],
-                live_scheduled_fns(txn, the_distant_future, &alice_pubkey,).unwrap(),
-            );
-
-            Result::<(), DatabaseError>::Ok(())
-        })
+    store
+        .upsert_scheduled_function(
+            &author,
+            &persisted_scheduled_fn,
+            &Some(persisted_schedule.clone()),
+            now,
+        )
         .await
         .unwrap();
+    store
+        .upsert_scheduled_function(&author, &ephemeral_scheduled_fn, &None, now)
+        .await
+        .unwrap();
+
+    assert!(fn_scheduled(persisted_scheduled_fn.clone()).await);
+    assert!(fn_scheduled(ephemeral_scheduled_fn.clone()).await);
+
+    // Deleting live ephemeral scheduled fns from now should delete.
+    store
+        .delete_live_ephemeral_scheduled_functions(&author, now)
+        .await
+        .unwrap();
+    assert!(!fn_scheduled(ephemeral_scheduled_fn.clone()).await);
+    assert!(fn_scheduled(persisted_scheduled_fn.clone()).await);
+
+    store
+        .upsert_scheduled_function(&author, &ephemeral_scheduled_fn, &None, now)
+        .await
+        .unwrap();
+    assert!(fn_scheduled(ephemeral_scheduled_fn.clone()).await);
+    assert!(fn_scheduled(persisted_scheduled_fn.clone()).await);
+
+    // Deleting live ephemeral fns from a past time should do nothing.
+    store
+        .delete_live_ephemeral_scheduled_functions(&author, the_past)
+        .await
+        .unwrap();
+    assert!(fn_scheduled(ephemeral_scheduled_fn.clone()).await);
+    assert!(fn_scheduled(persisted_scheduled_fn.clone()).await);
+
+    // Deleting live ephemeral fns from the future should delete.
+    store
+        .delete_live_ephemeral_scheduled_functions(&author, the_future)
+        .await
+        .unwrap();
+    assert!(!fn_scheduled(ephemeral_scheduled_fn.clone()).await);
+    assert!(fn_scheduled(persisted_scheduled_fn.clone()).await);
+
+    // Deleting all ephemeral fns should delete.
+    store
+        .upsert_scheduled_function(&author, &ephemeral_scheduled_fn, &None, now)
+        .await
+        .unwrap();
+    assert!(fn_scheduled(ephemeral_scheduled_fn.clone()).await);
+    store
+        .delete_all_ephemeral_scheduled_functions()
+        .await
+        .unwrap();
+    assert!(!fn_scheduled(ephemeral_scheduled_fn.clone()).await);
+    assert!(fn_scheduled(persisted_scheduled_fn.clone()).await);
+
+    let ephemeral_future_schedule = Schedule::Ephemeral(std::time::Duration::from_millis(1001));
+    store
+        .upsert_scheduled_function(
+            &author,
+            &ephemeral_scheduled_fn,
+            &Some(ephemeral_future_schedule.clone()),
+            now,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        vec![(
+            persisted_scheduled_fn.clone(),
+            Some(persisted_schedule.clone()),
+            false,
+        )],
+        store
+            .live_scheduled_functions(&author, the_future)
+            .await
+            .unwrap(),
+    );
+    assert_eq!(
+        vec![
+            (persisted_scheduled_fn, Some(persisted_schedule), false),
+            (ephemeral_scheduled_fn, Some(ephemeral_future_schedule), true),
+        ],
+        store
+            .live_scheduled_functions(&author, the_distant_future)
+            .await
+            .unwrap(),
+    );
+
     Ok(())
 }
 

--- a/crates/holochain/tests/tests/schedule.rs
+++ b/crates/holochain/tests/tests/schedule.rs
@@ -650,7 +650,11 @@ async fn schedule_test_low_level() -> anyhow::Result<()> {
     assert_eq!(
         vec![
             (persisted_scheduled_fn, Some(persisted_schedule), false),
-            (ephemeral_scheduled_fn, Some(ephemeral_future_schedule), true),
+            (
+                ephemeral_scheduled_fn,
+                Some(ephemeral_future_schedule),
+                true
+            ),
         ],
         store
             .live_scheduled_functions(&author, the_distant_future)

--- a/crates/holochain/tests/tests/warrants.rs
+++ b/crates/holochain/tests/tests/warrants.rs
@@ -12,9 +12,8 @@ use holochain::{
     },
     test_utils::retry_fn_until_timeout,
 };
-use holochain_sqlite::prelude::ReadAccess;
 use holochain_state::prelude::{insert_op_dht, set_validation_status, set_when_integrated};
-use holochain_state::query::{from_blob, CascadeTxnWrapper, StateQueryResult, Store};
+use holochain_state::query::{CascadeTxnWrapper, Store};
 use holochain_timestamp::Timestamp;
 use holochain_types::dht_op::DhtOpHashed;
 use holochain_types::prelude::WarrantOp;
@@ -23,7 +22,6 @@ use holochain_zome_types::prelude::{ChainIntegrityWarrant, ValidationStatus, War
 use holochain_zome_types::record::SignedAction;
 use holochain_zome_types::warrant::WarrantProof;
 use holochain_zome_types::Entry;
-use rusqlite::named_params;
 use serde::{Deserialize, Serialize};
 
 // Alice creates an invalid op and publishes it to Bob. Bob issues a warrant and
@@ -233,22 +231,17 @@ async fn author_of_invalid_warrant_is_blocked() {
     // Wait for Alice and Bob to sync.
     await_consistency([&alice, &bob]).await.unwrap();
 
-    let alice_authored_db = conductors[0]
-        .get_spaces()
-        .get_or_create_authored_db(dna_file.dna_hash(), alice.agent_pubkey().clone())
-        .unwrap();
-    let action = alice_authored_db
-        .read_async(move |txn| -> StateQueryResult<SignedAction> {
-            let action: Vec<u8> = txn.query_row(
-                "SELECT blob FROM Action WHERE hash = :hash",
-                named_params! {":hash": valid_action_hash},
-                |row| row.get(0),
-            )?;
-
-            from_blob(action)
-        })
+    // Fetch Alice's signed action from the merged store. The authored data now
+    // lives in the merged per-DNA store keyed by the action's author, so read it
+    // from there rather than the now-empty per-agent authored database.
+    let action: SignedAction = alice
+        .dht_store()
+        .as_read()
+        .retrieve_action(&valid_action_hash)
         .await
-        .unwrap();
+        .unwrap()
+        .expect("Alice's valid action should be in the merged store")
+        .into();
 
     // Now Bob needs to create a warrant against Alice's perfectly valid action.
     let warrant = Warrant::new(

--- a/crates/holochain/tests/tests/warrants.rs
+++ b/crates/holochain/tests/tests/warrants.rs
@@ -231,16 +231,14 @@ async fn author_of_invalid_warrant_is_blocked() {
     // Wait for Alice and Bob to sync.
     await_consistency([&alice, &bob]).await.unwrap();
 
-    // Fetch Alice's signed action from the merged store. The authored data now
-    // lives in the merged per-DNA store keyed by the action's author, so read it
-    // from there rather than the now-empty per-agent authored database.
+    // Fetch Alice's signed action from the DhtStore.
     let action: SignedAction = alice
         .dht_store()
         .as_read()
         .retrieve_action(&valid_action_hash)
         .await
         .unwrap()
-        .expect("Alice's valid action should be in the merged store")
+        .expect("Alice's valid action should be in the DhtStore")
         .into();
 
     // Now Bob needs to create a warrant against Alice's perfectly valid action.

--- a/crates/holochain_conductor_api/src/storage_info.rs
+++ b/crates/holochain_conductor_api/src/storage_info.rs
@@ -3,14 +3,19 @@ use holochain_types::prelude::*;
 /// Storage info for DNA used by one or more hApps.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, SerializedBytes)]
 pub struct DnaStorageInfo {
-    /// Size of the DHT data. Since the authored and DHT databases were merged
-    /// into a single per-DNA store, this also covers each agent's source-chain
-    /// (authored) data.
+    /// Size in bytes of the data in use by the DhtStore.
     pub dht_data_size: usize,
+    /// Size in bytes on disk of the DhtStore, including free space reserved by
+    /// the database.
     pub dht_data_size_on_disk: usize,
+    /// Size in bytes of the data in use by the cache store.
     pub cache_data_size: usize,
+    /// Size in bytes on disk of the cache store, including free space reserved
+    /// by the database.
     pub cache_data_size_on_disk: usize,
+    /// The hash of the DNA this storage information is for.
     pub dna_hash: DnaHash,
+    /// The installed apps that make use of this DNA.
     pub used_by: Vec<InstalledAppId>,
 }
 

--- a/crates/holochain_conductor_api/src/storage_info.rs
+++ b/crates/holochain_conductor_api/src/storage_info.rs
@@ -3,8 +3,9 @@ use holochain_types::prelude::*;
 /// Storage info for DNA used by one or more hApps.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, SerializedBytes)]
 pub struct DnaStorageInfo {
-    pub authored_data_size: usize,
-    pub authored_data_size_on_disk: usize,
+    /// Size of the DHT data. Since the authored and DHT databases were merged
+    /// into a single per-DNA store, this also covers each agent's source-chain
+    /// (authored) data.
     pub dht_data_size: usize,
     pub dht_data_size_on_disk: usize,
     pub cache_data_size: usize,

--- a/crates/holochain_conductor_api/src/storage_info.rs
+++ b/crates/holochain_conductor_api/src/storage_info.rs
@@ -8,11 +8,6 @@ pub struct DnaStorageInfo {
     /// Size in bytes on disk of the DhtStore, including free space reserved by
     /// the database.
     pub dht_data_size_on_disk: usize,
-    /// Size in bytes of the data in use by the cache store.
-    pub cache_data_size: usize,
-    /// Size in bytes on disk of the cache store, including free space reserved
-    /// by the database.
-    pub cache_data_size_on_disk: usize,
     /// The hash of the DNA this storage information is for.
     pub dna_hash: DnaHash,
     /// The installed apps that make use of this DNA.

--- a/crates/holochain_data/Cargo.toml
+++ b/crates/holochain_data/Cargo.toml
@@ -21,6 +21,7 @@ base64 = "0.22"
 sodoken = "0.1.0"
 tokio = { version = "1.27", features = ["full"] }
 libsqlite3-sys = "0.35"
+opentelemetry = "0.31"
 holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash" }
 holochain_types = { version = "^0.7.0-dev.31", path = "../holochain_types" }
 holochain_integrity_types = { version = "^0.7.0-dev.15", path = "../holochain_integrity_types" }

--- a/crates/holochain_data/src/dht.rs
+++ b/crates/holochain_data/src/dht.rs
@@ -17,6 +17,7 @@ mod db_operations;
 mod inner;
 mod tx_operations;
 
+pub use db_operations::ChainWritePermit;
 pub use inner::chain_op::InsertChainOp;
 pub use inner::deleted_link::InsertDeletedLink;
 pub use inner::deleted_record::InsertDeletedRecord;

--- a/crates/holochain_data/src/dht.rs
+++ b/crates/holochain_data/src/dht.rs
@@ -2201,6 +2201,60 @@ mod tests {
         assert_eq!(row.validation_status, i64::from(RecordValidity::Accepted));
     }
 
+    // Build a unique action hash from the author's first byte and the seq, so
+    // that two inserts for different (author, seq) pairs never collide on the
+    // primary key.
+    async fn insert_test_action(
+        db: &crate::handles::DbWrite<Dht>,
+        author: &AgentPubKey,
+        seq: u32,
+    ) -> (ActionHash, Timestamp) {
+        let mut hash_bytes = vec![0u8; 36];
+        hash_bytes[0] = author.get_raw_36()[0];
+        hash_bytes[1] = (seq & 0xff) as u8;
+        hash_bytes[2] = ((seq >> 8) & 0xff) as u8;
+        let hash = ActionHash::from_raw_36(hash_bytes);
+        let ts = Timestamp::from_micros(1_000_000 + seq as i64);
+        let action = Action {
+            header: ActionHeader {
+                author: author.clone(),
+                timestamp: ts,
+                action_seq: seq,
+                prev_action: None,
+            },
+            data: ActionData::InitZomesComplete(InitZomesCompleteData {}),
+        };
+        let hashed = HoloHashed::with_pre_hashed(action, hash.clone());
+        let signed = SignedHashed::with_presigned(hashed, Signature([0u8; 64]));
+        db.insert_action(&signed, None).await.unwrap();
+        (hash, ts)
+    }
+
+    #[tokio::test]
+    async fn chain_head_for_author_returns_max_seq() {
+        let db = test_open_db(dht_db_id()).await.unwrap();
+        let author = AgentPubKey::from_raw_36(vec![0x01; 36]);
+        let other = AgentPubKey::from_raw_36(vec![0x02; 36]);
+
+        insert_test_action(&db, &author, 0).await;
+        let head = insert_test_action(&db, &author, 1).await;
+        // Other author at a higher seq — must not affect `author`'s head.
+        insert_test_action(&db, &other, 5).await;
+
+        let got = db.as_ref().chain_head_for_author(&author).await.unwrap();
+        assert_eq!(got, Some((head.0, 1, head.1)));
+    }
+
+    #[tokio::test]
+    async fn chain_head_for_author_empty_chain_is_none() {
+        let db = test_open_db(dht_db_id()).await.unwrap();
+        let author = AgentPubKey::from_raw_36(vec![0x03; 36]);
+        assert_eq!(
+            db.as_ref().chain_head_for_author(&author).await.unwrap(),
+            None
+        );
+    }
+
     #[tokio::test]
     async fn set_chain_op_receipts_complete_round_trip() {
         let db = test_open_db(dht_db_id()).await.unwrap();

--- a/crates/holochain_data/src/dht.rs
+++ b/crates/holochain_data/src/dht.rs
@@ -2467,27 +2467,12 @@ mod tests {
         };
         let hashed = HoloHashed::with_pre_hashed(action, hash.clone());
         let signed = SignedHashed::with_presigned(hashed, Signature([0u8; 64]));
-        db.insert_action(&signed, None).await.unwrap();
-
-        // The head lookup scopes through the integrated `RegisterAgentActivity`
-        // op, so seed one for this action. `op_hash` reuses `hash_bytes`, which
-        // is unique per `(author, seq)`.
-        let op_hash = DhtOpHash::from_raw_36(hash.get_raw_36().to_vec());
-        db.insert_chain_op(InsertChainOp {
-            op_hash: &op_hash,
-            action_hash: &hash,
-            op_type: i64::from(holochain_zome_types::op::ChainOpType::RegisterAgentActivity),
-            basis_hash: &author.clone().into(),
-            storage_center_loc: 0,
-            validation_status: RecordValidity::Accepted,
-            locally_validated: true,
-            require_receipt: false,
-            when_received: ts,
-            when_integrated: ts,
-            serialized_size: 0,
-        })
-        .await
-        .unwrap();
+        // The head lookup reads the `Action` row's own `record_validity`, so a
+        // self-authored (`Accepted`) action is recognised as the head without
+        // any accompanying op.
+        db.insert_action(&signed, Some(RecordValidity::Accepted))
+            .await
+            .unwrap();
         (hash, ts)
     }
 

--- a/crates/holochain_data/src/dht.rs
+++ b/crates/holochain_data/src/dht.rs
@@ -24,6 +24,7 @@ pub use inner::limbo_chain_op::InsertLimboChainOp;
 pub use inner::limbo_chain_op::LimboChainOpJoinedRow;
 pub use inner::limbo_warrant::InsertLimboWarrant;
 pub use inner::link::InsertLink;
+pub use inner::remove_countersigning_session::RemoveCountersigningSessionOutcome;
 pub use inner::scheduled_function::InsertScheduledFunction;
 pub use inner::updated_record::InsertUpdatedRecord;
 pub use inner::warrant::InsertWarrant;
@@ -2153,6 +2154,192 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(row.withhold_publish, None);
+    }
+
+    /// Seed a self-authored countersigning-style record: a `Create` action plus
+    /// one `ChainOp` per `op_byte` (each with a `ChainOpPublish` row carrying
+    /// `withhold`), and the entry stored in `Entry` (public) or `PrivateEntry`
+    /// (when `private_author` is `Some`). Returns the action hash and op hashes.
+    async fn seed_countersigning_record(
+        db: &crate::handles::DbWrite<Dht>,
+        seed: u8,
+        entry_hash: &EntryHash,
+        op_specs: &[(u8, Option<bool>)],
+        private_author: Option<&AgentPubKey>,
+    ) -> (ActionHash, Vec<DhtOpHash>) {
+        let author = AgentPubKey::from_raw_36(vec![seed; 36]);
+        let action_hash = ActionHash::from_raw_36(vec![seed; 36]);
+        let action = Action {
+            header: ActionHeader {
+                author: author.clone(),
+                timestamp: Timestamp::from_micros(1_000_000 + seed as i64),
+                action_seq: seed as u32,
+                prev_action: Some(ActionHash::from_raw_36(vec![seed.wrapping_sub(1); 36])),
+            },
+            data: ActionData::Create(holochain_integrity_types::dht_v2::CreateData {
+                entry_type: holochain_integrity_types::EntryType::AgentPubKey,
+                entry_hash: entry_hash.clone(),
+            }),
+        };
+        let hashed = HoloHashed::with_pre_hashed(action, action_hash.clone());
+        let signed = SignedHashed::with_presigned(hashed, Signature([seed; 64]));
+        db.insert_action(&signed, Some(RecordValidity::Accepted))
+            .await
+            .unwrap();
+
+        let mut op_hashes = Vec::new();
+        for (op_byte, withhold) in op_specs {
+            let op_hash = DhtOpHash::from_raw_36(vec![*op_byte; 36]);
+            db.insert_chain_op(InsertChainOp {
+                op_hash: &op_hash,
+                action_hash: &action_hash,
+                op_type: 1,
+                basis_hash: &sample_basis(seed),
+                storage_center_loc: 0,
+                validation_status: RecordValidity::Accepted,
+                locally_validated: true,
+                require_receipt: false,
+                when_received: Timestamp::from_micros(1),
+                when_integrated: Timestamp::from_micros(2),
+                serialized_size: 0,
+            })
+            .await
+            .unwrap();
+            db.insert_chain_op_publish(&op_hash, None, None, *withhold)
+                .await
+                .unwrap();
+            op_hashes.push(op_hash);
+        }
+
+        let entry = Entry::Agent(author.clone());
+        match private_author {
+            Some(a) => db
+                .insert_private_entry(entry_hash, a, &entry)
+                .await
+                .unwrap(),
+            None => db.insert_entry(entry_hash, &entry).await.unwrap(),
+        }
+
+        (action_hash, op_hashes)
+    }
+
+    #[tokio::test]
+    async fn remove_countersigning_session_deletes_withheld_public_entry() {
+        let db = test_open_db(dht_db_id()).await.unwrap();
+        let entry_hash = EntryHash::from_raw_36(vec![0x77; 36]);
+        // Two withheld self-authored ops for one action (e.g. StoreRecord +
+        // StoreEntry) plus the public entry.
+        let (action_hash, op_hashes) = seed_countersigning_record(
+            &db,
+            0x30,
+            &entry_hash,
+            &[(0xA1, Some(true)), (0xA2, Some(true))],
+            None,
+        )
+        .await;
+
+        let outcome = db
+            .remove_countersigning_session(&action_hash, &entry_hash)
+            .await
+            .unwrap();
+        assert_eq!(outcome, RemoveCountersigningSessionOutcome::Removed);
+
+        // Action, both ops, both publish rows, and the public entry are gone.
+        assert!(db.as_ref().get_action(action_hash).await.unwrap().is_none());
+        for op_hash in op_hashes {
+            assert!(db
+                .as_ref()
+                .get_chain_op(op_hash.clone())
+                .await
+                .unwrap()
+                .is_none());
+            assert!(db
+                .as_ref()
+                .get_chain_op_publish(op_hash)
+                .await
+                .unwrap()
+                .is_none());
+        }
+        assert!(db
+            .as_ref()
+            .get_entry(entry_hash, None)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn remove_countersigning_session_deletes_private_entry() {
+        let db = test_open_db(dht_db_id()).await.unwrap();
+        let author = AgentPubKey::from_raw_36(vec![0x31; 36]);
+        let entry_hash = EntryHash::from_raw_36(vec![0x78; 36]);
+        let (action_hash, _) = seed_countersigning_record(
+            &db,
+            0x31,
+            &entry_hash,
+            &[(0xB1, Some(true))],
+            Some(&author),
+        )
+        .await;
+
+        // The private entry is present before removal.
+        assert!(db
+            .as_ref()
+            .get_entry(entry_hash.clone(), Some(&author))
+            .await
+            .unwrap()
+            .is_some());
+
+        let outcome = db
+            .remove_countersigning_session(&action_hash, &entry_hash)
+            .await
+            .unwrap();
+        assert_eq!(outcome, RemoveCountersigningSessionOutcome::Removed);
+
+        assert!(db.as_ref().get_action(action_hash).await.unwrap().is_none());
+        assert!(db
+            .as_ref()
+            .get_entry(entry_hash, Some(&author))
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn remove_countersigning_session_refuses_when_published() {
+        let db = test_open_db(dht_db_id()).await.unwrap();
+        let entry_hash = EntryHash::from_raw_36(vec![0x79; 36]);
+        // One withheld op and one published op (withhold cleared) for the same
+        // action: the published op must block removal.
+        let (action_hash, op_hashes) = seed_countersigning_record(
+            &db,
+            0x32,
+            &entry_hash,
+            &[(0xC1, Some(true)), (0xC2, None)],
+            None,
+        )
+        .await;
+
+        let outcome = db
+            .remove_countersigning_session(&action_hash, &entry_hash)
+            .await
+            .unwrap();
+        assert_eq!(
+            outcome,
+            RemoveCountersigningSessionOutcome::AlreadyPublished
+        );
+
+        // Nothing was deleted.
+        assert!(db.as_ref().get_action(action_hash).await.unwrap().is_some());
+        for op_hash in op_hashes {
+            assert!(db.as_ref().get_chain_op(op_hash).await.unwrap().is_some());
+        }
+        assert!(db
+            .as_ref()
+            .get_entry(entry_hash, None)
+            .await
+            .unwrap()
+            .is_some());
     }
 
     #[tokio::test]

--- a/crates/holochain_data/src/dht.rs
+++ b/crates/holochain_data/src/dht.rs
@@ -2299,4 +2299,76 @@ mod tests {
             .expect("row");
         assert_eq!(row.receipts_complete, Some(1));
     }
+
+    #[tokio::test]
+    async fn live_scheduled_functions_predicate() {
+        let db = test_open_db(dht_db_id()).await.unwrap();
+        let alice = AgentPubKey::from_raw_36(vec![0x01; 36]);
+        let bob = AgentPubKey::from_raw_36(vec![0x02; 36]);
+        let now = Timestamp::from_micros(500);
+        let payload = b"schedule-blob";
+
+        // Alice: ephemeral, live (start_at=200 <= now=500 <= end_at=MAX).
+        db.upsert_scheduled_function(InsertScheduledFunction {
+            author: &alice,
+            zome_name: "z",
+            scheduled_fn: "ephemeral_live",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(200),
+            end_at: Timestamp::from_micros(i64::MAX),
+            ephemeral: true,
+        })
+        .await
+        .unwrap();
+
+        // Alice: persisted, future (start_at=700 > now=500 → not live).
+        db.upsert_scheduled_function(InsertScheduledFunction {
+            author: &alice,
+            zome_name: "z",
+            scheduled_fn: "persisted_future",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(700),
+            end_at: Timestamp::from_micros(900),
+            ephemeral: false,
+        })
+        .await
+        .unwrap();
+
+        // Alice: ephemeral, already past end_at (now=500 > end_at=400 → not live).
+        db.upsert_scheduled_function(InsertScheduledFunction {
+            author: &alice,
+            zome_name: "z",
+            scheduled_fn: "past",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(100),
+            end_at: Timestamp::from_micros(400),
+            ephemeral: true,
+        })
+        .await
+        .unwrap();
+
+        // Bob: ephemeral, live — must NOT be returned for alice.
+        db.upsert_scheduled_function(InsertScheduledFunction {
+            author: &bob,
+            zome_name: "z",
+            scheduled_fn: "ephemeral_live",
+            maybe_schedule: payload,
+            start_at: Timestamp::from_micros(200),
+            end_at: Timestamp::from_micros(i64::MAX),
+            ephemeral: true,
+        })
+        .await
+        .unwrap();
+
+        let live = db
+            .as_ref()
+            .get_live_scheduled_functions(&alice, now)
+            .await
+            .unwrap();
+
+        assert_eq!(live.len(), 1, "expected exactly one live fn for alice");
+        assert_eq!(live[0].0, "z");
+        assert_eq!(live[0].1, "ephemeral_live");
+        assert!(live[0].3, "expected ephemeral=true for the live fn");
+    }
 }

--- a/crates/holochain_data/src/dht.rs
+++ b/crates/holochain_data/src/dht.rs
@@ -2468,6 +2468,26 @@ mod tests {
         let hashed = HoloHashed::with_pre_hashed(action, hash.clone());
         let signed = SignedHashed::with_presigned(hashed, Signature([0u8; 64]));
         db.insert_action(&signed, None).await.unwrap();
+
+        // The head lookup scopes through the integrated `RegisterAgentActivity`
+        // op, so seed one for this action. `op_hash` reuses `hash_bytes`, which
+        // is unique per `(author, seq)`.
+        let op_hash = DhtOpHash::from_raw_36(hash.get_raw_36().to_vec());
+        db.insert_chain_op(InsertChainOp {
+            op_hash: &op_hash,
+            action_hash: &hash,
+            op_type: i64::from(holochain_zome_types::op::ChainOpType::RegisterAgentActivity),
+            basis_hash: &author.clone().into(),
+            storage_center_loc: 0,
+            validation_status: RecordValidity::Accepted,
+            locally_validated: true,
+            require_receipt: false,
+            when_received: ts,
+            when_integrated: ts,
+            serialized_size: 0,
+        })
+        .await
+        .unwrap();
         (hash, ts)
     }
 

--- a/crates/holochain_data/src/dht.rs
+++ b/crates/holochain_data/src/dht.rs
@@ -215,6 +215,60 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn entry_batch_fetch_by_hashes() {
+        let db = test_open_db(dht_db_id()).await.unwrap();
+        let author = AgentPubKey::from_raw_36(vec![9u8; 36]);
+
+        // Two public entries and one private entry owned by `author`.
+        let (pub_hash_a, pub_entry_a) = sample_entry(20);
+        let (pub_hash_b, pub_entry_b) = sample_entry(21);
+        let (priv_hash, priv_entry) = sample_entry(22);
+        db.insert_entry(&pub_hash_a, &pub_entry_a).await.unwrap();
+        db.insert_entry(&pub_hash_b, &pub_entry_b).await.unwrap();
+        db.insert_private_entry(&priv_hash, &author, &priv_entry)
+            .await
+            .unwrap();
+
+        // A hash that was never inserted.
+        let missing_hash = EntryHash::from_raw_36(vec![99u8; 36]);
+
+        // With the owning author, the private entry resolves alongside the
+        // public ones; the missing hash is simply absent from the map.
+        let map = db
+            .as_ref()
+            .get_entries_by_hashes(
+                &[
+                    pub_hash_a.clone(),
+                    pub_hash_b.clone(),
+                    priv_hash.clone(),
+                    missing_hash.clone(),
+                ],
+                Some(&author),
+            )
+            .await
+            .unwrap();
+        assert_eq!(map.len(), 3);
+        assert_eq!(map.get(&pub_hash_a), Some(&pub_entry_a));
+        assert_eq!(map.get(&pub_hash_b), Some(&pub_entry_b));
+        assert_eq!(map.get(&priv_hash), Some(&priv_entry));
+        assert_eq!(map.get(&missing_hash), None);
+
+        // Without an author the private entry is excluded, public entries still
+        // resolve, and duplicate input hashes collapse to one map entry.
+        let map_public = db
+            .as_ref()
+            .get_entries_by_hashes(
+                &[pub_hash_a.clone(), pub_hash_a.clone(), priv_hash.clone()],
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(map_public.len(), 1);
+        assert_eq!(map_public.get(&pub_hash_a), Some(&pub_entry_a));
+        assert_eq!(map_public.get(&priv_hash), None);
+    }
+
     /// Verifies that a TxWrite bundling an Action + Entry insert can be rolled back
     /// and neither survives. Also exercises the Tx* wrapper methods.
     #[tokio::test]

--- a/crates/holochain_data/src/dht.rs
+++ b/crates/holochain_data/src/dht.rs
@@ -116,7 +116,9 @@ mod tests {
         let author_a = AgentPubKey::from_raw_36(vec![1u8; 36]);
         let a_inserted: Vec<_> = (0..2u8).map(sample_action).collect();
         for action in &a_inserted {
-            db.insert_action(action, None).await.unwrap();
+            db.insert_action(action, Some(RecordValidity::Accepted))
+                .await
+                .unwrap();
         }
 
         let other_author = AgentPubKey::from_raw_36(vec![0x99; 36]);
@@ -137,7 +139,9 @@ mod tests {
             ),
             Signature([0xCC; 64]),
         );
-        db.insert_action(&other, None).await.unwrap();
+        db.insert_action(&other, Some(RecordValidity::Accepted))
+            .await
+            .unwrap();
 
         let a_results = db.as_ref().get_actions_by_author(author_a).await.unwrap();
         assert_eq!(a_results, a_inserted);
@@ -148,6 +152,23 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(b_results, vec![other]);
+    }
+
+    #[tokio::test]
+    async fn actions_by_author_excludes_unvalidated() {
+        let db = test_open_db(dht_db_id()).await.unwrap();
+        let author = AgentPubKey::from_raw_36(vec![1u8; 36]);
+        // Pending (network-arrived) rows are not part of the author's committed
+        // chain, so they are excluded.
+        for action in (0..2u8).map(sample_action) {
+            db.insert_action(&action, None).await.unwrap();
+        }
+        assert!(db
+            .as_ref()
+            .get_actions_by_author(author)
+            .await
+            .unwrap()
+            .is_empty());
     }
 
     fn sample_entry(seed: u8) -> (EntryHash, Entry) {
@@ -2082,6 +2103,79 @@ mod tests {
         assert_eq!(row.locally_validated, 1); // promoted from limbo = locally validated
         assert_eq!(row.when_received, 100);
         assert_eq!(row.storage_center_loc, 42);
+    }
+
+    #[tokio::test]
+    async fn promote_aggregates_record_validity_onto_action() {
+        async fn record_validity(
+            db: &crate::handles::DbWrite<Dht>,
+            action_hash: &ActionHash,
+        ) -> Option<i64> {
+            sqlx::query_scalar("SELECT record_validity FROM Action WHERE hash = ?")
+                .bind(action_hash.get_raw_36())
+                .fetch_one(db.pool())
+                .await
+                .unwrap()
+        }
+
+        let db = test_open_db(dht_db_id()).await.unwrap();
+
+        // A network-received action is inserted pending (record_validity = NULL).
+        let action_hash = seed_action_for_op(&db, 0).await;
+        assert_eq!(record_validity(&db, &action_hash).await, None);
+
+        // Integrating an accepted op aggregates Accepted onto the action.
+        let accepted_op = DhtOpHash::from_raw_36(vec![0xE1; 36]);
+        db.insert_limbo_chain_op(InsertLimboChainOp {
+            op_hash: &accepted_op,
+            action_hash: &action_hash,
+            op_type: 1,
+            basis_hash: &sample_basis(1),
+            storage_center_loc: 0,
+            require_receipt: false,
+            when_received: Timestamp::from_micros(100),
+            serialized_size: 0,
+        })
+        .await
+        .unwrap();
+        db.promote_limbo_chain_op(
+            &accepted_op,
+            RecordValidity::Accepted,
+            Timestamp::from_micros(500),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            record_validity(&db, &action_hash).await,
+            Some(i64::from(RecordValidity::Accepted))
+        );
+
+        // A later rejected op for the same action rejects the record: any
+        // rejected op wins over accepted ones.
+        let rejected_op = DhtOpHash::from_raw_36(vec![0xE2; 36]);
+        db.insert_limbo_chain_op(InsertLimboChainOp {
+            op_hash: &rejected_op,
+            action_hash: &action_hash,
+            op_type: 2,
+            basis_hash: &sample_basis(2),
+            storage_center_loc: 0,
+            require_receipt: false,
+            when_received: Timestamp::from_micros(200),
+            serialized_size: 0,
+        })
+        .await
+        .unwrap();
+        db.promote_limbo_chain_op(
+            &rejected_op,
+            RecordValidity::Rejected,
+            Timestamp::from_micros(600),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            record_validity(&db, &action_hash).await,
+            Some(i64::from(RecordValidity::Rejected))
+        );
     }
 
     #[tokio::test]

--- a/crates/holochain_data/src/dht/db_operations.rs
+++ b/crates/holochain_data/src/dht/db_operations.rs
@@ -11,6 +11,7 @@ mod chain_lock;
 mod chain_op;
 mod chain_op_publish;
 mod chain_write_permit;
+pub use chain_write_permit::ChainWritePermit;
 mod db_size;
 mod deleted_link;
 mod deleted_record;

--- a/crates/holochain_data/src/dht/db_operations.rs
+++ b/crates/holochain_data/src/dht/db_operations.rs
@@ -18,6 +18,7 @@ mod limbo_warrant;
 mod link;
 mod move_to_limbo;
 mod op_exists;
+mod remove_countersigning_session;
 mod scheduled_function;
 mod slice_hash;
 mod sync_queries;

--- a/crates/holochain_data/src/dht/db_operations.rs
+++ b/crates/holochain_data/src/dht/db_operations.rs
@@ -10,6 +10,7 @@ mod cap_grant;
 mod chain_lock;
 mod chain_op;
 mod chain_op_publish;
+mod chain_write_permit;
 mod deleted_link;
 mod deleted_record;
 mod entry;

--- a/crates/holochain_data/src/dht/db_operations.rs
+++ b/crates/holochain_data/src/dht/db_operations.rs
@@ -11,6 +11,7 @@ mod chain_lock;
 mod chain_op;
 mod chain_op_publish;
 mod chain_write_permit;
+mod db_size;
 mod deleted_link;
 mod deleted_record;
 mod entry;

--- a/crates/holochain_data/src/dht/db_operations/action.rs
+++ b/crates/holochain_data/src/dht/db_operations/action.rs
@@ -23,7 +23,8 @@ impl DbRead<Dht> {
     /// Fetch a single action by hash, returning it with its stored signature
     /// and hash as a [`SignedActionHashed`].
     pub async fn get_action(&self, hash: ActionHash) -> sqlx::Result<Option<SignedActionHashed>> {
-        action::get_action(self.pool(), hash).await
+        let mut conn = self.timed_conn().await?;
+        action::get_action(&mut *conn, hash).await
     }
 
     /// Fetch all actions for a given author, ordered by `action_seq` ascending.
@@ -31,7 +32,8 @@ impl DbRead<Dht> {
         &self,
         author: AgentPubKey,
     ) -> sqlx::Result<Vec<SignedActionHashed>> {
-        action::get_actions_by_author(self.pool(), author).await
+        let mut conn = self.timed_conn().await?;
+        action::get_actions_by_author(&mut *conn, author).await
     }
 
     /// Count actions authored by `author`, capped at `cap`. See
@@ -41,7 +43,8 @@ impl DbRead<Dht> {
         author: &AgentPubKey,
         cap: i64,
     ) -> sqlx::Result<i64> {
-        action::count_author_actions_capped(self.pool(), author, cap).await
+        let mut conn = self.timed_conn().await?;
+        action::count_author_actions_capped(&mut *conn, author, cap).await
     }
 
     /// The author's chain head from the merged store: the highest-sequence
@@ -50,7 +53,8 @@ impl DbRead<Dht> {
         &self,
         author: &AgentPubKey,
     ) -> sqlx::Result<Option<(ActionHash, u32, holochain_timestamp::Timestamp)>> {
-        action::chain_head_for_author(self.pool(), author).await
+        let mut conn = self.timed_conn().await?;
+        action::chain_head_for_author(&mut *conn, author).await
     }
 
     /// Integrated `RegisterAgentActivity` actions for `author`, ordered by
@@ -60,7 +64,8 @@ impl DbRead<Dht> {
         author: AgentPubKey,
         include_entries: bool,
     ) -> sqlx::Result<Vec<AgentActivityItem>> {
-        action::get_agent_activity(self.pool(), &author, include_entries).await
+        let mut conn = self.timed_conn().await?;
+        action::get_agent_activity(&mut *conn, &author, include_entries).await
     }
 
     /// Bounded `RegisterAgentActivity` scan: `author`'s integrated actions with
@@ -72,7 +77,8 @@ impl DbRead<Dht> {
         chain_top_seq: u32,
         until_seq: Option<u32>,
     ) -> sqlx::Result<Vec<SignedActionHashed>> {
-        action::get_filtered_agent_activity(self.pool(), &author, chain_top_seq, until_seq).await
+        let mut conn = self.timed_conn().await?;
+        action::get_filtered_agent_activity(&mut *conn, &author, chain_top_seq, until_seq).await
     }
 
     /// The chain sequence and authored timestamp of `action_hash`, if it is an
@@ -82,7 +88,8 @@ impl DbRead<Dht> {
         author: AgentPubKey,
         action_hash: ActionHash,
     ) -> sqlx::Result<Option<(u32, holochain_timestamp::Timestamp)>> {
-        action::get_action_seq_and_timestamp(self.pool(), &author, &action_hash).await
+        let mut conn = self.timed_conn().await?;
+        action::get_action_seq_and_timestamp(&mut *conn, &author, &action_hash).await
     }
 
     /// Fetch all actions with `prev_hash = prev_hash` and `hash != exclude_hash`.
@@ -92,7 +99,8 @@ impl DbRead<Dht> {
         prev_hash: &ActionHash,
         exclude_hash: &ActionHash,
     ) -> sqlx::Result<Vec<SignedActionHashed>> {
-        action::get_actions_by_prev_hash(self.pool(), prev_hash, exclude_hash).await
+        let mut conn = self.timed_conn().await?;
+        action::get_actions_by_prev_hash(&mut *conn, prev_hash, exclude_hash).await
     }
 
     /// The entry's `StoreEntry` create actions at `validation_status`.
@@ -102,7 +110,8 @@ impl DbRead<Dht> {
         author: Option<&AgentPubKey>,
         validation_status: RecordValidity,
     ) -> sqlx::Result<Vec<SignedActionHashed>> {
-        action::get_create_actions_for_entry(self.pool(), entry_hash, author, validation_status)
+        let mut conn = self.timed_conn().await?;
+        action::get_create_actions_for_entry(&mut *conn, entry_hash, author, validation_status)
             .await
     }
 
@@ -111,7 +120,8 @@ impl DbRead<Dht> {
         &self,
         entry_hash: &EntryHash,
     ) -> sqlx::Result<Vec<SignedActionHashed>> {
-        action::get_delete_actions_for_entry(self.pool(), entry_hash).await
+        let mut conn = self.timed_conn().await?;
+        action::get_delete_actions_for_entry(&mut *conn, entry_hash).await
     }
 
     /// The `Update` actions from `entry_hash`.
@@ -119,7 +129,8 @@ impl DbRead<Dht> {
         &self,
         entry_hash: &EntryHash,
     ) -> sqlx::Result<Vec<SignedActionHashed>> {
-        action::get_update_actions_for_entry(self.pool(), entry_hash).await
+        let mut conn = self.timed_conn().await?;
+        action::get_update_actions_for_entry(&mut *conn, entry_hash).await
     }
 
     /// Live `StoreEntry` create actions for `entry_hash` (valid, integrated,
@@ -129,7 +140,8 @@ impl DbRead<Dht> {
         entry_hash: &EntryHash,
         author: Option<&AgentPubKey>,
     ) -> sqlx::Result<Vec<SignedActionHashed>> {
-        action::get_live_entry_creates(self.pool(), entry_hash, author).await
+        let mut conn = self.timed_conn().await?;
+        action::get_live_entry_creates(&mut *conn, entry_hash, author).await
     }
 
     /// The `Delete` actions targeting `record_action_hash`.
@@ -137,7 +149,8 @@ impl DbRead<Dht> {
         &self,
         record_action_hash: &ActionHash,
     ) -> sqlx::Result<Vec<SignedActionHashed>> {
-        action::get_delete_actions_for_record(self.pool(), record_action_hash).await
+        let mut conn = self.timed_conn().await?;
+        action::get_delete_actions_for_record(&mut *conn, record_action_hash).await
     }
 
     /// The `Update` actions that update `record_action_hash`.
@@ -145,7 +158,8 @@ impl DbRead<Dht> {
         &self,
         record_action_hash: &ActionHash,
     ) -> sqlx::Result<Vec<SignedActionHashed>> {
-        action::get_update_actions_for_record(self.pool(), record_action_hash).await
+        let mut conn = self.timed_conn().await?;
+        action::get_update_actions_for_record(&mut *conn, record_action_hash).await
     }
 
     /// The live `CreateLink` actions on `base` (excluding tombstoned links).
@@ -153,7 +167,8 @@ impl DbRead<Dht> {
         &self,
         base: &AnyLinkableHash,
     ) -> sqlx::Result<Vec<SignedActionHashed>> {
-        action::get_live_link_actions(self.pool(), base).await
+        let mut conn = self.timed_conn().await?;
+        action::get_live_link_actions(&mut *conn, base).await
     }
 
     /// All `CreateLink` actions on `base` (live and tombstoned).
@@ -161,7 +176,8 @@ impl DbRead<Dht> {
         &self,
         base: &AnyLinkableHash,
     ) -> sqlx::Result<Vec<SignedActionHashed>> {
-        action::get_link_create_actions(self.pool(), base).await
+        let mut conn = self.timed_conn().await?;
+        action::get_link_create_actions(&mut *conn, base).await
     }
 
     /// The `DeleteLink` actions tombstoning `create_link_hash`.
@@ -169,7 +185,8 @@ impl DbRead<Dht> {
         &self,
         create_link_hash: &ActionHash,
     ) -> sqlx::Result<Vec<SignedActionHashed>> {
-        action::get_delete_link_actions(self.pool(), create_link_hash).await
+        let mut conn = self.timed_conn().await?;
+        action::get_delete_link_actions(&mut *conn, create_link_hash).await
     }
 
     /// Authority-serving create-link actions for `base` (locally-validated only),
@@ -178,7 +195,8 @@ impl DbRead<Dht> {
         &self,
         base: &AnyLinkableHash,
     ) -> sqlx::Result<Vec<(SignedActionHashed, RecordValidity)>> {
-        action::get_authority_link_creates(self.pool(), base).await
+        let mut conn = self.timed_conn().await?;
+        action::get_authority_link_creates(&mut *conn, base).await
     }
 
     /// Authority-serving delete-link actions targeting `base`'s links
@@ -187,7 +205,8 @@ impl DbRead<Dht> {
         &self,
         base: &AnyLinkableHash,
     ) -> sqlx::Result<Vec<(SignedActionHashed, RecordValidity)>> {
-        action::get_authority_delete_links(self.pool(), base).await
+        let mut conn = self.timed_conn().await?;
+        action::get_authority_delete_links(&mut *conn, base).await
     }
 
     /// Authority-serving `StoreRecord` action for `action_hash` (locally-validated
@@ -196,7 +215,8 @@ impl DbRead<Dht> {
         &self,
         action_hash: &ActionHash,
     ) -> sqlx::Result<Option<(SignedActionHashed, RecordValidity)>> {
-        action::get_authority_store_record(self.pool(), action_hash).await
+        let mut conn = self.timed_conn().await?;
+        action::get_authority_store_record(&mut *conn, action_hash).await
     }
 
     /// Authority-serving deletes targeting record `record_action_hash`
@@ -205,7 +225,8 @@ impl DbRead<Dht> {
         &self,
         record_action_hash: &ActionHash,
     ) -> sqlx::Result<Vec<(SignedActionHashed, RecordValidity)>> {
-        action::get_authority_deletes_for_record(self.pool(), record_action_hash).await
+        let mut conn = self.timed_conn().await?;
+        action::get_authority_deletes_for_record(&mut *conn, record_action_hash).await
     }
 
     /// Authority-serving updates targeting record `record_action_hash`
@@ -214,7 +235,8 @@ impl DbRead<Dht> {
         &self,
         record_action_hash: &ActionHash,
     ) -> sqlx::Result<Vec<(SignedActionHashed, RecordValidity)>> {
-        action::get_authority_updates_for_record(self.pool(), record_action_hash).await
+        let mut conn = self.timed_conn().await?;
+        action::get_authority_updates_for_record(&mut *conn, record_action_hash).await
     }
 
     /// Authority-serving create actions for entry `entry_hash` (locally-validated
@@ -223,7 +245,8 @@ impl DbRead<Dht> {
         &self,
         entry_hash: &EntryHash,
     ) -> sqlx::Result<Vec<(SignedActionHashed, RecordValidity)>> {
-        action::get_authority_entry_creates(self.pool(), entry_hash).await
+        let mut conn = self.timed_conn().await?;
+        action::get_authority_entry_creates(&mut *conn, entry_hash).await
     }
 
     /// Authority-serving deletes targeting entry `entry_hash` (locally-validated
@@ -232,7 +255,8 @@ impl DbRead<Dht> {
         &self,
         entry_hash: &EntryHash,
     ) -> sqlx::Result<Vec<(SignedActionHashed, RecordValidity)>> {
-        action::get_authority_deletes_for_entry(self.pool(), entry_hash).await
+        let mut conn = self.timed_conn().await?;
+        action::get_authority_deletes_for_entry(&mut *conn, entry_hash).await
     }
 
     /// Authority-serving updates targeting entry `entry_hash` (locally-validated
@@ -241,6 +265,7 @@ impl DbRead<Dht> {
         &self,
         entry_hash: &EntryHash,
     ) -> sqlx::Result<Vec<(SignedActionHashed, RecordValidity)>> {
-        action::get_authority_updates_for_entry(self.pool(), entry_hash).await
+        let mut conn = self.timed_conn().await?;
+        action::get_authority_updates_for_entry(&mut *conn, entry_hash).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/action.rs
+++ b/crates/holochain_data/src/dht/db_operations/action.rs
@@ -47,8 +47,8 @@ impl DbRead<Dht> {
         action::count_author_actions_capped(&mut *conn, author, cap).await
     }
 
-    /// The author's chain head from the merged store: the highest-sequence
-    /// action they authored, or `None` for an empty chain (pre-genesis).
+    /// The author's chain head: the highest-sequence action they authored, or
+    /// `None` for an empty chain (pre-genesis).
     pub async fn chain_head_for_author(
         &self,
         author: &AgentPubKey,

--- a/crates/holochain_data/src/dht/db_operations/action.rs
+++ b/crates/holochain_data/src/dht/db_operations/action.rs
@@ -44,6 +44,15 @@ impl DbRead<Dht> {
         action::count_author_actions_capped(self.pool(), author, cap).await
     }
 
+    /// The author's chain head from the merged store: the highest-sequence
+    /// action they authored, or `None` for an empty chain (pre-genesis).
+    pub async fn chain_head_for_author(
+        &self,
+        author: &AgentPubKey,
+    ) -> sqlx::Result<Option<(ActionHash, u32, holochain_timestamp::Timestamp)>> {
+        action::chain_head_for_author(self.pool(), author).await
+    }
+
     /// Integrated `RegisterAgentActivity` actions for `author`, ordered by
     /// chain sequence. `include_entries` joins the public entry (Full mode).
     pub async fn get_agent_activity(

--- a/crates/holochain_data/src/dht/db_operations/cap_claim.rs
+++ b/crates/holochain_data/src/dht/db_operations/cap_claim.rs
@@ -24,7 +24,8 @@ impl DbRead<Dht> {
         author: AgentPubKey,
         grantor: AgentPubKey,
     ) -> sqlx::Result<Vec<CapClaimRow>> {
-        cap_claim::get_cap_claims_by_grantor(self.pool(), author, grantor).await
+        let mut conn = self.timed_conn().await?;
+        cap_claim::get_cap_claims_by_grantor(&mut *conn, author, grantor).await
     }
 
     pub async fn get_cap_claims_by_tag(
@@ -32,6 +33,7 @@ impl DbRead<Dht> {
         author: AgentPubKey,
         tag: &str,
     ) -> sqlx::Result<Vec<CapClaimRow>> {
-        cap_claim::get_cap_claims_by_tag(self.pool(), author, tag).await
+        let mut conn = self.timed_conn().await?;
+        cap_claim::get_cap_claims_by_tag(&mut *conn, author, tag).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/cap_grant.rs
+++ b/crates/holochain_data/src/dht/db_operations/cap_grant.rs
@@ -23,7 +23,8 @@ impl DbRead<Dht> {
         author: AgentPubKey,
         cap_access: i64,
     ) -> sqlx::Result<Vec<CapGrantRow>> {
-        cap_grant::get_cap_grants_by_access(self.pool(), author, cap_access).await
+        let mut conn = self.timed_conn().await?;
+        cap_grant::get_cap_grants_by_access(&mut *conn, author, cap_access).await
     }
 
     pub async fn get_cap_grants_by_tag(
@@ -31,6 +32,7 @@ impl DbRead<Dht> {
         author: AgentPubKey,
         tag: &str,
     ) -> sqlx::Result<Vec<CapGrantRow>> {
-        cap_grant::get_cap_grants_by_tag(self.pool(), author, tag).await
+        let mut conn = self.timed_conn().await?;
+        cap_grant::get_cap_grants_by_tag(&mut *conn, author, tag).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/chain_lock.rs
+++ b/crates/holochain_data/src/dht/db_operations/chain_lock.rs
@@ -36,6 +36,7 @@ impl DbRead<Dht> {
         author: AgentPubKey,
         now: Timestamp,
     ) -> sqlx::Result<Option<ChainLockRow>> {
-        chain_lock::get_chain_lock(self.pool(), author, now).await
+        let mut conn = self.timed_conn().await?;
+        chain_lock::get_chain_lock(&mut *conn, author, now).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/chain_op.rs
+++ b/crates/holochain_data/src/dht/db_operations/chain_op.rs
@@ -30,23 +30,27 @@ impl DbWrite<Dht> {
 
 impl DbRead<Dht> {
     pub async fn get_chain_op(&self, hash: DhtOpHash) -> sqlx::Result<Option<ChainOpRow>> {
-        chain_op::get_chain_op(self.pool(), hash).await
+        let mut conn = self.timed_conn().await?;
+        chain_op::get_chain_op(&mut *conn, hash).await
     }
 
     pub async fn get_chain_ops_by_basis(&self, basis: AnyDhtHash) -> sqlx::Result<Vec<ChainOpRow>> {
-        chain_op::get_chain_ops_by_basis(self.pool(), basis).await
+        let mut conn = self.timed_conn().await?;
+        chain_op::get_chain_ops_by_basis(&mut *conn, basis).await
     }
 
     /// `(hash, basis_hash, storage_center_loc)` for every integrated chain op.
     pub async fn integrated_op_locations(&self) -> sqlx::Result<Vec<OpLocationRow>> {
-        chain_op::integrated_op_locations(self.pool()).await
+        let mut conn = self.timed_conn().await?;
+        chain_op::integrated_op_locations(&mut *conn).await
     }
 
     pub async fn get_chain_ops_for_action(
         &self,
         action_hash: ActionHash,
     ) -> sqlx::Result<Vec<ChainOpRow>> {
-        chain_op::get_chain_ops_for_action(self.pool(), action_hash).await
+        let mut conn = self.timed_conn().await?;
+        chain_op::get_chain_ops_for_action(&mut *conn, action_hash).await
     }
 
     /// Terminal validation outcome of the chain op for `(action_hash,
@@ -57,12 +61,14 @@ impl DbRead<Dht> {
         action_hash: &ActionHash,
         op_type: i64,
     ) -> sqlx::Result<Option<i64>> {
-        chain_op::op_validation_outcome(self.pool(), action_hash, op_type).await
+        let mut conn = self.timed_conn().await?;
+        chain_op::op_validation_outcome(&mut *conn, action_hash, op_type).await
     }
 
     /// Return integrated, validated `ChainOp` rows that still require a
     /// validation receipt to be sent.
     pub async fn pending_validation_receipts(&self) -> sqlx::Result<Vec<PendingReceiptRow>> {
-        chain_op::pending_validation_receipts(self.pool()).await
+        let mut conn = self.timed_conn().await?;
+        chain_op::pending_validation_receipts(&mut *conn).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/chain_op_publish.rs
+++ b/crates/holochain_data/src/dht/db_operations/chain_op_publish.rs
@@ -53,6 +53,15 @@ impl DbRead<Dht> {
         chain_op_publish::get_chain_op_publish(self.pool(), op_hash).await
     }
 
+    /// Count integrated ops authored by `author` that have been published at
+    /// least once. Used by the source-chain dump to compute `published_ops_count`.
+    pub async fn count_published_ops_for_author(
+        &self,
+        author: &AgentPubKey,
+    ) -> sqlx::Result<i64> {
+        chain_op_publish::count_published_ops_for_author(self.pool(), author).await
+    }
+
     /// Ops eligible to be published for `author`. See
     /// `chain_op_publish::get_ops_to_publish`.
     pub async fn get_ops_to_publish(

--- a/crates/holochain_data/src/dht/db_operations/chain_op_publish.rs
+++ b/crates/holochain_data/src/dht/db_operations/chain_op_publish.rs
@@ -50,16 +50,15 @@ impl DbRead<Dht> {
         &self,
         op_hash: DhtOpHash,
     ) -> sqlx::Result<Option<ChainOpPublishRow>> {
-        chain_op_publish::get_chain_op_publish(self.pool(), op_hash).await
+        let mut conn = self.timed_conn().await?;
+        chain_op_publish::get_chain_op_publish(&mut *conn, op_hash).await
     }
 
     /// Count integrated ops authored by `author` that have been published at
     /// least once. Used by the source-chain dump to compute `published_ops_count`.
-    pub async fn count_published_ops_for_author(
-        &self,
-        author: &AgentPubKey,
-    ) -> sqlx::Result<i64> {
-        chain_op_publish::count_published_ops_for_author(self.pool(), author).await
+    pub async fn count_published_ops_for_author(&self, author: &AgentPubKey) -> sqlx::Result<i64> {
+        let mut conn = self.timed_conn().await?;
+        chain_op_publish::count_published_ops_for_author(&mut *conn, author).await
     }
 
     /// Ops eligible to be published for `author`. See
@@ -69,12 +68,14 @@ impl DbRead<Dht> {
         author: &AgentPubKey,
         recency_threshold_micros: i64,
     ) -> sqlx::Result<Vec<OpToPublishRow>> {
-        chain_op_publish::get_ops_to_publish(self.pool(), author, recency_threshold_micros).await
+        let mut conn = self.timed_conn().await?;
+        chain_op_publish::get_ops_to_publish(&mut *conn, author, recency_threshold_micros).await
     }
 
     /// Count ops authored by `author` that may still need publishing. See
     /// `chain_op_publish::num_still_needing_publish`.
     pub async fn num_still_needing_publish(&self, author: &AgentPubKey) -> sqlx::Result<i64> {
-        chain_op_publish::num_still_needing_publish(self.pool(), author).await
+        let mut conn = self.timed_conn().await?;
+        chain_op_publish::num_still_needing_publish(&mut *conn, author).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/chain_write_permit.rs
+++ b/crates/holochain_data/src/dht/db_operations/chain_write_permit.rs
@@ -21,9 +21,7 @@ impl DbWrite<Dht> {
     /// different authors — and the same author on different DNAs — never block
     /// one another. The DNA is identified by the database's stable
     /// [`database_id`](crate::DatabaseIdentifier::database_id) (the DHT
-    /// database is per-DNA), combined with the author key. This mirrors the
-    /// granularity of the legacy `holochain_sqlite` authored-DB write permit,
-    /// which was keyed by the per-cell `DbKind::Authored(CellId)`.
+    /// database is per-DNA), combined with the author key.
     pub async fn acquire_chain_write_permit(&self, author: &AgentPubKey) -> OwnedSemaphorePermit {
         let key = (self.identifier().database_id().to_string(), author.clone());
         chain_write_semaphore(key)
@@ -36,11 +34,9 @@ impl DbWrite<Dht> {
 /// Fetch (or lazily create) the single-permit semaphore for a
 /// `(database_id, author)` key.
 ///
-/// Mirrors the keyed-`Lazy`-static semaphore pattern used by the legacy
-/// `holochain_sqlite` write permit, but keyed per author so each chain
-/// serializes independently. The map is never pruned; the number of live keys
-/// is bounded by the installed `(DNA, author)` cells, matching the legacy
-/// per-cell authored-DB semaphore map.
+/// The semaphore is keyed per author so each chain serializes independently.
+/// The map is never pruned; the number of live keys is bounded by the
+/// installed `(DNA, author)` cells.
 fn chain_write_semaphore(key: (String, AgentPubKey)) -> Arc<Semaphore> {
     type SemaphoreMap = HashMap<(String, AgentPubKey), Arc<Semaphore>>;
     static MAP: LazyLock<Mutex<SemaphoreMap>> = LazyLock::new(|| Mutex::new(HashMap::new()));

--- a/crates/holochain_data/src/dht/db_operations/chain_write_permit.rs
+++ b/crates/holochain_data/src/dht/db_operations/chain_write_permit.rs
@@ -1,0 +1,131 @@
+//! Per-author source-chain write permit for the DHT database.
+
+use crate::handles::DbWrite;
+use crate::kind::Dht;
+use crate::DatabaseIdentifier;
+use holo_hash::AgentPubKey;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+impl DbWrite<Dht> {
+    /// Acquire the per-author source-chain write permit for this DHT database.
+    ///
+    /// Source-chain flushes for a single `(DNA, author)` chain must be
+    /// serialized: two concurrent flushes that both read the same chain head,
+    /// pass their as-at check, and then write would fork the chain. Holding
+    /// this permit across the as-at check and the source-chain write closes
+    /// that window.
+    ///
+    /// Each `(DNA, author)` pair has an independent single-permit semaphore, so
+    /// different authors — and the same author on different DNAs — never block
+    /// one another. The DNA is identified by the database's stable
+    /// [`database_id`](crate::DatabaseIdentifier::database_id) (the DHT
+    /// database is per-DNA), combined with the author key. This mirrors the
+    /// granularity of the legacy `holochain_sqlite` authored-DB write permit,
+    /// which was keyed by the per-cell `DbKind::Authored(CellId)`.
+    pub async fn acquire_chain_write_permit(&self, author: &AgentPubKey) -> OwnedSemaphorePermit {
+        let key = (self.identifier().database_id().to_string(), author.clone());
+        chain_write_semaphore(key)
+            .acquire_owned()
+            .await
+            .expect("chain write semaphore is never closed")
+    }
+}
+
+/// Fetch (or lazily create) the single-permit semaphore for a
+/// `(database_id, author)` key.
+///
+/// Mirrors the keyed-`Lazy`-static semaphore pattern used by the legacy
+/// `holochain_sqlite` write permit, but keyed per author so each chain
+/// serializes independently. The map is never pruned; the number of live keys
+/// is bounded by the installed `(DNA, author)` cells, matching the legacy
+/// per-cell authored-DB semaphore map.
+fn chain_write_semaphore(key: (String, AgentPubKey)) -> Arc<Semaphore> {
+    type SemaphoreMap = HashMap<(String, AgentPubKey), Arc<Semaphore>>;
+    static MAP: LazyLock<Mutex<SemaphoreMap>> = LazyLock::new(|| Mutex::new(HashMap::new()));
+    MAP.lock()
+        .expect("chain write semaphore map is not poisoned")
+        .entry(key)
+        .or_insert_with(|| Arc::new(Semaphore::new(1)))
+        .clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::kind::Dht;
+    use crate::test_open_db;
+    use holo_hash::{AgentPubKey, DnaHash};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    fn dht_db_id(seed: u8) -> Dht {
+        Dht::new(Arc::new(DnaHash::from_raw_36(vec![seed; 36])))
+    }
+
+    /// Two acquisitions for the same `(DNA, author)` chain must not overlap: the
+    /// second blocks until the first permit is dropped.
+    #[tokio::test]
+    async fn same_author_serializes() {
+        let db = test_open_db(dht_db_id(0)).await.unwrap();
+        let author = AgentPubKey::from_raw_36(vec![1u8; 36]);
+
+        let permit1 = db.acquire_chain_write_permit(&author).await;
+
+        let db2 = db.clone();
+        let author2 = author.clone();
+        let handle = tokio::spawn(async move {
+            let _p = db2.acquire_chain_write_permit(&author2).await;
+        });
+
+        // Give the spawned task a chance to run; it must still be blocked while
+        // we hold the first permit.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !handle.is_finished(),
+            "second acquire for the same author must block while the first permit is held"
+        );
+
+        drop(permit1);
+
+        // Once the first permit is released the second acquire completes.
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("second acquire should complete after the first permit is dropped")
+            .unwrap();
+    }
+
+    /// Different authors on the same DHT database use independent semaphores and
+    /// do not block one another.
+    #[tokio::test]
+    async fn different_authors_do_not_block() {
+        let db = test_open_db(dht_db_id(0)).await.unwrap();
+        let alice = AgentPubKey::from_raw_36(vec![1u8; 36]);
+        let bob = AgentPubKey::from_raw_36(vec![2u8; 36]);
+
+        let _alice_permit = db.acquire_chain_write_permit(&alice).await;
+
+        let _bob_permit =
+            tokio::time::timeout(Duration::from_secs(1), db.acquire_chain_write_permit(&bob))
+                .await
+                .expect("a different author must not be blocked by alice's permit");
+    }
+
+    /// The same author on different DHT databases (different DNAs) uses
+    /// independent semaphores and does not block.
+    #[tokio::test]
+    async fn same_author_different_dna_do_not_block() {
+        let db_a = test_open_db(dht_db_id(0)).await.unwrap();
+        let db_b = test_open_db(dht_db_id(9)).await.unwrap();
+        let author = AgentPubKey::from_raw_36(vec![1u8; 36]);
+
+        let _permit_a = db_a.acquire_chain_write_permit(&author).await;
+
+        let _permit_b = tokio::time::timeout(
+            Duration::from_secs(1),
+            db_b.acquire_chain_write_permit(&author),
+        )
+        .await
+        .expect("the same author on a different DNA must not be blocked");
+    }
+}

--- a/crates/holochain_data/src/dht/db_operations/chain_write_permit.rs
+++ b/crates/holochain_data/src/dht/db_operations/chain_write_permit.rs
@@ -8,6 +8,16 @@ use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, Mutex};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
+/// A held source-chain write permit for one `(DNA, author)` chain.
+///
+/// Returned by [`DbWrite::acquire_chain_write_permit`]; holding it serializes
+/// flushes for that chain and dropping it releases the permit. Wrapping the
+/// underlying semaphore permit keeps the public API stable if the
+/// serialization mechanism changes.
+pub struct ChainWritePermit {
+    _permit: OwnedSemaphorePermit,
+}
+
 impl DbWrite<Dht> {
     /// Acquire the per-author source-chain write permit for this DHT database.
     ///
@@ -22,12 +32,13 @@ impl DbWrite<Dht> {
     /// one another. The DNA is identified by the database's stable
     /// [`database_id`](crate::DatabaseIdentifier::database_id) (the DHT
     /// database is per-DNA), combined with the author key.
-    pub async fn acquire_chain_write_permit(&self, author: &AgentPubKey) -> OwnedSemaphorePermit {
+    pub async fn acquire_chain_write_permit(&self, author: &AgentPubKey) -> ChainWritePermit {
         let key = (self.identifier().database_id().to_string(), author.clone());
-        chain_write_semaphore(key)
+        let permit = chain_write_semaphore(key)
             .acquire_owned()
             .await
-            .expect("chain write semaphore is never closed")
+            .expect("chain write semaphore is never closed");
+        ChainWritePermit { _permit: permit }
     }
 }
 

--- a/crates/holochain_data/src/dht/db_operations/db_size.rs
+++ b/crates/holochain_data/src/dht/db_operations/db_size.rs
@@ -1,0 +1,19 @@
+//! `DbRead<Dht>` API for database size statistics.
+
+use super::super::inner::db_size;
+use crate::handles::DbRead;
+use crate::kind::Dht;
+
+impl DbRead<Dht> {
+    /// Total bytes occupied on disk by every page of the database, including
+    /// the unused (free) bytes within each page.
+    pub async fn get_size_on_disk(&self) -> sqlx::Result<u64> {
+        db_size::get_size_on_disk(self.pool()).await
+    }
+
+    /// Bytes actually in use by the database, excluding the free space within
+    /// pages.
+    pub async fn get_used_size(&self) -> sqlx::Result<u64> {
+        db_size::get_used_size(self.pool()).await
+    }
+}

--- a/crates/holochain_data/src/dht/db_operations/db_size.rs
+++ b/crates/holochain_data/src/dht/db_operations/db_size.rs
@@ -8,12 +8,14 @@ impl DbRead<Dht> {
     /// Total bytes occupied on disk by every page of the database, including
     /// the unused (free) bytes within each page.
     pub async fn get_size_on_disk(&self) -> sqlx::Result<u64> {
-        db_size::get_size_on_disk(self.pool()).await
+        let mut conn = self.timed_conn().await?;
+        db_size::get_size_on_disk(&mut *conn).await
     }
 
     /// Bytes actually in use by the database, excluding the free space within
     /// pages.
     pub async fn get_used_size(&self) -> sqlx::Result<u64> {
-        db_size::get_used_size(self.pool()).await
+        let mut conn = self.timed_conn().await?;
+        db_size::get_used_size(&mut *conn).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/deleted_link.rs
+++ b/crates/holochain_data/src/dht/db_operations/deleted_link.rs
@@ -21,6 +21,7 @@ impl DbRead<Dht> {
         &self,
         create_link_hash: ActionHash,
     ) -> sqlx::Result<Vec<DeletedLinkRow>> {
-        deleted_link::get_deleted_links(self.pool(), create_link_hash).await
+        let mut conn = self.timed_conn().await?;
+        deleted_link::get_deleted_links(&mut *conn, create_link_hash).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/deleted_record.rs
+++ b/crates/holochain_data/src/dht/db_operations/deleted_record.rs
@@ -21,6 +21,7 @@ impl DbRead<Dht> {
         &self,
         deletes_action_hash: ActionHash,
     ) -> sqlx::Result<Vec<DeletedRecordRow>> {
-        deleted_record::get_deleted_records(self.pool(), deletes_action_hash).await
+        let mut conn = self.timed_conn().await?;
+        deleted_record::get_deleted_records(&mut *conn, deletes_action_hash).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/entry.rs
+++ b/crates/holochain_data/src/dht/db_operations/entry.rs
@@ -30,7 +30,8 @@ impl DbRead<Dht> {
         hash: EntryHash,
         author: Option<&AgentPubKey>,
     ) -> sqlx::Result<Option<Entry>> {
-        entry::get_entry(self.pool(), hash, author).await
+        let mut conn = self.timed_conn().await?;
+        entry::get_entry(&mut *conn, hash, author).await
     }
 
     /// Batch-reads entries by hash in a single query per chunk, keyed by entry
@@ -42,6 +43,7 @@ impl DbRead<Dht> {
         hashes: &[EntryHash],
         author: Option<&AgentPubKey>,
     ) -> sqlx::Result<HashMap<EntryHash, Entry>> {
-        entry::get_entries_by_hashes(self.pool(), hashes, author).await
+        let mut conn = self.timed_conn().await?;
+        entry::get_entries_by_hashes(&mut conn, hashes, author).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/entry.rs
+++ b/crates/holochain_data/src/dht/db_operations/entry.rs
@@ -5,6 +5,7 @@ use crate::handles::{DbRead, DbWrite};
 use crate::kind::Dht;
 use holo_hash::{AgentPubKey, EntryHash};
 use holochain_integrity_types::entry::Entry;
+use std::collections::HashMap;
 
 impl DbWrite<Dht> {
     pub async fn insert_entry(&self, hash: &EntryHash, entry: &Entry) -> sqlx::Result<()> {
@@ -30,5 +31,17 @@ impl DbRead<Dht> {
         author: Option<&AgentPubKey>,
     ) -> sqlx::Result<Option<Entry>> {
         entry::get_entry(self.pool(), hash, author).await
+    }
+
+    /// Batch-reads entries by hash in a single query per chunk, keyed by entry
+    /// hash. Visibility matches [`get_entry`](Self::get_entry): public entries
+    /// always resolve, and `author = Some(_)` additionally surfaces that
+    /// author's private entries. Hashes with no entry are absent from the map.
+    pub async fn get_entries_by_hashes(
+        &self,
+        hashes: &[EntryHash],
+        author: Option<&AgentPubKey>,
+    ) -> sqlx::Result<HashMap<EntryHash, Entry>> {
+        entry::get_entries_by_hashes(self.pool(), hashes, author).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/limbo_chain_op.rs
+++ b/crates/holochain_data/src/dht/db_operations/limbo_chain_op.rs
@@ -64,28 +64,32 @@ impl DbRead<Dht> {
         &self,
         hash: DhtOpHash,
     ) -> sqlx::Result<Option<LimboChainOpRow>> {
-        limbo_chain_op::get_limbo_chain_op(self.pool(), hash).await
+        let mut conn = self.timed_conn().await?;
+        limbo_chain_op::get_limbo_chain_op(&mut *conn, hash).await
     }
 
     pub async fn limbo_chain_ops_pending_sys_validation(
         &self,
         limit: u32,
     ) -> sqlx::Result<Vec<LimboChainOpRow>> {
-        limbo_chain_op::limbo_chain_ops_pending_sys_validation(self.pool(), limit).await
+        let mut conn = self.timed_conn().await?;
+        limbo_chain_op::limbo_chain_ops_pending_sys_validation(&mut *conn, limit).await
     }
 
     pub async fn limbo_chain_ops_pending_app_validation(
         &self,
         limit: u32,
     ) -> sqlx::Result<Vec<LimboChainOpRow>> {
-        limbo_chain_op::limbo_chain_ops_pending_app_validation(self.pool(), limit).await
+        let mut conn = self.timed_conn().await?;
+        limbo_chain_op::limbo_chain_ops_pending_app_validation(&mut *conn, limit).await
     }
 
     pub async fn limbo_chain_ops_ready_for_integration(
         &self,
         limit: u32,
     ) -> sqlx::Result<Vec<LimboChainOpRow>> {
-        limbo_chain_op::limbo_chain_ops_ready_for_integration(self.pool(), limit).await
+        let mut conn = self.timed_conn().await?;
+        limbo_chain_op::limbo_chain_ops_ready_for_integration(&mut *conn, limit).await
     }
 
     /// Fetch limbo chain ops pending sys-validation joined with their `Action`
@@ -94,7 +98,8 @@ impl DbRead<Dht> {
         &self,
         limit: u32,
     ) -> sqlx::Result<Vec<limbo_chain_op::LimboChainOpJoinedRow>> {
-        limbo_chain_op::limbo_chain_ops_pending_sys_validation_with_action(self.pool(), limit).await
+        let mut conn = self.timed_conn().await?;
+        limbo_chain_op::limbo_chain_ops_pending_sys_validation_with_action(&mut *conn, limit).await
     }
 
     /// Fetch limbo chain ops pending app-validation joined with their `Action`
@@ -103,6 +108,7 @@ impl DbRead<Dht> {
         &self,
         limit: u32,
     ) -> sqlx::Result<Vec<limbo_chain_op::LimboChainOpJoinedRow>> {
-        limbo_chain_op::limbo_chain_ops_pending_app_validation_with_action(self.pool(), limit).await
+        let mut conn = self.timed_conn().await?;
+        limbo_chain_op::limbo_chain_ops_pending_app_validation_with_action(&mut *conn, limit).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/limbo_warrant.rs
+++ b/crates/holochain_data/src/dht/db_operations/limbo_warrant.rs
@@ -56,20 +56,23 @@ impl DbRead<Dht> {
         &self,
         hash: DhtOpHash,
     ) -> sqlx::Result<Option<LimboWarrantRow>> {
-        limbo_warrant::get_limbo_warrant(self.pool(), hash).await
+        let mut conn = self.timed_conn().await?;
+        limbo_warrant::get_limbo_warrant(&mut *conn, hash).await
     }
 
     pub async fn limbo_warrants_pending_sys_validation(
         &self,
         limit: u32,
     ) -> sqlx::Result<Vec<LimboWarrantRow>> {
-        limbo_warrant::limbo_warrants_pending_sys_validation(self.pool(), limit).await
+        let mut conn = self.timed_conn().await?;
+        limbo_warrant::limbo_warrants_pending_sys_validation(&mut *conn, limit).await
     }
 
     pub async fn limbo_warrants_ready_for_integration(
         &self,
         limit: u32,
     ) -> sqlx::Result<Vec<LimboWarrantRow>> {
-        limbo_warrant::limbo_warrants_ready_for_integration(self.pool(), limit).await
+        let mut conn = self.timed_conn().await?;
+        limbo_warrant::limbo_warrants_ready_for_integration(&mut *conn, limit).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/link.rs
+++ b/crates/holochain_data/src/dht/db_operations/link.rs
@@ -15,6 +15,7 @@ impl DbWrite<Dht> {
 
 impl DbRead<Dht> {
     pub async fn get_links_by_base(&self, base: AnyLinkableHash) -> sqlx::Result<Vec<LinkRow>> {
-        link::get_links_by_base(self.pool(), base).await
+        let mut conn = self.timed_conn().await?;
+        link::get_links_by_base(&mut *conn, base).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/op_exists.rs
+++ b/crates/holochain_data/src/dht/db_operations/op_exists.rs
@@ -9,12 +9,14 @@ impl DbRead<Dht> {
     /// Returns `true` if the given op hash appears in any op-bearing
     /// table (`ChainOp`, `LimboChainOp`, `Warrant`, `LimboWarrant`).
     pub async fn op_exists(&self, hash: &DhtOpHash) -> sqlx::Result<bool> {
-        op_exists::op_exists(self.pool(), hash).await
+        let mut conn = self.timed_conn().await?;
+        op_exists::op_exists(&mut *conn, hash).await
     }
 
     /// For each input hash, return whether it appears in any
     /// op-bearing table. Result aligns 1:1 with the input.
     pub async fn op_hashes_present(&self, hashes: &[DhtOpHash]) -> sqlx::Result<Vec<bool>> {
-        op_exists::op_hashes_present(self.pool(), hashes).await
+        let mut conn = self.timed_conn().await?;
+        op_exists::op_hashes_present(&mut conn, hashes).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/remove_countersigning_session.rs
+++ b/crates/holochain_data/src/dht/db_operations/remove_countersigning_session.rs
@@ -10,9 +10,9 @@ use holo_hash::{ActionHash, EntryHash};
 
 impl DbWrite<Dht> {
     /// Force-remove a self-authored countersigning session, wrapped in a single
-    /// transaction so the published guard and the deletes are atomic. See
-    /// [`remove_countersigning_session::remove_countersigning_session`] for the
-    /// guard and deletion semantics.
+    /// transaction so the published guard and the deletes are atomic. See the
+    /// inner `remove_countersigning_session` for the guard and deletion
+    /// semantics.
     pub async fn remove_countersigning_session(
         &self,
         action_hash: &ActionHash,

--- a/crates/holochain_data/src/dht/db_operations/remove_countersigning_session.rs
+++ b/crates/holochain_data/src/dht/db_operations/remove_countersigning_session.rs
@@ -1,0 +1,31 @@
+//! `DbWrite<Dht>` API for force-removing a self-authored countersigning
+//! session.
+
+use super::super::inner::remove_countersigning_session::{
+    self, RemoveCountersigningSessionOutcome,
+};
+use crate::handles::DbWrite;
+use crate::kind::Dht;
+use holo_hash::{ActionHash, EntryHash};
+
+impl DbWrite<Dht> {
+    /// Force-remove a self-authored countersigning session, wrapped in a single
+    /// transaction so the published guard and the deletes are atomic. See
+    /// [`remove_countersigning_session::remove_countersigning_session`] for the
+    /// guard and deletion semantics.
+    pub async fn remove_countersigning_session(
+        &self,
+        action_hash: &ActionHash,
+        entry_hash: &EntryHash,
+    ) -> sqlx::Result<RemoveCountersigningSessionOutcome> {
+        let mut tx = self.begin().await?;
+        let outcome = remove_countersigning_session::remove_countersigning_session(
+            tx.conn_mut(),
+            action_hash,
+            entry_hash,
+        )
+        .await?;
+        tx.commit().await?;
+        Ok(outcome)
+    }
+}

--- a/crates/holochain_data/src/dht/db_operations/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/db_operations/scheduled_function.rs
@@ -20,8 +20,7 @@ impl DbRead<Dht> {
 
     /// Return live scheduled-function rows for `author` at `now`.
     ///
-    /// A row is "live" when `start_at <= now AND now <= end_at`, mirroring the
-    /// legacy `live_scheduled_fns` predicate. Returns
+    /// A row is "live" when `start_at <= now AND now <= end_at`. Returns
     /// `(zome_name, scheduled_fn, maybe_schedule_blob, ephemeral)` tuples.
     pub async fn get_live_scheduled_functions(
         &self,

--- a/crates/holochain_data/src/dht/db_operations/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/db_operations/scheduled_function.rs
@@ -30,6 +30,18 @@ impl DbRead<Dht> {
     ) -> sqlx::Result<Vec<(String, String, Vec<u8>, bool)>> {
         scheduled_function::get_live_scheduled_functions(self.pool(), author, now).await
     }
+
+    /// Return `true` if a scheduled-function row exists for the given
+    /// `(author, zome_name, scheduled_fn)` tuple, regardless of liveness.
+    pub async fn is_function_scheduled(
+        &self,
+        author: &AgentPubKey,
+        zome_name: &str,
+        scheduled_fn: &str,
+    ) -> sqlx::Result<bool> {
+        scheduled_function::is_function_scheduled(self.pool(), author, zome_name, scheduled_fn)
+            .await
+    }
 }
 
 impl DbWrite<Dht> {
@@ -62,5 +74,11 @@ impl DbWrite<Dht> {
     ) -> sqlx::Result<u64> {
         scheduled_function::delete_live_ephemeral_scheduled_functions(self.pool(), author, now)
             .await
+    }
+
+    /// Delete every ephemeral scheduled-function row, regardless of author or
+    /// liveness. Returns the number of rows deleted.
+    pub async fn delete_all_ephemeral_scheduled_functions(&self) -> sqlx::Result<u64> {
+        scheduled_function::delete_all_ephemeral_scheduled_functions(self.pool()).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/db_operations/scheduled_function.rs
@@ -17,6 +17,19 @@ impl DbRead<Dht> {
         scheduled_function::get_expired_persisted_scheduled_functions(self.pool(), author, now)
             .await
     }
+
+    /// Return live scheduled-function rows for `author` at `now`.
+    ///
+    /// A row is "live" when `start_at <= now AND now <= end_at`, mirroring the
+    /// legacy `live_scheduled_fns` predicate. Returns
+    /// `(zome_name, scheduled_fn, maybe_schedule_blob, ephemeral)` tuples.
+    pub async fn get_live_scheduled_functions(
+        &self,
+        author: &AgentPubKey,
+        now: Timestamp,
+    ) -> sqlx::Result<Vec<(String, String, Vec<u8>, bool)>> {
+        scheduled_function::get_live_scheduled_functions(self.pool(), author, now).await
+    }
 }
 
 impl DbWrite<Dht> {

--- a/crates/holochain_data/src/dht/db_operations/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/db_operations/scheduled_function.rs
@@ -14,8 +14,8 @@ impl DbRead<Dht> {
         author: &AgentPubKey,
         now: Timestamp,
     ) -> sqlx::Result<Vec<(String, String, Vec<u8>)>> {
-        scheduled_function::get_expired_persisted_scheduled_functions(self.pool(), author, now)
-            .await
+        let mut conn = self.timed_conn().await?;
+        scheduled_function::get_expired_persisted_scheduled_functions(&mut *conn, author, now).await
     }
 
     /// Return live scheduled-function rows for `author` at `now`.
@@ -28,7 +28,8 @@ impl DbRead<Dht> {
         author: &AgentPubKey,
         now: Timestamp,
     ) -> sqlx::Result<Vec<(String, String, Vec<u8>, bool)>> {
-        scheduled_function::get_live_scheduled_functions(self.pool(), author, now).await
+        let mut conn = self.timed_conn().await?;
+        scheduled_function::get_live_scheduled_functions(&mut *conn, author, now).await
     }
 
     /// Return `true` if a scheduled-function row exists for the given
@@ -39,8 +40,8 @@ impl DbRead<Dht> {
         zome_name: &str,
         scheduled_fn: &str,
     ) -> sqlx::Result<bool> {
-        scheduled_function::is_function_scheduled(self.pool(), author, zome_name, scheduled_fn)
-            .await
+        let mut conn = self.timed_conn().await?;
+        scheduled_function::is_function_scheduled(&mut *conn, author, zome_name, scheduled_fn).await
     }
 }
 

--- a/crates/holochain_data/src/dht/db_operations/slice_hash.rs
+++ b/crates/holochain_data/src/dht/db_operations/slice_hash.rs
@@ -21,7 +21,8 @@ impl DbWrite<Dht> {
 impl DbRead<Dht> {
     /// Number of stored slices for the arc, or 0 if none.
     pub async fn slice_hash_count(&self, arc_start: u32, arc_end: u32) -> sqlx::Result<u64> {
-        slice_hash::slice_hash_count(self.pool(), arc_start, arc_end).await
+        let mut conn = self.timed_conn().await?;
+        slice_hash::slice_hash_count(&mut *conn, arc_start, arc_end).await
     }
 
     /// Single slice hash, if any.
@@ -31,7 +32,8 @@ impl DbRead<Dht> {
         arc_end: u32,
         slice_index: u64,
     ) -> sqlx::Result<Option<Vec<u8>>> {
-        slice_hash::get_slice_hash(self.pool(), arc_start, arc_end, slice_index).await
+        let mut conn = self.timed_conn().await?;
+        slice_hash::get_slice_hash(&mut *conn, arc_start, arc_end, slice_index).await
     }
 
     /// Every `(slice_index, hash)` pair stored for the arc.
@@ -40,6 +42,7 @@ impl DbRead<Dht> {
         arc_start: u32,
         arc_end: u32,
     ) -> sqlx::Result<Vec<SliceHashIndexedRow>> {
-        slice_hash::get_slice_hashes(self.pool(), arc_start, arc_end).await
+        let mut conn = self.timed_conn().await?;
+        slice_hash::get_slice_hashes(&mut *conn, arc_start, arc_end).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/sync_queries.rs
+++ b/crates/holochain_data/src/dht/db_operations/sync_queries.rs
@@ -21,8 +21,9 @@ impl DbRead<Dht> {
         t_start_micros: i64,
         t_end_micros: i64,
     ) -> sqlx::Result<Vec<K2OpHashRow>> {
+        let mut conn = self.timed_conn().await?;
         sync_queries::op_hashes_in_time_slice(
-            self.pool(),
+            &mut *conn,
             ArcBounds {
                 start: arc_start,
                 end: arc_end,
@@ -42,8 +43,9 @@ impl DbRead<Dht> {
         t_min_micros: i64,
         limit: u32,
     ) -> sqlx::Result<Vec<K2OpIdSinceRow>> {
+        let mut conn = self.timed_conn().await?;
         sync_queries::op_ids_since_time_batch(
-            self.pool(),
+            &mut *conn,
             ArcBounds {
                 start: arc_start,
                 end: arc_end,
@@ -60,7 +62,8 @@ impl DbRead<Dht> {
         &self,
         op_hashes: &[Vec<u8>],
     ) -> sqlx::Result<Vec<K2OpPresentRow>> {
-        sync_queries::check_op_hashes_present(self.pool(), op_hashes).await
+        let mut conn = self.timed_conn().await?;
+        sync_queries::check_op_hashes_present(&mut *conn, op_hashes).await
     }
 
     /// Full chain-op rows (joined with `Action` and optional `Entry`) for
@@ -69,7 +72,8 @@ impl DbRead<Dht> {
         &self,
         op_hashes: &[Vec<u8>],
     ) -> sqlx::Result<Vec<K2ChainOpForWireRow>> {
-        sync_queries::get_chain_ops_for_wire(self.pool(), op_hashes).await
+        let mut conn = self.timed_conn().await?;
+        sync_queries::get_chain_ops_for_wire(&mut *conn, op_hashes).await
     }
 
     /// Full warrant rows for the given op hashes.
@@ -77,7 +81,8 @@ impl DbRead<Dht> {
         &self,
         op_hashes: &[Vec<u8>],
     ) -> sqlx::Result<Vec<K2WarrantForWireRow>> {
-        sync_queries::get_warrants_for_wire(self.pool(), op_hashes).await
+        let mut conn = self.timed_conn().await?;
+        sync_queries::get_warrants_for_wire(&mut *conn, op_hashes).await
     }
 
     /// Earliest authored timestamp across both tables within the arc, or
@@ -87,8 +92,9 @@ impl DbRead<Dht> {
         arc_start: u32,
         arc_end: u32,
     ) -> sqlx::Result<Option<i64>> {
+        let mut conn = self.timed_conn().await?;
         sync_queries::earliest_authored_timestamp_in_arc(
-            self.pool(),
+            &mut *conn,
             ArcBounds {
                 start: arc_start,
                 end: arc_end,
@@ -100,40 +106,46 @@ impl DbRead<Dht> {
     /// Total count of every integrated op + warrant (no `locally_validated`
     /// filter).
     pub async fn count_integrated_ops(&self) -> sqlx::Result<u64> {
-        Ok(sync_queries::count_integrated_ops(self.pool()).await? as u64)
+        let mut conn = self.timed_conn().await?;
+        Ok(sync_queries::count_integrated_ops(&mut *conn).await? as u64)
     }
 
     /// `(validation_limbo, integration_limbo, integrated)` counts for the
     /// integration-state report. Integrated counts locally-validated
     /// `ChainOp` rows (cache-only copies excluded) plus all `WarrantOp` rows.
     pub async fn limbo_state_counts(&self) -> sqlx::Result<(i64, i64, i64)> {
-        sync_queries::limbo_state_counts(self.pool()).await
+        let mut conn = self.timed_conn().await?;
+        sync_queries::limbo_state_counts(&mut *conn).await
     }
 
     /// Count of integrated, locally-validated `ChainOp` rows that passed
     /// validation (rejected and GET-cached ops excluded).
     #[cfg(any(test, feature = "inspection"))]
     pub async fn count_valid_integrated_ops(&self) -> sqlx::Result<u64> {
-        Ok(sync_queries::count_valid_integrated_ops(self.pool()).await? as u64)
+        let mut conn = self.timed_conn().await?;
+        Ok(sync_queries::count_valid_integrated_ops(&mut *conn).await? as u64)
     }
 
     /// Count of `LimboChainOp` rows that passed both sys- and app-validation
     /// but are not yet integrated.
     #[cfg(any(test, feature = "inspection"))]
     pub async fn count_valid_not_integrated_ops(&self) -> sqlx::Result<u64> {
-        Ok(sync_queries::count_valid_not_integrated_ops(self.pool()).await? as u64)
+        let mut conn = self.timed_conn().await?;
+        Ok(sync_queries::count_valid_not_integrated_ops(&mut *conn).await? as u64)
     }
 
     /// Count of not-yet-integrated chain ops authored by `author`.
     #[cfg(any(test, feature = "inspection"))]
     pub async fn count_pending_ops_for_author(&self, author: &AgentPubKey) -> sqlx::Result<u64> {
-        Ok(sync_queries::count_pending_ops_for_author(self.pool(), author).await? as u64)
+        let mut conn = self.timed_conn().await?;
+        Ok(sync_queries::count_pending_ops_for_author(&mut *conn, author).await? as u64)
     }
 
     /// Hashes of integrated, rejected chain ops (GET-cached copies excluded).
     #[cfg(any(test, feature = "inspection"))]
     pub async fn rejected_integrated_op_hashes(&self) -> sqlx::Result<Vec<DhtOpHash>> {
-        Ok(sync_queries::rejected_integrated_op_hashes(self.pool())
+        let mut conn = self.timed_conn().await?;
+        Ok(sync_queries::rejected_integrated_op_hashes(&mut *conn)
             .await?
             .into_iter()
             .map(DhtOpHash::from_raw_36)
@@ -143,25 +155,29 @@ impl DbRead<Dht> {
     /// Total count of every op (integrated and limbo) held in this DHT store.
     #[cfg(any(test, feature = "inspection"))]
     pub async fn count_all_ops(&self) -> sqlx::Result<u64> {
-        Ok(sync_queries::count_all_ops(self.pool()).await? as u64)
+        let mut conn = self.timed_conn().await?;
+        Ok(sync_queries::count_all_ops(&mut *conn).await? as u64)
     }
 
     /// Whether the integrated chain op `op_hash` requires a validation receipt.
     #[cfg(any(test, feature = "inspection"))]
     pub async fn op_requires_receipt(&self, op_hash: &DhtOpHash) -> sqlx::Result<bool> {
-        sync_queries::op_requires_receipt(self.pool(), op_hash).await
+        let mut conn = self.timed_conn().await?;
+        sync_queries::op_requires_receipt(&mut *conn, op_hash).await
     }
 
     /// Whether `op_hash` is present in the limbo (not-yet-integrated) chain ops.
     #[cfg(any(test, feature = "inspection"))]
     pub async fn limbo_op_exists(&self, op_hash: &DhtOpHash) -> sqlx::Result<bool> {
-        sync_queries::limbo_op_exists(self.pool(), op_hash).await
+        let mut conn = self.timed_conn().await?;
+        sync_queries::limbo_op_exists(&mut *conn, op_hash).await
     }
 
     /// Hashes of limbo chain ops flagged as requiring a validation receipt.
     #[cfg(any(test, feature = "inspection"))]
     pub async fn limbo_op_hashes_requiring_receipt(&self) -> sqlx::Result<Vec<DhtOpHash>> {
-        Ok(sync_queries::limbo_op_hashes_requiring_receipt(self.pool())
+        let mut conn = self.timed_conn().await?;
+        Ok(sync_queries::limbo_op_hashes_requiring_receipt(&mut *conn)
             .await?
             .into_iter()
             .map(DhtOpHash::from_raw_36)
@@ -171,7 +187,8 @@ impl DbRead<Dht> {
     /// Hashes of integrated chain ops with the given DHT `basis`.
     #[cfg(any(test, feature = "inspection"))]
     pub async fn get_ops_at_basis(&self, basis: &AnyLinkableHash) -> sqlx::Result<Vec<DhtOpHash>> {
-        Ok(sync_queries::get_ops_at_basis(self.pool(), basis)
+        let mut conn = self.timed_conn().await?;
+        Ok(sync_queries::get_ops_at_basis(&mut *conn, basis)
             .await?
             .into_iter()
             .map(DhtOpHash::from_raw_36)
@@ -181,7 +198,8 @@ impl DbRead<Dht> {
     /// Count of rows in the public `Entry` table.
     #[cfg(any(test, feature = "inspection"))]
     pub async fn count_entries(&self) -> sqlx::Result<u64> {
-        Ok(sync_queries::count_entries(self.pool()).await? as u64)
+        let mut conn = self.timed_conn().await?;
+        Ok(sync_queries::count_entries(&mut *conn).await? as u64)
     }
 
     /// Integrated chain-op rows for the integration dump, paginated forward
@@ -191,7 +209,8 @@ impl DbRead<Dht> {
         &self,
         after: Option<(i64, &[u8])>,
     ) -> sqlx::Result<Vec<DumpChainOpRow>> {
-        sync_queries::integrated_chain_ops_for_dump(self.pool(), after).await
+        let mut conn = self.timed_conn().await?;
+        sync_queries::integrated_chain_ops_for_dump(&mut *conn, after).await
     }
 
     /// Limbo chain-op rows for the integration dump. `ready` selects the
@@ -200,7 +219,8 @@ impl DbRead<Dht> {
         &self,
         ready: bool,
     ) -> sqlx::Result<Vec<K2ChainOpForWireRow>> {
-        sync_queries::limbo_chain_ops_for_dump(self.pool(), ready).await
+        let mut conn = self.timed_conn().await?;
+        sync_queries::limbo_chain_ops_for_dump(&mut *conn, ready).await
     }
 
     /// Chain-op rows authored and shared by `author`, joined for wire
@@ -210,11 +230,13 @@ impl DbRead<Dht> {
         &self,
         author: &AgentPubKey,
     ) -> sqlx::Result<Vec<K2ChainOpForWireRow>> {
-        sync_queries::ops_to_publish_for_wire(self.pool(), author).await
+        let mut conn = self.timed_conn().await?;
+        sync_queries::ops_to_publish_for_wire(&mut *conn, author).await
     }
 
     /// Every integrated warrant row for the integration dump.
     pub async fn integrated_warrants_for_dump(&self) -> sqlx::Result<Vec<K2WarrantForWireRow>> {
-        sync_queries::integrated_warrants_for_dump(self.pool()).await
+        let mut conn = self.timed_conn().await?;
+        sync_queries::integrated_warrants_for_dump(&mut *conn).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/updated_record.rs
+++ b/crates/holochain_data/src/dht/db_operations/updated_record.rs
@@ -21,6 +21,7 @@ impl DbRead<Dht> {
         &self,
         original_action_hash: ActionHash,
     ) -> sqlx::Result<Vec<UpdatedRecordRow>> {
-        updated_record::get_updated_records(self.pool(), original_action_hash).await
+        let mut conn = self.timed_conn().await?;
+        updated_record::get_updated_records(&mut *conn, original_action_hash).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/validation_receipt.rs
+++ b/crates/holochain_data/src/dht/db_operations/validation_receipt.rs
@@ -31,7 +31,8 @@ impl DbRead<Dht> {
         &self,
         op_hash: DhtOpHash,
     ) -> sqlx::Result<Vec<ValidationReceiptRow>> {
-        validation_receipt::get_validation_receipts(self.pool(), op_hash).await
+        let mut conn = self.timed_conn().await?;
+        validation_receipt::get_validation_receipts(&mut *conn, op_hash).await
     }
 
     /// Validation receipts for every op of `action_hash`, joined with op type
@@ -41,6 +42,7 @@ impl DbRead<Dht> {
         &self,
         action_hash: ActionHash,
     ) -> sqlx::Result<Vec<ValidationReceiptForActionRow>> {
-        validation_receipt::validation_receipts_for_action(self.pool(), action_hash).await
+        let mut conn = self.timed_conn().await?;
+        validation_receipt::validation_receipts_for_action(&mut *conn, action_hash).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/warrant.rs
+++ b/crates/holochain_data/src/dht/db_operations/warrant.rs
@@ -18,14 +18,16 @@ impl DbWrite<Dht> {
 
 impl DbRead<Dht> {
     pub async fn get_warrant(&self, hash: DhtOpHash) -> sqlx::Result<Option<WarrantRow>> {
-        warrant::get_warrant(self.pool(), hash).await
+        let mut conn = self.timed_conn().await?;
+        warrant::get_warrant(&mut *conn, hash).await
     }
 
     pub async fn get_warrants_by_warrantee(
         &self,
         warrantee: AgentPubKey,
     ) -> sqlx::Result<Vec<WarrantRow>> {
-        warrant::get_warrants_by_warrantee(self.pool(), warrantee).await
+        let mut conn = self.timed_conn().await?;
+        warrant::get_warrants_by_warrantee(&mut *conn, warrantee).await
     }
 
     /// Warrants authored by `author` (the warrant issuer).
@@ -33,7 +35,8 @@ impl DbRead<Dht> {
         &self,
         author: AgentPubKey,
     ) -> sqlx::Result<Vec<WarrantRow>> {
-        warrant::get_warrants_by_author(self.pool(), author).await
+        let mut conn = self.timed_conn().await?;
+        warrant::get_warrants_by_author(&mut *conn, author).await
     }
 
     /// Terminal validation status of an integrated warrant op, or `None`.
@@ -41,7 +44,8 @@ impl DbRead<Dht> {
         &self,
         op_hash: &DhtOpHash,
     ) -> sqlx::Result<Option<i64>> {
-        warrant::warrant_op_validation_status(self.pool(), op_hash).await
+        let mut conn = self.timed_conn().await?;
+        warrant::warrant_op_validation_status(&mut *conn, op_hash).await
     }
 
     /// Serialized `WarrantProof`s of pending-or-valid warrants against
@@ -51,6 +55,7 @@ impl DbRead<Dht> {
         &self,
         warrantee: &AgentPubKey,
     ) -> sqlx::Result<Vec<Vec<u8>>> {
-        warrant::pending_or_valid_warrant_proofs_by_warrantee(self.pool(), warrantee).await
+        let mut conn = self.timed_conn().await?;
+        warrant::pending_or_valid_warrant_proofs_by_warrantee(&mut *conn, warrantee).await
     }
 }

--- a/crates/holochain_data/src/dht/db_operations/warrant_publish.rs
+++ b/crates/holochain_data/src/dht/db_operations/warrant_publish.rs
@@ -22,6 +22,7 @@ impl DbRead<Dht> {
         &self,
         warrant_hash: DhtOpHash,
     ) -> sqlx::Result<Option<WarrantPublishRow>> {
-        warrant_publish::get_warrant_publish(self.pool(), warrant_hash).await
+        let mut conn = self.timed_conn().await?;
+        warrant_publish::get_warrant_publish(&mut *conn, warrant_hash).await
     }
 }

--- a/crates/holochain_data/src/dht/inner.rs
+++ b/crates/holochain_data/src/dht/inner.rs
@@ -12,6 +12,7 @@ pub(crate) mod cap_grant;
 pub(crate) mod chain_lock;
 pub(crate) mod chain_op;
 pub(crate) mod chain_op_publish;
+pub(crate) mod db_size;
 pub(crate) mod deleted_link;
 pub(crate) mod deleted_record;
 pub(crate) mod entry;

--- a/crates/holochain_data/src/dht/inner.rs
+++ b/crates/holochain_data/src/dht/inner.rs
@@ -20,6 +20,7 @@ pub(crate) mod limbo_warrant;
 pub(crate) mod link;
 pub(crate) mod move_to_limbo;
 pub(crate) mod op_exists;
+pub(crate) mod remove_countersigning_session;
 pub(crate) mod scheduled_function;
 pub(crate) mod slice_hash;
 pub(crate) mod sync_queries;

--- a/crates/holochain_data/src/dht/inner/action.rs
+++ b/crates/holochain_data/src/dht/inner/action.rs
@@ -177,6 +177,13 @@ where
 /// `RegisterAgentActivity` op, ordered by chain sequence. When
 /// `include_entries` is set, the public
 /// `Entry` blob is joined in (Full mode); otherwise the entry column is `NULL`.
+///
+/// Ops withheld from publishing (in-flight countersigning sessions, where
+/// `ChainOpPublish.withhold_publish` is set) are excluded: such an op is
+/// authored locally but must not surface as live agent activity until the
+/// session completes and the withhold flag is cleared. The `LEFT JOIN` leaves
+/// ordinary ops — which have either no `ChainOpPublish` row (network/other-agent
+/// activity) or a row with `withhold_publish` `NULL` — unaffected.
 pub(crate) async fn get_agent_activity<'e, E>(
     executor: E,
     author: &AgentPubKey,
@@ -192,7 +199,8 @@ where
          FROM ChainOp c
          JOIN Action a ON c.action_hash = a.hash
          LEFT JOIN Entry e ON a.entry_hash = e.hash
-         WHERE a.author = ? AND c.op_type = ?
+         LEFT JOIN ChainOpPublish cp ON cp.op_hash = c.hash
+         WHERE a.author = ? AND c.op_type = ? AND cp.withhold_publish IS NULL
          ORDER BY a.seq ASC"
     } else {
         "SELECT a.hash, a.author, a.seq, a.prev_hash, a.timestamp, a.action_type,
@@ -200,7 +208,8 @@ where
                 c.validation_status, NULL AS entry_blob
          FROM ChainOp c
          JOIN Action a ON c.action_hash = a.hash
-         WHERE a.author = ? AND c.op_type = ?
+         LEFT JOIN ChainOpPublish cp ON cp.op_hash = c.hash
+         WHERE a.author = ? AND c.op_type = ? AND cp.withhold_publish IS NULL
          ORDER BY a.seq ASC"
     };
     let rows: Vec<AgentActivityRow> = sqlx::query_as(sql)

--- a/crates/holochain_data/src/dht/inner/action.rs
+++ b/crates/holochain_data/src/dht/inner/action.rs
@@ -148,8 +148,21 @@ where
         .await
 }
 
-/// The author's chain head: the highest-sequence action they authored.
-/// Returns `None` for an empty chain (pre-genesis).
+/// The author's chain head: the highest-sequence action they authored that has
+/// an integrated `RegisterAgentActivity` op. Returns `None` for an empty chain
+/// (pre-genesis).
+///
+/// Scoping through the integrated `RegisterAgentActivity` `ChainOp` (rather than
+/// scanning the raw `Action` table) deliberately excludes limbo arrivals: the
+/// `Action` table also holds unintegrated network ops recorded via
+/// `record_incoming_ops`, and a peer could otherwise inject a high-seq op forged
+/// as the local author to falsely trip the flush as-at / head-moved check and
+/// DoS the local chain writer. This is safe for self-authored data because the
+/// source-chain flush inserts each self-authored `ChainOp` with `when_integrated`
+/// already set (see `source_chain.rs`), so a freshly committed head is
+/// immediately visible here. Withheld in-flight countersigning actions are still
+/// integrated (only publishing is withheld), so they remain part of the head and
+/// are intentionally not filtered out.
 pub(crate) async fn chain_head_for_author<'e, E>(
     executor: E,
     author: &AgentPubKey,
@@ -158,10 +171,13 @@ where
     E: Executor<'e, Database = Sqlite>,
 {
     let row: Option<(Vec<u8>, i64, i64)> = sqlx::query_as(
-        "SELECT hash, seq, timestamp FROM Action
-         WHERE author = ? ORDER BY seq DESC LIMIT 1",
+        "SELECT a.hash, a.seq, a.timestamp FROM ChainOp c
+         JOIN Action a ON c.action_hash = a.hash
+         WHERE a.author = ? AND c.op_type = ?
+         ORDER BY a.seq DESC LIMIT 1",
     )
     .bind(author.get_raw_36())
+    .bind(i64::from(ChainOpType::RegisterAgentActivity))
     .fetch_optional(executor)
     .await?;
     Ok(row.map(|(hash_bytes, seq, ts)| {

--- a/crates/holochain_data/src/dht/inner/action.rs
+++ b/crates/holochain_data/src/dht/inner/action.rs
@@ -112,6 +112,11 @@ where
     row.map(row_to_signed_action_hashed).transpose()
 }
 
+/// The author's committed source chain, ordered by sequence.
+///
+/// Restricted to accepted rows (`record_validity = Accepted`): integrated
+/// actions whose ops all pass validation. Pending (limbo) and rejected rows are
+/// excluded, so this agrees with [`chain_head_for_author`].
 pub(crate) async fn get_actions_by_author<'e, E>(
     executor: E,
     author: AgentPubKey,
@@ -122,9 +127,10 @@ where
     let rows: Vec<ActionRow> = sqlx::query_as(
         "SELECT hash, author, seq, prev_hash, timestamp, action_type,
                 action_data, signature, entry_hash, private_entry, record_validity
-         FROM Action WHERE author = ? ORDER BY seq ASC",
+         FROM Action WHERE author = ? AND record_validity = ? ORDER BY seq ASC",
     )
     .bind(author.get_raw_36())
+    .bind(i64::from(RecordValidity::Accepted))
     .fetch_all(executor)
     .await?;
     rows.into_iter().map(row_to_signed_action_hashed).collect()
@@ -154,15 +160,16 @@ where
 ///
 /// Acceptability is read from the `Action` row's own `record_validity` state,
 /// not by joining to an op row, so the result never depends on holding a
-/// particular op such as `RegisterAgentActivity`. `record_validity` is
-/// `Accepted` only for actions written by the local source-chain flush; network
-/// arrivals are inserted as pending (`NULL`) and stay pending, so limbo copies
-/// of the author's chain — including a peer's forged high-sequence action —
-/// are excluded and cannot falsely trip the flush as-at / head-moved check. The
+/// particular op such as `RegisterAgentActivity`. `record_validity` is the
+/// action's aggregated integration status: a self-authored action is `Accepted`
+/// when the flush writes it, and a network-received action becomes `Accepted`
+/// once its ops integrate. Pending (limbo) and rejected actions are excluded, so
+/// a forged high-sequence action — which cannot pass validation to reach
+/// `Accepted` — cannot falsely trip the flush as-at / head-moved check. The
 /// flush writes the action and its ops in one transaction, so a freshly
-/// committed head is immediately visible here. Withheld in-flight
-/// countersigning actions are self-authored and keep `Accepted`, so they remain
-/// part of the head; only their publishing is withheld.
+/// committed head is immediately visible here. Withheld in-flight countersigning
+/// actions are self-authored and keep `Accepted`, so they remain part of the
+/// head; only their publishing is withheld.
 pub(crate) async fn chain_head_for_author<'e, E>(
     executor: E,
     author: &AgentPubKey,

--- a/crates/holochain_data/src/dht/inner/action.rs
+++ b/crates/holochain_data/src/dht/inner/action.rs
@@ -148,6 +148,31 @@ where
         .await
 }
 
+/// The author's chain head: the highest-sequence action they authored.
+/// Returns `None` for an empty chain (pre-genesis).
+pub(crate) async fn chain_head_for_author<'e, E>(
+    executor: E,
+    author: &AgentPubKey,
+) -> sqlx::Result<Option<(ActionHash, u32, holochain_timestamp::Timestamp)>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let row: Option<(Vec<u8>, i64, i64)> = sqlx::query_as(
+        "SELECT hash, seq, timestamp FROM Action
+         WHERE author = ? ORDER BY seq DESC LIMIT 1",
+    )
+    .bind(author.get_raw_36())
+    .fetch_optional(executor)
+    .await?;
+    Ok(row.map(|(hash_bytes, seq, ts)| {
+        (
+            ActionHash::from_raw_36(hash_bytes),
+            seq as u32,
+            holochain_timestamp::Timestamp::from_micros(ts),
+        )
+    }))
+}
+
 /// All actions authored by `author` that have an integrated
 /// `RegisterAgentActivity` op, ordered by chain sequence. When
 /// `include_entries` is set, the public

--- a/crates/holochain_data/src/dht/inner/action.rs
+++ b/crates/holochain_data/src/dht/inner/action.rs
@@ -148,21 +148,21 @@ where
         .await
 }
 
-/// The author's chain head: the highest-sequence action they authored that has
-/// an integrated `RegisterAgentActivity` op. Returns `None` for an empty chain
+/// The author's committed source-chain head: the highest-sequence action they
+/// authored that is marked accepted. Returns `None` for an empty chain
 /// (pre-genesis).
 ///
-/// Scoping through the integrated `RegisterAgentActivity` `ChainOp` (rather than
-/// scanning the raw `Action` table) deliberately excludes limbo arrivals: the
-/// `Action` table also holds unintegrated network ops recorded via
-/// `record_incoming_ops`, and a peer could otherwise inject a high-seq op forged
-/// as the local author to falsely trip the flush as-at / head-moved check and
-/// DoS the local chain writer. This is safe for self-authored data because the
-/// source-chain flush inserts each self-authored `ChainOp` with `when_integrated`
-/// already set (see `source_chain.rs`), so a freshly committed head is
-/// immediately visible here. Withheld in-flight countersigning actions are still
-/// integrated (only publishing is withheld), so they remain part of the head and
-/// are intentionally not filtered out.
+/// Acceptability is read from the `Action` row's own `record_validity` state,
+/// not by joining to an op row, so the result never depends on holding a
+/// particular op such as `RegisterAgentActivity`. `record_validity` is
+/// `Accepted` only for actions written by the local source-chain flush; network
+/// arrivals are inserted as pending (`NULL`) and stay pending, so limbo copies
+/// of the author's chain — including a peer's forged high-sequence action —
+/// are excluded and cannot falsely trip the flush as-at / head-moved check. The
+/// flush writes the action and its ops in one transaction, so a freshly
+/// committed head is immediately visible here. Withheld in-flight
+/// countersigning actions are self-authored and keep `Accepted`, so they remain
+/// part of the head; only their publishing is withheld.
 pub(crate) async fn chain_head_for_author<'e, E>(
     executor: E,
     author: &AgentPubKey,
@@ -171,13 +171,12 @@ where
     E: Executor<'e, Database = Sqlite>,
 {
     let row: Option<(Vec<u8>, i64, i64)> = sqlx::query_as(
-        "SELECT a.hash, a.seq, a.timestamp FROM ChainOp c
-         JOIN Action a ON c.action_hash = a.hash
-         WHERE a.author = ? AND c.op_type = ?
-         ORDER BY a.seq DESC LIMIT 1",
+        "SELECT hash, seq, timestamp FROM Action
+         WHERE author = ? AND record_validity = ?
+         ORDER BY seq DESC LIMIT 1",
     )
     .bind(author.get_raw_36())
-    .bind(i64::from(ChainOpType::RegisterAgentActivity))
+    .bind(i64::from(RecordValidity::Accepted))
     .fetch_optional(executor)
     .await?;
     Ok(row.map(|(hash_bytes, seq, ts)| {

--- a/crates/holochain_data/src/dht/inner/chain_op_publish.rs
+++ b/crates/holochain_data/src/dht/inner/chain_op_publish.rs
@@ -151,6 +151,30 @@ where
     .await
 }
 
+/// Count integrated ops authored by `author` that have been published at
+/// least once (i.e. `ChainOpPublish.last_publish_time IS NOT NULL`).
+///
+/// Used by [`crate::dht`] to compute the `published_ops_count` field in the
+/// source-chain dump.
+pub(crate) async fn count_published_ops_for_author<'e, E>(
+    executor: E,
+    author: &AgentPubKey,
+) -> sqlx::Result<i64>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    sqlx::query_scalar(
+        "SELECT COUNT(ChainOp.hash) FROM ChainOp
+         JOIN Action ON ChainOp.action_hash = Action.hash
+         JOIN ChainOpPublish ON ChainOpPublish.op_hash = ChainOp.hash
+         WHERE Action.author = ?
+           AND ChainOpPublish.last_publish_time IS NOT NULL",
+    )
+    .bind(author.get_raw_36())
+    .fetch_one(executor)
+    .await
+}
+
 /// Count ops authored by `author` that may still need to be published.
 ///
 /// Like [`get_ops_to_publish`] but ignores the recency window: an op counts as

--- a/crates/holochain_data/src/dht/inner/db_size.rs
+++ b/crates/holochain_data/src/dht/inner/db_size.rs
@@ -1,0 +1,64 @@
+//! Database size statistics derived from the `dbstat` virtual table.
+//!
+//! These mirror the legacy `holochain_sqlite::stats` helpers so that the
+//! merged DHT store can report per-DNA storage usage. They rely on the
+//! `dbstat` virtual table, which is compiled into the bundled SQLCipher build
+//! (`SQLITE_ENABLE_DBSTAT_VTAB`).
+
+use sqlx::{Executor, Sqlite};
+
+/// Total bytes occupied on disk by every page of the database, including the
+/// unused (free) bytes within each page.
+///
+/// Computed as `sum(pgsize)` over the `dbstat` virtual table.
+pub(crate) async fn get_size_on_disk<'e, E>(executor: E) -> sqlx::Result<u64>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let size: i64 = sqlx::query_scalar("SELECT COALESCE(sum(pgsize), 0) FROM dbstat")
+        .fetch_one(executor)
+        .await?;
+    Ok(size as u64)
+}
+
+/// Bytes actually in use by the database, excluding the free space within
+/// pages.
+///
+/// Computed as `sum(pgsize - unused)` over the `dbstat` virtual table.
+pub(crate) async fn get_used_size<'e, E>(executor: E) -> sqlx::Result<u64>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let size: i64 = sqlx::query_scalar("SELECT COALESCE(sum(pgsize - unused), 0) FROM dbstat")
+        .fetch_one(executor)
+        .await?;
+    Ok(size as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::kind::Dht;
+    use crate::test_open_db;
+    use holo_hash::DnaHash;
+    use std::sync::Arc;
+
+    fn dht_id() -> Dht {
+        Dht::new(Arc::new(DnaHash::from_raw_36(vec![0u8; 36])))
+    }
+
+    #[tokio::test]
+    async fn dbstat_reports_nonzero_sizes() {
+        let db = test_open_db(dht_id()).await.unwrap();
+
+        // A migrated database has tables and indexes, so both measures must be
+        // positive. This also confirms the `dbstat` virtual table is available
+        // on this SQLite build.
+        let on_disk = db.as_ref().get_size_on_disk().await.unwrap();
+        let used = db.as_ref().get_used_size().await.unwrap();
+
+        assert!(on_disk > 0, "expected nonzero on-disk size");
+        assert!(used > 0, "expected nonzero used size");
+        // Used size can never exceed the on-disk page total.
+        assert!(used <= on_disk);
+    }
+}

--- a/crates/holochain_data/src/dht/inner/db_size.rs
+++ b/crates/holochain_data/src/dht/inner/db_size.rs
@@ -1,7 +1,6 @@
 //! Database size statistics derived from the `dbstat` virtual table.
 //!
-//! These mirror the legacy `holochain_sqlite::stats` helpers so that the
-//! merged DHT store can report per-DNA storage usage. They rely on the
+//! These let the DHT database report per-DNA storage usage. They rely on the
 //! `dbstat` virtual table, which is compiled into the bundled SQLCipher build
 //! (`SQLITE_ENABLE_DBSTAT_VTAB`).
 

--- a/crates/holochain_data/src/dht/inner/entry.rs
+++ b/crates/holochain_data/src/dht/inner/entry.rs
@@ -2,7 +2,7 @@
 
 use holo_hash::{AgentPubKey, EntryHash};
 use holochain_integrity_types::entry::Entry;
-use sqlx::{Executor, QueryBuilder, Sqlite};
+use sqlx::{Executor, QueryBuilder, Sqlite, SqliteConnection};
 use std::collections::{HashMap, HashSet};
 
 pub(crate) async fn insert_entry<'e, E>(
@@ -59,14 +59,11 @@ where
 /// The input is de-duplicated and chunked so arbitrarily long chains stay well
 /// within SQLite's bound-parameter limit (each hash is bound up to twice per
 /// query — once for the public branch and once for the private branch).
-pub(crate) async fn get_entries_by_hashes<'e, E>(
-    executor: E,
+pub(crate) async fn get_entries_by_hashes(
+    executor: &mut SqliteConnection,
     hashes: &[EntryHash],
     author: Option<&AgentPubKey>,
-) -> sqlx::Result<HashMap<EntryHash, Entry>>
-where
-    E: Executor<'e, Database = Sqlite> + Copy,
-{
+) -> sqlx::Result<HashMap<EntryHash, Entry>> {
     // SQLite caps bound parameters at ~32766; 500 hashes (bound at most twice
     // each, plus the author) stays comfortably under that on every supported
     // build.
@@ -104,7 +101,7 @@ where
             qb.push(")");
         }
 
-        let rows: Vec<(Vec<u8>, Vec<u8>)> = qb.build_query_as().fetch_all(executor).await?;
+        let rows: Vec<(Vec<u8>, Vec<u8>)> = qb.build_query_as().fetch_all(&mut *executor).await?;
 
         for (hash_bytes, blob) in rows {
             let hash = EntryHash::from_raw_36(hash_bytes);

--- a/crates/holochain_data/src/dht/inner/entry.rs
+++ b/crates/holochain_data/src/dht/inner/entry.rs
@@ -2,7 +2,8 @@
 
 use holo_hash::{AgentPubKey, EntryHash};
 use holochain_integrity_types::entry::Entry;
-use sqlx::{Executor, Sqlite};
+use sqlx::{Executor, QueryBuilder, Sqlite};
+use std::collections::{HashMap, HashSet};
 
 pub(crate) async fn insert_entry<'e, E>(
     executor: E,
@@ -43,15 +44,92 @@ where
     .bind(author_bytes)
     .fetch_optional(executor)
     .await?;
-    row.map(|(blob,)| {
-        holochain_serialized_bytes::decode::<_, Entry>(&blob).map_err(|e| {
-            sqlx::Error::Decode(Box::new(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                format!("decode Entry: {e}"),
-            )))
-        })
+    row.map(|(blob,)| decode_entry_blob(&blob)).transpose()
+}
+
+/// Batch-reads entries by hash, mirroring [`get_entry`]'s visibility rules but
+/// in a single query per chunk instead of one round-trip per hash.
+///
+/// Each requested hash resolves to its decoded [`Entry`] when present: a public
+/// `Entry` is preferred, and — only when `author` is `Some` — that author's
+/// `PrivateEntry` is used as a fallback. Hashes with no matching entry are
+/// simply absent from the returned map, so the caller can treat a miss as
+/// `None`.
+///
+/// The input is de-duplicated and chunked so arbitrarily long chains stay well
+/// within SQLite's bound-parameter limit (each hash is bound up to twice per
+/// query — once for the public branch and once for the private branch).
+pub(crate) async fn get_entries_by_hashes<'e, E>(
+    executor: E,
+    hashes: &[EntryHash],
+    author: Option<&AgentPubKey>,
+) -> sqlx::Result<HashMap<EntryHash, Entry>>
+where
+    E: Executor<'e, Database = Sqlite> + Copy,
+{
+    // SQLite caps bound parameters at ~32766; 500 hashes (bound at most twice
+    // each, plus the author) stays comfortably under that on every supported
+    // build.
+    const CHUNK_SIZE: usize = 500;
+
+    // De-duplicate so a hash repeated across actions is fetched only once.
+    let mut seen: HashSet<&EntryHash> = HashSet::with_capacity(hashes.len());
+    let unique: Vec<&EntryHash> = hashes.iter().filter(|h| seen.insert(h)).collect();
+
+    let mut out: HashMap<EntryHash, Entry> = HashMap::with_capacity(unique.len());
+    for chunk in unique.chunks(CHUNK_SIZE) {
+        // Public entries first, then — only when an author is supplied — that
+        // author's private entries. The ordering reproduces `get_entry`'s
+        // `UNION ALL ... LIMIT 1` precedence, where a public `Entry` outranks a
+        // same-hash `PrivateEntry`.
+        let mut qb: QueryBuilder<Sqlite> =
+            QueryBuilder::new("SELECT hash, blob FROM Entry WHERE hash IN (");
+        {
+            let mut sep = qb.separated(", ");
+            for h in chunk {
+                sep.push_bind(h.get_raw_36().to_vec());
+            }
+        }
+        qb.push(")");
+        if let Some(author) = author {
+            qb.push(" UNION ALL SELECT hash, blob FROM PrivateEntry WHERE author = ");
+            qb.push_bind(author.get_raw_36().to_vec());
+            qb.push(" AND hash IN (");
+            {
+                let mut sep = qb.separated(", ");
+                for h in chunk {
+                    sep.push_bind(h.get_raw_36().to_vec());
+                }
+            }
+            qb.push(")");
+        }
+
+        let rows: Vec<(Vec<u8>, Vec<u8>)> = qb.build_query_as().fetch_all(executor).await?;
+
+        for (hash_bytes, blob) in rows {
+            let hash = EntryHash::from_raw_36(hash_bytes);
+            // Public rows precede private rows in the `UNION ALL`, so a hash
+            // already present came from the public `Entry` table and wins —
+            // matching `get_entry`'s `LIMIT 1`. Skip before decoding so a
+            // shadowed private blob is never deserialized.
+            if out.contains_key(&hash) {
+                continue;
+            }
+            out.insert(hash, decode_entry_blob(&blob)?);
+        }
+    }
+    Ok(out)
+}
+
+/// Decode an `Entry` blob, mapping a deserialization failure to the same
+/// [`sqlx::Error::Decode`] shape that [`get_entry`] uses.
+fn decode_entry_blob(blob: &[u8]) -> sqlx::Result<Entry> {
+    holochain_serialized_bytes::decode::<_, Entry>(blob).map_err(|e| {
+        sqlx::Error::Decode(Box::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("decode Entry: {e}"),
+        )))
     })
-    .transpose()
 }
 
 pub(crate) async fn insert_private_entry<'e, E>(

--- a/crates/holochain_data/src/dht/inner/limbo_chain_op.rs
+++ b/crates/holochain_data/src/dht/inner/limbo_chain_op.rs
@@ -419,6 +419,30 @@ pub(crate) async fn promote_to_chain_op(
         .await?;
     }
 
+    // Aggregate the action's record validity from all its integrated ops (see
+    // docs/design/state_model.md, "Record Validity Aggregation"): any rejected
+    // op rejects the record; otherwise an accepted op accepts it. A validator
+    // may hold only some of a record's ops under the sharding model, so this
+    // reflects the ops known locally. Network-received actions are inserted
+    // pending (`NULL`) and gain their status here on first integration.
+    sqlx::query(
+        "UPDATE Action
+         SET record_validity = (
+             SELECT CASE
+                 WHEN COUNT(CASE WHEN validation_status = 2 THEN 1 END) > 0 THEN 2
+                 WHEN COUNT(CASE WHEN validation_status = 1 THEN 1 END) > 0 THEN 1
+                 ELSE NULL
+             END
+             FROM ChainOp
+             WHERE action_hash = ?
+         )
+         WHERE hash = ?",
+    )
+    .bind(&limbo.action_hash)
+    .bind(&limbo.action_hash)
+    .execute(&mut *conn)
+    .await?;
+
     // DELETE the limbo row.
     sqlx::query("DELETE FROM LimboChainOp WHERE hash = ?")
         .bind(op_hash.get_raw_36())

--- a/crates/holochain_data/src/dht/inner/op_exists.rs
+++ b/crates/holochain_data/src/dht/inner/op_exists.rs
@@ -1,7 +1,7 @@
 //! Existence checks for op hashes across all op-bearing DHT tables.
 
 use holo_hash::DhtOpHash;
-use sqlx::{Executor, Sqlite};
+use sqlx::{Executor, Sqlite, SqliteConnection};
 
 /// Returns `true` if the given op hash appears in any of the op-bearing
 /// tables (`ChainOp`, `LimboChainOp`, `WarrantOp`, `LimboWarrantOp`).
@@ -39,16 +39,16 @@ where
 ///
 /// Performs N round-trips for simplicity. If profiling shows it
 /// matters, switch to a single `WHERE ... IN (?, ?, ...)` query later.
-pub(crate) async fn op_hashes_present<'e, E>(
-    executor: E,
+///
+/// Takes a `&mut SqliteConnection` rather than a generic executor because it
+/// re-borrows the connection for each per-hash query.
+pub(crate) async fn op_hashes_present(
+    executor: &mut SqliteConnection,
     hashes: &[DhtOpHash],
-) -> sqlx::Result<Vec<bool>>
-where
-    E: Executor<'e, Database = Sqlite> + Copy,
-{
+) -> sqlx::Result<Vec<bool>> {
     let mut out = Vec::with_capacity(hashes.len());
     for h in hashes {
-        out.push(op_exists(executor, h).await?);
+        out.push(op_exists(&mut *executor, h).await?);
     }
     Ok(out)
 }

--- a/crates/holochain_data/src/dht/inner/remove_countersigning_session.rs
+++ b/crates/holochain_data/src/dht/inner/remove_countersigning_session.rs
@@ -1,4 +1,4 @@
-//! Force-remove a self-authored countersigning session from the merged store.
+//! Force-remove a self-authored countersigning session.
 
 use holo_hash::{ActionHash, EntryHash};
 use sqlx::SqliteConnection;
@@ -16,14 +16,9 @@ pub enum RemoveCountersigningSessionOutcome {
 /// Force-remove a self-authored countersigning session identified by its
 /// action hash and entry hash.
 ///
-/// This is the merged-store equivalent of the legacy
-/// `holochain_state::mutations::remove_countersigning_session`, which operated
-/// on the authored DHT database:
-///
 /// 1. **Published guard.** A self-authored op is "published" when it has a
 ///    `ChainOpPublish` row whose `withhold_publish` flag has been cleared
-///    (`NULL`) — mirroring the authored semantics where published ops carried a
-///    `NULL` withhold flag. If any of the action's ops is published the function
+///    (`NULL`). If any of the action's ops is published the function
 ///    makes no changes and returns
 ///    [`RemoveCountersigningSessionOutcome::AlreadyPublished`]: once a session's
 ///    ops have been shared with the network it is unacceptable to remove them.

--- a/crates/holochain_data/src/dht/inner/remove_countersigning_session.rs
+++ b/crates/holochain_data/src/dht/inner/remove_countersigning_session.rs
@@ -1,0 +1,93 @@
+//! Force-remove a self-authored countersigning session from the merged store.
+
+use holo_hash::{ActionHash, EntryHash};
+use sqlx::SqliteConnection;
+
+/// Outcome of [`remove_countersigning_session`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoveCountersigningSessionOutcome {
+    /// The session's rows were deleted.
+    Removed,
+    /// Refused: at least one of the session action's ops is already published
+    /// (it has a `ChainOpPublish` row with `withhold_publish IS NULL`).
+    AlreadyPublished,
+}
+
+/// Force-remove a self-authored countersigning session identified by its
+/// action hash and entry hash.
+///
+/// This is the merged-store equivalent of the legacy
+/// `holochain_state::mutations::remove_countersigning_session`, which operated
+/// on the authored DHT database:
+///
+/// 1. **Published guard.** A self-authored op is "published" when it has a
+///    `ChainOpPublish` row whose `withhold_publish` flag has been cleared
+///    (`NULL`) — mirroring the authored semantics where published ops carried a
+///    `NULL` withhold flag. If any of the action's ops is published the function
+///    makes no changes and returns
+///    [`RemoveCountersigningSessionOutcome::AlreadyPublished`]: once a session's
+///    ops have been shared with the network it is unacceptable to remove them.
+///    Ops with no `ChainOpPublish` row (network-received, not self-authored) are
+///    not counted as published by us and never arise for the abandon path.
+/// 2. **Delete.** Otherwise it deletes, in foreign-key-safe order, the action's
+///    `ChainOpPublish` rows, its `ChainOp` rows, the `Action` row, and the entry
+///    from both `Entry` and `PrivateEntry` (a countersign entry may be private).
+///    Once the guard has passed, every self-authored op for this action is
+///    withheld, so deleting all of the action's `ChainOp` rows removes exactly
+///    the session and lets the `Action` row's foreign key be satisfied.
+///
+/// **The caller must wrap this in a transaction** so the guard and the deletes
+/// are applied atomically.
+pub(crate) async fn remove_countersigning_session(
+    conn: &mut SqliteConnection,
+    action_hash: &ActionHash,
+    entry_hash: &EntryHash,
+) -> sqlx::Result<RemoveCountersigningSessionOutcome> {
+    // Published guard: refuse if any self-authored op for this action has had
+    // its withhold flag cleared (i.e. it is publishable / published).
+    let published: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM ChainOp
+         JOIN ChainOpPublish ON ChainOpPublish.op_hash = ChainOp.hash
+         WHERE ChainOp.action_hash = ?1 AND ChainOpPublish.withhold_publish IS NULL",
+    )
+    .bind(action_hash.get_raw_36())
+    .fetch_one(&mut *conn)
+    .await?;
+    if published != 0 {
+        return Ok(RemoveCountersigningSessionOutcome::AlreadyPublished);
+    }
+
+    // Delete the publish rows first (FK: ChainOpPublish -> ChainOp), then the
+    // ops (FK: ChainOp -> Action), then the action, then the entry from both
+    // the public and private tables. Foreign keys do not cascade for these
+    // tables, so the order matters.
+    sqlx::query(
+        "DELETE FROM ChainOpPublish
+         WHERE op_hash IN (SELECT hash FROM ChainOp WHERE action_hash = ?1)",
+    )
+    .bind(action_hash.get_raw_36())
+    .execute(&mut *conn)
+    .await?;
+
+    sqlx::query("DELETE FROM ChainOp WHERE action_hash = ?1")
+        .bind(action_hash.get_raw_36())
+        .execute(&mut *conn)
+        .await?;
+
+    sqlx::query("DELETE FROM Action WHERE hash = ?1")
+        .bind(action_hash.get_raw_36())
+        .execute(&mut *conn)
+        .await?;
+
+    sqlx::query("DELETE FROM Entry WHERE hash = ?1")
+        .bind(entry_hash.get_raw_36())
+        .execute(&mut *conn)
+        .await?;
+
+    sqlx::query("DELETE FROM PrivateEntry WHERE hash = ?1")
+        .bind(entry_hash.get_raw_36())
+        .execute(&mut *conn)
+        .await?;
+
+    Ok(RemoveCountersigningSessionOutcome::Removed)
+}

--- a/crates/holochain_data/src/dht/inner/remove_countersigning_session.rs
+++ b/crates/holochain_data/src/dht/inner/remove_countersigning_session.rs
@@ -3,7 +3,7 @@
 use holo_hash::{ActionHash, EntryHash};
 use sqlx::SqliteConnection;
 
-/// Outcome of [`remove_countersigning_session`].
+/// Outcome of `remove_countersigning_session`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RemoveCountersigningSessionOutcome {
     /// The session's rows were deleted.

--- a/crates/holochain_data/src/dht/inner/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/inner/scheduled_function.rs
@@ -112,8 +112,7 @@ where
 }
 
 /// Return live scheduled-function rows for `author` where `now` falls between
-/// `start_at` and `end_at` (inclusive on both sides), mirroring the legacy
-/// `live_scheduled_fns` predicate (`start <= now AND now <= end`).
+/// `start_at` and `end_at` (inclusive on both sides): `start <= now AND now <= end`.
 ///
 /// Returns `(zome_name, scheduled_fn, maybe_schedule_blob, ephemeral)` tuples,
 /// ordered by `start_at ASC`.

--- a/crates/holochain_data/src/dht/inner/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/inner/scheduled_function.rs
@@ -147,7 +147,14 @@ where
 
     Ok(rows
         .into_iter()
-        .map(|r| (r.zome_name, r.scheduled_fn, r.maybe_schedule, r.ephemeral != 0))
+        .map(|r| {
+            (
+                r.zome_name,
+                r.scheduled_fn,
+                r.maybe_schedule,
+                r.ephemeral != 0,
+            )
+        })
         .collect())
 }
 

--- a/crates/holochain_data/src/dht/inner/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/inner/scheduled_function.rs
@@ -111,6 +111,46 @@ where
         .collect())
 }
 
+/// Return live scheduled-function rows for `author` where `now` falls between
+/// `start_at` and `end_at` (inclusive on both sides), mirroring the legacy
+/// `live_scheduled_fns` predicate (`start <= now AND now <= end`).
+///
+/// Returns `(zome_name, scheduled_fn, maybe_schedule_blob, ephemeral)` tuples,
+/// ordered by `start_at ASC`.
+pub(crate) async fn get_live_scheduled_functions<'e, E>(
+    executor: E,
+    author: &AgentPubKey,
+    now: Timestamp,
+) -> sqlx::Result<Vec<(String, String, Vec<u8>, bool)>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    #[derive(sqlx::FromRow)]
+    struct Row {
+        zome_name: String,
+        scheduled_fn: String,
+        maybe_schedule: Vec<u8>,
+        ephemeral: i64,
+    }
+
+    let rows: Vec<Row> = sqlx::query_as(
+        "SELECT zome_name, scheduled_fn, maybe_schedule, ephemeral
+         FROM ScheduledFunction
+         WHERE author = ? AND start_at <= ? AND ? <= end_at
+         ORDER BY start_at ASC",
+    )
+    .bind(author.get_raw_36())
+    .bind(now.as_micros())
+    .bind(now.as_micros())
+    .fetch_all(executor)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| (r.zome_name, r.scheduled_fn, r.maybe_schedule, r.ephemeral != 0))
+        .collect())
+}
+
 /// Delete all live ephemeral scheduled-function rows for `author` whose
 /// `start_at` is at or before `now`. Returns the number of rows deleted.
 pub(crate) async fn delete_live_ephemeral_scheduled_functions<'e, E>(

--- a/crates/holochain_data/src/dht/inner/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/inner/scheduled_function.rs
@@ -172,6 +172,49 @@ where
     Ok(result.rows_affected())
 }
 
+/// Delete every ephemeral scheduled-function row in the store, regardless of
+/// author or liveness. Returns the number of rows deleted.
+///
+/// Used at conductor startup to clear ephemeral schedules left over from a
+/// previous run — ephemeral schedules do not survive a reboot.
+pub(crate) async fn delete_all_ephemeral_scheduled_functions<'e, E>(
+    executor: E,
+) -> sqlx::Result<u64>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let result = sqlx::query("DELETE FROM ScheduledFunction WHERE ephemeral = 1")
+        .execute(executor)
+        .await?;
+    Ok(result.rows_affected())
+}
+
+/// Return `true` if a scheduled-function row exists for the given
+/// `(author, zome_name, scheduled_fn)` tuple, regardless of liveness — i.e.
+/// whether `now` falls within the row's `[start_at, end_at]` window.
+pub(crate) async fn is_function_scheduled<'e, E>(
+    executor: E,
+    author: &AgentPubKey,
+    zome_name: &str,
+    scheduled_fn: &str,
+) -> sqlx::Result<bool>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let row: (i64,) = sqlx::query_as(
+        "SELECT EXISTS (
+            SELECT 1 FROM ScheduledFunction
+            WHERE author = ? AND zome_name = ? AND scheduled_fn = ?
+         )",
+    )
+    .bind(author.get_raw_36())
+    .bind(zome_name)
+    .bind(scheduled_fn)
+    .fetch_one(executor)
+    .await?;
+    Ok(row.0 != 0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/holochain_data/src/dht/tx_operations.rs
+++ b/crates/holochain_data/src/dht/tx_operations.rs
@@ -16,6 +16,7 @@ mod entry;
 mod limbo_chain_op;
 mod limbo_warrant;
 mod link;
+mod remove_countersigning_session;
 mod scheduled_function;
 mod updated_record;
 mod validation_receipt;

--- a/crates/holochain_data/src/dht/tx_operations/remove_countersigning_session.rs
+++ b/crates/holochain_data/src/dht/tx_operations/remove_countersigning_session.rs
@@ -10,9 +10,8 @@ use holo_hash::{ActionHash, EntryHash};
 
 impl TxWrite<Dht> {
     /// Force-remove a self-authored countersigning session using the caller's
-    /// transaction. See
-    /// [`remove_countersigning_session::remove_countersigning_session`] for the
-    /// guard and deletion semantics; commit or rollback is the caller's
+    /// transaction. See the inner `remove_countersigning_session` for the guard
+    /// and deletion semantics; commit or rollback is the caller's
     /// responsibility.
     pub async fn remove_countersigning_session(
         &mut self,

--- a/crates/holochain_data/src/dht/tx_operations/remove_countersigning_session.rs
+++ b/crates/holochain_data/src/dht/tx_operations/remove_countersigning_session.rs
@@ -1,0 +1,29 @@
+//! `TxWrite<Dht>` API for force-removing a self-authored countersigning
+//! session within an in-flight transaction.
+
+use super::super::inner::remove_countersigning_session::{
+    self, RemoveCountersigningSessionOutcome,
+};
+use crate::handles::TxWrite;
+use crate::kind::Dht;
+use holo_hash::{ActionHash, EntryHash};
+
+impl TxWrite<Dht> {
+    /// Force-remove a self-authored countersigning session using the caller's
+    /// transaction. See
+    /// [`remove_countersigning_session::remove_countersigning_session`] for the
+    /// guard and deletion semantics; commit or rollback is the caller's
+    /// responsibility.
+    pub async fn remove_countersigning_session(
+        &mut self,
+        action_hash: &ActionHash,
+        entry_hash: &EntryHash,
+    ) -> sqlx::Result<RemoveCountersigningSessionOutcome> {
+        remove_countersigning_session::remove_countersigning_session(
+            self.conn_mut(),
+            action_hash,
+            entry_hash,
+        )
+        .await
+    }
+}

--- a/crates/holochain_data/src/dht/tx_operations/scheduled_function.rs
+++ b/crates/holochain_data/src/dht/tx_operations/scheduled_function.rs
@@ -55,4 +55,10 @@ impl TxWrite<Dht> {
         scheduled_function::delete_live_ephemeral_scheduled_functions(self.conn_mut(), author, now)
             .await
     }
+
+    /// Delete every ephemeral scheduled-function row, regardless of author or
+    /// liveness. Returns the number of rows deleted.
+    pub async fn delete_all_ephemeral_scheduled_functions(&mut self) -> sqlx::Result<u64> {
+        scheduled_function::delete_all_ephemeral_scheduled_functions(self.conn_mut()).await
+    }
 }

--- a/crates/holochain_data/src/handles.rs
+++ b/crates/holochain_data/src/handles.rs
@@ -5,8 +5,12 @@
 //! handle only allows read operations. You can obtain a [`DbRead`] from a [`DbWrite`],
 //! but not the reverse.
 
+use crate::metrics::{create_connection_use_time_metric, ConnectionUseTimeMetric};
 use crate::DatabaseIdentifier;
+use sqlx::pool::PoolConnection;
 use sqlx::{Pool, Sqlite, SqliteConnection, Transaction};
+use std::ops::{Deref, DerefMut};
+use std::time::Instant;
 
 /// A read-only database handle.
 ///
@@ -16,6 +20,9 @@ use sqlx::{Pool, Sqlite, SqliteConnection, Transaction};
 pub struct DbRead<I: DatabaseIdentifier> {
     pub(crate) pool: Pool<Sqlite>,
     pub(crate) identifier: I,
+    /// Records `hc.db.connections.use_time` for connections borrowed from
+    /// [`pool`](Self::pool) via [`timed_conn`](Self::timed_conn).
+    use_time_metric: ConnectionUseTimeMetric,
 }
 
 impl<I: DatabaseIdentifier> DbRead<I> {
@@ -24,7 +31,24 @@ impl<I: DatabaseIdentifier> DbRead<I> {
     /// This is primarily for internal use. Users should obtain handles
     /// via [`open_db`](crate::open_db) or by converting from a [`DbWrite`] handle.
     pub(crate) fn new(pool: Pool<Sqlite>, identifier: I) -> Self {
-        Self { pool, identifier }
+        let use_time_metric = create_connection_use_time_metric(&identifier);
+        Self {
+            pool,
+            identifier,
+            use_time_metric,
+        }
+    }
+
+    /// Acquire a connection from the pool, timing its use.
+    ///
+    /// The returned [`TimedConn`] dereferences to a [`SqliteConnection`] and,
+    /// when dropped, records the elapsed time it was held as the
+    /// `hc.db.connections.use_time` metric. Read operations route through this
+    /// so that connection-use is measured the same way `holochain_sqlite`
+    /// measured borrowed rusqlite connections.
+    pub(crate) async fn timed_conn(&self) -> sqlx::Result<TimedConn> {
+        let conn = self.pool.acquire().await?;
+        Ok(TimedConn::new(conn, self.use_time_metric.clone()))
     }
 
     /// Get a reference to the database identifier.
@@ -230,5 +254,49 @@ impl<I: DatabaseIdentifier> AsRef<TxRead<I>> for TxWrite<I> {
 impl<I: DatabaseIdentifier> AsMut<TxRead<I>> for TxWrite<I> {
     fn as_mut(&mut self) -> &mut TxRead<I> {
         &mut self.0
+    }
+}
+
+/// A pooled connection whose use is timed.
+///
+/// Obtained from [`DbRead::timed_conn`]. Dereferences to the borrowed
+/// [`SqliteConnection`] (so it can be passed to any `sqlx::Executor`-bound
+/// operation), and records the time it was held as the
+/// `hc.db.connections.use_time` metric when dropped. The connection is
+/// returned to the pool by the inner [`PoolConnection`]'s own drop.
+pub(crate) struct TimedConn {
+    conn: PoolConnection<Sqlite>,
+    use_time_metric: ConnectionUseTimeMetric,
+    acquired_at: Instant,
+}
+
+impl TimedConn {
+    fn new(conn: PoolConnection<Sqlite>, use_time_metric: ConnectionUseTimeMetric) -> Self {
+        Self {
+            conn,
+            use_time_metric,
+            acquired_at: Instant::now(),
+        }
+    }
+}
+
+impl Deref for TimedConn {
+    type Target = SqliteConnection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.conn
+    }
+}
+
+impl DerefMut for TimedConn {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.conn
+    }
+}
+
+impl Drop for TimedConn {
+    fn drop(&mut self) {
+        self.use_time_metric
+            .record(self.acquired_at.elapsed().as_secs_f64());
     }
 }

--- a/crates/holochain_data/src/lib.rs
+++ b/crates/holochain_data/src/lib.rs
@@ -15,6 +15,7 @@ pub use key::DbKey;
 
 pub mod example;
 mod handles;
+mod metrics;
 pub use handles::{DbRead, DbWrite, TxRead, TxWrite};
 pub mod conductor;
 pub mod dht;

--- a/crates/holochain_data/src/metrics.rs
+++ b/crates/holochain_data/src/metrics.rs
@@ -1,0 +1,75 @@
+//! OpenTelemetry instrumentation for the database layer.
+//!
+//! Mirrors the connection-use-time metric historically emitted by
+//! `holochain_sqlite`, so that reads served from the merged `holochain_data`
+//! store keep reporting `hc.db.connections.use_time`. The metric is created
+//! once per database handle and recorded each time a borrowed connection is
+//! returned to the pool (see [`crate::handles::TimedConn`]).
+
+use crate::kind::DbKind;
+use crate::DatabaseIdentifier;
+use opentelemetry::{global::meter, metrics, KeyValue};
+
+/// An OpenTelemetry `f64` histogram pre-bound to a fixed set of attributes.
+///
+/// Cloning is cheap; clones share the same underlying instrument and
+/// attribute set, so a handle can hand a clone to every connection guard it
+/// creates.
+#[derive(Clone)]
+pub(crate) struct Histogram {
+    histogram: metrics::Histogram<f64>,
+    attributes: Vec<KeyValue>,
+}
+
+impl std::fmt::Debug for Histogram {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `metrics::Histogram` does not implement `Debug`, so report only the
+        // bound attributes (which is the useful part for diagnostics).
+        f.debug_struct("Histogram")
+            .field("attributes", &self.attributes)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Histogram {
+    /// Record a value against the pre-bound attributes.
+    pub(crate) fn record(&self, value: f64) {
+        self.histogram.record(value, &self.attributes);
+    }
+}
+
+/// Metric for `hc.db.connections.use_time`.
+pub(crate) type ConnectionUseTimeMetric = Histogram;
+
+/// Create a [`ConnectionUseTimeMetric`] bound to the given database identifier.
+///
+/// The histogram carries two attributes derived from `identifier`:
+/// - `kind`: the database kind (e.g. `dht`), and
+/// - `id`: the stable per-database identifier ([`DatabaseIdentifier::database_id`]).
+pub(crate) fn create_connection_use_time_metric<I: DatabaseIdentifier>(
+    identifier: &I,
+) -> ConnectionUseTimeMetric {
+    let histogram = meter("hc.db")
+        .f64_histogram("hc.db.connections.use_time")
+        .with_unit("s")
+        .with_description("The time between borrowing a connection and returning it to the pool")
+        .build();
+    let attributes = vec![
+        KeyValue::new("kind", db_kind_name(identifier.db_kind())),
+        KeyValue::new("id", identifier.database_id().to_string()),
+    ];
+    Histogram {
+        histogram,
+        attributes,
+    }
+}
+
+/// Stable metric label for a database kind.
+fn db_kind_name(kind: DbKind) -> &'static str {
+    match kind {
+        DbKind::Wasm => "wasm",
+        DbKind::Conductor => "conductor",
+        DbKind::PeerMetaStore => "peer_meta_store",
+        DbKind::Dht => "dht",
+    }
+}

--- a/crates/holochain_data/src/metrics.rs
+++ b/crates/holochain_data/src/metrics.rs
@@ -1,10 +1,9 @@
 //! OpenTelemetry instrumentation for the database layer.
 //!
-//! Mirrors the connection-use-time metric historically emitted by
-//! `holochain_sqlite`, so that reads served from the merged `holochain_data`
-//! store keep reporting `hc.db.connections.use_time`. The metric is created
-//! once per database handle and recorded each time a borrowed connection is
-//! returned to the pool (see [`crate::handles::TimedConn`]).
+//! Emits the `hc.db.connections.use_time` metric for reads served by the
+//! `holochain_data` store. The metric is created once per database handle and
+//! recorded each time a borrowed connection is returned to the pool (see
+//! [`crate::handles::TimedConn`]).
 
 use crate::kind::DbKind;
 use crate::DatabaseIdentifier;

--- a/crates/holochain_sqlite/src/sql.rs
+++ b/crates/holochain_sqlite/src/sql.rs
@@ -7,6 +7,8 @@ pub mod sql_cell {
     pub const DELETE_ACTIONS_AFTER_SEQ: &str =
         include_str!("sql/cell/delete_actions_after_seq.sql");
 
+    // #5370: production-unused — agent-key validity now reads from the merged
+    // store (`DhtStoreRead::valid_create_agent_key_action`).
     pub const SELECT_VALID_AGENT_PUB_KEY: &str =
         include_str!("sql/cell/select_valid_agent_pub_key.sql");
 
@@ -53,8 +55,11 @@ pub mod sql_conductor {
         include_str!("sql/conductor/from_block_span_where_overlapping.sql");
     pub const IS_BLOCKED: &str = include_str!("sql/conductor/is_blocked.sql");
     pub const IS_ANY_BLOCKED: &str = include_str!("sql/conductor/is_any_blocked.sql");
+    // #5370: production-unused — cap-grant validity now reads from the merged
+    // store (`DhtStoreRead::valid_cap_grants`).
     pub const SELECT_VALID_CAP_GRANT_FOR_CAP_SECRET: &str =
         include_str!("sql/conductor/select_valid_cap_grant_for_cap_secret.sql");
+    // #5370: production-unused — see `SELECT_VALID_CAP_GRANT_FOR_CAP_SECRET`.
     pub const SELECT_VALID_UNRESTRICTED_CAP_GRANT: &str =
         include_str!("sql/conductor/select_valid_unrestricted_cap_grant.sql");
 }

--- a/crates/holochain_sqlite/src/sql.rs
+++ b/crates/holochain_sqlite/src/sql.rs
@@ -7,8 +7,7 @@ pub mod sql_cell {
     pub const DELETE_ACTIONS_AFTER_SEQ: &str =
         include_str!("sql/cell/delete_actions_after_seq.sql");
 
-    // #5370: production-unused — agent-key validity now reads from the merged
-    // store (`DhtStoreRead::valid_create_agent_key_action`).
+    // #5370: production-unused.
     pub const SELECT_VALID_AGENT_PUB_KEY: &str =
         include_str!("sql/cell/select_valid_agent_pub_key.sql");
 
@@ -55,11 +54,10 @@ pub mod sql_conductor {
         include_str!("sql/conductor/from_block_span_where_overlapping.sql");
     pub const IS_BLOCKED: &str = include_str!("sql/conductor/is_blocked.sql");
     pub const IS_ANY_BLOCKED: &str = include_str!("sql/conductor/is_any_blocked.sql");
-    // #5370: production-unused — cap-grant validity now reads from the merged
-    // store (`DhtStoreRead::valid_cap_grants`).
+    // #5370: production-unused.
     pub const SELECT_VALID_CAP_GRANT_FOR_CAP_SECRET: &str =
         include_str!("sql/conductor/select_valid_cap_grant_for_cap_secret.sql");
-    // #5370: production-unused — see `SELECT_VALID_CAP_GRANT_FOR_CAP_SECRET`.
+    // #5370: production-unused.
     pub const SELECT_VALID_UNRESTRICTED_CAP_GRANT: &str =
         include_str!("sql/conductor/select_valid_unrestricted_cap_grant.sql");
 }

--- a/crates/holochain_sqlite/src/sql.rs
+++ b/crates/holochain_sqlite/src/sql.rs
@@ -7,7 +7,6 @@ pub mod sql_cell {
     pub const DELETE_ACTIONS_AFTER_SEQ: &str =
         include_str!("sql/cell/delete_actions_after_seq.sql");
 
-    // #5370: production-unused.
     pub const SELECT_VALID_AGENT_PUB_KEY: &str =
         include_str!("sql/cell/select_valid_agent_pub_key.sql");
 
@@ -54,10 +53,8 @@ pub mod sql_conductor {
         include_str!("sql/conductor/from_block_span_where_overlapping.sql");
     pub const IS_BLOCKED: &str = include_str!("sql/conductor/is_blocked.sql");
     pub const IS_ANY_BLOCKED: &str = include_str!("sql/conductor/is_any_blocked.sql");
-    // #5370: production-unused.
     pub const SELECT_VALID_CAP_GRANT_FOR_CAP_SECRET: &str =
         include_str!("sql/conductor/select_valid_cap_grant_for_cap_secret.sql");
-    // #5370: production-unused.
     pub const SELECT_VALID_UNRESTRICTED_CAP_GRANT: &str =
         include_str!("sql/conductor/select_valid_unrestricted_cap_grant.sql");
 }

--- a/crates/holochain_state/src/chain_lock.rs
+++ b/crates/holochain_state/src/chain_lock.rs
@@ -18,6 +18,19 @@ pub struct ChainLock {
 }
 
 impl ChainLock {
+    /// Construct a `ChainLock` from its parts.
+    ///
+    /// Used by the [`DhtStore`](crate::dht_store::DhtStore) chain-lock wrapper to
+    /// build a `ChainLock` from a `holochain_data` row. The returned lock is not
+    /// filtered by expiry; callers decide whether it is still valid via
+    /// [`ChainLock::is_expired_at`].
+    pub(crate) fn from_parts(subject: Vec<u8>, expires_at: Timestamp) -> Self {
+        Self {
+            subject,
+            expires_at,
+        }
+    }
+
     /// Get the subject of the lock.
     pub fn subject(&self) -> &[u8] {
         &self.subject

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -193,7 +193,7 @@ impl DhtStore<DbWrite<Dht>> {
     ///
     /// Called once per space at conductor startup to clear ephemeral schedules
     /// left over from a previous run — ephemeral schedules do not survive a
-    /// reboot. A single call covers every author, since the store is per-DNA.
+    /// reboot. A single call covers every author.
     pub async fn delete_all_ephemeral_scheduled_functions(&self) -> DhtStoreResult<u64> {
         Ok(self.db.delete_all_ephemeral_scheduled_functions().await?)
     }
@@ -351,8 +351,7 @@ impl DhtStore<DbWrite<Dht>> {
 
     /// Return the live scheduled functions for `author` at `now`.
     ///
-    /// A function is "live" when `start_at <= now AND now <= end_at`,
-    /// mirroring the legacy `live_scheduled_fns` predicate exactly.
+    /// A function is "live" when `start_at <= now AND now <= end_at`.
     /// Returns `(ScheduledFn, Option<Schedule>, ephemeral)` tuples ordered by
     /// `start_at ASC`.
     pub async fn live_scheduled_functions(
@@ -962,7 +961,7 @@ impl DhtStore<DbWrite<Dht>> {
 
     /// Try to acquire the source-chain lock for `author`.
     ///
-    /// Returns `Ok(true)` when the caller now holds the lock (no lock existed,
+    /// Returns `Ok(true)` when the caller holds the lock (no lock existed,
     /// the existing lock had expired relative to `now`, or the existing lock's
     /// `subject` matched and was therefore extended), and `Ok(false)` when a
     /// different subject still holds an unexpired lock.
@@ -988,16 +987,14 @@ impl DhtStore<DbWrite<Dht>> {
     }
 
     /// Force-remove a self-authored countersigning session (its `Action`,
-    /// `ChainOp`/`ChainOpPublish` rows and entry) from the merged store,
+    /// `ChainOp`/`ChainOpPublish` rows and entry) from the DhtStore,
     /// identified by `(action_hash, entry_hash)`.
     ///
-    /// This is the merged-store replacement for the legacy
-    /// `mutations::remove_countersigning_session` and is defensive about
-    /// sessions whose ops have already been published: if any of the action's
-    /// ops has a `ChainOpPublish` row with `withhold_publish IS NULL` the
-    /// removal is refused with [`StateMutationError::CannotRemoveFullyPublished`]
-    /// and no rows are touched. The guard and deletes run in a single
-    /// transaction.
+    /// This is defensive about sessions whose ops have already been published:
+    /// if any of the action's ops has a `ChainOpPublish` row with
+    /// `withhold_publish IS NULL` the removal is refused with
+    /// [`StateMutationError::CannotRemoveFullyPublished`] and no rows are
+    /// touched. The guard and deletes run in a single transaction.
     pub async fn remove_countersigning_session(
         &self,
         action_hash: ActionHash,

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -1146,6 +1146,34 @@ impl DhtStore<DbWrite<Dht>> {
         Ok(())
     }
 
+    /// Test-only: insert an entry into the store, routing a private entry to
+    /// the `PrivateEntry` table (owned by `private_author`) and a public entry
+    /// to the `Entry` table. Mirrors the entry write in the flush path so that
+    /// store reads which resolve a full record — e.g.
+    /// [`current_countersigning_session`](DhtStore::current_countersigning_session) —
+    /// can find the entry of a hand-authored op inserted via
+    /// [`test_insert_authored_chain_op`](DhtStore::test_insert_authored_chain_op).
+    pub async fn test_insert_entry(
+        &self,
+        entry_hash: &holo_hash::EntryHash,
+        entry: &holochain_types::prelude::Entry,
+        private_author: Option<&AgentPubKey>,
+    ) -> StateMutationResult<()> {
+        match private_author {
+            Some(author) => self
+                .db
+                .insert_private_entry(entry_hash, author, entry)
+                .await
+                .map_err(StateMutationError::from)?,
+            None => self
+                .db
+                .insert_entry(entry_hash, entry)
+                .await
+                .map_err(StateMutationError::from)?,
+        }
+        Ok(())
+    }
+
     /// Test-only: read the `last_publish_time` recorded for a chain op.
     pub async fn test_chain_op_publish_time(
         &self,

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -188,6 +188,16 @@ impl DhtStore<DbWrite<Dht>> {
             .await?)
     }
 
+    /// Delete every ephemeral scheduled-function row for this DNA, regardless
+    /// of author or liveness. Returns the number of rows deleted.
+    ///
+    /// Called once per space at conductor startup to clear ephemeral schedules
+    /// left over from a previous run — ephemeral schedules do not survive a
+    /// reboot. A single call covers every author, since the store is per-DNA.
+    pub async fn delete_all_ephemeral_scheduled_functions(&self) -> DhtStoreResult<u64> {
+        Ok(self.db.delete_all_ephemeral_scheduled_functions().await?)
+    }
+
     /// Re-evaluate every expired persisted scheduled function for `author` at
     /// `now`.
     ///

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -5,8 +5,11 @@
 //! obtain a reference from [`Space`](crate) and invoke named methods; they do
 //! not need to interact with the underlying handle directly.
 
-use holo_hash::{AgentPubKey, DhtOpHash, HasHash};
-use holochain_data::dht::{InsertLimboChainOp, InsertLimboWarrant, InsertScheduledFunction};
+use holo_hash::{ActionHash, AgentPubKey, DhtOpHash, EntryHash, HasHash};
+use holochain_data::dht::{
+    InsertLimboChainOp, InsertLimboWarrant, InsertScheduledFunction,
+    RemoveCountersigningSessionOutcome,
+};
 use holochain_data::kind::Dht;
 use holochain_data::DbWrite;
 use holochain_types::dht_op::{DhtOp, DhtOpHashed};
@@ -958,6 +961,40 @@ impl DhtStore<DbWrite<Dht>> {
     pub async fn release_chain_lock(&self, author: &AgentPubKey) -> StateMutationResult<()> {
         self.db.release_chain_lock(author).await?;
         Ok(())
+    }
+
+    /// Force-remove a self-authored countersigning session (its `Action`,
+    /// `ChainOp`/`ChainOpPublish` rows and entry) from the merged store,
+    /// identified by `(action_hash, entry_hash)`.
+    ///
+    /// This is the merged-store replacement for the legacy
+    /// `mutations::remove_countersigning_session` and is defensive about
+    /// sessions whose ops have already been published: if any of the action's
+    /// ops has a `ChainOpPublish` row with `withhold_publish IS NULL` the
+    /// removal is refused with [`StateMutationError::CannotRemoveFullyPublished`]
+    /// and no rows are touched. The guard and deletes run in a single
+    /// transaction.
+    pub async fn remove_countersigning_session(
+        &self,
+        action_hash: ActionHash,
+        entry_hash: EntryHash,
+    ) -> StateMutationResult<()> {
+        let mut tx = self.db.begin().await.map_err(StateMutationError::from)?;
+        let outcome = tx
+            .remove_countersigning_session(&action_hash, &entry_hash)
+            .await
+            .map_err(StateMutationError::from)?;
+        match outcome {
+            RemoveCountersigningSessionOutcome::AlreadyPublished => {
+                // Drop the transaction without committing (no rows were
+                // written) and refuse the removal.
+                Err(StateMutationError::CannotRemoveFullyPublished)
+            }
+            RemoveCountersigningSessionOutcome::Removed => {
+                tx.commit().await.map_err(StateMutationError::from)?;
+                Ok(())
+            }
+        }
     }
 
     /// Downgrade this writable store to a read-only store.

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -14,6 +14,7 @@ use holochain_types::prelude::{Schedule, ScheduledFn, Timestamp};
 use holochain_zome_types::schedule::ScheduleError;
 
 use crate::mutations::{StateMutationError, StateMutationResult};
+use crate::query::StateQueryResult;
 
 /// Summary of a single op promoted by [`DhtStore::integrate_ready_ops`].
 ///
@@ -319,6 +320,36 @@ impl DhtStore<DbWrite<Dht>> {
                 scheduled_fn.fn_name().0.as_str(),
             )
             .await?)
+    }
+
+    /// Return the live scheduled functions for `author` at `now`.
+    ///
+    /// A function is "live" when `start_at <= now AND now <= end_at`,
+    /// mirroring the legacy `live_scheduled_fns` predicate exactly.
+    /// Returns `(ScheduledFn, Option<Schedule>, ephemeral)` tuples ordered by
+    /// `start_at ASC`.
+    pub async fn live_scheduled_functions(
+        &self,
+        author: &AgentPubKey,
+        now: Timestamp,
+    ) -> StateQueryResult<Vec<(ScheduledFn, Option<Schedule>, bool)>> {
+        let rows = self
+            .db
+            .as_ref()
+            .get_live_scheduled_functions(author, now)
+            .await?;
+
+        let mut result = Vec::with_capacity(rows.len());
+        for (zome_name, fn_name, maybe_schedule_blob, ephemeral) in rows {
+            let maybe_schedule: Option<Schedule> =
+                holochain_serialized_bytes::decode(&maybe_schedule_blob)?;
+            result.push((
+                ScheduledFn::new(zome_name.into(), fn_name.into()),
+                maybe_schedule,
+                ephemeral,
+            ));
+        }
+        Ok(result)
     }
 
     /// Insert a `SignedValidationReceipt` into the `ValidationReceipt` table

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -1205,7 +1205,7 @@ impl DhtStore<DbWrite<Dht>> {
         let now = Timestamp::now();
 
         let mut tx = self.db.begin().await.map_err(StateMutationError::from)?;
-        tx.insert_action(&new_sah, None)
+        tx.insert_action(&new_sah, Some(RecordValidity::Accepted))
             .await
             .map_err(StateMutationError::from)?;
         tx.insert_chain_op(InsertChainOp {
@@ -1245,9 +1245,7 @@ impl DhtStore<DbWrite<Dht>> {
     /// Use this after
     /// [`test_insert_authored_chain_op`](DhtStore::test_insert_authored_chain_op),
     /// which inserts the action once, to add the sibling op types for the same
-    /// action without colliding on the `Action` primary key. This matters for
-    /// the chain-head lookup, which only recognises the integrated
-    /// `RegisterAgentActivity` op.
+    /// action without colliding on the `Action` primary key.
     pub async fn test_insert_additional_integrated_op(
         &self,
         op: DhtOpHashed,

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -902,6 +902,33 @@ impl DhtStore<DbWrite<Dht>> {
             .await?)
     }
 
+    /// Try to acquire the source-chain lock for `author`.
+    ///
+    /// Returns `Ok(true)` when the caller now holds the lock (no lock existed,
+    /// the existing lock had expired relative to `now`, or the existing lock's
+    /// `subject` matched and was therefore extended), and `Ok(false)` when a
+    /// different subject still holds an unexpired lock.
+    pub async fn acquire_chain_lock(
+        &self,
+        author: &AgentPubKey,
+        subject: &[u8],
+        expires_at: Timestamp,
+        now: Timestamp,
+    ) -> StateMutationResult<bool> {
+        Ok(self
+            .db
+            .acquire_chain_lock(author, subject, expires_at, now)
+            .await?)
+    }
+
+    /// Release the source-chain lock for `author` by deleting the lock row.
+    ///
+    /// Releasing a non-existent lock is a no-op.
+    pub async fn release_chain_lock(&self, author: &AgentPubKey) -> StateMutationResult<()> {
+        self.db.release_chain_lock(author).await?;
+        Ok(())
+    }
+
     /// Downgrade this writable store to a read-only store.
     pub fn as_read(&self) -> DhtStoreRead {
         DhtStore::new(self.db.as_ref().clone())

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -171,7 +171,7 @@ impl DhtStore<DbWrite<Dht>> {
     pub async fn acquire_chain_write_permit(
         &self,
         author: &AgentPubKey,
-    ) -> tokio::sync::OwnedSemaphorePermit {
+    ) -> holochain_data::dht::ChainWritePermit {
         self.db.acquire_chain_write_permit(author).await
     }
 

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -1238,6 +1238,66 @@ impl DhtStore<DbWrite<Dht>> {
         Ok(())
     }
 
+    /// Test-only: insert an integrated self-authored chain op
+    /// (`locally_validated = true`, `when_integrated = now`) plus its
+    /// `ChainOpPublish` row, WITHOUT inserting the parent `Action`.
+    ///
+    /// A committed record produces several ops that share one action — a
+    /// `Create`, for instance, yields `StoreRecord`, `RegisterAgentActivity`,
+    /// and `StoreEntry` ops — all written integrated by the source-chain flush.
+    /// Use this after
+    /// [`test_insert_authored_chain_op`](DhtStore::test_insert_authored_chain_op),
+    /// which inserts the action once, to add the sibling op types for the same
+    /// action without colliding on the `Action` primary key. This matters for
+    /// the chain-head lookup, which only recognises the integrated
+    /// `RegisterAgentActivity` op.
+    pub async fn test_insert_additional_integrated_op(
+        &self,
+        op: DhtOpHashed,
+        withhold_publish: Option<bool>,
+    ) -> StateMutationResult<()> {
+        use holochain_data::dht::InsertChainOp;
+        use holochain_zome_types::dht_v2::RecordValidity;
+
+        let op_hash = op.as_hash().clone();
+        let serialized_size = holochain_serialized_bytes::encode(op.as_content())
+            .map_err(StateMutationError::from)?
+            .len() as u32;
+        let chain_op = match op.into_inner().0 {
+            DhtOp::ChainOp(c) => c,
+            DhtOp::WarrantOp(_) => {
+                panic!("test_insert_additional_integrated_op requires a ChainOp")
+            }
+        };
+
+        let action_hash = holo_hash::ActionHash::with_data_sync(chain_op.signed_action().action());
+        let basis_hash = chain_op.dht_basis();
+        let storage_center_loc = basis_hash.get_loc();
+        let now = Timestamp::now();
+
+        let mut tx = self.db.begin().await.map_err(StateMutationError::from)?;
+        tx.insert_chain_op(InsertChainOp {
+            op_hash: &op_hash,
+            action_hash: &action_hash,
+            op_type: i64::from(chain_op.get_type()),
+            basis_hash: &basis_hash,
+            storage_center_loc,
+            validation_status: RecordValidity::Accepted,
+            locally_validated: true,
+            require_receipt: true,
+            when_received: now,
+            when_integrated: now,
+            serialized_size,
+        })
+        .await
+        .map_err(StateMutationError::from)?;
+        tx.insert_chain_op_publish(&op_hash, None, None, withhold_publish)
+            .await
+            .map_err(StateMutationError::from)?;
+        tx.commit().await.map_err(StateMutationError::from)?;
+        Ok(())
+    }
+
     /// Test-only: insert an entry into the store, routing a private entry to
     /// the `PrivateEntry` table (owned by `private_author`) and a public entry
     /// to the `Entry` table. Mirrors the entry write in the flush path so that

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -161,6 +161,20 @@ impl<Db> DhtStore<Db> {
 }
 
 impl DhtStore<DbWrite<Dht>> {
+    /// Acquire the per-author source-chain write permit for this store.
+    ///
+    /// Serializes source-chain flushes for a single `(DNA, author)` chain so
+    /// two concurrent flushes cannot both pass the as-at check and fork the
+    /// chain. Different authors — and the same author on different DNAs — never
+    /// block one another. See
+    /// [`DbWrite::acquire_chain_write_permit`](holochain_data::DbWrite::acquire_chain_write_permit).
+    pub async fn acquire_chain_write_permit(
+        &self,
+        author: &AgentPubKey,
+    ) -> tokio::sync::OwnedSemaphorePermit {
+        self.db.acquire_chain_write_permit(author).await
+    }
+
     /// Delete all live ephemeral scheduled-function rows for `author` at or
     /// before `now`. Returns the number of rows deleted.
     pub async fn delete_live_ephemeral_scheduled_functions(

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -18,7 +18,7 @@ use holochain_types::chain::ChainItem;
 use holochain_types::dht_op::DhtOpHashed;
 use holochain_types::prelude::{
     ActionHashedContainer, AgentActivityResponse, ChainItems, ChainItemsSource,
-    MustGetAgentActivityResponse, RegisterAgentActivity, Timestamp,
+    MustGetAgentActivityResponse, RegisterAgentActivity, ScheduledFn, Timestamp,
 };
 use holochain_types::warrant::WarrantOp;
 use holochain_zome_types::chain::{ChainFilter, LimitConditions};
@@ -53,6 +53,28 @@ impl DhtStore<DbRead<Dht>> {
     /// space within pages.
     pub async fn used_size(&self) -> StateQueryResult<u64> {
         Ok(self.db().get_used_size().await?)
+    }
+
+    /// Returns `true` if a scheduled-function row exists for `author` and
+    /// `scheduled_fn`, regardless of liveness — i.e. whether the current time
+    /// falls within the row's `[start_at, end_at]` window.
+    ///
+    /// This is a membership check on the scheduled-functions table: it stays
+    /// `true` for a persisted cron function between firings, and becomes
+    /// `false` once an ephemeral function is consumed.
+    pub async fn is_function_scheduled(
+        &self,
+        author: &AgentPubKey,
+        scheduled_fn: &ScheduledFn,
+    ) -> StateQueryResult<bool> {
+        Ok(self
+            .db()
+            .is_function_scheduled(
+                author,
+                scheduled_fn.zome_name().0.as_ref(),
+                scheduled_fn.fn_name().0.as_str(),
+            )
+            .await?)
     }
 
     /// Count integrated, locally-validated chain ops that passed validation

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -3620,6 +3620,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_agent_activity_excludes_withheld_publish_ops() {
+        // A self-authored op whose `ChainOpPublish.withhold_publish` is set
+        // (an in-flight countersigning session) must NOT surface as live agent
+        // activity until the session completes and the withhold flag is cleared.
+        // Ordinary self-authored ops (withhold NULL) are always visible.
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let author = AgentPubKey::from_raw_36(vec![23u8; 36]);
+        let prev = ActionHash::from_raw_36(vec![0u8; 36]);
+
+        // seqs 0 and 1: ordinary self-authored ops (withhold NULL -> visible).
+        store
+            .test_insert_authored_chain_op(make_fork_op(&author, &prev, 0, 1), None, None, None)
+            .await
+            .unwrap();
+        store
+            .test_insert_authored_chain_op(make_fork_op(&author, &prev, 1, 2), None, None, None)
+            .await
+            .unwrap();
+        // seq 2: a withheld countersigning op (withhold_publish = true -> hidden).
+        let withheld = make_fork_op(&author, &prev, 2, 3);
+        let withheld_hash = withheld.as_hash().clone();
+        store
+            .test_insert_authored_chain_op(withheld, None, None, Some(true))
+            .await
+            .unwrap();
+
+        let opts = GetAgentActivityOptions {
+            include_valid_activity: true,
+            include_rejected_activity: false,
+            include_warrants: false,
+            include_full_records: false,
+        };
+
+        // While withheld, only seqs 0 and 1 are reported.
+        let resp = store
+            .as_read()
+            .get_agent_activity(&author, &ChainQueryFilter::new(), &opts)
+            .await
+            .unwrap();
+        match resp.valid_activity {
+            ChainItems::Hashes(h) => {
+                assert_eq!(h.len(), 2, "withheld op must be hidden");
+                assert_eq!(h[0].0, 0);
+                assert_eq!(h[1].0, 1);
+            }
+            other => panic!("expected Hashes, got {other:?}"),
+        }
+
+        // Clearing the withhold flag (as session completion does) reveals seq 2.
+        store
+            .test_set_chain_op_publish(&withheld_hash, None, None, None)
+            .await
+            .unwrap();
+        let resp = store
+            .as_read()
+            .get_agent_activity(&author, &ChainQueryFilter::new(), &opts)
+            .await
+            .unwrap();
+        match resp.valid_activity {
+            ChainItems::Hashes(h) => {
+                assert_eq!(h.len(), 3, "revealed op must be visible after clearing withhold");
+                assert_eq!(h[2].0, 2);
+            }
+            other => panic!("expected Hashes, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn get_agent_activity_detects_fork() {
         let store = crate::dht_store::DhtStore::new_test(dht_id())
             .await

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -246,6 +246,36 @@ impl DhtStore<DbRead<Dht>> {
             }))
     }
 
+    /// Get the source-chain lock for `author`, if one exists.
+    ///
+    /// Returns *any* lock row for the author, including one that has already
+    /// expired — matching the legacy
+    /// [`get_chain_lock`](crate::chain_lock::get_chain_lock) semantics. Callers
+    /// are responsible for checking [`ChainLock::is_expired_at`] when expiry
+    /// matters; several countersigning call sites must respect an expired lock
+    /// (a lock that exists at all means a session is mid-flight and the chain
+    /// must not be re-used until it is cleaned up).
+    ///
+    /// This is why a `Timestamp::MIN` sentinel is passed to the underlying
+    /// `holochain_data` reader: that reader filters out locks whose
+    /// `expires_at <= now`, so `MIN` makes the expiry filter a no-op and every
+    /// existing row is returned.
+    pub async fn get_chain_lock(
+        &self,
+        author: AgentPubKey,
+    ) -> StateQueryResult<Option<crate::chain_lock::ChainLock>> {
+        Ok(self
+            .db()
+            .get_chain_lock(author, Timestamp::MIN)
+            .await?
+            .map(|row| {
+                crate::chain_lock::ChainLock::from_parts(
+                    row.subject,
+                    Timestamp::from_micros(row.expires_at_timestamp),
+                )
+            }))
+    }
+
     /// Validation receipts for every chain op of `action_hash`, grouped into a
     /// [`ValidationReceiptSet`](holochain_zome_types::prelude::ValidationReceiptSet) per op.
     ///

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -43,13 +43,13 @@ impl DhtStore<DbRead<Dht>> {
         Ok(self.db().count_integrated_ops().await?)
     }
 
-    /// Total bytes occupied on disk by this DNA's merged store, including the
+    /// Total bytes occupied on disk by this DNA's DhtStore, including the
     /// unused (free) bytes within each page.
     pub async fn size_on_disk(&self) -> StateQueryResult<u64> {
         Ok(self.db().get_size_on_disk().await?)
     }
 
-    /// Bytes actually in use by this DNA's merged store, excluding the free
+    /// Bytes actually in use by this DNA's DhtStore, excluding the free
     /// space within pages.
     pub async fn used_size(&self) -> StateQueryResult<u64> {
         Ok(self.db().get_used_size().await?)
@@ -129,9 +129,6 @@ impl DhtStore<DbRead<Dht>> {
     }
 
     /// Op hashes of the integrated chain ops for `action_hash`.
-    ///
-    /// #5370: backs the countersigning success path's withhold-publish clear,
-    /// replacing the legacy authored-DB `get_countersigning_op_hashes` query.
     pub async fn chain_op_hashes_for_action(
         &self,
         action_hash: holo_hash::ActionHash,
@@ -283,8 +280,7 @@ impl DhtStore<DbRead<Dht>> {
         Ok(self.db().count_author_actions_capped(author, 3).await? >= 3)
     }
 
-    /// The author's source-chain head from the merged store, or `None`
-    /// pre-genesis.
+    /// The author's source-chain head, or `None` pre-genesis.
     pub async fn chain_head_for_author(
         &self,
         author: &AgentPubKey,
@@ -303,10 +299,9 @@ impl DhtStore<DbRead<Dht>> {
     /// Get the source-chain lock for `author`, if one exists.
     ///
     /// Returns *any* lock row for the author, including one that has already
-    /// expired — matching the legacy
-    /// [`get_chain_lock`](crate::chain_lock::get_chain_lock) semantics. Callers
-    /// are responsible for checking `ChainLock::is_expired_at` when expiry
-    /// matters; several countersigning call sites must respect an expired lock
+    /// expired. Callers are responsible for checking `ChainLock::is_expired_at`
+    /// when expiry matters; several countersigning call sites must respect an
+    /// expired lock
     /// (a lock that exists at all means a session is mid-flight and the chain
     /// must not be re-used until it is cleaned up).
     ///
@@ -334,12 +329,9 @@ impl DhtStore<DbRead<Dht>> {
     /// session, and if so the session record, its entry hash, and the decoded
     /// [`CounterSigningSessionData`](holochain_zome_types::countersigning::CounterSigningSessionData).
     ///
-    /// This is the merged-store counterpart of the legacy
-    /// [`current_countersigning_session`](crate::source_chain::current_countersigning_session):
-    /// it reads the chain head and head record from the store rather than the
-    /// authored database. `author` is threaded through to
-    /// [`retrieve_record`](Self::retrieve_record) so the author's own
-    /// (potentially private) countersigning entry is visible.
+    /// This reads the chain head and head record from the store. `author` is
+    /// threaded through to [`retrieve_record`](Self::retrieve_record) so the
+    /// author's own (potentially private) countersigning entry is visible.
     ///
     /// Returns `None` when the chain is empty (pre-genesis), the head record is
     /// unavailable, or the head action does not carry a `CounterSign` entry. A
@@ -1199,8 +1191,8 @@ impl DhtStore<DbRead<Dht>> {
     /// filtered by link type, tag prefix, author, and time. Builds each
     /// [`holochain_zome_types::link::Link`] from its `CreateLink` action.
     ///
-    /// Time bounds mirror the legacy `LinksQuery`: `after` is inclusive
-    /// (`timestamp >= after`) and `before` is inclusive (`timestamp <= before`).
+    /// Time bounds: `after` is inclusive (`timestamp >= after`) and `before` is
+    /// inclusive (`timestamp <= before`).
     pub async fn get_links(
         &self,
         base: &holo_hash::AnyLinkableHash,
@@ -2242,7 +2234,7 @@ impl DhtStore<DbRead<Dht>> {
 
     /// Dump the author's source chain as a `SourceChainDump`.
     ///
-    /// Reads all actions authored by `author` from the merged DHT store in
+    /// Reads all actions authored by `author` from the DhtStore in
     /// chain-sequence order, resolves each action's entry from both the public
     /// `Entry` table and the author's private `PrivateEntry` table, and counts
     /// the ops that have been published at least once.
@@ -2261,7 +2253,7 @@ impl DhtStore<DbRead<Dht>> {
 
         let mut records = Vec::with_capacity(v2_actions.len());
         for v2_sah in &v2_actions {
-            // Convert to the legacy (v1) SignedActionHashed.
+            // Convert to the v1 SignedActionHashed.
             let sah = to_legacy_signed_action(v2_sah);
             let action_address = sah.as_hash().clone();
             let signature = sah.signature().clone();
@@ -2293,24 +2285,21 @@ impl DhtStore<DbRead<Dht>> {
         })
     }
 
-    /// Read the author's committed source-chain records from the merged store.
+    /// Read the author's committed source-chain records.
     ///
     /// Returns every action authored by `author`, in ascending chain-sequence
-    /// order, as a legacy [`Record`](holochain_zome_types::record::Record).
+    /// order, as a [`Record`](holochain_zome_types::record::Record).
     /// This is the committed-record source behind
     /// [`SourceChain::query`](crate::source_chain::SourceChain::query): no
     /// [`ChainQueryFilter`] filtering or fork disambiguation is applied here.
     /// The caller overlays the scratch and then applies
-    /// [`ChainQueryFilter::filter_records`], which is the authoritative filter,
-    /// exactly as the legacy authored-DB query did (the SQL pre-filtering there
-    /// was only an optimisation over the same `filter_records`).
+    /// [`ChainQueryFilter::filter_records`], which is the authoritative filter.
     ///
-    /// Entry inclusion mirrors the legacy row mapper: an entry is attached only
-    /// when `include_entries` is set and the entry is either public or
-    /// `public_only` is `false`. A private entry is therefore redacted (`None`)
-    /// under `public_only`. The private entry itself is resolved via
-    /// `get_entry(.., Some(author))`, so an author always sees their own private
-    /// entries and never another agent's.
+    /// An entry is attached only when `include_entries` is set and the entry is
+    /// either public or `public_only` is `false`. A private entry is therefore
+    /// redacted (`None`) under `public_only`. The private entry itself is
+    /// resolved via `get_entry(.., Some(author))`, so an author always sees
+    /// their own private entries and never another agent's.
     pub async fn source_chain_records(
         &self,
         author: &AgentPubKey,
@@ -2322,10 +2311,10 @@ impl DhtStore<DbRead<Dht>> {
 
         let v2_actions = self.db().get_actions_by_author(author.clone()).await?;
 
-        // Convert each action to its legacy form once, and decide which entries
-        // to attach. Collect the entry hashes that actually need fetching so
-        // they can be read in a single batch — fetching them one-at-a-time was
-        // an N+1 over the chain length.
+        // Convert each action to its v1 form once, and decide which entries to
+        // attach. Collect the entry hashes that actually need fetching so they
+        // can be read in a single batch rather than one-at-a-time (an N+1 over
+        // the chain length).
         let sahs: Vec<holochain_zome_types::record::SignedActionHashed> =
             v2_actions.iter().map(to_legacy_signed_action).collect();
         let mut wanted_entry_hashes: Vec<EntryHash> = Vec::new();
@@ -2371,16 +2360,15 @@ impl DhtStore<DbRead<Dht>> {
         Ok(records)
     }
 
-    /// The author's valid agent-key `Create` action, read from the merged store.
+    /// The author's valid agent-key `Create` action.
     ///
-    /// Faithfully reproduces the legacy `SELECT_VALID_AGENT_PUB_KEY` query that
-    /// ran over the authored database: the author's `Create` action whose entry
-    /// is the `AgentPubKey` entry (`entry_hash == author.into()`) and that has
-    /// NOT been updated or deleted **by the author**. Returns `None` when no
-    /// such action exists or it has been modified, so the caller maps that to
+    /// Returns the author's `Create` action whose entry is the `AgentPubKey`
+    /// entry (`entry_hash == author.into()`) and that has NOT been updated or
+    /// deleted **by the author**. Returns `None` when no such action exists or
+    /// it has been modified, so the caller maps that to
     /// [`SourceChainError::InvalidAgentKey`](crate::source_chain::SourceChainError::InvalidAgentKey).
     ///
-    /// The "not updated/deleted" exclusion matches the legacy SQL exactly via
+    /// The "not updated/deleted" exclusion is applied via
     /// `entry_updated_or_deleted_by_author`.
     pub async fn valid_create_agent_key_action(
         &self,
@@ -2389,10 +2377,9 @@ impl DhtStore<DbRead<Dht>> {
         let agent_key_entry_hash: EntryHash = author.clone().into();
 
         // The agent-key `Create` is written to the author's chain at genesis;
-        // find it among the author's actions. The merged-store `Action` table
-        // carries `action_type` but not `entry_type`, so the `Create` +
-        // entry-hash match (with an `AgentPubKey` entry-type guard) reproduces
-        // the legacy `type`/`entry_type`/`entry_hash` filter.
+        // find it among the author's actions. The `Action` table carries
+        // `action_type` but not `entry_type`, so filter on `Create` + the entry
+        // hash with an `AgentPubKey` entry-type guard.
         let actions = self.db().get_actions_by_author(author.clone()).await?;
         let create = actions.iter().find_map(|v2_sah| {
             let action = holochain_zome_types::dht_v2::to_legacy_signed_action(v2_sah)
@@ -2420,26 +2407,20 @@ impl DhtStore<DbRead<Dht>> {
     }
 
     /// The author's candidate capability grants for the `is_valid` loop in
-    /// [`SourceChain::valid_cap_grant`](crate::source_chain::SourceChain::valid_cap_grant),
-    /// read from the merged store.
-    ///
-    /// Faithfully reproduces the legacy `SELECT_VALID_CAP_GRANT_FOR_CAP_SECRET`
-    /// / `SELECT_VALID_UNRESTRICTED_CAP_GRANT` queries:
+    /// [`SourceChain::valid_cap_grant`](crate::source_chain::SourceChain::valid_cap_grant).
     ///
     /// - When `check_secret` is `Some`, only grants that carry a secret
-    ///   (`Transferable` / `Assigned`) are considered — matching the legacy
-    ///   `Entry.cap_secret = ?` pre-filter. The exact-secret match is left to
-    ///   the caller's [`CapGrant::is_valid`], which is equivalent because
-    ///   `is_valid` requires `secret == given` for both secret-bearing variants
-    ///   (and a secret-bearing check can therefore never match an `Unrestricted`
-    ///   grant, just as the legacy `cap_secret` filter excluded them).
+    ///   (`Transferable` / `Assigned`) are considered. The exact-secret match is
+    ///   left to the caller's [`CapGrant::is_valid`], which is equivalent
+    ///   because `is_valid` requires `secret == given` for both secret-bearing
+    ///   variants (a secret-bearing check therefore never matches an
+    ///   `Unrestricted` grant).
     /// - When `check_secret` is `None`, only `Unrestricted` grants are
-    ///   considered — matching the legacy `access_type = Unrestricted` filter.
+    ///   considered.
     ///
     /// Candidates are restricted to grants authored by `author` (the `CapGrant`
-    /// index join already filters on `Action.author`) and dropped when their
-    /// entry has been updated or deleted by the author — the same "not
-    /// updated/deleted" semantics as the legacy SQL.
+    /// index join filters on `Action.author`) and dropped when their entry has
+    /// been updated or deleted by the author.
     pub async fn valid_cap_grants(
         &self,
         author: &AgentPubKey,
@@ -2507,13 +2488,11 @@ impl DhtStore<DbRead<Dht>> {
         Ok(grants)
     }
 
-    /// `true` if `entry_hash` has been updated or deleted by `author` in the
-    /// merged store — the "not updated/deleted" exclusion shared by the
-    /// agent-key and cap-grant validity reads.
+    /// `true` if `entry_hash` has been updated or deleted by `author` — the
+    /// "not updated/deleted" exclusion shared by the agent-key and cap-grant
+    /// validity reads.
     ///
-    /// Matches the legacy SQL `ModifiedAction.author = :author AND
-    /// (original_entry_hash = :entry_hash OR deletes_entry_hash = :entry_hash)`:
-    /// the `UpdatedRecord` / `DeletedRecord` indexes are keyed on the original /
+    /// The `UpdatedRecord` / `DeletedRecord` indexes are keyed on the original /
     /// deleted *entry* hash (see
     /// [`get_update_actions_for_entry`](holochain_data::DbRead::get_update_actions_for_entry)
     /// / [`get_delete_actions_for_entry`](holochain_data::DbRead::get_delete_actions_for_entry)),

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -2237,6 +2237,61 @@ impl DhtStore<DbRead<Dht>> {
             published_ops_count,
         })
     }
+
+    /// Read the author's committed source-chain records from the merged store.
+    ///
+    /// Returns every action authored by `author`, in ascending chain-sequence
+    /// order, as a legacy [`Record`](holochain_zome_types::record::Record).
+    /// This is the committed-record source behind
+    /// [`SourceChain::query`](crate::source_chain::SourceChain::query): no
+    /// [`ChainQueryFilter`] filtering or fork disambiguation is applied here.
+    /// The caller overlays the scratch and then applies
+    /// [`ChainQueryFilter::filter_records`], which is the authoritative filter,
+    /// exactly as the legacy authored-DB query did (the SQL pre-filtering there
+    /// was only an optimisation over the same `filter_records`).
+    ///
+    /// Entry inclusion mirrors the legacy row mapper: an entry is attached only
+    /// when `include_entries` is set and the entry is either public or
+    /// `public_only` is `false`. A private entry is therefore redacted (`None`)
+    /// under `public_only`. The private entry itself is resolved via
+    /// `get_entry(.., Some(author))`, so an author always sees their own private
+    /// entries and never another agent's.
+    pub async fn source_chain_records(
+        &self,
+        author: &AgentPubKey,
+        include_entries: bool,
+        public_only: bool,
+    ) -> StateQueryResult<Vec<holochain_zome_types::record::Record>> {
+        use holochain_zome_types::dht_v2::to_legacy_signed_action;
+        use holochain_zome_types::prelude::EntryVisibility;
+
+        let v2_actions = self.db().get_actions_by_author(author.clone()).await?;
+
+        let mut records = Vec::with_capacity(v2_actions.len());
+        for v2_sah in &v2_actions {
+            let sah = to_legacy_signed_action(v2_sah);
+
+            let private_entry = sah
+                .action()
+                .entry_type()
+                .is_some_and(|e| *e.visibility() == EntryVisibility::Private);
+
+            let entry = if include_entries && (!private_entry || !public_only) {
+                match sah.action().entry_hash() {
+                    Some(entry_hash) => {
+                        self.db().get_entry(entry_hash.clone(), Some(author)).await?
+                    }
+                    None => None,
+                }
+            } else {
+                None
+            };
+
+            records.push(holochain_zome_types::record::Record::new(sah, entry));
+        }
+
+        Ok(records)
+    }
 }
 
 /// Whether `action`'s entry (if any) is declared private.

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -305,7 +305,7 @@ impl DhtStore<DbRead<Dht>> {
     /// Returns *any* lock row for the author, including one that has already
     /// expired — matching the legacy
     /// [`get_chain_lock`](crate::chain_lock::get_chain_lock) semantics. Callers
-    /// are responsible for checking [`ChainLock::is_expired_at`] when expiry
+    /// are responsible for checking `ChainLock::is_expired_at` when expiry
     /// matters; several countersigning call sites must respect an expired lock
     /// (a lock that exists at all means a session is mid-flight and the chain
     /// must not be re-used until it is cleaned up).
@@ -2240,7 +2240,7 @@ impl DhtStore<DbRead<Dht>> {
         Ok(out.into_iter().map(|(_, _, op)| op).collect())
     }
 
-    /// Dump the author's source chain as a [`SourceChainDump`].
+    /// Dump the author's source chain as a `SourceChainDump`.
     ///
     /// Reads all actions authored by `author` from the merged DHT store in
     /// chain-sequence order, resolves each action's entry from both the public
@@ -2381,7 +2381,7 @@ impl DhtStore<DbRead<Dht>> {
     /// [`SourceChainError::InvalidAgentKey`](crate::source_chain::SourceChainError::InvalidAgentKey).
     ///
     /// The "not updated/deleted" exclusion matches the legacy SQL exactly via
-    /// [`entry_updated_or_deleted_by_author`](Self::entry_updated_or_deleted_by_author).
+    /// `entry_updated_or_deleted_by_author`.
     pub async fn valid_create_agent_key_action(
         &self,
         author: &AgentPubKey,

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -3675,15 +3675,15 @@ mod tests {
         (entry_hash, entry, action, preflight_request)
     }
 
-    /// Insert `action` and its `entry` as an INTEGRATED self-authored chain
-    /// head: a `RegisterAgentActivity` op (so `chain_head_for_author`, which
-    /// scopes to the integrated agent-activity chain, sees the head) plus the
-    /// entry in the store.
+    /// Insert `action` and its `entry` as a committed self-authored chain head:
+    /// an integrated op whose `Action` is written with `record_validity =
+    /// Accepted` (so `chain_head_for_author`, which reads that state, sees the
+    /// head) plus the entry in the store.
     ///
-    /// This mirrors the source-chain flush, which writes each self-authored op
-    /// already integrated. `record_incoming_ops` instead lands ops in limbo,
-    /// whose actions are deliberately excluded from the chain head — so it is
-    /// not a faithful stand-in for a committed self-authored head here.
+    /// This mirrors the source-chain flush, which writes each self-authored
+    /// action as `Accepted`. `record_incoming_ops` instead inserts actions as
+    /// pending (`NULL`), which are deliberately excluded from the chain head —
+    /// so it is not a faithful stand-in for a committed self-authored head here.
     async fn insert_integrated_head(
         store: &DhtStore<DbWrite<Dht>>,
         action: Action,

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -43,6 +43,18 @@ impl DhtStore<DbRead<Dht>> {
         Ok(self.db().count_integrated_ops().await?)
     }
 
+    /// Total bytes occupied on disk by this DNA's merged store, including the
+    /// unused (free) bytes within each page.
+    pub async fn size_on_disk(&self) -> StateQueryResult<u64> {
+        Ok(self.db().get_size_on_disk().await?)
+    }
+
+    /// Bytes actually in use by this DNA's merged store, excluding the free
+    /// space within pages.
+    pub async fn used_size(&self) -> StateQueryResult<u64> {
+        Ok(self.db().get_used_size().await?)
+    }
+
     /// Count integrated, locally-validated chain ops that passed validation
     /// (rejected and GET-cached ops excluded).
     #[cfg(any(test, feature = "inspection"))]

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -9,7 +9,9 @@ use super::DhtStore;
 use crate::prelude::ActionSequenceAndHash;
 use crate::query::StateQueryResult;
 use crate::scratch::SyncScratch;
-use holo_hash::{AgentPubKey, AnyLinkableHash, DhtOpHash, ExternalHash, HasHash};
+use holo_hash::{
+    ActionHash, AgentPubKey, AnyLinkableHash, DhtOpHash, EntryHash, ExternalHash, HasHash,
+};
 use holochain_data::kind::Dht;
 use holochain_data::DbRead;
 use holochain_types::chain::ChainItem;
@@ -22,7 +24,8 @@ use holochain_types::warrant::WarrantOp;
 use holochain_zome_types::chain::{ChainFilter, LimitConditions};
 use holochain_zome_types::dht_v2::RecordValidity;
 use holochain_zome_types::prelude::{
-    Action, ChainFork, ChainHead, ChainQueryFilter, ChainStatus, HighestObserved, SignedWarrant,
+    Action, CapGrant, CapSecret, ChainFork, ChainHead, ChainQueryFilter, ChainStatus, EntryType,
+    HighestObserved, SignedWarrant,
 };
 use holochain_zome_types::validate::ValidationStatus;
 use std::collections::{HashMap, HashSet};
@@ -2215,7 +2218,11 @@ impl DhtStore<DbRead<Dht>> {
 
             // Resolve the entry (public OR private) when the action references one.
             let entry = match action.entry_hash() {
-                Some(entry_hash) => self.db().get_entry(entry_hash.clone(), Some(author)).await?,
+                Some(entry_hash) => {
+                    self.db()
+                        .get_entry(entry_hash.clone(), Some(author))
+                        .await?
+                }
                 None => None,
             };
 
@@ -2227,10 +2234,7 @@ impl DhtStore<DbRead<Dht>> {
             });
         }
 
-        let published_ops_count = self
-            .db()
-            .count_published_ops_for_author(author)
-            .await? as usize;
+        let published_ops_count = self.db().count_published_ops_for_author(author).await? as usize;
 
         Ok(SourceChainDump {
             records,
@@ -2279,7 +2283,9 @@ impl DhtStore<DbRead<Dht>> {
             let entry = if include_entries && (!private_entry || !public_only) {
                 match sah.action().entry_hash() {
                     Some(entry_hash) => {
-                        self.db().get_entry(entry_hash.clone(), Some(author)).await?
+                        self.db()
+                            .get_entry(entry_hash.clone(), Some(author))
+                            .await?
                     }
                     None => None,
                 }
@@ -2291,6 +2297,157 @@ impl DhtStore<DbRead<Dht>> {
         }
 
         Ok(records)
+    }
+
+    /// The author's valid agent-key `Create` action, read from the merged store.
+    ///
+    /// Faithfully reproduces the legacy `SELECT_VALID_AGENT_PUB_KEY` query that
+    /// ran over the authored database: the author's `Create` action whose entry
+    /// is the `AgentPubKey` entry (`entry_hash == author.into()`) and that has
+    /// NOT been updated or deleted **by the author**. Returns `None` when no
+    /// such action exists or it has been modified, so the caller maps that to
+    /// [`SourceChainError::InvalidAgentKey`](crate::source_chain::SourceChainError::InvalidAgentKey).
+    ///
+    /// The "not updated/deleted" exclusion matches the legacy SQL exactly via
+    /// [`entry_updated_or_deleted_by_author`](Self::entry_updated_or_deleted_by_author).
+    pub async fn valid_create_agent_key_action(
+        &self,
+        author: &AgentPubKey,
+    ) -> StateQueryResult<Option<Action>> {
+        let agent_key_entry_hash: EntryHash = author.clone().into();
+
+        // The agent-key `Create` is written to the author's chain at genesis;
+        // find it among the author's actions. The merged-store `Action` table
+        // carries `action_type` but not `entry_type`, so the `Create` +
+        // entry-hash match (with an `AgentPubKey` entry-type guard) reproduces
+        // the legacy `type`/`entry_type`/`entry_hash` filter.
+        let actions = self.db().get_actions_by_author(author.clone()).await?;
+        let create = actions.iter().find_map(|v2_sah| {
+            let action = holochain_zome_types::dht_v2::to_legacy_signed_action(v2_sah)
+                .action()
+                .clone();
+            let is_agent_key_create = matches!(action, Action::Create(_))
+                && action.entry_type() == Some(&EntryType::AgentPubKey)
+                && action.entry_hash() == Some(&agent_key_entry_hash);
+            is_agent_key_create.then_some(action)
+        });
+
+        let Some(create) = create else {
+            return Ok(None);
+        };
+
+        // Agent key must not have been updated or deleted by the author.
+        if self
+            .entry_updated_or_deleted_by_author(&agent_key_entry_hash, author)
+            .await?
+        {
+            return Ok(None);
+        }
+
+        Ok(Some(create))
+    }
+
+    /// The author's candidate capability grants for the `is_valid` loop in
+    /// [`SourceChain::valid_cap_grant`](crate::source_chain::SourceChain::valid_cap_grant),
+    /// read from the merged store.
+    ///
+    /// Faithfully reproduces the legacy `SELECT_VALID_CAP_GRANT_FOR_CAP_SECRET`
+    /// / `SELECT_VALID_UNRESTRICTED_CAP_GRANT` queries:
+    ///
+    /// - When `check_secret` is `Some`, only grants that carry a secret
+    ///   (`Transferable` / `Assigned`) are considered — matching the legacy
+    ///   `Entry.cap_secret = ?` pre-filter. The exact-secret match is left to
+    ///   the caller's [`CapGrant::is_valid`], which is equivalent because
+    ///   `is_valid` requires `secret == given` for both secret-bearing variants
+    ///   (and a secret-bearing check can therefore never match an `Unrestricted`
+    ///   grant, just as the legacy `cap_secret` filter excluded them).
+    /// - When `check_secret` is `None`, only `Unrestricted` grants are
+    ///   considered — matching the legacy `access_type = Unrestricted` filter.
+    ///
+    /// Candidates are restricted to grants authored by `author` (the `CapGrant`
+    /// index join already filters on `Action.author`) and dropped when their
+    /// entry has been updated or deleted by the author — the same "not
+    /// updated/deleted" semantics as the legacy SQL.
+    pub async fn valid_cap_grants(
+        &self,
+        author: &AgentPubKey,
+        check_secret: Option<&CapSecret>,
+    ) -> StateQueryResult<Vec<CapGrant>> {
+        // `CapAccess` integer encoding (see the DHT schema): 0=Unrestricted,
+        // 1=Transferable, 2=Assigned. A secret-bearing check looks only at the
+        // grants that carry a secret; an unrestricted check only at unrestricted
+        // grants.
+        let access_types: &[i64] = if check_secret.is_some() {
+            &[1, 2]
+        } else {
+            &[0]
+        };
+
+        let mut grants = Vec::new();
+        for &access in access_types {
+            let rows = self
+                .db()
+                .get_cap_grants_by_access(author.clone(), access)
+                .await?;
+            for row in rows {
+                let action_hash = ActionHash::from_raw_36(row.action_hash);
+                // Resolve the grant's entry hash from its create/update action.
+                let Some(v2_sah) = self.db().get_action(action_hash).await? else {
+                    continue;
+                };
+                let action = holochain_zome_types::dht_v2::to_legacy_signed_action(&v2_sah);
+                let Some(entry_hash) = action.action().entry_hash().cloned() else {
+                    continue;
+                };
+                // Skip grants whose entry was updated or deleted by the author.
+                if self
+                    .entry_updated_or_deleted_by_author(&entry_hash, author)
+                    .await?
+                {
+                    continue;
+                }
+                // Cap-grant entries are private; resolve from the author's
+                // `PrivateEntry` store and deserialize.
+                let Some(entry) = self.db().get_entry(entry_hash, Some(author)).await? else {
+                    continue;
+                };
+                if let Some(grant) = entry.as_cap_grant() {
+                    grants.push(grant);
+                }
+            }
+        }
+        Ok(grants)
+    }
+
+    /// `true` if `entry_hash` has been updated or deleted by `author` in the
+    /// merged store — the "not updated/deleted" exclusion shared by the
+    /// agent-key and cap-grant validity reads.
+    ///
+    /// Matches the legacy SQL `ModifiedAction.author = :author AND
+    /// (original_entry_hash = :entry_hash OR deletes_entry_hash = :entry_hash)`:
+    /// the `UpdatedRecord` / `DeletedRecord` indexes are keyed on the original /
+    /// deleted *entry* hash (see
+    /// [`get_update_actions_for_entry`](holochain_data::DbRead::get_update_actions_for_entry)
+    /// / [`get_delete_actions_for_entry`](holochain_data::DbRead::get_delete_actions_for_entry)),
+    /// and the author filter restricts to the author's own modifications. The
+    /// author's own `Update`/`Delete` actions populate these indexes at
+    /// source-chain flush time.
+    async fn entry_updated_or_deleted_by_author(
+        &self,
+        entry_hash: &EntryHash,
+        author: &AgentPubKey,
+    ) -> StateQueryResult<bool> {
+        let updates = self.db().get_update_actions_for_entry(entry_hash).await?;
+        if updates
+            .iter()
+            .any(|sah| &sah.hashed.content.header.author == author)
+        {
+            return Ok(true);
+        }
+        let deletes = self.db().get_delete_actions_for_entry(entry_hash).await?;
+        Ok(deletes
+            .iter()
+            .any(|sah| &sah.hashed.content.header.author == author))
     }
 }
 

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -2322,30 +2322,51 @@ impl DhtStore<DbRead<Dht>> {
 
         let v2_actions = self.db().get_actions_by_author(author.clone()).await?;
 
-        let mut records = Vec::with_capacity(v2_actions.len());
-        for v2_sah in &v2_actions {
-            let sah = to_legacy_signed_action(v2_sah);
+        // Convert each action to its legacy form once, and decide which entries
+        // to attach. Collect the entry hashes that actually need fetching so
+        // they can be read in a single batch — fetching them one-at-a-time was
+        // an N+1 over the chain length.
+        let sahs: Vec<holochain_zome_types::record::SignedActionHashed> =
+            v2_actions.iter().map(to_legacy_signed_action).collect();
+        let mut wanted_entry_hashes: Vec<EntryHash> = Vec::new();
+        // For each action, `Some(hash)` means "attach this entry if present";
+        // `None` means "no entry" (condition not met, or no entry hash).
+        let attach: Vec<Option<EntryHash>> = sahs
+            .iter()
+            .map(|sah| {
+                let private_entry = sah
+                    .action()
+                    .entry_type()
+                    .is_some_and(|e| *e.visibility() == EntryVisibility::Private);
 
-            let private_entry = sah
-                .action()
-                .entry_type()
-                .is_some_and(|e| *e.visibility() == EntryVisibility::Private);
-
-            let entry = if include_entries && (!private_entry || !public_only) {
-                match sah.action().entry_hash() {
-                    Some(entry_hash) => {
-                        self.db()
-                            .get_entry(entry_hash.clone(), Some(author))
-                            .await?
+                if include_entries && (!private_entry || !public_only) {
+                    if let Some(entry_hash) = sah.action().entry_hash() {
+                        wanted_entry_hashes.push(entry_hash.clone());
+                        return Some(entry_hash.clone());
                     }
-                    None => None,
                 }
-            } else {
                 None
-            };
+            })
+            .collect();
 
-            records.push(holochain_zome_types::record::Record::new(sah, entry));
-        }
+        // Batch-fetch the needed entries. The author context resolves the
+        // author's own private entries, exactly as the per-action
+        // `get_entry(.., Some(author))` did.
+        let entries = self
+            .db()
+            .get_entries_by_hashes(&wanted_entry_hashes, Some(author))
+            .await?;
+
+        // Assemble records in chain order. An absent hash maps to `None`,
+        // matching the previous `get_entry` miss behaviour.
+        let records = sahs
+            .into_iter()
+            .zip(attach)
+            .map(|(sah, want)| {
+                let entry = want.and_then(|h| entries.get(&h).cloned());
+                holochain_zome_types::record::Record::new(sah, entry)
+            })
+            .collect();
 
         Ok(records)
     }
@@ -2440,9 +2461,15 @@ impl DhtStore<DbRead<Dht>> {
                 .db()
                 .get_cap_grants_by_access(author.clone(), access)
                 .await?;
+
+            // Resolve each grant's entry hash (from its create/update action)
+            // and drop grants whose entry was updated or deleted by the author.
+            // The per-grant `get_action` / modification checks stay one-by-one
+            // (cap-grant counts are small), but the grant entries are then read
+            // in a single batch rather than one query per grant.
+            let mut candidate_hashes: Vec<EntryHash> = Vec::new();
             for row in rows {
                 let action_hash = ActionHash::from_raw_36(row.action_hash);
-                // Resolve the grant's entry hash from its create/update action.
                 let Some(v2_sah) = self.db().get_action(action_hash).await? else {
                     continue;
                 };
@@ -2457,9 +2484,19 @@ impl DhtStore<DbRead<Dht>> {
                 {
                     continue;
                 }
-                // Cap-grant entries are private; resolve from the author's
-                // `PrivateEntry` store and deserialize.
-                let Some(entry) = self.db().get_entry(entry_hash, Some(author)).await? else {
+                candidate_hashes.push(entry_hash);
+            }
+
+            // Cap-grant entries are private; resolve them from the author's
+            // `PrivateEntry` store in one batch and deserialize. Iterating
+            // `candidate_hashes` (which preserves row order and any duplicates)
+            // keeps the produced grants identical to the per-grant lookup.
+            let entries = self
+                .db()
+                .get_entries_by_hashes(&candidate_hashes, Some(author))
+                .await?;
+            for entry_hash in candidate_hashes {
+                let Some(entry) = entries.get(&entry_hash) else {
                     continue;
                 };
                 if let Some(grant) = entry.as_cap_grant() {

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -3696,9 +3696,37 @@ mod tests {
         (entry_hash, entry, action, preflight_request)
     }
 
+    /// Insert `action` and its `entry` as an INTEGRATED self-authored chain
+    /// head: a `RegisterAgentActivity` op (so `chain_head_for_author`, which
+    /// scopes to the integrated agent-activity chain, sees the head) plus the
+    /// entry in the store.
+    ///
+    /// This mirrors the source-chain flush, which writes each self-authored op
+    /// already integrated. `record_incoming_ops` instead lands ops in limbo,
+    /// whose actions are deliberately excluded from the chain head — so it is
+    /// not a faithful stand-in for a committed self-authored head here.
+    async fn insert_integrated_head(
+        store: &DhtStore<DbWrite<Dht>>,
+        action: Action,
+        entry_hash: &EntryHash,
+        entry: &holochain_types::prelude::Entry,
+        private_author: Option<&AgentPubKey>,
+    ) {
+        let op = DhtOpHashed::from_content_sync(DhtOp::ChainOp(Box::new(
+            ChainOp::RegisterAgentActivity(Signature::from([7u8; 64]), action),
+        )));
+        store
+            .test_insert_authored_chain_op(op, None, None, None)
+            .await
+            .unwrap();
+        store
+            .test_insert_entry(entry_hash, entry, private_author)
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn current_countersigning_session_returns_session_at_chain_head() {
-        use holochain_types::prelude::RecordEntry;
         use holochain_zome_types::entry_def::EntryVisibility;
 
         let store = crate::dht_store::DhtStore::new_test(dht_id())
@@ -3711,14 +3739,11 @@ mod tests {
             countersigning_head(&alice, &bob, 3, EntryVisibility::Public);
         let head_hash = ActionHash::with_data_sync(&head_action);
 
-        // Record a StoreRecord op so both the head action and the CounterSign
-        // entry land in the store.
-        let op = DhtOpHashed::from_content_sync(DhtOp::ChainOp(Box::new(ChainOp::StoreRecord(
-            Signature::from([7u8; 64]),
-            head_action,
-            RecordEntry::Present(cs_entry),
-        ))));
-        store.record_incoming_ops(vec![(op, false)]).await.unwrap();
+        // Insert the head as a committed self-authored op: an integrated
+        // `RegisterAgentActivity` op (so it is the chain head) plus the
+        // `CounterSign` entry in the store. This is the shape a real
+        // source-chain flush produces.
+        insert_integrated_head(&store, head_action, &cs_entry_hash, &cs_entry, None).await;
 
         let (record, entry_hash, returned_session) = store
             .as_read()
@@ -3742,8 +3767,10 @@ mod tests {
             .unwrap();
         let alice = AgentPubKey::from_raw_36(vec![4u8; 36]);
 
-        // A normal app entry at the chain head (seq 1), recorded as a StoreRecord
-        // op so the action and entry are both present.
+        // A normal app entry at the chain head (seq 1), inserted as an
+        // integrated self-authored head so the head is genuinely found and the
+        // `None` result comes from the entry being an ordinary App entry rather
+        // than a `CounterSign`.
         let entry = holochain_types::prelude::Entry::App(holochain_types::prelude::AppEntryBytes(
             holochain_serialized_bytes::SerializedBytes::from(
                 holochain_serialized_bytes::UnsafeBytes::from(vec![9u8; 8]),
@@ -3760,15 +3787,10 @@ mod tests {
                 0.into(),
                 holochain_zome_types::entry_def::EntryVisibility::Public,
             )),
-            entry_hash,
+            entry_hash: entry_hash.clone(),
             weight: Default::default(),
         });
-        let op = DhtOpHashed::from_content_sync(DhtOp::ChainOp(Box::new(ChainOp::StoreRecord(
-            Signature::from([7u8; 64]),
-            action,
-            holochain_types::prelude::RecordEntry::Present(entry),
-        ))));
-        store.record_incoming_ops(vec![(op, false)]).await.unwrap();
+        insert_integrated_head(&store, action, &entry_hash, &entry, None).await;
 
         let result = store
             .as_read()

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -229,6 +229,23 @@ impl DhtStore<DbRead<Dht>> {
         Ok(self.db().count_author_actions_capped(author, 3).await? >= 3)
     }
 
+    /// The author's source-chain head from the merged store, or `None`
+    /// pre-genesis.
+    pub async fn chain_head_for_author(
+        &self,
+        author: &AgentPubKey,
+    ) -> StateQueryResult<Option<crate::source_chain::HeadInfo>> {
+        Ok(self
+            .db()
+            .chain_head_for_author(author)
+            .await?
+            .map(|(action, seq, timestamp)| crate::source_chain::HeadInfo {
+                action,
+                seq,
+                timestamp,
+            }))
+    }
+
     /// Validation receipts for every chain op of `action_hash`, grouped into a
     /// [`ValidationReceiptSet`](holochain_zome_types::prelude::ValidationReceiptSet) per op.
     ///

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -94,6 +94,23 @@ impl DhtStore<DbRead<Dht>> {
             .collect())
     }
 
+    /// Op hashes of the integrated chain ops for `action_hash`.
+    ///
+    /// #5370: backs the countersigning success path's withhold-publish clear,
+    /// replacing the legacy authored-DB `get_countersigning_op_hashes` query.
+    pub async fn chain_op_hashes_for_action(
+        &self,
+        action_hash: holo_hash::ActionHash,
+    ) -> StateQueryResult<Vec<DhtOpHash>> {
+        Ok(self
+            .db()
+            .get_chain_ops_for_action(action_hash)
+            .await?
+            .into_iter()
+            .map(|r| DhtOpHash::from_raw_36(r.hash))
+            .collect())
+    }
+
     /// Total count of every op (integrated and limbo) held in the DHT store.
     #[cfg(any(test, feature = "inspection"))]
     pub async fn count_all_ops(&self) -> StateQueryResult<u64> {

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -2185,6 +2185,58 @@ impl DhtStore<DbRead<Dht>> {
         out.truncate(limit as usize);
         Ok(out.into_iter().map(|(_, _, op)| op).collect())
     }
+
+    /// Dump the author's source chain as a [`SourceChainDump`].
+    ///
+    /// Reads all actions authored by `author` from the merged DHT store in
+    /// chain-sequence order, resolves each action's entry from both the public
+    /// `Entry` table and the author's private `PrivateEntry` table, and counts
+    /// the ops that have been published at least once.
+    ///
+    /// This is the production path behind the admin `DumpState` / `DumpFullState`
+    /// APIs. It is **not** gated behind `inspection`.
+    pub async fn dump_source_chain(
+        &self,
+        author: &AgentPubKey,
+    ) -> StateQueryResult<holochain_state_types::SourceChainDump> {
+        use holochain_state_types::{SourceChainDump, SourceChainDumpRecord};
+        use holochain_zome_types::dht_v2::to_legacy_signed_action;
+
+        // All actions for this author in seq order (v2 SignedActionHashed).
+        let v2_actions = self.db().get_actions_by_author(author.clone()).await?;
+
+        let mut records = Vec::with_capacity(v2_actions.len());
+        for v2_sah in &v2_actions {
+            // Convert to the legacy (v1) SignedActionHashed.
+            let sah = to_legacy_signed_action(v2_sah);
+            let action_address = sah.as_hash().clone();
+            let signature = sah.signature().clone();
+            let action = sah.action().clone();
+
+            // Resolve the entry (public OR private) when the action references one.
+            let entry = match action.entry_hash() {
+                Some(entry_hash) => self.db().get_entry(entry_hash.clone(), Some(author)).await?,
+                None => None,
+            };
+
+            records.push(SourceChainDumpRecord {
+                signature,
+                action_address,
+                action,
+                entry,
+            });
+        }
+
+        let published_ops_count = self
+            .db()
+            .count_published_ops_for_author(author)
+            .await? as usize;
+
+        Ok(SourceChainDump {
+            records,
+            published_ops_count,
+        })
+    }
 }
 
 /// Whether `action`'s entry (if any) is declared private.

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -276,6 +276,50 @@ impl DhtStore<DbRead<Dht>> {
             }))
     }
 
+    /// Whether `author`'s source-chain head is a committed countersigning
+    /// session, and if so the session record, its entry hash, and the decoded
+    /// [`CounterSigningSessionData`](holochain_zome_types::countersigning::CounterSigningSessionData).
+    ///
+    /// This is the merged-store counterpart of the legacy
+    /// [`current_countersigning_session`](crate::source_chain::current_countersigning_session):
+    /// it reads the chain head and head record from the store rather than the
+    /// authored database. `author` is threaded through to
+    /// [`retrieve_record`](Self::retrieve_record) so the author's own
+    /// (potentially private) countersigning entry is visible.
+    ///
+    /// Returns `None` when the chain is empty (pre-genesis), the head record is
+    /// unavailable, or the head action does not carry a `CounterSign` entry. A
+    /// `Some` result guarantees the `CounterSign` entry blob is present in the
+    /// store — the match requires it — so callers need not re-check the entry.
+    pub async fn current_countersigning_session(
+        &self,
+        author: &AgentPubKey,
+    ) -> StateQueryResult<
+        Option<(
+            holochain_zome_types::record::Record,
+            holo_hash::EntryHash,
+            holochain_zome_types::countersigning::CounterSigningSessionData,
+        )>,
+    > {
+        use holochain_types::prelude::Entry;
+
+        let head = match self.chain_head_for_author(author).await? {
+            Some(h) => h,
+            None => return Ok(None),
+        };
+        let record = match self.retrieve_record(&head.action, Some(author)).await? {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+        let (sah, entry) = record.clone().into_inner();
+        Ok(match (sah.action().entry_hash(), entry.into_option()) {
+            (Some(entry_hash), Some(Entry::CounterSign(cs, _))) => {
+                Some((record, entry_hash.clone(), *cs))
+            }
+            _ => None,
+        })
+    }
+
     /// Validation receipts for every chain op of `action_hash`, grouped into a
     /// [`ValidationReceiptSet`](holochain_zome_types::prelude::ValidationReceiptSet) per op.
     ///
@@ -3228,6 +3272,181 @@ mod tests {
         );
     }
 
+    /// Builds the `(EntryHash, Entry, Action)` for a committed countersigning
+    /// session at `seq` on `author`'s chain. The session is the minimal valid
+    /// shape: two signing agents (`author` at index 0, `other` at index 1).
+    fn countersigning_head(
+        author: &AgentPubKey,
+        other: &AgentPubKey,
+        seq: u32,
+        visibility: holochain_zome_types::entry_def::EntryVisibility,
+    ) -> (
+        EntryHash,
+        holochain_types::prelude::Entry,
+        Action,
+        holochain_zome_types::countersigning::PreflightRequest,
+    ) {
+        use holochain_types::prelude::{AppEntryBytes, Entry};
+        use holochain_zome_types::countersigning::{
+            ActionBase, CounterSigningAgentState, CounterSigningSessionData,
+            CounterSigningSessionTimes, CreateBase, PreflightBytes, PreflightRequest,
+        };
+
+        let app_entry_type = EntryType::App(AppEntryDef::new(0.into(), 0.into(), visibility));
+        let session_times = CounterSigningSessionTimes::try_new(
+            Timestamp::from_micros(1_000),
+            Timestamp::from_micros(1_000_000_000),
+        )
+        .unwrap();
+        let preflight_request = PreflightRequest::try_new(
+            EntryHash::from_raw_36(vec![5u8; 36]),
+            vec![(author.clone(), vec![]), (other.clone(), vec![])],
+            vec![],
+            0,
+            false,
+            session_times,
+            ActionBase::Create(CreateBase::new(app_entry_type.clone())),
+            PreflightBytes(vec![]),
+        )
+        .unwrap();
+        let session_data = CounterSigningSessionData::try_new(
+            preflight_request.clone(),
+            vec![
+                (
+                    CounterSigningAgentState::new(0, ActionHash::from_raw_36(vec![10u8; 36]), 2),
+                    Signature::from([0u8; 64]),
+                ),
+                (
+                    CounterSigningAgentState::new(1, ActionHash::from_raw_36(vec![11u8; 36]), 2),
+                    Signature::from([1u8; 64]),
+                ),
+            ],
+            vec![],
+        )
+        .unwrap();
+
+        let entry = Entry::CounterSign(
+            Box::new(session_data),
+            AppEntryBytes(holochain_serialized_bytes::SerializedBytes::from(
+                holochain_serialized_bytes::UnsafeBytes::from(vec![1u8; 8]),
+            )),
+        );
+        let entry_hash = EntryHash::with_data_sync(&entry);
+        let action = Action::Create(Create {
+            author: author.clone(),
+            timestamp: Timestamp::from_micros(2_000),
+            action_seq: seq,
+            prev_action: ActionHash::from_raw_36(vec![3u8; 36]),
+            entry_type: app_entry_type,
+            entry_hash: entry_hash.clone(),
+            weight: Default::default(),
+        });
+        (entry_hash, entry, action, preflight_request)
+    }
+
+    #[tokio::test]
+    async fn current_countersigning_session_returns_session_at_chain_head() {
+        use holochain_types::prelude::RecordEntry;
+        use holochain_zome_types::entry_def::EntryVisibility;
+
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let alice = AgentPubKey::from_raw_36(vec![1u8; 36]);
+        let bob = AgentPubKey::from_raw_36(vec![2u8; 36]);
+
+        let (cs_entry_hash, cs_entry, head_action, preflight_request) =
+            countersigning_head(&alice, &bob, 3, EntryVisibility::Public);
+        let head_hash = ActionHash::with_data_sync(&head_action);
+
+        // Record a StoreRecord op so both the head action and the CounterSign
+        // entry land in the store.
+        let op = DhtOpHashed::from_content_sync(DhtOp::ChainOp(Box::new(ChainOp::StoreRecord(
+            Signature::from([7u8; 64]),
+            head_action,
+            RecordEntry::Present(cs_entry),
+        ))));
+        store.record_incoming_ops(vec![(op, false)]).await.unwrap();
+
+        let (record, entry_hash, returned_session) = store
+            .as_read()
+            .current_countersigning_session(&alice)
+            .await
+            .unwrap()
+            .expect("the chain head is a countersigning session");
+
+        assert_eq!(entry_hash, cs_entry_hash);
+        assert_eq!(record.action_address(), &head_hash);
+        assert_eq!(
+            returned_session.preflight_request().fingerprint().unwrap(),
+            preflight_request.fingerprint().unwrap(),
+        );
+    }
+
+    #[tokio::test]
+    async fn current_countersigning_session_none_when_head_is_normal_entry() {
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let alice = AgentPubKey::from_raw_36(vec![4u8; 36]);
+
+        // A normal app entry at the chain head (seq 1), recorded as a StoreRecord
+        // op so the action and entry are both present.
+        let entry = holochain_types::prelude::Entry::App(holochain_types::prelude::AppEntryBytes(
+            holochain_serialized_bytes::SerializedBytes::from(
+                holochain_serialized_bytes::UnsafeBytes::from(vec![9u8; 8]),
+            ),
+        ));
+        let entry_hash = EntryHash::with_data_sync(&entry);
+        let action = Action::Create(Create {
+            author: alice.clone(),
+            timestamp: Timestamp::from_micros(2_000),
+            action_seq: 1,
+            prev_action: ActionHash::from_raw_36(vec![3u8; 36]),
+            entry_type: EntryType::App(AppEntryDef::new(
+                0.into(),
+                0.into(),
+                holochain_zome_types::entry_def::EntryVisibility::Public,
+            )),
+            entry_hash,
+            weight: Default::default(),
+        });
+        let op = DhtOpHashed::from_content_sync(DhtOp::ChainOp(Box::new(ChainOp::StoreRecord(
+            Signature::from([7u8; 64]),
+            action,
+            holochain_types::prelude::RecordEntry::Present(entry),
+        ))));
+        store.record_incoming_ops(vec![(op, false)]).await.unwrap();
+
+        let result = store
+            .as_read()
+            .current_countersigning_session(&alice)
+            .await
+            .unwrap();
+        assert!(
+            result.is_none(),
+            "a normal entry at the chain head is not a countersigning session"
+        );
+    }
+
+    #[tokio::test]
+    async fn current_countersigning_session_none_for_empty_chain() {
+        let store = crate::dht_store::DhtStore::new_test(dht_id())
+            .await
+            .unwrap();
+        let alice = AgentPubKey::from_raw_36(vec![6u8; 36]);
+
+        let result = store
+            .as_read()
+            .current_countersigning_session(&alice)
+            .await
+            .unwrap();
+        assert!(
+            result.is_none(),
+            "an empty chain has no countersigning session"
+        );
+    }
+
     #[tokio::test]
     async fn op_exists_returns_false_for_unknown_hash() {
         let store = crate::dht_store::DhtStore::new_test(dht_id())
@@ -3682,7 +3901,11 @@ mod tests {
             .unwrap();
         match resp.valid_activity {
             ChainItems::Hashes(h) => {
-                assert_eq!(h.len(), 3, "revealed op must be visible after clearing withhold");
+                assert_eq!(
+                    h.len(),
+                    3,
+                    "revealed op must be visible after clearing withhold"
+                );
                 assert_eq!(h[2].0, 2);
             }
             other => panic!("expected Hashes, got {other:?}"),

--- a/crates/holochain_state/src/dht_store/tests.rs
+++ b/crates/holochain_state/src/dht_store/tests.rs
@@ -737,6 +737,99 @@ async fn apply_countersigning_success_no_op_when_row_absent() {
 }
 
 #[tokio::test]
+async fn remove_countersigning_session_deletes_withheld_session() {
+    use holo_hash::HasHash;
+
+    let store = DhtStore::new_test(dht_id()).await.unwrap();
+    let (op, _) = build_test_store_record_op_hashed(40);
+    let chain_op = match op.as_content() {
+        DhtOp::ChainOp(c) => (**c).clone(),
+        DhtOp::WarrantOp(_) => unreachable!(),
+    };
+    let action = chain_op.action();
+    let action_hash = ActionHash::with_data_sync(&action);
+    let entry_hash = action.entry_hash().unwrap().clone();
+
+    // Withheld self-authored op (withhold_publish = Some(true)) plus its entry.
+    store
+        .test_insert_authored_chain_op(op.clone(), None, None, Some(true))
+        .await
+        .unwrap();
+    let entry = match chain_op.entry().into_option() {
+        Some(e) => e.clone(),
+        None => unreachable!(),
+    };
+    store
+        .test_insert_entry(&entry_hash, &entry, None)
+        .await
+        .unwrap();
+
+    store
+        .remove_countersigning_session(action_hash.clone(), entry_hash.clone())
+        .await
+        .unwrap();
+
+    assert!(store
+        .db()
+        .as_ref()
+        .get_action(action_hash)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(store
+        .db()
+        .as_ref()
+        .get_chain_op(op.as_hash().clone())
+        .await
+        .unwrap()
+        .is_none());
+    assert!(store
+        .db()
+        .as_ref()
+        .get_entry(entry_hash, None)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn remove_countersigning_session_refuses_published() {
+    let store = DhtStore::new_test(dht_id()).await.unwrap();
+    let (op, _) = build_test_store_record_op_hashed(41);
+    let chain_op = match op.as_content() {
+        DhtOp::ChainOp(c) => (**c).clone(),
+        DhtOp::WarrantOp(_) => unreachable!(),
+    };
+    let action = chain_op.action();
+    let action_hash = ActionHash::with_data_sync(&action);
+    let entry_hash = action.entry_hash().unwrap().clone();
+
+    // Published op: withhold_publish cleared (None).
+    store
+        .test_insert_authored_chain_op(op.clone(), None, None, None)
+        .await
+        .unwrap();
+
+    let err = store
+        .remove_countersigning_session(action_hash.clone(), entry_hash)
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        crate::mutations::StateMutationError::CannotRemoveFullyPublished
+    ));
+
+    // The op was not removed.
+    assert!(store
+        .db()
+        .as_ref()
+        .get_action(action_hash)
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
 async fn record_published_op_hashes_updates_publish_time() {
     let store = DhtStore::new_test(dht_id()).await.unwrap();
     // Seed an op in ChainOp via the standard pipeline.

--- a/crates/holochain_state/src/dht_store/tests.rs
+++ b/crates/holochain_state/src/dht_store/tests.rs
@@ -67,14 +67,14 @@ async fn chain_lock_acquire_get_release_roundtrip() {
         .unwrap()
         .is_none());
 
-    // Acquiring succeeds and reports the caller now holds the lock.
+    // Acquiring succeeds and reports the caller holds the lock.
     let acquired = store
         .acquire_chain_lock(&author, &subject, expires_at, now)
         .await
         .unwrap();
     assert!(acquired);
 
-    // The lock is now readable with the expected subject.
+    // The lock is readable with the expected subject.
     let lock = store
         .as_read()
         .get_chain_lock(author.clone())
@@ -1097,8 +1097,8 @@ async fn op_validation_status_returns_status_only_when_locally_validated() {
 #[tokio::test]
 async fn op_validation_status_reads_decided_limbo_op() {
     // A limbo op that has a validation decision but is NOT yet integrated must
-    // still surface its outcome (matching the legacy pre-integration behavior),
-    // so a warrant dependency is ready as soon as it is validated.
+    // still surface its outcome, so a warrant dependency is ready as soon as it
+    // is validated.
     let store = DhtStore::new_test(dht_id()).await.unwrap();
 
     // sys + app accepted (not integrated) -> Valid.

--- a/crates/holochain_state/src/dht_store/tests.rs
+++ b/crates/holochain_state/src/dht_store/tests.rs
@@ -52,6 +52,77 @@ async fn delete_live_ephemeral_scheduled_functions_roundtrip() {
 }
 
 #[tokio::test]
+async fn chain_lock_acquire_get_release_roundtrip() {
+    let store = DhtStore::new_test(dht_id()).await.unwrap();
+    let author = agent(5);
+    let subject = vec![9u8; 32];
+    let expires_at = Timestamp::from_micros(10_000);
+    let now = Timestamp::from_micros(0);
+
+    // Initially there is no lock.
+    assert!(store
+        .as_read()
+        .get_chain_lock(author.clone())
+        .await
+        .unwrap()
+        .is_none());
+
+    // Acquiring succeeds and reports the caller now holds the lock.
+    let acquired = store
+        .acquire_chain_lock(&author, &subject, expires_at, now)
+        .await
+        .unwrap();
+    assert!(acquired);
+
+    // The lock is now readable with the expected subject.
+    let lock = store
+        .as_read()
+        .get_chain_lock(author.clone())
+        .await
+        .unwrap()
+        .expect("expected an active lock");
+    assert_eq!(lock.subject(), subject.as_slice());
+
+    // Releasing removes the lock.
+    store.release_chain_lock(&author).await.unwrap();
+    assert!(store
+        .as_read()
+        .get_chain_lock(author)
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn chain_lock_get_returns_expired_lock() {
+    let store = DhtStore::new_test(dht_id()).await.unwrap();
+    let author = agent(6);
+
+    // Acquire a lock that expires at t=100.
+    store
+        .acquire_chain_lock(
+            &author,
+            &[1u8; 32],
+            Timestamp::from_micros(100),
+            Timestamp::from_micros(0),
+        )
+        .await
+        .unwrap();
+
+    // The store's `get_chain_lock` must still return the lock even though it has
+    // expired (now = 200 > 100). Several countersigning sites rely on this
+    // "respect even expired locks" semantic, which differs from the underlying
+    // `holochain_data` reader that filters expired rows.
+    let lock = store
+        .as_read()
+        .get_chain_lock(author)
+        .await
+        .unwrap()
+        .expect("expired lock must still be returned");
+    assert!(lock.is_expired_at(Timestamp::from_micros(200)));
+}
+
+#[tokio::test]
 async fn upsert_scheduled_function_none_schedule_writes_ephemeral_row() {
     let store = DhtStore::new_test(dht_id()).await.unwrap();
     let author = agent(2);

--- a/crates/holochain_state/src/mutations.rs
+++ b/crates/holochain_state/src/mutations.rs
@@ -960,10 +960,7 @@ pub fn unlock_chain(txn: &mut Transaction, author: &AgentPubKey) -> StateMutatio
     Ok(())
 }
 
-// #5370 — no production callers; writes the authored DB which is being
-// retired. Scheduling now uses the merged store
-// (`DhtStore::delete_all_ephemeral_scheduled_functions`). Now fully unused;
-// retained for retirement together with `DbKindAuthored`.
+// #5370: dead once DbKindAuthored is retired.
 pub fn delete_all_ephemeral_scheduled_fns(txn: &mut Transaction) -> StateMutationResult<()> {
     txn.execute(
         holochain_sqlite::sql::sql_cell::schedule::DELETE_ALL_EPHEMERAL,
@@ -972,10 +969,7 @@ pub fn delete_all_ephemeral_scheduled_fns(txn: &mut Transaction) -> StateMutatio
     Ok(())
 }
 
-// #5370 — no production callers; writes the authored DB which is being
-// retired. Scheduling now uses the merged store
-// (`DhtStore::delete_live_ephemeral_scheduled_functions`). Now fully unused;
-// retained for retirement together with `DbKindAuthored`.
+// #5370: dead once DbKindAuthored is retired.
 pub fn delete_live_ephemeral_scheduled_fns(
     txn: &mut Transaction,
     now: Timestamp,
@@ -991,7 +985,7 @@ pub fn delete_live_ephemeral_scheduled_fns(
     Ok(())
 }
 
-// #5370 — no production callers; reads authored DB which is being retired.
+// #5370: dead once DbKindAuthored is retired.
 pub fn reschedule_expired(
     txn: &mut Transaction,
     now: Timestamp,
@@ -1031,10 +1025,7 @@ pub fn reschedule_expired(
 }
 
 /// Remove a function from the schedule.
-// #5370 — no production callers (its previous caller in `Cell::dispatch_scheduled_fns`
-// was removed); writes the authored DB which is being retired. Reachable only via
-// the `schedule_fn`/`reschedule_expired` legacy helpers, themselves #5370-dead.
-// Retained for retirement together with `DbKindAuthored`.
+// #5370: dead once DbKindAuthored is retired.
 pub fn unschedule_fn(txn: &mut Transaction, author: &AgentPubKey, scheduled_fn: &ScheduledFn) {
     match txn.execute(
         holochain_sqlite::sql::sql_cell::schedule::DELETE,
@@ -1058,10 +1049,7 @@ pub fn unschedule_fn(txn: &mut Transaction, author: &AgentPubKey, scheduled_fn: 
 /// Set a function to be called by the scheduler at a later time determined by `maybe_schedule`.
 ///
 /// If the function was already scheduled, its schedule will be updated.
-// #5370 — no production callers; writes the authored DB which is being retired.
-// Scheduling now uses the merged store (`DhtStore::upsert_scheduled_function`).
-// Now reached only from the #5370-dead `reschedule_expired`; retained for
-// retirement together with `DbKindAuthored`.
+// #5370: dead once DbKindAuthored is retired.
 pub fn schedule_fn(
     txn: &mut Transaction,
     author: &AgentPubKey,
@@ -1137,9 +1125,7 @@ pub fn schedule_fn(
 /// Note that this mutation is defensive about sessions that have any of their ops published to the
 /// network. If any of the ops have been published, the session cannot be removed.
 ///
-/// #5370: superseded by [`crate::dht_store::DhtStore::remove_countersigning_session`], which
-/// performs the equivalent operation against the merged store. Retained for retirement together
-/// with `DbKindAuthored`.
+/// #5370: dead once DbKindAuthored is retired.
 pub fn remove_countersigning_session(
     txn: &mut Transaction,
     cs_action: Action,

--- a/crates/holochain_state/src/mutations.rs
+++ b/crates/holochain_state/src/mutations.rs
@@ -983,6 +983,7 @@ pub fn delete_live_ephemeral_scheduled_fns(
     Ok(())
 }
 
+// #5370 — no production callers; reads authored DB which is being retired.
 pub fn reschedule_expired(
     txn: &mut Transaction,
     now: Timestamp,

--- a/crates/holochain_state/src/mutations.rs
+++ b/crates/holochain_state/src/mutations.rs
@@ -960,6 +960,10 @@ pub fn unlock_chain(txn: &mut Transaction, author: &AgentPubKey) -> StateMutatio
     Ok(())
 }
 
+// #5370 — no production callers; writes the authored DB which is being
+// retired. Scheduling now uses the merged store
+// (`DhtStore::delete_all_ephemeral_scheduled_functions`). Kept only for the
+// self-contained `schedule_test_low_level` test until DbKindAuthored is removed.
 pub fn delete_all_ephemeral_scheduled_fns(txn: &mut Transaction) -> StateMutationResult<()> {
     txn.execute(
         holochain_sqlite::sql::sql_cell::schedule::DELETE_ALL_EPHEMERAL,
@@ -968,6 +972,10 @@ pub fn delete_all_ephemeral_scheduled_fns(txn: &mut Transaction) -> StateMutatio
     Ok(())
 }
 
+// #5370 — no production callers; writes the authored DB which is being
+// retired. Scheduling now uses the merged store
+// (`DhtStore::delete_live_ephemeral_scheduled_functions`). Kept only for the
+// self-contained `schedule_test_low_level` test until DbKindAuthored is removed.
 pub fn delete_live_ephemeral_scheduled_fns(
     txn: &mut Transaction,
     now: Timestamp,
@@ -1023,6 +1031,10 @@ pub fn reschedule_expired(
 }
 
 /// Remove a function from the schedule.
+// #5370 — no production callers (its previous caller in `Cell::dispatch_scheduled_fns`
+// was removed); writes the authored DB which is being retired. Reachable only via
+// the `schedule_fn`/`reschedule_expired` legacy helpers, themselves #5370-dead. Kept
+// for the self-contained `schedule_test_low_level` test until DbKindAuthored is removed.
 pub fn unschedule_fn(txn: &mut Transaction, author: &AgentPubKey, scheduled_fn: &ScheduledFn) {
     match txn.execute(
         holochain_sqlite::sql::sql_cell::schedule::DELETE,
@@ -1046,6 +1058,10 @@ pub fn unschedule_fn(txn: &mut Transaction, author: &AgentPubKey, scheduled_fn: 
 /// Set a function to be called by the scheduler at a later time determined by `maybe_schedule`.
 ///
 /// If the function was already scheduled, its schedule will be updated.
+// #5370 — no production callers; writes the authored DB which is being retired.
+// Scheduling now uses the merged store (`DhtStore::upsert_scheduled_function`).
+// Kept only for the self-contained `schedule_test_low_level` test (and reached
+// by the #5370-dead `reschedule_expired`) until DbKindAuthored is removed.
 pub fn schedule_fn(
     txn: &mut Transaction,
     author: &AgentPubKey,

--- a/crates/holochain_state/src/mutations.rs
+++ b/crates/holochain_state/src/mutations.rs
@@ -1120,6 +1120,10 @@ pub fn schedule_fn(
 ///
 /// Note that this mutation is defensive about sessions that have any of their ops published to the
 /// network. If any of the ops have been published, the session cannot be removed.
+///
+/// #5370: superseded by [`crate::dht_store::DhtStore::remove_countersigning_session`], which
+/// performs the equivalent operation against the merged store. Retained for retirement together
+/// with `DbKindAuthored`.
 pub fn remove_countersigning_session(
     txn: &mut Transaction,
     cs_action: Action,

--- a/crates/holochain_state/src/mutations.rs
+++ b/crates/holochain_state/src/mutations.rs
@@ -962,8 +962,8 @@ pub fn unlock_chain(txn: &mut Transaction, author: &AgentPubKey) -> StateMutatio
 
 // #5370 — no production callers; writes the authored DB which is being
 // retired. Scheduling now uses the merged store
-// (`DhtStore::delete_all_ephemeral_scheduled_functions`). Kept only for the
-// self-contained `schedule_test_low_level` test until DbKindAuthored is removed.
+// (`DhtStore::delete_all_ephemeral_scheduled_functions`). Now fully unused;
+// retained for retirement together with `DbKindAuthored`.
 pub fn delete_all_ephemeral_scheduled_fns(txn: &mut Transaction) -> StateMutationResult<()> {
     txn.execute(
         holochain_sqlite::sql::sql_cell::schedule::DELETE_ALL_EPHEMERAL,
@@ -974,8 +974,8 @@ pub fn delete_all_ephemeral_scheduled_fns(txn: &mut Transaction) -> StateMutatio
 
 // #5370 — no production callers; writes the authored DB which is being
 // retired. Scheduling now uses the merged store
-// (`DhtStore::delete_live_ephemeral_scheduled_functions`). Kept only for the
-// self-contained `schedule_test_low_level` test until DbKindAuthored is removed.
+// (`DhtStore::delete_live_ephemeral_scheduled_functions`). Now fully unused;
+// retained for retirement together with `DbKindAuthored`.
 pub fn delete_live_ephemeral_scheduled_fns(
     txn: &mut Transaction,
     now: Timestamp,
@@ -1033,8 +1033,8 @@ pub fn reschedule_expired(
 /// Remove a function from the schedule.
 // #5370 — no production callers (its previous caller in `Cell::dispatch_scheduled_fns`
 // was removed); writes the authored DB which is being retired. Reachable only via
-// the `schedule_fn`/`reschedule_expired` legacy helpers, themselves #5370-dead. Kept
-// for the self-contained `schedule_test_low_level` test until DbKindAuthored is removed.
+// the `schedule_fn`/`reschedule_expired` legacy helpers, themselves #5370-dead.
+// Retained for retirement together with `DbKindAuthored`.
 pub fn unschedule_fn(txn: &mut Transaction, author: &AgentPubKey, scheduled_fn: &ScheduledFn) {
     match txn.execute(
         holochain_sqlite::sql::sql_cell::schedule::DELETE,
@@ -1060,8 +1060,8 @@ pub fn unschedule_fn(txn: &mut Transaction, author: &AgentPubKey, scheduled_fn: 
 /// If the function was already scheduled, its schedule will be updated.
 // #5370 — no production callers; writes the authored DB which is being retired.
 // Scheduling now uses the merged store (`DhtStore::upsert_scheduled_function`).
-// Kept only for the self-contained `schedule_test_low_level` test (and reached
-// by the #5370-dead `reschedule_expired`) until DbKindAuthored is removed.
+// Now reached only from the #5370-dead `reschedule_expired`; retained for
+// retirement together with `DbKindAuthored`.
 pub fn schedule_fn(
     txn: &mut Transaction,
     author: &AgentPubKey,

--- a/crates/holochain_state/src/schedule.rs
+++ b/crates/holochain_state/src/schedule.rs
@@ -50,6 +50,10 @@ pub fn compute_schedule_params(
     }
 }
 
+// #5370 — no production callers; reads the authored DB which is being retired.
+// Membership is now read from the merged store via
+// `DhtStore::is_function_scheduled`. Kept only for the self-contained
+// `schedule_test_low_level` test until DbKindAuthored is removed.
 pub fn fn_is_scheduled(
     txn: &Transaction,
     scheduled_fn: ScheduledFn,
@@ -83,6 +87,10 @@ pub fn fn_is_scheduled(
 ///
 /// Returns the list of scheduled functions with their next schedule and a bool indicating
 /// if the schedule is ephemeral or not.
+// #5370 — no production callers; reads the authored DB which is being retired.
+// Live scheduling is now read from the merged store via
+// `DhtStore::live_scheduled_functions`. Kept only for the self-contained
+// `schedule_test_low_level` test until DbKindAuthored is removed.
 pub fn live_scheduled_fns(
     txn: &Transaction,
     now: Timestamp,

--- a/crates/holochain_state/src/schedule.rs
+++ b/crates/holochain_state/src/schedule.rs
@@ -52,8 +52,8 @@ pub fn compute_schedule_params(
 
 // #5370 — no production callers; reads the authored DB which is being retired.
 // Membership is now read from the merged store via
-// `DhtStore::is_function_scheduled`. Kept only for the self-contained
-// `schedule_test_low_level` test until DbKindAuthored is removed.
+// `DhtStore::is_function_scheduled`. Now reached only from the #5370-dead
+// `schedule_fn`; retained for retirement together with `DbKindAuthored`.
 pub fn fn_is_scheduled(
     txn: &Transaction,
     scheduled_fn: ScheduledFn,
@@ -89,8 +89,8 @@ pub fn fn_is_scheduled(
 /// if the schedule is ephemeral or not.
 // #5370 — no production callers; reads the authored DB which is being retired.
 // Live scheduling is now read from the merged store via
-// `DhtStore::live_scheduled_functions`. Kept only for the self-contained
-// `schedule_test_low_level` test until DbKindAuthored is removed.
+// `DhtStore::live_scheduled_functions`. Now fully unused; retained for
+// retirement together with `DbKindAuthored`.
 pub fn live_scheduled_fns(
     txn: &Transaction,
     now: Timestamp,

--- a/crates/holochain_state/src/schedule.rs
+++ b/crates/holochain_state/src/schedule.rs
@@ -50,10 +50,7 @@ pub fn compute_schedule_params(
     }
 }
 
-// #5370 — no production callers; reads the authored DB which is being retired.
-// Membership is now read from the merged store via
-// `DhtStore::is_function_scheduled`. Now reached only from the #5370-dead
-// `schedule_fn`; retained for retirement together with `DbKindAuthored`.
+// #5370: dead once DbKindAuthored is retired.
 pub fn fn_is_scheduled(
     txn: &Transaction,
     scheduled_fn: ScheduledFn,
@@ -87,10 +84,7 @@ pub fn fn_is_scheduled(
 ///
 /// Returns the list of scheduled functions with their next schedule and a bool indicating
 /// if the schedule is ephemeral or not.
-// #5370 — no production callers; reads the authored DB which is being retired.
-// Live scheduling is now read from the merged store via
-// `DhtStore::live_scheduled_functions`. Now fully unused; retained for
-// retirement together with `DbKindAuthored`.
+// #5370: dead once DbKindAuthored is retired.
 pub fn live_scheduled_fns(
     txn: &Transaction,
     now: Timestamp,

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -17,14 +17,8 @@ use holo_hash::DnaHash;
 use holo_hash::EntryHash;
 use holo_hash::HasHash;
 use holochain_keystore::MetaLairClient;
-use holochain_sqlite::rusqlite;
-use holochain_sqlite::rusqlite::params;
 use holochain_sqlite::rusqlite::Transaction;
-use holochain_sqlite::sql::sql_cell::SELECT_VALID_AGENT_PUB_KEY;
-use holochain_sqlite::sql::sql_conductor::SELECT_VALID_CAP_GRANT_FOR_CAP_SECRET;
-use holochain_sqlite::sql::sql_conductor::SELECT_VALID_UNRESTRICTED_CAP_GRANT;
 use holochain_state_types::SourceChainDump;
-use holochain_types::sql::AsSql;
 use kitsune2_api::DhtArc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -732,40 +726,17 @@ impl SourceChain {
     ///
     /// Valid means that there's no [`Update`] or [`Delete`] action for the key on the chain.
     /// Returns the create action if it is valid, and an [`SourceChainError::InvalidAgentKey`] otherwise.
+    // #5370: reads the agent's valid key-create from the merged store instead
+    // of the legacy authored DB (`SELECT_VALID_AGENT_PUB_KEY`).
     pub async fn valid_create_agent_key_action(&self) -> SourceChainResult<Action> {
-        let agent_key_entry_hash: EntryHash = self.agent_pubkey().clone().into();
-        self.author_db()
-            .read_async({
-                let agent_key = self.agent_pubkey().clone();
-                let cell_id = self.cell_id().as_ref().clone();
-                move |txn| {
-                    txn.query_row(
-                        SELECT_VALID_AGENT_PUB_KEY,
-                        named_params! {
-                            ":author": agent_key.clone(),
-                            ":type": ActionType::Create.to_string(),
-                            ":entry_type": EntryType::AgentPubKey.to_string(),
-                            ":entry_hash": agent_key_entry_hash
-                        },
-                        |row| {
-                            let create_agent_signed_action = from_blob::<SignedAction>(row.get(0)?)
-                                .map_err(|_| rusqlite::Error::BlobSizeError)?;
-                            let create_agent_action = create_agent_signed_action.action().clone();
-                            Ok(create_agent_action)
-                        },
-                    )
-                    .map_err(|err| match err {
-                        rusqlite::Error::BlobSizeError | rusqlite::Error::QueryReturnedNoRows => {
-                            SourceChainError::InvalidAgentKey(agent_key, cell_id)
-                        }
-                        _ => {
-                            tracing::error!(?err, "Error looking up valid agent pub key");
-                            SourceChainError::other(err)
-                        }
-                    })
-                }
+        let agent_key = self.agent_pubkey().clone();
+        self.dht_store
+            .as_read()
+            .valid_create_agent_key_action(&agent_key)
+            .await?
+            .ok_or_else(|| {
+                SourceChainError::InvalidAgentKey(agent_key, self.cell_id().as_ref().clone())
             })
-            .await
     }
 
     /// Deletes the current [`AgentPubKey`] of the source chain if it is valid and returns a [`SourceChainError::InvalidAgentKey`]
@@ -966,69 +937,26 @@ where
             return Ok(Some(author_grant));
         }
 
-        // remote caller
-        let maybe_cap_grant = self
-            .vault
-            .read_async({
-                let author = self.agent_pubkey().clone();
-                move |txn| -> Result<_, DatabaseError> {
-                    // closure to process resulting rows from query
-                    let query_row_fn = |row: &Row| {
-                        from_blob::<Entry>(row.get("blob")?)
-                            .and_then(|entry| {
-                                entry.as_cap_grant().ok_or_else(|| {
-                                    crate::query::StateQueryError::SerializedBytesError(
-                                        SerializedBytesError::Deserialize(
-                                            "could not deserialize cap grant from entry"
-                                                .to_string(),
-                                        ),
-                                    )
-                                })
-                            })
-                            .map_err(|err| {
-                                holochain_sqlite::rusqlite::Error::InvalidColumnType(
-                                    0,
-                                    err.to_string(),
-                                    holochain_sqlite::rusqlite::types::Type::Blob,
-                                )
-                            })
-                    };
-
-                    // query cap grants depending on whether cap secret provided or not
-                    let cap_grants = if let Some(cap_secret) = &check_secret {
-                        let cap_secret_blob = to_blob(cap_secret).map_err(|err| {
-                            DatabaseError::SerializedBytes(SerializedBytesError::Serialize(
-                                err.to_string(),
-                            ))
-                        })?;
-
-                        // cap grant for cap secret must exist
-                        // that has not been updated or deleted
-                        let mut stmt = txn.prepare(SELECT_VALID_CAP_GRANT_FOR_CAP_SECRET)?;
-                        let rows = stmt.query(params![cap_secret_blob, author])?;
-                        let cap_grant: Vec<CapGrant> = rows.map(query_row_fn).collect()?;
-                        cap_grant
-                    } else {
-                        // unrestricted cap grant must exist
-                        // that has not been updated or deleted
-                        let mut stmt = txn.prepare(SELECT_VALID_UNRESTRICTED_CAP_GRANT)?;
-                        let rows = stmt.query(params![CapAccess::Unrestricted.as_sql(), author])?;
-                        let cap_grants: Vec<CapGrant> = rows.map(query_row_fn).collect()?;
-                        cap_grants
-                    };
-                    // loop over all found cap grants and check if one of them
-                    // is valid for assignee and function
-                    for cap_grant in cap_grants {
-                        if cap_grant.is_valid(&check_function, &check_agent, check_secret.as_ref())
-                        {
-                            return Ok(Some(cap_grant));
-                        }
-                    }
-                    Ok(None)
-                }
-            })
+        // Remote caller. #5370: the candidate grants are read from the merged
+        // store instead of the legacy authored DB
+        // (`SELECT_VALID_CAP_GRANT_FOR_CAP_SECRET` /
+        // `SELECT_VALID_UNRESTRICTED_CAP_GRANT`). The store read applies the
+        // same access-type pre-filter and "not updated/deleted" exclusion as the
+        // legacy SQL; the exact secret/assignee/function match remains the
+        // authority of `CapGrant::is_valid` below.
+        let cap_grants = self
+            .dht_store
+            .as_read()
+            .valid_cap_grants(self.agent_pubkey(), check_secret.as_ref())
             .await?;
-        Ok(maybe_cap_grant)
+        // Loop over all found cap grants and check if one of them is valid for
+        // assignee and function.
+        for cap_grant in cap_grants {
+            if cap_grant.is_valid(&check_function, &check_agent, check_secret.as_ref()) {
+                return Ok(Some(cap_grant));
+            }
+        }
+        Ok(None)
     }
 
     /// Query Actions in the source chain.
@@ -1831,6 +1759,24 @@ mod tests {
         Ok(())
     }
 
+    // The genesis agent-key `Create` is read back from the merged store as the
+    // valid agent-key action.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn valid_create_agent_key_action_reads_from_store() {
+        let TestCase {
+            chain, agent_key, ..
+        } = TestCase::new().await;
+
+        let action = chain.valid_create_agent_key_action().await.unwrap();
+
+        // It is the agent-key `Create`: an `AgentPubKey`-typed `Create` whose
+        // entry hash is the agent key.
+        assert_matches!(action, Action::Create(_));
+        assert_eq!(action.entry_type(), Some(&EntryType::AgentPubKey));
+        let agent_key_entry_hash: EntryHash = agent_key.into();
+        assert_eq!(action.entry_hash(), Some(&agent_key_entry_hash));
+    }
+
     // Test that a valid agent pub key can be deleted and that repeated deletes fail.
     #[tokio::test(flavor = "multi_thread")]
     async fn delete_valid_agent_pub_key() {
@@ -1844,6 +1790,45 @@ mod tests {
         // pub key can be found.
         let result = chain.delete_valid_agent_pub_key().await.unwrap_err();
         assert_matches!(result, SourceChainError::InvalidAgentKey(invalid_key, cell_id) if invalid_key == *chain.author && cell_id == *chain.cell_id());
+    }
+
+    // An `Update` targeting the agent-key entry invalidates the key, just like
+    // a `Delete` does, so `valid_create_agent_key_action` returns
+    // `InvalidAgentKey`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn updated_agent_key_is_invalid() {
+        let TestCase {
+            chain, agent_key, ..
+        } = TestCase::new().await;
+
+        // Valid before any modification.
+        let create = chain.valid_create_agent_key_action().await.unwrap();
+        let agent_key_entry_hash: EntryHash = agent_key.clone().into();
+
+        // Author an `Update` whose original entry is the agent-key entry. This
+        // populates the `UpdatedRecord` index (keyed on `original_entry_hash`)
+        // for the agent key.
+        let action_builder = builder::Update {
+            entry_type: EntryType::AgentPubKey,
+            entry_hash: agent_key_entry_hash.clone(),
+            original_action_address: create.to_hash(),
+            original_entry_address: agent_key_entry_hash,
+        };
+        chain
+            .put_weightless(
+                action_builder,
+                Some(Entry::Agent(agent_key.clone())),
+                ChainTopOrdering::default(),
+            )
+            .await
+            .unwrap();
+        chain.flush(vec![DhtArc::Empty]).await.unwrap();
+
+        let result = chain.valid_create_agent_key_action().await.unwrap_err();
+        assert_matches!(
+            result,
+            SourceChainError::InvalidAgentKey(invalid_key, _) if invalid_key == agent_key
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -2,12 +2,10 @@ use crate::chain_lock::ChainLock;
 // #5370: import kept (function still used by callers) pending DbKindDht retirement.
 #[allow(unused_imports)]
 use crate::integrate::authored_ops_to_dht_db;
-use crate::integrate::authored_ops_to_dht_db_without_check;
 use crate::prelude::*;
 use crate::query::chain_head::AuthoredChainHeadQuery;
 use crate::scratch::ScratchError;
 use crate::scratch::SyncScratchError;
-use crate::source_chain;
 use async_recursion::async_recursion;
 pub use error::*;
 use holo_hash::ActionHash;
@@ -1198,40 +1196,24 @@ pub async fn genesis(
     }
 
     // Clone the actions and agent entry for the new-DB write block.
-    // The originals are moved into the legacy authored write closure below.
+    // #5370: the originals are no longer moved into a legacy authored write
+    // (that write has been removed); the clones feed the store-mirror block
+    // below unchanged.
     let dna_action_for_new_db = dna_action.clone();
     let agent_validation_action_for_new_db = agent_validation_action.clone();
     let agent_action_for_new_db = agent_action.clone();
-    // `agent_entry` is `Option<Entry>` — clone before move.
+    // `agent_entry` is `Option<Entry>`; clone it for the store-mirror block.
     let agent_entry_for_new_db = agent_entry.clone();
     // Entry hash for the agent entry (AgentPubKey → EntryHash via Into).
     let agent_entry_hash: EntryHash = agent_pubkey.into();
 
-    let mut ops_to_integrate = Vec::new();
-
-    let ops_to_integrate = authored
-        .write_async(move |txn| {
-            ops_to_integrate.extend(source_chain::put_raw(txn, dna_action, dna_ops, None)?);
-            ops_to_integrate.extend(source_chain::put_raw(
-                txn,
-                agent_validation_action,
-                avh_ops,
-                None,
-            )?);
-            ops_to_integrate.extend(source_chain::put_raw(
-                txn,
-                agent_action,
-                agent_ops,
-                agent_entry,
-            )?);
-            SourceChainResult::Ok(ops_to_integrate)
-        })
-        .await?;
-
-    // We don't check for authorityship here because during genesis we have no opportunity
-    // to discover that the network is sharded and that we should not be an authority for
-    // these items, so we assume we are an authority.
-    authored_ops_to_dht_db_without_check(ops_to_integrate, authored.clone().into(), dht_db).await?;
+    // #5370: the legacy authored-DB genesis write has been removed. The genesis
+    // actions, the agent entry and their ops are now written solely to the
+    // merged DhtStore in the block below. `put_raw`,
+    // `authored_ops_to_dht_db_without_check` and the `authored` / `dht_db`
+    // inputs remain dead pending DbKindAuthored / DbKindDht retirement.
+    let _ = &authored;
+    let _ = &dht_db;
 
     // Write the genesis actions, entries and ops to the new holochain_data DHT DB.
     {
@@ -1314,6 +1296,8 @@ pub async fn genesis(
 
 /// Should only be used to put items into the Authored DB.
 /// Hash transfer fields (source, transfer_method, transfer_time) are not set.
+// #5370: production-unused after the genesis authored-DB write was removed;
+// retained pending DbKindAuthored retirement.
 pub fn put_raw(
     txn: &mut Transaction,
     shh: SignedActionHashed,
@@ -1990,7 +1974,7 @@ mod tests {
         // to access carol's chain
         {
             let extra_dht_store = crate::test_utils::test_dht_store(fake_dna_hash(1)).await;
-            source_chain::genesis(
+            genesis(
                 db.clone(),
                 dht_db.to_db(),
                 extra_dht_store.clone(),
@@ -2120,7 +2104,7 @@ mod tests {
         {
             {
                 let extra_dht_store = crate::test_utils::test_dht_store(fake_dna_hash(1)).await;
-                source_chain::genesis(
+                genesis(
                     db.clone(),
                     dht_db.to_db(),
                     extra_dht_store.clone(),
@@ -2347,6 +2331,54 @@ mod tests {
         assert_eq!(res.len(), 5);
         assert_eq!(*res[3].action_address(), h1);
         assert_eq!(*res[4].action_address(), h2);
+
+        Ok(())
+    }
+
+    /// #5370: genesis writes to the merged store only (the legacy authored-DB
+    /// write was removed). After `genesis`, the store reports the author has
+    /// genesis, the chain head is the seq-2 AgentId `Create`, and the head
+    /// record is retrievable from the store.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn genesis_writes_to_merged_store() -> SourceChainResult<()> {
+        holochain_trace::test_run();
+        let authored = test_authored_db();
+        let dht_db = test_dht_db();
+        let keystore = test_keystore();
+        let dna_hash = fixt!(DnaHash);
+        let dht_store = crate::test_utils::test_dht_store(dna_hash.clone()).await;
+        let author = keystore.new_sign_keypair_random().await.unwrap();
+
+        genesis(
+            authored.to_db(),
+            dht_db.to_db(),
+            dht_store.clone(),
+            keystore.clone(),
+            dna_hash,
+            author.clone(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let store = dht_store.as_read();
+
+        // `has_genesis` requires all three genesis actions to be present.
+        assert!(store.has_genesis(&author).await?);
+
+        // The chain head is the seq-2 AgentId `Create`.
+        let head = store
+            .chain_head_for_author(&author)
+            .await?
+            .expect("chain head present after genesis");
+        assert_eq!(head.seq, 2);
+
+        let head_record = store
+            .retrieve_record(&head.action, Some(&author))
+            .await?
+            .expect("head record present in store");
+        assert_eq!(head_record.action().action_seq(), 2);
+        assert!(matches!(head_record.action(), Action::Create(_)));
 
         Ok(())
     }

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -1,4 +1,4 @@
-use crate::chain_lock::{get_chain_lock, ChainLock};
+use crate::chain_lock::ChainLock;
 // #5370: import kept (function still used by callers) pending DbKindDht retirement.
 #[allow(unused_imports)]
 use crate::integrate::authored_ops_to_dht_db;
@@ -67,12 +67,10 @@ pub type SourceChainRead = SourceChain<DbRead<DbKindAuthored>, DbRead<DbKindDht>
 impl SourceChain {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub async fn unlock_chain(&self) -> SourceChainResult<()> {
-        self.vault
-            .write_async({
-                let author = self.author.clone();
-
-                move |txn| unlock_chain(txn, &author)
-            })
+        // #5370: the chain lock now lives in the merged store, not the legacy
+        // authored DB.
+        self.dht_store
+            .release_chain_lock(self.author.as_ref())
             .await?;
         Ok(())
     }
@@ -93,31 +91,51 @@ impl SourceChain {
             preflight_request.signing_agents[agent_index as usize].0
         );
 
-        let countersigning_agent_state = self
-            .vault
-            .write_async(move |txn| {
-                // Check for a chain lock.
-                // Note that the lock may not be valid anymore, but we must respect it here anyway.
-                let chain_lock = get_chain_lock(txn, author.as_ref())?;
-                if chain_lock.is_some() {
-                    return Err(SourceChainError::ChainLocked);
-                }
-                let HeadInfo {
-                    action: persisted_head,
-                    seq: persisted_seq,
-                    ..
-                } = chain_head_db_nonempty(txn)?;
-                let countersigning_agent_state =
-                    CounterSigningAgentState::new(agent_index, persisted_head, persisted_seq);
-                lock_chain(
-                    txn,
-                    author.as_ref(),
-                    &hashed_preflight_request,
-                    preflight_request.session_times.end(),
-                )?;
-                SourceChainResult::Ok(countersigning_agent_state)
-            })
+        // Check for a chain lock.
+        // Note that the lock may not be valid anymore, but we must respect it here anyway.
+        // `get_chain_lock` returns any lock row, including an expired one, so an
+        // expired lock still rejects acceptance exactly as the legacy authored-DB
+        // path did.
+        if self
+            .dht_store
+            .as_read()
+            .get_chain_lock(author.as_ref().clone())
+            .await?
+            .is_some()
+        {
+            return Err(SourceChainError::ChainLocked);
+        }
+
+        let HeadInfo {
+            action: persisted_head,
+            seq: persisted_seq,
+            ..
+        } = self
+            .dht_store
+            .as_read()
+            .chain_head_for_author(author.as_ref())
+            .await?
+            .ok_or(SourceChainError::ChainEmpty)?;
+        let countersigning_agent_state =
+            CounterSigningAgentState::new(agent_index, persisted_head, persisted_seq);
+
+        // Take out the lock. We verified above that no lock exists, so this must
+        // succeed; the bool guards against a concurrent writer slipping a lock in
+        // between the check and here, in which case we reject as `ChainLocked`
+        // rather than extending or stealing the lock.
+        let acquired = self
+            .dht_store
+            .acquire_chain_lock(
+                author.as_ref(),
+                &hashed_preflight_request,
+                *preflight_request.session_times.end(),
+                Timestamp::now(),
+            )
             .await?;
+        if !acquired {
+            return Err(SourceChainError::ChainLocked);
+        }
+
         Ok(countersigning_agent_state)
     }
 
@@ -331,42 +349,38 @@ impl SourceChain {
         // before starting any database read/write operations.
         let write_permit = self.vault.acquire_write_permit().await?;
 
-        // If there are records to write, then we need to respect the chain lock
+        // If there are records to write, then we need to respect the chain lock.
+        // #5370: the lock now lives in the merged store. Reading it here (outside
+        // the authored write txn) opens a tiny TOCTOU window, but this is a coarse
+        // countersigning-session guard and the window is acceptable.
         if !records.is_empty() {
-            self.vault
-                .read_async({
-                    let author = author.clone();
-                    move |txn| {
-                        let chain_lock = get_chain_lock(txn, author.as_ref())?;
-                        match chain_lock {
-                            Some(chain_lock) => {
-                                // If the chain is locked, the lock must be for this entry.
-                                if chain_lock.subject() != lock_subject {
-                                    return Err(SourceChainError::ChainLocked);
-                                }
-                                // If the lock is expired then we can't write this countersigning session.
-                                else if chain_lock.is_expired_at(now) {
-                                    return Err(SourceChainError::LockExpired);
-                                }
-
-                                // Otherwise, the lock matches this entry and has not expired. We can proceed!
-                            }
-                            None => {
-                                // If this is a countersigning entry but there is no chain lock then maybe
-                                // the session expired before the entry could be written or maybe the app
-                                // has just made a mistake. Either way, it's not valid to write this entry!
-                                if is_countersigning_session {
-                                    return Err(
-                                        SourceChainError::CountersigningWriteWithoutSession,
-                                    );
-                                }
-                            }
-                        }
-
-                        Ok(())
-                    }
-                })
+            let chain_lock = self
+                .dht_store
+                .as_read()
+                .get_chain_lock(author.as_ref().clone())
                 .await?;
+            match chain_lock {
+                Some(chain_lock) => {
+                    // If the chain is locked, the lock must be for this entry.
+                    if chain_lock.subject() != lock_subject {
+                        return Err(SourceChainError::ChainLocked);
+                    }
+                    // If the lock is expired then we can't write this countersigning session.
+                    else if chain_lock.is_expired_at(now) {
+                        return Err(SourceChainError::LockExpired);
+                    }
+
+                    // Otherwise, the lock matches this entry and has not expired. We can proceed!
+                }
+                None => {
+                    // If this is a countersigning entry but there is no chain lock then maybe
+                    // the session expired before the entry could be written or maybe the app
+                    // has just made a mistake. Either way, it's not valid to write this entry!
+                    if is_countersigning_session {
+                        return Err(SourceChainError::CountersigningWriteWithoutSession);
+                    }
+                }
+            }
         }
 
         let chain_flush_result = self
@@ -1227,10 +1241,11 @@ where
     }
 
     pub async fn get_chain_lock(&self) -> SourceChainResult<Option<ChainLock>> {
-        let author = self.author.clone();
+        // #5370: the chain lock now lives in the merged store.
         Ok(self
-            .vault
-            .read_async(move |txn| get_chain_lock(txn, author.as_ref()))
+            .dht_store
+            .as_read()
+            .get_chain_lock(self.author.as_ref().clone())
             .await?)
     }
 

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -1038,210 +1038,25 @@ where
     pub async fn query(&self, query: QueryFilter) -> SourceChainResult<Vec<Record>> {
         let public_only = self.public_only;
 
-        let entry_type_filters_count = query.entry_type.as_ref().map_or(0, |t| t.len());
-        let action_type_filters_count = query.action_type.as_ref().map_or(0, |t| t.len());
-
-        let (scratch_seq_start, scratch_seq_end) =
-            self.scratch.apply(|scratch| match &query.sequence_range {
-                ChainQueryFilterRange::ActionHashRange(start, end) => {
-                    let start_seq = scratch.actions().find_map(|a| {
-                        if a.as_hash() == start {
-                            Some(a.seq())
-                        } else {
-                            None
-                        }
-                    });
-                    let end_seq = scratch.actions().find_map(|a| {
-                        if a.as_hash() == end {
-                            Some(a.seq())
-                        } else {
-                            None
-                        }
-                    });
-
-                    (start_seq, end_seq)
-                }
-                ChainQueryFilterRange::ActionHashTerminated(end, _) => {
-                    let end_seq = scratch.actions().find_map(|a| {
-                        if a.as_hash() == end {
-                            Some(a.seq())
-                        } else {
-                            None
-                        }
-                    });
-                    (None, end_seq)
-                }
-                _ => (None, None),
-            })?;
-
+        // #5370: the source chain is now read from the merged store, not the
+        // legacy authored DB. Fetch the author's committed records (no
+        // filtering applied here). Ordering and filtering are handled below to
+        // exactly match the legacy authored-DB query, whose final authority was
+        // also `ChainQueryFilter::filter_records` (the SQL pre-filtering there
+        // was only an optimisation over the same `filter_records`).
         let mut records = self
-            .vault
-            .read_async({
-                let query = query.clone();
-                move |txn| {
-                    // This type is similar to what `named_params!` from rusqlite creates, except for the use of
-                    // boxing to allow references to be passed to the query. The reserved capacity here should
-                    // account for the number of parameters inserted below, including the variable inputs like
-                    // entry_types and actions_types.
-                    let mut args: Vec<(String, Box<dyn rusqlite::ToSql>)> = Vec::with_capacity(
-                        6 + entry_type_filters_count + action_type_filters_count,
-                    );
-
-                    // Build the SELECT part of the query
-                    let mut sql =
-                        "SELECT DISTINCT Action.hash AS action_hash, Action.blob AS action_blob"
-                            .to_string();
-                    if query.include_entries {
-                        sql.push_str(", Entry.blob AS entry_blob");
-                    }
-
-                    // Build the FROM and JOIN parts of the query
-                    sql.push_str("\nFROM Action");
-                    if query.include_entries {
-                        sql.push_str("\nLEFT JOIN Entry On Action.entry_hash = Entry.hash");
-                    }
-
-                    match &query.sequence_range {
-                        ChainQueryFilterRange::Unbounded => {
-                            sql.push_str("\nWHERE 1=1");
-                        }
-                        ChainQueryFilterRange::ActionSeqRange(start, end) => {
-                            args.push((":range_start".to_string(), Box::new(start)));
-                            args.push((":range_end".to_string(), Box::new(end)));
-
-                            sql.push_str("\nWHERE Action.seq BETWEEN :range_start AND :range_end");
-                        }
-                        ChainQueryFilterRange::ActionHashRange(
-                            start_action_hash,
-                            end_action_hash,
-                        ) => {
-                            let start_seq = match scratch_seq_start {
-                                Some(scratch_start) => scratch_start,
-                                None => txn.query_row(
-                                    "SELECT seq from Action WHERE hash = :range_start_hash",
-                                    named_params! {":range_start_hash": start_action_hash.clone()},
-                                    |row| row.get::<_, u32>(0),
-                                )?,
-                            };
-                            let end_seq = match scratch_seq_end {
-                                Some(scratch_end) => scratch_end,
-                                None => txn.query_row(
-                                    "SELECT seq from Action WHERE hash = :range_end_hash",
-                                    named_params! {":range_end_hash": end_action_hash.clone()},
-                                    |row| row.get::<_, u32>(0),
-                                )?,
-                            };
-
-                            sql.push_str(&format!(
-                                "\nWHERE Action.seq BETWEEN {start_seq} AND {end_seq}"
-                            ));
-                        }
-                        ChainQueryFilterRange::ActionHashTerminated(
-                            end_action_hash,
-                            prior_count,
-                        ) => {
-                            let end_seq = match scratch_seq_end {
-                                Some(scratch_end) => scratch_end,
-                                None => txn.query_row(
-                                    "SELECT seq from Action WHERE hash = :range_end_hash",
-                                    named_params! {":range_end_hash": end_action_hash.clone()},
-                                    |row| row.get::<_, u32>(0),
-                                )?,
-                            };
-
-                            let start_seq = end_seq.saturating_sub(*prior_count);
-
-                            sql.push_str(&format!(
-                                "\nWHERE Action.seq BETWEEN {start_seq} AND {end_seq}"
-                            ));
-                        }
-                    }
-
-                    match query.sequence_range {
-                        ChainQueryFilterRange::Unbounded
-                        | ChainQueryFilterRange::ActionSeqRange(_, _) => {
-                            if let Some(action_types) = &query.action_type {
-                                if !action_types.is_empty() {
-                                    for (i, _) in action_types.iter().enumerate() {
-                                        args.push((
-                                            format!(":action_type_{i}"),
-                                            Box::new(action_types[i].as_sql()),
-                                        ));
-                                    }
-
-                                    sql.push_str(
-                                        format!(
-                                            "\nAND Action.type IN ({})",
-                                            named_param_seq("action_type", action_types.len())
-                                        )
-                                        .as_str(),
-                                    );
-                                }
-                            }
-
-                            if let Some(entry_types) = &query.entry_type {
-                                if !entry_types.is_empty() {
-                                    for (i, _) in entry_types.iter().enumerate() {
-                                        args.push((
-                                            format!(":entry_type_{i}"),
-                                            Box::new(entry_types[i].as_sql()),
-                                        ));
-                                    }
-
-                                    sql.push_str(
-                                        format!(
-                                            "\nAND Action.entry_type IN ({})",
-                                            named_param_seq("entry_type", entry_types.len())
-                                        )
-                                        .as_str(),
-                                    );
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-
-                    sql.push_str("\nORDER BY Action.seq");
-                    sql.push_str(if query.order_descending {
-                        " DESC"
-                    } else {
-                        " ASC"
-                    });
-                    let mut stmt = txn.prepare(&sql)?;
-
-                    let records = stmt
-                        .query_and_then(
-                            args.iter()
-                                .map(|a| (a.0.as_str(), a.1.as_ref()))
-                                .collect::<Vec<(&str, &dyn rusqlite::ToSql)>>()
-                                .as_slice(),
-                            |row| {
-                                let action = from_blob::<SignedAction>(row.get("action_blob")?)?;
-                                let (action, signature) = action.into();
-                                let private_entry = action
-                                    .entry_type()
-                                    .is_some_and(|e| *e.visibility() == EntryVisibility::Private);
-                                let hash: ActionHash = row.get("action_hash")?;
-                                let action = ActionHashed::with_pre_hashed(action, hash);
-                                let sah = SignedActionHashed::with_presigned(action, signature);
-                                let entry =
-                                    if query.include_entries && (!private_entry || !public_only) {
-                                        let entry: Option<Vec<u8>> = row.get("entry_blob")?;
-                                        match entry {
-                                            Some(entry) => Some(from_blob::<Entry>(entry)?),
-                                            None => None,
-                                        }
-                                    } else {
-                                        None
-                                    };
-                                StateQueryResult::Ok(Record::new(sah, entry))
-                            },
-                        )?
-                        .collect::<StateQueryResult<Vec<_>>>();
-                    records
-                }
-            })
+            .dht_store
+            .as_read()
+            .source_chain_records(self.author.as_ref(), query.include_entries, public_only)
             .await?;
+
+        // The store returns committed records in ascending sequence order. The
+        // legacy SQL applied `order_descending` to the committed records only
+        // (the scratch was always appended in ascending order below), so mirror
+        // that here by reversing the committed records for a descending query.
+        if query.order_descending {
+            records.reverse();
+        }
 
         // Just take anything from the scratch for now. More filtering is possibly needed against
         // the results returned from the database anyway.
@@ -1303,19 +1118,6 @@ where
     pub async fn dump(&self) -> SourceChainResult<SourceChainDump> {
         dump_state(&self.dht_store.as_read(), (*self.author).clone()).await
     }
-}
-
-fn named_param_seq(base_name: &str, repeat: usize) -> String {
-    if repeat == 0 {
-        return String::new();
-    }
-
-    let mut seq = format!(":{base_name}");
-    for i in 0..repeat {
-        seq.push_str(format!(", :{base_name}_{i}").as_str());
-    }
-
-    seq
 }
 
 pub fn chain_lock_subject_for_entry(entry: Option<&Entry>) -> SourceChainResult<Vec<u8>> {
@@ -2842,6 +2644,122 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn source_chain_query_private_entry_redacted_under_public_only() {
+        let TestCase {
+            mut chain,
+            agent_key: alice,
+            keystore,
+            ..
+        } = TestCase::new().await;
+
+        let private_entry_type = EntryType::App(AppEntryDef {
+            zome_index: 0.into(),
+            entry_index: 0.into(),
+            visibility: EntryVisibility::Private,
+        });
+        let public_entry_type = EntryType::App(AppEntryDef {
+            zome_index: 0.into(),
+            entry_index: 1.into(),
+            visibility: EntryVisibility::Public,
+        });
+
+        // Commit a Create with a PRIVATE entry to the merged store via flush.
+        let chain_top = chain.chain_head_nonempty().unwrap();
+        let private_entry_hashed = EntryHashed::from_content_sync(Entry::App(fixt!(AppEntryBytes)));
+        let private_create = Action::Create(Create {
+            author: alice.clone(),
+            timestamp: Timestamp::now(),
+            action_seq: chain_top.seq + 1,
+            prev_action: chain_top.action.as_hash().clone(),
+            entry_type: private_entry_type.clone(),
+            entry_hash: private_entry_hashed.hash.clone(),
+            weight: EntryRateWeight::default(),
+        });
+        let sig = alice.sign(&keystore, &private_create).await.unwrap();
+        let private_sah = SignedActionHashed::from_content_sync((private_create, sig).into());
+        let private_action_hash = private_sah.as_hash().clone();
+        chain
+            .scratch()
+            .apply({
+                let private_sah = private_sah.clone();
+                move |scratch| {
+                    scratch.add_action(private_sah, ChainTopOrdering::Strict);
+                    scratch.add_entry(private_entry_hashed, ChainTopOrdering::Strict);
+                }
+            })
+            .unwrap();
+        chain.flush(vec![DhtArc::Empty]).await.unwrap();
+
+        // Add an uncommitted public Create to the scratch.
+        let chain_top = chain.chain_head_nonempty().unwrap();
+        let public_entry_hashed = EntryHashed::from_content_sync(Entry::App(fixt!(AppEntryBytes)));
+        let public_create = Action::Create(Create {
+            author: alice.clone(),
+            timestamp: Timestamp::now(),
+            action_seq: chain_top.seq + 1,
+            prev_action: chain_top.action.as_hash().clone(),
+            entry_type: public_entry_type.clone(),
+            entry_hash: public_entry_hashed.hash.clone(),
+            weight: EntryRateWeight::default(),
+        });
+        let sig = alice.sign(&keystore, &public_create).await.unwrap();
+        let public_sah = SignedActionHashed::from_content_sync((public_create, sig).into());
+        let scratch_action_hash = public_sah.as_hash().clone();
+        chain
+            .scratch()
+            .apply({
+                let public_sah = public_sah.clone();
+                move |scratch| {
+                    scratch.add_action(public_sah, ChainTopOrdering::Strict);
+                    scratch.add_entry(public_entry_hashed, ChainTopOrdering::Strict);
+                }
+            })
+            .unwrap();
+
+        // With full visibility, the committed private entry is present and the
+        // uncommitted scratch record is visible.
+        let q = ChainQueryFilter::default().include_entries(true);
+        let records = chain.query(q.clone()).await.unwrap();
+        let committed_private = records
+            .iter()
+            .find(|r| r.action_address() == &private_action_hash)
+            .expect("committed private record present");
+        assert!(
+            matches!(committed_private.entry(), RecordEntry::Present(_)),
+            "private entry should be present without public_only"
+        );
+        assert!(
+            records
+                .iter()
+                .any(|r| r.action_address() == &scratch_action_hash),
+            "uncommitted scratch record should be visible"
+        );
+
+        // With public_only set, the committed private entry is redacted (the
+        // action remains) but the scratch record — this agent's own data — still
+        // carries its entry.
+        chain.public_only();
+        let records = chain.query(q).await.unwrap();
+        let committed_private = records
+            .iter()
+            .find(|r| r.action_address() == &private_action_hash)
+            .expect("committed private action still present under public_only");
+        assert!(
+            matches!(committed_private.entry(), RecordEntry::Hidden),
+            "private entry should be redacted (Hidden) under public_only, got {:?}",
+            committed_private.entry()
+        );
+        let scratch_record = records
+            .iter()
+            .find(|r| r.action_address() == &scratch_action_hash)
+            .expect("scratch record still visible under public_only");
+        assert!(
+            matches!(scratch_record.entry(), RecordEntry::Present(_)),
+            "scratch entry (own data) should remain present under public_only"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -330,17 +330,13 @@ impl SourceChain {
 
         let now = Timestamp::now();
 
-        // #5370: clones reused by the authoritative merged-store write below,
-        // after the transitional authored dual-write consumes the originals.
-        // The authored dual-write — and therefore these clones — is kept only
-        // until the source-chain *readers* that still query the legacy authored
-        // DB are migrated to the merged store: `SourceChain::query`,
-        // `valid_cap_grant`, `valid_create_agent_key_action` /
-        // `delete_valid_agent_pub_key`, and `zomes_initialized`. Cheap clones
-        // (`Vec<HoloHashed<_>>` / `Vec<ScheduledFn>`).
-        let entries_for_authored = entries.clone();
-        let actions_for_authored = actions.clone();
-        let ops_for_authored = ops.clone();
+        // #5370: clone reused by the transitional authored scheduled-functions
+        // dual-write below, after the merged-store write consumes the original.
+        // The source chain itself is no longer written to the authored DB — the
+        // merged store is the sole source-chain write. Only scheduled functions
+        // are still dual-written, because the scheduling reader `fn_is_scheduled`
+        // still queries the authored DB. Remove once scheduling is migrated to
+        // the merged store. Cheap clone (`Vec<ScheduledFn>`).
         let scheduled_fns_for_authored = scheduled_fns.clone();
 
         // Acquire the per-author chain write permit on the merged store and
@@ -418,36 +414,19 @@ impl SourceChain {
                 }
             }
 
-            // #5370: transitional authored source-chain dual-write. The merged
-            // store below is the authority for serialization (the chain permit)
-            // and the as-at, but the legacy authored DB is still written because
-            // production source-chain readers — `SourceChain::query`,
-            // `valid_cap_grant`, `valid_create_agent_key_action` /
-            // `delete_valid_agent_pub_key`, and `zomes_initialized` — still query
-            // it. This write is no longer guarded by its own as-at; the store
-            // as-at above (under the chain permit) gates it. Remove once those
-            // readers are migrated to the merged store.
+            // #5370: transitional authored scheduled-functions dual-write. The
+            // source chain (entries, actions, ops) is no longer written to the
+            // authored DB — the merged-store write below is the sole authority
+            // for it. Only scheduled functions are still written here, because
+            // the scheduling reader `fn_is_scheduled` still queries the authored
+            // DB. Remove this block once scheduling is migrated to the merged
+            // store.
             {
                 let author = author.clone();
                 self.vault
                     .write_async(move |txn| -> SourceChainResult<()> {
                         for scheduled_fn in scheduled_fns_for_authored {
                             schedule_fn(txn, author.as_ref(), scheduled_fn, None, now)?;
-                        }
-                        for entry in entries_for_authored {
-                            insert_entry(txn, entry.as_hash(), entry.as_content())?;
-                        }
-                        for shh in actions_for_authored.iter() {
-                            insert_action(txn, shh)?;
-                        }
-                        for (op, op_hash, op_order, timestamp, _dep) in &ops_for_authored {
-                            insert_op_lite_into_authored(txn, op, op_hash, op_order, timestamp)?;
-                            // If this is a countersigning session we want to
-                            // withhold publishing the ops until the session is
-                            // successful.
-                            if is_countersigning_session {
-                                set_withhold_publish(txn, op_hash)?;
-                            }
                         }
                         Ok(())
                     })
@@ -2332,31 +2311,27 @@ mod tests {
             .unwrap();
         source_chain.flush(vec![DhtArc::Empty]).await.unwrap();
 
-        vault
-            .read_async({
-                let check_h1 = h1.clone();
-                let check_h2 = h2.clone();
+        // #5370: the source chain is now written to the merged store, not the
+        // authored DB, so the head and full records are read from the store.
+        let head = dht_store
+            .as_read()
+            .chain_head_for_author(author.as_ref())
+            .await?
+            .expect("chain head present after flush");
+        assert_eq!(head.action, h2);
 
-                move |txn| -> DatabaseResult<()> {
-                    assert_eq!(chain_head_db_nonempty(txn).unwrap().action, check_h2);
-                    // get the full record
-                    let store = CascadeTxnWrapper::from(txn);
-                    let h1_record_fetched = store
-                        .get_record(&check_h1.clone().into())
-                        .expect("error retrieving")
-                        .expect("entry not found");
-                    let h2_record_fetched = store
-                        .get_record(&check_h2.clone().into())
-                        .expect("error retrieving")
-                        .expect("entry not found");
-                    assert_eq!(check_h1, *h1_record_fetched.action_address());
-                    assert_eq!(check_h2, *h2_record_fetched.action_address());
-
-                    Ok(())
-                }
-            })
-            .await
-            .unwrap();
+        let h1_record_fetched = dht_store
+            .as_read()
+            .retrieve_record(&h1, Some(author.as_ref()))
+            .await?
+            .expect("h1 record present in store");
+        let h2_record_fetched = dht_store
+            .as_read()
+            .retrieve_record(&h2, Some(author.as_ref()))
+            .await?
+            .expect("h2 record present in store");
+        assert_eq!(h1, *h1_record_fetched.action_address());
+        assert_eq!(h2, *h2_record_fetched.action_address());
 
         // check that you can iterate on the chain
         let source_chain = SourceChain::new(

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -23,7 +23,7 @@ use holochain_sqlite::rusqlite::Transaction;
 use holochain_sqlite::sql::sql_cell::SELECT_VALID_AGENT_PUB_KEY;
 use holochain_sqlite::sql::sql_conductor::SELECT_VALID_CAP_GRANT_FOR_CAP_SECRET;
 use holochain_sqlite::sql::sql_conductor::SELECT_VALID_UNRESTRICTED_CAP_GRANT;
-use holochain_state_types::SourceChainDumpRecord;
+use holochain_state_types::SourceChainDump;
 use holochain_types::sql::AsSql;
 use kitsune2_api::DhtArc;
 use std::sync::atomic::AtomicBool;
@@ -1278,7 +1278,7 @@ where
     }
 
     pub async fn dump(&self) -> SourceChainResult<SourceChainDump> {
-        dump_state(self.author_db().clone().into(), (*self.author).clone()).await
+        dump_state(&self.dht_store.as_read(), (*self.author).clone()).await
     }
 }
 
@@ -1660,70 +1660,26 @@ pub fn current_countersigning_session(
     }
 }
 
-/// dump the entire source chain as a pretty-printed json string
+/// Dump the entire source chain from the merged DHT store.
+///
+/// Reads from the merged per-DNA `holochain_data` store rather than the legacy
+/// authored database. Private entries are included — the query looks in both
+/// the public `Entry` table and the author's `PrivateEntry` table — so the
+/// dump faithfully reflects the author's own chain. `published_ops_count` is
+/// the number of integrated ops that have been published at least once.
+///
+/// This is the production path backing the admin `DumpState` and `DumpFullState`
+/// APIs. It is **not** gated behind `inspection` or `test_utils`.
+// #5370: `vault` (DbRead<DbKindAuthored>) parameter removed; reads the merged store.
 #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub async fn dump_state(
-    vault: DbRead<DbKindAuthored>,
+    dht_store: &DhtStoreRead,
     author: AgentPubKey,
 ) -> Result<SourceChainDump, SourceChainError> {
-    Ok(vault
-        .read_async(move |txn| {
-            let records = txn
-                .prepare(
-                    "
-                SELECT DISTINCT
-                Action.blob AS action_blob, Entry.blob AS entry_blob,
-                Action.hash AS action_hash
-                FROM Action
-                JOIN DhtOp ON DhtOp.action_hash = Action.hash
-                LEFT JOIN Entry ON Action.entry_hash = Entry.hash
-                WHERE
-                Action.author = :author
-                ORDER BY Action.seq ASC
-                ",
-                )?
-                .query_and_then(
-                    named_params! {
-                        ":author": author,
-                    },
-                    |row| {
-                        let action: SignedAction = from_blob(row.get("action_blob")?)?;
-                        let (action, signature) = action.into();
-                        let action_address = row.get("action_hash")?;
-                        let entry: Option<Vec<u8>> = row.get("entry_blob")?;
-                        let entry: Option<Entry> = match entry {
-                            Some(entry) => Some(from_blob(entry)?),
-                            None => None,
-                        };
-                        StateQueryResult::Ok(SourceChainDumpRecord {
-                            signature,
-                            action_address,
-                            action,
-                            entry,
-                        })
-                    },
-                )?
-                .collect::<StateQueryResult<Vec<_>>>()?;
-            let published_ops_count = txn.query_row(
-                "
-                SELECT COUNT(DhtOp.hash) FROM DhtOp
-                JOIN Action ON DhtOp.action_hash = Action.hash
-                WHERE
-                Action.author = :author
-                AND
-                last_publish_time IS NOT NULL
-                ",
-                named_params! {
-                ":author": author,
-                },
-                |row| row.get(0),
-            )?;
-            StateQueryResult::Ok(SourceChainDump {
-                records,
-                published_ops_count,
-            })
-        })
-        .await?)
+    dht_store
+        .dump_source_chain(&author)
+        .await
+        .map_err(SourceChainError::other)
 }
 
 // ---------------------------------------------------------------------------
@@ -2593,16 +2549,75 @@ mod tests {
         Ok(())
     }
 
+    /// Verify that `DhtStore::dump_source_chain` returns records in seq order,
+    /// resolves private-entry records' entry data from `PrivateEntry`, and
+    /// reports the correct published-op count.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn dump_state_from_store() -> SourceChainResult<()> {
+        let TestCase {
+            chain,
+            agent_key,
+            dht_store,
+            ..
+        } = TestCase::new().await;
+
+        // Add a private-entry action (seq 3) on top of the genesis 3-action chain.
+        let private_entry = Entry::App(fixt!(AppEntryBytes));
+        let private_entry_hash = EntryHash::with_data_sync(&private_entry);
+        let create = builder::Create {
+            entry_type: EntryType::App(AppEntryDef::new(
+                0.into(),
+                0.into(),
+                EntryVisibility::Private,
+            )),
+            entry_hash: private_entry_hash.clone(),
+        };
+        chain
+            .put_weightless(create, Some(private_entry.clone()), ChainTopOrdering::default())
+            .await?;
+        chain.flush(vec![DhtArc::Empty]).await?;
+
+        let dump = dht_store.as_read().dump_source_chain(&agent_key).await?;
+
+        // Four records: Dna(0), AgentValidationPkg(1), Create/AgentId(2), Create/Private(3).
+        assert_eq!(dump.records.len(), 4, "expected 4 records after genesis + 1");
+
+        // Verify seq order.
+        for (i, rec) in dump.records.iter().enumerate() {
+            assert_eq!(
+                rec.action.action_seq(),
+                i as u32,
+                "record {i} out of order"
+            );
+        }
+
+        // The private-entry record (seq 3) must expose its entry.
+        let private_rec = &dump.records[3];
+        assert_eq!(
+            private_rec.entry.as_ref(),
+            Some(&private_entry),
+            "private-entry record must include the entry"
+        );
+
+        // No publishing has occurred — published_ops_count must be 0.
+        assert_eq!(
+            dump.published_ops_count, 0,
+            "no ops have been published yet"
+        );
+
+        Ok(())
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn source_chain_buffer_dump_entries_json() -> SourceChainResult<()> {
         let TestCase {
             chain: _,
             agent_key,
-            authored,
+            dht_store,
             ..
         } = TestCase::new().await;
 
-        let json = dump_state(authored.clone().into(), agent_key.clone()).await?;
+        let json = dump_state(&dht_store.as_read(), agent_key.clone()).await?;
         let json = serde_json::to_string_pretty(&json)?;
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
 

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -328,15 +328,6 @@ impl SourceChain {
 
         let now = Timestamp::now();
 
-        // #5370: clone reused by the transitional authored scheduled-functions
-        // dual-write below, after the merged-store write consumes the original.
-        // The source chain itself is no longer written to the authored DB — the
-        // merged store is the sole source-chain write. Only scheduled functions
-        // are still dual-written, because the scheduling reader `fn_is_scheduled`
-        // still queries the authored DB. Remove once scheduling is migrated to
-        // the merged store. Cheap clone (`Vec<ScheduledFn>`).
-        let scheduled_fns_for_authored = scheduled_fns.clone();
-
         // Acquire the per-author chain write permit on the merged store and
         // perform the source-chain write under it, gated by an as-at check
         // against the store head. The permit serializes flushes for this
@@ -410,25 +401,6 @@ impl SourceChain {
                         head_info,
                     ));
                 }
-            }
-
-            // #5370: transitional authored scheduled-functions dual-write. The
-            // source chain (entries, actions, ops) is no longer written to the
-            // authored DB — the merged-store write below is the sole authority
-            // for it. Only scheduled functions are still written here, because
-            // the scheduling reader `fn_is_scheduled` still queries the authored
-            // DB. Remove this block once scheduling is migrated to the merged
-            // store.
-            {
-                let author = author.clone();
-                self.vault
-                    .write_async(move |txn| -> SourceChainResult<()> {
-                        for scheduled_fn in scheduled_fns_for_authored {
-                            schedule_fn(txn, author.as_ref(), scheduled_fn, None, now)?;
-                        }
-                        Ok(())
-                    })
-                    .await?;
             }
 
             // The authoritative source-chain write: entries, actions, ops and

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -3118,6 +3118,99 @@ mod tests {
         Ok(())
     }
 
+    /// Concurrent strict flushes from the same chain head must not fork the
+    /// chain. Two `SourceChain` handles for the same `(DNA, author)` observe the
+    /// same store head, each stage one strict action, then flush in true
+    /// parallel. The per-`(DNA, author)` chain write permit acquired in `flush`,
+    /// combined with the as-at check against the store head, serializes the two
+    /// flushes: exactly one commits and the other gets `HeadMoved`. The store
+    /// head must advance by exactly one — never forking into two actions at the
+    /// same sequence. Both flushing both successfully would be the fork bug the
+    /// permit prevents, in which case this test fails.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn concurrent_strict_flushes_do_not_fork_chain() -> SourceChainResult<()> {
+        let TestCase {
+            chain: _chain,
+            agent_key: alice,
+            authored: db,
+            dht: dht_db,
+            dht_store,
+            keystore,
+        } = TestCase::new().await;
+
+        // The head sequence both chains start contending from (the genesis head).
+        let pre_seq = dht_store
+            .as_read()
+            .chain_head_for_author(&alice)
+            .await?
+            .expect("genesis chain head present")
+            .seq;
+
+        // Two fresh chains for the same author, both observing the same head.
+        let chain_a = SourceChain::new(
+            db.clone(),
+            dht_db.to_db(),
+            dht_store.clone(),
+            keystore.clone(),
+            alice.clone(),
+        )
+        .await?;
+        let chain_b = SourceChain::new(
+            db.clone(),
+            dht_db.to_db(),
+            dht_store.clone(),
+            keystore.clone(),
+            alice.clone(),
+        )
+        .await?;
+
+        // Each stages one strict action from the same head; the flush loser gets
+        // a clean `HeadMoved` (strict ordering means no relaxed rebase/retry).
+        let action_builder = builder::CloseChain { new_target: None };
+        chain_a
+            .put(action_builder.clone(), None, ChainTopOrdering::Strict)
+            .await?;
+        chain_b
+            .put(action_builder, None, ChainTopOrdering::Strict)
+            .await?;
+
+        // Flush both in true parallel on the multi-threaded runtime via spawned
+        // tasks. `SourceChain` is `Clone` + `Send` + `'static`, so each owned
+        // handle moves into its own task.
+        let arcs_a = vec![DhtArc::Empty];
+        let arcs_b = arcs_a.clone();
+        let task_a = tokio::spawn(async move { chain_a.flush(arcs_a).await });
+        let task_b = tokio::spawn(async move { chain_b.flush(arcs_b).await });
+        let (res_a, res_b) = tokio::join!(task_a, task_b);
+        let res_a = res_a.expect("flush task a did not panic");
+        let res_b = res_b.expect("flush task b did not panic");
+
+        // Exactly one flush committed (`Ok`) and exactly one was rejected with
+        // `HeadMoved`. Don't assume which won the race.
+        let oks = [&res_a, &res_b].iter().filter(|r| r.is_ok()).count();
+        assert_eq!(
+            oks, 1,
+            "exactly one flush must commit; a={res_a:?}, b={res_b:?}"
+        );
+        let loser = if res_a.is_err() { &res_a } else { &res_b };
+        assert_matches!(loser, Err(SourceChainError::HeadMoved(_, _, _, _)));
+
+        // No fork: the store head advanced by exactly one.
+        let new_seq = dht_store
+            .as_read()
+            .chain_head_for_author(&alice)
+            .await?
+            .expect("chain head present after flush")
+            .seq;
+        assert_eq!(
+            new_seq,
+            pre_seq + 1,
+            "store head must advance by exactly one, not fork"
+        );
+
+        Ok(())
+    }
+
     struct TestCase {
         chain: SourceChain,
         agent_key: AgentPubKey,

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -112,7 +112,11 @@ impl SourceChain {
         // Take out the lock. We verified above that no lock exists, so this must
         // succeed; the bool guards against a concurrent writer slipping a lock in
         // between the check and here, in which case we reject as `ChainLocked`
-        // rather than extending or stealing the lock.
+        // rather than extending or stealing the lock. The head read above and
+        // this lock acquisition are separate operations, not one transaction: a
+        // concurrent flush can move the head in between, but a stale captured
+        // head is rejected by the as-at check when the session commits, so the
+        // session fails cleanly rather than forking the chain.
         let acquired = self
             .dht_store
             .acquire_chain_lock(
@@ -1335,7 +1339,7 @@ pub fn current_countersigning_session(
 /// integrated ops that have been published at least once.
 ///
 /// This is the production path backing the admin `DumpState` and `DumpFullState`
-/// APIs. It is **not** gated behind `inspection` or `test_utils`.
+/// APIs.
 #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub async fn dump_state(
     dht_store: &DhtStoreRead,

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -766,7 +766,13 @@ where
     ) -> SourceChainResult<Self> {
         let scratch = Scratch::new().into_sync();
         let author = Arc::new(author);
-        let head_info = Some(vault.read_async(chain_head_db_nonempty).await?);
+        let head_info = Some(
+            dht_store
+                .as_read()
+                .chain_head_for_author(author.as_ref())
+                .await?
+                .ok_or(SourceChainError::ChainEmpty)?,
+        );
         Ok(Self {
             scratch,
             vault,
@@ -793,7 +799,10 @@ where
     ) -> SourceChainResult<Self> {
         let scratch = Scratch::new().into_sync();
         let author = Arc::new(author);
-        let head_info = vault.read_async(chain_head_db).await?;
+        let head_info = dht_store
+            .as_read()
+            .chain_head_for_author(author.as_ref())
+            .await?;
         Ok(Self {
             scratch,
             vault,
@@ -2205,7 +2214,7 @@ mod tests {
             source_chain::genesis(
                 db.clone(),
                 dht_db.to_db(),
-                extra_dht_store,
+                extra_dht_store.clone(),
                 keystore.clone(),
                 fake_dna_hash(1),
                 carol.clone(),
@@ -2216,7 +2225,7 @@ mod tests {
             let carol_chain = SourceChain::new(
                 db.clone(),
                 dht_db.clone(),
-                dht_store.clone(),
+                extra_dht_store,
                 keystore.clone(),
                 carol.clone(),
             )
@@ -2335,7 +2344,7 @@ mod tests {
                 source_chain::genesis(
                     db.clone(),
                     dht_db.to_db(),
-                    extra_dht_store,
+                    extra_dht_store.clone(),
                     keystore.clone(),
                     fake_dna_hash(1),
                     bob.clone(),
@@ -2346,7 +2355,7 @@ mod tests {
                 let bob_chain = SourceChain::new(
                     db.clone(),
                     dht_db.clone(),
-                    dht_store.clone(),
+                    extra_dht_store,
                     keystore.clone(),
                     bob.clone(),
                 )
@@ -3035,6 +3044,61 @@ mod tests {
             "expected at least one ChainOpPublish row with withhold_publish=1 \
              after countersigning flush, got 0"
         );
+    }
+
+    /// Verify that [`SourceChain::new`] reads the chain head from the DHT store, not the
+    /// authored DB.
+    ///
+    /// Design: after genesis + one flush, we construct a *fresh* authored DB (empty — nothing
+    /// written to it). The DHT store still holds all written data. If `new` reads from the
+    /// authored DB the construction will fail with `ChainEmpty`; if it reads from the DHT
+    /// store it will succeed and return the correct head.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn chain_head_read_from_store() -> SourceChainResult<()> {
+        let TestCase {
+            chain,
+            agent_key: alice,
+            dht: dht_db,
+            dht_store,
+            keystore,
+            ..
+        } = TestCase::new().await;
+
+        // Author one action and flush it so the DHT store has a head beyond genesis.
+        let storage_arcs = vec![DhtArc::Empty];
+        chain
+            .put_weightless(
+                builder::CloseChain { new_target: None },
+                None,
+                ChainTopOrdering::Strict,
+            )
+            .await?;
+        let (flushed_actions, _) = chain.flush(storage_arcs).await?;
+        let expected_head = flushed_actions
+            .last()
+            .expect("flush must return at least one action")
+            .as_hash()
+            .clone();
+
+        // Construct a fresh authored DB that has never had genesis written to it.
+        // - Old code (`vault.read_async(chain_head_db_nonempty)`): fails with `ChainEmpty`.
+        // - New code (`dht_store.chain_head_for_author(...)`): succeeds.
+        let fresh_authored = test_authored_db();
+        let chain2 = SourceChain::new(
+            fresh_authored.to_db(),
+            dht_db.to_db(),
+            dht_store.clone(),
+            keystore,
+            alice,
+        )
+        .await?;
+
+        assert_eq!(
+            chain2.persisted_head_info().map(|h| h.action),
+            Some(expected_head),
+        );
+
+        Ok(())
     }
 
     struct TestCase {

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -1633,6 +1633,8 @@ pub type CurrentCountersigningSessionOpt = Option<(Record, EntryHash, CounterSig
 
 /// Check if there is a current countersigning session and if so, return the
 /// session data and the entry hash.
+// #5370: kept for the legacy authored path; retire with DbKindAuthored. The
+// merged-store equivalent is `DhtStore::current_countersigning_session`.
 pub fn current_countersigning_session(
     txn: &Txn<DbKindAuthored>,
 ) -> SourceChainResult<CurrentCountersigningSessionOpt> {

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -1,5 +1,5 @@
 use crate::chain_lock::ChainLock;
-// #5370: import kept (function still used by callers) pending DbKindDht retirement.
+// #5370: import retained pending DbKindDht retirement.
 #[allow(unused_imports)]
 use crate::integrate::authored_ops_to_dht_db;
 use crate::prelude::*;
@@ -59,8 +59,7 @@ pub type SourceChainRead = SourceChain<DbRead<DbKindAuthored>, DbRead<DbKindDht>
 impl SourceChain {
     #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
     pub async fn unlock_chain(&self) -> SourceChainResult<()> {
-        // #5370: the chain lock now lives in the merged store, not the legacy
-        // authored DB.
+        // The chain lock lives in the DhtStore.
         self.dht_store
             .release_chain_lock(self.author.as_ref())
             .await?;
@@ -86,8 +85,7 @@ impl SourceChain {
         // Check for a chain lock.
         // Note that the lock may not be valid anymore, but we must respect it here anyway.
         // `get_chain_lock` returns any lock row, including an expired one, so an
-        // expired lock still rejects acceptance exactly as the legacy authored-DB
-        // path did.
+        // expired lock still rejects acceptance.
         if self
             .dht_store
             .as_read()
@@ -276,9 +274,8 @@ impl SourceChain {
     ///   entry is written without an active chain lock.
     #[async_recursion]
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
-    // #5370: `storage_arcs` is now only used in the recursive call after the
-    // legacy DhtOp authored-ops dual-write was removed; restored when that
-    // write path is fully retired.
+    // #5370: `storage_arcs` is only used in the recursive call; retained for
+    // the authored-ops write path.
     #[allow(clippy::only_used_in_recursion)]
     pub async fn flush(
         &self,
@@ -328,7 +325,7 @@ impl SourceChain {
 
         let now = Timestamp::now();
 
-        // Acquire the per-author chain write permit on the merged store and
+        // Acquire the per-author chain write permit on the DhtStore and
         // perform the source-chain write under it, gated by an as-at check
         // against the store head. The permit serializes flushes for this
         // (DNA, author) chain so a concurrent flush cannot also pass the
@@ -344,11 +341,10 @@ impl SourceChain {
                 .await;
 
             // If there are records to write, then we need to respect the chain
-            // lock. #5370: the lock now lives in the merged store. Reading it
-            // here opens a tiny TOCTOU window (the lock is mutated by the
-            // countersigning workflow, not by flush, so the chain permit does
-            // not stabilise it), but this is a coarse countersigning-session
-            // guard and the window is acceptable.
+            // lock. Reading it here opens a tiny TOCTOU window (the lock is
+            // mutated by the countersigning workflow, not by flush, so the
+            // chain permit does not stabilise it), but this is a coarse
+            // countersigning-session guard and the window is acceptable.
             if !records.is_empty() {
                 let chain_lock = self
                     .dht_store
@@ -404,7 +400,7 @@ impl SourceChain {
             }
 
             // The authoritative source-chain write: entries, actions, ops and
-            // scheduled fns into the merged store, in one transaction.
+            // scheduled fns into the DhtStore, in one transaction.
             let mut tx = self
                 .dht_store
                 .db()
@@ -587,11 +583,8 @@ impl SourceChain {
                 }
             }
             Ok(actions) => {
-                // #5370: legacy DhtOp authored-ops dual-write removed; authored
-                // ops are written to the DhtStore in the permit-scoped block
-                // above (insert_chain_op + ChainOpPublish). `authored_ops_to_dht_db`,
-                // `ops_to_integrate` and the `dht_db` input remain as dead code
-                // pending DbKindDht retirement.
+                // #5370: `authored_ops_to_dht_db`, `ops_to_integrate` and the
+                // `dht_db` input are dead code pending DbKindDht retirement.
                 let _ = &ops_to_integrate;
 
                 // Insert warrants into DHT database.
@@ -617,13 +610,13 @@ impl SourceChain {
                     }
                 }
 
-                // Write warrants to DHT database (legacy) and collect the
-                // successfully-inserted ops for mirroring into the new DhtStore.
+                // Write warrants to the DHT database and collect the
+                // successfully-inserted ops to insert into the DhtStore.
                 let (total_inserted_warrants, warrant_ops_for_new_db) = match self
                     .dht_db
-                    // #5370: legacy DhtOp warrant dual-write removed; the
-                    // `_txn` input and `insert_op_dht` are dead. Warrants are
-                    // mirrored into the DhtStore below.
+                    // #5370: the `_txn` input and `insert_op_dht` are dead
+                    // pending DbKindDht retirement. Warrants are inserted into
+                    // the DhtStore below.
                     .write_async(|_txn| -> DatabaseResult<(u32, Vec<DhtOpHashed>)> {
                         let mut inserted_warrants = 0u32;
                         let mut inserted_ops: Vec<DhtOpHashed> = Vec::new();
@@ -675,8 +668,6 @@ impl SourceChain {
     ///
     /// Valid means that there's no [`Update`] or [`Delete`] action for the key on the chain.
     /// Returns the create action if it is valid, and an [`SourceChainError::InvalidAgentKey`] otherwise.
-    // #5370: reads the agent's valid key-create from the merged store instead
-    // of the legacy authored DB (`SELECT_VALID_AGENT_PUB_KEY`).
     pub async fn valid_create_agent_key_action(&self) -> SourceChainResult<Action> {
         let agent_key = self.agent_pubkey().clone();
         self.dht_store
@@ -886,12 +877,9 @@ where
             return Ok(Some(author_grant));
         }
 
-        // Remote caller. #5370: the candidate grants are read from the merged
-        // store instead of the legacy authored DB
-        // (`SELECT_VALID_CAP_GRANT_FOR_CAP_SECRET` /
-        // `SELECT_VALID_UNRESTRICTED_CAP_GRANT`). The store read applies the
-        // same access-type pre-filter and "not updated/deleted" exclusion as the
-        // legacy SQL; the exact secret/assignee/function match remains the
+        // Remote caller. The candidate grants are read from the DhtStore, which
+        // applies the access-type pre-filter and "not updated/deleted"
+        // exclusion; the exact secret/assignee/function match remains the
         // authority of `CapGrant::is_valid` below.
         let cap_grants = self
             .dht_store
@@ -915,22 +903,19 @@ where
     pub async fn query(&self, query: QueryFilter) -> SourceChainResult<Vec<Record>> {
         let public_only = self.public_only;
 
-        // #5370: the source chain is now read from the merged store, not the
-        // legacy authored DB. Fetch the author's committed records (no
-        // filtering applied here). Ordering and filtering are handled below to
-        // exactly match the legacy authored-DB query, whose final authority was
-        // also `ChainQueryFilter::filter_records` (the SQL pre-filtering there
-        // was only an optimisation over the same `filter_records`).
+        // Fetch the author's committed records from the DhtStore (no filtering
+        // applied here). Ordering and filtering are handled below;
+        // `ChainQueryFilter::filter_records` is the final authority.
         let mut records = self
             .dht_store
             .as_read()
             .source_chain_records(self.author.as_ref(), query.include_entries, public_only)
             .await?;
 
-        // The store returns committed records in ascending sequence order. The
-        // legacy SQL applied `order_descending` to the committed records only
-        // (the scratch was always appended in ascending order below), so mirror
-        // that here by reversing the committed records for a descending query.
+        // The store returns committed records in ascending sequence order.
+        // `order_descending` applies to the committed records only (the scratch
+        // is always appended in ascending order below), so reverse the
+        // committed records for a descending query.
         if query.order_descending {
             records.reverse();
         }
@@ -956,7 +941,7 @@ where
     }
 
     pub async fn get_chain_lock(&self) -> SourceChainResult<Option<ChainLock>> {
-        // #5370: the chain lock now lives in the merged store.
+        // The chain lock lives in the DhtStore.
         Ok(self
             .dht_store
             .as_read()
@@ -1135,10 +1120,10 @@ pub async fn genesis(
     let (agent_action, agent_entry) = agent_record.clone().into_inner();
     let agent_entry = agent_entry.into_option();
 
-    // Pre-compute (op, op_hash, timestamp) tuples for the new-DB write block.
+    // Pre-compute (op, op_hash, timestamp) tuples for the DhtStore write block.
     // This matches what put_raw does internally via ChainOpUniqueForm::op_hash,
     // but done upfront so we can keep the actions and ops available for the
-    // new-DB write without moving them into the legacy closure.
+    // DhtStore write without moving them into the dht_db closure.
     //
     // Each triple is (ChainOpLite, DhtOpHash, Timestamp) for one op.
     let mut ops_with_hashes_for_new_db: Vec<(ChainOpLite, DhtOpHash, Timestamp)> = Vec::new();
@@ -1167,27 +1152,23 @@ pub async fn genesis(
         }
     }
 
-    // Clone the actions and agent entry for the new-DB write block.
-    // #5370: the originals are no longer moved into a legacy authored write
-    // (that write has been removed); the clones feed the store-mirror block
-    // below unchanged.
+    // Clone the actions and agent entry for the DhtStore write block below.
     let dna_action_for_new_db = dna_action.clone();
     let agent_validation_action_for_new_db = agent_validation_action.clone();
     let agent_action_for_new_db = agent_action.clone();
-    // `agent_entry` is `Option<Entry>`; clone it for the store-mirror block.
+    // `agent_entry` is `Option<Entry>`; clone it for the DhtStore write block.
     let agent_entry_for_new_db = agent_entry.clone();
     // Entry hash for the agent entry (AgentPubKey → EntryHash via Into).
     let agent_entry_hash: EntryHash = agent_pubkey.into();
 
-    // #5370: the legacy authored-DB genesis write has been removed. The genesis
-    // actions, the agent entry and their ops are now written solely to the
-    // merged DhtStore in the block below. `put_raw`,
+    // The genesis actions, the agent entry and their ops are written to the
+    // DhtStore in the block below. #5370: `put_raw`,
     // `authored_ops_to_dht_db_without_check` and the `authored` / `dht_db`
-    // inputs remain dead pending DbKindAuthored / DbKindDht retirement.
+    // inputs are dead pending DbKindAuthored / DbKindDht retirement.
     let _ = &authored;
     let _ = &dht_db;
 
-    // Write the genesis actions, entries and ops to the new holochain_data DHT DB.
+    // Write the genesis actions, entries and ops to the DhtStore.
     {
         let mut tx = dht_store
             .db()
@@ -1268,8 +1249,7 @@ pub async fn genesis(
 
 /// Should only be used to put items into the Authored DB.
 /// Hash transfer fields (source, transfer_method, transfer_time) are not set.
-// #5370: production-unused after the genesis authored-DB write was removed;
-// retained pending DbKindAuthored retirement.
+// #5370: production-unused pending DbKindAuthored retirement.
 pub fn put_raw(
     txn: &mut Transaction,
     shh: SignedActionHashed,
@@ -1321,8 +1301,7 @@ pub type CurrentCountersigningSessionOpt = Option<(Record, EntryHash, CounterSig
 
 /// Check if there is a current countersigning session and if so, return the
 /// session data and the entry hash.
-// #5370: kept for the legacy authored path; retire with DbKindAuthored. The
-// merged-store equivalent is `DhtStore::current_countersigning_session`.
+// #5370: dead once DbKindAuthored is retired.
 pub fn current_countersigning_session(
     txn: &Txn<DbKindAuthored>,
 ) -> SourceChainResult<CurrentCountersigningSessionOpt> {
@@ -1348,17 +1327,15 @@ pub fn current_countersigning_session(
     }
 }
 
-/// Dump the entire source chain from the merged DHT store.
+/// Dump the entire source chain from the DhtStore.
 ///
-/// Reads from the merged per-DNA `holochain_data` store rather than the legacy
-/// authored database. Private entries are included — the query looks in both
-/// the public `Entry` table and the author's `PrivateEntry` table — so the
-/// dump faithfully reflects the author's own chain. `published_ops_count` is
-/// the number of integrated ops that have been published at least once.
+/// Private entries are included — the query looks in both the public `Entry`
+/// table and the author's `PrivateEntry` table — so the dump faithfully
+/// reflects the author's own chain. `published_ops_count` is the number of
+/// integrated ops that have been published at least once.
 ///
 /// This is the production path backing the admin `DumpState` and `DumpFullState`
 /// APIs. It is **not** gated behind `inspection` or `test_utils`.
-// #5370: `vault` (DbRead<DbKindAuthored>) parameter removed; reads the merged store.
 #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
 pub async fn dump_state(
     dht_store: &DhtStoreRead,
@@ -1413,10 +1390,8 @@ fn cap_grant_index_params(
         CapAccess::Transferable { .. } => 1_i64,
         CapAccess::Assigned { .. } => 2_i64,
     };
-    // Deliberate empty→NULL normalisation: the new schema stores an absent tag
-    // as NULL rather than an empty string (the legacy DB stores ""). This is a
-    // behavioural difference that becomes visible at read-cutover and must be
-    // accounted for when reads switch to the new DB.
+    // Deliberate empty→NULL normalisation: the schema stores an absent tag as
+    // NULL rather than an empty string.
     let tag = if cap_grant.tag.is_empty() {
         None
     } else {
@@ -1426,11 +1401,9 @@ fn cap_grant_index_params(
     Some((cap_access_i64, tag))
 }
 
-/// Serialize `None` as an `Option<Schedule>` blob — the same encoding that
-/// the legacy `schedule_fn` mutation uses when `maybe_schedule` is `None`.
+/// Serialize `None` as an `Option<Schedule>` blob.
 ///
-/// In the legacy code (`mutations.rs::schedule_fn`), `None` is serialized via
-/// `to_blob::<Option<Schedule>>(&None)`, which calls
+/// `None` is serialized via
 /// `holochain_serialized_bytes::encode(&None::<Schedule>)`.
 fn serialize_maybe_schedule_none(
 ) -> Result<Vec<u8>, holochain_serialized_bytes::SerializedBytesError> {
@@ -1539,8 +1512,7 @@ mod tests {
 
         let storage_arcs = vec![DhtArc::Empty];
         chain_1.flush(storage_arcs.clone()).await?;
-        // #5370: the source chain is now written to the merged store, not the
-        // authored DB, so the head is read from the store.
+        // Read the chain head from the DhtStore.
         let seq = dht_store
             .as_read()
             .chain_head_for_author(&alice)
@@ -1553,8 +1525,7 @@ mod tests {
             chain_2.flush(storage_arcs.clone()).await,
             Err(SourceChainError::HeadMoved(_, _, _, _))
         ));
-        // #5370: the source chain is now written to the merged store, not the
-        // authored DB, so the head is read from the store.
+        // Read the chain head from the DhtStore.
         let seq = dht_store
             .as_read()
             .chain_head_for_author(&alice)
@@ -1564,8 +1535,7 @@ mod tests {
         assert_eq!(seq, 3);
 
         chain_3.flush(storage_arcs).await?;
-        // #5370: the source chain is now written to the merged store, not the
-        // authored DB, so the head is read from the store.
+        // Read the chain head from the DhtStore.
         let seq = dht_store
             .as_read()
             .chain_head_for_author(&alice)
@@ -1644,8 +1614,7 @@ mod tests {
 
         let storage_arcs = vec![DhtArc::Empty];
         chain_1.flush(storage_arcs.clone()).await?;
-        // #5370: the source chain is now written to the merged store, not the
-        // authored DB, so the head is read from the store.
+        // Read the chain head from the DhtStore.
         let seq = dht_store
             .as_read()
             .chain_head_for_author(&alice)
@@ -1660,7 +1629,7 @@ mod tests {
         ));
 
         chain_3.flush(storage_arcs).await?;
-        // #5370: the head is read from the merged store, not the authored DB.
+        // Read the chain head from the DhtStore.
         let head = dht_store
             .as_read()
             .chain_head_for_author(&alice)
@@ -1671,9 +1640,9 @@ mod tests {
         assert_ne!(head.action, old_h2);
         assert_eq!(head.seq, 4);
 
-        // #5370: the full records are read from the merged store. h1 is public;
-        // h2 (the head) is a private entry, so the author key is passed so the
-        // store attaches the author's `PrivateEntry`.
+        // The full records are read from the DhtStore. h1 is public; h2 (the
+        // head) is a private entry, so the author key is passed so the store
+        // attaches the author's `PrivateEntry`.
         let h1_record_entry_fetched = dht_store
             .as_read()
             .retrieve_record(&h1, Some(&alice))
@@ -1694,7 +1663,7 @@ mod tests {
         Ok(())
     }
 
-    // The genesis agent-key `Create` is read back from the merged store as the
+    // The genesis agent-key `Create` is read back from the DhtStore as the
     // valid agent-key action.
     #[tokio::test(flavor = "multi_thread")]
     async fn valid_create_agent_key_action_reads_from_store() {
@@ -2267,8 +2236,7 @@ mod tests {
             .unwrap();
         source_chain.flush(vec![DhtArc::Empty]).await.unwrap();
 
-        // #5370: the source chain is now written to the merged store, not the
-        // authored DB, so the head and full records are read from the store.
+        // The head and full records are read from the DhtStore.
         let head = dht_store
             .as_read()
             .chain_head_for_author(author.as_ref())
@@ -2307,10 +2275,9 @@ mod tests {
         Ok(())
     }
 
-    /// #5370: genesis writes to the merged store only (the legacy authored-DB
-    /// write was removed). After `genesis`, the store reports the author has
-    /// genesis, the chain head is the seq-2 AgentId `Create`, and the head
-    /// record is retrievable from the store.
+    /// After `genesis`, the store reports the author has done genesis, the
+    /// chain head is the seq-2 AgentId `Create`, and the head record is
+    /// retrievable from the store.
     #[tokio::test(flavor = "multi_thread")]
     async fn genesis_writes_to_merged_store() -> SourceChainResult<()> {
         holochain_trace::test_run();
@@ -2630,7 +2597,7 @@ mod tests {
             visibility: EntryVisibility::Public,
         });
 
-        // Commit a Create with a PRIVATE entry to the merged store via flush.
+        // Commit a Create with a PRIVATE entry to the DhtStore via flush.
         let chain_top = chain.chain_head_nonempty().unwrap();
         let private_entry_hashed = EntryHashed::from_content_sync(Entry::App(fixt!(AppEntryBytes)));
         let private_create = Action::Create(Create {
@@ -2781,7 +2748,7 @@ mod tests {
         let warrantee = fixt!(AgentPubKey);
 
         // The warrant is authored by `agent_key` (the warrant issuer). Read it
-        // back via the DhtStore (limbo + integrated) rather than the legacy DB.
+        // back via the DhtStore (limbo + integrated).
         let actual_warrants = dht_store
             .as_read()
             .warrants_by_author(agent_key.clone())
@@ -3059,10 +3026,10 @@ mod tests {
         Ok(())
     }
 
-    /// #5370: the flush as-at now reads the *merged store* head, not the legacy
-    /// authored DB. Two source chains for the same author share the store; once
-    /// one flushes, the other's stale `persisted_head` must be detected as
-    /// `HeadMoved`, and a normal flush's action must be visible via the store.
+    /// The flush as-at check reads the store head. Two source chains for the
+    /// same author share the store; once one flushes, the other's stale
+    /// `persisted_head` must be detected as `HeadMoved`, and a normal flush's
+    /// action must be visible via the store.
     #[tokio::test(flavor = "multi_thread")]
     async fn flush_as_at_detects_head_moved_against_store() -> SourceChainResult<()> {
         let TestCase {
@@ -3108,7 +3075,7 @@ mod tests {
             .expect("store head present after flush");
         assert_eq!(store_head.action, flushed_head);
 
-        // chain_2's persisted_head is now stale; a strict flush must detect the
+        // chain_2's persisted_head is stale; a strict flush must detect the
         // moved store head and fail with HeadMoved.
         assert_matches!(
             chain_2.flush(vec![DhtArc::Empty]).await,

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -331,72 +331,87 @@ impl SourceChain {
             .map(|op| (op.1.clone(), op.0.dht_basis()))
             .collect::<Vec<_>>();
 
-        // Write the entries, actions and ops to the database in one transaction.
         let author = self.author.clone();
         let persisted_head = self.head_info.as_ref().map(|h| h.action.clone());
 
         let now = Timestamp::now();
 
-        // Snapshots reused by the new-DB write block after the legacy closure
-        // consumes the originals; these clones are cheap
-        // (Vec<HoloHashed<_>> / Vec<ScheduledFn>).
-        let entries_for_new_db = entries.clone();
-        let actions_for_new_db = actions.clone();
-        let ops_for_new_db = ops.clone();
-        let scheduled_fns_for_new_db = scheduled_fns.clone();
+        // #5370: clones reused by the authoritative merged-store write below,
+        // after the transitional authored dual-write consumes the originals.
+        // The authored dual-write — and therefore these clones — is kept only
+        // until the source-chain *readers* that still query the legacy authored
+        // DB are migrated to the merged store: `SourceChain::query`,
+        // `valid_cap_grant`, `valid_create_agent_key_action` /
+        // `delete_valid_agent_pub_key`, and `zomes_initialized`. Cheap clones
+        // (`Vec<HoloHashed<_>>` / `Vec<ScheduledFn>`).
+        let entries_for_authored = entries.clone();
+        let actions_for_authored = actions.clone();
+        let ops_for_authored = ops.clone();
+        let scheduled_fns_for_authored = scheduled_fns.clone();
 
-        // Take out a write lock as late as possible, after doing everything we can in memory and
-        // before starting any database read/write operations.
-        let write_permit = self.vault.acquire_write_permit().await?;
-
-        // If there are records to write, then we need to respect the chain lock.
-        // #5370: the lock now lives in the merged store. Reading it here (outside
-        // the authored write txn) opens a tiny TOCTOU window, but this is a coarse
-        // countersigning-session guard and the window is acceptable.
-        if !records.is_empty() {
-            let chain_lock = self
+        // Acquire the per-author chain write permit on the merged store and
+        // perform the source-chain write under it, gated by an as-at check
+        // against the store head. The permit serializes flushes for this
+        // (DNA, author) chain so a concurrent flush cannot also pass the
+        // as-at and fork the chain.
+        //
+        // The permit is acquired and released *inside* this async block so it
+        // is not held when the relaxed-ordering rebase below recurses into
+        // `flush` (which re-acquires it).
+        let chain_flush_result: SourceChainResult<Vec<SignedActionHashed>> = async {
+            let _chain_write_permit = self
                 .dht_store
-                .as_read()
-                .get_chain_lock(author.as_ref().clone())
-                .await?;
-            match chain_lock {
-                Some(chain_lock) => {
-                    // If the chain is locked, the lock must be for this entry.
-                    if chain_lock.subject() != lock_subject {
-                        return Err(SourceChainError::ChainLocked);
-                    }
-                    // If the lock is expired then we can't write this countersigning session.
-                    else if chain_lock.is_expired_at(now) {
-                        return Err(SourceChainError::LockExpired);
-                    }
+                .acquire_chain_write_permit(author.as_ref())
+                .await;
 
-                    // Otherwise, the lock matches this entry and has not expired. We can proceed!
-                }
-                None => {
-                    // If this is a countersigning entry but there is no chain lock then maybe
-                    // the session expired before the entry could be written or maybe the app
-                    // has just made a mistake. Either way, it's not valid to write this entry!
-                    if is_countersigning_session {
-                        return Err(SourceChainError::CountersigningWriteWithoutSession);
+            // If there are records to write, then we need to respect the chain
+            // lock. #5370: the lock now lives in the merged store. Reading it
+            // here opens a tiny TOCTOU window (the lock is mutated by the
+            // countersigning workflow, not by flush, so the chain permit does
+            // not stabilise it), but this is a coarse countersigning-session
+            // guard and the window is acceptable.
+            if !records.is_empty() {
+                let chain_lock = self
+                    .dht_store
+                    .as_read()
+                    .get_chain_lock(author.as_ref().clone())
+                    .await?;
+                match chain_lock {
+                    Some(chain_lock) => {
+                        // If the chain is locked, the lock must be for this entry.
+                        if chain_lock.subject() != lock_subject {
+                            return Err(SourceChainError::ChainLocked);
+                        }
+                        // If the lock is expired then we can't write this countersigning session.
+                        else if chain_lock.is_expired_at(now) {
+                            return Err(SourceChainError::LockExpired);
+                        }
+
+                        // Otherwise, the lock matches this entry and has not expired. We can proceed!
+                    }
+                    None => {
+                        // If this is a countersigning entry but there is no chain lock then maybe
+                        // the session expired before the entry could be written or maybe the app
+                        // has just made a mistake. Either way, it's not valid to write this entry!
+                        if is_countersigning_session {
+                            return Err(SourceChainError::CountersigningWriteWithoutSession);
+                        }
                     }
                 }
             }
-        }
 
-        let chain_flush_result = self
-            .vault
-            .write_async_with_permit(write_permit, move |txn| {
-                for scheduled_fn in scheduled_fns {
-                    schedule_fn(txn, author.as_ref(), scheduled_fn, None, now)?;
-                }
-
-                if actions.last().is_none() {
-                    // Nothing to write
-                    return Ok(Vec::new());
-                }
-
-                // As at check.
-                let head_info = chain_head_db(txn)?;
+            // As-at check against the STORE head, under the permit, before the
+            // write. Only meaningful when there are actions that move the head.
+            // The permit guarantees no concurrent flush commits between this
+            // read and the write below, and no other code path writes this
+            // author's chain head, so reading on a pool connection (rather than
+            // inside `tx`) is safe.
+            if !actions.is_empty() {
+                let head_info = self
+                    .dht_store
+                    .as_read()
+                    .chain_head_for_author(author.as_ref())
+                    .await?;
                 let latest_head = head_info.as_ref().map(|h| h.action.clone());
 
                 if persisted_head != latest_head {
@@ -407,24 +422,187 @@ impl SourceChain {
                         head_info,
                     ));
                 }
+            }
 
-                for entry in entries {
-                    insert_entry(txn, entry.as_hash(), entry.as_content())?;
-                }
-                for shh in actions.iter() {
-                    insert_action(txn, shh)?;
-                }
-                for (op, op_hash, op_order, timestamp, _dep) in &ops {
-                    insert_op_lite_into_authored(txn, op, op_hash, op_order, timestamp)?;
-                    // If this is a countersigning session we want to withhold
-                    // publishing the ops until the session is successful.
-                    if is_countersigning_session {
-                        set_withhold_publish(txn, op_hash)?;
+            // #5370: transitional authored source-chain dual-write. The merged
+            // store below is the authority for serialization (the chain permit)
+            // and the as-at, but the legacy authored DB is still written because
+            // production source-chain readers — `SourceChain::query`,
+            // `valid_cap_grant`, `valid_create_agent_key_action` /
+            // `delete_valid_agent_pub_key`, and `zomes_initialized` — still query
+            // it. This write is no longer guarded by its own as-at; the store
+            // as-at above (under the chain permit) gates it. Remove once those
+            // readers are migrated to the merged store.
+            {
+                let author = author.clone();
+                self.vault
+                    .write_async(move |txn| -> SourceChainResult<()> {
+                        for scheduled_fn in scheduled_fns_for_authored {
+                            schedule_fn(txn, author.as_ref(), scheduled_fn, None, now)?;
+                        }
+                        for entry in entries_for_authored {
+                            insert_entry(txn, entry.as_hash(), entry.as_content())?;
+                        }
+                        for shh in actions_for_authored.iter() {
+                            insert_action(txn, shh)?;
+                        }
+                        for (op, op_hash, op_order, timestamp, _dep) in &ops_for_authored {
+                            insert_op_lite_into_authored(txn, op, op_hash, op_order, timestamp)?;
+                            // If this is a countersigning session we want to
+                            // withhold publishing the ops until the session is
+                            // successful.
+                            if is_countersigning_session {
+                                set_withhold_publish(txn, op_hash)?;
+                            }
+                        }
+                        Ok(())
+                    })
+                    .await?;
+            }
+
+            // The authoritative source-chain write: entries, actions, ops and
+            // scheduled fns into the merged store, in one transaction.
+            let mut tx = self
+                .dht_store
+                .db()
+                .begin()
+                .await
+                .map_err(SourceChainError::other)?;
+
+            // Collect the set of entry hashes whose authoring action declares
+            // them as private. Entries whose hash matches one of these go to
+            // `PrivateEntry`; every other entry — including any whose hash is
+            // not referenced by an in-batch action — goes to the public `Entry`
+            // table.
+            let private_entry_hashes = actions
+                .iter()
+                .filter_map(|sah| {
+                    let action = sah.action();
+                    let visibility = action.entry_visibility()?;
+                    if *visibility == EntryVisibility::Private {
+                        action.entry_hash().cloned()
+                    } else {
+                        None
                     }
+                })
+                .collect::<std::collections::HashSet<_>>();
+
+            for entry_hashed in &entries {
+                let entry_hash = entry_hashed.as_hash();
+                let entry = entry_hashed.as_content();
+                if private_entry_hashes.contains(entry_hash) {
+                    tx.insert_private_entry(entry_hash, author.as_ref(), entry)
+                        .await
+                        .map_err(SourceChainError::other)?;
+                } else {
+                    tx.insert_entry(entry_hash, entry)
+                        .await
+                        .map_err(SourceChainError::other)?;
                 }
-                SourceChainResult::Ok(actions)
-            })
-            .await;
+            }
+
+            // Track which action hashes were successfully inserted into the
+            // store. Ops whose action insert failed must also be skipped to
+            // avoid FK violations on ChainOp.action_hash.
+            let mut inserted_action_hashes = std::collections::HashSet::<ActionHash>::new();
+
+            for sah in &actions {
+                let new_sah = holochain_zome_types::dht_v2::from_legacy_signed_action(sah);
+
+                tx.insert_action(
+                    &new_sah,
+                    Some(holochain_zome_types::dht_v2::RecordValidity::Accepted),
+                )
+                .await
+                .map_err(SourceChainError::other)?;
+
+                // Record that this action hash is present in the store.
+                inserted_action_hashes.insert(sah.as_hash().clone());
+
+                crate::dht_store::action_indexes::insert_action_indexes(
+                    &mut tx,
+                    new_sah.as_hash(),
+                    &new_sah.hashed.content.data,
+                )
+                .await
+                .map_err(SourceChainError::other)?;
+
+                // For Create/Update of a CapGrant entry type, insert a CapGrant index row.
+                if let Some((cap_access, tag)) = cap_grant_index_params(sah, &entries) {
+                    tx.insert_cap_grant(new_sah.as_hash(), cap_access, tag.as_deref())
+                        .await
+                        .map_err(SourceChainError::other)?;
+                }
+            }
+
+            for (op, op_hash, _op_order, timestamp, _dep) in &ops {
+                let op_as_chain = match op.as_chain_op() {
+                    Some(c) => c,
+                    None => continue, // warrant ops: skip for this slice
+                };
+                // Skip ops whose action hash was not recorded as successfully inserted.
+                if !inserted_action_hashes.contains(op_as_chain.action_hash()) {
+                    continue;
+                }
+                let basis_hash = op_as_chain.dht_basis().clone();
+                let storage_center_loc = basis_hash.get_loc();
+
+                let serialized_size = encoded_chain_op_size(op_as_chain, &actions, &entries);
+                tx.insert_chain_op(holochain_data::dht::InsertChainOp {
+                    op_hash,
+                    action_hash: op_as_chain.action_hash(),
+                    op_type: i64::from(op_as_chain.get_type()),
+                    basis_hash: &basis_hash,
+                    storage_center_loc,
+                    validation_status: holochain_zome_types::dht_v2::RecordValidity::Accepted,
+                    locally_validated: true,
+                    require_receipt: false,
+                    when_received: *timestamp,
+                    when_integrated: *timestamp,
+                    serialized_size,
+                })
+                .await
+                .map_err(SourceChainError::other)?;
+
+                // Always insert a ChainOpPublish row for self-authored ops so the
+                // publish workflow can track them without a separate lookup.
+                // Countersigning ops are withheld from publishing until the
+                // session succeeds.
+                let withhold = if is_countersigning_session {
+                    Some(true)
+                } else {
+                    None
+                };
+                tx.insert_chain_op_publish(op_hash, None, None, withhold)
+                    .await
+                    .map_err(SourceChainError::other)?;
+            }
+
+            // Scheduled functions flushed from the scratch are always written
+            // with `maybe_schedule = None` (see schedule_fn in mutations.rs).
+            // None => start=now, end=Timestamp::max(), ephemeral=true.
+            for scheduled_fn in &scheduled_fns {
+                let maybe_schedule_blob =
+                    serialize_maybe_schedule_none().map_err(SourceChainError::other)?;
+                let _ = tx
+                    .upsert_scheduled_function(holochain_data::dht::InsertScheduledFunction {
+                        author: author.as_ref(),
+                        zome_name: scheduled_fn.zome_name().0.as_ref(),
+                        scheduled_fn: scheduled_fn.fn_name().0.as_ref(),
+                        maybe_schedule: &maybe_schedule_blob,
+                        start_at: now,
+                        end_at: Timestamp::max(),
+                        ephemeral: true,
+                    })
+                    .await
+                    .map_err(SourceChainError::other)?;
+            }
+
+            tx.commit().await.map_err(SourceChainError::other)?;
+
+            SourceChainResult::Ok(actions)
+        }
+        .await;
 
         match chain_flush_result {
             Err(SourceChainError::HeadMoved(actions, entries, old_head, Some(new_head_info))) => {
@@ -465,167 +643,12 @@ impl SourceChain {
                     ))
                 }
             }
-            Ok((actions, permit)) => {
-                drop(permit);
-
-                // Write the authored-side data to the new holochain_data DHT DB.
-                // Strict on failure: if anything here fails, the whole flush fails.
-                {
-                    // `author` was moved into the legacy closure above; re-clone from `self`.
-                    let author = self.author.clone();
-                    let mut tx = self
-                        .dht_store
-                        .db()
-                        .begin()
-                        .await
-                        .map_err(SourceChainError::other)?;
-
-                    // Collect the set of entry hashes whose authoring action declares
-                    // them as private. Entries whose hash matches one of these go to
-                    // `PrivateEntry`; every other entry — including any whose hash is
-                    // not referenced by an in-batch action — goes to the public `Entry`
-                    // table, matching the legacy authored-DB write below.
-                    let private_entry_hashes = actions_for_new_db
-                        .iter()
-                        .filter_map(|sah| {
-                            let action = sah.action();
-                            let visibility = action.entry_visibility()?;
-                            if *visibility == EntryVisibility::Private {
-                                action.entry_hash().cloned()
-                            } else {
-                                None
-                            }
-                        })
-                        .collect::<std::collections::HashSet<_>>();
-
-                    for entry_hashed in &entries_for_new_db {
-                        let entry_hash = entry_hashed.as_hash();
-                        let entry = entry_hashed.as_content();
-                        if private_entry_hashes.contains(entry_hash) {
-                            tx.insert_private_entry(entry_hash, author.as_ref(), entry)
-                                .await
-                                .map_err(SourceChainError::other)?;
-                        } else {
-                            tx.insert_entry(entry_hash, entry)
-                                .await
-                                .map_err(SourceChainError::other)?;
-                        }
-                    }
-
-                    // Track which action hashes were successfully inserted into the new DB.
-                    // Ops whose action insert failed must also be skipped to avoid FK
-                    // violations on ChainOp.action_hash.
-                    let mut inserted_action_hashes = std::collections::HashSet::<ActionHash>::new();
-
-                    for sah in &actions_for_new_db {
-                        let new_sah = holochain_zome_types::dht_v2::from_legacy_signed_action(sah);
-
-                        tx.insert_action(
-                            &new_sah,
-                            Some(holochain_zome_types::dht_v2::RecordValidity::Accepted),
-                        )
-                        .await
-                        .map_err(SourceChainError::other)?;
-
-                        // Record that this action hash is present in the new DB.
-                        inserted_action_hashes.insert(sah.as_hash().clone());
-
-                        crate::dht_store::action_indexes::insert_action_indexes(
-                            &mut tx,
-                            new_sah.as_hash(),
-                            &new_sah.hashed.content.data,
-                        )
-                        .await
-                        .map_err(SourceChainError::other)?;
-
-                        // For Create/Update of a CapGrant entry type, insert a CapGrant index row.
-                        if let Some((cap_access, tag)) =
-                            cap_grant_index_params(sah, &entries_for_new_db)
-                        {
-                            tx.insert_cap_grant(new_sah.as_hash(), cap_access, tag.as_deref())
-                                .await
-                                .map_err(SourceChainError::other)?;
-                        }
-                    }
-
-                    for (op, op_hash, _op_order, timestamp, _dep) in &ops_for_new_db {
-                        let op_as_chain = match op.as_chain_op() {
-                            Some(c) => c,
-                            None => continue, // warrant ops: skip for this slice
-                        };
-                        // Skip ops whose action hash was not recorded as successfully inserted.
-                        if !inserted_action_hashes.contains(op_as_chain.action_hash()) {
-                            continue;
-                        }
-                        let basis_hash = op_as_chain.dht_basis().clone();
-                        let storage_center_loc = basis_hash.get_loc();
-
-                        let serialized_size = encoded_chain_op_size(
-                            op_as_chain,
-                            &actions_for_new_db,
-                            &entries_for_new_db,
-                        );
-                        tx.insert_chain_op(holochain_data::dht::InsertChainOp {
-                            op_hash,
-                            action_hash: op_as_chain.action_hash(),
-                            op_type: i64::from(op_as_chain.get_type()),
-                            basis_hash: &basis_hash,
-                            storage_center_loc,
-                            validation_status:
-                                holochain_zome_types::dht_v2::RecordValidity::Accepted,
-                            locally_validated: true,
-                            require_receipt: false,
-                            when_received: *timestamp,
-                            when_integrated: *timestamp,
-                            serialized_size,
-                        })
-                        .await
-                        .map_err(SourceChainError::other)?;
-
-                        // Always insert a ChainOpPublish row for self-authored ops so the
-                        // publish workflow can track them without a separate lookup.
-                        // Countersigning ops are withheld from publishing until the
-                        // session succeeds.
-                        let withhold = if is_countersigning_session {
-                            Some(true)
-                        } else {
-                            None
-                        };
-                        tx.insert_chain_op_publish(op_hash, None, None, withhold)
-                            .await
-                            .map_err(SourceChainError::other)?;
-                    }
-
-                    // Scheduled functions flushed from the scratch are always written
-                    // with `maybe_schedule = None` (see schedule_fn in mutations.rs).
-                    // None => start=now, end=Timestamp::max(), ephemeral=true.
-                    for scheduled_fn in &scheduled_fns_for_new_db {
-                        let maybe_schedule_blob =
-                            serialize_maybe_schedule_none().map_err(SourceChainError::other)?;
-                        let _ = tx
-                            .upsert_scheduled_function(
-                                holochain_data::dht::InsertScheduledFunction {
-                                    author: author.as_ref(),
-                                    zome_name: scheduled_fn.zome_name().0.as_ref(),
-                                    scheduled_fn: scheduled_fn.fn_name().0.as_ref(),
-                                    maybe_schedule: &maybe_schedule_blob,
-                                    start_at: now,
-                                    end_at: Timestamp::max(),
-                                    ephemeral: true,
-                                },
-                            )
-                            .await
-                            .map_err(SourceChainError::other)?;
-                    }
-
-                    tx.commit().await.map_err(SourceChainError::other)?;
-                }
-
+            Ok(actions) => {
                 // #5370: legacy DhtOp authored-ops dual-write removed; authored
-                // ops are written to the DhtStore above (insert_chain_op +
-                // ChainOpPublish). `authored_ops_to_dht_db`, `ops_to_integrate`
-                // and the `dht_db` input remain as dead code pending DbKindDht
-                // retirement.
+                // ops are written to the DhtStore in the permit-scoped block
+                // above (insert_chain_op + ChainOpPublish). `authored_ops_to_dht_db`,
+                // `ops_to_integrate` and the `dht_db` input remain as dead code
+                // pending DbKindDht retirement.
                 let _ = &ops_to_integrate;
 
                 // Insert warrants into DHT database.
@@ -1851,9 +1874,13 @@ mod tests {
 
         let storage_arcs = vec![DhtArc::Empty];
         chain_1.flush(storage_arcs.clone()).await?;
-        let seq = db
-            .write_async(move |txn| chain_head_db_nonempty(txn))
+        // #5370: the source chain is now written to the merged store, not the
+        // authored DB, so the head is read from the store.
+        let seq = dht_store
+            .as_read()
+            .chain_head_for_author(&alice)
             .await?
+            .expect("chain head present after flush")
             .seq;
         assert_eq!(seq, 3);
 
@@ -1861,16 +1888,24 @@ mod tests {
             chain_2.flush(storage_arcs.clone()).await,
             Err(SourceChainError::HeadMoved(_, _, _, _))
         ));
-        let seq = db
-            .write_async(move |txn| chain_head_db_nonempty(txn))
+        // #5370: the source chain is now written to the merged store, not the
+        // authored DB, so the head is read from the store.
+        let seq = dht_store
+            .as_read()
+            .chain_head_for_author(&alice)
             .await?
+            .expect("chain head present after flush")
             .seq;
         assert_eq!(seq, 3);
 
         chain_3.flush(storage_arcs).await?;
-        let seq = db
-            .write_async(move |txn| chain_head_db_nonempty(txn))
+        // #5370: the source chain is now written to the merged store, not the
+        // authored DB, so the head is read from the store.
+        let seq = dht_store
+            .as_read()
+            .chain_head_for_author(&alice)
             .await?
+            .expect("chain head present after flush")
             .seq;
         assert_eq!(seq, 4);
 
@@ -1944,9 +1979,13 @@ mod tests {
 
         let storage_arcs = vec![DhtArc::Empty];
         chain_1.flush(storage_arcs.clone()).await?;
-        let seq = db
-            .write_async(move |txn| chain_head_db_nonempty(txn))
+        // #5370: the source chain is now written to the merged store, not the
+        // authored DB, so the head is read from the store.
+        let seq = dht_store
+            .as_read()
+            .chain_head_for_author(&alice)
             .await?
+            .expect("chain head present after flush")
             .seq;
         assert_eq!(seq, 3);
 
@@ -1956,35 +1995,36 @@ mod tests {
         ));
 
         chain_3.flush(storage_arcs).await?;
-        let head = db
-            .write_async(move |txn| chain_head_db_nonempty(txn))
-            .await?;
+        // #5370: the head is read from the merged store, not the authored DB.
+        let head = dht_store
+            .as_read()
+            .chain_head_for_author(&alice)
+            .await?
+            .expect("chain head present after flush");
 
         // not equal since action hash change due to rebasing
         assert_ne!(head.action, old_h2);
         assert_eq!(head.seq, 4);
 
-        db.read_async(move |txn| -> DatabaseResult<()> {
-            // get the full record
-            let store = CascadeTxnWrapper::from(txn);
-            let h1_record_entry_fetched = store
-                .get_record(&h1.clone().into())
-                .expect("error retrieving")
-                .expect("entry not found")
-                .into_inner()
-                .1;
-            let h2_record_entry_fetched = store
-                .get_record(&head.action.clone().into())
-                .expect("error retrieving")
-                .expect("entry not found")
-                .into_inner()
-                .1;
-            assert_eq!(RecordEntry::Present(entry_1), h1_record_entry_fetched);
-            assert_eq!(RecordEntry::Present(entry_2), h2_record_entry_fetched);
-
-            Ok(())
-        })
-        .await?;
+        // #5370: the full records are read from the merged store. h1 is public;
+        // h2 (the head) is a private entry, so the author key is passed so the
+        // store attaches the author's `PrivateEntry`.
+        let h1_record_entry_fetched = dht_store
+            .as_read()
+            .retrieve_record(&h1, Some(&alice))
+            .await?
+            .expect("h1 record present in store")
+            .into_inner()
+            .1;
+        let h2_record_entry_fetched = dht_store
+            .as_read()
+            .retrieve_record(&head.action, Some(&alice))
+            .await?
+            .expect("h2 record present in store")
+            .into_inner()
+            .1;
+        assert_eq!(RecordEntry::Present(entry_1), h1_record_entry_fetched);
+        assert_eq!(RecordEntry::Present(entry_2), h2_record_entry_fetched);
 
         Ok(())
     }
@@ -2573,22 +2613,26 @@ mod tests {
             entry_hash: private_entry_hash.clone(),
         };
         chain
-            .put_weightless(create, Some(private_entry.clone()), ChainTopOrdering::default())
+            .put_weightless(
+                create,
+                Some(private_entry.clone()),
+                ChainTopOrdering::default(),
+            )
             .await?;
         chain.flush(vec![DhtArc::Empty]).await?;
 
         let dump = dht_store.as_read().dump_source_chain(&agent_key).await?;
 
         // Four records: Dna(0), AgentValidationPkg(1), Create/AgentId(2), Create/Private(3).
-        assert_eq!(dump.records.len(), 4, "expected 4 records after genesis + 1");
+        assert_eq!(
+            dump.records.len(),
+            4,
+            "expected 4 records after genesis + 1"
+        );
 
         // Verify seq order.
         for (i, rec) in dump.records.iter().enumerate() {
-            assert_eq!(
-                rec.action.action_seq(),
-                i as u32,
-                "record {i} out of order"
-            );
+            assert_eq!(rec.action.action_seq(), i as u32, "record {i} out of order");
         }
 
         // The private-entry record (seq 3) must expose its entry.
@@ -3128,6 +3172,65 @@ mod tests {
         assert_eq!(
             chain2.persisted_head_info().map(|h| h.action),
             Some(expected_head),
+        );
+
+        Ok(())
+    }
+
+    /// #5370: the flush as-at now reads the *merged store* head, not the legacy
+    /// authored DB. Two source chains for the same author share the store; once
+    /// one flushes, the other's stale `persisted_head` must be detected as
+    /// `HeadMoved`, and a normal flush's action must be visible via the store.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn flush_as_at_detects_head_moved_against_store() -> SourceChainResult<()> {
+        let TestCase {
+            chain: chain_1,
+            agent_key: alice,
+            authored: db,
+            dht: dht_db,
+            dht_store,
+            keystore,
+        } = TestCase::new().await;
+
+        // A second chain reading the same store head; it goes stale once
+        // chain_1 flushes.
+        let chain_2 = SourceChain::new(
+            db.clone(),
+            dht_db.to_db(),
+            dht_store.clone(),
+            keystore.clone(),
+            alice.clone(),
+        )
+        .await?;
+
+        let action_builder = builder::CloseChain { new_target: None };
+        chain_1
+            .put(action_builder.clone(), None, ChainTopOrdering::Strict)
+            .await?;
+        chain_2
+            .put(action_builder, None, ChainTopOrdering::Strict)
+            .await?;
+
+        // chain_1 flushes: its action becomes the store head and is visible via
+        // the store.
+        let (flushed, _) = chain_1.flush(vec![DhtArc::Empty]).await?;
+        let flushed_head = flushed
+            .last()
+            .expect("flush returns at least one action")
+            .as_hash()
+            .clone();
+        let store_head = dht_store
+            .as_read()
+            .chain_head_for_author(&alice)
+            .await?
+            .expect("store head present after flush");
+        assert_eq!(store_head.action, flushed_head);
+
+        // chain_2's persisted_head is now stale; a strict flush must detect the
+        // moved store head and fail with HeadMoved.
+        assert_matches!(
+            chain_2.flush(vec![DhtArc::Empty]).await,
+            Err(SourceChainError::HeadMoved(_, _, _, _))
         );
 
         Ok(())

--- a/crates/holochain_zome_types/src/record.rs
+++ b/crates/holochain_zome_types/src/record.rs
@@ -27,11 +27,13 @@ impl HashableContent for SignedAction {
     }
 
     fn hashable_content(&self) -> HashableContentBytes {
-        HashableContentBytes::Content(
-            self.action()
-                .try_into()
-                .expect("Could not serialize HashableContent"),
-        )
+        // A `SignedAction` must hash to the same canonical `ActionHash` as its
+        // inner `Action`. #5822 flipped `Action`'s hash to the content-derived
+        // v2 projection but missed this impl, which used to serialize the legacy
+        // action bytes — so hashing a bare `SignedAction` produced a hash that
+        // disagreed with `Action`, `SignedActionHashed`, and every stored
+        // `action_hash`. Delegate to the inner `Action` to keep the identity.
+        self.action().hashable_content()
     }
 }
 

--- a/crates/holochain_zome_types/src/record.rs
+++ b/crates/holochain_zome_types/src/record.rs
@@ -28,11 +28,9 @@ impl HashableContent for SignedAction {
 
     fn hashable_content(&self) -> HashableContentBytes {
         // A `SignedAction` must hash to the same canonical `ActionHash` as its
-        // inner `Action`. #5822 flipped `Action`'s hash to the content-derived
-        // v2 projection but missed this impl, which used to serialize the legacy
-        // action bytes — so hashing a bare `SignedAction` produced a hash that
-        // disagreed with `Action`, `SignedActionHashed`, and every stored
-        // `action_hash`. Delegate to the inner `Action` to keep the identity.
+        // inner `Action`, so delegate to the inner `Action`'s hashable content
+        // to keep the identity consistent with `Action`, `SignedActionHashed`,
+        // and every stored `action_hash`.
         self.action().hashable_content()
     }
 }


### PR DESCRIPTION
## Summary

Moves all source-chain access off the separate per-agent database and onto the per-DNA DHT database, so an agent's authored data and the DHT data it holds share one database — part of consolidating data access into `holochain_data`.

- **Reads** now come from the per-DNA database: chain head, chain lock, source-chain query and dump, HDK `query`, countersigning session recovery, scheduled-function dispatch, and cap-grant / agent-key validation.
- **Writes**: it is the sole source-chain writer, guarded by a per-`(DNA, author)` write permit and an as-at head check to prevent chain forks.
- Integration aggregates each action's validation status onto the record; the committed-chain reads use it.

No user-facing behaviour change. Legacy code left unused by this change is removed in a follow-up.

**Breaking (API):** `DnaStorageInfo` drops its `authored_*` and `cache_*` size fields; authored data is included in the reported DHT size.

Closes #5853
