### PR TITLE
fix(ci): mark dna/wasm test fixtures as binary in git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.dna binary
+*.wasm binary

--- a/crates/hc_bundle/tests/test_cli.rs
+++ b/crates/hc_bundle/tests/test_cli.rs
@@ -167,7 +167,6 @@ async fn test_integrity() {
 /// Test that a manifest with multiple integrity zomes and dependencies parses
 /// to the correct dna file.
 #[tokio::test]
-#[cfg_attr(target_os = "windows", ignore = "theres a hash mismatch - check crlf?")]
 #[cfg(not(feature = "unstable-migration"))]
 async fn test_multi_integrity() {
     let pack_dna = |path| async move {
@@ -272,7 +271,6 @@ async fn test_multi_integrity() {
 /// Test that a manifest with multiple integrity zomes and dependencies parses
 /// to the correct dna file.
 #[tokio::test]
-#[cfg_attr(target_os = "windows", ignore = "theres a hash mismatch - check crlf?")]
 #[cfg(feature = "unstable-migration")]
 async fn test_multi_integrity() {
     let pack_dna = |path| async move {

--- a/crates/hc_bundle/tests/test_cli.rs
+++ b/crates/hc_bundle/tests/test_cli.rs
@@ -388,7 +388,6 @@ async fn test_multi_integrity() {
 }
 
 #[tokio::test]
-#[cfg_attr(target_os = "windows", ignore = "theres a hash mismatch - check crlf?")]
 async fn test_hash_dna_function() {
     {
         let mut cmd = Command::new(assert_cmd::cargo_bin!("hc-dna"));


### PR DESCRIPTION
### Summary

Hashing a DNA bundle file was reported to give a different hash on Windows than on Linux and macOS (#4555). A test that checks this exists, but it was skipped on Windows because the hash did not match there.

The cause turned out to be how Windows checks out the repository. The test fixture files (a packed `.dna` file and some `.wasm` files) are binary, but git had no explicit instruction to treat them as binary, so on Windows it could alter their line endings during checkout. That changed the file's bytes, which changed the hash. Adding a `.gitattributes` entry that marks `.dna` and `.wasm` files as binary tells git to leave them alone on any platform. With that in place, the Windows CI run now produces the same hash as Linux and macOS, so the test is turned back on for Windows.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs