### PR TITLE
fix(ci): select the release tag from the release commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,13 +299,14 @@ jobs:
 
           # Push just the Holochain tag initially, so that GitHub Actions will create an event based on it.
           # Pushing a batch larger than 3 tags will cause the event to be ignored -> https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push
-          # TODO Once this has been tested, removed the `set +eu` and `set -eu` lines. That is just to prevent this from making the workflow fail.
-          set +eu
-          SEARCH_PATTERN="^holochain-[0-9]"
-          ALL_HOLOCHAIN_TAGS=$(git -c 'versionsort.suffix=-beta-dev' -c 'versionsort.suffix=-dev' -c 'versionsort.suffix=-rc' tag --sort='v:refname' | cut --delimiter='/' --fields=3)
-          LATEST_MATCHING_TAG=$(echo "$ALL_HOLOCHAIN_TAGS" | grep -E "$SEARCH_PATTERN" | tail -n 1)
-          git push origin ${LATEST_MATCHING_TAG}
-          set -eu
+          # The tag is the nearest one reachable from the release commit, so a release from a maintenance
+          # branch picks its own tag rather than a higher-versioned tag from another release line.
+          RELEASE_TAG=$(git describe --tags --match 'holochain-[0-9]*' --abbrev=0 HEAD || true)
+          if [[ -n "${RELEASE_TAG}" ]]; then
+            git push origin "${RELEASE_TAG}"
+          else
+            echo "::warning::No holochain-* tag is reachable from the release commit, so the release dispatch will not be triggered"
+          fi
 
           git push origin ${HOLOCHAIN_TARGET_BRANCH} --tags
 


### PR DESCRIPTION
The release workflow pushes a single `holochain-*` tag ahead of the bulk tag push so GitHub emits a push event for it — batches of more than three tags are ignored. That tag was picked by version-sorting every tag in the repo and taking the last one, which selects the highest version across all release lines rather than the tag the release just created.

Since the 0.8 development line opened, 0.7 maintenance releases re-pushed the already-published `holochain-0.8.0-dev.5` tag (`Everything up-to-date`), so the new tag only went out in the 25-tag bulk push and [`Holochain release dispatch`](https://github.com/holochain/holochain/actions/workflows/release-dispatch.yml) never ran for `holochain-0.7.1-rc.0` or `holochain-0.7.1-rc.1`.

Now uses the nearest `holochain-*` tag reachable from the release commit, which is correct on both maintenance and development lines, and warns rather than silently continuing when no tag is found.