### PR TITLE
fix(keystore): don't bind a unix socket for the in-process lair keystore

### DIFF
--- a/crates/holochain_keystore/src/lair_keystore.rs
+++ b/crates/holochain_keystore/src/lair_keystore.rs
@@ -2,7 +2,7 @@
 
 use crate::*;
 use ::lair_keystore::dependencies::lair_keystore_api;
-use ::lair_keystore::server::StandaloneServer;
+use lair_keystore_api::in_proc_keystore::InProcKeystore;
 use lair_keystore_api::prelude::*;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -18,24 +18,55 @@ pub async fn spawn_lair_keystore(
 
 /// Spawn an in-process keystore backed by lair_keystore.
 /// @param config_path - path to the lair config yaml file
+///
+/// This runs the lair server inside this process and talks to it over
+/// in-memory channels. It deliberately does *not* go through
+/// `lair_keystore::server::StandaloneServer`, which would bind the unix domain
+/// socket named by `config.connection_url` and connect back to it over IPC.
+///
+/// Binding that socket makes holochain unusable on iOS. `sockaddr_un.sun_path`
+/// is capped at ~104 bytes, while an iOS app container is ~84 bytes (device) to
+/// ~162 bytes (simulator) before anything is appended — so the conventional
+/// data directory (`Library/Application Support/<bundle-id>/...`) can never
+/// hold the socket, and startup fails with
+/// `InvalidInput: "path must be shorter than SUN_LEN"`.
+///
+/// The standalone server was used here to get its pid-checks; those are kept
+/// below by calling `lair_keystore::pid_check::pid_check` directly, so the only behaviour dropped is
+/// the socket itself. `config.connection_url` is still honoured for the server
+/// identity key (`?k=`), so existing configs keep working unchanged — only the
+/// path component goes unused, and no `socket` file is created.
 pub async fn spawn_lair_keystore_in_proc(
     config_path: &PathBuf,
     passphrase: SharedLockedArray,
 ) -> LairResult<MetaLairClient> {
     let config = get_config(config_path, passphrase.clone()).await?;
-    let connection_url = config.connection_url.clone();
 
-    // rather than using the in-proc server directly,
-    // use the actual standalone server so we get the pid-checks, etc
-    let mut server = StandaloneServer::new(config).await?;
+    // Same guard StandaloneServer::new applies before touching the store, so a
+    // second process cannot claim a store this one is using.
+    {
+        let config = config.clone();
+        // TODO - make pid_check async friendly
+        tokio::task::spawn_blocking(move || ::lair_keystore::pid_check::pid_check(&config))
+            .await
+            .map_err(one_err::OneErr::new)??;
+    }
 
-    server.run(passphrase.clone()).await?;
+    // The same persistent sqlcipher store StandaloneServer would have built.
+    let store_factory =
+        ::lair_keystore::create_sql_pool_factory(&config.store_file, &config.database_salt);
+
+    let keystore = InProcKeystore::new(config, store_factory, passphrase).await?;
+    let client = keystore.new_client().await?;
 
     // just incase a Drop gets impld at some point...
-    std::mem::forget(server);
+    std::mem::forget(keystore);
 
-    // now, just connect to it : )
-    spawn_lair_keystore(connection_url.into(), passphrase).await
+    // In-process transport cannot drop the way an IPC socket can, so the
+    // connection-health checker MetaLairClient::new sets up has nothing to do;
+    // hand it a sender whose receiver is closed (as spawn_mem_keystore does).
+    let (s, _) = tokio::sync::mpsc::unbounded_channel();
+    Ok(MetaLairClient(Arc::new(parking_lot::Mutex::new(client)), s))
 }
 
 async fn get_config(


### PR DESCRIPTION

## Summary

Below is a Claude generated PR to an issue found when proving out building on iOS.   Note that all verification was done on the [iOS branch of Android Service Runtime](https://github.com/holochain/android-service-runtime/tree/ios)

I'm not conversant in all the issues of lair and the reasons for the domain socket in the linux case, so treat this as a POC and information, not a full merge request.

Calude Generated PR:

## Problem

On iOS the conductor never starts, because the in-process keystore binds a unix
domain socket.

`spawn_lair_keystore_in_proc` runs a `StandaloneServer`, which binds
`<data_root>/socket` and connects back to it over IPC. `sockaddr_un.sun_path` is
capped at ~104 bytes, but an iOS app container path is already ~84 bytes on
device and ~162 in the simulator before anything is appended. The conventional
data directory therefore blows the limit as soon as `/socket` is added:

    <container>/Library/Application Support/<bundle-id>/holochain/socket
      158 bytes on device, 236 in the simulator   (limit ~104)

The bind fails and startup aborts with:

    Lair({"error":"InvalidInput","message":"path must be shorter than SUN_LEN"})

There is no iOS-legal path short enough to work around this: the bundle id alone
is ~28 bytes, and lair canonicalizes the root, which on device turns `/var` into
`/private/var` for another 8. Anything under `app_data_dir()` is unreachable, so
the conductor cannot boot from a location an app is actually supposed to use.

## Fix

Use `InProcKeystore` instead of `StandaloneServer`. It connects client to server
over in-memory channels and never binds — holochain already uses this shape in
`spawn_mem_keystore()`; the only difference for a persistent keystore is the
store factory, and `lair_keystore::create_sql_pool_factory` is a public
re-export of exactly what `StandaloneServer::run` builds internally.

**The pid-check is kept.** `pid_check` is public and is now called directly, the
same way `StandaloneServer::new` does, so the only behaviour dropped is the
socket.

**No config change.** `connection_url` is still honoured for the server identity
key (`?k=`), so existing lair configs work untouched. The only visible
difference on disk is that no `socket` file appears; `pid_file`, `store_file`
and the databases are unchanged.

## On the socket and the security model

The socket is genuinely part of the security model for the **standalone
daemon** — separate process, multiple clients, file permissions deciding who may
connect. Nothing here changes that.

The narrower claim is that the *in-process* path inherited that machinery
without needing it. Server and client are the same process, so binding a
filesystem-visible endpoint only widens the surface; removing it means the
keystore is reachable solely from within the process's own address space. lair's
own checks are untouched either way — the in-proc connection still runs
`hello(srv_pub_key)` and `unlock(passphrase)`.

Worth noting for iOS specifically: every third-party app runs as the same uid
(`euid=501`), so POSIX permissions cannot isolate one app from another there;
the kernel sandbox does, and it already protects the container regardless of
whether a socket exists.

## Testing

- `holochain_keystore` builds clean; `cargo fmt --check` and `clippy` pass.
- Verified end to end via [holochain/android-service-runtime](https://github.com/holochain/android-service-runtime)
  (in-process `tauri-plugin-holochain`) on an **iPhone 12 mini / iOS 18.7.8**
  and an **iOS 26.5 simulator**: conductor boots from the standard
  `app_data_dir()`, installs a hApp, and completes a zome call, signing and an
  app signal. No SUN_LEN error, no `socket` file created, and data persists
  across restarts.
- 6/6 `tauri-plugin-holochain` desktop tests pass against this change.

## Open question

If anything relies on attaching external tooling to a conductor's *in-process*
lair over that socket, this would regress it — and that would be the argument
for gating this on `cfg(target_os = "ios")` or a config flag rather than making
it unconditional. I'm not aware of such a workflow; happy to narrow the change
if one exists.

### TODO:
- [ ] CHANGELOGs updated with appropriate info
- [ ] All code changes are reflected in docs, including module-level docs