### PR TITLE
fix: increase SQLite busy_timeout to 15s

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Increase the SQLite `busy_timeout` from sqlx's 5s default to 15s, to reduce spurious "database is locked" errors logged by queue consumer workflows under writer contention.
 - **BREAKING CHANGE**: `holochain_zome_types::query::AgentActivity`, the response type of `hdk::chain::get_agent_activity`, is renamed to `AgentActivityStatus`. This resolves a name collision with the unrelated `AgentActivity` `Op` variant struct.
 - **BREAKING CHANGE**: `holochain_integrity_types::action::CapAccess` (the `CapGrant.cap_access` column discriminant) is renamed to `CapAccessType`. This resolves a name collision with `holochain_integrity_types::capability::CapAccess`, the data-carrying grant-access type used by `ZomeCallCapGrant`, which keeps the `CapAccess` name. \#5882
 - Remove the unused `holochain_zome_types::crdt::CrdtType` placeholder type.

--- a/crates/holochain_data/src/lib.rs
+++ b/crates/holochain_data/src/lib.rs
@@ -218,6 +218,10 @@ fn configure_sqlite_options(
     // Always enable WAL mode for better concurrency
     opts = opts.journal_mode(SqliteJournalMode::Wal);
 
+    // Tolerate longer writer contention than sqlx's 5s default before a
+    // write fails with "database is locked".
+    opts = opts.busy_timeout(std::time::Duration::from_secs(15));
+
     // Set other pragmas
     let sync_value = config.sync_level.as_pragma_value().to_string();
     opts = opts


### PR DESCRIPTION
sqlx's 5s default busy_timeout was too short to ride out brief writer contention (e.g. `integrate_dht_ops_workflow` batching many ready ops into one transaction), causing queue consumer workflows to log spurious `database is locked` errors. These are already retried automatically, so waiting longer before giving up cuts the log noise without changing fast-path behavior.

This brings the behavior back to being more similar to holochain_sqlite behavior. We allowed even more time for that before starting to report problems.