### PR TITLE
fix!: include sending agent in direct signals

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- **BREAKING CHANGE**: `Signal::AppDirect`, delivered to an app when another agent sends it a direct signal via `SendDirectSignal`, now includes the sending agent's public key as `from_agent`. \#5938
 - **BREAKING CHANGE**: Errors for zome calls against a cell that is not running now state why. `ConductorError::CellDisabled` is replaced by `ConductorError::CellNotRunning(cell_id, reason)`, where the reason distinguishes an app that is disabled, awaiting membrane proofs, restoring its source chains, or permanently unrecoverable, from a disabled clone cell or a cell that has not finished starting.
 
 ## 0.8.0-dev.2

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -459,6 +459,7 @@ impl holochain_p2p::event::HcP2pHandler for Cell {
 
             if let Err(e) = self.signal_tx.send(Signal::AppDirect {
                 cell_id: CellId::new(dna_hash, to_agent),
+                from_agent,
                 signal: signal.0,
             }) {
                 info!(?e, "Failed to relay direct signal to app")

--- a/crates/holochain/tests/tests/signals/direct.rs
+++ b/crates/holochain/tests/tests/signals/direct.rs
@@ -59,17 +59,22 @@ async fn send_direct_signal(
     .unwrap()
 }
 
-/// Wait for the next direct (`Signal::AppDirect`) signal on this socket, returning the target cell
-/// and payload. Other signal kinds are ignored. Returns `None` if `timeout` elapses first.
+/// Wait for the next direct (`Signal::AppDirect`) signal on this socket, returning the target cell,
+/// sending agent, and payload. Other signal kinds are ignored. Returns `None` if `timeout` elapses
+/// first.
 async fn try_recv_direct_signal(
     rx: &mut WebsocketReceiver,
     timeout: Duration,
-) -> Option<(CellId, Vec<u8>)> {
+) -> Option<(CellId, AgentPubKey, Vec<u8>)> {
     tokio::time::timeout(timeout, async {
         loop {
             match rx.recv::<AppResponse>().await.unwrap() {
                 ReceiveMessage::Signal(bytes) => match Signal::try_from_vec(bytes).unwrap() {
-                    Signal::AppDirect { cell_id, signal } => return (cell_id, signal),
+                    Signal::AppDirect {
+                        cell_id,
+                        from_agent,
+                        signal,
+                    } => return (cell_id, from_agent, signal),
                     _ => continue,
                 },
                 _ => panic!("expected a signal on the app socket"),
@@ -157,10 +162,12 @@ async fn direct_signal_to_another_conductor() {
         "unexpected response: {response:?}"
     );
 
-    let (cell_id, signal) = try_recv_direct_signal(&mut bob_rx, Duration::from_secs(60))
-        .await
-        .expect("Bob did not receive the direct signal");
+    let (cell_id, from_agent, signal) =
+        try_recv_direct_signal(&mut bob_rx, Duration::from_secs(60))
+            .await
+            .expect("Bob did not receive the direct signal");
     assert_eq!(cell_id, *bob.cell_id());
+    assert_eq!(from_agent, *alice.agent_pubkey());
     assert_eq!(signal, payload);
 }
 
@@ -171,7 +178,7 @@ async fn direct_signal_to_agent_on_same_conductor() {
     let mut conductor = SweetConductor::standard().await;
     let dna = SweetDnaFile::unique_empty().await;
 
-    let _alice_app = conductor
+    let alice_app = conductor
         .setup_app("alice-app", std::slice::from_ref(&dna))
         .await
         .unwrap();
@@ -200,10 +207,12 @@ async fn direct_signal_to_agent_on_same_conductor() {
         "unexpected response: {response:?}"
     );
 
-    let (cell_id, signal) = try_recv_direct_signal(&mut bob_rx, Duration::from_secs(30))
-        .await
-        .expect("Bob did not receive the direct signal");
+    let (cell_id, from_agent, signal) =
+        try_recv_direct_signal(&mut bob_rx, Duration::from_secs(30))
+            .await
+            .expect("Bob did not receive the direct signal");
     assert_eq!(cell_id, bob_cell_id);
+    assert_eq!(&from_agent, alice_app.agent());
     assert_eq!(signal, payload);
 }
 
@@ -250,17 +259,20 @@ async fn direct_signal_to_multiple_agents() {
         "unexpected response: {response:?}"
     );
 
-    let (bob_cell_id, bob_signal) = try_recv_direct_signal(&mut bob_rx, Duration::from_secs(60))
-        .await
-        .expect("Bob did not receive the direct signal");
+    let (bob_cell_id, bobs_from_agent, bob_signal) =
+        try_recv_direct_signal(&mut bob_rx, Duration::from_secs(60))
+            .await
+            .expect("Bob did not receive the direct signal");
     assert_eq!(bob_cell_id, *bob.cell_id());
+    assert_eq!(bobs_from_agent, *alice.agent_pubkey());
     assert_eq!(bob_signal, payload);
 
-    let (carol_cell_id, carol_signal) =
+    let (carol_cell_id, carols_from_agent, carol_signal) =
         try_recv_direct_signal(&mut carol_rx, Duration::from_secs(60))
             .await
             .expect("Carol did not receive the direct signal");
     assert_eq!(carol_cell_id, *carol.cell_id());
+    assert_eq!(carols_from_agent, *alice.agent_pubkey());
     assert_eq!(carol_signal, payload);
 }
 

--- a/crates/holochain_types/src/signal.rs
+++ b/crates/holochain_types/src/signal.rs
@@ -29,6 +29,9 @@ pub enum Signal {
         /// The receiving `CellId`.
         cell_id: CellId,
 
+        /// The agent who sent the signal.
+        from_agent: AgentPubKey,
+
         /// The payload sent by the remote agent.
         signal: Vec<u8>,
     },


### PR DESCRIPTION
### Summary

`Signal::AppDirect` now includes the sending agent's public key as `from_agent`.

BREAKING CHANGE: New field added to type.

Closes #5938.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs