### PR TITLE
feat(holochain_p2p): add get_agent_activity_multi fan-out call

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## 0.7.0-rc.0
 
+- Added a new `get_agent_activity_multi` p2p call (`HcP2p`, `HolochainP2pDnaT`, and a `CascadeImpl` passthrough): a multi-peer fan-out that returns each authority's `AgentActivityResponse` independently, paired with the responding peer, for use by source-chain restore. Fails with the new `HolochainP2pError::Timeout` when fewer than `min_responses` responses arrive within the timeout. The existing `get_agent_activity` behaviour is unchanged. \#5799
 - **BREAKING CHANGE**: Removed the `transport-iroh` feature flag from `holochain`, `holochain_p2p`, `holochain_cascade`, `holochain_client`, `hc`, `hc_client`, and `hc_sandbox`. The iroh (QUIC) transport is the only network backend and is now compiled in unconditionally rather than gated behind an (on-by-default) optional feature. Downstream crates that built with `default-features = false` and explicitly listed `transport-iroh` must drop it, as the feature no longer exists.
 - Made the workspace crates’ feature flags build independently and removed unused dependencies across the workspace, trimming the dependency tree.
 - **BREAKING CHANGE** `wire_rows_to_v2_ops` is renamed to `wire_rows_to_ops` now that there is no legacy v1 op form to distinguish it from.

--- a/crates/holochain_cascade/src/agent_activity_multi_tests.rs
+++ b/crates/holochain_cascade/src/agent_activity_multi_tests.rs
@@ -1,0 +1,120 @@
+//! Tests for the `get_agent_activity_multi` cascade passthrough.
+
+use super::*;
+use ::fixt::fixt;
+use holo_hash::fixt::AgentPubKeyFixturator;
+use holochain_p2p::actor::GetActivityMultiOptions;
+use holochain_p2p::MockHolochainP2pDnaT;
+use holochain_types::activity::AgentActivityResponse;
+
+async fn empty_store() -> holochain_state::dht_store::DhtStore {
+    let dna_hash = holo_hash::DnaHash::from_raw_36(vec![42u8; 36]);
+    holochain_state::test_utils::test_dht_store(dna_hash).await
+}
+
+/// The cascade forwards the multi call to the network and returns the
+/// per-peer responses untouched: no merging, no cache writes.
+#[tokio::test]
+async fn agent_activity_multi_passes_through_network_responses() {
+    let store = empty_store().await;
+    let queried_agent = fixt!(AgentPubKey);
+    let responder = fixt!(AgentPubKey);
+
+    let canned = vec![(
+        responder.clone(),
+        AgentActivityResponse {
+            agent: queried_agent.clone(),
+            valid_activity: ChainItems::NotRequested,
+            rejected_activity: ChainItems::NotRequested,
+            status: ChainStatus::Empty,
+            highest_observed: None,
+            warrants: Vec::new(),
+        },
+    )];
+
+    let mut network = MockHolochainP2pDnaT::new();
+    let mock_response = canned.clone();
+    network
+        .expect_get_agent_activity_multi()
+        .times(1)
+        .returning(move |_, _, _| Ok(mock_response.clone()));
+
+    let cascade = CascadeImpl::empty(store).with_network(Arc::new(network));
+
+    let responses = cascade
+        .get_agent_activity_multi(
+            queried_agent,
+            ChainQueryFilter::new(),
+            GetActivityMultiOptions::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(responses.len(), 1);
+    assert_eq!(responses[0].0, responder);
+}
+
+/// A network `InsufficientResponses` (fewer than `required_responses`
+/// peers answered with data in time) surfaces as an error instead of
+/// being swallowed. This is the contract restore relies on: unlike
+/// `fetch_agent_activity`, which downgrades some network failures to an
+/// empty result, the multi call must never let a degraded network look
+/// like a valid quorum sample.
+#[tokio::test]
+async fn agent_activity_multi_propagates_insufficient_responses_error() {
+    let store = empty_store().await;
+
+    let mut network = MockHolochainP2pDnaT::new();
+    network
+        .expect_get_agent_activity_multi()
+        .times(1)
+        .returning(|_, _, _| {
+            Err(holochain_p2p::HolochainP2pError::InsufficientResponses {
+                operation: "get_agent_activity_multi".to_string(),
+                received: 1,
+                required: 2,
+            })
+        });
+
+    let cascade = CascadeImpl::empty(store).with_network(Arc::new(network));
+
+    let err = cascade
+        .get_agent_activity_multi(
+            fixt!(AgentPubKey),
+            ChainQueryFilter::new(),
+            GetActivityMultiOptions::default(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            CascadeError::NetworkError(holochain_p2p::HolochainP2pError::InsufficientResponses {
+                received: 1,
+                required: 2,
+                ..
+            })
+        ),
+        "unexpected error: {err:?}"
+    );
+}
+
+/// Without a network handle the call fails loudly instead of returning an
+/// empty vector — restore must never mistake "offline" for "no activity".
+#[tokio::test]
+async fn agent_activity_multi_without_network_errors() {
+    let store = empty_store().await;
+    let cascade = CascadeImpl::empty(store);
+
+    let err = cascade
+        .get_agent_activity_multi(
+            fixt!(AgentPubKey),
+            ChainQueryFilter::new(),
+            GetActivityMultiOptions::default(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, CascadeError::NetworkNotInitialized));
+}

--- a/crates/holochain_cascade/src/fetch.rs
+++ b/crates/holochain_cascade/src/fetch.rs
@@ -253,6 +253,32 @@ impl CascadeImpl {
         Ok(results)
     }
 
+    /// Get agent activity from multiple authorities, returning each
+    /// peer's response independently, paired with the responding peer.
+    ///
+    /// Unlike [`fetch_agent_activity`](Self::fetch_agent_activity), a
+    /// missing network is a hard error and `NoPeersForLocation` is not
+    /// swallowed: the caller must be able to distinguish "no answer"
+    /// from "empty answer".
+    #[cfg_attr(feature = "instrument", tracing::instrument(skip(self, options)))]
+    pub(crate) async fn fetch_agent_activity_multi(
+        &self,
+        agent: AgentPubKey,
+        query: ChainQueryFilter,
+        options: GetActivityMultiOptions,
+    ) -> CascadeResult<Vec<(AgentPubKey, AgentActivityResponse)>> {
+        let network = self
+            .network
+            .as_ref()
+            .ok_or(CascadeError::NetworkNotInitialized)?;
+
+        network
+            .get_agent_activity_multi(agent, query, options)
+            .await
+            .inspect_err(|_| self.record_fetch_error("agent_activity_multi"))
+            .map_err(Into::into)
+    }
+
     /// Fetch hash bounded agent activity from the network.
     #[cfg_attr(feature = "instrument", tracing::instrument(skip(self)))]
     pub(crate) async fn fetch_must_get_agent_activity(

--- a/crates/holochain_cascade/src/lib.rs
+++ b/crates/holochain_cascade/src/lib.rs
@@ -36,7 +36,7 @@ use holo_hash::AgentPubKey;
 use holo_hash::AnyDhtHash;
 use holo_hash::EntryHash;
 use holochain_p2p::actor::GetLinksRequestOptions;
-use holochain_p2p::actor::{GetActivityOptions, NetworkRequestOptions};
+use holochain_p2p::actor::{GetActivityMultiOptions, GetActivityOptions, NetworkRequestOptions};
 use holochain_p2p::{DynHolochainP2pDna, HolochainP2pError};
 use holochain_state::dht_store::DhtStore;
 use holochain_state::host_fn_workspace::HostFnStores;
@@ -807,6 +807,29 @@ impl CascadeImpl {
         Ok(r)
     }
 
+    /// Get agent activity from multiple authorities, returning each
+    /// peer's response independently, paired with the responding peer.
+    ///
+    /// This is a network-only call: responses are not merged, not
+    /// overlaid with local state, and not written to any store, leaving
+    /// callers free to apply their own cross-peer agreement rules. Fails
+    /// with [`CascadeError::NetworkNotInitialized`] when the cascade has
+    /// no network, and with an insufficient-responses error when fewer
+    /// than `options.required_responses` peers answer with data in time.
+    #[cfg_attr(
+        feature = "instrument",
+        tracing::instrument(skip(self, agent, query, options))
+    )]
+    pub async fn get_agent_activity_multi(
+        &self,
+        agent: AgentPubKey,
+        query: ChainQueryFilter,
+        options: GetActivityMultiOptions,
+    ) -> CascadeResult<Vec<(AgentPubKey, AgentActivityResponse)>> {
+        let _guard = self.time_cascade();
+        self.fetch_agent_activity_multi(agent, query, options).await
+    }
+
     /// Looks through a [ChainItems] object and fills in any missing entry data.
     ///
     /// For any [RecordEntry::NotStored] entries, this function will attempt to fetch the entry data
@@ -1011,3 +1034,7 @@ impl Cascade for CascadeImpl {
 /// scratch-only content through the requester-read methods.
 #[cfg(all(test, feature = "test_utils"))]
 mod dht_store_scratch_overlay_tests;
+
+/// Tests for the `get_agent_activity_multi` network passthrough.
+#[cfg(all(test, feature = "test_utils"))]
+mod agent_activity_multi_tests;

--- a/crates/holochain_p2p/src/lib.rs
+++ b/crates/holochain_p2p/src/lib.rs
@@ -187,6 +187,18 @@ pub trait HolochainP2pDnaT: Send + Sync + 'static {
         zome_call_origin: Option<(ZomeName, FunctionName)>,
     ) -> HolochainP2pResult<Vec<AgentActivityResponse>>;
 
+    /// Get agent activity from multiple authorities on the DHT, returning
+    /// each peer's response independently, paired with the responding
+    /// peer.
+    ///
+    /// See [`actor::HcP2p::get_agent_activity_multi`] for semantics.
+    async fn get_agent_activity_multi(
+        &self,
+        agent: AgentPubKey,
+        query: ChainQueryFilter,
+        options: actor::GetActivityMultiOptions,
+    ) -> HolochainP2pResult<Vec<(AgentPubKey, AgentActivityResponse)>>;
+
     /// Get agent activity deterministically from the DHT.
     async fn must_get_agent_activity(
         &self,
@@ -390,6 +402,17 @@ impl HolochainP2pDnaT for HolochainP2pDna {
     ) -> HolochainP2pResult<Vec<AgentActivityResponse>> {
         self.sender
             .get_agent_activity(self.dna_hash(), agent, query, options, zome_call_origin)
+            .await
+    }
+
+    async fn get_agent_activity_multi(
+        &self,
+        agent: AgentPubKey,
+        query: ChainQueryFilter,
+        options: actor::GetActivityMultiOptions,
+    ) -> HolochainP2pResult<Vec<(AgentPubKey, AgentActivityResponse)>> {
+        self.sender
+            .get_agent_activity_multi(self.dna_hash(), agent, query, options)
             .await
     }
 

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -1551,6 +1551,92 @@ where
     }
 }
 
+/// Collects non-empty responses from `futures` until `required_responses`
+/// have arrived, returning as soon as that threshold is met so one slow
+/// peer cannot stall an operation whose threshold is already reached.
+///
+/// Failed futures are logged and skipped. Responses for which `is_empty`
+/// returns true are discarded and do not count towards the threshold: an
+/// "I hold nothing" answer contributes no data to the caller. This
+/// mirrors [`select_ok_non_empty`], except that all `required_responses`
+/// winners are returned instead of just the first.
+///
+/// Fails with [`HolochainP2pError::InsufficientResponses`] when the
+/// threshold cannot be met, either because every future completed
+/// without enough non-empty responses or because `timeout` elapsed
+/// first. Fewer `futures` than `required_responses` fail immediately,
+/// without waiting for the timeout. Note that the error's `received`
+/// count only covers non-empty responses: empty and failed responses
+/// are excluded, and futures still pending when the threshold becomes
+/// unreachable are abandoned without being counted.
+async fn gather_required_responses<I, O>(
+    tag: &'static str,
+    futures: I,
+    required_responses: usize,
+    timeout: Duration,
+    is_empty: fn(&O) -> bool,
+) -> HolochainP2pResult<Vec<O>>
+where
+    I: IntoIterator,
+    I::Item: Future<Output = HolochainP2pResult<O>> + Unpin,
+{
+    let mut futures = futures
+        .into_iter()
+        .collect::<futures::stream::FuturesUnordered<_>>();
+    let mut responses = Vec::with_capacity(required_responses);
+    let mut empty_count = 0_usize;
+    let mut failed_count = 0_usize;
+
+    // A single overall deadline for the gather; per-peer requests carry
+    // their own timeout inside each future.
+    let gather = async {
+        while responses.len() < required_responses {
+            if futures.len() < required_responses - responses.len() {
+                // Not enough pending futures left to ever meet the threshold.
+                break;
+            }
+
+            match futures::StreamExt::next(&mut futures).await {
+                // A peer responded with data.
+                Some(Ok(response)) if !is_empty(&response) => responses.push(response),
+                // A peer responded without holding anything; it contributes
+                // nothing towards the threshold.
+                Some(Ok(_)) => empty_count += 1,
+                // A peer failed or timed out individually; wait for the rest.
+                Some(Err(err)) => {
+                    failed_count += 1;
+                    tracing::debug!(?err, tag, "peer request failed during multi gather");
+                }
+                // All futures have completed.
+                None => break,
+            }
+        }
+    };
+    // The timeout result is deliberately unused: hitting the deadline is
+    // just another way for the gather to stop short of the threshold,
+    // which the check below reports.
+    let _ = tokio::time::timeout(timeout, gather).await;
+
+    if responses.len() < required_responses {
+        tracing::debug!(
+            tag,
+            non_empty = responses.len(),
+            empty = empty_count,
+            failed = failed_count,
+            pending = futures.len(),
+            required = required_responses,
+            "insufficient non-empty responses during multi gather"
+        );
+        return Err(HolochainP2pError::InsufficientResponses {
+            operation: tag.to_string(),
+            received: responses.len(),
+            required: required_responses,
+        });
+    }
+
+    Ok(responses)
+}
+
 impl actor::HcP2p for HolochainP2pActor {
     #[cfg(feature = "test_utils")]
     fn test_kitsune(&self) -> &DynKitsune {
@@ -2238,25 +2324,110 @@ impl actor::HcP2p for HolochainP2pActor {
                         .await
                     })
                 }),
-                |agent_activity| {
-                    matches!(
-                        agent_activity,
-                        AgentActivityResponse {
-                            valid_activity: ChainItems::NotRequested,
-                            rejected_activity: ChainItems::NotRequested,
-                            status: ChainStatus::Empty,
-                            highest_observed: None,
-                            warrants,
-                            ..
-                        } if warrants.is_empty()
-                    )
-                },
+                AgentActivityResponse::is_empty,
             )
             .await;
 
             timing_trace_out!(out, start, a = "send_get_agent_activity");
 
             out.map(|x| vec![x])
+        })
+    }
+
+    fn get_agent_activity_multi(
+        &self,
+        dna_hash: DnaHash,
+        agent: AgentPubKey,
+        query: ChainQueryFilter,
+        options: actor::GetActivityMultiOptions,
+    ) -> BoxFut<'_, HolochainP2pResult<Vec<(AgentPubKey, AgentActivityResponse)>>> {
+        Box::pin(async move {
+            if options.required_responses == 0
+                || options.required_responses > options.target_peer_count
+            {
+                return Err(HolochainP2pError::InvalidRequest(format!(
+                    "required_responses ({}) must be between 1 and target_peer_count ({})",
+                    options.required_responses, options.target_peer_count
+                )));
+            }
+
+            let space_id = dna_hash.to_k2_space();
+            let space = self
+                .kitsune
+                .space_if_exists(space_id.clone())
+                .await
+                .ok_or(HolochainP2pError::K2SpaceNotFound(space_id))?;
+            let loc = agent.get_loc();
+
+            // Only used for peer selection and the per-request timeout;
+            // aggregation is handled by gather_required_responses below.
+            let network_req_options = NetworkRequestOptions {
+                remote_agent_count: options.target_peer_count,
+                timeout_ms: options.timeout_ms,
+                as_race: false,
+            };
+            let agents = self
+                .get_peers_for_location_weighted(
+                    "get_agent_activity_multi",
+                    &space,
+                    loc,
+                    &network_req_options,
+                )
+                .await?;
+
+            let timeout = match options.timeout_ms {
+                Some(ms) => Duration::from_millis(ms),
+                None => self.request_timeout,
+            };
+
+            let start = std::time::Instant::now();
+
+            let r_options = options.remote_options.clone();
+            let out = gather_required_responses(
+                "get_agent_activity_multi",
+                agents.into_iter().map(|(to_agent, to_url)| {
+                    let r_options = r_options.clone();
+                    Box::pin(async {
+                        let (msg_id, req) = WireMessage::get_agent_activity_req(
+                            to_agent.clone(),
+                            agent.clone(),
+                            query.clone(),
+                            r_options,
+                        );
+
+                        let response = self
+                            .send_request(
+                                "get_agent_activity_multi",
+                                &space,
+                                to_url,
+                                msg_id,
+                                req,
+                                dna_hash.clone(),
+                                network_req_options.clone(),
+                                None,
+                                |res| match res {
+                                    WireMessage::GetAgentActivityRes { response, .. } => {
+                                        Ok(response)
+                                    }
+                                    _ => Err(HolochainP2pError::other(format!(
+                                        "invalid response to get_agent_activity_multi: {res:?}"
+                                    ))),
+                                },
+                            )
+                            .await?;
+
+                        Ok((to_agent, response))
+                    })
+                }),
+                options.required_responses as usize,
+                timeout,
+                |(_, response)| response.is_empty(),
+            )
+            .await;
+
+            timing_trace_out!(out, start, a = "send_get_agent_activity_multi");
+
+            out
         })
     }
 
@@ -3954,6 +4125,195 @@ mod tests {
         assert!(
             result.is_err(),
             "PingRes from wrong peer should not resolve the pending ping"
+        );
+    }
+
+    /// No value is considered empty; used by tests that don't exercise
+    /// the empty-response filter.
+    fn never_empty(_: &u8) -> bool {
+        false
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn select_ok_non_empty_prefers_slow_data_over_fast_empty() {
+        // A fast "I hold nothing" reply must not win the race over a
+        // slower peer that actually has data.
+        let futures = vec![
+            Box::pin(async { Ok::<_, HolochainP2pError>(0u8) }) as BoxFut<'static, _>,
+            Box::pin(async {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                Ok(7u8)
+            }),
+        ];
+
+        let out = select_ok_non_empty(futures, |v| *v == 0).await.unwrap();
+        assert_eq!(out, 7);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn select_ok_non_empty_falls_back_to_empty_when_no_data() {
+        // When every peer answers empty, the empty response is still
+        // returned once all futures have completed.
+        let futures = vec![
+            Box::pin(async { Ok::<_, HolochainP2pError>(0u8) }) as BoxFut<'static, _>,
+            Box::pin(async { Err(HolochainP2pError::other("boom")) }),
+        ];
+
+        let out = select_ok_non_empty(futures, |v: &u8| *v == 0)
+            .await
+            .unwrap();
+        assert_eq!(out, 0u8);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gather_required_responses_stops_at_threshold() {
+        let futures = vec![
+            futures::future::ready(Ok::<_, HolochainP2pError>(1u8)),
+            futures::future::ready(Ok(2u8)),
+            futures::future::ready(Ok(3u8)),
+        ];
+
+        let out = gather_required_responses("t", futures, 2, Duration::from_secs(5), never_empty)
+            .await
+            .unwrap();
+        assert_eq!(out.len(), 2, "must stop at the threshold: {out:?}");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gather_required_responses_skips_errors_but_keeps_successes() {
+        let futures = vec![
+            Box::pin(async { Ok::<_, HolochainP2pError>(1u8) }) as BoxFut<'static, _>,
+            Box::pin(async { Err(HolochainP2pError::other("boom")) }),
+            Box::pin(async { Ok(3u8) }),
+        ];
+
+        let mut out =
+            gather_required_responses("t", futures, 2, Duration::from_secs(5), never_empty)
+                .await
+                .unwrap();
+        out.sort();
+        assert_eq!(out, vec![1u8, 3]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gather_required_responses_ignores_empty_responses() {
+        // Zeroes are "empty": they must not count towards the threshold.
+        // With at most one non-empty response available the call must
+        // fail as soon as the threshold becomes unreachable.
+        let futures = vec![
+            Box::pin(async { Ok::<_, HolochainP2pError>(0u8) }) as BoxFut<'static, _>,
+            Box::pin(async { Ok(0u8) }),
+            Box::pin(async { Ok(3u8) }),
+        ];
+
+        let err = gather_required_responses("t", futures, 2, Duration::from_secs(5), |v| *v == 0)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                HolochainP2pError::InsufficientResponses {
+                    received: 0 | 1,
+                    required: 2,
+                    ..
+                }
+            ),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gather_required_responses_collects_past_empty_responses() {
+        // Empty responses are skipped but non-empty ones from other
+        // peers still satisfy the threshold.
+        let futures = vec![
+            Box::pin(async { Ok::<_, HolochainP2pError>(0u8) }) as BoxFut<'static, _>,
+            Box::pin(async { Ok(2u8) }),
+            Box::pin(async { Ok(3u8) }),
+        ];
+
+        let mut out =
+            gather_required_responses("t", futures, 2, Duration::from_secs(5), |v| *v == 0)
+                .await
+                .unwrap();
+        out.sort();
+        assert_eq!(out, vec![2u8, 3]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gather_required_responses_times_out_below_threshold() {
+        // One instant success, one peer that never answers: with
+        // required_responses = 2 the deadline fires and the call must
+        // fail with InsufficientResponses(received = 1, required = 2)
+        // instead of hanging or returning a short vector.
+        let futures = vec![
+            Box::pin(async { Ok::<_, HolochainP2pError>(1u8) }) as BoxFut<'static, _>,
+            Box::pin(std::future::pending()),
+        ];
+
+        let err = gather_required_responses("t", futures, 2, Duration::from_secs(5), never_empty)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                HolochainP2pError::InsufficientResponses {
+                    received: 1,
+                    required: 2,
+                    ..
+                }
+            ),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gather_required_responses_slow_peer_does_not_block_result() {
+        // A peer that never answers must not delay the call at all once
+        // the threshold has been met.
+        let futures = vec![
+            Box::pin(async { Ok::<_, HolochainP2pError>(1u8) }) as BoxFut<'static, _>,
+            Box::pin(std::future::pending()),
+        ];
+
+        let start = tokio::time::Instant::now();
+        let out = gather_required_responses("t", futures, 1, Duration::from_secs(5), never_empty)
+            .await
+            .unwrap();
+        assert_eq!(out, vec![1u8]);
+        assert_eq!(
+            start.elapsed(),
+            Duration::ZERO,
+            "must return without waiting for the slow peer"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn gather_required_responses_fails_fast_with_too_few_futures() {
+        // A single peer can never satisfy a threshold of two: the call
+        // must fail immediately instead of burning the whole timeout.
+        let futures =
+            vec![Box::pin(std::future::pending()) as BoxFut<'static, HolochainP2pResult<u8>>];
+
+        let start = tokio::time::Instant::now();
+        let err = gather_required_responses("t", futures, 2, Duration::from_secs(5), never_empty)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                HolochainP2pError::InsufficientResponses {
+                    received: 0,
+                    required: 2,
+                    ..
+                }
+            ),
+            "unexpected error: {err:?}"
+        );
+        assert_eq!(
+            start.elapsed(),
+            Duration::ZERO,
+            "must fail without waiting for the timeout"
         );
     }
 }

--- a/crates/holochain_p2p/src/types.rs
+++ b/crates/holochain_p2p/src/types.rs
@@ -41,6 +41,24 @@ pub enum HolochainP2pError {
     #[error("The K2 Space {0} does not exist")]
     K2SpaceNotFound(kitsune2_api::SpaceId),
 
+    /// A request is malformed and can never succeed, e.g. because its
+    /// options are contradictory.
+    #[error("InvalidRequest: {0}")]
+    InvalidRequest(String),
+
+    /// A multi-peer request could not gather the required number of
+    /// responses, either because every peer answered without providing
+    /// enough data or because the timeout elapsed first.
+    #[error("{operation}: gathered {received} of {required} required responses")]
+    InsufficientResponses {
+        /// The operation that failed to gather enough responses.
+        operation: String,
+        /// The number of usable responses received.
+        received: usize,
+        /// The number of responses required.
+        required: usize,
+    },
+
     /// Other
     #[error("Other: {0}")]
     Other(Box<dyn std::error::Error + Send + Sync>),

--- a/crates/holochain_p2p/src/types/actor.rs
+++ b/crates/holochain_p2p/src/types/actor.rs
@@ -105,6 +105,44 @@ impl Default for GetActivityOptions {
     }
 }
 
+/// Options for a multi-peer agent activity request.
+///
+/// Unlike [`GetActivityOptions`], which races peers and returns the first
+/// non-empty response, these options control a fan-out that returns every
+/// peer's response independently.
+#[derive(Debug, Clone)]
+pub struct GetActivityMultiOptions {
+    /// Fan out to up to this many authorities near the agent's DHT
+    /// location.
+    pub target_peer_count: u8,
+    /// Number of non-empty responses required for the call to succeed.
+    ///
+    /// The fan-out stops gathering as soon as this many peers have
+    /// answered with data. If fewer arrive before the timeout, the call
+    /// fails with [`HolochainP2pError::InsufficientResponses`] rather
+    /// than returning a short vector. Must be at least 1 and no greater
+    /// than `target_peer_count`.
+    pub required_responses: u8,
+    /// Overall timeout for gathering responses, also applied to each
+    /// per-peer request.
+    ///
+    /// When `None`, the conductor's default request timeout is used.
+    pub timeout_ms: Option<u64>,
+    /// Options forwarded to each remote agent processing the request.
+    pub remote_options: event::GetActivityOptions,
+}
+
+impl Default for GetActivityMultiOptions {
+    fn default() -> Self {
+        Self {
+            target_peer_count: 3,
+            required_responses: 2,
+            timeout_ms: None,
+            remote_options: Default::default(),
+        }
+    }
+}
+
 /// Trait defining the main holochain_p2p interface.
 #[cfg_attr(feature = "test_utils", automock)]
 pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug + Any {
@@ -290,6 +328,27 @@ pub trait HcP2p: 'static + Send + Sync + std::fmt::Debug + Any {
         options: GetActivityOptions,
         zome_call_origin: Option<(ZomeName, FunctionName)>,
     ) -> BoxFut<'_, HolochainP2pResult<Vec<AgentActivityResponse>>>;
+
+    /// Get agent activity from multiple authorities on the DHT.
+    ///
+    /// Fans out to up to `target_peer_count` authorities near the agent's
+    /// DHT location and gathers non-empty responses until
+    /// `options.required_responses` have arrived, each paired with the
+    /// peer that produced it. No merging or first-response racing is
+    /// performed, leaving callers free to apply their own cross-peer
+    /// agreement rules.
+    ///
+    /// Fails with [`HolochainP2pError::InsufficientResponses`] when fewer
+    /// than `options.required_responses` non-empty responses arrive in
+    /// time, and with [`HolochainP2pError::InvalidRequest`] when the
+    /// options are contradictory (see [`GetActivityMultiOptions`]).
+    fn get_agent_activity_multi(
+        &self,
+        dna_hash: DnaHash,
+        agent: AgentPubKey,
+        query: ChainQueryFilter,
+        options: GetActivityMultiOptions,
+    ) -> BoxFut<'_, HolochainP2pResult<Vec<(AgentPubKey, AgentActivityResponse)>>>;
 
     /// A remote node is requesting agent activity from us.
     /// Optional zome call origin for metrics attribution.

--- a/crates/holochain_p2p/tests/tests/node_messaging.rs
+++ b/crates/holochain_p2p/tests/tests/node_messaging.rs
@@ -155,6 +155,133 @@ impl HcP2pHandler for UnresponsiveHandler {
     }
 }
 
+/// Answers `get_agent_activity` by echoing the responding agent
+/// (`to_agent`) into the response's `agent` field, so tests can verify
+/// which peer produced which response. All other requests hang forever.
+#[derive(Clone, Debug)]
+struct EchoingActivityHandler;
+
+impl HcP2pHandler for EchoingActivityHandler {
+    fn handle_call_remote(
+        &self,
+        _dna_hash: DnaHash,
+        _to_agent: AgentPubKey,
+        _zome_call_params_serialized: ExternIO,
+        _signature: Signature,
+    ) -> BoxFut<'_, HolochainP2pResult<SerializedBytes>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn handle_remote_signal_direct(
+        &self,
+        _dna_hash: DnaHash,
+        _to_agent: AgentPubKey,
+        _signal: Vec<u8>,
+        _from_agent: AgentPubKey,
+        _signature: Signature,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn handle_publish(
+        &self,
+        _dna_hash: DnaHash,
+        _ops: Vec<(holochain_types::op::DhtOp, bool)>,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn handle_get(
+        &self,
+        _dna_hash: DnaHash,
+        _to_agent: AgentPubKey,
+        _dht_hash: holo_hash::AnyDhtHash,
+    ) -> BoxFut<'_, HolochainP2pResult<WireOps>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn handle_get_links(
+        &self,
+        _dna_hash: DnaHash,
+        _to_agent: AgentPubKey,
+        _link_key: WireLinkKey,
+        _options: GetLinksOptions,
+    ) -> BoxFut<'_, HolochainP2pResult<WireLinkOps>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn handle_count_links(
+        &self,
+        _dna_hash: DnaHash,
+        _to_agent: AgentPubKey,
+        _query: WireLinkQuery,
+    ) -> BoxFut<'_, HolochainP2pResult<CountLinksResponse>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn handle_get_agent_activity(
+        &self,
+        _dna_hash: DnaHash,
+        to_agent: AgentPubKey,
+        _agent: AgentPubKey,
+        _query: ChainQueryFilter,
+        _options: GetActivityOptions,
+    ) -> BoxFut<'_, HolochainP2pResult<AgentActivityResponse>> {
+        Box::pin(async move {
+            Ok(AgentActivityResponse {
+                // Echo the responder identity so tests can check pairing.
+                agent: to_agent,
+                valid_activity: ChainItems::NotRequested,
+                rejected_activity: ChainItems::NotRequested,
+                status: ChainStatus::Empty,
+                // A highest observed action marks the response as
+                // non-empty, so the multi fan-out does not discard it.
+                highest_observed: Some(HighestObserved {
+                    action_seq: 1,
+                    hash: vec![ActionHash::from_raw_36(vec![7; 36])],
+                }),
+                warrants: Vec::new(),
+            })
+        })
+    }
+
+    fn handle_must_get_agent_activity(
+        &self,
+        _dna_hash: DnaHash,
+        _to_agent: AgentPubKey,
+        _author: AgentPubKey,
+        _filter: holochain_zome_types::chain::ChainFilter,
+    ) -> BoxFut<'_, HolochainP2pResult<MustGetAgentActivityResponse>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn handle_validation_receipts_received(
+        &self,
+        _dna_hash: DnaHash,
+        _to_agent: AgentPubKey,
+        _receipts: ValidationReceiptBundle,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn handle_publish_countersign(
+        &self,
+        _dna_hash: DnaHash,
+        _op: holochain_types::op::ChainOp,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn handle_countersigning_session_negotiation(
+        &self,
+        _dna_hash: DnaHash,
+        _to_agent: AgentPubKey,
+        _message: CountersigningSessionNegotiationMessage,
+    ) -> BoxFut<'_, HolochainP2pResult<()>> {
+        Box::pin(std::future::pending())
+    }
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn test_call_remote() {
     test_run();
@@ -923,6 +1050,192 @@ async fn test_get_agent_activity_with_unresponsive_agents() {
 
     let requests = handler.calls.lock().unwrap();
     assert_eq!(*requests, ["get_agent_activity"]);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_agent_activity_multi_pairs_responses_with_peers() {
+    let dna_hash = DnaHash::from_raw_36(vec![0; 36]);
+    let space = dna_hash.to_k2_space();
+    let handler = Arc::new(EchoingActivityHandler);
+
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), handler.clone(), &addr).await;
+    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), handler, &addr).await;
+
+    hc1.test_set_full_arcs(space.clone()).await;
+    hc2.test_set_full_arcs(space.clone()).await;
+    hc3.test_set_full_arcs(space.clone()).await;
+
+    let responses = tokio::time::timeout(UNRESPONSIVE_TIMEOUT, async {
+        loop {
+            tokio::time::sleep(WAIT_BETWEEN_CALLS).await;
+
+            // Retry until peer discovery lets the full fan-out succeed.
+            if let Ok(responses) = hc1
+                .get_agent_activity_multi(
+                    dna_hash.clone(),
+                    AgentPubKey::from_raw_36(vec![2; 36]),
+                    ChainQueryFilter {
+                        sequence_range: ChainQueryFilterRange::Unbounded,
+                        entry_type: None,
+                        entry_hashes: None,
+                        action_type: None,
+                        include_entries: false,
+                        order_descending: false,
+                    },
+                    holochain_p2p::actor::GetActivityMultiOptions {
+                        target_peer_count: 2,
+                        required_responses: 2,
+                        timeout_ms: Some(5_000),
+                        ..Default::default()
+                    },
+                )
+                .await
+            {
+                return responses;
+            }
+        }
+    })
+    .await
+    .unwrap();
+
+    // At least required_responses entries, one per responding peer.
+    assert!(responses.len() >= 2, "got {} responses", responses.len());
+
+    // Each response is paired with the peer that produced it: the echoing
+    // handler wrote its own identity (`to_agent`) into `response.agent`.
+    for (peer, response) in &responses {
+        assert_eq!(peer, &response.agent);
+    }
+
+    // All responding peers are distinct.
+    let mut peers: Vec<_> = responses.iter().map(|(peer, _)| peer.clone()).collect();
+    peers.sort();
+    peers.dedup();
+    assert_eq!(peers.len(), responses.len());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_agent_activity_multi_fails_when_below_required_responses() {
+    let dna_hash = DnaHash::from_raw_36(vec![0; 36]);
+    let space = dna_hash.to_k2_space();
+    let responsive = Arc::new(EchoingActivityHandler);
+    let unresponsive = Arc::new(UnresponsiveHandler);
+
+    let (_bootstrap_srv, addr) = spawn_test_bootstrap().await.unwrap();
+    let (_agent1, hc1, _) = spawn_test(dna_hash.clone(), responsive.clone(), &addr).await;
+    let (_agent2, hc2, _) = spawn_test(dna_hash.clone(), responsive, &addr).await;
+    let (_agent3, hc3, _) = spawn_test(dna_hash.clone(), unresponsive.clone(), &addr).await;
+    let (_agent4, hc4, _) = spawn_test(dna_hash.clone(), unresponsive, &addr).await;
+
+    hc1.test_set_full_arcs(space.clone()).await;
+    hc2.test_set_full_arcs(space.clone()).await;
+    hc3.test_set_full_arcs(space.clone()).await;
+    hc4.test_set_full_arcs(space.clone()).await;
+
+    // Wait for discovery so the fan-out sees all four nodes.
+    wait_for_peers(&hc1, dna_hash.clone(), 4).await;
+
+    let query = ChainQueryFilter {
+        sequence_range: ChainQueryFilterRange::Unbounded,
+        entry_type: None,
+        entry_hashes: None,
+        action_type: None,
+        include_entries: false,
+        order_descending: false,
+    };
+
+    // Requiring more responses than the responsive peer count (1 remote
+    // responder from hc1's perspective, since hc3/hc4 never answer) must
+    // produce an InsufficientResponses error, bounded by the configured
+    // timeout rather than blocking on the unresponsive peers.
+    let start = std::time::Instant::now();
+    let result = hc1
+        .get_agent_activity_multi(
+            dna_hash.clone(),
+            AgentPubKey::from_raw_36(vec![2; 36]),
+            query.clone(),
+            holochain_p2p::actor::GetActivityMultiOptions {
+                target_peer_count: 3,
+                required_responses: 2,
+                timeout_ms: Some(3_000),
+                ..Default::default()
+            },
+        )
+        .await;
+    let elapsed = start.elapsed();
+
+    match result {
+        Err(HolochainP2pError::InsufficientResponses {
+            received, required, ..
+        }) => {
+            assert!(received < 2, "received {received}");
+            assert_eq!(required, 2);
+        }
+        other => panic!("expected InsufficientResponses error, got: {other:?}"),
+    }
+    // Slow peers must not block far past the configured timeout.
+    assert!(elapsed < Duration::from_secs(10), "took {elapsed:?}");
+
+    // With an achievable minimum, the same topology succeeds and the
+    // unresponsive peers are simply absent from the result.
+    let responses = tokio::time::timeout(UNRESPONSIVE_TIMEOUT, async {
+        loop {
+            tokio::time::sleep(WAIT_BETWEEN_CALLS).await;
+
+            if let Ok(responses) = hc1
+                .get_agent_activity_multi(
+                    dna_hash.clone(),
+                    AgentPubKey::from_raw_36(vec![2; 36]),
+                    query.clone(),
+                    holochain_p2p::actor::GetActivityMultiOptions {
+                        target_peer_count: 3,
+                        required_responses: 1,
+                        timeout_ms: Some(3_000),
+                        ..Default::default()
+                    },
+                )
+                .await
+            {
+                return responses;
+            }
+        }
+    })
+    .await
+    .unwrap();
+
+    assert!(!responses.is_empty());
+    for (peer, response) in &responses {
+        assert_eq!(peer, &response.agent);
+    }
+
+    // Contradictory options fail fast with InvalidRequest instead of
+    // fanning out and burning the timeout.
+    for options in [
+        holochain_p2p::actor::GetActivityMultiOptions {
+            target_peer_count: 2,
+            required_responses: 3,
+            ..Default::default()
+        },
+        holochain_p2p::actor::GetActivityMultiOptions {
+            required_responses: 0,
+            ..Default::default()
+        },
+    ] {
+        let result = hc1
+            .get_agent_activity_multi(
+                dna_hash.clone(),
+                AgentPubKey::from_raw_36(vec![2; 36]),
+                query.clone(),
+                options,
+            )
+            .await;
+        assert!(
+            matches!(result, Err(HolochainP2pError::InvalidRequest(_))),
+            "expected InvalidRequest error, got: {result:?}"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/holochain_types/src/activity.rs
+++ b/crates/holochain_types/src/activity.rs
@@ -31,6 +31,21 @@ pub struct AgentActivityResponse {
 }
 
 impl AgentActivityResponse {
+    /// Whether this response carries no information about the agent's chain.
+    ///
+    /// An empty response means the authority holds nothing for the agent:
+    /// no valid or rejected activity, an [`ChainStatus::Empty`] status, no
+    /// highest observed action and no warrants. Callers that aggregate
+    /// responses from several authorities use this to tell "I hold
+    /// nothing" answers apart from answers that contribute data.
+    pub fn is_empty(&self) -> bool {
+        self.valid_activity.is_empty()
+            && self.rejected_activity.is_empty()
+            && matches!(self.status, ChainStatus::Empty)
+            && self.highest_observed.is_none()
+            && self.warrants.is_empty()
+    }
+
     /// Convert an empty response to a different type.
     pub fn from_empty(other: AgentActivityResponse) -> Self {
         let convert_activity = |items: &ChainItems| match items {
@@ -94,6 +109,18 @@ pub enum ChainItems {
     NotRequested,
 }
 
+impl ChainItems {
+    /// Whether these items carry no activity, either because none was
+    /// requested or because the requested list came back empty.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            ChainItems::Full(records) => records.is_empty(),
+            ChainItems::Hashes(hashes) => hashes.is_empty(),
+            ChainItems::NotRequested => true,
+        }
+    }
+}
+
 impl From<AgentActivityResponse> for AgentActivity {
     fn from(a: AgentActivityResponse) -> Self {
         let valid_activity = match a.valid_activity {
@@ -154,6 +181,53 @@ impl ChainItemsSource for Vec<(u32, ActionHash)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn empty_response_detection() {
+        // An authority holding nothing for the agent: with activity
+        // requested the payload is an empty `Hashes` list, not
+        // `NotRequested`. Both shapes carry no information and must be
+        // treated as empty.
+        let empty = AgentActivityResponse {
+            agent: AgentPubKey::from_raw_32(vec![2; 32]),
+            valid_activity: ChainItems::Hashes(vec![]),
+            rejected_activity: ChainItems::Hashes(vec![]),
+            status: ChainStatus::Empty,
+            highest_observed: None,
+            warrants: vec![],
+        };
+        assert!(empty.is_empty());
+        assert!(AgentActivityResponse {
+            valid_activity: ChainItems::NotRequested,
+            rejected_activity: ChainItems::NotRequested,
+            ..empty.clone()
+        }
+        .is_empty());
+
+        // Any piece of information makes the response non-empty.
+        let head = ChainHead {
+            action_seq: 5,
+            hash: ActionHash::from_raw_32(vec![1; 32]),
+        };
+        assert!(!AgentActivityResponse {
+            valid_activity: ChainItems::Hashes(vec![(0, ActionHash::from_raw_32(vec![3; 32]))]),
+            ..empty.clone()
+        }
+        .is_empty());
+        assert!(!AgentActivityResponse {
+            status: ChainStatus::Valid(head.clone()),
+            ..empty.clone()
+        }
+        .is_empty());
+        assert!(!AgentActivityResponse {
+            highest_observed: Some(HighestObserved {
+                action_seq: head.action_seq,
+                hash: vec![head.hash],
+            }),
+            ..empty.clone()
+        }
+        .is_empty());
+    }
 
     #[test]
     fn status_only_preserves_status() {


### PR DESCRIPTION
### Summary

Closes #5799

Adds a new peer-to-peer call, `get_agent_activity_multi`, that asks several network authorities for an agent's activity and returns every answer separately, each labelled with the peer that produced it. The upcoming source-chain restore workflow (#5800) needs this because it must check that multiple independent peers agree on an agent's chain history before trusting it. The existing `get_agent_activity` call could not be used for that: it is built for speed and keeps only the first useful answer.

The call asks up to a configurable number of peers and waits, up to a timeout, for all of them to reply. If fewer than a configurable minimum reply in time, the call fails with a new `Timeout` error instead of quietly returning too little data, so a degraded network can never be mistaken for a valid sample. Answers that report an empty history are kept, because a peer honestly saying it holds nothing is useful information for the agreement check.

No network protocol change is involved: the call reuses the existing request and response messages, so peers on the serving side need no update. The existing `get_agent_activity` behaviour is untouched and its tests pass unchanged. The call is exposed through the usual layers (`HcP2p`, `HolochainP2pDnaT`, and a simple pass-through on the cascade) ready for the restore workflow to consume.

Covered by deterministic unit tests for the gathering logic (all answers collected, failures skipped, timeout and minimum enforced), two real-network tests (answers correctly paired with the peers that produced them, and slow peers do not block the call), and cascade tests (responses passed through untouched, errors surfaced rather than swallowed).

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs