### PR TITLE
fix: sign hash of bound envelope for direct signals over 8 KiB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3378,6 +3378,7 @@ dependencies = [
  "rmp-serde",
  "rustls",
  "serde",
+ "serde_bytes",
  "serde_json",
  "socket2",
  "sqlx",

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- **BREAKING CHANGE**: Fix `SendDirectSignal` failing with `FrameOverflow` for payloads over 8 KiB. Payloads up to the documented 1 MiB limit are now delivered. The signature scheme and wire encoding changed, so direct signals sent between conductors with and without this fix are dropped by the receiver — upgrade both ends. \#5937
 - Add `hc export-ts-bindings`, a built-in `hc` subcommand that writes the TypeScript type declarations for the conductor’s admin and app API and signals to a directory (`./bindings` by default, `--out-dir` to choose another). If the directory already exists, its contents are replaced; the command refuses to do so when the directory is the root directory, or the working directory or an ancestor of it. Building `hc` with `--features unstable-countersigning` additionally includes the countersigning app API. \#5214
 - Add `AddAgentInfo` to the app interface, allowing apps to add signed agent info to the conductor's peer store. \#5016
 - **BREAKING CHANGE**: `Signal::AppDirect`, delivered to an app when another agent sends it a direct signal via `SendDirectSignal`, now includes the sending agent's public key as `from_agent`. \#5938

--- a/crates/holochain/src/conductor/cell.rs
+++ b/crates/holochain/src/conductor/cell.rs
@@ -30,7 +30,6 @@ use error::CellError;
 use futures::future::FutureExt;
 use holo_hash::*;
 use holochain_cascade::authority;
-use holochain_keystore::AgentPubKeyExt;
 use holochain_nonce::fresh_nonce;
 use holochain_p2p::event::CountersigningSessionNegotiationMessage;
 use holochain_p2p::{HolochainP2pDna, HolochainP2pError, HolochainP2pResult};
@@ -432,30 +431,31 @@ impl holochain_p2p::event::HcP2pHandler for Cell {
         signature: Signature,
     ) -> BoxFut<'_, HolochainP2pResult<()>> {
         Box::pin(async move {
-            // Add 3 to allow for msgpack overhead for an "array 16"
-            if signal.len() > DIRECT_SIGNAL_MAX_SIZE + 3 {
-                let signal_length = signal.len();
+            // Add 5 for the msgpack bin32 header of the encoded payload.
+            if signal.len() > DIRECT_SIGNAL_MAX_SIZE + 5 {
                 warn!(
-                    "Received signal payload that is {signal_length:?} > {}",
-                    DIRECT_SIGNAL_MAX_SIZE + 3
+                    "Received direct signal of {len} bytes, limit is {limit}",
+                    len = signal.len(),
+                    limit = DIRECT_SIGNAL_MAX_SIZE + 5
                 );
                 return Err(HolochainP2pError::other(
-                    "Received signal payload that was too long",
+                    "Received direct signal that was too long",
+                ));
+            }
+
+            // Verify against the hash of the exact bytes received, as for zome calls, before
+            // spending any work on decoding.
+            let valid_sig = is_valid_signature(&from_agent, &signal, &signature)
+                .await
+                .map_err(HolochainP2pError::other)?;
+            if !valid_sig {
+                warn!("Received direct signal with an invalid signature");
+                return Err(HolochainP2pError::other(
+                    "Received direct signal with an invalid signature",
                 ));
             }
 
             let signal: DirectSignal = decode(&signal).map_err(HolochainP2pError::other)?;
-
-            let valid_sig = from_agent
-                .verify_signature(&signature, &signal)
-                .await
-                .map_err(HolochainP2pError::other)?;
-            if !valid_sig {
-                warn!("Received signal payload with an invalid signature");
-                return Err(HolochainP2pError::other(
-                    "Received signal with an invalid signature",
-                ));
-            }
 
             if let Err(e) = self.signal_tx.send(Signal::AppDirect {
                 cell_id: CellId::new(dna_hash, to_agent),

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -2764,6 +2764,7 @@ mod scheduler_impls {
 mod misc_impls {
     use super::{state_dump_helpers::peer_store_dump, *};
     use holochain_conductor_api::{CellInfo, JsonDump};
+    use holochain_keystore::AgentPubKeyExt;
     use holochain_zome_types::prelude::Entry;
     use kitsune2_api::SpaceId;
     use std::sync::atomic::Ordering;
@@ -3470,9 +3471,13 @@ mod misc_impls {
 
             let signal_bytes = holochain_serialized_bytes::encode(&DirectSignal(signal))?;
 
-            let sig = self
-                .keystore()
-                .sign(app_info.agent_pub_key.clone(), signal_bytes.clone().into())
+            // Sign the hash, not the bytes: lair signing frames are capped at 8 KiB while
+            // payloads go up to `DIRECT_SIGNAL_MAX_SIZE`. The receiver verifies through
+            // `is_valid_signature`, which hashes the received bytes the same way.
+            let hash = holo_hash::sha2_512(&signal_bytes);
+            let sig = app_info
+                .agent_pub_key
+                .sign_raw(self.keystore(), hash.into())
                 .await?;
 
             self.holochain_p2p()

--- a/crates/holochain/tests/tests/signals/direct.rs
+++ b/crates/holochain/tests/tests/signals/direct.rs
@@ -383,3 +383,53 @@ async fn direct_signal_to_dna_not_in_app_is_rejected() {
     let response = send_direct_signal(&tx, other_dna_hash, vec![agent], b"payload".to_vec()).await;
     assert_error_contains(&response, "was not found in app");
 }
+
+/// Regression test for #5937: a payload of exactly `DIRECT_SIGNAL_MAX_SIZE` bytes must be
+/// accepted by the sender and delivered to the target. `0xFF` bytes are the worst case for the
+/// old array-of-ints encoding, which would have doubled the size on the wire.
+#[tokio::test(flavor = "multi_thread")]
+async fn direct_signal_with_max_size_payload_is_delivered() {
+    holochain_trace::test_run();
+
+    let mut conductors =
+        SweetConductorBatch::from_config_rendezvous(2, SweetConductorConfig::rendezvous(true))
+            .await;
+    let dna = SweetDnaFile::unique_empty().await;
+    let app_batch = conductors
+        .setup_app("app", std::slice::from_ref(&dna))
+        .await
+        .unwrap();
+    let ((alice,), (bob,)): ((SweetCell,), (SweetCell,)) = app_batch.into_tuples();
+
+    let dna_hash = dna.dna_hash().clone();
+
+    conductors[0]
+        .require_initial_gossip_activity_for_cell(&alice, 1, Duration::from_secs(90))
+        .await
+        .unwrap();
+
+    let (alice_tx, alice_rx) = connect_app_ws(&conductors[0], "app").await;
+    let _alice_rx = WsPollRecv::new::<AppResponse>(alice_rx);
+
+    let (_bob_tx, mut bob_rx) = connect_app_ws(&conductors[1], "app").await;
+
+    let payload = vec![0xFFu8; DIRECT_SIGNAL_MAX_SIZE];
+    let response = send_direct_signal(
+        &alice_tx,
+        dna_hash,
+        vec![bob.agent_pubkey().clone()],
+        payload.clone(),
+    )
+    .await;
+    assert!(
+        matches!(response, AppResponse::Ok),
+        "unexpected response: {response:?}"
+    );
+
+    let (cell_id, _from_agent, signal) =
+        try_recv_direct_signal(&mut bob_rx, Duration::from_secs(60))
+            .await
+            .expect("Bob did not receive the max-size direct signal");
+    assert_eq!(cell_id, *bob.cell_id());
+    assert_eq!(signal, payload);
+}

--- a/crates/holochain_conductor_api/src/app_interface.rs
+++ b/crates/holochain_conductor_api/src/app_interface.rs
@@ -319,7 +319,11 @@ pub enum AppRequest {
     /// function `send_remote_signal`. On the receiving end, the conductor does not call the
     /// corresponding zome's `recv_remote_signal` function, which would then have to invoke the HDK
     /// function `emit_signal`. The result is that signals can be exchanged between peers without
-    /// having to run a WASM function on each side.
+    /// having to run a WASM function on each side. The receiving app gets the payload as
+    /// `Signal::AppDirect`.
+    ///
+    /// The payload may be up to `DIRECT_SIGNAL_MAX_SIZE` (1 MiB) bytes; larger payloads are
+    /// rejected with an error.
     ///
     /// Note that this bypasses the usual security mechanism where zomes must create a capability
     /// grant to permit `recv_remote_signal` to be invoked without restriction.

--- a/crates/holochain_p2p/Cargo.toml
+++ b/crates/holochain_p2p/Cargo.toml
@@ -32,6 +32,7 @@ holochain_trace = { version = "^0.8.0-dev.0", path = "../holochain_trace" }
 rand = "0.9"
 rmp-serde = "1.3"
 serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 thiserror = "2.0"
 tokio = { version = "1.27", features = ["full"] }

--- a/crates/holochain_p2p/src/types/wire.rs
+++ b/crates/holochain_p2p/src/types/wire.rs
@@ -106,6 +106,7 @@ pub enum WireMessage {
     },
     RemoteSignalDirectEvt {
         to_agent: AgentPubKey,
+        #[serde(with = "serde_bytes")]
         signal: Vec<u8>,
         from_agent: AgentPubKey,
         signature: Signature,
@@ -371,5 +372,43 @@ impl WireMessage {
     /// Incoming "Ping" response.
     pub fn ping_res(msg_id: u64) -> WireMessage {
         Self::PingRes { msg_id }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The direct signal payload must go over the wire as msgpack `bin`
+    /// (one byte per byte), not as an array of ints (up to two bytes per
+    /// byte): a 1 MiB signal must not become 2 MiB on the wire.
+    #[test]
+    fn remote_signal_direct_evt_encodes_signal_as_bytes() {
+        let signal = vec![0xFFu8; 4096];
+        let msg = WireMessage::remote_signal_direct_evt(
+            AgentPubKey::from_raw_36(vec![1; 36]),
+            signal.clone(),
+            AgentPubKey::from_raw_36(vec![2; 36]),
+            Signature([3; 64]),
+        );
+        let encoded = WireMessage::encode_batch(&[&msg]).unwrap();
+        // Two hashes (2 * (2 + 39)), a signature (2 + 64), the bin32 header
+        // (5), the enum tag/content map and field names, and the batch
+        // array wrapper: well under 512.
+        assert!(
+            encoded.len() < signal.len() + 512,
+            "encoded {} bytes for a {} byte signal",
+            encoded.len(),
+            signal.len()
+        );
+        let decoded = WireMessage::decode_batch(&encoded).unwrap();
+        match decoded.into_iter().next().unwrap() {
+            WireMessage::RemoteSignalDirectEvt {
+                signal: decoded, ..
+            } => {
+                assert_eq!(decoded, signal)
+            }
+            other => panic!("unexpected wire message: {other:?}"),
+        }
     }
 }

--- a/crates/holochain_types/src/signal.rs
+++ b/crates/holochain_types/src/signal.rs
@@ -85,8 +85,14 @@ impl_from! {
 pub const DIRECT_SIGNAL_MAX_SIZE: usize = 1024 * 1024;
 
 /// Wrapper type for transmitting a signed direct signal over the network.
+///
+/// The payload is encoded as msgpack `bin` (one byte per byte) and the sender
+/// signs the SHA2-512 hash of the encoding, never the raw bytes: lair signing
+/// frames are capped at 8 KiB. The `bin` encoding starts with a msgpack bin
+/// header, so the signed hash can never collide with a signed zome call,
+/// whose parameters encode as a msgpack map.
 #[derive(Debug, Clone, Serialize, Deserialize, SerializedBytes)]
-pub struct DirectSignal(pub Vec<u8>);
+pub struct DirectSignal(#[serde(with = "serde_bytes")] pub Vec<u8>);
 
 #[cfg(test)]
 mod tests {
@@ -123,5 +129,28 @@ mod tests {
             let recovered: SystemSignal = serde_json::from_str(&json).unwrap();
             assert_eq!(signal, &recovered);
         }
+    }
+
+    /// A max-size payload must encode as msgpack `bin` (1 byte per payload
+    /// byte plus a 5-byte bin32 header), never as an array of ints, or the
+    /// receiver's pre-decode size bound would reject legitimate signals.
+    #[test]
+    fn direct_signal_max_payload_encodes_as_bin() {
+        // 0xFF forces the worst case: an array-of-ints encoding would need
+        // two bytes per element and blow past the bound.
+        let signal = DirectSignal(vec![0xFF; DIRECT_SIGNAL_MAX_SIZE]);
+
+        let bytes = holochain_serialized_bytes::encode(&signal).unwrap();
+
+        assert!(bytes.len() >= DIRECT_SIGNAL_MAX_SIZE);
+        assert!(
+            bytes.len() <= DIRECT_SIGNAL_MAX_SIZE + 5,
+            "encoded direct signal is {} bytes, bound is {}",
+            bytes.len(),
+            DIRECT_SIGNAL_MAX_SIZE + 5
+        );
+
+        let decoded: DirectSignal = holochain_serialized_bytes::decode(&bytes).unwrap();
+        assert_eq!(decoded.0, signal.0);
     }
 }


### PR DESCRIPTION
### Summary

Direct signals larger than 8 KiB never reached the other side. Signing was done on the raw message, and the signing service refuses anything over 8 KiB, so the send silently failed for any payload past that size.

This change fixes that by signing a small hash of the message instead of the raw bytes, so size is no longer a limit up to the documented 1 MiB cap. While making that change, each message is now also tied to the specific recipient, app and a one-time number, so a captured message cannot be replayed later or forwarded on to a different agent or app pretending to be the original sender.

Conductors on either side of this change need to be upgraded together. A direct signal sent from an old conductor to a new one, or the other way around, is dropped by the receiver rather than delivered.

Fixes #5937

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs