### PR TITLE
Merge release-20260715.141229 back into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,86 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Bump holonix rust version to 1.71.1. [\#2660](https://github.com/holochain/holochain/pull/2660)
 - Add `override` to `devSells.holonix` and `packages.holochain` [\#2862](https://github.com/holochain/holochain/pull/2862)
 
+# 20260715.141229
+
+## [hcterm-0.7.0-rc.0](crates/hcterm/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_cli-0.7.0-rc.0](crates/holochain_cli/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_cli\_bundle-0.7.0-rc.0](crates/holochain_cli_bundle/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_cli\_client-0.7.0-rc.0](crates/holochain_cli_client/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_cli\_sandbox-0.7.0-rc.0](crates/holochain_cli_sandbox/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_client-0.9.0-rc.0](crates/holochain_client/CHANGELOG.md#0.9.0-rc.0)
+
+## [holochain-0.7.0-rc.0](crates/holochain/CHANGELOG.md#0.7.0-rc.0)
+
+- **BREAKING CHANGE**: Removed the `transport-iroh` feature flag from `holochain`, `holochain_p2p`, `holochain_cascade`, `holochain_client`, `hc`, `hc_client`, and `hc_sandbox`. The iroh (QUIC) transport is the only network backend and is now compiled in unconditionally rather than gated behind an (on-by-default) optional feature. Downstream crates that built with `default-features = false` and explicitly listed `transport-iroh` must drop it, as the feature no longer exists.
+- Made the workspace crates’ feature flags build independently and removed unused dependencies across the workspace, trimming the dependency tree.
+- **BREAKING CHANGE** `wire_rows_to_v2_ops` is renamed to `wire_rows_to_ops` now that there is no legacy v1 op form to distinguish it from.
+- **BREAKING CHANGE** `build_chain_dht_op_v2` and `build_warrant_dht_op_v2` (in `holochain_p2p`) are renamed to `build_chain_dht_op` and `build_warrant_dht_op` now that there is no legacy v1 op-construction path to distinguish them from.
+- Disable `reqwest`’s default features, including `native-tls`, in `holochain_metrics`. We are using `rustls-tls` anyway and `native-tls` requires a non-vendored OpenSSL to be installed. \#5878
+- Implemented more graceful handling of invalid or missing `hc` subcommands. Originally the code panicked with an ambiguous “File or directory not found error”. [\#5867](https://github.com/holochain/holochain/pull/5867)
+- **BREAKING CHANGE** Remove the legacy per-variant action types now that the v2 `Action` model (`ActionHeader` + `ActionData`) is canonical. The `holochain_integrity_types::action` per-variant structs (`Create`, `Update`, `Delete`, `Dna`, `CreateLink`, `DeleteLink`, `OpenChain`, `CloseChain`, `AgentValidationPkg`, `InitZomesComplete`), the `ActionBuilder`/`ActionBuilderCommon` builder, the `EntryCreationAction`/`NewEntryAction`/`NewEntryActionRef` wrapper enums, and the `rate_limit` module (`RateWeight`/`EntryRateWeight` and the action-weight machinery) are all removed. \#5860
+- Holochain gains a new `encryption` feature to control whether its databases are encrypted or not. This replaces the previous `sqlite-encrypted` feature which no longer has any effect.
+- **BREAKING CHANGE** Remove the `holochain_sqlite` crate now that persistence has moved to `holochain_data`.
+- **BREAKING CHANGE** Databases created by Holochain have been renamed now that the legacy databases are no longer in use.
+- **BREAKING CHANGE**: `DnaStorageInfo` (returned by the `StorageInfo` admin call) drops its `authored_data_size`/`authored_data_size_on_disk` and `cache_data_size`/`cache_data_size_on_disk` fields. An agent’s source-chain data now lives in the per-DNA DHT database and is counted in `dht_data_size`/`dht_data_size_on_disk`; the separate cache figure is removed. \#5844
+
+## [holochain\_cascade-0.7.0-rc.0](crates/holochain_cascade/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_conductor\_config-0.7.0-rc.0](crates/holochain_conductor_config/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_metrics-0.7.0-rc.0](crates/holochain_metrics/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_test\_wasm\_common-0.7.0-rc.0](crates/holochain_test_wasm_common/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_wasm\_test\_utils-0.7.0-rc.0](crates/holochain_wasm_test_utils/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_websocket-0.7.0-rc.0](crates/holochain_websocket/CHANGELOG.md#0.7.0-rc.0)
+
+## [hdk-0.7.0-rc.0](crates/hdk/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_p2p-0.7.0-rc.0](crates/holochain_p2p/CHANGELOG.md#0.7.0-rc.0)
+
+## [hdi-0.8.0-rc.0](crates/hdi/CHANGELOG.md#0.8.0-rc.0)
+
+## [holochain\_state-0.7.0-rc.0](crates/holochain_state/CHANGELOG.md#0.7.0-rc.0)
+
+## [hdk\_derive-0.7.0-rc.0](crates/hdk_derive/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_data-0.7.0-rc.0](crates/holochain_data/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_conductor\_api-0.7.0-rc.0](crates/holochain_conductor_api/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_state\_types-0.7.0-rc.0](crates/holochain_state_types/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_types-0.7.0-rc.0](crates/holochain_types/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_keystore-0.7.0-rc.0](crates/holochain_keystore/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_trace-0.7.0-rc.0](crates/holochain_trace/CHANGELOG.md#0.7.0-rc.0)
+
+## [mr\_bundle-0.7.0-rc.0](crates/mr_bundle/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_zome\_types-0.7.0-rc.0](crates/holochain_zome_types/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_integrity\_types-0.7.0-rc.0](crates/holochain_integrity_types/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_nonce-0.7.0-rc.0](crates/holochain_nonce/CHANGELOG.md#0.7.0-rc.0)
+
+## [holo\_hash-0.7.0-rc.0](crates/holo_hash/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_secure\_primitive-0.7.0-rc.0](crates/holochain_secure_primitive/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_timestamp-0.7.0-rc.0](crates/holochain_timestamp/CHANGELOG.md#0.7.0-rc.0)
+
+## [fixt-0.7.0-rc.0](crates/fixt/CHANGELOG.md#0.7.0-rc.0)
+
+## [holochain\_util-0.7.0-rc.0](crates/holochain_util/CHANGELOG.md#0.7.0-rc.0)
+
 # 20260701.171007
 
 ## [hcterm-0.7.0-dev.32](crates/hcterm/CHANGELOG.md#0.7.0-dev.32)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,7 +2146,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixt"
-version = "0.7.0-dev.1"
+version = "0.7.0-rc.0"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -2630,7 +2630,7 @@ dependencies = [
 
 [[package]]
 name = "hcterm"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "hdi"
-version = "0.8.0-dev.15"
+version = "0.8.0-rc.0"
 dependencies = [
  "fixt",
  "getrandom 0.3.4",
@@ -2674,7 +2674,7 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.7.0-dev.21"
+version = "0.7.0-rc.0"
 dependencies = [
  "getrandom 0.3.4",
  "hdi",
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.7.0-dev.15"
+version = "0.7.0-rc.0"
 dependencies = [
  "darling 0.21.3",
  "heck",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.7.0-dev.11"
+version = "0.7.0-rc.0"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 dependencies = [
  "anyhow",
  "assert2",
@@ -2948,7 +2948,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 dependencies = [
  "async-trait",
  "fixt",
@@ -2973,7 +2973,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2989,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_bundle"
-version = "0.7.0-dev.31"
+version = "0.7.0-rc.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_client"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -3038,7 +3038,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_cli_sandbox"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_client"
-version = "0.9.0-dev.32"
+version = "0.9.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3095,7 +3095,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.7.0-dev.31"
+version = "0.7.0-rc.0"
 dependencies = [
  "derive_more",
  "holo_hash",
@@ -3129,7 +3129,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_config"
-version = "0.7.0-dev.31"
+version = "0.7.0-rc.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -3147,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_data"
-version = "0.7.0-dev.21"
+version = "0.7.0-rc.0"
 dependencies = [
  "base64",
  "bytes",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.7.0-dev.15"
+version = "0.7.0-rc.0"
 dependencies = [
  "derive_builder",
  "fixt",
@@ -3195,7 +3195,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.7.0-dev.20"
+version = "0.7.0-rc.0"
 dependencies = [
  "assert_cmd",
  "base64",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_metrics"
-version = "0.7.0-dev.6"
+version = "0.7.0-rc.0"
 dependencies = [
  "digest 0.10.7",
  "dirs",
@@ -3250,7 +3250,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.7.0-dev.2"
+version = "0.7.0-rc.0"
 dependencies = [
  "getrandom 0.3.4",
  "holochain_secure_primitive",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_p2p"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_secure_primitive"
-version = "0.7.0-dev.1"
+version = "0.7.0-rc.0"
 dependencies = [
  "paste",
  "serde",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 dependencies = [
  "async-recursion",
  "base64",
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_state_types"
-version = "0.7.0-dev.15"
+version = "0.7.0-rc.0"
 dependencies = [
  "holo_hash",
  "holochain_integrity_types",
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.7.0-dev.21"
+version = "0.7.0-rc.0"
 dependencies = [
  "hdk",
  "holochain_serialized_bytes",
@@ -3400,7 +3400,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_timestamp"
-version = "0.7.0-dev.1"
+version = "0.7.0-rc.0"
 dependencies = [
  "chrono",
  "holochain_serialized_bytes",
@@ -3409,7 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_trace"
-version = "0.7.0-dev.1"
+version = "0.7.0-rc.0"
 dependencies = [
  "chrono",
  "derive_more",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.7.0-dev.31"
+version = "0.7.0-rc.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.7.0-dev.1"
+version = "0.7.0-rc.0"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -3494,7 +3494,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_test_utils"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 dependencies = [
  "holochain_types",
  "strum 0.27.2",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.7.0-dev.31"
+version = "0.7.0-rc.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3568,7 +3568,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.7.0-dev.20"
+version = "0.7.0-rc.0"
 dependencies = [
  "derive_builder",
  "derive_more",
@@ -5061,7 +5061,7 @@ checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "mr_bundle"
-version = "0.7.0-dev.2"
+version = "0.7.0-rc.0"
 dependencies = [
  "bytes",
  "dunce",

--- a/crates/client/CHANGELOG.md
+++ b/crates/client/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.9.0-rc.0
+
 ## 0.9.0-dev.32
 
 ## 0.9.0-dev.31

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_client"
-version = "0.9.0-dev.32"
+version = "0.9.0-rc.0"
 description = "A Rust client for the Holochain Conductor API"
 authors = [
   "Holochain Core Dev Team <devcore@holochain.org>",
@@ -18,14 +18,14 @@ anyhow = "1.0"
 async-trait = "0.1"
 ed25519-dalek = { version = "2.1", features = ["rand_core"] }
 event-emitter-rs = "0.1"
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash", features = [
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash", features = [
   "encoding",
 ] }
-holochain_conductor_api = { version = "^0.7.0-dev.31", path = "../holochain_conductor_api" }
-holochain_nonce = { version = "^0.7.0-dev.2", path = "../holochain_nonce" }
-holochain_types = { version = "^0.7.0-dev.31", path = "../holochain_types" }
-holochain_websocket = { version = "^0.7.0-dev.31", path = "../holochain_websocket" }
-holochain_zome_types = { version = "^0.7.0-dev.20", path = "../holochain_zome_types" }
+holochain_conductor_api = { version = "^0.7.0-rc.0", path = "../holochain_conductor_api" }
+holochain_nonce = { version = "^0.7.0-rc.0", path = "../holochain_nonce" }
+holochain_types = { version = "^0.7.0-rc.0", path = "../holochain_types" }
+holochain_websocket = { version = "^0.7.0-rc.0", path = "../holochain_websocket" }
+holochain_zome_types = { version = "^0.7.0-rc.0", path = "../holochain_zome_types" }
 kitsune2_api = "0.5.0-dev.6"
 lair_keystore_api = { version = "0.7.1", optional = true }
 parking_lot = "0.12.1"
@@ -36,11 +36,11 @@ tokio = { version = "1.36", features = ["rt"] }
 
 [dev-dependencies]
 bytes = "1.10.1"
-mr_bundle = { version = "^0.7.0-dev.2", path = "../mr_bundle" }
-holochain = { version = "^0.7.0-dev.32", path = "../holochain", default-features = false, features = [
+mr_bundle = { version = "^0.7.0-rc.0", path = "../mr_bundle" }
+holochain = { version = "^0.7.0-rc.0", path = "../holochain", default-features = false, features = [
   "sweettest",
 ] }
-holochain_wasm_test_utils = { version = "^0.7.0-dev.32", path = "../test_utils/wasm" }
+holochain_wasm_test_utils = { version = "^0.7.0-rc.0", path = "../test_utils/wasm" }
 
 kitsune2_core = "0.5.0-dev.6"
 kitsune2_test_utils = "0.5.0-dev.6"

--- a/crates/fixt/CHANGELOG.md
+++ b/crates/fixt/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/holochain/holochain/compare/fixt-v0.0.2-alpha.1...HEAD)
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.1
 
 ## 0.7.0-dev.0

--- a/crates/fixt/Cargo.toml
+++ b/crates/fixt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixt"
-version = "0.7.0-dev.1"
+version = "0.7.0-rc.0"
 description = "minimum viable fixtures"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"

--- a/crates/fixt/test/Cargo.toml
+++ b/crates/fixt/test/Cargo.toml
@@ -13,5 +13,5 @@ publish = false
 
 # reminder - do not use workspace deps
 [dependencies]
-fixt = { path = "..", version = "^0.7.0-dev.1" }
+fixt = { path = "..", version = "^0.7.0-rc.0"}
 paste = "1.0.12"

--- a/crates/hc/CHANGELOG.md
+++ b/crates/hc/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.32
 
 ## 0.7.0-dev.31

--- a/crates/hc/Cargo.toml
+++ b/crates/hc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 repository = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
@@ -27,10 +27,10 @@ path = "src/lib.rs"
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive", "cargo"] }
 lazy_static = "1.4"
-holochain_cli_bundle = { path = "../hc_bundle", version = "^0.7.0-dev.31", default-features = false }
-holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.7.0-dev.32", default-features = false }
-holochain_cli_client = { path = "../hc_client", version = "^0.7.0-dev.32", default-features = false }
-holochain_trace = { version = "^0.7.0-dev.1", path = "../holochain_trace" }
+holochain_cli_bundle = { path = "../hc_bundle", version = "^0.7.0-rc.0", default-features = false }
+holochain_cli_sandbox = { path = "../hc_sandbox", version = "^0.7.0-rc.0", default-features = false }
+holochain_cli_client = { path = "../hc_client", version = "^0.7.0-rc.0", default-features = false }
+holochain_trace = { version = "^0.7.0-rc.0", path = "../holochain_trace" }
 tokio = { version = "1.36.0", features = ["full"] }
 
 [dev-dependencies]

--- a/crates/hc_bundle/CHANGELOG.md
+++ b/crates/hc_bundle/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.31
 
 ## 0.7.0-dev.30

--- a/crates/hc_bundle/Cargo.toml
+++ b/crates/hc_bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_bundle"
-version = "0.7.0-dev.31"
+version = "0.7.0-rc.0"
 description = "DNA and hApp bundling functionality for the `hc` Holochain CLI utility"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
@@ -26,12 +26,12 @@ path = "src/bin/hc-dna.rs"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
-holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util", features = [
+holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util", features = [
   "backtrace",
 ] }
 holochain_serialized_bytes = "=0.0.57"
-holochain_types = { version = "^0.7.0-dev.31", path = "../holochain_types" }
-mr_bundle = { version = "^0.7.0-dev.2", path = "../mr_bundle", features = [
+holochain_types = { version = "^0.7.0-rc.0", path = "../holochain_types" }
+mr_bundle = { version = "^0.7.0-rc.0", path = "../mr_bundle", features = [
   "fs",
 ] }
 yaml_serde = "0.10"

--- a/crates/hc_client/CHANGELOG.md
+++ b/crates/hc_client/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.32
 
 ## 0.7.0-dev.31

--- a/crates/hc_client/Cargo.toml
+++ b/crates/hc_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_client"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 edition = "2021"
 description = "CLI utilities for interacting with Holochain conductors"
 license = "Apache-2.0"
@@ -22,13 +22,13 @@ chrono = { version = "0.4.22", default-features = false, features = [
 clap = { version = "4.0", features = ["derive", "env"] }
 ed25519-dalek = "2.1"
 hc_serde_json = { version = "1", package = "hc_serde_json" }
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash", features = [
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash", features = [
   "kitsune2",
 ] }
-holochain_client = { version = "^0.9.0-dev.32", path = "../client", default-features = false }
-holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.7.0-dev.31" }
-holochain_types = { path = "../holochain_types", version = "^0.7.0-dev.31" }
-holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util", features = [
+holochain_client = { version = "^0.9.0-rc.0", path = "../client", default-features = false }
+holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.7.0-rc.0"}
+holochain_types = { path = "../holochain_types", version = "^0.7.0-rc.0"}
+holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util", features = [
   "pw",
 ] }
 kitsune2_api = "0.5.0-dev.6"
@@ -40,10 +40,10 @@ sodoken = "0.1.0"
 tokio = { version = "1.36.0", features = ["full"] }
 indexmap = "2.0"
 
-holochain = { version = "^0.7.0-dev.32", path = "../holochain", default-features = false, optional = true }
+holochain = { version = "^0.7.0-rc.0", path = "../holochain", default-features = false, optional = true }
 
 [dev-dependencies]
-holochain = { version = "^0.7.0-dev.32", path = "../holochain", default-features = false, features = [
+holochain = { version = "^0.7.0-rc.0", path = "../holochain", default-features = false, features = [
   "sweettest",
 ] }
 tokio = { version = "1.36.0", features = ["full"] }

--- a/crates/hc_client/Cargo.toml
+++ b/crates/hc_client/Cargo.toml
@@ -26,8 +26,8 @@ holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash", features = [
   "kitsune2",
 ] }
 holochain_client = { version = "^0.9.0-rc.0", path = "../client", default-features = false }
-holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.7.0-rc.0"}
-holochain_types = { path = "../holochain_types", version = "^0.7.0-rc.0"}
+holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.7.0-rc.0" }
+holochain_types = { path = "../holochain_types", version = "^0.7.0-rc.0" }
 holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util", features = [
   "pw",
 ] }

--- a/crates/hc_sandbox/CHANGELOG.md
+++ b/crates/hc_sandbox/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.32
 
 ## 0.7.0-dev.31

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cli_sandbox"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 repository = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_cli_sandbox"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
@@ -24,17 +24,17 @@ anyhow = "1.0"
 ansi_term = "0.12"
 clap = { version = "4.0", features = ["derive", "env"] }
 futures = "0.3"
-holochain_client = { version = "^0.9.0-dev.32", path = "../client", default-features = false }
-holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.7.0-dev.31" }
-holochain_types = { path = "../holochain_types", version = "^0.7.0-dev.31", features = [
+holochain_client = { version = "^0.9.0-rc.0", path = "../client", default-features = false }
+holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.7.0-rc.0"}
+holochain_types = { path = "../holochain_types", version = "^0.7.0-rc.0", features = [
   "fixturators",
 ] }
-holochain_conductor_config = { version = "^0.7.0-dev.31", path = "../holochain_conductor_config" }
-holochain_websocket = { path = "../holochain_websocket", version = "^0.7.0-dev.31" }
-holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util", features = [
+holochain_conductor_config = { version = "^0.7.0-rc.0", path = "../holochain_conductor_config" }
+holochain_websocket = { path = "../holochain_websocket", version = "^0.7.0-rc.0"}
+holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util", features = [
   "pw",
 ] }
-holochain_trace = { version = "^0.7.0-dev.1", path = "../holochain_trace" }
+holochain_trace = { version = "^0.7.0-rc.0", path = "../holochain_trace" }
 serde = { version = "1.0", features = ["derive"] }
 yaml_serde = "0.10"
 serde_json = "1.0"

--- a/crates/hc_sandbox/Cargo.toml
+++ b/crates/hc_sandbox/Cargo.toml
@@ -25,12 +25,12 @@ ansi_term = "0.12"
 clap = { version = "4.0", features = ["derive", "env"] }
 futures = "0.3"
 holochain_client = { version = "^0.9.0-rc.0", path = "../client", default-features = false }
-holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.7.0-rc.0"}
+holochain_conductor_api = { path = "../holochain_conductor_api", version = "^0.7.0-rc.0" }
 holochain_types = { path = "../holochain_types", version = "^0.7.0-rc.0", features = [
   "fixturators",
 ] }
 holochain_conductor_config = { version = "^0.7.0-rc.0", path = "../holochain_conductor_config" }
-holochain_websocket = { path = "../holochain_websocket", version = "^0.7.0-rc.0"}
+holochain_websocket = { path = "../holochain_websocket", version = "^0.7.0-rc.0" }
 holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util", features = [
   "pw",
 ] }

--- a/crates/hdi/CHANGELOG.md
+++ b/crates/hdi/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.8.0-rc.0
+
 ## 0.8.0-dev.15
 
 ## 0.8.0-dev.14

--- a/crates/hdi/Cargo.toml
+++ b/crates/hdi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdi"
-version = "0.8.0-dev.15"
+version = "0.8.0-rc.0"
 description = "The HDI"
 license = "CAL-1.0"
 repository = "https://github.com/holochain/holochain/tree/develop/crates/hdi"
@@ -12,8 +12,8 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-hdk_derive = { version = "^0.7.0-dev.15", path = "../hdk_derive" }
-holo_hash = { version = "^0.7.0-dev.11", features = [
+hdk_derive = { version = "^0.7.0-rc.0", path = "../hdk_derive" }
+holo_hash = { version = "^0.7.0-rc.0", features = [
   "hashing",
 ], path = "../holo_hash" }
 holochain_wasmer_guest = "=0.0.103"
@@ -21,7 +21,7 @@ holochain_serialized_bytes = "=0.0.57"
 holochain_serialized_bytes_derive = "=0.0.57"
 # it's important that we depend on holochain_integrity_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
-holochain_integrity_types = { version = "^0.7.0-dev.15", path = "../holochain_integrity_types", default-features = false }
+holochain_integrity_types = { version = "^0.7.0-rc.0", path = "../holochain_integrity_types", default-features = false }
 paste = "1.0"
 serde = "1.0"
 serde_bytes = "0.11"

--- a/crates/hdi/README.md
+++ b/crates/hdi/README.md
@@ -65,8 +65,8 @@ validated.
 All of these validation rules are declared in the `validate` callback. It
 is executed for a new action by each validation authority.
 
-There's a helper type called `FlatOp` available for easy access to
-all link and entry variants when validating an operation. In many cases, this type can be
+There's a helper type called `FlatOp` available for easy access
+to all link and entry variants when validating an operation. In many cases, this type can be
 easier to work with than the bare `Op`.
 `FlatOp` contains the same information as
 `Op` but with a flatter, more accessible data

--- a/crates/hdk/CHANGELOG.md
+++ b/crates/hdk/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.21
 
 ## 0.7.0-dev.20

--- a/crates/hdk/Cargo.toml
+++ b/crates/hdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk"
-version = "0.7.0-dev.21"
+version = "0.7.0-rc.0"
 description = "The Holochain HDK"
 license = "CAL-1.0"
 repository = "https://github.com/holochain/holochain/tree/develop/crates/hdk"
@@ -12,13 +12,13 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-hdi = { version = "=0.8.0-dev.15", path = "../hdi", features = ["trace"] }
-hdk_derive = { version = "^0.7.0-dev.15", path = "../hdk_derive" }
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash" }
+hdi = { version = "=0.8.0-rc.0", path = "../hdi", features = ["trace"] }
+hdk_derive = { version = "^0.7.0-rc.0", path = "../hdk_derive" }
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash" }
 holochain_wasmer_guest = "=0.0.103"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdk_derive, to reduce code bloat
-holochain_zome_types = { version = "^0.7.0-dev.20", path = "../holochain_zome_types", default-features = false }
+holochain_zome_types = { version = "^0.7.0-rc.0", path = "../holochain_zome_types", default-features = false }
 paste = "1.0"
 serde = "1.0"
 tracing = "0.1"

--- a/crates/hdk_derive/CHANGELOG.md
+++ b/crates/hdk_derive/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.15
 
 ## 0.7.0-dev.14

--- a/crates/hdk_derive/Cargo.toml
+++ b/crates/hdk_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdk_derive"
-version = "0.7.0-dev.15"
+version = "0.7.0-rc.0"
 description = "derive macros for the holochain hdk"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
@@ -23,7 +23,7 @@ darling = "0.21.3"
 heck = "0.5"
 # it's important that we depend on holochain_zome_types with no default
 # features, both here AND in hdi, to reduce code bloat
-holochain_integrity_types = { version = "^0.7.0-dev.15", path = "../holochain_integrity_types", default-features = false }
+holochain_integrity_types = { version = "^0.7.0-rc.0", path = "../holochain_integrity_types", default-features = false }
 proc-macro-error = "1.0.4"
 
 [dev-dependencies]

--- a/crates/holo_hash/CHANGELOG.md
+++ b/crates/holo_hash/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.11
 
 ## 0.7.0-dev.10

--- a/crates/holo_hash/Cargo.toml
+++ b/crates/holo_hash/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holo_hash"
-version = "0.7.0-dev.11"
+version = "0.7.0-rc.0"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 keywords = ["holochain", "holo", "hash", "blake", "blake2b"]
 categories = ["cryptography"]
@@ -26,10 +26,10 @@ derive_more = { version = "2.0", features = [
   "into",
   "from",
 ], optional = true }
-fixt = { version = "^0.7.0-dev.1", path = "../fixt", optional = true }
+fixt = { version = "^0.7.0-rc.0", path = "../fixt", optional = true }
 futures = { version = "0.3", optional = true }
 holochain_serialized_bytes = { version = "=0.0.57", optional = true }
-holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util", default-features = false }
+holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util", default-features = false }
 kitsune2_api = { version = "0.5.0-dev.6", optional = true }
 must_future = { version = "0.1", optional = true }
 proptest = { version = "1", optional = true }

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,8 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.7.0-rc.0
+
 - **BREAKING CHANGE**: Removed the `transport-iroh` feature flag from `holochain`, `holochain_p2p`, `holochain_cascade`, `holochain_client`, `hc`, `hc_client`, and `hc_sandbox`. The iroh (QUIC) transport is the only network backend and is now compiled in unconditionally rather than gated behind an (on-by-default) optional feature. Downstream crates that built with `default-features = false` and explicitly listed `transport-iroh` must drop it, as the feature no longer exists.
-- Made the workspace crates' feature flags build independently and removed unused dependencies across the workspace, trimming the dependency tree.
+- Made the workspace crates’ feature flags build independently and removed unused dependencies across the workspace, trimming the dependency tree.
 - **BREAKING CHANGE** `wire_rows_to_v2_ops` is renamed to `wire_rows_to_ops` now that there is no legacy v1 op form to distinguish it from.
 - **BREAKING CHANGE** `build_chain_dht_op_v2` and `build_warrant_dht_op_v2` (in `holochain_p2p`) are renamed to `build_chain_dht_op` and `build_warrant_dht_op` now that there is no legacy v1 op-construction path to distinguish them from.
 - Disable `reqwest`’s default features, including `native-tls`, in `holochain_metrics`. We are using `rustls-tls` anyway and `native-tls` requires a non-vendored OpenSSL to be installed. \#5878

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 description = "Holochain, a framework for distributed applications"
 license = "CAL-1.0"
 repository = "https://github.com/holochain/holochain"
@@ -27,41 +27,41 @@ derive_more = { version = "2.0", features = ["display", "index"] }
 either = "1.5.0"
 futures = "0.3"
 getrandom = "0.3"
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash", features = [
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash", features = [
   "full",
 ] }
-holochain_cascade = { version = "^0.7.0-dev.32", default-features = false, path = "../holochain_cascade" }
-holochain_conductor_api = { version = "^0.7.0-dev.31", path = "../holochain_conductor_api", default-features = false }
-holochain_keystore = { version = "^0.7.0-dev.20", path = "../holochain_keystore", default-features = false }
-holochain_p2p = { version = "^0.7.0-dev.32", default-features = false, path = "../holochain_p2p" }
+holochain_cascade = { version = "^0.7.0-rc.0", default-features = false, path = "../holochain_cascade" }
+holochain_conductor_api = { version = "^0.7.0-rc.0", path = "../holochain_conductor_api", default-features = false }
+holochain_keystore = { version = "^0.7.0-rc.0", path = "../holochain_keystore", default-features = false }
+holochain_p2p = { version = "^0.7.0-rc.0", default-features = false, path = "../holochain_p2p" }
 holochain_serialized_bytes = "=0.0.57"
-holochain_state = { version = "^0.7.0-dev.32", path = "../holochain_state" }
-holochain_types = { version = "^0.7.0-dev.31", path = "../holochain_types" }
-holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util" }
+holochain_state = { version = "^0.7.0-rc.0", path = "../holochain_state" }
+holochain_types = { version = "^0.7.0-rc.0", path = "../holochain_types" }
+holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util" }
 holochain_wasmer_host = { version = "=0.0.103", default-features = false, features = [
   "error-as-host",
 ] }
-holochain_websocket = { version = "^0.7.0-dev.31", path = "../holochain_websocket" }
-holochain_zome_types = { version = "^0.7.0-dev.20", path = "../holochain_zome_types", features = [
+holochain_websocket = { version = "^0.7.0-rc.0", path = "../holochain_websocket" }
+holochain_zome_types = { version = "^0.7.0-rc.0", path = "../holochain_zome_types", features = [
   "full",
 ] }
-holochain_nonce = { version = "^0.7.0-dev.2", path = "../holochain_nonce" }
-holochain_secure_primitive = { version = "^0.7.0-dev.1", path = "../holochain_secure_primitive" }
-holochain_conductor_config = { version = "^0.7.0-dev.31", path = "../holochain_conductor_config", default-features = false }
-holochain_timestamp = { version = "^0.7.0-dev.1", path = "../timestamp" }
+holochain_nonce = { version = "^0.7.0-rc.0", path = "../holochain_nonce" }
+holochain_secure_primitive = { version = "^0.7.0-rc.0", path = "../holochain_secure_primitive" }
+holochain_conductor_config = { version = "^0.7.0-rc.0", path = "../holochain_conductor_config", default-features = false }
+holochain_timestamp = { version = "^0.7.0-rc.0", path = "../timestamp" }
 human-panic = "2.0"
 itertools = { version = "0.14" }
 kitsune2_api = "0.5.0-dev.6"
 kitsune2_core = "0.5.0-dev.6"
 mockall = "0.13"
-mr_bundle = { version = "^0.7.0-dev.2", path = "../mr_bundle", features = [
+mr_bundle = { version = "^0.7.0-rc.0", path = "../mr_bundle", features = [
   "fs",
 ] }
 must_future = "0.1.1"
 moka = { version = "0.12", features = ["future"] }
 nanoid = "0.4"
-holochain_trace = { version = "^0.7.0-dev.1", path = "../holochain_trace" }
-holochain_metrics = { version = "^0.7.0-dev.6", path = "../holochain_metrics" }
+holochain_trace = { version = "^0.7.0-rc.0", path = "../holochain_trace" }
+holochain_metrics = { version = "^0.7.0-rc.0", path = "../holochain_metrics" }
 lair_keystore_api = "=0.7.1"
 once_cell = "1.4.1"
 one_err = "0.0.8"
@@ -96,12 +96,12 @@ wasmer = { version = "7.1.0", default-features = false }
 wasmer-middlewares = { version = "7.1.0", optional = true, default-features = false }
 
 # Dependencies for test_utils / other optional deps
-fixt = { version = "^0.7.0-dev.1", path = "../fixt", optional = true }
+fixt = { version = "^0.7.0-rc.0", path = "../fixt", optional = true }
 diff = { version = "0.1", optional = true }
-hdk = { version = "^0.7.0-dev.21", path = "../hdk", optional = true }
+hdk = { version = "^0.7.0-rc.0", path = "../hdk", optional = true }
 matches = { version = "0.1.8", optional = true }
-holochain_wasm_test_utils = { version = "^0.7.0-dev.32", path = "../test_utils/wasm", optional = true }
-holochain_test_wasm_common = { version = "^0.7.0-dev.21", path = "../test_utils/wasm_common", optional = true }
+holochain_wasm_test_utils = { version = "^0.7.0-rc.0", path = "../test_utils/wasm", optional = true }
+holochain_test_wasm_common = { version = "^0.7.0-rc.0", path = "../test_utils/wasm_common", optional = true }
 unwrap_to = { version = "0.1.0", optional = true }
 kitsune2_bootstrap_srv = { version = "0.5.0-dev.6", default-features = false, optional = true }
 schemars = "0.9"
@@ -114,7 +114,7 @@ holochain = { path = ".", default-features = false, features = [
   "test_utils",
   "slow_tests",
 ] }
-holochain_state = { version = "^0.7.0-dev.32", path = "../holochain_state", features = [
+holochain_state = { version = "^0.7.0-rc.0", path = "../holochain_state", features = [
   "test_utils",
 ] }
 
@@ -133,7 +133,7 @@ kitsune2_test_utils = "0.5.0-dev.6"
 rand_dalek = { version = "0.8", package = "rand" }
 
 [build-dependencies]
-hdk = { version = "^0.7.0-dev.21", path = "../hdk" }
+hdk = { version = "^0.7.0-rc.0", path = "../hdk" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.51" }
 chrono = { version = "0.4.6", features = ["serde"] }

--- a/crates/holochain_cascade/CHANGELOG.md
+++ b/crates/holochain_cascade/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.32
 
 ## 0.7.0-dev.31

--- a/crates/holochain_cascade/Cargo.toml
+++ b/crates/holochain_cascade/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_cascade"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 description = "Logic for cascading updates to Holochain state and network interaction"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
@@ -10,18 +10,18 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-fixt = { version = "^0.7.0-dev.1", path = "../fixt" }
+fixt = { version = "^0.7.0-rc.0", path = "../fixt" }
 futures = "0.3"
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash", features = [
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash", features = [
   "full",
 ] }
-holochain_keystore = { version = "^0.7.0-dev.20", path = "../holochain_keystore" }
-holochain_p2p = { version = "^0.7.0-dev.32", default-features = false, path = "../holochain_p2p" }
+holochain_keystore = { version = "^0.7.0-rc.0", path = "../holochain_keystore" }
+holochain_p2p = { version = "^0.7.0-rc.0", default-features = false, path = "../holochain_p2p" }
 holochain_serialized_bytes = "=0.0.57"
-holochain_state = { version = "^0.7.0-dev.32", path = "../holochain_state" }
-holochain_types = { version = "^0.7.0-dev.31", path = "../holochain_types" }
-holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util" }
-holochain_zome_types = { version = "^0.7.0-dev.20", path = "../holochain_zome_types" }
+holochain_state = { version = "^0.7.0-rc.0", path = "../holochain_state" }
+holochain_types = { version = "^0.7.0-rc.0", path = "../holochain_types" }
+holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util" }
+holochain_zome_types = { version = "^0.7.0-rc.0", path = "../holochain_zome_types" }
 parking_lot = "0.12.1"
 tokio = { version = "1.36.0", features = ["full"] }
 thiserror = "2.0"

--- a/crates/holochain_conductor_api/CHANGELOG.md
+++ b/crates/holochain_conductor_api/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.31
 
 ## 0.7.0-dev.30

--- a/crates/holochain_conductor_api/Cargo.toml
+++ b/crates/holochain_conductor_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_conductor_api"
-version = "0.7.0-dev.31"
+version = "0.7.0-rc.0"
 description = "Message types for Holochain admin and app interface protocols"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
@@ -12,14 +12,14 @@ edition = "2021"
 [dependencies]
 kitsune2_transport_iroh = { version = "0.5.0-dev.6", optional = true, default-features = false }
 derive_more = { version = "2.0", features = ["from"] }
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash", features = [
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash", features = [
   "full",
 ] }
-holochain_state_types = { version = "^0.7.0-dev.15", path = "../holochain_state_types" }
+holochain_state_types = { version = "^0.7.0-rc.0", path = "../holochain_state_types" }
 holochain_serialized_bytes = "=0.0.57"
-holochain_types = { version = "^0.7.0-dev.31", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.7.0-dev.20", path = "../holochain_zome_types" }
-holochain_util = { version = "^0.7.0-dev.1", default-features = false, path = "../holochain_util", features = [
+holochain_types = { version = "^0.7.0-rc.0", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.7.0-rc.0", path = "../holochain_zome_types" }
+holochain_util = { version = "^0.7.0-rc.0", default-features = false, path = "../holochain_util", features = [
   "jsonschema",
 ] }
 kitsune2_api = "0.5.0-dev.6"
@@ -31,7 +31,7 @@ yaml_serde = "0.10"
 tracing = "0.1.26"
 thiserror = "2.0"
 url2 = "0.0.6"
-holochain_keystore = { version = "^0.7.0-dev.20", path = "../holochain_keystore" }
+holochain_keystore = { version = "^0.7.0-rc.0", path = "../holochain_keystore" }
 shrinkwraprs = "0.3.0"
 indexmap = { version = "2.6.0", features = ["serde"] }
 schemars = "0.9"
@@ -43,7 +43,7 @@ holochain_conductor_api = { path = ".", features = ["test-utils", "schema"] }
 serde_json = "1.0"
 rmp-serde = "1.3"
 matches = { version = "0.1.8" }
-holochain_trace = { version = "^0.7.0-dev.1", path = "../holochain_trace" }
+holochain_trace = { version = "^0.7.0-rc.0", path = "../holochain_trace" }
 pretty_assertions = "1.4"
 jsonschema = "0.45"
 

--- a/crates/holochain_conductor_config/CHANGELOG.md
+++ b/crates/holochain_conductor_config/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.31
 
 ## 0.7.0-dev.30

--- a/crates/holochain_conductor_config/Cargo.toml
+++ b/crates/holochain_conductor_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_conductor_config"
-version = "0.7.0-dev.31"
+version = "0.7.0-rc.0"
 description = "Provides utilities for generating holochain conductor configuration."
 repository = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_conductor_config"
@@ -14,9 +14,9 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0"
 ansi_term = "0.12"
-holochain_conductor_api = { version = "^0.7.0-dev.31", path = "../holochain_conductor_api", default-features = false }
-holochain_types = { version = "^0.7.0-dev.31", path = "../holochain_types" }
-holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util", default-features = false, features = [
+holochain_conductor_api = { version = "^0.7.0-rc.0", path = "../holochain_conductor_api", default-features = false }
+holochain_types = { version = "^0.7.0-rc.0", path = "../holochain_types" }
+holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util", default-features = false, features = [
   "pw",
 ] }
 nanoid = "0.4"

--- a/crates/holochain_data/CHANGELOG.md
+++ b/crates/holochain_data/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.21
 
 ## 0.7.0-dev.20

--- a/crates/holochain_data/Cargo.toml
+++ b/crates/holochain_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_data"
-version = "0.7.0-dev.21"
+version = "0.7.0-rc.0"
 description = "Database abstraction layer for Holochain using sqlx"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
@@ -22,14 +22,14 @@ sodoken = "0.1.0"
 tokio = { version = "1.27", features = ["full"] }
 libsqlite3-sys = "0.35"
 opentelemetry = "0.31"
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash" }
-holochain_types = { version = "^0.7.0-dev.31", path = "../holochain_types" }
-holochain_integrity_types = { version = "^0.7.0-dev.15", path = "../holochain_integrity_types" }
-holochain_zome_types = { version = "^0.7.0-dev.20", path = "../holochain_zome_types" }
-holochain_conductor_api = { version = "^0.7.0-dev.31", path = "../holochain_conductor_api" }
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash" }
+holochain_types = { version = "^0.7.0-rc.0", path = "../holochain_types" }
+holochain_integrity_types = { version = "^0.7.0-rc.0", path = "../holochain_integrity_types" }
+holochain_zome_types = { version = "^0.7.0-rc.0", path = "../holochain_zome_types" }
+holochain_conductor_api = { version = "^0.7.0-rc.0", path = "../holochain_conductor_api" }
 holochain_serialized_bytes = "=0.0.57"
-holochain_nonce = { version = "^0.7.0-dev.2", path = "../holochain_nonce" }
-holochain_timestamp = { version = "^0.7.0-dev.1", path = "../timestamp" }
+holochain_nonce = { version = "^0.7.0-rc.0", path = "../holochain_nonce" }
+holochain_timestamp = { version = "^0.7.0-rc.0", path = "../timestamp" }
 serde_json = "1.0"
 indexmap = { version = "2.6.0", features = ["serde"] }
 bytes = "1"

--- a/crates/holochain_integrity_types/CHANGELOG.md
+++ b/crates/holochain_integrity_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.15
 
 ## 0.7.0-dev.14

--- a/crates/holochain_integrity_types/Cargo.toml
+++ b/crates/holochain_integrity_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_integrity_types"
-version = "0.7.0-dev.15"
+version = "0.7.0-rc.0"
 description = "Holochain integrity types"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
@@ -10,18 +10,18 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash", features = [
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash", features = [
   "encoding",
 ] }
 holochain_serialized_bytes = "=0.0.57"
-holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util", default-features = false }
-holochain_secure_primitive = { version = "^0.7.0-dev.1", path = "../holochain_secure_primitive" }
+holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util", default-features = false }
+holochain_secure_primitive = { version = "^0.7.0-rc.0", path = "../holochain_secure_primitive" }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 schemars = { version = "0.9", optional = true }
 
 # Just the bare minimum timestamp with no extra features.
-holochain_timestamp = { version = "^0.7.0-dev.1", path = "../timestamp", default-features = false }
+holochain_timestamp = { version = "^0.7.0-rc.0", path = "../timestamp", default-features = false }
 
 # TODO: Figure out how to remove these dependencies.
 subtle = "2"
@@ -38,7 +38,7 @@ tracing = { version = "0.1", optional = true }
 [dev-dependencies]
 holochain_integrity_types = { path = ".", features = ["test_utils", "fuzzing"] }
 serde_json = "1.0"
-fixt = { version = "^0.7.0-dev.1", path = "../fixt" }
+fixt = { version = "^0.7.0-rc.0", path = "../fixt" }
 
 [lints]
 workspace = true

--- a/crates/holochain_keystore/CHANGELOG.md
+++ b/crates/holochain_keystore/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.20
 
 ## 0.7.0-dev.19

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_keystore"
-version = "0.7.0-dev.20"
+version = "0.7.0-rc.0"
 description = "keystore for libsodium keypairs"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
@@ -15,13 +15,13 @@ edition = "2021"
 base64 = "0.22"
 derive_more = { version = "2.0", features = ["from"] }
 futures = "0.3"
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash", features = [
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash", features = [
   "full",
 ] }
 holochain_serialized_bytes = "=0.0.57"
-holochain_zome_types = { version = "^0.7.0-dev.20", path = "../holochain_zome_types" }
-holochain_secure_primitive = { version = "^0.7.0-dev.1", path = "../holochain_secure_primitive" }
-holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util" }
+holochain_zome_types = { version = "^0.7.0-rc.0", path = "../holochain_zome_types" }
+holochain_secure_primitive = { version = "^0.7.0-rc.0", path = "../holochain_secure_primitive" }
+holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util" }
 lair_keystore = { version = "0.7.1", default-features = false }
 must_future = "0.1.2"
 nanoid = "0.4"

--- a/crates/holochain_metrics/CHANGELOG.md
+++ b/crates/holochain_metrics/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.6
 
 ## 0.7.0-dev.5

--- a/crates/holochain_metrics/Cargo.toml
+++ b/crates/holochain_metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_metrics"
-version = "0.7.0-dev.6"
+version = "0.7.0-rc.0"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 description = "High-level Rust integration of opentelemetry metrics and InfluxDB"

--- a/crates/holochain_nonce/CHANGELOG.md
+++ b/crates/holochain_nonce/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.2
 
 ## 0.7.0-dev.1

--- a/crates/holochain_nonce/Cargo.toml
+++ b/crates/holochain_nonce/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_nonce"
-version = "0.7.0-dev.2"
+version = "0.7.0-rc.0"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 description = "This crate is for generating nonces."
@@ -11,8 +11,8 @@ documentation = "https://docs.rs/holochain_nonce"
 # reminder - do not use workspace deps
 [dependencies]
 getrandom = { version = "0.3", default-features = false, features = ["std"] }
-holochain_timestamp = { version = "^0.7.0-dev.1", path = "../timestamp" }
-holochain_secure_primitive = { version = "^0.7.0-dev.1", path = "../holochain_secure_primitive", default-features = false }
+holochain_timestamp = { version = "^0.7.0-rc.0", path = "../timestamp" }
+holochain_secure_primitive = { version = "^0.7.0-rc.0", path = "../holochain_secure_primitive", default-features = false }
 subtle-encoding = "0.5"
 
 [lints]

--- a/crates/holochain_p2p/CHANGELOG.md
+++ b/crates/holochain_p2p/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.32
 
 ## 0.7.0-dev.31

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_p2p"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 description = "holochain specific wrapper around more generic p2p module"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
@@ -15,20 +15,20 @@ edition = "2021"
 async-trait = "0.1"
 base64 = "0.22"
 blake2b_simd = "1.0.3"
-fixt = { path = "../fixt", version = "^0.7.0-dev.1" }
+fixt = { path = "../fixt", version = "^0.7.0-rc.0"}
 futures = "0.3"
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash", features = [
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash", features = [
   "kitsune2",
   "encoding",
   "hashing",
 ] }
-holochain_keystore = { version = "^0.7.0-dev.20", path = "../holochain_keystore" }
+holochain_keystore = { version = "^0.7.0-rc.0", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.57"
-holochain_types = { version = "^0.7.0-dev.31", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.7.0-dev.20", path = "../holochain_zome_types" }
-holochain_nonce = { version = "^0.7.0-dev.2", path = "../holochain_nonce" }
+holochain_types = { version = "^0.7.0-rc.0", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.7.0-rc.0", path = "../holochain_zome_types" }
+holochain_nonce = { version = "^0.7.0-rc.0", path = "../holochain_nonce" }
 mockall = "0.13"
-holochain_trace = { version = "^0.7.0-dev.1", path = "../holochain_trace" }
+holochain_trace = { version = "^0.7.0-rc.0", path = "../holochain_trace" }
 rand = "0.9"
 rmp-serde = "1.3"
 serde = { version = "1.0", features = ["derive"] }
@@ -60,8 +60,8 @@ quinn-proto = { version = "=0.11.14", default-features = false }
 socket2 = { version = "=0.6.3", default-features = false }
 bytes = "1.10"
 parking_lot = "0.12.3"
-holochain_state = { version = "^0.7.0-dev.32", path = "../holochain_state" }
-holochain_timestamp = { version = "^0.7.0-dev.1", path = "../timestamp" }
+holochain_state = { version = "^0.7.0-rc.0", path = "../holochain_state" }
+holochain_timestamp = { version = "^0.7.0-rc.0", path = "../timestamp" }
 
 [dev-dependencies]
 holochain_p2p = { path = ".", default-features = false, features = [

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2021"
 async-trait = "0.1"
 base64 = "0.22"
 blake2b_simd = "1.0.3"
-fixt = { path = "../fixt", version = "^0.7.0-rc.0"}
+fixt = { path = "../fixt", version = "^0.7.0-rc.0" }
 futures = "0.3"
 holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash", features = [
   "kitsune2",

--- a/crates/holochain_secure_primitive/CHANGELOG.md
+++ b/crates/holochain_secure_primitive/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.1
 
 ## 0.7.0-dev.0

--- a/crates/holochain_secure_primitive/Cargo.toml
+++ b/crates/holochain_secure_primitive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "holochain_secure_primitive"
 description = "Crate for the secure primitive macros"
-version = "0.7.0-dev.1"
+version = "0.7.0-rc.0"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
 documentation = "https://docs.rs/holochain_secure_primitive"

--- a/crates/holochain_state/CHANGELOG.md
+++ b/crates/holochain_state/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.32
 
 ## 0.7.0-dev.31

--- a/crates/holochain_state/Cargo.toml
+++ b/crates/holochain_state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_state"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 description = "Holochain persisted state datatypes and functions"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
@@ -17,21 +17,21 @@ chrono = { version = "0.4.22", default-features = false, features = [
   "serde",
 ] }
 derive_more = { version = "2.0", features = ["display", "deref", "deref_mut"] }
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash", features = [
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash", features = [
   "full",
 ] }
 fallible-iterator = "0.3.0"
-holochain_data = { version = "^0.7.0-dev.21", path = "../holochain_data" }
-holochain_keystore = { version = "^0.7.0-dev.20", path = "../holochain_keystore" }
+holochain_data = { version = "^0.7.0-rc.0", path = "../holochain_data" }
+holochain_keystore = { version = "^0.7.0-rc.0", path = "../holochain_keystore" }
 holochain_serialized_bytes = "=0.0.57"
 sqlx = { version = "0.9.0" }
-holochain_types = { version = "^0.7.0-dev.31", path = "../holochain_types" }
-holochain_zome_types = { version = "^0.7.0-dev.20", path = "../holochain_zome_types", features = [
+holochain_types = { version = "^0.7.0-rc.0", path = "../holochain_types" }
+holochain_zome_types = { version = "^0.7.0-rc.0", path = "../holochain_zome_types", features = [
   "full",
 ] }
-holochain_state_types = { version = "^0.7.0-dev.15", path = "../holochain_state_types" }
-holochain_nonce = { version = "^0.7.0-dev.2", path = "../holochain_nonce" }
-holochain_timestamp = { version = "^0.7.0-dev.1", path = "../timestamp", optional = true }
+holochain_state_types = { version = "^0.7.0-rc.0", path = "../holochain_state_types" }
+holochain_nonce = { version = "^0.7.0-rc.0", path = "../holochain_nonce" }
+holochain_timestamp = { version = "^0.7.0-rc.0", path = "../timestamp", optional = true }
 one_err = "0.0.8"
 shrinkwraprs = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -56,7 +56,7 @@ fixt = { path = "../fixt" }
 holochain_wasm_test_utils = { path = "../test_utils/wasm", features = [
   "build",
 ] }
-holochain_trace = { version = "^0.7.0-dev.1", path = "../holochain_trace" }
+holochain_trace = { version = "^0.7.0-rc.0", path = "../holochain_trace" }
 matches = "0.1.8"
 tempfile = "3.3"
 rand = "0.9"

--- a/crates/holochain_state/README.md
+++ b/crates/holochain_state/README.md
@@ -14,8 +14,8 @@ The Holochain state crate provides helpers and abstractions for working
 with Holochain's persistent data stores.
 
 ### Reads
-The main abstraction for creating data read queries is the `Query` trait.
-This can be implemented to make constructing complex queries easier.
+The [`DhtStore`] and [`DhtStoreRead`] types are the main abstractions for
+reading data, combining database access with the in-memory scratch space.
 
 The [`source_chain`] module provides the `SourceChain` type,
 which is the abstraction for working with chains of actions.
@@ -23,7 +23,7 @@ which is the abstraction for working with chains of actions.
 The [`host_fn_workspace`] module provides abstractions for reading data during workflows.
 
 ### Writes
-The `mutations` module provides error types for state write operations.
+The [`mutations`] module provides error types for state write operations.
 
 ### In-memory
 The [`scratch`] module provides the `Scratch` type for
@@ -31,8 +31,5 @@ reading and writing data in memory that is not visible anywhere else.
 
 The SourceChain type uses the Scratch for in-memory operations which
 can be flushed to the database.
-
-The Query trait allows combining arbitrary database SQL queries with
-the scratch space so reads can union across the database and in-memory data.
 
 <!-- cargo-rdme end -->

--- a/crates/holochain_state_types/CHANGELOG.md
+++ b/crates/holochain_state_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.15
 
 ## 0.7.0-dev.14

--- a/crates/holochain_state_types/Cargo.toml
+++ b/crates/holochain_state_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_state_types"
-version = "0.7.0-dev.15"
+version = "0.7.0-rc.0"
 description = "Types for the holochain_state crate"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
@@ -11,8 +11,8 @@ edition = "2021"
 # reminder - do not use workspace deps
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-holochain_integrity_types = { version = "^0.7.0-dev.15", path = "../holochain_integrity_types", default-features = false }
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash" }
+holochain_integrity_types = { version = "^0.7.0-rc.0", path = "../holochain_integrity_types", default-features = false }
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash" }
 
 [lints]
 workspace = true

--- a/crates/holochain_terminal/CHANGELOG.md
+++ b/crates/holochain_terminal/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.32
 
 ## 0.7.0-dev.31

--- a/crates/holochain_terminal/Cargo.toml
+++ b/crates/holochain_terminal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hcterm"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 description = "A terminal for Holochain"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
@@ -22,14 +22,14 @@ clap = { version = "4", features = ["derive"] }
 url = "2"
 once_cell = "1"
 chrono = "0.4"
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash", features = [
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash", features = [
   "encoding",
   "kitsune2",
 ] }
-holochain_client = { version = "^0.9.0-dev.32", path = "../client", default-features = false }
-holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util" }
-holochain_conductor_api = { version = "^0.7.0-dev.31", path = "../holochain_conductor_api", default-features = false }
-holochain_types = { version = "^0.7.0-dev.31", path = "../holochain_types" }
+holochain_client = { version = "^0.9.0-rc.0", path = "../client", default-features = false }
+holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util" }
+holochain_conductor_api = { version = "^0.7.0-rc.0", path = "../holochain_conductor_api", default-features = false }
+holochain_types = { version = "^0.7.0-rc.0", path = "../holochain_types" }
 tokio = { version = "1.36.0", features = ["full"] }
 kitsune2_api = "0.5.0-dev.6"
 kitsune2_core = "0.5.0-dev.6"

--- a/crates/holochain_trace/CHANGELOG.md
+++ b/crates/holochain_trace/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.1
 
 ## 0.7.0-dev.0

--- a/crates/holochain_trace/Cargo.toml
+++ b/crates/holochain_trace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_trace"
-version = "0.7.0-dev.1"
+version = "0.7.0-rc.0"
 authors = [
   "freesig <tom.gowan@holo.host>",
   "Holochain Core Dev Team <devcore@holochain.org>",

--- a/crates/holochain_types/CHANGELOG.md
+++ b/crates/holochain_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.31
 
 ## 0.7.0-dev.30

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_types"
-version = "0.7.0-dev.31"
+version = "0.7.0-rc.0"
 description = "Holochain common types"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
@@ -18,26 +18,26 @@ base64 = "0.22"
 derive_builder = "0.20"
 derive_more = { version = "2.0", features = ["constructor", "into_iterator"] }
 futures = "0.3"
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash", features = [
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash", features = [
   "encoding",
   "schema",
 ] }
-holochain_keystore = { version = "^0.7.0-dev.20", path = "../holochain_keystore" }
-holochain_nonce = { version = "^0.7.0-dev.2", path = "../holochain_nonce" }
+holochain_keystore = { version = "^0.7.0-rc.0", path = "../holochain_keystore" }
+holochain_nonce = { version = "^0.7.0-rc.0", path = "../holochain_nonce" }
 holochain_serialized_bytes = "=0.0.57"
-holochain_trace = { version = "^0.7.0-dev.1", path = "../holochain_trace" }
-holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util", features = [
+holochain_trace = { version = "^0.7.0-rc.0", path = "../holochain_trace" }
+holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util", features = [
   "backtrace",
 ] }
-holochain_zome_types = { path = "../holochain_zome_types", version = "^0.7.0-dev.20", features = [
+holochain_zome_types = { path = "../holochain_zome_types", version = "^0.7.0-rc.0", features = [
   "full",
 ] }
-holochain_timestamp = { version = "^0.7.0-dev.1", path = "../timestamp" }
+holochain_timestamp = { version = "^0.7.0-rc.0", path = "../timestamp" }
 kitsune2_api = "0.5.0-dev.6"
 itertools = { version = "0.14" }
 mr_bundle = { path = "../mr_bundle", features = [
   "fs",
-], version = "^0.7.0-dev.2" }
+], version = "^0.7.0-rc.0"}
 must_future = "0.1.1"
 nanoid = "0.4"
 parking_lot = "0.12"
@@ -59,7 +59,7 @@ indexmap = { version = "2.6.0", features = ["serde"] }
 schemars = "0.9"
 bytes = { version = "1.10.1", features = ["serde"] }
 
-fixt = { path = "../fixt", version = "^0.7.0-dev.1", optional = true }
+fixt = { path = "../fixt", version = "^0.7.0-rc.0", optional = true }
 proptest = { version = "1", optional = true }
 proptest-derive = { version = "0", optional = true }
 

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -37,7 +37,7 @@ kitsune2_api = "0.5.0-dev.6"
 itertools = { version = "0.14" }
 mr_bundle = { path = "../mr_bundle", features = [
   "fs",
-], version = "^0.7.0-rc.0"}
+], version = "^0.7.0-rc.0" }
 must_future = "0.1.1"
 nanoid = "0.4"
 parking_lot = "0.12"

--- a/crates/holochain_util/CHANGELOG.md
+++ b/crates/holochain_util/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.1
 
 ## 0.7.0-dev.0

--- a/crates/holochain_util/Cargo.toml
+++ b/crates/holochain_util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_util"
-version = "0.7.0-dev.1"
+version = "0.7.0-rc.0"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 description = "This crate is a collection of various utility functions that are used in the other crates in the holochain repository."

--- a/crates/holochain_websocket/CHANGELOG.md
+++ b/crates/holochain_websocket/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.31
 
 ## 0.7.0-dev.30

--- a/crates/holochain_websocket/Cargo.toml
+++ b/crates/holochain_websocket/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_websocket"
-version = "0.7.0-dev.31"
+version = "0.7.0-rc.0"
 description = "Holochain utilities for serving and connection with websockets"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
@@ -12,7 +12,7 @@ edition = "2021"
 [dependencies]
 futures = "0.3"
 holochain_serialized_bytes = "=0.0.57"
-holochain_types = { version = "^0.7.0-dev.31", path = "../holochain_types" }
+holochain_types = { version = "^0.7.0-rc.0", path = "../holochain_types" }
 serde = "1.0"
 serde_bytes = "0.11.14"
 tokio = { version = "1.36.0", features = ["full"] }
@@ -23,7 +23,7 @@ thiserror = "2.0"
 bytes = "1.10.1"
 
 [dev-dependencies]
-holochain_trace = { version = "^0.7.0-dev.1", path = "../holochain_trace" }
+holochain_trace = { version = "^0.7.0-rc.0", path = "../holochain_trace" }
 criterion = "0.6"
 
 [lints]

--- a/crates/holochain_zome_types/CHANGELOG.md
+++ b/crates/holochain_zome_types/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.20
 
 ## 0.7.0-dev.19

--- a/crates/holochain_zome_types/Cargo.toml
+++ b/crates/holochain_zome_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_zome_types"
-version = "0.7.0-dev.20"
+version = "0.7.0-rc.0"
 description = "Holochain zome types"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"
@@ -11,14 +11,14 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
-holochain_timestamp = { version = "^0.7.0-dev.1", path = "../timestamp" }
-holo_hash = { version = "^0.7.0-dev.11", path = "../holo_hash", features = [
+holochain_timestamp = { version = "^0.7.0-rc.0", path = "../timestamp" }
+holo_hash = { version = "^0.7.0-rc.0", path = "../holo_hash", features = [
   "encoding",
 ] }
-holochain_integrity_types = { version = "^0.7.0-dev.15", path = "../holochain_integrity_types", features = [
+holochain_integrity_types = { version = "^0.7.0-rc.0", path = "../holochain_integrity_types", features = [
   "tracing",
 ] }
-holochain_nonce = { version = "^0.7.0-dev.2", path = "../holochain_nonce" }
+holochain_nonce = { version = "^0.7.0-rc.0", path = "../holochain_nonce" }
 holochain_serialized_bytes = "=0.0.57"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_bytes = "0.11"
@@ -38,7 +38,7 @@ derive_more = { version = "2.0", features = [
 ] }
 
 # fixturator dependencies
-fixt = { version = "^0.7.0-dev.1", path = "../fixt", optional = true }
+fixt = { version = "^0.7.0-rc.0", path = "../fixt", optional = true }
 rand = { version = "0.9", optional = true }
 
 # full-dna-def dependencies

--- a/crates/mr_bundle/CHANGELOG.md
+++ b/crates/mr_bundle/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.2
 
 ## 0.7.0-dev.1

--- a/crates/mr_bundle/Cargo.toml
+++ b/crates/mr_bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mr_bundle"
-version = "0.7.0-dev.2"
+version = "0.7.0-rc.0"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2021"
 description = "Implements the un-/packing of bundles that either embed or reference a set of resources"
@@ -18,7 +18,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 # reminder - do not use workspace deps
 [dependencies]
 flate2 = "1.0"
-holochain_util = { version = "^0.7.0-dev.1", path = "../holochain_util" }
+holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util" }
 futures = "0.3"
 rmp-serde = "=1.3.0"
 serde = { version = "1.0", features = ["serde_derive", "derive"] }

--- a/crates/test_utils/wasm/CHANGELOG.md
+++ b/crates/test_utils/wasm/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.32
 
 ## 0.7.0-dev.31

--- a/crates/test_utils/wasm/Cargo.toml
+++ b/crates/test_utils/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_wasm_test_utils"
-version = "0.7.0-dev.32"
+version = "0.7.0-rc.0"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
 description = "Utilities for Wasm testing for Holochain"
@@ -20,7 +20,7 @@ unstable-functions = []
 
 # reminder - do not use workspace deps
 [dependencies]
-holochain_types = { version = "^0.7.0-dev.31", path = "../../holochain_types" }
+holochain_types = { version = "^0.7.0-rc.0", path = "../../holochain_types" }
 strum = "0.27"
 strum_macros = "0.27"
 

--- a/crates/test_utils/wasm/wasm_workspace/Cargo.lock
+++ b/crates/test_utils/wasm/wasm_workspace/Cargo.lock
@@ -359,7 +359,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixt"
-version = "0.7.0-dev.1"
+version = "0.7.0-rc.0"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -532,7 +532,7 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hdi"
-version = "0.8.0-dev.15"
+version = "0.8.0-rc.0"
 dependencies = [
  "getrandom 0.3.4",
  "hdk_derive",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.7.0-dev.21"
+version = "0.7.0-rc.0"
 dependencies = [
  "getrandom 0.3.4",
  "hdi",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.7.0-dev.15"
+version = "0.7.0-rc.0"
 dependencies = [
  "darling 0.21.3",
  "heck",
@@ -587,7 +587,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "holo_hash"
-version = "0.7.0-dev.11"
+version = "0.7.0-rc.0"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.7.0-dev.15"
+version = "0.7.0-rc.0"
 dependencies = [
  "derive_builder",
  "holo_hash",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.7.0-dev.2"
+version = "0.7.0-rc.0"
 dependencies = [
  "getrandom 0.3.4",
  "holochain_secure_primitive",
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_secure_primitive"
-version = "0.7.0-dev.1"
+version = "0.7.0-rc.0"
 dependencies = [
  "paste",
  "serde",
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_test_wasm_common"
-version = "0.7.0-dev.21"
+version = "0.7.0-rc.0"
 dependencies = [
  "hdk",
  "holochain_serialized_bytes",
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_timestamp"
-version = "0.7.0-dev.1"
+version = "0.7.0-rc.0"
 dependencies = [
  "chrono",
  "serde",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.7.0-dev.1"
+version = "0.7.0-rc.0"
 dependencies = [
  "cfg-if",
  "colored",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.7.0-dev.20"
+version = "0.7.0-rc.0"
 dependencies = [
  "derive_builder",
  "derive_more",

--- a/crates/test_utils/wasm_common/CHANGELOG.md
+++ b/crates/test_utils/wasm_common/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.21
 
 ## 0.7.0-dev.20

--- a/crates/test_utils/wasm_common/Cargo.toml
+++ b/crates/test_utils/wasm_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_test_wasm_common"
-version = "0.7.0-dev.21"
+version = "0.7.0-rc.0"
 authors = ["thedavidmeister", "thedavidmeister@gmail.com"]
 edition = "2021"
 description = "Common code for Wasm testing for Holochain"
@@ -14,6 +14,6 @@ path = "src/lib.rs"
 
 # reminder - do not use workspace deps
 [dependencies]
-hdk = { path = "../../hdk", version = "^0.7.0-dev.21" }
+hdk = { path = "../../hdk", version = "^0.7.0-rc.0"}
 holochain_serialized_bytes = "0.0.57"
 serde = "1.0"

--- a/crates/timestamp/CHANGELOG.md
+++ b/crates/timestamp/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## \[Unreleased\]
 
+## 0.7.0-rc.0
+
 ## 0.7.0-dev.1
 
 ## 0.7.0-dev.0

--- a/crates/timestamp/Cargo.toml
+++ b/crates/timestamp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "holochain_timestamp"
-version = "0.7.0-dev.1"
+version = "0.7.0-rc.0"
 description = "Microsecond-precision timestamp datatype for Holochain"
 license = "Apache-2.0"
 repository = "https://github.com/holochain/holochain"


### PR DESCRIPTION
Please double-check the consistency of the CHANGELOG.md files

This completes the 0.7.0-rc.0 release manually: the automated release workflow (run [29422449610](https://github.com/holochain/holochain/actions/runs/29422449610)) published all crates successfully but then failed in the "Publish crates" step because `release-automation` did not recognize cargo's current "already exists on crates.io index" message as a tolerable already-published condition, aborting before the remaining finalize steps (tags, this merge-back, and the GitHub release) could run.