### PR TITLE
feat(client): add connection resilience to the Rust client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,6 +3150,7 @@ dependencies = [
  "event-emitter-rs",
  "holo_hash",
  "holochain",
+ "holochain_client",
  "holochain_conductor_api",
  "holochain_nonce",
  "holochain_serialized_bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3168,6 +3168,7 @@ dependencies = [
  "serde",
  "thiserror 2.0.20",
  "tokio",
+ "tracing",
  "yaml_serde",
 ]
 

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -33,11 +33,12 @@ parking_lot = "0.12.1"
 rand = { version = "0.8" }
 serde = "1.0"
 thiserror = "2.0"
-tokio = { version = "1.36", features = ["rt", "sync", "time", "macros"] }
+tokio = { version = "1.36", features = ["rt", "sync", "time"] }
 tracing = "0.1"
 
 [dev-dependencies]
 bytes = "1.10.1"
+tokio = { version = "1.36", features = ["macros"] }
 mr_bundle = { version = "^0.8.0-dev.1", path = "../mr_bundle" }
 holochain = { version = "^0.8.0-dev.2", path = "../holochain", default-features = false, features = [
   "sweettest",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -33,7 +33,7 @@ parking_lot = "0.12.1"
 rand = { version = "0.8" }
 serde = "1.0"
 thiserror = "2.0"
-tokio = { version = "1.36", features = ["rt"] }
+tokio = { version = "1.36", features = ["rt", "sync", "time", "macros"] }
 
 [dev-dependencies]
 bytes = "1.10.1"
@@ -41,6 +41,7 @@ mr_bundle = { version = "^0.8.0-dev.1", path = "../mr_bundle" }
 holochain = { version = "^0.8.0-dev.2", path = "../holochain", default-features = false, features = [
   "sweettest",
 ] }
+holochain_client = { path = ".", features = ["test_utils"] }
 holochain_wasm_test_utils = { version = "^0.8.0-dev.2", path = "../test_utils/wasm" }
 
 kitsune2_core = "0.5.0"
@@ -51,6 +52,8 @@ yaml_serde = "0.10"
 default = ["lair_signing"]
 
 lair_signing = ["dep:lair_keystore_api"]
+
+test_utils = []
 
 wasmer-sys-cranelift = ["holochain/wasmer-sys-cranelift"]
 wasmer-wasmi = ["holochain/wasmer-wasmi"]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -34,6 +34,7 @@ rand = { version = "0.8" }
 serde = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.36", features = ["rt", "sync", "time", "macros"] }
+tracing = "0.1"
 
 [dev-dependencies]
 bytes = "1.10.1"

--- a/crates/client/README.md
+++ b/crates/client/README.md
@@ -16,6 +16,26 @@ Types and bindings to connect easily to a running Holochain conductor from Rust.
 
 **Rust client v0.5.x** is compatible with **Holochain v0.3.x**.
 
+## Connection resilience
+
+`AdminWebsocket` and `AppWebsocket` are single connections. When the conductor
+restarts, they stop working and the caller reconnects.
+
+`ReconnectingAdminWebsocket` and `ReconnectingAppWebsocket` repair themselves.
+Use `connect` when the conductor should already be running and a failure is
+worth reporting, and `connect_with_retry` when you are waiting for one to
+start; the latter never gives up, so bound it with `tokio::time::timeout` if
+you need it to.
+
+Requests made while a connection is down return
+`ConductorApiError::Disconnected`; retry them once the connection is back.
+Zome calls are never retried for you, because re-signing one mints a fresh
+nonce and could write to the source chain twice.
+
+Signals emitted while a client is disconnected are lost — Holochain has no
+signal replay. A `SignalStream` therefore reports `SignalEvent::Interrupted`
+when it resumes, so state derived from signals can be re-read.
+
 ## Running the tests
 
 ``` bash

--- a/crates/client/src/admin_websocket.rs
+++ b/crates/client/src/admin_websocket.rs
@@ -1,5 +1,5 @@
 use crate::error::{ConductorApiError, ConductorApiResult};
-use crate::util::AbortOnDropHandle;
+use crate::util::{AbortOnDropHandle, ClosedNotify};
 use holo_hash::{ActionHash, DnaHash};
 use holochain_conductor_api::{
     AdminInterfaceConfig, AdminRequest, AdminResponse, AppAuthenticationToken,
@@ -125,11 +125,7 @@ impl AdminWebsocket {
             }
         }
 
-        Err(last_err.unwrap_or_else(|| {
-            ConductorApiError::WebsocketError(holochain_websocket::WebsocketError::Other(
-                "No addresses resolved".to_string(),
-            ))
-        }))
+        Err(last_err.unwrap_or(ConductorApiError::NoAddressesResolved))
     }
 
     /// Connect to a Conductor API admin websocket with a custom [ConnectRequest] and [WebsocketConfig].
@@ -175,17 +171,47 @@ impl AdminWebsocket {
         request: ConnectRequest,
         websocket_config: Arc<WebsocketConfig>,
     ) -> ConductorApiResult<Self> {
+        let (admin_ws, _closed) = Self::connect_with_notify(request, websocket_config).await?;
+        Ok(admin_ws)
+    }
+
+    /// Connects and additionally returns a notification that resolves when the
+    /// connection is no longer usable.
+    pub(crate) async fn connect_with_notify(
+        request: ConnectRequest,
+        websocket_config: Arc<WebsocketConfig>,
+    ) -> ConductorApiResult<(Self, ClosedNotify)> {
         let (tx, mut rx) = connect(websocket_config.clone(), request).await?;
+
+        let (closed_tx, closed_rx) = tokio::sync::oneshot::channel();
 
         // WebsocketReceiver needs to be polled in order to receive responses
         // from remote to sender requests.
-        let poll_handle =
-            tokio::task::spawn(async move { while rx.recv::<AdminResponse>().await.is_ok() {} });
+        let poll_handle = tokio::task::spawn(async move {
+            while rx.recv::<AdminResponse>().await.is_ok() {}
+            let _ = closed_tx.send(());
+        });
 
-        Ok(Self {
-            tx,
-            _poll_handle: Arc::new(AbortOnDropHandle::new(poll_handle.abort_handle())),
-        })
+        Ok((
+            Self {
+                tx,
+                _poll_handle: Arc::new(AbortOnDropHandle::new(poll_handle.abort_handle())),
+            },
+            ClosedNotify::new(closed_rx),
+        ))
+    }
+
+    #[cfg(feature = "test_utils")]
+    /// Connects and returns the close notification, for tests that assert
+    /// disconnection is observed.
+    pub async fn connect_for_test(
+        socket_addr: impl ToSocketAddrs,
+    ) -> ConductorApiResult<(Self, crate::util::ClosedNotify)> {
+        let addr = socket_addr
+            .to_socket_addrs()?
+            .next()
+            .ok_or(ConductorApiError::NoAddressesResolved)?;
+        Self::connect_with_notify(addr.into(), Arc::new(WebsocketConfig::CLIENT_DEFAULT)).await
     }
 
     /// Issue an app authentication token for the specified app.

--- a/crates/client/src/app_connect.rs
+++ b/crates/client/src/app_connect.rs
@@ -8,7 +8,6 @@ use holochain_types::app::InstalledAppId;
 /// An interface qualifies when it is either unrestricted or bound to this app,
 /// and its allowed origins admit `origin`. Where several qualify, the lowest
 /// port is chosen so that repeated calls against an unchanged conductor agree.
-#[allow(dead_code)] // reachable only via the `test_utils`-gated re-export for now
 pub async fn discover_app_interface_port(
     admin_ws: &AdminWebsocket,
     installed_app_id: &InstalledAppId,

--- a/crates/client/src/app_connect.rs
+++ b/crates/client/src/app_connect.rs
@@ -1,0 +1,35 @@
+use crate::error::{ConductorApiError, ConductorApiResult};
+use crate::AdminWebsocket;
+use holochain_types::app::InstalledAppId;
+
+/// Finds the port of an app interface that accepts `installed_app_id` from
+/// `origin`.
+///
+/// An interface qualifies when it is either unrestricted or bound to this app,
+/// and its allowed origins admit `origin`. Where several qualify, the lowest
+/// port is chosen so that repeated calls against an unchanged conductor agree.
+#[allow(dead_code)] // reachable only via the `test_utils`-gated re-export for now
+pub async fn discover_app_interface_port(
+    admin_ws: &AdminWebsocket,
+    installed_app_id: &InstalledAppId,
+    origin: Option<&str>,
+) -> ConductorApiResult<u16> {
+    let interfaces = admin_ws.list_app_interfaces().await?;
+
+    interfaces
+        .iter()
+        .filter(|interface| match &interface.installed_app_id {
+            Some(bound) => bound == installed_app_id,
+            None => true,
+        })
+        .filter(|interface| match origin {
+            Some(origin) => interface.allowed_origins.is_allowed(origin),
+            None => true,
+        })
+        .map(|interface| interface.port)
+        .min()
+        .ok_or_else(|| ConductorApiError::AppInterfaceNotFound {
+            installed_app_id: installed_app_id.clone(),
+            origin: origin.map(str::to_string),
+        })
+}

--- a/crates/client/src/app_websocket.rs
+++ b/crates/client/src/app_websocket.rs
@@ -1,5 +1,6 @@
 use crate::app_websocket_inner::AppWebsocketInner;
 use crate::signing::DynAgentSigner;
+use crate::util::ClosedNotify;
 use crate::{signing::sign_zome_call, ConductorApiError, ConductorApiResult};
 use anyhow::{anyhow, Result};
 use holo_hash::{AgentPubKey, DnaHash};
@@ -78,7 +79,7 @@ impl AppWebsocket {
         signer: DynAgentSigner,
         origin: Option<String>,
     ) -> ConductorApiResult<Self> {
-        let app_ws = AppWebsocketInner::connect(socket_addr, origin).await?;
+        let (app_ws, _closed) = AppWebsocketInner::connect(socket_addr, origin).await?;
         Self::post_connect(app_ws, token, signer).await
     }
 
@@ -118,7 +119,7 @@ impl AppWebsocket {
         signer: DynAgentSigner,
         origin: Option<String>,
     ) -> ConductorApiResult<Self> {
-        let app_ws =
+        let (app_ws, _closed) =
             AppWebsocketInner::connect_with_config(socket_addr, websocket_config, origin).await?;
         Self::post_connect(app_ws, token, signer).await
     }
@@ -178,9 +179,23 @@ impl AppWebsocket {
         token: AppAuthenticationToken,
         signer: DynAgentSigner,
     ) -> ConductorApiResult<Self> {
-        let app_ws =
+        let (app_ws, _closed) =
             AppWebsocketInner::connect_with_config_and_request(websocket_config, request).await?;
         Self::post_connect(app_ws, token, signer).await
+    }
+
+    /// Connects and additionally returns a notification that resolves when the
+    /// connection is no longer usable.
+    #[allow(dead_code)]
+    pub(crate) async fn connect_with_notify(
+        request: ConnectRequest,
+        websocket_config: Arc<WebsocketConfig>,
+        token: AppAuthenticationToken,
+        signer: DynAgentSigner,
+    ) -> ConductorApiResult<(Self, ClosedNotify)> {
+        let (app_ws, closed) =
+            AppWebsocketInner::connect_with_config_and_request(websocket_config, request).await?;
+        Ok((Self::post_connect(app_ws, token, signer).await?, closed))
     }
 
     async fn post_connect(

--- a/crates/client/src/app_websocket.rs
+++ b/crates/client/src/app_websocket.rs
@@ -186,7 +186,6 @@ impl AppWebsocket {
 
     /// Connects and additionally returns a notification that resolves when the
     /// connection is no longer usable.
-    #[allow(dead_code)]
     pub(crate) async fn connect_with_notify(
         request: ConnectRequest,
         websocket_config: Arc<WebsocketConfig>,

--- a/crates/client/src/app_websocket_inner.rs
+++ b/crates/client/src/app_websocket_inner.rs
@@ -1,5 +1,5 @@
 use crate::error::{ConductorApiError, ConductorApiResult};
-use crate::util::AbortOnDropHandle;
+use crate::util::{AbortOnDropHandle, ClosedNotify};
 use event_emitter_rs::EventEmitter;
 use holochain_conductor_api::{
     AppAuthenticationRequest, AppAuthenticationToken, AppInfo, AppRequest, AppResponse,
@@ -29,7 +29,7 @@ impl AppWebsocketInner {
     pub(crate) async fn connect(
         socket_addr: impl ToSocketAddrs,
         origin: Option<String>,
-    ) -> ConductorApiResult<Self> {
+    ) -> ConductorApiResult<(Self, ClosedNotify)> {
         let websocket_config = Arc::new(WebsocketConfig::CLIENT_DEFAULT);
 
         Self::connect_with_config(socket_addr, websocket_config, origin).await
@@ -40,7 +40,7 @@ impl AppWebsocketInner {
         socket_addr: impl ToSocketAddrs,
         websocket_config: Arc<WebsocketConfig>,
         origin: Option<String>,
-    ) -> ConductorApiResult<Self> {
+    ) -> ConductorApiResult<(Self, ClosedNotify)> {
         let mut last_err = None;
         for addr in socket_addr.to_socket_addrs()? {
             let request: ConnectRequest = if let Some(o) = &origin {
@@ -57,22 +57,20 @@ impl AppWebsocketInner {
             }
         }
 
-        Err(last_err.unwrap_or_else(|| {
-            ConductorApiError::WebsocketError(holochain_websocket::WebsocketError::Other(
-                "No addresses resolved".to_string(),
-            ))
-        }))
+        Err(last_err.unwrap_or(ConductorApiError::NoAddressesResolved))
     }
 
     /// Connect to a Conductor API app websocket with a custom [WebsocketConfig] and [ConnectRequest].
     pub async fn connect_with_config_and_request(
         websocket_config: Arc<WebsocketConfig>,
         request: ConnectRequest,
-    ) -> ConductorApiResult<Self> {
+    ) -> ConductorApiResult<(Self, ClosedNotify)> {
         let (tx, mut rx) = connect(websocket_config, request).await?;
 
         let event_emitter = EventEmitter::new();
         let mutex = Arc::new(Mutex::new(event_emitter));
+
+        let (closed_tx, closed_rx) = tokio::sync::oneshot::channel();
 
         let poll_handle = tokio::task::spawn({
             let mutex = mutex.clone();
@@ -83,14 +81,18 @@ impl AppWebsocketInner {
                         event_emitter.emit("signal", signal_bytes);
                     }
                 }
+                let _ = closed_tx.send(());
             }
         });
 
-        Ok(Self {
-            tx,
-            event_emitter: mutex,
-            _abort_handle: Arc::new(AbortOnDropHandle::new(poll_handle.abort_handle())),
-        })
+        Ok((
+            Self {
+                tx,
+                event_emitter: mutex,
+                _abort_handle: Arc::new(AbortOnDropHandle::new(poll_handle.abort_handle())),
+            },
+            ClosedNotify::new(closed_rx),
+        ))
     }
 
     pub(crate) async fn on_signal<F: Fn(Signal) + 'static + Sync + Send>(

--- a/crates/client/src/error.rs
+++ b/crates/client/src/error.rs
@@ -21,6 +21,11 @@ pub enum ConductorApiError {
     Disconnected,
     #[error("No socket addresses resolved")]
     NoAddressesResolved,
+    #[error("No app interface accepts app {installed_app_id} from origin {origin:?}")]
+    AppInterfaceNotFound {
+        installed_app_id: holochain_types::app::InstalledAppId,
+        origin: Option<String>,
+    },
 }
 
 pub type ConductorApiResult<T> = Result<T, ConductorApiError>;

--- a/crates/client/src/error.rs
+++ b/crates/client/src/error.rs
@@ -17,6 +17,10 @@ pub enum ConductorApiError {
     AppNotFound,
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),
+    #[error("Not connected to the conductor")]
+    Disconnected,
+    #[error("No socket addresses resolved")]
+    NoAddressesResolved,
 }
 
 pub type ConductorApiResult<T> = Result<T, ConductorApiError>;

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -3,6 +3,7 @@ mod app_websocket;
 mod app_websocket_inner;
 mod error;
 mod reconnect;
+mod reconnecting_admin_websocket;
 mod signal_stream;
 mod signing;
 mod util;
@@ -27,6 +28,7 @@ pub use holochain_zome_types::prelude::{
 };
 pub use kitsune2_api::Url;
 pub use reconnect::ReconnectConfig;
+pub use reconnecting_admin_websocket::ReconnectingAdminWebsocket;
 pub use signal_stream::{SignalEvent, SignalStream};
 pub use signing::client_signing::{ClientAgentSigner, SigningCredentials};
 #[cfg(feature = "lair_signing")]

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -5,6 +5,7 @@ mod app_websocket_inner;
 mod error;
 mod reconnect;
 mod reconnecting_admin_websocket;
+mod reconnecting_app_websocket;
 mod signal_stream;
 mod signing;
 mod util;
@@ -32,6 +33,7 @@ pub use holochain_zome_types::prelude::{
 pub use kitsune2_api::Url;
 pub use reconnect::ReconnectConfig;
 pub use reconnecting_admin_websocket::ReconnectingAdminWebsocket;
+pub use reconnecting_app_websocket::{ReconnectingAppWebsocket, ReconnectingAppWebsocketBuilder};
 pub use signal_stream::{SignalEvent, SignalStream};
 pub use signing::client_signing::{ClientAgentSigner, SigningCredentials};
 #[cfg(feature = "lair_signing")]

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -2,6 +2,7 @@ mod admin_websocket;
 mod app_websocket;
 mod app_websocket_inner;
 mod error;
+mod reconnect;
 mod signing;
 mod util;
 
@@ -24,6 +25,7 @@ pub use holochain_zome_types::prelude::{
     CellId, ClonedCell, ExternIO, GrantedFunctions, Timestamp,
 };
 pub use kitsune2_api::Url;
+pub use reconnect::ReconnectConfig;
 pub use signing::client_signing::{ClientAgentSigner, SigningCredentials};
 #[cfg(feature = "lair_signing")]
 pub use signing::lair_signing::LairAgentSigner;

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -28,3 +28,5 @@ pub use signing::client_signing::{ClientAgentSigner, SigningCredentials};
 #[cfg(feature = "lair_signing")]
 pub use signing::lair_signing::LairAgentSigner;
 pub use signing::{AgentSigner, DynAgentSigner};
+#[cfg(feature = "test_utils")]
+pub use util::ClosedNotify;

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,4 +1,5 @@
 mod admin_websocket;
+mod app_connect;
 mod app_websocket;
 mod app_websocket_inner;
 mod error;
@@ -9,6 +10,8 @@ mod signing;
 mod util;
 
 pub use admin_websocket::{AdminWebsocket, AuthorizeSigningCredentialsPayload, EnableAppResponse};
+#[cfg(feature = "test_utils")]
+pub use app_connect::discover_app_interface_port as discover_app_interface_port_for_test;
 pub use app_websocket::{AppWebsocket, CallZomeOptions, ZomeCallTarget};
 pub use error::{ConductorApiError, ConductorApiResult};
 pub use holochain_conductor_api::{

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,3 +1,48 @@
+//! A Rust client for the Holochain Conductor API.
+//!
+//! [`AdminWebsocket`] and [`AppWebsocket`] are single connections that fail
+//! when the conductor goes away. [`ReconnectingAdminWebsocket`] and
+//! [`ReconnectingAppWebsocket`] re-establish themselves instead.
+//!
+//! A conductor restart invalidates every app authentication token and moves
+//! any app interface attached on port 0, so a resilient app connection is
+//! identified by the admin address and the installed app id rather than by an
+//! app interface port.
+//!
+//! `connect` fails if the conductor does not accept, which suits a CLI.
+//! `connect_with_retry` waits for a conductor that has not started yet; bound
+//! it with [`tokio::time::timeout`] if you do not want to wait forever.
+//!
+//! ```rust,no_run
+//! # #[tokio::main]
+//! # async fn main() {
+//! use std::net::{Ipv4Addr, SocketAddr};
+//! use holochain_client::{
+//!     ClientAgentSigner, ReconnectingAppWebsocket, SignalEvent,
+//! };
+//!
+//! let app_ws = ReconnectingAppWebsocket::builder(
+//!     SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 30_000),
+//!     "my-app".to_string(),
+//!     ClientAgentSigner::default().into(),
+//! )
+//! .origin("my-service")
+//! .connect_with_retry()
+//! .await
+//! .unwrap();
+//!
+//! let mut signals = app_ws.signals();
+//! while let Some(event) = signals.next().await {
+//!     match event {
+//!         SignalEvent::Signal(signal) => println!("{signal:?}"),
+//!         // Signals were missed while the connection was down. Holochain does
+//!         // not replay them, so re-read any state derived from signals.
+//!         SignalEvent::Interrupted => println!("re-syncing"),
+//!     }
+//! }
+//! # }
+//! ```
+
 mod admin_websocket;
 mod app_connect;
 mod app_websocket;

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -3,6 +3,7 @@ mod app_websocket;
 mod app_websocket_inner;
 mod error;
 mod reconnect;
+mod signal_stream;
 mod signing;
 mod util;
 
@@ -26,6 +27,7 @@ pub use holochain_zome_types::prelude::{
 };
 pub use kitsune2_api::Url;
 pub use reconnect::ReconnectConfig;
+pub use signal_stream::{SignalEvent, SignalStream};
 pub use signing::client_signing::{ClientAgentSigner, SigningCredentials};
 #[cfg(feature = "lair_signing")]
 pub use signing::lair_signing::LairAgentSigner;

--- a/crates/client/src/reconnect.rs
+++ b/crates/client/src/reconnect.rs
@@ -70,7 +70,7 @@ where
         match factory().await {
             Ok(value) => {
                 if attempt > 0 {
-                    tracing::info!(target = label, attempts = attempt, "reconnected");
+                    tracing::info!(connection = label, attempts = attempt, "reconnected");
                 }
                 return value;
             }
@@ -78,14 +78,14 @@ where
                 let delay = delay_for_attempt(attempt, config);
                 if attempt >= config.escalate_after {
                     tracing::error!(
-                        target = label,
+                        connection = label,
                         attempt,
                         ?delay,
                         error = %err,
                         "reconnect failing persistently, operator attention needed"
                     );
                 } else {
-                    tracing::warn!(target = label, attempt, ?delay, error = %err, "reconnect attempt failed");
+                    tracing::warn!(connection = label, attempt, ?delay, error = %err, "reconnect attempt failed");
                 }
                 attempt = attempt.saturating_add(1);
                 tokio::time::sleep(delay).await;

--- a/crates/client/src/reconnect.rs
+++ b/crates/client/src/reconnect.rs
@@ -1,0 +1,154 @@
+use rand::Rng;
+use std::future::Future;
+use std::time::Duration;
+
+/// Controls how a resilient connection backs off between reconnect attempts.
+///
+/// Reconnection never gives up. A connection that cannot be re-established —
+/// because the conductor is down, or because its app interface rejects the
+/// configured origin — keeps retrying at `max_delay` until it succeeds or the
+/// connection handle is dropped.
+#[derive(Debug, Clone)]
+pub struct ReconnectConfig {
+    /// Delay before the first retry.
+    pub initial_delay: Duration,
+    /// Upper bound on the delay between retries.
+    pub max_delay: Duration,
+    /// Consecutive failures after which attempts are logged at `error` rather
+    /// than `warn`, so operator alerting can fire.
+    pub escalate_after: u32,
+}
+
+impl Default for ReconnectConfig {
+    fn default() -> Self {
+        Self {
+            initial_delay: Duration::from_secs(1),
+            max_delay: Duration::from_secs(30),
+            escalate_after: 5,
+        }
+    }
+}
+
+/// Computes the delay before the retry that follows `attempt`.
+///
+/// The delay doubles per attempt, is capped at [`ReconnectConfig::max_delay`],
+/// and carries up to 10% jitter so that many clients reconnecting to the same
+/// conductor do not synchronise.
+#[allow(dead_code)]
+pub(crate) fn delay_for_attempt(attempt: u32, config: &ReconnectConfig) -> Duration {
+    let factor = 1u32.checked_shl(attempt.min(20)).unwrap_or(u32::MAX);
+    let capped = config
+        .initial_delay
+        .saturating_mul(factor)
+        .min(config.max_delay);
+
+    let jitter_ceiling = capped.mul_f64(0.1).as_nanos() as u64;
+    let jitter = if jitter_ceiling == 0 {
+        0
+    } else {
+        rand::thread_rng().gen_range(0..=jitter_ceiling)
+    };
+
+    capped.saturating_add(Duration::from_nanos(jitter))
+}
+
+/// Calls `factory` until it succeeds, backing off between attempts.
+///
+/// This never returns an error. Cancel it by dropping the future, which is how
+/// a resilient connection stops reconnecting when its handle goes away.
+#[allow(dead_code)]
+pub(crate) async fn connect_with_backoff<F, Fut, T, E>(
+    label: &str,
+    config: &ReconnectConfig,
+    factory: F,
+) -> T
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+    E: std::fmt::Display,
+{
+    let mut attempt: u32 = 0;
+    loop {
+        match factory().await {
+            Ok(value) => {
+                if attempt > 0 {
+                    tracing::info!(target = label, attempts = attempt, "reconnected");
+                }
+                return value;
+            }
+            Err(err) => {
+                let delay = delay_for_attempt(attempt, config);
+                if attempt >= config.escalate_after {
+                    tracing::error!(
+                        target = label,
+                        attempt,
+                        ?delay,
+                        error = %err,
+                        "reconnect failing persistently, operator attention needed"
+                    );
+                } else {
+                    tracing::warn!(target = label, attempt, ?delay, error = %err, "reconnect attempt failed");
+                }
+                attempt = attempt.saturating_add(1);
+                tokio::time::sleep(delay).await;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    #[test]
+    fn delay_starts_at_the_initial_delay() {
+        let config = ReconnectConfig::default();
+        let delay = delay_for_attempt(0, &config);
+        assert!(delay >= config.initial_delay);
+        assert!(delay <= config.initial_delay.mul_f64(1.1));
+    }
+
+    #[test]
+    fn delay_doubles_per_attempt() {
+        let config = ReconnectConfig::default();
+        assert!(delay_for_attempt(1, &config) >= config.initial_delay * 2);
+        assert!(delay_for_attempt(2, &config) >= config.initial_delay * 4);
+    }
+
+    #[test]
+    fn delay_is_capped_at_the_maximum() {
+        let config = ReconnectConfig::default();
+        let delay = delay_for_attempt(20, &config);
+        assert!(delay >= config.max_delay);
+        assert!(delay <= config.max_delay.mul_f64(1.1));
+    }
+
+    #[test]
+    fn delay_does_not_overflow_at_large_attempt_counts() {
+        let config = ReconnectConfig::default();
+        let delay = delay_for_attempt(u32::MAX, &config);
+        assert!(delay <= config.max_delay.mul_f64(1.1));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retries_until_the_factory_succeeds() {
+        let attempts = Arc::new(AtomicU32::new(0));
+
+        let value = connect_with_backoff("test", &ReconnectConfig::default(), || {
+            let attempts = attempts.clone();
+            async move {
+                if attempts.fetch_add(1, Ordering::SeqCst) < 2 {
+                    Err("not yet")
+                } else {
+                    Ok(42u32)
+                }
+            }
+        })
+        .await;
+
+        assert_eq!(value, 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+}

--- a/crates/client/src/reconnect.rs
+++ b/crates/client/src/reconnect.rs
@@ -34,7 +34,6 @@ impl Default for ReconnectConfig {
 /// The delay doubles per attempt, is capped at [`ReconnectConfig::max_delay`],
 /// and carries up to 10% jitter so that many clients reconnecting to the same
 /// conductor do not synchronise.
-#[allow(dead_code)]
 pub(crate) fn delay_for_attempt(attempt: u32, config: &ReconnectConfig) -> Duration {
     let factor = 1u32.checked_shl(attempt.min(20)).unwrap_or(u32::MAX);
     let capped = config
@@ -56,7 +55,6 @@ pub(crate) fn delay_for_attempt(attempt: u32, config: &ReconnectConfig) -> Durat
 ///
 /// This never returns an error. Cancel it by dropping the future, which is how
 /// a resilient connection stops reconnecting when its handle goes away.
-#[allow(dead_code)]
 pub(crate) async fn connect_with_backoff<F, Fut, T, E>(
     label: &str,
     config: &ReconnectConfig,

--- a/crates/client/src/reconnect.rs
+++ b/crates/client/src/reconnect.rs
@@ -94,6 +94,21 @@ where
     }
 }
 
+/// Defines a method on a reconnecting wrapper that forwards to the live socket.
+///
+/// The body resolves the current connection, so a request made while the
+/// connection is down fails with [`crate::ConductorApiError::Disconnected`].
+macro_rules! delegate {
+    ($(#[$meta:meta])* $name:ident($($arg:ident: $ty:ty),* $(,)?) -> $ret:ty) => {
+        $(#[$meta])*
+        pub async fn $name(&self, $($arg: $ty),*) -> $crate::error::ConductorApiResult<$ret> {
+            self.current()?.$name($($arg),*).await
+        }
+    };
+}
+
+pub(crate) use delegate;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/client/src/reconnecting_admin_websocket.rs
+++ b/crates/client/src/reconnecting_admin_websocket.rs
@@ -1,0 +1,145 @@
+use crate::error::{ConductorApiError, ConductorApiResult};
+use crate::reconnect::{connect_with_backoff, ReconnectConfig};
+use crate::util::AbortOnDropHandle;
+use crate::AdminWebsocket;
+use holochain_websocket::{ConnectRequest, WebsocketConfig};
+use parking_lot::RwLock;
+use std::fmt::Formatter;
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::sync::Arc;
+
+/// An admin websocket that re-establishes itself after the conductor restarts.
+///
+/// Requests made while the connection is down fail with
+/// [`ConductorApiError::Disconnected`] rather than blocking. Reconnection never
+/// gives up; drop every clone of this handle to stop it.
+#[derive(Clone)]
+pub struct ReconnectingAdminWebsocket {
+    current: Arc<RwLock<Option<AdminWebsocket>>>,
+    _task: Arc<AbortOnDropHandle>,
+}
+
+impl std::fmt::Debug for ReconnectingAdminWebsocket {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReconnectingAdminWebsocket").finish()
+    }
+}
+
+impl ReconnectingAdminWebsocket {
+    /// Connects to a conductor admin interface and keeps the connection alive.
+    ///
+    /// The initial connection is attempted once per resolved address and fails
+    /// if none of them accept, so that a typo'd port or a rejected origin is
+    /// reported rather than retried silently. Use
+    /// [`ReconnectingAdminWebsocket::connect_with_retry`] to wait for a
+    /// conductor that has not started yet. Once this returns, connection
+    /// failures are repaired instead of reported.
+    pub async fn connect(
+        socket_addr: impl ToSocketAddrs,
+        origin: Option<String>,
+        config: ReconnectConfig,
+    ) -> ConductorApiResult<Self> {
+        let addrs = resolve(socket_addr)?;
+        let connected = connect_once(&addrs, &origin).await?;
+        Ok(Self::start(addrs, origin, config, connected))
+    }
+
+    /// Connects to a conductor admin interface, waiting for it to accept.
+    ///
+    /// Unlike [`ReconnectingAdminWebsocket::connect`] this retries the initial
+    /// connection with the same backoff used for reconnection, so it is the
+    /// right choice when the conductor may not have started yet. It never
+    /// gives up; bound it by wrapping the call in [`tokio::time::timeout`],
+    /// which works because the retry loop is cancel safe.
+    pub async fn connect_with_retry(
+        socket_addr: impl ToSocketAddrs,
+        origin: Option<String>,
+        config: ReconnectConfig,
+    ) -> ConductorApiResult<Self> {
+        let addrs = resolve(socket_addr)?;
+        let connected = connect_with_backoff("holochain_client::admin", &config, || {
+            connect_once(&addrs, &origin)
+        })
+        .await;
+        Ok(Self::start(addrs, origin, config, connected))
+    }
+
+    fn start(
+        addrs: Vec<SocketAddr>,
+        origin: Option<String>,
+        config: ReconnectConfig,
+        connected: (AdminWebsocket, crate::util::ClosedNotify),
+    ) -> Self {
+        let (admin_ws, closed) = connected;
+
+        let current = Arc::new(RwLock::new(Some(admin_ws)));
+
+        let task = tokio::task::spawn({
+            let current = current.clone();
+            async move {
+                let mut closed = closed;
+                loop {
+                    closed.closed().await;
+                    current.write().take();
+
+                    let (admin_ws, next_closed) =
+                        connect_with_backoff("holochain_client::admin", &config, || {
+                            connect_once(&addrs, &origin)
+                        })
+                        .await;
+
+                    current.write().replace(admin_ws);
+                    closed = next_closed;
+                }
+            }
+        });
+
+        Self {
+            current,
+            _task: Arc::new(AbortOnDropHandle::new(task.abort_handle())),
+        }
+    }
+
+    /// Returns the live admin websocket.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConductorApiError::Disconnected`] while the connection is
+    /// being re-established.
+    pub fn current(&self) -> ConductorApiResult<AdminWebsocket> {
+        self.current
+            .read()
+            .clone()
+            .ok_or(ConductorApiError::Disconnected)
+    }
+}
+
+fn resolve(socket_addr: impl ToSocketAddrs) -> ConductorApiResult<Vec<SocketAddr>> {
+    let addrs: Vec<SocketAddr> = socket_addr.to_socket_addrs()?.collect();
+    if addrs.is_empty() {
+        return Err(ConductorApiError::NoAddressesResolved);
+    }
+    Ok(addrs)
+}
+
+async fn connect_once(
+    addrs: &[SocketAddr],
+    origin: &Option<String>,
+) -> ConductorApiResult<(AdminWebsocket, crate::util::ClosedNotify)> {
+    let websocket_config = Arc::new(WebsocketConfig::CLIENT_DEFAULT);
+
+    let mut last_err = None;
+    for addr in addrs {
+        let request: ConnectRequest = match origin {
+            Some(o) => Into::<ConnectRequest>::into(*addr).try_set_header("Origin", o.as_str())?,
+            None => (*addr).into(),
+        };
+
+        match AdminWebsocket::connect_with_notify(request, websocket_config.clone()).await {
+            Ok(connected) => return Ok(connected),
+            Err(e) => last_err = Some(e),
+        }
+    }
+
+    Err(last_err.unwrap_or(ConductorApiError::NoAddressesResolved))
+}

--- a/crates/client/src/reconnecting_admin_websocket.rs
+++ b/crates/client/src/reconnecting_admin_websocket.rs
@@ -1,9 +1,25 @@
 use crate::error::{ConductorApiError, ConductorApiResult};
-use crate::reconnect::{connect_with_backoff, delay_for_attempt, ReconnectConfig};
+use crate::reconnect::{connect_with_backoff, delay_for_attempt, delegate, ReconnectConfig};
 use crate::util::AbortOnDropHandle;
-use crate::AdminWebsocket;
+use crate::{AdminWebsocket, AuthorizeSigningCredentialsPayload, EnableAppResponse};
+use holo_hash::{ActionHash, DnaHash};
+use holochain_conductor_api::{
+    AdminInterfaceConfig, AppAuthenticationToken, AppAuthenticationTokenIssued, AppInfo,
+    AppInterfaceInfo, AppStatusFilter, DhtOpsCursor, FullStateDump,
+    IssueAppAuthenticationTokenPayload, OpTimingsCursor, OpTimingsDump, PeerMetaInfo,
+    SourceChainCursor, StorageInfo,
+};
+use holochain_types::dna::AgentPubKey;
+use holochain_types::network::HolochainTransportStats;
+use holochain_types::prelude::{
+    AppCapGrantInfo, CellId, DeleteCloneCellPayload, InstallAppPayload, UpdateCoordinatorsPayload,
+};
+use holochain_types::websocket::AllowedOrigins;
 use holochain_websocket::{ConnectRequest, WebsocketConfig};
+use holochain_zome_types::prelude::{DnaDef, GrantZomeCallCapabilityPayload};
+use kitsune2_api::Url;
 use parking_lot::RwLock;
+use std::collections::BTreeMap;
 use std::fmt::Formatter;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::sync::Arc;
@@ -126,6 +142,11 @@ impl ReconnectingAdminWebsocket {
 
     /// Returns the live admin websocket.
     ///
+    /// The returned socket is a snapshot of the connection as it stands, and a
+    /// reconnect replaces it. Call this once per request and drop the result;
+    /// a stored socket stops working at the next reconnect and reports raw
+    /// websocket errors instead of [`ConductorApiError::Disconnected`].
+    ///
     /// # Errors
     ///
     /// Returns [`ConductorApiError::Disconnected`] while the connection is
@@ -136,6 +157,157 @@ impl ReconnectingAdminWebsocket {
             .clone()
             .ok_or(ConductorApiError::Disconnected)
     }
+
+    delegate!(
+        /// Issues an app authentication token for an app.
+        issue_app_auth_token(
+            payload: IssueAppAuthenticationTokenPayload,
+        ) -> AppAuthenticationTokenIssued
+    );
+    delegate!(
+        /// Revokes a previously issued app authentication token.
+        revoke_app_authentication_token(token: AppAuthenticationToken) -> ()
+    );
+    delegate!(
+        /// Generates a new agent public key in the keystore.
+        generate_agent_pub_key() -> AgentPubKey
+    );
+    delegate!(
+        /// Adds admin interfaces to the conductor.
+        add_admin_interfaces(configs: Vec<AdminInterfaceConfig>) -> ()
+    );
+    delegate!(
+        /// Lists the app interfaces attached to the conductor.
+        list_app_interfaces() -> Vec<AppInterfaceInfo>
+    );
+    delegate!(
+        /// Attaches an app interface and returns the port it listens on.
+        attach_app_interface(
+            port: u16,
+            danger_bind_addr: Option<String>,
+            allowed_origins: AllowedOrigins,
+            installed_app_id: Option<String>,
+        ) -> u16
+    );
+    delegate!(
+        /// Lists the installed apps, optionally filtered by status.
+        list_apps(status_filter: Option<AppStatusFilter>) -> Vec<AppInfo>
+    );
+    delegate!(
+        /// Installs an app.
+        install_app(payload: InstallAppPayload) -> AppInfo
+    );
+    delegate!(
+        /// Uninstalls an app.
+        uninstall_app(installed_app_id: String, force: bool) -> ()
+    );
+    delegate!(
+        /// Lists the DNAs registered with the conductor.
+        list_dnas() -> Vec<DnaHash>
+    );
+    delegate!(
+        /// Enables an app.
+        enable_app(installed_app_id: String) -> EnableAppResponse
+    );
+    delegate!(
+        /// Disables an app.
+        disable_app(installed_app_id: String) -> ()
+    );
+    delegate!(
+        /// Lists the cell ids the conductor is running.
+        list_cell_ids() -> Vec<CellId>
+    );
+    delegate!(
+        /// Gets a cell's DNA definition.
+        get_dna_definition(cell_id: CellId) -> DnaDef
+    );
+    delegate!(
+        /// Grants a zome call capability on a cell.
+        grant_zome_call_capability(payload: GrantZomeCallCapabilityPayload) -> ActionHash
+    );
+    delegate!(
+        /// Lists an app's capability grants.
+        list_capability_grants(
+            installed_app_id: String,
+            include_revoked: bool,
+        ) -> AppCapGrantInfo
+    );
+    delegate!(
+        /// Revokes a zome call capability on a cell.
+        revoke_zome_call_capability(cell_id: CellId, action_hash: ActionHash) -> ()
+    );
+    delegate!(
+        /// Deletes a disabled clone cell.
+        delete_clone_cell(payload: DeleteCloneCellPayload) -> ()
+    );
+    delegate!(
+        /// Reports the conductor's storage usage.
+        storage_info() -> StorageInfo
+    );
+    delegate!(
+        /// Dumps network transport statistics.
+        dump_network_stats() -> HolochainTransportStats
+    );
+    delegate!(
+        /// Dumps one page of a cell's source-chain state.
+        dump_state(
+            cell_id: CellId,
+            source_chain_cursor: Option<SourceChainCursor>,
+            limit: Option<u32>,
+        ) -> String
+    );
+    delegate!(
+        /// Dumps the conductor's state.
+        dump_conductor_state() -> String
+    );
+    delegate!(
+        /// Dumps one page of a cell's full state.
+        dump_full_state(
+            cell_id: CellId,
+            dht_ops_cursor: Option<DhtOpsCursor>,
+            limit: Option<u32>,
+        ) -> FullStateDump
+    );
+    delegate!(
+        /// Dumps one page of a DNA's DHT-op lifecycle timings.
+        dump_op_timings(
+            dna_hash: DnaHash,
+            cursor: Option<OpTimingsCursor>,
+            limit: Option<u32>,
+        ) -> OpTimingsDump
+    );
+    delegate!(
+        /// Dumps network metrics.
+        dump_network_metrics(
+            dna_hash: Option<DnaHash>,
+            include_dht_summary: bool,
+        ) -> std::collections::HashMap<DnaHash, holochain_types::network::Kitsune2NetworkMetrics>
+    );
+    delegate!(
+        /// Updates an app's coordinator zomes.
+        update_coordinators(update_coordinators_payload: UpdateCoordinatorsPayload) -> ()
+    );
+    delegate!(
+        /// Lists known peers, optionally restricted to some DNAs.
+        agent_info(dna_hashes: Option<Vec<DnaHash>>) -> Vec<String>
+    );
+    delegate!(
+        /// Adds signed agent info to the conductor's peer store.
+        add_agent_info(agent_infos: Vec<String>) -> ()
+    );
+    delegate!(
+        /// Reads the peer meta store for an agent at a URL.
+        peer_meta_info(
+            url: Url,
+            dna_hashes: Option<Vec<DnaHash>>,
+        ) -> BTreeMap<DnaHash, BTreeMap<String, PeerMetaInfo>>
+    );
+    delegate!(
+        /// Grants a capability to a freshly generated signing keypair.
+        authorize_signing_credentials(
+            request: AuthorizeSigningCredentialsPayload,
+        ) -> crate::signing::client_signing::SigningCredentials
+    );
 }
 
 fn resolve(socket_addr: impl ToSocketAddrs) -> ConductorApiResult<Vec<SocketAddr>> {

--- a/crates/client/src/reconnecting_admin_websocket.rs
+++ b/crates/client/src/reconnecting_admin_websocket.rs
@@ -95,7 +95,7 @@ impl ReconnectingAdminWebsocket {
                     if connected_at.elapsed() < config.initial_delay {
                         let delay = delay_for_attempt(flaps, &config);
                         tracing::warn!(
-                            target = "holochain_client::admin",
+                            target: "holochain_client::admin",
                             flaps,
                             ?delay,
                             "connection closed shortly after connecting, backing off before reconnecting"

--- a/crates/client/src/reconnecting_admin_websocket.rs
+++ b/crates/client/src/reconnecting_admin_websocket.rs
@@ -1,5 +1,5 @@
 use crate::error::{ConductorApiError, ConductorApiResult};
-use crate::reconnect::{connect_with_backoff, ReconnectConfig};
+use crate::reconnect::{connect_with_backoff, delay_for_attempt, ReconnectConfig};
 use crate::util::AbortOnDropHandle;
 use crate::AdminWebsocket;
 use holochain_websocket::{ConnectRequest, WebsocketConfig};
@@ -11,8 +11,12 @@ use std::sync::Arc;
 /// An admin websocket that re-establishes itself after the conductor restarts.
 ///
 /// Requests made while the connection is down fail with
-/// [`ConductorApiError::Disconnected`] rather than blocking. Reconnection never
-/// gives up; drop every clone of this handle to stop it.
+/// [`ConductorApiError::Disconnected`] rather than blocking. Between a
+/// connection dying and that being observed, a request can still be issued on
+/// the dead socket and fail with the underlying websocket error instead; both
+/// are retryable and callers need not distinguish them.
+///
+/// Reconnection never gives up; drop every clone of this handle to stop it.
 #[derive(Clone)]
 pub struct ReconnectingAdminWebsocket {
     current: Arc<RwLock<Option<AdminWebsocket>>>,
@@ -78,9 +82,29 @@ impl ReconnectingAdminWebsocket {
             let current = current.clone();
             async move {
                 let mut closed = closed;
+                let mut flaps: u32 = 0;
                 loop {
+                    let connected_at = std::time::Instant::now();
                     closed.closed().await;
                     current.write().take();
+
+                    // A connection accepted and then dropped straight away
+                    // would otherwise reconnect with no delay, because the
+                    // backoff counter only advances on failed connects. Count
+                    // a short-lived connection as a failed attempt.
+                    if connected_at.elapsed() < config.initial_delay {
+                        let delay = delay_for_attempt(flaps, &config);
+                        tracing::warn!(
+                            target = "holochain_client::admin",
+                            flaps,
+                            ?delay,
+                            "connection closed shortly after connecting, backing off before reconnecting"
+                        );
+                        flaps = flaps.saturating_add(1);
+                        tokio::time::sleep(delay).await;
+                    } else {
+                        flaps = 0;
+                    }
 
                     let (admin_ws, next_closed) =
                         connect_with_backoff("holochain_client::admin", &config, || {

--- a/crates/client/src/reconnecting_app_websocket.rs
+++ b/crates/client/src/reconnecting_app_websocket.rs
@@ -1,0 +1,405 @@
+use crate::app_connect::discover_app_interface_port;
+use crate::error::{ConductorApiError, ConductorApiResult};
+use crate::reconnect::{connect_with_backoff, delay_for_attempt, ReconnectConfig};
+use crate::signal_stream::{signal_stream, SignalEvent, SignalStream, SIGNAL_CHANNEL_CAPACITY};
+use crate::util::{AbortOnDropHandle, ClosedNotify};
+use crate::{AdminWebsocket, AppWebsocket, DynAgentSigner, ReconnectingAdminWebsocket};
+use holo_hash::DnaHash;
+use holochain_conductor_api::{
+    AppInfo, IssueAppAuthenticationTokenPayload, OpTimingsCursor, OpTimingsDump, PeerMetaInfo,
+    ZomeCallParamsSigned,
+};
+use holochain_types::app::{
+    CreateCloneCellPayload, DisableCloneCellPayload, EnableCloneCellPayload, InstalledAppId,
+    MemproofMap,
+};
+use holochain_websocket::{ConnectRequest, WebsocketConfig};
+use holochain_zome_types::clone::ClonedCell;
+use holochain_zome_types::prelude::{ExternIO, FunctionName, ZomeName};
+use kitsune2_api::Url;
+use parking_lot::RwLock;
+use std::collections::BTreeMap;
+use std::fmt::Formatter;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+/// Builds a [`ReconnectingAppWebsocket`].
+pub struct ReconnectingAppWebsocketBuilder {
+    admin_addr: SocketAddr,
+    installed_app_id: InstalledAppId,
+    signer: DynAgentSigner,
+    origin: Option<String>,
+    reconnect_config: ReconnectConfig,
+}
+
+impl ReconnectingAppWebsocketBuilder {
+    /// Sets the origin sent when connecting, which must be admitted by the
+    /// app interface's allowed origins.
+    pub fn origin(mut self, origin: impl Into<String>) -> Self {
+        self.origin = Some(origin.into());
+        self
+    }
+
+    /// Sets the backoff applied between reconnect attempts.
+    pub fn reconnect_config(mut self, config: ReconnectConfig) -> Self {
+        self.reconnect_config = config;
+        self
+    }
+
+    /// Establishes the connection, failing if the conductor does not accept.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the conductor is unreachable, if no app interface
+    /// accepts this app from this origin, or if the app is not installed. Use
+    /// [`ReconnectingAppWebsocketBuilder::connect_with_retry`] to wait for a
+    /// conductor that has not started yet. After this returns successfully,
+    /// connection failures are repaired instead of reported.
+    pub async fn connect(self) -> ConductorApiResult<ReconnectingAppWebsocket> {
+        let admin_ws = ReconnectingAdminWebsocket::connect(
+            self.admin_addr,
+            self.origin.clone(),
+            self.reconnect_config.clone(),
+        )
+        .await?;
+
+        let connected = connect_app(
+            &admin_ws,
+            self.admin_addr,
+            &self.installed_app_id,
+            self.origin.as_deref(),
+            self.signer.clone(),
+        )
+        .await?;
+
+        Ok(self.start(admin_ws, connected).await)
+    }
+
+    /// Establishes the connection, waiting for the conductor to accept.
+    ///
+    /// Retries with the same backoff used for reconnection, so it is the right
+    /// choice when the conductor may not have started yet, or when its app
+    /// interface or the app itself is still being set up. It never gives up;
+    /// bound it by wrapping the call in [`tokio::time::timeout`], which works
+    /// because the retry loop is cancel safe.
+    pub async fn connect_with_retry(self) -> ConductorApiResult<ReconnectingAppWebsocket> {
+        let admin_ws = ReconnectingAdminWebsocket::connect_with_retry(
+            self.admin_addr,
+            self.origin.clone(),
+            self.reconnect_config.clone(),
+        )
+        .await?;
+
+        let connected =
+            connect_with_backoff("holochain_client::app", &self.reconnect_config, || {
+                connect_app(
+                    &admin_ws,
+                    self.admin_addr,
+                    &self.installed_app_id,
+                    self.origin.as_deref(),
+                    self.signer.clone(),
+                )
+            })
+            .await;
+
+        Ok(self.start(admin_ws, connected).await)
+    }
+
+    async fn start(
+        self,
+        admin_ws: ReconnectingAdminWebsocket,
+        connected: (AppWebsocket, ClosedNotify),
+    ) -> ReconnectingAppWebsocket {
+        let (app_ws, closed) = connected;
+
+        let (signal_tx, _) = broadcast::channel(SIGNAL_CHANNEL_CAPACITY);
+
+        forward_signals(&app_ws, signal_tx.clone()).await;
+
+        let current = Arc::new(RwLock::new(Some(app_ws)));
+
+        let task = tokio::task::spawn({
+            let current = current.clone();
+            let signal_tx = signal_tx.clone();
+            let admin_ws = admin_ws.clone();
+            let installed_app_id = self.installed_app_id.clone();
+            let admin_addr = self.admin_addr;
+            let origin = self.origin.clone();
+            let signer = self.signer.clone();
+            let config = self.reconnect_config.clone();
+            async move {
+                let mut closed = closed;
+                let mut flaps: u32 = 0;
+                loop {
+                    let connected_at = std::time::Instant::now();
+                    closed.closed().await;
+                    current.write().take();
+
+                    // A connection accepted and then dropped straight away
+                    // would otherwise reconnect with no delay, because the
+                    // backoff counter only advances on failed connects. Count
+                    // a short-lived connection as a failed attempt.
+                    if connected_at.elapsed() < config.initial_delay {
+                        let delay = delay_for_attempt(flaps, &config);
+                        tracing::warn!(
+                            target = "holochain_client::app",
+                            flaps,
+                            ?delay,
+                            "connection closed shortly after connecting, backing off before reconnecting"
+                        );
+                        flaps = flaps.saturating_add(1);
+                        tokio::time::sleep(delay).await;
+                    } else {
+                        flaps = 0;
+                    }
+
+                    let (app_ws, next_closed) =
+                        connect_with_backoff("holochain_client::app", &config, || {
+                            connect_app(
+                                &admin_ws,
+                                admin_addr,
+                                &installed_app_id,
+                                origin.as_deref(),
+                                signer.clone(),
+                            )
+                        })
+                        .await;
+
+                    // Report the gap before signals start flowing again, so a
+                    // consumer re-syncs against a live connection.
+                    let _ = signal_tx.send(SignalEvent::Interrupted);
+                    forward_signals(&app_ws, signal_tx.clone()).await;
+
+                    current.write().replace(app_ws);
+                    closed = next_closed;
+                }
+            }
+        });
+
+        ReconnectingAppWebsocket {
+            current,
+            signal_tx,
+            _admin_ws: admin_ws,
+            _task: Arc::new(AbortOnDropHandle::new(task.abort_handle())),
+        }
+    }
+}
+
+/// An app websocket that re-establishes itself after the conductor restarts.
+///
+/// Between a connection dying and that being observed, a request can still be
+/// issued on the dead socket and fail with the underlying websocket error
+/// rather than [`ConductorApiError::Disconnected`]; both are retryable and
+/// callers need not distinguish them.
+///
+/// Requests made while the connection is down fail with
+/// [`ConductorApiError::Disconnected`] and are never retried automatically,
+/// because re-signing a zome call mints a fresh nonce and would risk writing
+/// to the source chain twice. Signal subscriptions taken from
+/// [`ReconnectingAppWebsocket::signals`] survive reconnects.
+///
+/// Reconnection never gives up. Drop every clone of this handle to stop it.
+#[derive(Clone)]
+pub struct ReconnectingAppWebsocket {
+    current: Arc<RwLock<Option<AppWebsocket>>>,
+    signal_tx: broadcast::Sender<SignalEvent>,
+    _admin_ws: ReconnectingAdminWebsocket,
+    _task: Arc<AbortOnDropHandle>,
+}
+
+impl std::fmt::Debug for ReconnectingAppWebsocket {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReconnectingAppWebsocket").finish()
+    }
+}
+
+macro_rules! delegate {
+    ($(#[$meta:meta])* $name:ident($($arg:ident: $ty:ty),* $(,)?) -> $ret:ty) => {
+        $(#[$meta])*
+        pub async fn $name(&self, $($arg: $ty),*) -> ConductorApiResult<$ret> {
+            self.current()?.$name($($arg),*).await
+        }
+    };
+}
+
+impl ReconnectingAppWebsocket {
+    /// Starts building a connection to an app.
+    ///
+    /// The connection is identified by the conductor's admin address and the
+    /// installed app id rather than by an app interface port, because the port
+    /// an app interface listens on is not stable across a conductor restart.
+    pub fn builder(
+        admin_addr: SocketAddr,
+        installed_app_id: InstalledAppId,
+        signer: DynAgentSigner,
+    ) -> ReconnectingAppWebsocketBuilder {
+        ReconnectingAppWebsocketBuilder {
+            admin_addr,
+            installed_app_id,
+            signer,
+            origin: None,
+            reconnect_config: ReconnectConfig::default(),
+        }
+    }
+
+    /// Subscribes to the app's signals.
+    ///
+    /// Each call returns an independent subscription that receives every signal
+    /// from this point on, and keeps doing so across reconnects. Signals
+    /// emitted while the connection was down are reported as
+    /// [`SignalEvent::Interrupted`] rather than delivered, because Holochain
+    /// does not replay them.
+    pub fn signals(&self) -> SignalStream {
+        signal_stream(self.signal_tx.subscribe())
+    }
+
+    /// Returns the live app websocket.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConductorApiError::Disconnected`] while the connection is
+    /// being re-established.
+    pub fn current(&self) -> ConductorApiResult<AppWebsocket> {
+        self.current
+            .read()
+            .clone()
+            .ok_or(ConductorApiError::Disconnected)
+    }
+
+    delegate!(
+        /// Calls a zome function using the connection-level default timeout.
+        call_zome(
+            target: crate::ZomeCallTarget,
+            zome_name: ZomeName,
+            fn_name: FunctionName,
+            payload: ExternIO,
+        ) -> ExternIO
+    );
+    delegate!(
+        /// Calls a zome function with per-call options.
+        call_zome_with_options(
+            target: crate::ZomeCallTarget,
+            zome_name: ZomeName,
+            fn_name: FunctionName,
+            payload: ExternIO,
+            options: crate::CallZomeOptions,
+        ) -> ExternIO
+    );
+    delegate!(
+        /// Sends a pre-signed zome call.
+        signed_call_zome(signed_params: ZomeCallParamsSigned) -> ExternIO
+    );
+    delegate!(
+        /// Sends a pre-signed zome call with per-call options.
+        signed_call_zome_with_options(
+            signed_params: ZomeCallParamsSigned,
+            options: crate::CallZomeOptions,
+        ) -> ExternIO
+    );
+    delegate!(
+        /// Gets the app's current info.
+        app_info() -> Option<AppInfo>
+    );
+    delegate!(
+        /// Enables the app.
+        enable_app() -> ()
+    );
+    delegate!(
+        /// Provides membrane proofs for a deferred-memproof app.
+        provide_memproofs(memproofs: MemproofMap) -> ()
+    );
+    delegate!(
+        /// Creates a clone cell.
+        create_clone_cell(msg: CreateCloneCellPayload) -> ClonedCell
+    );
+    delegate!(
+        /// Disables a clone cell.
+        disable_clone_cell(payload: DisableCloneCellPayload) -> ()
+    );
+    delegate!(
+        /// Enables a clone cell.
+        enable_clone_cell(payload: EnableCloneCellPayload) -> ClonedCell
+    );
+    delegate!(
+        /// Lists the host functions available to wasm.
+        list_wasm_host_functions() -> Vec<String>
+    );
+    delegate!(
+        /// Dumps network transport statistics.
+        dump_network_stats() -> holochain_types::network::HolochainTransportStats
+    );
+    delegate!(
+        /// Dumps network metrics.
+        dump_network_metrics(
+            dna_hash: Option<DnaHash>,
+            include_dht_summary: bool,
+        ) -> std::collections::HashMap<DnaHash, holochain_types::network::Kitsune2NetworkMetrics>
+    );
+    delegate!(
+        /// Dumps one page of DHT-op lifecycle timings.
+        dump_op_timings(
+            dna_hash: DnaHash,
+            cursor: Option<OpTimingsCursor>,
+            limit: Option<u32>,
+        ) -> OpTimingsDump
+    );
+    delegate!(
+        /// Lists connected peers for the app's DNAs.
+        agent_info(dna_hashes: Option<Vec<DnaHash>>) -> Vec<String>
+    );
+    delegate!(
+        /// Adds signed agent info to the conductor's peer store.
+        add_agent_info(agent_infos: Vec<String>) -> ()
+    );
+    delegate!(
+        /// Reads the peer meta store for an agent at a URL.
+        peer_meta_info(
+            url: Url,
+            dna_hashes: Option<Vec<DnaHash>>,
+        ) -> BTreeMap<DnaHash, BTreeMap<String, PeerMetaInfo>>
+    );
+}
+
+async fn forward_signals(app_ws: &AppWebsocket, signal_tx: broadcast::Sender<SignalEvent>) {
+    app_ws
+        .on_signal(move |signal| {
+            let _ = signal_tx.send(SignalEvent::Signal(signal));
+        })
+        .await;
+}
+
+async fn connect_app(
+    admin_ws: &ReconnectingAdminWebsocket,
+    admin_addr: SocketAddr,
+    installed_app_id: &InstalledAppId,
+    origin: Option<&str>,
+    signer: DynAgentSigner,
+) -> ConductorApiResult<(AppWebsocket, ClosedNotify)> {
+    let admin: AdminWebsocket = admin_ws.current()?;
+
+    let port = discover_app_interface_port(&admin, installed_app_id, origin).await?;
+
+    let token = admin
+        .issue_app_auth_token(IssueAppAuthenticationTokenPayload::for_installed_app_id(
+            installed_app_id.clone(),
+        ))
+        .await?
+        .token;
+
+    // The app interface listens on the same host as the admin interface, so
+    // reuse its address and take only the discovered port.
+    let addr = SocketAddr::new(admin_addr.ip(), port);
+    let request: ConnectRequest = match origin {
+        Some(o) => Into::<ConnectRequest>::into(addr).try_set_header("Origin", o)?,
+        None => addr.into(),
+    };
+
+    AppWebsocket::connect_with_notify(
+        request,
+        Arc::new(WebsocketConfig::CLIENT_DEFAULT),
+        token,
+        signer,
+    )
+    .await
+}

--- a/crates/client/src/reconnecting_app_websocket.rs
+++ b/crates/client/src/reconnecting_app_websocket.rs
@@ -36,6 +36,10 @@ pub struct ReconnectingAppWebsocketBuilder {
 impl ReconnectingAppWebsocketBuilder {
     /// Sets the origin sent when connecting, which must be admitted by the
     /// app interface's allowed origins.
+    ///
+    /// The same origin is sent when connecting to the admin interface, so it
+    /// has to be admitted by both interfaces. There is no way to give the two
+    /// different origins.
     pub fn origin(mut self, origin: impl Into<String>) -> Self {
         self.origin = Some(origin.into());
         self
@@ -83,6 +87,12 @@ impl ReconnectingAppWebsocketBuilder {
     /// interface or the app itself is still being set up. It never gives up;
     /// bound it by wrapping the call in [`tokio::time::timeout`], which works
     /// because the retry loop is cancel safe.
+    ///
+    /// A permanent misconfiguration, such as an app id that is not installed
+    /// or an origin no app interface admits, retries exactly as a conductor
+    /// that is merely down does. To tell the two apart, connect with
+    /// [`ReconnectingAppWebsocketBuilder::connect`] or bound this call with a
+    /// timeout.
     pub async fn connect_with_retry(self) -> ConductorApiResult<ReconnectingAppWebsocket> {
         let admin_ws = ReconnectingAdminWebsocket::connect_with_retry(
             self.admin_addr,
@@ -143,7 +153,7 @@ impl ReconnectingAppWebsocketBuilder {
                     if connected_at.elapsed() < config.initial_delay {
                         let delay = delay_for_attempt(flaps, &config);
                         tracing::warn!(
-                            target = "holochain_client::app",
+                            target: "holochain_client::app",
                             flaps,
                             ?delay,
                             "connection closed shortly after connecting, backing off before reconnecting"
@@ -166,12 +176,16 @@ impl ReconnectingAppWebsocketBuilder {
                         })
                         .await;
 
-                    // Report the gap before signals start flowing again, so a
-                    // consumer re-syncs against a live connection.
+                    // The connection is published before the gap is
+                    // reported, so a consumer woken by `Interrupted` re-syncs
+                    // against a live connection. A signal arriving before the
+                    // forwarder is registered is dropped, which is what the
+                    // `Interrupted` that precedes it tells the consumer to
+                    // recover.
+                    current.write().replace(app_ws.clone());
                     let _ = signal_tx.send(SignalEvent::Interrupted);
                     forward_signals(&app_ws, signal_tx.clone()).await;
 
-                    current.write().replace(app_ws);
                     closed = next_closed;
                 }
             }

--- a/crates/client/src/reconnecting_app_websocket.rs
+++ b/crates/client/src/reconnecting_app_websocket.rs
@@ -1,6 +1,6 @@
 use crate::app_connect::discover_app_interface_port;
 use crate::error::{ConductorApiError, ConductorApiResult};
-use crate::reconnect::{connect_with_backoff, delay_for_attempt, ReconnectConfig};
+use crate::reconnect::{connect_with_backoff, delay_for_attempt, delegate, ReconnectConfig};
 use crate::signal_stream::{signal_stream, SignalEvent, SignalStream, SIGNAL_CHANNEL_CAPACITY};
 use crate::util::{AbortOnDropHandle, ClosedNotify};
 use crate::{AdminWebsocket, AppWebsocket, DynAgentSigner, ReconnectingAdminWebsocket};
@@ -228,15 +228,6 @@ impl std::fmt::Debug for ReconnectingAppWebsocket {
     }
 }
 
-macro_rules! delegate {
-    ($(#[$meta:meta])* $name:ident($($arg:ident: $ty:ty),* $(,)?) -> $ret:ty) => {
-        $(#[$meta])*
-        pub async fn $name(&self, $($arg: $ty),*) -> ConductorApiResult<$ret> {
-            self.current()?.$name($($arg),*).await
-        }
-    };
-}
-
 impl ReconnectingAppWebsocket {
     /// Starts building a connection to an app.
     ///
@@ -269,6 +260,11 @@ impl ReconnectingAppWebsocket {
     }
 
     /// Returns the live app websocket.
+    ///
+    /// The returned socket is a snapshot of the connection as it stands, and a
+    /// reconnect replaces it. Call this once per request and drop the result;
+    /// a stored socket stops working at the next reconnect and reports raw
+    /// websocket errors instead of [`ConductorApiError::Disconnected`].
     ///
     /// # Errors
     ///

--- a/crates/client/src/signal_stream.rs
+++ b/crates/client/src/signal_stream.rs
@@ -1,0 +1,114 @@
+use holochain_types::prelude::Signal;
+use tokio::sync::broadcast::{self, error::RecvError};
+
+/// How many signals a resilient connection buffers per subscriber.
+#[allow(dead_code)]
+pub(crate) const SIGNAL_CHANNEL_CAPACITY: usize = 1024;
+
+/// An item yielded by a [`SignalStream`].
+#[derive(Clone, Debug)]
+pub enum SignalEvent {
+    /// A signal emitted by the app.
+    Signal(Signal),
+    /// Signals were missed and any state derived from them needs re-syncing.
+    ///
+    /// This is reported when the connection to the conductor dropped and has
+    /// been re-established, and when this subscriber fell far enough behind
+    /// that buffered signals were discarded. Holochain does not replay
+    /// signals, so the missed ones cannot be recovered.
+    Interrupted,
+}
+
+/// A subscription to the signals emitted by an app.
+///
+/// The subscription outlives the underlying websocket, so it keeps yielding
+/// across reconnects without being re-registered. It ends only when the
+/// connection it came from is dropped.
+pub struct SignalStream(broadcast::Receiver<SignalEvent>);
+
+impl SignalStream {
+    /// Waits for the next event, or returns `None` once the connection this
+    /// subscription came from has been dropped.
+    ///
+    /// This is cancel safe: dropping the returned future loses no events.
+    pub async fn next(&mut self) -> Option<SignalEvent> {
+        match self.0.recv().await {
+            Ok(event) => Some(event),
+            Err(RecvError::Lagged(_)) => Some(SignalEvent::Interrupted),
+            Err(RecvError::Closed) => None,
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) fn signal_stream(rx: broadcast::Receiver<SignalEvent>) -> SignalStream {
+    SignalStream(rx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use holo_hash::EntryHash;
+    use holochain_types::prelude::{Signal, SystemSignal};
+
+    /// Builds a distinct signal per byte.
+    ///
+    /// `Signal::App` needs a real `CellId` and `ZomeName`; a system signal
+    /// carries a single hash and is cheaper to construct. These tests only
+    /// need a `Signal` value that differs per call.
+    fn a_signal(byte: u8) -> Signal {
+        Signal::System(SystemSignal::SuccessfulCountersigning(
+            EntryHash::from_raw_32(vec![byte; 32]),
+        ))
+    }
+
+    #[tokio::test]
+    async fn yields_signals_in_order() {
+        let (tx, rx) = broadcast::channel(SIGNAL_CHANNEL_CAPACITY);
+        let mut stream = signal_stream(rx);
+
+        tx.send(SignalEvent::Signal(a_signal(1))).unwrap();
+        tx.send(SignalEvent::Signal(a_signal(2))).unwrap();
+
+        assert!(matches!(stream.next().await, Some(SignalEvent::Signal(_))));
+        assert!(matches!(stream.next().await, Some(SignalEvent::Signal(_))));
+    }
+
+    #[tokio::test]
+    async fn reports_interruption() {
+        let (tx, rx) = broadcast::channel(SIGNAL_CHANNEL_CAPACITY);
+        let mut stream = signal_stream(rx);
+
+        tx.send(SignalEvent::Interrupted).unwrap();
+
+        assert!(matches!(
+            stream.next().await,
+            Some(SignalEvent::Interrupted)
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_lagging_consumer_is_reported_as_an_interruption() {
+        let (tx, rx) = broadcast::channel(2);
+        let mut stream = signal_stream(rx);
+
+        for byte in 0..5 {
+            tx.send(SignalEvent::Signal(a_signal(byte))).unwrap();
+        }
+
+        assert!(matches!(
+            stream.next().await,
+            Some(SignalEvent::Interrupted)
+        ));
+    }
+
+    #[tokio::test]
+    async fn ends_when_the_sender_is_dropped() {
+        let (tx, rx) = broadcast::channel(SIGNAL_CHANNEL_CAPACITY);
+        let mut stream = signal_stream(rx);
+
+        drop(tx);
+
+        assert!(stream.next().await.is_none());
+    }
+}

--- a/crates/client/src/signal_stream.rs
+++ b/crates/client/src/signal_stream.rs
@@ -2,7 +2,6 @@ use holochain_types::prelude::Signal;
 use tokio::sync::broadcast::{self, error::RecvError};
 
 /// How many signals a resilient connection buffers per subscriber.
-#[allow(dead_code)]
 pub(crate) const SIGNAL_CHANNEL_CAPACITY: usize = 1024;
 
 /// An item yielded by a [`SignalStream`].
@@ -40,7 +39,6 @@ impl SignalStream {
     }
 }
 
-#[allow(dead_code)]
 pub(crate) fn signal_stream(rx: broadcast::Receiver<SignalEvent>) -> SignalStream {
     SignalStream(rx)
 }

--- a/crates/client/src/util.rs
+++ b/crates/client/src/util.rs
@@ -1,3 +1,4 @@
+use tokio::sync::oneshot;
 use tokio::task::AbortHandle;
 
 pub(crate) struct AbortOnDropHandle(AbortHandle);
@@ -11,5 +12,24 @@ impl AbortOnDropHandle {
 impl Drop for AbortOnDropHandle {
     fn drop(&mut self) {
         self.0.abort();
+    }
+}
+
+/// Resolves when a websocket connection is no longer usable.
+///
+/// The client polls each websocket on a background task. That task ends when
+/// the connection drops, which is what this notification reports.
+pub struct ClosedNotify(oneshot::Receiver<()>);
+
+impl ClosedNotify {
+    pub(crate) fn new(rx: oneshot::Receiver<()>) -> Self {
+        Self(rx)
+    }
+
+    /// Waits until the connection is no longer usable.
+    pub async fn closed(self) {
+        // An error means the poll task was aborted because the websocket was
+        // dropped, which is equally a reason to stop using the connection.
+        let _ = self.0.await;
     }
 }

--- a/crates/client/tests/common/mod.rs
+++ b/crates/client/tests/common/mod.rs
@@ -1,3 +1,9 @@
+// Each test binary compiles this module and uses only part of it.
+#![allow(dead_code)]
+
+use holochain::sweettest::{SweetConductor, SweetConductorConfig, SweetLocalRendezvous};
+use holochain_conductor_api::{AdminInterfaceConfig, InterfaceDriver};
+use holochain_types::websocket::AllowedOrigins;
 use kitsune2_api::{DynLocalAgent, SpaceId};
 use kitsune2_core::Ed25519LocalAgent;
 use kitsune2_test_utils::agent::AgentBuilder;
@@ -11,4 +17,33 @@ pub fn make_agent(space: &SpaceId) -> String {
     .build(Arc::new(Ed25519LocalAgent::default()) as DynLocalAgent)
     .encode()
     .unwrap()
+}
+
+/// Picks a port that is free at this instant.
+///
+/// Restart tests need the admin port to stay put, which the standard sweettest
+/// config does not do because it binds port 0.
+pub fn free_port() -> u16 {
+    let listener = std::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0)).unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+/// Builds a conductor whose admin interface keeps the same port across a
+/// shutdown and startup cycle.
+pub async fn conductor_with_fixed_admin_port() -> (SweetConductor, u16) {
+    let port = free_port();
+    (conductor_on_admin_port(port).await, port)
+}
+
+/// Builds a conductor whose admin interface listens on `port`.
+pub async fn conductor_on_admin_port(port: u16) -> SweetConductor {
+    let mut config = SweetConductorConfig::rendezvous(true);
+    config.admin_interfaces = Some(vec![AdminInterfaceConfig {
+        driver: InterfaceDriver::Websocket {
+            port,
+            danger_bind_addr: None,
+            allowed_origins: AllowedOrigins::Any,
+        },
+    }]);
+    SweetConductor::from_config_rendezvous(config, SweetLocalRendezvous::new().await).await
 }

--- a/crates/client/tests/common/mod.rs
+++ b/crates/client/tests/common/mod.rs
@@ -1,12 +1,18 @@
 // Each test binary compiles this module and uses only part of it.
 #![allow(dead_code)]
 
+use holochain::prelude::AppBundleSource;
 use holochain::sweettest::{SweetConductor, SweetConductorConfig, SweetLocalRendezvous};
-use holochain_conductor_api::{AdminInterfaceConfig, InterfaceDriver};
+use holochain_client::{
+    AdminWebsocket, AuthorizeSigningCredentialsPayload, ClientAgentSigner, DynAgentSigner,
+    InstallAppPayload, InstalledAppId,
+};
+use holochain_conductor_api::{AdminInterfaceConfig, CellInfo, InterfaceDriver};
 use holochain_types::websocket::AllowedOrigins;
 use kitsune2_api::{DynLocalAgent, SpaceId};
 use kitsune2_core::Ed25519LocalAgent;
 use kitsune2_test_utils::agent::AgentBuilder;
+use std::net::Ipv4Addr;
 use std::sync::Arc;
 
 pub fn make_agent(space: &SpaceId) -> String {
@@ -46,4 +52,97 @@ pub async fn conductor_on_admin_port(port: u16) -> SweetConductor {
         },
     }]);
     SweetConductor::from_config_rendezvous(config, SweetLocalRendezvous::new().await).await
+}
+
+/// The zome the fixture app exposes.
+pub const FIXTURE_ZOME_NAME: &str = "foo";
+
+/// The function the fixture app exposes to emit a signal.
+pub const FIXTURE_EMIT_FN_NAME: &str = "emitter";
+
+/// The payload the fixture app's emitter sends.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct TestString(pub String);
+
+/// Installs the fixture app on a conductor whose admin port survives a restart,
+/// and returns a signer authorized to call its zomes.
+pub async fn install_fixture_app_with_fixed_admin_port(
+) -> (SweetConductor, u16, InstalledAppId, DynAgentSigner) {
+    let (conductor, admin_port) = conductor_with_fixed_admin_port().await;
+
+    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port), None)
+        .await
+        .unwrap();
+
+    let app_id: InstalledAppId = "test-app".into();
+    admin_ws
+        .install_app(InstallAppPayload {
+            agent_key: None,
+            installed_app_id: Some(app_id.clone()),
+            network_seed: None,
+            roles_settings: None,
+            source: AppBundleSource::Bytes(crate::fixture::get_fixture_app_bundle()),
+            ignore_genesis_failure: false,
+            restore_from_dht: false,
+        })
+        .await
+        .unwrap();
+    admin_ws.enable_app(app_id.clone()).await.unwrap();
+
+    // Attached on port 0, so the conductor restores it on a different port
+    // after a restart. That is what makes the rediscovery path load bearing.
+    admin_ws
+        .attach_app_interface(
+            0,
+            None,
+            AllowedOrigins::Origins(vec!["my-service".to_string()].into_iter().collect()),
+            Some(app_id.clone()),
+        )
+        .await
+        .unwrap();
+
+    let token = admin_ws
+        .issue_app_auth_token(app_id.clone().into())
+        .await
+        .unwrap()
+        .token;
+    let port = holochain_client::discover_app_interface_port_for_test(
+        &admin_ws,
+        &app_id,
+        Some("my-service"),
+    )
+    .await
+    .unwrap();
+
+    let signer = ClientAgentSigner::default();
+    let app_ws = holochain_client::AppWebsocket::connect(
+        (Ipv4Addr::LOCALHOST, port),
+        token,
+        signer.clone().into(),
+        Some("my-service".to_string()),
+    )
+    .await
+    .unwrap();
+
+    let cell_id = provisioned_cell_id(app_ws.cached_app_info());
+
+    let credentials = admin_ws
+        .authorize_signing_credentials(AuthorizeSigningCredentialsPayload {
+            cell_id: cell_id.clone(),
+            functions: None,
+        })
+        .await
+        .unwrap();
+    signer.add_credentials(cell_id, credentials);
+
+    (conductor, admin_port, app_id, signer.into())
+}
+
+/// Reads the provisioned cell id out of an app's info.
+pub fn provisioned_cell_id(app_info: &holochain_client::AppInfo) -> holochain_client::CellId {
+    let cells = app_info.cell_info.values().next().unwrap();
+    match &cells[0] {
+        CellInfo::Provisioned(c) => c.cell_id.clone(),
+        _ => panic!("Expected a provisioned cell"),
+    }
 }

--- a/crates/client/tests/common/mod.rs
+++ b/crates/client/tests/common/mod.rs
@@ -67,7 +67,7 @@ pub struct TestString(pub String);
 /// Installs the fixture app on a conductor whose admin port survives a restart,
 /// and returns a signer authorized to call its zomes.
 pub async fn install_fixture_app_with_fixed_admin_port(
-) -> (SweetConductor, u16, InstalledAppId, DynAgentSigner) {
+) -> (SweetConductor, u16, InstalledAppId, DynAgentSigner, u16) {
     let (conductor, admin_port) = conductor_with_fixed_admin_port().await;
 
     let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port), None)
@@ -90,7 +90,8 @@ pub async fn install_fixture_app_with_fixed_admin_port(
     admin_ws.enable_app(app_id.clone()).await.unwrap();
 
     // Attached on port 0, so the conductor restores it on a different port
-    // after a restart. That is what makes the rediscovery path load bearing.
+    // after a restart. That is what makes the rediscovery path load bearing,
+    // and why the discovered port is returned for a caller to compare against.
     admin_ws
         .attach_app_interface(
             0,
@@ -135,7 +136,18 @@ pub async fn install_fixture_app_with_fixed_admin_port(
         .unwrap();
     signer.add_credentials(cell_id, credentials);
 
-    (conductor, admin_port, app_id, signer.into())
+    (conductor, admin_port, app_id, signer.into(), port)
+}
+
+/// Discovers the port the fixture app's interface is currently listening on.
+pub async fn discover_fixture_app_port(admin_port: u16, app_id: &InstalledAppId) -> u16 {
+    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port), None)
+        .await
+        .unwrap();
+
+    holochain_client::discover_app_interface_port_for_test(&admin_ws, app_id, Some("my-service"))
+        .await
+        .unwrap()
 }
 
 /// Reads the provisioned cell id out of an app's info.

--- a/crates/client/tests/reconnection_tests.rs
+++ b/crates/client/tests/reconnection_tests.rs
@@ -2,6 +2,8 @@ use holochain::sweettest::SweetConductor;
 use holochain_client::{AdminWebsocket, ConductorApiError};
 use holochain_zome_types::prelude::ExternIO;
 use std::net::{Ipv4Addr, SocketAddr};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 mod common;
@@ -248,6 +250,13 @@ async fn signals_resume_on_the_same_subscription_after_a_restart() {
     .await;
     assert!(interrupted.is_ok(), "no Interrupted event after restart");
 
+    // The gap is reported only once the connection is live again, so a
+    // consumer re-syncing in response to it finds a usable socket.
+    assert!(
+        app_ws.current().is_ok(),
+        "Interrupted arrived before the connection was published"
+    );
+
     // And real signals flow again on that same subscription.
     let deadline = std::time::Instant::now() + Duration::from_secs(60);
     loop {
@@ -292,27 +301,61 @@ async fn signals_resume_on_the_same_subscription_after_a_restart() {
 async fn dropping_the_connection_stops_reconnecting() {
     let (mut conductor, admin_port) = common::conductor_with_fixed_admin_port().await;
 
+    // Short delays so several reconnect attempts land inside the test.
+    let config = holochain_client::ReconnectConfig {
+        initial_delay: Duration::from_millis(100),
+        max_delay: Duration::from_millis(200),
+        escalate_after: u32::MAX,
+    };
+
     let admin_ws = holochain_client::ReconnectingAdminWebsocket::connect(
         (Ipv4Addr::LOCALHOST, admin_port),
         None,
-        holochain_client::ReconnectConfig::default(),
+        config,
     )
     .await
     .unwrap();
 
     conductor.shutdown().await;
 
-    // Let the reconnect loop start failing, then drop the handle.
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    // Stand in for the conductor so reconnect attempts are observable. Each
+    // accepted connection is one dial by the client; closing it immediately
+    // fails the client's websocket handshake, so it backs off and dials again.
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, admin_port))
+        .await
+        .unwrap();
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let acceptor = tokio::spawn({
+        let attempts = attempts.clone();
+        async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                drop(stream);
+            }
+        }
+    });
+
+    // The client dials repeatedly while the handle is alive.
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    while attempts.load(Ordering::SeqCst) < 3 {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "client never retried the connection"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
     drop(admin_ws);
 
-    // Nothing is left holding the conductor's port open, so a fresh listener
-    // can take it. This would fail if the reconnect task were still running
-    // and had won the race to reconnect.
+    // Let any dial already in flight finish, then confirm dialling has stopped.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let after_drop = attempts.load(Ordering::SeqCst);
     tokio::time::sleep(Duration::from_secs(2)).await;
-    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, admin_port));
-    assert!(
-        listener.is_ok(),
-        "port still in use after dropping the handle"
+    assert_eq!(
+        attempts.load(Ordering::SeqCst),
+        after_drop,
+        "reconnect attempts continued after the handle was dropped"
     );
+
+    acceptor.abort();
 }

--- a/crates/client/tests/reconnection_tests.rs
+++ b/crates/client/tests/reconnection_tests.rs
@@ -1,5 +1,6 @@
 use holochain::sweettest::SweetConductor;
 use holochain_client::{AdminWebsocket, ConductorApiError};
+use holochain_zome_types::prelude::ExternIO;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
@@ -211,4 +212,107 @@ async fn app_requests_fail_fast_while_disconnected() {
             }
         }
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn signals_resume_on_the_same_subscription_after_a_restart() {
+    let (mut conductor, admin_port, app_id, signer) =
+        common::install_fixture_app_with_fixed_admin_port().await;
+
+    let app_ws = holochain_client::ReconnectingAppWebsocket::builder(
+        SocketAddr::new(Ipv4Addr::LOCALHOST.into(), admin_port),
+        app_id,
+        signer,
+    )
+    .origin("my-service")
+    .connect()
+    .await
+    .unwrap();
+
+    // Taken once, never re-registered.
+    let mut signals = app_ws.signals();
+
+    conductor.shutdown().await;
+    conductor.startup().await;
+
+    // The conductor restart moved the app interface port, because
+    // startup_app_interfaces restores an interface on its originally
+    // requested port. The subscription still resumes.
+    let interrupted = tokio::time::timeout(Duration::from_secs(90), async {
+        loop {
+            if let Some(holochain_client::SignalEvent::Interrupted) = signals.next().await {
+                return;
+            }
+        }
+    })
+    .await;
+    assert!(interrupted.is_ok(), "no Interrupted event after restart");
+
+    // And real signals flow again on that same subscription.
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        let Ok(app) = app_ws.current() else {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "app never became callable"
+            );
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            continue;
+        };
+        let cell_id = common::provisioned_cell_id(app.cached_app_info());
+        if app_ws
+            .call_zome(
+                cell_id.into(),
+                common::FIXTURE_ZOME_NAME.into(),
+                common::FIXTURE_EMIT_FN_NAME.into(),
+                ExternIO::encode(()).unwrap(),
+            )
+            .await
+            .is_ok()
+        {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "app never became callable"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    let signal = tokio::time::timeout(Duration::from_secs(30), signals.next())
+        .await
+        .expect("no signal after reconnect");
+    assert!(matches!(
+        signal,
+        Some(holochain_client::SignalEvent::Signal(_))
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dropping_the_connection_stops_reconnecting() {
+    let (mut conductor, admin_port) = common::conductor_with_fixed_admin_port().await;
+
+    let admin_ws = holochain_client::ReconnectingAdminWebsocket::connect(
+        (Ipv4Addr::LOCALHOST, admin_port),
+        None,
+        holochain_client::ReconnectConfig::default(),
+    )
+    .await
+    .unwrap();
+
+    conductor.shutdown().await;
+
+    // Let the reconnect loop start failing, then drop the handle.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    drop(admin_ws);
+
+    // Nothing is left holding the conductor's port open, so a fresh listener
+    // can take it. This would fail if the reconnect task were still running
+    // and had won the race to reconnect.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let listener = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, admin_port));
+    assert!(
+        listener.is_ok(),
+        "port still in use after dropping the handle"
+    );
 }

--- a/crates/client/tests/reconnection_tests.rs
+++ b/crates/client/tests/reconnection_tests.rs
@@ -1,5 +1,6 @@
 use holochain::sweettest::SweetConductor;
 use holochain_client::{AdminWebsocket, ConductorApiError};
+use holochain_websocket::{WebsocketConfig, WebsocketListener};
 use holochain_zome_types::prelude::ExternIO;
 use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -184,7 +185,7 @@ async fn connect_with_retry_waits_for_the_conductor() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn app_requests_fail_fast_while_disconnected() {
-    let (mut conductor, admin_port, app_id, signer) =
+    let (mut conductor, admin_port, app_id, signer, _app_port) =
         common::install_fixture_app_with_fixed_admin_port().await;
 
     let app_ws = holochain_client::ReconnectingAppWebsocket::builder(
@@ -218,12 +219,12 @@ async fn app_requests_fail_fast_while_disconnected() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn signals_resume_on_the_same_subscription_after_a_restart() {
-    let (mut conductor, admin_port, app_id, signer) =
+    let (mut conductor, admin_port, app_id, signer, app_port) =
         common::install_fixture_app_with_fixed_admin_port().await;
 
     let app_ws = holochain_client::ReconnectingAppWebsocket::builder(
         SocketAddr::new(Ipv4Addr::LOCALHOST.into(), admin_port),
-        app_id,
+        app_id.clone(),
         signer,
     )
     .origin("my-service")
@@ -255,6 +256,14 @@ async fn signals_resume_on_the_same_subscription_after_a_restart() {
     assert!(
         app_ws.current().is_ok(),
         "Interrupted arrived before the connection was published"
+    );
+
+    // The interface was attached on port 0, so the restart puts it on a
+    // different port and the reconnect only succeeds by rediscovering it.
+    let restarted_app_port = common::discover_fixture_app_port(admin_port, &app_id).await;
+    assert_ne!(
+        restarted_app_port, app_port,
+        "app interface port did not move across the restart, so rediscovery is untested"
     );
 
     // And real signals flow again on that same subscription.
@@ -358,4 +367,89 @@ async fn dropping_the_connection_stops_reconnecting() {
     );
 
     acceptor.abort();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn a_connection_that_drops_immediately_is_backed_off() {
+    // A peer that completes the websocket handshake and then closes drives the
+    // uptime guard, which the handshake-failing paths do not reach because
+    // they back off inside `connect_with_backoff` instead.
+    let listener = WebsocketListener::bind(
+        Arc::new(WebsocketConfig::LISTENER_DEFAULT),
+        (Ipv4Addr::LOCALHOST, 0),
+    )
+    .await
+    .unwrap();
+    let port = listener.local_addrs().unwrap()[0].port();
+
+    // Held long enough that the client is certainly connected, and far short
+    // of `initial_delay` so every connection counts as short lived.
+    const HOLD: Duration = Duration::from_millis(200);
+    const INITIAL_DELAY: Duration = Duration::from_secs(2);
+
+    let accepted: Arc<std::sync::Mutex<Vec<std::time::Instant>>> = Arc::default();
+    let rejected = Arc::new(AtomicUsize::new(0));
+    let server = tokio::spawn({
+        let accepted = accepted.clone();
+        let rejected = rejected.clone();
+        async move {
+            loop {
+                match listener.accept().await {
+                    Ok(connection) => {
+                        accepted.lock().unwrap().push(std::time::Instant::now());
+                        tokio::time::sleep(HOLD).await;
+                        drop(connection);
+                    }
+                    Err(_) => {
+                        rejected.fetch_add(1, Ordering::SeqCst);
+                    }
+                }
+            }
+        }
+    });
+
+    let _admin_ws = holochain_client::ReconnectingAdminWebsocket::connect(
+        (Ipv4Addr::LOCALHOST, port),
+        Some("flap-test".to_string()),
+        holochain_client::ReconnectConfig {
+            initial_delay: INITIAL_DELAY,
+            max_delay: INITIAL_DELAY,
+            escalate_after: u32::MAX,
+        },
+    )
+    .await
+    .unwrap();
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        if accepted.lock().unwrap().len() >= 3 {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "client did not reconnect three times"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Every dial completed a handshake, so each reconnect followed a live
+    // connection rather than a failed connect.
+    assert_eq!(rejected.load(Ordering::SeqCst), 0);
+
+    // Without the guard the reconnect would follow the close immediately, so
+    // the gaps would be about `HOLD`.
+    let gaps: Vec<Duration> = accepted
+        .lock()
+        .unwrap()
+        .windows(2)
+        .map(|w| w[1] - w[0])
+        .collect();
+    for gap in &gaps {
+        assert!(
+            *gap >= HOLD + INITIAL_DELAY.mul_f64(0.75),
+            "reconnected after {gap:?}, which is too soon to have been delayed by the guard"
+        );
+    }
+
+    server.abort();
 }

--- a/crates/client/tests/reconnection_tests.rs
+++ b/crates/client/tests/reconnection_tests.rs
@@ -1,0 +1,23 @@
+use holochain::sweettest::SweetConductor;
+use holochain_client::AdminWebsocket;
+use std::net::Ipv4Addr;
+use std::time::Duration;
+
+// `mod common;` arrives in Task 5 and `mod fixture;` in Task 7, with the
+// tests that use them. Declaring an unused module here would warn.
+
+#[tokio::test(flavor = "multi_thread")]
+async fn admin_close_notify_fires_on_conductor_shutdown() {
+    let mut conductor = SweetConductor::standard().await;
+    let admin_port = conductor.get_arbitrary_admin_websocket_port().unwrap();
+
+    let (_admin_ws, closed) = AdminWebsocket::connect_for_test((Ipv4Addr::LOCALHOST, admin_port))
+        .await
+        .unwrap();
+
+    conductor.shutdown().await;
+
+    tokio::time::timeout(Duration::from_secs(10), closed.closed())
+        .await
+        .expect("close notification did not fire within 10s");
+}

--- a/crates/client/tests/reconnection_tests.rs
+++ b/crates/client/tests/reconnection_tests.rs
@@ -78,3 +78,49 @@ async fn admin_requests_resume_after_a_conductor_restart() {
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn app_interface_discovery_finds_a_matching_interface() {
+    let (conductor, admin_port) = common::conductor_with_fixed_admin_port().await;
+
+    let admin_ws = AdminWebsocket::connect((Ipv4Addr::LOCALHOST, admin_port), None)
+        .await
+        .unwrap();
+
+    let app_id: holochain_client::InstalledAppId = "test-app".into();
+    let attached_port = admin_ws
+        .attach_app_interface(
+            0,
+            None,
+            holochain_client::AllowedOrigins::Origins(
+                vec!["my-service".to_string()].into_iter().collect(),
+            ),
+            Some(app_id.clone()),
+        )
+        .await
+        .unwrap();
+
+    let found = holochain_client::discover_app_interface_port_for_test(
+        &admin_ws,
+        &app_id,
+        Some("my-service"),
+    )
+    .await
+    .unwrap();
+    assert_eq!(found, attached_port);
+
+    // An origin the interface does not allow finds nothing.
+    let err = holochain_client::discover_app_interface_port_for_test(
+        &admin_ws,
+        &app_id,
+        Some("other-service"),
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        matches!(err, ConductorApiError::AppInterfaceNotFound { .. }),
+        "got {err:?}"
+    );
+
+    drop(conductor);
+}

--- a/crates/client/tests/reconnection_tests.rs
+++ b/crates/client/tests/reconnection_tests.rs
@@ -1,10 +1,11 @@
 use holochain::sweettest::SweetConductor;
-use holochain_client::AdminWebsocket;
+use holochain_client::{AdminWebsocket, ConductorApiError};
 use std::net::Ipv4Addr;
 use std::time::Duration;
 
-// `mod common;` arrives in Task 5 and `mod fixture;` in Task 7, with the
-// tests that use them. Declaring an unused module here would warn.
+mod common;
+
+// `mod fixture;` arrives in a later task, with the tests that use it.
 
 #[tokio::test(flavor = "multi_thread")]
 async fn admin_close_notify_fires_on_conductor_shutdown() {
@@ -20,4 +21,60 @@ async fn admin_close_notify_fires_on_conductor_shutdown() {
     tokio::time::timeout(Duration::from_secs(10), closed.closed())
         .await
         .expect("close notification did not fire within 10s");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn admin_requests_resume_after_a_conductor_restart() {
+    let (mut conductor, admin_port) = common::conductor_with_fixed_admin_port().await;
+
+    let admin_ws = holochain_client::ReconnectingAdminWebsocket::connect(
+        (Ipv4Addr::LOCALHOST, admin_port),
+        None,
+        holochain_client::ReconnectConfig::default(),
+    )
+    .await
+    .unwrap();
+
+    admin_ws
+        .current()
+        .unwrap()
+        .list_app_interfaces()
+        .await
+        .unwrap();
+
+    conductor.shutdown().await;
+
+    // While down, requests fail rather than blocking. The reconnect task has
+    // to observe the close notification before `current` reports it, so poll
+    // rather than asserting on the first read.
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        match admin_ws.current() {
+            Err(ConductorApiError::Disconnected) => break,
+            other => {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "never reported Disconnected, last read {other:?}"
+                );
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+
+    conductor.startup().await;
+
+    // The connection repairs itself without the caller reconnecting.
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        if let Ok(admin) = admin_ws.current() {
+            if admin.list_app_interfaces().await.is_ok() {
+                break;
+            }
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "did not reconnect within 60s"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
 }

--- a/crates/client/tests/reconnection_tests.rs
+++ b/crates/client/tests/reconnection_tests.rs
@@ -1,11 +1,10 @@
 use holochain::sweettest::SweetConductor;
 use holochain_client::{AdminWebsocket, ConductorApiError};
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::time::Duration;
 
 mod common;
-
-// `mod fixture;` arrives in a later task, with the tests that use it.
+mod fixture;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn admin_close_notify_fires_on_conductor_shutdown() {
@@ -123,4 +122,93 @@ async fn app_interface_discovery_finds_a_matching_interface() {
     );
 
     drop(conductor);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn connect_fails_fast_when_nothing_is_listening() {
+    let port = common::free_port();
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        holochain_client::ReconnectingAdminWebsocket::connect(
+            (Ipv4Addr::LOCALHOST, port),
+            None,
+            holochain_client::ReconnectConfig::default(),
+        ),
+    )
+    .await
+    .expect("connect hung instead of failing fast");
+
+    assert!(result.is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn connect_with_retry_waits_for_the_conductor() {
+    // Reserve a port, then hand it to a conductor that starts only after the
+    // connect attempt is already retrying.
+    let port = common::free_port();
+
+    let connecting = tokio::spawn(async move {
+        holochain_client::ReconnectingAdminWebsocket::connect_with_retry(
+            (Ipv4Addr::LOCALHOST, port),
+            None,
+            holochain_client::ReconnectConfig::default(),
+        )
+        .await
+    });
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    assert!(
+        !connecting.is_finished(),
+        "connected before anything was listening"
+    );
+
+    let _conductor = common::conductor_on_admin_port(port).await;
+
+    let admin_ws = tokio::time::timeout(Duration::from_secs(60), connecting)
+        .await
+        .expect("connect_with_retry did not complete within 60s")
+        .unwrap()
+        .unwrap();
+
+    admin_ws
+        .current()
+        .unwrap()
+        .list_app_interfaces()
+        .await
+        .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn app_requests_fail_fast_while_disconnected() {
+    let (mut conductor, admin_port, app_id, signer) =
+        common::install_fixture_app_with_fixed_admin_port().await;
+
+    let app_ws = holochain_client::ReconnectingAppWebsocket::builder(
+        SocketAddr::new(Ipv4Addr::LOCALHOST.into(), admin_port),
+        app_id,
+        signer,
+    )
+    .origin("my-service")
+    .connect()
+    .await
+    .unwrap();
+
+    app_ws.app_info().await.unwrap();
+
+    conductor.shutdown().await;
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        match app_ws.app_info().await {
+            Err(ConductorApiError::Disconnected) => break,
+            _ => {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "never reported Disconnected"
+                );
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
 }

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Added `ReconnectingAdminWebsocket` and `ReconnectingAppWebsocket` to the Rust
+  client. These re-establish their connection after the conductor restarts,
+  with capped exponential backoff. Their `connect_with_retry` constructors also
+  wait for a conductor that has not started yet, while `connect` reports the
+  failure. Requests made while the connection is down fail with
+  `ConductorApiError::Disconnected` and are never retried automatically. A
+  signal subscription taken from `ReconnectingAppWebsocket::signals` survives
+  reconnects and reports missed signals as `SignalEvent::Interrupted`, because
+  Holochain does not replay signals emitted while a client was disconnected.
 - **BREAKING CHANGE**: Fix `SendDirectSignal` failing with `FrameOverflow` for payloads over 8 KiB. Payloads up to the documented 1 MiB limit are now delivered. The signature scheme and wire encoding changed, so direct signals sent between conductors with and without this fix are dropped by the receiver — upgrade both ends. \#5937
 - Add `hc export-ts-bindings`, a built-in `hc` subcommand that writes the TypeScript type declarations for the conductor’s admin and app API and signals to a directory (`./bindings` by default, `--out-dir` to choose another). If the directory already exists, its contents are replaced; the command refuses to do so when the directory is the root directory, or the working directory or an ancestor of it. Building `hc` with `--features unstable-countersigning` additionally includes the countersigning app API. \#5214
 - Add `AddAgentInfo` to the app interface, allowing apps to add signed agent info to the conductor's peer store. \#5016

--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- `holochain_websocket` reports connection loss precisely. `WebsocketError`
+  carries `ReceiverClosed`, `ResponderDropped` and `UnexpectedRawFrame`
+  variants, and `WebsocketError::is_connection_closed` tells a caller whether an
+  error means the connection is gone and reconnecting is worthwhile, rather
+  than a request-level failure. `WebsocketError` is `#[non_exhaustive]`, so
+  matches on it need a wildcard arm.
 - Added `ReconnectingAdminWebsocket` and `ReconnectingAppWebsocket` to the Rust
   client. These re-establish their connection after the conductor restarts,
   with capped exponential backoff. Their `connect_with_retry` constructors also

--- a/crates/holochain_websocket/src/lib.rs
+++ b/crates/holochain_websocket/src/lib.rs
@@ -275,8 +275,10 @@ pub enum WebsocketError {
 impl WebsocketError {
     /// Returns `true` if this error means the connection is no longer usable.
     ///
-    /// A request timeout and a deserialization failure both leave the
-    /// connection viable, so they return `false`.
+    /// Errors raised inside `WsCoreSync::exec` tear the connection down and
+    /// return `true`. A request timeout, a dropped responder and a
+    /// deserialization failure are all raised outside `exec`, leave the
+    /// connection viable, and return `false`.
     pub fn is_connection_closed(&self) -> bool {
         matches!(
             self,
@@ -284,7 +286,6 @@ impl WebsocketError {
                 | WebsocketError::Websocket(_)
                 | WebsocketError::Io(_)
                 | WebsocketError::ReceiverClosed
-                | WebsocketError::ResponderDropped
                 | WebsocketError::UnexpectedRawFrame
         )
     }
@@ -1084,12 +1085,12 @@ mod test;
 #[cfg(test)]
 mod error_tests {
     use super::WebsocketError;
+    use holochain_serialized_bytes::prelude::SerializedBytesError;
 
     #[test]
     fn connection_closed_classification() {
         assert!(WebsocketError::Close("ConnectionClosed".to_string()).is_connection_closed());
         assert!(WebsocketError::ReceiverClosed.is_connection_closed());
-        assert!(WebsocketError::ResponderDropped.is_connection_closed());
         assert!(WebsocketError::UnexpectedRawFrame.is_connection_closed());
         assert!(WebsocketError::Io(std::io::Error::other("boom")).is_connection_closed());
     }
@@ -1103,5 +1104,12 @@ mod error_tests {
             .unwrap_err();
         assert!(!WebsocketError::Timeout(elapsed).is_connection_closed());
         assert!(!WebsocketError::Other("something else".to_string()).is_connection_closed());
+        // A response carrying no data drops the responder on a live
+        // connection, so this is a request-level failure.
+        assert!(!WebsocketError::ResponderDropped.is_connection_closed());
+        assert!(
+            !WebsocketError::Deserialize(SerializedBytesError::Deserialize("boom".to_string()))
+                .is_connection_closed()
+        );
     }
 }

--- a/crates/holochain_websocket/src/lib.rs
+++ b/crates/holochain_websocket/src/lib.rs
@@ -242,6 +242,7 @@ impl RMap {
 /// It is intended to capture all the errors that a caller might want to handle. Other errors that
 /// are unlikely to be recoverable are mapped to [WebsocketError::Other].
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum WebsocketError {
     /// The websocket has been closed by the other side.
     #[error("Websocket closed: {0}")]

--- a/crates/holochain_websocket/src/lib.rs
+++ b/crates/holochain_websocket/src/lib.rs
@@ -258,9 +258,36 @@ pub enum WebsocketError {
     /// An IO error occurred.
     #[error("IO error: {0}")]
     Io(#[from] Error),
+    /// The receive half of the connection has closed.
+    #[error("Receiver closed")]
+    ReceiverClosed,
+    /// The responder for a request was dropped before a response arrived.
+    #[error("Responder dropped")]
+    ResponderDropped,
+    /// A raw websocket frame arrived where a complete message was expected.
+    #[error("Unexpected raw frame")]
+    UnexpectedRawFrame,
     /// Some other error occurred.
     #[error("Other error: {0}")]
     Other(String),
+}
+
+impl WebsocketError {
+    /// Returns `true` if this error means the connection is no longer usable.
+    ///
+    /// A request timeout and a deserialization failure both leave the
+    /// connection viable, so they return `false`.
+    pub fn is_connection_closed(&self) -> bool {
+        matches!(
+            self,
+            WebsocketError::Close(_)
+                | WebsocketError::Websocket(_)
+                | WebsocketError::Io(_)
+                | WebsocketError::ReceiverClosed
+                | WebsocketError::ResponderDropped
+                | WebsocketError::UnexpectedRawFrame
+        )
+    }
 }
 
 /// A result type, with the error type [WebsocketError].
@@ -466,9 +493,7 @@ impl WebsocketReceiver {
                         .await
                         .next()
                         .await
-                        .ok_or::<WebsocketError>(WebsocketError::Other(
-                            "ReceiverClosed".to_string(),
-                        ))?
+                        .ok_or::<WebsocketError>(WebsocketError::ReceiverClosed)?
                         .map_err(Box::new)?;
                     let msg = match msg {
                         Message::Text(s) => s.as_bytes().to_vec(),
@@ -486,9 +511,7 @@ impl WebsocketReceiver {
                         Message::Close(frame) => {
                             return Err(WebsocketError::Close(format!("{frame:?}")));
                         }
-                        Message::Frame(_) => {
-                            return Err(WebsocketError::Other("UnexpectedRawFrame".to_string()))
-                        }
+                        Message::Frame(_) => return Err(WebsocketError::UnexpectedRawFrame),
                     };
                     match WireMessage::try_from_bytes(msg)? {
                         WireMessage::Authenticate { data } => {
@@ -636,7 +659,7 @@ impl WebsocketSender {
             // await the response
             let resp = resp_r
                 .await
-                .map_err(|_| WebsocketError::Other("ResponderDropped".to_string()))??;
+                .map_err(|_| WebsocketError::ResponderDropped)??;
 
             // decode the response
             let res = decode(&Vec::from(UnsafeBytes::from(resp)))?;
@@ -1057,3 +1080,28 @@ impl Callback for ConnectCallback {
 
 #[cfg(test)]
 mod test;
+
+#[cfg(test)]
+mod error_tests {
+    use super::WebsocketError;
+
+    #[test]
+    fn connection_closed_classification() {
+        assert!(WebsocketError::Close("ConnectionClosed".to_string()).is_connection_closed());
+        assert!(WebsocketError::ReceiverClosed.is_connection_closed());
+        assert!(WebsocketError::ResponderDropped.is_connection_closed());
+        assert!(WebsocketError::UnexpectedRawFrame.is_connection_closed());
+        assert!(WebsocketError::Io(std::io::Error::other("boom")).is_connection_closed());
+    }
+
+    #[tokio::test]
+    async fn request_level_errors_are_not_connection_closed() {
+        // A request timeout is awaited outside `WsCoreSync::exec`, so it does
+        // not tear the connection down.
+        let elapsed = tokio::time::timeout(std::time::Duration::ZERO, std::future::pending::<()>())
+            .await
+            .unwrap_err();
+        assert!(!WebsocketError::Timeout(elapsed).is_connection_closed());
+        assert!(!WebsocketError::Other("something else".to_string()).is_connection_closed());
+    }
+}


### PR DESCRIPTION
### Summary

Adds opt-in reconnecting wrappers to `holochain_client`, for #5957.

`ReconnectingAdminWebsocket` and `ReconnectingAppWebsocket` repair the transport
after a conductor restart. Requests made while down fail fast with
`ConductorApiError::Disconnected` and are never retried automatically, because
re-signing a zome call mints a fresh nonce and would risk a double source-chain
write. `connect` reports a conductor that will not accept; `connect_with_retry`
waits for one.

Signals are the reason reconnection is not fully transparent. Holochain has no
signal replay, so a subscription from `ReconnectingAppWebsocket::signals()`
survives reconnects and reports the gap as `SignalEvent::Interrupted`, letting a
consumer re-sync rather than silently diverging.

An app connection is keyed on admin address plus installed app id rather than a
port, because a restart invalidates every auth token and moves app interface
ports — `startup_app_interfaces` restores an interface on its originally
requested port, so one attached on port 0 returns on a different port. Every
reconnect therefore replays the whole chain: discover interface, issue token,
connect, authenticate, refetch app info.

Also adds typed `WebsocketError` variants and `is_connection_closed`, so
consumers classify connection failures without matching on message strings, and
marks that enum `#[non_exhaustive]`.

Note: `hc_client`'s `zome_call`, `zome_call_auth` and `zome_call_returns_hash`
fail on this branch with `missing field \`access\``. That is the committed
fixture wasm (last built 2025-11-21) rotting against `capability/` changes made
on develop in July and August; it reproduces on develop and is unrelated to
these changes.

### TODO:
- [x] CHANGELOGs updated with appropriate info
- [x] All code changes are reflected in docs, including module-level docs
