### PR TITLE
Reduce keystore dep impact

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,12 +3200,15 @@ name = "holochain_keystore"
 version = "0.7.0-rc.1"
 dependencies = [
  "assert_cmd",
+ "async-trait",
  "base64",
  "derive_more",
  "futures",
  "holo_hash",
  "holochain_secure_primitive",
  "holochain_serialized_bytes",
+ "holochain_timestamp",
+ "holochain_types",
  "holochain_util",
  "holochain_zome_types",
  "lair_keystore",
@@ -3431,16 +3434,13 @@ name = "holochain_types"
 version = "0.7.0-rc.2"
 dependencies = [
  "anyhow",
- "async-trait",
  "backtrace",
- "base64",
  "bytes",
  "derive_builder",
  "derive_more",
  "fixt",
  "futures",
  "holo_hash",
- "holochain_keystore",
  "holochain_nonce",
  "holochain_serialized_bytes",
  "holochain_timestamp",

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- **BREAKING CHANGE**: `holochain_types` no longer depends on `holochain_keystore`. The signing/verification extension traits and methods that lived on `holochain_types` types (`SignedActionHashedExt`, `ValidationReceipt::sign`, `WarrantOp::sign`, `ReportEntryFetchedOps::verify`) have moved to new extension traits in `holochain_keystore` (`SignedActionHashedExt`, `ValidationReceiptExt`, `WarrantOpExt`, `ReportEntryFetchedOpsExt`). `holochain_types::prelude` no longer re-exports `holochain_keystore::AgentPubKeyExt`. Downstream code using these methods must import the traits from `holochain_keystore` instead.
 - Increase the SQLite `busy_timeout` from sqlx's 5s default to 15s, to reduce spurious "database is locked" errors logged by queue consumer workflows under writer contention.
 - **BREAKING CHANGE**: `holochain_zome_types::query::AgentActivity`, the response type of `hdk::chain::get_agent_activity`, is renamed to `AgentActivityStatus`. This resolves a name collision with the unrelated `AgentActivity` `Op` variant struct.
 - **BREAKING CHANGE**: `holochain_integrity_types::action::CapAccess` (the `CapGrant.cap_access` column discriminant) is renamed to `CapAccessType`. This resolves a name collision with `holochain_integrity_types::capability::CapAccess`, the data-carrying grant-access type used by `ZomeCallCapGrant`, which keeps the `CapAccess` name. \#5882

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -30,6 +30,7 @@ use error::CellError;
 use futures::future::FutureExt;
 use holo_hash::*;
 use holochain_cascade::authority;
+use holochain_keystore::AgentPubKeyExt;
 use holochain_nonce::fresh_nonce;
 use holochain_p2p::event::CountersigningSessionNegotiationMessage;
 use holochain_p2p::{HolochainP2pDna, HolochainP2pError, HolochainP2pResult};

--- a/crates/holochain/src/conductor/cell/test.rs
+++ b/crates/holochain/src/conductor/cell/test.rs
@@ -8,6 +8,7 @@ use crate::sweettest::SweetConductorConfig;
 use crate::test_utils::fake_valid_dna_file;
 use holo_hash::HasHash;
 use holochain_conductor_api::conductor::paths::DataRootPath;
+use holochain_keystore::SignedActionHashedExt;
 use holochain_p2p::actor::MockHcP2p;
 use holochain_p2p::HolochainP2pDna;
 use holochain_state::prelude::*;

--- a/crates/holochain/src/core/sys_validate/tests.rs
+++ b/crates/holochain/src/core/sys_validate/tests.rs
@@ -29,23 +29,16 @@
 
 use super::*;
 use crate::conductor::space::TestSpaces;
-use crate::core::workflow::sys_validation_workflow::sys_validate_record;
-use crate::sweettest::SweetAgents;
-use crate::sweettest::SweetConductor;
 use ::fixt::prelude::*;
 use error::SysValidationError;
 use holo_hash::fixt::ActionHashFixturator;
 use holo_hash::fixt::DnaHashFixturator;
 use holo_hash::fixt::EntryHashFixturator;
-use holochain_cascade::MockCascade;
 use holochain_keystore::test_keystore;
 use holochain_keystore::AgentPubKeyExt;
 use holochain_serialized_bytes::SerializedBytes;
-use holochain_types::test_utils::valid_arbitrary_chain;
-use holochain_types::test_utils::ActionRefMut;
 use holochain_zome_types::fixt::{ActionFixturator, CreateAction, CreateLinkAction};
 use matches::assert_matches;
-use std::time::Duration;
 
 /// Entry type in the action matches the entry variant
 #[test]
@@ -180,40 +173,4 @@ fn create_entry_op_rejects_private_entry() {
         check_entry_visibility(&ChainOp::CreateRecord(sa, OpEntry::Hidden)),
         Ok(())
     );
-}
-
-/// Test that the valid_chain contrafact matches our chain validation function,
-/// since many other tests will depend on this constraint
-#[tokio::test(flavor = "multi_thread")]
-// XXX: the valid_arbitrary_chain as used here can't handle actions with
-// sys validation dependencies, so we filter out those action types.
-// Also, there are several other problems here that need to be addressed
-// to make this not flaky.
-#[ignore = "flaky"]
-async fn valid_chain_fact_test() {
-    let n = 100;
-    let keystore = SweetConductor::standard().await.keystore();
-    let author = SweetAgents::one(keystore.clone()).await;
-
-    let mut chain = valid_arbitrary_chain(&keystore, author, n).await;
-
-    validate_chain(chain.iter().map(|r| r.signed_action()), &None).unwrap();
-
-    let mut last = chain.pop().unwrap();
-    let penult = chain.last().unwrap();
-
-    // clean up this record so it's valid
-    *last.as_action_mut().timestamp_mut() =
-        (penult.action().timestamp() + Duration::from_secs(1)).unwrap();
-    // re-sign it
-    last.signed_action = SignedActionHashed::sign(
-        &keystore,
-        holo_hash::HoloHashed::from_content_sync(last.action().clone()),
-    )
-    .await
-    .unwrap();
-
-    let cascade = MockCascade::with_records(chain);
-
-    sys_validate_record(&last, Arc::new(cascade)).await.unwrap();
 }

--- a/crates/holochain/src/core/workflow/app_validation_workflow/run_validation_callback_tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/run_validation_callback_tests.rs
@@ -14,12 +14,12 @@ use hdk::prelude::EntryFixturator;
 use holo_hash::fixt::AgentPubKeyFixturator;
 use holo_hash::{ActionHash, AgentPubKey, HashableContentExtSync};
 use holochain_keystore::MetaLairClient;
+use holochain_keystore::SignedActionHashedExt;
 use holochain_p2p::MockHolochainP2pDnaT;
 use holochain_state::host_fn_workspace::HostFnWorkspaceRead;
 use holochain_types::{
     chain::MustGetAgentActivityResponse,
     op::{ChainOp, DhtOp, DhtOpHashed},
-    prelude::SignedActionHashedExt,
     record::WireRecordOps,
     wire_ops::{RenderedOp, RenderedOps, WireOps},
 };

--- a/crates/holochain/src/core/workflow/sys_validation_workflow.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow.rs
@@ -110,7 +110,7 @@ use futures::StreamExt;
 use holo_hash::DhtOpHash;
 use holochain_cascade::Cascade;
 use holochain_cascade::CascadeImpl;
-use holochain_keystore::MetaLairClient;
+use holochain_keystore::{AgentPubKeyExt, MetaLairClient, WarrantOpExt};
 use holochain_p2p::DynHolochainP2pDna;
 use holochain_state::dht_store::DhtStore;
 use holochain_state::prelude::*;

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/tests.rs
@@ -5,6 +5,7 @@ use crate::test_utils::host_fn_caller::*;
 use crate::test_utils::{assert_limbo_empty, wait_for_integration};
 use crate::{conductor::ConductorHandle, core::MAX_TAG_SIZE};
 use holo_hash::fixt::AgentPubKeyFixturator;
+use holochain_keystore::SignedActionHashedExt;
 use holochain_wasm_test_utils::TestWasm;
 use holochain_zome_types::action::SignedAction;
 use holochain_zome_types::fixt::{ActionFixturator, CreateAction, DnaAction};

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/unit_tests.rs
@@ -13,6 +13,7 @@ use holo_hash::DhtOpHash;
 use holo_hash::DnaHash;
 use holo_hash::HasHash;
 use holochain_keystore::MetaLairClient;
+use holochain_keystore::{SignedActionHashedExt, WarrantOpExt};
 use holochain_p2p::MockHolochainP2pDnaT;
 use holochain_state::mutations::StateMutationResult;
 use holochain_timestamp::Timestamp;
@@ -20,7 +21,6 @@ use holochain_types::op::ChainOp;
 use holochain_types::op::DhtOp;
 use holochain_types::op::DhtOpHashed;
 use holochain_types::op::OpEntry;
-use holochain_types::record::SignedActionHashedExt;
 use holochain_types::record::WireRecordOps;
 use holochain_types::wire_ops::WireOps;
 use holochain_zome_types::fixt::{

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validate_op_tests.rs
@@ -13,6 +13,7 @@ use holo_hash::fixt::DnaHashFixturator;
 use holo_hash::fixt::EntryHashFixturator;
 use holochain_cascade::CascadeSource;
 use holochain_cascade::MockCascade;
+use holochain_keystore::SignedActionHashedExt;
 use holochain_zome_types::fixt::{
     ActionFixturator, AgentValidationPkgAction, CloseChainAction, CreateAction, CreateLinkAction,
     DeleteAction, DeleteLinkAction, DnaAction, InitZomesCompleteAction, UpdateAction,

--- a/crates/holochain/src/core/workflow/sys_validation_workflow/validate_warrant_tests.rs
+++ b/crates/holochain/src/core/workflow/sys_validation_workflow/validate_warrant_tests.rs
@@ -17,6 +17,8 @@ use ::fixt::prelude::*;
 use holo_hash::fixt::ActionHashFixturator;
 use holo_hash::fixt::EntryHashFixturator;
 use holochain_cascade::CascadeSource;
+use holochain_keystore::SignedActionHashedExt;
+use holochain_keystore::WarrantOpExt;
 use holochain_zome_types::fixt::{ActionFixturator, CreateAction};
 
 /// Test that a valid ChainFork warrant is accepted when both actions:

--- a/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
+++ b/crates/holochain/src/core/workflow/validation_receipt_workflow.rs
@@ -1,7 +1,7 @@
 use super::error::WorkflowResult;
 use crate::core::queue_consumer::WorkComplete;
 use futures::{stream, StreamExt};
-use holochain_keystore::MetaLairClient;
+use holochain_keystore::{MetaLairClient, ValidationReceiptExt};
 use holochain_p2p::DynHolochainP2pDna;
 use holochain_state::dht_store::DhtStore;
 use holochain_state::prelude::*;

--- a/crates/holochain/tests/tests/warrants.rs
+++ b/crates/holochain/tests/tests/warrants.rs
@@ -12,6 +12,7 @@ use holochain::{
     },
     test_utils::retry_fn_until_timeout,
 };
+use holochain_keystore::WarrantOpExt;
 use holochain_timestamp::Timestamp;
 use holochain_types::op::{DhtOp, DhtOpHashed};
 use holochain_types::prelude::WarrantOp;

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -1,8 +1,8 @@
 use crate::peer_meta::PeerMetaInfo;
 use crate::{AppAuthenticationToken, ExternalApiWireError};
 use holo_hash::AgentPubKey;
-use holochain_keystore::LairResult;
 use holochain_keystore::MetaLairClient;
+use holochain_keystore::{AgentPubKeyExt, LairResult};
 use holochain_types::prelude::*;
 use indexmap::IndexMap;
 use kitsune2_api::Url;

--- a/crates/holochain_keystore/Cargo.toml
+++ b/crates/holochain_keystore/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 
 # reminder - do not use workspace deps
 [dependencies]
+async-trait = "0.1"
 base64 = "0.22"
 derive_more = { version = "2.0", features = ["from"] }
 futures = "0.3"
@@ -19,6 +20,7 @@ holo_hash = { version = "^0.7.0-rc.1", path = "../holo_hash", features = [
   "full",
 ] }
 holochain_serialized_bytes = "=0.0.57"
+holochain_types = { version = "0.7.0-rc.1", path = "../holochain_types" }
 holochain_zome_types = { version = "^0.7.0-rc.1", path = "../holochain_zome_types" }
 holochain_secure_primitive = { version = "^0.7.0-rc.1", path = "../holochain_secure_primitive" }
 holochain_util = { version = "^0.7.0-rc.1", path = "../holochain_util" }
@@ -40,6 +42,7 @@ tracing = "0.1"
 url2 = "0.0.6"
 
 [dev-dependencies]
+holochain_timestamp = { version = "0.7.0-rc.1", path = "../timestamp" }
 assert_cmd = "2.0.4"
 yaml_serde = "0.10"
 tempfile = "3.23"

--- a/crates/holochain_keystore/src/action_ext.rs
+++ b/crates/holochain_keystore/src/action_ext.rs
@@ -91,8 +91,8 @@ mod test {
         }
     }
 
-    #[tokio::test]
-    async fn test_signed_action_roundtrip() {
+    #[test]
+    fn signed_action_round_trip() {
         let signature = Signature([9u8; 64]);
         let action = sample_action();
         let signed_action = SignedAction::new(action.clone(), signature.clone());

--- a/crates/holochain_keystore/src/action_ext.rs
+++ b/crates/holochain_keystore/src/action_ext.rs
@@ -1,0 +1,109 @@
+use crate::{AgentPubKeyExt, KeystoreError, LairResult, MetaLairClient};
+use holo_hash::{AgentPubKey, HashableContentExtSync};
+use holochain_types::prelude::{
+    Action, ActionData, CloseChainData, MigrationTarget, SignedAction, SignedActionHashed,
+};
+
+/// Extension for keystore operations on a [`SignedActionHashed`].
+#[async_trait::async_trait]
+pub trait SignedActionHashedExt {
+    /// Create a hash from data
+    fn from_content_sync(signed_action: SignedAction) -> SignedActionHashed;
+    /// Sign some content
+    async fn sign(
+        keystore: &MetaLairClient,
+        action: holo_hash::HoloHashed<Action>,
+    ) -> LairResult<SignedActionHashed>;
+    /// Validate the data
+    async fn verify_signature(&self) -> Result<(), KeystoreError>;
+}
+
+#[async_trait::async_trait]
+impl SignedActionHashedExt for SignedActionHashed {
+    fn from_content_sync(signed_action: SignedAction) -> Self
+    where
+        Self: Sized,
+    {
+        let (action, signature) = signed_action.into();
+        Self::with_presigned(action.into_hashed(), signature)
+    }
+
+    /// Construct by signing the Action (NOT including the hash)
+    async fn sign(
+        keystore: &MetaLairClient,
+        action_hashed: holo_hash::HoloHashed<Action>,
+    ) -> LairResult<Self> {
+        let signature = action_signer(&action_hashed.content)
+            .sign(keystore, &action_hashed.content)
+            .await?;
+        Ok(Self::with_presigned(action_hashed, signature))
+    }
+
+    /// Verify that the signature matches the signed action
+    async fn verify_signature(&self) -> Result<(), KeystoreError> {
+        if !action_signer(&self.hashed.content)
+            .verify_signature(self.signature(), &self.hashed.content)
+            .await?
+        {
+            return Err(KeystoreError::InvalidSignature(
+                self.signature().clone(),
+                format!("action {:?}", self.as_hash()),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// The public key that should sign (and later verify) this action.
+///
+/// This is the author for every variant except a `CloseChain` that names an
+/// agent migration target: that variant is signed with the *new* key so the
+/// forward reference it carries is provably endorsed by the destination
+/// agent.
+fn action_signer(action: &Action) -> &AgentPubKey {
+    match &action.data {
+        ActionData::CloseChain(CloseChainData {
+            new_target: Some(MigrationTarget::Agent(agent)),
+            ..
+        }) => agent,
+        _ => &action.header.author,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::SignedActionHashedExt;
+    use holo_hash::{AgentPubKey, HoloHashed};
+    use holochain_types::prelude::*;
+    use holochain_zome_types::prelude::{SignedAction, SignedActionHashed};
+
+    fn sample_action() -> Action {
+        Action {
+            header: ActionHeader {
+                author: AgentPubKey::from_raw_36(vec![1u8; 36]),
+                timestamp: holochain_timestamp::Timestamp::from_micros(42),
+                action_seq: 0,
+                prev_action: None,
+            },
+            data: ActionData::Dna(DnaData {
+                dna_hash: DnaHash::from_raw_36(vec![2u8; 36]),
+            }),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_signed_action_roundtrip() {
+        let signature = Signature([9u8; 64]);
+        let action = sample_action();
+        let signed_action = SignedAction::new(action.clone(), signature.clone());
+
+        let shh = SignedActionHashed::from_content_sync(signed_action);
+
+        assert_eq!(
+            shh.as_hash(),
+            &HoloHashed::<Action>::from_content_sync(action.clone()).into_hash()
+        );
+        assert_eq!(shh.hashed.content, action);
+        assert_eq!(shh.signature, signature);
+    }
+}

--- a/crates/holochain_keystore/src/lib.rs
+++ b/crates/holochain_keystore/src/lib.rs
@@ -51,6 +51,18 @@ pub use meta_lair_client::*;
 mod agent_pubkey_ext;
 pub use agent_pubkey_ext::*;
 
+mod action_ext;
+pub use action_ext::*;
+
+mod validation_receipt_ext;
+pub use validation_receipt_ext::*;
+
+mod report_ext;
+pub use report_ext::*;
+
+mod warrant_ext;
+pub use warrant_ext::*;
+
 pub mod lair_keystore;
 
 pub mod paths;

--- a/crates/holochain_keystore/src/report_ext.rs
+++ b/crates/holochain_keystore/src/report_ext.rs
@@ -1,0 +1,65 @@
+//! Extension trait definition [`ReportEntryFetchedOpsExt`].
+
+use crate::AgentPubKeyExt;
+use base64::prelude::*;
+use holo_hash::AgentPubKey;
+use holochain_types::report::ReportEntryFetchedOps;
+use must_future::MustBoxFuture;
+
+/// Extension for keystore operations on a [`ReportEntryFetchedOps`].
+pub trait ReportEntryFetchedOpsExt {
+    /// Verify the signatures.
+    fn verify(&self) -> MustBoxFuture<'static, bool>;
+}
+
+impl ReportEntryFetchedOpsExt for ReportEntryFetchedOps {
+    fn verify(&self) -> MustBoxFuture<'static, bool> {
+        let to_verify = self.encode_for_verification();
+
+        tracing::trace!(to_verify = %String::from_utf8_lossy(&to_verify), report = ?self, "verify");
+
+        if self.agent_pubkeys.is_empty() || self.agent_pubkeys.len() != self.signatures.len() {
+            tracing::trace!("report signatures invalid");
+            return MustBoxFuture::new(async move { false });
+        }
+
+        let iter = self
+            .agent_pubkeys
+            .iter()
+            .cloned()
+            .zip(self.signatures.iter().cloned())
+            .collect::<Vec<_>>();
+
+        MustBoxFuture::new(async move {
+            for (agent, sig) in iter {
+                let agent = agent.trim_start_matches("u");
+                let agent = match BASE64_URL_SAFE_NO_PAD.decode(agent) {
+                    Ok(agent) => agent,
+                    Err(_) => return false,
+                };
+                if agent.len() != 39 {
+                    return false;
+                }
+                let sig = match BASE64_URL_SAFE_NO_PAD.decode(sig) {
+                    Ok(sig) => sig,
+                    Err(_) => return false,
+                };
+                if sig.len() != 64 {
+                    return false;
+                }
+                let sig: [u8; 64] = sig.try_into().expect("array conversion failed");
+
+                let pk = AgentPubKey::from_raw_39(agent);
+                match pk
+                    .verify_signature_raw(&sig.into(), to_verify.clone().into())
+                    .await
+                {
+                    Ok(true) => (),
+                    _ => return false,
+                }
+            }
+
+            true
+        })
+    }
+}

--- a/crates/holochain_keystore/src/validation_receipt_ext.rs
+++ b/crates/holochain_keystore/src/validation_receipt_ext.rs
@@ -65,7 +65,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_try_stream_of_results() {
+    async fn check_try_stream_of_results() {
         let iter: Vec<futures::future::Ready<Result<i32, String>>> = vec![];
         let stream = futures::stream::iter(iter);
         assert_eq!(Ok(vec![]), try_stream_of_results(stream).await);

--- a/crates/holochain_keystore/src/validation_receipt_ext.rs
+++ b/crates/holochain_keystore/src/validation_receipt_ext.rs
@@ -1,0 +1,92 @@
+//! Extension trait definition [`ValidationReceiptExt`].
+
+use crate::{AgentPubKeyExt, LairResult, MetaLairClient};
+use futures::{Stream, StreamExt, TryStreamExt};
+use holochain_types::prelude::{SignedValidationReceipt, ValidationReceipt};
+use must_future::MustBoxFuture;
+
+/// Extension for keystore operations on a [`ValidationReceipt`].
+pub trait ValidationReceiptExt {
+    /// Sign this validation receipt.
+    fn sign(
+        self,
+        keystore: &MetaLairClient,
+    ) -> MustBoxFuture<'static, LairResult<Option<SignedValidationReceipt>>>;
+}
+
+impl ValidationReceiptExt for ValidationReceipt {
+    fn sign(
+        self,
+        keystore: &MetaLairClient,
+    ) -> MustBoxFuture<'static, LairResult<Option<SignedValidationReceipt>>> {
+        let keystore = keystore.clone();
+        MustBoxFuture::new(async move {
+            if self.validators.is_empty() {
+                return Ok(None);
+            }
+            let this = self.clone();
+            // Try to sign with all validators but silently fail on
+            // any that cannot sign.
+            // If all signatures fail then return an error.
+            let futures = self
+                .validators
+                .iter()
+                .map(|validator| {
+                    let this = this.clone();
+                    let validator = validator.clone();
+                    let keystore = keystore.clone();
+                    async move { validator.sign(&keystore.clone(), this).await }
+                })
+                .collect::<Vec<_>>();
+            let stream = futures::stream::iter(futures);
+            let signatures = try_stream_of_results(stream).await?;
+            if signatures.is_empty() {
+                unreachable!("Signatures cannot be empty because the validators vec is not empty");
+            }
+            Ok(Some(SignedValidationReceipt {
+                receipt: self,
+                validators_signatures: signatures,
+            }))
+        })
+    }
+}
+
+/// Try to collect a stream of futures that return results into a vec.
+async fn try_stream_of_results<T, U, E>(stream: U) -> Result<Vec<T>, E>
+where
+    U: Stream,
+    <U as Stream>::Item: futures::Future<Output = Result<T, E>>,
+{
+    stream.buffer_unordered(10).map(|r| r).try_collect().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_try_stream_of_results() {
+        let iter: Vec<futures::future::Ready<Result<i32, String>>> = vec![];
+        let stream = futures::stream::iter(iter);
+        assert_eq!(Ok(vec![]), try_stream_of_results(stream).await);
+
+        let iter = vec![async move { Result::<_, String>::Ok(0) }];
+        let stream = futures::stream::iter(iter);
+        assert_eq!(Ok(vec![0]), try_stream_of_results(stream).await);
+
+        let iter = (0..10).map(|i| async move { Result::<_, String>::Ok(i) });
+        let stream = futures::stream::iter(iter);
+        assert_eq!(
+            Ok((0..10).collect::<Vec<_>>()),
+            try_stream_of_results(stream).await
+        );
+
+        let iter = vec![async move { Result::<i32, String>::Err("test".to_string()) }];
+        let stream = futures::stream::iter(iter);
+        assert_eq!(Err("test".to_string()), try_stream_of_results(stream).await);
+
+        let iter = (0..10).map(|_| async move { Result::<i32, String>::Err("test".to_string()) });
+        let stream = futures::stream::iter(iter);
+        assert_eq!(Err("test".to_string()), try_stream_of_results(stream).await);
+    }
+}

--- a/crates/holochain_keystore/src/warrant_ext.rs
+++ b/crates/holochain_keystore/src/warrant_ext.rs
@@ -1,0 +1,29 @@
+//! Extension trait definition [`WarrantOpExt`].
+
+use crate::{AgentPubKeyExt, LairResult, MetaLairClient};
+use futures::FutureExt;
+use holochain_types::prelude::WarrantOp;
+use holochain_zome_types::prelude::{SignedWarrant, Warrant};
+use must_future::MustBoxFuture;
+
+/// Extension for keystore operations on a [`WarrantOp`].
+pub trait WarrantOpExt {
+    /// Sign the warrant for use as a [`WarrantOp`].
+    fn sign(
+        keystore: &MetaLairClient,
+        warrant: Warrant,
+    ) -> MustBoxFuture<'static, LairResult<WarrantOp>>;
+}
+
+impl WarrantOpExt for WarrantOp {
+    fn sign(
+        keystore: &MetaLairClient,
+        warrant: Warrant,
+    ) -> MustBoxFuture<'static, LairResult<WarrantOp>> {
+        let f = warrant
+            .author
+            .sign(keystore, warrant.clone())
+            .map(|res| res.map(|sig| Self::from(SignedWarrant::new(warrant, sig))));
+        MustBoxFuture::new(f)
+    }
+}

--- a/crates/holochain_p2p/src/hc_report.rs
+++ b/crates/holochain_p2p/src/hc_report.rs
@@ -54,6 +54,7 @@ mod config {
 }
 
 pub use config::*;
+use holochain_keystore::ReportEntryFetchedOpsExt;
 
 /// Holochain report module. See module level docs for details.
 pub struct HcReportFactory {

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -15,12 +15,11 @@ use holo_hash::HasHash;
 use holo_hash::HoloHashed;
 use holochain_data::kind::Dht;
 use holochain_data::{DbRead, DbWrite};
-use holochain_keystore::MetaLairClient;
+use holochain_keystore::{AgentPubKeyExt, MetaLairClient, SignedActionHashedExt};
 use holochain_state_types::SourceChainDump;
 use holochain_types::op::{
     produce_ops_from_record, ChainOp, DhtOp, DhtOpHashed, HashedChainOp, OpEntry,
 };
-use holochain_types::prelude::SignedActionHashedExt;
 use holochain_types::warrant::WarrantOp;
 use holochain_zome_types::prelude::{
     build_action, from_countersigning_data, Action, ActionData, ActionHeader,

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -12,9 +12,7 @@ edition = "2021"
 # reminder - do not use workspace deps
 [dependencies]
 anyhow = "1.0"
-async-trait = "0.1"
 backtrace = "0.3.27"
-base64 = "0.22"
 derive_builder = "0.20"
 derive_more = { version = "2.0", features = ["constructor", "into_iterator"] }
 futures = "0.3"
@@ -22,7 +20,6 @@ holo_hash = { version = "^0.7.0-rc.1", path = "../holo_hash", features = [
   "encoding",
   "schema",
 ] }
-holochain_keystore = { version = "^0.7.0-rc.1", path = "../holochain_keystore" }
 holochain_nonce = { version = "^0.7.0-rc.1", path = "../holochain_nonce" }
 holochain_serialized_bytes = "=0.0.57"
 holochain_trace = { version = "^0.7.0-rc.1", path = "../holochain_trace" }
@@ -82,7 +79,6 @@ fixturators = ["dep:fixt", "holochain_zome_types/fixturators"]
 test_utils = [
   "fixturators",
   "fuzzing",
-  "holochain_keystore/test_utils",
   "holochain_zome_types/test_utils",
 ]
 

--- a/crates/holochain_types/Cargo.toml
+++ b/crates/holochain_types/Cargo.toml
@@ -76,11 +76,7 @@ default = []
 
 fixturators = ["dep:fixt", "holochain_zome_types/fixturators"]
 
-test_utils = [
-  "fixturators",
-  "fuzzing",
-  "holochain_zome_types/test_utils",
-]
+test_utils = ["fixturators", "fuzzing", "holochain_zome_types/test_utils"]
 
 unstable-migration = ["holochain_zome_types/unstable-migration"]
 

--- a/crates/holochain_types/src/prelude.rs
+++ b/crates/holochain_types/src/prelude.rs
@@ -22,7 +22,6 @@ pub use crate::signal::*;
 pub use crate::validation_receipt::*;
 pub use crate::warrant::*;
 pub use crate::wire_ops::*;
-pub use holochain_keystore::AgentPubKeyExt;
 pub use holochain_nonce::Nonce256Bits;
 pub use holochain_serialized_bytes::prelude::*;
 pub use holochain_util::{ffs, tokio_helper};

--- a/crates/holochain_types/src/record.rs
+++ b/crates/holochain_types/src/record.rs
@@ -1,10 +1,7 @@
 //! Defines a Record, the basic unit of Holochain data.
 
 use crate::prelude::*;
-use holochain_keystore::KeystoreError;
-use holochain_keystore::LairResult;
-use holochain_keystore::MetaLairClient;
-use holochain_zome_types::prelude::{CloseChainData, EntryHashed, SignedWarrant};
+use holochain_zome_types::prelude::{EntryHashed, SignedWarrant};
 
 /// The record-serving response to a get-record request.
 ///
@@ -91,112 +88,4 @@ pub struct RecordStatus {
     pub record: Record,
     /// Validation status of this record.
     pub status: ValidationStatus,
-}
-
-/// The public key that should sign (and later verify) this action.
-///
-/// This is the author for every variant except a `CloseChain` that names an
-/// agent migration target: that variant is signed with the *new* key so the
-/// forward reference it carries is provably endorsed by the destination
-/// agent.
-fn action_signer(action: &Action) -> &AgentPubKey {
-    match &action.data {
-        ActionData::CloseChain(CloseChainData {
-            new_target: Some(MigrationTarget::Agent(agent)),
-            ..
-        }) => agent,
-        _ => &action.header.author,
-    }
-}
-
-/// Extension trait to keep zome types minimal
-#[async_trait::async_trait]
-pub trait SignedActionHashedExt {
-    /// Create a hash from data
-    fn from_content_sync(signed_action: SignedAction) -> SignedActionHashed;
-    /// Sign some content
-    #[allow(clippy::new_ret_no_self)]
-    async fn sign(
-        keystore: &MetaLairClient,
-        action: holo_hash::HoloHashed<Action>,
-    ) -> LairResult<SignedActionHashed>;
-    /// Validate the data
-    async fn verify_signature(&self) -> Result<(), KeystoreError>;
-}
-
-#[allow(missing_docs)]
-#[async_trait::async_trait]
-impl SignedActionHashedExt for SignedActionHashed {
-    fn from_content_sync(signed_action: SignedAction) -> Self
-    where
-        Self: Sized,
-    {
-        let (action, signature) = signed_action.into();
-        Self::with_presigned(action.into_hashed(), signature)
-    }
-
-    /// Construct by signing the Action (NOT including the hash)
-    async fn sign(
-        keystore: &MetaLairClient,
-        action_hashed: holo_hash::HoloHashed<Action>,
-    ) -> LairResult<Self> {
-        let signature = action_signer(&action_hashed.content)
-            .sign(keystore, &action_hashed.content)
-            .await?;
-        Ok(Self::with_presigned(action_hashed, signature))
-    }
-
-    /// Verify that the signature matches the signed action
-    async fn verify_signature(&self) -> Result<(), KeystoreError> {
-        if !action_signer(&self.hashed.content)
-            .verify_signature(self.signature(), &self.hashed.content)
-            .await?
-        {
-            return Err(KeystoreError::InvalidSignature(
-                self.signature().clone(),
-                format!("action {:?}", self.as_hash()),
-            ));
-        }
-        Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::SignedAction;
-    use super::SignedActionHashed;
-    use super::SignedActionHashedExt;
-    use crate::prelude::*;
-    use holo_hash::{AgentPubKey, DnaHash, HasHash, HoloHashed};
-    use holochain_zome_types::prelude::{ActionHeader, DnaData};
-
-    fn sample_action() -> Action {
-        Action {
-            header: ActionHeader {
-                author: AgentPubKey::from_raw_36(vec![1u8; 36]),
-                timestamp: holochain_timestamp::Timestamp::from_micros(42),
-                action_seq: 0,
-                prev_action: None,
-            },
-            data: ActionData::Dna(DnaData {
-                dna_hash: DnaHash::from_raw_36(vec![2u8; 36]),
-            }),
-        }
-    }
-
-    #[tokio::test]
-    async fn test_signed_action_roundtrip() {
-        let signature = Signature([9u8; 64]);
-        let action = sample_action();
-        let signed_action = SignedAction::new(action.clone(), signature.clone());
-
-        let shh = SignedActionHashed::from_content_sync(signed_action);
-
-        assert_eq!(
-            shh.as_hash(),
-            &HoloHashed::<Action>::from_content_sync(action.clone()).into_hash()
-        );
-        assert_eq!(shh.hashed.content, action);
-        assert_eq!(shh.signature, signature);
-    }
 }

--- a/crates/holochain_types/src/report.rs
+++ b/crates/holochain_types/src/report.rs
@@ -98,49 +98,4 @@ impl ReportEntryFetchedOps {
         }
         out
     }
-
-    /// Verify the signatures.
-    pub async fn verify(&self) -> bool {
-        use base64::prelude::*;
-
-        let to_verify = self.encode_for_verification();
-
-        tracing::trace!(to_verify = %String::from_utf8_lossy(&to_verify), report = ?self, "verify");
-
-        if self.agent_pubkeys.is_empty() || self.agent_pubkeys.len() != self.signatures.len() {
-            tracing::trace!("report signatures invalid");
-            return false;
-        }
-
-        for (agent, sig) in self.agent_pubkeys.iter().zip(self.signatures.iter()) {
-            let agent = agent.trim_start_matches("u");
-            let agent = match BASE64_URL_SAFE_NO_PAD.decode(agent) {
-                Ok(agent) => agent,
-                Err(_) => return false,
-            };
-            if agent.len() != 39 {
-                return false;
-            }
-            let sig = match BASE64_URL_SAFE_NO_PAD.decode(sig) {
-                Ok(sig) => sig,
-                Err(_) => return false,
-            };
-            if sig.len() != 64 {
-                return false;
-            }
-            let sig: [u8; 64] = sig.try_into().expect("array conversion failed");
-
-            let pk = crate::prelude::AgentPubKey::from_raw_39(agent);
-            use holochain_keystore::AgentPubKeyExt;
-            match pk
-                .verify_signature_raw(&sig.into(), to_verify.clone().into())
-                .await
-            {
-                Ok(true) => (),
-                _ => return false,
-            }
-        }
-
-        true
-    }
 }

--- a/crates/holochain_types/src/test_utils.rs
+++ b/crates/holochain_types/src/test_utils.rs
@@ -2,11 +2,7 @@
 
 use crate::dna::wasm::DnaWasm;
 use crate::prelude::*;
-use crate::record::SignedActionHashedExt;
-use holochain_keystore::MetaLairClient;
-use holochain_zome_types::prelude::{
-    ActionHeader, AgentValidationPkgData, CreateData, DnaData, InitZomesCompleteData, UpdateData,
-};
+use holochain_zome_types::prelude::{CreateData, UpdateData};
 pub use holochain_zome_types::test_utils::*;
 use std::path::PathBuf;
 
@@ -98,35 +94,6 @@ pub fn fake_cap_secret() -> CapSecret {
     [0; CAP_SECRET_BYTES].into()
 }
 
-/// Create a fake SignedActionHashed and EntryHashed pair with random content
-pub async fn fake_unique_record(
-    keystore: &MetaLairClient,
-    agent_key: AgentPubKey,
-    visibility: EntryVisibility,
-) -> anyhow::Result<(SignedActionHashed, EntryHashed)> {
-    let content: SerializedBytes =
-        UnsafeBytes::from(nanoid::nanoid!().as_bytes().to_owned()).into();
-    let entry = Entry::App(content.try_into().unwrap()).into_hashed();
-    let app_entry_def = AppEntryDefFixturator::new(visibility).next().unwrap();
-    let action_1 = Action {
-        header: ActionHeader {
-            author: agent_key,
-            timestamp: Timestamp::now(),
-            action_seq: 0,
-            prev_action: Some(fake_action_hash(1)),
-        },
-        data: ActionData::Create(CreateData {
-            entry_type: EntryType::App(app_entry_def),
-            entry_hash: entry.as_hash().to_owned(),
-        }),
-    };
-
-    Ok((
-        SignedActionHashed::sign(keystore, action_1.into_hashed()).await?,
-        entry,
-    ))
-}
-
 #[allow(missing_docs)]
 pub trait ActionRefMut {
     fn author_mut(&mut self) -> &mut AgentPubKey;
@@ -177,107 +144,4 @@ impl ActionRefMut for Action {
     fn timestamp_mut(&mut self) -> &mut Timestamp {
         &mut self.header.timestamp
     }
-}
-
-/// Create test chain data
-pub async fn valid_arbitrary_chain(
-    keystore: &MetaLairClient,
-    author: AgentPubKey,
-    length: usize,
-) -> Vec<Record> {
-    use ::fixt::*;
-    use holo_hash::fixt::DnaHashFixturator;
-
-    let mut out = Vec::new();
-    let extend_out = |mut out: Vec<Record>, action: Action, entry: Option<Entry>| async move {
-        out.push(Record::new(
-            SignedActionHashed::sign(keystore, action.into_hashed())
-                .await
-                .unwrap(),
-            match entry {
-                Some(entry) => RecordEntry::Present(entry),
-                None => RecordEntry::NA,
-            },
-        ));
-        out
-    };
-
-    let dna = Action {
-        header: ActionHeader {
-            author: author.clone(),
-            timestamp: Timestamp::now(),
-            action_seq: 0,
-            prev_action: None,
-        },
-        data: ActionData::Dna(DnaData {
-            dna_hash: fixt!(DnaHash),
-        }),
-    };
-    out = extend_out(out, dna, None).await;
-
-    let avp = Action {
-        header: ActionHeader {
-            author: author.clone(),
-            timestamp: Timestamp::now(),
-            action_seq: 1,
-            prev_action: Some(out.last().as_ref().unwrap().action_address().clone()),
-        },
-        data: ActionData::AgentValidationPkg(AgentValidationPkgData {
-            membrane_proof: None,
-        }),
-    };
-    out = extend_out(out, avp, None).await;
-
-    let agent_entry = Entry::Agent(author.clone());
-
-    let agent = Action {
-        header: ActionHeader {
-            author: author.clone(),
-            timestamp: Timestamp::now(),
-            action_seq: 2,
-            prev_action: Some(out.last().as_ref().unwrap().action_address().clone()),
-        },
-        data: ActionData::Create(CreateData {
-            entry_type: EntryType::AgentPubKey,
-            entry_hash: agent_entry.clone().into_hashed().hash,
-        }),
-    };
-    out = extend_out(out, agent, Some(agent_entry)).await;
-
-    let init_zomes = Action {
-        header: ActionHeader {
-            author: author.clone(),
-            timestamp: Timestamp::now(),
-            action_seq: 3,
-            prev_action: Some(out.last().as_ref().unwrap().action_address().clone()),
-        },
-        data: ActionData::InitZomesComplete(InitZomesCompleteData {}),
-    };
-    out = extend_out(out, init_zomes, None).await;
-
-    for action_seq in 4..length {
-        let entry = Entry::App(AppEntryBytes(SerializedBytes::from(UnsafeBytes::from(
-            nanoid::nanoid!().as_bytes().to_owned(),
-        ))));
-
-        let action = Action {
-            header: ActionHeader {
-                author: author.clone(),
-                timestamp: Timestamp::now(),
-                action_seq: action_seq as u32,
-                prev_action: Some(out.last().as_ref().unwrap().action_address().clone()),
-            },
-            data: ActionData::Create(CreateData {
-                entry_type: EntryType::App(AppEntryDef::new(
-                    0.into(),
-                    1.into(),
-                    EntryVisibility::Public,
-                )),
-                entry_hash: entry.clone().into_hashed().hash,
-            }),
-        };
-        out = extend_out(out, action, Some(entry)).await;
-    }
-
-    out
 }

--- a/crates/holochain_types/src/validation_receipt.rs
+++ b/crates/holochain_types/src/validation_receipt.rs
@@ -1,9 +1,7 @@
 //! Types for validation receipts and signed validation receipts to be sent between peers.
 
 use crate::prelude::{Signature, Timestamp};
-use futures::{Stream, StreamExt, TryStreamExt};
 use holo_hash::{AgentPubKey, DhtOpHash};
-use holochain_keystore::{AgentPubKeyExt, MetaLairClient};
 use holochain_serialized_bytes::prelude::*;
 use holochain_zome_types::prelude::*;
 use std::vec::IntoIter;
@@ -33,50 +31,6 @@ pub struct ValidationReceipt {
 
     /// Time when the op was integrated
     pub when_integrated: Timestamp,
-}
-
-impl ValidationReceipt {
-    /// Sign this validation receipt.
-    pub async fn sign(
-        self,
-        keystore: &MetaLairClient,
-    ) -> holochain_keystore::LairResult<Option<SignedValidationReceipt>> {
-        if self.validators.is_empty() {
-            return Ok(None);
-        }
-        let this = self.clone();
-        // Try to sign with all validators but silently fail on
-        // any that cannot sign.
-        // If all signatures fail then return an error.
-        let futures = self
-            .validators
-            .iter()
-            .map(|validator| {
-                let this = this.clone();
-                let validator = validator.clone();
-                let keystore = keystore.clone();
-                async move { validator.sign(&keystore, this).await }
-            })
-            .collect::<Vec<_>>();
-        let stream = futures::stream::iter(futures);
-        let signatures = try_stream_of_results(stream).await?;
-        if signatures.is_empty() {
-            unreachable!("Signatures cannot be empty because the validators vec is not empty");
-        }
-        Ok(Some(SignedValidationReceipt {
-            receipt: self,
-            validators_signatures: signatures,
-        }))
-    }
-}
-
-/// Try to collect a stream of futures that return results into a vec.
-async fn try_stream_of_results<T, U, E>(stream: U) -> Result<Vec<T>, E>
-where
-    U: Stream,
-    <U as Stream>::Item: futures::Future<Output = Result<T, E>>,
-{
-    stream.buffer_unordered(10).map(|r| r).try_collect().await
 }
 
 /// A full, signed validation receipt.
@@ -118,36 +72,5 @@ impl IntoIterator for ValidationReceiptBundle {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::validation_receipt::try_stream_of_results;
-
-    #[tokio::test]
-    async fn test_try_stream_of_results() {
-        let iter: Vec<futures::future::Ready<Result<i32, String>>> = vec![];
-        let stream = futures::stream::iter(iter);
-        assert_eq!(Ok(vec![]), try_stream_of_results(stream).await);
-
-        let iter = vec![async move { Result::<_, String>::Ok(0) }];
-        let stream = futures::stream::iter(iter);
-        assert_eq!(Ok(vec![0]), try_stream_of_results(stream).await);
-
-        let iter = (0..10).map(|i| async move { Result::<_, String>::Ok(i) });
-        let stream = futures::stream::iter(iter);
-        assert_eq!(
-            Ok((0..10).collect::<Vec<_>>()),
-            try_stream_of_results(stream).await
-        );
-
-        let iter = vec![async move { Result::<i32, String>::Err("test".to_string()) }];
-        let stream = futures::stream::iter(iter);
-        assert_eq!(Err("test".to_string()), try_stream_of_results(stream).await);
-
-        let iter = (0..10).map(|_| async move { Result::<i32, String>::Err("test".to_string()) });
-        let stream = futures::stream::iter(iter);
-        assert_eq!(Err("test".to_string()), try_stream_of_results(stream).await);
     }
 }

--- a/crates/holochain_types/src/warrant.rs
+++ b/crates/holochain_types/src/warrant.rs
@@ -1,7 +1,6 @@
 //! Defines the Warrant variant of DhtOp
 
 use holo_hash::{hash_type, HashableContent, HashableContentBytes};
-use holochain_keystore::{AgentPubKeyExt, LairResult, MetaLairClient};
 use holochain_serialized_bytes::prelude::*;
 use holochain_timestamp::Timestamp;
 use holochain_zome_types::prelude::{SignedWarrant, Warrant, WarrantProof};
@@ -27,12 +26,6 @@ impl WarrantOp {
         match self.proof {
             WarrantProof::ChainIntegrity(_) => WarrantOpType::ChainIntegrityWarrant,
         }
-    }
-
-    /// Sign the warrant for use as an Op
-    pub async fn sign(keystore: &MetaLairClient, warrant: Warrant) -> LairResult<Self> {
-        let signature = warrant.author.sign(keystore, warrant.clone()).await?;
-        Ok(Self::from(SignedWarrant::new(warrant, signature)))
     }
 
     /// Accessor for the timestamp of the warrant

--- a/crates/holochain_zome_types/src/signature.rs
+++ b/crates/holochain_zome_types/src/signature.rs
@@ -13,7 +13,6 @@ pub struct Sign {
     pub key: holo_hash::AgentPubKey,
 
     /// The data that should be signed.
-    // TODO double check
     pub data: Bytes,
 }
 


### PR DESCRIPTION
### Summary

This is a proposal for `holochain_types` to not depend on `holochain_keystore`. We already had a pattern to not include `holochain_keystore` as a dependency of `holo_hash` by using an extension trait in `holochain_keystore`. It does mean a small amount of business logic moves into `holochain_keystore` but it also means that users of `holochain_types` aren't forced to build rusqlite, which we now always force to have encryption enabled - so everyone then needs `perl` available to build `holochain_types`.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs