### PR TITLE
test: stabilize the multi_conductor publish test

### DIFF
--- a/crates/holochain/tests/tests/multi_conductor/mod.rs
+++ b/crates/holochain/tests/tests/multi_conductor/mod.rs
@@ -13,19 +13,22 @@ struct AppString(String);
 /// even with gossip disabled.
 #[cfg(feature = "test_utils")]
 #[tokio::test(flavor = "multi_thread")]
-async fn test_publish() {
+async fn publish() {
     use holochain::{retry_until_timeout, test_utils::inline_zomes::simple_create_read_zome};
-    use holochain_conductor_api::conductor::{ConductorConfig, NetworkConfig};
 
     holochain_trace::test_run();
 
-    let config = ConductorConfig {
-        network: NetworkConfig {
-            disable_gossip: true,
-            ..Default::default()
-        },
-        ..Default::default()
-    };
+    let config = SweetConductorConfig::rendezvous(true)
+        .tune_network_config(|nc| {
+            nc.disable_gossip = true;
+        })
+        .tune_conductor(|tune| {
+            // Publishing an op is a best-effort notification. Keep the
+            // publish loop and the per-op publish cooldown short so that a
+            // missed notification is retried within this test's timeout.
+            tune.publish_trigger_interval = Some(std::time::Duration::from_millis(500));
+            tune.min_publish_interval = Some(std::time::Duration::from_millis(500));
+        });
 
     let mut conductors = SweetConductorBatch::from_config_rendezvous(2, config).await;
     let dna_file = SweetDnaFile::unique_from_inline_zomes(("simple", simple_create_read_zome()))


### PR DESCRIPTION
Closes #5902.

The test built a bare `ConductorConfig`, which `apply_rendezvous` leaves untouched because it only rewrites URLs equal to `"rendezvous:"`. It was therefore running against the public bootstrap server and the public n0 relay rather than the in-process rendezvous server.

It also kept the default publish tuning, where an op is not republished for five minutes. Publishing is a best-effort notification, so the single publish following the create call had to land first time or the test could never pass, whatever its timeout — which matches the observed failure: Bob's op count frozen with nothing pending validation.

Builds the config from `SweetConductorConfig::rendezvous` and shortens the publish trigger and minimum publish interval so a missed notification is retried inside the test's timeout. Locally: 6 failures in 20 runs before, 0 in 40 after.

Also drops the `test_` prefix from the name, per the project convention.