### PR TITLE
test: do not check wasm.usage metric when on wasmer-wasmi

### DIFF
--- a/crates/holochain/tests/tests/metrics.rs
+++ b/crates/holochain/tests/tests/metrics.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 // - hc.conductor.workflow.validation_attempts
 // - hc.conductor.post_commit.duration
 // - hc.conductor.uptime
-// - hc.ribosome.wasm.usage
+// - hc.ribosome.wasm.usage (only with the wasmer-sys backends; wasmi has no metering)
 // - hc.ribosome.zome_call.duration
 // - hc.ribosome.wasm_call.duration
 // - hc.ribosome.host_fn_call.duration
@@ -124,6 +124,13 @@ async fn metrics() {
         .await;
 
     // Wait until the influx file contains enough exported records to satisfy every assertion below.
+    //
+    // Metering is only implemented for the wasmer-sys backends, so the wasmi
+    // interpreter never records `hc.ribosome.wasm.usage`.
+    let expect_wasm_usage = cfg!(any(
+        feature = "wasmer-sys-cranelift",
+        feature = "wasmer-sys-llvm"
+    ));
     let metrics = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             let metrics = read_to_string(&influxive_file).unwrap();
@@ -136,7 +143,7 @@ async fn metrics() {
                 && metrics.contains("hc.conductor.workflow.validation_attempts")
                 && metrics.contains("hc.conductor.post_commit.duration")
                 && metrics.contains("hc.conductor.uptime")
-                && metrics.matches("hc.ribosome.wasm.usage").count() >= 4
+                && (!expect_wasm_usage || metrics.matches("hc.ribosome.wasm.usage").count() >= 4)
                 && metrics.contains("hc.ribosome.zome_call.duration")
                 && metrics.matches("hc.ribosome.wasm_call.duration").count() >= 4
                 && metrics.matches("hc.ribosome.host_fn_call.duration").count() >= 4


### PR DESCRIPTION
### Summary

`tests::metrics::metrics` is always failing after 60e24e8d6.

Since now hc.ribosome.wasm.usage is no more collected under wasmer-wasmi, we can ignore that check on that platform.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs