### PR TITLE
feat(admin_api): expose DHT op timings via DumpOpTimings

### DIFF
--- a/crates/client/src/admin_websocket.rs
+++ b/crates/client/src/admin_websocket.rs
@@ -4,8 +4,8 @@ use holo_hash::{ActionHash, DnaHash};
 use holochain_conductor_api::{
     AdminInterfaceConfig, AdminRequest, AdminResponse, AppAuthenticationToken,
     AppAuthenticationTokenIssued, AppInfo, AppInterfaceInfo, AppStatusFilter, DhtOpsCursor,
-    FullStateDump, IssueAppAuthenticationTokenPayload, PeerMetaInfo, SourceChainCursor,
-    StorageInfo,
+    FullStateDump, IssueAppAuthenticationTokenPayload, OpTimingsCursor, OpTimingsDump,
+    PeerMetaInfo, SourceChainCursor, StorageInfo,
 };
 use holochain_types::network::HolochainTransportStats;
 use holochain_types::websocket::AllowedOrigins;
@@ -501,6 +501,32 @@ impl AdminWebsocket {
         let response = self.send(msg).await?;
         match response {
             AdminResponse::FullStateDumped(state) => Ok(state),
+            _ => unreachable!("Unexpected response {:?}", response),
+        }
+    }
+
+    /// Dump one page of a DNA's DHT-op lifecycle timings.
+    ///
+    /// Pass the previous page's `cursor` to resume; `None` starts at the
+    /// oldest op by received time.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the request fails or the limit is zero.
+    pub async fn dump_op_timings(
+        &self,
+        dna_hash: DnaHash,
+        cursor: Option<OpTimingsCursor>,
+        limit: Option<u32>,
+    ) -> ConductorApiResult<OpTimingsDump> {
+        let msg = AdminRequest::DumpOpTimings {
+            dna_hash,
+            cursor,
+            limit,
+        };
+        let response = self.send(msg).await?;
+        match response {
+            AdminResponse::OpTimingsDumped(timings) => Ok(timings),
             _ => unreachable!("Unexpected response {:?}", response),
         }
     }

--- a/crates/client/src/app_websocket.rs
+++ b/crates/client/src/app_websocket.rs
@@ -4,8 +4,8 @@ use crate::{signing::sign_zome_call, ConductorApiError, ConductorApiResult};
 use anyhow::{anyhow, Result};
 use holo_hash::{AgentPubKey, DnaHash};
 use holochain_conductor_api::{
-    AppAuthenticationToken, AppInfo, AppRequest, AppResponse, CellInfo, PeerMetaInfo,
-    ProvisionedCell, ZomeCallParamsSigned,
+    AppAuthenticationToken, AppInfo, AppRequest, AppResponse, CellInfo, OpTimingsCursor,
+    OpTimingsDump, PeerMetaInfo, ProvisionedCell, ZomeCallParamsSigned,
 };
 use holochain_nonce::fresh_nonce;
 use holochain_types::app::{
@@ -456,6 +456,30 @@ impl AppWebsocket {
         let response = self.inner.send(msg).await?;
         match response {
             AppResponse::NetworkMetricsDumped(metrics) => Ok(metrics),
+            _ => unreachable!("Unexpected response {:?}", response),
+        }
+    }
+
+    /// Dump one page of DHT-op lifecycle timings for a DNA of this app.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this app runs no cell of `dna_hash`, the request
+    /// fails, or the limit is zero.
+    pub async fn dump_op_timings(
+        &self,
+        dna_hash: DnaHash,
+        cursor: Option<OpTimingsCursor>,
+        limit: Option<u32>,
+    ) -> ConductorApiResult<OpTimingsDump> {
+        let msg = AppRequest::DumpOpTimings {
+            dna_hash,
+            cursor,
+            limit,
+        };
+        let response = self.inner.send(msg).await?;
+        match response {
+            AppResponse::OpTimingsDumped(timings) => Ok(timings),
             _ => unreachable!("Unexpected response {:?}", response),
         }
     }

--- a/crates/hc_client/src/calls.rs
+++ b/crates/hc_client/src/calls.rs
@@ -12,7 +12,7 @@ use holochain_client::AdminWebsocket;
 use holochain_conductor_api::InterfaceDriver;
 use holochain_conductor_api::PeerMetaInfo;
 use holochain_conductor_api::{AdminInterfaceConfig, AppInfo};
-use holochain_conductor_api::{AppStatusFilter, DhtOpsCursor, SourceChainCursor};
+use holochain_conductor_api::{AppStatusFilter, DhtOpsCursor, OpTimingsCursor, SourceChainCursor};
 use holochain_types::app::AppManifest;
 use holochain_types::app::RoleSettingsMap;
 use holochain_types::app::RoleSettingsMapYaml;
@@ -76,6 +76,8 @@ pub enum AdminRequestCli {
     DumpState(DumpState),
     /// Calls [`AdminWebsocket::dump_full_state`].
     DumpFullState(DumpFullState),
+    /// Calls [`AdminWebsocket::dump_op_timings`].
+    DumpOpTimings(DumpOpTimings),
     /// Calls [`AdminWebsocket::dump_conductor_state`].
     DumpConductorState,
     /// Calls [`AdminWebsocket::dump_network_metrics`].
@@ -246,12 +248,28 @@ pub struct DumpFullState {
     #[arg(value_parser = parse_agent_key)]
     pub agent_key: AgentPubKey,
 
-    /// Last receipt timestamp and DHT op hash returned by the previous page.
+    /// Last received timestamp and DHT op hash returned by the previous page.
     #[arg(long, num_args = 2, value_names = ["WHEN_RECEIVED", "DHT_OP_HASH"])]
     pub cursor: Option<Vec<String>>,
 
     /// Maximum number of DHT ops across all lifecycle buckets to return.
     /// Must be greater than zero.
+    #[arg(long, value_parser = parse_dump_limit)]
+    pub limit: Option<u32>,
+}
+
+/// Calls [`AdminWebsocket::dump_op_timings`] and dumps one page of op timings.
+#[derive(Debug, Args, Clone)]
+pub struct DumpOpTimings {
+    /// The DNA hash whose DHT arc to dump.
+    #[arg(value_parser = parse_dna_hash)]
+    pub dna: DnaHash,
+
+    /// Last received timestamp and DHT op hash returned by the previous page.
+    #[arg(long, num_args = 2, value_names = ["WHEN_RECEIVED", "DHT_OP_HASH"])]
+    pub cursor: Option<Vec<String>>,
+
+    /// Maximum number of ops to return. Must be greater than zero.
     #[arg(long, value_parser = parse_dump_limit)]
     pub limit: Option<u32>,
 }
@@ -431,6 +449,15 @@ async fn call_inner(client: &mut AdminWebsocket, call: AdminRequestCli) -> anyho
             let cell_id = CellId::new(args.dna, args.agent_key);
             let state = client.dump_full_state(cell_id, cursor, args.limit).await?;
             println!("{}", serde_json::to_string(&state)?);
+        }
+        AdminRequestCli::DumpOpTimings(args) => {
+            let cursor = args
+                .cursor
+                .as_deref()
+                .map(parse_op_timings_cursor)
+                .transpose()?;
+            let timings = client.dump_op_timings(args.dna, cursor, args.limit).await?;
+            println!("{}", serde_json::to_string(&timings)?);
         }
         AdminRequestCli::DumpConductorState => {
             let state = client.dump_conductor_state().await?;
@@ -752,12 +779,27 @@ fn parse_source_chain_cursor(arg: &str) -> anyhow::Result<SourceChainCursor> {
 
 fn parse_dht_ops_cursor(values: &[String]) -> anyhow::Result<DhtOpsCursor> {
     let [when_received, hash] = values else {
-        return Err(anyhow!("DHT cursor requires a receipt time and op hash"));
+        return Err(anyhow!("DHT cursor requires a received time and op hash"));
     };
     Ok(DhtOpsCursor {
         when_received: when_received
             .parse()
-            .map_err(|e| anyhow!("Invalid receipt time: {e}"))?,
+            .map_err(|e| anyhow!("Invalid received time: {e}"))?,
+        hash: DhtOpHash::try_from(hash.as_str())
+            .map_err(|e| anyhow!("Invalid DHT op hash: {e}"))?,
+    })
+}
+
+fn parse_op_timings_cursor(values: &[String]) -> anyhow::Result<OpTimingsCursor> {
+    let [when_received, hash] = values else {
+        return Err(anyhow!(
+            "op-timings cursor requires a received time and op hash"
+        ));
+    };
+    Ok(OpTimingsCursor {
+        when_received: when_received
+            .parse()
+            .map_err(|e| anyhow!("Invalid received time: {e}"))?,
         hash: DhtOpHash::try_from(hash.as_str())
             .map_err(|e| anyhow!("Invalid DHT op hash: {e}"))?,
     })
@@ -807,6 +849,7 @@ mod tests {
     use holo_hash::{AgentPubKey, DnaHash};
     use holochain_client::{SerializedBytes, Timestamp};
     use holochain_conductor_api::CellInfo;
+    use holochain_conductor_api::OpTimingsCursor;
     use holochain_types::app::{AppManifestV0Builder, AppRoleManifest, AppStatus};
     use holochain_types::prelude::{CellId, DnaModifiers, RoleName};
     use indexmap::IndexMap;
@@ -904,6 +947,69 @@ mod tests {
             "not-a-sequence-or-action-hash",
         ])
         .is_err());
+    }
+
+    #[test]
+    fn parses_dump_op_timings_cursor_pair() {
+        let dna = "uhC0kWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+        let hash = "uhCQkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+        let call = Call::try_parse_from([
+            "hc-client",
+            "--port",
+            "1234",
+            "dump-op-timings",
+            dna,
+            "--limit",
+            "10",
+            "--cursor",
+            "99",
+            hash,
+        ])
+        .unwrap();
+
+        let AdminRequestCli::DumpOpTimings(args) = call.call else {
+            panic!("expected dump-op-timings arguments");
+        };
+        assert_eq!(args.limit, Some(10));
+        assert_eq!(
+            parse_op_timings_cursor(args.cursor.as_deref().unwrap()).unwrap(),
+            OpTimingsCursor {
+                when_received: 99,
+                hash: DhtOpHash::try_from(hash).unwrap(),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_dump_op_timings_arguments() {
+        let dna = "uhC0kWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+
+        // Zero limit.
+        assert!(Call::try_parse_from([
+            "hc-client",
+            "--port",
+            "1234",
+            "dump-op-timings",
+            dna,
+            "--limit",
+            "0",
+        ])
+        .is_err());
+
+        // Cursor needs both a received time and a hash.
+        assert!(Call::try_parse_from([
+            "hc-client",
+            "--port",
+            "1234",
+            "dump-op-timings",
+            dna,
+            "--cursor",
+            "99",
+        ])
+        .is_err());
+
+        // Cursor hash must be a DHT op hash.
+        assert!(parse_op_timings_cursor(&["99".to_string(), "not-a-hash".to_string()]).is_err());
     }
 
     #[test]

--- a/crates/hc_client/tests/integration.rs
+++ b/crates/hc_client/tests/integration.rs
@@ -3,7 +3,7 @@ use std::process::Command as StdCommand;
 use std::time::Duration;
 
 use anyhow::{ensure, Result};
-use holo_hash::{ActionHash, AgentPubKey, AgentPubKeyB64, DnaHash, DnaHashB64, HasHash};
+use holo_hash::{ActionHash, AgentPubKey, AgentPubKeyB64, DhtOpHash, DnaHash, DnaHashB64, HasHash};
 use holochain::{sweettest::*, test_utils::inline_zomes::simple_crud_zome};
 use holochain_client::AdminWebsocket;
 use holochain_conductor_api::{AdminInterfaceConfig, DhtOpsCursor, FullStateDump, InterfaceDriver};
@@ -264,6 +264,90 @@ async fn dump_commands_return_single_cursor_page() -> Result<()> {
     assert_eq!(
         actual_hashes.into_iter().collect::<HashSet<_>>(),
         expected_hashes
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dump_op_timings_command_pages() -> Result<()> {
+    let mut conductor = SweetConductor::standard().await;
+    let (dna, _, _) = SweetDnaFile::unique_from_inline_zomes(simple_crud_zome()).await;
+    let app = conductor.setup_app("app", &[dna]).await?;
+    let cell_id = app.cells()[0].cell_id().clone();
+    let dna_hash = cell_id.dna_hash().clone();
+    let dna = dna_hash.to_string();
+    let admin_port = conductor
+        .get_arbitrary_admin_websocket_port()
+        .expect("admin port");
+    let admin_port_arg = admin_port.to_string();
+    let admin_ws = AdminWebsocket::connect(format!("127.0.0.1:{admin_port}"), None).await?;
+
+    let unbounded = admin_ws.dump_op_timings(dna_hash, None, None).await?;
+    ensure!(
+        unbounded.timings.len() >= 2,
+        "expected the genesis ops to be dumped"
+    );
+
+    let first_page = get_hc_client_command()
+        .args([
+            "call",
+            "--port",
+            admin_port_arg.as_str(),
+            "dump-op-timings",
+            dna.as_str(),
+            "--limit",
+            "1",
+        ])
+        .output()?;
+    ensure!(first_page.status.success(), "dump-op-timings failed");
+
+    let first_json: serde_json::Value = serde_json::from_slice(&first_page.stdout)?;
+    let timings = first_json["timings"]
+        .as_array()
+        .expect("timings array")
+        .clone();
+    ensure!(timings.len() == 1, "limit was not applied");
+    ensure!(
+        timings[0]["when_received"].is_i64(),
+        "received time is reported"
+    );
+
+    let when_received = first_json["cursor"]["when_received"]
+        .as_i64()
+        .expect("cursor received time")
+        .to_string();
+    // `DhtOpHash` serializes to JSON as a byte array (see `holo_hash::ser`), not a
+    // base64 string, so it must be decoded before it can be passed back to the CLI,
+    // which expects the base64 string form accepted by `DhtOpHash::try_from(&str)`.
+    let cursor_hash: DhtOpHash = serde_json::from_value(first_json["cursor"]["hash"].clone())?;
+    let cursor_hash = cursor_hash.to_string();
+
+    let second_page = get_hc_client_command()
+        .args([
+            "call",
+            "--port",
+            admin_port_arg.as_str(),
+            "dump-op-timings",
+            dna.as_str(),
+            "--limit",
+            "1",
+            "--cursor",
+            when_received.as_str(),
+            cursor_hash.as_str(),
+        ])
+        .output()?;
+    ensure!(second_page.status.success(), "paged dump-op-timings failed");
+
+    let second_json: serde_json::Value = serde_json::from_slice(&second_page.stdout)?;
+    let second_timings = second_json["timings"].as_array().expect("timings array");
+    ensure!(
+        second_timings.len() == 1,
+        "second page limit was not applied"
+    );
+    ensure!(
+        second_timings[0]["op_hash"] != timings[0]["op_hash"],
+        "cursor is exclusive"
     );
 
     Ok(())

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Add `DumpOpTimings` to the admin and app APIs, plus a matching `hc client dump-op-timings` command. It reports, for each DHT op the conductor holds for a DNA, when the op was received, when it was integrated or when its validation was abandoned, whether it was accepted or rejected, and whether this node validated it locally. The request takes a DNA hash: the DHT database is shared by every cell running the same DNA, so the dump covers the whole DHT arc this conductor is currently holding for that DNA rather than the ops of any one agent. On the app API the DNA must be one the calling app runs. Results are paginated with an exclusive cursor over received time and op hash, covering both in-flight and integrated ops. [\#5772](https://github.com/holochain/holochain/issues/5772)
+
 ## 0.7.0-rc.4
 
 - Add exclusive cursor pagination and optional limits to `DumpState` and `DumpFullState`, plus matching `hc client` options. Full-state limits apply globally to integrated and limbo chain ops and warrants, ordered by receipt time and op hash. [\#5774](https://github.com/holochain/holochain/issues/5774)

--- a/crates/holochain/src/conductor/api/api_external/admin_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/admin_interface.rs
@@ -214,6 +214,17 @@ impl AdminInterfaceApi {
                     .await?;
                 Ok(AdminResponse::FullStateDumped(state))
             }
+            DumpOpTimings {
+                dna_hash,
+                cursor,
+                limit,
+            } => {
+                let timings = self
+                    .conductor_handle
+                    .dump_op_timings(&dna_hash, cursor, limit)
+                    .await?;
+                Ok(AdminResponse::OpTimingsDumped(timings))
+            }
             DumpNetworkMetrics {
                 dna_hash,
                 include_dht_summary,

--- a/crates/holochain/src/conductor/api/api_external/app_interface.rs
+++ b/crates/holochain/src/conductor/api/api_external/app_interface.rs
@@ -167,6 +167,17 @@ impl AppInterfaceApi {
                     .await?;
                 Ok(AppResponse::CloneCellEnabled(enabled_cell))
             }
+            AppRequest::DumpOpTimings {
+                dna_hash,
+                cursor,
+                limit,
+            } => {
+                let timings = self
+                    .conductor_handle
+                    .dump_op_timings_for_app(&installed_app_id, &dna_hash, cursor, limit)
+                    .await?;
+                Ok(AppResponse::OpTimingsDumped(timings))
+            }
             AppRequest::DumpNetworkMetrics {
                 dna_hash,
                 include_dht_summary,

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -82,7 +82,9 @@ use holochain_conductor_api::AppStatusFilter;
 use holochain_conductor_api::FullStateDump;
 use holochain_conductor_api::IntegrationStateDump;
 use holochain_conductor_api::PeerMetaInfo;
-use holochain_conductor_api::{DhtOpsCursor, FullIntegrationStateDump, SourceChainCursor};
+use holochain_conductor_api::{
+    DhtOpsCursor, FullIntegrationStateDump, OpTimingsCursor, OpTimingsDump, SourceChainCursor,
+};
 use holochain_keystore::lair_keystore::spawn_lair_keystore;
 use holochain_keystore::lair_keystore::spawn_lair_keystore_in_proc;
 use holochain_keystore::MetaLairClient;
@@ -2605,6 +2607,65 @@ mod misc_impls {
                 .await?,
             };
             Ok(out)
+        }
+
+        /// Dump one page of DHT-op lifecycle timings for a DNA.
+        ///
+        /// Ops are ordered by `(when_received, op_hash)` across both
+        /// validation limbos and the integrated set, so a page can mix
+        /// in-flight and integrated ops.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if the DNA's DHT store cannot be read or the
+        /// limit is zero.
+        pub async fn dump_op_timings(
+            &self,
+            dna_hash: &DnaHash,
+            cursor: Option<OpTimingsCursor>,
+            limit: Option<u32>,
+        ) -> ConductorApiResult<OpTimingsDump> {
+            let dht_store = self.get_or_create_dht_store(dna_hash)?;
+            Ok(dht_store
+                .as_read()
+                .op_timings_page_for_dump(cursor.as_ref(), limit)
+                .await?)
+        }
+
+        /// Dump one page of DHT-op lifecycle timings for a DNA of `installed_app_id`.
+        ///
+        /// This is the app-interface entry point: `dna_hash` must be the DNA of
+        /// one of the calling app's cells, so an app cannot inspect the DHT of
+        /// a DNA it does not run.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error if the app is unknown, the app runs no cell of
+        /// `dna_hash`, the DHT store cannot be read, or the limit is zero.
+        pub async fn dump_op_timings_for_app(
+            &self,
+            installed_app_id: &InstalledAppId,
+            dna_hash: &DnaHash,
+            cursor: Option<OpTimingsCursor>,
+            limit: Option<u32>,
+        ) -> ConductorApiResult<OpTimingsDump> {
+            let belongs_to_app = {
+                let state = self.get_state().await?;
+                let installed_app = state.get_app(installed_app_id)?;
+                // `all_cells()` borrows from `state`, and as the block's tail
+                // expression its temporary would outlive `state` (E0597). The
+                // binding forces the iterator to drop before the block ends,
+                // so do not collapse it into the tail expression.
+                let belongs = installed_app
+                    .all_cells()
+                    .any(|id| id.dna_hash() == dna_hash);
+                belongs
+            };
+            if !belongs_to_app {
+                return Err(ConductorApiError::Other("DNA hash not found in app".into()));
+            }
+
+            self.dump_op_timings(dna_hash, cursor, limit).await
         }
 
         /// Dump of network metrics from Kitsune2.

--- a/crates/holochain/src/conductor/conductor/tests/state_dump.rs
+++ b/crates/holochain/src/conductor/conductor/tests/state_dump.rs
@@ -7,7 +7,7 @@ use crate::{
     sweettest::{SweetConductor, SweetDnaFile, SweetZome},
 };
 use holo_hash::{ActionHash, DhtOpHash, HasHash};
-use holochain_conductor_api::{FullIntegrationStateDump, FullStateDump};
+use holochain_conductor_api::{FullIntegrationStateDump, FullStateDump, OpTimingsCursor};
 use holochain_state::dht_store::SysOutcome;
 use holochain_state::source_chain;
 use holochain_types::op::{DhtOp, DhtOpHashed};
@@ -206,4 +206,138 @@ async fn dump_full_state() {
             .await
             .is_err()
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dump_op_timings_pages_in_received_order() {
+    let mut conductor = SweetConductor::standard().await;
+    let dna_file = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Crd])
+        .await
+        .0;
+    let app = conductor.setup_app("", &[dna_file]).await.unwrap();
+    let cell_id = app.cells()[0].cell_id();
+    let _: ActionHash = conductor
+        .call(
+            &SweetZome::new(cell_id.clone(), TestWasm::Crd.coordinator_zome_name()),
+            "create",
+            (),
+        )
+        .await;
+
+    // Wait until the authored ops have been integrated so the dump has both
+    // an integration time and a locally-validated flag to report.
+    retry_until_timeout!({
+        if conductor
+            .all_ops_integrated(cell_id.dna_hash())
+            .await
+            .unwrap()
+        {
+            break;
+        }
+    });
+
+    let unbounded = conductor
+        .raw_handle()
+        .dump_op_timings(cell_id.dna_hash(), None, None)
+        .await
+        .unwrap();
+    assert!(unbounded.timings.len() >= 2, "expected several ops");
+    assert!(
+        unbounded
+            .timings
+            .iter()
+            .all(|t| t.when_integrated.is_some()),
+        "every op is integrated by now: {:?}",
+        unbounded.timings
+    );
+    assert!(
+        unbounded.timings.iter().all(|t| t.validation_status
+            == Some(holochain_zome_types::prelude::OpValidity::Accepted)
+            && t.abandoned_at.is_none()),
+        "integrated ops are accepted and not abandoned: {:?}",
+        unbounded.timings
+    );
+    assert!(
+        unbounded
+            .timings
+            .iter()
+            .any(|t| t.locally_validated == Some(true)),
+        "authored ops are recorded as locally validated: {:?}",
+        unbounded.timings
+    );
+
+    // Ordered by (when_received, op_hash), ascending.
+    let keys: Vec<_> = unbounded
+        .timings
+        .iter()
+        .map(|t| (t.when_received, t.op_hash.clone()))
+        .collect();
+    let mut sorted = keys.clone();
+    sorted.sort();
+    assert_eq!(keys, sorted);
+
+    // Paging one at a time visits exactly the same ops, in the same order.
+    let mut paged = Vec::new();
+    let mut cursor: Option<OpTimingsCursor> = None;
+    loop {
+        let page = conductor
+            .raw_handle()
+            .dump_op_timings(cell_id.dna_hash(), cursor.clone(), Some(1))
+            .await
+            .unwrap();
+        assert!(page.timings.len() <= 1);
+        paged.extend(page.timings.iter().map(|t| t.op_hash.clone()));
+        cursor = page.cursor;
+        if cursor.is_none() {
+            break;
+        }
+    }
+    assert_eq!(
+        paged,
+        unbounded
+            .timings
+            .iter()
+            .map(|t| t.op_hash.clone())
+            .collect::<Vec<_>>()
+    );
+
+    // A zero limit is rejected rather than silently treated as unbounded.
+    assert!(conductor
+        .raw_handle()
+        .dump_op_timings(cell_id.dna_hash(), None, Some(0))
+        .await
+        .is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dump_op_timings_for_app_rejects_a_foreign_dna() {
+    let mut conductor = SweetConductor::standard().await;
+    let dna_file = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Crd])
+        .await
+        .0;
+    let other_dna_file = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Crd])
+        .await
+        .0;
+    let app = conductor.setup_app("app", &[dna_file]).await.unwrap();
+    let other_app = conductor
+        .setup_app("other", &[other_dna_file])
+        .await
+        .unwrap();
+    let dna_hash = app.cells()[0].cell_id().dna_hash().clone();
+    let other_dna_hash = other_app.cells()[0].cell_id().dna_hash().clone();
+    assert_ne!(dna_hash, other_dna_hash);
+
+    // A DNA the app runs is dumpable.
+    conductor
+        .raw_handle()
+        .dump_op_timings_for_app(&"app".to_string(), &dna_hash, None, None)
+        .await
+        .unwrap();
+
+    // A DNA only another app runs is not.
+    assert!(conductor
+        .raw_handle()
+        .dump_op_timings_for_app(&"app".to_string(), &other_dna_hash, None, None)
+        .await
+        .is_err());
 }

--- a/crates/holochain_conductor_api/src/admin_interface.rs
+++ b/crates/holochain_conductor_api/src/admin_interface.rs
@@ -1,5 +1,5 @@
 use crate::peer_meta::PeerMetaInfo;
-use crate::{AppInfo, FullStateDump, StorageInfo};
+use crate::{AppInfo, FullStateDump, OpTimingsDump, StorageInfo};
 use holo_hash::*;
 use holochain_types::prelude::*;
 use holochain_types::websocket::AllowedOrigins;
@@ -273,6 +273,36 @@ pub enum AdminRequest {
         limit: Option<u32>,
     },
 
+    /// Dump the lifecycle timings of the DHT ops held by this conductor for
+    /// the DNA specified by argument `dna_hash`.
+    ///
+    /// The DHT database is shared by every cell running the same DNA, so the
+    /// dump covers the whole DHT arc this conductor is currently holding for
+    /// that DNA, not the ops of any one agent running the DNA.
+    ///
+    /// Ops are returned oldest received first, across both validation limbos
+    /// and the integrated set, so a page can mix in-flight and integrated ops.
+    ///
+    /// The DHT op tables carry no index on received time, so each page is a
+    /// full scan and sort of the arc. Dumping a large arc is expensive;
+    /// always pass `limit` and page with the returned cursor.
+    ///
+    /// # Returns
+    ///
+    /// [`AdminResponse::OpTimingsDumped`]
+    DumpOpTimings {
+        /// The DNA whose DHT arc to dump op timings for
+        dna_hash: DnaHash,
+        /// Pagination cursor from a previous `DumpOpTimings`; only ops
+        /// ordered strictly after it are returned. `None` starts from the
+        /// beginning.
+        #[serde(default)]
+        cursor: Option<crate::state_dump::OpTimingsCursor>,
+        /// Maximum number of ops to return. Must be greater than zero.
+        #[serde(default)]
+        limit: Option<u32>,
+    },
+
     /// Dump the network metrics tracked by kitsune.
     ///
     /// # Returns
@@ -510,6 +540,11 @@ pub enum AdminResponse {
     /// Note that this result can be very big, as it's requesting the full database of the cell.
     FullStateDumped(FullStateDump),
 
+    /// The successful response to an [`AdminRequest::DumpOpTimings`].
+    ///
+    /// Contains one page of op timings plus the cursor to resume from.
+    OpTimingsDumped(OpTimingsDump),
+
     /// The successful response to an [`AdminRequest::DumpConductorState`].
     ///
     /// Simply a JSON serialized snapshot of `Conductor` and `ConductorState` from the `holochain` crate.
@@ -722,7 +757,7 @@ pub struct AppAuthenticationTokenIssued {
 
 #[cfg(test)]
 mod tests {
-    use crate::{AdminRequest, AdminResponse, DhtOpsCursor, ExternalApiWireError};
+    use crate::{AdminRequest, AdminResponse, DhtOpsCursor, ExternalApiWireError, OpTimingsCursor};
     use holo_hash::{AgentPubKey, DhtOpHash, DnaHash};
     use holochain_zome_types::cell::CellId;
     use serde::Deserialize;
@@ -822,5 +857,40 @@ mod tests {
 
         assert_eq!(value["when_received"], 42);
         assert!(value.get("when_integrated").is_none());
+    }
+
+    #[test]
+    fn dump_op_timings_request_defaults_omitted_pagination_fields() {
+        let dna_hash = DnaHash::from_raw_36(vec![1; 36]);
+
+        let request: AdminRequest = serde_json::from_value(serde_json::json!({
+            "type": "dump_op_timings",
+            "value": { "dna_hash": dna_hash }
+        }))
+        .unwrap();
+
+        assert!(matches!(
+            request,
+            AdminRequest::DumpOpTimings {
+                cursor: None,
+                limit: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn op_timings_cursor_round_trips() {
+        let cursor = OpTimingsCursor {
+            when_received: 42,
+            hash: DhtOpHash::from_raw_36(vec![3; 36]),
+        };
+        let value = serde_json::to_value(cursor.clone()).unwrap();
+
+        assert_eq!(value["when_received"], 42);
+        assert_eq!(
+            serde_json::from_value::<OpTimingsCursor>(value).unwrap(),
+            cursor
+        );
     }
 }

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -1,4 +1,5 @@
 use crate::peer_meta::PeerMetaInfo;
+use crate::state_dump::{OpTimingsCursor, OpTimingsDump};
 use crate::{AppAuthenticationToken, ExternalApiWireError};
 use holo_hash::AgentPubKey;
 use holochain_keystore::MetaLairClient;
@@ -193,6 +194,33 @@ pub enum AppRequest {
     /// [`AppResponse::CloneCellEnabled`]
     EnableCloneCell(Box<EnableCloneCellPayload>),
 
+    /// Dump the lifecycle timings of the DHT ops held by this conductor for
+    /// the DNA of one of this app's cells.
+    ///
+    /// Identical to [`AdminRequest::DumpOpTimings`](crate::admin_interface::AdminRequest::DumpOpTimings)
+    /// except that `dna_hash` must be the DNA of a cell of the app this
+    /// connection is authenticated for. As there, the DHT database is shared
+    /// by every cell running the same DNA, so the dump covers the whole DHT
+    /// arc this conductor is currently holding for that DNA, not the ops of
+    /// any one agent running the DNA.
+    ///
+    /// # Returns
+    ///
+    /// [`AppResponse::OpTimingsDumped`]
+    DumpOpTimings {
+        /// The DNA whose DHT arc to dump op timings for. This app must run a
+        /// cell of this DNA.
+        dna_hash: DnaHash,
+        /// Pagination cursor from a previous `DumpOpTimings`; only ops
+        /// ordered strictly after it are returned. `None` starts from the
+        /// beginning.
+        #[serde(default)]
+        cursor: Option<OpTimingsCursor>,
+        /// Maximum number of ops to return. Must be greater than zero.
+        #[serde(default)]
+        limit: Option<u32>,
+    },
+
     /// Retrieve network metrics for the current app.
     ///
     /// Identical to what [`AdminRequest::DumpNetworkMetrics`](crate::admin_interface::AdminRequest::DumpNetworkMetrics)
@@ -336,6 +364,9 @@ pub enum AppResponse {
     /// A previously disabled clone cell has been enabled. The [`ClonedCell`]
     /// is returned.
     CloneCellEnabled(ClonedCell),
+
+    /// The successful result of a call to [`AppRequest::DumpOpTimings`].
+    OpTimingsDumped(OpTimingsDump),
 
     /// The successful result of a call to [`AppRequest::DumpNetworkMetrics`].
     NetworkMetricsDumped(HashMap<DnaHash, Kitsune2NetworkMetrics>),
@@ -643,5 +674,27 @@ mod tests {
             serde_json::to_string(&status).unwrap(),
             "{\"type\":\"disabled\",\"value\":{\"type\":\"user\"}}",
         );
+    }
+
+    #[test]
+    fn dump_op_timings_request_defaults_omitted_pagination_fields() {
+        use holo_hash::DnaHash;
+
+        let dna_hash = DnaHash::from_raw_36(vec![1; 36]);
+
+        let request: AppRequest = serde_json::from_value(serde_json::json!({
+            "type": "dump_op_timings",
+            "value": { "dna_hash": dna_hash }
+        }))
+        .unwrap();
+
+        assert!(matches!(
+            request,
+            AppRequest::DumpOpTimings {
+                cursor: None,
+                limit: None,
+                ..
+            }
+        ));
     }
 }

--- a/crates/holochain_conductor_api/src/state_dump.rs
+++ b/crates/holochain_conductor_api/src/state_dump.rs
@@ -4,6 +4,7 @@ use holo_hash::DnaHash;
 pub use holochain_state_types::SourceChainCursor;
 use holochain_state_types::SourceChainDump;
 use holochain_types::op::DhtOp;
+use holochain_types::prelude::{OpValidity, Timestamp};
 use serde::Deserialize;
 use serde::Serialize;
 use std::sync::Arc;
@@ -69,7 +70,67 @@ pub struct FullIntegrationStateDump {
 /// `(when_received, hash)`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct DhtOpsCursor {
-    /// Microsecond receipt timestamp of the last op selected.
+    /// Microsecond received timestamp of the last op selected.
+    pub when_received: i64,
+    /// Hash of the last op selected (tie-breaks ops sharing a timestamp).
+    pub hash: DhtOpHash,
+}
+
+/// Lifecycle timings for one DHT op in the DHT arc this conductor is currently
+/// holding for a DNA.
+///
+/// The DHT database is shared by every cell running the same DNA, so a dump
+/// covers every op this conductor holds for that DNA rather than only the ops
+/// of one agent running the DNA.
+///
+/// Ops that are still in a validation limbo report `when_integrated: None`
+/// and `validation_status: None`. `locally_validated` is only recorded for
+/// integrated chain ops; it is `None` for limbo ops and for warrants. A
+/// `Some(false)` value means the op was inserted by the cache rather than
+/// validated by this node, which is why its integration time can equal its
+/// received time.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct OpTimingDump {
+    /// Hash of the DHT op these timings describe.
+    pub op_hash: DhtOpHash,
+    /// When the op was received by this conductor.
+    pub when_received: Timestamp,
+    /// When the op was integrated, or `None` while it is still in limbo.
+    pub when_integrated: Option<Timestamp>,
+    /// When validation of the op was abandoned, where recorded. An abandoned
+    /// op stays in limbo and will not integrate.
+    pub abandoned_at: Option<Timestamp>,
+    /// Whether the op was accepted or rejected, or `None` while validation
+    /// has not concluded.
+    pub validation_status: Option<OpValidity>,
+    /// Whether this node validated the op itself, where recorded.
+    pub locally_validated: Option<bool>,
+}
+
+/// One page of op timings for a DNA, ordered by `(when_received, op_hash)`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct OpTimingsDump {
+    /// Timings for the ops selected by this page, oldest received first.
+    pub timings: Vec<OpTimingDump>,
+    /// Cursor marking the last op selected by this page.
+    ///
+    /// Pass it to a subsequent `DumpOpTimings` request to resume strictly
+    /// after it. `None` when the page selected no ops.
+    pub cursor: Option<OpTimingsCursor>,
+}
+
+/// Exclusive pagination cursor for [`OpTimingsDump`].
+///
+/// `(when_received, hash)`. The hash breaks ties between ops that share a
+/// received timestamp, which is common because received times are stamped per
+/// batch of incoming ops rather than per op.
+///
+/// This duplicates the shape of [`DhtOpsCursor`] on purpose: the two dumps
+/// select different op sets and page through them independently, so their
+/// cursors are not interchangeable and must stay separate types.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct OpTimingsCursor {
+    /// Microsecond received timestamp of the last op selected.
     pub when_received: i64,
     /// Hash of the last op selected (tie-breaks ops sharing a timestamp).
     pub hash: DhtOpHash,

--- a/crates/holochain_data/src/dht/db_operations/sync_queries.rs
+++ b/crates/holochain_data/src/dht/db_operations/sync_queries.rs
@@ -5,7 +5,7 @@ use crate::handles::DbRead;
 use crate::kind::Dht;
 use crate::models::dht::{
     DumpChainOpRow, DumpOpPage, K2ChainOpForWireRow, K2OpHashRow, K2OpIdSinceRow, K2OpPresentRow,
-    K2WarrantForWireRow,
+    K2WarrantForWireRow, OpTimingsPage,
 };
 #[cfg(any(test, feature = "inspection"))]
 use holo_hash::AnyLinkableHash;
@@ -235,6 +235,20 @@ impl DbRead<Dht> {
         let page = sync_queries::dht_ops_page_for_dump(tx.conn_mut(), after, limit).await?;
         tx.close().await?;
         Ok(page)
+    }
+
+    /// One page of DHT-op lifecycle timings ordered by `(when_received, hash)`.
+    ///
+    /// Covers limbo and integrated chain ops and warrants, including
+    /// cache-inserted ops. `after` is exclusive; `None` starts at the
+    /// beginning and `None` for `limit` returns the full remaining set.
+    pub async fn op_timings_page(
+        &self,
+        after: Option<(i64, &DhtOpHash)>,
+        limit: Option<u32>,
+    ) -> sqlx::Result<OpTimingsPage> {
+        let mut conn = self.timed_conn().await?;
+        sync_queries::op_timings_page(&mut *conn, after, limit).await
     }
 
     /// Limbo chain-op rows for the integration dump. `ready` selects the

--- a/crates/holochain_data/src/dht/inner/sync_queries.rs
+++ b/crates/holochain_data/src/dht/inner/sync_queries.rs
@@ -39,6 +39,7 @@
 use crate::models::dht::{
     DumpChainOpRow, DumpOpCursorRow, DumpOpPage, DumpOpRow, DumpOpState, DumpOpWireRow,
     K2ChainOpForWireRow, K2OpHashRow, K2OpIdSinceRow, K2OpPresentRow, K2WarrantForWireRow,
+    OpTimingRow, OpTimingsPage,
 };
 #[cfg(any(test, feature = "inspection"))]
 use holo_hash::AnyLinkableHash;
@@ -655,6 +656,101 @@ pub(crate) async fn dht_ops_page_for_dump(
     Ok(DumpOpPage { rows, cursor })
 }
 
+/// Select one globally ordered page of DHT-op lifecycle timings.
+///
+/// Unions the two limbo tables with the two integrated tables so in-flight and
+/// integrated ops share one `(when_received, hash)` ordering and one limit.
+/// Unlike [`dht_ops_page_for_dump`] this does not filter out cache-inserted
+/// chain ops: `locally_validated = 0` is what explains an op whose integration
+/// time equals its received time.
+///
+/// One op hash can be present in an integrated table and in its limbo
+/// counterpart at the same time, so each pair carries a `NOT EXISTS` clause
+/// that suppresses the shadowed row and keeps the page at one row per op:
+///
+/// - `ChainOp` / `LimboChainOp`: the cascade mirrors ops into `ChainOp` with
+///   `locally_validated = 0` without deleting anything from limbo, and
+///   `op_exists` deliberately ignores those mirrored rows so the op is still
+///   delivered into the validation path. The limbo row is the truthful one
+///   there — the op is not integrated, its mirrored `when_integrated` is just
+///   the cache-write time — so the mirror is dropped. In the reverse case
+///   (`locally_validated = 1` alongside a limbo row, which promotion should
+///   have deleted) the integrated row is the truthful one and the limbo row is
+///   dropped instead.
+/// - `WarrantOp` / `LimboWarrantOp`: the cascade re-stages warrants that come
+///   back with a get response into limbo unconditionally, so an already
+///   integrated warrant can regain a limbo row. A `WarrantOp` row is only ever
+///   written by promotion, so it always wins and the limbo row is dropped.
+pub(crate) async fn op_timings_page<'e, E>(
+    executor: E,
+    after: Option<(i64, &DhtOpHash)>,
+    limit: Option<u32>,
+) -> sqlx::Result<OpTimingsPage>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    let mut qb: QueryBuilder<Sqlite> = QueryBuilder::new(
+        "SELECT hash, when_received, when_integrated, abandoned_at,
+                validation_status, locally_validated FROM (
+            SELECT hash, when_received, when_integrated,
+                   NULL AS abandoned_at, validation_status, locally_validated
+            FROM ChainOp
+            WHERE locally_validated = 1
+               OR NOT EXISTS (
+                   SELECT 1 FROM LimboChainOp
+                   WHERE LimboChainOp.hash = ChainOp.hash
+               )
+            UNION ALL
+            SELECT hash, when_received, when_integrated,
+                   NULL AS abandoned_at, validation_status,
+                   NULL AS locally_validated
+            FROM WarrantOp
+            UNION ALL
+            SELECT hash, when_received, NULL AS when_integrated, abandoned_at,
+                   NULL AS validation_status, NULL AS locally_validated
+            FROM LimboChainOp
+            WHERE NOT EXISTS (
+                SELECT 1 FROM ChainOp
+                WHERE ChainOp.hash = LimboChainOp.hash
+                  AND ChainOp.locally_validated = 1
+            )
+            UNION ALL
+            SELECT hash, when_received, NULL AS when_integrated, abandoned_at,
+                   NULL AS validation_status, NULL AS locally_validated
+            FROM LimboWarrantOp
+            WHERE NOT EXISTS (
+                SELECT 1 FROM WarrantOp
+                WHERE WarrantOp.hash = LimboWarrantOp.hash
+            )
+         ) WHERE 1 = 1",
+    );
+    if let Some((when_received, hash)) = after {
+        qb.push(" AND (when_received > ");
+        qb.push_bind(when_received);
+        qb.push(" OR (when_received = ");
+        qb.push_bind(when_received);
+        qb.push(" AND hash > ");
+        qb.push_bind(hash.get_raw_36());
+        qb.push("))");
+    }
+    qb.push(" ORDER BY when_received ASC, hash ASC");
+    if let Some(limit) = limit {
+        qb.push(" LIMIT ");
+        qb.push_bind(i64::from(limit));
+    }
+
+    let rows = qb
+        .build_query_as::<OpTimingRow>()
+        .fetch_all(executor)
+        .await?;
+    let cursor = rows.last().map(|row| DumpOpCursorRow {
+        when_received: row.when_received,
+        hash: DhtOpHash::from_raw_36(row.hash.clone()),
+    });
+
+    Ok(OpTimingsPage { rows, cursor })
+}
+
 fn dump_hashes(keys: &[DumpOpKeyRow], state: Option<i64>, kind: i64) -> Vec<Vec<u8>> {
     keys.iter()
         .filter(|key| key.kind == kind && state.is_none_or(|state| key.state == state))
@@ -1064,7 +1160,7 @@ where
 mod tests {
     use crate::handles::DbWrite;
     use crate::kind::Dht;
-    use crate::models::dht::{DumpOpCursorRow, DumpOpRow, DumpOpState, DumpOpWireRow};
+    use crate::models::dht::{DumpOpCursorRow, DumpOpRow, DumpOpState, DumpOpWireRow, OpTimingRow};
     use crate::test_open_db;
     use holo_hash::{AgentPubKey, DhtOpHash, DnaHash};
     use sqlx::{Pool, Sqlite};
@@ -1514,5 +1610,167 @@ mod tests {
             unbounded.cursor.unwrap().hash,
             DhtOpHash::from_raw_36(expected.last().unwrap().0.clone())
         );
+    }
+
+    #[tokio::test]
+    async fn op_timings_page_orders_and_pages_every_op_table() {
+        let db = test_open_db(dht_id()).await.unwrap();
+        // Two ops share when_received = 100 so the hash tie-break is exercised.
+        let integrated_chain = seed_op(db.pool(), 1, STORE_RECORD, 0, 100).await;
+        let integrated_warrant = seed_warrant_op(db.pool(), 2, 100, DumpOpState::Integrated).await;
+        let limbo_chain = seed_limbo_chain_op(db.pool(), 3, 200, false).await;
+        let limbo_warrant = seed_warrant_op(db.pool(), 4, 300, DumpOpState::ValidationLimbo).await;
+        let cache_only = seed_op(db.pool(), 5, STORE_RECORD, 0, 400).await;
+        sqlx::query("UPDATE ChainOp SET locally_validated = 0 WHERE hash = ?")
+            .bind(&cache_only)
+            .execute(db.pool())
+            .await
+            .unwrap();
+        let abandoned = seed_limbo_chain_op(db.pool(), 6, 500, false).await;
+        sqlx::query("UPDATE LimboChainOp SET abandoned_at = 550 WHERE hash = ?")
+            .bind(&abandoned)
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        let expected = vec![
+            integrated_chain,
+            integrated_warrant,
+            limbo_chain,
+            limbo_warrant,
+            cache_only.clone(),
+            abandoned.clone(),
+        ];
+
+        // Page through two at a time.
+        let mut actual: Vec<Vec<u8>> = Vec::new();
+        let mut cursor: Option<DumpOpCursorRow> = None;
+        loop {
+            let page = db
+                .as_ref()
+                .op_timings_page(
+                    cursor
+                        .as_ref()
+                        .map(|cursor| (cursor.when_received, &cursor.hash)),
+                    Some(2),
+                )
+                .await
+                .unwrap();
+            assert!(page.rows.len() <= 2);
+            actual.extend(page.rows.iter().map(|row| row.hash.clone()));
+            cursor = page.cursor;
+            if cursor.is_none() {
+                break;
+            }
+        }
+        assert_eq!(actual, expected);
+
+        // Unbounded read reports the per-state fields.
+        let unbounded = db.as_ref().op_timings_page(None, None).await.unwrap();
+        let by_hash = |hash: &[u8]| -> OpTimingRow {
+            unbounded
+                .rows
+                .iter()
+                .find(|row| row.hash == hash)
+                .expect("seeded op present")
+                .clone()
+        };
+
+        let integrated = by_hash(&expected[0]);
+        assert_eq!(integrated.when_received, 100);
+        assert_eq!(integrated.when_integrated, Some(100));
+        assert_eq!(integrated.abandoned_at, None);
+        assert_eq!(integrated.validation_status, Some(1));
+        assert_eq!(integrated.locally_validated, Some(1));
+
+        let warrant = by_hash(&expected[1]);
+        assert_eq!(warrant.when_integrated, Some(1_100));
+        assert_eq!(warrant.validation_status, Some(1));
+        assert_eq!(warrant.locally_validated, None);
+
+        let limbo = by_hash(&expected[2]);
+        assert_eq!(limbo.when_received, 200);
+        assert_eq!(limbo.when_integrated, None);
+        assert_eq!(limbo.abandoned_at, None);
+        assert_eq!(limbo.validation_status, None);
+        assert_eq!(limbo.locally_validated, None);
+
+        let cached = by_hash(&cache_only);
+        assert_eq!(cached.locally_validated, Some(0));
+        // A cache insert stamps `when_integrated` with the received time, which
+        // is exactly what `locally_validated = 0` explains.
+        assert_eq!(cached.when_integrated, Some(400));
+
+        let abandoned_row = by_hash(&abandoned);
+        assert_eq!(abandoned_row.when_received, 500);
+        assert_eq!(abandoned_row.when_integrated, None);
+        assert_eq!(abandoned_row.abandoned_at, Some(550));
+        assert_eq!(abandoned_row.validation_status, None);
+    }
+
+    /// One op hash can be present in an integrated table and its limbo
+    /// counterpart at the same time: the cascade mirrors an op into `ChainOp`
+    /// with `locally_validated = 0` while the same op sits in `LimboChainOp`,
+    /// and it re-stages an already integrated warrant into `LimboWarrantOp`.
+    /// Every such op must still be reported exactly once, by the row that
+    /// reflects its real lifecycle position.
+    #[tokio::test]
+    async fn op_timings_page_reports_a_shadowed_op_once() {
+        let db = test_open_db(dht_id()).await.unwrap();
+
+        // Cache mirror of an op that is also awaiting validation in limbo.
+        let cache_shadowed = seed_op(db.pool(), 1, STORE_RECORD, 0, 100).await;
+        sqlx::query("UPDATE ChainOp SET locally_validated = 0 WHERE hash = ?")
+            .bind(&cache_shadowed)
+            .execute(db.pool())
+            .await
+            .unwrap();
+        seed_limbo_chain_op(db.pool(), 1, 150, false).await;
+
+        // Integrated chain op with a stale limbo row still present.
+        let integrated_shadowed = seed_op(db.pool(), 2, STORE_RECORD, 0, 200).await;
+        seed_limbo_chain_op(db.pool(), 2, 250, false).await;
+
+        // Integrated warrant re-staged into limbo by a later cascade fetch.
+        let warrant_shadowed = seed_warrant_op(db.pool(), 3, 300, DumpOpState::Integrated).await;
+        sqlx::query(
+            "INSERT INTO LimboWarrantOp
+                (hash, storage_center_loc, sys_validation_status,
+                 when_received, serialized_size)
+             VALUES (?, 0, NULL, ?, 10)",
+        )
+        .bind(&warrant_shadowed)
+        .bind(350_i64)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let page = db.as_ref().op_timings_page(None, None).await.unwrap();
+        assert_eq!(page.rows.len(), 3, "each op hash must be reported once");
+        let by_hash = |hash: &[u8]| -> OpTimingRow {
+            page.rows
+                .iter()
+                .find(|row| row.hash == hash)
+                .expect("seeded op present")
+                .clone()
+        };
+
+        // The limbo row wins over a cache mirror: the op is not integrated yet.
+        let cached = by_hash(&cache_shadowed);
+        assert_eq!(cached.when_received, 150);
+        assert_eq!(cached.when_integrated, None);
+        assert_eq!(cached.locally_validated, None);
+
+        // The integrated row wins over a stale limbo row.
+        let integrated = by_hash(&integrated_shadowed);
+        assert_eq!(integrated.when_received, 200);
+        assert_eq!(integrated.when_integrated, Some(200));
+        assert_eq!(integrated.locally_validated, Some(1));
+
+        // The integrated warrant wins over its re-staged limbo row.
+        let warrant = by_hash(&warrant_shadowed);
+        assert_eq!(warrant.when_received, 300);
+        assert_eq!(warrant.when_integrated, Some(1_300));
+        assert_eq!(warrant.locally_validated, None);
     }
 }

--- a/crates/holochain_data/src/models/dht.rs
+++ b/crates/holochain_data/src/models/dht.rs
@@ -518,6 +518,40 @@ pub struct DumpOpPage {
     pub cursor: Option<DumpOpCursorRow>,
 }
 
+/// Lifecycle timings for one DHT op, selected for an op-timings dump page.
+///
+/// `when_integrated`, `validation_status` and `locally_validated` are `NULL`
+/// for ops still in a validation limbo, and `locally_validated` is always
+/// `NULL` for warrants, whose table has no such column. `abandoned_at` is only
+/// recorded on the limbo tables, so it is `NULL` for integrated ops.
+#[derive(Debug, Clone, sqlx::FromRow, PartialEq, Eq)]
+pub struct OpTimingRow {
+    /// DHT op hash.
+    pub hash: Vec<u8>,
+    /// Microsecond timestamp at which the op was received.
+    pub when_received: i64,
+    /// Microsecond timestamp at which the op was integrated, where recorded.
+    pub when_integrated: Option<i64>,
+    /// Microsecond timestamp at which validation of the op was abandoned,
+    /// where recorded. An abandoned op stays in limbo and will not integrate.
+    pub abandoned_at: Option<i64>,
+    /// `1` when the op was accepted, `2` when it was rejected, `NULL` while
+    /// validation has not concluded.
+    pub validation_status: Option<i64>,
+    /// `1` when this authority validated the op itself, `0` when it was
+    /// accepted from the cache, `NULL` when not recorded.
+    pub locally_validated: Option<i64>,
+}
+
+/// One globally ordered page of op timings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpTimingsPage {
+    /// Rows in global `(when_received, hash)` order.
+    pub rows: Vec<OpTimingRow>,
+    /// Last database key selected, or `None` when the page was empty.
+    pub cursor: Option<DumpOpCursorRow>,
+}
+
 /// `(slice_index, hash)` pair returned when enumerating slice hashes.
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq, Eq)]
 pub struct SliceHashIndexedRow {

--- a/crates/holochain_state/src/dht_store.rs
+++ b/crates/holochain_state/src/dht_store.rs
@@ -127,8 +127,9 @@ pub type DhtStoreRead = DhtStore<holochain_data::DbRead<Dht>>;
 // downstream crates (`holochain_p2p`) can consume them without depending
 // on `holochain_data` directly.
 pub use holochain_data::models::dht::{
-    DumpOpPage, DumpOpRow, DumpOpState, DumpOpWireRow, K2ChainOpForWireRow, K2OpHashRow,
-    K2OpIdSinceRow, K2OpPresentRow, K2WarrantForWireRow, SliceHashIndexedRow,
+    DumpOpCursorRow, DumpOpPage, DumpOpRow, DumpOpState, DumpOpWireRow, K2ChainOpForWireRow,
+    K2OpHashRow, K2OpIdSinceRow, K2OpPresentRow, K2WarrantForWireRow, OpTimingRow, OpTimingsPage,
+    SliceHashIndexedRow,
 };
 use holochain_zome_types::prelude::{Action, ActionData, OpValidity, SignedActionHashed};
 

--- a/crates/holochain_state/src/dht_store/sync_reads.rs
+++ b/crates/holochain_state/src/dht_store/sync_reads.rs
@@ -6,12 +6,15 @@
 //! `DhtStore<DbWrite<Dht>>` expose them; the slice-hash write needs
 //! `DbWrite`. All `sqlx::Error`s map into `StateQueryError`.
 
+use holochain_conductor_api::{OpTimingDump, OpTimingsCursor, OpTimingsDump};
 use holochain_data::kind::Dht;
+use holochain_data::models::dht::OpTimingRow;
 use holochain_data::DbWrite;
-use holochain_types::prelude::{AgentPubKey, DhtOpHash, Timestamp};
+use holochain_types::prelude::{AgentPubKey, DhtOpHash, OpValidity, Timestamp};
 
 use super::DhtStore;
 use crate::mutations::{StateMutationError, StateMutationResult};
+use crate::query::{StateQueryError, StateQueryResult};
 
 impl<Db> DhtStore<Db>
 where
@@ -177,6 +180,48 @@ where
             .map_err(crate::query::StateQueryError::Sqlx)
     }
 
+    /// One page of DHT-op lifecycle timings ordered by `(when_received, hash)`.
+    ///
+    /// `after` is exclusive, so passing the previous page's cursor resumes
+    /// strictly after it. `None` for `limit` returns the full remaining set.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `limit` is zero, the database query fails, or a
+    /// stored validation status is not a value this version can decode.
+    pub async fn op_timings_page_for_dump(
+        &self,
+        after: Option<&OpTimingsCursor>,
+        limit: Option<u32>,
+    ) -> StateQueryResult<OpTimingsDump> {
+        if limit == Some(0) {
+            return Err(StateQueryError::InvalidInput(
+                "dump limit must be greater than zero".to_string(),
+            ));
+        }
+        let page = self
+            .db
+            .as_ref()
+            .op_timings_page(
+                after.map(|cursor| (cursor.when_received, &cursor.hash)),
+                limit,
+            )
+            .await
+            .map_err(StateQueryError::Sqlx)?;
+
+        Ok(OpTimingsDump {
+            timings: page
+                .rows
+                .into_iter()
+                .map(op_timing_dump)
+                .collect::<StateQueryResult<Vec<_>>>()?,
+            cursor: page.cursor.map(|cursor| OpTimingsCursor {
+                when_received: cursor.when_received,
+                hash: cursor.hash,
+            }),
+        })
+    }
+
     /// Limbo chain-op rows for the integration dump. `ready` selects the
     /// integration-limbo subset; `!ready` selects the validation-limbo subset.
     pub async fn limbo_chain_ops_for_dump(
@@ -271,6 +316,29 @@ where
             .await
             .map_err(crate::query::StateQueryError::Sqlx)
     }
+}
+
+/// Decode one raw op-timings row into its typed dump form.
+///
+/// # Errors
+///
+/// Returns an error if the row's `validation_status` is not a value this
+/// version can decode.
+fn op_timing_dump(row: OpTimingRow) -> StateQueryResult<OpTimingDump> {
+    Ok(OpTimingDump {
+        op_hash: DhtOpHash::from_raw_36(row.hash),
+        when_received: Timestamp::from_micros(row.when_received),
+        when_integrated: row.when_integrated.map(Timestamp::from_micros),
+        abandoned_at: row.abandoned_at.map(Timestamp::from_micros),
+        validation_status: row
+            .validation_status
+            .map(OpValidity::try_from)
+            .transpose()
+            .map_err(|status| {
+                StateQueryError::Other(format!("invalid stored validation status {status}"))
+            })?,
+        locally_validated: row.locally_validated.map(|flag| flag != 0),
+    })
 }
 
 impl DhtStore<DbWrite<Dht>> {

--- a/crates/holochain_state/src/dht_store/tests.rs
+++ b/crates/holochain_state/src/dht_store/tests.rs
@@ -2731,6 +2731,32 @@ async fn authority_updates_for_entry_returns_integrated_updates() {
     assert_eq!(updates[0].1, ValidationStatus::Valid);
 }
 
+#[tokio::test]
+async fn op_timings_page_rejects_zero_limit() {
+    let store = DhtStore::new_test(dht_id()).await.unwrap();
+
+    let err = store
+        .op_timings_page_for_dump(None, Some(0))
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(err, crate::query::StateQueryError::InvalidInput(ref msg)
+            if msg == "dump limit must be greater than zero"),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn op_timings_page_is_empty_for_a_fresh_store() {
+    let store = DhtStore::new_test(dht_id()).await.unwrap();
+
+    let page = store.op_timings_page_for_dump(None, None).await.unwrap();
+
+    assert!(page.timings.is_empty());
+    assert!(page.cursor.is_none());
+}
+
 /// Direct coverage of the publish-queue query (`get_ops_to_publish` /
 /// `num_still_needing_publish`) against the `DhtStore`. The publish *workflow*
 /// that consumes this query is tested in the `publish_dht_ops_workflow` unit


### PR DESCRIPTION
## What changed

This adds a new admin and app API call, DumpOpTimings, that reports timing information for the data (called DHT ops) a conductor holds for a given cell's DNA. For each op it reports when it was received, when it finished being processed (integrated), and whether this node validated it itself. Results come back a page at a time, ordered by receipt time, so large amounts of data can be fetched without overloading the caller. A matching `hc client dump-op-timings` command is also added so this can be used from the command line.

## Why

This gives operators and developers visibility into how quickly data is being processed on a conductor, which is useful for diagnosing performance issues and understanding the health of an app's DHT participation. Closes #5772.

## Notes

The data returned is shared across every cell running the same DNA. Only the DNA part of the cell identifier is used to select the data, so the results are not limited to a single agent's data.