### PR TITLE
feat: do not record a publish that reached no peers

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Ops authored while no peer is reachable are no longer recorded as published. Previously a publish that reached nobody, such as one attempted before peer discovery had found anyone, was treated as successful and the ops were not offered to the network again for the minimum publish interval (5 minutes by default). Such ops are now published as soon as the publish workflow next runs with a peer available. [\#5919](https://github.com/holochain/holochain/issues/5919)
+
 ## 0.7.0-rc.5
 
 - Add `DumpOpTimings` to the admin and app APIs, plus a matching `hc client dump-op-timings` command. It reports, for each DHT op the conductor holds for a DNA, when the op was received, when it was integrated or when its validation was abandoned, whether it was accepted or rejected, and whether this node validated it locally. The request takes a DNA hash: the DHT database is shared by every cell running the same DNA, so the dump covers the whole DHT arc this conductor is currently holding for that DNA rather than the ops of any one agent. On the app API the DNA must be one the calling app runs. Results are paginated with an exclusive cursor over received time and op hash, covering both in-flight and integrated ops. [\#5772](https://github.com/holochain/holochain/issues/5772)

--- a/crates/holochain/src/conductor/conductor/tests/state_dump.rs
+++ b/crates/holochain/src/conductor/conductor/tests/state_dump.rs
@@ -4,7 +4,9 @@ use crate::{
         full_integration_dump,
     },
     retry_until_timeout,
-    sweettest::{SweetConductor, SweetDnaFile, SweetZome},
+    sweettest::{
+        SweetConductor, SweetConductorConfig, SweetDnaFile, SweetLocalRendezvous, SweetZome,
+    },
 };
 use holo_hash::{ActionHash, DhtOpHash, HasHash};
 use holochain_conductor_api::{FullIntegrationStateDump, FullStateDump, OpTimingsCursor};
@@ -17,7 +19,7 @@ use holochain_zome_types::prelude::{
     AgentPubKey, ChainIntegrityWarrant, ChainOpType, Signature, SignedWarrant, Timestamp, Warrant,
     WarrantProof,
 };
-use std::{collections::HashSet, time::Duration};
+use std::collections::HashSet;
 
 fn test_warrant(seed: u8) -> DhtOpHashed {
     let warrant = SignedWarrant::new(
@@ -53,7 +55,13 @@ fn dump_op_hashes(dump: &FullIntegrationStateDump) -> Vec<DhtOpHash> {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn dump_full_state() {
-    let mut conductor = SweetConductor::standard().await;
+    // The publish workflow raises `published_ops_count` in the background as it
+    // records publish times, which would race the expected and actual dumps
+    // built a moment apart below. Publishing is not under test here.
+    let config =
+        SweetConductorConfig::rendezvous(true).tune_network_config(|nc| nc.disable_publish = true);
+    let mut conductor =
+        SweetConductor::from_config_rendezvous(config, SweetLocalRendezvous::new().await).await;
     let dna_file = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Crd])
         .await
         .0;
@@ -78,25 +86,6 @@ async fn dump_full_state() {
     });
 
     let dht_store = conductor.get_dht_store(cell_id.dna_hash()).unwrap();
-
-    // Wait for publishing to quiesce so the two dumps below observe the same
-    // `published_ops_count`. The publish workflow runs in the background and
-    // raises that count as it records publish times, so building the expected
-    // and actual dumps a moment apart would otherwise race it. With a recency
-    // window wide enough to exclude anything published during the test, an op
-    // only remains in `get_ops_to_publish` until it has been published at least
-    // once; an empty result therefore means every publishable op has a recorded
-    // publish time and the count is stable.
-    retry_until_timeout!(30_000, 100, {
-        let pending = dht_store
-            .as_read()
-            .get_ops_to_publish(cell_id.agent_pubkey(), Duration::from_secs(60 * 60))
-            .await
-            .unwrap();
-        if pending.is_empty() {
-            break;
-        }
-    });
 
     let peer_dump = peer_store_dump(&conductor, cell_id).await.unwrap();
     let source_chain_dump =

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow.rs
@@ -54,6 +54,12 @@ pub async fn publish_dht_ops_workflow(
             .publish(basis, agent.clone(), op_hash_list.clone(), None)
             .await
         {
+            // Nothing was sent, so the ops are left unrecorded and stay queued
+            // for a later run of this workflow. Having no peers is expected
+            // while offline, so it is not reported as a failure.
+            Err(holochain_p2p::HolochainP2pError::NoPeersForLocation(_, loc)) => {
+                debug!(?loc, "No peers to publish to");
+            }
             Err(e) => {
                 // If we get a routing error it means the space hasn't started yet and we should try publishing again.
                 if let holochain_p2p::HolochainP2pError::RoutingDnaError(_) = e {

--- a/crates/holochain/src/core/workflow/publish_dht_ops_workflow/unit_tests.rs
+++ b/crates/holochain/src/core/workflow/publish_dht_ops_workflow/unit_tests.rs
@@ -120,6 +120,45 @@ async fn workflow_handles_publish_errors() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn no_publish_time_recorded_without_peers() {
+    holochain_trace::test_run();
+
+    let dht_store = test_dht_store(fixt!(DnaHash)).await;
+
+    let agent = fixt!(AgentPubKey);
+
+    let op_hash = create_op(&dht_store, agent.clone()).await.unwrap();
+
+    let mut network = MockHolochainP2pDnaT::new();
+    network.expect_publish().return_once(|_, _, _, _| {
+        Err(holochain_p2p::HolochainP2pError::NoPeersForLocation(
+            "publish".to_string(),
+            0,
+        ))
+    });
+
+    let (tx, rx) =
+        TriggerSender::new_with_loop(Duration::from_secs(5)..Duration::from_secs(30), true);
+
+    let work_complete = publish_dht_ops_workflow(
+        dht_store.clone(),
+        Arc::new(network),
+        tx,
+        agent,
+        ConductorTuningParams::default().min_publish_interval(),
+    )
+    .await
+    .unwrap();
+
+    let publish_timestamp = get_publish_time(&dht_store, op_hash).await;
+
+    assert_eq!(WorkComplete::Complete, work_complete);
+    // The op stays queued so a later run can publish it once peers are known.
+    assert!(!rx.is_paused());
+    assert!(publish_timestamp.is_none());
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn retry_publish_until_receipts_received() {
     holochain_trace::test_run();
 

--- a/crates/holochain_p2p/src/spawn/actor.rs
+++ b/crates/holochain_p2p/src/spawn/actor.rs
@@ -1990,6 +1990,15 @@ impl actor::HcP2p for HolochainP2pActor {
             })
             .collect();
 
+            // Report reaching nobody as an error so the caller does not treat
+            // these ops as published.
+            if urls.is_empty() {
+                return Err(HolochainP2pError::NoPeersForLocation(
+                    String::from("publish"),
+                    basis_hash.get_loc(),
+                ));
+            }
+
             for url in urls {
                 space
                     .publish()

--- a/crates/holochain_p2p/tests/tests/node_messaging.rs
+++ b/crates/holochain_p2p/tests/tests/node_messaging.rs
@@ -463,18 +463,25 @@ async fn test_publish() {
         loop {
             tokio::time::sleep(WAIT_BETWEEN_CALLS).await;
 
-            hc2.publish(
-                dna_hash.clone(),
-                HoloHash::from_raw_36_and_type(
-                    op_hash.get_raw_36().to_vec(),
-                    holo_hash::hash_type::AnyLinkable::Action,
-                ),
-                AgentPubKey::from_raw_32(vec![2; 32]),
-                vec![op_hash.clone()],
-                None,
-            )
-            .await
-            .unwrap();
+            match hc2
+                .publish(
+                    dna_hash.clone(),
+                    HoloHash::from_raw_36_and_type(
+                        op_hash.get_raw_36().to_vec(),
+                        holo_hash::hash_type::AnyLinkable::Action,
+                    ),
+                    AgentPubKey::from_raw_32(vec![2; 32]),
+                    vec![op_hash.clone()],
+                    None,
+                )
+                .await
+            {
+                Ok(()) => (),
+                // Peer discovery may not have reached this node yet, leaving
+                // nobody to publish to. Keep waiting.
+                Err(HolochainP2pError::NoPeersForLocation(_, _)) => continue,
+                Err(err) => panic!("publish failed: {err:?}"),
+            }
 
             if let Some(res) = handler.calls.lock().unwrap().first() {
                 assert_eq!("publish", res);


### PR DESCRIPTION
Closes #5919.

**Draft — not finished.** The full workspace suite has not been run against this branch. `make static-all` and the targeted publish-workflow, `state_dump` and `holochain_p2p` tests were green before the rebase; everything since is unverified beyond `cargo check`.

`HolochainP2pDna::publish` returned `Ok(())` when it found no peers to publish to, and the publish workflow recorded a publish time for those ops. `get_ops_to_publish` then skipped them until the minimum publish interval elapsed — five minutes by default — even though nothing had been sent. A node that authored data while it had no peers therefore did not offer that data to the network for five minutes after peers appeared, which cuts against the offline-friendly goal in `CLAUDE.md`.

This reports an empty target set as `NoPeersForLocation`, matching how `get` already reports it, and leaves the ops queued for the next run of the workflow. Having no peers is expected while offline, so it is logged at debug rather than treated as a failure.

Two tests depended on the old behaviour:

- `dump_full_state` waited for the publish queue to drain on a conductor with no peers, which no longer happens; it disables publishing instead.
- The `holochain_p2p` publish test could send its first publish before peer discovery completed, so it retries on that error rather than unwrapping.

Note this does not make the transport reliable. K2's `CorePublish::publish_ops` only queues the message and a later send failure is a warning, so `Ok(())` still does not prove delivery. This only fixes the case where Holochain itself knows nothing was sent.

To finish: run the full workspace suite, then mark ready.