### PR TITLE
Source-chain restore crash recovery

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix a source-chain restore bug where ordinary gossip for the restoring agent's own chain could be rejected during validation and permanently block restore's own write, leaving the cell's chain looking empty after `enable_app`.
+- Fix source-chain restore stalling permanently when no peers are yet known for the agent's DHT location. It now retries like any other insufficient-peers response.
+
 ## 0.8.0-dev.4
 
 ## 0.8.0-dev.3

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Fix source-chain restore was ignoring an app's manifest `bootstrap_url`/`relay_url` overrides, and instead always joined the network with the conductor's default config.
 - Fix a source-chain restore bug where ordinary gossip for the restoring agent's own chain could be rejected during validation and permanently block restore's own write, leaving the cell's chain looking empty after `enable_app`.
 - Fix source-chain restore stalling permanently when no peers are yet known for the agent's DHT location. It now retries like any other insufficient-peers response.
 

--- a/crates/holochain/Cargo.toml
+++ b/crates/holochain/Cargo.toml
@@ -130,6 +130,7 @@ predicates = "3.1"
 assert2 = "0.3.15"
 kitsune2_test_utils = "0.5.0"
 rand_dalek = { version = "0.8", package = "rand" }
+url2 = "0.0.6"
 
 [build-dependencies]
 hdk = { version = "^0.8.0-dev.2", path = "../hdk" }

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1729,6 +1729,7 @@ const RESTORE_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(
 /// of an app's cells and determines the app-level status and signals from the per-cell results.
 mod restore_impls {
     use super::*;
+    use holochain_types::cell_config_overrides::CellConfigOverrides;
 
     impl Conductor {
         /// Spawn the per-app restore orchestrator as a conductor-managed task, so it is cancelled
@@ -1779,11 +1780,17 @@ mod restore_impls {
         // Required for gossip received during restore, otherwise it fails validation as DnaMissing
         conductor.load_wasms_into_ribosome_for_app(app).await?;
 
+        let config_override = Conductor::p2p_config_overrides(&app.manifest);
         let quorum = conductor.config.restore_chain_quorum;
 
         for cell_id in cell_ids {
             let (cascade, dht_store, network, sys_validation_trigger) =
-                join_network_and_build_restore_cascade(&conductor, &cell_id).await?;
+                join_network_and_build_restore_cascade(
+                    &conductor,
+                    &cell_id,
+                    config_override.clone(),
+                )
+                .await?;
 
             // Marks the cell as undergoing chain restore for the lifetime of this guard
             let _restoring_guard = RestoringCellGuard::new(conductor.clone(), cell_id.clone())?;
@@ -1869,7 +1876,9 @@ mod restore_impls {
     ///
     /// Joining the network is required, otherwise the cell wouldn't join until the app is enabled
     /// and any P2P query against it would fail. The joined network handle is returned so the caller
-    /// can leave it again if restore ends in permanent failure.
+    /// can leave it again if restore ends in permanent failure. `config_override` should be the
+    /// same value `enable_app` would later join with, so restore doesn't create the DNA's network
+    /// space with different config than the rest of the app expects.
     ///
     /// Also spawns (or reuses, if already running for this DNA) the sys/app validation, integration
     /// and validation-receipt consumers, and returns the sys-validation trigger. A restoring cell
@@ -1878,6 +1887,7 @@ mod restore_impls {
     async fn join_network_and_build_restore_cascade(
         conductor: &ConductorHandle,
         cell_id: &CellId,
+        config_override: Option<CellConfigOverrides>,
     ) -> ConductorResult<(
         CascadeImpl,
         DhtStore,
@@ -1891,7 +1901,7 @@ mod restore_impls {
             cell_id.dna_hash().clone(),
         ));
         network
-            .join(cell_id.agent_pubkey().clone(), None, None)
+            .join(cell_id.agent_pubkey().clone(), None, config_override)
             .await?;
         let cascade = CascadeImpl::empty(dht_store.clone()).with_network(network.clone());
 

--- a/crates/holochain/src/conductor/conductor.rs
+++ b/crates/holochain/src/conductor/conductor.rs
@@ -1770,11 +1770,14 @@ mod restore_impls {
         installed_app_id: InstalledAppId,
     ) -> ConductorResult<()> {
         let state = conductor.get_state().await?;
-        let cell_ids: Vec<CellId> = state
-            .get_app(&installed_app_id)?
+        let app = state.get_app(&installed_app_id)?;
+        let cell_ids: Vec<CellId> = app
             .provisioned_cells()
             .map(|(_, cell_id)| cell_id)
             .collect();
+
+        // Required for gossip received during restore, otherwise it fails validation as DnaMissing
+        conductor.load_wasms_into_ribosome_for_app(app).await?;
 
         let quorum = conductor.config.restore_chain_quorum;
 

--- a/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
+++ b/crates/holochain/src/core/workflow/app_validation_workflow/tests.rs
@@ -1,3 +1,4 @@
+use crate::conductor::conductor::InstallAppCommonFlags;
 use crate::conductor::{Conductor, ConductorHandle};
 use crate::core::ribosome::guest_callback::validate::ValidateResult;
 use crate::core::ribosome::ZomeCallInvocation;
@@ -716,6 +717,100 @@ async fn handle_error_in_op_validation() {
         .unwrap()
         .len();
     assert_eq!(ops_to_validate, 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restoring_app_validation_rejects_and_warrants_op_once_ribosome_is_loaded() {
+    holochain_trace::test_run();
+
+    let entry_def = EntryDef::default_from_id("entry_def_id");
+    let zomes = SweetInlineZomes::new(vec![entry_def], 0).integrity_function(
+        "validate",
+        move |_, op: Op| match op {
+            Op::CreateEntry(_) => Ok(ValidateCallbackResult::Invalid("rejected by test".into())),
+            _ => Ok(ValidateCallbackResult::Valid),
+        },
+    );
+
+    let (dna_file, _, _) = SweetDnaFile::unique_from_inline_zomes(zomes).await;
+    let dna_hash = dna_file.dna_hash().clone();
+
+    let mut conductor = SweetConductor::standard().await;
+    let agent = SweetAgents::one(conductor.keystore()).await;
+    let app_id = "restoring".to_string();
+    conductor
+        .install_app(
+            &app_id,
+            Some(agent.clone()),
+            std::slice::from_ref(&dna_file),
+            Some(InstallAppCommonFlags {
+                restore_from_dht: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    // Restart as ribosomes are always loaded for freshly-installed apps but are only reloaded for
+    // enabled apps at startup. A restoring app is never enabled, so the restore orchestrator is the
+    // only thing that reloads this app's ribosome.
+    conductor.shutdown().await;
+    conductor.startup().await;
+
+    let app_validation_workspace = Arc::new(AppValidationWorkspace::new(
+        conductor.get_dht_store(&dna_hash).unwrap(),
+        conductor.keystore(),
+    ));
+
+    let mut create = fixt!(Action, CreateAction);
+    *create.entry_type_mut().unwrap() = EntryType::App(AppEntryDef {
+        entry_index: 0.into(),
+        zome_index: 0.into(),
+        visibility: Default::default(),
+    });
+    let entry = fixt!(Entry);
+    let op_hashed = DhtOpHashed::from_content_sync(DhtOp::from(ChainOp::CreateEntry(
+        SignedAction::new(create, fixt!(Signature)),
+        OpEntry::Present(entry),
+    )));
+    let op_hash = op_hashed.as_hash().clone();
+
+    app_validation_workspace
+        .dht_store
+        .record_incoming_ops(vec![(op_hashed, false)])
+        .await
+        .unwrap();
+    app_validation_workspace
+        .dht_store
+        .record_chain_op_sys_validation_outcomes(vec![(op_hash, SysOutcome::Accepted)])
+        .await
+        .unwrap();
+
+    let network = Arc::new(HolochainP2pDna::new(
+        conductor.holochain_p2p().clone(),
+        dna_hash.clone(),
+    ));
+
+    // The restore orchestrator that reloads the ribosome runs as a background task, so we don't
+    // know when it's done. A rejection plus a warrant is proof that the real validation ran.
+    crate::test_utils::retry_fn_until_timeout(
+        || async {
+            let outcome_summary = app_validation_workflow_inner(
+                Arc::new(dna_hash.clone()),
+                app_validation_workspace.clone(),
+                conductor.raw_handle(),
+                network.clone(),
+                agent.clone(),
+            )
+            .await
+            .unwrap();
+            outcome_summary.rejected == 1 && outcome_summary.warranted == 1
+        },
+        Some(10_000),
+        Some(100),
+    )
+    .await
+    .unwrap();
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/holochain/src/core/workflow/restore_workflow/agent_activity.rs
+++ b/crates/holochain/src/core/workflow/restore_workflow/agent_activity.rs
@@ -96,6 +96,16 @@ pub(super) async fn acquire_responses(
                 Vec::new(),
             ));
         }
+        // No peers are known for the agent's location but may be discovered later.
+        Err(CascadeError::NetworkError(HolochainP2pError::NoPeersForLocation(..))) => {
+            return Ok((
+                AcquireOutcome::Retry(RetryReason::TooFewResponses {
+                    got: 0,
+                    need: quorum as usize,
+                }),
+                Vec::new(),
+            ));
+        }
         Err(err) => return Err(WorkflowError::CascadeError(err)),
     };
 
@@ -832,6 +842,27 @@ mod tests {
         assert!(matches!(
             outcome,
             AcquireOutcome::Retry(RetryReason::TooFewResponses { got: 1, need: 2 })
+        ));
+        assert!(warrants.is_empty());
+    }
+
+    #[tokio::test]
+    async fn acquire_responses_maps_no_peers_for_location_to_retry() {
+        let agent = ::fixt::fixt!(AgentPubKey);
+        let mut mock = holochain_p2p::MockHolochainP2pDnaT::new();
+        mock.expect_get_agent_activity_multi().returning(|_, _, _| {
+            Err(holochain_p2p::HolochainP2pError::NoPeersForLocation(
+                "get_agent_activity_multi".into(),
+                0,
+            ))
+        });
+        let network: holochain_p2p::DynHolochainP2pDna = std::sync::Arc::new(mock);
+        let cascade = cascade_with_network(network).await;
+
+        let (outcome, warrants) = acquire_responses(&cascade, &agent, 2).await.unwrap();
+        assert!(matches!(
+            outcome,
+            AcquireOutcome::Retry(RetryReason::TooFewResponses { got: 0, need: 2 })
         ));
         assert!(warrants.is_empty());
     }

--- a/crates/holochain/tests/tests/restore.rs
+++ b/crates/holochain/tests/tests/restore.rs
@@ -8,7 +8,7 @@ use holochain::sweettest::*;
 use holochain_conductor_api::CellInfo;
 use holochain_keystore::{AgentPubKeyExt, WarrantOpExt};
 use holochain_state::dht_store::DhtStore;
-use holochain_types::app::{AppStatus, DisabledAppReason};
+use holochain_types::app::{AppManifest, AppManifestV0, AppStatus, DisabledAppReason};
 use holochain_types::prelude::*;
 use holochain_types::signal::SystemSignal;
 use holochain_wasm_test_utils::TestWasm;
@@ -230,6 +230,104 @@ async fn restore_from_dht_end_to_end() {
         .call(&restore_cell.zome(TestWasm::Create), "get_post", new_hash)
         .await;
     assert_eq!(new_record.unwrap().action().action_seq(), last_seq_on_a + 1);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_from_dht_respects_manifest_p2p_config_overrides() {
+    holochain_trace::test_run();
+
+    let dedicated_bootstrap = kitsune2_test_utils::bootstrap::TestBootstrapSrv::new(false).await;
+    let dedicated_bootstrap_url = dedicated_bootstrap.addr().to_string();
+
+    let rendezvous = SweetLocalRendezvous::new().await;
+    let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+
+    let mut config_a = SweetConductorConfig::rendezvous(true);
+    config_a.network.bootstrap_url = url2::url2!("{dedicated_bootstrap_url}");
+    let mut conductor_a =
+        SweetConductor::from_config_rendezvous(config_a, rendezvous.clone()).await;
+    let keystore = conductor_a.keystore();
+    let agent = SweetAgents::one(keystore.clone()).await;
+    let cell_a = conductor_a
+        .setup_app_for_agent("app", agent.clone(), std::slice::from_ref(&dna_file))
+        .await
+        .unwrap()
+        .into_cells()
+        .remove(0);
+    conductor_a
+        .declare_full_storage_arcs(cell_a.dna_hash())
+        .await;
+    let _: ActionHash = conductor_a
+        .call(&cell_a.zome(TestWasm::Create), "create_entry", ())
+        .await;
+
+    let mut config_c = SweetConductorConfig::rendezvous(true);
+    config_c.network.bootstrap_url = url2::url2!("{dedicated_bootstrap_url}");
+    let mut conductor_c =
+        SweetConductor::from_config_rendezvous(config_c, rendezvous.clone()).await;
+    let cell_c = conductor_c
+        .setup_app("app", std::slice::from_ref(&dna_file))
+        .await
+        .unwrap()
+        .into_cells()
+        .remove(0);
+    conductor_c
+        .declare_full_storage_arcs(cell_c.dna_hash())
+        .await;
+
+    await_consistency([&cell_a, &cell_c]).await.unwrap();
+    conductor_a.shutdown().await;
+
+    // Conductor B's own default bootstrap is the shared rendezvous, which never heard of conductor C,
+    // so restore can only succeed via the manifest's bootstrap_url override.
+    let mut config_b = SweetConductorConfig::rendezvous(true);
+    config_b.restore_chain_quorum = 1;
+    let mut conductor_b =
+        SweetConductor::create_with_defaults(config_b, Some(keystore), Some(rendezvous)).await;
+
+    let app_id = "restored".to_string();
+    let mut signal_rx = conductor_b.subscribe_to_app_signals(app_id.clone());
+    let restore_cell_id = CellId::new(dna_file.dna_hash().clone(), agent.clone());
+
+    let manifest = AppManifest::V0(AppManifestV0 {
+        allow_deferred_memproofs: false,
+        description: None,
+        name: "restored".to_string(),
+        roles: vec![],
+        bootstrap_url: Some(dedicated_bootstrap_url),
+        relay_url: None,
+    });
+
+    conductor_b
+        .install_app_with_manifest(
+            &app_id,
+            Some(agent.clone()),
+            [&("role".to_string(), dna_file.clone())],
+            Some(InstallAppCommonFlags {
+                restore_from_dht: true,
+                ..Default::default()
+            }),
+            manifest,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::RestoreComplete {
+            cell_id: restore_cell_id
+        }
+    );
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::AppRestoreComplete {
+            installed_app_id: app_id.clone()
+        }
+    );
+    assert_eq!(
+        app_status(&conductor_b, &app_id).await,
+        AppStatus::Disabled(DisabledAppReason::NeverStarted)
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/holochain/tests/tests/restore.rs
+++ b/crates/holochain/tests/tests/restore.rs
@@ -232,6 +232,137 @@ async fn restore_from_dht_end_to_end() {
     assert_eq!(new_record.unwrap().action().action_seq(), last_seq_on_a + 1);
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_resumes_after_conductor_restart_before_completion() {
+    holochain_trace::test_run();
+
+    let rendezvous = SweetLocalRendezvous::new().await;
+    let (dna_file, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+
+    // Conductor A authors a chain for the agent
+    let mut conductor_a = SweetConductor::from_config_rendezvous(
+        SweetConductorConfig::rendezvous(true),
+        rendezvous.clone(),
+    )
+    .await;
+    let keystore = conductor_a.keystore();
+    let agent = SweetAgents::one(keystore.clone()).await;
+
+    let app_a = conductor_a
+        .setup_app_for_agent("app", agent.clone(), std::slice::from_ref(&dna_file))
+        .await
+        .unwrap();
+    let cell_a = app_a.into_cells().remove(0);
+    conductor_a
+        .declare_full_storage_arcs(cell_a.dna_hash())
+        .await;
+
+    // Conductor C gossips with A so it can be the authority for the restore
+    let mut conductor_c = SweetConductor::from_config_rendezvous(
+        SweetConductorConfig::rendezvous(true),
+        rendezvous.clone(),
+    )
+    .await;
+    let app_c = conductor_c
+        .setup_app("app", std::slice::from_ref(&dna_file))
+        .await
+        .unwrap();
+    let cell_c = app_c.into_cells().remove(0);
+    conductor_c
+        .declare_full_storage_arcs(cell_c.dna_hash())
+        .await;
+
+    let _: ActionHash = conductor_a
+        .call(&cell_a.zome(TestWasm::Create), "create_entry", ())
+        .await;
+    let last_hash_on_a: ActionHash = conductor_a
+        .call(&cell_a.zome(TestWasm::Create), "create_entry", ())
+        .await;
+
+    await_consistency([&cell_a, &cell_c]).await.unwrap();
+
+    let last_record_on_a: Option<Record> = conductor_a
+        .call(&cell_a.zome(TestWasm::Create), "get_post", last_hash_on_a)
+        .await;
+    let last_seq_on_a = last_record_on_a.unwrap().action().action_seq();
+
+    // Shutdown the original device and the authority
+    conductor_a.shutdown().await;
+    conductor_c.shutdown().await;
+
+    let mut config_b = SweetConductorConfig::rendezvous(true);
+    config_b.restore_chain_quorum = 1;
+    config_b.network.request_timeout_s = 10;
+    let mut conductor_b =
+        SweetConductor::create_with_defaults(config_b, Some(keystore.clone()), Some(rendezvous))
+            .await;
+
+    let app_id = "restored".to_string();
+    let restore_cell_id = CellId::new(dna_file.dna_hash().clone(), agent.clone());
+
+    conductor_b
+        .install_app(
+            &app_id,
+            Some(agent.clone()),
+            std::slice::from_ref(&dna_file),
+            Some(InstallAppCommonFlags {
+                restore_from_dht: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        app_status(&conductor_b, &app_id).await,
+        AppStatus::AwaitingRestore
+    );
+
+    // Restart the restoring conductor during the restore to simulate a crash
+    conductor_b.shutdown().await;
+    conductor_b.startup().await;
+
+    assert_eq!(
+        app_status(&conductor_b, &app_id).await,
+        AppStatus::AwaitingRestore
+    );
+
+    let mut signal_rx = conductor_b.subscribe_to_app_signals(app_id.clone());
+
+    // Make the authority available, allowing the restore to complete
+    conductor_c.startup().await;
+    SweetConductor::exchange_peer_info([&conductor_b, &conductor_c]).await;
+
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::RestoreComplete {
+            cell_id: restore_cell_id.clone()
+        }
+    );
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::AppRestoreComplete {
+            installed_app_id: app_id.clone()
+        }
+    );
+    assert_eq!(
+        app_status(&conductor_b, &app_id).await,
+        AppStatus::Disabled(DisabledAppReason::NeverStarted)
+    );
+
+    conductor_b.enable_app(app_id).await.unwrap();
+
+    // The cell continues authoring on the restored chain head
+    let restore_cell = conductor_b.get_sweet_cell(restore_cell_id).unwrap();
+    let new_hash: ActionHash = conductor_b
+        .call(&restore_cell.zome(TestWasm::Create), "create_entry", ())
+        .await;
+    let new_record: Option<Record> = conductor_b
+        .call(&restore_cell.zome(TestWasm::Create), "get_post", new_hash)
+        .await;
+    assert_eq!(new_record.unwrap().action().action_seq(), last_seq_on_a + 1);
+}
+
 /// Installs a restoring app on a conductor with no peers to restore from, so the restore keeps
 /// retrying and the app stays in [`AppStatus::AwaitingRestore`]. Confirms a zome call in that state
 /// is rejected with a reason naming the restore, rather than looking like a plain disabled app.

--- a/crates/holochain/tests/tests/restore.rs
+++ b/crates/holochain/tests/tests/restore.rs
@@ -916,3 +916,186 @@ async fn restore_from_dht_chain_fork_warrant_transitions_to_unrecoverable() {
         "expected AppStatusError, got: {err:?}"
     );
 }
+
+/// Number of accepted actions authored by `agent` in `dna_hash`'s per-DNA database. Reads the DB
+/// directly rather than via `dump_full_cell_state`, which also pulls peer info and so requires the
+/// DNA's network space to already exist.
+async fn authored_action_count(
+    conductor: &SweetConductor,
+    dna_hash: &DnaHash,
+    agent: &AgentPubKey,
+) -> usize {
+    let store = conductor.get_dht_store(dna_hash).unwrap();
+    holochain_state::source_chain::dump_state(&store.as_read(), agent.clone())
+        .await
+        .unwrap()
+        .records
+        .len()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_multi_cell_app_permanent_failure_discovered_after_restart() {
+    holochain_trace::test_run();
+
+    let rendezvous = SweetLocalRendezvous::new().await;
+    let (dna_first, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+    let (dna_second, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+    let dnas = [dna_first.clone(), dna_second.clone()];
+
+    let mut conductor_a = SweetConductor::from_config_rendezvous(
+        SweetConductorConfig::rendezvous(true),
+        rendezvous.clone(),
+    )
+    .await;
+    let keystore = conductor_a.keystore();
+    let agent = SweetAgents::one(keystore.clone()).await;
+    let cell_a_first = conductor_a
+        .setup_app_for_agent("app", agent.clone(), std::slice::from_ref(&dna_first))
+        .await
+        .unwrap()
+        .into_cells()
+        .remove(0);
+    conductor_a
+        .declare_full_storage_arcs(dna_first.dna_hash())
+        .await;
+    let _: ActionHash = conductor_a
+        .call(&cell_a_first.zome(TestWasm::Create), "create_entry", ())
+        .await;
+
+    // Conductor C is the authority for the first DNA and stays up throughout.
+    let mut conductor_c = SweetConductor::from_config_rendezvous(
+        SweetConductorConfig::rendezvous(true),
+        rendezvous.clone(),
+    )
+    .await;
+    let cell_c = conductor_c
+        .setup_app("authority-first", std::slice::from_ref(&dna_first))
+        .await
+        .unwrap()
+        .into_cells()
+        .remove(0);
+    conductor_c
+        .declare_full_storage_arcs(dna_first.dna_hash())
+        .await;
+
+    await_consistency([&cell_a_first, &cell_c]).await.unwrap();
+    conductor_a.shutdown().await;
+
+    // Conductor W holds a fabricated fork and matching warrant for the second DNA, but is shut down
+    // until after the restart, so the app is still awaiting restore at the crash.
+    let mut conductor_w = SweetConductor::from_config_rendezvous(
+        SweetConductorConfig::rendezvous(true),
+        rendezvous.clone(),
+    )
+    .await;
+    let cell_w = conductor_w
+        .setup_app("authority-second", std::slice::from_ref(&dna_second))
+        .await
+        .unwrap()
+        .into_cells()
+        .remove(0);
+    conductor_w
+        .declare_full_storage_arcs(dna_second.dna_hash())
+        .await;
+
+    let (a1, a2) = build_fork_pair(&keystore, &agent, dna_second.dna_hash()).await;
+    let store_w = conductor_w.get_dht_store(dna_second.dna_hash()).unwrap();
+    insert_fetchable_action(&store_w, &a1).await;
+    insert_fetchable_action(&store_w, &a2).await;
+
+    let warrant = Warrant::new(
+        WarrantProof::ChainIntegrity(ChainIntegrityWarrant::ChainFork {
+            chain_author: agent.clone(),
+            action_pair: (
+                (a1.as_hash().clone(), a1.signature.clone()),
+                (a2.as_hash().clone(), a2.signature.clone()),
+            ),
+            seq: 0,
+        }),
+        cell_w.agent_pubkey().clone(),
+        Timestamp::now(),
+        agent.clone(),
+    );
+    let warrant_op = WarrantOp::sign(&conductor_w.keystore(), warrant)
+        .await
+        .unwrap();
+    let warrant_op_hashed = DhtOpHashed::from_content_sync(DhtOp::from((*warrant_op).clone()));
+    store_w
+        .test_insert_integrated_warrant(warrant_op_hashed)
+        .await
+        .unwrap();
+
+    conductor_w.shutdown().await;
+
+    let mut config_b = SweetConductorConfig::rendezvous(true);
+    config_b.restore_chain_quorum = 1;
+    config_b.network.request_timeout_s = 10;
+    let mut conductor_b =
+        SweetConductor::create_with_defaults(config_b, Some(keystore), Some(rendezvous)).await;
+
+    let app_id = "restored".to_string();
+    let mut signal_rx = conductor_b.subscribe_to_app_signals(app_id.clone());
+    let cell_id_first = CellId::new(dna_first.dna_hash().clone(), agent.clone());
+    let cell_id_second = CellId::new(dna_second.dna_hash().clone(), agent.clone());
+
+    conductor_b
+        .install_app(
+            &app_id,
+            Some(agent.clone()),
+            &dnas,
+            Some(InstallAppCommonFlags {
+                restore_from_dht: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::RestoreComplete {
+            cell_id: cell_id_first.clone()
+        }
+    );
+    let first_pass_count = authored_action_count(&conductor_b, dna_first.dna_hash(), &agent).await;
+
+    // The second cell has no authority yet, so the app is certain to still be awaiting restore.
+    assert_eq!(
+        app_status(&conductor_b, &app_id).await,
+        AppStatus::AwaitingRestore
+    );
+
+    conductor_b.shutdown().await;
+    conductor_b.startup().await;
+
+    let mut signal_rx = conductor_b.subscribe_to_app_signals(app_id.clone());
+
+    // The orchestrator re-walks from cell 0, re-processing it before reattempting cell 1.
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::RestoreComplete {
+            cell_id: cell_id_first.clone()
+        }
+    );
+
+    conductor_w.startup().await;
+    SweetConductor::exchange_peer_info([&conductor_b, &conductor_w]).await;
+
+    let (failed_cell_id, reason) = match next_restore_signal(&mut signal_rx).await {
+        SystemSignal::RestoreFailed { cell_id, reason } => (cell_id, reason),
+        signal => panic!("expected RestoreFailed, got: {signal:?}"),
+    };
+    assert_eq!(failed_cell_id, cell_id_second);
+    assert!(
+        matches!(reason, UnrecoverableCellReason::ChainForkWarrant(_)),
+        "expected a ChainForkWarrant reason, got: {reason:?}"
+    );
+    assert_eq!(
+        app_status(&conductor_b, &app_id).await,
+        AppStatus::Unrecoverable(cell_id_second, reason)
+    );
+
+    // Cell 0's already-restored chain survives the restart and the second cell's failure.
+    let final_count = authored_action_count(&conductor_b, dna_first.dna_hash(), &agent).await;
+    assert_eq!(first_pass_count, final_count);
+}

--- a/crates/holochain/tests/tests/restore.rs
+++ b/crates/holochain/tests/tests/restore.rs
@@ -610,6 +610,175 @@ async fn restore_multi_cell_app_does_not_settle_until_the_last_cell_completes() 
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn restore_resumes_multi_cell_app_after_conductor_restart() {
+    holochain_trace::test_run();
+
+    let rendezvous = SweetLocalRendezvous::new().await;
+    let (dna_first, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+    let (dna_second, _, _) = SweetDnaFile::unique_from_test_wasms(vec![TestWasm::Create]).await;
+    let dnas = [dna_first.clone(), dna_second.clone()];
+
+    let mut conductor_a = SweetConductor::from_config_rendezvous(
+        SweetConductorConfig::rendezvous(true),
+        rendezvous.clone(),
+    )
+    .await;
+    let keystore = conductor_a.keystore();
+    let agent = SweetAgents::one(keystore.clone()).await;
+    let cells_a = conductor_a
+        .setup_app_for_agent("app", agent.clone(), &dnas)
+        .await
+        .unwrap()
+        .into_cells();
+    for dna in &dnas {
+        conductor_a.declare_full_storage_arcs(dna.dna_hash()).await;
+    }
+    for cell in &cells_a {
+        let _: ActionHash = conductor_a
+            .call(&cell.zome(TestWasm::Create), "create_entry", ())
+            .await;
+    }
+    let cell_a_first = cells_a
+        .iter()
+        .find(|c| c.dna_hash() == dna_first.dna_hash())
+        .unwrap();
+    let cell_a_second = cells_a
+        .iter()
+        .find(|c| c.dna_hash() == dna_second.dna_hash())
+        .unwrap();
+
+    // Conductor C is the authority for the first DNA and stays up throughout
+    let mut conductor_c = SweetConductor::from_config_rendezvous(
+        SweetConductorConfig::rendezvous(true),
+        rendezvous.clone(),
+    )
+    .await;
+    let cell_c = conductor_c
+        .setup_app("authority-first", std::slice::from_ref(&dna_first))
+        .await
+        .unwrap()
+        .into_cells()
+        .remove(0);
+    conductor_c
+        .declare_full_storage_arcs(dna_first.dna_hash())
+        .await;
+
+    // Conductor D is the authority for the second DNA. It gossips with A, then is shut down so the
+    // second cell has no authority until it is deliberately started back up.
+    let mut conductor_d = SweetConductor::from_config_rendezvous(
+        SweetConductorConfig::rendezvous(true),
+        rendezvous.clone(),
+    )
+    .await;
+    let cell_d = conductor_d
+        .setup_app("authority-second", std::slice::from_ref(&dna_second))
+        .await
+        .unwrap()
+        .into_cells()
+        .remove(0);
+    conductor_d
+        .declare_full_storage_arcs(dna_second.dna_hash())
+        .await;
+
+    await_consistency([cell_a_first, &cell_c]).await.unwrap();
+    await_consistency([cell_a_second, &cell_d]).await.unwrap();
+
+    conductor_a.shutdown().await;
+    conductor_d.shutdown().await;
+
+    let mut config_b = SweetConductorConfig::rendezvous(true);
+    config_b.restore_chain_quorum = 1;
+    config_b.network.request_timeout_s = 10;
+    let mut conductor_b =
+        SweetConductor::create_with_defaults(config_b, Some(keystore), Some(rendezvous)).await;
+
+    let app_id = "restored".to_string();
+    let mut signal_rx = conductor_b.subscribe_to_app_signals(app_id.clone());
+    let cell_id_first = CellId::new(dna_first.dna_hash().clone(), agent.clone());
+    let cell_id_second = CellId::new(dna_second.dna_hash().clone(), agent.clone());
+
+    conductor_b
+        .install_app(
+            &app_id,
+            Some(agent.clone()),
+            &dnas,
+            Some(InstallAppCommonFlags {
+                restore_from_dht: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::RestoreComplete {
+            cell_id: cell_id_first.clone()
+        }
+    );
+    let first_pass_dump = conductor_b
+        .raw_handle()
+        .dump_full_cell_state(&cell_id_first, None, None)
+        .await
+        .unwrap();
+
+    // The second cell has no authority yet, so the app is certain to still be awaiting restore
+    assert_eq!(
+        app_status(&conductor_b, &app_id).await,
+        AppStatus::AwaitingRestore
+    );
+
+    conductor_b.shutdown().await;
+    conductor_b.startup().await;
+
+    let mut signal_rx = conductor_b.subscribe_to_app_signals(app_id.clone());
+
+    // The orchestrator re-walks from cell 0, so the first cell is re-processed, but unchanged,
+    // before the second cell is attempted again
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::RestoreComplete {
+            cell_id: cell_id_first.clone()
+        }
+    );
+    assert_eq!(
+        app_status(&conductor_b, &app_id).await,
+        AppStatus::AwaitingRestore
+    );
+
+    conductor_d.startup().await;
+    SweetConductor::exchange_peer_info([&conductor_b, &conductor_d]).await;
+
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::RestoreComplete {
+            cell_id: cell_id_second.clone()
+        }
+    );
+    assert_eq!(
+        next_restore_signal(&mut signal_rx).await,
+        SystemSignal::AppRestoreComplete {
+            installed_app_id: app_id.clone()
+        }
+    );
+    assert_eq!(
+        app_status(&conductor_b, &app_id).await,
+        AppStatus::Disabled(DisabledAppReason::NeverStarted)
+    );
+
+    // Re-processing the first cell did not duplicate or lose any of its rows
+    let final_dump = conductor_b
+        .raw_handle()
+        .dump_full_cell_state(&cell_id_first, None, None)
+        .await
+        .unwrap();
+    assert_eq!(
+        first_pass_dump.source_chain_dump.records.len(),
+        final_dump.source_chain_dump.records.len()
+    );
+}
+
 async fn build_fork_pair(
     keystore: &holochain_keystore::MetaLairClient,
     agent: &AgentPubKey,

--- a/crates/holochain_state/src/dht_store/restore.rs
+++ b/crates/holochain_state/src/dht_store/restore.rs
@@ -260,6 +260,140 @@ mod tests {
         );
     }
 
+    /// Crash recovery for a cell whose chain was partially written before the crash.
+    #[tokio::test]
+    async fn write_restored_chain_is_idempotent_when_replayed() {
+        let store = DhtStore::new_test(dht_id()).await.unwrap();
+        let author = fixt!(AgentPubKey);
+
+        let dna = dna_record(&author);
+        let create = create_record(
+            &author,
+            dna.action_address().clone(),
+            EntryType::App(AppEntryDef::new(
+                0.into(),
+                0.into(),
+                EntryVisibility::Public,
+            )),
+            app_entry(1),
+        );
+        let create_action = create.action().clone();
+        let create_entry_hash = create.action().entry_hash().unwrap().clone();
+
+        let action1_entry = app_entry(2);
+        let action1 = make_record(
+            Action {
+                header: ActionHeader {
+                    author: author.clone(),
+                    timestamp: Timestamp::from_micros(2000),
+                    action_seq: 2,
+                    prev_action: Some(create.action_address().clone()),
+                },
+                data: ActionData::Create(CreateData {
+                    entry_type: EntryType::App(AppEntryDef::new(
+                        0.into(),
+                        0.into(),
+                        EntryVisibility::Public,
+                    )),
+                    entry_hash: EntryHash::with_data_sync(&action1_entry),
+                }),
+            },
+            Some(action1_entry),
+        );
+        let action1_entry_hash = action1.action().entry_hash().unwrap().clone();
+
+        let action2_entry = app_entry(3);
+        let action2 = make_record(
+            Action {
+                header: ActionHeader {
+                    author: author.clone(),
+                    timestamp: Timestamp::from_micros(3000),
+                    action_seq: 3,
+                    prev_action: Some(action1.action_address().clone()),
+                },
+                data: ActionData::Create(CreateData {
+                    entry_type: EntryType::App(AppEntryDef::new(
+                        0.into(),
+                        0.into(),
+                        EntryVisibility::Public,
+                    )),
+                    entry_hash: EntryHash::with_data_sync(&action2_entry),
+                }),
+            },
+            Some(action2_entry),
+        );
+
+        // Simulate a crash by writing part of the chain
+        store
+            .write_restored_chain(&author, vec![dna.clone(), create.clone(), action1.clone()])
+            .await
+            .unwrap();
+
+        // Only the first 3 actions are in the DB
+        let by_author = store
+            .db()
+            .as_ref()
+            .get_actions_by_author(author.clone())
+            .await
+            .unwrap();
+        assert_eq!(by_author.len(), 3);
+
+        // Simulate a resume by now writing the full chain
+        store
+            .write_restored_chain(&author, vec![dna, create, action1, action2])
+            .await
+            .unwrap();
+
+        // No duplicate action rows and the new record was appended
+        let by_author = store
+            .db()
+            .as_ref()
+            .get_actions_by_author(author)
+            .await
+            .unwrap();
+        assert_eq!(by_author.len(), 4);
+
+        // The replayed entries are still readable after being written twice
+        for hash in [&create_entry_hash, &action1_entry_hash] {
+            assert!(
+                store
+                    .db()
+                    .as_ref()
+                    .get_entry(hash.clone(), None)
+                    .await
+                    .unwrap()
+                    .is_some(),
+                "replayed entry should still be readable"
+            );
+        }
+
+        // No duplicate chain op or publish rows for the replayed op
+        let op_hash = {
+            use holochain_types::op::ChainOpUniqueForm;
+            use holochain_zome_types::op::ChainOpType;
+            ChainOpUniqueForm::op_hash(ChainOpType::CreateRecord, &create_action)
+        };
+        let row = store
+            .db()
+            .as_ref()
+            .get_chain_op(op_hash.clone())
+            .await
+            .unwrap()
+            .expect("chain op row should still exist after replay");
+        assert_eq!(row.validation_status, i64::from(RecordValidity::Accepted));
+
+        let publish_row = store
+            .db()
+            .as_ref()
+            .get_chain_op_publish(op_hash)
+            .await
+            .unwrap();
+        assert!(
+            publish_row.is_some(),
+            "the ChainOpPublish row should still exist after replay"
+        );
+    }
+
     #[tokio::test]
     async fn identical_entry_content_with_different_visibility_is_written_to_both_tables() {
         let store = DhtStore::new_test(dht_id()).await.unwrap();


### PR DESCRIPTION
### Summary

Most of the source-chain restore work was done in #5920. The goal of this PR was to add additional tests for that work to cover #5801; however, in doing so, some issues were identified and resolved. These were:


1. If no peers were found for the agent's location during the restore, it caused the restore to fail and not retry.
2. Any gossip that happened during the restore was rejected, which then blocked the chain write as part of the store because the chain was already written as rejected.
3. The source-chain restore was ignoring the app's p2p config overrides, which meant that the default relay URL was used, meaning that if a custom relay is used by the app, no peers could be found.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs