### PR TITLE
chore: make `unwrap_to` a dev dependency rather than an optional one, enabled by the `test_utils` feature

### DIFF
--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -101,7 +101,6 @@ hdk = { version = "^0.7.0-rc.3", path = "../hdk", optional = true }
 matches = { version = "0.1.8", optional = true }
 holochain_wasm_test_utils = { version = "^0.7.0-rc.3", path = "../test_utils/wasm", optional = true }
 holochain_test_wasm_common = { version = "^0.7.0-rc.3", path = "../test_utils/wasm_common", optional = true }
-unwrap_to = { version = "0.1.0", optional = true }
 kitsune2_bootstrap_srv = { version = "0.5.0", default-features = false, optional = true }
 schemars = "0.9"
 
@@ -130,6 +129,7 @@ predicates = "3.1"
 assert2 = "0.3.15"
 kitsune2_test_utils = "0.5.0"
 rand_dalek = { version = "0.8", package = "rand" }
+unwrap_to = { version = "0.1.0" }
 
 [build-dependencies]
 hdk = { version = "^0.7.0-rc.3", path = "../hdk" }
@@ -178,7 +178,6 @@ test_utils = [
   "dep:matches",
   "dep:holochain_test_wasm_common",
   "dep:holochain_wasm_test_utils",
-  "dep:unwrap_to",
   "dep:kitsune2_bootstrap_srv",
   "holo_hash/fixturators",
 ]


### PR DESCRIPTION
### Summary

Closes https://github.com/holochain/holochain/issues/5873

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs