### PR TITLE
fix: recognize cargo's current already-published error message

### DIFF
--- a/crates/release-automation/src/lib/release.rs
+++ b/crates/release-automation/src/lib/release.rs
@@ -500,6 +500,7 @@ impl PublishError {
         static PACKAGE_NOT_FOUND_RE: OnceCell<regex::Regex> = OnceCell::new();
         static PACKAGE_VERSION_NOT_FOUND_RE: OnceCell<regex::Regex> = OnceCell::new();
         static ALREADY_UPLOADED_RE: OnceCell<regex::Regex> = OnceCell::new();
+        static ALREADY_EXISTS_RE: OnceCell<regex::Regex> = OnceCell::new();
         static PUBLISH_LIMIT_EXCEEDED_RE: OnceCell<regex::Regex> = OnceCell::new();
 
         if let Some(captures) = PACKAGE_NOT_FOUND_RE
@@ -613,6 +614,33 @@ impl PublishError {
                     package,
                     version,
                     path: path.map(|path| path.as_str().to_string()).unwrap_or_default(),
+                    location: location.as_str().to_string(),
+                    version_found,
+                }
+            }
+        } else if let Some(captures) = ALREADY_EXISTS_RE
+            .get_or_init(|| {
+                regex::Regex::new(indoc::indoc!(
+                    r#"
+                    error: crate \S+@(?P<version>\S+) already exists on (?P<location>.*)
+                    "#
+                ))
+                .expect("regex should compile")
+            })
+            .captures(&input)
+        {
+            if let (Some(location), Some(version_found)) = (
+                captures.name("location"),
+                captures.name("version"),
+            ) {
+                let version_found= version_found.as_str().to_string();
+                if version_found != version {
+                    warn!("version mismatch. got '{}' expected '{}'", version_found, version);
+                }
+                return PublishError::AlreadyUploaded {
+                    package,
+                    version,
+                    path: String::new(),
                     location: location.as_str().to_string(),
                     version_found,
                 }

--- a/crates/release-automation/src/lib/tests/mod.rs
+++ b/crates/release-automation/src/lib/tests/mod.rs
@@ -161,6 +161,25 @@ fn parse_publish_error() {
             },
         },
         TestCase {
+            package: "holochain_nonce",
+            version: "0.7.0-rc.0",
+            string: indoc::indoc!(
+                r#"
+                    Updating crates.io index
+                      Credential cargo:token get crates-io
+                    error: crate holochain_nonce@0.7.0-rc.0 already exists on crates.io index
+                "#
+            ),
+
+            expected_error: PublishError::AlreadyUploaded {
+                package: "holochain_nonce".to_string(),
+                version: "0.7.0-rc.0".to_string(),
+                path: "".to_string(),
+                location: "crates.io index".to_string(),
+                version_found: "0.7.0-rc.0".to_string(),
+            },
+        },
+        TestCase {
             package: "",
             version: "",
             string: indoc::indoc!(


### PR DESCRIPTION
The 0.7.0-rc.0 release run (https://github.com/holochain/holochain/actions/runs/29422449610) published all 33 crates successfully but the "Publish crates" step then failed because `PublishError::with_str` only recognized cargo's older "failed to publish to ... crate version `X` is already uploaded" wording. Current cargo reports this as "crate NAME@VERSION already exists on crates.io index", which fell through to `PublishError::Other` and is never tolerated, hard-failing an otherwise-successful/no-op retry.

Adds a second regex for the current message format, mapping it to the same `PublishError::AlreadyUploaded` variant so the existing tolerance check (matching version = tolerated) applies.