### PR TITLE
chore: clean up `println!`s and changelog

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.6.2-rc.0
 
-- **BREAKING CHANGE**: Implement the DNA migration design, adding a new `InitProperties` type to be used in the `init_properties` field on `RoleSettings::Provisioned`. The bytes are opaque to the conductor and stored in the conductor database thus never written to the DHT. They are written during the installation and are intended to seed a freshly migrated chain during `init`. They can only be retrieved from the `init` callback via the `get_init_properties` host function and its HDK wrapper. They are cleared upon a successful init or if the associated app is uninstalled. \#5827
+- **BREAKING CHANGE**: Implement the DNA migration design, adding a new `InitProperties` type to be used in the `init_properties` field on `RoleSettings::Provisioned`. The bytes are opaque to the conductor and stored in the conductor database thus never written to the DHT. They are written during the installation and are intended to seed a freshly migrated chain during `init`. They can only be retrieved from the `init` callback via the `get_init_properties` host function and its HDK wrapper. They are cleared upon a successful init. \#5827
 - Make Sweettest documentation available on docs.rs.
 
 ## 0.6.1

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -2924,8 +2924,6 @@ mod accessor_impls {
                     let mut stmt = txn
                         .prepare("DELETE FROM InitProperties WHERE app_id = ? AND role_name = ?")?;
 
-                    println!("Deleting init properties");
-
                     Ok(stmt.execute([&app_id, &role_name])?)
                 })
                 .await?;

--- a/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
+++ b/crates/holochain/src/core/workflow/initialize_zomes_workflow.rs
@@ -70,8 +70,6 @@ where
         // material to outlive the init callback. Do this before post-commit so cleanup is not
         // skipped if `send_post_commit` fails.
 
-        println!("Requesting deletion of init properties");
-
         conductor_handle
             .delete_init_properties_for_cell(&cell_id)
             .await


### PR DESCRIPTION
### Summary

Just some cleanup after #5842 

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs