### PR TITLE
feat(api)!: add paginated state dumps

### DIFF
--- a/crates/client/src/admin_websocket.rs
+++ b/crates/client/src/admin_websocket.rs
@@ -4,7 +4,8 @@ use holo_hash::{ActionHash, DnaHash};
 use holochain_conductor_api::{
     AdminInterfaceConfig, AdminRequest, AdminResponse, AppAuthenticationToken,
     AppAuthenticationTokenIssued, AppInfo, AppInterfaceInfo, AppStatusFilter, DhtOpsCursor,
-    FullStateDump, IssueAppAuthenticationTokenPayload, PeerMetaInfo, StorageInfo,
+    FullStateDump, IssueAppAuthenticationTokenPayload, PeerMetaInfo, SourceChainCursor,
+    StorageInfo,
 };
 use holochain_types::network::HolochainTransportStats;
 use holochain_types::websocket::AllowedOrigins;
@@ -449,9 +450,21 @@ impl AdminWebsocket {
         }
     }
 
-    pub async fn dump_state(&self, cell_id: CellId) -> ConductorApiResult<String> {
+    /// Dump one exclusive page of a cell's source-chain state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the pagination arguments are invalid.
+    pub async fn dump_state(
+        &self,
+        cell_id: CellId,
+        source_chain_cursor: Option<SourceChainCursor>,
+        limit: Option<u32>,
+    ) -> ConductorApiResult<String> {
         let msg = AdminRequest::DumpState {
             cell_id: Box::new(cell_id),
+            source_chain_cursor,
+            limit,
         };
         let response = self.send(msg).await?;
         match response {
@@ -469,14 +482,21 @@ impl AdminWebsocket {
         }
     }
 
+    /// Dump one page of a cell's full state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the limit is zero.
     pub async fn dump_full_state(
         &self,
         cell_id: CellId,
         dht_ops_cursor: Option<DhtOpsCursor>,
+        limit: Option<u32>,
     ) -> ConductorApiResult<FullStateDump> {
         let msg = AdminRequest::DumpFullState {
             cell_id: Box::new(cell_id),
             dht_ops_cursor,
+            limit,
         };
         let response = self.send(msg).await?;
         match response {

--- a/crates/hc_client/src/calls.rs
+++ b/crates/hc_client/src/calls.rs
@@ -7,12 +7,12 @@
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
 use clap::{Args, Parser, Subcommand};
-use holo_hash::{ActionHash, AgentPubKeyB64, DnaHashB64};
+use holo_hash::{ActionHash, AgentPubKeyB64, DhtOpHash, DnaHashB64};
 use holochain_client::AdminWebsocket;
-use holochain_conductor_api::AppStatusFilter;
 use holochain_conductor_api::InterfaceDriver;
 use holochain_conductor_api::PeerMetaInfo;
 use holochain_conductor_api::{AdminInterfaceConfig, AppInfo};
+use holochain_conductor_api::{AppStatusFilter, DhtOpsCursor, SourceChainCursor};
 use holochain_types::app::AppManifest;
 use holochain_types::app::RoleSettingsMap;
 use holochain_types::app::RoleSettingsMapYaml;
@@ -74,6 +74,8 @@ pub enum AdminRequestCli {
     DisableApp(DisableApp),
     /// Calls [`AdminWebsocket::dump_state`].
     DumpState(DumpState),
+    /// Calls [`AdminWebsocket::dump_full_state`].
+    DumpFullState(DumpFullState),
     /// Calls [`AdminWebsocket::dump_conductor_state`].
     DumpConductorState,
     /// Calls [`AdminWebsocket::dump_network_metrics`].
@@ -223,6 +225,35 @@ pub struct DumpState {
     /// The agent half of the cell ID to dump.
     #[arg(value_parser = parse_agent_key)]
     pub agent_key: AgentPubKey,
+
+    /// Last source-chain sequence or action hash returned by the previous page.
+    #[arg(long, value_parser = parse_source_chain_cursor)]
+    pub cursor: Option<SourceChainCursor>,
+
+    /// Maximum number of source-chain records to return. Must be greater than zero.
+    #[arg(long, value_parser = parse_dump_limit)]
+    pub limit: Option<u32>,
+}
+
+/// Calls [`AdminWebsocket::dump_full_state`] and dumps one page of DHT state.
+#[derive(Debug, Args, Clone)]
+pub struct DumpFullState {
+    /// The DNA hash half of the cell ID to dump.
+    #[arg(value_parser = parse_dna_hash)]
+    pub dna: DnaHash,
+
+    /// The agent half of the cell ID to dump.
+    #[arg(value_parser = parse_agent_key)]
+    pub agent_key: AgentPubKey,
+
+    /// Last receipt timestamp and DHT op hash returned by the previous page.
+    #[arg(long, num_args = 2, value_names = ["WHEN_RECEIVED", "DHT_OP_HASH"])]
+    pub cursor: Option<Vec<String>>,
+
+    /// Maximum number of DHT ops across all lifecycle buckets to return.
+    /// Must be greater than zero.
+    #[arg(long, value_parser = parse_dump_limit)]
+    pub limit: Option<u32>,
 }
 
 /// Arguments for dumping network metrics.
@@ -387,8 +418,19 @@ async fn call_inner(client: &mut AdminWebsocket, call: AdminRequestCli) -> anyho
             crate::msg!("Disabled app: \"{}\"", args.app_id);
         }
         AdminRequestCli::DumpState(args) => {
-            let state = client.dump_state(args.into()).await?;
+            let cell_id = CellId::new(args.dna, args.agent_key);
+            let state = client.dump_state(cell_id, args.cursor, args.limit).await?;
             println!("{state}");
+        }
+        AdminRequestCli::DumpFullState(args) => {
+            let cursor = args
+                .cursor
+                .as_deref()
+                .map(parse_dht_ops_cursor)
+                .transpose()?;
+            let cell_id = CellId::new(args.dna, args.agent_key);
+            let state = client.dump_full_state(cell_id, cursor, args.limit).await?;
+            println!("{}", serde_json::to_string(&state)?);
         }
         AdminRequestCli::DumpConductorState => {
             let state = client.dump_conductor_state().await?;
@@ -699,6 +741,38 @@ fn parse_dna_hash(arg: &str) -> anyhow::Result<DnaHash> {
     DnaHash::try_from(arg).map_err(|e| anyhow::anyhow!("{e:?}"))
 }
 
+fn parse_source_chain_cursor(arg: &str) -> anyhow::Result<SourceChainCursor> {
+    match arg.parse::<u32>() {
+        Ok(sequence) => Ok(SourceChainCursor::Sequence(sequence)),
+        Err(_) => ActionHash::try_from(arg)
+            .map(SourceChainCursor::ActionHash)
+            .map_err(|e| anyhow!("Invalid source-chain cursor: {e}")),
+    }
+}
+
+fn parse_dht_ops_cursor(values: &[String]) -> anyhow::Result<DhtOpsCursor> {
+    let [when_received, hash] = values else {
+        return Err(anyhow!("DHT cursor requires a receipt time and op hash"));
+    };
+    Ok(DhtOpsCursor {
+        when_received: when_received
+            .parse()
+            .map_err(|e| anyhow!("Invalid receipt time: {e}"))?,
+        hash: DhtOpHash::try_from(hash.as_str())
+            .map_err(|e| anyhow!("Invalid DHT op hash: {e}"))?,
+    })
+}
+
+fn parse_dump_limit(arg: &str) -> anyhow::Result<u32> {
+    let limit = arg
+        .parse()
+        .map_err(|e| anyhow!("Invalid dump limit: {e}"))?;
+    if limit == 0 {
+        return Err(anyhow!("dump limit must be greater than zero"));
+    }
+    Ok(limit)
+}
+
 fn parse_status_filter(arg: &str) -> anyhow::Result<AppStatusFilter> {
     match arg {
         "active" => Ok(AppStatusFilter::Enabled),
@@ -712,7 +786,12 @@ fn parse_status_filter(arg: &str) -> anyhow::Result<AppStatusFilter> {
 impl From<CellId> for DumpState {
     fn from(cell_id: CellId) -> Self {
         let (dna, agent_key) = cell_id.into_dna_and_agent();
-        Self { dna, agent_key }
+        Self {
+            dna,
+            agent_key,
+            cursor: None,
+            limit: None,
+        }
     }
 }
 
@@ -738,6 +817,122 @@ mod tests {
 
     fn test_agent_key(bytes: u8) -> AgentPubKey {
         AgentPubKey::from_raw_36(vec![bytes; 36])
+    }
+
+    #[test]
+    fn parses_dump_state_pagination_arguments() {
+        let dna = "uhC0kWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+        let agent = "uhCAkJCuynkgVdMn_bzZ2ZYaVfygkn0WCuzfFspczxFnZM1QAyXoo";
+        let call = Call::try_parse_from([
+            "hc-client",
+            "--port",
+            "1234",
+            "dump-state",
+            dna,
+            agent,
+            "--limit",
+            "5",
+            "--cursor",
+            "3",
+        ])
+        .unwrap();
+
+        let AdminRequestCli::DumpState(args) = call.call else {
+            panic!("expected dump-state arguments");
+        };
+        assert_eq!(args.limit, Some(5));
+        assert_eq!(args.cursor, Some(SourceChainCursor::Sequence(3)));
+    }
+
+    #[test]
+    fn parses_dump_full_state_cursor_pair() {
+        let dna = "uhC0kWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+        let agent = "uhCAkJCuynkgVdMn_bzZ2ZYaVfygkn0WCuzfFspczxFnZM1QAyXoo";
+        let hash = "uhCQkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+        let call = Call::try_parse_from([
+            "hc-client",
+            "--port",
+            "1234",
+            "dump-full-state",
+            dna,
+            agent,
+            "--limit",
+            "10",
+            "--cursor",
+            "99",
+            hash,
+        ])
+        .unwrap();
+
+        let AdminRequestCli::DumpFullState(args) = call.call else {
+            panic!("expected dump-full-state arguments");
+        };
+        assert_eq!(args.limit, Some(10));
+        assert_eq!(
+            parse_dht_ops_cursor(args.cursor.as_deref().unwrap()).unwrap(),
+            DhtOpsCursor {
+                when_received: 99,
+                hash: DhtOpHash::try_from(hash).unwrap(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_dump_state_arguments() {
+        let dna = "uhC0kWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+        let agent = "uhCAkJCuynkgVdMn_bzZ2ZYaVfygkn0WCuzfFspczxFnZM1QAyXoo";
+
+        assert!(Call::try_parse_from([
+            "hc-client",
+            "--port",
+            "1234",
+            "dump-state",
+            dna,
+            agent,
+            "--limit",
+            "0",
+        ])
+        .is_err());
+        assert!(Call::try_parse_from([
+            "hc-client",
+            "--port",
+            "1234",
+            "dump-state",
+            dna,
+            agent,
+            "--cursor",
+            "not-a-sequence-or-action-hash",
+        ])
+        .is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_dump_full_state_arguments() {
+        let dna = "uhC0kWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+        let agent = "uhCAkJCuynkgVdMn_bzZ2ZYaVfygkn0WCuzfFspczxFnZM1QAyXoo";
+
+        assert!(Call::try_parse_from([
+            "hc-client",
+            "--port",
+            "1234",
+            "dump-full-state",
+            dna,
+            agent,
+            "--limit",
+            "0",
+        ])
+        .is_err());
+        assert!(Call::try_parse_from([
+            "hc-client",
+            "--port",
+            "1234",
+            "dump-full-state",
+            dna,
+            agent,
+            "--cursor",
+            "99",
+        ])
+        .is_err());
     }
 
     fn test_cell_id(dna: u8, agent: u8) -> CellId {

--- a/crates/hc_client/tests/integration.rs
+++ b/crates/hc_client/tests/integration.rs
@@ -3,12 +3,14 @@ use std::process::Command as StdCommand;
 use std::time::Duration;
 
 use anyhow::{ensure, Result};
-use holo_hash::{AgentPubKey, AgentPubKeyB64, DnaHash, DnaHashB64};
+use holo_hash::{ActionHash, AgentPubKey, AgentPubKeyB64, DnaHash, DnaHashB64, HasHash};
 use holochain::{sweettest::*, test_utils::inline_zomes::simple_crud_zome};
-use holochain_conductor_api::{AdminInterfaceConfig, InterfaceDriver};
+use holochain_client::AdminWebsocket;
+use holochain_conductor_api::{AdminInterfaceConfig, DhtOpsCursor, FullStateDump, InterfaceDriver};
+use holochain_types::op::{DhtOp, DhtOpHashed};
 use holochain_types::prelude::CellId;
 use holochain_types::websocket::AllowedOrigins;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command as TokioCommand;
 use tokio::sync::OnceCell;
@@ -64,6 +66,205 @@ async fn list_dnas() -> Result<()> {
 
     let hashes: Vec<String> = serde_json::from_slice(&output.stdout)?;
     assert_eq!(hashes, vec![expected_hash]);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dump_commands_return_single_cursor_page() -> Result<()> {
+    let mut conductor = SweetConductor::standard().await;
+    let (dna, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
+    let app = conductor.setup_app("app", &[dna]).await?;
+    let cell_id = app.cells()[0].cell_id().clone();
+    let dna = cell_id.dna_hash().to_string();
+    let agent = cell_id.agent_pubkey().to_string();
+    let admin_port = conductor
+        .get_arbitrary_admin_websocket_port()
+        .expect("admin port");
+    let admin_port_arg = admin_port.to_string();
+    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{admin_port}"), None).await?;
+
+    let unbounded_source_json: serde_json::Value =
+        serde_json::from_str(&admin_ws.dump_state(cell_id.clone(), None, None).await?)?;
+    let unbounded_records = unbounded_source_json[0]["source_chain_dump"]["records"]
+        .as_array()
+        .expect("unbounded source-chain records")
+        .clone();
+    assert!(unbounded_source_json[1]
+        .as_str()
+        .expect("source-chain summary")
+        .contains("Records returned:"));
+    let unbounded_full = admin_ws
+        .dump_full_state(cell_id.clone(), None, None)
+        .await?;
+
+    let first_source_page = get_hc_client_command()
+        .args([
+            "call",
+            "--port",
+            admin_port_arg.as_str(),
+            "dump-state",
+            dna.as_str(),
+            agent.as_str(),
+            "--limit",
+            "2",
+        ])
+        .output()?;
+    assert!(first_source_page.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&first_source_page.stdout)
+            .lines()
+            .count(),
+        1
+    );
+    let first_source_json: serde_json::Value = serde_json::from_slice(&first_source_page.stdout)?;
+    let first_records = first_source_json[0]["source_chain_dump"]["records"]
+        .as_array()
+        .expect("source-chain records")
+        .clone();
+    assert_eq!(first_records.len(), 2);
+    assert!(first_source_json[1]
+        .as_str()
+        .expect("paginated source-chain summary")
+        .contains("Records returned: 2"));
+
+    let second_source_page = get_hc_client_command()
+        .args([
+            "call",
+            "--port",
+            admin_port_arg.as_str(),
+            "dump-state",
+            dna.as_str(),
+            agent.as_str(),
+            "--limit",
+            "2",
+            "--cursor",
+            "1",
+        ])
+        .output()?;
+    assert!(second_source_page.status.success());
+    let second_source_json: serde_json::Value = serde_json::from_slice(&second_source_page.stdout)?;
+    assert_eq!(
+        String::from_utf8_lossy(&second_source_page.stdout)
+            .lines()
+            .count(),
+        1
+    );
+    let second_records = second_source_json[0]["source_chain_dump"]["records"]
+        .as_array()
+        .expect("source-chain records")
+        .clone();
+    assert!(!second_records.is_empty());
+    assert_ne!(
+        first_records.last().unwrap()["action_address"],
+        second_records.first().unwrap()["action_address"]
+    );
+
+    let combined_records: Vec<_> = first_records
+        .iter()
+        .chain(&second_records)
+        .cloned()
+        .collect();
+    assert_eq!(combined_records, unbounded_records);
+
+    let source_hash_cursor: ActionHash =
+        serde_json::from_value(first_records.last().unwrap()["action_address"].clone())?;
+    let hash_source_page = get_hc_client_command()
+        .args([
+            "call",
+            "--port",
+            admin_port_arg.as_str(),
+            "dump-state",
+            dna.as_str(),
+            agent.as_str(),
+            "--limit",
+            "2",
+            "--cursor",
+            source_hash_cursor.to_string().as_str(),
+        ])
+        .output()?;
+    assert!(hash_source_page.status.success());
+    assert_eq!(
+        String::from_utf8_lossy(&hash_source_page.stdout)
+            .lines()
+            .count(),
+        1
+    );
+    let hash_source_json: serde_json::Value = serde_json::from_slice(&hash_source_page.stdout)?;
+    assert_eq!(
+        hash_source_json[0]["source_chain_dump"]["records"],
+        second_source_json[0]["source_chain_dump"]["records"]
+    );
+
+    let expected_hashes: HashSet<_> = unbounded_full
+        .integration_dump
+        .validation_limbo
+        .iter()
+        .chain(&unbounded_full.integration_dump.integration_limbo)
+        .chain(&unbounded_full.integration_dump.integrated)
+        .cloned()
+        .map(DhtOpHashed::from_content_sync)
+        .map(|op| op.as_hash().clone())
+        .collect();
+    let mut actual_hashes = Vec::new();
+    let mut cursor: Option<DhtOpsCursor> = None;
+    let mut page_index = 0;
+    loop {
+        let mut command = get_hc_client_command();
+        command.args([
+            "call",
+            "--port",
+            admin_port_arg.as_str(),
+            "dump-full-state",
+            dna.as_str(),
+            agent.as_str(),
+            "--limit",
+            "2",
+        ]);
+        if let Some(cursor) = &cursor {
+            command.args([
+                "--cursor",
+                cursor.when_received.to_string().as_str(),
+                cursor.hash.to_string().as_str(),
+            ]);
+        }
+        let page_output = command.output()?;
+        assert!(page_output.status.success());
+        assert_eq!(
+            String::from_utf8_lossy(&page_output.stdout).lines().count(),
+            1
+        );
+        let page: FullStateDump = serde_json::from_slice(&page_output.stdout)?;
+        if page_index == 0 {
+            assert_eq!(page.peer_dump, unbounded_full.peer_dump);
+            assert_eq!(page.source_chain_dump, unbounded_full.source_chain_dump);
+        }
+        let page_ops = page
+            .integration_dump
+            .validation_limbo
+            .into_iter()
+            .chain(page.integration_dump.integration_limbo)
+            .chain(page.integration_dump.integrated)
+            .collect::<Vec<DhtOp>>();
+        assert!(page_ops.len() <= 2);
+        actual_hashes.extend(
+            page_ops
+                .into_iter()
+                .map(DhtOpHashed::from_content_sync)
+                .map(|op| op.as_hash().clone()),
+        );
+        cursor = page.integration_dump.dht_ops_cursor;
+        page_index += 1;
+        if cursor.is_none() {
+            break;
+        }
+    }
+    assert!(page_index > 1);
+    assert_eq!(actual_hashes.len(), expected_hashes.len());
+    assert_eq!(
+        actual_hashes.into_iter().collect::<HashSet<_>>(),
+        expected_hashes
+    );
 
     Ok(())
 }

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Add exclusive cursor pagination and optional limits to `DumpState` and
+  `DumpFullState`, plus matching `hc client` options. Full-state limits apply
+  globally to integrated and limbo chain ops and warrants, ordered by receipt
+  time and op hash. [\#5774](https://github.com/holochain/holochain/issues/5774)
 - **BREAKING CHANGE**: The `holochain::conductor::state` module has been
   removed. Its public types (`ConductorState`, `ConductorStateTag`,
   `AppInterfaceId`, and `AppInterfaceConfig`) moved to

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -188,8 +188,15 @@ impl AdminInterfaceApi {
                 let interfaces = self.conductor_handle.list_app_interfaces().await?;
                 Ok(AdminResponse::AppInterfacesListed(interfaces))
             }
-            DumpState { cell_id } => {
-                let state = self.conductor_handle.dump_cell_state(&cell_id).await?;
+            DumpState {
+                cell_id,
+                source_chain_cursor,
+                limit,
+            } => {
+                let state = self
+                    .conductor_handle
+                    .dump_cell_state(&cell_id, source_chain_cursor.as_ref(), limit)
+                    .await?;
                 Ok(AdminResponse::StateDumped(state))
             }
             DumpConductorState => {
@@ -199,10 +206,11 @@ impl AdminInterfaceApi {
             DumpFullState {
                 cell_id,
                 dht_ops_cursor,
+                limit,
             } => {
                 let state = self
                     .conductor_handle
-                    .dump_full_cell_state(&cell_id, dht_ops_cursor)
+                    .dump_full_cell_state(&cell_id, dht_ops_cursor, limit)
                     .await?;
                 Ok(AdminResponse::FullStateDumped(state))
             }

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -82,7 +82,7 @@ use holochain_conductor_api::AppStatusFilter;
 use holochain_conductor_api::FullStateDump;
 use holochain_conductor_api::IntegrationStateDump;
 use holochain_conductor_api::PeerMetaInfo;
-use holochain_conductor_api::{DhtOpsCursor, FullIntegrationStateDump};
+use holochain_conductor_api::{DhtOpsCursor, FullIntegrationStateDump, SourceChainCursor};
 use holochain_keystore::lair_keystore::spawn_lair_keystore;
 use holochain_keystore::lair_keystore::spawn_lair_keystore_in_proc;
 use holochain_keystore::MetaLairClient;
@@ -2501,14 +2501,27 @@ mod misc_impls {
             Ok(AppCapGrantInfo(grant_info))
         }
 
-        /// Create a JSON dump of the cell's state
-        #[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
-        pub async fn dump_cell_state(&self, cell_id: &CellId) -> ConductorApiResult<String> {
+        /// Create a paginated JSON dump of the cell's state.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if the cell cannot be read or pagination is invalid.
+        pub async fn dump_cell_state(
+            &self,
+            cell_id: &CellId,
+            source_chain_cursor: Option<&SourceChainCursor>,
+            limit: Option<u32>,
+        ) -> ConductorApiResult<String> {
             let dht_store = self.get_or_create_dht_store(cell_id.dna_hash())?;
             let agent_pub_key = cell_id.agent_pubkey().clone();
             let peer_dump = peer_store_dump(self, cell_id).await?;
-            let source_chain_dump =
-                source_chain::dump_state(&dht_store.as_read(), agent_pub_key).await?;
+            let source_chain_dump = source_chain::dump_state_paginated(
+                &dht_store.as_read(),
+                agent_pub_key,
+                source_chain_cursor,
+                limit,
+            )
+            .await?;
 
             let out = JsonDump {
                 peer_dump,
@@ -2564,11 +2577,16 @@ mod misc_impls {
             Ok(out)
         }
 
-        /// Create a comprehensive structured dump of a cell's state.
+        /// Create one paginated comprehensive dump of a cell's state.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if the cell cannot be read or the limit is zero.
         pub async fn dump_full_cell_state(
             &self,
             cell_id: &CellId,
             dht_ops_cursor: Option<DhtOpsCursor>,
+            limit: Option<u32>,
         ) -> ConductorApiResult<FullStateDump> {
             let dht_store = self.get_or_create_dht_store(cell_id.dna_hash())?;
             let source_chain_dump =
@@ -2579,8 +2597,12 @@ mod misc_impls {
             let out = FullStateDump {
                 peer_dump,
                 source_chain_dump,
-                integration_dump: full_integration_dump(&dht_store.as_read(), dht_ops_cursor)
-                    .await?,
+                integration_dump: full_integration_dump_paginated(
+                    &dht_store.as_read(),
+                    dht_ops_cursor,
+                    limit,
+                )
+                .await?,
             };
             Ok(out)
         }
@@ -3599,41 +3621,48 @@ pub async fn full_integration_dump(
     dht_store: &DhtStoreRead,
     dht_ops_cursor: Option<DhtOpsCursor>,
 ) -> ConductorApiResult<FullIntegrationStateDump> {
-    // Page the (growing) integrated set by the `(when_integrated, hash)` cursor.
+    full_integration_dump_paginated(dht_store, dht_ops_cursor, None).await
+}
+
+/// Dump one page of the full integration JSON state.
+pub(crate) async fn full_integration_dump_paginated(
+    dht_store: &DhtStoreRead,
+    dht_ops_cursor: Option<DhtOpsCursor>,
+    limit: Option<u32>,
+) -> ConductorApiResult<FullIntegrationStateDump> {
     let after = dht_ops_cursor
         .as_ref()
-        .map(|c| (c.when_integrated, c.hash.get_raw_36().to_vec()));
-    let integrated_rows = dht_store
-        .integrated_chain_ops_for_dump(after.as_ref().map(|(t, h)| (*t, h.as_slice())))
-        .await?;
-
-    // The next cursor is the last integrated chain op returned (ordered by
-    // `(when_integrated, hash)`); `None` when nothing new was integrated.
-    let dht_ops_cursor = integrated_rows.last().map(|row| DhtOpsCursor {
-        when_integrated: row.when_integrated,
-        hash: holo_hash::DhtOpHash::from_raw_36(row.wire.op_hash.clone()),
+        .map(|cursor| (cursor.when_received, &cursor.hash));
+    let page = dht_store.dht_ops_page_for_dump(after, limit).await?;
+    let dht_ops_cursor = page.cursor.map(|cursor| DhtOpsCursor {
+        when_received: cursor.when_received,
+        hash: cursor.hash,
     });
-
-    let mut integrated: Vec<_> = integrated_rows
-        .into_iter()
-        .filter_map(|row| holochain_p2p::build_chain_dht_op(row.wire).ok())
-        .collect();
-    // Warrants are returned in full on every call (not cursor-paged); the cursor
-    // above tracks only the growing integrated chain-op list, so warrants can
-    // repeat across pages.
-    integrated.extend(
-        dht_store
-            .integrated_warrants_for_dump()
-            .await?
-            .into_iter()
-            .filter_map(|r| holochain_p2p::build_warrant_dht_op(r).ok()),
-    );
-
-    // Limbo sets are small and transient, so they are returned in full.
-    let validation_limbo =
-        wire_rows_to_ops(dht_store.limbo_chain_ops_for_dump(false).await?, Vec::new());
-    let integration_limbo =
-        wire_rows_to_ops(dht_store.limbo_chain_ops_for_dump(true).await?, Vec::new());
+    let mut validation_limbo = Vec::new();
+    let mut integration_limbo = Vec::new();
+    let mut integrated = Vec::new();
+    for row in page.rows {
+        let op = match row.wire {
+            holochain_state::dht_store::DumpOpWireRow::Chain(row) => {
+                holochain_p2p::build_chain_dht_op(row).ok()
+            }
+            holochain_state::dht_store::DumpOpWireRow::Warrant(row) => {
+                holochain_p2p::build_warrant_dht_op(row).ok()
+            }
+        };
+        let Some(op) = op else {
+            continue;
+        };
+        match row.state {
+            holochain_state::dht_store::DumpOpState::ValidationLimbo => {
+                validation_limbo.push(op);
+            }
+            holochain_state::dht_store::DumpOpState::IntegrationLimbo => {
+                integration_limbo.push(op);
+            }
+            holochain_state::dht_store::DumpOpState::Integrated => integrated.push(op),
+        }
+    }
 
     Ok(FullIntegrationStateDump {
         validation_limbo,

--- a/crates/holochain/src/conductor/conductor/tests/state_dump.rs
+++ b/crates/holochain/src/conductor/conductor/tests/state_dump.rs
@@ -1,13 +1,55 @@
 use crate::{
-    conductor::{conductor::state_dump_helpers::peer_store_dump, full_integration_dump},
+    conductor::{
+        conductor::{full_integration_dump_paginated, state_dump_helpers::peer_store_dump},
+        full_integration_dump,
+    },
     retry_until_timeout,
     sweettest::{SweetConductor, SweetDnaFile, SweetZome},
 };
-use holo_hash::ActionHash;
-use holochain_conductor_api::FullStateDump;
+use holo_hash::{ActionHash, DhtOpHash, HasHash};
+use holochain_conductor_api::{FullIntegrationStateDump, FullStateDump};
+use holochain_state::dht_store::SysOutcome;
 use holochain_state::source_chain;
+use holochain_types::op::{DhtOp, DhtOpHashed};
+use holochain_types::warrant::WarrantOp;
 use holochain_wasm_test_utils::TestWasm;
-use std::time::Duration;
+use holochain_zome_types::prelude::{
+    AgentPubKey, ChainIntegrityWarrant, ChainOpType, Signature, SignedWarrant, Timestamp, Warrant,
+    WarrantProof,
+};
+use std::{collections::HashSet, time::Duration};
+
+fn test_warrant(seed: u8) -> DhtOpHashed {
+    let warrant = SignedWarrant::new(
+        Warrant::new(
+            WarrantProof::ChainIntegrity(ChainIntegrityWarrant::InvalidChainOp {
+                action_author: AgentPubKey::from_raw_36(vec![seed; 36]),
+                action: (
+                    ActionHash::from_raw_36(vec![seed.wrapping_add(1); 36]),
+                    Signature::from([seed.wrapping_add(2); 64]),
+                ),
+                chain_op_type: ChainOpType::CreateRecord,
+                reason: "pagination test warrant".to_string(),
+            }),
+            AgentPubKey::from_raw_36(vec![seed.wrapping_add(3); 36]),
+            Timestamp::from_micros(i64::from(seed)),
+            AgentPubKey::from_raw_36(vec![seed.wrapping_add(4); 36]),
+        ),
+        Signature::from([seed.wrapping_add(5); 64]),
+    );
+    DhtOpHashed::from_content_sync(DhtOp::WarrantOp(Box::new(WarrantOp::from(warrant))))
+}
+
+fn dump_op_hashes(dump: &FullIntegrationStateDump) -> Vec<DhtOpHash> {
+    dump.validation_limbo
+        .iter()
+        .chain(&dump.integration_limbo)
+        .chain(&dump.integrated)
+        .cloned()
+        .map(DhtOpHashed::from_content_sync)
+        .map(|op| op.as_hash().clone())
+        .collect()
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn dump_full_state() {
@@ -69,6 +111,99 @@ async fn dump_full_state() {
             .unwrap(),
     };
 
-    let full_state_dump = conductor.dump_full_cell_state(cell_id, None).await.unwrap();
+    let full_state_dump = conductor
+        .dump_full_cell_state(cell_id, None, None)
+        .await
+        .unwrap();
     assert_eq!(full_state_dump, expected_state_dump);
+
+    let limited_full_state = conductor
+        .dump_full_cell_state(cell_id, None, Some(1))
+        .await
+        .unwrap();
+    assert_eq!(limited_full_state.peer_dump, full_state_dump.peer_dump);
+    assert_eq!(
+        limited_full_state.source_chain_dump,
+        full_state_dump.source_chain_dump
+    );
+    assert_eq!(
+        dump_op_hashes(&limited_full_state.integration_dump).len(),
+        1
+    );
+
+    for seed in [11, 21] {
+        dht_store
+            .test_insert_integrated_warrant(test_warrant(seed))
+            .await
+            .unwrap();
+    }
+
+    let validation_warrant = test_warrant(31);
+    let integration_warrant = test_warrant(41);
+    let integration_warrant_hash = integration_warrant.as_hash().clone();
+    dht_store
+        .record_incoming_ops(vec![
+            (validation_warrant, false),
+            (integration_warrant, false),
+        ])
+        .await
+        .unwrap();
+    dht_store
+        .record_warrant_sys_validation_outcomes(vec![(
+            integration_warrant_hash,
+            SysOutcome::Accepted,
+        )])
+        .await
+        .unwrap();
+
+    let unbounded = full_integration_dump(&dht_store.as_read(), None)
+        .await
+        .unwrap();
+    assert!(unbounded.integrated.len() > 5);
+    assert_eq!(unbounded.validation_limbo.len(), 1);
+    assert_eq!(unbounded.integration_limbo.len(), 1);
+    assert!(unbounded
+        .validation_limbo
+        .iter()
+        .any(|op| matches!(op, DhtOp::WarrantOp(_))));
+    assert!(unbounded
+        .integration_limbo
+        .iter()
+        .any(|op| matches!(op, DhtOp::WarrantOp(_))));
+    let expected_hashes: HashSet<_> = dump_op_hashes(&unbounded).into_iter().collect();
+
+    let mut actual_hashes = Vec::new();
+    let mut cursor = None;
+    let mut page_index = 0;
+    loop {
+        let page = full_integration_dump_paginated(&dht_store.as_read(), cursor, Some(5))
+            .await
+            .unwrap();
+        let page_hashes = dump_op_hashes(&page);
+        assert!(page_hashes.len() <= 5);
+        assert_eq!(page.dht_ops_cursor.is_some(), !page_hashes.is_empty());
+        actual_hashes.extend(page_hashes);
+        cursor = page.dht_ops_cursor;
+        if cursor.is_none() {
+            break;
+        }
+        if page_index == 0 {
+            dht_store
+                .integrate_ready_ops(Timestamp::now())
+                .await
+                .unwrap();
+        }
+        page_index += 1;
+    }
+    assert!(page_index > 1);
+    assert_eq!(actual_hashes.len(), expected_hashes.len());
+    assert_eq!(
+        actual_hashes.iter().cloned().collect::<HashSet<_>>(),
+        expected_hashes
+    );
+    assert!(
+        full_integration_dump_paginated(&dht_store.as_read(), None, Some(0))
+            .await
+            .is_err()
+    );
 }

--- a/crates/holochain/src/conductor/interface/websocket.rs
+++ b/crates/holochain/src/conductor/interface/websocket.rs
@@ -1174,11 +1174,16 @@ mod test {
         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
         // Get state
-        let expected = conductor_handle.dump_cell_state(&cell_id).await.unwrap();
+        let expected = conductor_handle
+            .dump_cell_state(&cell_id, None, None)
+            .await
+            .unwrap();
 
         let admin_api = AdminInterfaceApi::new(conductor_handle.clone());
         let msg = AdminRequest::DumpState {
             cell_id: Box::new(cell_id),
+            source_chain_cursor: None,
+            limit: None,
         };
         let respond = move |response: AdminResponse| {
             assert_matches!(response, AdminResponse::StateDumped(s) if s == expected);

--- a/crates/holochain/src/conductor/tests/cell.rs
+++ b/crates/holochain/src/conductor/tests/cell.rs
@@ -23,7 +23,7 @@ async fn check_or_run_zome_init_triggers_zome_initialization() {
     // Take state dump before calling check_or_run_zome_init
     let before_state_dump = conductor
         .raw_handle()
-        .dump_full_cell_state(cell_id, None)
+        .dump_full_cell_state(cell_id, None, None)
         .await
         .expect("Failed to get state dump");
 
@@ -49,7 +49,7 @@ async fn check_or_run_zome_init_triggers_zome_initialization() {
     // Take state dump after calling check_or_run_zome_init
     let after_state_dump = conductor
         .raw_handle()
-        .dump_full_cell_state(cell_id, None)
+        .dump_full_cell_state(cell_id, None, None)
         .await
         .expect("Failed to get state dump");
 
@@ -86,7 +86,7 @@ async fn check_or_run_zome_init_does_nothing_if_already_initialized() {
     // Take state dump before calling check_or_run_zome_init
     let before_state_dump = conductor
         .raw_handle()
-        .dump_full_cell_state(cell_id, None)
+        .dump_full_cell_state(cell_id, None, None)
         .await
         .expect("Failed to get state dump");
 
@@ -112,7 +112,7 @@ async fn check_or_run_zome_init_does_nothing_if_already_initialized() {
     // Take state dump after calling check_or_run_zome_init
     let after_state_dump = conductor
         .raw_handle()
-        .dump_full_cell_state(cell_id, None)
+        .dump_full_cell_state(cell_id, None, None)
         .await
         .expect("Failed to get state dump");
 

--- a/crates/holochain/src/conductor/tests/signed_zome_call.rs
+++ b/crates/holochain/src/conductor/tests/signed_zome_call.rs
@@ -375,7 +375,7 @@ async fn grant_zome_call_capability_call() {
     // Take state dump before calling grant_zome_call_capability
     let before_state_dump = conductor
         .raw_handle()
-        .dump_full_cell_state(cell_id, None)
+        .dump_full_cell_state(cell_id, None, None)
         .await
         .expect("Failed to get state dump");
 
@@ -423,7 +423,7 @@ async fn grant_zome_call_capability_call() {
     // Take state dump after calling grant_zome_call_capability
     let after_state_dump = conductor
         .raw_handle()
-        .dump_full_cell_state(cell_id, None)
+        .dump_full_cell_state(cell_id, None, None)
         .await
         .expect("Failed to get state dump");
 
@@ -471,7 +471,7 @@ async fn grant_zome_call_capability_call_ensures_zome_initialization() {
     // Take state dump before calling grant_zome_call_capability
     let before_state_dump = conductor
         .raw_handle()
-        .dump_full_cell_state(cell_id, None)
+        .dump_full_cell_state(cell_id, None, None)
         .await
         .expect("Failed to get state dump");
 
@@ -503,7 +503,7 @@ async fn grant_zome_call_capability_call_ensures_zome_initialization() {
     // Take state dump after calling grant_zome_call_capability
     let after_state_dump = conductor
         .raw_handle()
-        .dump_full_cell_state(cell_id, None)
+        .dump_full_cell_state(cell_id, None, None)
         .await
         .expect("Failed to get state dump");
 
@@ -579,7 +579,7 @@ async fn revoke_zome_call_capability_call() {
     // Take a state dump, before calling revoke_zome_call_capability
     let before_state_dump = conductor
         .raw_handle()
-        .dump_full_cell_state(cell_id, None)
+        .dump_full_cell_state(cell_id, None, None)
         .await
         .expect("Failed to get state dump");
 
@@ -601,7 +601,7 @@ async fn revoke_zome_call_capability_call() {
     // Take a state dump, after calling revoke_zome_call_capability
     let after_state_dump = conductor
         .raw_handle()
-        .dump_full_cell_state(cell_id, None)
+        .dump_full_cell_state(cell_id, None, None)
         .await
         .expect("Failed to get state dump");
 
@@ -672,7 +672,7 @@ async fn revoke_zome_call_capability_call_ensures_zome_initialization() {
     // Take a state dump, before calling revoke_zome_call_capability
     let before_state_dump = conductor
         .raw_handle()
-        .dump_full_cell_state(cell_id, None)
+        .dump_full_cell_state(cell_id, None, None)
         .await
         .expect("Failed to get state dump");
 
@@ -694,7 +694,7 @@ async fn revoke_zome_call_capability_call_ensures_zome_initialization() {
     // Take a state dump, after calling revoke_zome_call_capability
     let after_state_dump = conductor
         .raw_handle()
-        .dump_full_cell_state(cell_id, None)
+        .dump_full_cell_state(cell_id, None, None)
         .await
         .expect("Failed to get state dump");
 

--- a/crates/holochain/src/sweettest/sweet_consistency.rs
+++ b/crates/holochain/src/sweettest/sweet_consistency.rs
@@ -95,7 +95,7 @@ fn is_author_local_private_store_entry(op: &DhtOp) -> bool {
 /// their hashes match across nodes.
 async fn integrated_op_rows(dht_store: &DhtStoreRead) -> Result<Vec<DhtOpRow>, String> {
     let dump_rows = dht_store
-        .integrated_chain_ops_for_dump(None)
+        .integrated_chain_ops_for_dump(None, None)
         .await
         .map_err(|e| e.to_string())?;
     // Reconstruct each row on its own so its `when_integrated` stays paired with

--- a/crates/holochain/src/test_utils/conditional_consistency.rs
+++ b/crates/holochain/src/test_utils/conditional_consistency.rs
@@ -370,7 +370,7 @@ fn display_op(op: &DhtOp) -> String {
 /// their hashes match the published set.
 async fn get_integrated_ops(dht_store: &DhtStoreRead) -> Vec<DhtOp> {
     let chain = dht_store
-        .integrated_chain_ops_for_dump(None)
+        .integrated_chain_ops_for_dump(None, None)
         .await
         .unwrap()
         .into_iter()

--- a/crates/holochain/tests/tests/countersigning/session_interaction_over_websocket.rs
+++ b/crates/holochain/tests/tests/countersigning/session_interaction_over_websocket.rs
@@ -839,6 +839,7 @@ async fn await_dht_sync(agents: &[&Agent]) {
                 AdminRequest::DumpFullState {
                     cell_id: Box::new(agent.cell_id.clone()),
                     dht_ops_cursor: None,
+                    limit: None,
                 },
                 &agent.admin_tx,
             )

--- a/crates/holochain/tests/tests/test_utils/mod.rs
+++ b/crates/holochain/tests/tests/test_utils/mod.rs
@@ -426,6 +426,7 @@ pub async fn dump_full_state(
     let request = AdminRequest::DumpFullState {
         cell_id: Box::new(cell_id),
         dht_ops_cursor,
+        limit: None,
     };
     let response = client.request(request);
     let response = check_timeout(response, 3000).await?;

--- a/crates/holochain/tests/tests/websocket/mod.rs
+++ b/crates/holochain/tests/tests/websocket/mod.rs
@@ -817,26 +817,19 @@ async fn full_state_dump_returns_all_ops() {
         integrated_ops_count + validation_limbo_ops_count + integration_limbo_ops_count;
     assert_eq!(7, all_dhts_ops_count);
 
-    // The first dump returns every integrated op and a cursor marking the last,
-    // so a follow-up dump pages forward through only ops integrated since.
+    // The first dump returns every DHT op and a cursor marking the last, so a
+    // follow-up dump resumes after all integrated and limbo ops.
     let cursor = full_state.integration_dump.dht_ops_cursor;
     assert!(cursor.is_some());
 
     let full_state = dump_full_state(&mut client, cell_id, cursor).await.unwrap();
 
-    // Nothing has been integrated since, so paging from the cursor returns no
-    // further integrated ops and no onward cursor. The (here empty) limbo sets
-    // are not cursor-paged, so they come back unchanged.
+    // No DHT op was received after the cursor, so every bucket is empty and
+    // there is no onward cursor.
     assert!(full_state.integration_dump.integrated.is_empty());
     assert!(full_state.integration_dump.dht_ops_cursor.is_none());
-    assert_eq!(
-        full_state.integration_dump.validation_limbo.len(),
-        validation_limbo_ops_count
-    );
-    assert_eq!(
-        full_state.integration_dump.integration_limbo.len(),
-        integration_limbo_ops_count
-    );
+    assert!(full_state.integration_dump.validation_limbo.is_empty());
+    assert!(full_state.integration_dump.integration_limbo.is_empty());
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -229,6 +229,12 @@ pub enum AdminRequest {
     DumpState {
         /// The cell ID for which to dump state
         cell_id: Box<CellId>,
+        /// Last source-chain record seen; the next page starts after it.
+        #[serde(default)]
+        source_chain_cursor: Option<crate::state_dump::SourceChainCursor>,
+        /// Maximum number of source-chain records to return. Must be greater than zero.
+        #[serde(default)]
+        limit: Option<u32>,
     },
 
     /// Dump the state of the conductor, including the in-memory representation
@@ -257,9 +263,14 @@ pub enum AdminRequest {
     DumpFullState {
         /// The cell ID for which to dump the state
         cell_id: Box<CellId>,
-        /// Pagination cursor from a previous `DumpFullState`; only ops
-        /// integrated after it are returned. `None` starts from the beginning.
+        /// Pagination cursor from a previous `DumpFullState`; only DHT ops
+        /// received after it are returned. `None` starts from the beginning.
+        #[serde(default)]
         dht_ops_cursor: Option<crate::state_dump::DhtOpsCursor>,
+        /// Maximum number of DHT ops across all lifecycle buckets to return.
+        /// Must be greater than zero.
+        #[serde(default)]
+        limit: Option<u32>,
     },
 
     /// Dump the network metrics tracked by kitsune.
@@ -711,7 +722,9 @@ pub struct AppAuthenticationTokenIssued {
 
 #[cfg(test)]
 mod tests {
-    use crate::{AdminRequest, AdminResponse, ExternalApiWireError};
+    use crate::{AdminRequest, AdminResponse, DhtOpsCursor, ExternalApiWireError};
+    use holo_hash::{AgentPubKey, DhtOpHash, DnaHash};
+    use holochain_zome_types::cell::CellId;
     use serde::Deserialize;
 
     #[test]
@@ -761,5 +774,53 @@ mod tests {
         let json_actual = serde_json::to_string(&json_value).unwrap();
 
         assert_eq!(json_actual, json_expected);
+    }
+
+    #[test]
+    fn state_dump_requests_default_omitted_pagination_fields() {
+        let cell_id = CellId::new(
+            DnaHash::from_raw_36(vec![1; 36]),
+            AgentPubKey::from_raw_36(vec![2; 36]),
+        );
+
+        let dump_state: AdminRequest = serde_json::from_value(serde_json::json!({
+            "type": "dump_state",
+            "value": { "cell_id": cell_id.clone() }
+        }))
+        .unwrap();
+        assert!(matches!(
+            dump_state,
+            AdminRequest::DumpState {
+                source_chain_cursor: None,
+                limit: None,
+                ..
+            }
+        ));
+
+        let dump_full_state: AdminRequest = serde_json::from_value(serde_json::json!({
+            "type": "dump_full_state",
+            "value": { "cell_id": cell_id }
+        }))
+        .unwrap();
+        assert!(matches!(
+            dump_full_state,
+            AdminRequest::DumpFullState {
+                dht_ops_cursor: None,
+                limit: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn dht_ops_cursor_serializes_received_time() {
+        let cursor = DhtOpsCursor {
+            when_received: 42,
+            hash: DhtOpHash::from_raw_36(vec![3; 36]),
+        };
+        let value = serde_json::to_value(cursor).unwrap();
+
+        assert_eq!(value["when_received"], 42);
+        assert!(value.get("when_integrated").is_none());
     }
 }

--- a/crates/holochain_conductor_api/src/state_dump.rs
+++ b/crates/holochain_conductor_api/src/state_dump.rs
@@ -1,6 +1,7 @@
 use holo_hash::AgentPubKey;
 use holo_hash::DhtOpHash;
 use holo_hash::DnaHash;
+pub use holochain_state_types::SourceChainCursor;
 use holochain_state_types::SourceChainDump;
 use holochain_types::op::DhtOp;
 use serde::Deserialize;
@@ -54,33 +55,23 @@ pub struct FullIntegrationStateDump {
     /// Ops waiting to be integrated.
     pub integration_limbo: Vec<DhtOp>,
 
-    /// Ops that are integrated (includes rejected). Integrated **chain ops** are
-    /// paged by `dht_ops_cursor`; integrated **warrants** are appended in full on
-    /// every call and are not cursor-paged.
+    /// Ops that are integrated (includes rejected).
     pub integrated: Vec<DhtOp>,
 
-    /// Cursor marking the last integrated **chain op** returned. Pass it to a
-    /// subsequent `FullStateDump` to page forward through only the chain ops
-    /// integrated since. `None` when no integrated chain ops were returned.
-    ///
-    /// Only the (unbounded, growing) integrated chain-op list is paged. The two
-    /// limbo lists and integrated warrants are bounded/transient and returned in
-    /// full on every call, so they can repeat across pages.
+    /// Cursor marking the last DHT op selected across all lifecycle buckets.
+    /// Pass it to a subsequent `FullStateDump` to resume strictly after it.
+    /// `None` when the page selected no DHT ops.
     pub dht_ops_cursor: Option<DhtOpsCursor>,
 }
 
-/// Pagination cursor for the integrated **chain ops** in a
-/// [`FullIntegrationStateDump`]. Warrants and the limbo lists are not paged by it.
+/// Pagination cursor for all DHT ops in a [`FullIntegrationStateDump`].
 ///
-/// Integrated chain ops are ordered by `(when_integrated, hash)`; a cursor
-/// records the last op returned so the next dump resumes strictly after it.
-/// The DHT tables are `WITHOUT ROWID`, so pagination is keyed on this
-/// timestamp/hash pair rather than a rowid.
+/// `(when_received, hash)`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct DhtOpsCursor {
-    /// Microsecond integration timestamp of the last op returned.
-    pub when_integrated: i64,
-    /// Hash of the last op returned (tie-breaks ops sharing a timestamp).
+    /// Microsecond receipt timestamp of the last op selected.
+    pub when_received: i64,
+    /// Hash of the last op selected (tie-breaks ops sharing a timestamp).
     pub hash: DhtOpHash,
 }
 
@@ -115,7 +106,7 @@ impl std::fmt::Display for JsonDump {
         writeln!(f, "Number of other peers in p2p store: {num_other_peers},")?;
         writeln!(
             f,
-            "Records authored: {}, Ops published: {}",
+            "Records returned: {}, Ops published: {}",
             s.records.len(),
             s.published_ops_count
         )

--- a/crates/holochain_data/src/dht/db_operations/action.rs
+++ b/crates/holochain_data/src/dht/db_operations/action.rs
@@ -36,6 +36,35 @@ impl DbRead<Dht> {
         action::get_actions_by_author(&mut *conn, author).await
     }
 
+    /// Fetch an exclusive page of accepted actions authored by `author`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    pub async fn get_actions_by_author_paginated(
+        &self,
+        author: &AgentPubKey,
+        after_sequence: Option<u32>,
+        limit: Option<u32>,
+    ) -> sqlx::Result<Vec<SignedActionHashed>> {
+        let mut conn = self.timed_conn().await?;
+        action::get_actions_by_author_paginated(&mut *conn, author, after_sequence, limit).await
+    }
+
+    /// Resolve an accepted action hash to its sequence for `author`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails.
+    pub async fn get_accepted_action_sequence(
+        &self,
+        author: &AgentPubKey,
+        action_hash: &ActionHash,
+    ) -> sqlx::Result<Option<u32>> {
+        let mut conn = self.timed_conn().await?;
+        action::get_accepted_action_sequence(&mut *conn, author, action_hash).await
+    }
+
     /// Count actions authored by `author`, capped at `cap`. See
     /// `action::count_author_actions_capped`.
     pub async fn count_author_actions_capped(

--- a/crates/holochain_data/src/dht/db_operations/sync_queries.rs
+++ b/crates/holochain_data/src/dht/db_operations/sync_queries.rs
@@ -4,12 +4,12 @@ use super::super::inner::sync_queries::{self, ArcBounds};
 use crate::handles::DbRead;
 use crate::kind::Dht;
 use crate::models::dht::{
-    DumpChainOpRow, K2ChainOpForWireRow, K2OpHashRow, K2OpIdSinceRow, K2OpPresentRow,
+    DumpChainOpRow, DumpOpPage, K2ChainOpForWireRow, K2OpHashRow, K2OpIdSinceRow, K2OpPresentRow,
     K2WarrantForWireRow,
 };
-use holo_hash::AgentPubKey;
 #[cfg(any(test, feature = "inspection"))]
-use holo_hash::{AnyLinkableHash, DhtOpHash};
+use holo_hash::AnyLinkableHash;
+use holo_hash::{AgentPubKey, DhtOpHash};
 
 impl DbRead<Dht> {
     /// `(hash, basis, size)` for every integrated, locally-validated op
@@ -216,9 +216,25 @@ impl DbRead<Dht> {
     pub async fn integrated_chain_ops_for_dump(
         &self,
         after: Option<(i64, &[u8])>,
+        limit: Option<u32>,
     ) -> sqlx::Result<Vec<DumpChainOpRow>> {
         let mut conn = self.timed_conn().await?;
-        sync_queries::integrated_chain_ops_for_dump(&mut *conn, after).await
+        sync_queries::integrated_chain_ops_for_dump(&mut *conn, after, limit).await
+    }
+
+    /// Select and hydrate a global DHT-op dump page in one read snapshot.
+    ///
+    /// Rows across integrated and limbo chain ops and warrants are ordered by
+    /// `(when_received, op_hash)`. Cache-only integrated chain ops are omitted.
+    pub async fn dht_ops_page_for_dump(
+        &self,
+        after: Option<(i64, &DhtOpHash)>,
+        limit: Option<u32>,
+    ) -> sqlx::Result<DumpOpPage> {
+        let mut tx = self.begin().await?;
+        let page = sync_queries::dht_ops_page_for_dump(tx.conn_mut(), after, limit).await?;
+        tx.close().await?;
+        Ok(page)
     }
 
     /// Limbo chain-op rows for the integration dump. `ready` selects the

--- a/crates/holochain_data/src/dht/inner/action.rs
+++ b/crates/holochain_data/src/dht/inner/action.rs
@@ -7,7 +7,7 @@ use holochain_integrity_types::prelude::{
     SignedHashed,
 };
 use holochain_zome_types::prelude::{ChainOpType, SignedActionHashed};
-use sqlx::{Executor, Sqlite};
+use sqlx::{Executor, QueryBuilder, Sqlite};
 
 /// Insert an `Action` row. `record_validity` is `Some(Accepted)` for
 /// self-authored actions and `None` for incoming network actions.
@@ -132,6 +132,62 @@ where
     .fetch_all(executor)
     .await?;
     rows.into_iter().map(row_to_signed_action_hashed).collect()
+}
+
+/// Fetch an exclusive page of accepted actions authored by `author`.
+pub(crate) async fn get_actions_by_author_paginated<'e, E>(
+    executor: E,
+    author: &AgentPubKey,
+    after_sequence: Option<u32>,
+    limit: Option<u32>,
+) -> sqlx::Result<Vec<SignedActionHashed>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let mut query = QueryBuilder::<Sqlite>::new(
+        "SELECT hash, author, seq, prev_hash, timestamp, action_type,
+                action_data, signature, entry_hash, private_entry, record_validity
+         FROM Action WHERE author = ",
+    );
+    query.push_bind(author.get_raw_36());
+    query.push(" AND record_validity = ");
+    query.push_bind(i64::from(RecordValidity::Accepted));
+    if let Some(sequence) = after_sequence {
+        query.push(" AND seq > ");
+        query.push_bind(i64::from(sequence));
+    }
+    query.push(" ORDER BY seq ASC");
+    if let Some(limit) = limit {
+        query.push(" LIMIT ");
+        query.push_bind(i64::from(limit));
+    }
+
+    let rows = query
+        .build_query_as::<ActionRow>()
+        .fetch_all(executor)
+        .await?;
+    rows.into_iter().map(row_to_signed_action_hashed).collect()
+}
+
+/// Resolve an accepted action hash to its sequence for the specified author.
+pub(crate) async fn get_accepted_action_sequence<'e, E>(
+    executor: E,
+    author: &AgentPubKey,
+    action_hash: &ActionHash,
+) -> sqlx::Result<Option<u32>>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let sequence: Option<i64> = sqlx::query_scalar(
+        "SELECT seq FROM Action
+         WHERE hash = ? AND author = ? AND record_validity = ?",
+    )
+    .bind(action_hash.get_raw_36())
+    .bind(author.get_raw_36())
+    .bind(i64::from(RecordValidity::Accepted))
+    .fetch_optional(executor)
+    .await?;
+    Ok(sequence.map(|sequence| sequence as u32))
 }
 
 /// Count actions authored by `author`, stopping once `cap` rows have been

--- a/crates/holochain_data/src/dht/inner/sync_queries.rs
+++ b/crates/holochain_data/src/dht/inner/sync_queries.rs
@@ -37,13 +37,14 @@
 //! `WarrantOp`) to report the total observed DHT size.
 
 use crate::models::dht::{
-    DumpChainOpRow, K2ChainOpForWireRow, K2OpHashRow, K2OpIdSinceRow, K2OpPresentRow,
-    K2WarrantForWireRow,
+    DumpChainOpRow, DumpOpCursorRow, DumpOpPage, DumpOpRow, DumpOpState, DumpOpWireRow,
+    K2ChainOpForWireRow, K2OpHashRow, K2OpIdSinceRow, K2OpPresentRow, K2WarrantForWireRow,
 };
-use holo_hash::AgentPubKey;
 #[cfg(any(test, feature = "inspection"))]
-use holo_hash::{AnyLinkableHash, DhtOpHash};
+use holo_hash::AnyLinkableHash;
+use holo_hash::{AgentPubKey, DhtOpHash};
 use sqlx::{Executor, QueryBuilder, Sqlite};
+use std::collections::HashMap;
 
 /// Inclusive `[storage_start_loc, storage_end_loc]` arc bounds.
 #[derive(Debug, Clone, Copy)]
@@ -389,6 +390,7 @@ where
 pub(crate) async fn integrated_chain_ops_for_dump<'e, E>(
     executor: E,
     after: Option<(i64, &[u8])>,
+    limit: Option<u32>,
 ) -> sqlx::Result<Vec<DumpChainOpRow>>
 where
     E: Executor<'e, Database = Sqlite>,
@@ -422,6 +424,10 @@ where
         qb.push("))");
     }
     qb.push(" ORDER BY ChainOp.when_integrated ASC, ChainOp.hash ASC");
+    if let Some(limit) = limit {
+        qb.push(" LIMIT ");
+        qb.push_bind(i64::from(limit));
+    }
     qb.build_query_as::<DumpChainOpRow>()
         .fetch_all(executor)
         .await
@@ -529,6 +535,199 @@ where
     )
     .fetch_all(executor)
     .await
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct DumpOpKeyRow {
+    hash: Vec<u8>,
+    when_received: i64,
+    state: i64,
+    kind: i64,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DumpChainTable {
+    Integrated,
+    Limbo,
+}
+
+/// Select and hydrate one globally ordered DHT-op dump page.
+///
+/// The caller must pass a connection inside a [`TxRead`](crate::TxRead), so
+/// selecting lightweight keys and hydrating their wire rows observes one
+/// immutable snapshot while workflow transactions promote ops between tables.
+pub(crate) async fn dht_ops_page_for_dump(
+    conn: &mut sqlx::SqliteConnection,
+    after: Option<(i64, &DhtOpHash)>,
+    limit: Option<u32>,
+) -> sqlx::Result<DumpOpPage> {
+    let mut qb: QueryBuilder<Sqlite> = QueryBuilder::new(
+        "SELECT hash, when_received, state, kind FROM (
+            SELECT hash, when_received, 2 AS state, 0 AS kind
+            FROM ChainOp WHERE locally_validated = 1
+            UNION ALL
+            SELECT hash, when_received, 2 AS state, 1 AS kind FROM WarrantOp
+            UNION ALL
+            SELECT hash, when_received,
+                CASE WHEN ",
+    );
+    qb.push(LIMBO_CHAIN_OP_READY_PRED);
+    qb.push(
+        " THEN 1 ELSE 0 END AS state,
+            0 AS kind
+         FROM LimboChainOp
+         UNION ALL
+         SELECT hash, when_received,
+            CASE WHEN sys_validation_status IN (1, 2) THEN 1 ELSE 0 END AS state,
+            1 AS kind
+         FROM LimboWarrantOp
+         ) WHERE 1 = 1",
+    );
+    if let Some((when_received, hash)) = after {
+        qb.push(" AND (when_received > ");
+        qb.push_bind(when_received);
+        qb.push(" OR (when_received = ");
+        qb.push_bind(when_received);
+        qb.push(" AND hash > ");
+        qb.push_bind(hash.get_raw_36());
+        qb.push("))");
+    }
+    qb.push(" ORDER BY when_received ASC, hash ASC");
+    if let Some(limit) = limit {
+        qb.push(" LIMIT ");
+        qb.push_bind(i64::from(limit));
+    }
+    let keys = qb
+        .build_query_as::<DumpOpKeyRow>()
+        .fetch_all(&mut *conn)
+        .await?;
+
+    let cursor = keys.last().map(|key| DumpOpCursorRow {
+        when_received: key.when_received,
+        hash: DhtOpHash::from_raw_36(key.hash.clone()),
+    });
+    let integrated_chain_hashes = dump_hashes(&keys, Some(2), 0);
+    let limbo_chain_hashes = dump_hashes(&keys, None, 0);
+    let warrant_hashes = dump_hashes(&keys, None, 1);
+
+    let mut integrated_chain = chain_ops_for_dump_by_hashes(
+        &mut *conn,
+        DumpChainTable::Integrated,
+        &integrated_chain_hashes,
+    )
+    .await?
+    .into_iter()
+    .map(|row| (row.op_hash.clone(), row))
+    .collect::<HashMap<_, _>>();
+    let mut limbo_chain =
+        chain_ops_for_dump_by_hashes(&mut *conn, DumpChainTable::Limbo, &limbo_chain_hashes)
+            .await?
+            .into_iter()
+            .map(|row| (row.op_hash.clone(), row))
+            .collect::<HashMap<_, _>>();
+    let mut warrants = warrants_for_dump_by_hashes(&mut *conn, &warrant_hashes)
+        .await?
+        .into_iter()
+        .map(|row| (row.hash.clone(), row))
+        .collect::<HashMap<_, _>>();
+
+    let rows = keys
+        .into_iter()
+        .filter_map(|key| {
+            let state = match key.state {
+                0 => DumpOpState::ValidationLimbo,
+                1 => DumpOpState::IntegrationLimbo,
+                2 => DumpOpState::Integrated,
+                _ => return None,
+            };
+            let wire = match (key.kind, state) {
+                (0, DumpOpState::Integrated) => {
+                    integrated_chain.remove(&key.hash).map(DumpOpWireRow::Chain)
+                }
+                (0, _) => limbo_chain.remove(&key.hash).map(DumpOpWireRow::Chain),
+                (1, _) => warrants.remove(&key.hash).map(DumpOpWireRow::Warrant),
+                _ => None,
+            }?;
+            Some(DumpOpRow { state, wire })
+        })
+        .collect();
+
+    Ok(DumpOpPage { rows, cursor })
+}
+
+fn dump_hashes(keys: &[DumpOpKeyRow], state: Option<i64>, kind: i64) -> Vec<Vec<u8>> {
+    keys.iter()
+        .filter(|key| key.kind == kind && state.is_none_or(|state| key.state == state))
+        .map(|key| key.hash.clone())
+        .collect()
+}
+
+async fn chain_ops_for_dump_by_hashes(
+    conn: &mut sqlx::SqliteConnection,
+    table: DumpChainTable,
+    hashes: &[Vec<u8>],
+) -> sqlx::Result<Vec<K2ChainOpForWireRow>> {
+    if hashes.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut qb: QueryBuilder<Sqlite> = QueryBuilder::new(
+        "SELECT
+            op.hash AS op_hash,
+            op.basis_hash AS basis_hash,
+            op.op_type AS op_type,
+            Action.hash AS action_hash,
+            Action.author AS author,
+            Action.timestamp AS timestamp,
+            Action.seq AS seq,
+            Action.prev_hash AS prev_hash,
+            Action.action_data AS action_data,
+            Action.signature AS signature,
+            Entry.blob AS entry_blob
+         FROM ",
+    );
+    qb.push(match table {
+        DumpChainTable::Integrated => "ChainOp",
+        DumpChainTable::Limbo => "LimboChainOp",
+    });
+    qb.push(
+        " AS op
+         JOIN Action ON op.action_hash = Action.hash
+         LEFT JOIN Entry ON Action.entry_hash = Entry.hash
+         WHERE op.hash IN (",
+    );
+    {
+        let mut separated = qb.separated(", ");
+        for hash in hashes {
+            separated.push_bind(hash);
+        }
+    }
+    qb.push(")");
+    qb.build_query_as::<K2ChainOpForWireRow>()
+        .fetch_all(conn)
+        .await
+}
+
+async fn warrants_for_dump_by_hashes(
+    conn: &mut sqlx::SqliteConnection,
+    hashes: &[Vec<u8>],
+) -> sqlx::Result<Vec<K2WarrantForWireRow>> {
+    if hashes.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut qb: QueryBuilder<Sqlite> = QueryBuilder::new(
+        "SELECT hash, author, timestamp, warrantee, proof, signature
+         FROM Warrant WHERE hash IN (",
+    );
+    {
+        let mut separated = qb.separated(", ");
+        for hash in hashes {
+            separated.push_bind(hash);
+        }
+    }
+    qb.push(")");
+    qb.build_query_as::<K2WarrantForWireRow>()
+        .fetch_all(conn)
+        .await
 }
 
 /// Minimum authored timestamp across both `ChainOp` (joined with `Action`)
@@ -865,8 +1064,9 @@ where
 mod tests {
     use crate::handles::DbWrite;
     use crate::kind::Dht;
+    use crate::models::dht::{DumpOpCursorRow, DumpOpRow, DumpOpState, DumpOpWireRow};
     use crate::test_open_db;
-    use holo_hash::{AgentPubKey, DnaHash};
+    use holo_hash::{AgentPubKey, DhtOpHash, DnaHash};
     use sqlx::{Pool, Sqlite};
     use std::sync::Arc;
 
@@ -931,6 +1131,132 @@ mod tests {
         .unwrap();
 
         op_hash
+    }
+
+    async fn seed_limbo_chain_op(
+        pool: &Pool<Sqlite>,
+        op_tag: u8,
+        when_received: i64,
+        ready: bool,
+    ) -> Vec<u8> {
+        let op_hash = vec![op_tag; 36];
+        let action_hash = vec![op_tag + 100; 36];
+        sqlx::query(
+            "INSERT INTO Action
+                (hash, author, seq, prev_hash, timestamp, action_type,
+                 action_data, signature, entry_hash, private_entry, record_validity)
+             VALUES (?, ?, 0, NULL, ?, 0, ?, ?, NULL, 0, NULL)",
+        )
+        .bind(&action_hash)
+        .bind(vec![AUTHOR; 36])
+        .bind(when_received)
+        .bind(vec![0u8])
+        .bind(vec![0u8])
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO LimboChainOp
+                (hash, op_type, action_hash, basis_hash, storage_center_loc,
+                 sys_validation_status, app_validation_status, require_receipt,
+                 when_received, serialized_size)
+             VALUES (?, ?, ?, ?, 0, ?, ?, 0, ?, 10)",
+        )
+        .bind(&op_hash)
+        .bind(STORE_RECORD)
+        .bind(&action_hash)
+        .bind(vec![op_tag + 50; 36])
+        .bind(ready.then_some(1_i64))
+        .bind(ready.then_some(1_i64))
+        .bind(when_received)
+        .execute(pool)
+        .await
+        .unwrap();
+        op_hash
+    }
+
+    async fn seed_warrant_op(
+        pool: &Pool<Sqlite>,
+        op_tag: u8,
+        when_received: i64,
+        state: DumpOpState,
+    ) -> Vec<u8> {
+        let hash = vec![op_tag; 36];
+        sqlx::query(
+            "INSERT INTO Warrant
+                (hash, author, timestamp, warrantee, proof, signature, reason)
+             VALUES (?, ?, ?, ?, ?, ?, NULL)",
+        )
+        .bind(&hash)
+        .bind(vec![AUTHOR; 36])
+        .bind(when_received)
+        .bind(vec![op_tag + 40; 36])
+        .bind(vec![0u8])
+        .bind(vec![0u8])
+        .execute(pool)
+        .await
+        .unwrap();
+        match state {
+            DumpOpState::Integrated => {
+                sqlx::query(
+                    "INSERT INTO WarrantOp
+                        (hash, storage_center_loc, when_received, when_integrated,
+                         validation_status, serialized_size)
+                     VALUES (?, 0, ?, ?, 1, 10)",
+                )
+                .bind(&hash)
+                .bind(when_received)
+                .bind(when_received + 1_000)
+                .execute(pool)
+                .await
+                .unwrap();
+            }
+            DumpOpState::ValidationLimbo | DumpOpState::IntegrationLimbo => {
+                sqlx::query(
+                    "INSERT INTO LimboWarrantOp
+                        (hash, storage_center_loc, sys_validation_status,
+                         when_received, serialized_size)
+                     VALUES (?, 0, ?, ?, 10)",
+                )
+                .bind(&hash)
+                .bind((state == DumpOpState::IntegrationLimbo).then_some(1_i64))
+                .bind(when_received)
+                .execute(pool)
+                .await
+                .unwrap();
+            }
+        }
+        hash
+    }
+
+    fn dump_row_hash(row: &DumpOpRow) -> &[u8] {
+        match &row.wire {
+            DumpOpWireRow::Chain(row) => &row.op_hash,
+            DumpOpWireRow::Warrant(row) => &row.hash,
+        }
+    }
+
+    async fn promote_seeded_limbo_chain_op(db: &DbWrite<Dht>, hash: &[u8]) {
+        let mut tx = db.begin().await.unwrap();
+        sqlx::query(
+            "INSERT INTO ChainOp
+                (hash, op_type, action_hash, basis_hash, storage_center_loc,
+                 validation_status, locally_validated, require_receipt,
+                 when_received, when_integrated, serialized_size)
+             SELECT hash, op_type, action_hash, basis_hash, storage_center_loc,
+                    1, 1, require_receipt, when_received, 999, serialized_size
+             FROM LimboChainOp WHERE hash = ?",
+        )
+        .bind(hash)
+        .execute(tx.conn_mut())
+        .await
+        .unwrap();
+        sqlx::query("DELETE FROM LimboChainOp WHERE hash = ?")
+            .bind(hash)
+            .execute(tx.conn_mut())
+            .await
+            .unwrap();
+        tx.commit().await.unwrap();
     }
 
     /// Seed three integrated ops that exercise the private-entry filter:
@@ -1070,6 +1396,123 @@ mod tests {
         assert!(
             !hashes.contains(&private),
             "private CreateEntry op must never be published"
+        );
+    }
+
+    #[tokio::test]
+    async fn integrated_dump_uses_exclusive_bounded_cursor_pages() {
+        let (db, public, private, record) = seed_filter_fixture().await;
+        let tied = seed_op(db.pool(), 4, STORE_RECORD, 0, 2000).await;
+
+        let first_page = db
+            .as_ref()
+            .integrated_chain_ops_for_dump(None, Some(2))
+            .await
+            .unwrap();
+        let first_hashes: Vec<_> = first_page
+            .iter()
+            .map(|row| row.wire.op_hash.clone())
+            .collect();
+        assert_eq!(first_hashes, vec![private, public]);
+
+        let last = first_page.last().unwrap();
+        let second_page = db
+            .as_ref()
+            .integrated_chain_ops_for_dump(
+                Some((last.when_integrated, last.wire.op_hash.as_slice())),
+                Some(10),
+            )
+            .await
+            .unwrap();
+        let second_hashes: Vec<_> = second_page
+            .iter()
+            .map(|row| row.wire.op_hash.clone())
+            .collect();
+        assert_eq!(second_hashes, vec![tied, record]);
+
+        let empty_page = db
+            .as_ref()
+            .integrated_chain_ops_for_dump(
+                Some((
+                    second_page[1].when_integrated,
+                    second_page[1].wire.op_hash.as_slice(),
+                )),
+                Some(10),
+            )
+            .await
+            .unwrap();
+        assert!(empty_page.is_empty());
+
+        let unbounded = db
+            .as_ref()
+            .integrated_chain_ops_for_dump(None, None)
+            .await
+            .unwrap();
+        assert_eq!(unbounded.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn dht_dump_pages_all_tables_in_received_order() {
+        let db = test_open_db(dht_id()).await.unwrap();
+        let integrated_chain = seed_op(db.pool(), 1, STORE_RECORD, 0, 100).await;
+        let integrated_warrant = seed_warrant_op(db.pool(), 2, 100, DumpOpState::Integrated).await;
+        let validation_chain = seed_limbo_chain_op(db.pool(), 3, 100, false).await;
+        let integration_chain = seed_limbo_chain_op(db.pool(), 4, 100, true).await;
+        let validation_warrant =
+            seed_warrant_op(db.pool(), 5, 200, DumpOpState::ValidationLimbo).await;
+        let integration_warrant =
+            seed_warrant_op(db.pool(), 6, 200, DumpOpState::IntegrationLimbo).await;
+        let cache_only = seed_op(db.pool(), 7, STORE_RECORD, 0, 50).await;
+        sqlx::query("UPDATE ChainOp SET locally_validated = 0 WHERE hash = ?")
+            .bind(&cache_only)
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        let expected = vec![
+            (integrated_chain, DumpOpState::Integrated),
+            (integrated_warrant, DumpOpState::Integrated),
+            (validation_chain, DumpOpState::ValidationLimbo),
+            (integration_chain.clone(), DumpOpState::Integrated),
+            (validation_warrant, DumpOpState::ValidationLimbo),
+            (integration_warrant, DumpOpState::IntegrationLimbo),
+        ];
+        let mut actual = Vec::new();
+        let mut cursor = None;
+        let mut promoted = false;
+        loop {
+            let page = db
+                .as_ref()
+                .dht_ops_page_for_dump(
+                    cursor
+                        .as_ref()
+                        .map(|cursor: &DumpOpCursorRow| (cursor.when_received, &cursor.hash)),
+                    Some(2),
+                )
+                .await
+                .unwrap();
+            assert!(page.rows.len() <= 2);
+            actual.extend(
+                page.rows
+                    .iter()
+                    .map(|row| (dump_row_hash(row).to_vec(), row.state)),
+            );
+            cursor = page.cursor;
+            if cursor.is_none() {
+                break;
+            }
+            if !promoted {
+                promote_seeded_limbo_chain_op(&db, &integration_chain).await;
+                promoted = true;
+            }
+        }
+        assert_eq!(actual, expected);
+
+        let unbounded = db.as_ref().dht_ops_page_for_dump(None, None).await.unwrap();
+        assert_eq!(unbounded.rows.len(), expected.len());
+        assert_eq!(
+            unbounded.cursor.unwrap().hash,
+            DhtOpHash::from_raw_36(expected.last().unwrap().0.clone())
         );
     }
 }

--- a/crates/holochain_data/src/models/dht.rs
+++ b/crates/holochain_data/src/models/dht.rs
@@ -7,6 +7,7 @@
 //! [`holochain_integrity_types::action`] and
 //! [`holochain_zome_types::action`]).
 
+use holo_hash::DhtOpHash;
 use holochain_integrity_types::prelude::{Entry, RecordValidity};
 use holochain_zome_types::prelude::SignedActionHashed;
 
@@ -468,6 +469,53 @@ pub struct K2WarrantForWireRow {
     pub proof: Vec<u8>,
     /// 64-byte warrant signature.
     pub signature: Vec<u8>,
+}
+
+/// Lifecycle bucket containing a DHT op in a full state dump.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DumpOpState {
+    /// The op is awaiting validation.
+    ValidationLimbo,
+    /// The op has completed validation and is awaiting integration.
+    IntegrationLimbo,
+    /// The op has been integrated.
+    Integrated,
+}
+
+/// Hydrated wire row for a DHT op selected by dump pagination.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DumpOpWireRow {
+    /// A chain op joined with its action and optional entry.
+    Chain(K2ChainOpForWireRow),
+    /// A warrant op joined with its warrant content.
+    Warrant(K2WarrantForWireRow),
+}
+
+/// Hydrated DHT-op row selected for a full state-dump page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DumpOpRow {
+    /// Lifecycle bucket observed in the page's database snapshot.
+    pub state: DumpOpState,
+    /// Wire data required to reconstruct the DHT op.
+    pub wire: DumpOpWireRow,
+}
+
+/// Exclusive cursor key selected from the DHT database.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DumpOpCursorRow {
+    /// Microsecond timestamp at which the op was received.
+    pub when_received: i64,
+    /// DHT-op hash used to break timestamp ties.
+    pub hash: DhtOpHash,
+}
+
+/// One globally ordered page of DHT ops for a full state dump.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DumpOpPage {
+    /// Hydrated rows in global `(when_received, hash)` order.
+    pub rows: Vec<DumpOpRow>,
+    /// Last database key selected, even if wire reconstruction later fails.
+    pub cursor: Option<DumpOpCursorRow>,
 }
 
 /// `(slice_index, hash)` pair returned when enumerating slice hashes.

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -127,8 +127,8 @@ pub type DhtStoreRead = DhtStore<holochain_data::DbRead<Dht>>;
 // downstream crates (`holochain_p2p`) can consume them without depending
 // on `holochain_data` directly.
 pub use holochain_data::models::dht::{
-    K2ChainOpForWireRow, K2OpHashRow, K2OpIdSinceRow, K2OpPresentRow, K2WarrantForWireRow,
-    SliceHashIndexedRow,
+    DumpOpPage, DumpOpRow, DumpOpState, DumpOpWireRow, K2ChainOpForWireRow, K2OpHashRow,
+    K2OpIdSinceRow, K2OpPresentRow, K2WarrantForWireRow, SliceHashIndexedRow,
 };
 use holochain_zome_types::prelude::{Action, ActionData, OpValidity, SignedActionHashed};
 

--- a/crates/holochain_state/src/dht_store/reads.rs
+++ b/crates/holochain_state/src/dht_store/reads.rs
@@ -7,13 +7,14 @@
 
 use super::DhtStore;
 use crate::prelude::ActionSequenceAndHash;
-use crate::query::StateQueryResult;
+use crate::query::{StateQueryError, StateQueryResult};
 use crate::scratch::SyncScratch;
 use holo_hash::{
     ActionHash, AgentPubKey, AnyLinkableHash, DhtOpHash, EntryHash, ExternalHash, HasHash,
 };
 use holochain_data::kind::Dht;
 use holochain_data::DbRead;
+use holochain_state_types::{SourceChainCursor, SourceChainDump, SourceChainDumpRecord};
 use holochain_types::op::DhtOpHashed;
 use holochain_types::prelude::{
     ActionHashedContainer, AgentActivity, AgentActivityResponse, ChainItems, ChainItemsSource,
@@ -2101,11 +2102,47 @@ impl DhtStore<DbRead<Dht>> {
     pub async fn dump_source_chain(
         &self,
         author: &AgentPubKey,
-    ) -> StateQueryResult<holochain_state_types::SourceChainDump> {
-        use holochain_state_types::{SourceChainDump, SourceChainDumpRecord};
+    ) -> StateQueryResult<SourceChainDump> {
+        self.dump_source_chain_paginated(author, None, None).await
+    }
 
-        // All actions for this author in seq order.
-        let actions = self.db().get_actions_by_author(author.clone()).await?;
+    /// Dump one exclusive page of the author's source chain.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for a zero limit or an action-hash cursor that does not
+    /// identify an accepted action authored by `author`.
+    pub async fn dump_source_chain_paginated(
+        &self,
+        author: &AgentPubKey,
+        cursor: Option<&SourceChainCursor>,
+        limit: Option<u32>,
+    ) -> StateQueryResult<SourceChainDump> {
+        if limit == Some(0) {
+            return Err(StateQueryError::InvalidInput(
+                "dump limit must be greater than zero".to_string(),
+            ));
+        }
+
+        let after_sequence = match cursor {
+            Some(SourceChainCursor::Sequence(sequence)) => Some(*sequence),
+            Some(SourceChainCursor::ActionHash(action_hash)) => Some(
+                self.db()
+                    .get_accepted_action_sequence(author, action_hash)
+                    .await?
+                    .ok_or_else(|| {
+                        StateQueryError::InvalidInput(format!(
+                            "source-chain cursor {action_hash} is unknown or belongs to another author"
+                        ))
+                    })?,
+            ),
+            None => None,
+        };
+
+        let actions = self
+            .db()
+            .get_actions_by_author_paginated(author, after_sequence, limit)
+            .await?;
 
         let mut records = Vec::with_capacity(actions.len());
         for sah in &actions {

--- a/crates/holochain_state/src/dht_store/sync_reads.rs
+++ b/crates/holochain_state/src/dht_store/sync_reads.rs
@@ -8,8 +8,7 @@
 
 use holochain_data::kind::Dht;
 use holochain_data::DbWrite;
-use holochain_types::prelude::AgentPubKey;
-use holochain_types::prelude::Timestamp;
+use holochain_types::prelude::{AgentPubKey, DhtOpHash, Timestamp};
 
 use super::DhtStore;
 use crate::mutations::{StateMutationError, StateMutationResult};
@@ -128,17 +127,52 @@ where
         ))
     }
 
-    /// Integrated chain-op rows for the integration dump, paginated forward
-    /// from the `(when_integrated, op_hash)` cursor `after` (`None` from the
-    /// start, which yields the full set — also how the consistency harness
-    /// reads everything).
+    /// Return integrated chain-op rows after `after`, bounded by `limit`.
+    ///
+    /// `None` for `after` starts at the beginning, while `None` for `limit`
+    /// returns the full remaining set.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `limit` is zero or the database query fails.
     pub async fn integrated_chain_ops_for_dump(
         &self,
         after: Option<(i64, &[u8])>,
+        limit: Option<u32>,
     ) -> crate::query::StateQueryResult<Vec<holochain_data::models::dht::DumpChainOpRow>> {
+        if limit == Some(0) {
+            return Err(crate::query::StateQueryError::InvalidInput(
+                "dump limit must be greater than zero".to_string(),
+            ));
+        }
         self.db
             .as_ref()
-            .integrated_chain_ops_for_dump(after)
+            .integrated_chain_ops_for_dump(after, limit)
+            .await
+            .map_err(crate::query::StateQueryError::Sqlx)
+    }
+
+    /// Return one global DHT-op page ordered by `(when_received, op_hash)`.
+    ///
+    /// `None` for `after` starts at the beginning, while `None` for `limit`
+    /// returns the full remaining set.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `limit` is zero or the database query fails.
+    pub async fn dht_ops_page_for_dump(
+        &self,
+        after: Option<(i64, &DhtOpHash)>,
+        limit: Option<u32>,
+    ) -> crate::query::StateQueryResult<holochain_data::models::dht::DumpOpPage> {
+        if limit == Some(0) {
+            return Err(crate::query::StateQueryError::InvalidInput(
+                "dump limit must be greater than zero".to_string(),
+            ));
+        }
+        self.db
+            .as_ref()
+            .dht_ops_page_for_dump(after, limit)
             .await
             .map_err(crate::query::StateQueryError::Sqlx)
     }

--- a/crates/holochain_state/src/source_chain.rs
+++ b/crates/holochain_state/src/source_chain.rs
@@ -16,7 +16,7 @@ use holo_hash::HoloHashed;
 use holochain_data::kind::Dht;
 use holochain_data::{DbRead, DbWrite};
 use holochain_keystore::{AgentPubKeyExt, MetaLairClient, SignedActionHashedExt};
-use holochain_state_types::SourceChainDump;
+use holochain_state_types::{SourceChainCursor, SourceChainDump};
 use holochain_types::op::{
     produce_ops_from_record, ChainOp, DhtOp, DhtOpHashed, HashedChainOp, OpEntry,
 };
@@ -1139,8 +1139,23 @@ pub async fn dump_state(
     dht_store: &DhtStoreRead,
     author: AgentPubKey,
 ) -> Result<SourceChainDump, SourceChainError> {
+    dump_state_paginated(dht_store, author, None, None).await
+}
+
+/// Dump one exclusive page of an author's source chain.
+///
+/// # Errors
+///
+/// Returns an error for invalid pagination arguments or a failed state query.
+#[cfg_attr(feature = "instrument", tracing::instrument(skip_all))]
+pub async fn dump_state_paginated(
+    dht_store: &DhtStoreRead,
+    author: AgentPubKey,
+    cursor: Option<&SourceChainCursor>,
+    limit: Option<u32>,
+) -> Result<SourceChainDump, SourceChainError> {
     dht_store
-        .dump_source_chain(&author)
+        .dump_source_chain_paginated(&author, cursor, limit)
         .await
         .map_err(SourceChainError::other)
 }
@@ -1996,7 +2011,7 @@ mod tests {
             chain,
             agent_key,
             dht_store,
-            ..
+            keystore,
         } = TestCase::new().await;
 
         // Add a private-entry action (seq 3) on top of the genesis 3-action chain.
@@ -2046,6 +2061,118 @@ mod tests {
             dump.published_ops_count, 0,
             "no ops have been published yet"
         );
+
+        let published_op = dht_store
+            .as_read()
+            .ops_to_publish_for_wire(&agent_key)
+            .await?
+            .into_iter()
+            .next()
+            .expect("at least one authored op");
+        dht_store
+            .record_published_op_hashes(
+                vec![DhtOpHash::from_raw_36(published_op.op_hash)],
+                Timestamp::now(),
+            )
+            .await?;
+
+        let first_page = dht_store
+            .as_read()
+            .dump_source_chain_paginated(&agent_key, None, Some(2))
+            .await?;
+        assert_eq!(first_page.records.len(), 2);
+        assert_eq!(first_page.records, dump.records[..2]);
+        assert_eq!(first_page.published_ops_count, 1);
+
+        let sequence_page = dht_store
+            .as_read()
+            .dump_source_chain_paginated(
+                &agent_key,
+                Some(&SourceChainCursor::Sequence(1)),
+                Some(10),
+            )
+            .await?;
+        let hash_page = dht_store
+            .as_read()
+            .dump_source_chain_paginated(
+                &agent_key,
+                Some(&SourceChainCursor::ActionHash(
+                    dump.records[1].action_address.clone(),
+                )),
+                Some(10),
+            )
+            .await?;
+        assert_eq!(sequence_page, hash_page);
+        assert_eq!(sequence_page.records, dump.records[2..]);
+        assert_eq!(sequence_page.published_ops_count, 1);
+
+        let empty_page = dht_store
+            .as_read()
+            .dump_source_chain_paginated(&agent_key, Some(&SourceChainCursor::Sequence(3)), Some(5))
+            .await?;
+        assert!(empty_page.records.is_empty());
+        assert_eq!(empty_page.published_ops_count, 1);
+
+        assert!(dht_store
+            .as_read()
+            .dump_source_chain_paginated(&agent_key, None, Some(0))
+            .await
+            .is_err());
+        assert!(dht_store
+            .as_read()
+            .dump_source_chain_paginated(
+                &agent_key,
+                Some(&SourceChainCursor::ActionHash(ActionHash::from_raw_36(
+                    vec![42; 36],
+                ))),
+                Some(1),
+            )
+            .await
+            .is_err());
+
+        let mut rejected_action = dump.records[3].action.clone();
+        rejected_action.header.action_seq = 99;
+        rejected_action.header.prev_action = Some(dump.records[3].action_address.clone());
+        rejected_action.header.timestamp = Timestamp::now();
+        let rejected_action_hash = ActionHash::with_data_sync(&rejected_action);
+        let rejected_op =
+            DhtOpHashed::from_content_sync(DhtOp::ChainOp(Box::new(ChainOp::AgentActivity(
+                SignedAction::new(rejected_action, Signature::from([42; 64])),
+            ))));
+        dht_store
+            .record_incoming_ops(vec![(rejected_op, false)])
+            .await?;
+        assert!(dht_store
+            .as_read()
+            .dump_source_chain_paginated(
+                &agent_key,
+                Some(&SourceChainCursor::ActionHash(rejected_action_hash)),
+                Some(1),
+            )
+            .await
+            .is_err());
+
+        let other_agent = keystore.new_sign_keypair_random().await.unwrap();
+        genesis(
+            dht_store.clone(),
+            keystore,
+            chain.cell_id().dna_hash().clone(),
+            other_agent.clone(),
+            None,
+        )
+        .await?;
+        let other_dump = dht_store.as_read().dump_source_chain(&other_agent).await?;
+        assert!(dht_store
+            .as_read()
+            .dump_source_chain_paginated(
+                &agent_key,
+                Some(&SourceChainCursor::ActionHash(
+                    other_dump.records[0].action_address.clone(),
+                )),
+                Some(1),
+            )
+            .await
+            .is_err());
 
         Ok(())
     }

--- a/crates/holochain_state_types/src/lib.rs
+++ b/crates/holochain_state_types/src/lib.rs
@@ -18,6 +18,17 @@ pub struct SourceChainDumpRecord {
     pub entry: Option<Entry>,
 }
 
+/// Identifies the last source-chain record returned by a paginated dump.
+///
+/// The next page starts strictly after the identified record.
+#[derive(Serialize, Debug, Clone, Deserialize, PartialEq, Eq)]
+pub enum SourceChainCursor {
+    /// Resume after this action sequence number.
+    Sequence(u32),
+    /// Resume after the accepted action identified by this hash.
+    ActionHash(ActionHash),
+}
+
 pub mod prelude {
     pub use crate::*;
 }


### PR DESCRIPTION
### Summary

Adds pagination to standard and full state dumps so large cells can be inspected in smaller requests. Full DHT dump pages now share one stable receipt-time cursor across integrated operations, validation queues, and warrants, with one limit across the page. Source chain paging stays unchanged. This changes the DumpState and DumpFullState request fields and closes #5774.

### TODO:

- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs