### PR TITLE
test: add DHT sync coverage for private entries

### DIFF
--- a/crates/holochain/src/test_utils/inline_zomes.rs
+++ b/crates/holochain/src/test_utils/inline_zomes.rs
@@ -97,61 +97,82 @@ pub fn simple_crud_zome() -> InlineZomeSet {
     let string_entry_def = EntryDef::default_from_id("string");
     let unit_entry_def = EntryDef::default_from_id("unit");
     let bytes_entry_def = EntryDef::default_from_id("bytes");
+    let mut priv_string_entry_def = EntryDef::default_from_id("priv_string");
+    priv_string_entry_def.visibility = EntryVisibility::Private;
 
-    SweetInlineZomes::new(vec![string_entry_def, unit_entry_def, bytes_entry_def], 0)
-        .function("create_string", move |api, s: AppString| {
-            let entry = Entry::app(s.try_into().unwrap()).unwrap();
-            let hash = api.create(CreateInput::new(
-                InlineZomeSet::get_entry_location(&api, EntryDefIndex(0)),
-                EntryVisibility::Public,
-                entry,
-                ChainTopOrdering::default(),
-            ))?;
-            Ok(hash)
-        })
-        .function("create_unit", move |api, ()| {
-            let entry = Entry::app(().try_into().unwrap()).unwrap();
-            let hash = api.create(CreateInput::new(
-                InlineZomeSet::get_entry_location(&api, EntryDefIndex(1)),
-                EntryVisibility::Public,
-                entry,
-                ChainTopOrdering::default(),
-            ))?;
-            Ok(hash)
-        })
-        .function("create_bytes", move |api, bs: Bytes| {
-            let entry = Entry::app(UnsafeBytes::from(bs.to_vec()).into()).unwrap();
-            let hash = api.create(CreateInput::new(
-                InlineZomeSet::get_entry_location(&api, EntryDefIndex(2)),
-                EntryVisibility::Public,
-                entry,
-                ChainTopOrdering::default(),
-            ))?;
-            Ok(hash)
-        })
-        .function("delete", move |api, action_hash: ActionHash| {
-            let hash = api.delete(DeleteInput::new(action_hash, ChainTopOrdering::default()))?;
-            Ok(hash)
-        })
-        .function("read", |api, hash: ActionHash| {
-            api.get(vec![GetInput::new(hash.into(), GetOptions::default())])
-                .map(|e| e.into_iter().next().unwrap())
-                .map_err(Into::into)
-        })
-        .function("read_multi", |api, hashes: Vec<ActionHash>| {
-            let gets = hashes
-                .iter()
-                .map(|h| GetInput::new(h.clone().into(), GetOptions::default()))
-                .collect();
-            api.get(gets).map_err(Into::into)
-        })
-        .function("read_entry", |api, hash: EntryHash| {
-            api.get(vec![GetInput::new(hash.into(), GetOptions::default())])
-                .map_err(Into::into)
-        })
-        .function("emit_signal", |api, ()| {
-            api.emit_signal(AppSignal::new(ExternIO::encode(()).unwrap()))
-                .map_err(Into::into)
-        })
-        .0
+    SweetInlineZomes::new(
+        vec![
+            string_entry_def,
+            unit_entry_def,
+            bytes_entry_def,
+            priv_string_entry_def,
+        ],
+        0,
+    )
+    .function("create_string", move |api, s: AppString| {
+        let entry = Entry::app(s.try_into().unwrap()).unwrap();
+        let hash = api.create(CreateInput::new(
+            InlineZomeSet::get_entry_location(&api, EntryDefIndex(0)),
+            EntryVisibility::Public,
+            entry,
+            ChainTopOrdering::default(),
+        ))?;
+        Ok(hash)
+    })
+    .function("create_unit", move |api, ()| {
+        let entry = Entry::app(().try_into().unwrap()).unwrap();
+        let hash = api.create(CreateInput::new(
+            InlineZomeSet::get_entry_location(&api, EntryDefIndex(1)),
+            EntryVisibility::Public,
+            entry,
+            ChainTopOrdering::default(),
+        ))?;
+        Ok(hash)
+    })
+    .function("create_bytes", move |api, bs: Bytes| {
+        let entry = Entry::app(UnsafeBytes::from(bs.to_vec()).into()).unwrap();
+        let hash = api.create(CreateInput::new(
+            InlineZomeSet::get_entry_location(&api, EntryDefIndex(2)),
+            EntryVisibility::Public,
+            entry,
+            ChainTopOrdering::default(),
+        ))?;
+        Ok(hash)
+    })
+    .function("create_priv_string", move |api, s: AppString| {
+        let entry = Entry::app(s.try_into().unwrap()).unwrap();
+        let entry_hash = EntryHash::with_data_sync(&entry);
+        let action_hash = api.create(CreateInput::new(
+            InlineZomeSet::get_entry_location(&api, EntryDefIndex(3)),
+            EntryVisibility::Private,
+            entry,
+            ChainTopOrdering::default(),
+        ))?;
+        Ok((action_hash, entry_hash))
+    })
+    .function("delete", move |api, action_hash: ActionHash| {
+        let hash = api.delete(DeleteInput::new(action_hash, ChainTopOrdering::default()))?;
+        Ok(hash)
+    })
+    .function("read", |api, hash: ActionHash| {
+        api.get(vec![GetInput::new(hash.into(), GetOptions::default())])
+            .map(|e| e.into_iter().next().unwrap())
+            .map_err(Into::into)
+    })
+    .function("read_multi", |api, hashes: Vec<ActionHash>| {
+        let gets = hashes
+            .iter()
+            .map(|h| GetInput::new(h.clone().into(), GetOptions::default()))
+            .collect();
+        api.get(gets).map_err(Into::into)
+    })
+    .function("read_entry", |api, hash: EntryHash| {
+        api.get(vec![GetInput::new(hash.into(), GetOptions::default())])
+            .map_err(Into::into)
+    })
+    .function("emit_signal", |api, ()| {
+        api.emit_signal(AppSignal::new(ExternIO::encode(()).unwrap()))
+            .map_err(Into::into)
+    })
+    .0
 }

--- a/crates/holochain/tests/tests/gossip/mod.rs
+++ b/crates/holochain/tests/tests/gossip/mod.rs
@@ -10,7 +10,12 @@ use holochain::sweettest::SweetInlineZomes;
 use holochain::sweettest::{await_consistency, SweetConductor, SweetDnaFile};
 use holochain::sweettest::{SweetConductorBatch, SweetLocalRendezvous};
 use holochain::test_utils::inline_zomes::simple_crud_zome;
-use holochain_zome_types::prelude::Record;
+use holochain_p2p::HolochainOpStore;
+use holochain_types::op::{produce_ops_from_record, ChainOp, DhtOp, OpEntry};
+use holochain_zome_types::prelude::{ChainOpType, Record};
+use kitsune2_api::{DhtArc, OpId, OpStore};
+use std::collections::HashSet;
+use std::time::Duration;
 
 /// Test that conductors with arcs clamped to zero do not gossip.
 #[tokio::test(flavor = "multi_thread")]
@@ -208,13 +213,6 @@ async fn new_conductor_syncs_via_gossip_with_private_entries() {
 /// and storage arcs never grow.
 #[tokio::test(flavor = "multi_thread")]
 async fn advertised_ops_are_servable_with_private_entries_on_chain() {
-    use holochain_p2p::HolochainOpStore;
-    use holochain_types::op::{produce_ops_from_record, ChainOp, DhtOp, OpEntry};
-    use holochain_zome_types::prelude::ChainOpType;
-    use kitsune2_api::{DhtArc, OpId, OpStore};
-    use std::collections::HashSet;
-    use std::time::Duration;
-
     holochain_trace::test_run();
 
     let mut conductor = SweetConductor::standard().await;

--- a/crates/holochain/tests/tests/gossip/mod.rs
+++ b/crates/holochain/tests/tests/gossip/mod.rs
@@ -197,3 +197,145 @@ async fn new_conductor_syncs_via_gossip_with_private_entries() {
     let record: Option<Record> = conductor0.call(&zome0, "read", public_hash1.clone()).await;
     assert_eq!(record.unwrap().action_address(), &public_hash1);
 }
+
+/// Every op hash the kitsune2 op store advertises must be servable while
+/// private entries sit on the chain. An advertised-but-unservable op is the
+/// #5871 failure class: peers request it forever, op stores never converge,
+/// and storage arcs never grow.
+#[tokio::test(flavor = "multi_thread")]
+async fn advertised_ops_are_servable_with_private_entries_on_chain() {
+    use holochain_p2p::HolochainOpStore;
+    use holochain_types::op::{produce_ops_from_record, ChainOp, DhtOp, OpEntry};
+    use holochain_zome_types::prelude::ChainOpType;
+    use kitsune2_api::{DhtArc, OpId, OpStore};
+    use std::collections::HashSet;
+    use std::time::Duration;
+
+    holochain_trace::test_run();
+
+    let mut conductor = SweetConductor::standard().await;
+    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
+    let app = conductor.setup_app("app", [&dna_file]).await.unwrap();
+    let cell = app.into_cells().pop().unwrap();
+    let zome = cell.zome(SweetInlineZomes::COORDINATOR);
+
+    const PRIVATE_CONTENT: &str = "private-entry-content-sentinel";
+
+    let public_hash: ActionHash = conductor
+        .call(&zome, "create_string", "public-entry-content".to_string())
+        .await;
+    let (priv_action_hash, _priv_entry_hash): (ActionHash, EntryHash) = conductor
+        .call(&zome, "create_priv_string", PRIVATE_CONTENT.to_string())
+        .await;
+
+    // The author's own get returns the private record with its entry, which
+    // is what `produce_ops_from_record` needs to compute the full op set.
+    let public_record: Option<Record> = conductor.call(&zome, "read", public_hash.clone()).await;
+    let private_record: Option<Record> = conductor
+        .call(&zome, "read", priv_action_hash.clone())
+        .await;
+    let private_record = private_record.unwrap();
+    assert!(private_record.entry().as_option().is_some());
+
+    let priv_ops = produce_ops_from_record(&private_record);
+    let priv_create_entry = priv_ops
+        .iter()
+        .find(|o| o.op_type == ChainOpType::CreateEntry)
+        .expect("a private create must still produce a CreateEntry op locally");
+    let priv_create_entry_id = priv_create_entry
+        .op_hash
+        .to_located_k2_op_id(&priv_create_entry.basis_hash);
+    let priv_create_entry_raw = priv_create_entry.op_hash.get_raw_36().to_vec();
+
+    let expected_servable: HashSet<OpId> = produce_ops_from_record(&public_record.unwrap())
+        .iter()
+        .chain(
+            priv_ops
+                .iter()
+                .filter(|o| o.op_type != ChainOpType::CreateEntry),
+        )
+        .map(|o| o.op_hash.to_located_k2_op_id(&o.basis_hash))
+        .collect();
+
+    let op_store = HolochainOpStore::new(
+        cell.dht_store().clone(),
+        dna_file.dna_hash().clone(),
+        std::sync::Arc::new(std::sync::OnceLock::new()),
+    );
+
+    // Poll until validation and integration have made the authored records
+    // servable; the private CreateEntry op is processed in the same batch.
+    let advertised: Vec<OpId> = tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            let (ids, _total_size) = op_store
+                .retrieve_op_hashes_in_time_slice(
+                    DhtArc::FULL,
+                    kitsune2_api::Timestamp::from_micros(0),
+                    kitsune2_api::Timestamp::from_micros(i64::MAX),
+                )
+                .await
+                .unwrap();
+            let set: HashSet<OpId> = ids.iter().cloned().collect();
+            if expected_servable.is_subset(&set) {
+                break ids;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for authored ops to become servable");
+
+    // The private CreateEntry op is stored locally for its author, so this
+    // test is not passing vacuously.
+    let held = cell
+        .dht_store()
+        .as_read()
+        .check_op_hashes_present(&[priv_create_entry_raw])
+        .await
+        .unwrap();
+    assert_eq!(
+        held.len(),
+        1,
+        "private CreateEntry op must be stored locally"
+    );
+
+    // ...but it is never advertised.
+    let advertised_set: HashSet<OpId> = advertised.iter().cloned().collect();
+    assert!(
+        !advertised_set.contains(&priv_create_entry_id),
+        "private CreateEntry op must not be advertised"
+    );
+
+    // Everything advertised must be servable.
+    let served = op_store.retrieve_ops(advertised.clone()).await.unwrap();
+    let served_ids: HashSet<OpId> = served.iter().map(|op| op.op_id.clone()).collect();
+    assert_eq!(
+        advertised_set, served_ids,
+        "every advertised op must be servable"
+    );
+
+    // No served op carries the private entry content, and every served
+    // CreateEntry op carries its entry.
+    let sentinel = PRIVATE_CONTENT.as_bytes();
+    let mut served_create_entry_count = 0;
+    for meta_op in &served {
+        assert!(
+            !meta_op
+                .op_data
+                .windows(sentinel.len())
+                .any(|w| w == sentinel),
+            "private entry content leaked into a served op"
+        );
+        let op: DhtOp = holochain_serialized_bytes::prelude::decode(&meta_op.op_data).unwrap();
+        if let DhtOp::ChainOp(chain_op) = &op {
+            if let ChainOp::CreateEntry(_, entry) = &**chain_op {
+                assert!(
+                    matches!(entry, OpEntry::Present(_)),
+                    "served CreateEntry op is missing its entry"
+                );
+                served_create_entry_count += 1;
+            }
+        }
+    }
+    assert!(served_create_entry_count >= 1);
+}

--- a/crates/holochain/tests/tests/gossip/mod.rs
+++ b/crates/holochain/tests/tests/gossip/mod.rs
@@ -174,29 +174,32 @@ async fn new_conductor_syncs_via_gossip_with_private_entries() {
     let record: Option<Record> = conductor1.call(&zome1, "read", public_hash0.clone()).await;
     assert_eq!(record.unwrap().action_address(), &public_hash0);
 
-    // The private entry's basis has no authority: its CreateEntry op is
-    // withheld, so a get by entry hash finds nothing.
+    // Consistency has been reached, so the get finding nothing means the
+    // private entry's CreateEntry op is withheld from gossip: no authority
+    // holds the entry.
     let records: Vec<Option<Record>> = conductor1
         .call(&zome1, "read_entry", priv_entry_hash.clone())
         .await;
     assert!(records.into_iter().flatten().next().is_none());
 
     // Reverse direction with private entries on both chains: conductor1
-    // authors while conductor0 is offline, so publish cannot deliver the
-    // data and gossip must deliver it once conductor0 returns.
-    conductor0.shutdown().await;
+    // authors its own public and private entries and gossip carries the
+    // public data back to conductor0.
     let public_hash1: ActionHash = conductor1
         .call(&zome1, "create_string", "hello".to_string())
         .await;
-    let (_a, _e): (ActionHash, EntryHash) = conductor1
+    let (_priv_action_hash1, priv_entry_hash1): (ActionHash, EntryHash) = conductor1
         .call(&zome1, "create_priv_string", "also secret".to_string())
         .await;
-    conductor0.startup().await;
-    SweetConductor::exchange_peer_info([&conductor0, &conductor1]).await;
     await_consistency([&cell0, &cell1]).await.unwrap();
 
     let record: Option<Record> = conductor0.call(&zome0, "read", public_hash1.clone()).await;
     assert_eq!(record.unwrap().action_address(), &public_hash1);
+
+    let records: Vec<Option<Record>> = conductor0
+        .call(&zome0, "read_entry", priv_entry_hash1.clone())
+        .await;
+    assert!(records.into_iter().flatten().next().is_none());
 }
 
 /// Every op hash the kitsune2 op store advertises must be servable while

--- a/crates/holochain/tests/tests/gossip/mod.rs
+++ b/crates/holochain/tests/tests/gossip/mod.rs
@@ -140,11 +140,14 @@ async fn new_conductor_reaches_consistency_with_existing_conductor() {
 async fn new_conductor_syncs_via_gossip_with_private_entries() {
     holochain_trace::test_run();
     let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
-    let mut conductor0 = SweetConductor::from_config_rendezvous(
-        SweetConductorConfig::rendezvous(true),
-        SweetLocalRendezvous::new().await,
-    )
-    .await;
+    // Disable publishing on both conductors so gossip is the only possible
+    // transport, rather than relying on the publish interval to exceed the
+    // consistency window.
+    let config =
+        SweetConductorConfig::rendezvous(true).tune_network_config(|nc| nc.disable_publish = true);
+    let mut conductor0 =
+        SweetConductor::from_config_rendezvous(config.clone(), SweetLocalRendezvous::new().await)
+            .await;
     let app0 = conductor0.setup_app("app", [&dna_file]).await.unwrap();
     let cell0 = app0.into_cells().pop().unwrap();
     let zome0 = cell0.zome(SweetInlineZomes::COORDINATOR);
@@ -157,11 +160,9 @@ async fn new_conductor_syncs_via_gossip_with_private_entries() {
         .call(&zome0, "create_priv_string", "secret".to_string())
         .await;
 
-    let mut conductor1 = SweetConductor::from_config_rendezvous(
-        SweetConductorConfig::rendezvous(true),
-        conductor0.rendezvous().unwrap().clone(),
-    )
-    .await;
+    let mut conductor1 =
+        SweetConductor::from_config_rendezvous(config, conductor0.rendezvous().unwrap().clone())
+            .await;
     let app1 = conductor1.setup_app("app", [&dna_file]).await.unwrap();
     let cell1 = app1.into_cells().pop().unwrap();
     let zome1 = cell1.zome(SweetInlineZomes::COORDINATOR);
@@ -181,8 +182,8 @@ async fn new_conductor_syncs_via_gossip_with_private_entries() {
     assert!(records.into_iter().flatten().next().is_none());
 
     // Reverse direction with private entries on both chains: conductor1
-    // authors while conductor0 is offline, so publish cannot deliver and
-    // gossip must once conductor0 returns.
+    // authors while conductor0 is offline, so publish cannot deliver the
+    // data and gossip must deliver it once conductor0 returns.
     conductor0.shutdown().await;
     let public_hash1: ActionHash = conductor1
         .call(&zome1, "create_string", "hello".to_string())
@@ -263,8 +264,7 @@ async fn advertised_ops_are_servable_with_private_entries_on_chain() {
         std::sync::Arc::new(std::sync::OnceLock::new()),
     );
 
-    // Poll until validation and integration have made the authored records
-    // servable; the private CreateEntry op is processed in the same batch.
+    // Wait until the authored ops are advertised.
     let advertised: Vec<OpId> = tokio::time::timeout(Duration::from_secs(30), async {
         loop {
             let (ids, _total_size) = op_store

--- a/crates/holochain/tests/tests/gossip/mod.rs
+++ b/crates/holochain/tests/tests/gossip/mod.rs
@@ -4,6 +4,7 @@
 
 use hdk::prelude::*;
 use holo_hash::ActionHash;
+use holo_hash::EntryHash;
 use holochain::sweettest::SweetConductorConfig;
 use holochain::sweettest::SweetInlineZomes;
 use holochain::sweettest::{await_consistency, SweetConductor, SweetDnaFile};
@@ -128,4 +129,71 @@ async fn new_conductor_reaches_consistency_with_existing_conductor() {
     await_consistency([&cell0, &cell1]).await.unwrap();
     let record: Option<Record> = conductor1.call(&zome1, "read", hash.clone()).await;
     assert_eq!(record.unwrap().action_address(), &hash);
+}
+
+/// A conductor joining after private entries were authored on the existing
+/// chain must reach consistency via gossip alone: the private CreateEntry
+/// ops are withheld from advertisement and serving, while all public ops
+/// for the same records transfer normally (#5871).
+#[cfg(feature = "slow_tests")]
+#[tokio::test(flavor = "multi_thread")]
+async fn new_conductor_syncs_via_gossip_with_private_entries() {
+    holochain_trace::test_run();
+    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
+    let mut conductor0 = SweetConductor::from_config_rendezvous(
+        SweetConductorConfig::rendezvous(true),
+        SweetLocalRendezvous::new().await,
+    )
+    .await;
+    let app0 = conductor0.setup_app("app", [&dna_file]).await.unwrap();
+    let cell0 = app0.into_cells().pop().unwrap();
+    let zome0 = cell0.zome(SweetInlineZomes::COORDINATOR);
+
+    // Author public and private entries before conductor1 exists.
+    let public_hash0: ActionHash = conductor0
+        .call(&zome0, "create_string", "hi".to_string())
+        .await;
+    let (_priv_action_hash, priv_entry_hash): (ActionHash, EntryHash) = conductor0
+        .call(&zome0, "create_priv_string", "secret".to_string())
+        .await;
+
+    let mut conductor1 = SweetConductor::from_config_rendezvous(
+        SweetConductorConfig::rendezvous(true),
+        conductor0.rendezvous().unwrap().clone(),
+    )
+    .await;
+    let app1 = conductor1.setup_app("app", [&dna_file]).await.unwrap();
+    let cell1 = app1.into_cells().pop().unwrap();
+    let zome1 = cell1.zome(SweetInlineZomes::COORDINATOR);
+
+    SweetConductor::exchange_peer_info([&conductor0, &conductor1]).await;
+    await_consistency([&cell0, &cell1]).await.unwrap();
+
+    // The public record is available to the new conductor.
+    let record: Option<Record> = conductor1.call(&zome1, "read", public_hash0.clone()).await;
+    assert_eq!(record.unwrap().action_address(), &public_hash0);
+
+    // The private entry's basis has no authority: its CreateEntry op is
+    // withheld, so a get by entry hash finds nothing.
+    let records: Vec<Option<Record>> = conductor1
+        .call(&zome1, "read_entry", priv_entry_hash.clone())
+        .await;
+    assert!(records.into_iter().flatten().next().is_none());
+
+    // Reverse direction with private entries on both chains: conductor1
+    // authors while conductor0 is offline, so publish cannot deliver and
+    // gossip must once conductor0 returns.
+    conductor0.shutdown().await;
+    let public_hash1: ActionHash = conductor1
+        .call(&zome1, "create_string", "hello".to_string())
+        .await;
+    let (_a, _e): (ActionHash, EntryHash) = conductor1
+        .call(&zome1, "create_priv_string", "also secret".to_string())
+        .await;
+    conductor0.startup().await;
+    SweetConductor::exchange_peer_info([&conductor0, &conductor1]).await;
+    await_consistency([&cell0, &cell1]).await.unwrap();
+
+    let record: Option<Record> = conductor0.call(&zome0, "read", public_hash1.clone()).await;
+    assert_eq!(record.unwrap().action_address(), &public_hash1);
 }


### PR DESCRIPTION
## Summary
- Adds an end-to-end gossip test proving a conductor joining after private entries were authored reaches consistency via gossip alone (publishing disabled), in both directions, ending with private entries on both chains.
- Adds a serve-boundary test driving the real kitsune2 op store: every advertised op hash is servable, and the private `CreateEntry` op is held locally but never advertised or leaked.
- Extends `simple_crud_zome` with a private entry def and `create_priv_string`.

A plain two-conductor consistency test cannot catch this failure class because the publish path masks the gossip serve path — thanks @daniel-thisnow for that analysis on the issue.

Closes #5871