### PR TITLE
fix: `hc` CLI won't build without libsqlite3 provided

### DIFF
--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -22,7 +22,9 @@ holochain_serialized_bytes = "=0.0.57"
 holochain_zome_types = { version = "^0.7.0-rc.0", path = "../holochain_zome_types" }
 holochain_secure_primitive = { version = "^0.7.0-rc.0", path = "../holochain_secure_primitive" }
 holochain_util = { version = "^0.7.0-rc.0", path = "../holochain_util" }
-lair_keystore = { version = "0.7.1", default-features = false }
+lair_keystore = { version = "0.7.1", default-features = false, features = [
+  "rusqlite-bundled-sqlcipher-vendored-openssl",
+] }
 must_future = "0.1.2"
 nanoid = "0.4"
 one_err = "0.0.8"


### PR DESCRIPTION
### Summary



### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs