### PR TITLE
feat: report why a referenced cell is not running

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- **BREAKING CHANGE**: Errors for zome calls against a cell that is not running now state why. `ConductorError::CellDisabled` is replaced by `ConductorError::CellNotRunning(cell_id, reason)`, where the reason distinguishes an app that is disabled, awaiting membrane proofs, restoring its source chains, or permanently unrecoverable, from a disabled clone cell or a cell that has not finished starting.
+
 ## 0.8.0-dev.2
 
 - Add the source-chain restore workflow and allow installing an app with `InstallAppPayload::restore_from_dht: true`. Doing so skips genesis and reconstructs each cell’s chain from the DHT instead, letting an existing agent key resume authoring on a new node. The app sits in `AppStatus::AwaitingRestore` until every cell restores, then requires `enable_app` like a normal install. A validated `ChainIntegrityWarrant` against the agent moves the app to the terminal `AppStatus::Unrecoverable(cell_id, reason)` instead. There is no repair path if an app is marked as `AppStatus::Unrecoverable`, it can only be uninstalled. See `docs/design/source_chain_restore.md`. \#5800

--- a/crates/holochain/src/conductor/cell/error.rs
+++ b/crates/holochain/src/conductor/cell/error.rs
@@ -25,8 +25,6 @@ pub enum CellError {
     ActionError(#[from] ActionError),
     #[error("This cell has not had a successful genesis and cannot be created")]
     CellWithoutGenesis(CellId),
-    #[error("The cell with id {0} is disabled.")]
-    CellDisabled(CellId),
     #[error("Authentication failure. Bad signature {0:?} by provenance {1}.")]
     ZomeCallAuthenticationFailed(Signature, AgentPubKey),
     #[error(

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -38,7 +38,7 @@ use super::api::AppInterfaceApi;
 use super::config::AdminInterfaceConfig;
 use super::config::InterfaceDriver;
 use super::entry_def_store::get_entry_defs;
-use super::error::ConductorError;
+use super::error::{CellUnavailableReason, ConductorError};
 use super::interface::error::InterfaceResult;
 use super::interface::websocket::spawn_admin_interface_tasks;
 use super::interface::websocket::spawn_app_interface_task;
@@ -1943,25 +1943,45 @@ mod restore_impls {
 mod cell_impls {
     use super::*;
 
+    /// Classifies why a cell belonging to `app` is registered but not running.
+    fn cell_unavailable_reason(app: &InstalledApp, cell_id: &CellId) -> CellUnavailableReason {
+        match &app.status {
+            AppStatus::Disabled(reason) => CellUnavailableReason::AppDisabled(reason.clone()),
+            AppStatus::AwaitingMemproofs => CellUnavailableReason::AppAwaitingMemproofs,
+            AppStatus::AwaitingRestore => CellUnavailableReason::AppAwaitingRestore,
+            AppStatus::Unrecoverable(_, reason) => {
+                CellUnavailableReason::AppUnrecoverable(reason.clone())
+            }
+            // The app runs its cells, so the cell is either a disabled clone or still starting.
+            AppStatus::Enabled => {
+                if app.disabled_clone_cell_ids().any(|id| id == *cell_id) {
+                    CellUnavailableReason::CloneCellDisabled
+                } else {
+                    CellUnavailableReason::NotStarted
+                }
+            }
+        }
+    }
+
     impl Conductor {
         pub(crate) async fn cell_by_id(&self, cell_id: &CellId) -> ConductorResult<Arc<Cell>> {
             // Can only get a cell from the running_cells list
             if let Some(cell) = self.running_cells.share_ref(|c| c.get(cell_id).cloned()) {
                 Ok(cell)
             } else {
-                // If not in running_cells list, check if the cell id is registered at all,
-                // to give a different error message for disabled vs missing.
-                let present = self
-                    .get_state()
-                    .await?
+                // If not in running_cells list, find the app that owns the cell so the caller
+                // learns why it isn't callable, or that it isn't registered at all.
+                let state = self.get_state().await?;
+                let owning_app = state
                     .installed_apps()
                     .values()
-                    .flat_map(|app| app.all_cells())
-                    .any(|id| id == *cell_id);
-                if present {
-                    Err(ConductorError::CellDisabled(cell_id.clone()))
-                } else {
-                    Err(ConductorError::CellMissing(cell_id.clone()))
+                    .find(|app| app.all_cells().any(|id| id == *cell_id));
+                match owning_app {
+                    Some(app) => Err(ConductorError::CellNotRunning(
+                        cell_id.clone(),
+                        cell_unavailable_reason(app, cell_id),
+                    )),
+                    None => Err(ConductorError::CellMissing(cell_id.clone())),
                 }
             }
         }
@@ -2044,6 +2064,126 @@ mod cell_impls {
                     }
                 })
                 .collect())
+        }
+    }
+
+    #[cfg(test)]
+    mod cell_unavailable_reason_tests {
+        use super::*;
+        use ::fixt::prelude::*;
+        use holo_hash::fixt::{AgentPubKeyFixturator, DnaHashFixturator};
+
+        /// Builds an app with one provisioned cell and one disabled clone, returning both cell IDs.
+        fn app_with_status(status: AppStatus) -> (InstalledApp, CellId, CellId) {
+            let agent = fixt!(AgentPubKey);
+            let base_dna_hash = fixt!(DnaHash);
+            let clone_dna_hash = fixt!(DnaHash);
+            let role_name: RoleName = "role".into();
+
+            let manifest = AppManifestCurrentBuilder::default()
+                .name("test".into())
+                .description(None)
+                .roles(vec![AppRoleManifest {
+                    name: role_name.clone(),
+                    dna: AppRoleDnaManifest {
+                        path: None,
+                        modifiers: DnaModifiersOpt::none(),
+                        installed_hash: Some(base_dna_hash.clone().into()),
+                        clone_limit: 1,
+                    },
+                    provisioning: Some(CellProvisioning::Create { deferred: false }),
+                }])
+                .allow_deferred_memproofs(false)
+                .build()
+                .unwrap()
+                .into();
+
+            let mut primary = AppRolePrimary::new(base_dna_hash.clone(), true, 1);
+            primary
+                .disabled_clones
+                .insert(CloneId::new(&role_name, 0), clone_dna_hash.clone());
+
+            let app = InstalledApp::new(
+                InstalledAppCommon::new(
+                    "app".to_string(),
+                    agent.clone(),
+                    [(role_name, AppRoleAssignment::Primary(primary))],
+                    manifest,
+                    Timestamp::now(),
+                )
+                .unwrap(),
+                status,
+            );
+
+            (
+                app,
+                CellId::new(base_dna_hash, agent.clone()),
+                CellId::new(clone_dna_hash, agent),
+            )
+        }
+
+        #[test]
+        fn disabled_app_reports_the_disabled_reason() {
+            let (app, cell_id, _) =
+                app_with_status(AppStatus::Disabled(DisabledAppReason::NeverStarted));
+            assert_eq!(
+                cell_unavailable_reason(&app, &cell_id),
+                CellUnavailableReason::AppDisabled(DisabledAppReason::NeverStarted)
+            );
+        }
+
+        #[test]
+        fn app_awaiting_memproofs_is_distinguished() {
+            let (app, cell_id, _) = app_with_status(AppStatus::AwaitingMemproofs);
+            assert_eq!(
+                cell_unavailable_reason(&app, &cell_id),
+                CellUnavailableReason::AppAwaitingMemproofs
+            );
+        }
+
+        #[test]
+        fn app_awaiting_restore_is_distinguished() {
+            let (app, cell_id, _) = app_with_status(AppStatus::AwaitingRestore);
+            assert_eq!(
+                cell_unavailable_reason(&app, &cell_id),
+                CellUnavailableReason::AppAwaitingRestore
+            );
+        }
+
+        #[test]
+        fn unrecoverable_app_carries_the_failure_reason() {
+            let summary = WarrantSummary {
+                author: fixt!(AgentPubKey),
+                warrantee: fixt!(AgentPubKey),
+                timestamp: Timestamp::from_micros(1_000_000),
+            };
+            let reason = UnrecoverableCellReason::ChainForkWarrant(Box::new(summary));
+            let (app, cell_id, _) = app_with_status(AppStatus::Unrecoverable(
+                CellId::new(fixt!(DnaHash), fixt!(AgentPubKey)),
+                reason.clone(),
+            ));
+            assert_eq!(
+                cell_unavailable_reason(&app, &cell_id),
+                CellUnavailableReason::AppUnrecoverable(reason)
+            );
+        }
+
+        #[test]
+        fn disabled_clone_of_an_enabled_app_is_not_reported_as_an_app_problem() {
+            let (app, _, clone_cell_id) = app_with_status(AppStatus::Enabled);
+            assert_eq!(
+                cell_unavailable_reason(&app, &clone_cell_id),
+                CellUnavailableReason::CloneCellDisabled
+            );
+        }
+
+        #[test]
+        fn enabled_app_with_a_cell_yet_to_start_reports_not_started() {
+            let (app, cell_id, _) = app_with_status(AppStatus::Enabled);
+            assert_eq!(
+                cell_unavailable_reason(&app, &cell_id),
+                CellUnavailableReason::NotStarted
+            );
         }
     }
 }

--- a/crates/holochain/src/conductor/conductor/tests.rs
+++ b/crates/holochain/src/conductor/conductor/tests.rs
@@ -521,13 +521,12 @@ async fn test_deferred_memproof_provisioning() {
 
     let cell = conductor.get_sweet_cell(cell_id.clone()).unwrap();
 
-    //- Can't make zome calls, error returned is CellDisabled
-    //  (which isn't ideal, but gets the message across well enough)
+    //- Can't make zome calls while the app is awaiting its memproofs
     let result: Result<String, _> = conductor.call_fallible(&cell.zome("foo"), "foo", ()).await;
     assert_matches!(
         result,
         Err(ConductorApiError::ConductorError(
-            ConductorError::CellDisabled(_)
+            ConductorError::CellNotRunning(_, CellUnavailableReason::AppAwaitingMemproofs)
         ))
     );
 

--- a/crates/holochain/src/conductor/conductor/tests/app_state.rs
+++ b/crates/holochain/src/conductor/conductor/tests/app_state.rs
@@ -7,7 +7,7 @@ use crate::{
             },
             ConductorApiError,
         },
-        error::ConductorError,
+        error::{CellUnavailableReason, ConductorError},
         ribosome_store::RibosomeStore,
         space::Spaces,
         Conductor,
@@ -447,7 +447,7 @@ async fn disabled_clone_cell_cannot_be_called() {
     assert!(matches!(
         result,
         Err(ConductorApiError::ConductorError(
-            ConductorError::CellDisabled(_)
+            ConductorError::CellNotRunning(_, CellUnavailableReason::CloneCellDisabled)
         ))
     ));
 
@@ -465,7 +465,7 @@ async fn disabled_clone_cell_cannot_be_called() {
     assert!(matches!(
         result,
         Err(ConductorApiError::ConductorError(
-            ConductorError::CellDisabled(_)
+            ConductorError::CellNotRunning(_, CellUnavailableReason::CloneCellDisabled)
         ))
     ));
 

--- a/crates/holochain/src/conductor/error.rs
+++ b/crates/holochain/src/conductor/error.rs
@@ -13,6 +13,38 @@ use thiserror::Error;
 /// Custom result type for conductor errors with [`ConductorError`] as the error type.
 pub type ConductorResult<T> = Result<T, ConductorError>;
 
+/// Why a referenced cell is not currently running.
+///
+/// A cell can be registered in the conductor's state without being callable,
+/// either because the app that owns it is not in a state that runs cells, or
+/// because the cell itself is disabled or has not finished starting.
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum CellUnavailableReason {
+    /// The app that owns the cell is disabled.
+    #[error("the app is disabled: {0:?}")]
+    AppDisabled(DisabledAppReason),
+
+    /// The app that owns the cell is still awaiting its membrane proofs.
+    #[error("the app is awaiting membrane proofs")]
+    AppAwaitingMemproofs,
+
+    /// The app that owns the cell is restoring its source chains from the DHT.
+    #[error("the app is restoring its source chains from the DHT")]
+    AppAwaitingRestore,
+
+    /// The app that owns the cell failed to restore a source chain and cannot be enabled.
+    #[error("the app's source chain restore failed permanently: {0:?}")]
+    AppUnrecoverable(UnrecoverableCellReason),
+
+    /// The cell is a clone cell which has been disabled.
+    #[error("the clone cell is disabled")]
+    CloneCellDisabled,
+
+    /// The app that owns the cell is enabled but the cell has not finished starting.
+    #[error("the cell has not finished starting")]
+    NotStarted,
+}
+
 #[allow(missing_docs)]
 #[derive(Error, Debug)]
 pub enum ConductorError {
@@ -34,8 +66,8 @@ pub enum ConductorError {
     #[error("Cell already exists. CellId: {0:?}")]
     CellAlreadyExists(CellId),
 
-    #[error("Cell was referenced, but is currently disabled. CellId: {0:?}")]
-    CellDisabled(CellId),
+    #[error("Cell was referenced, but is not running. CellId: {0:?} Reason: {1}")]
+    CellNotRunning(CellId, CellUnavailableReason),
 
     #[error("Cell was referenced, but is missing from the conductor. CellId: {0:?}")]
     CellMissing(CellId),

--- a/crates/holochain/src/conductor/tests/cell_cloning.rs
+++ b/crates/holochain/src/conductor/tests/cell_cloning.rs
@@ -1,5 +1,8 @@
 use crate::{
-    conductor::{api::error::ConductorApiError, error::ConductorError, CellError},
+    conductor::{
+        api::error::ConductorApiError,
+        error::{CellUnavailableReason, ConductorError},
+    },
     sweettest::*,
 };
 use holo_hash::ActionHash;
@@ -419,7 +422,16 @@ async fn conductor_can_startup_with_cloned_cell() {
     let zome_call_response: Result<ActionHash, _> = conductor
         .call_fallible(&zome, "call_create_entry", ())
         .await;
-    matches!(zome_call_response, Err(ConductorApiError::CellError(CellError::CellDisabled(cell_id))) if cell_id == clone_cell.cell_id.clone());
+    assert!(
+        matches!(
+            &zome_call_response,
+            Err(ConductorApiError::ConductorError(ConductorError::CellNotRunning(
+                cell_id,
+                CellUnavailableReason::CloneCellDisabled
+            ))) if *cell_id == clone_cell.cell_id
+        ),
+        "expected CloneCellDisabled, got: {zome_call_response:?}"
+    );
 
     conductor.shutdown().await;
     conductor.startup(false).await;
@@ -432,5 +444,14 @@ async fn conductor_can_startup_with_cloned_cell() {
     let zome_call_response: Result<ActionHash, _> = conductor
         .call_fallible(&zome, "call_create_entry", ())
         .await;
-    matches!(zome_call_response, Err(ConductorApiError::CellError(CellError::CellDisabled(cell_id))) if cell_id == clone_cell.cell_id.clone());
+    assert!(
+        matches!(
+            &zome_call_response,
+            Err(ConductorApiError::ConductorError(ConductorError::CellNotRunning(
+                cell_id,
+                CellUnavailableReason::CloneCellDisabled
+            ))) if *cell_id == clone_cell.cell_id
+        ),
+        "expected CloneCellDisabled after restart, got: {zome_call_response:?}"
+    );
 }

--- a/crates/holochain/src/core/ribosome/guest_callback/init.rs
+++ b/crates/holochain/src/core/ribosome/guest_callback/init.rs
@@ -442,7 +442,12 @@ mod slow_tests {
 
             match create_post_result {
                 Err(crate::conductor::api::error::ConductorApiError::ConductorError(
-                    crate::conductor::error::ConductorError::CellDisabled(_),
+                    crate::conductor::error::ConductorError::CellNotRunning(
+                        _,
+                        // Which of the two is seen depends on where the enable race lands.
+                        crate::conductor::error::CellUnavailableReason::CloneCellDisabled
+                        | crate::conductor::error::CellUnavailableReason::NotStarted,
+                    ),
                 )) => {
                     // Expected errors
                 }

--- a/crates/holochain/tests/tests/restore.rs
+++ b/crates/holochain/tests/tests/restore.rs
@@ -3,7 +3,7 @@
 use holo_hash::ActionHash;
 use holochain::conductor::api::error::ConductorApiError;
 use holochain::conductor::conductor::InstallAppCommonFlags;
-use holochain::conductor::error::ConductorError;
+use holochain::conductor::error::{CellUnavailableReason, ConductorError};
 use holochain::sweettest::*;
 use holochain_conductor_api::CellInfo;
 use holochain_keystore::{AgentPubKeyExt, WarrantOpExt};
@@ -152,7 +152,8 @@ async fn restore_from_dht_end_to_end() {
         }
     });
 
-    // `enable_app` has not been called yet, so the cell must not be callable.
+    // `enable_app` has not been called yet, so the cell must not be callable. The restore may
+    // already have finished, which leaves the app disabled rather than awaiting restore.
     let err = conductor_b
         .call_fallible::<_, ActionHash>(&restore_cell.zome(TestWasm::Create), "create_entry", ())
         .await
@@ -160,9 +161,13 @@ async fn restore_from_dht_end_to_end() {
     assert!(
         matches!(
             err,
-            ConductorApiError::ConductorError(ConductorError::CellDisabled(_))
+            ConductorApiError::ConductorError(ConductorError::CellNotRunning(
+                _,
+                CellUnavailableReason::AppAwaitingRestore
+                    | CellUnavailableReason::AppDisabled(DisabledAppReason::NeverStarted)
+            ))
         ),
-        "expected CellDisabled while awaiting restore, got: {err:?}"
+        "expected the cell to not be callable before enable_app, got: {err:?}"
     );
 
     // Each cell emits `RestoreComplete` as it finishes, before the app-level `AppRestoreComplete`,
@@ -215,6 +220,66 @@ async fn restore_from_dht_end_to_end() {
         .call(&restore_cell.zome(TestWasm::Create), "get_post", new_hash)
         .await;
     assert_eq!(new_record.unwrap().action().action_seq(), last_seq_on_a + 1);
+}
+
+/// Installs a restoring app on a conductor with no peers to restore from, so the restore keeps
+/// retrying and the app stays in [`AppStatus::AwaitingRestore`]. Confirms a zome call in that state
+/// is rejected with a reason naming the restore, rather than looking like a plain disabled app.
+#[tokio::test(flavor = "multi_thread")]
+async fn zome_call_while_awaiting_restore_is_rejected() {
+    holochain_trace::test_run();
+
+    let rendezvous = SweetLocalRendezvous::new().await;
+    let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+
+    let mut conductor =
+        SweetConductor::from_config_rendezvous(SweetConductorConfig::rendezvous(true), rendezvous)
+            .await;
+    let agent = SweetAgents::one(conductor.keystore()).await;
+
+    let app_id = "restored".to_string();
+    conductor
+        .install_app(
+            &app_id,
+            Some(agent),
+            std::slice::from_ref(&dna_file),
+            Some(InstallAppCommonFlags {
+                restore_from_dht: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    let app_info = conductor
+        .raw_handle()
+        .get_app_info(&app_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(app_info.status, AppStatus::AwaitingRestore);
+
+    let role = dna_file.dna_hash().to_string();
+    let restore_cell_id = match app_info.cell_info[&role].first().unwrap() {
+        CellInfo::Provisioned(c) => c.cell_id.clone(),
+        other => panic!("Expected a provisioned cell, got: {other:?}"),
+    };
+    let restore_cell = conductor.get_sweet_cell(restore_cell_id).unwrap();
+
+    let err = conductor
+        .call_fallible::<_, ActionHash>(&restore_cell.zome(TestWasm::Create), "create_entry", ())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            ConductorApiError::ConductorError(ConductorError::CellNotRunning(
+                _,
+                CellUnavailableReason::AppAwaitingRestore
+            ))
+        ),
+        "expected AppAwaitingRestore, got: {err:?}"
+    );
 }
 
 async fn build_fork_pair(

--- a/crates/holochain/tests/tests/restore.rs
+++ b/crates/holochain/tests/tests/restore.rs
@@ -165,9 +165,15 @@ async fn restore_from_dht_end_to_end() {
         "expected CellDisabled while awaiting restore, got: {err:?}"
     );
 
+    // Each cell emits `RestoreComplete` as it finishes, before the app-level `AppRestoreComplete`,
+    // so collect the per-cell signals seen while waiting for the app-level one.
+    let mut restored_cells = Vec::new();
     let signal = tokio::time::timeout(std::time::Duration::from_secs(60), async {
         loop {
             match signal_rx.recv().await.unwrap() {
+                Signal::System(SystemSignal::RestoreComplete { cell_id }) => {
+                    restored_cells.push(cell_id)
+                }
                 signal @ Signal::System(SystemSignal::AppRestoreComplete { .. }) => break signal,
                 Signal::System(SystemSignal::RestoreFailed { cell_id, reason }) => {
                     panic!("Restore failed unexpectedly for {cell_id:?}: {reason:?}");
@@ -182,6 +188,11 @@ async fn restore_from_dht_end_to_end() {
         signal,
         Signal::System(SystemSignal::AppRestoreComplete { installed_app_id }) if installed_app_id == app_id
     ));
+    assert_eq!(
+        restored_cells,
+        vec![restore_cell.cell_id().clone()],
+        "expected a RestoreComplete for the app's only cell before AppRestoreComplete"
+    );
 
     let app_info = conductor_b
         .raw_handle()
@@ -330,6 +341,9 @@ async fn restore_from_dht_chain_fork_warrant_transitions_to_unrecoverable() {
                     }
                     signal @ Signal::System(SystemSignal::AppRestoreComplete { .. }) => {
                         panic!("Restore unexpectedly succeeded: {signal:?}");
+                    }
+                    signal @ Signal::System(SystemSignal::RestoreComplete { .. }) => {
+                        panic!("A permanently failed cell must not report completion: {signal:?}");
                     }
                     _ => continue,
                 }

--- a/crates/holochain/tests/tests/restore.rs
+++ b/crates/holochain/tests/tests/restore.rs
@@ -12,6 +12,7 @@ use holochain_types::app::{AppStatus, DisabledAppReason};
 use holochain_types::prelude::*;
 use holochain_types::signal::SystemSignal;
 use holochain_wasm_test_utils::TestWasm;
+use tokio::sync::broadcast;
 
 /// The kitsune2 agent IDs currently joined to the network space of the passed [`DnaHash`].
 async fn joined_agents(
@@ -32,6 +33,35 @@ async fn joined_agents(
         .into_iter()
         .map(|agent| agent.agent().clone())
         .collect()
+}
+
+/// Waits for the next restore signal on `signal_rx`, ignoring any other signals.
+async fn next_restore_signal(signal_rx: &mut broadcast::Receiver<Signal>) -> SystemSignal {
+    tokio::time::timeout(std::time::Duration::from_secs(60), async {
+        loop {
+            if let Signal::System(
+                signal @ (SystemSignal::RestoreComplete { .. }
+                | SystemSignal::AppRestoreComplete { .. }
+                | SystemSignal::RestoreFailed { .. }),
+            ) = signal_rx.recv().await.unwrap()
+            {
+                break signal;
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for a restore signal")
+}
+
+/// The current status of the `app_id` app on `conductor`.
+async fn app_status(conductor: &SweetConductor, app_id: &InstalledAppId) -> AppStatus {
+    conductor
+        .raw_handle()
+        .get_app_info(app_id)
+        .await
+        .unwrap()
+        .unwrap()
+        .status
 }
 
 /// Installs an app for an `agent` on a fresh conductor via the restore workflow.
@@ -170,43 +200,23 @@ async fn restore_from_dht_end_to_end() {
         "expected the cell to not be callable before enable_app, got: {err:?}"
     );
 
-    // Each cell emits `RestoreComplete` as it finishes, before the app-level `AppRestoreComplete`,
-    // so collect the per-cell signals seen while waiting for the app-level one.
-    let mut restored_cells = Vec::new();
-    let signal = tokio::time::timeout(std::time::Duration::from_secs(60), async {
-        loop {
-            match signal_rx.recv().await.unwrap() {
-                Signal::System(SystemSignal::RestoreComplete { cell_id }) => {
-                    restored_cells.push(cell_id)
-                }
-                signal @ Signal::System(SystemSignal::AppRestoreComplete { .. }) => break signal,
-                Signal::System(SystemSignal::RestoreFailed { cell_id, reason }) => {
-                    panic!("Restore failed unexpectedly for {cell_id:?}: {reason:?}");
-                }
-                _ => continue,
-            }
-        }
-    })
-    .await
-    .expect("timed out waiting for AppRestoreComplete");
-    assert!(matches!(
-        signal,
-        Signal::System(SystemSignal::AppRestoreComplete { installed_app_id }) if installed_app_id == app_id
-    ));
+    // The cell reports its own completion first, then the app-level signal follows once every cell
+    // is done.
     assert_eq!(
-        restored_cells,
-        vec![restore_cell.cell_id().clone()],
-        "expected a RestoreComplete for the app's only cell before AppRestoreComplete"
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::RestoreComplete {
+            cell_id: restore_cell.cell_id().clone()
+        }
+    );
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::AppRestoreComplete {
+            installed_app_id: app_id.clone()
+        }
     );
 
-    let app_info = conductor_b
-        .raw_handle()
-        .get_app_info(&app_id)
-        .await
-        .unwrap()
-        .unwrap();
     assert_eq!(
-        app_info.status,
+        app_status(&conductor_b, &app_id).await,
         AppStatus::Disabled(DisabledAppReason::NeverStarted)
     );
 
@@ -279,6 +289,193 @@ async fn zome_call_while_awaiting_restore_is_rejected() {
             ))
         ),
         "expected AppAwaitingRestore, got: {err:?}"
+    );
+}
+
+/// Authors a chain for a fresh agent in each of `dnas`, on a conductor which is then shut down so
+/// that it can't serve the restore of its own chains. A second conductor is a full-arc peer for each
+/// DNA in `authority_dnas` and stays up as the authority restore queries.
+///
+/// Returns the keystore holding the agent's key, the agent, and the authority conductor, which the
+/// caller must keep alive for as long as the restore needs it.
+async fn author_chains_to_restore(
+    rendezvous: DynSweetRendezvous,
+    dnas: &[DnaFile],
+    authority_dnas: &[DnaFile],
+) -> (
+    holochain_keystore::MetaLairClient,
+    AgentPubKey,
+    SweetConductor,
+) {
+    let mut conductor_a = SweetConductor::from_config_rendezvous(
+        SweetConductorConfig::rendezvous(true),
+        rendezvous.clone(),
+    )
+    .await;
+    let keystore = conductor_a.keystore();
+    let agent = SweetAgents::one(keystore.clone()).await;
+    let cells_a = conductor_a
+        .setup_app_for_agent("app", agent.clone(), dnas)
+        .await
+        .unwrap()
+        .into_cells();
+
+    let mut conductor_c =
+        SweetConductor::from_config_rendezvous(SweetConductorConfig::rendezvous(true), rendezvous)
+            .await;
+    let mut cells_c = Vec::new();
+    for dna in authority_dnas {
+        let app = conductor_c
+            .setup_app(
+                &format!("authority-{}", dna.dna_hash()),
+                std::slice::from_ref(dna),
+            )
+            .await
+            .unwrap();
+        cells_c.push(app.into_cells().remove(0));
+    }
+
+    for dna in dnas {
+        conductor_a.declare_full_storage_arcs(dna.dna_hash()).await;
+    }
+    for dna in authority_dnas {
+        conductor_c.declare_full_storage_arcs(dna.dna_hash()).await;
+    }
+
+    for cell in &cells_a {
+        let _: ActionHash = conductor_a
+            .call(&cell.zome(TestWasm::Create), "create_entry", ())
+            .await;
+    }
+
+    for cell_c in &cells_c {
+        let cell_a = cells_a
+            .iter()
+            .find(|cell| cell.dna_hash() == cell_c.dna_hash())
+            .unwrap();
+        await_consistency([cell_a, cell_c]).await.unwrap();
+    }
+
+    // Shut down the original, so it can't act as an authority for the restore of itself
+    conductor_a.shutdown().await;
+
+    (keystore, agent, conductor_c)
+}
+
+/// Restores an app with two provisioned cells, both with an authority to restore from. Confirms
+/// that the cells complete one at a time in the app's role order, and that the app settles into
+/// [`DisabledAppReason::NeverStarted`] once the last of them is done.
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_multi_cell_app_completes_cells_in_order() {
+    holochain_trace::test_run();
+
+    let rendezvous = SweetLocalRendezvous::new().await;
+    let (dna_first, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+    let (dna_second, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+    let dnas = [dna_first.clone(), dna_second.clone()];
+
+    let (keystore, agent, _authority) =
+        author_chains_to_restore(rendezvous.clone(), &dnas, &dnas).await;
+
+    let mut config_b = SweetConductorConfig::rendezvous(true);
+    config_b.restore_chain_quorum = 1;
+    // The first query a newly joined space makes goes unanswered, so cap how long the restore
+    // workflow waits before retrying it.
+    config_b.network.request_timeout_s = 10;
+    let mut conductor_b =
+        SweetConductor::create_with_defaults(config_b, Some(keystore), Some(rendezvous)).await;
+
+    let app_id = "restored".to_string();
+    let mut signal_rx = conductor_b.subscribe_to_app_signals(app_id.clone());
+
+    conductor_b
+        .install_app(
+            &app_id,
+            Some(agent.clone()),
+            &dnas,
+            Some(InstallAppCommonFlags {
+                restore_from_dht: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    // Cells restore in the app's role order, which here is the order the DNAs were installed in.
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::RestoreComplete {
+            cell_id: CellId::new(dna_first.dna_hash().clone(), agent.clone())
+        }
+    );
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::RestoreComplete {
+            cell_id: CellId::new(dna_second.dna_hash().clone(), agent.clone())
+        }
+    );
+
+    // Only with every cell restored does the app settle and become enableable.
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::AppRestoreComplete {
+            installed_app_id: app_id.clone()
+        }
+    );
+    assert_eq!(
+        app_status(&conductor_b, &app_id).await,
+        AppStatus::Disabled(DisabledAppReason::NeverStarted)
+    );
+}
+
+/// Restores an app with two provisioned cells where only the first has an authority to restore
+/// from. Confirms that the first cell still completes, and that the app stays in
+/// [`AppStatus::AwaitingRestore`] rather than settling while the last cell is outstanding.
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_multi_cell_app_does_not_settle_until_the_last_cell_completes() {
+    holochain_trace::test_run();
+
+    let rendezvous = SweetLocalRendezvous::new().await;
+    let (dna_first, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+    let (dna_second, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+    let dnas = [dna_first.clone(), dna_second.clone()];
+
+    let (keystore, agent, _authority) =
+        author_chains_to_restore(rendezvous.clone(), &dnas, std::slice::from_ref(&dna_first)).await;
+
+    let mut config_b = SweetConductorConfig::rendezvous(true);
+    config_b.restore_chain_quorum = 1;
+    let mut conductor_b =
+        SweetConductor::create_with_defaults(config_b, Some(keystore), Some(rendezvous)).await;
+
+    let app_id = "restored".to_string();
+    let mut signal_rx = conductor_b.subscribe_to_app_signals(app_id.clone());
+
+    conductor_b
+        .install_app(
+            &app_id,
+            Some(agent.clone()),
+            &dnas,
+            Some(InstallAppCommonFlags {
+                restore_from_dht: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::RestoreComplete {
+            cell_id: CellId::new(dna_first.dna_hash().clone(), agent.clone())
+        }
+    );
+
+    // The second cell has no authority to restore from, so it can never complete and the app can
+    // never settle, no matter how long the orchestrator is given.
+    assert_eq!(
+        app_status(&conductor_b, &app_id).await,
+        AppStatus::AwaitingRestore
     );
 }
 
@@ -397,39 +594,19 @@ async fn restore_from_dht_chain_fork_warrant_transitions_to_unrecoverable() {
         .await
         .unwrap();
 
-    let (restore_cell_id, reason) =
-        tokio::time::timeout(std::time::Duration::from_secs(60), async {
-            loop {
-                match signal_rx.recv().await.unwrap() {
-                    Signal::System(SystemSignal::RestoreFailed { cell_id, reason }) => {
-                        break (cell_id, reason);
-                    }
-                    signal @ Signal::System(SystemSignal::AppRestoreComplete { .. }) => {
-                        panic!("Restore unexpectedly succeeded: {signal:?}");
-                    }
-                    signal @ Signal::System(SystemSignal::RestoreComplete { .. }) => {
-                        panic!("A permanently failed cell must not report completion: {signal:?}");
-                    }
-                    _ => continue,
-                }
-            }
-        })
-        .await
-        .expect("timed out waiting for RestoreFailed");
+    // A permanently failed cell must report the failure rather than any form of completion.
+    let (restore_cell_id, reason) = match next_restore_signal(&mut signal_rx).await {
+        SystemSignal::RestoreFailed { cell_id, reason } => (cell_id, reason),
+        signal => panic!("expected RestoreFailed, got: {signal:?}"),
+    };
 
     assert!(
         matches!(reason, UnrecoverableCellReason::ChainForkWarrant(_)),
         "expected a ChainForkWarrant reason, got: {reason:?}"
     );
 
-    let app_info = conductor_d
-        .raw_handle()
-        .get_app_info(&app_id)
-        .await
-        .unwrap()
-        .unwrap();
     assert_eq!(
-        app_info.status,
+        app_status(&conductor_d, &app_id).await,
         AppStatus::Unrecoverable(restore_cell_id, reason)
     );
 

--- a/docs/design/source_chain_restore.md
+++ b/docs/design/source_chain_restore.md
@@ -93,7 +93,7 @@ Failure modes that must be explicit (no silent corruption):
 
 Restore is a new cell instantiation workflow that replaces `genesis_workflow` for installs flagged as restoring. It runs against the same empty per-DNA database that genesis would have run against, but the database it produces is one in which the authored chain has been reconstructed from the DHT instead of freshly created.
 
-The app stays in `AppStatus::AwaitingRestore` for the duration of the workflow (new variant, see [App status](#app-status) below). Zome calls — including any that would author new chain actions — are rejected while in this state. Network activity that supports the restore itself proceeds normally: incoming gossip, op validation, and integration must run so that records fetched as part of restore can land in the DHT side of the database, so writes performed by those workflows are not blocked by the app status. What is blocked is application-driven chain authoring.
+The app stays in `AppStatus::AwaitingRestore` for the duration of the workflow (new variant, see [App status](#app-status) below). Zome calls — including any that would author new chain actions — are rejected while in this state, with `ConductorError::CellNotRunning(cell_id, CellUnavailableReason::AppAwaitingRestore)` so the caller can tell a restore in progress from an app that is merely disabled. Network activity that supports the restore itself proceeds normally: incoming gossip, op validation, and integration must run so that records fetched as part of restore can land in the DHT side of the database, so writes performed by those workflows are not blocked by the app status. What is blocked is application-driven chain authoring.
 
 ### Per-app orchestration
 
@@ -346,6 +346,7 @@ Applications that rely on the lost categories must accept degraded post-restore 
 |---------|-----------|
 | `agent_key == None` with `restore_from_dht == true` | Reject the install at admit time. |
 | `agent_key` not present in local Lair | Reject the install at admit time. |
+| Zome call attempted while the app is in `AwaitingRestore` | Rejected with `ConductorError::CellNotRunning(cell_id, CellUnavailableReason::AppAwaitingRestore)`. Gossip, validation and integration are unaffected. |
 | Fewer than `restore_chain_quorum` peers respond | Internal retry (see [Retry behaviour](#retry-behaviour)). App stays in `AwaitingRestore`. |
 | Responding peers disagree on `ChainHead` | Internal retry. App stays in `AwaitingRestore`. |
 | Incomplete chain (gap in `0..=H`) | Internal retry. Re-runs Step 1 from scratch. App stays in `AwaitingRestore`. |


### PR DESCRIPTION
Closes the gaps left in #5809 by #5920.

- The restore integration tests now assert that each cell emits `SystemSignal::RestoreComplete` before the app-level `AppRestoreComplete`, and that a permanently failed cell never emits it.
- Two new tests cover a multi-cell app: cells restore one at a time in role order, and the app only settles into `Disabled(NeverStarted)` once the last cell has completed.
- `CellError::CellDisabled` conflated six different situations, so a zome call during restore looked identical to a call against a plain disabled app. `ConductorError::CellNotRunning` now carries a `CellUnavailableReason` naming the actual cause, which also distinguishes `AwaitingMemproofs` and disabled clone cells.

The design doc gains a failure-mode row for a zome call made while the app is in `AwaitingRestore`.

The multi-cell ordering test lowers `request_timeout_s` on the restoring conductor. The first request a conductor sends into a newly joined space is dropped, so the restore of every cell after the first waits out the full request timeout before its retry succeeds. That is a networking issue rather than one for this PR; the shorter timeout keeps the test at ~20s instead of ~70s.
