### PR TITLE
fix(mr_bundle): reject unsafe bundle resource ids

### DIFF
--- a/crates/holochain/CHANGELOG.md
+++ b/crates/holochain/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+- Reject bundle resource identifiers containing absolute paths or parent
+  directory traversal, preventing malicious bundles from writing resources
+  outside their extraction directory. \#5784
 - Fix `GrantZomeCallCapability` and `RevokeZomeCallCapability` bypassing self-validation. The admin calls now validate the commit the same way zome calls do, so granting or revoking a capability on a closed source chain fails instead of writing an invalid action that peers would reject and warrant the agent for. \#5949
 - `hc dna hash` now accepts modifier overrides: `--network-seed`/`-s` and
   `--role-settings <path to yaml>`, matching the semantics of

--- a/crates/mr_bundle/src/bundle.rs
+++ b/crates/mr_bundle/src/bundle.rs
@@ -6,6 +6,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Debug;
 use std::io::Read;
+use std::path::{Component, Path};
 
 pub mod resource;
 
@@ -16,6 +17,12 @@ pub type ResourceMap = BTreeMap<ResourceIdentifier, ResourceBytes>;
 ///
 /// This is meant to be serialized for standalone distribution, and deserialized
 /// by the receiver.
+///
+/// Resource-identifier safety (rejecting absolute paths and parent-directory
+/// traversal) is enforced only by [`Bundle::unpack`], not by this type's
+/// [`Deserialize`] impl. Callers that need that guarantee on untrusted bytes
+/// must go through [`Bundle::unpack`] rather than deserializing a `Bundle`
+/// directly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Bundle<M>
 where
@@ -59,10 +66,40 @@ where
 
     /// Unpack bytes produced by [`pack`](Bundle::pack) into a new [Bundle].
     ///
-    /// Uses [`unpack`](crate::unpack) to produce the new Bundle.
+    /// Uses [`unpack`](crate::unpack) to produce the new bundle.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MrBundleError::IoError`] if decompression fails,
+    /// [`MrBundleError::MsgpackDecodeError`] if deserialization fails, or
+    /// [`MrBundleError::InvalidResourceId`] if a resource identifier could
+    /// escape a consumer's bundle root.
     pub fn unpack(source: impl Read) -> MrBundleResult<Self> {
-        crate::unpack(source)
+        let bundle: Self = crate::unpack(source)?;
+
+        for resource_id in bundle.resources.keys() {
+            validate_resource_id(resource_id)?;
+        }
+
+        Ok(bundle)
     }
+}
+
+fn validate_resource_id(resource_id: &ResourceIdentifier) -> MrBundleResult<()> {
+    let path = Path::new(resource_id);
+    let escapes_root = path.is_absolute()
+        || path.components().any(|component| {
+            matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        });
+
+    if escapes_root {
+        return Err(MrBundleError::InvalidResourceId(resource_id.clone()));
+    }
+
+    Ok(())
 }
 
 // Same failure mode as `HoloHashed<C>` (`holo_hash::hashed`):
@@ -277,13 +314,32 @@ mod tests {
 
     #[test]
     fn round_trip_pack_unpack() {
-        let manifest = TestManifest(vec!["1.thing".into(), "2.thing".into()]);
+        let manifest = TestManifest(vec!["1.thing".into(), "nested/2.thing".into()]);
 
         let bundle = Bundle::new(
             manifest.clone(),
             vec![
                 ("1.thing".into(), vec![1].into()),
-                ("2.thing".into(), vec![2].into()),
+                ("nested/2.thing".into(), vec![2].into()),
+            ],
+        )
+        .unwrap();
+
+        let packed = bundle.pack().unwrap();
+        let unpacked = Bundle::unpack(packed.reader()).unwrap();
+
+        assert_eq!(bundle, unpacked);
+    }
+
+    #[test]
+    fn round_trip_pack_unpack_with_cur_dir_components() {
+        let manifest = TestManifest(vec!["./thing".into(), "nested/./thing".into()]);
+
+        let bundle = Bundle::new(
+            manifest.clone(),
+            vec![
+                ("./thing".into(), vec![1].into()),
+                ("nested/./thing".into(), vec![2].into()),
             ],
         )
         .unwrap();
@@ -331,5 +387,41 @@ mod tests {
             &ResourceBytes::from(vec![1]),
             bundle.get_resource(&"thing".into()).unwrap()
         );
+    }
+
+    fn packed_bundle_with_resource_id(resource_id: &str) -> bytes::Bytes {
+        Bundle::new(
+            TestManifest(vec![resource_id.to_string()]),
+            [(resource_id.to_string(), vec![1].into())],
+        )
+        .unwrap()
+        .pack()
+        .unwrap()
+    }
+
+    fn assert_unpack_rejects(resource_id: &str) {
+        let packed = packed_bundle_with_resource_id(resource_id);
+        let error = Bundle::<TestManifest>::unpack(packed.reader())
+            .expect_err("unsafe resource identifier unexpectedly unpacked");
+
+        assert!(
+            matches!(&error, MrBundleError::InvalidResourceId(id) if id == resource_id),
+            "expected InvalidResourceId({resource_id:?}), got {error:?}"
+        );
+    }
+
+    #[test]
+    fn unpack_rejects_unsafe_resource_ids() {
+        for resource_id in ["../outside", "nested/../../outside", "/outside"] {
+            assert_unpack_rejects(resource_id);
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn unpack_rejects_windows_prefixed_resource_ids() {
+        for resource_id in [r"C:\outside", r"C:outside"] {
+            assert_unpack_rejects(resource_id);
+        }
     }
 }

--- a/crates/mr_bundle/src/bundle.rs
+++ b/crates/mr_bundle/src/bundle.rs
@@ -19,10 +19,10 @@ pub type ResourceMap = BTreeMap<ResourceIdentifier, ResourceBytes>;
 /// by the receiver.
 ///
 /// Resource-identifier safety (rejecting absolute paths and parent-directory
-/// traversal) is enforced only by [`Bundle::unpack`], not by this type's
-/// [`Deserialize`] impl. Callers that need that guarantee on untrusted bytes
-/// must go through [`Bundle::unpack`] rather than deserializing a `Bundle`
-/// directly.
+/// traversal) is enforced by [`Bundle::unpack`] and filesystem expansion, not
+/// by this type's [`Deserialize`] impl. Callers that need that guarantee before
+/// other operations on untrusted bytes must go through [`Bundle::unpack`]
+/// rather than deserializing a `Bundle` directly.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Bundle<M>
 where
@@ -77,11 +77,13 @@ where
     pub fn unpack(source: impl Read) -> MrBundleResult<Self> {
         let bundle: Self = crate::unpack(source)?;
 
-        for resource_id in bundle.resources.keys() {
-            validate_resource_id(resource_id)?;
-        }
+        bundle.validate_resource_ids()?;
 
         Ok(bundle)
+    }
+
+    pub(crate) fn validate_resource_ids(&self) -> MrBundleResult<()> {
+        self.resources.keys().try_for_each(validate_resource_id)
     }
 }
 

--- a/crates/mr_bundle/src/error.rs
+++ b/crates/mr_bundle/src/error.rs
@@ -26,6 +26,10 @@ pub enum MrBundleError {
     #[error("Failed to decode bundle to [{0}] due to a deserialization error: {1}")]
     MsgpackDecodeError(String, rmp_serde::decode::Error),
 
+    /// A bundle resource identifier contains an unsafe path.
+    #[error("Invalid resource id in bundle: {0}")]
+    InvalidResourceId(ResourceIdentifier),
+
     /// A YAML error
     #[cfg(feature = "fs")]
     #[cfg_attr(docsrs, doc(cfg(feature = "fs")))]

--- a/crates/mr_bundle/src/fs.rs
+++ b/crates/mr_bundle/src/fs.rs
@@ -160,12 +160,19 @@ impl FileSystemBundler {
     ///
     /// This version of the [expand_to](FileSystemBundler::expand_to) has looser constraints on the
     /// contents of the manifest. As a consequence, the file name for the manifest must be provided.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a resource identifier could escape `target_dir`, the target directory
+    /// already exists without `force`, serialization fails, or a filesystem operation fails.
     pub async fn expand_named_to<M: Debug + Serialize + DeserializeOwned>(
         bundle: &Bundle<M>,
         manifest_file_name: &str,
         target_dir: impl AsRef<Path>,
         force: bool,
     ) -> MrBundleResult<()> {
+        bundle.validate_resource_ids()?;
+
         let target_dir = target_dir.as_ref();
 
         // If the directory already exists, and we're not forcing, then we can't continue.

--- a/crates/mr_bundle/tests/integration.rs
+++ b/crates/mr_bundle/tests/integration.rs
@@ -1,7 +1,8 @@
+use mr_bundle::error::MrBundleError;
 use mr_bundle::{
     resource_id_for_path, Bundle, FileSystemBundler, Manifest, ResourceBytes, ResourceIdentifier,
 };
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::PathBuf;
 
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -208,4 +209,35 @@ async fn file_system_bundler_with_raw_bundle() {
         "some content",
         std::fs::read_to_string(unpacked_dir.join("bundled.thing")).unwrap()
     );
+}
+
+#[tokio::test]
+async fn expand_named_to_rejects_unsafe_resource_ids() {
+    #[derive(serde::Serialize)]
+    struct UncheckedBundle {
+        manifest: yaml_serde::Value,
+        resources: BTreeMap<ResourceIdentifier, ResourceBytes>,
+    }
+
+    let resource_id = "../outside";
+    let unchecked_bundle = UncheckedBundle {
+        manifest: yaml_serde::Value::Null,
+        resources: [(resource_id.to_string(), vec![1].into())]
+            .into_iter()
+            .collect(),
+    };
+    let serialized = rmp_serde::to_vec(&unchecked_bundle).unwrap();
+    let bundle: Bundle<yaml_serde::Value> = rmp_serde::from_slice(&serialized).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let target_dir = dir.path().join("target");
+
+    let error = FileSystemBundler::expand_named_to(&bundle, "manifest.yaml", target_dir, false)
+        .await
+        .expect_err("unsafe resource identifier unexpectedly expanded");
+
+    assert!(
+        matches!(&error, MrBundleError::InvalidResourceId(id) if id == resource_id),
+        "expected InvalidResourceId({resource_id:?}), got {error:?}"
+    );
+    assert!(!dir.path().join("outside").exists());
 }


### PR DESCRIPTION
## What changed

Holochain rejects bundle files (DNA, hApp, and web hApp bundles) that contain unsafe internal file paths. Before this change, a malicious bundle could name one of its internal resources with a path like `../../etc/passwd` or an absolute path such as `/etc/passwd`. Now, unpacking a bundle checks every internal resource name and refuses the bundle if any name tries to point outside the folder it belongs in.

## Why

A bundle is a package that can be shared and installed by other people. If someone crafted a bundle with a bad internal path, tools that extract it to disk could be tricked into writing or reading files outside the intended folder, which is a security risk known as path traversal. This fix closes that gap by checking bundle contents as soon as they are read, before anything in the bundle is used. Fixes #5784.

## Notes

Valid relative paths inside a bundle, including nested folders, continue to work exactly as before. The check does not touch how bundles are written to disk, only how they are validated when read.