### PR TITLE
feat(hdi): TypedAction narrowing and agent-key ergonomics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Design references: `docs/design/state_model.md` and `docs/design/data_model.md` 
   - Test-support code exposed from library crates must be feature-gated so it never compiles into production builds. Read-only inspection queries (op counts, existence checks) use `#[cfg(any(test, feature = "inspection"))]`; test-only writes and fixture builders use `#[cfg(feature = "test_utils")]` (which also enables `inspection`).
 - **Errors**: prefer `thiserror` for crate error types; `anyhow` is for application/binary code, not library APIs.
 - **Compiler warnings are not OK** in shared code (CONTRIBUTING.md). Fix, surgically `#[allow(...)]`, or escalate — don't disable globally.
-- **Public API docs**: `///` rustdoc on public items; module/crate docs should describe structure.
+- **Public API docs**: `///` rustdoc on public items; module/crate docs should describe structure. Follow [rustdoc's guidance](https://doc.rust-lang.org/rustdoc/how-to-write-documentation.html#documenting-components): keep the first line a short, one-sentence summary — everything up to the first blank `///` line is reused as the summary in module/search listings — then a blank `///` line before any further detail.
 - **Commits**: Conventional Commits (`feat:`, `fix:`, `refactor:`, etc.), bodies wrapped near 72 chars.
 - **Changelog**: Write changelog entries only to
   `crates/holochain/CHANGELOG.md`. Include only information relevant to end

--- a/crates/hdi/src/flat_op.rs
+++ b/crates/hdi/src/flat_op.rs
@@ -69,28 +69,28 @@ impl<LT> OpLink<LT> {
     /// The base address of the link this operation touches.
     pub fn base_address(&self) -> &AnyLinkableHash {
         match self {
-            OpLink::CreateLink { action, .. } => &action.data.base_address,
-            OpLink::DeleteLink { action, .. } => &action.data.base_address,
+            OpLink::CreateLink { action, .. } => &action.base_address,
+            OpLink::DeleteLink { action, .. } => &action.base_address,
         }
     }
 
     /// The target address of the link this operation touches.
     pub fn target_address(&self) -> &AnyLinkableHash {
         match self {
-            OpLink::CreateLink { action, .. } => &action.data.target_address,
+            OpLink::CreateLink { action, .. } => &action.target_address,
             OpLink::DeleteLink {
                 original_action, ..
-            } => &original_action.data.target_address,
+            } => &original_action.target_address,
         }
     }
 
     /// The tag of the link this operation touches.
     pub fn tag(&self) -> &LinkTag {
         match self {
-            OpLink::CreateLink { action, .. } => &action.data.tag,
+            OpLink::CreateLink { action, .. } => &action.tag,
             OpLink::DeleteLink {
                 original_action, ..
-            } => &original_action.data.tag,
+            } => &original_action.tag,
         }
     }
 }

--- a/crates/hdi/src/flat_op/flat_op_activity.rs
+++ b/crates/hdi/src/flat_op/flat_op_activity.rs
@@ -31,6 +31,8 @@ pub enum OpActivity<UnitType, LT> {
     /// This operation registers the Action for an
     /// [`AgentPubKey`] to the author's chain.
     CreateAgent {
+        /// The agent key this action creates.
+        agent: AgentPubKey,
         /// The Create action that creates the entry.
         action: TypedAction<CreateData>,
     },
@@ -69,6 +71,10 @@ pub enum OpActivity<UnitType, LT> {
     /// This operation registers the Action for an
     /// updated [`AgentPubKey`] to the author's chain.
     UpdateAgent {
+        /// The new [`AgentPubKey`].
+        new_key: AgentPubKey,
+        /// The original [`AgentPubKey`].
+        original_key: AgentPubKey,
         /// The Update action that updates the agent's key.
         action: TypedAction<UpdateData>,
     },
@@ -151,32 +157,4 @@ pub enum OpActivity<UnitType, LT> {
         /// The InitZomesComplete action.
         action: TypedAction<InitZomesCompleteData>,
     },
-}
-
-impl<UnitType, LT> OpActivity<UnitType, LT> {
-    /// The agent key this action creates, for [`OpActivity::CreateAgent`].
-    pub fn agent(&self) -> Option<AgentPubKey> {
-        match self {
-            OpActivity::CreateAgent { action } => Some(action.data.entry_hash.clone().into()),
-            _ => None,
-        }
-    }
-
-    /// The new agent key this action updates to, for [`OpActivity::UpdateAgent`].
-    pub fn new_key(&self) -> Option<AgentPubKey> {
-        match self {
-            OpActivity::UpdateAgent { action } => Some(action.data.entry_hash.clone().into()),
-            _ => None,
-        }
-    }
-
-    /// The original agent key being updated, for [`OpActivity::UpdateAgent`].
-    pub fn original_key(&self) -> Option<AgentPubKey> {
-        match self {
-            OpActivity::UpdateAgent { action } => {
-                Some(action.data.original_entry_address.clone().into())
-            }
-            _ => None,
-        }
-    }
 }

--- a/crates/hdi/src/flat_op/flat_op_entry.rs
+++ b/crates/hdi/src/flat_op/flat_op_entry.rs
@@ -21,6 +21,8 @@ where
     /// This operation stores the [`Entry`](holochain_integrity_types::entry::Entry) for an
     /// [`AgentPubKey`].
     CreateAgent {
+        /// The agent key this action creates.
+        agent: AgentPubKey,
         /// The Create action that creates this agent's key.
         action: TypedAction<CreateData>,
     },
@@ -36,6 +38,10 @@ where
     /// This operation stores the [`Entry`](holochain_integrity_types::entry::Entry) for an updated
     /// [`AgentPubKey`].
     UpdateAgent {
+        /// The new [`AgentPubKey`].
+        new_key: AgentPubKey,
+        /// The original [`AgentPubKey`].
+        original_key: AgentPubKey,
         /// The Update action that updates this entry.
         action: TypedAction<UpdateData>,
     },
@@ -71,34 +77,6 @@ where
         /// The new entry to store.
         entry: CapClaimEntry,
     },
-}
-
-impl<ET: UnitEnum> OpEntry<ET> {
-    /// The agent key this action creates, for [`OpEntry::CreateAgent`].
-    pub fn agent(&self) -> Option<AgentPubKey> {
-        match self {
-            OpEntry::CreateAgent { action } => Some(action.data.entry_hash.clone().into()),
-            _ => None,
-        }
-    }
-
-    /// The new agent key this action updates to, for [`OpEntry::UpdateAgent`].
-    pub fn new_key(&self) -> Option<AgentPubKey> {
-        match self {
-            OpEntry::UpdateAgent { action } => Some(action.data.entry_hash.clone().into()),
-            _ => None,
-        }
-    }
-
-    /// The original agent key being updated, for [`OpEntry::UpdateAgent`].
-    pub fn original_key(&self) -> Option<AgentPubKey> {
-        match self {
-            OpEntry::UpdateAgent { action } => {
-                Some(action.data.original_entry_address.clone().into())
-            }
-            _ => None,
-        }
-    }
 }
 
 /// Data specific to the [`Op::Update`](holochain_integrity_types::op::Op::Update)
@@ -245,7 +223,7 @@ mod tests {
     }
 
     #[test]
-    fn op_entry_create_agent_exposes_agent_key() {
+    fn op_entry_create_agent_carries_the_agent_key() {
         let action = TypedAction {
             header: header(),
             data: CreateData {
@@ -253,34 +231,34 @@ mod tests {
                 entry_hash: eh(9),
             },
         };
-        let op = OpEntry::<()>::CreateAgent { action };
-        assert_eq!(op.agent(), Some(AgentPubKey::from(eh(9))));
-        assert_eq!(op.new_key(), None);
-    }
-
-    #[test]
-    fn op_entry_update_agent_exposes_keys() {
-        let action = update_action(ah(10), eh(11));
-        let op = OpEntry::<()>::UpdateAgent { action };
-        assert_eq!(op.new_key(), Some(AgentPubKey::from(eh(9))));
-        assert_eq!(op.original_key(), Some(AgentPubKey::from(eh(11))));
-    }
-
-    #[test]
-    fn op_entry_create_entry_has_no_agent_key() {
-        let action = TypedAction {
-            header: header(),
-            data: CreateData {
-                entry_type: holochain_integrity_types::action::EntryType::App(
-                    crate::test_utils::short_hand::public_app_entry_def(0, 0),
-                ),
-                entry_hash: eh(12),
-            },
-        };
-        let op = OpEntry::<()>::CreateEntry {
-            app_entry: (),
+        let op = OpEntry::<()>::CreateAgent {
+            agent: AgentPubKey::from(eh(9)),
             action,
         };
-        assert_eq!(op.agent(), None);
+        match op {
+            OpEntry::CreateAgent { agent, .. } => assert_eq!(agent, AgentPubKey::from(eh(9))),
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn op_entry_update_agent_carries_both_keys() {
+        let action = update_action(ah(10), eh(11));
+        let op = OpEntry::<()>::UpdateAgent {
+            new_key: AgentPubKey::from(eh(9)),
+            original_key: AgentPubKey::from(eh(11)),
+            action,
+        };
+        match op {
+            OpEntry::UpdateAgent {
+                new_key,
+                original_key,
+                ..
+            } => {
+                assert_eq!(new_key, AgentPubKey::from(eh(9)));
+                assert_eq!(original_key, AgentPubKey::from(eh(11)));
+            }
+            _ => unreachable!(),
+        }
     }
 }

--- a/crates/hdi/src/flat_op/flat_op_record.rs
+++ b/crates/hdi/src/flat_op/flat_op_record.rs
@@ -31,6 +31,8 @@ pub enum OpRecord<ET: UnitEnum, LT> {
     /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an
     /// [`AgentPubKey`] that has been created.
     CreateAgent {
+        /// The agent key this action creates.
+        agent: AgentPubKey,
         /// The Create action that creates the entry.
         action: TypedAction<CreateData>,
     },
@@ -71,6 +73,10 @@ pub enum OpRecord<ET: UnitEnum, LT> {
     /// This operation stores the [`Record`](holochain_integrity_types::record::Record) for an
     /// updated [`AgentPubKey`].
     UpdateAgent {
+        /// The new [`AgentPubKey`].
+        new_key: AgentPubKey,
+        /// The original [`AgentPubKey`].
+        original_key: AgentPubKey,
         /// The Update action that updates the entry.
         action: TypedAction<UpdateData>,
     },
@@ -152,32 +158,4 @@ pub enum OpRecord<ET: UnitEnum, LT> {
         /// The InitZomesComplete action.
         action: TypedAction<InitZomesCompleteData>,
     },
-}
-
-impl<ET: UnitEnum, LT> OpRecord<ET, LT> {
-    /// The agent key this action creates, for [`OpRecord::CreateAgent`].
-    pub fn agent(&self) -> Option<AgentPubKey> {
-        match self {
-            OpRecord::CreateAgent { action } => Some(action.data.entry_hash.clone().into()),
-            _ => None,
-        }
-    }
-
-    /// The new agent key this action updates to, for [`OpRecord::UpdateAgent`].
-    pub fn new_key(&self) -> Option<AgentPubKey> {
-        match self {
-            OpRecord::UpdateAgent { action } => Some(action.data.entry_hash.clone().into()),
-            _ => None,
-        }
-    }
-
-    /// The original agent key being updated, for [`OpRecord::UpdateAgent`].
-    pub fn original_key(&self) -> Option<AgentPubKey> {
-        match self {
-            OpRecord::UpdateAgent { action } => {
-                Some(action.data.original_entry_address.clone().into())
-            }
-            _ => None,
-        }
-    }
 }

--- a/crates/hdi/src/flat_op/typed_action.rs
+++ b/crates/hdi/src/flat_op/typed_action.rs
@@ -115,9 +115,7 @@ impl TypedAction<EntryCreationData> {
     /// [`TryFrom<Action>`](TypedAction#impl-TryFrom%3CAction%3E-for-TypedAction%3CEntryCreationData%3E),
     /// this returns [`ExternResult`] instead of [`WrongActionError`].
     pub fn try_from_action(action: Action) -> crate::prelude::ExternResult<Self> {
-        action
-            .try_into()
-            .map_err(|e: WrongActionError| crate::prelude::wasm_error!(e.to_string()))
+        narrow_action(action)
     }
 }
 
@@ -141,6 +139,168 @@ impl TryFrom<Action> for TypedAction<EntryCreationData> {
             header: action.header,
             data,
         })
+    }
+}
+
+/// Shared plumbing behind every `TypedAction<D>::try_from_action`: narrow, then convert a
+/// mismatch straight into a guest [`WasmError`](crate::prelude::WasmError) instead of a
+/// [`WrongActionError`].
+fn narrow_action<D>(action: Action) -> crate::prelude::ExternResult<TypedAction<D>>
+where
+    TypedAction<D>: TryFrom<Action, Error = WrongActionError>,
+{
+    action
+        .try_into()
+        .map_err(|e: WrongActionError| crate::prelude::wasm_error!(e.to_string()))
+}
+
+impl TryFrom<Action> for TypedAction<CreateData> {
+    type Error = WrongActionError;
+
+    /// Narrows a freshly-fetched [`Action`] down to the `Create` case, erroring if it's
+    /// anything else.
+    fn try_from(action: Action) -> Result<Self, Self::Error> {
+        let data = match action.data {
+            ActionData::Create(data) => data,
+            other => {
+                return Err(WrongActionError(format!(
+                    "Expected a Create action, got {:?}",
+                    other.action_type()
+                )))
+            }
+        };
+        Ok(TypedAction {
+            header: action.header,
+            data,
+        })
+    }
+}
+
+impl TypedAction<CreateData> {
+    /// Narrows a freshly-fetched [`Action`] down to the `Create` case, for use directly in
+    /// a validate callback's `?`-chain.
+    pub fn try_from_action(action: Action) -> crate::prelude::ExternResult<Self> {
+        narrow_action(action)
+    }
+}
+
+impl TryFrom<Action> for TypedAction<UpdateData> {
+    type Error = WrongActionError;
+
+    /// Narrows a freshly-fetched [`Action`] down to the `Update` case, erroring if it's
+    /// anything else.
+    fn try_from(action: Action) -> Result<Self, Self::Error> {
+        let data = match action.data {
+            ActionData::Update(data) => data,
+            other => {
+                return Err(WrongActionError(format!(
+                    "Expected an Update action, got {:?}",
+                    other.action_type()
+                )))
+            }
+        };
+        Ok(TypedAction {
+            header: action.header,
+            data,
+        })
+    }
+}
+
+impl TypedAction<UpdateData> {
+    /// Narrows a freshly-fetched [`Action`] down to the `Update` case, for use directly in
+    /// a validate callback's `?`-chain.
+    pub fn try_from_action(action: Action) -> crate::prelude::ExternResult<Self> {
+        narrow_action(action)
+    }
+}
+
+impl TryFrom<Action> for TypedAction<DeleteData> {
+    type Error = WrongActionError;
+
+    /// Narrows a freshly-fetched [`Action`] down to the `Delete` case, erroring if it's
+    /// anything else.
+    fn try_from(action: Action) -> Result<Self, Self::Error> {
+        let data = match action.data {
+            ActionData::Delete(data) => data,
+            other => {
+                return Err(WrongActionError(format!(
+                    "Expected a Delete action, got {:?}",
+                    other.action_type()
+                )))
+            }
+        };
+        Ok(TypedAction {
+            header: action.header,
+            data,
+        })
+    }
+}
+
+impl TypedAction<DeleteData> {
+    /// Narrows a freshly-fetched [`Action`] down to the `Delete` case, for use directly in
+    /// a validate callback's `?`-chain.
+    pub fn try_from_action(action: Action) -> crate::prelude::ExternResult<Self> {
+        narrow_action(action)
+    }
+}
+
+impl TryFrom<Action> for TypedAction<CreateLinkData> {
+    type Error = WrongActionError;
+
+    /// Narrows a freshly-fetched [`Action`] down to the `CreateLink` case, erroring if
+    /// it's anything else.
+    fn try_from(action: Action) -> Result<Self, Self::Error> {
+        let data = match action.data {
+            ActionData::CreateLink(data) => data,
+            other => {
+                return Err(WrongActionError(format!(
+                    "Expected a CreateLink action, got {:?}",
+                    other.action_type()
+                )))
+            }
+        };
+        Ok(TypedAction {
+            header: action.header,
+            data,
+        })
+    }
+}
+
+impl TypedAction<CreateLinkData> {
+    /// Narrows a freshly-fetched [`Action`] down to the `CreateLink` case, for use
+    /// directly in a validate callback's `?`-chain.
+    pub fn try_from_action(action: Action) -> crate::prelude::ExternResult<Self> {
+        narrow_action(action)
+    }
+}
+
+impl TryFrom<Action> for TypedAction<DeleteLinkData> {
+    type Error = WrongActionError;
+
+    /// Narrows a freshly-fetched [`Action`] down to the `DeleteLink` case, erroring if
+    /// it's anything else.
+    fn try_from(action: Action) -> Result<Self, Self::Error> {
+        let data = match action.data {
+            ActionData::DeleteLink(data) => data,
+            other => {
+                return Err(WrongActionError(format!(
+                    "Expected a DeleteLink action, got {:?}",
+                    other.action_type()
+                )))
+            }
+        };
+        Ok(TypedAction {
+            header: action.header,
+            data,
+        })
+    }
+}
+
+impl TypedAction<DeleteLinkData> {
+    /// Narrows a freshly-fetched [`Action`] down to the `DeleteLink` case, for use
+    /// directly in a validate callback's `?`-chain.
+    pub fn try_from_action(action: Action) -> crate::prelude::ExternResult<Self> {
+        narrow_action(action)
     }
 }
 
@@ -236,8 +396,9 @@ impl<D: IntoActionData> From<TypedAction<D>> for Action {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::short_hand::{ah, ak, eh, public_app_entry_def};
+    use crate::test_utils::short_hand::{ah, ak, eh, lh, public_app_entry_def};
     use holochain_integrity_types::action::DeleteData;
+    use holochain_integrity_types::prelude::{LinkType, ZomeIndex};
 
     fn header() -> ActionHeader {
         ActionHeader {
@@ -343,6 +504,105 @@ mod tests {
             }),
         };
         assert!(TypedAction::<EntryCreationData>::try_from_action(delete_action).is_err());
+    }
+
+    #[test]
+    fn single_variant_try_from_action_narrows_the_matching_case() {
+        let create = Action {
+            header: header(),
+            data: ActionData::Create(create_data()),
+        };
+        assert_eq!(
+            TypedAction::<CreateData>::try_from(create.clone())
+                .unwrap()
+                .data,
+            create_data()
+        );
+        assert!(TypedAction::<UpdateData>::try_from(create.clone()).is_err());
+        assert!(TypedAction::<DeleteData>::try_from(create.clone()).is_err());
+        assert!(TypedAction::<CreateLinkData>::try_from(create.clone()).is_err());
+        assert!(TypedAction::<DeleteLinkData>::try_from(create).is_err());
+
+        let update = Action {
+            header: header(),
+            data: ActionData::Update(update_data()),
+        };
+        assert_eq!(
+            TypedAction::<UpdateData>::try_from(update.clone())
+                .unwrap()
+                .data,
+            update_data()
+        );
+        assert!(TypedAction::<CreateData>::try_from(update).is_err());
+
+        let delete = Action {
+            header: header(),
+            data: ActionData::Delete(DeleteData {
+                deletes_address: ah(7),
+                deletes_entry_address: eh(8),
+            }),
+        };
+        assert_eq!(
+            TypedAction::<DeleteData>::try_from(delete.clone())
+                .unwrap()
+                .data,
+            DeleteData {
+                deletes_address: ah(7),
+                deletes_entry_address: eh(8),
+            }
+        );
+        assert!(TypedAction::<CreateData>::try_from(delete).is_err());
+
+        let create_link_data = CreateLinkData {
+            base_address: lh(10),
+            target_address: lh(11),
+            zome_index: ZomeIndex(0),
+            link_type: LinkType(0),
+            tag: LinkTag(vec![]),
+        };
+        let create_link = Action {
+            header: header(),
+            data: ActionData::CreateLink(create_link_data.clone()),
+        };
+        assert_eq!(
+            TypedAction::<CreateLinkData>::try_from(create_link.clone())
+                .unwrap()
+                .data,
+            create_link_data
+        );
+        assert!(TypedAction::<DeleteLinkData>::try_from(create_link).is_err());
+
+        let delete_link_data = DeleteLinkData {
+            base_address: lh(10),
+            link_add_address: ah(12),
+        };
+        let delete_link = Action {
+            header: header(),
+            data: ActionData::DeleteLink(delete_link_data.clone()),
+        };
+        assert_eq!(
+            TypedAction::<DeleteLinkData>::try_from(delete_link.clone())
+                .unwrap()
+                .data,
+            delete_link_data
+        );
+        assert!(TypedAction::<CreateLinkData>::try_from(delete_link).is_err());
+    }
+
+    #[test]
+    fn single_variant_try_from_action_returns_extern_result() {
+        let create = Action {
+            header: header(),
+            data: ActionData::Create(create_data()),
+        };
+        assert!(TypedAction::<CreateData>::try_from_action(create).is_ok());
+
+        let update = Action {
+            header: header(),
+            data: ActionData::Update(update_data()),
+        };
+        assert!(TypedAction::<CreateData>::try_from_action(update.clone()).is_err());
+        assert!(TypedAction::<UpdateData>::try_from_action(update).is_ok());
     }
 
     #[test]

--- a/crates/hdi/src/flat_op/typed_action.rs
+++ b/crates/hdi/src/flat_op/typed_action.rs
@@ -15,6 +15,14 @@ pub struct TypedAction<D> {
     pub data: D,
 }
 
+impl<D> std::ops::Deref for TypedAction<D> {
+    type Target = D;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
 impl<D> TypedAction<D> {
     /// The public key of the agent who authored this action.
     pub fn author(&self) -> &AgentPubKey {
@@ -101,6 +109,16 @@ impl TypedAction<EntryCreationData> {
     pub fn entry_hash(&self) -> &EntryHash {
         self.data.entry_hash()
     }
+
+    /// Narrows a freshly-fetched [`Action`] (e.g. from `must_get_action`) down to the
+    /// entry-creation case, for use directly in a validate callback's `?`-chain — unlike
+    /// [`TryFrom<Action>`](TypedAction#impl-TryFrom%3CAction%3E-for-TypedAction%3CEntryCreationData%3E),
+    /// this returns [`ExternResult`] instead of [`WrongActionError`].
+    pub fn try_from_action(action: Action) -> crate::prelude::ExternResult<Self> {
+        action
+            .try_into()
+            .map_err(|e: WrongActionError| crate::prelude::wasm_error!(e.to_string()))
+    }
 }
 
 impl TryFrom<Action> for TypedAction<EntryCreationData> {
@@ -123,6 +141,38 @@ impl TryFrom<Action> for TypedAction<EntryCreationData> {
             header: action.header,
             data,
         })
+    }
+}
+
+/// Data known statically to be a [`CreateData`] or [`UpdateData`]. Lets a
+/// `TypedAction<CreateData>` or `TypedAction<UpdateData>` convert into a
+/// `TypedAction<EntryCreationData>` via `.into()`, so validation code can share one
+/// function between the create and update path instead of the fallible narrowing that
+/// [`TryFrom<Action>`](TypedAction#impl-TryFrom<Action>-for-TypedAction<EntryCreationData>)
+/// provides for a freshly-fetched, statically-unknown [`Action`].
+pub trait IntoEntryCreationData {
+    /// Wrap this data in the matching [`EntryCreationData`] variant.
+    fn into_entry_creation_data(self) -> EntryCreationData;
+}
+
+impl IntoEntryCreationData for CreateData {
+    fn into_entry_creation_data(self) -> EntryCreationData {
+        EntryCreationData::Create(self)
+    }
+}
+
+impl IntoEntryCreationData for UpdateData {
+    fn into_entry_creation_data(self) -> EntryCreationData {
+        EntryCreationData::Update(self)
+    }
+}
+
+impl<D: IntoEntryCreationData> From<TypedAction<D>> for TypedAction<EntryCreationData> {
+    fn from(typed: TypedAction<D>) -> Self {
+        TypedAction {
+            header: typed.header,
+            data: typed.data.into_entry_creation_data(),
+        }
     }
 }
 
@@ -274,6 +324,56 @@ mod tests {
             }),
         };
         assert!(TypedAction::<EntryCreationData>::try_from(action).is_err());
+    }
+
+    #[test]
+    fn try_from_action_returns_extern_result() {
+        let create_action = Action {
+            header: header(),
+            data: ActionData::Create(create_data()),
+        };
+        let typed = TypedAction::<EntryCreationData>::try_from_action(create_action).unwrap();
+        assert!(matches!(typed.data, EntryCreationData::Create(_)));
+
+        let delete_action = Action {
+            header: header(),
+            data: ActionData::Delete(DeleteData {
+                deletes_address: ah(7),
+                deletes_entry_address: eh(8),
+            }),
+        };
+        assert!(TypedAction::<EntryCreationData>::try_from_action(delete_action).is_err());
+    }
+
+    #[test]
+    fn typed_action_derefs_to_its_data() {
+        let action = TypedAction {
+            header: header(),
+            data: create_data(),
+        };
+        assert_eq!(action.entry_hash, eh(3));
+    }
+
+    #[test]
+    fn typed_action_create_data_converts_into_entry_creation_data() {
+        let typed = TypedAction {
+            header: header(),
+            data: create_data(),
+        };
+        let converted: TypedAction<EntryCreationData> = typed.clone().into();
+        assert_eq!(converted.header, typed.header);
+        assert!(matches!(converted.data, EntryCreationData::Create(_)));
+    }
+
+    #[test]
+    fn typed_action_update_data_converts_into_entry_creation_data() {
+        let typed = TypedAction {
+            header: header(),
+            data: update_data(),
+        };
+        let converted: TypedAction<EntryCreationData> = typed.clone().into();
+        assert_eq!(converted.header, typed.header);
+        assert!(matches!(converted.data, EntryCreationData::Update(_)));
     }
 
     #[test]

--- a/crates/hdi/src/flat_op/typed_action.rs
+++ b/crates/hdi/src/flat_op/typed_action.rs
@@ -117,7 +117,9 @@ impl TypedAction<EntryCreationData> {
     }
 
     /// Narrows a freshly-fetched [`Action`] (e.g. from `must_get_action`) down to the
-    /// entry-creation case, for use directly in a validate callback's `?`-chain — unlike
+    /// entry-creation case.
+    ///
+    /// For use directly in a validate callback's `?`-chain — unlike
     /// [`TryFrom<Action>`](TypedAction#impl-TryFrom%3CAction%3E-for-TypedAction%3CEntryCreationData%3E),
     /// this returns [`ExternResult`](crate::prelude::ExternResult) instead of
     /// [`WrongActionError`].
@@ -149,9 +151,10 @@ impl TryFrom<Action> for TypedAction<EntryCreationData> {
     }
 }
 
-/// Shared plumbing behind every `TypedAction<D>::try_from_action`: narrow, then convert a
-/// mismatch straight into a guest [`WasmError`](crate::prelude::WasmError) instead of a
-/// [`WrongActionError`].
+/// Shared plumbing behind every `TypedAction<D>::try_from_action`.
+///
+/// Narrows the action, then converts a mismatch straight into a guest
+/// [`WasmError`](crate::prelude::WasmError) instead of a [`WrongActionError`].
 fn narrow_action<D>(action: Action) -> crate::prelude::ExternResult<TypedAction<D>>
 where
     TypedAction<D>: TryFrom<Action, Error = WrongActionError>,
@@ -311,8 +314,9 @@ impl TypedAction<DeleteLinkData> {
     }
 }
 
-/// Data known statically to be a [`CreateData`] or [`UpdateData`]. Lets a
-/// `TypedAction<CreateData>` or `TypedAction<UpdateData>` convert into a
+/// Data known statically to be a [`CreateData`] or [`UpdateData`].
+///
+/// Lets a `TypedAction<CreateData>` or `TypedAction<UpdateData>` convert into a
 /// `TypedAction<EntryCreationData>` via `.into()`, so validation code can share one
 /// function between the create and update path instead of the fallible narrowing that
 /// [`TryFrom<Action>`](TypedAction#impl-TryFrom<Action>-for-TypedAction<EntryCreationData>)

--- a/crates/hdi/src/flat_op/typed_action.rs
+++ b/crates/hdi/src/flat_op/typed_action.rs
@@ -1,6 +1,12 @@
 //! [`TypedAction`] pairs the header fields common to every action variant with action data
 //! whose specific shape is already known from context — the `FlatOp`/`OpEntry`/`OpUpdate`/...
 //! variant this value lives in already guarantees which [`ActionData`] case it holds.
+//!
+//! Every `try_from_action` in this module narrows an already-fetched [`Action`] whose shape
+//! sys validation has already guaranteed. If that narrowing ever fails, the guarantee was
+//! violated — that's a fault in how the op reached this code, not invalid application data.
+//! Propagate the error with `?` rather than returning `ValidateCallbackResult::Invalid`,
+//! which would incorrectly blame the data's author.
 
 use super::*;
 
@@ -113,7 +119,8 @@ impl TypedAction<EntryCreationData> {
     /// Narrows a freshly-fetched [`Action`] (e.g. from `must_get_action`) down to the
     /// entry-creation case, for use directly in a validate callback's `?`-chain — unlike
     /// [`TryFrom<Action>`](TypedAction#impl-TryFrom%3CAction%3E-for-TypedAction%3CEntryCreationData%3E),
-    /// this returns [`ExternResult`] instead of [`WrongActionError`].
+    /// this returns [`ExternResult`](crate::prelude::ExternResult) instead of
+    /// [`WrongActionError`].
     pub fn try_from_action(action: Action) -> crate::prelude::ExternResult<Self> {
         narrow_action(action)
     }

--- a/crates/hdi/src/flat_op/typed_action.rs
+++ b/crates/hdi/src/flat_op/typed_action.rs
@@ -170,14 +170,11 @@ impl TryFrom<Action> for TypedAction<CreateData> {
     /// Narrows a freshly-fetched [`Action`] down to the `Create` case, erroring if it's
     /// anything else.
     fn try_from(action: Action) -> Result<Self, Self::Error> {
-        let data = match action.data {
-            ActionData::Create(data) => data,
-            other => {
-                return Err(WrongActionError(format!(
-                    "Expected a Create action, got {:?}",
-                    other.action_type()
-                )))
-            }
+        let action_type = action.data.action_type();
+        let ActionData::Create(data) = action.data else {
+            return Err(WrongActionError(format!(
+                "Expected a Create action, got {action_type:?}"
+            )));
         };
         Ok(TypedAction {
             header: action.header,
@@ -200,14 +197,11 @@ impl TryFrom<Action> for TypedAction<UpdateData> {
     /// Narrows a freshly-fetched [`Action`] down to the `Update` case, erroring if it's
     /// anything else.
     fn try_from(action: Action) -> Result<Self, Self::Error> {
-        let data = match action.data {
-            ActionData::Update(data) => data,
-            other => {
-                return Err(WrongActionError(format!(
-                    "Expected an Update action, got {:?}",
-                    other.action_type()
-                )))
-            }
+        let action_type = action.data.action_type();
+        let ActionData::Update(data) = action.data else {
+            return Err(WrongActionError(format!(
+                "Expected an Update action, got {action_type:?}"
+            )));
         };
         Ok(TypedAction {
             header: action.header,
@@ -230,14 +224,11 @@ impl TryFrom<Action> for TypedAction<DeleteData> {
     /// Narrows a freshly-fetched [`Action`] down to the `Delete` case, erroring if it's
     /// anything else.
     fn try_from(action: Action) -> Result<Self, Self::Error> {
-        let data = match action.data {
-            ActionData::Delete(data) => data,
-            other => {
-                return Err(WrongActionError(format!(
-                    "Expected a Delete action, got {:?}",
-                    other.action_type()
-                )))
-            }
+        let action_type = action.data.action_type();
+        let ActionData::Delete(data) = action.data else {
+            return Err(WrongActionError(format!(
+                "Expected a Delete action, got {action_type:?}"
+            )));
         };
         Ok(TypedAction {
             header: action.header,
@@ -260,14 +251,11 @@ impl TryFrom<Action> for TypedAction<CreateLinkData> {
     /// Narrows a freshly-fetched [`Action`] down to the `CreateLink` case, erroring if
     /// it's anything else.
     fn try_from(action: Action) -> Result<Self, Self::Error> {
-        let data = match action.data {
-            ActionData::CreateLink(data) => data,
-            other => {
-                return Err(WrongActionError(format!(
-                    "Expected a CreateLink action, got {:?}",
-                    other.action_type()
-                )))
-            }
+        let action_type = action.data.action_type();
+        let ActionData::CreateLink(data) = action.data else {
+            return Err(WrongActionError(format!(
+                "Expected a CreateLink action, got {action_type:?}"
+            )));
         };
         Ok(TypedAction {
             header: action.header,
@@ -290,14 +278,11 @@ impl TryFrom<Action> for TypedAction<DeleteLinkData> {
     /// Narrows a freshly-fetched [`Action`] down to the `DeleteLink` case, erroring if
     /// it's anything else.
     fn try_from(action: Action) -> Result<Self, Self::Error> {
-        let data = match action.data {
-            ActionData::DeleteLink(data) => data,
-            other => {
-                return Err(WrongActionError(format!(
-                    "Expected a DeleteLink action, got {:?}",
-                    other.action_type()
-                )))
-            }
+        let action_type = action.data.action_type();
+        let ActionData::DeleteLink(data) = action.data else {
+            return Err(WrongActionError(format!(
+                "Expected a DeleteLink action, got {action_type:?}"
+            )));
         };
         Ok(TypedAction {
             header: action.header,

--- a/crates/hdi/src/op.rs
+++ b/crates/hdi/src/op.rs
@@ -100,6 +100,7 @@ impl OpHelper for Op {
                         };
                         match &d.entry_type {
                             EntryType::AgentPubKey => flat_op::OpRecord::CreateAgent {
+                                agent: d.entry_hash.clone().into(),
                                 action: typed_action,
                             },
                             EntryType::App(entry_def) => {
@@ -136,6 +137,8 @@ impl OpHelper for Op {
                         };
                         match &d.entry_type {
                             EntryType::AgentPubKey => flat_op::OpRecord::UpdateAgent {
+                                new_key: d.entry_hash.clone().into(),
+                                original_key: d.original_entry_address.clone().into(),
                                 action: typed_action,
                             },
                             EntryType::App(entry_def) => {
@@ -184,6 +187,7 @@ impl OpHelper for Op {
                         };
                         match &d.entry_type {
                             EntryType::AgentPubKey => flat_op::OpEntry::CreateAgent {
+                                agent: d.entry_hash.clone().into(),
                                 action: typed_action,
                             },
                             EntryType::App(entry_def) => flat_op::OpEntry::CreateEntry {
@@ -209,6 +213,8 @@ impl OpHelper for Op {
                         };
                         match &d.entry_type {
                             EntryType::AgentPubKey => flat_op::OpEntry::UpdateAgent {
+                                new_key: d.entry_hash.clone().into(),
+                                original_key: d.original_entry_address.clone().into(),
                                 action: typed_action,
                             },
                             EntryType::App(entry_def) => flat_op::OpEntry::UpdateEntry {
@@ -354,6 +360,7 @@ impl OpHelper for Op {
                                 }
                             }
                             ActivityEntry::Agent => flat_op::OpActivity::CreateAgent {
+                                agent: d.entry_hash.clone().into(),
                                 action: typed_action,
                             },
                             ActivityEntry::CapClaim => flat_op::OpActivity::CreateCapClaim {
@@ -383,6 +390,8 @@ impl OpHelper for Op {
                                 }
                             }
                             ActivityEntry::Agent => flat_op::OpActivity::UpdateAgent {
+                                new_key: d.entry_hash.clone().into(),
+                                original_key: d.original_entry_address.clone().into(),
                                 action: typed_action,
                             },
                             ActivityEntry::CapClaim => flat_op::OpActivity::UpdateCapClaim {
@@ -736,17 +745,47 @@ mod tests {
     #[test]
     fn store_record_create_agent_flattens_to_create_agent() {
         types();
+        let entry_hash = EntryHash::from_raw_36(vec![3u8; 36]);
         let signed = signed_from_data(ActionData::Create(CreateData {
             entry_type: EntryType::AgentPubKey,
-            entry_hash: EntryHash::from_raw_36(vec![3u8; 36]),
+            entry_hash: entry_hash.clone(),
         }));
         let record = Record::new(signed, RecordEntry::NA);
         let op = Op::CreateRecord(CreateRecord { record });
         let flat: FlatOp<EntryTypes, LinkTypes> = op.flattened().unwrap();
-        assert!(matches!(
-            flat,
-            FlatOp::CreateRecord(OpRecord::CreateAgent { .. })
-        ));
+        match flat {
+            FlatOp::CreateRecord(OpRecord::CreateAgent { agent, .. }) => {
+                assert_eq!(agent, AgentPubKey::from(entry_hash));
+            }
+            other => panic!("expected CreateAgent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn store_record_update_agent_flattens_to_update_agent() {
+        types();
+        let new_entry_hash = EntryHash::from_raw_36(vec![17u8; 36]);
+        let original_entry_hash = EntryHash::from_raw_36(vec![18u8; 36]);
+        let signed = signed_from_data(ActionData::Update(UpdateData {
+            original_action_address: ActionHash::from_raw_36(vec![19u8; 36]),
+            original_entry_address: original_entry_hash.clone(),
+            entry_type: EntryType::AgentPubKey,
+            entry_hash: new_entry_hash.clone(),
+        }));
+        let record = Record::new(signed, RecordEntry::NA);
+        let op = Op::CreateRecord(CreateRecord { record });
+        let flat: FlatOp<EntryTypes, LinkTypes> = op.flattened().unwrap();
+        match flat {
+            FlatOp::CreateRecord(OpRecord::UpdateAgent {
+                new_key,
+                original_key,
+                ..
+            }) => {
+                assert_eq!(new_key, AgentPubKey::from(new_entry_hash));
+                assert_eq!(original_key, AgentPubKey::from(original_entry_hash));
+            }
+            other => panic!("expected UpdateAgent, got {other:?}"),
+        }
     }
 
     #[test]
@@ -845,6 +884,56 @@ mod tests {
     }
 
     #[test]
+    fn store_entry_create_agent_flattens_to_create_agent() {
+        types();
+        let entry_hash = EntryHash::from_raw_36(vec![20u8; 36]);
+        let signed = signed_from_data(ActionData::Create(CreateData {
+            entry_type: EntryType::AgentPubKey,
+            entry_hash: entry_hash.clone(),
+        }));
+        let op = Op::CreateEntry(CreateEntry {
+            action: signed,
+            entry: Entry::Agent(AgentPubKey::from(entry_hash.clone())),
+        });
+        let flat: FlatOp<EntryTypes, LinkTypes> = op.flattened().unwrap();
+        match flat {
+            FlatOp::CreateEntry(OpEntry::CreateAgent { agent, .. }) => {
+                assert_eq!(agent, AgentPubKey::from(entry_hash));
+            }
+            other => panic!("expected CreateAgent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn store_entry_update_agent_flattens_to_update_agent() {
+        types();
+        let new_entry_hash = EntryHash::from_raw_36(vec![21u8; 36]);
+        let original_entry_hash = EntryHash::from_raw_36(vec![22u8; 36]);
+        let signed = signed_from_data(ActionData::Update(UpdateData {
+            original_action_address: ActionHash::from_raw_36(vec![23u8; 36]),
+            original_entry_address: original_entry_hash.clone(),
+            entry_type: EntryType::AgentPubKey,
+            entry_hash: new_entry_hash.clone(),
+        }));
+        let op = Op::CreateEntry(CreateEntry {
+            action: signed,
+            entry: Entry::Agent(AgentPubKey::from(new_entry_hash.clone())),
+        });
+        let flat: FlatOp<EntryTypes, LinkTypes> = op.flattened().unwrap();
+        match flat {
+            FlatOp::CreateEntry(OpEntry::UpdateAgent {
+                new_key,
+                original_key,
+                ..
+            }) => {
+                assert_eq!(new_key, AgentPubKey::from(new_entry_hash));
+                assert_eq!(original_key, AgentPubKey::from(original_entry_hash));
+            }
+            other => panic!("expected UpdateAgent, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn register_agent_activity_create_app_flattens_with_unit_type() {
         types();
         let signed = signed_from_data(create_app_data());
@@ -860,6 +949,56 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn register_agent_activity_create_agent_flattens_to_create_agent() {
+        types();
+        let entry_hash = EntryHash::from_raw_36(vec![24u8; 36]);
+        let signed = signed_from_data(ActionData::Create(CreateData {
+            entry_type: EntryType::AgentPubKey,
+            entry_hash: entry_hash.clone(),
+        }));
+        let op = Op::AgentActivity(AgentActivity {
+            action: signed,
+            cached_entry: None,
+        });
+        let flat: FlatOp<EntryTypes, LinkTypes> = op.flattened().unwrap();
+        match flat {
+            FlatOp::AgentActivity(OpActivity::CreateAgent { agent, .. }) => {
+                assert_eq!(agent, AgentPubKey::from(entry_hash));
+            }
+            other => panic!("expected CreateAgent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn register_agent_activity_update_agent_flattens_to_update_agent() {
+        types();
+        let new_entry_hash = EntryHash::from_raw_36(vec![25u8; 36]);
+        let original_entry_hash = EntryHash::from_raw_36(vec![26u8; 36]);
+        let signed = signed_from_data(ActionData::Update(UpdateData {
+            original_action_address: ActionHash::from_raw_36(vec![27u8; 36]),
+            original_entry_address: original_entry_hash.clone(),
+            entry_type: EntryType::AgentPubKey,
+            entry_hash: new_entry_hash.clone(),
+        }));
+        let op = Op::AgentActivity(AgentActivity {
+            action: signed,
+            cached_entry: None,
+        });
+        let flat: FlatOp<EntryTypes, LinkTypes> = op.flattened().unwrap();
+        match flat {
+            FlatOp::AgentActivity(OpActivity::UpdateAgent {
+                new_key,
+                original_key,
+                ..
+            }) => {
+                assert_eq!(new_key, AgentPubKey::from(new_entry_hash));
+                assert_eq!(original_key, AgentPubKey::from(original_entry_hash));
+            }
+            other => panic!("expected UpdateAgent, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
More improvements found while updating dino-adventure to 0.7.0-rc.3. I'm not unhappy with the state of things at that point but it could be better still.

Adds `TypedAction`/`EntryCreationData` conversions found missing while porting a real app to the new `TypedAction` API: `IntoEntryCreationData` + `Deref` + single-variant `TryFrom<Action>` narrowing (`CreateData`/`UpdateData`/`DeleteData`/`CreateLinkData`/`DeleteLinkData`) with an `ExternResult`-returning `try_from_action` sibling for each. Also restores the `agent`/`new_key`/`original_key` fields on `CreateAgent`/`UpdateAgent` variants (`OpEntry`, `OpActivity`, `OpRecord`) that the original `TypedAction` refactor dropped in favour of Option-returning accessors, and adds a doc note that narrowing failures should propagate as errors rather than `ValidateCallbackResult::Invalid`.